### PR TITLE
Blaze: fetch Blaze forecasted impressions

### DIFF
--- a/Networking/Networking/Model/BlazeImpressions.swift
+++ b/Networking/Networking/Model/BlazeImpressions.swift
@@ -3,7 +3,7 @@ import Codegen
 
 /// Impressions forecast for a Blaze campaign
 ///
-public struct BlazeImpressions: Decodable, Equatable, GeneratedFakeable {
+public struct BlazeImpressions: Decodable, Equatable, GeneratedCopiable, GeneratedFakeable {
 
     /// Minimum forecasted impressions a Blaze campaign might get
     public let totalImpressionsMin: Int64

--- a/Networking/Networking/Model/Copiable/Models+Copiable.generated.swift
+++ b/Networking/Networking/Model/Copiable/Models+Copiable.generated.swift
@@ -199,6 +199,21 @@ extension Networking.BlazeCampaign {
     }
 }
 
+extension Networking.BlazeImpressions {
+    public func copy(
+        totalImpressionsMin: CopiableProp<Int64> = .copy,
+        totalImpressionsMax: CopiableProp<Int64> = .copy
+    ) -> Networking.BlazeImpressions {
+        let totalImpressionsMin = totalImpressionsMin ?? self.totalImpressionsMin
+        let totalImpressionsMax = totalImpressionsMax ?? self.totalImpressionsMax
+
+        return Networking.BlazeImpressions(
+            totalImpressionsMin: totalImpressionsMin,
+            totalImpressionsMax: totalImpressionsMax
+        )
+    }
+}
+
 extension Networking.BlazeTargetDevice {
     public func copy(
         id: CopiableProp<String> = .copy,

--- a/Yosemite/Yosemite/Actions/BlazeAction.swift
+++ b/Yosemite/Yosemite/Actions/BlazeAction.swift
@@ -66,4 +66,13 @@ public enum BlazeAction: Action {
                               query: String,
                               locale: String,
                               onCompletion: (Result<[BlazeTargetLocation], Error>) -> Void)
+
+    /// Retrieves forecasted amount of available impressions for a Blaze campaign to be created.
+    ///
+    /// - `siteID`: the site to create Blaze campaign.
+    /// - `input`: the input for the forecasted impressions. Has various required and optional parameters.
+    /// - `onCompletion`: invoked when the fect operation finishes.
+    case fetchForecastedImpressions(siteID: Int64,
+                                    input: BlazeForecastedImpressionsInput,
+                                    onCompletion: (Result<BlazeImpressions, Error>) -> Void)
 }

--- a/Yosemite/Yosemite/Stores/BlazeStore.swift
+++ b/Yosemite/Yosemite/Stores/BlazeStore.swift
@@ -66,6 +66,8 @@ public final class BlazeStore: Store {
             synchronizeTargetTopics(siteID: siteID, locale: locale, onCompletion: onCompletion)
         case let .fetchTargetLocations(siteID, query, locale, onCompletion):
             fetchTargetLocations(siteID: siteID, query: query, locale: locale, onCompletion: onCompletion)
+        case let .fetchForecastedImpressions(siteID, input, onCompletion):
+            fetchForecastedImpressions(siteID: siteID, input: input, onCompletion: onCompletion)
         }
     }
 }
@@ -312,6 +314,28 @@ private extension BlazeStore {
                 onCompletion(.failure(error))
             }
         }
+    }
+}
+
+// MARK: - Fetch forecasted impressions for a campaign to be created
+private extension BlazeStore {
+    func fetchForecastedImpressions(siteID: Int64,
+                                    input: BlazeForecastedImpressionsInput,
+                                    onCompletion: @escaping (Result<BlazeImpressions, Error>) -> Void) {
+        Task { @MainActor in
+            do {
+                // TODO-11540: remove stubbed result when the API is ready.
+                let stubbedResult = BlazeImpressions(totalImpressionsMin: 5000, totalImpressionsMax: 10000)
+                let impressions: BlazeImpressions = try await mockResponse(stubbedResult: stubbedResult, onExecution: {
+                    try await remote.fetchForecastedImpressions(for: siteID, with: input)
+                })
+                onCompletion(.success(impressions))
+            } catch {
+                onCompletion(.failure(error))
+            }
+        }
+
+
     }
 }
 

--- a/Yosemite/YosemiteTests/Stores/BlazeStoreTests.swift
+++ b/Yosemite/YosemiteTests/Stores/BlazeStoreTests.swift
@@ -518,6 +518,30 @@ final class BlazeStoreTests: XCTestCase {
         XCTAssertTrue(result.isFailure)
         XCTAssertEqual(result.failure as? NetworkError, .timeout())
     }
+
+    // MARK: - Fetching forecasted impressions
+
+    func test_fetchForecastedImpressions_returns_error_on_failure() throws {
+        // Given
+        remote.whenFetchingForecastedImpressions(thenReturn: .failure(NetworkError.timeout()))
+        let store = BlazeStore(dispatcher: Dispatcher(),
+                               storageManager: storageManager,
+                               network: network,
+                               remote: remote)
+
+        // When
+        let result = waitFor { promise in
+            store.onAction(BlazeAction.fetchForecastedImpressions(siteID: self.sampleSiteID,
+                                                                  input: BlazeForecastedImpressionsInput.fake(),
+                                                                  onCompletion: { result in
+                promise(result)
+            }))
+        }
+
+        // Then
+        XCTAssertTrue(result.isFailure)
+        XCTAssertEqual(result.failure as? NetworkError, .timeout())
+    }
 }
 
 private extension BlazeStoreTests {

--- a/Yosemite/YosemiteTests/Stores/BlazeStoreTests.swift
+++ b/Yosemite/YosemiteTests/Stores/BlazeStoreTests.swift
@@ -521,6 +521,28 @@ final class BlazeStoreTests: XCTestCase {
 
     // MARK: - Fetching forecasted impressions
 
+    func test_fetchForecastedImpressions_is_successful_when_fetching_successfully() throws {
+        // Given
+        remote.whenFetchingForecastedImpressions(thenReturn: .success(.fake().copy(totalImpressionsMax: 12345)))
+        let store = BlazeStore(dispatcher: Dispatcher(),
+                               storageManager: storageManager,
+                               network: network,
+                               remote: remote)
+
+        // When
+        let result = waitFor { promise in
+            store.onAction(BlazeAction.fetchForecastedImpressions(siteID: self.sampleSiteID,
+                                                                  input: BlazeForecastedImpressionsInput.fake(),
+                                                                  onCompletion: { result in
+                promise(result)
+            }))
+        }
+
+        //Then
+        let impressions = try result.get()
+        XCTAssertEqual(impressions.totalImpressionsMax, 12345)
+    }
+
     func test_fetchForecastedImpressions_returns_error_on_failure() throws {
         // Given
         remote.whenFetchingForecastedImpressions(thenReturn: .failure(NetworkError.timeout()))


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #11559
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This is the final PR for the  impressions forecast endpoint. This adds the actual fetch impressions functionality.

## Testing instructions
CI passing should be sufficient.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->


---
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
