### PR TITLE
[Bundle products in order] Show bundle configuration form after scanning a bundle product

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -12,6 +12,7 @@
 - [*] Similar to orders above, the latest time range in analytics is now in the store time zone instead of the device time zone. [https://github.com/woocommerce/woocommerce-ios/pull/11479]
 - [*] For JCP sites, Jetpack installation flow should now succeed without an error in the beginning. [https://github.com/woocommerce/woocommerce-ios/pull/11558]
 - [*] Login: logging in to self-hosted sites without Jetpack connection (with application password) on multiple devices of the same device family (iPhone/iPad) is now supported. Previously, the previously logged in device becomes logged out after logging in to the same account/store on a different device of the same device family.   [https://github.com/woocommerce/woocommerce-ios/pull/11575]
+- [*] Product bundles: bundle configuration form is now shown after scanning a bundle product with barcode in the order list or order form. [https://github.com/woocommerce/woocommerce-ios/pull/11610]
 - [internal] Dashboard: The "Add products to sell" products onboarding banner is removed from the dashboard (replaced by Add Product task in store onboarding task list) [https://github.com/woocommerce/woocommerce-ios/pull/11596]
 
 16.7

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/EditableOrderViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/EditableOrderViewModel.swift
@@ -1441,21 +1441,18 @@ private extension EditableOrderViewModel {
     /// Updates the Order with the given product from SKU scanning
     ///
     func updateOrderWithBaseItem(_ item: OrderBaseItem) {
-        switch item {
-            case let .product(product) where product.productType == .bundle:
-                // When a scanned product is a bundle product, the bundle configuration view is shown first.
-                configurableScannedProductViewModel = .init(product: product,
-                                                     orderItem: nil,
-                                                     childItems: [],
-                                                     onConfigure: { [weak self] configuration in
-                    guard let self else { return }
-                    self.saveBundleConfigurationFromProductSelector(product: product, bundleConfiguration: configuration)
-                    self.syncOrderItems(products: self.selectedProducts, variations: self.selectedProductVariations)
-                    self.configurableScannedProductViewModel = nil
-                })
-                return
-            default:
-                break
+        // When a scanned product is a bundle product, the bundle configuration view is shown first.
+        if case let .product(product) = item, product.productType == .bundle {
+            configurableScannedProductViewModel = .init(product: product,
+                                                 orderItem: nil,
+                                                 childItems: [],
+                                                 onConfigure: { [weak self] configuration in
+                guard let self else { return }
+                self.saveBundleConfigurationFromProductSelector(product: product, bundleConfiguration: configuration)
+                self.syncOrderItems(products: self.selectedProducts, variations: self.selectedProductVariations)
+                self.configurableScannedProductViewModel = nil
+            })
+            return
         }
 
         guard currentOrderItems.contains(where: { $0.productOrVariationID == item.itemID }) else {

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/OrderForm.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/OrderForm.swift
@@ -543,6 +543,9 @@ private struct ProductsSection: View {
             .padding(.horizontal, insets: safeAreaInsets)
             .padding()
             .background(Color(.listForeground(modal: true)))
+            .sheet(item: $viewModel.configurableScannedProductViewModel) { configurableScannedProductViewModel in
+                ConfigurableBundleProductView(viewModel: configurableScannedProductViewModel)
+            }
             .sheet(isPresented: $viewModel.isProductSelectorPresented, onDismiss: {
                 scroll.scrollTo(addProductButton)
             }, content: {

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/EditableOrderViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/EditableOrderViewModelTests.swift
@@ -2390,6 +2390,18 @@ final class EditableOrderViewModelTests: XCTestCase {
         XCTAssertEqual(orderItem.quantity, 1)
     }
 
+    func test_when_initialItem_is_bundle_product_it_sets_configurableScannedProductViewModel_without_order_items() throws {
+        // Given
+        let bundleProduct = storageManager.createAndInsertBundleProduct(siteID: sampleSiteID, productID: 1, bundleItems: [.fake()])
+
+        // When
+        let viewModel = EditableOrderViewModel(siteID: sampleSiteID, storageManager: storageManager, initialItem: .product(bundleProduct))
+
+        // Then
+        XCTAssertNotNil(viewModel.configurableScannedProductViewModel)
+        XCTAssertEqual(viewModel.currentOrderItems.count, 0)
+    }
+
     func test_order_created_when_tax_based_on_is_customer_billing_address_then_property_is_updated() {
         stores.whenReceivingAction(ofType: SettingAction.self, thenCall: { action in
             switch action {


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #11598
<!-- Id number of the GitHub issue this PR addresses. -->

## Why
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

We implemented the bundle configuration screen after selecting a product in the product selector in the order form, but it wasn't added to the barcode scanning flow. This PR supports bundle configuration in the barcode scanning flow so that the app navigates to the bundle configuration screen after scanning a bundle product.

## How

First, a new observable property `configurableScannedProductViewModel: ConfigurableBundleProductViewModel?` was added to `EditableOrderViewModel` to be shown in a modal sheet in the order form.
Then, in the function `EditableOrderViewModel.updateOrderWithBaseItem` where we handle a scanned product or variation either from the order list or the order form entry point, `configurableScannedProductViewModel` is set to show the bundle configuration form. Upon configuration completion, it calls the same functions from selecting a bundle product in the product selector & confirming the selection. 

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

Hand-testing is optional, as it is reproducible. But feel free to give it a try on a physical device.

- [x] @jaclync tests the cases below

Prerequisite: the store has the [Product Bundles extension](https://woocommerce.com/products/product-bundles/) enabled, and a bundle product that has a barcode in the SKU.

### Order list entry point

- Go to the Orders tab
- Tap on the scan button in the navigation bar, accept the permission if needed
- Scan the barcode of the bundle product as in the prerequisite --> the bundle configuration form should be shown
- Close the configuration form --> the bundle product shouldn't be added to the order

### Order form entry point

- Go to the Orders tab
- Tap + to create an order
- Tap on the scan button in the products section
- Scan the barcode of the bundle product as in the prerequisite --> the bundle configuration form should be shown
- Proceed to complete the configuration and submit --> the bundle product should be added to the order

### Confidence check

Additional prerequisite: the store has a non-bundle product that has a barcode in the SKU.

- Go to the Orders tab
- Tap on the scan button in the navigation bar
- Scan the barcode of a non-bundle product --> notice the order with the non-bundle product is shown

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

### Order list entry point

https://github.com/woocommerce/woocommerce-ios/assets/1945542/b1a25a11-0ca7-45b8-b301-04db4da19eda

### Order form entry point

https://github.com/woocommerce/woocommerce-ios/assets/1945542/e49a0140-bc55-4921-9f4c-6dfde64b6f4b

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
