### PR TITLE
[Blaze] Edit Ad Screen UI

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Blaze/BlazeEditAd/BlazeEditAdHostingController.swift
+++ b/WooCommerce/Classes/ViewRelated/Blaze/BlazeEditAd/BlazeEditAdHostingController.swift
@@ -1,0 +1,127 @@
+import Photos
+import SwiftUI
+import Yosemite
+
+/// Blaze ad data for the "Edit Ad Screen" form
+struct BlazeEditAdData: Equatable {
+    let image: MediaPickerImage
+    let tagline: String
+    let description: String
+}
+
+/// Hosting controller for `BlazeEditAdView`.
+final class BlazeEditAdHostingController: UIHostingController<BlazeEditAdView> {
+    private var mediaPickingCoordinator: MediaPickingCoordinator?
+    private let productImageLoader: ProductUIImageLoader
+    private let siteID: Int64
+
+    init(viewModel: BlazeEditAdViewModel,
+         productImageLoader: ProductUIImageLoader = DefaultProductUIImageLoader(phAssetImageLoaderProvider: { PHImageManager.default() })) {
+        self.productImageLoader = productImageLoader
+        self.siteID = viewModel.siteID
+        super.init(rootView: BlazeEditAdView(viewModel: viewModel))
+        viewModel.onAddImage = { [weak self] source in
+            await self?.showImagePicker(source: source)
+        }
+    }
+
+    required dynamic init?(coder aDecoder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+}
+
+private extension BlazeEditAdHostingController {
+    @MainActor
+    func showImagePicker(source: MediaPickingSource) async -> MediaPickerImage? {
+        await withCheckedContinuation { continuation in
+            let mediaPickingCoordinator = MediaPickingCoordinator(siteID: siteID,
+                                                                  allowsMultipleImages: false,
+                                                                  flow: .blazeEditAdForm,
+                                                                  onCameraCaptureCompletion: { [weak self] asset, error in
+                guard let self else {
+                    return continuation.resume(returning: nil)
+                }
+                Task { @MainActor in
+                    let image = await self.onCameraCaptureCompletion(asset: asset, error: error)
+                    continuation.resume(returning: image)
+                }
+            }, onDeviceMediaLibraryPickerCompletion: { [weak self] assets in
+                guard let self else {
+                    return continuation.resume(returning: nil)
+                }
+                Task { @MainActor in
+                    let image = await self.onDeviceMediaLibraryPickerCompletion(assets: assets)
+                    continuation.resume(returning: image)
+                }
+            }, onWPMediaPickerCompletion: { [weak self] mediaItems in
+                guard let self else {
+                    return continuation.resume(returning: nil)
+                }
+                Task { @MainActor in
+                    let image = await self.onWPMediaPickerCompletion(mediaItems: mediaItems)
+                    continuation.resume(returning: image)
+                }
+            })
+            self.mediaPickingCoordinator = mediaPickingCoordinator
+            mediaPickingCoordinator.showMediaPicker(source: source, from: self)
+        }
+    }
+}
+
+// MARK: - Action handling for camera capture
+//
+private extension BlazeEditAdHostingController {
+    @MainActor
+    func onCameraCaptureCompletion(asset: PHAsset?, error: Error?) async -> MediaPickerImage? {
+        guard let asset else {
+            return nil
+        }
+        return await requestImage(from: asset)
+    }
+}
+
+// MARK: Action handling for device media library picker
+//
+private extension BlazeEditAdHostingController {
+    @MainActor
+    func onDeviceMediaLibraryPickerCompletion(assets: [PHAsset]) async -> MediaPickerImage? {
+        guard let asset = assets.first else {
+            return nil
+        }
+        return await requestImage(from: asset)
+    }
+}
+
+// MARK: - Action handling for WordPress Media Library
+//
+private extension BlazeEditAdHostingController {
+    @MainActor
+    func onWPMediaPickerCompletion(mediaItems: [Media]) async -> MediaPickerImage? {
+        guard let media = mediaItems.first else {
+            return nil
+        }
+        return await withCheckedContinuation { continuation in
+            let productImage = media.toProductImage
+            _ = productImageLoader.requestImage(productImage: productImage) { image in
+                continuation.resume(returning: .init(image: image, source: .media(media: media)))
+            }
+        }
+    }
+}
+
+private extension BlazeEditAdHostingController {
+    @MainActor
+    func requestImage(from asset: PHAsset) async -> MediaPickerImage? {
+        await withCheckedContinuation { continuation in
+            // PHImageManager.requestImageForAsset can be called more than once.
+            var hasReceivedImage = false
+            productImageLoader.requestImage(asset: asset, targetSize: PHImageManagerMaximumSize, skipsDegradedImage: true) { image in
+                guard hasReceivedImage == false else {
+                    return
+                }
+                continuation.resume(returning: .init(image: image, source: .asset(asset: asset)))
+                hasReceivedImage = true
+            }
+        }
+    }
+}

--- a/WooCommerce/Classes/ViewRelated/Blaze/BlazeEditAd/BlazeEditAdView.swift
+++ b/WooCommerce/Classes/ViewRelated/Blaze/BlazeEditAd/BlazeEditAdView.swift
@@ -38,7 +38,7 @@ struct BlazeEditAdView: View {
 
                         regenerateByAI
                     }
-                    .padding(insets: Layout.insets)
+                    .padding(insets: Layout.textBlockInsets)
                 }
             }
             .toolbar {
@@ -250,7 +250,7 @@ private extension BlazeEditAdView {
 
 private enum Layout {
     static let imageBlockInsets: EdgeInsets = .init(top: 24, leading: 16, bottom: 0, trailing: 16)
-    static let insets: EdgeInsets = .init(top: 24, leading: 16, bottom: 16, trailing: 16)
+    static let textBlockInsets: EdgeInsets = .init(top: 0, leading: 16, bottom: 16, trailing: 16)
 
     static let parentVerticalSpacing: CGFloat = 24
     static let childVerticalSpacing: CGFloat = 16

--- a/WooCommerce/Classes/ViewRelated/Blaze/BlazeEditAd/BlazeEditAdView.swift
+++ b/WooCommerce/Classes/ViewRelated/Blaze/BlazeEditAd/BlazeEditAdView.swift
@@ -263,7 +263,7 @@ private enum Layout {
 
     enum Image {
         static let imageViewSize: CGFloat = 148
-        static let cornerRadius: CGFloat = 7.4
+        static let cornerRadius: CGFloat = 8
     }
 
     enum Tagline {

--- a/WooCommerce/Classes/ViewRelated/Blaze/BlazeEditAd/BlazeEditAdView.swift
+++ b/WooCommerce/Classes/ViewRelated/Blaze/BlazeEditAd/BlazeEditAdView.swift
@@ -1,0 +1,289 @@
+import SwiftUI
+
+/// View to edit Blaze Ad
+///
+struct BlazeEditAdView: View {
+    private enum Field: Hashable {
+        case tagline
+        case description
+    }
+
+    @Environment(\.dismiss) private var dismiss
+    @ObservedObject private var viewModel: BlazeEditAdViewModel
+    @State private var isShowingMediaPickerSheet: Bool = false
+    @FocusState private var focusedField: Field?
+
+    /// Scale of the view based on accessibility changes
+    @ScaledMetric private var scale: CGFloat = 1.0
+
+    init(viewModel: BlazeEditAdViewModel) {
+        self.viewModel = viewModel
+    }
+
+    var body: some View {
+        NavigationView {
+            ScrollView {
+                VStack(spacing: Layout.parentVerticalSpacing) {
+                    imageBlock
+                        .padding(insets: Layout.imageBlockInsets)
+
+                    Divider()
+                        .frame(height: Layout.strokeWidth)
+                        .foregroundColor(Color(uiColor: .separator))
+
+                    VStack(alignment: .leading, spacing: Layout.childVerticalSpacing) {
+                        tagline
+
+                        description
+
+                        regenerateByAI
+                    }
+                    .padding(insets: Layout.insets)
+                }
+            }
+            .toolbar {
+                ToolbarItem(placement: .cancellationAction) {
+                    Button(Localization.cancel) {
+                        viewModel.didTapCancel()
+                        dismiss()
+                    }
+                    .buttonStyle(TextButtonStyle())
+                }
+
+                ToolbarItem(placement: .confirmationAction) {
+                    Button(Localization.save) {
+                        viewModel.didTapSave()
+                        dismiss()
+                    }
+                    .buttonStyle(TextButtonStyle())
+                    .disabled(!viewModel.isSaveButtonEnabled)
+                }
+            }
+            .navigationTitle(Localization.title)
+            .wooNavigationBarStyle()
+            .navigationBarTitleDisplayMode(.inline)
+        }
+    }
+}
+
+private extension BlazeEditAdView {
+    var imageBlock: some View {
+        VStack(alignment: .center, spacing: Layout.childVerticalSpacing) {
+            EditableImageView(imageState: viewModel.imageState,
+                              aspectRatio: .fill,
+                              emptyContent: {
+                Image(uiImage: .addImage)
+            })
+            .frame(width: Layout.Image.imageViewSize * scale, height: Layout.Image.imageViewSize * scale)
+            .cornerRadius(Layout.Image.cornerRadius)
+            .mediaSourceActionSheet(showsActionSheet: $isShowingMediaPickerSheet, selectMedia: { source in
+                viewModel.addImage(from: source)
+            })
+
+            Button(Localization.Image.changeImage) {
+                isShowingMediaPickerSheet = true
+            }
+            .buttonStyle(TextButtonStyle())
+        }
+    }
+
+    var tagline: some View {
+        VStack(alignment: .leading, spacing: Layout.textBlockVerticalSpacing) {
+            Text(Localization.Tagline.title)
+                .foregroundColor(Color(.label))
+                .subheadlineStyle()
+
+            ZStack(alignment: .topLeading) {
+                TextEditor(text: $viewModel.tagline)
+                    .onChange(of: viewModel.tagline) { newValue in
+                        viewModel.tagline = viewModel.formatTagline(newValue)
+                    }
+                    .bodyStyle()
+                    .foregroundColor(.secondary)
+                    .padding(insets: Layout.textFieldContentInsets)
+                    .frame(minHeight: Layout.Tagline.minimumEditorHeight * scale, maxHeight: .infinity)
+                    .focused($focusedField, equals: .tagline)
+
+                // Placeholder text
+                Text(Localization.Tagline.placeholder)
+                    .foregroundColor(Color(.placeholderText))
+                    .bodyStyle()
+                    .padding(insets: Layout.placeholderInsets)
+                    // Allows gestures to pass through to the `TextEditor`.
+                    .allowsHitTesting(false)
+                    .renderedIf(viewModel.tagline.isEmpty)
+            }
+            .redacted(reason: viewModel.generatingByAI ? .placeholder : [])
+            .shimmering(active: viewModel.generatingByAI)
+            .overlay(
+                RoundedRectangle(cornerRadius: Layout.cornerRadius)
+                    .stroke(focusedField == .tagline ? Color(.brand) : Color(.separator), lineWidth: Layout.strokeWidth)
+            )
+
+            Text(viewModel.taglineFooterText)
+                .footnoteStyle()
+        }
+    }
+
+    var description: some View {
+        VStack(alignment: .leading, spacing: Layout.textBlockVerticalSpacing) {
+            Text(Localization.Description.title)
+                .foregroundColor(Color(.label))
+                .subheadlineStyle()
+
+            ZStack(alignment: .topLeading) {
+                TextEditor(text: $viewModel.description)
+                    .onChange(of: viewModel.description) { newValue in
+                        viewModel.description = viewModel.formatDescription(newValue)
+                    }
+                    .bodyStyle()
+                    .foregroundColor(.secondary)
+                    .padding(insets: Layout.textFieldContentInsets)
+                    .frame(minHeight: Layout.Description.minimumEditorHeight * scale, maxHeight: .infinity)
+                    .focused($focusedField, equals: .description)
+
+                // Placeholder text
+                Text(Localization.Description.placeholder)
+                    .foregroundColor(Color(.placeholderText))
+                    .bodyStyle()
+                    .padding(insets: Layout.placeholderInsets)
+                    // Allows gestures to pass through to the `TextEditor`.
+                    .allowsHitTesting(false)
+                    .renderedIf(viewModel.description.isEmpty)
+            }
+            .redacted(reason: viewModel.generatingByAI ? .placeholder : [])
+            .shimmering(active: viewModel.generatingByAI)
+            .overlay(
+                RoundedRectangle(cornerRadius: Layout.cornerRadius)
+                    .stroke(focusedField == .description ? Color(.brand) : Color(.separator), lineWidth: Layout.strokeWidth)
+            )
+
+            Text(viewModel.descriptionFooterText)
+                .footnoteStyle()
+        }
+    }
+
+    var regenerateByAI: some View {
+        HStack {
+            Button {
+                viewModel.didTapRegenerateByAI()
+            } label: {
+                HStack {
+                    Image(uiImage: .sparklesImage)
+                        .renderingMode(.template)
+                        .resizable()
+                        .foregroundColor(viewModel.generatingByAI ? Color(.tertiaryLabel) : Color(.brand))
+                        .frame(width: Layout.sparkleIconSize * scale, height: Layout.sparkleIconSize * scale)
+
+                    Text(Localization.regenerateByAI)
+                        .fontWeight(.semibold)
+                        .foregroundColor(viewModel.generatingByAI ? Color(.tertiaryLabel) : Color(.brand))
+                        .bodyStyle()
+                }
+            }
+            .disabled(viewModel.generatingByAI)
+
+            Spacer()
+
+            ProgressView()
+                .tint(Color(.tertiaryLabel))
+                .renderedIf(viewModel.generatingByAI)
+        }
+    }
+}
+
+private extension BlazeEditAdView {
+    enum Localization {
+        static let title = NSLocalizedString(
+            "blazeEditAdView.title",
+            value: "Edit Ad",
+            comment: "Title for the Blaze Edit Ad screen."
+        )
+        static let cancel = NSLocalizedString(
+            "blazeEditAdView.cancel",
+            value: "Cancel",
+            comment: "Cancel button in the Blaze Edit Ad screen."
+        )
+        static let save = NSLocalizedString(
+            "blazeEditAdView.save",
+            value: "Save",
+            comment: "Save button in the Blaze Edit Ad screen."
+        )
+        enum Image {
+            static let changeImage = NSLocalizedString(
+                "blazeEditAdView.image.changeImage",
+                value: "Change image",
+                comment: "Change image button title in the Blaze Edit Ad screen."
+            )
+        }
+        enum Tagline {
+            static let title = NSLocalizedString(
+                "blazeEditAdView.tagline.title",
+                value: "Tagline",
+                comment: "Tagline title text in the Blaze Edit Ad screen."
+            )
+            static let placeholder = NSLocalizedString(
+                "blazeEditAdView.tagline.placeholder",
+                value: "Title for the Blaze Ad",
+                comment: "Placeholder for Tagline text field in the Blaze Edit Ad screen."
+            )
+        }
+        enum Description {
+            static let title = NSLocalizedString(
+                "blazeEditAdView.description.title",
+                value: "Description",
+                comment: "Description title text in the Blaze Edit Ad screen."
+            )
+            static let placeholder = NSLocalizedString(
+                "blazeEditAdView.description.placeholder",
+                value: "Description text for the Blaze Ad",
+                comment: "Placeholder for Description text field in the Blaze Edit Ad screen."
+            )
+        }
+        static let regenerateByAI = NSLocalizedString(
+            "blazeEditAdView.regenerateByAI",
+            value: "Regenerate by AI",
+            comment: "Regenerate by AI button title in the Blaze Edit Ad screen."
+        )
+    }
+}
+
+private enum Layout {
+    static let imageBlockInsets: EdgeInsets = .init(top: 24, leading: 16, bottom: 0, trailing: 16)
+    static let insets: EdgeInsets = .init(top: 24, leading: 16, bottom: 16, trailing: 16)
+
+    static let parentVerticalSpacing: CGFloat = 24
+    static let childVerticalSpacing: CGFloat = 16
+    static let textBlockVerticalSpacing: CGFloat = 8
+
+    static let cornerRadius: CGFloat = 8
+    static let strokeWidth: CGFloat = 1
+    static let textFieldContentInsets: EdgeInsets = .init(top: 10, leading: 10, bottom: 10, trailing: 10)
+    static let placeholderInsets: EdgeInsets = .init(top: 18, leading: 16, bottom: 18, trailing: 16)
+
+    enum Image {
+        static let imageViewSize: CGFloat = 148
+        static let cornerRadius: CGFloat = 7.4
+    }
+
+    enum Tagline {
+        static let minimumEditorHeight: CGFloat = 54
+    }
+
+    enum Description {
+        static let minimumEditorHeight: CGFloat = 140
+    }
+
+    static let sparkleIconSize: CGFloat = 24
+}
+
+struct BlazeEditAdView_Previews: PreviewProvider {
+    static var previews: some View {
+        BlazeEditAdView(viewModel: .init(siteID: 123,
+                                         adData: .init(image: .init(image: .init(), source: .asset(asset: .init())),
+                                                       tagline: "Tagline",
+                                                       description: "Description"),
+                                         onSave: { _ in })
+        )
+    }
+}

--- a/WooCommerce/Classes/ViewRelated/Blaze/BlazeEditAd/BlazeEditAdViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Blaze/BlazeEditAd/BlazeEditAdViewModel.swift
@@ -1,0 +1,204 @@
+import Foundation
+import Combine
+
+/// View model for `BlazeEditAdView`
+final class BlazeEditAdViewModel: ObservableObject {
+    typealias ImageState = EditableImageViewState
+
+    let siteID: Int64
+    private let adData: BlazeEditAdData
+
+    // Image selection
+    var onAddImage: ((MediaPickingSource) async -> MediaPickerImage?)?
+    @Published private(set) var imageState: ImageState
+    var image: MediaPickerImage? {
+        imageState.image
+    }
+
+    // Tagline
+    @Published var tagline: String = ""
+    var taglineFooterText: String {
+        taglineEmptyError ?? taglineLengthLimitLabel
+    }
+    private let taglineMaxLength = 32
+    @Published private var taglineRemainingLength: Int
+    private var taglineLengthLimitLabel: String {
+        String(format: Localization.taglineLengthLimit, taglineRemainingLength)
+    }
+    private var taglineEmptyError: String?
+
+    // Description
+    @Published var description: String = ""
+    var descriptionFooterText: String {
+        descriptionEmptyError ?? descriptionLengthLimitLabel
+    }
+    private let descriptionMaxLength = 140
+    @Published private var descriptionRemainingLength: Int
+    private var descriptionLengthLimitLabel: String {
+        String(format: Localization.descriptionLengthLimit, descriptionRemainingLength)
+    }
+    private var descriptionEmptyError: String?
+
+    // AI generation
+    @Published var generatingByAI = false
+
+    var isSaveButtonEnabled: Bool {
+        guard generatingByAI == false else {
+            return false
+        }
+
+        guard let editedAdData else {
+            return false
+        }
+
+        return editedAdData != adData
+    }
+
+    private var editedAdData: BlazeEditAdData? {
+        guard let image,
+              tagline.isNotEmpty,
+              description.isNotEmpty else {
+            return nil
+        }
+        return BlazeEditAdData(image: image,
+                               tagline: tagline,
+                               description: description)
+    }
+
+    private let onSave: (BlazeEditAdData) -> Void
+    private let analytics: Analytics
+    private var subscriptions: Set<AnyCancellable> = []
+
+    init(siteID: Int64,
+         adData: BlazeEditAdData,
+         onSave: @escaping (BlazeEditAdData) -> Void,
+         analytics: Analytics = ServiceLocator.analytics) {
+        self.siteID = siteID
+
+        self.adData = adData
+        self.imageState = .success(adData.image)
+        self.tagline = adData.tagline
+        self.description = adData.description
+
+        self.onSave = onSave
+        self.analytics = analytics
+        self.taglineRemainingLength = taglineMaxLength
+        self.descriptionRemainingLength = descriptionMaxLength
+
+        watchCharacterLimit()
+    }
+
+    func didTapSave() {
+        // TODO: 11512 Track Save button tap
+        guard let editedAdData else {
+            assertionFailure("Save button shouldn't be enabled when edited ad is nil")
+            return
+        }
+        onSave(editedAdData)
+    }
+
+    func didTapCancel() {
+        // TODO: 11512 Track Cancel button tap
+    }
+
+    /// Invoked after the user selects a media source to add an image.
+    /// - Parameter source: Source of the image.
+    func addImage(from source: MediaPickingSource) {
+        guard let onAddImage else {
+            return
+        }
+        let previousState = imageState
+        imageState = .loading
+        Task { @MainActor in
+            guard let image = await onAddImage(source) else {
+                return imageState = previousState
+            }
+            imageState = .success(image)
+        }
+    }
+
+    func didTapRegenerateByAI() {
+        Task {
+            generatingByAI = true
+            tagline = ""
+            description = ""
+            // TODO: Generate tagline and description
+            try? await Task.sleep(nanoseconds: UInt64(1_000_000_000))
+            generatingByAI = false
+        }
+    }
+}
+
+// MARK: Character length limit
+extension BlazeEditAdViewModel {
+    private func watchCharacterLimit() {
+        $tagline
+            .removeDuplicates()
+            .sink { [weak self] text in
+                guard let self else { return }
+                if text.count >= self.taglineMaxLength {
+                    self.taglineRemainingLength = 0
+                } else {
+                    self.taglineRemainingLength = self.taglineMaxLength - text.count
+                }
+
+                taglineEmptyError = text.isEmpty ? Localization.taglineEmpty : nil
+            }.store(in: &subscriptions)
+
+        $description
+            .removeDuplicates()
+            .sink { [weak self] text in
+                guard let self else { return }
+                if text.count >= self.descriptionMaxLength {
+                    self.descriptionRemainingLength = 0
+                } else {
+                    self.descriptionRemainingLength = self.descriptionMaxLength - text.count
+                }
+
+                descriptionEmptyError = text.isEmpty ? Localization.descriptionEmpty : nil
+            }.store(in: &subscriptions)
+    }
+
+    func formatTagline(_ newValue: String) -> String {
+        guard newValue.count > taglineMaxLength else {
+            return newValue
+        }
+        return String(newValue.prefix(taglineMaxLength))
+    }
+
+    func formatDescription(_ newValue: String) -> String {
+        guard newValue.count > descriptionMaxLength else {
+            return newValue
+        }
+        return String(newValue.prefix(descriptionMaxLength))
+    }
+}
+
+private extension BlazeEditAdViewModel {
+    enum Localization {
+        static let taglineLengthLimit = NSLocalizedString(
+            "blazeEditAdViewModel.tagline.lengthLimit",
+            value: "%1$d characters remaining",
+            comment: "Edit Blaze Ad screen: Text showing the max allowed characters length of Tagline field." +
+            " " +
+            "%1$d is replaced with the remaining available characters count. Reads like: 10 characters remaining"
+        )
+        static let taglineEmpty = NSLocalizedString(
+            "blazeEditAdViewModel.tagline.emptyError",
+            value: "Tagline cannot be empty",
+            comment: "Edit Blaze Ad screen: Error message if Tagline field is empty."
+        )
+        static let descriptionLengthLimit = NSLocalizedString(
+            "blazeEditAdViewModel.description.lengthLimit",
+            value: "%1$d characters remaining",
+            comment: "Text showing the max allowed characters length of Description field." +
+            " " +
+            "%1$d is replaced with the remaining available characters count. Reads like: 10 characters remaining"
+        )
+        static let descriptionEmpty = NSLocalizedString(
+            "blazeEditAdViewModel.description.emptyError",
+            value: "Description cannot be empty",
+            comment: "Edit Blaze Ad screen: Error message if Description field is empty."
+        )
+    }
+}

--- a/WooCommerce/Classes/ViewRelated/Blaze/BlazeEditAd/BlazeEditAdViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Blaze/BlazeEditAd/BlazeEditAdViewModel.swift
@@ -23,7 +23,10 @@ final class BlazeEditAdViewModel: ObservableObject {
     private let taglineMaxLength = 32
     @Published private var taglineRemainingLength: Int
     private var taglineLengthLimitLabel: String {
-        String(format: Localization.taglineLengthLimit, taglineRemainingLength)
+        let lengthText = String.pluralize(taglineRemainingLength,
+                                          singular: Localization.LengthLimit.singular,
+                                          plural: Localization.LengthLimit.plural)
+        return String(format: lengthText, taglineRemainingLength)
     }
     private var taglineEmptyError: String?
 
@@ -35,7 +38,10 @@ final class BlazeEditAdViewModel: ObservableObject {
     private let descriptionMaxLength = 140
     @Published private var descriptionRemainingLength: Int
     private var descriptionLengthLimitLabel: String {
-        String(format: Localization.descriptionLengthLimit, descriptionRemainingLength)
+        let lengthText = String.pluralize(descriptionRemainingLength,
+                                          singular: Localization.LengthLimit.singular,
+                                          plural: Localization.LengthLimit.plural)
+        return String(format: lengthText, descriptionRemainingLength)
     }
     private var descriptionEmptyError: String?
 
@@ -176,24 +182,26 @@ extension BlazeEditAdViewModel {
 
 private extension BlazeEditAdViewModel {
     enum Localization {
-        static let taglineLengthLimit = NSLocalizedString(
-            "blazeEditAdViewModel.tagline.lengthLimit",
-            value: "%1$d characters remaining",
-            comment: "Edit Blaze Ad screen: Text showing the max allowed characters length of Tagline field." +
-            " " +
-            "%1$d is replaced with the remaining available characters count. Reads like: 10 characters remaining"
-        )
+        enum LengthLimit {
+            static let plural = NSLocalizedString(
+                "blazeEditAdViewModel.lengthLimit.plural",
+                value: "%1$d characters remaining",
+                comment: "Edit Blaze Ad screen: Plural form text showing the max allowed characters length for Tagline or Description field." +
+                " " +
+                "%1$d is replaced with the remaining available characters count. Reads like: 10 characters remaining"
+            )
+            static let singular = NSLocalizedString(
+                "blazeEditAdViewModel.lengthLimit.singular",
+                value: "%1$d character remaining",
+                comment: "Edit Blaze Ad screen: Singular form text showing the max allowed characters length for Tagline or Description field." +
+                " " +
+                "%1$d is replaced with the remaining available characters count. Reads like: 1 character remaining"
+            )
+        }
         static let taglineEmpty = NSLocalizedString(
             "blazeEditAdViewModel.tagline.emptyError",
             value: "Tagline cannot be empty",
             comment: "Edit Blaze Ad screen: Error message if Tagline field is empty."
-        )
-        static let descriptionLengthLimit = NSLocalizedString(
-            "blazeEditAdViewModel.description.lengthLimit",
-            value: "%1$d characters remaining",
-            comment: "Text showing the max allowed characters length of Description field." +
-            " " +
-            "%1$d is replaced with the remaining available characters count. Reads like: 10 characters remaining"
         )
         static let descriptionEmpty = NSLocalizedString(
             "blazeEditAdViewModel.description.emptyError",

--- a/WooCommerce/Classes/ViewRelated/Blaze/CampaignCreation/BlazeCampaignCreationForm.swift
+++ b/WooCommerce/Classes/ViewRelated/Blaze/CampaignCreation/BlazeCampaignCreationForm.swift
@@ -2,13 +2,34 @@ import SwiftUI
 
 /// Hosting controller for `BlazeCampaignCreationForm`
 final class BlazeCampaignCreationFormHostingController: UIHostingController<BlazeCampaignCreationForm> {
+    private let viewModel: BlazeCampaignCreationFormViewModel
+
     init(viewModel: BlazeCampaignCreationFormViewModel) {
+        self.viewModel = viewModel
         super.init(rootView: .init(viewModel: viewModel))
+        self.viewModel.onEditAd = { [weak self] in
+            self?.navigateToEditAd()
+        }
     }
 
     @available(*, unavailable)
     required dynamic init?(coder aDecoder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
+    }
+}
+
+private extension BlazeCampaignCreationFormHostingController {
+    func navigateToEditAd() {
+        // TODO: Send ad data to edit screen
+        let adData = BlazeEditAdData(image: .init(image: .blazeIntroIllustration, source: .asset(asset: .init())),
+                                     tagline: "From $99",
+                                     description: "Get the latest white shirt for a stylish look")
+        let vc = BlazeEditAdHostingController(viewModel: BlazeEditAdViewModel(siteID: viewModel.siteID,
+                                                                              adData: adData,
+                                                                              onSave: { _ in
+            // TODO: Update ad with edited data
+        }))
+        present(vc, animated: true)
     }
 }
 
@@ -132,6 +153,7 @@ private extension BlazeCampaignCreationForm {
             // Button to edit ad details
             Button(action: {
                 // TODO
+                viewModel.didTapEditAd()
             }, label: {
                 Text(Localization.editAd)
                     .fontWeight(.semibold)

--- a/WooCommerce/Classes/ViewRelated/Blaze/CampaignCreation/BlazeCampaignCreationFormViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Blaze/CampaignCreation/BlazeCampaignCreationFormViewModel.swift
@@ -3,9 +3,10 @@ import Yosemite
 
 /// View model for `BlazeCampaignCreationForm`
 final class BlazeCampaignCreationFormViewModel: ObservableObject {
-    private let siteID: Int64
+    let siteID: Int64
     private let stores: StoresManager
     private let completionHandler: () -> Void
+    var onEditAd: (() -> Void)?
 
     init(siteID: Int64,
          stores: StoresManager = ServiceLocator.stores,
@@ -13,5 +14,9 @@ final class BlazeCampaignCreationFormViewModel: ObservableObject {
         self.siteID = siteID
         self.stores = stores
         self.completionHandler = onCompletion
+    }
+
+    func didTapEditAd() {
+        onEditAd?()
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Products/Media/MediaPickingCoordinator.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Media/MediaPickingCoordinator.swift
@@ -155,5 +155,6 @@ extension MediaPickingCoordinator {
     enum Flow: String {
         case productForm = "product_form"
         case productFromImageForm = "product_from_image_form"
+        case blazeEditAdForm = "blaze_edit_ad_form"
     }
 }

--- a/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/EditableImageView.swift
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/EditableImageView.swift
@@ -30,11 +30,14 @@ struct MediaPickerImage: Equatable {
 /// A view that hosts a mutable image in different states.
 struct EditableImageView<Content: View>: View {
     private let imageState: EditableImageViewState
+    private let aspectRatio: ContentMode
     private let emptyContent: () -> Content
 
     init(imageState: EditableImageViewState,
+         aspectRatio: ContentMode = .fit,
          @ViewBuilder emptyContent: @escaping () -> Content) {
         self.imageState = imageState
+        self.aspectRatio = aspectRatio
         self.emptyContent = emptyContent
     }
 
@@ -43,7 +46,7 @@ struct EditableImageView<Content: View>: View {
             case .success(let image):
                 Image(uiImage: image.image)
                     .resizable()
-                    .scaledToFit()
+                    .aspectRatio(contentMode: aspectRatio)
             case .loading:
                 ProgressView()
             case .empty:

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -2501,6 +2501,9 @@
 		EEBDF7E22A2F685C00EFEF47 /* DefaultShareProductAIEligibilityCheckerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EEBDF7E12A2F685C00EFEF47 /* DefaultShareProductAIEligibilityCheckerTests.swift */; };
 		EEBDF7E52A317BCE00EFEF47 /* FirstProductCreatedViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = EEBDF7E42A317BCE00EFEF47 /* FirstProductCreatedViewModel.swift */; };
 		EEBDF7E72A31A59F00EFEF47 /* FirstProductCreatedViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EEBDF7E62A31A59F00EFEF47 /* FirstProductCreatedViewModelTests.swift */; };
+		EEC259422B43EF33004D703C /* BlazeEditAdView.swift in Sources */ = {isa = PBXBuildFile; fileRef = EEC259412B43EF33004D703C /* BlazeEditAdView.swift */; };
+		EEC259442B43EF3B004D703C /* BlazeEditAdViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = EEC259432B43EF3B004D703C /* BlazeEditAdViewModel.swift */; };
+		EEC259462B4556B6004D703C /* BlazeEditAdHostingController.swift in Sources */ = {isa = PBXBuildFile; fileRef = EEC259452B4556B6004D703C /* BlazeEditAdHostingController.swift */; };
 		EEC2D27F292CF60E0072132E /* JetpackSetupHostingControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EEC2D27E292CF60E0072132E /* JetpackSetupHostingControllerTests.swift */; };
 		EEC2D281292D10520072132E /* SiteCredentialLoginHostingViewControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EEC2D280292D10520072132E /* SiteCredentialLoginHostingViewControllerTests.swift */; };
 		EEC5C8DA2ADE2FD80071E852 /* BlazeCampaignDashboardViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EEC5C8D92ADE2FD80071E852 /* BlazeCampaignDashboardViewModelTests.swift */; };
@@ -5136,6 +5139,9 @@
 		EEBDF7E12A2F685C00EFEF47 /* DefaultShareProductAIEligibilityCheckerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefaultShareProductAIEligibilityCheckerTests.swift; sourceTree = "<group>"; };
 		EEBDF7E42A317BCE00EFEF47 /* FirstProductCreatedViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FirstProductCreatedViewModel.swift; sourceTree = "<group>"; };
 		EEBDF7E62A31A59F00EFEF47 /* FirstProductCreatedViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FirstProductCreatedViewModelTests.swift; sourceTree = "<group>"; };
+		EEC259412B43EF33004D703C /* BlazeEditAdView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BlazeEditAdView.swift; sourceTree = "<group>"; };
+		EEC259432B43EF3B004D703C /* BlazeEditAdViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BlazeEditAdViewModel.swift; sourceTree = "<group>"; };
+		EEC259452B4556B6004D703C /* BlazeEditAdHostingController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BlazeEditAdHostingController.swift; sourceTree = "<group>"; };
 		EEC2D27E292CF60E0072132E /* JetpackSetupHostingControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JetpackSetupHostingControllerTests.swift; sourceTree = "<group>"; };
 		EEC2D280292D10520072132E /* SiteCredentialLoginHostingViewControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SiteCredentialLoginHostingViewControllerTests.swift; sourceTree = "<group>"; };
 		EEC5C8D92ADE2FD80071E852 /* BlazeCampaignDashboardViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BlazeCampaignDashboardViewModelTests.swift; sourceTree = "<group>"; };
@@ -11212,6 +11218,7 @@
 			isa = PBXGroup;
 			children = (
 				DE57462D2B43EAF20034B10D /* CampaignCreation */,
+				EEC259402B43E4D6004D703C /* BlazeEditAd */,
 				EE505DDB2B3C249E006E3323 /* BlazeIntro */,
 				DED91DF82AD78A1A00CDCC53 /* BlazeCampaignList */,
 			);
@@ -11664,6 +11671,16 @@
 				EEBDF7E42A317BCE00EFEF47 /* FirstProductCreatedViewModel.swift */,
 			);
 			path = FirstProductCreated;
+			sourceTree = "<group>";
+		};
+		EEC259402B43E4D6004D703C /* BlazeEditAd */ = {
+			isa = PBXGroup;
+			children = (
+				EEC259412B43EF33004D703C /* BlazeEditAdView.swift */,
+				EEC259432B43EF3B004D703C /* BlazeEditAdViewModel.swift */,
+				EEC259452B4556B6004D703C /* BlazeEditAdHostingController.swift */,
+			);
+			path = BlazeEditAd;
 			sourceTree = "<group>";
 		};
 		EEC5C8D82ADE2FB80071E852 /* Blaze */ = {
@@ -13269,6 +13286,7 @@
 				DE69C55527C5E317000BB888 /* ShippingLabelSampleData.swift in Sources */,
 				DE525499268C8B32007A5829 /* UIRefreshControl+Woo.swift in Sources */,
 				26C1633C29DA2CE700E482CE /* FreeTrialSummaryView.swift in Sources */,
+				EEC259442B43EF3B004D703C /* BlazeEditAdViewModel.swift in Sources */,
 				B541B2172189EED4008FE7C1 /* NSMutableAttributedString+Helpers.swift in Sources */,
 				26F94E2E267A96A000DB6CCF /* ProductAddOnViewModel.swift in Sources */,
 				02A9BCD42737DE0D00159C79 /* JetpackBenefitsView.swift in Sources */,
@@ -13451,6 +13469,7 @@
 				DE2FE58A2925EAAE0018040A /* LoginJetpackSetupCoordinator.swift in Sources */,
 				021EBB362A3054BE003634CA /* BlazeEligibilityChecker.swift in Sources */,
 				02820F3422C257B700DE0D37 /* UITableView+HeaderFooterHelpers.swift in Sources */,
+				EEC259422B43EF33004D703C /* BlazeEditAdView.swift in Sources */,
 				DE8FCD1C2A81010000CB707D /* StoreCreationProfilerQuestionContainerViewModel.swift in Sources */,
 				03E471C0293A158D001A58AD /* CardReaderConnectionAlertsProviding.swift in Sources */,
 				D8C2A291231BD0FD00F503E9 /* ReviewsDataSource.swift in Sources */,
@@ -14019,6 +14038,7 @@
 				02C0CD2C23B5BC9600F880B1 /* DefaultImageService.swift in Sources */,
 				B9D19A442AE7B66B00D944D8 /* CustomAmountRowView.swift in Sources */,
 				03E471C8293A3076001A58AD /* CardPresentModalBuiltInConnectingToReader.swift in Sources */,
+				EEC259462B4556B6004D703C /* BlazeEditAdHostingController.swift in Sources */,
 				EE5B5BC72AB8379C009BCBD6 /* AddProductWithAIContainerViewModel.swift in Sources */,
 				0365986529AF942700F297D3 /* PaymentSettingsFlowHint.swift in Sources */,
 				CE0F17CF22A8105800964A63 /* ReadMoreTableViewCell.swift in Sources */,


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of: #11588

## Description

Adds a new screen for editing a Blaze Ad's image, tagline and description. 

**Changes**
- Adds SwiftUI view for Blaze Edit Ad screen
- Navigates to Edit Ad screen from the campaign preview screen
- Most image picker logic is shamelessly copied from `AddProductFromImageFormImageView` and relevant files.
- We will add unit tests and other functionality in future PRs.

I'm sorry about the 500+ line changes. I added the image selection logic to make the UI flow testable.

## Testing instructions
- Log in to a store with at least one existing product and is eligible for Blaze.
- Navigate to the Products tab and select any public product.
- On the product form, select Promote with Blaze.
- Notice that the campaign creation form is presented.
- Select the "Edit Ad" button to open the new Edit Ad screen
- In the "Edit Ad" screen tap on the "Change image" button and validate that image selection works. (Test camera, device and media library)
- The "Tagline" and "Description" fields should be editable and the character length validation should work.
- Tapping on "Regenerate by AI" button should send the screen into loading mode.

## Screenshots

| Light | Dark |
|--------|--------|
| ![Simulator Screenshot - iPhone 14 Pro - 2024-01-03 at 17 39 44](https://github.com/woocommerce/woocommerce-ios/assets/524475/8b733c85-afb2-4d83-85b7-5b93704a86d2) | ![Simulator Screenshot - iPhone 14 Pro - 2024-01-03 at 17 39 52](https://github.com/woocommerce/woocommerce-ios/assets/524475/a6126a96-9950-435f-9e6a-44e995402617) | 

https://github.com/woocommerce/woocommerce-ios/assets/524475/20705b74-a3c7-4dcb-917a-d12e334dc369



---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
