### PR TITLE
Blaze: Sync target topics and fetch target locations by query

### DIFF
--- a/Storage/Storage/Tools/StorageType+Deletions.swift
+++ b/Storage/Storage/Tools/StorageType+Deletions.swift
@@ -143,6 +143,17 @@ public extension StorageType {
         }
     }
 
+    // MARK: - BlazeTargetTopic
+
+    /// Delete all of the stored Blaze target topics with the provided locale.
+    ///
+    func deleteBlazeTargetTopics(locale: String) {
+        let topics = loadAllBlazeTargetTopics(locale: locale)
+        for topic in topics {
+            deleteObject(topic)
+        }
+    }
+
     // MARK: - Coupons
 
     /// Deletes all of the stored Coupons for the provided siteID.

--- a/Storage/Storage/Tools/StorageType+Extensions.swift
+++ b/Storage/Storage/Tools/StorageType+Extensions.swift
@@ -571,6 +571,13 @@ public extension StorageType {
         return allObjects(ofType: BlazeTargetLanguage.self, matching: predicate, sortedBy: nil)
     }
 
+    /// Returns all Blaze target topics with the given locale.
+    ///
+    func loadAllBlazeTargetTopics(locale: String) -> [BlazeTargetTopic] {
+        let predicate = \BlazeTargetTopic.locale == locale
+        return allObjects(ofType: BlazeTargetTopic.self, matching: predicate, sortedBy: nil)
+    }
+
     // MARK: - Coupons
 
     /// Returns a single Coupon given a `siteID` and `CouponID`

--- a/Storage/StorageTests/Tools/StorageTypeDeletionsTests.swift
+++ b/Storage/StorageTests/Tools/StorageTypeDeletionsTests.swift
@@ -188,6 +188,28 @@ final class StorageTypeDeletionsTests: XCTestCase {
         let viLanguages = storage.loadAllBlazeTargetLanguages(locale: "vi")
         XCTAssertEqual(viLanguages.count, 1)
     }
+
+    func test_deleteBlazeTargetTopics_with_locale() throws {
+        // Given
+        let topic1 = storage.insertNewObject(ofType: BlazeTargetTopic.self)
+        topic1.id = "1"
+        topic1.name = "Cuisines"
+        topic1.locale = "en"
+
+        let topic2 = storage.insertNewObject(ofType: BlazeTargetTopic.self)
+        topic2.id = "1"
+        topic2.name = "Ẩm thực"
+        topic2.locale = "vi"
+
+        // When
+        storage.deleteBlazeTargetTopics(locale: "en")
+
+        // Then
+        let enTopics = storage.loadAllBlazeTargetTopics(locale: "en")
+        XCTAssertTrue(enTopics.isEmpty)
+        let viTopics = storage.loadAllBlazeTargetTopics(locale: "vi")
+        XCTAssertEqual(viTopics.count, 1)
+    }
 }
 
 private extension StorageTypeDeletionsTests {

--- a/Storage/StorageTests/Tools/StorageTypeExtensionsTests.swift
+++ b/Storage/StorageTests/Tools/StorageTypeExtensionsTests.swift
@@ -1324,4 +1324,24 @@ final class StorageTypeExtensionsTests: XCTestCase {
         XCTAssertEqual(foundLanguages.count, 1)
         XCTAssertEqual(foundLanguages.first, language1)
     }
+
+    func test_loadAllBlazeTargetTopics_with_locale() throws {
+        // Given
+        let topic1 = storage.insertNewObject(ofType: BlazeTargetTopic.self)
+        topic1.id = "1"
+        topic1.name = "Cuisines"
+        topic1.locale = "en"
+
+        let topic2 = storage.insertNewObject(ofType: BlazeTargetTopic.self)
+        topic2.id = "1"
+        topic2.name = "Ẩm thực"
+        topic2.locale = "vi"
+
+        // When
+        let foundTopics = try XCTUnwrap(storage.loadAllBlazeTargetTopics(locale: "en"))
+
+        // Then
+        XCTAssertEqual(foundTopics.count, 1)
+        XCTAssertEqual(foundTopics.first, topic1)
+    }
 }

