### PR TITLE
Blaze: UI for campaign creation form

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Blaze/CampaignCreation/BlazeCampaignCreationForm.swift
+++ b/WooCommerce/Classes/ViewRelated/Blaze/CampaignCreation/BlazeCampaignCreationForm.swift
@@ -1,6 +1,25 @@
 import SwiftUI
 
+/// Hosting controller for `BlazeCampaignCreationForm`
+final class BlazeCampaignCreationFormHostingController: UIHostingController<BlazeCampaignCreationForm> {
+    init(viewModel: BlazeCampaignCreationFormViewModel) {
+        super.init(rootView: .init(viewModel: viewModel))
+    }
+
+    @available(*, unavailable)
+    required dynamic init?(coder aDecoder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+}
+
+/// Form to enter details for creating a new Blaze campaign.
 struct BlazeCampaignCreationForm: View {
+    @ObservedObject private var viewModel: BlazeCampaignCreationFormViewModel
+
+    init(viewModel: BlazeCampaignCreationFormViewModel) {
+        self.viewModel = viewModel
+    }
+
     var body: some View {
         ScrollView {
             adPreview
@@ -15,20 +34,22 @@ private extension BlazeCampaignCreationForm {
         VStack {
             VStack(alignment: .leading, spacing: Layout.contentMargin) {
                 // TODO: use product image here
+                // Product image
                 Image(uiImage: .blazeIntroIllustration)
                     .resizable()
                     .aspectRatio(contentMode: .fill)
                     .cornerRadius(Layout.cornerRadius)
 
-                // TODO: dynamic text
+                // Tagline
                 Text("From $99")
                     .captionStyle()
 
                 HStack {
-                    // TODO: dynamic text
+                    // Description
                     Text("Get the latest white shirt for a stylish look")
                         .multilineTextAlignment(.leading)
                     Spacer()
+                    // Simulate shop button
                     Text(Localization.shopNow)
                         .fontWeight(.semibold)
                         .captionStyle()
@@ -41,6 +62,7 @@ private extension BlazeCampaignCreationForm {
             .cornerRadius(Layout.cornerRadius)
             .padding(Layout.contentPadding)
 
+            // Button to edit ad details
             Button(Localization.editAd) {
                 // TODO
             }
@@ -82,6 +104,6 @@ private extension BlazeCampaignCreationForm {
 
 struct BlazeCampaignCreationForm_Previews: PreviewProvider {
     static var previews: some View {
-        BlazeCampaignCreationForm()
+        BlazeCampaignCreationForm(viewModel: .init(siteID: 123) {})
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Blaze/CampaignCreation/BlazeCampaignCreationForm.swift
+++ b/WooCommerce/Classes/ViewRelated/Blaze/CampaignCreation/BlazeCampaignCreationForm.swift
@@ -1,0 +1,11 @@
+import SwiftUI
+
+struct BlazeCampaignCreationForm: View {
+    var body: some View {
+        Text(/*@START_MENU_TOKEN@*/"Hello, World!"/*@END_MENU_TOKEN@*/)
+    }
+}
+
+#Preview {
+    BlazeCampaignCreationForm()
+}

--- a/WooCommerce/Classes/ViewRelated/Blaze/CampaignCreation/BlazeCampaignCreationForm.swift
+++ b/WooCommerce/Classes/ViewRelated/Blaze/CampaignCreation/BlazeCampaignCreationForm.swift
@@ -109,6 +109,46 @@ private extension BlazeCampaignCreationForm {
             value: "Edit ad",
             comment: "Button to edit ad details on the Blaze campaign creation screen"
         )
+        static let details = NSLocalizedString(
+            "blazeCampaignCreationForm.details",
+            value: "Details",
+            comment: "Section title on the Blaze campaign creation screen"
+        )
+        static let budget = NSLocalizedString(
+            "blazeCampaignCreationForm.budget",
+            value: "Budget",
+            comment: "Title of the Budget field on the Blaze campaign creation screen"
+        )
+        static let language = NSLocalizedString(
+            "blazeCampaignCreationForm.language",
+            value: "Language",
+            comment: "Title of the Language field on the Blaze campaign creation screen"
+        )
+        static let devices = NSLocalizedString(
+            "blazeCampaignCreationForm.devices",
+            value: "Devices",
+            comment: "Title of the Devices field on the Blaze campaign creation screen"
+        )
+        static let location = NSLocalizedString(
+            "blazeCampaignCreationForm.location",
+            value: "Location",
+            comment: "Title of the Location field on the Blaze campaign creation screen"
+        )
+        static let interests = NSLocalizedString(
+            "blazeCampaignCreationForm.interests",
+            value: "Interests",
+            comment: "Title of the Interests field on the Blaze campaign creation screen"
+        )
+        static let adDestination = NSLocalizedString(
+            "blazeCampaignCreationForm.adDestination",
+            value: "Ad destination",
+            comment: "Title of the Ad destination field on the Blaze campaign creation screen"
+        )
+        static let confirmDetails = NSLocalizedString(
+            "blazeCampaignCreationForm.confirmDetails",
+            value: "Confirm Details",
+            comment: "Button to confirm ad details on the Blaze campaign creation screen"
+        )
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Blaze/CampaignCreation/BlazeCampaignCreationForm.swift
+++ b/WooCommerce/Classes/ViewRelated/Blaze/CampaignCreation/BlazeCampaignCreationForm.swift
@@ -2,10 +2,86 @@ import SwiftUI
 
 struct BlazeCampaignCreationForm: View {
     var body: some View {
-        Text(/*@START_MENU_TOKEN@*/"Hello, World!"/*@END_MENU_TOKEN@*/)
+        ScrollView {
+            adPreview
+            Spacer()
+        }
+        .navigationTitle(Localization.title)
     }
 }
 
-#Preview {
-    BlazeCampaignCreationForm()
+private extension BlazeCampaignCreationForm {
+    var adPreview: some View {
+        VStack {
+            VStack(alignment: .leading, spacing: Layout.contentMargin) {
+                // TODO: use product image here
+                Image(uiImage: .blazeIntroIllustration)
+                    .resizable()
+                    .aspectRatio(contentMode: .fill)
+                    .cornerRadius(Layout.cornerRadius)
+
+                // TODO: dynamic text
+                Text("From $99")
+                    .captionStyle()
+
+                HStack {
+                    // TODO: dynamic text
+                    Text("Get the latest white shirt for a stylish look")
+                        .multilineTextAlignment(.leading)
+                    Spacer()
+                    Text(Localization.shopNow)
+                        .fontWeight(.semibold)
+                        .captionStyle()
+                        .padding(Layout.contentMargin)
+                        .background(Color(uiColor: .systemGray))
+                        .cornerRadius(Layout.adButtonCornerRadius)
+                }
+            }
+            .padding(Layout.contentMargin)
+            .cornerRadius(Layout.cornerRadius)
+            .padding(Layout.contentPadding)
+
+            Button(Localization.editAd) {
+                // TODO
+            }
+            .buttonStyle(.plain)
+        }
+        .background(Color(uiColor: .systemGray6))
+        .cornerRadius(Layout.cornerRadius)
+        .padding(Layout.contentMargin)
+    }
+}
+
+private extension BlazeCampaignCreationForm {
+    enum Layout {
+        static let contentMargin: CGFloat = 8
+        static let contentPadding: CGFloat = 16
+        static let imagePadding: CGFloat = 8
+        static let cornerRadius: CGFloat = 8
+        static let adButtonCornerRadius: CGFloat = 4
+    }
+
+    enum Localization {
+        static let title = NSLocalizedString(
+            "blazeCampaignCreationForm.title",
+            value: "Preview",
+            comment: "Title of the Blaze campaign creation screen"
+        )
+        static let shopNow = NSLocalizedString(
+            "blazeCampaignCreationForm.shopNow",
+            value: "Shop Now",
+            comment: "Button to shop on the Blaze ad preview"
+        )
+        static let editAd = NSLocalizedString(
+            "blazeCampaignCreationForm.editAd",
+            value: "Edit ad",
+            comment: "Button to edit ad details on the Blaze campaign creation screen"
+        )
+    }
+}
+
+struct BlazeCampaignCreationForm_Previews: PreviewProvider {
+    static var previews: some View {
+        BlazeCampaignCreationForm()
+    }
 }

--- a/WooCommerce/Classes/ViewRelated/Blaze/CampaignCreation/BlazeCampaignCreationForm.swift
+++ b/WooCommerce/Classes/ViewRelated/Blaze/CampaignCreation/BlazeCampaignCreationForm.swift
@@ -181,7 +181,6 @@ private extension BlazeCampaignCreationForm {
     enum Layout {
         static let contentMargin: CGFloat = 8
         static let contentPadding: CGFloat = 16
-        static let imagePadding: CGFloat = 8
         static let cornerRadius: CGFloat = 8
         static let adButtonCornerRadius: CGFloat = 4
         static let strokeWidth: CGFloat = 1

--- a/WooCommerce/Classes/ViewRelated/Blaze/CampaignCreation/BlazeCampaignCreationForm.swift
+++ b/WooCommerce/Classes/ViewRelated/Blaze/CampaignCreation/BlazeCampaignCreationForm.swift
@@ -22,10 +22,69 @@ struct BlazeCampaignCreationForm: View {
 
     var body: some View {
         ScrollView {
-            adPreview
-            Spacer()
+            VStack(alignment: .leading, spacing: Layout.contentPadding) {
+                adPreview
+
+                Text(Localization.details)
+                    .subheadlineStyle()
+                    .foregroundColor(.init(uiColor: .text))
+
+                // Budget
+                detailView(title: Localization.budget, content: "$35, 7 days from Dec 13") {
+                    // TODO: open budget screen
+                }
+                .overlay { roundedRectangleBorder }
+
+                VStack(spacing: 0) {
+                    // Language
+                    detailView(title: Localization.language, content: "English, Chinese") {
+                        // TODO: open language screen
+                    }
+
+                    divider
+
+                    // Devices
+                    detailView(title: Localization.devices, content: "All") {
+                        // TODO: open devices screen
+                    }
+
+                    divider
+
+                    // Location
+                    detailView(title: Localization.location, content: "All") {
+                        // TODO: open location screen
+                    }
+
+                    divider
+
+                    // Interests
+                    detailView(title: Localization.interests, content: "Sports, Styles & Fashion, Travel, Shopping") {
+                        // TODO: open interests screen
+                    }
+                }
+                .overlay { roundedRectangleBorder }
+
+                // Ad destination
+                detailView(title: Localization.adDestination, content: "https://example.com") {
+                    // TODO: open destination screen
+                }
+                .overlay { roundedRectangleBorder }
+            }
+            .padding(.horizontal, Layout.contentPadding)
         }
         .navigationTitle(Localization.title)
+        .safeAreaInset(edge: .bottom) {
+            VStack(spacing: 0) {
+                Divider()
+
+                Button(Localization.confirmDetails) {
+                    // TODO: handle campaign creation
+                }
+                .buttonStyle(PrimaryLoadingButtonStyle(isLoading: false))
+                .padding(Layout.contentPadding)
+            }
+            .background(Color(uiColor: .systemBackground))
+        }
     }
 }
 
@@ -80,7 +139,37 @@ private extension BlazeCampaignCreationForm {
         .padding(Layout.contentPadding)
         .background(Color(uiColor: .systemGray6))
         .cornerRadius(Layout.cornerRadius)
-        .padding(Layout.contentPadding)
+        .padding(.vertical, Layout.contentPadding)
+    }
+
+    func detailView(title: String, content: String, action: @escaping () -> Void) -> some View {
+        Button(action: action, label: {
+            HStack {
+                VStack(alignment: .leading, spacing: Layout.detailContentSpacing) {
+                    Text(title)
+                        .bodyStyle()
+                    Text(content)
+                        .secondaryBodyStyle()
+                        .multilineTextAlignment(.leading)
+                }
+                Spacer()
+                Image(systemName: "chevron.right")
+                    .secondaryBodyStyle()
+            }
+            .padding(.horizontal, Layout.contentPadding)
+            .padding(.vertical, Layout.contentMargin)
+        })
+    }
+
+    var divider: some View {
+        Divider()
+            .frame(height: Layout.strokeWidth)
+            .foregroundColor(Color(uiColor: .separator))
+    }
+
+    var roundedRectangleBorder: some View {
+        RoundedRectangle(cornerRadius: Layout.cornerRadius)
+            .stroke(Color(uiColor: .separator), lineWidth: Layout.strokeWidth)
     }
 }
 
@@ -91,6 +180,8 @@ private extension BlazeCampaignCreationForm {
         static let imagePadding: CGFloat = 8
         static let cornerRadius: CGFloat = 8
         static let adButtonCornerRadius: CGFloat = 4
+        static let strokeWidth: CGFloat = 1
+        static let detailContentSpacing: CGFloat = 4
     }
 
     enum Localization {

--- a/WooCommerce/Classes/ViewRelated/Blaze/CampaignCreation/BlazeCampaignCreationForm.swift
+++ b/WooCommerce/Classes/ViewRelated/Blaze/CampaignCreation/BlazeCampaignCreationForm.swift
@@ -124,6 +124,10 @@ private extension BlazeCampaignCreationForm {
             .padding(Layout.contentPadding)
             .background(Color(uiColor: .systemBackground))
             .cornerRadius(Layout.cornerRadius)
+            .shadow(color: .black.opacity(0.05),
+                    radius: Layout.shadowRadius,
+                    x: 0,
+                    y: Layout.shadowYOffset)
 
             // Button to edit ad details
             Button(action: {
@@ -182,6 +186,8 @@ private extension BlazeCampaignCreationForm {
         static let adButtonCornerRadius: CGFloat = 4
         static let strokeWidth: CGFloat = 1
         static let detailContentSpacing: CGFloat = 4
+        static let shadowRadius: CGFloat = 2
+        static let shadowYOffset: CGFloat = 2
     }
 
     enum Localization {

--- a/WooCommerce/Classes/ViewRelated/Blaze/CampaignCreation/BlazeCampaignCreationForm.swift
+++ b/WooCommerce/Classes/ViewRelated/Blaze/CampaignCreation/BlazeCampaignCreationForm.swift
@@ -31,7 +31,7 @@ struct BlazeCampaignCreationForm: View {
 
 private extension BlazeCampaignCreationForm {
     var adPreview: some View {
-        VStack {
+        VStack(spacing: Layout.contentPadding) {
             VStack(alignment: .leading, spacing: Layout.contentMargin) {
                 // TODO: use product image here
                 // Product image
@@ -40,37 +40,47 @@ private extension BlazeCampaignCreationForm {
                     .aspectRatio(contentMode: .fill)
                     .cornerRadius(Layout.cornerRadius)
 
+                // TODO: dynamic content
                 // Tagline
                 Text("From $99")
                     .captionStyle()
 
-                HStack {
+                HStack(spacing: Layout.contentPadding) {
+                    // TODO: dynamic content
                     // Description
                     Text("Get the latest white shirt for a stylish look")
+                        .fontWeight(.semibold)
+                        .headlineStyle()
                         .multilineTextAlignment(.leading)
-                    Spacer()
+
                     // Simulate shop button
                     Text(Localization.shopNow)
                         .fontWeight(.semibold)
                         .captionStyle()
                         .padding(Layout.contentMargin)
-                        .background(Color(uiColor: .systemGray))
+                        .background(Color(uiColor: .systemGray6))
                         .cornerRadius(Layout.adButtonCornerRadius)
                 }
             }
-            .padding(Layout.contentMargin)
-            .cornerRadius(Layout.cornerRadius)
             .padding(Layout.contentPadding)
+            .background(Color(uiColor: .systemBackground))
+            .cornerRadius(Layout.cornerRadius)
 
             // Button to edit ad details
-            Button(Localization.editAd) {
+            Button(action: {
                 // TODO
-            }
+            }, label: {
+                Text(Localization.editAd)
+                    .fontWeight(.semibold)
+                    .font(.body)
+                    .foregroundColor(.accentColor)
+            })
             .buttonStyle(.plain)
         }
+        .padding(Layout.contentPadding)
         .background(Color(uiColor: .systemGray6))
         .cornerRadius(Layout.cornerRadius)
-        .padding(Layout.contentMargin)
+        .padding(Layout.contentPadding)
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Blaze/CampaignCreation/BlazeCampaignCreationFormViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Blaze/CampaignCreation/BlazeCampaignCreationFormViewModel.swift
@@ -1,0 +1,17 @@
+import Foundation
+import Yosemite
+
+/// View model for `BlazeCampaignCreationForm`
+final class BlazeCampaignCreationFormViewModel: ObservableObject {
+    private let siteID: Int64
+    private let stores: StoresManager
+    private let completionHandler: () -> Void
+
+    init(siteID: Int64,
+         stores: StoresManager = ServiceLocator.stores,
+         onCompletion: @escaping () -> Void) {
+        self.siteID = siteID
+        self.stores = stores
+        self.completionHandler = onCompletion
+    }
+}

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewController.swift
@@ -1141,14 +1141,22 @@ private extension ProductFormViewController {
     }
 
     private func navigateToBlazeCampaignCreation(siteUrl: String, source: BlazeSource) {
-        let blazeViewModel = BlazeWebViewModel(siteID: viewModel.productModel.siteID,
-                                               source: source,
-                                               siteURL: siteUrl,
-                                               productID: product.productID) { [weak self] in
-            self?.handlePostCreation()
+        if ServiceLocator.featureFlagService.isFeatureFlagEnabled(.blazei3NativeCampaignCreation) {
+            let viewModel = BlazeCampaignCreationFormViewModel(siteID: viewModel.productModel.siteID) { [weak self] in
+                self?.handlePostCreation()
+            }
+            let controller = BlazeCampaignCreationFormHostingController(viewModel: viewModel)
+            navigationController?.show(controller, sender: self)
+        } else {
+            let blazeViewModel = BlazeWebViewModel(siteID: viewModel.productModel.siteID,
+                                                   source: source,
+                                                   siteURL: siteUrl,
+                                                   productID: product.productID) { [weak self] in
+                self?.handlePostCreation()
+            }
+            let webViewController = AuthenticatedWebViewController(viewModel: blazeViewModel)
+            navigationController?.show(webViewController, sender: self)
         }
-        let webViewController = AuthenticatedWebViewController(viewModel: blazeViewModel)
-        navigationController?.show(webViewController, sender: self)
     }
 
     func handlePostCreation() {

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -2229,6 +2229,7 @@
 		DE50295728BF595200551736 /* WordPressOrgCredentialsAuthenticatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE50295628BF595200551736 /* WordPressOrgCredentialsAuthenticatorTests.swift */; };
 		DE525499268C8B32007A5829 /* UIRefreshControl+Woo.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE525498268C8B32007A5829 /* UIRefreshControl+Woo.swift */; };
 		DE57462F2B43EB0B0034B10D /* BlazeCampaignCreationForm.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE57462E2B43EB0B0034B10D /* BlazeCampaignCreationForm.swift */; };
+		DE5746312B43F6180034B10D /* BlazeCampaignCreationFormViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE5746302B43F6180034B10D /* BlazeCampaignCreationFormViewModel.swift */; };
 		DE5C19C52AC3F0700064600A /* AddProductNameWithAIViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE5C19C42AC3F0700064600A /* AddProductNameWithAIViewModelTests.swift */; };
 		DE5C19C72AC3F1D30064600A /* AddProductFeaturesViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE5C19C62AC3F1D30064600A /* AddProductFeaturesViewModelTests.swift */; };
 		DE5C19C92AC42E7E0064600A /* WooAnalyticsEvent+ProductNameAI.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE5C19C82AC42E7E0064600A /* WooAnalyticsEvent+ProductNameAI.swift */; };
@@ -4863,6 +4864,7 @@
 		DE50295628BF595200551736 /* WordPressOrgCredentialsAuthenticatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WordPressOrgCredentialsAuthenticatorTests.swift; sourceTree = "<group>"; };
 		DE525498268C8B32007A5829 /* UIRefreshControl+Woo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIRefreshControl+Woo.swift"; sourceTree = "<group>"; };
 		DE57462E2B43EB0B0034B10D /* BlazeCampaignCreationForm.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BlazeCampaignCreationForm.swift; sourceTree = "<group>"; };
+		DE5746302B43F6180034B10D /* BlazeCampaignCreationFormViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BlazeCampaignCreationFormViewModel.swift; sourceTree = "<group>"; };
 		DE5C19C42AC3F0700064600A /* AddProductNameWithAIViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddProductNameWithAIViewModelTests.swift; sourceTree = "<group>"; };
 		DE5C19C62AC3F1D30064600A /* AddProductFeaturesViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddProductFeaturesViewModelTests.swift; sourceTree = "<group>"; };
 		DE5C19C82AC42E7E0064600A /* WooAnalyticsEvent+ProductNameAI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "WooAnalyticsEvent+ProductNameAI.swift"; sourceTree = "<group>"; };
@@ -11053,6 +11055,7 @@
 			isa = PBXGroup;
 			children = (
 				DE57462E2B43EB0B0034B10D /* BlazeCampaignCreationForm.swift */,
+				DE5746302B43F6180034B10D /* BlazeCampaignCreationFormViewModel.swift */,
 			);
 			path = CampaignCreation;
 			sourceTree = "<group>";
@@ -12871,6 +12874,7 @@
 				EE3B17B62AA03837004D3E0C /* CelebrationView.swift in Sources */,
 				D85A3C5226C15DE200C0E026 /* InPersonPaymentsPluginNotSupportedVersionView.swift in Sources */,
 				EE57C11D297AC27300BC31E7 /* TrackEventRequestNotificationHandler.swift in Sources */,
+				DE5746312B43F6180034B10D /* BlazeCampaignCreationFormViewModel.swift in Sources */,
 				CE583A0B2107937F00D73C1C /* TextViewTableViewCell.swift in Sources */,
 				45AE150224A23F03005AA948 /* ProductParentCategoriesViewController.swift in Sources */,
 				B557652B20F681E800185843 /* StoreTableViewCell.swift in Sources */,

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -2228,6 +2228,7 @@
 		DE50295328BF4A8A00551736 /* JetpackConnectionWebViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE50295228BF4A8A00551736 /* JetpackConnectionWebViewModelTests.swift */; };
 		DE50295728BF595200551736 /* WordPressOrgCredentialsAuthenticatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE50295628BF595200551736 /* WordPressOrgCredentialsAuthenticatorTests.swift */; };
 		DE525499268C8B32007A5829 /* UIRefreshControl+Woo.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE525498268C8B32007A5829 /* UIRefreshControl+Woo.swift */; };
+		DE57462F2B43EB0B0034B10D /* BlazeCampaignCreationForm.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE57462E2B43EB0B0034B10D /* BlazeCampaignCreationForm.swift */; };
 		DE5C19C52AC3F0700064600A /* AddProductNameWithAIViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE5C19C42AC3F0700064600A /* AddProductNameWithAIViewModelTests.swift */; };
 		DE5C19C72AC3F1D30064600A /* AddProductFeaturesViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE5C19C62AC3F1D30064600A /* AddProductFeaturesViewModelTests.swift */; };
 		DE5C19C92AC42E7E0064600A /* WooAnalyticsEvent+ProductNameAI.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE5C19C82AC42E7E0064600A /* WooAnalyticsEvent+ProductNameAI.swift */; };
@@ -4861,6 +4862,7 @@
 		DE50295228BF4A8A00551736 /* JetpackConnectionWebViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JetpackConnectionWebViewModelTests.swift; sourceTree = "<group>"; };
 		DE50295628BF595200551736 /* WordPressOrgCredentialsAuthenticatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WordPressOrgCredentialsAuthenticatorTests.swift; sourceTree = "<group>"; };
 		DE525498268C8B32007A5829 /* UIRefreshControl+Woo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIRefreshControl+Woo.swift"; sourceTree = "<group>"; };
+		DE57462E2B43EB0B0034B10D /* BlazeCampaignCreationForm.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BlazeCampaignCreationForm.swift; sourceTree = "<group>"; };
 		DE5C19C42AC3F0700064600A /* AddProductNameWithAIViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddProductNameWithAIViewModelTests.swift; sourceTree = "<group>"; };
 		DE5C19C62AC3F1D30064600A /* AddProductFeaturesViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddProductFeaturesViewModelTests.swift; sourceTree = "<group>"; };
 		DE5C19C82AC42E7E0064600A /* WooAnalyticsEvent+ProductNameAI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "WooAnalyticsEvent+ProductNameAI.swift"; sourceTree = "<group>"; };
@@ -11047,6 +11049,14 @@
 			path = ProductSelector;
 			sourceTree = "<group>";
 		};
+		DE57462D2B43EAF20034B10D /* CampaignCreation */ = {
+			isa = PBXGroup;
+			children = (
+				DE57462E2B43EB0B0034B10D /* BlazeCampaignCreationForm.swift */,
+			);
+			path = CampaignCreation;
+			sourceTree = "<group>";
+		};
 		DE63115D2AF1E16500587641 /* WPComLogin */ = {
 			isa = PBXGroup;
 			children = (
@@ -11197,6 +11207,7 @@
 		DED91DF72AD78A0C00CDCC53 /* Blaze */ = {
 			isa = PBXGroup;
 			children = (
+				DE57462D2B43EAF20034B10D /* CampaignCreation */,
 				EE505DDB2B3C249E006E3323 /* BlazeIntro */,
 				DED91DF82AD78A1A00CDCC53 /* BlazeCampaignList */,
 			);
@@ -14140,6 +14151,7 @@
 				0365986729AFAEFC00F297D3 /* SetUpTapToPayViewModelsOrderedList.swift in Sources */,
 				DEDA8D992B04643E0076BF0F /* ProductSubscription+Empty.swift in Sources */,
 				6856D31F941A33BAE66F394D /* KeyboardFrameAdjustmentProvider.swift in Sources */,
+				DE57462F2B43EB0B0034B10D /* BlazeCampaignCreationForm.swift in Sources */,
 				CCFC50592743E021001E505F /* EditableOrderViewModel.swift in Sources */,
 				CCFBBCF429C4B8AF0081B595 /* ComponentsList.swift in Sources */,
 				6881CCC42A5EE6BF00AEDE36 /* WooPlanCardView.swift in Sources */,


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #11587 
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This PR adds the UI for the campaign creation form. The only entry point for now is the product form, since we'll need to show the product selector for the entry points from the dashboard and the campaign list screens. 

The view model has no logic for now, and all the text are for testing purpose. We'll need to integrate real data in a separate PR.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
- Log in to a store with at least one existing product and is eligible for Blaze.
- Navigate to the Products tab and select any public product.
- On the product form, select Promote with Blaze.
- Notice that the campaign creation form is presented.

Feel free to disable the feature flag `blazei3NativeCampaignCreation` - the web view for campaign creation should be displayed instead

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->


https://github.com/woocommerce/woocommerce-ios/assets/5533851/05c3082d-18fb-4201-9249-087e9387dced


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
