### PR TITLE
Fix errors in the Jetpack installation flow for JCP sites

### DIFF
--- a/Networking/Networking/Network/NetworkError.swift
+++ b/Networking/Networking/Network/NetworkError.swift
@@ -22,6 +22,20 @@ public enum NetworkError: Error, Equatable {
     /// Error for REST API requests with invalid cookie nonce
     case invalidCookieNonce
 
+    /// The HTTP response code of the network error, for cases that are deducted from the status code.
+    public var responseCode: Int? {
+        switch self {
+            case .notFound:
+                return StatusCode.notFound
+            case .timeout:
+                return StatusCode.timeout
+            case let .unacceptableStatusCode(statusCode, _):
+                return statusCode
+            default:
+                return nil
+        }
+    }
+
     /// Response data accompanied the error if available
     var response: Data? {
         switch self {

--- a/Networking/NetworkingTests/Network/AlamofireNetworkTests.swift
+++ b/Networking/NetworkingTests/Network/AlamofireNetworkTests.swift
@@ -32,6 +32,28 @@ final class AlamofireNetworkTests: XCTestCase {
         assertEqual(NetworkError.unacceptableStatusCode(statusCode: 401, response: responseData), error as? NetworkError)
     }
 
+    func test_responseData_completion_block_returns_NetworkError_notFound_when_status_code_is_404() throws {
+        // Given
+        let request = JetpackRequest(wooApiVersion: .mark1,
+                                     method: .get,
+                                     siteID: 1,
+                                     path: "test")
+        let urlRequest = try XCTUnwrap(try? request.asURLRequest())
+        MockURLProtocol.Mocks.mockResponse(["error": "not_found"], statusCode: 404, for: urlRequest)
+
+        // When
+        let network = AlamofireNetwork(credentials: nil, sessionManager: createSessionManagerWithMockURLProtocol())
+        let error = waitFor { promise in
+            network.responseData(for: request) { data, error in
+                promise(error)
+            }
+        }
+
+        // Then
+        let responseData = try JSONSerialization.data(withJSONObject: ["error": "not_found"])
+        assertEqual(NetworkError.notFound(response: responseData), error as? NetworkError)
+    }
+
     func test_responseData_completion_block_returns_nil_error_when_status_code_is_200() throws {
         // Given
         let request = JetpackRequest(wooApiVersion: .mark1,

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -10,6 +10,7 @@
 - [**] Lightweight Storefront: Added option to select themes for WPCom store in both Settings and Store Creation flows. [https://github.com/woocommerce/woocommerce-ios/issues/11291]
 - [*] Orders: order creation/paid/refund dates are now shown in the store time zone instead of the device time zone. [https://github.com/woocommerce/woocommerce-ios/pull/11539, https://github.com/woocommerce/woocommerce-ios/pull/11536]
 - [*] Similar to orders above, the latest time range in analytics is now in the store time zone instead of the device time zone. [https://github.com/woocommerce/woocommerce-ios/pull/11479]
+- [*] For JCP sites, Jetpack installation flow should now succeed without an error in the beginning. [https://github.com/woocommerce/woocommerce-ios/pull/11558]
 
 16.7
 -----

--- a/WooCommerce/Classes/Authentication/Jetpack Setup/Native Jetpack Setup/JetpackSetupViewModel.swift
+++ b/WooCommerce/Classes/Authentication/Jetpack Setup/Native Jetpack Setup/JetpackSetupViewModel.swift
@@ -1,6 +1,6 @@
 import Foundation
 import Yosemite
-import enum Alamofire.AFError
+import enum Networking.NetworkError
 
 /// View model for `JetpackSetupView`.
 ///
@@ -209,17 +209,21 @@ private extension JetpackSetupViewModel {
             case .failure(let error):
                 DDLogError("⛔️ Error retrieving Jetpack: \(error)")
                 self.setupError = error
-                if case .responseValidationFailed(reason: .unacceptableStatusCode(code: 404)) = error as? AFError {
-                    if self.connectionOnly {
-                        /// If site has WCPay installed and activated but not connected,
-                        /// plugins need to be installed even though we detected a connection before
-                        self.setupSteps = JetpackInstallStep.allCases
-                        self.connectionOnly = false
-                    }
-                    /// plugin is likely to not have been installed, so proceed to install it.
-                    self.installJetpack()
-                } else {
-                    self.setupFailed = true
+                guard let networkError = error as? NetworkError else {
+                    return self.setupFailed = true
+                }
+                switch networkError {
+                    case .notFound:
+                        if self.connectionOnly {
+                            /// If site has WCPay installed and activated but not connected,
+                            /// plugins need to be installed even though we detected a connection before
+                            self.setupSteps = JetpackInstallStep.allCases
+                            self.connectionOnly = false
+                        }
+                        /// plugin is likely to not have been installed, so proceed to install it.
+                        self.installJetpack()
+                    default:
+                        self.setupFailed = true
                 }
             }
         }

--- a/WooCommerce/Classes/Authentication/Jetpack Setup/Native Jetpack Setup/JetpackSetupViewModel.swift
+++ b/WooCommerce/Classes/Authentication/Jetpack Setup/Native Jetpack Setup/JetpackSetupViewModel.swift
@@ -209,21 +209,17 @@ private extension JetpackSetupViewModel {
             case .failure(let error):
                 DDLogError("⛔️ Error retrieving Jetpack: \(error)")
                 self.setupError = error
-                guard let networkError = error as? NetworkError else {
-                    return self.setupFailed = true
-                }
-                switch networkError {
-                    case .notFound:
-                        if self.connectionOnly {
-                            /// If site has WCPay installed and activated but not connected,
-                            /// plugins need to be installed even though we detected a connection before
-                            self.setupSteps = JetpackInstallStep.allCases
-                            self.connectionOnly = false
-                        }
-                        /// plugin is likely to not have been installed, so proceed to install it.
-                        self.installJetpack()
-                    default:
-                        self.setupFailed = true
+                if case .notFound = error as? NetworkError {
+                    if self.connectionOnly {
+                        /// If site has WCPay installed and activated but not connected,
+                        /// plugins need to be installed even though we detected a connection before
+                        self.setupSteps = JetpackInstallStep.allCases
+                        self.connectionOnly = false
+                    }
+                    /// plugin is likely to not have been installed, so proceed to install it.
+                    self.installJetpack()
+                } else {
+                    self.setupFailed = true
                 }
             }
         }

--- a/WooCommerce/Classes/ViewRelated/JetpackSetup/JetpackSetupCoordinator.swift
+++ b/WooCommerce/Classes/ViewRelated/JetpackSetup/JetpackSetupCoordinator.swift
@@ -1,6 +1,6 @@
 import UIKit
 import Yosemite
-import enum Alamofire.AFError
+import enum Networking.NetworkError
 import class Networking.AlamofireNetwork
 import WordPressAuthenticator
 import WooFoundation
@@ -134,14 +134,14 @@ private extension JetpackSetupCoordinator {
         do {
             let user = try await fetchJetpackUser()
             jetpackConnectedEmail = user.wpcomUser?.email
-        } catch AFError.responseValidationFailed(reason: .unacceptableStatusCode(code: 404)) {
+        } catch NetworkError.notFound {
             /// 404 error means Jetpack is not installed or activated yet.
             requiresConnectionOnly = false
             jetpackConnectedEmail = nil
             /// Early return because we know that Jetpack is not installed
             /// We don't have to check installation status by checking with the system plugin list.
             return
-        } catch AFError.responseValidationFailed(reason: .unacceptableStatusCode(code: 403)) {
+        } catch let NetworkError.unacceptableStatusCode(statusCode, _) where statusCode == 403 {
             /// 403 means the site Jetpack connection is not established yet
             /// and the user has no permission to handle this.
             throw JetpackCheckError.missingPermission

--- a/WooCommerce/WooCommerceTests/Authentication/Jetpack Setup/JetpackSetupViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/Authentication/Jetpack Setup/JetpackSetupViewModelTests.swift
@@ -1,7 +1,7 @@
 import XCTest
 import Yosemite
 @testable import WooCommerce
-import enum Alamofire.AFError
+import enum Networking.NetworkError
 import WordPressAuthenticator
 
 final class JetpackSetupViewModelTests: XCTestCase {
@@ -73,7 +73,7 @@ final class JetpackSetupViewModelTests: XCTestCase {
         stores.whenReceivingAction(ofType: JetpackConnectionAction.self) { action in
             switch action {
             case .retrieveJetpackPluginDetails(let completion):
-                completion(.failure(AFError.responseValidationFailed(reason: .unacceptableStatusCode(code: 403))))
+                completion(.failure(NetworkError.unacceptableStatusCode(statusCode: 403, response: nil)))
             default:
                 break
             }
@@ -94,7 +94,7 @@ final class JetpackSetupViewModelTests: XCTestCase {
         stores.whenReceivingAction(ofType: JetpackConnectionAction.self) { action in
             switch action {
             case .retrieveJetpackPluginDetails(let completion):
-                completion(.failure(AFError.responseValidationFailed(reason: .unacceptableStatusCode(code: 404))))
+                completion(.failure(NetworkError.notFound(response: nil)))
             case .installJetpackPlugin(let completion):
                 completion(.failure(NSError(domain: "Test", code: -1001)))
             default:
@@ -311,7 +311,7 @@ final class JetpackSetupViewModelTests: XCTestCase {
             switch action {
             case .retrieveJetpackPluginDetails(let completion):
                 triggeredRetrieveJetpackPluginDetails = true
-                let error = AFError.responseValidationFailed(reason: .unacceptableStatusCode(code: 404))
+                let error = NetworkError.notFound(response: nil)
                 completion(.failure(error))
             case .installJetpackPlugin(let completion):
                 completion(.success(()))
@@ -346,7 +346,7 @@ final class JetpackSetupViewModelTests: XCTestCase {
         stores.whenReceivingAction(ofType: JetpackConnectionAction.self) { action in
             switch action {
             case .retrieveJetpackPluginDetails(let completion):
-                let error = AFError.responseValidationFailed(reason: .unacceptableStatusCode(code: 404))
+                let error = NetworkError.notFound(response: nil)
                 completion(.failure(error))
             case .installJetpackPlugin:
                 triggeredJetpackInstallation = true
@@ -448,7 +448,7 @@ final class JetpackSetupViewModelTests: XCTestCase {
         stores.whenReceivingAction(ofType: JetpackConnectionAction.self) { action in
             switch action {
             case .retrieveJetpackPluginDetails(let completion):
-                let error = AFError.responseValidationFailed(reason: .unacceptableStatusCode(code: 404))
+                let error = NetworkError.notFound(response: nil)
                 completion(.failure(error))
             case .installJetpackPlugin(let completion):
                 completion(.success(()))
@@ -478,7 +478,7 @@ final class JetpackSetupViewModelTests: XCTestCase {
         stores.whenReceivingAction(ofType: JetpackConnectionAction.self) { action in
             switch action {
             case .retrieveJetpackPluginDetails(let completion):
-                let error = AFError.responseValidationFailed(reason: .unacceptableStatusCode(code: 404))
+                let error = NetworkError.notFound(response: nil)
                 completion(.failure(error))
             case .installJetpackPlugin(let completion):
                 completion(.success(()))
@@ -507,7 +507,7 @@ final class JetpackSetupViewModelTests: XCTestCase {
         stores.whenReceivingAction(ofType: JetpackConnectionAction.self) { action in
             switch action {
             case .retrieveJetpackPluginDetails(let completion):
-                let error = AFError.responseValidationFailed(reason: .unacceptableStatusCode(code: 404))
+                let error = NetworkError.notFound(response: nil)
                 completion(.failure(error))
             case .installJetpackPlugin(let completion):
                 completion(.success(()))
@@ -537,7 +537,7 @@ final class JetpackSetupViewModelTests: XCTestCase {
         stores.whenReceivingAction(ofType: JetpackConnectionAction.self) { action in
             switch action {
             case .retrieveJetpackPluginDetails(let completion):
-                let error = AFError.responseValidationFailed(reason: .unacceptableStatusCode(code: 404))
+                let error = NetworkError.notFound(response: nil)
                 completion(.failure(error))
             case .installJetpackPlugin(let completion):
                 completion(.success(()))
@@ -630,7 +630,7 @@ final class JetpackSetupViewModelTests: XCTestCase {
         stores.whenReceivingAction(ofType: JetpackConnectionAction.self) { action in
             switch action {
             case .retrieveJetpackPluginDetails(let completion):
-                completion(.failure(AFError.responseValidationFailed(reason: .unacceptableStatusCode(code: 403))))
+                completion(.failure(NetworkError.unacceptableStatusCode(statusCode: 403, response: nil)))
             default:
                 break
             }
@@ -656,7 +656,7 @@ final class JetpackSetupViewModelTests: XCTestCase {
         stores.whenReceivingAction(ofType: JetpackConnectionAction.self) { action in
             switch action {
             case .retrieveJetpackPluginDetails(let completion):
-                completion(.failure(AFError.responseValidationFailed(reason: .unacceptableStatusCode(code: 404))))
+                completion(.failure(NetworkError.notFound(response: nil)))
             case .installJetpackPlugin:
                 installJetpackTriggered = true
             default:
@@ -679,9 +679,9 @@ final class JetpackSetupViewModelTests: XCTestCase {
         stores.whenReceivingAction(ofType: JetpackConnectionAction.self) { action in
             switch action {
             case .retrieveJetpackPluginDetails(let completion):
-                completion(.failure(AFError.responseValidationFailed(reason: .unacceptableStatusCode(code: 404))))
+                completion(.failure(NetworkError.notFound(response: nil)))
             case .installJetpackPlugin(let completion):
-                completion(.failure(AFError.responseValidationFailed(reason: .unacceptableStatusCode(code: 501))))
+                completion(.failure(NetworkError.unacceptableStatusCode(statusCode: 501, response: nil)))
             default:
                 break
             }
@@ -832,7 +832,7 @@ final class JetpackSetupViewModelTests: XCTestCase {
         let analyticsProvider = MockAnalyticsProvider()
         let analytics = WooAnalytics(analyticsProvider: analyticsProvider)
         let viewModel = JetpackSetupViewModel(siteURL: testURL, connectionOnly: false, stores: stores, analytics: analytics)
-        let error = AFError.responseValidationFailed(reason: .unacceptableStatusCode(code: 404))
+        let error = NetworkError.notFound(response: nil)
 
         stores.whenReceivingAction(ofType: JetpackConnectionAction.self) { action in
             switch action {
@@ -859,7 +859,7 @@ final class JetpackSetupViewModelTests: XCTestCase {
         let analyticsProvider = MockAnalyticsProvider()
         let analytics = WooAnalytics(analyticsProvider: analyticsProvider)
         let viewModel = JetpackSetupViewModel(siteURL: testURL, connectionOnly: false, stores: stores, analytics: analytics)
-        let error = AFError.responseValidationFailed(reason: .unacceptableStatusCode(code: 404))
+        let error = NetworkError.notFound(response: nil)
 
         stores.whenReceivingAction(ofType: JetpackConnectionAction.self) { action in
             switch action {
@@ -886,7 +886,7 @@ final class JetpackSetupViewModelTests: XCTestCase {
         let analyticsProvider = MockAnalyticsProvider()
         let analytics = WooAnalytics(analyticsProvider: analyticsProvider)
         let viewModel = JetpackSetupViewModel(siteURL: testURL, connectionOnly: false, stores: stores, analytics: analytics)
-        let error = AFError.responseValidationFailed(reason: .unacceptableStatusCode(code: 404))
+        let error = NetworkError.notFound(response: nil)
 
         stores.whenReceivingAction(ofType: JetpackConnectionAction.self) { action in
             switch action {
@@ -915,7 +915,7 @@ final class JetpackSetupViewModelTests: XCTestCase {
         let analyticsProvider = MockAnalyticsProvider()
         let analytics = WooAnalytics(analyticsProvider: analyticsProvider)
         let viewModel = JetpackSetupViewModel(siteURL: testURL, connectionOnly: false, stores: stores, analytics: analytics)
-        let error = AFError.responseValidationFailed(reason: .unacceptableStatusCode(code: 404))
+        let error = NetworkError.notFound(response: nil)
 
         stores.whenReceivingAction(ofType: JetpackConnectionAction.self) { action in
             switch action {
@@ -943,7 +943,7 @@ final class JetpackSetupViewModelTests: XCTestCase {
         let analyticsProvider = MockAnalyticsProvider()
         let analytics = WooAnalytics(analyticsProvider: analyticsProvider)
         let viewModel = JetpackSetupViewModel(siteURL: testURL, connectionOnly: false, stores: stores, analytics: analytics)
-        let error = AFError.responseValidationFailed(reason: .unacceptableStatusCode(code: 404))
+        let error = NetworkError.notFound(response: nil)
         let testConnectionURL = try XCTUnwrap(URL(string: "https://test-connection.com"))
 
         stores.whenReceivingAction(ofType: JetpackConnectionAction.self) { action in
@@ -975,7 +975,7 @@ final class JetpackSetupViewModelTests: XCTestCase {
         let analyticsProvider = MockAnalyticsProvider()
         let analytics = WooAnalytics(analyticsProvider: analyticsProvider)
         let viewModel = JetpackSetupViewModel(siteURL: testURL, connectionOnly: false, stores: stores, analytics: analytics)
-        let error = AFError.responseValidationFailed(reason: .unacceptableStatusCode(code: 404))
+        let error = NetworkError.notFound(response: nil)
 
         stores.whenReceivingAction(ofType: JetpackConnectionAction.self) { action in
             switch action {

--- a/WooCommerce/WooCommerceTests/ViewRelated/JetpackSetup/JetpackSetupCoordinatorTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/JetpackSetup/JetpackSetupCoordinatorTests.swift
@@ -1,7 +1,6 @@
 import XCTest
 @testable import WooCommerce
 @testable import Yosemite
-import enum Alamofire.AFError
 
 final class JetpackSetupCoordinatorTests: XCTestCase {
 


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #11549 
<!-- Id number of the GitHub issue this PR addresses. -->

## Why
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

While testing JCP for a spike, I noticed that the pre-existing Jetpack installation flow consistently showed an error from the first CTA to initiate the flow. After checking the trends of 2 events that start the flow and when an error occurs from WPCOM login, it looks like something was introduced around late November/early December:

<img width="966" alt="Screenshot 2023-12-27 at 2 01 01 PM" src="https://github.com/woocommerce/woocommerce-ios/assets/1945542/1298adf1-714f-472d-aa44-de76802325fb">

It looks like it was from a change in https://github.com/woocommerce/woocommerce-ios/pull/11110 in release 16.3 (launched on Nov 27) on how network errors are returned. Previously, the error from the networking library (`AFError`) is returned for the more modern calls to make an API request in `AlamofireNetwork`. From the initial design of the app, the app doesn't use Almofire's `validate` to check if an API response is success/failure because Dotcom errors have a different way of returning an error (200 success with an error response body). `NetworkError` was designed to be the first error type from the networking layer that checks the status code, also to abstract the networking implementation (Alamofire). The changes to use `NetworkError` in the API request calls in https://github.com/woocommerce/woocommerce-ios/pull/11110 mean that `NetworkError` will be returned instead of the original `AFError` for failing requests. For the Jetpack installation flow (WPCOM login and Jetpack installation/activation), there is logic that handles specific error codes like 404 that are expected for certain Jetpack API requests for JCP sites. However, it's expecting `AFError` and thus the error handling code isn't executed to continue the login/installation flow. This PR fixes the issues by updating the logic from expecting `AFError` to `NetworkError`.

## How

There are two main steps in the Jetpack installation flow, 1) WPCOM login, and 2) Jetpack installation/activation.

The fix for the issue from the WPCOM login flow is in `JetpackSetupCoordinator.checkJetpackConnectionState`. For the Jetpack installation/activation flow, the main fix is in `JetpackSetupViewModel.retrieveJetpackPluginDetails` with some other updates to replace `AFError` with `NetworkError`.

There are a few other uses of handling `AFError` errors with specific status codes in the code base, but I thought it's best to update them when we can reproduce issues from the usage.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

Hand testing is optional, as it's time-consuming to create a JCP site and I can reproduce the issue. But feel free to suggest any other scenarios for me to test.

- On web, create a site with just WooCommerce using JN or Pressable if needed
- In the app, log in with application password by `Log In` > enter site address > enter wp-admin credentials
- Tap on the Jetpack benefits banner on the My store tab
- Tap `Log In to Continue` and enter the WPCOM credentials
- Continue with the Jetpack installation flow --> the flow should succeed in the end

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->


https://github.com/woocommerce/woocommerce-ios/assets/1945542/b54cf1a0-9679-46c2-95d8-c8a760bde88e




---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
