### PR TITLE
[Deposit Summary] Calculate next scheduled deposit in-app

### DIFF
--- a/Networking/Networking/Model/WooPaymentsDepositsOverview.swift
+++ b/Networking/Networking/Model/WooPaymentsDepositsOverview.swift
@@ -315,7 +315,7 @@ public enum WooPaymentsDepositInterval: Equatable, GeneratedFakeable, GeneratedC
             return localizedDayName
         }
 
-        private var dayIndex: Int {
+        public var dayIndex: Int {
             switch self {
             case .sunday:
                 return 0

--- a/Networking/Networking/Model/WooPaymentsDepositsOverview.swift
+++ b/Networking/Networking/Model/WooPaymentsDepositsOverview.swift
@@ -315,7 +315,29 @@ public enum WooPaymentsDepositInterval: Equatable, GeneratedFakeable, GeneratedC
             return localizedDayName
         }
 
-        public var dayIndex: Int {
+        // Identifier for the weekday unit
+        // The weekday units are the numbers 1 through N (where for the Gregorian calendar N=7 and 1 is Sunday)
+        // https://developer.apple.com/documentation/foundation/calendar/component/weekday
+        public var dayToInt: Int {
+            switch self {
+            case .sunday:
+                return 1
+            case .monday:
+                return 2
+            case .tuesday:
+                return 3
+            case .wednesday:
+                return 4
+            case .thursday:
+                return 5
+            case .friday:
+                return 6
+            case .saturday:
+                return 7
+            }
+        }
+
+        private var dayIndex: Int {
             switch self {
             case .sunday:
                 return 0

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Deposits Overview/WooPaymentsDepositsCurrencyOverviewView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Deposits Overview/WooPaymentsDepositsCurrencyOverviewView.swift
@@ -76,6 +76,14 @@ struct WooPaymentsDepositsCurrencyOverviewView: View {
 
                 Divider()
 
+                if let nextScheduledDeposit = viewModel.nextScheduledDeposit {
+                    Text("Next deposit is scheduled for \(nextScheduledDeposit)")
+                        .font(.footnote)
+                        .foregroundColor(.secondary)
+                        .padding(.vertical)
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                }
+
                 Button {
                     viewModel.learnMoreTapped()
                 } label: {
@@ -88,7 +96,6 @@ struct WooPaymentsDepositsCurrencyOverviewView: View {
                             .multilineTextAlignment(.leading)
                     }
                 }
-                .padding(.top)
                 .padding(.bottom)
             }
         }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Deposits Overview/WooPaymentsDepositsCurrencyOverviewView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Deposits Overview/WooPaymentsDepositsCurrencyOverviewView.swift
@@ -76,13 +76,11 @@ struct WooPaymentsDepositsCurrencyOverviewView: View {
 
                 Divider()
 
-                if let nextScheduledDeposit = viewModel.nextScheduledDeposit {
-                    Text("Next deposit is scheduled for \(nextScheduledDeposit)")
+                Text(viewModel.nextScheduledDepositText)
                         .font(.footnote)
                         .foregroundColor(.secondary)
                         .padding(.vertical)
                         .frame(maxWidth: .infinity, alignment: .leading)
-                }
 
                 Button {
                     viewModel.learnMoreTapped()

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Deposits Overview/WooPaymentsDepositsCurrencyOverviewViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Deposits Overview/WooPaymentsDepositsCurrencyOverviewViewModel.swift
@@ -69,9 +69,14 @@ final class WooPaymentsDepositsCurrencyOverviewViewModel: ObservableObject {
                 difference += 7
             }
             scheduledDate = calendar.date(byAdding: .day, value: difference, to: currentDate)
-        case let .monthly(anchor: data):
-            print(data)
-            break
+        case let .monthly(anchor: targetMonth):
+            let currentMonth = calendar.component(.month, from: currentDate)
+            var difference = targetMonth - currentMonth
+            // Adjust if needed, so the difference is always positive:
+            if difference < 0 {
+                difference += 12
+            }
+            scheduledDate = calendar.date(byAdding: .month, value: difference, to: currentDate)
         case .manual:
             break
         }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Deposits Overview/WooPaymentsDepositsCurrencyOverviewViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Deposits Overview/WooPaymentsDepositsCurrencyOverviewViewModel.swift
@@ -35,18 +35,24 @@ final class WooPaymentsDepositsCurrencyOverviewViewModel: ObservableObject {
         availableBalance = formatAmount(overview.availableBalance)
         depositScheduleHint = depositScheduleHintText()
         balanceTypeHint = balanceTypeHintText()
+        nextScheduledDeposit = calculateNextScheduledDeposit()
     }
 
     @Published var pendingBalance: String = ""
     @Published var lastDepositAmount: String = ""
     @Published var lastDepositDate: String = ""
     @Published var lastDepositStatus: WooPaymentsDepositStatus = .unknown
+    @Published var nextScheduledDeposit: String? = nil
     @Published var availableBalance: String = ""
     @Published var depositScheduleHint: String = ""
     @Published var balanceTypeHint: String = ""
     @Published var showWebviewURL: URL? = nil
     @Published var currency: CurrencyCode
     @Published var tabTitle: String
+
+    private func calculateNextScheduledDeposit() -> String {
+        return formatDate(Date()) ?? Localization.noDateString
+    }
 
     private func formatAmount(_ amount: NSDecimalNumber) -> String {
         if let wooCurrencyFormatter {

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Deposits Overview/WooPaymentsDepositsCurrencyOverviewViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Deposits Overview/WooPaymentsDepositsCurrencyOverviewViewModel.swift
@@ -51,7 +51,28 @@ final class WooPaymentsDepositsCurrencyOverviewViewModel: ObservableObject {
     @Published var tabTitle: String
 
     private func calculateNextScheduledDeposit() -> String {
-        return formatDate(Date()) ?? Localization.noDateString
+        let currentDate = Date()
+        let calendar = Calendar.current
+        var scheduledDate: Date? = nil
+
+        switch overview.depositInterval {
+        case .daily:
+            scheduledDate = calendar.date(byAdding: .day,
+                                         value: 1,
+                                         to: currentDate)
+        case let .weekly(anchor: dayOfTheWeek):
+            print(dayOfTheWeek)
+            break
+        case let .monthly(anchor: data):
+            print(data)
+            break
+        case .manual:
+            break
+        }
+        guard let scheduledDate else {
+            return Localization.noDateString
+        }
+        return formatDate(scheduledDate) ?? Localization.noDateString
     }
 
     private func formatAmount(_ amount: NSDecimalNumber) -> String {

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Deposits Overview/WooPaymentsDepositsCurrencyOverviewViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Deposits Overview/WooPaymentsDepositsCurrencyOverviewViewModel.swift
@@ -77,8 +77,8 @@ final class WooPaymentsDepositsCurrencyOverviewViewModel: ObservableObject {
                 difference += 12
             }
             scheduledDate = calendar.date(byAdding: .month, value: difference, to: currentDate)
-        case .manual:
-            break
+        default:
+            scheduledDate = nil
         }
         guard let scheduledDate else {
             return Localization.noDateString

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Deposits Overview/WooPaymentsDepositsCurrencyOverviewViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Deposits Overview/WooPaymentsDepositsCurrencyOverviewViewModel.swift
@@ -61,6 +61,9 @@ final class WooPaymentsDepositsCurrencyOverviewViewModel: ObservableObject {
         return Localization.noDateString
     }
 
+    // Mimics calculating the next scheduled deposit date in WooPayments
+    // https://github.com/Automattic/woocommerce-payments/blob/develop/client/deposits/utils/index.ts
+    //
     private func calculateNextScheduledDeposit() -> String {
         let currentDate = date
         let calendar = Calendar.current

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Deposits Overview/WooPaymentsDepositsCurrencyOverviewViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Deposits Overview/WooPaymentsDepositsCurrencyOverviewViewModel.swift
@@ -61,8 +61,14 @@ final class WooPaymentsDepositsCurrencyOverviewViewModel: ObservableObject {
                                          value: 1,
                                          to: currentDate)
         case let .weekly(anchor: dayOfTheWeek):
-            print(dayOfTheWeek)
-            break
+            let targetWeekday = dayOfTheWeek.dayIndex
+            let today = calendar.component(.weekday, from: currentDate)
+            var difference = targetWeekday - today
+            // Adjust so the difference is always positive:
+            if difference < 0 {
+                difference += 7
+            }
+            scheduledDate = calendar.date(byAdding: .day, value: difference, to: currentDate)
         case let .monthly(anchor: data):
             print(data)
             break

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Deposits Overview/WooPaymentsDepositsCurrencyOverviewViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Deposits Overview/WooPaymentsDepositsCurrencyOverviewViewModel.swift
@@ -53,6 +53,14 @@ final class WooPaymentsDepositsCurrencyOverviewViewModel: ObservableObject {
     @Published var currency: CurrencyCode
     @Published var tabTitle: String
 
+    var nextScheduledDepositText: String {
+        if let nextScheduledDeposit {
+            let text = String.localizedStringWithFormat(Localization.nextScheduledDepositText, nextScheduledDeposit)
+            return text
+        }
+        return Localization.noDateString
+    }
+
     private func calculateNextScheduledDeposit() -> String {
         let currentDate = date
         let calendar = Calendar.current
@@ -207,5 +215,11 @@ private extension WooPaymentsDepositsCurrencyOverviewViewModel {
             "Est. %1$@",
             comment: "String indicating that a deposit date is an estimate. Shown on whe WooPayments Deposits View. " +
             "%1$@ will be replaced with a locale-appropriate date string.")
+        static let nextScheduledDepositText = NSLocalizedString(
+            "deposits.currency.overview.nextScheduledDeposit",
+            value: "Next deposit is scheduled for %@",
+            comment: "Text indicating the date for the next scheduled deposit. " +
+            "Reads as 'Next deposit is scheduled for Dec 8, 2024'"
+        )
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Deposits Overview/WooPaymentsDepositsCurrencyOverviewViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Deposits Overview/WooPaymentsDepositsCurrencyOverviewViewModel.swift
@@ -7,16 +7,19 @@ final class WooPaymentsDepositsCurrencyOverviewViewModel: ObservableObject {
     private let analytics: Analytics
     private let currencySettings: CurrencySettings?
     private let locale: Locale
+    private let date: Date
 
     init(overview: WooPaymentsDepositsOverviewByCurrency,
          analytics: Analytics = ServiceLocator.analytics,
          siteCurrencySettings: CurrencySettings = ServiceLocator.currencySettings,
-         locale: Locale = Locale.current) {
+         locale: Locale = Locale.current,
+         date: Date = Date.init()) {
         self.overview = overview
         self.analytics = analytics
         self.currency = overview.currency
         self.tabTitle = overview.currency.rawValue.uppercased()
         self.locale = locale
+        self.date = date
 
         if overview.currency == siteCurrencySettings.currencyCode {
             currencySettings = siteCurrencySettings
@@ -51,7 +54,7 @@ final class WooPaymentsDepositsCurrencyOverviewViewModel: ObservableObject {
     @Published var tabTitle: String
 
     private func calculateNextScheduledDeposit() -> String {
-        let currentDate = Date()
+        let currentDate = date
         let calendar = Calendar.current
         var scheduledDate: Date? = nil
 
@@ -61,11 +64,11 @@ final class WooPaymentsDepositsCurrencyOverviewViewModel: ObservableObject {
                                          value: 1,
                                          to: currentDate)
         case let .weekly(anchor: dayOfTheWeek):
-            let targetWeekday = dayOfTheWeek.dayIndex
+            let targetWeekday = dayOfTheWeek.dayToInt
             let today = calendar.component(.weekday, from: currentDate)
             var difference = targetWeekday - today
             // Adjust so the difference is always positive:
-            if difference < 0 {
+            if difference <= 0 {
                 difference += 7
             }
             scheduledDate = calendar.date(byAdding: .day, value: difference, to: currentDate)

--- a/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Settings/In-Person Payments/Deposits Overview/WooPaymentsDepositsCurrencyOverviewViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Settings/In-Person Payments/Deposits Overview/WooPaymentsDepositsCurrencyOverviewViewModelTests.swift
@@ -96,12 +96,14 @@ final class WooPaymentsDepositsCurrencyOverviewViewModelTests: XCTestCase {
             return XCTFail("Unable to construct date.")
         }
         let nextExpectedScheduledDepositDate = "Jan 9, 2024"
+        let expectedString = "Next deposit is scheduled for Jan 9, 2024"
 
         // When
         sut = WooPaymentsDepositsCurrencyOverviewViewModel(overview: overview, date: date)
 
         // Then
         assertEqual(nextExpectedScheduledDepositDate, sut.nextScheduledDeposit)
+        assertEqual(expectedString, sut.nextScheduledDepositText)
     }
 
     func test_when_calculateNextScheduledDeposit_is_weekly_then_next_expected_deposit_scheduled_date_is_the_given_week_on_anchor_day() {
@@ -118,9 +120,11 @@ final class WooPaymentsDepositsCurrencyOverviewViewModelTests: XCTestCase {
         // When
         sut = WooPaymentsDepositsCurrencyOverviewViewModel(overview: overview,
                                                            date: date)
+        let expectedString = "Next deposit is scheduled for Jan 15, 2024"
 
         // Then
         assertEqual(nextExpectedScheduledDepositDate, sut.nextScheduledDeposit)
+        assertEqual(expectedString, sut.nextScheduledDepositText)
     }
 
     func test_when_calculateNextScheduledDeposit_is_monthly_then_next_expected_deposit_scheduled_date_is_the_given_month() {
@@ -137,9 +141,11 @@ final class WooPaymentsDepositsCurrencyOverviewViewModelTests: XCTestCase {
         // When
         sut = WooPaymentsDepositsCurrencyOverviewViewModel(overview: overview,
                                                            date: date)
+        let expectedString = "Next deposit is scheduled for Dec 8, 2024"
 
         // Then
         assertEqual(nextExpectedScheduledDepositDate, sut.nextScheduledDeposit)
+        assertEqual(expectedString, sut.nextScheduledDepositText)
     }
 
     func test_when_calculateNextScheduledDeposit_is_manual_then_next_expected_scheduled_deposit_date_is_not_applicable() {
@@ -147,12 +153,14 @@ final class WooPaymentsDepositsCurrencyOverviewViewModelTests: XCTestCase {
         let overview = WooPaymentsDepositsOverviewByCurrency
             .fake()
             .copy(depositInterval: .manual)
+        let nextExpectedScheduledDepositDate = "N/A"
+        let expectedString = "Next deposit is scheduled for N/A"
 
         // When
         sut = WooPaymentsDepositsCurrencyOverviewViewModel(overview: overview)
 
         // Then
-        assertEqual("N/A", sut.nextScheduledDeposit)
+        assertEqual(nextExpectedScheduledDepositDate, sut.nextScheduledDeposit)
+        assertEqual(expectedString, sut.nextScheduledDepositText)
     }
-
 }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Settings/In-Person Payments/Deposits Overview/WooPaymentsDepositsCurrencyOverviewViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Settings/In-Person Payments/Deposits Overview/WooPaymentsDepositsCurrencyOverviewViewModelTests.swift
@@ -88,4 +88,71 @@ final class WooPaymentsDepositsCurrencyOverviewViewModelTests: XCTestCase {
         assertEqual(sut.availableBalance, "CA$12.35")
     }
 
+    func test_when_calculateNextScheduledDeposit_is_daily_then_next_expected_scheduled_date_is_a_day_after() {
+        // Given
+        let overview = WooPaymentsDepositsOverviewByCurrency.fake().copy(depositInterval: .daily)
+        let currentDate = DateComponents(year: 2024, month: 1, day: 8)
+        guard let date = Calendar.current.date(from: currentDate) else {
+            return XCTFail("Unable to construct date.")
+        }
+        let nextExpectedScheduledDepositDate = "Jan 9, 2024"
+
+        // When
+        sut = WooPaymentsDepositsCurrencyOverviewViewModel(overview: overview, date: date)
+
+        // Then
+        assertEqual(nextExpectedScheduledDepositDate, sut.nextScheduledDeposit)
+    }
+
+    func test_when_calculateNextScheduledDeposit_is_weekly_then_next_expected_deposit_scheduled_date_is_the_given_week_on_anchor_day() {
+        // Given
+        let overview = WooPaymentsDepositsOverviewByCurrency
+            .fake()
+            .copy(depositInterval: .weekly(anchor: .monday))
+        let currentDate = DateComponents(year: 2024, month: 1, day: 8)
+        guard let date = Calendar.current.date(from: currentDate) else {
+            return XCTFail("Unable to construct date.")
+        }
+        let nextExpectedScheduledDepositDate = "Jan 15, 2024"
+
+        // When
+        sut = WooPaymentsDepositsCurrencyOverviewViewModel(overview: overview,
+                                                           date: date)
+
+        // Then
+        assertEqual(nextExpectedScheduledDepositDate, sut.nextScheduledDeposit)
+    }
+
+    func test_when_calculateNextScheduledDeposit_is_monthly_then_next_expected_deposit_scheduled_date_is_the_given_month() {
+        // Given
+        let overview = WooPaymentsDepositsOverviewByCurrency
+            .fake()
+            .copy(depositInterval: .monthly(anchor: 12))
+        let currentDate = DateComponents(year: 2024, month: 1, day: 8)
+        guard let date = Calendar.current.date(from: currentDate) else {
+            return XCTFail("Unable to construct date.")
+        }
+        let nextExpectedScheduledDepositDate = "Dec 8, 2024"
+
+        // When
+        sut = WooPaymentsDepositsCurrencyOverviewViewModel(overview: overview,
+                                                           date: date)
+
+        // Then
+        assertEqual(nextExpectedScheduledDepositDate, sut.nextScheduledDeposit)
+    }
+
+    func test_when_calculateNextScheduledDeposit_is_manual_then_next_expected_scheduled_deposit_date_is_not_applicable() {
+        // Given
+        let overview = WooPaymentsDepositsOverviewByCurrency
+            .fake()
+            .copy(depositInterval: .manual)
+
+        // When
+        sut = WooPaymentsDepositsCurrencyOverviewViewModel(overview: overview)
+
+        // Then
+        assertEqual("N/A", sut.nextScheduledDeposit)
+    }
+
 }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #11529
<!-- Id number of the GitHub issue this PR addresses. -->

## Description

This PR takes care of handling the next scheduled deposit date calculation in-app in order to show it within the Deposits Summary view. This calculation is done in the client since the API won't provide it for the time being ( ref: pdjTHR-3az-p2 ).

From the [source in wcpay](https://github.com/Automattic/woocommerce-payments/blob/15e611714c4b94a8772f8ba82dc20cd0b7c44be6/client/deposits/utils/index.ts#L57-L100 ), we only handle the cases for daily, weekly, and monthly intervals. We do so by calculating the distance between the current date and the next scheduled deposit day.

## Testing instructions
1. In Proxyman, add a breakpoint to the `/wc/v3/payments/deposits/overview-all` path
2. On an eligible store, go to Menu > Payments
3. The breakpoint should trigger now, in the body of the request you'll see the following bit:
```
"account": {
      "deposits_enabled": true,
      "deposits_blocked": false,
      "deposits_schedule": {
        "delay_days": 7,
        "interval": "weekly",
        "weekly_anchor": "wednesday"
      },
      "default_currency": "eur"
    }
```

### Daily case

- Update `"interval": "weekly"`, to `"interval": "daily"`
- Observe that the next day will be displayed

### Weekly case
- Update `"weekly_anchor": "wednesday"` to `"weekly_anchor": "friday"`, observe that next Friday will be displayed.
- Change `"weekly_anchor": "wednesday"`, to any day before the current one this week, eg: `"weekly_anchor": "monday"`, observe it still displays the date for the future Monday, not the past Monday.

### Monthly case
Update  `"interval": "weekly"` to `"interval": "monthly"`,  edit `weekly_anchor` for `monthly_anchor`, then add an Int to represent the month, eg: 3 will show the date as March:
```
"account": {
      "deposits_enabled": true,
      "deposits_blocked": false,
      "deposits_schedule": {
        "delay_days": 7,
        "interval": "monthly",
        "monthly_anchor": 3
      },
      "default_currency": "eur"
    }
```
4. Observe the line `Next deposit is scheduled for $date` rendering based on the data the API receives:

| Daily | Weekly | Monthly |
|--------|--------|--------|
| ![Simulator Screenshot - iPhone 15 - 2024-01-08 at 16 28 04](https://github.com/woocommerce/woocommerce-ios/assets/3812076/acc5d108-7ff5-4823-993b-5cdfcf1da80e) | ![simulator_screenshot_36F653DB-A0E8-4595-93AE-BDAA0DF0DA42](https://github.com/woocommerce/woocommerce-ios/assets/3812076/8ce150c4-359c-4e19-9d5c-b69ff176c4d4) |  ![Simulator Screenshot - iPhone 15 - 2024-01-09 at 10 57 04](https://github.com/woocommerce/woocommerce-ios/assets/3812076/e92ccbea-0aa4-4427-9fb1-e4bc2b8eb34d) | 