--- a/Yosemite/Yosemite.xcodeproj/project.pbxproj
+++ b/Yosemite/Yosemite.xcodeproj/project.pbxproj
@@ -425,6 +425,7 @@
 		DE6831DD26445B2B00E88B9E /* SitePluginStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE6831DC26445B2B00E88B9E /* SitePluginStoreTests.swift */; };
 		DEA493922B3BD49700EED015 /* BlazeTargetDevice+ReadOnlyConvertible.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEA493912B3BD49700EED015 /* BlazeTargetDevice+ReadOnlyConvertible.swift */; };
 		DEA493942B3D588500EED015 /* BlazeTargetLanguage+ReadonlyConvertible.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEA493932B3D588500EED015 /* BlazeTargetLanguage+ReadonlyConvertible.swift */; };
+		DEA493962B3D608B00EED015 /* BlazeTargetTopic+ReadonlyConvertible.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEA493952B3D608B00EED015 /* BlazeTargetTopic+ReadonlyConvertible.swift */; };
 		DED91DEE2AD673CF00CDCC53 /* BlazeAction.swift in Sources */ = {isa = PBXBuildFile; fileRef = DED91DED2AD673CF00CDCC53 /* BlazeAction.swift */; };
 		DED91DF02AD6756600CDCC53 /* BlazeStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = DED91DEF2AD6756600CDCC53 /* BlazeStore.swift */; };
 		DED91DF22AD679D300CDCC53 /* BlazeCampaign+ReadOnlyConvertible.swift in Sources */ = {isa = PBXBuildFile; fileRef = DED91DF12AD679D300CDCC53 /* BlazeCampaign+ReadOnlyConvertible.swift */; };
@@ -905,6 +906,7 @@
 		DE6831DC26445B2B00E88B9E /* SitePluginStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SitePluginStoreTests.swift; sourceTree = "<group>"; };
 		DEA493912B3BD49700EED015 /* BlazeTargetDevice+ReadOnlyConvertible.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "BlazeTargetDevice+ReadOnlyConvertible.swift"; sourceTree = "<group>"; };
 		DEA493932B3D588500EED015 /* BlazeTargetLanguage+ReadonlyConvertible.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "BlazeTargetLanguage+ReadonlyConvertible.swift"; sourceTree = "<group>"; };
+		DEA493952B3D608B00EED015 /* BlazeTargetTopic+ReadonlyConvertible.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "BlazeTargetTopic+ReadonlyConvertible.swift"; sourceTree = "<group>"; };
 		DED91DED2AD673CF00CDCC53 /* BlazeAction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BlazeAction.swift; sourceTree = "<group>"; };
 		DED91DEF2AD6756600CDCC53 /* BlazeStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BlazeStore.swift; sourceTree = "<group>"; };
 		DED91DF12AD679D300CDCC53 /* BlazeCampaign+ReadOnlyConvertible.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "BlazeCampaign+ReadOnlyConvertible.swift"; sourceTree = "<group>"; };
@@ -1371,6 +1373,7 @@
 				DED91DF12AD679D300CDCC53 /* BlazeCampaign+ReadOnlyConvertible.swift */,
 				DEA493912B3BD49700EED015 /* BlazeTargetDevice+ReadOnlyConvertible.swift */,
 				DEA493932B3D588500EED015 /* BlazeTargetLanguage+ReadonlyConvertible.swift */,
+				DEA493952B3D608B00EED015 /* BlazeTargetTopic+ReadonlyConvertible.swift */,
 				2685C10C263C900500D9EE97 /* AddOnGroup+ReadOnlyConvertible.swift */,
 				03101F0029DD7D9D00769CF3 /* CardReaderType+ReadOnlyConvertible.swift */,
 				45E4620D2684C45500011BF2 /* Country+ReadOnlyConvertible.swift */,
