### PR TITLE
Add Order Extension Notification unit tests

### DIFF
--- a/Networking/Networking/Model/Copiable/Models+Copiable.generated.swift
+++ b/Networking/Networking/Model/Copiable/Models+Copiable.generated.swift
@@ -712,6 +712,141 @@ extension Networking.Media {
     }
 }
 
+extension Networking.Note {
+    public func copy(
+        noteID: CopiableProp<Int64> = .copy,
+        hash: CopiableProp<Int64> = .copy,
+        read: CopiableProp<Bool> = .copy,
+        icon: NullableCopiableProp<String> = .copy,
+        noticon: NullableCopiableProp<String> = .copy,
+        timestamp: CopiableProp<String> = .copy,
+        timestampAsDate: CopiableProp<Date> = .copy,
+        kind: CopiableProp<Note.Kind> = .copy,
+        subkind: NullableCopiableProp<Note.Subkind> = .copy,
+        type: NullableCopiableProp<String> = .copy,
+        subtype: NullableCopiableProp<String> = .copy,
+        url: NullableCopiableProp<String> = .copy,
+        title: NullableCopiableProp<String> = .copy,
+        subjectAsData: CopiableProp<Data> = .copy,
+        subject: CopiableProp<[NoteBlock]> = .copy,
+        headerAsData: CopiableProp<Data> = .copy,
+        header: CopiableProp<[NoteBlock]> = .copy,
+        bodyAsData: CopiableProp<Data> = .copy,
+        body: CopiableProp<[NoteBlock]> = .copy,
+        metaAsData: CopiableProp<Data> = .copy,
+        meta: CopiableProp<MetaContainer> = .copy
+    ) -> Networking.Note {
+        let noteID = noteID ?? self.noteID
+        let hash = hash ?? self.hash
+        let read = read ?? self.read
+        let icon = icon ?? self.icon
+        let noticon = noticon ?? self.noticon
+        let timestamp = timestamp ?? self.timestamp
+        let timestampAsDate = timestampAsDate ?? self.timestampAsDate
+        let kind = kind ?? self.kind
+        let subkind = subkind ?? self.subkind
+        let type = type ?? self.type
+        let subtype = subtype ?? self.subtype
+        let url = url ?? self.url
+        let title = title ?? self.title
+        let subjectAsData = subjectAsData ?? self.subjectAsData
+        let subject = subject ?? self.subject
+        let headerAsData = headerAsData ?? self.headerAsData
+        let header = header ?? self.header
+        let bodyAsData = bodyAsData ?? self.bodyAsData
+        let body = body ?? self.body
+        let metaAsData = metaAsData ?? self.metaAsData
+        let meta = meta ?? self.meta
+
+        return Networking.Note(
+            noteID: noteID,
+            hash: hash,
+            read: read,
+            icon: icon,
+            noticon: noticon,
+            timestamp: timestamp,
+            timestampAsDate: timestampAsDate,
+            kind: kind,
+            subkind: subkind,
+            type: type,
+            subtype: subtype,
+            url: url,
+            title: title,
+            subjectAsData: subjectAsData,
+            subject: subject,
+            headerAsData: headerAsData,
+            header: header,
+            bodyAsData: bodyAsData,
+            body: body,
+            metaAsData: metaAsData,
+            meta: meta
+        )
+    }
+}
+
+extension Networking.NoteBlock {
+    public func copy(
+        media: CopiableProp<[NoteMedia]> = .copy,
+        ranges: CopiableProp<[NoteRange]> = .copy,
+        text: NullableCopiableProp<String> = .copy,
+        actions: CopiableProp<[String: Bool]> = .copy,
+        meta: CopiableProp<MetaContainer> = .copy,
+        type: NullableCopiableProp<String> = .copy
+    ) -> Networking.NoteBlock {
+        let media = media ?? self.media
+        let ranges = ranges ?? self.ranges
+        let text = text ?? self.text
+        let actions = actions ?? self.actions
+        let meta = meta ?? self.meta
+        let type = type ?? self.type
+
+        return Networking.NoteBlock(
+            media: media,
+            ranges: ranges,
+            text: text,
+            actions: actions,
+            meta: meta,
+            type: type
+        )
+    }
+}
+
+extension Networking.NoteRange {
+    public func copy(
+        kind: CopiableProp<NoteRange.Kind> = .copy,
+        type: NullableCopiableProp<String> = .copy,
+        range: CopiableProp<NSRange> = .copy,
+        url: NullableCopiableProp<URL> = .copy,
+        commentID: NullableCopiableProp<Int64> = .copy,
+        postID: NullableCopiableProp<Int64> = .copy,
+        siteID: NullableCopiableProp<Int64> = .copy,
+        userID: NullableCopiableProp<Int64> = .copy,
+        value: NullableCopiableProp<String> = .copy
+    ) -> Networking.NoteRange {
+        let kind = kind ?? self.kind
+        let type = type ?? self.type
+        let range = range ?? self.range
+        let url = url ?? self.url
+        let commentID = commentID ?? self.commentID
+        let postID = postID ?? self.postID
+        let siteID = siteID ?? self.siteID
+        let userID = userID ?? self.userID
+        let value = value ?? self.value
+
+        return Networking.NoteRange(
+            kind: kind,
+            type: type,
+            range: range,
+            url: url,
+            commentID: commentID,
+            postID: postID,
+            siteID: siteID,
+            userID: userID,
+            value: value
+        )
+    }
+}
+
 extension Networking.Order {
     public func copy(
         siteID: CopiableProp<Int64> = .copy,

--- a/Networking/Networking/Model/Note.swift
+++ b/Networking/Networking/Model/Note.swift
@@ -3,7 +3,7 @@ import Codegen
 
 // MARK: - Note: Represents a WordPress.com Notification
 //
-public struct Note: GeneratedFakeable {
+public struct Note: GeneratedFakeable, GeneratedCopiable {
 
 
     /// Notification's Primary Key.
@@ -93,8 +93,9 @@ public struct Note: GeneratedFakeable {
     /// Associated Metadata.
     ///
     public let meta: MetaContainer
+}
 
-
+extension Note {
     /// Designed Initializer.
     ///
     public init(noteID: Int64,

--- a/Networking/Networking/Model/NoteBlock.swift
+++ b/Networking/Networking/Model/NoteBlock.swift
@@ -3,7 +3,7 @@ import Codegen
 
 // MARK: - NotificationBlock Implementation
 //
-public struct NoteBlock: Equatable, GeneratedFakeable {
+public struct NoteBlock: Equatable, GeneratedFakeable, GeneratedCopiable {
 
     /// Parsed Media Entities.
     ///
@@ -19,7 +19,7 @@ public struct NoteBlock: Equatable, GeneratedFakeable {
 
     /// Available Actions collection.
     ///
-    private let actions: [String: Bool]
+    public let actions: [String: Bool]
 
     /// Meta Fields collection.
     ///
@@ -27,10 +27,10 @@ public struct NoteBlock: Equatable, GeneratedFakeable {
 
     /// Raw Type, expressed as a string.
     ///
-    private let type: String?
+    public let type: String?
+}
 
-
-
+extension NoteBlock {
     /// Designated Initializer.
     ///
     public init(media: [NoteMedia], ranges: [NoteRange], text: String?, actions: [String: Bool], meta: [String: AnyCodable], type: String?) {

--- a/Networking/Networking/Model/NoteRange.swift
+++ b/Networking/Networking/Model/NoteRange.swift
@@ -3,7 +3,7 @@ import Codegen
 
 // MARK: - NoteRange
 //
-public struct NoteRange: Equatable, GeneratedFakeable {
+public struct NoteRange: Equatable, GeneratedFakeable, GeneratedCopiable {
 
     /// NoteRange.Type expressed as a Swift Native Enum.
     ///
@@ -40,9 +40,9 @@ public struct NoteRange: Equatable, GeneratedFakeable {
     /// String Payload, if any.
     ///
     private(set) public var value: String?
+}
 
-
-
+extension NoteRange {
     /// Designated Initializer.
     ///
     public init(type: String?, range: NSRange, url: URL?, identifier: Int64?, postID: Int64?, siteID: Int64?, value: String?) {

--- a/WooCommerce/NotificationExtension/OrderNotificationView.swift
+++ b/WooCommerce/NotificationExtension/OrderNotificationView.swift
@@ -8,8 +8,8 @@ struct OrderNotificationView: View {
 
     /// Type that represents the necessary information for this view.
     ///
-    struct Content {
-        struct Product: Hashable {
+    struct Content: Equatable {
+        struct Product: Hashable, Equatable {
             let count: String
             let name: String
         }

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -871,6 +871,7 @@
 		269A2F47295CC683000828A8 /* GenerateVariationsSelectorCommand.swift in Sources */ = {isa = PBXBuildFile; fileRef = 269A2F46295CC683000828A8 /* GenerateVariationsSelectorCommand.swift */; };
 		269B46622A16D68A00ADA872 /* UpdateAnalyticsSettingsUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 269B46612A16D68A00ADA872 /* UpdateAnalyticsSettingsUseCase.swift */; };
 		269B46642A16D6ED00ADA872 /* UpdateAnalyticsSettingsUseCaseTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 269B46632A16D6ED00ADA872 /* UpdateAnalyticsSettingsUseCaseTests.swift */; };
+		26A280D42B45EFA000ACEE87 /* OrderNotificationViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2679F02C2AAADB1C00AF80C5 /* OrderNotificationViewModel.swift */; };
 		26A630ED253F3B5C00CBC3B1 /* RefundCreationUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26A630EC253F3B5C00CBC3B1 /* RefundCreationUseCase.swift */; };
 		26A630F3253F3CFE00CBC3B1 /* RefundCreationUseCaseTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26A630F2253F3CFE00CBC3B1 /* RefundCreationUseCaseTests.swift */; };
 		26A630FE253F63C300CBC3B1 /* RefundableOrderItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26A630FD253F63C300CBC3B1 /* RefundableOrderItem.swift */; };
@@ -14207,6 +14208,7 @@
 				098FFA1727AD7F5D002EBEE4 /* OrderStatusListDataSourceTests.swift in Sources */,
 				DE19BB1D26C6911900AB70D9 /* ShippingLabelCustomsFormListViewModelTests.swift in Sources */,
 				D449C52C26E02F2F00D75B02 /* WhatsNewFactoryTests.swift in Sources */,
+				26A280D42B45EFA000ACEE87 /* OrderNotificationViewModel.swift in Sources */,
 				5761298B24589B84007BB2D9 /* NumberFormatter+LocalizedOrNinetyNinePlusTests.swift in Sources */,
 				2667BFD7252E5DBF008099D4 /* RefundItemViewModelTests.swift in Sources */,
 				7435E59021C0162C00216F0F /* OrderNoteWooTests.swift in Sources */,

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -871,7 +871,8 @@
 		269A2F47295CC683000828A8 /* GenerateVariationsSelectorCommand.swift in Sources */ = {isa = PBXBuildFile; fileRef = 269A2F46295CC683000828A8 /* GenerateVariationsSelectorCommand.swift */; };
 		269B46622A16D68A00ADA872 /* UpdateAnalyticsSettingsUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 269B46612A16D68A00ADA872 /* UpdateAnalyticsSettingsUseCase.swift */; };
 		269B46642A16D6ED00ADA872 /* UpdateAnalyticsSettingsUseCaseTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 269B46632A16D6ED00ADA872 /* UpdateAnalyticsSettingsUseCaseTests.swift */; };
-		26A280D42B45EFA000ACEE87 /* OrderNotificationViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2679F02C2AAADB1C00AF80C5 /* OrderNotificationViewModel.swift */; };
+		26A280D62B45F00F00ACEE87 /* OrderNotificationViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26A280D52B45F00F00ACEE87 /* OrderNotificationViewModelTests.swift */; };
+		26A280D72B46027A00ACEE87 /* OrderNotificationView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26CA2BC52AAA1773003B16C2 /* OrderNotificationView.swift */; };
 		26A630ED253F3B5C00CBC3B1 /* RefundCreationUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26A630EC253F3B5C00CBC3B1 /* RefundCreationUseCase.swift */; };
 		26A630F3253F3CFE00CBC3B1 /* RefundCreationUseCaseTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26A630F2253F3CFE00CBC3B1 /* RefundCreationUseCaseTests.swift */; };
 		26A630FE253F63C300CBC3B1 /* RefundableOrderItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26A630FD253F63C300CBC3B1 /* RefundableOrderItem.swift */; };
@@ -894,6 +895,9 @@
 		26B9875F273CB6AA0090E8CA /* SimplePaymentsNoteViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26B9875E273CB6AA0090E8CA /* SimplePaymentsNoteViewModelTests.swift */; };
 		26BBEA8528C6ADAC00ED7F6C /* Images.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 26FFD32628C6A0A4002E5E5E /* Images.xcassets */; };
 		26BBEA8628C6AE1400ED7F6C /* UIImage+Widgets.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26FFD32928C6A0F4002E5E5E /* UIImage+Widgets.swift */; };
+		26C0D1E32B460E5700F6EDA5 /* OrderNotificationViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2679F02C2AAADB1C00AF80C5 /* OrderNotificationViewModel.swift */; };
+		26C0D1E42B460E9000F6EDA5 /* AppLocalizedString.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F50FE4228CAEBA800C89201 /* AppLocalizedString.swift */; };
+		26C0D1E52B460EB700F6EDA5 /* WooConstants.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5D1AFBF20BC67C200DB0E8C /* WooConstants.swift */; };
 		26C1633C29DA2CE700E482CE /* FreeTrialSummaryView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26C1633B29DA2CE700E482CE /* FreeTrialSummaryView.swift */; };
 		26C6439327B5DBE900DD00D1 /* OrderSynchronizer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26C6439227B5DBE900DD00D1 /* OrderSynchronizer.swift */; };
 		26C6E8E026E2B7BD00C7BB0F /* CountrySelectorViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26C6E8DF26E2B7BD00C7BB0F /* CountrySelectorViewModel.swift */; };
