### PR TITLE
Update auth lib for for security keys fixes

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -85,7 +85,7 @@ target 'WooCommerce' do
   # To allow pod to pick up beta versions use -beta. E.g., 1.1.7-beta.1
   # pod 'WordPressAuthenticator', '~> 8.0'
   # pod 'WordPressAuthenticator', git: 'https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git', branch: ''
-  pod 'WordPressAuthenticator', git: 'https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git', commit: '556c2f0c9b740ee7793e6c2eb78c73e08f4f7ba4'
+  pod 'WordPressAuthenticator', git: 'https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git', commit: '359d555371a7862d20a8b7c09b94cb11af127738'
   # pod 'WordPressAuthenticator', path: '../WordPressAuthenticator-iOS'
 
   wordpress_shared

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -71,7 +71,7 @@ DEPENDENCIES:
   - Sourcery (~> 1.0.3)
   - StripeTerminal (~> 3.1.0)
   - WordPress-Editor-iOS (~> 1.19.9)
-  - WordPressAuthenticator (from `https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git`, commit `556c2f0c9b740ee7793e6c2eb78c73e08f4f7ba4`)
+  - WordPressAuthenticator (from `https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git`, commit `359d555371a7862d20a8b7c09b94cb11af127738`)
   - WordPressShared (~> 2.1)
   - WordPressUI (~> 1.13)
   - Wormholy (~> 1.6.6)
@@ -114,12 +114,12 @@ SPEC REPOS:
 
 EXTERNAL SOURCES:
   WordPressAuthenticator:
-    :commit: 556c2f0c9b740ee7793e6c2eb78c73e08f4f7ba4
+    :commit: 359d555371a7862d20a8b7c09b94cb11af127738
     :git: https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git
 
 CHECKOUT OPTIONS:
   WordPressAuthenticator:
-    :commit: 556c2f0c9b740ee7793e6c2eb78c73e08f4f7ba4
+    :commit: 359d555371a7862d20a8b7c09b94cb11af127738
     :git: https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git
 
 SPEC CHECKSUMS:
@@ -155,6 +155,6 @@ SPEC CHECKSUMS:
   ZendeskSupportProvidersSDK: 685b5d185af47ced0ec40564ec46355c838bbd06
   ZendeskSupportSDK: 92e6f9d334e81e9186f8a17583862350460a5393
 
-PODFILE CHECKSUM: 0c5925a82b2ecb89d6972c875313e44b3ed156ef
+PODFILE CHECKSUM: 37fc7eb18ec960d5f2beaf02d25a616faae293c4
 
 COCOAPODS: 1.14.0


### PR DESCRIPTION
depends https://github.com/wordpress-mobile/WordPressAuthenticator-iOS/pull/820

# Why

This PR updates the `WordPressAuthentication` library to fix an issue where the "use security key" option was visible where it shouldn't be.

# Demo


https://github.com/woocommerce/woocommerce-ios/assets/562080/3ba76d70-4d63-40d5-94b9-76f5e392d37b

# Testing (Optional, was tested in https://github.com/wordpress-mobile/WordPressAuthenticator-iOS/pull/820#issuecomment-1871367068)

## Setup:

- Account A has a security key set up
- Account B has two-factor authentication enabled, but no security key

## Steps:

- Log in with account A (using password autofill)
- Tap "Back" on the second factor screen
- Log in with account B

## Expected Result

- The second factor screen does not show "Use a security key" option.


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
