### PR TITLE
[Blaze] Create campaign - Networking layer

### DIFF
--- a/Fakes/Fakes/Networking.generated.swift
+++ b/Fakes/Fakes/Networking.generated.swift
@@ -329,6 +329,7 @@ extension Networking.CreateBlazeCampaign {
     public static func fake() -> Networking.CreateBlazeCampaign {
         .init(
             origin: .fake(),
+            originVersion: .fake(),
             paymentMethodID: .fake(),
             startDate: .fake(),
             endDate: .fake(),

--- a/Fakes/Fakes/Networking.generated.swift
+++ b/Fakes/Fakes/Networking.generated.swift
@@ -232,6 +232,18 @@ extension Networking.BlazeTargetLocation {
         )
     }
 }
+extension Networking.BlazeTargetOptions {
+    /// Returns a "ready to use" type filled with fake values.
+    ///
+    public static func fake() -> Networking.BlazeTargetOptions {
+        .init(
+            locations: .fake(),
+            languages: .fake(),
+            devices: .fake(),
+            pageTopics: .fake()
+        )
+    }
+}
 extension Networking.BlazeTargetTopic {
     /// Returns a "ready to use" type filled with fake values.
     ///
@@ -340,18 +352,6 @@ extension Networking.CreateBlazeCampaign.Image {
         .init(
             url: .fake(),
             mimeType: .fake()
-        )
-    }
-}
-extension Networking.CreateBlazeCampaign.Targeting {
-    /// Returns a "ready to use" type filled with fake values.
-    ///
-    public static func fake() -> Networking.CreateBlazeCampaign.Targeting {
-        .init(
-            locations: .fake(),
-            languages: .fake(),
-            devices: .fake(),
-            pageTopics: .fake()
         )
     }
 }

--- a/Fakes/Fakes/Networking.generated.swift
+++ b/Fakes/Fakes/Networking.generated.swift
@@ -311,6 +311,50 @@ extension Networking.CouponReport {
         )
     }
 }
+extension Networking.CreateBlazeCampaign {
+    /// Returns a "ready to use" type filled with fake values.
+    ///
+    public static func fake() -> Networking.CreateBlazeCampaign {
+        .init(
+            origin: .fake(),
+            paymentMethodID: .fake(),
+            startDate: .fake(),
+            endDate: .fake(),
+            timeZone: .fake(),
+            totalBudget: .fake(),
+            siteName: .fake(),
+            textSnippet: .fake(),
+            targetUrl: .fake(),
+            urlParams: .fake(),
+            mainImage: .fake(),
+            targeting: .fake(),
+            targetUrn: .fake(),
+            type: .fake()
+        )
+    }
+}
+extension Networking.CreateBlazeCampaign.Image {
+    /// Returns a "ready to use" type filled with fake values.
+    ///
+    public static func fake() -> Networking.CreateBlazeCampaign.Image {
+        .init(
+            url: .fake(),
+            mimeType: .fake()
+        )
+    }
+}
+extension Networking.CreateBlazeCampaign.Targeting {
+    /// Returns a "ready to use" type filled with fake values.
+    ///
+    public static func fake() -> Networking.CreateBlazeCampaign.Targeting {
+        .init(
+            locations: .fake(),
+            languages: .fake(),
+            devices: .fake(),
+            pageTopics: .fake()
+        )
+    }
+}
 extension Networking.CreateProductVariation {
     /// Returns a "ready to use" type filled with fake values.
     ///

--- a/Networking/Networking.xcodeproj/project.pbxproj
+++ b/Networking/Networking.xcodeproj/project.pbxproj
@@ -986,6 +986,9 @@
 		EE839C262ABEF9C900049545 /* AIProductMapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE839C252ABEF9C900049545 /* AIProductMapper.swift */; };
 		EE84D62B2B0B46E7008EA80A /* product-variation-subscription-incomplete.json in Resources */ = {isa = PBXBuildFile; fileRef = EE84D62A2B0B46E7008EA80A /* product-variation-subscription-incomplete.json */; };
 		EE8A86F1286C5226003E8AA4 /* media-update-product-id-in-wordpress-site.json in Resources */ = {isa = PBXBuildFile; fileRef = EE8A86F0286C5226003E8AA4 /* media-update-product-id-in-wordpress-site.json */; };
+		EE8C20292B4784F400FE967B /* CreateBlazeCampaignMapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE8C20282B4784F400FE967B /* CreateBlazeCampaignMapper.swift */; };
+		EE8C202B2B4786D500FE967B /* blaze-create-campaign-success.json in Resources */ = {isa = PBXBuildFile; fileRef = EE8C202A2B4786D500FE967B /* blaze-create-campaign-success.json */; };
+		EE8C202D2B47886500FE967B /* CreateBlazeCampaignMapperTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE8C202C2B47886500FE967B /* CreateBlazeCampaignMapperTests.swift */; };
 		EE8DE432294B17CD005054E7 /* DefaultApplicationPasswordUseCaseTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE8DE431294B17CD005054E7 /* DefaultApplicationPasswordUseCaseTests.swift */; };
 		EE9826902B17189B00A3F57E /* product-subscription-sync-renewals-day-month-format.json in Resources */ = {isa = PBXBuildFile; fileRef = EE98268F2B17189B00A3F57E /* product-subscription-sync-renewals-day-month-format.json */; };
 		EE9826922B17569400A3F57E /* product-subscription-sync-renewals-day-month-format-int-values.json in Resources */ = {isa = PBXBuildFile; fileRef = EE9826912B17569400A3F57E /* product-subscription-sync-renewals-day-month-format-int-values.json */; };
@@ -2034,6 +2037,9 @@
 		EE839C252ABEF9C900049545 /* AIProductMapper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AIProductMapper.swift; sourceTree = "<group>"; };
 		EE84D62A2B0B46E7008EA80A /* product-variation-subscription-incomplete.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "product-variation-subscription-incomplete.json"; sourceTree = "<group>"; };
 		EE8A86F0286C5226003E8AA4 /* media-update-product-id-in-wordpress-site.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "media-update-product-id-in-wordpress-site.json"; sourceTree = "<group>"; };
+		EE8C20282B4784F400FE967B /* CreateBlazeCampaignMapper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CreateBlazeCampaignMapper.swift; sourceTree = "<group>"; };
+		EE8C202A2B4786D500FE967B /* blaze-create-campaign-success.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "blaze-create-campaign-success.json"; sourceTree = "<group>"; };
+		EE8C202C2B47886500FE967B /* CreateBlazeCampaignMapperTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CreateBlazeCampaignMapperTests.swift; sourceTree = "<group>"; };
 		EE8DE431294B17CD005054E7 /* DefaultApplicationPasswordUseCaseTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefaultApplicationPasswordUseCaseTests.swift; sourceTree = "<group>"; };
 		EE98268F2B17189B00A3F57E /* product-subscription-sync-renewals-day-month-format.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "product-subscription-sync-renewals-day-month-format.json"; sourceTree = "<group>"; };
 		EE9826912B17569400A3F57E /* product-subscription-sync-renewals-day-month-format-int-values.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "product-subscription-sync-renewals-day-month-format-int-values.json"; sourceTree = "<group>"; };
@@ -2653,6 +2659,7 @@
 				EE66BB052B29791500518DAF /* theme-activate-success.json */,
 				EE66BB012B2893AF00518DAF /* theme-install-success.json */,
 				DEDA8DB62B187E770076BF0F /* theme-mine-success.json */,
+				EE8C202A2B4786D500FE967B /* blaze-create-campaign-success.json */,
 				DED91DDE2AD63C2800CDCC53 /* blaze-campaigns-success.json */,
 				DEDA8DA42B1839320076BF0F /* theme-list-success.json */,
 				EE28C7D72AC17960004A69F4 /* generate-product-failure.json */,
@@ -3173,6 +3180,7 @@
 				DEDA8DB42B187DE40076BF0F /* WordPressThemeMapper.swift */,
 				DEA4936C2B3995B700EED015 /* BlazeTargetOptionMappers.swift */,
 				8617EDA32B3C040700BD9D1B /* BlazeImpressionsMapper.swift */,
+				EE8C20282B4784F400FE967B /* CreateBlazeCampaignMapper.swift */,
 			);
 			path = Mapper;
 			sourceTree = "<group>";
@@ -3341,6 +3349,7 @@
 				DEDA8DB82B187EC90076BF0F /* WordPressThemeMapperTests.swift */,
 				DEA493762B39987B00EED015 /* BlazeTargetOptionMapperTests.swift */,
 				8617EDA52B3C093200BD9D1B /* BlazeImpressionsMapperTests.swift */,
+				EE8C202C2B47886500FE967B /* CreateBlazeCampaignMapperTests.swift */,
 			);
 			path = Mapper;
 			sourceTree = "<group>";