@@ -3488,6 +3492,7 @@
 		269A2F46295CC683000828A8 /* GenerateVariationsSelectorCommand.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GenerateVariationsSelectorCommand.swift; sourceTree = "<group>"; };
 		269B46612A16D68A00ADA872 /* UpdateAnalyticsSettingsUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UpdateAnalyticsSettingsUseCase.swift; sourceTree = "<group>"; };
 		269B46632A16D6ED00ADA872 /* UpdateAnalyticsSettingsUseCaseTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UpdateAnalyticsSettingsUseCaseTests.swift; sourceTree = "<group>"; };
+		26A280D52B45F00F00ACEE87 /* OrderNotificationViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OrderNotificationViewModelTests.swift; sourceTree = "<group>"; };
 		26A630EC253F3B5C00CBC3B1 /* RefundCreationUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RefundCreationUseCase.swift; sourceTree = "<group>"; };
 		26A630F2253F3CFE00CBC3B1 /* RefundCreationUseCaseTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RefundCreationUseCaseTests.swift; sourceTree = "<group>"; };
 		26A630FD253F63C300CBC3B1 /* RefundableOrderItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RefundableOrderItem.swift; sourceTree = "<group>"; };
@@ -9044,6 +9049,7 @@
 				B5718D6421B56B3F0026C9F0 /* PushNotificationsManagerTests.swift */,
 				DEDAE30A2A0B523F00F9635F /* LocalNotificationTests.swift */,
 				026D684A2A0E0A9600D8C22C /* LocalNotificationSchedulerTests.swift */,
