### PR TITLE
[Deposit Summary] Update model due to API changes

### DIFF
--- a/Fakes/Fakes/Networking.generated.swift
+++ b/Fakes/Fakes/Networking.generated.swift
@@ -2314,7 +2314,6 @@ extension Networking.WooPaymentsCurrencyDeposits {
     public static func fake() -> Networking.WooPaymentsCurrencyDeposits {
         .init(
             lastPaid: .fake(),
-            nextScheduled: .fake(),
             lastManualDeposits: .fake()
         )
     }

--- a/Fakes/Fakes/Networking.generated.swift
+++ b/Fakes/Fakes/Networking.generated.swift
@@ -2292,8 +2292,7 @@ extension Networking.WooPaymentsBalance {
     public static func fake() -> Networking.WooPaymentsBalance {
         .init(
             amount: .fake(),
-            currency: .fake(),
-            depositsCount: .fake()
+            currency: .fake()
         )
     }
 }

--- a/Networking/Networking/Model/Copiable/Models+Copiable.generated.swift
+++ b/Networking/Networking/Model/Copiable/Models+Copiable.generated.swift
@@ -3241,17 +3241,14 @@ extension Networking.WooPaymentsAccountDepositSummary {
 extension Networking.WooPaymentsBalance {
     public func copy(
         amount: CopiableProp<Int> = .copy,
-        currency: CopiableProp<String> = .copy,
-        depositsCount: NullableCopiableProp<Int> = .copy
+        currency: CopiableProp<String> = .copy
     ) -> Networking.WooPaymentsBalance {
         let amount = amount ?? self.amount
         let currency = currency ?? self.currency
-        let depositsCount = depositsCount ?? self.depositsCount
 
         return Networking.WooPaymentsBalance(
             amount: amount,
-            currency: currency,
-            depositsCount: depositsCount
+            currency: currency
         )
     }
 }

--- a/Networking/Networking/Model/Copiable/Models+Copiable.generated.swift
+++ b/Networking/Networking/Model/Copiable/Models+Copiable.generated.swift
@@ -3277,16 +3277,13 @@ extension Networking.WooPaymentsCurrencyBalances {
 extension Networking.WooPaymentsCurrencyDeposits {
     public func copy(
         lastPaid: CopiableProp<[WooPaymentsDeposit]> = .copy,
-        nextScheduled: CopiableProp<[WooPaymentsDeposit]> = .copy,
         lastManualDeposits: CopiableProp<[WooPaymentsManualDeposit]> = .copy
     ) -> Networking.WooPaymentsCurrencyDeposits {
         let lastPaid = lastPaid ?? self.lastPaid
-        let nextScheduled = nextScheduled ?? self.nextScheduled
         let lastManualDeposits = lastManualDeposits ?? self.lastManualDeposits
 
         return Networking.WooPaymentsCurrencyDeposits(
             lastPaid: lastPaid,
-            nextScheduled: nextScheduled,
             lastManualDeposits: lastManualDeposits
         )
     }

--- a/Networking/Networking/Model/WooPaymentsDepositsOverview.swift
+++ b/Networking/Networking/Model/WooPaymentsDepositsOverview.swift
@@ -17,20 +17,16 @@ public struct WooPaymentsDepositsOverview: Codable, GeneratedFakeable, Generated
 
 public struct WooPaymentsCurrencyDeposits: Codable, GeneratedFakeable, GeneratedCopiable, Equatable {
     public let lastPaid: [WooPaymentsDeposit]
-    public let nextScheduled: [WooPaymentsDeposit]
     public let lastManualDeposits: [WooPaymentsManualDeposit]
 
     public init(lastPaid: [WooPaymentsDeposit],
-                nextScheduled: [WooPaymentsDeposit],
                 lastManualDeposits: [WooPaymentsManualDeposit]) {
         self.lastPaid = lastPaid
-        self.nextScheduled = nextScheduled
         self.lastManualDeposits = lastManualDeposits
     }
 
     enum CodingKeys: String, CodingKey {
         case lastPaid = "last_paid"
-        case nextScheduled = "next_scheduled"
         case lastManualDeposits = "last_manual_deposits"
     }
 }

--- a/Networking/Networking/Model/WooPaymentsDepositsOverview.swift
+++ b/Networking/Networking/Model/WooPaymentsDepositsOverview.swift
@@ -166,18 +166,15 @@ public struct WooPaymentsCurrencyBalances: Codable, GeneratedFakeable, Generated
 public struct WooPaymentsBalance: Codable, GeneratedFakeable, GeneratedCopiable, Equatable {
     public let amount: Int
     public let currency: String
-    public let depositsCount: Int?
 
-    public init(amount: Int, currency: String, depositsCount: Int?) {
+    public init(amount: Int, currency: String) {
         self.amount = amount
         self.currency = currency
-        self.depositsCount = depositsCount
     }
 
     public enum CodingKeys: String, CodingKey {
         case amount
         case currency
-        case depositsCount = "deposits_count"
     }
 }
 

--- a/Networking/NetworkingTests/Responses/deposits-overview-all-no-default-currency.json
+++ b/Networking/NetworkingTests/Responses/deposits-overview-all-no-default-currency.json
@@ -16,21 +16,6 @@
           "created": 1696550400
         }
       ],
-      "next_scheduled": [
-        {
-          "id": "wcpay_estimated_weekly_eur_1701820800",
-          "date": 1701820800000,
-          "type": "deposit",
-          "amount": 2018,
-          "status": "estimated",
-          "bankAccount": "STRIPE TEST BANK •••• 5432 (EUR)",
-          "currency": "eur",
-          "automatic": true,
-          "fee": 0,
-          "fee_percentage": 0,
-          "created": 1701820800
-        }
-      ],
       "last_manual_deposits": []
     },
     "balance": {
@@ -40,8 +25,7 @@
           "currency": "eur",
           "source_types": {
             "card": 2018
-          },
-          "deposits_count": 1
+          }
         }
       ],
       "available": [

--- a/Networking/NetworkingTests/Responses/deposits-overview-all.json
+++ b/Networking/NetworkingTests/Responses/deposits-overview-all.json
@@ -29,34 +29,6 @@
           "created": 1696550400
         }
       ],
