### PR TITLE
[Tablet Orders] Update coupons row format in Order total bottom drawer

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/PaymentSection/OrderPaymentSection.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/PaymentSection/OrderPaymentSection.swift
@@ -97,11 +97,16 @@ private extension OrderPaymentSection {
     @ViewBuilder var appliedCouponsRows: some View {
         VStack {
             ForEach(viewModel.couponLineViewModels, id: \.title) { viewModel in
-                TitleAndValueRow(title: viewModel.title,
-                                 titleSuffixImage: rowsEditImage,
-                                 value: .content(viewModel.discount),
-                                 selectionStyle: editableRowsSelectionStyle) {
-                    selectedCouponLineDetailsViewModel = viewModel.detailsViewModel
+                VStack(alignment: .leading, spacing: .zero) {
+                    TitleAndValueRow(title: Localization.coupon,
+                                     titleSuffixImage: rowsEditImage,
+                                     value: .content(viewModel.discount),
+                                     selectionStyle: editableRowsSelectionStyle) {
+                        selectedCouponLineDetailsViewModel = viewModel.detailsViewModel
+                    }
+                    Text(viewModel.detailsViewModel.code)
+                        .footnoteStyle()
+                        .padding(.horizontal, Constants.horizontalPadding)
                 }
             }
         }
@@ -300,6 +305,7 @@ private extension OrderPaymentSection {
         static let taxRateAddedAutomaticallyRowHorizontalSpacing: CGFloat = 8
         static let taxesAdaptativeStacksSpacing: CGFloat = 4
         static let sectionPadding: CGFloat = 16
+        static let horizontalPadding: CGFloat = 16
         static let rowMinHeight: CGFloat = 44
         static let infoTooltipCornerRadius: CGFloat = 4
     }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #11548
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
As part of the updated UI designs ( 6kkCwI9VOEYcidp6UT5bln-fi-457_31227 ), this PR updates the coupon lines in the Order Total bottom drawer so it looks closer to the gifts row.

Rather than showing the coupon code between parenthesis, we move this to be a greyed-out subheading just below:

| Before | After |
|--------|--------|
| <img width="412" alt="Screenshot 2023-12-26 at 12 29 20" src="https://github.com/woocommerce/woocommerce-ios/assets/3812076/11083037-aaf7-4ac5-95f5-27c653d7730a"> | <img width="432" alt="Screenshot 2023-12-26 at 12 29 34" src="https://github.com/woocommerce/woocommerce-ios/assets/3812076/48867de3-915b-4e20-a789-dbbb7154bcca">|

## Changes
We wrap the current row view into a VStack and add a new Text View with the coupon code in it. There are no changes on the existing logic for coupons or orders, we just update the UI.


## Testing instructions
1. On a Store with coupons setup
2. Go to `Orders` > `+` > Add a product/s to an order > Tap on `+ Add Coupons`> Add one or several coupons to an order
3. Expand the Order Total bottom drawer. Observe that the coupon row UI looks like the screenshots below:

<img width=800 src="https://github.com/woocommerce/woocommerce-ios/assets/3812076/59d12109-16fb-413f-8cc0-125fcd4cdd21">
