### PR TITLE
Remove `AnyView` property from `TopTabItem` while keeping it generic

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Deposits Overview/WooPaymentsDepositsOverviewView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Deposits Overview/WooPaymentsDepositsOverviewView.swift
@@ -10,9 +10,10 @@ struct WooPaymentsDepositsOverviewView: View {
     var tabs: [TopTabItem<WooPaymentsDepositsCurrencyOverviewView>] {
         viewModel.currencyViewModels.map { currencyViewModel in
             TopTabItem(name: currencyViewModel.tabTitle,
-                       view: WooPaymentsDepositsCurrencyOverviewView(viewModel: currencyViewModel,
-                                                                     isExpanded: $isExpanded),
-                       onSelected: {
+                       content: {
+                WooPaymentsDepositsCurrencyOverviewView(viewModel: currencyViewModel,
+                                                        isExpanded: $isExpanded)
+            }, onSelected: {
                 viewModel.currencySelected(currencyViewModel: currencyViewModel)
             })
         }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Deposits Overview/WooPaymentsDepositsOverviewView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Deposits Overview/WooPaymentsDepositsOverviewView.swift
@@ -7,11 +7,11 @@ struct WooPaymentsDepositsOverviewView: View {
 
     @State var isExpanded: Bool = false
 
-    var tabs: [TopTabItem] {
+    var tabs: [TopTabItem<WooPaymentsDepositsCurrencyOverviewView>] {
         viewModel.currencyViewModels.map { currencyViewModel in
             TopTabItem(name: currencyViewModel.tabTitle,
-                       view: AnyView(WooPaymentsDepositsCurrencyOverviewView(viewModel: currencyViewModel,
-                                                                             isExpanded: $isExpanded)),
+                       view: WooPaymentsDepositsCurrencyOverviewView(viewModel: currencyViewModel,
+                                                                     isExpanded: $isExpanded),
                        onSelected: {
                 viewModel.currencySelected(currencyViewModel: currencyViewModel)
             })

--- a/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/TopTabView.swift
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/TopTabView.swift
@@ -1,21 +1,20 @@
 import SwiftUI
 
-struct TopTabItem<ViewType: View> {
+struct TopTabItem<Content: View> {
     let name: String
-    let view: ViewType
+    let content: () -> Content
     let onSelected: (() -> Void)?
 
     init(name: String,
-         view: ViewType,
+         @ViewBuilder content: @escaping () -> Content,
          onSelected: (() -> Void)? = nil) {
         self.name = name
-        self.view = view
+        self.content = content
         self.onSelected = onSelected
     }
 }
 
-@available(iOS 16.0, *)
-struct TopTabView<ViewType: View>: View {
+struct TopTabView<Content: View>: View {
     @State private var selectedTab = 0
     @State private var underlineOffset: CGFloat = 0
     @State private var tabWidths: [CGFloat]
@@ -24,9 +23,9 @@ struct TopTabView<ViewType: View>: View {
 
     @Binding var showTabs: Bool
 
-    let tabs: [TopTabItem<ViewType>]
+    let tabs: [TopTabItem<Content>]
 
-    init(tabs: [TopTabItem<ViewType>],
+    init(tabs: [TopTabItem<Content>],
          showTabs: Binding<Bool> = .constant(true)) {
         self.tabs = tabs
         self._showTabs = showTabs
@@ -96,7 +95,7 @@ struct TopTabView<ViewType: View>: View {
                 HStack(spacing: 0) {
                     ForEach(0..<tabs.count, id: \.self) { index in
                         // Tab content as passed to the TopTabView at init
-                        tabs[index].view
+                        tabs[index].content()
                             .frame(width: geometry.size.width)
                     }
                 }
@@ -214,33 +213,44 @@ struct TopTabView<ViewType: View>: View {
     }
 }
 
-@available(iOS 16.0, *)
 struct ContentView_Previews: PreviewProvider {
     static var previews: some View {
         let tabs: [TopTabItem] = [
-            TopTabItem(name: "A tab name", view: AnyView(Text("Content for Tab 1")
-                .font(.largeTitle)
-                .padding())),
-            TopTabItem(name: "Tab2", view: AnyView(Text("Content for Tab 2")
-                .font(.largeTitle)
-                .padding())),
-            TopTabItem(name: "More detail", view: AnyView(Text("Content for Tab 3")
-                .font(.largeTitle)
-                .padding())),
-            TopTabItem(name: "A really long tab name", view: AnyView(Text("Content for Tab 4")
-                .font(.largeTitle)
-                .padding())),
-            TopTabItem(name: "Tab", view: AnyView(Text("Content for Tab 5")
-                .font(.largeTitle)
-                .padding())),
+            TopTabItem(name: "A tab name", content: {
+                Text("Content for Tab 1")
+                    .font(.largeTitle)
+                    .padding()
+            }),
+            TopTabItem(name: "A tab name", content: {
+                Text("Content for Tab 2")
+                    .font(.largeTitle)
+                    .padding()
+            }),
+            TopTabItem(name: "More detail", content: {
+                Text("Content for Tab 3")
+                    .font(.largeTitle)
+                    .padding()
+            }),
+            TopTabItem(name: "A really long tab name", content: {
+                Text("Content for Tab 4")
+                    .font(.largeTitle)
+                    .padding()
+            }),
+            TopTabItem(name: "Tab", content: {
+                Text("Content for Tab 5")
+                    .font(.largeTitle)
+                    .padding()
+            })
         ]
         TopTabView(tabs: tabs)
             .previewLayout(.sizeThatFits)
 
         let oneTab: [TopTabItem] = [
-            TopTabItem(name: "A tab name", view: AnyView(Text("Content for Tab 1")
-                .font(.largeTitle)
-                .padding()))
+            TopTabItem(name: "A tab name", content: {
+                Text("Content for Tab 1")
+                    .font(.largeTitle)
+                    .padding()
+            })
         ]
         TopTabView(tabs: oneTab)
             .previewLayout(.sizeThatFits)

--- a/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/TopTabView.swift
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/TopTabView.swift
@@ -1,12 +1,12 @@
 import SwiftUI
 
-struct TopTabItem {
+struct TopTabItem<ViewType: View> {
     let name: String
-    let view: AnyView
+    let view: ViewType
     let onSelected: (() -> Void)?
 
     init(name: String,
-         view: AnyView,
+         view: ViewType,
          onSelected: (() -> Void)? = nil) {
         self.name = name
         self.view = view
@@ -14,7 +14,8 @@ struct TopTabItem {
     }
 }
 
-struct TopTabView: View {
+@available(iOS 16.0, *)
+struct TopTabView<ViewType: View>: View {
     @State private var selectedTab = 0
     @State private var underlineOffset: CGFloat = 0
     @State private var tabWidths: [CGFloat]
@@ -23,9 +24,9 @@ struct TopTabView: View {
 
     @Binding var showTabs: Bool
 
-    let tabs: [TopTabItem]
+    let tabs: [TopTabItem<ViewType>]
 
-    init(tabs: [TopTabItem],
+    init(tabs: [TopTabItem<ViewType>],
          showTabs: Binding<Bool> = .constant(true)) {
         self.tabs = tabs
         self._showTabs = showTabs
@@ -204,15 +205,16 @@ struct TopTabView: View {
     }
 
     private enum Layout {
-        static let tabPadding: CGFloat = 10
-        static let selectedTabIndicatorHeight: CGFloat = 2
+        static var tabPadding: CGFloat { 10 }
+        static var selectedTabIndicatorHeight: CGFloat { 2 }
     }
 
     private enum Colors {
-        static let selected: Color = .withColorStudio(name: .wooCommercePurple, shade: .shade50)
+        static var selected: Color { .withColorStudio(name: .wooCommercePurple, shade: .shade50) }
     }
 }
 
+@available(iOS 16.0, *)
 struct ContentView_Previews: PreviewProvider {
     static var previews: some View {
         let tabs: [TopTabItem] = [


### PR DESCRIPTION
Closes: #11602

## Description

This PR changes the `TopTabItem` struct to accept a generic that conforms to the `View` protocol, rather than having an `AnyView` property inside the object. This way we can avoid using `AnyView` for performance reasons, and to avoid type-erasure of the underlying view ( context: paNNhX-dg-p2 ).

## Changes
- This is currently used to wrap `WooPaymentsDepositsCurrencyOverviewView` only, so we adapt it to the new implementation. 
- We're also forced to declare `@available(iOS 16.0, *)` when we pass it, since the `WooPaymentsDepositsCurrencyOverviewView` is marked as such.

## Testing instructions
- On a site with multi-currency active ( you can use https://jhmulticurrency.mystagingwebsite.com )
- Navigate to Menu > Payments > Tap the disclosure indicator to expand the Summary Deposits view
- Confirm that the view shows up and tapping between different currencies switches the view as expected

## Screenshots
![Simulator Screen Recording - iPhone 15 - 2024-01-04 at 16 15 24](https://github.com/woocommerce/woocommerce-ios/assets/3812076/3cf09b66-6c74-4800-a8da-5d00973f8e97)