### PR TITLE
Blaze: Sync target languages

### DIFF
--- a/Storage/Storage/Tools/StorageType+Deletions.swift
+++ b/Storage/Storage/Tools/StorageType+Deletions.swift
@@ -132,6 +132,17 @@ public extension StorageType {
         }
     }
 
+    // MARK: - BlazeTargetLanguage
+
+    /// Delete all of the stored Blaze target languages with the provided locale.
+    ///
+    func deleteBlazeTargetLanguages(locale: String) {
+        let languages = loadAllBlazeTargetLanguages(locale: locale)
+        for language in languages {
+            deleteObject(language)
+        }
+    }
+
     // MARK: - Coupons
 
     /// Deletes all of the stored Coupons for the provided siteID.

--- a/Storage/Storage/Tools/StorageType+Extensions.swift
+++ b/Storage/Storage/Tools/StorageType+Extensions.swift
@@ -562,6 +562,15 @@ public extension StorageType {
         return allObjects(ofType: BlazeTargetDevice.self, matching: predicate, sortedBy: nil)
     }
 
+    // MARK: BlazeTargetLanguage
+
+    /// Returns all Blaze target languages with the given locale.
+    ///
+    func loadAllBlazeTargetLanguages(locale: String) -> [BlazeTargetLanguage] {
+        let predicate = \BlazeTargetLanguage.locale == locale
+        return allObjects(ofType: BlazeTargetLanguage.self, matching: predicate, sortedBy: nil)
+    }
+
     // MARK: - Coupons
 
     /// Returns a single Coupon given a `siteID` and `CouponID`

--- a/Storage/StorageTests/Tools/StorageTypeDeletionsTests.swift
+++ b/Storage/StorageTests/Tools/StorageTypeDeletionsTests.swift
@@ -166,6 +166,28 @@ final class StorageTypeDeletionsTests: XCTestCase {
         let esDevices = storage.loadAllBlazeTargetDevices(locale: "es")
         XCTAssertEqual(esDevices.count, 1)
     }
+
+    func test_deleteBlazeTargetLanguages_with_locale() throws {
+        // Given
+        let language1 = storage.insertNewObject(ofType: BlazeTargetLanguage.self)
+        language1.id = "en"
+        language1.name = "English"
+        language1.locale = "en"
+
+        let language2 = storage.insertNewObject(ofType: BlazeTargetLanguage.self)
+        language2.id = "en"
+        language2.name = "Tiếng Anh"
+        language2.locale = "vi"
+
+        // When
+        storage.deleteBlazeTargetLanguages(locale: "en")
+
+        // Then
+        let enLanguages = storage.loadAllBlazeTargetLanguages(locale: "en")
+        XCTAssertTrue(enLanguages.isEmpty)
+        let viLanguages = storage.loadAllBlazeTargetLanguages(locale: "vi")
+        XCTAssertEqual(viLanguages.count, 1)
+    }
 }
 
 private extension StorageTypeDeletionsTests {

--- a/Storage/StorageTests/Tools/StorageTypeExtensionsTests.swift
+++ b/Storage/StorageTests/Tools/StorageTypeExtensionsTests.swift
@@ -1304,4 +1304,24 @@ final class StorageTypeExtensionsTests: XCTestCase {
         XCTAssertEqual(foundDevices.count, 1)
         XCTAssertEqual(foundDevices.first, device1)
     }
+
+    func test_loadAllBlazeTargetLanguages_with_locale() throws {
+        // Given
+        let language1 = storage.insertNewObject(ofType: BlazeTargetLanguage.self)
+        language1.id = "en"
+        language1.name = "English"
+        language1.locale = "en"
+
+        let language2 = storage.insertNewObject(ofType: BlazeTargetLanguage.self)
+        language2.id = "en"
+        language2.name = "Tiếng Anh"
+        language2.locale = "vi"
+
+        // When
+        let foundLanguages = try XCTUnwrap(storage.loadAllBlazeTargetLanguages(locale: "en"))
+
+        // Then
+        XCTAssertEqual(foundLanguages.count, 1)
+        XCTAssertEqual(foundLanguages.first, language1)
+    }
 }