-      "next_scheduled": [
-        {
-          "id": "wcpay_estimated_weekly_eur_1701820800",
-          "date": 1701820800000,
-          "type": "deposit",
-          "amount": 2018,
-          "status": "estimated",
-          "bankAccount": "STRIPE TEST BANK •••• 5432 (EUR)",
-          "currency": "eur",
-          "automatic": true,
-          "fee": 0,
-          "fee_percentage": 0,
-          "created": 1701820800
-        },
-        {
-          "id": "wcpay_estimated_weekly_gbp_1701820800",
-          "date": 1701820800000,
-          "type": "deposit",
-          "amount": 3454,
-          "status": "estimated",
-          "bankAccount": "STRIPE TEST BANK •••• 2345 (GBP)",
-          "currency": "GBP",
-          "automatic": true,
-          "fee": 0,
-          "fee_percentage": 0,
-          "created": 1701820800
-        }
-      ],
       "last_manual_deposits": []
     },
     "balance": {
@@ -66,16 +38,14 @@
           "currency": "eur",
           "source_types": {
             "card": 2018
-          },
-          "deposits_count": 1
+          }
         },
         {
           "amount": 3454,
           "currency": "GBP",
           "source_types": {
             "card": 3454
-          },
-          "deposits_count": 1
+          }
         }
       ],
       "available": [


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Partially closes: #11529
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
This PR updates the Deposits Summary model to account for the latest API update (pdjTHR-3az-p2), since one of the necessary properties to initialize the model is no longer served (`next_scheduled`) we wouldn't render the deposits summary at all.

## Changes
- Removed `nextScheduled` property from `WooPaymentsCurrencyDeposits` model
- Removed `deposits_count` property from `WooPaymentsBalance` model
- Updated mocked responses from networking tests to account for these changes, as well as generated files.

## Testing instructions
###  Single-currency store:
1. In Proxyman, add a breakpoint to the `/wc/v3/payments/deposits/overview-all` path
2. On an eligible store, go to Menu > Payments
3. The breakpoint should trigger now, update the body of the request to the following:
```
{
  "data": {
    "deposit": {
      "last_paid": [
        {
          "id": "po_1OOVCZ2HCBWb6DsLMYNRU3WC",
          "date": 1702857600000,
          "type": "deposit",
          "amount": 1265,
          "status": "paid",
          "bankAccount": "STRIPE TEST BANK \u2022\u2022\u2022\u2022 6789 (USD)",
          "currency": "usd",
          "automatic": true,
          "fee": 0,
          "fee_percentage": 0,
          "created": 1702857600
        }
      ],
      "last_manual_deposits": []
    },
    "balance": {
      "pending": [
        {
          "amount": 0,
          "currency": "usd",
          "source_types": {
            "card": 0
          }
        }
      ],
      "available": [
        {
          "amount": 0,
          "currency": "usd",
          "source_types": {
            "card": 0
          }
        }
      ],
      "instant": [
        {
          "amount": 0,
          "currency": "usd",
          "fee": 0,
          "fee_percentage": 1.5,
          "net": 0
        }
      ]
    },
    "account": {
      "deposits_enabled": true,
      "deposits_blocked": false,
      "deposits_schedule": {
        "delay_days": 2,
        "interval": "daily"
      },
      "default_currency": "usd"
    }
  }
}
```
4. Observe that the Deposits Summary view renders correctly and behaves as expected.

### Multi-currency store:
1. Same instructions as above, but when the breakpoint is triggered, pass the following body to the request:
```
{
  "data": {
    "deposit": {
      "last_paid": [
        {
          "id": "po_1OOVCZ2HCBWb6DsLMYNRU3WC",
          "date": 1702857600000,
          "type": "deposit",
          "amount": 1265,
          "status": "paid",
          "bankAccount": "STRIPE TEST BANK \u2022\u2022\u2022\u2022 6789 (EUR)",
          "currency": "eur",
          "automatic": true,
          "fee": 0,
          "fee_percentage": 0,
          "created": 1702857600
        }
      ],
      "last_manual_deposits": []
    },
    "balance": {
      "pending": [
        {
          "amount": 0,
          "currency": "eur",
          "source_types": {
            "card": 0
          }
        },
        {
          "amount": 0,
          "currency": "gbp",
          "source_types": {
            "card": 0
          }
        }
      ],
      "available": [
        {
          "amount": 0,
          "currency": "eur",
          "source_types": {
            "card": 0
          }
        },
        {
          "amount": 0,
          "currency": "gbp",
          "source_types": {
            "card": 0
          }
        }
      ],
      "instant": [
        {
          "amount": 0,
          "currency": "eur",
          "fee": 0,
          "fee_percentage": 1.5,
          "net": 0
        }
      ]
    },
    "account": {
      "deposits_enabled": true,
      "deposits_blocked": false,
      "deposits_schedule": {
        "delay_days": 2,
        "interval": "daily"
      },
      "default_currency": "eur"
    }
  }
}
```

## Screenshots
| Single-currency store | Multi-currency store |
|--------|--------|
| ![Simulator Screenshot - iPhone 15 - 2024-01-08 at 09 51 41](https://github.com/woocommerce/woocommerce-ios/assets/3812076/49af8ed9-a8e9-4398-ad20-2600f1447aab) | ![Simulator Screenshot - iPhone 15 - 2024-01-08 at 09 52 04](https://github.com/woocommerce/woocommerce-ios/assets/3812076/0357b902-27a5-4ad3-bfa0-6fa0a210cbd1) | 

---
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.