### PR TITLE
Blaze: Remove code and iso code from target locations

### DIFF
--- a/Fakes/Fakes/Networking.generated.swift
+++ b/Fakes/Fakes/Networking.generated.swift
@@ -226,8 +226,6 @@ extension Networking.BlazeTargetLocation {
             id: .fake(),
             name: .fake(),
             type: .fake(),
-            code: .fake(),
-            isoCode: .fake(),
             parentLocation: .fake()
         )
     }

--- a/Networking/Networking/Model/BlazeTargetOptions.swift
+++ b/Networking/Networking/Model/BlazeTargetOptions.swift
@@ -111,12 +111,6 @@ public final class BlazeTargetLocation: NSObject, Decodable, GeneratedCopiable, 
     /// Type of the location
     public let type: String
 
-    /// Post code of the location (if available)
-    public let code: String?
-
-    /// ISO code of the location (if available)
-    public let isoCode: String?
-
     /// Parent of the location.
     /// "Parent" refers to the larger geographical context of a given location.
     /// For example the parent of a city is a state, or the parent of a country is a continent.
@@ -125,14 +119,10 @@ public final class BlazeTargetLocation: NSObject, Decodable, GeneratedCopiable, 
     public init(id: Int64,
                 name: String,
                 type: String,
-                code: String? = nil,
-                isoCode: String? = nil,
                 parentLocation: BlazeTargetLocation? = nil) {
         self.id = id
         self.name = name
         self.type = type
-        self.code = code
-        self.isoCode = isoCode
         self.parentLocation = parentLocation
     }
 }

--- a/Networking/Networking/Model/Copiable/Models+Copiable.generated.swift
+++ b/Networking/Networking/Model/Copiable/Models+Copiable.generated.swift
@@ -255,23 +255,17 @@ extension Networking.BlazeTargetLocation {
         id: CopiableProp<Int64> = .copy,
         name: CopiableProp<String> = .copy,
         type: CopiableProp<String> = .copy,
-        code: NullableCopiableProp<String> = .copy,
-        isoCode: NullableCopiableProp<String> = .copy,
         parentLocation: NullableCopiableProp<BlazeTargetLocation> = .copy
     ) -> Networking.BlazeTargetLocation {
         let id = id ?? self.id
         let name = name ?? self.name
         let type = type ?? self.type
-        let code = code ?? self.code
-        let isoCode = isoCode ?? self.isoCode
         let parentLocation = parentLocation ?? self.parentLocation
 
         return Networking.BlazeTargetLocation(
             id: id,
             name: name,
             type: type,
-            code: code,
-            isoCode: isoCode,
             parentLocation: parentLocation
         )
     }

