### PR TITLE
[Product Creation AI] Update Survey

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -2,6 +2,7 @@
 
 16.9
 -----
+- [internal] Product Creation AI: Change when and how many times we ask users to participate in survey. [https://github.com/woocommerce/woocommerce-ios/pull/11646]
 
 
 16.8

--- a/WooCommerce/Classes/Extensions/UserDefaults+Woo.swift
+++ b/WooCommerce/Classes/Extensions/UserDefaults+Woo.swift
@@ -50,7 +50,7 @@ extension UserDefaults {
         case hasDismissedBlazeSectionOnMyStore
 
         // Product Creation AI
-        case numberOfTimesAIProductCreationAISurveySuggested
+        case numberOfTimesProductCreationAISurveySuggested
         case didStartProductCreationAISurvey
 
         // Theme installation

--- a/WooCommerce/Classes/Extensions/UserDefaults+Woo.swift
+++ b/WooCommerce/Classes/Extensions/UserDefaults+Woo.swift
@@ -50,8 +50,8 @@ extension UserDefaults {
         case hasDismissedBlazeSectionOnMyStore
 
         // Product Creation AI
-        case numberOfTimesAIProductCreated
-        case didSuggestProductCreationAISurvey
+        case numberOfTimesAIProductCreationAISurveySuggested
+        case didStartProductCreationAISurvey
 
         // Theme installation
         case themesPendingInstall

--- a/WooCommerce/Classes/System/SessionManager.swift
+++ b/WooCommerce/Classes/System/SessionManager.swift
@@ -173,7 +173,7 @@ final class SessionManager: SessionManagerProtocol {
         defaults[.aiPromptTone] = nil
         defaults[.hasDisplayedTipAfterBlazeCampaignCreation] = nil
         defaults[.hasDismissedBlazeSectionOnMyStore] = nil
-        defaults[.numberOfTimesAIProductCreationAISurveySuggested] = nil
+        defaults[.numberOfTimesProductCreationAISurveySuggested] = nil
         defaults[.didStartProductCreationAISurvey] = nil
         defaults[.themesPendingInstall] = nil
         defaults[.siteIDPendingStoreSwitch] = nil

--- a/WooCommerce/Classes/System/SessionManager.swift
+++ b/WooCommerce/Classes/System/SessionManager.swift
@@ -173,8 +173,8 @@ final class SessionManager: SessionManagerProtocol {
         defaults[.aiPromptTone] = nil
         defaults[.hasDisplayedTipAfterBlazeCampaignCreation] = nil
         defaults[.hasDismissedBlazeSectionOnMyStore] = nil
-        defaults[.numberOfTimesAIProductCreated] = nil
-        defaults[.didSuggestProductCreationAISurvey] = nil
+        defaults[.numberOfTimesAIProductCreationAISurveySuggested] = nil
+        defaults[.didStartProductCreationAISurvey] = nil
         defaults[.themesPendingInstall] = nil
         defaults[.siteIDPendingStoreSwitch] = nil
         defaults[.expectedStoreNamePendingStoreSwitch] = nil

--- a/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductCoordinator.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductCoordinator.swift
@@ -358,7 +358,6 @@ private extension AddProductCoordinator {
     ///
     func presentProductCreationAIFeedbackIfApplicable() {
         let useCase = ProductCreationAISurveyUseCase()
-        useCase.didCreateAIProduct()
 
         guard useCase.shouldShowProductCreationAISurvey() else {
             return
@@ -370,6 +369,7 @@ private extension AddProductCoordinator {
             self.productCreationAISurveyPresenter.dismiss(onDismiss: { [weak self] in
                 let survey = SurveyCoordinatingController(survey: .productCreationAI)
                 self?.navigationController.present(survey, animated: true, completion: nil)
+                useCase.didStartProductCreationAISurvey()
             })
         }, onSkip: { [weak self] in
             self?.productCreationAISurveyPresenter.dismiss()

--- a/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductWithAI/Survey/ProductCreationAISurveyConfirmationView.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductWithAI/Survey/ProductCreationAISurveyConfirmationView.swift
@@ -31,7 +31,7 @@ struct ProductCreationAISurveyConfirmationView: View {
                         .headlineStyle()
                         .multilineTextAlignment(.center)
 
-                    Text(Localization.subtitle)
+                    Text(Localization.description)
                         .foregroundColor(Color(.text))
                         .subheadlineStyle()
                         .multilineTextAlignment(.center)
@@ -44,7 +44,7 @@ struct ProductCreationAISurveyConfirmationView: View {
                 .buttonStyle(PrimaryButtonStyle())
                 .padding(.horizontal, Layout.buttonHorizontalPadding)
 
-                Button(Localization.skip) {
+                Button(viewModel.skipButtonTitle) {
                     viewModel.didTapSkip()
                 }
                 .buttonStyle(SecondaryButtonStyle())
@@ -68,21 +68,14 @@ private extension ProductCreationAISurveyConfirmationView {
                                              value: "We value your input!",
                                              comment: "Title in Product Creation AI survey confirmation view.")
 
-        static let subtitle = NSLocalizedString("productCreationAISurveyConfirmationView.subtitle",
-                                                value: "You've used our AI-assisted feature to add products multiple times now."
-                                                + " "
-                                                + "We'd love to hear your thoughts to make it even better.",
-                                                comment: "Subtitle in Product Creation AI survey confirmation view.")
+        static let description = NSLocalizedString("productCreationAISurveyConfirmationView.description",
+                                                   value: "Got a minute? Help us improve our AI-assisted features with your quick feedback.",
+                                                   comment: "Description in Product Creation AI survey confirmation view.")
 
         static let startTheSurvey = NSLocalizedString("productCreationAISurveyConfirmationView.startTheSurvey",
                                                       value: "Start the Survey",
                                                       comment: "Start Survey button title in Product Creation AI survey confirmation view.")
-
-        static let skip = NSLocalizedString("productCreationAISurveyConfirmationView.skip",
-                                            value: "Skip",
-                                            comment: "Dismiss button title in Product Creation AI survey confirmation view.")
     }
-
 }
 
 struct ProductCreationAISurveyConfirmationView_Previews: PreviewProvider {

--- a/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductWithAI/Survey/ProductCreationAISurveyConfirmationViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductWithAI/Survey/ProductCreationAISurveyConfirmationViewModel.swift
@@ -14,7 +14,7 @@ struct ProductCreationAISurveyConfirmationViewModel {
         self.onSkip = onSkip
         self.analytics = analytics
         let useCase = ProductCreationAISurveyUseCase()
-        skipButtonTitle = useCase.numberOfTimesAIProductCreationAISurveySuggested == 0 ? Localization.remindMeLater : Localization.dontShowItAgain
+        skipButtonTitle = useCase.numberOfTimesProductCreationAISurveySuggested == 0 ? Localization.remindMeLater : Localization.dontShowItAgain
     }
 
     func didTapStartTheSurvey() {

--- a/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductWithAI/Survey/ProductCreationAISurveyConfirmationViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductWithAI/Survey/ProductCreationAISurveyConfirmationViewModel.swift
@@ -5,6 +5,7 @@ struct ProductCreationAISurveyConfirmationViewModel {
     private let onStart: () -> Void
     private let onSkip: () -> Void
     private let analytics: Analytics
+    let skipButtonTitle: String
 
     init(onStart: @escaping () -> Void,
          onSkip: @escaping () -> Void,
@@ -12,6 +13,8 @@ struct ProductCreationAISurveyConfirmationViewModel {
         self.onStart = onStart
         self.onSkip = onSkip
         self.analytics = analytics
+        let useCase = ProductCreationAISurveyUseCase()
+        skipButtonTitle = useCase.numberOfTimesAIProductCreationAISurveySuggested == 0 ? Localization.remindMeLater : Localization.dontShowItAgain
     }
 
     func didTapStartTheSurvey() {
@@ -22,5 +25,17 @@ struct ProductCreationAISurveyConfirmationViewModel {
     func didTapSkip() {
         analytics.track(event: .ProductCreationAI.Survey.skip())
         onSkip()
+    }
+}
+
+private extension ProductCreationAISurveyConfirmationViewModel {
+    enum Localization {
+        static let remindMeLater = NSLocalizedString("productCreationAISurveyConfirmationViewModel.remindMeLater",
+                                                     value: "Remind Me Later",
+                                                     comment: "Dismiss button title in Product Creation AI survey confirmation view.")
+
+        static let dontShowItAgain = NSLocalizedString("productCreationAISurveyConfirmationViewModel.dontShowItAgain",
+                                                       value: "Don’t Show it Again",
+                                                       comment: "Dismiss button title in Product Creation AI survey confirmation view.")
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductWithAI/Survey/ProductCreationAISurveyConfirmationViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductWithAI/Survey/ProductCreationAISurveyConfirmationViewModel.swift
@@ -14,7 +14,7 @@ struct ProductCreationAISurveyConfirmationViewModel {
         self.onSkip = onSkip
         self.analytics = analytics
         let useCase = ProductCreationAISurveyUseCase()
-        skipButtonTitle = useCase.numberOfTimesProductCreationAISurveySuggested == 0 ? Localization.remindMeLater : Localization.dontShowItAgain
+        skipButtonTitle = useCase.haveSuggestedSurveyBefore() ? Localization.dontShowItAgain : Localization.remindMeLater
     }
 
     func didTapStartTheSurvey() {

--- a/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductWithAI/Survey/ProductCreationAISurveyUseCase.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductWithAI/Survey/ProductCreationAISurveyUseCase.swift
@@ -12,13 +12,19 @@ final class ProductCreationAISurveyUseCase {
         self.analytics = analytics
     }
 
-    private(set) var numberOfTimesProductCreationAISurveySuggested: Int {
+    private var numberOfTimesProductCreationAISurveySuggested: Int {
         get {
             defaults.integer(forKey: UserDefaults.Key.numberOfTimesProductCreationAISurveySuggested.rawValue)
         }
         set {
             defaults.set(newValue, forKey: UserDefaults.Key.numberOfTimesProductCreationAISurveySuggested.rawValue)
         }
+    }
+
+    /// Returns `true` if Survey has been suggested before
+    ///
+    func haveSuggestedSurveyBefore() -> Bool {
+        numberOfTimesProductCreationAISurveySuggested > 0
     }
 
     /// Returns `true` if it is time to present Product Creation AI survey.

--- a/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductWithAI/Survey/ProductCreationAISurveyUseCase.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductWithAI/Survey/ProductCreationAISurveyUseCase.swift
@@ -12,12 +12,12 @@ final class ProductCreationAISurveyUseCase {
         self.analytics = analytics
     }
 
-    private(set) var numberOfTimesAIProductCreationAISurveySuggested: Int {
+    private(set) var numberOfTimesProductCreationAISurveySuggested: Int {
         get {
-            defaults.integer(forKey: UserDefaults.Key.numberOfTimesAIProductCreationAISurveySuggested.rawValue)
+            defaults.integer(forKey: UserDefaults.Key.numberOfTimesProductCreationAISurveySuggested.rawValue)
         }
         set {
-            defaults.set(newValue, forKey: UserDefaults.Key.numberOfTimesAIProductCreationAISurveySuggested.rawValue)
+            defaults.set(newValue, forKey: UserDefaults.Key.numberOfTimesProductCreationAISurveySuggested.rawValue)
         }
     }
 
@@ -27,13 +27,13 @@ final class ProductCreationAISurveyUseCase {
         guard !defaults.bool(forKey: UserDefaults.Key.didStartProductCreationAISurvey.rawValue) else {
             return false
         }
-        return numberOfTimesAIProductCreationAISurveySuggested < 2
+        return numberOfTimesProductCreationAISurveySuggested < 2
     }
 
     /// Increments the survey suggested counter by 1
     ///
     func didSuggestProductCreationAISurvey() {
-        numberOfTimesAIProductCreationAISurveySuggested += 1
+        numberOfTimesProductCreationAISurveySuggested += 1
         analytics.track(event: .ProductCreationAI.Survey.confirmationViewDisplayed())
     }
 

--- a/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductWithAI/Survey/ProductCreationAISurveyUseCase.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductWithAI/Survey/ProductCreationAISurveyUseCase.swift
@@ -12,34 +12,34 @@ final class ProductCreationAISurveyUseCase {
         self.analytics = analytics
     }
 
-    private var numberOfTimesAIProductCreated: Int {
+    private(set) var numberOfTimesAIProductCreationAISurveySuggested: Int {
         get {
-            defaults.integer(forKey: UserDefaults.Key.numberOfTimesAIProductCreated.rawValue)
+            defaults.integer(forKey: UserDefaults.Key.numberOfTimesAIProductCreationAISurveySuggested.rawValue)
         }
         set {
-            defaults.set(newValue, forKey: UserDefaults.Key.numberOfTimesAIProductCreated.rawValue)
+            defaults.set(newValue, forKey: UserDefaults.Key.numberOfTimesAIProductCreationAISurveySuggested.rawValue)
         }
     }
 
     /// Returns `true` if it is time to present Product Creation AI survey.
     ///
     func shouldShowProductCreationAISurvey() -> Bool {
-        guard numberOfTimesAIProductCreated >= 3 else {
+        guard !defaults.bool(forKey: UserDefaults.Key.didStartProductCreationAISurvey.rawValue) else {
             return false
         }
-        return !defaults.bool(forKey: UserDefaults.Key.didSuggestProductCreationAISurvey.rawValue)
+        return numberOfTimesAIProductCreationAISurveySuggested < 2
     }
 
-    /// Saves that we have asked the user to provide feedback in survey
+    /// Increments the survey suggested counter by 1
     ///
     func didSuggestProductCreationAISurvey() {
+        numberOfTimesAIProductCreationAISurveySuggested += 1
         analytics.track(event: .ProductCreationAI.Survey.confirmationViewDisplayed())
-        defaults[.didSuggestProductCreationAISurvey] = true
     }
 
-    /// Increments the AI product created count by 1
+    /// Saves that user started the survey
     ///
-    func didCreateAIProduct() {
-        numberOfTimesAIProductCreated += 1
+    func didStartProductCreationAISurvey() {
+        defaults[.didStartProductCreationAISurvey] = true
     }
 }

--- a/WooCommerce/WooCommerceTests/System/SessionManagerTests.swift
+++ b/WooCommerce/WooCommerceTests/System/SessionManagerTests.swift
@@ -319,25 +319,25 @@ class SessionManagerTests: XCTestCase {
         XCTAssertNil(defaults[.hasDisplayedTipAfterBlazeCampaignCreation])
     }
 
-    /// Verifies that `numberOfTimesAIProductCreationAISurveySuggested` is set to `nil` upon reset
+    /// Verifies that `numberOfTimesProductCreationAISurveySuggested` is set to `nil` upon reset
     ///
-    func test_numberOfTimesAIProductCreationAISurveySuggested_is_set_to_nil_upon_reset() throws {
+    func test_numberOfTimesProductCreationAISurveySuggested_is_set_to_nil_upon_reset() throws {
         // Given
         let uuid = UUID().uuidString
         let defaults = try XCTUnwrap(UserDefaults(suiteName: uuid))
         let sut = SessionManager(defaults: defaults, keychainServiceName: Settings.keychainServiceName)
 
         // When
-        defaults[UserDefaults.Key.numberOfTimesAIProductCreationAISurveySuggested] = 2
+        defaults[UserDefaults.Key.numberOfTimesProductCreationAISurveySuggested] = 2
 
         // Then
-        XCTAssertEqual(try XCTUnwrap(defaults[UserDefaults.Key.numberOfTimesAIProductCreationAISurveySuggested] as? Int), 2)
+        XCTAssertEqual(try XCTUnwrap(defaults[UserDefaults.Key.numberOfTimesProductCreationAISurveySuggested] as? Int), 2)
 
         // When
         sut.reset()
 
         // Then
-        XCTAssertNil(defaults[UserDefaults.Key.numberOfTimesAIProductCreationAISurveySuggested])
+        XCTAssertNil(defaults[UserDefaults.Key.numberOfTimesProductCreationAISurveySuggested])
     }
 
     /// Verifies that `didStartProductCreationAISurvey` is set to `nil` upon reset

--- a/WooCommerce/WooCommerceTests/System/SessionManagerTests.swift
+++ b/WooCommerce/WooCommerceTests/System/SessionManagerTests.swift
@@ -319,46 +319,46 @@ class SessionManagerTests: XCTestCase {
         XCTAssertNil(defaults[.hasDisplayedTipAfterBlazeCampaignCreation])
     }
 
-    /// Verifies that `numberOfTimesAIProductCreated` is set to `nil` upon reset
+    /// Verifies that `numberOfTimesAIProductCreationAISurveySuggested` is set to `nil` upon reset
     ///
-    func test_numberOfTimesAIProductCreated_is_set_to_nil_upon_reset() throws {
+    func test_numberOfTimesAIProductCreationAISurveySuggested_is_set_to_nil_upon_reset() throws {
         // Given
         let uuid = UUID().uuidString
         let defaults = try XCTUnwrap(UserDefaults(suiteName: uuid))
         let sut = SessionManager(defaults: defaults, keychainServiceName: Settings.keychainServiceName)
 
         // When
-        defaults[UserDefaults.Key.numberOfTimesAIProductCreated] = 3
+        defaults[UserDefaults.Key.numberOfTimesAIProductCreationAISurveySuggested] = 2
 
         // Then
-        XCTAssertEqual(try XCTUnwrap(defaults[UserDefaults.Key.numberOfTimesAIProductCreated] as? Int), 3)
+        XCTAssertEqual(try XCTUnwrap(defaults[UserDefaults.Key.numberOfTimesAIProductCreationAISurveySuggested] as? Int), 2)
 
         // When
         sut.reset()
 
         // Then
-        XCTAssertNil(defaults[UserDefaults.Key.numberOfTimesAIProductCreated])
+        XCTAssertNil(defaults[UserDefaults.Key.numberOfTimesAIProductCreationAISurveySuggested])
     }
 
-    /// Verifies that `didSuggestProductCreationAISurvey` is set to `nil` upon reset
+    /// Verifies that `didStartProductCreationAISurvey` is set to `nil` upon reset
     ///
-    func test_didSuggestProductCreationAISurvey_is_set_to_nil_upon_reset() throws {
+    func test_didStartProductCreationAISurvey_is_set_to_nil_upon_reset() throws {
         // Given
         let uuid = UUID().uuidString
         let defaults = try XCTUnwrap(UserDefaults(suiteName: uuid))
         let sut = SessionManager(defaults: defaults, keychainServiceName: Settings.keychainServiceName)
 
         // When
-        defaults[.didSuggestProductCreationAISurvey] = true
+        defaults[.didStartProductCreationAISurvey] = true
 
         // Then
-        XCTAssertTrue(try XCTUnwrap(defaults[UserDefaults.Key.didSuggestProductCreationAISurvey] as? Bool))
+        XCTAssertTrue(try XCTUnwrap(defaults[UserDefaults.Key.didStartProductCreationAISurvey] as? Bool))
 
         // When
         sut.reset()
 
         // Then
-        XCTAssertNil(defaults[.didSuggestProductCreationAISurvey])
+        XCTAssertNil(defaults[.didStartProductCreationAISurvey])
     }
 
     /// Verifies that `themesPendingInstall` is set to `nil` upon reset

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/Add Product/AddProductWithAI/ProductCreationAISurveyUseCaseTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/Add Product/AddProductWithAI/ProductCreationAISurveyUseCaseTests.swift
@@ -2,7 +2,7 @@ import XCTest
 @testable import WooCommerce
 
 final class ProductCreationAISurveyUseCaseTests: XCTestCase {
-    func test_shouldShowProductCreationAISurvey_is_false_true_if_survey_not_displayed_before() throws {
+    func test_shouldShowProductCreationAISurvey_is_true_if_survey_not_displayed_before() throws {
         // Given
         let uuid = UUID().uuidString
         let defaults = try XCTUnwrap(UserDefaults(suiteName: uuid))
@@ -11,7 +11,7 @@ final class ProductCreationAISurveyUseCaseTests: XCTestCase {
         let sut = ProductCreationAISurveyUseCase(defaults: defaults)
 
         // Then
-        XCTAssertFalse(sut.shouldShowProductCreationAISurvey())
+        XCTAssertTrue(sut.shouldShowProductCreationAISurvey())
     }
 
     func test_it_asks_to_show_survey_if_user_dismissed_first_time() throws {

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/Add Product/AddProductWithAI/ProductCreationAISurveyUseCaseTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/Add Product/AddProductWithAI/ProductCreationAISurveyUseCaseTests.swift
@@ -2,48 +2,58 @@ import XCTest
 @testable import WooCommerce
 
 final class ProductCreationAISurveyUseCaseTests: XCTestCase {
-    func test_shouldShowProductCreationAISurvey_is_false_when_number_of_AI_generation_is_less_than_3() throws {
+    func test_shouldShowProductCreationAISurvey_is_false_true_if_survey_not_displayed_before() throws {
         // Given
         let uuid = UUID().uuidString
         let defaults = try XCTUnwrap(UserDefaults(suiteName: uuid))
 
         // When
         let sut = ProductCreationAISurveyUseCase(defaults: defaults)
-        sut.didCreateAIProduct()
-        sut.didCreateAIProduct()
 
         // Then
         XCTAssertFalse(sut.shouldShowProductCreationAISurvey())
     }
 
-    func test_it_asks_to_show_survey_when_number_of_AI_generation_is_greater_than_3() throws {
+    func test_it_asks_to_show_survey_if_user_dismissed_first_time() throws {
         // Given
         let uuid = UUID().uuidString
         let defaults = try XCTUnwrap(UserDefaults(suiteName: uuid))
 
         // When
         let sut = ProductCreationAISurveyUseCase(defaults: defaults)
-        sut.didCreateAIProduct()
-        sut.didCreateAIProduct()
-        sut.didCreateAIProduct()
-        sut.didCreateAIProduct()
+        XCTAssertTrue(sut.shouldShowProductCreationAISurvey())
+
+        sut.didSuggestProductCreationAISurvey()
 
         // Then
         XCTAssertTrue(sut.shouldShowProductCreationAISurvey())
     }
 
-    func test_it_asks_to_not_show_survey_when_number_of_AI_generation_is_greater_than_3_but_we_asked_confirmation_already() throws {
+    func test_it_asks_to_not_show_survey_if_user_dismissed_second_time() throws {
         // Given
         let uuid = UUID().uuidString
         let defaults = try XCTUnwrap(UserDefaults(suiteName: uuid))
 
         // When
         let sut = ProductCreationAISurveyUseCase(defaults: defaults)
-        defaults.set(true, forKey: UserDefaults.Key.didSuggestProductCreationAISurvey.rawValue)
-        sut.didCreateAIProduct()
-        sut.didCreateAIProduct()
-        sut.didCreateAIProduct()
-        sut.didCreateAIProduct()
+        XCTAssertTrue(sut.shouldShowProductCreationAISurvey())
+
+        sut.didSuggestProductCreationAISurvey()
+        sut.didSuggestProductCreationAISurvey()
+
+        // Then
+        XCTAssertFalse(sut.shouldShowProductCreationAISurvey())
+    }
+
+    func test_it_asks_to_not_show_survey_if_user_started_survey_already() throws {
+        // Given
+        let uuid = UUID().uuidString
+        let defaults = try XCTUnwrap(UserDefaults(suiteName: uuid))
+        let sut = ProductCreationAISurveyUseCase(defaults: defaults)
+        defaults.set(true, forKey: UserDefaults.Key.didStartProductCreationAISurvey.rawValue)
+
+        // When
+        sut.didStartProductCreationAISurvey()
 
         // Then
         XCTAssertFalse(sut.shouldShowProductCreationAISurvey())
@@ -63,18 +73,5 @@ final class ProductCreationAISurveyUseCaseTests: XCTestCase {
 
         // Then
         XCTAssertNotNil(analyticsProvider.receivedEvents.first(where: { $0 == "product_creation_ai_survey_confirmation_view_displayed" }))
-    }
-
-    func test_it_saves_asked_confirmation_value_to_defaults() throws {
-        // Given
-        let uuid = UUID().uuidString
-        let defaults = try XCTUnwrap(UserDefaults(suiteName: uuid))
-        let sut = ProductCreationAISurveyUseCase(defaults: defaults)
-
-        // When
-        sut.didSuggestProductCreationAISurvey()
-
-        // Then
-        XCTAssertEqual(try XCTUnwrap(defaults.bool(forKey: UserDefaults.Key.didSuggestProductCreationAISurvey.rawValue)), true)
     }
 }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/Add Product/AddProductWithAI/ProductCreationAISurveyUseCaseTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/Add Product/AddProductWithAI/ProductCreationAISurveyUseCaseTests.swift
@@ -74,4 +74,31 @@ final class ProductCreationAISurveyUseCaseTests: XCTestCase {
         // Then
         XCTAssertNotNil(analyticsProvider.receivedEvents.first(where: { $0 == "product_creation_ai_survey_confirmation_view_displayed" }))
     }
+
+    // MARK: haveSuggestedSurveyBefore
+
+    func test_haveSuggestedSurveyBefore_is_false_if_survey_not_displayed_before() throws {
+        // Given
+        let uuid = UUID().uuidString
+        let defaults = try XCTUnwrap(UserDefaults(suiteName: uuid))
+
+        // When
+        let sut = ProductCreationAISurveyUseCase(defaults: defaults)
+
+        // Then
+        XCTAssertFalse(sut.haveSuggestedSurveyBefore())
+    }
+
+    func test_haveSuggestedSurveyBefore_is_true_if_survey_displayed_before() throws {
+        // Given
+        let uuid = UUID().uuidString
+        let defaults = try XCTUnwrap(UserDefaults(suiteName: uuid))
+        let sut = ProductCreationAISurveyUseCase(defaults: defaults)
+
+        // When
+        sut.didSuggestProductCreationAISurvey()
+
+        // Then
+        XCTAssertTrue(sut.haveSuggestedSurveyBefore())
+    }
 }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #11643 
<!-- Id number of the GitHub issue this PR addresses. -->

## Description

This PR updates the survey with the following changes in order to make more users participate in the survey.

1. Ask users to participate in the survey when they create one product using AI. (Previously, we waited for them to create three products.)
2. Ask again if they skip the first time. (Previously, we asked only once.)

## Testing instructions

Prerequisites
1. Create a JN site
2. Install Jetpack and Woo plugins

#### Skip survey
- Launch the app
- Navigate to Products
- Tap `+` -> `Create a product with AI`
- Finish the steps and create a product
- You will be asked to participate in a survey
- Tap "Remind me later" to skip the survey
- Create another AI product, and you should be asked again to participate in a survey
- Tap "Don't show it again" to skip
- Create yet another AI product and validate that you don't see the survey sheet again
- Logout of the app and login again using the same store
- Create another AI product, and you should be asked again to participate in a survey

#### Participate in the survey
- Launch the app
- Navigate to Products
- Tap `+` -> `Create a product with AI`
- Finish the steps and create a product
- You will be asked to participate in a survey
- Tap "Start the Survey" and participate in the survey
- Create another AI product and validate that you don't see the survey sheet again

## Screenshots
| First time | Second time |
|--------|--------|
| ![FirstTime](https://github.com/woocommerce/woocommerce-ios/assets/524475/004d5a85-21d6-4aeb-a722-3e62ef49594f) | ![SecondTime](https://github.com/woocommerce/woocommerce-ios/assets/524475/5de530e9-582a-4545-b3f2-7bae289e2fd1) | 

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
