### PR TITLE
Blaze: On Product Form, auto-dismiss Blaze webview on completion and show celebration

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewController.swift
@@ -1133,9 +1133,15 @@ private extension ProductFormViewController {
         let blazeViewModel = BlazeWebViewModel(siteID: viewModel.productModel.siteID,
                                                source: source,
                                                siteURL: siteUrl,
-                                               productID: product.productID)
+                                               productID: product.productID) {
+            self.handlePostCreation()
+        }
         let webViewController = AuthenticatedWebViewController(viewModel: blazeViewModel)
         navigationController?.show(webViewController, sender: self)
+    }
+
+    func handlePostCreation() {
+        navigationController?.popViewController(animated: true)
     }
 
     func trackVariationRemoveButtonTapped() {

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewController.swift
@@ -1146,7 +1146,7 @@ private extension ProductFormViewController {
         showBlazeCreationCelebrationView()
     }
 
-    func showBlazeCreationCelebrationView() {
+    func showBlazeCampaignCelebrationView() {
         productFormBottomSheetPresenter = buildBottomSheetPresenter()
         let controller = CelebrationHostingController(
             title: Localization.Blaze.celebrationTitle,

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewController.swift
@@ -1134,8 +1134,8 @@ private extension ProductFormViewController {
         let blazeViewModel = BlazeWebViewModel(siteID: viewModel.productModel.siteID,
                                                source: source,
                                                siteURL: siteUrl,
-                                               productID: product.productID) {
-            self.handlePostCreation()
+                                               productID: product.productID) { [weak self] in
+            self?.handlePostCreation()
         }
         let webViewController = AuthenticatedWebViewController(viewModel: blazeViewModel)
         navigationController?.show(webViewController, sender: self)

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewController.swift
@@ -48,6 +48,7 @@ final class ProductFormViewController<ViewModel: ProductFormViewModelProtocol>: 
     private let productUIImageLoader: ProductUIImageLoader
     private let productImageUploader: ProductImageUploaderProtocol
     private var tooltipPresenter: TooltipPresenter?
+    private var productFormBottomSheetPresenter: BottomSheetPresenter?
 
     private let currency: String
 
@@ -1142,6 +1143,20 @@ private extension ProductFormViewController {
 
     func handlePostCreation() {
         navigationController?.popViewController(animated: true)
+        showBlazeCreationCelebrationView()
+    }
+
+    func showBlazeCreationCelebrationView() {
+        productFormBottomSheetPresenter = buildBottomSheetPresenter()
+        let controller = CelebrationHostingController(
+            title: Localization.Blaze.celebrationTitle,
+            subtitle: Localization.Blaze.celebrationSubtitle,
+            closeButtonTitle: Localization.Blaze.celebrationCTA,
+            onTappingDone: { [weak self] in
+            self?.productFormBottomSheetPresenter?.dismiss()
+            self?.productFormBottomSheetPresenter = nil
+        })
+        productFormBottomSheetPresenter?.present(controller, from: self)
     }
 
     func trackVariationRemoveButtonTapped() {
@@ -1971,6 +1986,22 @@ private extension ProductFormViewController {
     }
 }
 
+
+// MARK: Bottom sheet helpers
+//
+private extension ProductFormViewController {
+    func buildBottomSheetPresenter() -> BottomSheetPresenter {
+        BottomSheetPresenter(configure: { bottomSheet in
+            var sheet = bottomSheet
+            sheet.prefersEdgeAttachedInCompactHeight = true
+            sheet.largestUndimmedDetentIdentifier = .none
+            sheet.prefersGrabberVisible = true
+            sheet.detents = [.medium()]
+        })
+    }
+}
+
+
 // MARK: Constants
 //
 private enum Localization {
@@ -2000,6 +2031,24 @@ private enum Localization {
                                                comment: "The message for the Write with AI tooltip")
         static let gotIt = NSLocalizedString("Got it",
                                              comment: "Button title that dismisses the Write with AI tooltip")
+    }
+
+    enum Blaze {
+        static let celebrationTitle = NSLocalizedString(
+            "productFormViewController.blazeCelebrationTitle",
+            value: "All set!",
+            comment: "Title of the celebration view when a Blaze campaign is successfully created."
+        )
+        static let celebrationSubtitle = NSLocalizedString(
+            "productFormViewController.blazeCelebrationSubtitle",
+            value: "The ad has been submitted for approval. We'll send you a confirmation email once it's approved and running.",
+            comment: "Subtitle of the celebration view when a Blaze campaign is successfully created."
+        )
+        static let celebrationCTA = NSLocalizedString(
+            "productFormViewController.blazeCelebrationCTA",
+            value: "Got it",
+            comment: "Button to dismiss the celebration view when a Blaze campaign is successfully created."
+        )
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewController.swift
@@ -1996,7 +1996,7 @@ private extension ProductFormViewController {
             sheet.prefersEdgeAttachedInCompactHeight = true
             sheet.largestUndimmedDetentIdentifier = .none
             sheet.prefersGrabberVisible = true
-            sheet.detents = [.medium()]
+            sheet.detents = [.medium(), .large()]
         })
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewController.swift
@@ -1143,7 +1143,7 @@ private extension ProductFormViewController {
 
     func handlePostCreation() {
         navigationController?.popViewController(animated: true)
-        showBlazeCreationCelebrationView()
+        showBlazeCampaignCelebrationView()
     }
 
     func showBlazeCampaignCelebrationView() {


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #11535
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

This PR adds automatic Blaze webview dismissal once creation is done. This functionality matches the behavior that already exists on the Campaign List & Dashboard flows for Blaze creation.

This PR also adds the celebration bottom sheet:

![image](https://github.com/woocommerce/woocommerce-ios/assets/266376/f2b8e6d9-f9cd-46a1-b265-8d351558e4dd)

Previously, this bottom sheet only appear in the Campaign List flow, _and_ it is only shown once. It is also shown on the Dashboard flow (where after completion, it automatically redirects to Campaign List and show the sheet).

With this PR, it shows the bottom sheet **all the time** on Product Form. This is because it is now the only way a merchant knows that campaign creation is completed, and likely a better UX than only showing it once.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
0. Use a site that's eligible for Blaze,
1. Go to the product form of a product,
2. Tap the Blaze button,
3. Ensure webview is shown, complete the Blaze creation,
4. Observe that the webview is immediately dismissed, and a celebration view is shown.
5. Tap "Got it" and ensure the celebration view is hidden.
6. Extra: Make another campaign and ensure the "Got it" celebration appears again for it.

Check video below:

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->


https://github.com/woocommerce/woocommerce-ios/assets/266376/b5caa1d7-7438-493b-a3e3-caf32b65743a