+				26A280D52B45F00F00ACEE87 /* OrderNotificationViewModelTests.swift */,
 			);
 			path = Notifications;
 			sourceTree = "<group>";
@@ -14208,7 +14214,6 @@
 				098FFA1727AD7F5D002EBEE4 /* OrderStatusListDataSourceTests.swift in Sources */,
 				DE19BB1D26C6911900AB70D9 /* ShippingLabelCustomsFormListViewModelTests.swift in Sources */,
 				D449C52C26E02F2F00D75B02 /* WhatsNewFactoryTests.swift in Sources */,
-				26A280D42B45EFA000ACEE87 /* OrderNotificationViewModel.swift in Sources */,
 				5761298B24589B84007BB2D9 /* NumberFormatter+LocalizedOrNinetyNinePlusTests.swift in Sources */,
 				2667BFD7252E5DBF008099D4 /* RefundItemViewModelTests.swift in Sources */,
 				7435E59021C0162C00216F0F /* OrderNoteWooTests.swift in Sources */,
@@ -14338,6 +14343,7 @@
 				02645D8227BA20A30065DC68 /* InboxViewModelTests.swift in Sources */,
 				57ABE36824EB048A00A64F49 /* MockSwitchStoreUseCase.swift in Sources */,
 				311F827626CD8AB100DF5BAD /* MockCardReaderSettingsAlerts.swift in Sources */,
