### PR TITLE
[Blaze] Add Create campaign BlazeAction

### DIFF
--- a/Yosemite/Yosemite/Actions/BlazeAction.swift
+++ b/Yosemite/Yosemite/Actions/BlazeAction.swift
@@ -5,6 +5,18 @@ import Networking
 //
 public enum BlazeAction: Action {
 
+    /// Creates a new Blaze campaign
+    ///
+    /// - `campaign`: New Blaze campaign to be created
+    /// - `siteID`: the site in which Blaze campaign should be created.
+    /// - `onCompletion`: invoked when the create operation finishes.
+    ///     - `result.success(String)`: ID of the newly created Blaze campaign.
+    ///     - `result.failure(Error)`: error indicates issues creating a Blaze campaign.
+    ///
+    case createCampaign(campaign: CreateBlazeCampaign,
+                        siteID: Int64,
+                        onCompletion: (Result<String, Error>) -> Void)
+
     /// Retrieves and stores Blaze Campaign for a site
     ///
     /// - `siteID`: the site for which Blaze campaigns should be fetched.

--- a/Yosemite/Yosemite/Actions/BlazeAction.swift
+++ b/Yosemite/Yosemite/Actions/BlazeAction.swift
@@ -10,12 +10,12 @@ public enum BlazeAction: Action {
     /// - `campaign`: New Blaze campaign to be created
     /// - `siteID`: the site in which Blaze campaign should be created.
     /// - `onCompletion`: invoked when the create operation finishes.
-    ///     - `result.success(String)`: ID of the newly created Blaze campaign.
+    ///     - `result.success()`: Successfully created Blaze campaign.
     ///     - `result.failure(Error)`: error indicates issues creating a Blaze campaign.
     ///
     case createCampaign(campaign: CreateBlazeCampaign,
                         siteID: Int64,
-                        onCompletion: (Result<String, Error>) -> Void)
+                        onCompletion: (Result<Void, Error>) -> Void)
 
     /// Retrieves and stores Blaze Campaign for a site
     ///

--- a/Yosemite/Yosemite/Stores/BlazeStore.swift
+++ b/Yosemite/Yosemite/Stores/BlazeStore.swift
@@ -79,15 +79,14 @@ public final class BlazeStore: Store {
 private extension BlazeStore {
     func createCampaign(campaign: CreateBlazeCampaign,
                         siteID: Int64,
-                        onCompletion: @escaping (Result<String, Error>) -> Void) {
+                        onCompletion: @escaping (Result<Void, Error>) -> Void) {
         Task { @MainActor in
             do {
                 // TODO-11540: remove stubbed result when the API is ready.
-                let stubbedResult = "campaign-12345"
-                let campaignID = try await mockResponse(stubbedResult: stubbedResult, onExecution: {
+                try await mockResponse(stubbedResult: (), onExecution: {
                     try await remote.createCampaign(campaign, siteID: siteID)
                 })
-                onCompletion(.success(campaignID))
+                onCompletion(.success(()))
             } catch {
                 onCompletion(.failure(error))
             }

--- a/Yosemite/Yosemite/Stores/BlazeStore.swift
+++ b/Yosemite/Yosemite/Stores/BlazeStore.swift
@@ -54,6 +54,8 @@ public final class BlazeStore: Store {
         }
 
         switch action {
+        case let .createCampaign(campaign, siteID, onCompletion):
+            createCampaign(campaign: campaign, siteID: siteID, onCompletion: onCompletion)
         case let .synchronizeCampaigns(siteID, pageNumber, onCompletion):
             synchronizeCampaigns(siteID: siteID,
                                  pageNumber: pageNumber,
@@ -68,6 +70,27 @@ public final class BlazeStore: Store {
             fetchTargetLocations(siteID: siteID, query: query, locale: locale, onCompletion: onCompletion)
         case let .fetchForecastedImpressions(siteID, input, onCompletion):
             fetchForecastedImpressions(siteID: siteID, input: input, onCompletion: onCompletion)
+        }
+    }
+}
+
+// MARK: - Create a new Blaze campaign
+//
+private extension BlazeStore {
+    func createCampaign(campaign: CreateBlazeCampaign,
+                        siteID: Int64,
+                        onCompletion: @escaping (Result<String, Error>) -> Void) {
+        Task { @MainActor in
+            do {
+                // TODO-11540: remove stubbed result when the API is ready.
+                let stubbedResult = "campaign-12345"
+                let campaignID = try await mockResponse(stubbedResult: stubbedResult, onExecution: {
+                    try await remote.createCampaign(campaign, siteID: siteID)
+                })
+                onCompletion(.success(campaignID))
+            } catch {
+                onCompletion(.failure(error))
+            }
         }
     }
 }

--- a/Yosemite/YosemiteTests/Stores/BlazeStoreTests.swift
+++ b/Yosemite/YosemiteTests/Stores/BlazeStoreTests.swift
@@ -73,9 +73,9 @@ final class BlazeStoreTests: XCTestCase {
 
     // MARK: - Create campaign
 
-    func test_createCampaign_returns_campaign_ID_upon_success() throws {
+    func test_createCampaign_does_not_throw_errors_upon_success() throws {
         // Given
-        remote.whenCreatingCampaign(thenReturn: .success("12345"))
+        remote.whenCreatingCampaign(thenReturn: .success(()))
         let store = BlazeStore(dispatcher: Dispatcher(),
                                storageManager: storageManager,
                                network: network,
@@ -91,8 +91,7 @@ final class BlazeStoreTests: XCTestCase {
         }
 
         //Then
-        let campaignID = try result.get()
-        XCTAssertEqual(campaignID, "12345")
+        try result.get()
     }
 
     func test_createCampaign_returns_error_on_failure() throws {

--- a/Yosemite/YosemiteTests/Stores/BlazeStoreTests.swift
+++ b/Yosemite/YosemiteTests/Stores/BlazeStoreTests.swift
@@ -71,6 +71,52 @@ final class BlazeStoreTests: XCTestCase {
         super.tearDown()
     }
 
+    // MARK: - Create campaign
+
+    func test_createCampaign_returns_campaign_ID_upon_success() throws {
+        // Given
+        remote.whenCreatingCampaign(thenReturn: .success("12345"))
+        let store = BlazeStore(dispatcher: Dispatcher(),
+                               storageManager: storageManager,
+                               network: network,
+                               remote: remote)
+
+        // When
+        let result = waitFor { promise in
+            store.onAction(BlazeAction.createCampaign(campaign: .fake(),
+                                                      siteID: self.sampleSiteID,
+                                                      onCompletion: { result in
+                promise(result)
+            }))
+        }
+
+        //Then
+        let campaignID = try result.get()
+        XCTAssertEqual(campaignID, "12345")
+    }
+
+    func test_createCampaign_returns_error_on_failure() throws {
+        // Given
+        remote.whenCreatingCampaign(thenReturn: .failure(NetworkError.timeout()))
+        let store = BlazeStore(dispatcher: Dispatcher(),
+                               storageManager: storageManager,
+                               network: network,
+                               remote: remote)
+
+        // When
+        let result = waitFor { promise in
+            store.onAction(BlazeAction.createCampaign(campaign: .fake(),
+                                                      siteID: self.sampleSiteID,
+                                                      onCompletion: { result in
+                promise(result)
+            }))
+        }
+
+        // Then
+        XCTAssertTrue(result.isFailure)
+        XCTAssertEqual(result.failure as? NetworkError, .timeout())
+    }
+
     // MARK: - synchronizeCampaigns
 
     func test_synchronizeCampaigns_returns_false_for_hasNextPage_when_number_of_retrieved_results_is_zero() throws {


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #11615
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
Adds a new action in `BlazeStore` to create Blaze campaign.

The response is mocked until the API gets ready. 

## Testing instructions
CI passing is enough.

## Screenshots
NA

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
