### PR TITLE
Blaze: Add time zone to estimated impression fetch request

### DIFF
--- a/Fakes/Fakes/Networking.generated.swift
+++ b/Fakes/Fakes/Networking.generated.swift
@@ -181,6 +181,7 @@ extension Networking.BlazeForecastedImpressionsInput {
         .init(
             startDate: .fake(),
             endDate: .fake(),
+            timeZone: .fake(),
             totalBudget: .fake(),
             targetings: .fake()
         )

--- a/Networking/Networking/Remote/BlazeRemote.swift
+++ b/Networking/Networking/Remote/BlazeRemote.swift
@@ -188,6 +188,8 @@ public struct BlazeForecastedImpressionsInput: Encodable, GeneratedFakeable {
     public let startDate: Date
     // End date of the campaign
     public let endDate: Date
+    // Time zone of the user
+    public let timeZone: String
     // Total budget of the campaign
     public let totalBudget: Double
     // Target options for the campaign. Optional.
@@ -195,10 +197,12 @@ public struct BlazeForecastedImpressionsInput: Encodable, GeneratedFakeable {
 
     public init(startDate: Date,
                 endDate: Date,
+                timeZone: String,
                 totalBudget: Double,
                 targetings: BlazeTargetOptions? = nil) {
         self.startDate = startDate
         self.endDate = endDate
+        self.timeZone = timeZone
         self.totalBudget = totalBudget
         self.targetings = targetings
     }
@@ -206,6 +210,7 @@ public struct BlazeForecastedImpressionsInput: Encodable, GeneratedFakeable {
     private enum CodingKeys: String, CodingKey {
         case startDate
         case endDate
+        case timeZone
         case totalBudget
         case targetings
     }

--- a/Networking/NetworkingTests/Encoder/BlazeForecastedImpressionsInputEncoderTests.swift
+++ b/Networking/NetworkingTests/Encoder/BlazeForecastedImpressionsInputEncoderTests.swift
@@ -10,12 +10,14 @@ final class BlazeForecastedImpressionsInputEncoderTests: XCTestCase {
         let startDate = try XCTUnwrap(dateFormatter.date(from: "2023-12-05"))
         let endDate = try XCTUnwrap(dateFormatter.date(from: "2023-12-11"))
         let totalBudget = 35.00
+        let timeZone = "America/New_York"
         let targetOptions = BlazeTargetOptions(locations: [29211, 42546],
                                                languages: ["en", "de"],
                                                devices: ["mobile"],
                                                pageTopics: ["IAB3", "IAB4"])
         let input = BlazeForecastedImpressionsInput(startDate: startDate,
                                                     endDate: endDate,
+                                                    timeZone: timeZone,
                                                     totalBudget: totalBudget,
                                                     targetings: targetOptions)
 
@@ -26,6 +28,7 @@ final class BlazeForecastedImpressionsInputEncoderTests: XCTestCase {
         XCTAssertEqual(parameters["start_date"] as? String, "2023-12-05")
         XCTAssertEqual(parameters["end_date"] as? String, "2023-12-11")
         XCTAssertEqual(parameters["total_budget"] as? Double, 35.00)
+        XCTAssertEqual(parameters["time_zone"] as? String, timeZone)
 
         let targetingsParams = try XCTUnwrap(parameters["targetings"] as? [String: Any])
         XCTAssertEqual(targetingsParams["locations"] as? [Int64], [29211, 42546])

--- a/Networking/NetworkingTests/Remote/BlazeRemoteTests.swift
+++ b/Networking/NetworkingTests/Remote/BlazeRemoteTests.swift
@@ -343,10 +343,7 @@ final class BlazeRemoteTests: XCTestCase {
 
             _ = try await remote.fetchForecastedImpressions(
                 for: sampleSiteID,
-                with: BlazeForecastedImpressionsInput(startDate: dateFormatter.date(from: "2023-12-5")!,
-                                                      endDate: dateFormatter.date(from: "2023-12-11")!,
-                                                      totalBudget: 35
-                                                     )
+                with: BlazeForecastedImpressionsInput.fake()
             )
 
             // Then

--- a/WooCommerce/Classes/ViewRelated/Blaze/BudgetSetting/BlazeBudgetSettingViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Blaze/BudgetSetting/BlazeBudgetSettingViewModel.swift
@@ -51,6 +51,7 @@ final class BlazeBudgetSettingViewModel: ObservableObject {
     }()
 
     private let siteID: Int64
+    private let timeZone: TimeZone
     private let targetOptions: BlazeTargetOptions?
     private let stores: StoresManager
 
@@ -63,6 +64,7 @@ final class BlazeBudgetSettingViewModel: ObservableObject {
          dailyBudget: Double,
          duration: Int,
          startDate: Date,
+         timeZone: TimeZone = .current,
          targetOptions: BlazeTargetOptions? = nil,
          stores: StoresManager = ServiceLocator.stores,
          onCompletion: @escaping BlazeBudgetSettingCompletionHandler) {
@@ -70,6 +72,7 @@ final class BlazeBudgetSettingViewModel: ObservableObject {
         self.dailyAmount = dailyBudget
         self.dayCount = Double(duration)
         self.startDate = startDate
+        self.timeZone = timeZone
         self.targetOptions = targetOptions
         self.stores = stores
         self.completionHandler = onCompletion
@@ -92,7 +95,11 @@ final class BlazeBudgetSettingViewModel: ObservableObject {
         forecastedImpressionState = .loading
         let endDate = calculateEndDate(from: startDate, dayCount: dayCount)
         let totalBudget = calculateTotalBudget(dailyBudget: dailyBudget, dayCount: dayCount)
-        let input = BlazeForecastedImpressionsInput(startDate: startDate, endDate: endDate, totalBudget: totalBudget, targetings: targetOptions)
+        let input = BlazeForecastedImpressionsInput(startDate: startDate,
+                                                    endDate: endDate,
+                                                    timeZone: timeZone.identifier,
+                                                    totalBudget: totalBudget,
+                                                    targetings: targetOptions)
         do {
             let result = try await fetchForecastedImpressions(input: input)
             let formattedImpressions = String(format: "%d - %d", result.totalImpressionsMin, result.totalImpressionsMax)

--- a/WooCommerce/WooCommerceTests/ViewRelated/Blaze/BlazeBudgetSettingViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Blaze/BlazeBudgetSettingViewModelTests.swift
@@ -87,16 +87,18 @@ final class BlazeBudgetSettingViewModelTests: XCTestCase {
         XCTAssertEqual(viewModel.forecastedImpressionState, .failure)
     }
 
-    func test_retryFetchingImpressions_requests_fetching_impression_with_latest_settings() async {
+    func test_retryFetchingImpressions_requests_fetching_impression_with_latest_settings() async throws {
         // Given
         var fetchInput: BlazeForecastedImpressionsInput?
         let expectedStartDate = Date(timeIntervalSinceNow: 86400) // Next day
+        let timeZone = try XCTUnwrap(TimeZone(identifier: "Europe/London"))
         let targetOptions = BlazeTargetOptions(locations: [11, 22], languages: ["en", "vi"], devices: nil, pageTopics: ["Entertainment"])
         let stores = MockStoresManager(sessionManager: .makeForTesting())
         let viewModel = BlazeBudgetSettingViewModel(siteID: 123,
                                                     dailyBudget: 15,
                                                     duration: 3,
                                                     startDate: .now,
+                                                    timeZone: timeZone,
                                                     targetOptions: targetOptions,
                                                     stores: stores,
                                                     onCompletion: { _, _, _ in })
@@ -120,6 +122,7 @@ final class BlazeBudgetSettingViewModelTests: XCTestCase {
         XCTAssertEqual(fetchInput?.startDate, expectedStartDate)
         XCTAssertEqual(fetchInput?.endDate, Date(timeInterval: 7 * 86400, since: expectedStartDate))
         XCTAssertEqual(fetchInput?.totalBudget, 20 * 7)
+        XCTAssertEqual(fetchInput?.timeZone, "Europe/London")
         XCTAssertEqual(fetchInput?.targetings, targetOptions)
     }
 }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of #11622 
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This PR adds an additional parameter to the request for estimated impressions for Blaze campaigns following peeHDf-2fw-p2#comment-1761.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
The time zone is not displayed on the UI, and the API response is still mocked, so just CI passing is sufficient.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->
N/A

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