@@ -2258,6 +2261,7 @@
 				D831E2E4230E3524000037D0 /* ProductReviewAction.swift in Sources */,
 				02393065291A018600B2632F /* DomainAction.swift in Sources */,
 				D831E2E6230E7149000037D0 /* ProductReview+ReadOnlyConvertible.swift in Sources */,
+				DEA493962B3D608B00EED015 /* BlazeTargetTopic+ReadonlyConvertible.swift in Sources */,
 				CC24A4F129ED4CEB0009D6DA /* ProductSubscription+ReadOnlyConvertible.swift in Sources */,
 				03101F0129DD7D9D00769CF3 /* CardReaderType+ReadOnlyConvertible.swift in Sources */,
 				CE4FD4502350F27C00A16B31 /* OrderItemTax+ReadOnlyConvertible.swift in Sources */,

--- a/Yosemite/Yosemite/Actions/BlazeAction.swift
+++ b/Yosemite/Yosemite/Actions/BlazeAction.swift
@@ -40,4 +40,16 @@ public enum BlazeAction: Action {
     case synchronizeTargetLanguages(siteID: Int64,
                                     locale: String,
                                     onCompletion: (Result<[BlazeTargetLanguage], Error>) -> Void)
+
+    /// Retrieves and stores target topics for create Blaze campaigns for a site.
+    ///
+    /// - `siteID`: the site to create Blaze campaign.
+    /// - `locale`: the locale for the response.
+    /// - `onCompletion`: invoked when the sync operation finishes.
+    ///     - `result.success([BlazeTargetTopic])`: list of target topics for Blaze campaigns.
+    ///     - `result.failure(Error)`: error indicates issues syncing data.
+    ///
+    case synchronizeTargetTopics(siteID: Int64,
+                                 locale: String,
+                                 onCompletion: (Result<[BlazeTargetTopic], Error>) -> Void)
 }

--- a/Yosemite/Yosemite/Actions/BlazeAction.swift
+++ b/Yosemite/Yosemite/Actions/BlazeAction.swift
@@ -17,7 +17,7 @@ public enum BlazeAction: Action {
                               pageNumber: Int,
                               onCompletion: (Result<Bool, Error>) -> Void)
 
-    /// Retrieves and stores target devices for create Blaze campaigns for a site.
+    /// Retrieves and stores target devices for creating Blaze campaigns for a site.
     ///
     /// - `siteID`: the site to create Blaze campaign.
     /// - `locale`: the locale for the response.
@@ -29,7 +29,7 @@ public enum BlazeAction: Action {
                                   locale: String,
                                   onCompletion: (Result<[BlazeTargetDevice], Error>) -> Void)
 
-    /// Retrieves and stores target languages for create Blaze campaigns for a site.
+    /// Retrieves and stores target languages for creating Blaze campaigns for a site.
     ///
     /// - `siteID`: the site to create Blaze campaign.
     /// - `locale`: the locale for the response.
@@ -41,7 +41,7 @@ public enum BlazeAction: Action {
                                     locale: String,
                                     onCompletion: (Result<[BlazeTargetLanguage], Error>) -> Void)
 
-    /// Retrieves and stores target topics for create Blaze campaigns for a site.
+    /// Retrieves and stores target topics for creating Blaze campaigns for a site.
     ///
     /// - `siteID`: the site to create Blaze campaign.
     /// - `locale`: the locale for the response.
