### PR TITLE
[Tablet Orders] Load and select first Order when Split View

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Orders/OrderListViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrderListViewController.swift
@@ -180,6 +180,8 @@ final class OrderListViewController: UIViewController, GhostableViewController {
         configureSyncingCoordinator()
 
         configureStorePlanBannerPresenter()
+
+        checkSelectedItem()
     }
 
     override func viewWillAppear(_ animated: Bool) {

--- a/WooCommerce/Classes/ViewRelated/Orders/OrderListViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrderListViewController.swift
@@ -45,6 +45,17 @@ final class OrderListViewController: UIViewController, GhostableViewController {
         return dataSource
     }()
 
+    /// Returns the first Order in the OrderList datasource
+    ///
+    var firstOrderInIndexPath: Order? {
+        let firstIndexPath = IndexPath(row: 0, section: 0)
+        guard let objectID = dataSource.itemIdentifier(for: firstIndexPath),
+              let orderViewModel = viewModel.detailsViewModel(withID: objectID) else {
+            return nil
+        }
+        return orderViewModel.order
+    }
+
     lazy var ghostTableViewController = GhostTableViewController(options: GhostTableViewOptions(cellClass: OrderTableViewCell.self,
                                                                                                 estimatedRowHeight: Settings.estimatedRowHeight,
                                                                                                 tableViewStyle: .grouped,

--- a/WooCommerce/Classes/ViewRelated/Orders/OrderListViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrderListViewController.swift
@@ -47,7 +47,7 @@ final class OrderListViewController: UIViewController, GhostableViewController {
 
     /// Returns the first Order in the OrderList datasource
     ///
-    var firstOrderInIndexPath: Order? {
+    var firstAvailableOrder: Order? {
         let firstIndexPath = IndexPath(row: 0, section: 0)
         guard let objectID = dataSource.itemIdentifier(for: firstIndexPath),
               let orderViewModel = viewModel.detailsViewModel(withID: objectID) else {

--- a/WooCommerce/Classes/ViewRelated/Orders/OrdersRootViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrdersRootViewController.swift
@@ -111,9 +111,10 @@ final class OrdersRootViewController: UIViewController {
             self.configureStatusResultsController()
         }
 
-        /// Attempts to navigate and open the first Order in the Order List when Split View is enabled
-        /// 
-        if featureFlagService.isFeatureFlagEnabled(.splitViewInOrdersTab) {
+        /// Attempts to navigate and open the first Order in the Order List when Split View is enabled,
+        /// only on iPad
+        ///
+        if featureFlagService.isFeatureFlagEnabled(.splitViewInOrdersTab), UIDevice.current.userInterfaceIdiom == .pad {
             navigateToFirstOrderIfPossible()
         }
     }

--- a/WooCommerce/Classes/ViewRelated/Orders/OrdersRootViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrdersRootViewController.swift
@@ -110,6 +110,12 @@ final class OrdersRootViewController: UIViewController {
             guard let self = self else { return }
             self.configureStatusResultsController()
         }
+
+        /// Attempts to navigate and open the first Order in the Order List when Split View is enabled
+        /// 
+        if featureFlagService.isFeatureFlagEnabled(.splitViewInOrdersTab) {
+            navigateToFirstOrderIfPossible()
+        }
     }
 
     override func viewWillAppear(_ animated: Bool) {
@@ -169,6 +175,15 @@ final class OrdersRootViewController: UIViewController {
     private func presentOrderCreationFlowWithScannedProduct(_ result: SKUSearchResult) {
         let viewModel = EditableOrderViewModel(siteID: siteID, initialItem: result)
         setupNavigation(viewModel: viewModel)
+    }
+
+    /// Attempts to navigate to the first Order in the Order List by opening its details
+    ///
+    private func navigateToFirstOrderIfPossible() {
+        guard let order = ordersViewController.firstOrderInIndexPath else {
+            return
+        }
+        self.navigateToOrderDetail(order)
     }
 
     /// Coordinates the navigation between the different views involved in Order Creation, Editing, and Details

--- a/WooCommerce/Classes/ViewRelated/Orders/OrdersRootViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrdersRootViewController.swift
@@ -114,8 +114,8 @@ final class OrdersRootViewController: UIViewController {
         /// Attempts to navigate and open the first Order in the Order List when Split View is enabled,
         /// only on iPad
         ///
-        if featureFlagService.isFeatureFlagEnabled(.splitViewInOrdersTab), UIDevice.current.userInterfaceIdiom == .pad {
-            navigateToFirstOrderIfPossible()
+        if featureFlagService.isFeatureFlagEnabled(.splitViewInOrdersTab) {
+            navigateToFirstOrderIfPad()
         }
     }
 
@@ -178,10 +178,10 @@ final class OrdersRootViewController: UIViewController {
         setupNavigation(viewModel: viewModel)
     }
 
-    /// Attempts to navigate to the first Order in the Order List by opening its details
+    /// On iPad, attempts to navigate to the first Order in the Order List by opening its details
     ///
-    private func navigateToFirstOrderIfPossible() {
-        guard let order = ordersViewController.firstOrderInIndexPath else {
+    private func navigateToFirstOrderIfPad() {
+        guard let order = ordersViewController.firstAvailableOrder, UIDevice.current.userInterfaceIdiom == .pad else {
             return
         }
         self.navigateToOrderDetail(order)


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #11570 

Important: Please note that there's a known crash in iOS17 ( https://github.com/woocommerce/woocommerce-ios/issues/10815) when attempting to open orders on an iPhone with this feature flag enabled. We'll address this on a different PR, for the moment this should work fine on iPads and we just enable the flag for testing.

## Description
At the moment, no order is selected nor order details are loaded in split view when loading the `Orders` tab, if no orders were previously selected by a merchant. 

This PR modifies this behaviour, so the first order (most recent) in `Orders` is always pre-selected and its details pre-loaded upon running the app and going to the `Orders` tab.

If the merchant selects a different order and navigates through the app then nothing will change, the last order that has been selected will be still selected when going back to the `Order` tab.

| Before | After |
|--------|--------|
| ![Simulator Screenshot - iPad Pro (12 9-inch) (6th generation) - 2023-12-28 at 12 42 42](https://github.com/woocommerce/woocommerce-ios/assets/3812076/be164943-9967-404f-a83d-8f4d2c4d4e37) | ![Simulator Screenshot - iPad Pro (12 9-inch) (6th generation) - 2023-12-28 at 12 37 48](https://github.com/woocommerce/woocommerce-ios/assets/3812076/4aa39514-0ddc-4169-bbfe-3b1c2718d921) |

## Changes:
- We use the existing `navigateToOrderDetail(Order)` method to navigate to the first Order (if possible) upon `viewDidLoad()`, since we only need this to happen once, and cannot be done on init since the orders datasource might not be ready yet.
- Along with the above, we also call the existing `checkSelectedItem()` to select the Order in the Order List.

I haven't found a good way to unit test the changes, since we're modifying the ViewController, everything is private, and there's no defined service to inject. Happy to iterate if you think there's a better way to handle this to make it more testable.

## Testing instructions
- Switch `.splitViewInOrdersTab` flag to `true`, 
- Run the app on iPad simulator (e.g: iPad Pro 6gen iOS17.0) or physical device.
- Go to Menu > Orders
- Observe how the first Order in Order List is preloaded to the right (Order Details), as well as selected to the left.
- Select a different Order, navigate through the app, then come back to Orders. Note how the latest order that was selected is still selected.