--- a/Yosemite/Yosemite.xcodeproj/project.pbxproj
+++ b/Yosemite/Yosemite.xcodeproj/project.pbxproj
@@ -424,6 +424,7 @@
 		DE50296728C7114800551736 /* JetpackConnectionStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE50296628C7114800551736 /* JetpackConnectionStoreTests.swift */; };
 		DE6831DD26445B2B00E88B9E /* SitePluginStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE6831DC26445B2B00E88B9E /* SitePluginStoreTests.swift */; };
 		DEA493922B3BD49700EED015 /* BlazeTargetDevice+ReadOnlyConvertible.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEA493912B3BD49700EED015 /* BlazeTargetDevice+ReadOnlyConvertible.swift */; };
+		DEA493942B3D588500EED015 /* BlazeTargetLanguage+ReadonlyConvertible.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEA493932B3D588500EED015 /* BlazeTargetLanguage+ReadonlyConvertible.swift */; };
 		DED91DEE2AD673CF00CDCC53 /* BlazeAction.swift in Sources */ = {isa = PBXBuildFile; fileRef = DED91DED2AD673CF00CDCC53 /* BlazeAction.swift */; };
 		DED91DF02AD6756600CDCC53 /* BlazeStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = DED91DEF2AD6756600CDCC53 /* BlazeStore.swift */; };
 		DED91DF22AD679D300CDCC53 /* BlazeCampaign+ReadOnlyConvertible.swift in Sources */ = {isa = PBXBuildFile; fileRef = DED91DF12AD679D300CDCC53 /* BlazeCampaign+ReadOnlyConvertible.swift */; };
@@ -903,6 +904,7 @@
 		DE50296628C7114800551736 /* JetpackConnectionStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JetpackConnectionStoreTests.swift; sourceTree = "<group>"; };
 		DE6831DC26445B2B00E88B9E /* SitePluginStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SitePluginStoreTests.swift; sourceTree = "<group>"; };
 		DEA493912B3BD49700EED015 /* BlazeTargetDevice+ReadOnlyConvertible.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "BlazeTargetDevice+ReadOnlyConvertible.swift"; sourceTree = "<group>"; };
+		DEA493932B3D588500EED015 /* BlazeTargetLanguage+ReadonlyConvertible.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "BlazeTargetLanguage+ReadonlyConvertible.swift"; sourceTree = "<group>"; };
 		DED91DED2AD673CF00CDCC53 /* BlazeAction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BlazeAction.swift; sourceTree = "<group>"; };
 		DED91DEF2AD6756600CDCC53 /* BlazeStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BlazeStore.swift; sourceTree = "<group>"; };
 		DED91DF12AD679D300CDCC53 /* BlazeCampaign+ReadOnlyConvertible.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "BlazeCampaign+ReadOnlyConvertible.swift"; sourceTree = "<group>"; };
@@ -1368,6 +1370,7 @@
 				03FBDA3D2632E29600ACE257 /* Coupon+ReadOnlyConvertible.swift */,
 				DED91DF12AD679D300CDCC53 /* BlazeCampaign+ReadOnlyConvertible.swift */,
 				DEA493912B3BD49700EED015 /* BlazeTargetDevice+ReadOnlyConvertible.swift */,
+				DEA493932B3D588500EED015 /* BlazeTargetLanguage+ReadonlyConvertible.swift */,
 				2685C10C263C900500D9EE97 /* AddOnGroup+ReadOnlyConvertible.swift */,
 				03101F0029DD7D9D00769CF3 /* CardReaderType+ReadOnlyConvertible.swift */,
 				45E4620D2684C45500011BF2 /* Country+ReadOnlyConvertible.swift */,
@@ -2302,6 +2305,7 @@
 				DE3C5B1D286AEDA10049E6AA /* MockOrderCardPresentPaymentEligibilityActionHandler.swift in Sources */,
 				CE0DB6C0233EB3F300A27E7A /* OrderRefundCondensed+ReadOnlyConvertible.swift in Sources */,
 				247CE87225832E7000F9D9D1 /* MockProductReviewAction.swift in Sources */,
+				DEA493942B3D588500EED015 /* BlazeTargetLanguage+ReadonlyConvertible.swift in Sources */,
 				0225512122FC2F3000D98613 /* OrderStatsV4Interval+Date.swift in Sources */,
 				0202B690238790E200F3EBE0 /* ProductsFeatureSwitchPListWrapper.swift in Sources */,
 				077F39DE26A5A1CB00ABEADC /* SystemStatusAction.swift in Sources */,

