### PR TITLE
Fix app becoming logged out after logging in to the same store/account on a different device

### DIFF
--- a/Networking/Networking/ApplicationPassword/ApplicationPasswordUseCase.swift
+++ b/Networking/Networking/ApplicationPassword/ApplicationPasswordUseCase.swift
@@ -52,7 +52,8 @@ final public class DefaultApplicationPasswordUseCase: ApplicationPasswordUseCase
         get async {
             let bundleIdentifier = Bundle.main.bundleIdentifier ?? "Unknown"
             let model = await UIDevice.current.model
-            return bundleIdentifier + ".ios-app-client." + model
+            let identifierForVendor = await UIDevice.current.identifierForVendor?.uuidString ?? ""
+            return "\(bundleIdentifier).ios-app-client.\(model).\(identifierForVendor)"
         }
     }
 

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -11,6 +11,7 @@
 - [*] Orders: order creation/paid/refund dates are now shown in the store time zone instead of the device time zone. [https://github.com/woocommerce/woocommerce-ios/pull/11539, https://github.com/woocommerce/woocommerce-ios/pull/11536]
 - [*] Similar to orders above, the latest time range in analytics is now in the store time zone instead of the device time zone. [https://github.com/woocommerce/woocommerce-ios/pull/11479]
 - [*] For JCP sites, Jetpack installation flow should now succeed without an error in the beginning. [https://github.com/woocommerce/woocommerce-ios/pull/11558]
+- [*] Login: logging in to self-hosted sites without Jetpack connection (with application password) on multiple devices of the same device family (iPhone/iPad) is now supported. Previously, the previously logged in device becomes logged out after logging in to the same account/store on a different device of the same device family.   [https://github.com/woocommerce/woocommerce-ios/pull/11575]
 
 16.7
 -----


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #11560 
<!-- Id number of the GitHub issue this PR addresses. -->

## Why
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

In production, the app becomes logged out on the next launch after logging in to the same store and wp-admin account) on a different device of the same device family (e.g. iPhone/iPad) between the login/logout time. i.e. the same admin account cannot be used on two devices at the same time. There are also some app store reviews (p1698022386212079-slack-C013AAPA4G0) mentioning the issue of the app being logged out.

The reason is that the application password name is not unique for the same device family, as `UIDevice.current.model` is the same for all models of iPhones / iPads. It's probably not uncommon when the merchant only uses the app on multiple iPhones.

https://github.com/woocommerce/woocommerce-ios/blob/0027bda6f14ec465584463eb33495f0041ff777e/Networking/Networking/ApplicationPassword/ApplicationPasswordUseCase.swift#L53-L55

When logging into the same admin account/store on a different device of the same device family, a new application password is created to replace the previous one. Because they have the same name, the password for the previous device no longer works and this results in the app being logged out.

## How

From the discussion in p1703573538106279-slack-C03L1NF1EA3, it'd be better to use a unique identifier per device. `UIDevice.identifierForVendor` ([official doc](https://developer.apple.com/documentation/uikit/uidevice/1620059-identifierforvendor)) seems like the best option without requiring a third-party library:

> An alphanumeric string that uniquely identifies a device to the app’s vendor

Since the value type is optional, to understand more about when the value can be nil:

> If the value is nil, wait and get the value again later. This happens, for example, after the device has been restarted but before the user has unlocked the device.

As the application password is most likely created when the app is in the foreground (e.g. logging in), and the app wouldn't be generating an application password in the example scenario (after restarting and before unlocking the device), the value is expected to be non-nil for most cases. From my testing, it was non-nil in both simulators and physical devices.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

Hand testing is optional, as I can reproduce the logged-out issue and verify the fix.

Prerequisite: the site is not Jetpack connected (like with just the WC plugin) so one can log in with an application password.

- Log out if needed
- Log in to the app with the application password by `Log In` > enter site address in the prerequisite > enter wp-admin credentials --> wait until the the store is shown
- On a different device of the same device family (e.g. another iPhone if the previous login was on an iPhone, and vice versa), log in to the app with the application password to the same store and wp-admin account
- Relaunch the app on the device that was logged in first --> the app becomes logged out

A few other scenarios to consider tested by @jaclync:
- [x] If the app is logged in with application password without the PR changes, launching the app with the PR changes does not affect the app behavior
- [x] Logging in to the third device/simulator does not affect the logged in state of the other two devices


## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

<img width="903" alt="Screenshot 2023-12-28 at 4 09 13 PM" src="https://github.com/woocommerce/woocommerce-ios/assets/1945542/da454f1d-383e-4336-b652-6eb39c4c1069">


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
