### PR TITLE
[Performance] Remove multiple API requests to sync Blaze campaigns

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Dashboard/DashboardViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/DashboardViewController.swift
@@ -922,9 +922,6 @@ private extension DashboardViewController {
             }
             self.updateUI(site: site)
             self.trackDeviceTimezoneDifferenceWithStore(siteGMTOffset: site.gmtOffset)
-            Task { @MainActor [weak self] in
-                await self?.viewModel.reloadBlazeCampaignView()
-            }
         }.store(in: &subscriptions)
     }
 

--- a/WooCommerce/Classes/ViewRelated/Dashboard/DashboardViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/DashboardViewController.swift
@@ -913,11 +913,11 @@ private extension DashboardViewController {
 //
 private extension DashboardViewController {
     func observeSiteForUIUpdates() {
-        ServiceLocator.stores.site.sink { [weak self] site in
-            guard let self = self else { return }
+        ServiceLocator.stores.site.removeDuplicates().sink { [weak self] site in
+            guard let self else { return }
             // We always want to update UI based on the latest site only if it matches the view controller's site ID.
             // When switching stores, this is triggered on the view controller of the previous site ID.
-            guard let site = site, site.siteID == self.siteID else {
+            guard let site, site.siteID == self.siteID else {
                 return
             }
             self.updateUI(site: site)


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of #11592
<!-- Id number of the GitHub issue this PR addresses. -->

## Why

A recent audit of the API requests made when the app launches (pe5pgL-4e2-p2) found that three requests are made to sync Blaze campaigns on the dashboard. To help improve performance, we want to reduce unnecessary API requests on app launch. This PR removes the extra requests to load the Blaze campaign UI on the dashboard.

@selanthiraiyan FYI since you're more familiar with the Blaze campaign code; please let me know if you see any issues with these changes!

## How

The Blaze campaign section in the dashboard is reloaded every time the dashboard view loads, in `DashboardViewController.observeBlazeCampaignViewVisibility()`. This makes an API request to sync the store's Blaze campaigns.

The Blaze campaign section was also reloaded in `DashboardViewController.observeSiteForUIUpdates()`, which caused two additional API requests. This PR removes those additional requests:

1. `observeSiteForUIUpdates()` now uses `removeDuplicates()` to avoid repeat actions when the selected site hasn't changed.
2. `observeSiteForUIUpdates()` no longer calls `viewModel.reloadBlazeCampaignView()`. I couldn't identify any scenarios where this was needed for the Blaze campaign to be reloaded (e.g. after logging in or switching sites).

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

Optional hand testing:

1. Build and run the app.
2. Log out and log in again, confirming that the Blaze campaign section loads in the dashboard.
3. Force close the app and relaunch it, confirming that the Blaze campaign section loads in the dashboard.
4. Switch sites and confirm the Blaze campaign section reloads.

You can also check Menu > Settings > Launch Wormholy Debug to confirm there is only a single request to the Blaze campaigns endpoint (`GET https://public-api.wordpress.com/wpcom/v2/sites/{SITE_ID}/wordads/dsp/api/v1/search/campaigns/site/{SITE_ID}`) when the dashboard loads (including on app launch).

@rachelmcr will test that the expected Blaze campaign section loads with the following scenarios:

- [x] A store with no products (no Blaze section appears)
- [x] A store with products but no campaigns (Blaze section appears with a product)
- [x] A store with Blaze campaigns (Blaze section appears with campaign list)
- [x] Logging in to the app
- [x] Switching sites
- [x] Pull to refresh


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.