### PR TITLE
[Performance] Include Blaze campaign syncing in waiting time tracker for app launch

### DIFF
--- a/WooCommerce/Classes/Analytics/AppStartupWaitingTimeTracker.swift
+++ b/WooCommerce/Classes/Analytics/AppStartupWaitingTimeTracker.swift
@@ -13,6 +13,7 @@ class AppStartupWaitingTimeTracker: WaitingTimeTracker {
     enum StartupAction: CaseIterable {
         case syncDashboardStats
         case loadOnboardingTasks
+        case syncBlazeCampaigns
     }
 
     /// Represents all of the app startup actions waiting to be completed.

--- a/WooCommerce/Classes/ViewRelated/Dashboard/DashboardViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/DashboardViewModel.swift
@@ -34,6 +34,7 @@ final class DashboardViewModel {
     private let userDefaults: UserDefaults
     private let storeCreationProfilerUploadAnswersUseCase: StoreCreationProfilerUploadAnswersUseCaseProtocol
     private let themeInstaller: ThemeInstaller
+    private let startupWaitingTimeTracker: AppStartupWaitingTimeTracker
 
     var siteURLToShare: URL? {
         if let site = stores.sessionManager.defaultSite,
@@ -50,7 +51,8 @@ final class DashboardViewModel {
          analytics: Analytics = ServiceLocator.analytics,
          userDefaults: UserDefaults = .standard,
          storeCreationProfilerUploadAnswersUseCase: StoreCreationProfilerUploadAnswersUseCaseProtocol? = nil,
-         themeInstaller: ThemeInstaller = DefaultThemeInstaller()) {
+         themeInstaller: ThemeInstaller = DefaultThemeInstaller(),
+         startupWaitingTimeTracker: AppStartupWaitingTimeTracker = ServiceLocator.startupWaitingTimeTracker) {
         self.siteID = siteID
         self.stores = stores
         self.featureFlagService = featureFlags
@@ -62,6 +64,7 @@ final class DashboardViewModel {
         self.blazeCampaignDashboardViewModel = .init(siteID: siteID)
         self.storeCreationProfilerUploadAnswersUseCase = storeCreationProfilerUploadAnswersUseCase ?? StoreCreationProfilerUploadAnswersUseCase(siteID: siteID)
         self.themeInstaller = themeInstaller
+        self.startupWaitingTimeTracker = startupWaitingTimeTracker
         setupObserverForShowOnboarding()
         setupObserverForBlazeCampaignView()
         installPendingThemeIfNeeded()
@@ -83,6 +86,7 @@ final class DashboardViewModel {
     ///
     func reloadBlazeCampaignView() async {
         await blazeCampaignDashboardViewModel.reload()
+        startupWaitingTimeTracker.end(action: .syncBlazeCampaigns)
     }
 
     /// Syncs store stats for dashboard UI.

--- a/WooCommerce/WooCommerceTests/System/AppStartupWaitingTimeTrackerTests.swift
+++ b/WooCommerce/WooCommerceTests/System/AppStartupWaitingTimeTrackerTests.swift
@@ -29,7 +29,7 @@ final class AppStartupWaitingTimeTrackerTests: XCTestCase {
         XCTAssertEqual(analyticsProvider.receivedEvents.count, 0)
 
         // When all actions are ended
-        tracker.end(action: .loadOnboardingTasks)
+        completeAllStartupActions()
 
         // Then
         XCTAssertEqual(analyticsProvider.receivedEvents.count, 1)

--- a/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/DashboardViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/DashboardViewModelTests.swift
@@ -602,6 +602,20 @@ final class DashboardViewModelTests: XCTestCase {
         //  Then
         XCTAssertEqual(themeInstaller.installPendingThemeCalledForSiteID, sampleSiteID)
     }
+
+    // MARK: Blaze Campaigns
+    func test_it_tracks_end_of_blaze_campaign_sync_action_when_blaze_campaign_view_reloads() async {
+        // Given
+        let waitingTimeTracker = AppStartupWaitingTimeTracker()
+        let viewModel = DashboardViewModel(siteID: sampleSiteID, startupWaitingTimeTracker: waitingTimeTracker)
+        XCTAssertTrue(waitingTimeTracker.startupActionsPending.contains(.syncBlazeCampaigns))
+
+        // Then
+        await viewModel.reloadBlazeCampaignView()
+
+        // Then
+        XCTAssertFalse(waitingTimeTracker.startupActionsPending.contains(.syncBlazeCampaigns))
+    }
 }
 
 private extension DashboardViewModelTests {


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of #11592
⚠️ Depends on 11601 ⚠️ 
<!-- Id number of the GitHub issue this PR addresses. -->

## Why

We have a waiting time tracker that tracks the waiting time for app startup (`AppStartupWaitingTimeTracker`). This tracker should include any actions that contribute to the perceived initial loading time on the dashboard.

Because the Blaze campaign section is part of the dashboard, and has a visible loading view while the campaigns are being synced remotely, it should be included in the tracker.

## How

* Adds a `syncBlazeCampaigns` case to the startup actions included in the tracker.
* Tracks when that action is complete at the end of `DashboardViewModel.reloadBlazeCampaignView()` (after any remote syncing for eligible stores).

## Testing instructions

Optional hand testing:

1. Build and run the app.
2. Confirm the analytics event `application_opened_waiting_time_loaded` is tracked after the Blaze campaigns are synced (after the remote request is completed).
3. On a store that is not eligible for Blaze (e.g. has no products), confirm the analytics event is still tracked after the dashboard finishes loading, even though there is no request to sync Blaze campaigns.


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
