### PR TITLE
Blaze: Add UI for budget setting screen

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Blaze/BudgetSetting/BlazeBudgetSettingView.swift
+++ b/WooCommerce/Classes/ViewRelated/Blaze/BudgetSetting/BlazeBudgetSettingView.swift
@@ -151,7 +151,7 @@ private extension BlazeBudgetSettingView {
 
     var durationSettingView: some View {
         ScrollView {
-            Text("Set duration")
+            Text(Localization.setDuration)
                 .headlineStyle()
                 .padding(.horizontal, Layout.contentPadding)
                 .padding(.vertical, Layout.sectionSpacing)
@@ -169,7 +169,7 @@ private extension BlazeBudgetSettingView {
 
             VStack {
                 HStack {
-                    Text("Starts")
+                    Text(Localization.starts)
                         .bodyStyle()
 
                     Spacer()
@@ -186,7 +186,7 @@ private extension BlazeBudgetSettingView {
 
             Spacer()
 
-            Button("Apply") {
+            Button(Localization.apply) {
                 showingDurationSetting = false
             }
             .buttonStyle(PrimaryButtonStyle())
@@ -255,6 +255,21 @@ private extension BlazeBudgetSettingView {
             "blazeBudgetSettingView.done",
             value: "Done",
             comment: "Button to dismiss the Blaze impression info screen"
+        )
+        static let setDuration = NSLocalizedString(
+            "blazeBudgetSettingView.setDuration",
+            value: "Set duration",
+            comment: "Title of the Blaze campaign duration setting screen"
+        )
+        static let starts = NSLocalizedString(
+            "blazeBudgetSettingView.starts",
+            value: "Starts",
+            comment: "Label of the start date picker on the Blaze campaign duration setting screen"
+        )
+        static let apply = NSLocalizedString(
+            "blazeBudgetSettingView.apply",
+            value: "Apply",
+            comment: "Button to apply the changes on the Blaze campaign duration setting screen"
         )
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Blaze/BudgetSetting/BlazeBudgetSettingView.swift
+++ b/WooCommerce/Classes/ViewRelated/Blaze/BudgetSetting/BlazeBudgetSettingView.swift
@@ -61,7 +61,7 @@ private extension BlazeBudgetSettingView {
             }
 
             VStack {
-                Text("$35")
+                Text(viewModel.totalAmountText)
                     .bold()
                     .largeTitleStyle()
 
@@ -69,15 +69,14 @@ private extension BlazeBudgetSettingView {
                     .foregroundColor(Color.secondary)
                     .bold()
                     .largeTitleStyle()
-
-                Text("Total spend $1055")
-                    .subheadlineStyle()
             }
 
             VStack {
-                Text("$5 daily")
+                Text(viewModel.dailyAmountText)
 
-                Slider(value: $viewModel.amount, in: 5...50, step: viewModel.dayCount)
+                Slider(value: $viewModel.dailyAmount,
+                       in: viewModel.dailyAmountSliderRange,
+                       step: BlazeBudgetSettingViewModel.Constants.dailyAmountSliderStep)
 
                 AdaptiveStack {
                     Text(Localization.estimatedImpressions)

--- a/WooCommerce/Classes/ViewRelated/Blaze/BudgetSetting/BlazeBudgetSettingView.swift
+++ b/WooCommerce/Classes/ViewRelated/Blaze/BudgetSetting/BlazeBudgetSettingView.swift
@@ -5,7 +5,12 @@ struct BlazeBudgetSettingView: View {
 
     @Binding var isPresented: Bool
 
-    @State private var amount: Double = 0
+    @ObservedObject private var viewModel: BlazeBudgetSettingViewModel
+
+    init(isPresented: Binding<Bool>, viewModel: BlazeBudgetSettingViewModel) {
+        self._isPresented = isPresented
+        self.viewModel = viewModel
+    }
 
     var body: some View {
         VStack(spacing: Layout.sectionSpacing) {
@@ -45,7 +50,7 @@ struct BlazeBudgetSettingView: View {
                 VStack {
                     Text("$5 daily")
 
-                    Slider(value: $amount) {
+                    Slider(value: $viewModel.amount) {
                         Text("")
                     } minimumValueLabel: {
                         Text("")
@@ -146,6 +151,7 @@ private extension BlazeBudgetSettingView {
 
 struct BlazeBudgetSettingView_Previews: PreviewProvider {
     static var previews: some View {
-        BlazeBudgetSettingView(isPresented: .constant(true))
+        BlazeBudgetSettingView(isPresented: .constant(true),
+                               viewModel: BlazeBudgetSettingViewModel())
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Blaze/BudgetSetting/BlazeBudgetSettingView.swift
+++ b/WooCommerce/Classes/ViewRelated/Blaze/BudgetSetting/BlazeBudgetSettingView.swift
@@ -156,7 +156,6 @@ private extension BlazeBudgetSettingView {
                 }
             }
         }
-        .padding(.top)
     }
 
     var durationSettingView: some View {

--- a/WooCommerce/Classes/ViewRelated/Blaze/BudgetSetting/BlazeBudgetSettingView.swift
+++ b/WooCommerce/Classes/ViewRelated/Blaze/BudgetSetting/BlazeBudgetSettingView.swift
@@ -129,17 +129,19 @@ private extension BlazeBudgetSettingView {
             ScrollView {
                 Text(Localization.impressionInfo)
                     .bodyStyle()
+                    .padding(Layout.contentPadding)
             }
             .navigationTitle(Localization.title)
             .navigationBarTitleDisplayMode(.inline)
             .toolbar {
-                ToolbarItem(placement: .topBarTrailing) {
+                ToolbarItem(placement: .confirmationAction) {
                     Button(Localization.done) {
                         showingImpressionInfo = false
                     }
                 }
             }
         }
+        .padding(.top)
     }
 }
 
@@ -193,9 +195,9 @@ private extension BlazeBudgetSettingView {
         )
         static let impressionInfo = NSLocalizedString(
             "blazeBudgetSettingView.impressionInfo",
-            value: "Impressions reflect the frequency with which your ad appears to potential customers.\n" +
+            value: "Impressions reflect the frequency with which your ad appears to potential customers.\n\n" +
             "While exact numbers can't be assured due to fluctuating online traffic and user behavior," +
-            " we aim to match your ad's actual impressions as closely as possible to your target count.\n" +
+            " we aim to match your ad's actual impressions as closely as possible to your target count.\n\n" +
             "Remember, impressions are about visibility, not action taken by viewers.",
             comment: "Explanation about Blaze campaign impression"
         )

--- a/WooCommerce/Classes/ViewRelated/Blaze/BudgetSetting/BlazeBudgetSettingView.swift
+++ b/WooCommerce/Classes/ViewRelated/Blaze/BudgetSetting/BlazeBudgetSettingView.swift
@@ -22,7 +22,7 @@ struct BlazeBudgetSettingView: View {
                 Spacer()
             }
 
-            mainContent
+            mainContentView
         }
         .padding(Layout.contentPadding)
         .safeAreaInset(edge: .bottom) {
@@ -39,7 +39,7 @@ struct BlazeBudgetSettingView: View {
 }
 
 private extension BlazeBudgetSettingView {
-    var mainContent: some View {
+    var mainContentView: some View {
         ScrollableVStack(spacing: Layout.sectionSpacing) {
             VStack(spacing: Layout.sectionContentSpacing) {
                 Text(Localization.title)

--- a/WooCommerce/Classes/ViewRelated/Blaze/BudgetSetting/BlazeBudgetSettingView.swift
+++ b/WooCommerce/Classes/ViewRelated/Blaze/BudgetSetting/BlazeBudgetSettingView.swift
@@ -3,7 +3,8 @@ import SwiftUI
 /// View to set budget for a new Blaze campaign
 struct BlazeBudgetSettingView: View {
 
-    @Environment(\.dismiss) var dismiss
+    @Environment(\.dismiss) private var dismiss
+    @State private var showingImpressionInfo = false
 
     @ObservedObject private var viewModel: BlazeBudgetSettingViewModel
 
@@ -21,83 +22,123 @@ struct BlazeBudgetSettingView: View {
                 Spacer()
             }
 
-            ScrollableVStack(spacing: Layout.sectionSpacing) {
-                VStack(spacing: Layout.sectionContentSpacing) {
-                    Text(Localization.title)
-                        .bold()
-                        .largeTitleStyle()
-
-                    Text(Localization.subtitle)
-                        .multilineTextAlignment(.center)
-                        .subheadlineStyle()
-                }
-
-                VStack {
-                    Text("$35")
-                        .bold()
-                        .largeTitleStyle()
-
-                    Text("for 7 days")
-                        .foregroundColor(Color.secondary)
-                        .bold()
-                        .largeTitleStyle()
-
-                    Text("Total spend $1055")
-                        .subheadlineStyle()
-                }
-
-                VStack {
-                    Text("$5 daily")
-
-                    Slider(value: $viewModel.amount) {
-                        Text("")
-                    } minimumValueLabel: {
-                        Text("")
-                    } maximumValueLabel: {
-                        Text("")
-                    }
-
-                    Text(Localization.estimatedImpressions)
-                        .font(.subheadline)
-                        .foregroundColor(.secondary)
-                    + Text(" ")
-                    + Text(Image(systemName: "info.circle"))
-                        .font(.subheadline)
-
-                    Text("2,588 - 3,458")
-                        .bold()
-                        .font(.subheadline)
-                }
-            }
+            mainContent
         }
         .padding(Layout.contentPadding)
         .safeAreaInset(edge: .bottom) {
-            VStack(alignment: .leading, spacing: Layout.sectionContentSpacing) {
-                Divider()
-
-                Text(Localization.duration)
-                    .secondaryBodyStyle()
-                    .padding(.horizontal, Layout.contentPadding)
-                    .padding(.top, Layout.sectionContentSpacing)
-
-                HStack {
-                    Text("Dec 13 - Dec 19, 2023")
-                        .bold()
-                        .bodyStyle()
-                    Text("·")
-                    Text(Localization.edit)
-                        .bodyStyle()
-                }
-                .padding(.horizontal, Layout.contentPadding)
-
-                Button(Localization.update) {
-                    // TODO: show duration sheet
-                }
-                .buttonStyle(PrimaryButtonStyle())
-                .padding([.horizontal, .bottom], Layout.contentPadding)
-                .padding(.top, Layout.sectionContentSpacing)
+            footerView
+        }
+        .sheet(isPresented: $showingImpressionInfo) {
+            if #available(iOS 16, *) {
+                impressionInfoView.presentationDetents([.medium, .large])
+            } else {
+                impressionInfoView
             }
-            .background(Color(.systemBackground))
+        }
+    }
+}
+
+private extension BlazeBudgetSettingView {
+    var mainContent: some View {
+        ScrollableVStack(spacing: Layout.sectionSpacing) {
+            VStack(spacing: Layout.sectionContentSpacing) {
+                Text(Localization.title)
+                    .bold()
+                    .largeTitleStyle()
+
+                Text(Localization.subtitle)
+                    .multilineTextAlignment(.center)
+                    .subheadlineStyle()
+            }
+
+            VStack {
+                Text("$35")
+                    .bold()
+                    .largeTitleStyle()
+
+                Text("for 7 days")
+                    .foregroundColor(Color.secondary)
+                    .bold()
+                    .largeTitleStyle()
+
+                Text("Total spend $1055")
+                    .subheadlineStyle()
+            }
+
+            VStack {
+                Text("$5 daily")
+
+                Slider(value: $viewModel.amount) {
+                    Text("")
+                } minimumValueLabel: {
+                    Text("")
+                } maximumValueLabel: {
+                    Text("")
+                }
+
+                AdaptiveStack {
+                    Text(Localization.estimatedImpressions)
+                        .font(.subheadline)
+                        .foregroundColor(.secondary)
+
+                    Image(systemName: "info.circle")
+                     .font(.subheadline)
+                }
+                .onTapGesture {
+                    showingImpressionInfo = true
+                }
+
+                Text("2,588 - 3,458")
+                    .bold()
+                    .font(.subheadline)
+            }
+        }
+    }
+
+    var footerView: some View {
+        VStack(alignment: .leading, spacing: Layout.sectionContentSpacing) {
+            Divider()
+
+            Text(Localization.duration)
+                .secondaryBodyStyle()
+                .padding(.horizontal, Layout.contentPadding)
+                .padding(.top, Layout.sectionContentSpacing)
+
+            HStack {
+                Text("Dec 13 - Dec 19, 2023")
+                    .bold()
+                    .bodyStyle()
+                Text("·")
+                Text(Localization.edit)
+                    .bodyStyle()
+            }
+            .padding(.horizontal, Layout.contentPadding)
+
+            Button(Localization.update) {
+                // TODO: show duration sheet
+            }
+            .buttonStyle(PrimaryButtonStyle())
+            .padding([.horizontal, .bottom], Layout.contentPadding)
+            .padding(.top, Layout.sectionContentSpacing)
+        }
+        .background(Color(.systemBackground))
+    }
+
+    var impressionInfoView: some View {
+        NavigationView {
+            ScrollView {
+                Text(Localization.impressionInfo)
+                    .bodyStyle()
+            }
+            .navigationTitle(Localization.title)
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .topBarTrailing) {
+                    Button(Localization.done) {
+                        showingImpressionInfo = false
+                    }
+                }
+            }
         }
     }
 }
@@ -144,6 +185,24 @@ private extension BlazeBudgetSettingView {
             "blazeBudgetSettingView.update",
             value: "Update",
             comment: "Button to update the budget on the Blaze budget setting screen"
+        )
+        static let impressions = NSLocalizedString(
+            "blazeBudgetSettingView.impressions",
+            value: "Impressions",
+            comment: "Title of the modal to explain Blaze campaign impressions"
+        )
+        static let impressionInfo = NSLocalizedString(
+            "blazeBudgetSettingView.impressionInfo",
+            value: "Impressions reflect the frequency with which your ad appears to potential customers.\n" +
+            "While exact numbers can't be assured due to fluctuating online traffic and user behavior," +
+            " we aim to match your ad's actual impressions as closely as possible to your target count.\n" +
+            "Remember, impressions are about visibility, not action taken by viewers.",
+            comment: "Explanation about Blaze campaign impression"
+        )
+        static let done = NSLocalizedString(
+            "blazeBudgetSettingView.done",
+            value: "Done",
+            comment: "Button to dismiss the Blaze impression info screen"
         )
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Blaze/BudgetSetting/BlazeBudgetSettingView.swift
+++ b/WooCommerce/Classes/ViewRelated/Blaze/BudgetSetting/BlazeBudgetSettingView.swift
@@ -182,13 +182,13 @@ private extension BlazeBudgetSettingView {
 
             // Start date picker
             VStack {
-                HStack {
+                AdaptiveStack(horizontalAlignment: .leading) {
                     Text(Localization.starts)
                         .bodyStyle()
 
                     Spacer()
 
-                    DatePicker(selection: $viewModel.startDate, displayedComponents: [.date]) {
+                    DatePicker(selection: $viewModel.startDate, in: Date()..., displayedComponents: [.date]) {
                         EmptyView()
                     }
                     .datePickerStyle(.compact)

--- a/WooCommerce/Classes/ViewRelated/Blaze/BudgetSetting/BlazeBudgetSettingView.swift
+++ b/WooCommerce/Classes/ViewRelated/Blaze/BudgetSetting/BlazeBudgetSettingView.swift
@@ -69,6 +69,9 @@ private extension BlazeBudgetSettingView {
                     .foregroundColor(Color.secondary)
                     .bold()
                     .largeTitleStyle()
+
+                Text(Localization.totalSpend)
+                    .subheadlineStyle()
             }
 
             VStack {
@@ -218,6 +221,11 @@ private extension BlazeBudgetSettingView {
             "blazeBudgetSettingView.subtitle",
             value: "How much would you like to spend on your product promotion campaign?",
             comment: "Subtitle of the Blaze budget setting screen"
+        )
+        static let totalSpend = NSLocalizedString(
+            "blazeBudgetSettingView.totalSpend",
+            value: "Total spend",
+            comment: "Label for total spend on the Blaze budget setting screen"
         )
         static let estimatedImpressions = NSLocalizedString(
             "blazeBudgetSettingView.estimatedImpressions",

--- a/WooCommerce/Classes/ViewRelated/Blaze/BudgetSetting/BlazeBudgetSettingView.swift
+++ b/WooCommerce/Classes/ViewRelated/Blaze/BudgetSetting/BlazeBudgetSettingView.swift
@@ -3,12 +3,11 @@ import SwiftUI
 /// View to set budget for a new Blaze campaign
 struct BlazeBudgetSettingView: View {
 
-    @Binding var isPresented: Bool
+    @Environment(\.dismiss) var dismiss
 
     @ObservedObject private var viewModel: BlazeBudgetSettingViewModel
 
-    init(isPresented: Binding<Bool>, viewModel: BlazeBudgetSettingViewModel) {
-        self._isPresented = isPresented
+    init(viewModel: BlazeBudgetSettingViewModel) {
         self.viewModel = viewModel
     }
 
@@ -17,7 +16,7 @@ struct BlazeBudgetSettingView: View {
             // Cancel button
             HStack {
                 Button(Localization.cancel) {
-                    isPresented.toggle()
+                    dismiss()
                 }
                 Spacer()
             }
@@ -151,7 +150,6 @@ private extension BlazeBudgetSettingView {
 
 struct BlazeBudgetSettingView_Previews: PreviewProvider {
     static var previews: some View {
-        BlazeBudgetSettingView(isPresented: .constant(true),
-                               viewModel: BlazeBudgetSettingViewModel())
+        BlazeBudgetSettingView(viewModel: BlazeBudgetSettingViewModel())
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Blaze/BudgetSetting/BlazeBudgetSettingView.swift
+++ b/WooCommerce/Classes/ViewRelated/Blaze/BudgetSetting/BlazeBudgetSettingView.swift
@@ -4,7 +4,7 @@ import SwiftUI
 struct BlazeBudgetSettingView: View {
 
     @Environment(\.dismiss) private var dismiss
-    @Environment(\.sizeCategory) var sizeCategory
+    @Environment(\.sizeCategory) private var sizeCategory
     @State private var showingImpressionInfo = false
     @State private var showingDurationSetting = false
 

--- a/WooCommerce/Classes/ViewRelated/Blaze/BudgetSetting/BlazeBudgetSettingView.swift
+++ b/WooCommerce/Classes/ViewRelated/Blaze/BudgetSetting/BlazeBudgetSettingView.swift
@@ -65,7 +65,7 @@ private extension BlazeBudgetSettingView {
                     .bold()
                     .largeTitleStyle()
 
-                Text("for 7 days")
+                Text(viewModel.formattedTotalDuration)
                     .foregroundColor(Color.secondary)
                     .bold()
                     .largeTitleStyle()
@@ -158,7 +158,7 @@ private extension BlazeBudgetSettingView {
             Spacer()
 
             VStack(spacing: Layout.sectionContentSpacing) {
-                Text("7 days")
+                Text(viewModel.formattedDayCount)
                     .fontWeight(.semibold)
                     .bodyStyle()
 

--- a/WooCommerce/Classes/ViewRelated/Blaze/BudgetSetting/BlazeBudgetSettingView.swift
+++ b/WooCommerce/Classes/ViewRelated/Blaze/BudgetSetting/BlazeBudgetSettingView.swift
@@ -162,7 +162,9 @@ private extension BlazeBudgetSettingView {
                     .fontWeight(.semibold)
                     .bodyStyle()
 
-                Slider(value: $viewModel.dayCount, in: 1...28, step: 1)
+                Slider(value: $viewModel.dayCount,
+                       in: viewModel.dayCountSliderRange,
+                       step: Double(BlazeBudgetSettingViewModel.Constants.dayCountSliderStep))
             }
             .padding(Layout.contentPadding)
 

--- a/WooCommerce/Classes/ViewRelated/Blaze/BudgetSetting/BlazeBudgetSettingView.swift
+++ b/WooCommerce/Classes/ViewRelated/Blaze/BudgetSetting/BlazeBudgetSettingView.swift
@@ -5,6 +5,7 @@ struct BlazeBudgetSettingView: View {
 
     @Environment(\.dismiss) private var dismiss
     @State private var showingImpressionInfo = false
+    @State private var showingDurationSetting = false
 
     @ObservedObject private var viewModel: BlazeBudgetSettingViewModel
 
@@ -35,6 +36,14 @@ struct BlazeBudgetSettingView: View {
                 impressionInfoView
             }
         }
+        .sheet(isPresented: $showingDurationSetting) {
+            if #available(iOS 16, *) {
+                durationSettingView.presentationDetents([.medium, .large])
+            } else {
+                durationSettingView
+            }
+        }
+
     }
 }
 
@@ -68,26 +77,18 @@ private extension BlazeBudgetSettingView {
             VStack {
                 Text("$5 daily")
 
-                Slider(value: $viewModel.amount) {
-                    Text("")
-                } minimumValueLabel: {
-                    Text("")
-                } maximumValueLabel: {
-                    Text("")
-                }
+                Slider(value: $viewModel.amount, in: 5...50, step: viewModel.dayCount)
 
                 AdaptiveStack {
                     Text(Localization.estimatedImpressions)
-                        .font(.subheadline)
-                        .foregroundColor(.secondary)
-
                     Image(systemName: "info.circle")
-                     .font(.subheadline)
                 }
+                .font(.subheadline)
                 .onTapGesture {
                     showingImpressionInfo = true
                 }
 
+                // TODO: fetch impressions and display
                 Text("2,588 - 3,458")
                     .bold()
                     .font(.subheadline)
@@ -110,9 +111,13 @@ private extension BlazeBudgetSettingView {
                     .bodyStyle()
                 Text("·")
                 Text(Localization.edit)
+                    .foregroundColor(.accentColor)
                     .bodyStyle()
             }
             .padding(.horizontal, Layout.contentPadding)
+            .onTapGesture {
+                showingDurationSetting = true
+            }
 
             Button(Localization.update) {
                 // TODO: show duration sheet
@@ -142,6 +147,51 @@ private extension BlazeBudgetSettingView {
             }
         }
         .padding(.top)
+    }
+
+    var durationSettingView: some View {
+        ScrollView {
+            Text("Set duration")
+                .headlineStyle()
+                .padding(.horizontal, Layout.contentPadding)
+                .padding(.vertical, Layout.sectionSpacing)
+
+            Spacer()
+
+            VStack(spacing: Layout.sectionContentSpacing) {
+                Text("7 days")
+                    .fontWeight(.semibold)
+                    .bodyStyle()
+
+                Slider(value: $viewModel.dayCount, in: 1...28, step: 1)
+            }
+            .padding(Layout.contentPadding)
+
+            VStack {
+                HStack {
+                    Text("Starts")
+                        .bodyStyle()
+
+                    Spacer()
+
+                    DatePicker(selection: $viewModel.startDate, displayedComponents: [.date]) {
+                        EmptyView()
+                    }
+                    .datePickerStyle(.compact)
+                }
+                .padding(Layout.contentPadding)
+
+                Divider()
+            }
+
+            Spacer()
+
+            Button("Apply") {
+                showingDurationSetting = false
+            }
+            .buttonStyle(PrimaryButtonStyle())
+            .padding(Layout.contentPadding)
+        }
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Blaze/BudgetSetting/BlazeBudgetSettingView.swift
+++ b/WooCommerce/Classes/ViewRelated/Blaze/BudgetSetting/BlazeBudgetSettingView.swift
@@ -19,11 +19,11 @@ struct BlazeBudgetSettingView: View {
 
             ScrollableVStack(spacing: Layout.sectionSpacing) {
                 VStack(spacing: Layout.sectionContentSpacing) {
-                    Text("Set your budget")
+                    Text(Localization.title)
                         .bold()
                         .largeTitleStyle()
 
-                    Text("How much would you like to spend on your product promotion campaign?")
+                    Text(Localization.subtitle)
                         .multilineTextAlignment(.center)
                         .subheadlineStyle()
                 }
@@ -53,7 +53,7 @@ struct BlazeBudgetSettingView: View {
                         Text("")
                     }
 
-                    Text("Estimated people reached per day")
+                    Text(Localization.estimatedImpressions)
                         .font(.subheadline)
                         .foregroundColor(.secondary)
                     + Text(" ")
@@ -71,7 +71,7 @@ struct BlazeBudgetSettingView: View {
             VStack(alignment: .leading, spacing: Layout.sectionContentSpacing) {
                 Divider()
 
-                Text("Duration")
+                Text(Localization.duration)
                     .secondaryBodyStyle()
                     .padding(.horizontal, Layout.contentPadding)
                     .padding(.top, Layout.sectionContentSpacing)
@@ -81,12 +81,12 @@ struct BlazeBudgetSettingView: View {
                         .bold()
                         .bodyStyle()
                     Text("·")
-                    Text("Edit")
+                    Text(Localization.edit)
                         .bodyStyle()
                 }
                 .padding(.horizontal, Layout.contentPadding)
 
-                Button("Update") {
+                Button(Localization.update) {
                     // TODO: show duration sheet
                 }
                 .buttonStyle(PrimaryButtonStyle())
@@ -110,6 +110,36 @@ private extension BlazeBudgetSettingView {
             "blazeBudgetSettingView.cancel",
             value: "Cancel",
             comment: "Button to dismiss the Blaze budget setting screen"
+        )
+        static let title = NSLocalizedString(
+            "blazeBudgetSettingView.title",
+            value: "Set your budget",
+            comment: "Title of the Blaze budget setting screen"
+        )
+        static let subtitle = NSLocalizedString(
+            "blazeBudgetSettingView.subtitle",
+            value: "How much would you like to spend on your product promotion campaign?",
+            comment: "Subtitle of the Blaze budget setting screen"
+        )
+        static let estimatedImpressions = NSLocalizedString(
+            "blazeBudgetSettingView.estimatedImpressions",
+            value: "Estimated people reached per day",
+            comment: "Label for the estimated impressions on the Blaze budget setting screen"
+        )
+        static let duration = NSLocalizedString(
+            "blazeBudgetSettingView.duration",
+            value: "Duration",
+            comment: "Label for the campaign duration on the Blaze budget setting screen"
+        )
+        static let edit = NSLocalizedString(
+            "blazeBudgetSettingView.edit",
+            value: "Edit",
+            comment: "Button to edit the campaign duration on the Blaze budget setting screen"
+        )
+        static let update = NSLocalizedString(
+            "blazeBudgetSettingView.update",
+            value: "Update",
+            comment: "Button to update the budget on the Blaze budget setting screen"
         )
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Blaze/BudgetSetting/BlazeBudgetSettingView.swift
+++ b/WooCommerce/Classes/ViewRelated/Blaze/BudgetSetting/BlazeBudgetSettingView.swift
@@ -50,6 +50,7 @@ struct BlazeBudgetSettingView: View {
 private extension BlazeBudgetSettingView {
     var mainContentView: some View {
         ScrollableVStack(spacing: Layout.sectionSpacing) {
+            // Title and subtitle
             VStack(spacing: Layout.sectionContentSpacing) {
                 Text(Localization.title)
                     .bold()
@@ -60,6 +61,7 @@ private extension BlazeBudgetSettingView {
                     .subheadlineStyle()
             }
 
+            // Total budget amount details
             VStack {
                 Text(viewModel.totalAmountText)
                     .bold()
@@ -74,6 +76,7 @@ private extension BlazeBudgetSettingView {
                     .subheadlineStyle()
             }
 
+            // Daily amount slider and estimated impression
             VStack {
                 Text(viewModel.dailyAmountText)
 
@@ -102,11 +105,13 @@ private extension BlazeBudgetSettingView {
         VStack(alignment: .leading, spacing: Layout.sectionContentSpacing) {
             Divider()
 
+            // Duration title
             Text(Localization.duration)
                 .secondaryBodyStyle()
                 .padding(.horizontal, Layout.contentPadding)
                 .padding(.top, Layout.sectionContentSpacing)
 
+            // Formatted duration
             HStack {
                 Text(viewModel.formattedDateRange)
                     .bold()
@@ -121,6 +126,7 @@ private extension BlazeBudgetSettingView {
                 showingDurationSetting = true
             }
 
+            // CTA to confirm all settings
             Button(Localization.update) {
                 viewModel.confirmSettings()
                 dismiss()
@@ -154,6 +160,7 @@ private extension BlazeBudgetSettingView {
 
     var durationSettingView: some View {
         ScrollView {
+            // Title
             Text(Localization.setDuration)
                 .headlineStyle()
                 .padding(.horizontal, Layout.contentPadding)
@@ -161,6 +168,7 @@ private extension BlazeBudgetSettingView {
 
             Spacer()
 
+            // Duration slider
             VStack(spacing: Layout.sectionContentSpacing) {
                 Text(viewModel.formattedDayCount)
                     .fontWeight(.semibold)
@@ -172,6 +180,7 @@ private extension BlazeBudgetSettingView {
             }
             .padding(Layout.contentPadding)
 
+            // Start date picker
             VStack {
                 HStack {
                     Text(Localization.starts)
@@ -191,6 +200,7 @@ private extension BlazeBudgetSettingView {
 
             Spacer()
 
+            // CTA
             Button(Localization.apply) {
                 showingDurationSetting = false
             }

--- a/WooCommerce/Classes/ViewRelated/Blaze/BudgetSetting/BlazeBudgetSettingView.swift
+++ b/WooCommerce/Classes/ViewRelated/Blaze/BudgetSetting/BlazeBudgetSettingView.swift
@@ -122,7 +122,8 @@ private extension BlazeBudgetSettingView {
             }
 
             Button(Localization.update) {
-                // TODO: show duration sheet
+                viewModel.confirmSettings()
+                dismiss()
             }
             .buttonStyle(PrimaryButtonStyle())
             .padding([.horizontal, .bottom], Layout.contentPadding)
@@ -285,6 +286,6 @@ private extension BlazeBudgetSettingView {
 
 struct BlazeBudgetSettingView_Previews: PreviewProvider {
     static var previews: some View {
-        BlazeBudgetSettingView(viewModel: BlazeBudgetSettingViewModel())
+        BlazeBudgetSettingView(viewModel: BlazeBudgetSettingViewModel(dailyBudget: 5, duration: 7, startDate: .now) { _, _, _ in })
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Blaze/BudgetSetting/BlazeBudgetSettingView.swift
+++ b/WooCommerce/Classes/ViewRelated/Blaze/BudgetSetting/BlazeBudgetSettingView.swift
@@ -160,53 +160,57 @@ private extension BlazeBudgetSettingView {
     }
 
     var durationSettingView: some View {
-        ScrollView {
-            // Title
-            Text(Localization.setDuration)
-                .headlineStyle()
-                .padding(.horizontal, Layout.contentPadding)
-                .padding(.vertical, Layout.sectionSpacing)
-
-            Spacer()
-
-            // Duration slider
-            VStack(spacing: Layout.sectionContentSpacing) {
-                Text(viewModel.formattedDayCount)
-                    .fontWeight(.semibold)
-                    .bodyStyle()
-
-                Slider(value: $viewModel.dayCount,
-                       in: viewModel.dayCountSliderRange,
-                       step: Double(BlazeBudgetSettingViewModel.Constants.dayCountSliderStep))
-            }
-            .padding(Layout.contentPadding)
-
-            // Start date picker
-            VStack {
-                AdaptiveStack(horizontalAlignment: .leading) {
-                    Text(Localization.starts)
+        NavigationView {
+            ScrollView {
+                // Duration slider
+                VStack(spacing: Layout.sectionContentSpacing) {
+                    Text(viewModel.formattedDayCount)
+                        .fontWeight(.semibold)
                         .bodyStyle()
 
-                    Spacer()
-
-                    DatePicker(selection: $viewModel.startDate, in: Date()..., displayedComponents: [.date]) {
-                        EmptyView()
-                    }
-                    .datePickerStyle(.compact)
+                    Slider(value: $viewModel.dayCount,
+                           in: viewModel.dayCountSliderRange,
+                           step: Double(BlazeBudgetSettingViewModel.Constants.dayCountSliderStep))
                 }
                 .padding(Layout.contentPadding)
+                .padding(.top, Layout.sectionSpacing)
 
-                Divider()
+                // Start date picker
+                VStack {
+                    AdaptiveStack(horizontalAlignment: .leading) {
+                        Text(Localization.starts)
+                            .bodyStyle()
+
+                        Spacer()
+
+                        DatePicker(selection: $viewModel.startDate, in: Date()..., displayedComponents: [.date]) {
+                            EmptyView()
+                        }
+                        .datePickerStyle(.compact)
+                    }
+                    .padding(Layout.contentPadding)
+
+                    Divider()
+                }
+
+                Spacer()
+
+                // CTA
+                Button(Localization.apply) {
+                    showingDurationSetting = false
+                }
+                .buttonStyle(PrimaryButtonStyle())
+                .padding(Layout.contentPadding)
             }
-
-            Spacer()
-
-            // CTA
-            Button(Localization.apply) {
-                showingDurationSetting = false
+            .navigationBarTitleDisplayMode(.inline)
+            .navigationTitle(Localization.setDuration)
+            .toolbar {
+                ToolbarItem(placement: .cancellationAction) {
+                    Button(Localization.cancel) {
+                        showingDurationSetting = false
+                    }
+                }
             }
-            .buttonStyle(PrimaryButtonStyle())
-            .padding(Layout.contentPadding)
         }
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Blaze/BudgetSetting/BlazeBudgetSettingView.swift
+++ b/WooCommerce/Classes/ViewRelated/Blaze/BudgetSetting/BlazeBudgetSettingView.swift
@@ -2,13 +2,120 @@ import SwiftUI
 
 /// View to set budget for a new Blaze campaign
 struct BlazeBudgetSettingView: View {
+
+    @Binding var isPresented: Bool
+
+    @State private var amount: Double = 0
+
     var body: some View {
-        Text(/*@START_MENU_TOKEN@*/"Hello, World!"/*@END_MENU_TOKEN@*/)
+        VStack(spacing: Layout.sectionSpacing) {
+            // Cancel button
+            HStack {
+                Button(Localization.cancel) {
+                    isPresented.toggle()
+                }
+                Spacer()
+            }
+
+            ScrollableVStack(spacing: Layout.sectionSpacing) {
+                VStack(spacing: Layout.sectionContentSpacing) {
+                    Text("Set your budget")
+                        .bold()
+                        .largeTitleStyle()
+
+                    Text("How much would you like to spend on your product promotion campaign?")
+                        .multilineTextAlignment(.center)
+                        .subheadlineStyle()
+                }
+
+                VStack {
+                    Text("$35")
+                        .bold()
+                        .largeTitleStyle()
+
+                    Text("for 7 days")
+                        .foregroundColor(Color.secondary)
+                        .bold()
+                        .largeTitleStyle()
+
+                    Text("Total spend $1055")
+                        .subheadlineStyle()
+                }
+
+                VStack {
+                    Text("$5 daily")
+
+                    Slider(value: $amount) {
+                        Text("")
+                    } minimumValueLabel: {
+                        Text("")
+                    } maximumValueLabel: {
+                        Text("")
+                    }
+
+                    Text("Estimated people reached per day")
+                        .font(.subheadline)
+                        .foregroundColor(.secondary)
+                    + Text(" ")
+                    + Text(Image(systemName: "info.circle"))
+                        .font(.subheadline)
+
+                    Text("2,588 - 3,458")
+                        .bold()
+                        .font(.subheadline)
+                }
+            }
+        }
+        .padding(Layout.contentPadding)
+        .safeAreaInset(edge: .bottom) {
+            VStack(alignment: .leading, spacing: Layout.sectionContentSpacing) {
+                Divider()
+
+                Text("Duration")
+                    .secondaryBodyStyle()
+                    .padding(.horizontal, Layout.contentPadding)
+                    .padding(.top, Layout.sectionContentSpacing)
+
+                HStack {
+                    Text("Dec 13 - Dec 19, 2023")
+                        .bold()
+                        .bodyStyle()
+                    Text("·")
+                    Text("Edit")
+                        .bodyStyle()
+                }
+                .padding(.horizontal, Layout.contentPadding)
+
+                Button("Update") {
+                    // TODO: show duration sheet
+                }
+                .buttonStyle(PrimaryButtonStyle())
+                .padding([.horizontal, .bottom], Layout.contentPadding)
+                .padding(.top, Layout.sectionContentSpacing)
+            }
+            .background(Color(.systemBackground))
+        }
+    }
+}
+
+private extension BlazeBudgetSettingView {
+    enum Layout {
+        static let contentPadding: CGFloat = 16
+        static let sectionContentSpacing: CGFloat = 8
+        static let sectionSpacing: CGFloat = 32
+    }
+
+    enum Localization {
+        static let cancel = NSLocalizedString(
+            "blazeBudgetSettingView.cancel",
+            value: "Cancel",
+            comment: "Button to dismiss the Blaze budget setting screen"
+        )
     }
 }
 
 struct BlazeBudgetSettingView_Previews: PreviewProvider {
     static var previews: some View {
-        BlazeBudgetSettingView()
+        BlazeBudgetSettingView(isPresented: .constant(true))
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Blaze/BudgetSetting/BlazeBudgetSettingView.swift
+++ b/WooCommerce/Classes/ViewRelated/Blaze/BudgetSetting/BlazeBudgetSettingView.swift
@@ -4,6 +4,7 @@ import SwiftUI
 struct BlazeBudgetSettingView: View {
 
     @Environment(\.dismiss) private var dismiss
+    @Environment(\.sizeCategory) var sizeCategory
     @State private var showingImpressionInfo = false
     @State private var showingDurationSetting = false
 
@@ -31,14 +32,14 @@ struct BlazeBudgetSettingView: View {
         }
         .sheet(isPresented: $showingImpressionInfo) {
             if #available(iOS 16, *) {
-                impressionInfoView.presentationDetents([.medium, .large])
+                impressionInfoView.presentationDetents(sizeCategory.isAccessibilityCategory ? [.medium, .large] : [.medium])
             } else {
                 impressionInfoView
             }
         }
         .sheet(isPresented: $showingDurationSetting) {
             if #available(iOS 16, *) {
-                durationSettingView.presentationDetents([.medium, .large])
+                durationSettingView.presentationDetents(sizeCategory.isAccessibilityCategory ? [.medium, .large] : [.medium])
             } else {
                 durationSettingView
             }

--- a/WooCommerce/Classes/ViewRelated/Blaze/BudgetSetting/BlazeBudgetSettingView.swift
+++ b/WooCommerce/Classes/ViewRelated/Blaze/BudgetSetting/BlazeBudgetSettingView.swift
@@ -108,7 +108,7 @@ private extension BlazeBudgetSettingView {
                 .padding(.top, Layout.sectionContentSpacing)
 
             HStack {
-                Text("Dec 13 - Dec 19, 2023")
+                Text(viewModel.formattedDateRange)
                     .bold()
                     .bodyStyle()
                 Text("·")

--- a/WooCommerce/Classes/ViewRelated/Blaze/BudgetSetting/BlazeBudgetSettingView.swift
+++ b/WooCommerce/Classes/ViewRelated/Blaze/BudgetSetting/BlazeBudgetSettingView.swift
@@ -1,0 +1,14 @@
+import SwiftUI
+
+/// View to set budget for a new Blaze campaign
+struct BlazeBudgetSettingView: View {
+    var body: some View {
+        Text(/*@START_MENU_TOKEN@*/"Hello, World!"/*@END_MENU_TOKEN@*/)
+    }
+}
+
+struct BlazeBudgetSettingView_Previews: PreviewProvider {
+    static var previews: some View {
+        BlazeBudgetSettingView()
+    }
+}

--- a/WooCommerce/Classes/ViewRelated/Blaze/BudgetSetting/BlazeBudgetSettingViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Blaze/BudgetSetting/BlazeBudgetSettingViewModel.swift
@@ -1,0 +1,6 @@
+import Foundation
+
+/// View model for `BlazeBudgetSettingView`
+final class BlazeBudgetSettingViewModel: ObservableObject {
+    @Published var amount: Double = 0
+}

--- a/WooCommerce/Classes/ViewRelated/Blaze/BudgetSetting/BlazeBudgetSettingViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Blaze/BudgetSetting/BlazeBudgetSettingViewModel.swift
@@ -2,5 +2,7 @@ import Foundation
 
 /// View model for `BlazeBudgetSettingView`
 final class BlazeBudgetSettingViewModel: ObservableObject {
-    @Published var amount: Double = 0
+    @Published var amount: Double = 5
+    @Published var dayCount: Double = 1
+    @Published var startDate = Date.now
 }

--- a/WooCommerce/Classes/ViewRelated/Blaze/BudgetSetting/BlazeBudgetSettingViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Blaze/BudgetSetting/BlazeBudgetSettingViewModel.swift
@@ -20,15 +20,27 @@ final class BlazeBudgetSettingViewModel: ObservableObject {
         let totalAmount = dailyAmount * dayCount
         return String(format: "$%.0f", totalAmount)
     }
+
+    var formattedTotalDuration: String {
+        String.pluralize(Int(dayCount),
+                         singular: Localization.totalDurationSingleDay,
+                         plural: Localization.totalDurationMultipleDays)
+    }
+
+    var formattedDayCount: String {
+        String.pluralize(Int(dayCount),
+                         singular: Localization.singleDay,
+                         plural: Localization.multipleDays)
+    }
 }
 
 extension BlazeBudgetSettingViewModel {
     enum Constants {
         static let minimumDailyAmount: Double = 5
         static let maximumDailyAmount: Double = 50
-        static let minimumDayCount: Int = 1
-        static let maximumDayCount: Int = 28
         static let dailyAmountSliderStep: Double = 1
+        static let minimumDayCount = 1
+        static let maximumDayCount = 28
     }
 
     private enum Localization {
@@ -37,6 +49,29 @@ extension BlazeBudgetSettingViewModel {
             value: "%1$@ daily",
             comment: "The formatted amount to be spent on a Blaze campaign daily. " +
             "Reads like: $15 daily"
+        )
+        static let singleDay = NSLocalizedString(
+            "blazeBudgetSettingViewModel.singleDay",
+            value: "%1$d day",
+            comment: "The duration for a Blaze campaign in singular form."
+        )
+        static let multipleDays = NSLocalizedString(
+            "blazeBudgetSettingViewModel.multipleDays",
+            value: "%1$d days",
+            comment: "The duration for a Blaze campaign in plural form. " +
+            "Reads like: 10 days"
+        )
+        static let totalDurationSingleDay = NSLocalizedString(
+            "blazeBudgetSettingViewModel.totalDurationSingleDay",
+            value: "for %1$d day",
+            comment: "The total duration for a Blaze campaign in singular form. " +
+            "Reads like: for 1 day"
+        )
+        static let totalDurationMultipleDays = NSLocalizedString(
+            "blazeBudgetSettingViewModel.totalDurationMultipleDays",
+            value: "for %1$d days",
+            comment: "The total duration for a Blaze campaign in plural form. " +
+            "Reads like: for 10 days"
         )
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Blaze/BudgetSetting/BlazeBudgetSettingViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Blaze/BudgetSetting/BlazeBudgetSettingViewModel.swift
@@ -2,7 +2,41 @@ import Foundation
 
 /// View model for `BlazeBudgetSettingView`
 final class BlazeBudgetSettingViewModel: ObservableObject {
-    @Published var amount: Double = 5
-    @Published var dayCount: Double = 1
+    @Published var dailyAmount = Constants.minimumDailyAmount
+
+    /// Using Double because Slider doesn't work with Int
+    @Published var dayCount = Double(Constants.maximumDayCount)
+
     @Published var startDate = Date.now
+
+    let dailyAmountSliderRange = Constants.minimumDailyAmount...Constants.maximumDailyAmount
+
+    var dailyAmountText: String {
+        let formattedAmount = String(format: "$%.0f", dailyAmount)
+        return String.localizedStringWithFormat(Localization.dailyAmount, formattedAmount)
+    }
+
+    var totalAmountText: String {
+        let totalAmount = dailyAmount * dayCount
+        return String(format: "$%.0f", totalAmount)
+    }
+}
+
+extension BlazeBudgetSettingViewModel {
+    enum Constants {
+        static let minimumDailyAmount: Double = 5
+        static let maximumDailyAmount: Double = 50
+        static let minimumDayCount: Int = 1
+        static let maximumDayCount: Int = 28
+        static let dailyAmountSliderStep: Double = 1
+    }
+
+    private enum Localization {
+        static let dailyAmount = NSLocalizedString(
+            "blazeBudgetSettingViewModel.dailyAmount",
+            value: "%1$@ daily",
+            comment: "The formatted amount to be spent on a Blaze campaign daily. " +
+            "Reads like: $15 daily"
+        )
+    }
 }

--- a/WooCommerce/Classes/ViewRelated/Blaze/BudgetSetting/BlazeBudgetSettingViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Blaze/BudgetSetting/BlazeBudgetSettingViewModel.swift
@@ -24,7 +24,7 @@ final class BlazeBudgetSettingViewModel: ObservableObject {
 
     var totalAmountText: String {
         let totalAmount = dailyAmount * dayCount
-        return String(format: "$%.0f", totalAmount)
+        return String(format: "$%.0f USD", totalAmount)
     }
 
     var formattedTotalDuration: String {

--- a/WooCommerce/Classes/ViewRelated/Blaze/BudgetSetting/BlazeBudgetSettingViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Blaze/BudgetSetting/BlazeBudgetSettingViewModel.swift
@@ -2,12 +2,15 @@ import Foundation
 
 /// View model for `BlazeBudgetSettingView`
 final class BlazeBudgetSettingViewModel: ObservableObject {
-    @Published var dailyAmount = Constants.minimumDailyAmount
+    @Published var dailyAmount: Double
 
     /// Using Double because Slider doesn't work with Int
-    @Published var dayCount = Double(Constants.defaultDayCount)
+    @Published var dayCount: Double
 
-    @Published var startDate = Date.now
+    @Published var startDate: Date
+
+    typealias BlazeBudgetSettingCompletionHandler = (_ dailyBudget: Double, _ duration: Int, _ startDate: Date) -> Void
+    private let completionHandler: BlazeBudgetSettingCompletionHandler
 
     let dailyAmountSliderRange = Constants.minimumDailyAmount...Constants.maximumDailyAmount
 
@@ -48,6 +51,18 @@ final class BlazeBudgetSettingViewModel: ObservableObject {
 
         // Use the configured formatter to generate the string.
         return dateFormatter.string(from: startDate, to: endDate)
+    }
+
+    init(dailyBudget: Double, duration: Int, startDate: Date, onCompletion: @escaping BlazeBudgetSettingCompletionHandler) {
+        self.dailyAmount = dailyBudget
+        self.dayCount = Double(duration)
+        self.startDate = startDate
+        self.completionHandler = onCompletion
+    }
+
+    func confirmSettings() {
+        // TODO: track confirmation
+        completionHandler(dailyAmount, Int(dayCount), startDate)
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Blaze/BudgetSetting/BlazeBudgetSettingViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Blaze/BudgetSetting/BlazeBudgetSettingViewModel.swift
@@ -5,7 +5,7 @@ final class BlazeBudgetSettingViewModel: ObservableObject {
     @Published var dailyAmount = Constants.minimumDailyAmount
 
     /// Using Double because Slider doesn't work with Int
-    @Published var dayCount = Double(Constants.maximumDayCount)
+    @Published var dayCount = Double(Constants.defaultDayCount)
 
     @Published var startDate = Date.now
 
@@ -13,7 +13,7 @@ final class BlazeBudgetSettingViewModel: ObservableObject {
 
     /// Using Double because Slider doesn't work with Int
     let dayCountSliderRange = Double(Constants.minimumDayCount)...Double(Constants.maximumDayCount)
-    
+
     var dailyAmountText: String {
         let formattedAmount = String(format: "$%.0f", dailyAmount)
         return String.localizedStringWithFormat(Localization.dailyAmount, formattedAmount)
@@ -35,15 +35,31 @@ final class BlazeBudgetSettingViewModel: ObservableObject {
                          singular: Localization.singleDay,
                          plural: Localization.multipleDays)
     }
+
+    private let dateFormatter: DateIntervalFormatter = {
+        let formatter = DateIntervalFormatter()
+        formatter.dateStyle = .medium
+        formatter.timeStyle = .none
+        return formatter
+    }()
+
+    var formattedDateRange: String {
+        let endDate = Date(timeInterval: Constants.oneDayInSeconds * dayCount, since: startDate)
+
+        // Use the configured formatter to generate the string.
+        return dateFormatter.string(from: startDate, to: endDate)
+    }
 }
 
 extension BlazeBudgetSettingViewModel {
     enum Constants {
+        static let oneDayInSeconds: Double = 86400
         static let minimumDailyAmount: Double = 5
         static let maximumDailyAmount: Double = 50
         static let dailyAmountSliderStep: Double = 1
         static let minimumDayCount = 1
         static let maximumDayCount = 28
+        static let defaultDayCount = 7
         static let dayCountSliderStep = 1
     }
 

--- a/WooCommerce/Classes/ViewRelated/Blaze/BudgetSetting/BlazeBudgetSettingViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Blaze/BudgetSetting/BlazeBudgetSettingViewModel.swift
@@ -11,6 +11,9 @@ final class BlazeBudgetSettingViewModel: ObservableObject {
 
     let dailyAmountSliderRange = Constants.minimumDailyAmount...Constants.maximumDailyAmount
 
+    /// Using Double because Slider doesn't work with Int
+    let dayCountSliderRange = Double(Constants.minimumDayCount)...Double(Constants.maximumDayCount)
+    
     var dailyAmountText: String {
         let formattedAmount = String(format: "$%.0f", dailyAmount)
         return String.localizedStringWithFormat(Localization.dailyAmount, formattedAmount)
@@ -41,6 +44,7 @@ extension BlazeBudgetSettingViewModel {
         static let dailyAmountSliderStep: Double = 1
         static let minimumDayCount = 1
         static let maximumDayCount = 28
+        static let dayCountSliderStep = 1
     }
 
     private enum Localization {

--- a/WooCommerce/Classes/ViewRelated/Blaze/CampaignCreation/BlazeCampaignCreationForm.swift
+++ b/WooCommerce/Classes/ViewRelated/Blaze/CampaignCreation/BlazeCampaignCreationForm.swift
@@ -32,7 +32,7 @@ struct BlazeCampaignCreationForm: View {
                     .foregroundColor(.init(uiColor: .text))
 
                 // Budget
-                detailView(title: Localization.budget, content: "$35, 7 days from Dec 13") {
+                detailView(title: Localization.budget, content: viewModel.budgetDetailText) {
                     isShowingBudgetSetting = true
                 }
                 .overlay { roundedRectangleBorder }

--- a/WooCommerce/Classes/ViewRelated/Blaze/CampaignCreation/BlazeCampaignCreationForm.swift
+++ b/WooCommerce/Classes/ViewRelated/Blaze/CampaignCreation/BlazeCampaignCreationForm.swift
@@ -16,6 +16,8 @@ final class BlazeCampaignCreationFormHostingController: UIHostingController<Blaz
 struct BlazeCampaignCreationForm: View {
     @ObservedObject private var viewModel: BlazeCampaignCreationFormViewModel
 
+    @State private var isShowingBudgetSetting = false
+
     init(viewModel: BlazeCampaignCreationFormViewModel) {
         self.viewModel = viewModel
     }
@@ -31,7 +33,7 @@ struct BlazeCampaignCreationForm: View {
 
                 // Budget
                 detailView(title: Localization.budget, content: "$35, 7 days from Dec 13") {
-                    // TODO: open budget screen
+                    isShowingBudgetSetting = true
                 }
                 .overlay { roundedRectangleBorder }
 
@@ -84,6 +86,9 @@ struct BlazeCampaignCreationForm: View {
                 .padding(Layout.contentPadding)
             }
             .background(Color(uiColor: .systemBackground))
+        }
+        .sheet(isPresented: $isShowingBudgetSetting) {
+            BlazeBudgetSettingView(viewModel: viewModel.budgetSettingViewModel)
         }
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Blaze/CampaignCreation/BlazeCampaignCreationFormViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Blaze/CampaignCreation/BlazeCampaignCreationFormViewModel.swift
@@ -3,9 +3,12 @@ import Yosemite
 
 /// View model for `BlazeCampaignCreationForm`
 final class BlazeCampaignCreationFormViewModel: ObservableObject {
+    
     private let siteID: Int64
     private let stores: StoresManager
     private let completionHandler: () -> Void
+
+    let budgetSettingViewModel = BlazeBudgetSettingViewModel()
 
     init(siteID: Int64,
          stores: StoresManager = ServiceLocator.stores,

--- a/WooCommerce/Classes/ViewRelated/Blaze/CampaignCreation/BlazeCampaignCreationFormViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Blaze/CampaignCreation/BlazeCampaignCreationFormViewModel.swift
@@ -4,7 +4,7 @@ import Yosemite
 /// View model for `BlazeCampaignCreationForm`
 final class BlazeCampaignCreationFormViewModel: ObservableObject {
 
-    private let siteID: Int64
+    let siteID: Int64
     private let stores: StoresManager
     private let completionHandler: () -> Void
     private let dateFormatter: DateFormatter = {
@@ -42,6 +42,10 @@ final class BlazeCampaignCreationFormViewModel: ObservableObject {
 
         updateBudgetDetails()
     }
+
+    func didTapEditAd() {
+        onEditAd?()
+    }
 }
 
 private extension BlazeCampaignCreationFormViewModel {
@@ -70,9 +74,5 @@ private extension BlazeCampaignCreationFormViewModel {
             comment: "Blaze campaign budget details with duration in plural form. " +
             "Reads like: $35, 15 days from Dec 31"
         )
-    }
-
-    func didTapEditAd() {
-        onEditAd?()
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Blaze/CampaignCreation/BlazeCampaignCreationFormViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Blaze/CampaignCreation/BlazeCampaignCreationFormViewModel.swift
@@ -7,6 +7,12 @@ final class BlazeCampaignCreationFormViewModel: ObservableObject {
     private let siteID: Int64
     private let stores: StoresManager
     private let completionHandler: () -> Void
+    private let dateFormatter: DateFormatter = {
+        let dateFormatter = DateFormatter()
+        dateFormatter.timeStyle = .none
+        dateFormatter.dateStyle = .medium
+        return dateFormatter
+    }()
 
     // Budget details
     private var startDate = Date.now
@@ -18,9 +24,12 @@ final class BlazeCampaignCreationFormViewModel: ObservableObject {
             guard let self else { return }
             self.startDate = startDate
             self.duration = duration
-            self.startDate = startDate
+            self.dailyBudget = dailyBudget
+            self.updateBudgetDetails()
         }
     }
+
+    @Published private(set) var budgetDetailText: String = ""
 
     init(siteID: Int64,
          stores: StoresManager = ServiceLocator.stores,
@@ -28,5 +37,36 @@ final class BlazeCampaignCreationFormViewModel: ObservableObject {
         self.siteID = siteID
         self.stores = stores
         self.completionHandler = onCompletion
+
+        updateBudgetDetails()
+    }
+}
+
+private extension BlazeCampaignCreationFormViewModel {
+    func updateBudgetDetails() {
+        let amount = String(format: "$%.0f", dailyBudget * Double(duration))
+        let date = dateFormatter.string(for: startDate) ?? ""
+        budgetDetailText = String.pluralize(
+            duration,
+            singular: String(format: Localization.budgetSingleDay, amount, duration, date),
+            plural: String(format: Localization.budgetMultipleDays, amount, duration, date)
+        )
+    }
+}
+
+private extension BlazeCampaignCreationFormViewModel {
+    enum Localization {
+        static let budgetSingleDay = NSLocalizedString(
+            "blazeCampaignCreationFormViewModel.budgetSingleDay",
+            value: "%1$@, %2$d day from %3$@",
+            comment: "Blaze campaign budget details with duration in singular form. " +
+            "Reads like: $35, 1 day from Dec 31"
+        )
+        static let budgetMultipleDays = NSLocalizedString(
+            "blazeCampaignCreationFormViewModel.budgetMultipleDays",
+            value: "%1$@, %2$d days from %3$@",
+            comment: "Blaze campaign budget details with duration in plural form. " +
+            "Reads like: $35, 15 days from Dec 31"
+        )
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Blaze/CampaignCreation/BlazeCampaignCreationFormViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Blaze/CampaignCreation/BlazeCampaignCreationFormViewModel.swift
@@ -8,7 +8,19 @@ final class BlazeCampaignCreationFormViewModel: ObservableObject {
     private let stores: StoresManager
     private let completionHandler: () -> Void
 
-    let budgetSettingViewModel = BlazeBudgetSettingViewModel()
+    // Budget details
+    private var startDate = Date.now
+    private var dailyBudget = BlazeBudgetSettingViewModel.Constants.minimumDailyAmount
+    private var duration = BlazeBudgetSettingViewModel.Constants.defaultDayCount
+
+    var budgetSettingViewModel: BlazeBudgetSettingViewModel {
+        BlazeBudgetSettingViewModel(dailyBudget: dailyBudget, duration: duration, startDate: startDate) { [weak self] dailyBudget, duration, startDate in
+            guard let self else { return }
+            self.startDate = startDate
+            self.duration = duration
+            self.startDate = startDate
+        }
+    }
 
     init(siteID: Int64,
          stores: StoresManager = ServiceLocator.stores,

--- a/WooCommerce/Classes/ViewRelated/Blaze/CampaignCreation/BlazeCampaignCreationFormViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Blaze/CampaignCreation/BlazeCampaignCreationFormViewModel.swift
@@ -44,7 +44,7 @@ final class BlazeCampaignCreationFormViewModel: ObservableObject {
 
 private extension BlazeCampaignCreationFormViewModel {
     func updateBudgetDetails() {
-        let amount = String(format: "$%.0f", dailyBudget * Double(duration))
+        let amount = String(format: "$%.0f USD", dailyBudget * Double(duration))
         let date = dateFormatter.string(for: startDate) ?? ""
         budgetDetailText = String.pluralize(
             duration,

--- a/WooCommerce/Classes/ViewRelated/Blaze/CampaignCreation/BlazeCampaignCreationFormViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Blaze/CampaignCreation/BlazeCampaignCreationFormViewModel.swift
@@ -3,7 +3,7 @@ import Yosemite
 
 /// View model for `BlazeCampaignCreationForm`
 final class BlazeCampaignCreationFormViewModel: ObservableObject {
-    
+
     private let siteID: Int64
     private let stores: StoresManager
     private let completionHandler: () -> Void

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -2229,6 +2229,7 @@
 		DE57462F2B43EB0B0034B10D /* BlazeCampaignCreationForm.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE57462E2B43EB0B0034B10D /* BlazeCampaignCreationForm.swift */; };
 		DE5746312B43F6180034B10D /* BlazeCampaignCreationFormViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE5746302B43F6180034B10D /* BlazeCampaignCreationFormViewModel.swift */; };
 		DE5746342B4512900034B10D /* BlazeBudgetSettingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE5746332B4512900034B10D /* BlazeBudgetSettingView.swift */; };
+		DE5746362B4522ED0034B10D /* BlazeBudgetSettingViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE5746352B4522ED0034B10D /* BlazeBudgetSettingViewModel.swift */; };
 		DE5C19C52AC3F0700064600A /* AddProductNameWithAIViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE5C19C42AC3F0700064600A /* AddProductNameWithAIViewModelTests.swift */; };
 		DE5C19C72AC3F1D30064600A /* AddProductFeaturesViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE5C19C62AC3F1D30064600A /* AddProductFeaturesViewModelTests.swift */; };
 		DE5C19C92AC42E7E0064600A /* WooAnalyticsEvent+ProductNameAI.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE5C19C82AC42E7E0064600A /* WooAnalyticsEvent+ProductNameAI.swift */; };
@@ -4865,6 +4866,7 @@
 		DE57462E2B43EB0B0034B10D /* BlazeCampaignCreationForm.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BlazeCampaignCreationForm.swift; sourceTree = "<group>"; };
 		DE5746302B43F6180034B10D /* BlazeCampaignCreationFormViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BlazeCampaignCreationFormViewModel.swift; sourceTree = "<group>"; };
 		DE5746332B4512900034B10D /* BlazeBudgetSettingView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BlazeBudgetSettingView.swift; sourceTree = "<group>"; };
+		DE5746352B4522ED0034B10D /* BlazeBudgetSettingViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BlazeBudgetSettingViewModel.swift; sourceTree = "<group>"; };
 		DE5C19C42AC3F0700064600A /* AddProductNameWithAIViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddProductNameWithAIViewModelTests.swift; sourceTree = "<group>"; };
 		DE5C19C62AC3F1D30064600A /* AddProductFeaturesViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddProductFeaturesViewModelTests.swift; sourceTree = "<group>"; };
 		DE5C19C82AC42E7E0064600A /* WooAnalyticsEvent+ProductNameAI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "WooAnalyticsEvent+ProductNameAI.swift"; sourceTree = "<group>"; };
@@ -11064,6 +11066,7 @@
 			isa = PBXGroup;
 			children = (
 				DE5746332B4512900034B10D /* BlazeBudgetSettingView.swift */,
+				DE5746352B4522ED0034B10D /* BlazeBudgetSettingViewModel.swift */,
 			);
 			path = BudgetSetting;
 			sourceTree = "<group>";
@@ -13718,6 +13721,7 @@
 				DEF36DE82898D3CF00178AC2 /* JetpackSetupWebViewModel.swift in Sources */,
 				0270F47624D005B00005210A /* ProductFormViewModelProtocol.swift in Sources */,
 				268EC46126D3F67800716F5C /* EditCustomerNoteViewModel.swift in Sources */,
+				DE5746362B4522ED0034B10D /* BlazeBudgetSettingViewModel.swift in Sources */,
 				B555530D21B57DC300449E71 /* UserNotificationsCenterAdapter.swift in Sources */,
 				45C8B2662316AB460002FA77 /* BillingAddressTableViewCell.swift in Sources */,
 				E11228BC2707161E004E9F2D /* CardPresentModalUpdateFailed.swift in Sources */,

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -2228,6 +2228,7 @@
 		DE525499268C8B32007A5829 /* UIRefreshControl+Woo.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE525498268C8B32007A5829 /* UIRefreshControl+Woo.swift */; };
 		DE57462F2B43EB0B0034B10D /* BlazeCampaignCreationForm.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE57462E2B43EB0B0034B10D /* BlazeCampaignCreationForm.swift */; };
 		DE5746312B43F6180034B10D /* BlazeCampaignCreationFormViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE5746302B43F6180034B10D /* BlazeCampaignCreationFormViewModel.swift */; };
+		DE5746342B4512900034B10D /* BlazeBudgetSettingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE5746332B4512900034B10D /* BlazeBudgetSettingView.swift */; };
 		DE5C19C52AC3F0700064600A /* AddProductNameWithAIViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE5C19C42AC3F0700064600A /* AddProductNameWithAIViewModelTests.swift */; };
 		DE5C19C72AC3F1D30064600A /* AddProductFeaturesViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE5C19C62AC3F1D30064600A /* AddProductFeaturesViewModelTests.swift */; };
 		DE5C19C92AC42E7E0064600A /* WooAnalyticsEvent+ProductNameAI.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE5C19C82AC42E7E0064600A /* WooAnalyticsEvent+ProductNameAI.swift */; };
@@ -4863,6 +4864,7 @@
 		DE525498268C8B32007A5829 /* UIRefreshControl+Woo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIRefreshControl+Woo.swift"; sourceTree = "<group>"; };
 		DE57462E2B43EB0B0034B10D /* BlazeCampaignCreationForm.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BlazeCampaignCreationForm.swift; sourceTree = "<group>"; };
 		DE5746302B43F6180034B10D /* BlazeCampaignCreationFormViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BlazeCampaignCreationFormViewModel.swift; sourceTree = "<group>"; };
+		DE5746332B4512900034B10D /* BlazeBudgetSettingView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BlazeBudgetSettingView.swift; sourceTree = "<group>"; };
 		DE5C19C42AC3F0700064600A /* AddProductNameWithAIViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddProductNameWithAIViewModelTests.swift; sourceTree = "<group>"; };
 		DE5C19C62AC3F1D30064600A /* AddProductFeaturesViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddProductFeaturesViewModelTests.swift; sourceTree = "<group>"; };
 		DE5C19C82AC42E7E0064600A /* WooAnalyticsEvent+ProductNameAI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "WooAnalyticsEvent+ProductNameAI.swift"; sourceTree = "<group>"; };
@@ -11058,6 +11060,14 @@
 			path = CampaignCreation;
 			sourceTree = "<group>";
 		};
+		DE5746322B4512750034B10D /* BudgetSetting */ = {
+			isa = PBXGroup;
+			children = (
+				DE5746332B4512900034B10D /* BlazeBudgetSettingView.swift */,
+			);
+			path = BudgetSetting;
+			sourceTree = "<group>";
+		};
 		DE63115D2AF1E16500587641 /* WPComLogin */ = {
 			isa = PBXGroup;
 			children = (
@@ -11208,6 +11218,7 @@
 		DED91DF72AD78A0C00CDCC53 /* Blaze */ = {
 			isa = PBXGroup;
 			children = (
+				DE5746322B4512750034B10D /* BudgetSetting */,
 				DE57462D2B43EAF20034B10D /* CampaignCreation */,
 				EE505DDB2B3C249E006E3323 /* BlazeIntro */,
 				DED91DF82AD78A1A00CDCC53 /* BlazeCampaignList */,
@@ -13230,6 +13241,7 @@
 				02695770237281A9001BA0BF /* AztecTextViewAttachmentHandler.swift in Sources */,
 				CCCFFC5A2934EF5E006130AF /* StatsIntervalDataParser.swift in Sources */,
 				AEA3F90F27BE8EB400B9F555 /* ShippingLineDetailsViewModel.swift in Sources */,
+				DE5746342B4512900034B10D /* BlazeBudgetSettingView.swift in Sources */,
 				02B038CC2A61843E00467F06 /* AddProductFromImageTextFieldViewModel.swift in Sources */,
 				26771A14256FFA8700EE030E /* IssueRefundCoordinatingController.swift in Sources */,
 				027A2E162513356100DA6ACB /* AppleIDCredentialChecker.swift in Sources */,


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of #11599 
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This PR adds a new screen for setting up the budget for a Blaze campaign. This includes only the UI logic and budget calculation for the screen. Fetching and displaying estimated impressions will be added in a separate PR. Unit tests will also be added later.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
- Log in to a store with at least one existing product and is eligible for Blaze.
- Navigate to the Products tab and select any public product.
- On the product form, select Promote with Blaze.
- Notice that the campaign creation form is presented.
- Select the budget field, notice that a new screen for budget setting is displayed.
- Tap the estimated impression text, a new sheet should be displayed for more information on impressions.
- Tap the Edit button on the date range to change the duration and start date. The formatted duration should be updated correctly.
- Update the budget with the budget slider, the formatted amount should be updated correctly.
- Tap Update button, the details should be updated correctly on the budget field of the campaign creation form.

📝 There's still an ongoing discussion regarding formatting the budget amount on Figma - I'll update the format later after we reach a conclusion.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

https://github.com/woocommerce/woocommerce-ios/assets/5533851/48a4a3ae-4bcf-40e5-8850-6d4bf4db9de8



---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