@@ -52,4 +52,18 @@ public enum BlazeAction: Action {
     case synchronizeTargetTopics(siteID: Int64,
                                  locale: String,
                                  onCompletion: (Result<[BlazeTargetTopic], Error>) -> Void)
+
+    /// Retrieves target locations for creating Blaze campaigns for a site.
+    ///
+    /// - `siteID`: the site to create Blaze campaign.
+    /// - `query`: Keyword to search for locations. Requires a minimum of 3 characters.
+    /// - `locale`: the locale for the response.
+    /// - `onCompletion`: invoked when the sync operation finishes.
+    ///     - `result.success([BlazeTargetLocation])`: list of target locations for Blaze campaigns.
+    ///     - `result.failure(Error)`: error indicates issues syncing data.
+    ///
+    case fetchTargetLocations(siteID: Int64,
+                              query: String,
+                              locale: String,
+                              onCompletion: (Result<[BlazeTargetLocation], Error>) -> Void)
 }

--- a/Yosemite/Yosemite/Model/Storage/BlazeTargetTopic+ReadonlyConvertible.swift
+++ b/Yosemite/Yosemite/Model/Storage/BlazeTargetTopic+ReadonlyConvertible.swift
@@ -1,0 +1,20 @@
+import Foundation
+import Storage
+
+// MARK: - Storage.BlazeTargetTopic: ReadOnlyConvertible
+//
+extension Storage.BlazeTargetTopic: ReadOnlyConvertible {
+    /// Updates the `Storage.BlazeTargetTopic` from the ReadOnly representation (`Networking.BlazeTargetTopic`)
+    ///
+    public func update(with campaign: Yosemite.BlazeTargetTopic) {
+        id = campaign.id
+        name = campaign.description
+        locale = campaign.locale
+    }
+
+    /// Returns a ReadOnly (`Networking.BlazeTargetTopic`) version of the `Storage.BlazeTargetTopic`
+    ///
+    public func toReadOnly() -> BlazeTargetTopic {
+        .init(id: id, description: name, locale: locale)
+    }
+}

--- a/Yosemite/Yosemite/Stores/BlazeStore.swift
+++ b/Yosemite/Yosemite/Stores/BlazeStore.swift
@@ -64,6 +64,8 @@ public final class BlazeStore: Store {
             synchronizeTargetLanguages(siteID: siteID, locale: locale, onCompletion: onCompletion)
         case let .synchronizeTargetTopics(siteID, locale, onCompletion):
             synchronizeTargetTopics(siteID: siteID, locale: locale, onCompletion: onCompletion)
+        case let .fetchTargetLocations(siteID, query, locale, onCompletion):
+            fetchTargetLocations(siteID: siteID, query: query, locale: locale, onCompletion: onCompletion)
         }
     }
 }
@@ -260,6 +262,23 @@ private extension BlazeStore {
 
         storageManager.saveDerivedType(derivedStorage: derivedStorage) {
             DispatchQueue.main.async(execute: onCompletion)
+        }
+    }
+}
+
+// MARK: - Fetch target location by keyword
+private extension BlazeStore {
+    func fetchTargetLocations(siteID: Int64,
+                              query: String,
+                              locale: String,
+                              onCompletion: @escaping (Result<[BlazeTargetLocation], Error>) -> Void) {
+        Task { @MainActor in
+            do {
+                let locations = try await remote.fetchTargetLocations(for: siteID, query: query, locale: locale)
+                onCompletion(.success(locations))
+            } catch {
+                onCompletion(.failure(error))
+            }
         }
     }
 }

