### PR TITLE
[Networking] Revert change to handle mapping in background thread

### DIFF
--- a/Networking/Networking.xcodeproj/project.pbxproj
+++ b/Networking/Networking.xcodeproj/project.pbxproj
@@ -3,7 +3,7 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 53;
+	objectVersion = 54;
 	objects = {
 
 /* Begin PBXBuildFile section */
@@ -999,7 +999,6 @@
 		EEA658462966C67C00112DF0 /* products-ids-only-without-data.json in Resources */ = {isa = PBXBuildFile; fileRef = EEA658452966C67C00112DF0 /* products-ids-only-without-data.json */; };
 		EEA658482966CBAD00112DF0 /* EntityIDMapperTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EEA658472966CBAD00112DF0 /* EntityIDMapperTests.swift */; };
 		EEA6584C2966CC4800112DF0 /* product-id-only-without-data.json in Resources */ = {isa = PBXBuildFile; fileRef = EEA6584B2966CC4800112DF0 /* product-id-only-without-data.json */; };
-		EEA693572B21703D00BAECA6 /* Publisher+Concurrency.swift in Sources */ = {isa = PBXBuildFile; fileRef = EEA693562B21703D00BAECA6 /* Publisher+Concurrency.swift */; };
 		EEAB476A2A851AFD00E55B25 /* site-upload-profiler-answers-success.json in Resources */ = {isa = PBXBuildFile; fileRef = EEAB47692A851AFD00E55B25 /* site-upload-profiler-answers-success.json */; };
 		EEC312C32AFDF79E004369F7 /* ProductSubscriptionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EEC312C22AFDF79E004369F7 /* ProductSubscriptionTests.swift */; };
 		EEC312C52AFE01BC004369F7 /* ProductEncoderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EEC312C42AFE01BC004369F7 /* ProductEncoderTests.swift */; };
