### PR TITLE
[Tablet Orders] Replace taxes `(?)` button with a Learn More link

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/EditableOrderViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/EditableOrderViewModel.swift
@@ -2367,13 +2367,16 @@ extension TaxBasedOnSetting {
     var displayString: String {
         switch self {
         case .customerBillingAddress:
-            return NSLocalizedString("Calculated on billing address",
+            return NSLocalizedString("editableOrderViewModel.taxBasedOnSetting.customerBillingAddress",
+                                     value: "Calculated on billing address.",
                                      comment: "The string to show on order taxes when they are calculated based on the billing address")
         case .customerShippingAddress:
-            return NSLocalizedString("Calculated on shipping address",
+            return NSLocalizedString("editableOrderViewModel.taxBasedOnSetting.customerShippingAddress",
+                                     value: "Calculated on shipping address.",
                                      comment: "The string to show on order taxes when they are calculated based on the shipping address")
         case .shopBaseAddress:
-            return NSLocalizedString("Calculated on shop base address",
+            return NSLocalizedString("editableOrderViewModel.taxBasedOnSetting.shopBaseAddress",
+                                     value: "Calculated on shop base address.",
                                      comment: "The string to show on order taxes when they are calculated based on the shop base address")
         }
     }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/PaymentSection/OrderPaymentSection.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/PaymentSection/OrderPaymentSection.swift
@@ -179,6 +179,10 @@ private extension OrderPaymentSection {
             taxSectionTitle
             taxLines
             taxBasedOnLine
+                .onTapGesture {
+                    shouldShowTaxEducationalDialog = true
+                    viewModel.onTaxHelpButtonTappedClosure()
+                }
             .renderedIf(viewModel.taxBasedOnSetting != nil)
         }
         .padding(Constants.sectionPadding)
@@ -194,16 +198,6 @@ private extension OrderPaymentSection {
         AdaptiveStack(horizontalAlignment: .leading, spacing: Constants.taxesAdaptativeStacksSpacing) {
             Text(Localization.taxes)
                 .bodyStyle()
-
-            Button {
-                shouldShowTaxEducationalDialog = true
-                viewModel.onTaxHelpButtonTappedClosure()
-            } label: {
-                Image(systemName: "questionmark.circle")
-                    .foregroundColor(Color(.wooCommercePurple(.shade60)))
-                    .accessibilityLabel(Localization.taxInformationAccessibilityLabel)
-            }
-            .renderedIf(viewModel.shouldShowTaxesInfoButton)
 
             Spacer()
 
@@ -234,9 +228,17 @@ private extension OrderPaymentSection {
     }
 
     @ViewBuilder var taxBasedOnLine: some View {
-        Text(viewModel.taxBasedOnSetting?.displayString ?? "")
-            .footnoteStyle()
-            .multilineTextAlignment(.leading)
+        HStack(spacing: Constants.taxBasedOnLineTextPadding) {
+            Text(viewModel.taxBasedOnSetting?.displayString ?? "")
+                .footnoteStyle()
+                .multilineTextAlignment(.leading)
+            Text(Localization.taxInformationLearnMore)
+                .font(.footnote)
+                .foregroundColor(Color(.wooCommercePurple(.shade60)))
+                .accessibilityLabel(Localization.taxInformationAccessibilityLabel)
+                .renderedIf(viewModel.shouldShowTaxesInfoButton)
+        }
+
     }
 
     @ViewBuilder var taxRateAddedAutomaticallyRow: some View {
@@ -273,25 +275,32 @@ private extension OrderPaymentSection {
 // MARK: Constants
 private extension OrderPaymentSection {
     enum Localization {
-        static let paymentTotals = NSLocalizedString("orderPaymentSection.paymentTotals",
-                                                     value: "Payment totals",
-                                                     comment: "Title text of the section that shows Payment details when creating a new order")
-        static let productsTotal = NSLocalizedString("orderPaymentSection.products",
-                                                     value: "Products",
-                                                     comment: "Label for the row showing the total cost of products in the order")
+        static let paymentTotals = NSLocalizedString(
+            "orderPaymentSection.paymentTotals",
+            value: "Payment totals",
+            comment: "Title text of the section that shows Payment details when creating a new order")
+        static let productsTotal = NSLocalizedString(
+            "orderPaymentSection.products",
+            value: "Products",
+            comment: "Label for the row showing the total cost of products in the order")
         static let discountTotal = NSLocalizedString("Discount total", comment: "Label for the the row showing the total discount of the order")
         static let shippingTotal = NSLocalizedString("Shipping", comment: "Label for the row showing the cost of shipping in the order")
-        static let customAmountsTotal = NSLocalizedString("orderPaymentSection.customAmounts",
-                                                          value: "Custom amounts",
-                                                          comment: "Label for the row showing the cost of fees in the order")
+        static let customAmountsTotal = NSLocalizedString(
+            "orderPaymentSection.customAmounts",
+            value: "Custom amounts",
+            comment: "Label for the row showing the cost of fees in the order")
         static let taxes = NSLocalizedString("Taxes", comment: "Label for the row showing the taxes in the order")
         static let coupon = NSLocalizedString("Coupon", comment: "Label for the row showing the cost of coupon in the order")
         static let taxRateAddedAutomaticallyRowText = NSLocalizedString("Tax rate location added automatically",
                                                                         comment: "Notice in editable order details when the tax rate was added to the order")
+        static let taxInformationLearnMore = NSLocalizedString(
+            "order.form.paymentSection.taxes.learnMore",
+            value: "Learn More.",
+            comment: "A 'Learn More' label text, which shows tax information upon being clicked.")
         static let taxInformationAccessibilityLabel = NSLocalizedString(
             "order.form.paymentSection.taxes.moreInfo.accessibilityLabel",
             value: "Tax information",
-            comment: "An accessibility label for a More info button, rendered as a question mark icon, which shows tax information.")
+            comment: "An accessibility label for a Learn More button, which shows tax information.")
     }
 
     enum Constants {
@@ -299,6 +308,7 @@ private extension OrderPaymentSection {
         static let taxesSectionVerticalSpacing: CGFloat = 8
         static let taxRateAddedAutomaticallyRowHorizontalSpacing: CGFloat = 8
         static let taxesAdaptativeStacksSpacing: CGFloat = 4
+        static let taxBasedOnLineTextPadding: CGFloat = 4
         static let sectionPadding: CGFloat = 16
         static let rowMinHeight: CGFloat = 44
         static let infoTooltipCornerRadius: CGFloat = 4

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/PaymentSection/OrderPaymentSection.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/PaymentSection/OrderPaymentSection.swift
@@ -235,7 +235,6 @@ private extension OrderPaymentSection {
             Text(Localization.taxInformationLearnMore)
                 .font(.footnote)
                 .foregroundColor(Color(.wooCommercePurple(.shade60)))
-                .accessibilityLabel(Localization.taxInformationAccessibilityLabel)
                 .renderedIf(viewModel.shouldShowTaxesInfoButton)
         }
 
@@ -311,10 +310,6 @@ private extension OrderPaymentSection {
             "order.form.paymentSection.taxes.learnMore",
             value: "Learn More.",
             comment: "A 'Learn More' label text, which shows tax information upon being clicked.")
-        static let taxInformationAccessibilityLabel = NSLocalizedString(
-            "order.form.paymentSection.taxes.moreInfo.accessibilityLabel",
-            value: "Tax information",
-            comment: "An accessibility label for a Learn More button, which shows tax information.")
     }
 
     enum Constants {

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/PaymentSection/OrderPaymentSection.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/PaymentSection/OrderPaymentSection.swift
@@ -285,11 +285,11 @@ private extension OrderPaymentSection {
             comment: "Label for the row showing the total cost of products in the order")
         static let discountTotal = NSLocalizedString(
             "orderPaymentSection.discountTotal",
-            value:"Discount total",
+            value: "Discount total",
             comment: "Label for the the row showing the total discount of the order")
         static let shippingTotal = NSLocalizedString(
             "orderPaymentSection.shippingTotal",
-            value:"Shipping",
+            value: "Shipping",
             comment: "Label for the row showing the cost of shipping in the order")
         static let customAmountsTotal = NSLocalizedString(
             "orderPaymentSection.customAmountsTotal",
@@ -297,15 +297,15 @@ private extension OrderPaymentSection {
             comment: "Label for the row showing the cost of fees in the order")
         static let taxes = NSLocalizedString(
             "orderPaymentSection.taxes",
-            value:"Taxes",
+            value: "Taxes",
             comment: "Label for the row showing the taxes in the order")
         static let coupon = NSLocalizedString(
             "orderPaymentSection.coupon",
-            value:"Coupon",
+            value: "Coupon",
             comment: "Label for the row showing the cost of coupon in the order")
         static let taxRateAddedAutomaticallyRowText = NSLocalizedString(
             "orderPaymentSection.taxRateAddedAutomaticallyRowText",
-            value:"Tax rate location added automatically",
+            value: "Tax rate location added automatically",
             comment: "Notice in editable order details when the tax rate was added to the order")
         static let taxInformationLearnMore = NSLocalizedString(
             "order.form.paymentSection.taxes.learnMore",

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/PaymentSection/OrderPaymentSection.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/PaymentSection/OrderPaymentSection.swift
@@ -280,19 +280,33 @@ private extension OrderPaymentSection {
             value: "Payment totals",
             comment: "Title text of the section that shows Payment details when creating a new order")
         static let productsTotal = NSLocalizedString(
-            "orderPaymentSection.products",
+            "orderPaymentSection.productsTotal",
             value: "Products",
             comment: "Label for the row showing the total cost of products in the order")
-        static let discountTotal = NSLocalizedString("Discount total", comment: "Label for the the row showing the total discount of the order")
-        static let shippingTotal = NSLocalizedString("Shipping", comment: "Label for the row showing the cost of shipping in the order")
+        static let discountTotal = NSLocalizedString(
+            "orderPaymentSection.discountTotal",
+            value:"Discount total",
+            comment: "Label for the the row showing the total discount of the order")
+        static let shippingTotal = NSLocalizedString(
+            "orderPaymentSection.shippingTotal",
+            value:"Shipping",
+            comment: "Label for the row showing the cost of shipping in the order")
         static let customAmountsTotal = NSLocalizedString(
-            "orderPaymentSection.customAmounts",
+            "orderPaymentSection.customAmountsTotal",
             value: "Custom amounts",
             comment: "Label for the row showing the cost of fees in the order")
-        static let taxes = NSLocalizedString("Taxes", comment: "Label for the row showing the taxes in the order")
-        static let coupon = NSLocalizedString("Coupon", comment: "Label for the row showing the cost of coupon in the order")
-        static let taxRateAddedAutomaticallyRowText = NSLocalizedString("Tax rate location added automatically",
-                                                                        comment: "Notice in editable order details when the tax rate was added to the order")
+        static let taxes = NSLocalizedString(
+            "orderPaymentSection.taxes",
+            value:"Taxes",
+            comment: "Label for the row showing the taxes in the order")
+        static let coupon = NSLocalizedString(
+            "orderPaymentSection.coupon",
+            value:"Coupon",
+            comment: "Label for the row showing the cost of coupon in the order")
+        static let taxRateAddedAutomaticallyRowText = NSLocalizedString(
+            "orderPaymentSection.taxRateAddedAutomaticallyRowText",
+            value:"Tax rate location added automatically",
+            comment: "Notice in editable order details when the tax rate was added to the order")
         static let taxInformationLearnMore = NSLocalizedString(
             "order.form.paymentSection.taxes.learnMore",
             value: "Learn More.",

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/EditableOrderViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/EditableOrderViewModelTests.swift
@@ -2403,7 +2403,7 @@ final class EditableOrderViewModelTests: XCTestCase {
         let viewModel = EditableOrderViewModel(siteID: sampleSiteID,
                                                stores: stores)
 
-        XCTAssertEqual(viewModel.paymentDataViewModel.taxBasedOnSetting?.displayString, NSLocalizedString("Calculated on billing address", comment: ""))
+        XCTAssertEqual(viewModel.paymentDataViewModel.taxBasedOnSetting?.displayString, NSLocalizedString("Calculated on billing address.", comment: ""))
     }
 
     func test_order_created_when_tax_based_on_is_shop_base_address_then_property_is_updated() {
@@ -2419,7 +2419,7 @@ final class EditableOrderViewModelTests: XCTestCase {
         let viewModel = EditableOrderViewModel(siteID: sampleSiteID,
                                                stores: stores)
 
-        XCTAssertEqual(viewModel.paymentDataViewModel.taxBasedOnSetting?.displayString, NSLocalizedString("Calculated on shop base address", comment: ""))
+        XCTAssertEqual(viewModel.paymentDataViewModel.taxBasedOnSetting?.displayString, NSLocalizedString("Calculated on shop base address.", comment: ""))
     }
 
     func test_order_created_when_tax_based_on_is_customer_shipping_address_then_property_is_updated() {
@@ -2435,7 +2435,7 @@ final class EditableOrderViewModelTests: XCTestCase {
         let viewModel = EditableOrderViewModel(siteID: sampleSiteID,
                                                stores: stores)
 
-        XCTAssertEqual(viewModel.paymentDataViewModel.taxBasedOnSetting?.displayString, NSLocalizedString("Calculated on shipping address", comment: ""))
+        XCTAssertEqual(viewModel.paymentDataViewModel.taxBasedOnSetting?.displayString, NSLocalizedString("Calculated on shipping address.", comment: ""))
     }
 
     func test_payment_data_view_model_when_calling_onDismissWpAdminWebViewClosure_then_calls_to_update_elements() {


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #11545 . 
Merge https://github.com/woocommerce/woocommerce-ios/pull/11544 first

## Description
As part of the updated designs for enabling tablet support, this PR updates the `(?)` button icon that appears along the _"calculated on"_ line in order taxes for a `Learn More` link instead. No logic is altered regarding when the button should appear, we only update the UI ( button for text)

![Simulator Screen Recording - iPhone 15 - 2023-12-26 at 11 16 04](https://github.com/woocommerce/woocommerce-ios/assets/3812076/bf381942-8d88-488c-9119-d383c37e5a4a)


Since we're already here, we also update the different `NSLocalizedStrings` in the affected files to follow the latest guidelines. 

## Testing instructions
1. On a store with [taxes set](https://woo.com/document/setting-up-taxes-in-woocommerce/)
2. Go to Orders > Tap `+` > Tap `+ Add Product` > Tap `Set New Tax rate` > Select the tax rate
3. Expand the "Order Total" bottom drawer. Observe how a Learn More clickable text appears along _"Calculated on..."_

<img width="413" alt="Screenshot 2023-12-26 at 11 42 56" src="https://github.com/woocommerce/woocommerce-ios/assets/3812076/01b23721-b8c4-4f4c-86ec-0441ae25c33f">

4. Clicking the text will open the existing `Taxes & Tax Rates` modal with information and links.

<img width=600 src="https://github.com/woocommerce/woocommerce-ios/assets/3812076/c9f57da6-aa24-49b3-b0ab-252fffcb5fd6">