--- a/Yosemite/Yosemite/Actions/BlazeAction.swift
+++ b/Yosemite/Yosemite/Actions/BlazeAction.swift
@@ -28,4 +28,16 @@ public enum BlazeAction: Action {
     case synchronizeTargetDevices(siteID: Int64,
                                   locale: String,
                                   onCompletion: (Result<[BlazeTargetDevice], Error>) -> Void)
+
+    /// Retrieves and stores target languages for create Blaze campaigns for a site.
+    ///
+    /// - `siteID`: the site to create Blaze campaign.
+    /// - `locale`: the locale for the response.
+    /// - `onCompletion`: invoked when the sync operation finishes.
+    ///     - `result.success([BlazeTargetLanguage])`: list of target languages for Blaze campaigns.
+    ///     - `result.failure(Error)`: error indicates issues syncing data.
+    ///
+    case synchronizeTargetLanguages(siteID: Int64,
+                                    locale: String,
+                                    onCompletion: (Result<[BlazeTargetLanguage], Error>) -> Void)
 }

--- a/Yosemite/Yosemite/Model/Storage/BlazeTargetLanguage+ReadonlyConvertible.swift
+++ b/Yosemite/Yosemite/Model/Storage/BlazeTargetLanguage+ReadonlyConvertible.swift
@@ -1,0 +1,20 @@
+import Foundation
+import Storage
+
+// MARK: - Storage.BlazeTargetLanguage: ReadOnlyConvertible
+//
+extension Storage.BlazeTargetLanguage: ReadOnlyConvertible {
+    /// Updates the `Storage.BlazeTargetLanguage` from the ReadOnly representation (`Networking.BlazeTargetLanguage`)
+    ///
+    public func update(with campaign: Yosemite.BlazeTargetLanguage) {
+        id = campaign.id
+        name = campaign.name
+        locale = campaign.locale
+    }
+
+    /// Returns a ReadOnly (`Networking.BlazeTargetLanguage`) version of the `Storage.BlazeTargetLanguage`
+    ///
+    public func toReadOnly() -> BlazeTargetLanguage {
+        .init(id: id, name: name, locale: locale)
+    }
+}

--- a/Yosemite/Yosemite/Stores/BlazeStore.swift
+++ b/Yosemite/Yosemite/Stores/BlazeStore.swift
@@ -205,8 +205,8 @@ private extension BlazeStore {
         derivedStorage.perform {
             derivedStorage.deleteBlazeTargetLanguages(locale: locale)
             for language in readonlyLanguages {
-                let storageDevice = derivedStorage.insertNewObject(ofType: Storage.BlazeTargetLanguage.self)
-                storageDevice.update(with: language)
+                let storageLanguage = derivedStorage.insertNewObject(ofType: Storage.BlazeTargetLanguage.self)
+                storageLanguage.update(with: language)
             }
         }
 

--- a/Yosemite/Yosemite/Stores/BlazeStore.swift
+++ b/Yosemite/Yosemite/Stores/BlazeStore.swift
@@ -60,6 +60,8 @@ public final class BlazeStore: Store {
                                  onCompletion: onCompletion)
         case let .synchronizeTargetDevices(siteID, locale, onCompletion):
             synchronizeTargetDevices(siteID: siteID, locale: locale, onCompletion: onCompletion)
+        case let .synchronizeTargetLanguages(siteID, locale, onCompletion):
+            synchronizeTargetLanguages(siteID: siteID, locale: locale, onCompletion: onCompletion)
         }
     }
 }
