### PR TITLE
[Blaze] Unit tests for Edit Ad view

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Blaze/BlazeEditAd/BlazeEditAdViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Blaze/BlazeEditAd/BlazeEditAdViewModel.swift
@@ -46,7 +46,7 @@ final class BlazeEditAdViewModel: ObservableObject {
     private var descriptionEmptyError: String?
 
     // AI generation
-    @Published var generatingByAI = false
+    @Published private(set) var generatingByAI = false
 
     var isSaveButtonEnabled: Bool {
         guard generatingByAI == false else {

--- a/WooCommerce/Classes/ViewRelated/Blaze/BlazeEditAd/BlazeEditAdViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Blaze/BlazeEditAd/BlazeEditAdViewModel.swift
@@ -180,7 +180,7 @@ extension BlazeEditAdViewModel {
     }
 }
 
-private extension BlazeEditAdViewModel {
+extension BlazeEditAdViewModel {
     enum Localization {
         enum LengthLimit {
             static let plural = NSLocalizedString(

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -2451,6 +2451,7 @@
 		EE505DE12B3D321A006E3323 /* BlazeLearnHowView.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE505DE02B3D321A006E3323 /* BlazeLearnHowView.swift */; };
 		EE505DE32B3D36F0006E3323 /* BlazeCreateCampaignIntroViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE505DE22B3D36F0006E3323 /* BlazeCreateCampaignIntroViewModel.swift */; };
 		EE5366A52B0673760008E61E /* SubscriptionExpiryViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE5366A42B0673760008E61E /* SubscriptionExpiryViewModelTests.swift */; };
+		EE572A212B4684FF00B74B2E /* BlazeEditAdViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE572A202B4684FF00B74B2E /* BlazeEditAdViewModelTests.swift */; };
 		EE57C11D297AC27300BC31E7 /* TrackEventRequestNotificationHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE57C11C297AC27300BC31E7 /* TrackEventRequestNotificationHandler.swift */; };
 		EE57C11F297E742200BC31E7 /* WooAnalyticsEvent+ApplicationPassword.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE57C11E297E742200BC31E7 /* WooAnalyticsEvent+ApplicationPassword.swift */; };
 		EE57C121297E76E000BC31E7 /* TrackEventRequestNotificationHandlerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE57C120297E76E000BC31E7 /* TrackEventRequestNotificationHandlerTests.swift */; };
@@ -5090,6 +5091,7 @@
 		EE505DE02B3D321A006E3323 /* BlazeLearnHowView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BlazeLearnHowView.swift; sourceTree = "<group>"; };
 		EE505DE22B3D36F0006E3323 /* BlazeCreateCampaignIntroViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BlazeCreateCampaignIntroViewModel.swift; sourceTree = "<group>"; };
 		EE5366A42B0673760008E61E /* SubscriptionExpiryViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SubscriptionExpiryViewModelTests.swift; sourceTree = "<group>"; };
+		EE572A202B4684FF00B74B2E /* BlazeEditAdViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BlazeEditAdViewModelTests.swift; sourceTree = "<group>"; };
 		EE57C11C297AC27300BC31E7 /* TrackEventRequestNotificationHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TrackEventRequestNotificationHandler.swift; sourceTree = "<group>"; };
 		EE57C11E297E742200BC31E7 /* WooAnalyticsEvent+ApplicationPassword.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "WooAnalyticsEvent+ApplicationPassword.swift"; sourceTree = "<group>"; };
 		EE57C120297E76E000BC31E7 /* TrackEventRequestNotificationHandlerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TrackEventRequestNotificationHandlerTests.swift; sourceTree = "<group>"; };
@@ -5789,6 +5791,7 @@
 				024D4E962A2EC68B0090E0E6 /* BlazeWebViewModelTests.swift */,
 				021EBB372A3076F4003634CA /* BlazeEligibilityCheckerTests.swift */,
 				DEA357122ADCC4C9006380BA /* BlazeCampaignListViewModelTests.swift */,
+				EE572A202B4684FF00B74B2E /* BlazeEditAdViewModelTests.swift */,
 			);
 			path = Blaze;
 			sourceTree = "<group>";
