### PR TITLE
[Performance] Remove completed A/A tests

### DIFF
--- a/Experiments/Experiments/ABTest.swift
+++ b/Experiments/Experiments/ABTest.swift
@@ -6,14 +6,6 @@ public enum ABTest: String, Codable, CaseIterable {
     /// Mocks for unit testing
     case mockLoggedIn, mockLoggedOut
 
-    /// A/A test to make sure there is no bias in the logged out state.
-    /// Experiment ref: pbxNRc-1QS-p2
-    case aaTestLoggedIn = "woocommerceios_explat_aa_test_logged_in_202212_v2"
-
-    /// A/A test to make sure there is no bias in the logged out state.
-    /// Experiment ref: pbxNRc-1S0-p2
-    case aaTestLoggedOut = "woocommerceios_explat_aa_test_logged_out_202212_v2"
-
     /// Returns a variation for the given experiment
     ///
     public var variation: Variation? {
@@ -25,10 +17,6 @@ public enum ABTest: String, Codable, CaseIterable {
     /// When adding a new experiment, add it to the appropriate case depending on its context (logged-in or logged-out experience).
     public var context: ExperimentContext {
         switch self {
-        case .aaTestLoggedIn:
-            return .loggedIn
-        case .aaTestLoggedOut:
-            return .loggedOut
         // Mocks
         case .mockLoggedIn:
             return .loggedIn


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of #11592
<!-- Id number of the GitHub issue this PR addresses. -->

## Why

We are making unnecessary API requests to fetch assignments for completed A/A tests. Removing these tests from the app is routine cleanup and will also improve the app's performance on launch, since we currently don't need to fetch any experiment assignments.

## How

Removes two completed A/A tests from `ABTest`:

* `woocommerceios_explat_aa_test_logged_in_202212_v2`
* `woocommerceios_explat_aa_test_logged_out_202212_v2`

## Testing instructions

1. Build and run the app and confirm it launches as expected.
2. Go to Menu > Settings > Launch Wormholy Debug and confirm there are no requests made to the `/wpcom/v2/experiments/0.1.0/assignments/woocommerceios` endpoint.


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