+				26A280D62B45F00F00ACEE87 /* OrderNotificationViewModelTests.swift in Sources */,
 				EE45E2C22A42C9D80085F227 /* ProductDescriptionAITooltipUseCaseTests.swift in Sources */,
 				DEDAE30B2A0B523F00F9635F /* LocalNotificationTests.swift in Sources */,
 				B935D35F2A9F4EDA0067B927 /* WPAdminTaxSettingsURLProviderTests.swift in Sources */,
@@ -14360,6 +14366,7 @@
 				0259EF77246BF4EC00B84FDF /* ProductDetailsFactoryTests.swift in Sources */,
 				EE0EE7A828B74EF300F6061E /* CustomHelpCenterContentTests.swift in Sources */,
 				4574745F24EA9ADE00CF49BC /* ProductTypeBottomSheetListSelectorCommandTests.swift in Sources */,
+				26C0D1E52B460EB700F6EDA5 /* WooConstants.swift in Sources */,
 				AEE2611126E6785400B142A0 /* EditOrderAddressFormViewModelTests.swift in Sources */,
 				0212683724C049F000F8A892 /* ProductListMultiSelectorDataSourceTests.swift in Sources */,
 				0252273529A89B0F0074EBFC /* StoreOnboardingCoordinatorTests.swift in Sources */,