@@ -14400,6 +14403,7 @@
 				B98968572A98F227007A2FBE /* TaxEducationalDialogViewModelTests.swift in Sources */,
 				57B374B6245B331100D58BE0 /* EmptyStateViewControllerTests.swift in Sources */,
 				EE6F08662A718DFB00AA9B88 /* FreeTrialSurveyViewModelTests.swift in Sources */,
+				EE572A212B4684FF00B74B2E /* BlazeEditAdViewModelTests.swift in Sources */,
 				02D7E7CC2A4CE5060003049A /* LocalAnnouncementsProviderTests.swift in Sources */,
 				020BE76923B4A268007FE54C /* AztecItalicFormatBarCommandTests.swift in Sources */,
 				0271E1642509C66200633F7A /* DefaultProductFormTableViewModelTests.swift in Sources */,

--- a/WooCommerce/WooCommerceTests/ViewRelated/Blaze/BlazeEditAdViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Blaze/BlazeEditAdViewModelTests.swift
@@ -37,7 +37,7 @@ final class BlazeEditAdViewModelTests: XCTestCase {
         XCTAssertEqual(sut.taglineFooterText, expectedString)
     }
 
-    func test_tagline_footer_text_is_singular_when_zero_character_remaining() {
+    func test_tagline_footer_text_is_plural_when_zero_characters_remaining() {
         // Given
         let sut = BlazeEditAdViewModel(siteID: 123,
                                        adData: sampleAdData,
@@ -91,7 +91,7 @@ final class BlazeEditAdViewModelTests: XCTestCase {
         XCTAssertEqual(sut.descriptionFooterText, expectedString)
     }
 
-    func test_description_footer_text_is_singular_when_zero_character_remaining() {
+    func test_description_footer_text_is_plural_when_zero_characters_remaining() {
         // Given
         let sut = BlazeEditAdViewModel(siteID: 123,
                                        adData: sampleAdData,

--- a/WooCommerce/WooCommerceTests/ViewRelated/Blaze/BlazeEditAdViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Blaze/BlazeEditAdViewModelTests.swift
@@ -1,0 +1,187 @@
+import Foundation
+import XCTest
+import Yosemite
+import Photos
+@testable import WooCommerce
+
+final class BlazeEditAdViewModelTests: XCTestCase {
+    private let sampleAdData = BlazeEditAdData(image: MediaPickerImage(image: UIImage.emailImage,
+                                                                       source: .media(media: .fake())),
+                                               tagline: "Sample Tagline",
+                                               description: "Sample description")
+
+    // MARK: Tagline
+    func test_tagline_footer_text_is_plural_when_multiple_characters_remaining() {
+        // Given
+        let sut = BlazeEditAdViewModel(siteID: 123,
+                                       adData: sampleAdData,
+                                       onSave: { _ in })
+        // When
+        sut.tagline = sampleString(length: 1)
+
+        // Then
+        let expectedString = String(format: BlazeEditAdViewModel.Localization.LengthLimit.plural, 31)
+        XCTAssertEqual(sut.taglineFooterText, expectedString)
+    }
+
+    func test_tagline_footer_text_is_singular_when_one_character_remaining() {
+        // Given
+        let sut = BlazeEditAdViewModel(siteID: 123,
+                                       adData: sampleAdData,
+                                       onSave: { _ in })
+        // When
+        sut.tagline = sampleString(length: 31)
+
+        // Then
+        let expectedString = String(format: BlazeEditAdViewModel.Localization.LengthLimit.singular, 1)
+        XCTAssertEqual(sut.taglineFooterText, expectedString)
+    }
+
+    func test_tagline_footer_text_is_singular_when_zero_character_remaining() {
+        // Given
+        let sut = BlazeEditAdViewModel(siteID: 123,
+                                       adData: sampleAdData,
+                                       onSave: { _ in })
+        // When
+        sut.tagline = sampleString(length: 32)
+
+        // Then
+        let expectedString = String(format: BlazeEditAdViewModel.Localization.LengthLimit.plural, 0)
+        XCTAssertEqual(sut.taglineFooterText, expectedString)
+    }
+
+    func test_tagline_footer_text_shows_error_when_tagline_is_empty() {
+        // Given
+        let sut = BlazeEditAdViewModel(siteID: 123,
+                                       adData: sampleAdData,
+                                       onSave: { _ in })
+
+        // When
+        sut.tagline = ""
+
+        // Then
+        XCTAssertEqual(sut.taglineFooterText, BlazeEditAdViewModel.Localization.taglineEmpty)
+    }
+
+    // MARK: Description
+
+    func test_description_footer_text_is_plural_when_multiple_characters_remaining() {
+        // Given
+        let sut = BlazeEditAdViewModel(siteID: 123,
+                                       adData: sampleAdData,
+                                       onSave: { _ in })
+        // When
+        sut.description = sampleString(length: 1)
+
+        // Then
+        let expectedString = String(format: BlazeEditAdViewModel.Localization.LengthLimit.plural, 139)
+        XCTAssertEqual(sut.descriptionFooterText, expectedString)
+    }
+
+    func test_description_footer_text_is_singular_when_one_character_remaining() {
+        // Given
+        let sut = BlazeEditAdViewModel(siteID: 123,
+                                       adData: sampleAdData,
+                                       onSave: { _ in })
+        // When
+        sut.description = sampleString(length: 139)
+
+        // Then
+        let expectedString = String(format: BlazeEditAdViewModel.Localization.LengthLimit.singular, 1)
+        XCTAssertEqual(sut.descriptionFooterText, expectedString)
+    }
+
+    func test_description_footer_text_is_singular_when_zero_character_remaining() {
+        // Given
+        let sut = BlazeEditAdViewModel(siteID: 123,
+                                       adData: sampleAdData,
+                                       onSave: { _ in })
+        // When
+        sut.description = sampleString(length: 140)
+
+        // Then
+        let expectedString = String(format: BlazeEditAdViewModel.Localization.LengthLimit.plural, 0)
+        XCTAssertEqual(sut.descriptionFooterText, expectedString)
+    }
+
+    func test_description_footer_text_shows_error_when_description_is_empty() {
+        // Given
+        let sut = BlazeEditAdViewModel(siteID: 123,
+                                       adData: sampleAdData,
+                                       onSave: { _ in })
+
+        // When
+        sut.description = ""
+
+        // Then
+        XCTAssertEqual(sut.descriptionFooterText, BlazeEditAdViewModel.Localization.descriptionEmpty)
+    }
+
+    // MARK: Save button
+    func test_save_button_is_disabled_when_no_change_made_to_ad_data() {
+        // Given
+        let sut = BlazeEditAdViewModel(siteID: 123,
+                                       adData: sampleAdData,
+                                       onSave: { _ in })
+
+        // Then
+        XCTAssertFalse(sut.isSaveButtonEnabled)
+    }
+
+    func test_save_button_is_enabled_when_image_is_changed() {
+        // Given
+        let sut = BlazeEditAdViewModel(siteID: 123,
+                                       adData: sampleAdData,
+                                       onSave: { _ in })
+
+        // When
+        sut.onAddImage = { _ in
+            MediaPickerImage(image: UIImage.calendar,
+                             source: .media(media: .fake()))
+        }
+
+        // Then
+        sut.addImage(from: .siteMediaLibrary)
+        waitUntil {
+            sut.isSaveButtonEnabled == true
+        }
+    }
+
+    func test_save_button_is_enabled_when_tagline_is_changed() {
+        // Given
+        let sut = BlazeEditAdViewModel(siteID: 123,
+                                       adData: sampleAdData,
+                                       onSave: { _ in })
+
+        // When
+        sut.tagline = "Test"
+
+        // Then
+        XCTAssertTrue(sut.isSaveButtonEnabled)
+    }
+
+    func test_save_button_is_enabled_when_description_is_changed() {
+        // Given
+        let sut = BlazeEditAdViewModel(siteID: 123,
+                                       adData: sampleAdData,
+                                       onSave: { _ in })
+
+        // When
+        sut.description = "Test"
+
+        // Then
+        XCTAssertTrue(sut.isSaveButtonEnabled)
+    }
+}
+
+private extension BlazeEditAdViewModelTests {
+    func sampleString(length: Int) -> String {
+        let letters = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"
+        var string = ""
+        for _ in 1...length {
+            let letter = letters.randomElement() ?? "a"
+            string.append(letter)
+        }
+        return string
+    }
+}


### PR DESCRIPTION
Part of: #11588
<!-- Id number of the GitHub issue this PR addresses. -->

## Description

This PR adds unit tests for the `BlazeEditAdViewModel`. 

These are the initial round of unit tests. We will add more tests as we integrate AI generation into this view. 

## Testing instructions
CI passing is enough.

## Screenshots
NA

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