@@ -3968,6 +3977,7 @@
 				74ABA1CB213F19FE00FFAD30 /* top-performers-week.json in Resources */,
 				B9CA4F332AB213DF00285AB9 /* tax.json in Resources */,
 				456930AD2652AF00009ED69D /* shipping-label-carriers-and-rates-success.json in Resources */,
+				EE8C202B2B4786D500FE967B /* blaze-create-campaign-success.json in Resources */,
 				B524194721AC643900D6FC0A /* device-settings.json in Resources */,
 				6846B01B2A61B590008EB143 /* iap-transaction-handled.json in Resources */,
 				CE13681129FA809600EBF43C /* product-variation-min-max-quantities.json in Resources */,
@@ -4151,6 +4161,7 @@
 				02C1CEF424C6A02B00703EBA /* ProductVariationMapper.swift in Sources */,
 				3105470C262E27F000C5C02B /* WCPayPaymentIntentStatusEnum.swift in Sources */,
 				EE71CC3D2951A8EA0074D908 /* ApplicationPasswordStorage.swift in Sources */,
+				EE8C20292B4784F400FE967B /* CreateBlazeCampaignMapper.swift in Sources */,
 				311D41302783C0E200052F64 /* StripeRemote.swift in Sources */,
 				267313312559CC930026F7EF /* PaymentGateway.swift in Sources */,
 				B58E5BEA20FFB3D0003C986E /* CodingUserInfoKey+Woo.swift in Sources */,
@@ -4553,6 +4564,7 @@
 				D8FBFF1C22D51C34006E3336 /* OrderStatsRemoteV4Tests.swift in Sources */,
 				EE62EE61295ACF8D009C965B /* RequestConverterTests.swift in Sources */,
 				EE62EE65295AD46D009C965B /* String+URLTests.swift in Sources */,
+				EE8C202D2B47886500FE967B /* CreateBlazeCampaignMapperTests.swift in Sources */,
 				CE6D666F2379E82A007835A1 /* ArrayWooTests.swift in Sources */,
 				DE2E8EAD295418D8002E4B14 /* WordPressSiteRemoteTests.swift in Sources */,
 				45D685FC23D0C739005F87D0 /* ProductSkuMapperTests.swift in Sources */,

--- a/Networking/Networking.xcodeproj/project.pbxproj
+++ b/Networking/Networking.xcodeproj/project.pbxproj
@@ -3,7 +3,7 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 54;
+	objectVersion = 53;
 	objects = {
 
 /* Begin PBXBuildFile section */
@@ -940,6 +940,7 @@
 		EE4D51B62ACD331300783D77 /* product-categories-created-without-data.json in Resources */ = {isa = PBXBuildFile; fileRef = EE4D51B42ACD331300783D77 /* product-categories-created-without-data.json */; };
 		EE54C89F2947782E00A9BF61 /* ApplicationPasswordUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE54C89E2947782E00A9BF61 /* ApplicationPasswordUseCase.swift */; };
 		EE54C8A729486B6800A9BF61 /* ApplicationPasswordMapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE54C8A629486B6800A9BF61 /* ApplicationPasswordMapper.swift */; };
+		EE572A232B46D2AC00B74B2E /* CreateBlazeCampaign.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE572A222B46D2AC00B74B2E /* CreateBlazeCampaign.swift */; };
 		EE57C10E2979277300BC31E7 /* ApplicationPasswordNameAndUUID.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE57C10D2979277300BC31E7 /* ApplicationPasswordNameAndUUID.swift */; };
 		EE57C111297927C600BC31E7 /* ApplicationPasswordNameAndUUIDMapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE57C110297927C600BC31E7 /* ApplicationPasswordNameAndUUIDMapper.swift */; };
 		EE57C1152979371B00BC31E7 /* ApplicationPassword.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE57C1142979371B00BC31E7 /* ApplicationPassword.swift */; };
@@ -1987,6 +1988,7 @@
 		EE4D51B42ACD331300783D77 /* product-categories-created-without-data.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "product-categories-created-without-data.json"; sourceTree = "<group>"; };
 		EE54C89E2947782E00A9BF61 /* ApplicationPasswordUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ApplicationPasswordUseCase.swift; sourceTree = "<group>"; };
 		EE54C8A629486B6800A9BF61 /* ApplicationPasswordMapper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ApplicationPasswordMapper.swift; sourceTree = "<group>"; };
+		EE572A222B46D2AC00B74B2E /* CreateBlazeCampaign.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CreateBlazeCampaign.swift; sourceTree = "<group>"; };
 		EE57C10D2979277300BC31E7 /* ApplicationPasswordNameAndUUID.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ApplicationPasswordNameAndUUID.swift; sourceTree = "<group>"; };
 		EE57C110297927C600BC31E7 /* ApplicationPasswordNameAndUUIDMapper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ApplicationPasswordNameAndUUIDMapper.swift; sourceTree = "<group>"; };
 		EE57C1142979371B00BC31E7 /* ApplicationPassword.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ApplicationPassword.swift; sourceTree = "<group>"; };
@@ -2629,6 +2631,7 @@
 				B990FA912AA1EBC600496375 /* TaxRate.swift */,
 				EE078D8E2AD2E65400C1199E /* JWToken.swift */,
 				DED91DDC2AD62DCB00CDCC53 /* BlazeCampaign.swift */,
+				EE572A222B46D2AC00B74B2E /* CreateBlazeCampaign.swift */,
 				DEDA8DA02B182E850076BF0F /* WordPressTheme.swift */,
 				DE78DE452B2AE880002E58DE /* WordPressPage.swift */,
 				DEA4936A2B398FD700EED015 /* BlazeTargetOptions.swift */,
@@ -4464,6 +4467,7 @@
 				CE17C6B1229462C000AACE1C /* ProductStockStatus.swift in Sources */,
 				B557DA0420975500005962F4 /* OrdersRemote.swift in Sources */,
 				CCA1D60629437D8F00B40560 /* SiteSummaryStatsMapper.swift in Sources */,
+				EE572A232B46D2AC00B74B2E /* CreateBlazeCampaign.swift in Sources */,
 				CE43066C2347C5F90073CBFF /* OrderItemRefund.swift in Sources */,
 				02AAFCD22A132C1D00F05E60 /* DotcomSitePlugin.swift in Sources */,
 				45CCFCE427A2DC270012E8CB /* InboxAction.swift in Sources */,

