### PR TITLE
[Custom Amounts] Render edit button only if Custom Amounts row is editable

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/CustomAmounts/CustomAmountRowView.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/CustomAmounts/CustomAmountRowView.swift
@@ -31,6 +31,7 @@ struct CustomAmountRowView: View {
                 .foregroundColor(Color(.wooCommercePurple(.shade60)))
                 .accessibilityAddTraits(.isButton)
                 .accessibilityLabel(Localization.editButtonAccessibilityLabel)
+                .renderedIf(editable)
         }
         .padding(Layout.contentPadding)
         .contentShape(Rectangle())


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #11554

## Description

This PR addresses a bug where a pencil edit icon appears in the Custom Amounts row on an Order, both when the Order is editable (correct) and non-editable (incorrect). 

The Custom Amount was correctly editable or non-editable depending on the case, the issue is only regarding rendering the incorrect icon in the UI.

## Changes
- We already have the `editable` property passed down to the view in order to render this correctly, but it was never used.

## Testing instructions
* Go to Orders > `+` > `+ Add Custom Amount` > Create the Order > Tap `Collect Payment` > Tap `Cash` > Tap `Mark as Paid`, so the order is marked as "Completed".
* Tap on Edit, observe that since the order is already paid and non-editable, the `Custom Amounts` row  shows the lock icon, and does not show the pencil icon.
* On a new Order, repeat the process without collecting payment, so the order remains as "Pending Payment". In the Order, tap `Edit`. Observe how the custom amounts row shows a pencil icon, and can be edited.

## Screenshots
| Editable | Non-editable |
|--------|--------|
| ![Simulator Screenshot - iPhone 15 - 2023-12-29 at 08 14 25](https://github.com/woocommerce/woocommerce-ios/assets/3812076/f34687dc-615d-4321-ad85-728205cc3b17) | ![Simulator Screenshot - iPhone 15 - 2023-12-29 at 08 14 38](https://github.com/woocommerce/woocommerce-ios/assets/3812076/c6d3cfe1-60f5-43f3-9444-5c702dc192eb) | 


---
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