@@ -2046,7 +2045,6 @@
 		EEA658452966C67C00112DF0 /* products-ids-only-without-data.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "products-ids-only-without-data.json"; sourceTree = "<group>"; };
 		EEA658472966CBAD00112DF0 /* EntityIDMapperTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EntityIDMapperTests.swift; sourceTree = "<group>"; };
 		EEA6584B2966CC4800112DF0 /* product-id-only-without-data.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "product-id-only-without-data.json"; sourceTree = "<group>"; };
-		EEA693562B21703D00BAECA6 /* Publisher+Concurrency.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Publisher+Concurrency.swift"; sourceTree = "<group>"; };
 		EEAB47692A851AFD00E55B25 /* site-upload-profiler-answers-success.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "site-upload-profiler-answers-success.json"; sourceTree = "<group>"; };
 		EEC312C22AFDF79E004369F7 /* ProductSubscriptionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductSubscriptionTests.swift; sourceTree = "<group>"; };
 		EEC312C42AFE01BC004369F7 /* ProductEncoderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductEncoderTests.swift; sourceTree = "<group>"; };
@@ -3206,7 +3204,6 @@
 		B5BB1D0A20A204F400112D92 /* Extensions */ = {
 			isa = PBXGroup;
 			children = (
-				EEA693562B21703D00BAECA6 /* Publisher+Concurrency.swift */,
 				CE6D666B2379E19D007835A1 /* Array+Woo.swift */,
 				B58E5BE920FFB3D0003C986E /* CodingUserInfoKey+Woo.swift */,
 				B5BB1D0B20A2050300112D92 /* DateFormatter+Woo.swift */,
@@ -4174,7 +4171,6 @@
 				31D27C8B26028D96002EDB1D /* SitePlugin.swift in Sources */,
 				D89A01D426D3F8D9008195BE /* ReaderLocation.swift in Sources */,
 				74C8F06420EEB44800B6EDC9 /* OrderNote.swift in Sources */,
-				EEA693572B21703D00BAECA6 /* Publisher+Concurrency.swift in Sources */,
 				02C254AC2563781800A04423 /* ShippingLabelStatus.swift in Sources */,
 				0359EA1B27AAC7CC0048DE2D /* WCPayCardPresentReceiptDetails.swift in Sources */,
 				74ABA1D3213F25AE00FFAD30 /* TopEarnerStatsMapper.swift in Sources */,

--- a/Networking/Networking/Remote/Remote.swift
+++ b/Networking/Networking/Remote/Remote.swift
@@ -98,22 +98,16 @@ public class Remote: NSObject {
                 return
             }
 
-            Task {
-                do {
-                    let validator = request.responseDataValidator()
-                    try validator.validate(data: data)
-                    let parsed = try mapper.map(response: data)
-                    await MainActor.run {
-                        completion(parsed, nil)
-                    }
-                } catch {
-                    self.handleResponseError(error: error, for: request)
-                    self.handleDecodingError(error: error, for: request, entityName: "\(M.Output.self)")
-                    DDLogError("<> Mapping Error: \(error)")
-                    await MainActor.run {
-                        completion(nil, error)
-                    }
-                }
+            do {
+                let validator = request.responseDataValidator()
+                try validator.validate(data: data)
+                let parsed = try mapper.map(response: data)
+                completion(parsed, nil)
+            } catch {
+                self.handleResponseError(error: error, for: request)
+                self.handleDecodingError(error: error, for: request, entityName: "\(M.Output.self)")
+                DDLogError("<> Mapping Error: \(error)")
+                completion(nil, error)
             }
         }
     }
@@ -137,22 +131,16 @@ public class Remote: NSObject {
 
             switch result {
             case .success(let data):
-                Task {
-                    do {
-                        let validator = request.responseDataValidator()
-                        try validator.validate(data: data)
-                        let parsed = try mapper.map(response: data)
-                        await MainActor.run {
-                            completion(.success(parsed))
-                        }
-                    } catch {
-                        self.handleResponseError(error: error, for: request)
-                        self.handleDecodingError(error: error, for: request, entityName: "\(M.Output.self)")
-                        DDLogError("<> Mapping Error: \(error)")
-                        await MainActor.run {
-                            completion(.failure(error))
-                        }
-                    }
+                do {
+                    let validator = request.responseDataValidator()
+                    try validator.validate(data: data)
+                    let parsed = try mapper.map(response: data)
+                    completion(.success(parsed))
+                } catch {
+                    self.handleResponseError(error: error, for: request)
+                    self.handleDecodingError(error: error, for: request, entityName: "\(M.Output.self)")
+                    DDLogError("<> Mapping Error: \(error)")
+                    completion(.failure(error))
                 }
             case .failure(let error):
                 completion(.failure(self.mapNetworkError(error: error, for: request)))
@@ -172,7 +160,7 @@ public class Remote: NSObject {
     /// - Returns: A publisher that emits result upon completion.
     func enqueue<M: Mapper>(_ request: Request, mapper: M) -> AnyPublisher<Result<M.Output, Error>, Never> {
         network.responseDataPublisher(for: request)
-            .asyncMap { [weak self] (result: Result<Data, Error>) -> Result<M.Output, Error> in
+            .map { [weak self] (result: Result<Data, Error>) -> Result<M.Output, Error> in
                 switch result {
                 case .success(let data):
                     do {
@@ -188,7 +176,6 @@ public class Remote: NSObject {
                     return .failure(self?.mapNetworkError(error: error, for: request) ?? error)
                 }
             }
-            .receive(on: DispatchQueue.main)
             .handleEvents(receiveOutput: { [weak self] result in
                 if let dotcomError = result.failure as? DotcomError {
                     self?.handleResponseError(error: dotcomError, for: request)
@@ -226,22 +213,16 @@ public class Remote: NSObject {
                                                 return
                                             }
 
-                                            Task {
-                                                do {
-                                                    let validator = request.responseDataValidator()
-                                                    try validator.validate(data: data)
-                                                    let parsed = try mapper.map(response: data)
-                                                    await MainActor.run {
-                                                        completion(.success(parsed))
-                                                    }
-                                                } catch {
-                                                    self.handleResponseError(error: error, for: request)
-                                                    self.handleDecodingError(error: error, for: request, entityName: "\(M.Output.self)")
-                                                    DDLogError("<> Mapping Error: \(error)")
-                                                    await MainActor.run {
-                                                        completion(.failure(error))
-                                                    }
-                                                }
+                                            do {
+                                                let validator = request.responseDataValidator()
+                                                try validator.validate(data: data)
+                                                let parsed = try mapper.map(response: data)
+                                                completion(.success(parsed))
+                                            } catch {
+                                                self.handleResponseError(error: error, for: request)
+                                                self.handleDecodingError(error: error, for: request, entityName: "\(M.Output.self)")
+                                                DDLogError("<> Mapping Error: \(error)")
+                                                completion(.failure(error))
                                             }
         }
     }
@@ -260,18 +241,16 @@ public class Remote: NSObject {
 
                 switch result {
                 case .success(let data):
-                    Task {
-                        do {
-                            let validator = request.responseDataValidator()
-                            try validator.validate(data: data)
-                            let parsed = try mapper.map(response: data)
-                            continuation.resume(returning: parsed)
-                        } catch {
-                            DDLogError("<> Mapping Error: \(error)")
-                            self.handleResponseError(error: error, for: request)
-                            self.handleDecodingError(error: error, for: request, entityName: "\(M.Output.self)")
-                            continuation.resume(throwing: error)
-                        }
+                    do {
+                        let validator = request.responseDataValidator()
+                        try validator.validate(data: data)
+                        let parsed = try mapper.map(response: data)
+                        continuation.resume(returning: parsed)
+                    } catch {
+                        DDLogError("<> Mapping Error: \(error)")
+                        self.handleResponseError(error: error, for: request)
+                        self.handleDecodingError(error: error, for: request, entityName: "\(M.Output.self)")
+                        continuation.resume(throwing: error)
                     }
                 case .failure(let error):
                     continuation.resume(throwing: self.mapNetworkError(error: error, for: request))

--- a/Networking/NetworkingTests/Remote/RemoteTests.swift
+++ b/Networking/NetworkingTests/Remote/RemoteTests.swift
@@ -8,6 +8,7 @@ import TestKit
 
 /// Remote UnitTests
 ///
+@MainActor
 final class RemoteTests: XCTestCase {
 
     /// Sample Request

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -36,6 +36,7 @@
 - [*] Payments menu: restored the ability to search for Payments in device Spotlight. [https://github.com/woocommerce/woocommerce-ios/pull/11343]
 - [*] Payments menu: show the selected payment gateway when there's more than one to choose from [https://github.com/woocommerce/woocommerce-ios/pull/11345]
 - [**] Fixed a crash that occurred when reordering product images during the image upload process. Now, users will not be able to reorder images until the upload is complete, providing a smoother and more stable experience. [https://github.com/woocommerce/woocommerce-ios/pull/11350]
+- [internal] Process network response in background thread to avoid blocking main thread. [https://github.com/woocommerce/woocommerce-ios/pull/11381]
 - [**] Attempted to fix a crash that has been occurring for some users during magic link login. [https://github.com/woocommerce/woocommerce-ios/pull/11373]
 - [*] Fixed a crash due to using unavailable system image in devices below iOS 16.0. [https://github.com/woocommerce/woocommerce-ios/pull/11394]
 

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -36,7 +36,6 @@
 - [*] Payments menu: restored the ability to search for Payments in device Spotlight. [https://github.com/woocommerce/woocommerce-ios/pull/11343]
 - [*] Payments menu: show the selected payment gateway when there's more than one to choose from [https://github.com/woocommerce/woocommerce-ios/pull/11345]
 - [**] Fixed a crash that occurred when reordering product images during the image upload process. Now, users will not be able to reorder images until the upload is complete, providing a smoother and more stable experience. [https://github.com/woocommerce/woocommerce-ios/pull/11350]
-- [internal] Process network response in background thread to avoid blocking main thread. [https://github.com/woocommerce/woocommerce-ios/pull/11381]
 - [**] Attempted to fix a crash that has been occurring for some users during magic link login. [https://github.com/woocommerce/woocommerce-ios/pull/11373]
 - [*] Fixed a crash due to using unavailable system image in devices below iOS 16.0. [https://github.com/woocommerce/woocommerce-ios/pull/11394]
 

--- a/WooCommerce/Classes/Extensions/Publisher+Concurrency.swift
+++ b/WooCommerce/Classes/Extensions/Publisher+Concurrency.swift
@@ -1,6 +1,6 @@
 import Combine
 
-public extension Publisher {
+extension Publisher {
     /// Transforms the publisher with an async operator that does not throw an error.
     ///
     /// Original implementation:

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -368,6 +368,7 @@
 		028B68C32A574DC500FE03A8 /* AddProductFromImageViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 028B68C22A574DC500FE03A8 /* AddProductFromImageViewModelTests.swift */; };
 		028BAC3D22F2DECE008BB4AF /* StoreStatsAndTopPerformersViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 028BAC3C22F2DECE008BB4AF /* StoreStatsAndTopPerformersViewController.swift */; };
 		028BAC4722F3B550008BB4AF /* StatsTimeRangeV4+UI.swift in Sources */ = {isa = PBXBuildFile; fileRef = 028BAC4622F3B550008BB4AF /* StatsTimeRangeV4+UI.swift */; };
+		028CB70F290138EF00331C09 /* Publisher+Concurrency.swift in Sources */ = {isa = PBXBuildFile; fileRef = 028CB70E290138EF00331C09 /* Publisher+Concurrency.swift */; };
 		028E19BA28053443001C36E0 /* MockOrderDetailsPaymentAlerts.swift in Sources */ = {isa = PBXBuildFile; fileRef = 028E19B928053443001C36E0 /* MockOrderDetailsPaymentAlerts.swift */; };
 		028E19BC2805BD22001C36E0 /* RefundSubmissionUseCaseTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 028E19BB2805BD22001C36E0 /* RefundSubmissionUseCaseTests.swift */; };
 		028E1F702833DD0A001F8829 /* DashboardViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 028E1F6F2833DD0A001F8829 /* DashboardViewModel.swift */; };
@@ -2988,6 +2989,7 @@
 		028B68C22A574DC500FE03A8 /* AddProductFromImageViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddProductFromImageViewModelTests.swift; sourceTree = "<group>"; };
 		028BAC3C22F2DECE008BB4AF /* StoreStatsAndTopPerformersViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StoreStatsAndTopPerformersViewController.swift; sourceTree = "<group>"; };
 		028BAC4622F3B550008BB4AF /* StatsTimeRangeV4+UI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "StatsTimeRangeV4+UI.swift"; sourceTree = "<group>"; };
+		028CB70E290138EF00331C09 /* Publisher+Concurrency.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Publisher+Concurrency.swift"; sourceTree = "<group>"; };
 		028E19B928053443001C36E0 /* MockOrderDetailsPaymentAlerts.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockOrderDetailsPaymentAlerts.swift; sourceTree = "<group>"; };
 		028E19BB2805BD22001C36E0 /* RefundSubmissionUseCaseTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RefundSubmissionUseCaseTests.swift; sourceTree = "<group>"; };
 		028E1F6F2833DD0A001F8829 /* DashboardViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DashboardViewModel.swift; sourceTree = "<group>"; };
@@ -10183,6 +10185,7 @@
 				B9B6DEEE283F8B9F00901FB7 /* Site+URL.swift */,
 				021DD44C286A3A8D004F0468 /* UIViewController+Navigation.swift */,
 				DE61978A28991F0E005E4362 /* WKWebView+Authenticated.swift */,
+				028CB70E290138EF00331C09 /* Publisher+Concurrency.swift */,
 				DE4D239729ADF8E3003A4B5D /* WordPressAuthenticator+Woo.swift */,
 				EE2A57D629E399CC009F61E1 /* CaseIterable+Helpers.swift */,
 				02D29A9129F7C39200473D6D /* UIImage+Text.swift */,
@@ -14091,6 +14094,7 @@
 				DEDA8D9D2B1609DE0076BF0F /* UserDefaults+Blaze.swift in Sources */,
 				038BC37F29C37B0E00EAF565 /* SetUpTapToPayCompleteViewController.swift in Sources */,
 				E16715CB26663B0B00326230 /* CardPresentModalSuccessWithoutEmail.swift in Sources */,
+				028CB70F290138EF00331C09 /* Publisher+Concurrency.swift in Sources */,
 				311F827426CD897900DF5BAD /* CardReaderSettingsAlertsProvider.swift in Sources */,
 				020DD0AF294A06C400727BEF /* StoreCreationSellingStatusQuestionView.swift in Sources */,
 				CC4D1D8625E6CDDE00B6E4E7 /* RenameAttributesViewModel.swift in Sources */,

--- a/Yosemite/YosemiteTests/Stores/ShipmentStoreTests.swift
+++ b/Yosemite/YosemiteTests/Stores/ShipmentStoreTests.swift
@@ -562,17 +562,13 @@ final class ShipmentStoreTests: XCTestCase {
         let mockTrackingID = "f2e7783b40837b9e1ec503a149dab4a1"
         let mockDateShipped = "2019-04-01"
 
-        let error = waitFor { promise in
-            shipmentStore.addTracking(siteID: self.sampleSiteID,
-                                      orderID: self.sampleOrderID,
-                                      providerGroupName: mockGroupName,
-                                      providerName: mockProviderName,
-                                      trackingNumber: mockTrackingNumber, dateShipped: mockDateShipped) { error in
-                promise(error)
-            }
+        shipmentStore.addTracking(siteID: sampleSiteID,
+                                  orderID: sampleOrderID,
+                                  providerGroupName: mockGroupName,
+                                  providerName: mockProviderName,
+                                  trackingNumber: mockTrackingNumber, dateShipped: mockDateShipped) { error in
+                                    XCTAssertNil(error)
         }
-
-        XCTAssertNil(error)
 
         XCTAssertEqual(self.viewStorage.countObjects(ofType: Storage.ShipmentTracking.self), 1)
 


### PR DESCRIPTION
Closes: #11595
<!-- Id number of the GitHub issue this PR addresses. -->

## Description

### What? 

Reverts changes made to move the network response processing away from the main thread. https://github.com/woocommerce/woocommerce-ios/pull/11381

### Why?

In https://github.com/woocommerce/woocommerce-ios/pull/11381 I moved the network response mapping away from the main thread, hoping it would resolve the `WatchdogTermination` issue that we were facing in Sentry. However, the fix didn't resolve [the `WatchdogTermination` issue in Sentry](https://a8c.sentry.io/issues/4294572038/?project=1458804).

Due to this change, we started having crashes from the `Combine` based `enqueue` method from `Remote`. [Code](https://github.com/woocommerce/woocommerce-ios/blob/trunk/Networking/Networking/Remote/Remote.swift#L173)
Internal - peaMlT-mj-p2

As this fix didn't resolve the original `WatchdogTermination` issue, it isn't worth retaining this change. So, I am reverting the changes using this PR. 

### How?

- I used GH to create this revert PR. It will be easier to track. 
- I am targeting `trunk` because of the following reasons.
    - [This issue](https://a8c.sentry.io/issues/4742089958/?project=1458804) has affected 16 users so far. 
    - I want this change to go through the beta testing cycle. 

## Testing instructions

Smoke test the app using WPCOM and wporg login and ensure that it works as before.


## Screenshots
NA

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.