--- a/Yosemite/Yosemite/Stores/BlazeStore.swift
+++ b/Yosemite/Yosemite/Stores/BlazeStore.swift
@@ -274,7 +274,39 @@ private extension BlazeStore {
                               onCompletion: @escaping (Result<[BlazeTargetLocation], Error>) -> Void) {
         Task { @MainActor in
             do {
-                let locations = try await remote.fetchTargetLocations(for: siteID, query: query, locale: locale)
+                // TODO-11540: remove stubbed result when the API is ready.
+                let stubbedResult: [BlazeTargetLocation] = [
+                    .init(id: 1439,
+                          name: "Madrid",
+                          type: "state",
+                          parentLocation: .init(id: 69,
+                                                name: "Comunidad De Madrid",
+                                                type: "region",
+                                                parentLocation: .init(id: 228,
+                                                                      name: "Spain",
+                                                                      type: "country",
+                                                                      isoCode: "ESP"))),
+                    .init(id: 2035,
+                          name: "Madre De Dios",
+                          type: "state",
+                          parentLocation: .init(id: 57, name: "Peru", type: "country", isoCode: "PER")),
+                    .init(id: 6457,
+                          name: "Madrid",
+                          type: "city",
+                          parentLocation: .init(id: 1841,
+                                                name: "Iowa",
+                                                type: "state",
+                                                parentLocation: .init(id: 174,
+                                                                      name: "Midwest",
+                                                                      type: "region",
+                                                                      parentLocation: .init(id: 152,
+                                                                                            name: "United States",
+                                                                                            type: "country",
+                                                                                           isoCode: "USA"))))
+                ]
+                let locations: [BlazeTargetLocation] = try await mockResponse(stubbedResult: stubbedResult, onExecution: {
+                    try await remote.fetchTargetLocations(for: siteID, query: query, locale: locale)
+                })
                 onCompletion(.success(locations))
             } catch {
                 onCompletion(.failure(error))

--- a/Yosemite/YosemiteTests/Stores/BlazeStoreTests.swift
+++ b/Yosemite/YosemiteTests/Stores/BlazeStoreTests.swift
@@ -427,7 +427,7 @@ final class BlazeStoreTests: XCTestCase {
         XCTAssertEqual(storedTargetTopicCount, 1)
     }
 
-    func test_synchronizeTargetTopics_overwrites_existing_devices_with_the_given_locale() throws {
+    func test_synchronizeTargetTopics_overwrites_existing_topics_with_the_given_locale() throws {
         // Given
         let locale = "en"
         storeTargetTopic(.init(id: "test", description: "Test", locale: locale))

--- a/Yosemite/YosemiteTests/Stores/BlazeStoreTests.swift
+++ b/Yosemite/YosemiteTests/Stores/BlazeStoreTests.swift
@@ -476,6 +476,48 @@ final class BlazeStoreTests: XCTestCase {
         XCTAssertTrue(result.isFailure)
         XCTAssertEqual(result.failure as? NetworkError, .timeout())
     }
+
+    // MARK: - Fetching target locations
+
+    func test_fetchTargetLocations_is_successful_when_fetching_successfully() throws {
+        // Given
+        remote.whenFetchingTargetLocations(thenReturn: .success([.fake().copy(id: 123)]))
+        let store = BlazeStore(dispatcher: Dispatcher(),
+                               storageManager: storageManager,
+                               network: network,
+                               remote: remote)
+
+        // When
+        let result = waitFor { promise in
+            store.onAction(BlazeAction.fetchTargetLocations(siteID: self.sampleSiteID, query: "test", locale: "en", onCompletion: { result in
+                promise(result)
+            }))
+        }
+
+        //Then
+        let locations = try result.get()
+        XCTAssertEqual(locations.count, 1)
+    }
+
+    func test_fetchTargetLocations_returns_error_on_failure() throws {
+        // Given
+        remote.whenFetchingTargetLocations(thenReturn: .failure(NetworkError.timeout()))
+        let store = BlazeStore(dispatcher: Dispatcher(),
+                               storageManager: storageManager,
+                               network: network,
+                               remote: remote)
+
+        // When
+        let result = waitFor { promise in
+            store.onAction(BlazeAction.fetchTargetLocations(siteID: self.sampleSiteID, query: "test", locale: "en", onCompletion: { result in
+                promise(result)
+            }))
+        }
+
+        // Then
+        XCTAssertTrue(result.isFailure)
+        XCTAssertEqual(result.failure as? NetworkError, .timeout())
+    }
 }
 
 private extension BlazeStoreTests {


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes #11540 
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This PR completes the endpoints for target options by adding support to sync target topics and fetch locations. Since locations require query in the requests, they will not be cached in the storage.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
CI passing should be sufficient.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->
N/A

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
