### PR TITLE
[Blaze] Feature flag for native campaign creation

### DIFF
--- a/Experiments/Experiments/DefaultFeatureFlagService.swift
+++ b/Experiments/Experiments/DefaultFeatureFlagService.swift
@@ -84,6 +84,8 @@ public struct DefaultFeatureFlagService: FeatureFlagService {
             return buildConfig == .localDeveloper || buildConfig == .alpha
         case .scanToUpdateInventory:
             return true
+        case .blazei3NativeCampaignCreation:
+            return buildConfig == .localDeveloper || buildConfig == .alpha
         default:
             return true
         }

--- a/Experiments/Experiments/FeatureFlag.swift
+++ b/Experiments/Experiments/FeatureFlag.swift
@@ -183,4 +183,8 @@ public enum FeatureFlag: Int {
     /// Enables the Scan to Update Inventory feature.
     ///
     case scanToUpdateInventory
+
+    /// Enables Blaze native campaign creation.
+    ///
+    case blazei3NativeCampaignCreation
 }

--- a/WooCommerce/WooCommerceTests/Mocks/MockFeatureFlagService.swift
+++ b/WooCommerce/WooCommerceTests/Mocks/MockFeatureFlagService.swift
@@ -22,6 +22,7 @@ struct MockFeatureFlagService: FeatureFlagService {
     private let productBundles: Bool
     private let productBundlesInOrderForm: Bool
     private let isScanToUpdateInventoryEnabled: Bool
+    private let blazei3NativeCampaignCreation: Bool
 
     init(isInboxOn: Bool = false,
          isSplitViewInOrdersTabOn: Bool = false,
@@ -42,7 +43,8 @@ struct MockFeatureFlagService: FeatureFlagService {
          productCreationAI: Bool = false,
          productBundles: Bool = false,
          productBundlesInOrderForm: Bool = false,
-         isScanToUpdateInventoryEnabled: Bool = false) {
+         isScanToUpdateInventoryEnabled: Bool = false,
+         blazei3NativeCampaignCreation: Bool = false) {
         self.isInboxOn = isInboxOn
         self.isSplitViewInOrdersTabOn = isSplitViewInOrdersTabOn
         self.isUpdateOrderOptimisticallyOn = isUpdateOrderOptimisticallyOn
@@ -63,6 +65,7 @@ struct MockFeatureFlagService: FeatureFlagService {
         self.productBundles = productBundles
         self.productBundlesInOrderForm = productBundlesInOrderForm
         self.isScanToUpdateInventoryEnabled = isScanToUpdateInventoryEnabled
+        self.blazei3NativeCampaignCreation = blazei3NativeCampaignCreation
     }
 
     func isFeatureFlagEnabled(_ featureFlag: FeatureFlag) -> Bool {
@@ -105,6 +108,8 @@ struct MockFeatureFlagService: FeatureFlagService {
             return productBundlesInOrderForm
         case .scanToUpdateInventory:
             return isScanToUpdateInventoryEnabled
+        case .blazei3NativeCampaignCreation:
+            return blazei3NativeCampaignCreation
         default:
             return false
         }


### PR DESCRIPTION

Closes: #11563 
<!-- Id number of the GitHub issue this PR addresses. -->

## Description

Adds `blazei3NativeCampaignCreation` feature flag for Blaze native campaign creation feature development.

## Testing instructions
CI passing is sufficient.


## Screenshots
NA

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