@@ -14403,6 +14410,7 @@
 				EEB221A729B9B5B300662A12 /* CouponLineDetailsViewModelTests.swift in Sources */,
 				026D684B2A0E0A9600D8C22C /* LocalNotificationSchedulerTests.swift in Sources */,
 				02038C612AF222D600CD36D9 /* ConfigurableVariableBundleAttributePickerViewModelTests.swift in Sources */,
+				26C0D1E32B460E5700F6EDA5 /* OrderNotificationViewModel.swift in Sources */,
 				20A3AFE12B0F750B0033AF2D /* MockInPersonPaymentsCashOnDeliveryToggleRowViewModel.swift in Sources */,
 				2683835A296F9C1A00CCF60A /* GenerateAllVariationsUseCaseTests.swift in Sources */,
 				020ACF8A299B746700B3638B /* DomainContactInfoFormViewModelTests.swift in Sources */,
@@ -14441,6 +14449,7 @@
 				D8F82AC522AF903700B67E4B /* IconsTests.swift in Sources */,
 				2667BFE92530ECE4008099D4 /* RefundProductsTotalViewModelTests.swift in Sources */,
 				D810F8F82639EDE900437C67 /* CardPresentPaymentsModalViewControllerTests.swift in Sources */,
+				26C0D1E42B460E9000F6EDA5 /* AppLocalizedString.swift in Sources */,
 				DEDA8D972B034C260076BF0F /* ProductSubscriptionPeriodPickerUseCaseTests.swift in Sources */,
 				02A275C623FE9EFC005C560F /* MockFeatureFlagService.swift in Sources */,
 				31F635DC273AF0B100E14F10 /* VersionHelpersTests.swift in Sources */,
@@ -14694,6 +14703,7 @@
 				20BCF6F02B0E48CC00954840 /* WooPaymentsDepositsOverviewViewModelTests.swift in Sources */,
 				261AA30E275506DE009530FE /* PaymentMethodsViewModelTests.swift in Sources */,
 				4524CDA1242D045C00B2F20A /* ProductStatusSettingListSelectorCommandTests.swift in Sources */,
+				26A280D72B46027A00ACEE87 /* OrderNotificationView.swift in Sources */,
 				02077F72253816FF005A78EF /* ProductFormActionsFactory+ReadonlyProductTests.swift in Sources */,
 				D8C11A6222E24C4A00D4A88D /* LedgerTableViewCellTests.swift in Sources */,
 				027111422913B9FC00F5269A /* AccountCreationFormViewModelTests.swift in Sources */,

--- a/WooCommerce/WooCommerceTests/Notifications/OrderNotificationViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/Notifications/OrderNotificationViewModelTests.swift
@@ -1,36 +1,53 @@
-//
-//  OrderNotificationViewModelTests.swift
-//  WooCommerceTests
-//
-//  Created by Ernesto Carrion on 3/01/24.
-//  Copyright © 2024 Automattic. All rights reserved.
-//
-
 import XCTest