@@ -159,6 +161,52 @@ private extension BlazeStore {
             for device in readonlyDevices {
                 let storageDevice = derivedStorage.insertNewObject(ofType: Storage.BlazeTargetDevice.self)
                 storageDevice.update(with: device)
+            }
+        }
+
+        storageManager.saveDerivedType(derivedStorage: derivedStorage) {
+            DispatchQueue.main.async(execute: onCompletion)
+        }
+    }
+}
+
+// MARK: - Synchronize target languages
+private extension BlazeStore {
+    func synchronizeTargetLanguages(siteID: Int64,
+                                    locale: String,
+                                    onCompletion: @escaping (Result<[BlazeTargetLanguage], Error>) -> Void) {
+        Task { @MainActor in
+            do {
+                let stubbedResult = [
+                    BlazeTargetLanguage(id: "en", name: "English", locale: locale),
+                    BlazeTargetLanguage(id: "es", name: "Spanish", locale: locale)
+                ]
+                // TODO-11540: remove stubbed result when the API is ready.
+                let languages: [BlazeTargetLanguage] = try await mockResponse(stubbedResult: stubbedResult, onExecution: {
+                    try await remote.fetchTargetLanguages(for: siteID, locale: locale)
+                })
+                insertStoredTargetLanguagesInBackground(readonlyLanguages: languages, locale: locale) {
+                    onCompletion(.success(languages))
+                }
+            } catch {
+                onCompletion(.failure(error))
+            }
+        }
+    }
+
+    /// Removes BlazeTargetLanguage entities with the given locale
+    /// and inserts specified BlazeTargetLanguage Entities in a background thread.
+    /// `onCompletion` will be called on the main thread.
+    ///
+    func insertStoredTargetLanguagesInBackground(readonlyLanguages: [Networking.BlazeTargetLanguage],
+                                                 locale: String,
+                                                 onCompletion: @escaping () -> Void) {
+        let derivedStorage = sharedDerivedStorage
+        derivedStorage.perform {
+            derivedStorage.deleteBlazeTargetLanguages(locale: locale)
+            for language in readonlyLanguages {
+                let storageDevice = derivedStorage.insertNewObject(ofType: Storage.BlazeTargetLanguage.self)
+                storageDevice.update(with: language)
             }
         }
 

--- a/Yosemite/YosemiteTests/Stores/BlazeStoreTests.swift
+++ b/Yosemite/YosemiteTests/Stores/BlazeStoreTests.swift
@@ -330,7 +330,7 @@ final class BlazeStoreTests: XCTestCase {
         XCTAssertEqual(storedTargetLanguageCount, 1)
     }
 
-    func test_synchronizeTargetLanguages_overwrites_existing_devices_with_the_given_locale() throws {
+    func test_synchronizeTargetLanguages_overwrites_existing_languages_with_the_given_locale() throws {
         // Given
         let locale = "en"
         storeTargetLanguage(.init(id: "test", name: "Test", locale: locale))

--- a/Yosemite/YosemiteTests/Stores/BlazeStoreTests.swift
+++ b/Yosemite/YosemiteTests/Stores/BlazeStoreTests.swift
@@ -309,7 +309,7 @@ final class BlazeStoreTests: XCTestCase {
         XCTAssertEqual(languages.count, 1)
     }
 
-    func test_synchronizeTargetLanguages_stores_devices_upon_success() throws {
+    func test_synchronizeTargetLanguages_stores_languages_upon_success() throws {
         // Given
         remote.whenFetchingTargetLanguages(thenReturn: .success([.fake().copy(id: "en")]))
         let store = BlazeStore(dispatcher: Dispatcher(),

--- a/Yosemite/YosemiteTests/Stores/BlazeStoreTests.swift
+++ b/Yosemite/YosemiteTests/Stores/BlazeStoreTests.swift
@@ -38,6 +38,10 @@ final class BlazeStoreTests: XCTestCase {
         return viewStorage.countObjects(ofType: StorageBlazeTargetDevice.self)
     }
 
+    private var storedTargetLanguageCount: Int {
+        return viewStorage.countObjects(ofType: StorageBlazeTargetLanguage.self)
+    }
+
     /// SiteID
     ///
     private let sampleSiteID: Int64 = 120934
@@ -282,6 +286,99 @@ final class BlazeStoreTests: XCTestCase {
         XCTAssertTrue(result.isFailure)
         XCTAssertEqual(result.failure as? NetworkError, .timeout())
     }
+
+    // MARK: - Synchronize target languages
+
+    func test_synchronizeTargetLanguages_is_successful_when_fetching_successfully() throws {
+        // Given
+        remote.whenFetchingTargetLanguages(thenReturn: .success([.fake().copy(id: "en")]))
+        let store = BlazeStore(dispatcher: Dispatcher(),
+                               storageManager: storageManager,
+                               network: network,
+                               remote: remote)
+
+        // When
+        let result = waitFor { promise in
+            store.onAction(BlazeAction.synchronizeTargetLanguages(siteID: self.sampleSiteID, locale: "en", onCompletion: { result in
+                promise(result)
+            }))
+        }
+
+        //Then
+        let languages = try result.get()
+        XCTAssertEqual(languages.count, 1)
+    }
+
+    func test_synchronizeTargetLanguages_stores_devices_upon_success() throws {
+        // Given
+        remote.whenFetchingTargetLanguages(thenReturn: .success([.fake().copy(id: "en")]))
+        let store = BlazeStore(dispatcher: Dispatcher(),
+                               storageManager: storageManager,
+                               network: network,
+                               remote: remote)
+        XCTAssertEqual(storedTargetLanguageCount, 0)
+
+        // When
+        let result = waitFor { promise in
+            store.onAction(BlazeAction.synchronizeTargetLanguages(siteID: self.sampleSiteID, locale: "en", onCompletion: { result in
+                promise(result)
+            }))
+        }
+
+        // Then
+        XCTAssertTrue(result.isSuccess)
+        XCTAssertEqual(storedTargetLanguageCount, 1)
+    }
+
+    func test_synchronizeTargetLanguages_overwrites_existing_devices_with_the_given_locale() throws {
+        // Given
+        let locale = "en"
+        storeTargetLanguage(.init(id: "test", name: "Test", locale: locale))
+        storeTargetLanguage(.init(id: "test-2", name: "Test 2", locale: "vi"))
+        remote.whenFetchingTargetLanguages(thenReturn: .success([.init(id: "en", name: "English", locale: locale)]))
+        let store = BlazeStore(dispatcher: Dispatcher(),
+                               storageManager: storageManager,
+                               network: network,
+                               remote: remote)
+        XCTAssertEqual(storedTargetLanguageCount, 2)
+
+        // When
+        let result = waitFor { promise in
+            store.onAction(BlazeAction.synchronizeTargetLanguages(siteID: self.sampleSiteID, locale: locale, onCompletion: { result in
+                promise(result)
+            }))
+        }
+
+        // Then
+        XCTAssertTrue(result.isSuccess)
+        XCTAssertEqual(storedTargetLanguageCount, 2)
+        let languages = viewStorage.loadAllBlazeTargetLanguages(locale: locale)
+        XCTAssertEqual(languages.count, 1)
+        let language = try XCTUnwrap(languages.first)
+        XCTAssertEqual(language.id, "en")
+        XCTAssertEqual(language.name, "English")
+        XCTAssertEqual(language.locale, locale)
+    }
+
+    func test_synchronizeTargetLanguages_returns_error_on_failure() throws {
+        // Given
+        remote.whenFetchingTargetLanguages(thenReturn: .failure(NetworkError.timeout()))
+        let store = BlazeStore(dispatcher: Dispatcher(),
+                               storageManager: storageManager,
+                               network: network,
+                               remote: remote)
+
+        // When
+        let result = waitFor { promise in
+            store.onAction(BlazeAction.synchronizeTargetLanguages(siteID: self.sampleSiteID, locale: "en", onCompletion: { result in
+                promise(result)
+            }))
+        }
+
+        // Then
+        XCTAssertTrue(result.isFailure)
+        XCTAssertEqual(result.failure as? NetworkError, .timeout())
+    }
 }
 
 private extension BlazeStoreTests {
@@ -298,5 +395,12 @@ private extension BlazeStoreTests {
         let storedDevice = storage.insertNewObject(ofType: BlazeTargetDevice.self)
         storedDevice.update(with: device)
         return storedDevice
+    }
+
+    @discardableResult
+    func storeTargetLanguage(_ language: Networking.BlazeTargetLanguage) -> Storage.BlazeTargetLanguage {
+        let storedLanguage = storage.insertNewObject(ofType: BlazeTargetLanguage.self)
+        storedLanguage.update(with: language)
+        return storedLanguage
     }
 }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of #11540 
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This PR updates the Yosemite layer to support syncing target languages. This includes updating `BlazeAction` and `BlazeStore` with a new method to sync languages by locale.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
CI passing should be sufficient.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->
N/A

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