--- a/Networking/Networking/Mapper/CreateBlazeCampaignMapper.swift
+++ b/Networking/Networking/Mapper/CreateBlazeCampaignMapper.swift
@@ -6,10 +6,10 @@ struct CreateBlazeCampaignMapper: Mapper {
 
     /// (Attempts) to parse the create Blaze campaign response
     ///
-    func map(response: Data) throws -> String {
+    func map(response: Data) throws -> Void {
         let decoder = JSONDecoder()
         decoder.keyDecodingStrategy = .convertFromSnakeCase
-        return try decoder.decode(CreateBlazeCampaignResponse.self, from: response).id
+        _ = try decoder.decode(CreateBlazeCampaignResponse.self, from: response)
     }
 }
 

--- a/Networking/Networking/Mapper/CreateBlazeCampaignMapper.swift
+++ b/Networking/Networking/Mapper/CreateBlazeCampaignMapper.swift
@@ -1,0 +1,18 @@
+import Foundation
+
+/// Mapper: Create Blaze Campaign request
+///
+struct CreateBlazeCampaignMapper: Mapper {
+
+    /// (Attempts) to parse the create Blaze campaign response
+    ///
+    func map(response: Data) throws -> Int64 {
+        let decoder = JSONDecoder()
+        decoder.keyDecodingStrategy = .convertFromSnakeCase
+        return try decoder.decode(CreateBlazeCampaignResponse.self, from: response).id
+    }
+}
+
+private struct CreateBlazeCampaignResponse: Decodable {
+    public let id: Int64
+}

--- a/Networking/Networking/Mapper/CreateBlazeCampaignMapper.swift
+++ b/Networking/Networking/Mapper/CreateBlazeCampaignMapper.swift
@@ -6,7 +6,7 @@ struct CreateBlazeCampaignMapper: Mapper {
 
     /// (Attempts) to parse the create Blaze campaign response
     ///
-    func map(response: Data) throws -> Int64 {
+    func map(response: Data) throws -> String {
         let decoder = JSONDecoder()
         decoder.keyDecodingStrategy = .convertFromSnakeCase
         return try decoder.decode(CreateBlazeCampaignResponse.self, from: response).id
@@ -14,5 +14,5 @@ struct CreateBlazeCampaignMapper: Mapper {
 }
 
 private struct CreateBlazeCampaignResponse: Decodable {
-    public let id: Int64
+    public let id: String
 }

--- a/Networking/Networking/Model/Copiable/Models+Copiable.generated.swift
+++ b/Networking/Networking/Model/Copiable/Models+Copiable.generated.swift
@@ -394,6 +394,93 @@ extension Networking.CouponReport {
     }
 }
 
+extension Networking.CreateBlazeCampaign {
+    public func copy(
+        origin: CopiableProp<String> = .copy,
+        paymentMethodID: CopiableProp<String> = .copy,
+        startDate: CopiableProp<String> = .copy,
+        endDate: CopiableProp<String> = .copy,
+        timeZone: CopiableProp<String> = .copy,
+        totalBudget: CopiableProp<Double> = .copy,
+        siteName: CopiableProp<String> = .copy,
+        textSnippet: CopiableProp<String> = .copy,
+        targetUrl: CopiableProp<String> = .copy,
+        urlParams: CopiableProp<String> = .copy,
+        mainImage: CopiableProp<CreateBlazeCampaign.Image> = .copy,
+        targeting: NullableCopiableProp<CreateBlazeCampaign.Targeting> = .copy,
+        targetUrn: CopiableProp<String> = .copy,
+        type: CopiableProp<String> = .copy
+    ) -> Networking.CreateBlazeCampaign {
+        let origin = origin ?? self.origin
+        let paymentMethodID = paymentMethodID ?? self.paymentMethodID
+        let startDate = startDate ?? self.startDate
+        let endDate = endDate ?? self.endDate
+        let timeZone = timeZone ?? self.timeZone
+        let totalBudget = totalBudget ?? self.totalBudget
+        let siteName = siteName ?? self.siteName
+        let textSnippet = textSnippet ?? self.textSnippet
+        let targetUrl = targetUrl ?? self.targetUrl
+        let urlParams = urlParams ?? self.urlParams
+        let mainImage = mainImage ?? self.mainImage
+        let targeting = targeting ?? self.targeting
+        let targetUrn = targetUrn ?? self.targetUrn
+        let type = type ?? self.type
+
+        return Networking.CreateBlazeCampaign(
+            origin: origin,
+            paymentMethodID: paymentMethodID,
+            startDate: startDate,
+            endDate: endDate,
+            timeZone: timeZone,
+            totalBudget: totalBudget,
+            siteName: siteName,
+            textSnippet: textSnippet,
+            targetUrl: targetUrl,
+            urlParams: urlParams,
+            mainImage: mainImage,
+            targeting: targeting,
+            targetUrn: targetUrn,
+            type: type
+        )
+    }
+}
+
+extension Networking.CreateBlazeCampaign.Image {
+    public func copy(
+        url: CopiableProp<String> = .copy,
+        mimeType: CopiableProp<String> = .copy
+    ) -> Networking.CreateBlazeCampaign.Image {
+        let url = url ?? self.url
+        let mimeType = mimeType ?? self.mimeType
+
+        return Networking.CreateBlazeCampaign.Image(
+            url: url,
+            mimeType: mimeType
+        )
+    }
+}
+
+extension Networking.CreateBlazeCampaign.Targeting {
+    public func copy(
+        locations: NullableCopiableProp<[Int64]> = .copy,
+        languages: NullableCopiableProp<[String]> = .copy,
+        devices: NullableCopiableProp<[String]> = .copy,
+        pageTopics: NullableCopiableProp<[String]> = .copy
+    ) -> Networking.CreateBlazeCampaign.Targeting {
+        let locations = locations ?? self.locations
+        let languages = languages ?? self.languages
+        let devices = devices ?? self.devices
+        let pageTopics = pageTopics ?? self.pageTopics
+
+        return Networking.CreateBlazeCampaign.Targeting(
+            locations: locations,
+            languages: languages,
+            devices: devices,
+            pageTopics: pageTopics
+        )
+    }
+}
+
 extension Networking.CreateProductVariation {
     public func copy(
         regularPrice: CopiableProp<String> = .copy,

--- a/Networking/Networking/Model/Copiable/Models+Copiable.generated.swift
+++ b/Networking/Networking/Model/Copiable/Models+Copiable.generated.swift
@@ -277,6 +277,27 @@ extension Networking.BlazeTargetLocation {
     }
 }
 
+extension Networking.BlazeTargetOptions {
+    public func copy(
+        locations: NullableCopiableProp<[Int64]> = .copy,
+        languages: NullableCopiableProp<[String]> = .copy,
+        devices: NullableCopiableProp<[String]> = .copy,
+        pageTopics: NullableCopiableProp<[String]> = .copy
+    ) -> Networking.BlazeTargetOptions {
+        let locations = locations ?? self.locations
+        let languages = languages ?? self.languages
+        let devices = devices ?? self.devices
+        let pageTopics = pageTopics ?? self.pageTopics
+
+        return Networking.BlazeTargetOptions(
+            locations: locations,
+            languages: languages,
+            devices: devices,
+            pageTopics: pageTopics
+        )
+    }
+}
+
 extension Networking.BlazeTargetTopic {
     public func copy(
         id: CopiableProp<String> = .copy,
@@ -398,8 +419,8 @@ extension Networking.CreateBlazeCampaign {
     public func copy(
         origin: CopiableProp<String> = .copy,
         paymentMethodID: CopiableProp<String> = .copy,
-        startDate: CopiableProp<String> = .copy,
-        endDate: CopiableProp<String> = .copy,
+        startDate: CopiableProp<Date> = .copy,
+        endDate: CopiableProp<Date> = .copy,
         timeZone: CopiableProp<String> = .copy,
         totalBudget: CopiableProp<Double> = .copy,
         siteName: CopiableProp<String> = .copy,
@@ -407,7 +428,7 @@ extension Networking.CreateBlazeCampaign {
         targetUrl: CopiableProp<String> = .copy,
         urlParams: CopiableProp<String> = .copy,
         mainImage: CopiableProp<CreateBlazeCampaign.Image> = .copy,
-        targeting: NullableCopiableProp<CreateBlazeCampaign.Targeting> = .copy,
+        targeting: NullableCopiableProp<BlazeTargetOptions> = .copy,
         targetUrn: CopiableProp<String> = .copy,
         type: CopiableProp<String> = .copy
     ) -> Networking.CreateBlazeCampaign {
@@ -456,27 +477,6 @@ extension Networking.CreateBlazeCampaign.Image {
         return Networking.CreateBlazeCampaign.Image(
             url: url,
             mimeType: mimeType
-        )
-    }
-}
-
-extension Networking.CreateBlazeCampaign.Targeting {
-    public func copy(
-        locations: NullableCopiableProp<[Int64]> = .copy,
-        languages: NullableCopiableProp<[String]> = .copy,
-        devices: NullableCopiableProp<[String]> = .copy,
-        pageTopics: NullableCopiableProp<[String]> = .copy
-    ) -> Networking.CreateBlazeCampaign.Targeting {
-        let locations = locations ?? self.locations
-        let languages = languages ?? self.languages
-        let devices = devices ?? self.devices
-        let pageTopics = pageTopics ?? self.pageTopics
-
-        return Networking.CreateBlazeCampaign.Targeting(
-            locations: locations,
-            languages: languages,
-            devices: devices,
-            pageTopics: pageTopics
         )
     }
 }

--- a/Networking/Networking/Model/Copiable/Models+Copiable.generated.swift
+++ b/Networking/Networking/Model/Copiable/Models+Copiable.generated.swift
@@ -418,6 +418,7 @@ extension Networking.CouponReport {
 extension Networking.CreateBlazeCampaign {
     public func copy(
         origin: CopiableProp<String> = .copy,
+        originVersion: CopiableProp<String> = .copy,
         paymentMethodID: CopiableProp<String> = .copy,
         startDate: CopiableProp<Date> = .copy,
         endDate: CopiableProp<Date> = .copy,
@@ -433,6 +434,7 @@ extension Networking.CreateBlazeCampaign {
         type: CopiableProp<String> = .copy
     ) -> Networking.CreateBlazeCampaign {
         let origin = origin ?? self.origin
+        let originVersion = originVersion ?? self.originVersion
         let paymentMethodID = paymentMethodID ?? self.paymentMethodID
         let startDate = startDate ?? self.startDate
         let endDate = endDate ?? self.endDate
@@ -449,6 +451,7 @@ extension Networking.CreateBlazeCampaign {
 
         return Networking.CreateBlazeCampaign(
             origin: origin,
+            originVersion: originVersion,
             paymentMethodID: paymentMethodID,
             startDate: startDate,
             endDate: endDate,

--- a/Networking/Networking/Model/CreateBlazeCampaign.swift
+++ b/Networking/Networking/Model/CreateBlazeCampaign.swift
@@ -3,8 +3,8 @@ import Codegen
 
 /// Represents the entity sent for creating a new Blaze Campaign
 ///
-public struct CreateBlazeCampaign: Encodable, Equatable, GeneratedFakeable, GeneratedCopiable {
-    public struct Image: Encodable, Equatable, GeneratedFakeable, GeneratedCopiable {
+public struct CreateBlazeCampaign: Encodable, GeneratedFakeable, GeneratedCopiable {
+    public struct Image: Encodable, GeneratedFakeable, GeneratedCopiable {
         /// URL of the image for the campaign
         ///
         public let url: String
@@ -16,31 +16,6 @@ public struct CreateBlazeCampaign: Encodable, Equatable, GeneratedFakeable, Gene
         public init(url: String, mimeType: String) {
             self.url = url
             self.mimeType = mimeType
-        }
-    }
-
-    public struct Targeting: Encodable, Equatable, GeneratedFakeable, GeneratedCopiable {
-        /// IDs of locations => GET /locations/search?keyword=city
-        ///
-        public let locations: [Int64]?
-
-        /// IDs of languages => GET /targeting/languages
-        ///
-        public let languages: [String]?
-
-        /// IDs of devices => GET /targeting/devices (absent if any)
-        ///
-        public let devices: [String]?
-
-        /// IDs of pageTopics => GET /targeting/page-topics (absent if any)
-        ///
-        public let pageTopics: [String]?
-
-        public init(locations: [Int64]?, languages: [String]?, devices: [String]?, pageTopics: [String]?) {
-            self.locations = locations
-            self.languages = languages
-            self.devices = devices
-            self.pageTopics = pageTopics
         }
     }
 
@@ -94,7 +69,7 @@ public struct CreateBlazeCampaign: Encodable, Equatable, GeneratedFakeable, Gene
     /// Targeting
     /// Can be nil if no targeting
     ///
-    public let targeting: Targeting?
+    public let targeting: BlazeTargetOptions?
 
     /// Sample format `urn:wpcom:post:123456:789`
     /// - 123456 is the site ID
@@ -117,7 +92,7 @@ public struct CreateBlazeCampaign: Encodable, Equatable, GeneratedFakeable, Gene
                 targetUrl: String,
                 urlParams: String,
                 mainImage: Image,
-                targeting: Targeting?,
+                targeting: BlazeTargetOptions?,
                 targetUrn: String,
                 type: String) {
         self.origin = origin

--- a/Networking/Networking/Model/CreateBlazeCampaign.swift
+++ b/Networking/Networking/Model/CreateBlazeCampaign.swift
@@ -28,15 +28,17 @@ public struct CreateBlazeCampaign: Encodable, GeneratedFakeable, GeneratedCopiab
     ///
     public let paymentMethodID: String
 
-    /// Sample format `2023-12-05`
+    /// Start date of the campaign
+    ///
     /// Including, can't be less than 24 hours after submission time
     ///
-    public let startDate: String
+    public let startDate: Date
 
-    /// Sample format `2023-12-11`
+    /// End date of the campaign
+    ///
     /// Including
     ///
-    public let endDate: String
+    public let endDate: Date
 
     /// Time zone identifier (TZ database name).
     ///
@@ -83,8 +85,8 @@ public struct CreateBlazeCampaign: Encodable, GeneratedFakeable, GeneratedCopiab
 
     public init(origin: String,
                 paymentMethodID: String,
-                startDate: String,
-                endDate: String,
+                startDate: Date,
+                endDate: Date,
                 timeZone: String,
                 totalBudget: Double,
                 siteName: String,

--- a/Networking/Networking/Model/CreateBlazeCampaign.swift
+++ b/Networking/Networking/Model/CreateBlazeCampaign.swift
@@ -24,6 +24,10 @@ public struct CreateBlazeCampaign: Encodable, GeneratedFakeable, GeneratedCopiab
     ///
     public let origin: String
 
+    /// App version to track origin
+    ///
+    public let originVersion: String
+
     /// See peeHDf-2ii-p2
     ///
     public let paymentMethodID: String
@@ -84,6 +88,7 @@ public struct CreateBlazeCampaign: Encodable, GeneratedFakeable, GeneratedCopiab
     public let type: String
 
     public init(origin: String,
+                originVersion: String,
                 paymentMethodID: String,
                 startDate: Date,
                 endDate: Date,
@@ -98,6 +103,7 @@ public struct CreateBlazeCampaign: Encodable, GeneratedFakeable, GeneratedCopiab
                 targetUrn: String,
                 type: String) {
         self.origin = origin
+        self.originVersion = originVersion
         self.paymentMethodID = paymentMethodID
         self.startDate = startDate
         self.endDate = endDate

--- a/Networking/Networking/Model/CreateBlazeCampaign.swift
+++ b/Networking/Networking/Model/CreateBlazeCampaign.swift
@@ -1,0 +1,138 @@
+import Foundation
+import Codegen
+
+/// Represents the entity sent for creating a new Blaze Campaign
+///
+public struct CreateBlazeCampaign: Encodable, Equatable, GeneratedFakeable, GeneratedCopiable {
+    public struct Image: Encodable, Equatable, GeneratedFakeable, GeneratedCopiable {
+        /// URL of the image for the campaign
+        ///
+        public let url: String
+
+        /// mime type of the image
+        ///
+        public let mimeType: String
+
+        public init(url: String, mimeType: String) {
+            self.url = url
+            self.mimeType = mimeType
+        }
+    }
+
+    public struct Targeting: Encodable, Equatable, GeneratedFakeable, GeneratedCopiable {
+        /// IDs of locations => GET /locations/search?keyword=city
+        ///
+        public let locations: [Int64]?
+
+        /// IDs of languages => GET /targeting/languages
+        ///
+        public let languages: [String]?
+
+        /// IDs of devices => GET /targeting/devices (absent if any)
+        ///
+        public let devices: [String]?
+
+        /// IDs of pageTopics => GET /targeting/page-topics (absent if any)
+        ///
+        public let pageTopics: [String]?
+
+        public init(locations: [Int64]?, languages: [String]?, devices: [String]?, pageTopics: [String]?) {
+            self.locations = locations
+            self.languages = languages
+            self.devices = devices
+            self.pageTopics = pageTopics
+        }
+    }
+
+    /// Origin of the campaign creation
+    /// Accepted options are calypso, jetpack, wc-mobile-app, wp-mobile-app
+    ///
+    public let origin: String
+
+    /// See peeHDf-2ii-p2
+    ///
+    public let paymentMethodID: String
+
+    /// Sample format `2023-12-05`
+    /// Including, can't be less than 24 hours after submission time
+    ///
+    public let startDate: String
+
+    /// Sample format `2023-12-11`
+    /// Including
+    ///
+    public let endDate: String
+
+    /// Time zone identifier (TZ database name).
+    ///
+    public let timeZone: String
+
+    /// Total campaign budget in USD
+    ///
+    public let totalBudget: Double
+
+    /// Tagline of the campaign
+    ///
+    public let siteName: String
+
+    /// Description of the campaign
+    ///
+    public let textSnippet: String
+
+    /// URL of the campaign
+    ///
+    public let targetUrl: String
+
+    /// URL parameters of the campaign
+    ///
+    public let urlParams: String
+
+    /// Image for the campaign
+    ///
+    public let mainImage: Image
+
+    /// Targeting
+    /// Can be nil if no targeting
+    ///
+    public let targeting: Targeting?
+
+    /// Sample format `urn:wpcom:post:123456:789`
+    /// - 123456 is the site ID
+    /// - 789 is the product ID
+    ///
+    public let targetUrn: String
+
+    /// Accepted options - post, page, product
+    ///
+    public let type: String
+
+    public init(origin: String,
+                paymentMethodID: String,
+                startDate: String,
+                endDate: String,
+                timeZone: String,
+                totalBudget: Double,
+                siteName: String,
+                textSnippet: String,
+                targetUrl: String,
+                urlParams: String,
+                mainImage: Image,
+                targeting: Targeting?,
+                targetUrn: String,
+                type: String) {
+        self.origin = origin
+        self.paymentMethodID = paymentMethodID
+        self.startDate = startDate
+        self.endDate = endDate
+        self.timeZone = timeZone
+        self.totalBudget = totalBudget
+        self.siteName = siteName
+        self.textSnippet = textSnippet
+        self.targetUrl = targetUrl
+        self.urlParams = urlParams
+        self.mainImage = mainImage
+        self.targeting = targeting
+        self.targetUrn = targetUrn
+        self.type = type
+    }
+}

--- a/Networking/Networking/Remote/BlazeRemote.swift
+++ b/Networking/Networking/Remote/BlazeRemote.swift
@@ -8,9 +8,10 @@ public protocol BlazeRemoteProtocol {
     /// - Parameters:
     ///    - campaign: Details of the Blaze campaign to be created
     ///    - siteID: WPCom ID for the site to create the campaign in.
+    /// - Returns: Newly created Blaze campaign's ID
     ///
     func createCampaign(_ campaign: CreateBlazeCampaign,
-                        siteID: Int64) async throws
+                        siteID: Int64) async throws -> Int64
 
     /// Loads campaigns for the site with the provided ID on the given page number.
     /// - Parameters:
@@ -64,11 +65,12 @@ public protocol BlazeRemoteProtocol {
 public final class BlazeRemote: Remote, BlazeRemoteProtocol {
 
     public func createCampaign(_ campaign: CreateBlazeCampaign,
-                               siteID: Int64) async throws {
+                               siteID: Int64) async throws -> Int64 {
         let path = Paths.campaigns(siteID: siteID)
         let parameters = try campaign.toDictionary(keyEncodingStrategy: .convertToSnakeCase)
         let request = DotcomRequest(wordpressApiVersion: .wpcomMark2, method: .post, path: path, parameters: parameters)
-        return try await enqueue(request)
+        let mapper = CreateBlazeCampaignMapper()
+        return try await enqueue(request, mapper: mapper)
     }
 
     public func loadCampaigns(for siteID: Int64, pageNumber: Int) async throws -> [BlazeCampaign] {

--- a/Networking/Networking/Remote/BlazeRemote.swift
+++ b/Networking/Networking/Remote/BlazeRemote.swift
@@ -232,16 +232,17 @@ public struct BlazeForecastedImpressionsInput: Encodable, GeneratedFakeable {
         case targetings
     }
 }
+
 /// Blaze Forecasted Impressions sub-input related to targetings.
-public struct BlazeTargetOptions: Encodable {
+public struct BlazeTargetOptions: Codable, GeneratedFakeable, GeneratedCopiable {
     // Target location IDs for the campaign. Optional.
-    let locations: [Int64]?
+    public let locations: [Int64]?
     // Target languages for the campaign. Optional.
-    let languages: [String]?
+    public let languages: [String]?
     // Target devices for the campaign. Optional.
-    let devices: [String]?
+    public let devices: [String]?
     // Target topics for the campaign. Optional.
-    let pageTopics: [String]?
+    public let pageTopics: [String]?
 
     public init(locations: [Int64]?,
                 languages: [String]?,

--- a/Networking/Networking/Remote/BlazeRemote.swift
+++ b/Networking/Networking/Remote/BlazeRemote.swift
@@ -8,10 +8,9 @@ public protocol BlazeRemoteProtocol {
     /// - Parameters:
     ///    - campaign: Details of the Blaze campaign to be created
     ///    - siteID: WPCom ID for the site to create the campaign in.
-    /// - Returns: Newly created Blaze campaign's ID
     ///
     func createCampaign(_ campaign: CreateBlazeCampaign,
-                        siteID: Int64) async throws -> String
+                        siteID: Int64) async throws
 
     /// Loads campaigns for the site with the provided ID on the given page number.
     /// - Parameters:
@@ -65,7 +64,7 @@ public protocol BlazeRemoteProtocol {
 public final class BlazeRemote: Remote, BlazeRemoteProtocol {
 
     public func createCampaign(_ campaign: CreateBlazeCampaign,
-                               siteID: Int64) async throws -> String {
+                               siteID: Int64) async throws {
         let path = Paths.campaigns(siteID: siteID)
 
         let dateFormatter = DateFormatter()
@@ -74,7 +73,7 @@ public final class BlazeRemote: Remote, BlazeRemoteProtocol {
 
         let request = DotcomRequest(wordpressApiVersion: .wpcomMark2, method: .post, path: path, parameters: parameters)
         let mapper = CreateBlazeCampaignMapper()
-        return try await enqueue(request, mapper: mapper)
+        try await enqueue(request, mapper: mapper)
     }
 
     public func loadCampaigns(for siteID: Int64, pageNumber: Int) async throws -> [BlazeCampaign] {

--- a/Networking/Networking/Remote/BlazeRemote.swift
+++ b/Networking/Networking/Remote/BlazeRemote.swift
@@ -11,7 +11,7 @@ public protocol BlazeRemoteProtocol {
     /// - Returns: Newly created Blaze campaign's ID
     ///
     func createCampaign(_ campaign: CreateBlazeCampaign,
-                        siteID: Int64) async throws -> Int64
+                        siteID: Int64) async throws -> String
 
     /// Loads campaigns for the site with the provided ID on the given page number.
     /// - Parameters:
@@ -65,7 +65,7 @@ public protocol BlazeRemoteProtocol {
 public final class BlazeRemote: Remote, BlazeRemoteProtocol {
 
     public func createCampaign(_ campaign: CreateBlazeCampaign,
-                               siteID: Int64) async throws -> Int64 {
+                               siteID: Int64) async throws -> String {
         let path = Paths.campaigns(siteID: siteID)
 
         let dateFormatter = DateFormatter()

--- a/Networking/Networking/Remote/BlazeRemote.swift
+++ b/Networking/Networking/Remote/BlazeRemote.swift
@@ -67,7 +67,11 @@ public final class BlazeRemote: Remote, BlazeRemoteProtocol {
     public func createCampaign(_ campaign: CreateBlazeCampaign,
                                siteID: Int64) async throws -> Int64 {
         let path = Paths.campaigns(siteID: siteID)
-        let parameters = try campaign.toDictionary(keyEncodingStrategy: .convertToSnakeCase)
+
+        let dateFormatter = DateFormatter()
+        dateFormatter.dateFormat = Constants.dateFormat
+        let parameters = try campaign.toDictionary(keyEncodingStrategy: .convertToSnakeCase, dateFormatter: dateFormatter)
+
         let request = DotcomRequest(wordpressApiVersion: .wpcomMark2, method: .post, path: path, parameters: parameters)
         let mapper = CreateBlazeCampaignMapper()
         return try await enqueue(request, mapper: mapper)

--- a/Networking/Networking/Remote/BlazeRemote.swift
+++ b/Networking/Networking/Remote/BlazeRemote.swift
@@ -4,6 +4,14 @@ import Foundation
 /// Protocol for `BlazeRemote` mainly used for mocking.
 ///
 public protocol BlazeRemoteProtocol {
+    /// Creates a new Blaze campaign
+    /// - Parameters:
+    ///    - campaign: Details of the Blaze campaign to be created
+    ///    - siteID: WPCom ID for the site to create the campaign in.
+    ///
+    func createCampaign(_ campaign: CreateBlazeCampaign,
+                        siteID: Int64) async throws
+
     /// Loads campaigns for the site with the provided ID on the given page number.
     /// - Parameters:
     ///    - siteID: WPCom ID for the site to load ads campaigns.
@@ -54,6 +62,14 @@ public protocol BlazeRemoteProtocol {
 /// Blaze: Remote Endpoints
 ///
 public final class BlazeRemote: Remote, BlazeRemoteProtocol {
+
+    public func createCampaign(_ campaign: CreateBlazeCampaign,
+                               siteID: Int64) async throws {
+        let path = Paths.campaigns(siteID: siteID)
+        let parameters = try campaign.toDictionary(keyEncodingStrategy: .convertToSnakeCase)
+        let request = DotcomRequest(wordpressApiVersion: .wpcomMark2, method: .post, path: path, parameters: parameters)
+        return try await enqueue(request)
+    }
 
     public func loadCampaigns(for siteID: Int64, pageNumber: Int) async throws -> [BlazeCampaign] {
         let path = Paths.campaignSearch(siteID: siteID)
@@ -155,6 +171,10 @@ private extension BlazeRemote {
     }
 
     enum Paths {
+        static func campaigns(siteID: Int64) -> String {
+            "sites/\(siteID)/wordads/dsp/api/v1.1/campaigns"
+        }
+
         static func campaignSearch(siteID: Int64) -> String {
             "sites/\(siteID)/wordads/dsp/api/v1/search/campaigns/site/\(siteID)"
         }

--- a/Networking/NetworkingTests/Mapper/CreateBlazeCampaignMapperTests.swift
+++ b/Networking/NetworkingTests/Mapper/CreateBlazeCampaignMapperTests.swift
@@ -8,7 +8,7 @@ final class CreateBlazeCampaignMapperTests: XCTestCase {
     func test_CreateBlazeCampaignMapper_parses_response() throws {
         let id = try mapLoadCreateBlazeCampaignResponse()
 
-        XCTAssertEqual(id, 12345)
+        XCTAssertEqual(id, "campaign-12345")
     }
 }
 
@@ -18,7 +18,7 @@ private extension CreateBlazeCampaignMapperTests {
 
     /// Returns the CreateBlazeCampaignMapper output upon receiving `filename` (Data Encoded)
     ///
-    func mapCreateBlazeCampaignResponse(from filename: String) throws -> Int64 {
+    func mapCreateBlazeCampaignResponse(from filename: String) throws -> String {
         guard let response = Loader.contentsOf(filename) else {
             throw FileNotFoundError()
         }
@@ -28,7 +28,7 @@ private extension CreateBlazeCampaignMapperTests {
 
     /// Returns the CreateBlazeCampaignMapper output from `blaze-create-campaign-success.json`
     ///
-    func mapLoadCreateBlazeCampaignResponse() throws -> Int64 {
+    func mapLoadCreateBlazeCampaignResponse() throws -> String {
         return try mapCreateBlazeCampaignResponse(from: "blaze-create-campaign-success")
     }
 

--- a/Networking/NetworkingTests/Mapper/CreateBlazeCampaignMapperTests.swift
+++ b/Networking/NetworkingTests/Mapper/CreateBlazeCampaignMapperTests.swift
@@ -5,10 +5,8 @@ final class CreateBlazeCampaignMapperTests: XCTestCase {
 
     /// Verifies that the response is parsed
     ///
-    func test_CreateBlazeCampaignMapper_parses_response() throws {
-        let id = try mapLoadCreateBlazeCampaignResponse()
-
-        XCTAssertEqual(id, "campaign-12345")
+    func test_CreateBlazeCampaignMapper_parses_response_without_error() throws {
+        try mapLoadCreateBlazeCampaignResponse()
     }
 }
 
@@ -18,7 +16,7 @@ private extension CreateBlazeCampaignMapperTests {
 
     /// Returns the CreateBlazeCampaignMapper output upon receiving `filename` (Data Encoded)
     ///
-    func mapCreateBlazeCampaignResponse(from filename: String) throws -> String {
+    func mapCreateBlazeCampaignResponse(from filename: String) throws {
         guard let response = Loader.contentsOf(filename) else {
             throw FileNotFoundError()
         }
@@ -28,7 +26,7 @@ private extension CreateBlazeCampaignMapperTests {
 
     /// Returns the CreateBlazeCampaignMapper output from `blaze-create-campaign-success.json`
     ///
-    func mapLoadCreateBlazeCampaignResponse() throws -> String {
+    func mapLoadCreateBlazeCampaignResponse() throws {
         return try mapCreateBlazeCampaignResponse(from: "blaze-create-campaign-success")
     }
 

--- a/Networking/NetworkingTests/Mapper/CreateBlazeCampaignMapperTests.swift
+++ b/Networking/NetworkingTests/Mapper/CreateBlazeCampaignMapperTests.swift
@@ -1,0 +1,36 @@
+import XCTest
+@testable import Networking
+
+final class CreateBlazeCampaignMapperTests: XCTestCase {
+
+    /// Verifies that the response is parsed
+    ///
+    func test_CreateBlazeCampaignMapper_parses_response() throws {
+        let id = try mapLoadCreateBlazeCampaignResponse()
+
+        XCTAssertEqual(id, 12345)
+    }
+}
+
+// MARK: - Test Helpers
+//
+private extension CreateBlazeCampaignMapperTests {
+
+    /// Returns the CreateBlazeCampaignMapper output upon receiving `filename` (Data Encoded)
+    ///
+    func mapCreateBlazeCampaignResponse(from filename: String) throws -> Int64 {
+        guard let response = Loader.contentsOf(filename) else {
+            throw FileNotFoundError()
+        }
+
+        return try CreateBlazeCampaignMapper().map(response: response)
+    }
+
+    /// Returns the CreateBlazeCampaignMapper output from `blaze-create-campaign-success.json`
+    ///
+    func mapLoadCreateBlazeCampaignResponse() throws -> Int64 {
+        return try mapCreateBlazeCampaignResponse(from: "blaze-create-campaign-success")
+    }
+
+    struct FileNotFoundError: Error {}
+}

--- a/Networking/NetworkingTests/Remote/BlazeRemoteTests.swift
+++ b/Networking/NetworkingTests/Remote/BlazeRemoteTests.swift
@@ -63,6 +63,7 @@ final class BlazeRemoteTests: XCTestCase {
                                            devices: ["mobile"],
                                            pageTopics: ["IAB3", "IAB4"])
         let campaign = CreateBlazeCampaign.fake().copy(origin: "WooMobile",
+                                                       originVersion: "1.0.1",
                                                        paymentMethodID: "payment-method-id-123",
                                                        startDate: startDate,
                                                        endDate: endDate,
@@ -83,6 +84,7 @@ final class BlazeRemoteTests: XCTestCase {
         // Then
         let request = try XCTUnwrap(network.requestsForResponseData.first as? DotcomRequest)
         XCTAssertEqual(request.parameters?["origin"] as? String, campaign.origin)
+        XCTAssertEqual(request.parameters?["origin_version"] as? String, campaign.originVersion)
         XCTAssertEqual(request.parameters?["payment_method_id"] as? String, campaign.paymentMethodID)
         XCTAssertEqual(request.parameters?["start_date"] as? String, startDateString)
         XCTAssertEqual(request.parameters?["end_date"] as? String, endDateString)
@@ -104,6 +106,7 @@ final class BlazeRemoteTests: XCTestCase {
         XCTAssertEqual(targetingDict["page_topics"] as? [String], targeting.pageTopics)
 
         XCTAssertEqual(request.parameters?["target_urn"] as? String, campaign.targetUrn)
+        XCTAssertEqual(request.parameters?["type"] as? String, campaign.type)
     }
 
     func test_createCampaign_properly_relays_networking_errors() async {

--- a/Networking/NetworkingTests/Remote/BlazeRemoteTests.swift
+++ b/Networking/NetworkingTests/Remote/BlazeRemoteTests.swift
@@ -37,7 +37,7 @@ final class BlazeRemoteTests: XCTestCase {
         let result = try await remote.createCampaign(.fake(), siteID: sampleSiteID)
 
         // Then
-        XCTAssertEqual(result, 12345)
+        XCTAssertEqual(result, "campaign-12345")
     }
 
     func test_createCampaign_sends_correct_parameters() async throws {

--- a/Networking/NetworkingTests/Remote/BlazeRemoteTests.swift
+++ b/Networking/NetworkingTests/Remote/BlazeRemoteTests.swift
@@ -21,6 +21,99 @@ final class BlazeRemoteTests: XCTestCase {
         super.tearDown()
     }
 
+    // MARK: - Create campaign
+
+    func test_createCampaign_returns_successfully() async throws {
+        // Given
+        let remote = BlazeRemote(network: network)
+        let suffix = "sites/\(sampleSiteID)/wordads/dsp/api/v1.1/campaigns"
+
+        network.simulateResponse(requestUrlSuffix: suffix, filename: "generic_success")
+
+        // When
+        _ = try await remote.createCampaign(.fake(), siteID: sampleSiteID)
+
+        // Then
+        // No error
+    }
+
+    func test_createCampaign_sends_correct_parameters() async throws {
+        // Given
+        let remote = BlazeRemote(network: network)
+        let suffix = "sites/\(sampleSiteID)/wordads/dsp/api/v1.1/campaigns"
+
+        network.simulateResponse(requestUrlSuffix: suffix, filename: "generic_success")
+
+        let mainImage = CreateBlazeCampaign.Image(url: "https://example.com/wp-content/uploads/2023/06/0_1-2.png?quality=80&strip=info&w=1500",
+                                                  mimeType: "image/png")
+        let targeting = CreateBlazeCampaign.Targeting(locations: [29211, 42546],
+                                                      languages: ["en", "de"],
+                                                      devices: ["mobile"],
+                                                      pageTopics: ["IAB3", "IAB4"])
+        let campaign = CreateBlazeCampaign.fake().copy(origin: "WooMobile",
+                                                       paymentMethodID: "payment-method-id-123",
+                                                       startDate: "2023-12-05",
+                                                       endDate: "2023-12-11",
+                                                       timeZone: "America/New_York",
+                                                       totalBudget: 35.00,
+                                                       siteName: "Unleash Your Brain's Potential",
+                                                       textSnippet: "Discover the power of computer neural networks in unlocking your brain's full potential.",
+                                                       targetUrl: "https://example.com/2023/06/25/unlocking-the-secrets-of-computer-neural-networks/",
+                                                       urlParams: "var1=val2&var2=val2",
+                                                       mainImage: mainImage,
+                                                       targeting: targeting,
+                                                       targetUrn: "urn:wpcom:post:191174658:47",
+                                                       type: "product")
+
+        // When
+        _ = try await remote.createCampaign(campaign, siteID: sampleSiteID)
+
+        // Then
+        let request = try XCTUnwrap(network.requestsForResponseData.first as? DotcomRequest)
+        XCTAssertEqual(request.parameters?["origin"] as? String, campaign.origin)
+        XCTAssertEqual(request.parameters?["payment_method_id"] as? String, campaign.paymentMethodID)
+        XCTAssertEqual(request.parameters?["start_date"] as? String, campaign.startDate)
+        XCTAssertEqual(request.parameters?["end_date"] as? String, campaign.endDate)
+        XCTAssertEqual(request.parameters?["time_zone"] as? String, campaign.timeZone)
+        XCTAssertEqual(request.parameters?["total_budget"] as? Double, campaign.totalBudget)
+        XCTAssertEqual(request.parameters?["site_name"] as? String, campaign.siteName)
+        XCTAssertEqual(request.parameters?["text_snippet"] as? String, campaign.textSnippet)
+        XCTAssertEqual(request.parameters?["target_url"] as? String, campaign.targetUrl)
+        XCTAssertEqual(request.parameters?["url_params"] as? String, campaign.urlParams)
+
+        let mainImageDict = try XCTUnwrap(request.parameters?["main_image"] as? [String: Any])
+        XCTAssertEqual(mainImageDict["url"] as? String, mainImage.url)
+        XCTAssertEqual(mainImageDict["mime_type"] as? String, mainImage.mimeType)
+
+        let targetingDict = try XCTUnwrap(request.parameters?["targeting"] as? [String: Any])
+        XCTAssertEqual(targetingDict["locations"] as? [Int64], targeting.locations)
+        XCTAssertEqual(targetingDict["languages"] as? [String], targeting.languages)
+        XCTAssertEqual(targetingDict["devices"] as? [String], targeting.devices)
+        XCTAssertEqual(targetingDict["page_topics"] as? [String], targeting.pageTopics)
+
+        XCTAssertEqual(request.parameters?["target_urn"] as? String, campaign.targetUrn)
+    }
+
+    func test_createCampaign_properly_relays_networking_errors() async {
+        // Given
+        let remote = BlazeRemote(network: network)
+
+        let expectedError = NetworkError.unacceptableStatusCode(statusCode: 403)
+        let suffix = "sites/\(sampleSiteID)/wordads/dsp/api/v1.1/campaigns"
+        network.simulateError(requestUrlSuffix: suffix, error: expectedError)
+
+        do {
+            // When
+            _ = try await remote.createCampaign(.fake(), siteID: sampleSiteID)
+
+            // Then
+            XCTFail("Request should fail")
+        } catch {
+            // Then
+            XCTAssertEqual(error as? NetworkError, expectedError)
+        }
+    }
+
     // MARK: - Load campaigns tests
 
     /// Verifies that loadCampaign properly parses the response.

--- a/Networking/NetworkingTests/Remote/BlazeRemoteTests.swift
+++ b/Networking/NetworkingTests/Remote/BlazeRemoteTests.swift
@@ -47,16 +47,25 @@ final class BlazeRemoteTests: XCTestCase {
 
         network.simulateResponse(requestUrlSuffix: suffix, filename: "blaze-create-campaign-success")
 
+        let dateFormatter = DateFormatter()
+        dateFormatter.dateFormat = "yyyy-MM-dd"
+
+        let startDateString = "2023-12-05"
+        let startDate = try XCTUnwrap(dateFormatter.date(from: startDateString))
+
+        let endDateString = "2023-12-11"
+        let endDate = try XCTUnwrap(dateFormatter.date(from: endDateString))
+
         let mainImage = CreateBlazeCampaign.Image(url: "https://example.com/wp-content/uploads/2023/06/0_1-2.png?quality=80&strip=info&w=1500",
                                                   mimeType: "image/png")
-        let targeting = CreateBlazeCampaign.Targeting(locations: [29211, 42546],
-                                                      languages: ["en", "de"],
-                                                      devices: ["mobile"],
-                                                      pageTopics: ["IAB3", "IAB4"])
+        let targeting = BlazeTargetOptions(locations: [29211, 42546],
+                                           languages: ["en", "de"],
+                                           devices: ["mobile"],
+                                           pageTopics: ["IAB3", "IAB4"])
         let campaign = CreateBlazeCampaign.fake().copy(origin: "WooMobile",
                                                        paymentMethodID: "payment-method-id-123",
-                                                       startDate: "2023-12-05",
-                                                       endDate: "2023-12-11",
+                                                       startDate: startDate,
+                                                       endDate: endDate,
                                                        timeZone: "America/New_York",
                                                        totalBudget: 35.00,
                                                        siteName: "Unleash Your Brain's Potential",
@@ -75,8 +84,8 @@ final class BlazeRemoteTests: XCTestCase {
         let request = try XCTUnwrap(network.requestsForResponseData.first as? DotcomRequest)
         XCTAssertEqual(request.parameters?["origin"] as? String, campaign.origin)
         XCTAssertEqual(request.parameters?["payment_method_id"] as? String, campaign.paymentMethodID)
-        XCTAssertEqual(request.parameters?["start_date"] as? String, campaign.startDate)
-        XCTAssertEqual(request.parameters?["end_date"] as? String, campaign.endDate)
+        XCTAssertEqual(request.parameters?["start_date"] as? String, startDateString)
+        XCTAssertEqual(request.parameters?["end_date"] as? String, endDateString)
         XCTAssertEqual(request.parameters?["time_zone"] as? String, campaign.timeZone)
         XCTAssertEqual(request.parameters?["total_budget"] as? Double, campaign.totalBudget)
         XCTAssertEqual(request.parameters?["site_name"] as? String, campaign.siteName)

--- a/Networking/NetworkingTests/Remote/BlazeRemoteTests.swift
+++ b/Networking/NetworkingTests/Remote/BlazeRemoteTests.swift
@@ -28,13 +28,16 @@ final class BlazeRemoteTests: XCTestCase {
         let remote = BlazeRemote(network: network)
         let suffix = "sites/\(sampleSiteID)/wordads/dsp/api/v1.1/campaigns"
 
-        network.simulateResponse(requestUrlSuffix: suffix, filename: "generic_success")
+        network.simulateResponse(requestUrlSuffix: suffix, filename: "blaze-create-campaign-success")
 
         // When
         _ = try await remote.createCampaign(.fake(), siteID: sampleSiteID)
 
+        // When
+        let result = try await remote.createCampaign(.fake(), siteID: sampleSiteID)
+
         // Then
-        // No error
+        XCTAssertEqual(result, 12345)
     }
 
     func test_createCampaign_sends_correct_parameters() async throws {
@@ -42,7 +45,7 @@ final class BlazeRemoteTests: XCTestCase {
         let remote = BlazeRemote(network: network)
         let suffix = "sites/\(sampleSiteID)/wordads/dsp/api/v1.1/campaigns"
 
-        network.simulateResponse(requestUrlSuffix: suffix, filename: "generic_success")
+        network.simulateResponse(requestUrlSuffix: suffix, filename: "blaze-create-campaign-success")
 
         let mainImage = CreateBlazeCampaign.Image(url: "https://example.com/wp-content/uploads/2023/06/0_1-2.png?quality=80&strip=info&w=1500",
                                                   mimeType: "image/png")

--- a/Networking/NetworkingTests/Remote/BlazeRemoteTests.swift
+++ b/Networking/NetworkingTests/Remote/BlazeRemoteTests.swift
@@ -31,13 +31,10 @@ final class BlazeRemoteTests: XCTestCase {
         network.simulateResponse(requestUrlSuffix: suffix, filename: "blaze-create-campaign-success")
 
         // When
-        _ = try await remote.createCampaign(.fake(), siteID: sampleSiteID)
-
-        // When
-        let result = try await remote.createCampaign(.fake(), siteID: sampleSiteID)
+        try await remote.createCampaign(.fake(), siteID: sampleSiteID)
 
         // Then
-        XCTAssertEqual(result, "campaign-12345")
+        // No error
     }
 
     func test_createCampaign_sends_correct_parameters() async throws {

--- a/Networking/NetworkingTests/Responses/blaze-create-campaign-success.json
+++ b/Networking/NetworkingTests/Responses/blaze-create-campaign-success.json
@@ -1,25 +1,21 @@
 {
-    "id": 12345,
-    "start_time": "2023-12-05T02:00:00.000Z",
-    "end_time": "2023-12-11T01:59:59.999Z",
+    "id": "campaign-12345",
+    "status": "pending",
+    "target_urn": "urn:wpcom:post:191174658:47",
+    "start_time": "2023-01-15T02:00:00.000Z",
+    "duration_days": 4,
     "total_budget": 35.00,
     "site_name": "Unleash Your Brain's Potential",
     "text_snippet": "Discover the power of computer neural networks in unlocking your brain's full potential.",
-    "target_url": "https://botvik.com/2023/06/25/unlocking-the-secrets-of-computer-neural-networks/?var1=val2&var2=val2",
+    "target_url": "https://example.com/2023/06/25/unlocking-the-secrets-of-computer-neural-networks/?var1=val2&var2=val2",
     "main_image": {
-        "url": "https://i0.wp.com/botvik.com/wp-content/uploads/2023/06/0_1-2.png?quality=80&strip=info&w=1500",
+        "url": "https://example.com/botvik.com/wp-content/uploads/2023/06/0_1-2.png?quality=80&strip=info&w=1500",
         "mime_type": "image/png",
         "crop": {
-            "x": 1.3407676898918837,
-            "y": 1.3407676898918837,
-            "width": 97.31846462021623,
-            "height": 97.31846462021623
+            "x": 1,
+            "y": 1,
+            "width": 97,
+            "height": 97
         }
-    },
-    "targeting": {
-        "locations": [29211, 42546],
-        "languages": ["en", "de"],
-        "devices": ["mobile"],
-        "page_topics": ["IAB3", "IAB4"]
     }
 }

--- a/Networking/NetworkingTests/Responses/blaze-create-campaign-success.json
+++ b/Networking/NetworkingTests/Responses/blaze-create-campaign-success.json
@@ -1,0 +1,25 @@
+{
+    "id": 12345,
+    "start_time": "2023-12-05T02:00:00.000Z",
+    "end_time": "2023-12-11T01:59:59.999Z",
+    "total_budget": 35.00,
+    "site_name": "Unleash Your Brain's Potential",
+    "text_snippet": "Discover the power of computer neural networks in unlocking your brain's full potential.",
+    "target_url": "https://botvik.com/2023/06/25/unlocking-the-secrets-of-computer-neural-networks/?var1=val2&var2=val2",
+    "main_image": {
+        "url": "https://i0.wp.com/botvik.com/wp-content/uploads/2023/06/0_1-2.png?quality=80&strip=info&w=1500",
+        "mime_type": "image/png",
+        "crop": {
+            "x": 1.3407676898918837,
+            "y": 1.3407676898918837,
+            "width": 97.31846462021623,
+            "height": 97.31846462021623
+        }
+    },
+    "targeting": {
+        "locations": [29211, 42546],
+        "languages": ["en", "de"],
+        "devices": ["mobile"],
+        "page_topics": ["IAB3", "IAB4"]
+    }
+}

--- a/Yosemite/YosemiteTests/Mocks/Networking/Remote/MockBlazeRemote.swift
+++ b/Yosemite/YosemiteTests/Mocks/Networking/Remote/MockBlazeRemote.swift
@@ -4,7 +4,7 @@ import Networking
 /// Mock for `BlazeRemote`.
 ///
 final class MockBlazeRemote {
-    private var creatingCampaignResult: Result<Int64, Error>?
+    private var creatingCampaignResult: Result<String, Error>?
     private var loadingCampaignResult: Result<[BlazeCampaign], Error>?
     private var fetchingTargetLanguagesResult: Result<[BlazeTargetLanguage], Error>?
     private var fetchingTargetDevicesResult: Result<[BlazeTargetDevice], Error>?
@@ -12,7 +12,7 @@ final class MockBlazeRemote {
     private var fetchingTargetLocationsResult: Result<[BlazeTargetLocation], Error>?
     private var fetchingForecastedImpressionsResult: Result<BlazeImpressions, Error>?
 
-    func whenCreatingCampaign(thenReturn result: Result<Int64, Error>) {
+    func whenCreatingCampaign(thenReturn result: Result<String, Error>) {
         creatingCampaignResult = result
     }
 
@@ -43,7 +43,7 @@ final class MockBlazeRemote {
 
 extension MockBlazeRemote: BlazeRemoteProtocol {
     func createCampaign(_ campaign: CreateBlazeCampaign,
-                        siteID: Int64) async throws -> Int64 {
+                        siteID: Int64) async throws -> String {
         guard let result = creatingCampaignResult else {
             XCTFail("Could not find result for creating campaign.")
             throw NetworkError.notFound()

--- a/Yosemite/YosemiteTests/Mocks/Networking/Remote/MockBlazeRemote.swift
+++ b/Yosemite/YosemiteTests/Mocks/Networking/Remote/MockBlazeRemote.swift
@@ -4,7 +4,7 @@ import Networking
 /// Mock for `BlazeRemote`.
 ///
 final class MockBlazeRemote {
-    private var creatingCampaignResult: Result<String, Error>?
+    private var creatingCampaignResult: Result<Void, Error>?
     private var loadingCampaignResult: Result<[BlazeCampaign], Error>?
     private var fetchingTargetLanguagesResult: Result<[BlazeTargetLanguage], Error>?
     private var fetchingTargetDevicesResult: Result<[BlazeTargetDevice], Error>?
@@ -12,7 +12,7 @@ final class MockBlazeRemote {
     private var fetchingTargetLocationsResult: Result<[BlazeTargetLocation], Error>?
     private var fetchingForecastedImpressionsResult: Result<BlazeImpressions, Error>?
 
-    func whenCreatingCampaign(thenReturn result: Result<String, Error>) {
+    func whenCreatingCampaign(thenReturn result: Result<Void, Error>) {
         creatingCampaignResult = result
     }
 

--- a/Yosemite/YosemiteTests/Mocks/Networking/Remote/MockBlazeRemote.swift
+++ b/Yosemite/YosemiteTests/Mocks/Networking/Remote/MockBlazeRemote.swift
@@ -4,12 +4,17 @@ import Networking
 /// Mock for `BlazeRemote`.
 ///
 final class MockBlazeRemote {
+    private var creatingCampaignResult: Result<Void, Error>?
     private var loadingCampaignResult: Result<[BlazeCampaign], Error>?
     private var fetchingTargetLanguagesResult: Result<[BlazeTargetLanguage], Error>?
     private var fetchingTargetDevicesResult: Result<[BlazeTargetDevice], Error>?
     private var fetchingTargetTopicsResult: Result<[BlazeTargetTopic], Error>?
     private var fetchingTargetLocationsResult: Result<[BlazeTargetLocation], Error>?
     private var fetchingForecastedImpressionsResult: Result<BlazeImpressions, Error>?
+
+    func whenCreatingCampaign(thenReturn result: Result<Void, Error>) {
+        creatingCampaignResult = result
+    }
 
     func whenLoadingCampaign(thenReturn result: Result<[BlazeCampaign], Error>) {
         loadingCampaignResult = result
@@ -37,6 +42,19 @@ final class MockBlazeRemote {
 }
 
 extension MockBlazeRemote: BlazeRemoteProtocol {
+    func createCampaign(_ campaign: Networking.CreateBlazeCampaign, siteID: Int64) async throws {
+        guard let result = creatingCampaignResult else {
+            XCTFail("Could not find result for creating campaign.")
+            throw NetworkError.notFound()
+        }
+        switch result {
+        case .success:
+            return
+        case .failure(let error):
+            throw error
+        }
+    }
+
     func fetchTargetLanguages(for siteID: Int64, locale: String) async throws -> [BlazeTargetLanguage] {
         guard let result = fetchingTargetLanguagesResult else {
             XCTFail("Could not find result for fetching target languages.")

--- a/Yosemite/YosemiteTests/Mocks/Networking/Remote/MockBlazeRemote.swift
+++ b/Yosemite/YosemiteTests/Mocks/Networking/Remote/MockBlazeRemote.swift
@@ -43,14 +43,14 @@ final class MockBlazeRemote {
 
 extension MockBlazeRemote: BlazeRemoteProtocol {
     func createCampaign(_ campaign: CreateBlazeCampaign,
-                        siteID: Int64) async throws -> String {
+                        siteID: Int64) async throws {
         guard let result = creatingCampaignResult else {
             XCTFail("Could not find result for creating campaign.")
             throw NetworkError.notFound()
         }
         switch result {
-        case .success(let id):
-            return id
+        case .success:
+            return
         case .failure(let error):
             throw error
         }

--- a/Yosemite/YosemiteTests/Mocks/Networking/Remote/MockBlazeRemote.swift
+++ b/Yosemite/YosemiteTests/Mocks/Networking/Remote/MockBlazeRemote.swift
@@ -4,7 +4,7 @@ import Networking
 /// Mock for `BlazeRemote`.
 ///
 final class MockBlazeRemote {
-    private var creatingCampaignResult: Result<Void, Error>?
+    private var creatingCampaignResult: Result<Int64, Error>?
     private var loadingCampaignResult: Result<[BlazeCampaign], Error>?
     private var fetchingTargetLanguagesResult: Result<[BlazeTargetLanguage], Error>?
     private var fetchingTargetDevicesResult: Result<[BlazeTargetDevice], Error>?
@@ -12,7 +12,7 @@ final class MockBlazeRemote {
     private var fetchingTargetLocationsResult: Result<[BlazeTargetLocation], Error>?
     private var fetchingForecastedImpressionsResult: Result<BlazeImpressions, Error>?
 
-    func whenCreatingCampaign(thenReturn result: Result<Void, Error>) {
+    func whenCreatingCampaign(thenReturn result: Result<Int64, Error>) {
         creatingCampaignResult = result
     }
 
@@ -42,14 +42,15 @@ final class MockBlazeRemote {
 }
 
 extension MockBlazeRemote: BlazeRemoteProtocol {
-    func createCampaign(_ campaign: Networking.CreateBlazeCampaign, siteID: Int64) async throws {
+    func createCampaign(_ campaign: CreateBlazeCampaign,
+                        siteID: Int64) async throws -> Int64 {
         guard let result = creatingCampaignResult else {
             XCTFail("Could not find result for creating campaign.")
             throw NetworkError.notFound()
         }
         switch result {
-        case .success:
-            return
+        case .success(let id):
+            return id
         case .failure(let error):
             throw error
         }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of: #11615
<!-- Id number of the GitHub issue this PR addresses. -->

## Description

This PR adds changes to the Networking layer to support creating a Blaze campaign. 

- The mapper parses only the blaze campaign's ID from the response because we won't use the response inside the app in this iteration. 
- Change to the Yosemite layer will be made in a subsequent PR. 

## Testing instructions
CI passing is enough. 

## Screenshots
NA

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