--- a/Networking/NetworkingTests/Mapper/BlazeTargetOptionMapperTests.swift
+++ b/Networking/NetworkingTests/Mapper/BlazeTargetOptionMapperTests.swift
@@ -54,8 +54,6 @@ final class BlazeTargetOptionMapperTests: XCTestCase {
         XCTAssertEqual(firstItem.id, 1439)
         XCTAssertEqual(firstItem.name, "Madrid")
         XCTAssertEqual(firstItem.type, "state")
-        XCTAssertNil(firstItem.code)
-        XCTAssertNil(firstItem.isoCode)
         XCTAssertEqual(firstItem.parentLocation?.id, 69)
         XCTAssertEqual(firstItem.parentLocation?.parentLocation?.id, 228)
         XCTAssertEqual(firstItem.parentLocation?.parentLocation?.parentLocation?.id, 5)

--- a/Networking/NetworkingTests/Remote/BlazeRemoteTests.swift
+++ b/Networking/NetworkingTests/Remote/BlazeRemoteTests.swift
@@ -372,8 +372,6 @@ final class BlazeRemoteTests: XCTestCase {
         XCTAssertEqual(firstItem.id, 1439)
         XCTAssertEqual(firstItem.name, "Madrid")
         XCTAssertEqual(firstItem.type, "state")
-        XCTAssertNil(firstItem.code)
-        XCTAssertNil(firstItem.isoCode)
         XCTAssertEqual(firstItem.parentLocation?.id, 69)
         XCTAssertEqual(firstItem.parentLocation?.parentLocation?.id, 228)
         XCTAssertEqual(firstItem.parentLocation?.parentLocation?.parentLocation?.id, 5)

--- a/Networking/NetworkingTests/Responses/blaze-target-locations.json
+++ b/Networking/NetworkingTests/Responses/blaze-target-locations.json
@@ -3,26 +3,19 @@
         "id": 1439,
         "name": "Madrid",
         "type": "state",
-        "code": null,
-        "iso_code": null,
         "parent_location": {
             "id": 69,
-            "code": null,
             "name": "Comunidad De Madrid",
             "type": "region",
-            "iso_code": null,
             "parent_location": {
                 "id": 228,
-                "code": null,
                 "name": "Spain",
                 "type": "country",
                 "iso_code": "ESP",
                 "parent_location": {
                     "id": 5,
-                    "code": null,
                     "name": "Europe",
                     "type": "continent",
-                    "iso_code": null,
                     "parent_location": null
                 }
             }
@@ -32,20 +25,15 @@
         "id": 2035,
         "name": "Madre De Dios",
         "type": "state",
-        "code": null,
-        "iso_code": null,
         "parent_location": {
             "id": 57,
-            "code": null,
             "name": "Peru",
             "type": "country",
             "iso_code": "PER",
             "parent_location": {
                 "id": 8,
-                "code": null,
                 "name": "South America",
                 "type": "continent",
-                "iso_code": null,
                 "parent_location": null
             }
         }
@@ -54,32 +42,22 @@
         "id": 6457,
         "name": "Madrid",
         "type": "city",
-        "code": null,
-        "iso_code": null,
         "parent_location": {
             "id": 1841,
-            "code": null,
             "name": "Iowa",
             "type": "state",
-            "iso_code": null,
             "parent_location": {
                 "id": 174,
-                "code": null,
                 "name": "Midwest",
                 "type": "region",
-                "iso_code": null,
                 "parent_location": {
                     "id": 152,
-                    "code": null,
                     "name": "United States",
                     "type": "country",
-                    "iso_code": "USA",
                     "parent_location": {
                         "id": 6,
-                        "code": null,
                         "name": "North America",
                         "type": "continent",
-                        "iso_code": null,
                         "parent_location": null
                     }
                 }

--- a/Yosemite/Yosemite/Stores/BlazeStore.swift
+++ b/Yosemite/Yosemite/Stores/BlazeStore.swift
@@ -286,12 +286,11 @@ private extension BlazeStore {
                                                 type: "region",
                                                 parentLocation: .init(id: 228,
                                                                       name: "Spain",
-                                                                      type: "country",
-                                                                      isoCode: "ESP"))),
+                                                                      type: "country"))),
                     .init(id: 2035,
                           name: "Madre De Dios",
                           type: "state",
-                          parentLocation: .init(id: 57, name: "Peru", type: "country", isoCode: "PER")),
+                          parentLocation: .init(id: 57, name: "Peru", type: "country")),
                     .init(id: 6457,
                           name: "Madrid",
                           type: "city",
@@ -303,8 +302,7 @@ private extension BlazeStore {
                                                                       type: "region",
                                                                       parentLocation: .init(id: 152,
                                                                                             name: "United States",
-                                                                                            type: "country",
-                                                                                           isoCode: "USA"))))
+                                                                                            type: "country"))))
                 ]
                 let locations: [BlazeTargetLocation] = try await mockResponse(stubbedResult: stubbedResult, onExecution: {
                     try await remote.fetchTargetLocations(for: siteID, query: query, locale: locale)


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of #11622 
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This PR removes 2 properties `code` and `isoCode` from target locations following peeHDf-2fw-p2#comment-1761. 

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
Target locations haven't been integrated to the UI yet so just CI passing is sufficient.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->
N/A

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
