### PR TITLE
Update WordPredssAuthenticator for custom spacings on TwoFAViewController

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -85,7 +85,7 @@ target 'WooCommerce' do
   # To allow pod to pick up beta versions use -beta. E.g., 1.1.7-beta.1
   # pod 'WordPressAuthenticator', '~> 8.0'
   # pod 'WordPressAuthenticator', git: 'https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git', branch: ''
-  pod 'WordPressAuthenticator', git: 'https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git', commit: '24b3cf8b04ce7cccb0dde3124a2a4588af0c5c0e'
+  pod 'WordPressAuthenticator', git: 'https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git', commit: '556c2f0c9b740ee7793e6c2eb78c73e08f4f7ba4'
   # pod 'WordPressAuthenticator', path: '../WordPressAuthenticator-iOS'
 
   wordpress_shared

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -71,7 +71,7 @@ DEPENDENCIES:
   - Sourcery (~> 1.0.3)
   - StripeTerminal (~> 3.1.0)
   - WordPress-Editor-iOS (~> 1.19.9)
-  - WordPressAuthenticator (from `https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git`, commit `24b3cf8b04ce7cccb0dde3124a2a4588af0c5c0e`)
+  - WordPressAuthenticator (from `https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git`, commit `556c2f0c9b740ee7793e6c2eb78c73e08f4f7ba4`)
   - WordPressShared (~> 2.1)
   - WordPressUI (~> 1.13)
   - Wormholy (~> 1.6.6)
@@ -114,12 +114,12 @@ SPEC REPOS:
 
 EXTERNAL SOURCES:
   WordPressAuthenticator:
-    :commit: 24b3cf8b04ce7cccb0dde3124a2a4588af0c5c0e
+    :commit: 556c2f0c9b740ee7793e6c2eb78c73e08f4f7ba4
     :git: https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git
 
 CHECKOUT OPTIONS:
   WordPressAuthenticator:
-    :commit: 24b3cf8b04ce7cccb0dde3124a2a4588af0c5c0e
+    :commit: 556c2f0c9b740ee7793e6c2eb78c73e08f4f7ba4
     :git: https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git
 
 SPEC CHECKSUMS:
@@ -155,6 +155,6 @@ SPEC CHECKSUMS:
   ZendeskSupportProvidersSDK: 685b5d185af47ced0ec40564ec46355c838bbd06
   ZendeskSupportSDK: 92e6f9d334e81e9186f8a17583862350460a5393
 
-PODFILE CHECKSUM: 20ff2af003391e3a26053e4b322d8ad138577d2c
+PODFILE CHECKSUM: 0c5925a82b2ecb89d6972c875313e44b3ed156ef
 
 COCOAPODS: 1.14.0


### PR DESCRIPTION
depends on https://github.com/wordpress-mobile/WordPressAuthenticator-iOS/pull/819

# Why

This PR updates the `WordPredssAuthenticator` lib to apply some [design updates](https://github.com/wordpress-mobile/WordPressAuthenticator-iOS/issues/804) that were requested for the 2 Factor Auth screen 

| Before | After |
|--------|--------|
![old](https://github.com/woocommerce/woocommerce-ios/assets/562080/75867e18-f12b-4b2e-b06a-66e7743126e6) | ![new](https://github.com/woocommerce/woocommerce-ios/assets/562080/f3faec51-5aab-4e85-9882-b144a36aa62c)

# Testing (Optional)

- Login to the app with an A8C account that has 2FA enabled
- See the new spacings on the 2FA Screen

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
