### PR TITLE
[Tablet Orders] Remove Payment totals section from bottom drawer

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/PaymentSection/OrderPaymentSection.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/PaymentSection/OrderPaymentSection.swift
@@ -46,9 +46,6 @@ struct OrderPaymentSection: View {
 
     var body: some View {
         VStack(alignment: .leading, spacing: .zero) {
-            // Title
-            orderWithItemsTitle
-
             // Order components
             Group {
                 productsRow
@@ -75,25 +72,6 @@ struct OrderPaymentSection: View {
 }
 
 private extension OrderPaymentSection {
-    @ViewBuilder var orderWithItemsTitle: some View {
-        HStack {
-            Text(Localization.paymentTotals)
-                .accessibilityAddTraits(.isHeader)
-                .headlineStyle()
-
-            Spacer()
-
-            Image(uiImage: .lockImage)
-                .foregroundColor(Color(.brand))
-                .renderedIf(viewModel.showNonEditableIndicators)
-
-            ProgressView()
-                .renderedIf(viewModel.isLoading)
-        }
-        .padding()
-        .renderedIf(!viewModel.orderIsEmpty)
-    }
-
     @ViewBuilder var appliedCouponsRows: some View {
         VStack {
             ForEach(viewModel.couponLineViewModels, id: \.title) { viewModel in
@@ -273,9 +251,6 @@ private extension OrderPaymentSection {
 // MARK: Constants
 private extension OrderPaymentSection {
     enum Localization {
-        static let paymentTotals = NSLocalizedString("orderPaymentSection.paymentTotals",
-                                                     value: "Payment totals",
-                                                     comment: "Title text of the section that shows Payment details when creating a new order")
         static let productsTotal = NSLocalizedString("orderPaymentSection.products",
                                                      value: "Products",
                                                      comment: "Label for the row showing the total cost of products in the order")


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #11553 

## Description
As per designs ( 6kkCwI9VOEYcidp6UT5bln-fi-457_31020 ), this PR removes the `Payment totals` section that appears in the new Order bottom drawer both in order creation and order editing:

| Before | After |
|--------|--------|
| <img width="500" alt="Screenshot 2023-12-27 at 11 42 56" src="https://github.com/woocommerce/woocommerce-ios/assets/3812076/b8161cda-b65c-4b09-9cf9-7bc8d19dca4d"> | <img width="500" src="https://github.com/woocommerce/woocommerce-ios/assets/3812076/10e6ec23-a6c7-401e-b152-d734ae60f205"> | 


## Testing instructions
1. On Orders > Tap `+` > Add different products and custom amounts to an Order. 
2. Tap the disclosure indicator to expand the bottom drawer, observe that the `Payment totals` string/section is not there.
3. Go back to orders, select a `completed` order, and attempt to edit it. Upon expanding the bottom drawer, observe that the `Payment totals` string/section and its locker icon  is not there. Repeat the process for an editable order, for example marked as `Pending Payment`.