+@testable import Networking
+@testable import WooCommerce
 
 final class OrderNotificationViewModelTests: XCTestCase {
 
-    override func setUpWithError() throws {
-        // Put setup code here. This method is called before the invocation of each test method in the class.
+    func test_view_model_extract_information_correctly() {
+        // Given
+        let note = sampleNote()
+        let order = sampleOrder()
+
+        // When
+        let viewModel = OrderNotificationViewModel()
+        let notificationContent = viewModel.formatContent(note: note, order: order)
+
+        // Then
+        let formatter = DateFormatter()
+        formatter.dateStyle = .medium
+        formatter.timeStyle = .none
+
+        let expectedProducts = OrderNotificationView.Content.Product(count: "3", name: "Product 1")
+        let expectedContent = OrderNotificationView.Content(storeName: "My Test Store",
+                                                            date: formatter.string(from: Date()),
+                                                            orderNumber: "#123",
+                                                            amount: "$123.23",
+                                                            paymentMethod: "visa",
+                                                            shippingMethod: "Pick Up",
+                                                            products: [expectedProducts])
+
+        XCTAssertEqual(notificationContent, expectedContent)
+    }
+}
+
+extension OrderNotificationViewModelTests {
+    func sampleNote() -> Note {
+        let storeTitle = "My Test Store"
+        let range = NoteRange.fake().copy(range: .init(location: 23, length: 13))
+        let block = NoteBlock.fake().copy(ranges: [range], text: "You have a new Order - My Test Store")
+        return Note.fake().copy(subject: [block])
     }
 
-    override func tearDownWithError() throws {
-        // Put teardown code here. This method is called after the invocation of each test method in the class.
+    func sampleOrder() -> Order {
+        let item = OrderItem.fake().copy(name: "Product 1", quantity: 3)
+        let shipping = ShippingLine.fake().copy(methodTitle: "Pick Up")
+        return Order.fake().copy(orderID: 123,
+                                 currencySymbol: "$",
+                                 datePaid: Date(),
+                                 total: "123.23",
+                                 paymentMethodTitle: "Visa",
+                                 items: [item],
+                                 shippingLines: [shipping])
     }
-
-    func testExample() throws {
-        // This is an example of a functional test case.
-        // Use XCTAssert and related functions to verify your tests produce the correct results.
-        // Any test you write for XCTest can be annotated as throws and async.
-        // Mark your test throws to produce an unexpected failure when your test encounters an uncaught error.
-        // Mark your test async to allow awaiting for asynchronous code to complete. Check the results with assertions afterwards.
-    }
-
-    func testPerformanceExample() throws {
-        // This is an example of a performance test case.
-        self.measure {
-            // Put the code you want to measure the time of here.
-        }
-    }
-
 }

--- a/WooCommerce/WooCommerceTests/Notifications/OrderNotificationViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/Notifications/OrderNotificationViewModelTests.swift
@@ -1,0 +1,36 @@
+//
+//  OrderNotificationViewModelTests.swift
+//  WooCommerceTests
+//
+//  Created by Ernesto Carrion on 3/01/24.
+//  Copyright © 2024 Automattic. All rights reserved.
+//
+
+import XCTest
+
+final class OrderNotificationViewModelTests: XCTestCase {
+
+    override func setUpWithError() throws {
+        // Put setup code here. This method is called before the invocation of each test method in the class.
+    }
+
+    override func tearDownWithError() throws {
+        // Put teardown code here. This method is called after the invocation of each test method in the class.
+    }
+
+    func testExample() throws {
+        // This is an example of a functional test case.
+        // Use XCTAssert and related functions to verify your tests produce the correct results.
+        // Any test you write for XCTest can be annotated as throws and async.
+        // Mark your test throws to produce an unexpected failure when your test encounters an uncaught error.
+        // Mark your test async to allow awaiting for asynchronous code to complete. Check the results with assertions afterwards.
+    }
+
+    func testPerformanceExample() throws {
+        // This is an example of a performance test case.
+        self.measure {
+            // Put the code you want to measure the time of here.
+        }
+    }
+
+}


### PR DESCRIPTION
closes #10683 

# Why

- This PR adds unit tests to `OrderNotificationViewMode` as a leftover task from a previous HACK-Week.

- Additionally, it adds and fixes some copiable generated methods to note objets.

# Testing

Not needed, just make sure unit tests pass,

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
