### PR TITLE
Blaze: Add device picker for campaign creation

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Blaze/CampaignCreation/BlazeCampaignCreationForm.swift
+++ b/WooCommerce/Classes/ViewRelated/Blaze/CampaignCreation/BlazeCampaignCreationForm.swift
@@ -54,6 +54,7 @@ struct BlazeCampaignCreationForm: View {
 
     @State private var isShowingBudgetSetting = false
     @State private var isShowingLanguagePicker = false
+    @State private var isShowingDevicePicker = false
 
     init(viewModel: BlazeCampaignCreationFormViewModel) {
         self.viewModel = viewModel
@@ -83,8 +84,8 @@ struct BlazeCampaignCreationForm: View {
                     divider
 
                     // Devices
-                    detailView(title: Localization.devices, content: "All") {
-                        // TODO: open devices screen
+                    detailView(title: Localization.devices, content: viewModel.targetDeviceText) {
+                        isShowingDevicePicker = true
                     }
 
                     divider
@@ -130,7 +131,11 @@ struct BlazeCampaignCreationForm: View {
             BlazeTargetLanguagePickerView(viewModel: viewModel.targetLanguageViewModel, selectedLanguages: viewModel.languages) {
                 isShowingLanguagePicker = false
             }
-
+        }
+        .sheet(isPresented: $isShowingDevicePicker) {
+            BlazeTargetDevicePickerView(viewModel: viewModel.targetDeviceViewModel, selectedDevices: viewModel.devices) {
+                isShowingDevicePicker = false
+            }
         }
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Blaze/CampaignCreation/BlazeCampaignCreationFormViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Blaze/CampaignCreation/BlazeCampaignCreationFormViewModel.swift
@@ -58,8 +58,16 @@ final class BlazeCampaignCreationFormViewModel: ObservableObject {
         }
     }
 
+    var targetDeviceViewModel: BlazeTargetDevicePickerViewModel {
+        BlazeTargetDevicePickerViewModel(siteID: siteID) { [weak self] selectedDevices in
+            self?.devices = selectedDevices
+            self?.updateTargetDevicesText()
+        }
+    }
+
     @Published private(set) var budgetDetailText: String = ""
     @Published private(set) var targetLanguageText: String = ""
+    @Published private(set) var targetDeviceText: String = ""
 
     init(siteID: Int64,
          stores: StoresManager = ServiceLocator.stores,
@@ -70,6 +78,7 @@ final class BlazeCampaignCreationFormViewModel: ObservableObject {
 
         updateBudgetDetails()
         updateTargetLanguagesText()
+        updateTargetDevicesText()
     }
 
     func didTapEditAd() {
@@ -94,6 +103,18 @@ private extension BlazeCampaignCreationFormViewModel {
                 return Localization.all
             }
             return languages
+                .map { $0.name }
+                .sorted()
+                .joined(separator: ", ")
+        }()
+    }
+
+    func updateTargetDevicesText() {
+        targetDeviceText = {
+            guard let devices, devices.isEmpty == false else {
+                return Localization.all
+            }
+            return devices
                 .map { $0.name }
                 .sorted()
                 .joined(separator: ", ")

--- a/WooCommerce/Classes/ViewRelated/Blaze/TargetDevices/BlazeTargetDevicePickerView.swift
+++ b/WooCommerce/Classes/ViewRelated/Blaze/TargetDevices/BlazeTargetDevicePickerView.swift
@@ -1,0 +1,57 @@
+import SwiftUI
+import struct Yosemite.BlazeTargetDevice
+
+/// View for picking target devices for a Blaze campaign
+struct BlazeTargetDevicePickerView: View {
+
+    @ObservedObject private var viewModel: BlazeTargetDevicePickerViewModel
+
+    private let selectedDevices: Set<BlazeTargetDevice>?
+    private let onDismiss: () -> Void
+
+    init(viewModel: BlazeTargetDevicePickerViewModel,
+         selectedDevices: Set<BlazeTargetDevice>?,
+         onDismiss: @escaping () -> Void) {
+        self.viewModel = viewModel
+        self.selectedDevices = selectedDevices
+        self.onDismiss = onDismiss
+    }
+
+    var body: some View {
+        MultiSelectionList(title: Localization.title,
+                           allOptionsTitle: Localization.allTitle,
+                           contents: viewModel.devices,
+                           contentKeyPath: \.name,
+                           selectedItems: selectedDevices,
+                           onDismiss: onDismiss,
+                           onCompletion: { selectedDevices in
+                                viewModel.confirmSelection(selectedDevices)
+                                onDismiss()
+                            })
+        .task {
+            await viewModel.syncDevices()
+        }
+
+    }
+}
+
+private extension BlazeTargetDevicePickerView {
+    enum Localization {
+        static let title = NSLocalizedString(
+            "blazeTargetLanguagePickerView.title",
+            value: "Devices",
+            comment: "Title of the target device picker view for Blaze campaign creation"
+        )
+        static let allTitle = NSLocalizedString(
+            "blazeTargetLanguagePickerView.allTitle",
+            value: "All devices",
+            comment: "Title of the row to select all target devices for Blaze campaign creation"
+        )
+    }
+}
+
+struct BlazeTargetDevicePickerView_Previews: PreviewProvider {
+    static var previews: some View {
+        BlazeTargetDevicePickerView(viewModel: BlazeTargetDevicePickerViewModel(siteID: 123) { _ in }, selectedDevices: nil, onDismiss: {})
+    }
+}

--- a/WooCommerce/Classes/ViewRelated/Blaze/TargetDevices/BlazeTargetDevicePickerViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Blaze/TargetDevices/BlazeTargetDevicePickerViewModel.swift
@@ -1,0 +1,62 @@
+import Foundation
+import Yosemite
+import protocol Storage.StorageManagerType
+
+/// View model for `BlazeTargetDevicePicker`
+final class BlazeTargetDevicePickerViewModel: ObservableObject {
+
+    @Published private(set) var devices: [BlazeTargetDevice] = []
+
+    /// Blaze target device ResultsController.
+    private lazy var resultsController: ResultsController<StorageBlazeTargetDevice> = {
+        let predicate = NSPredicate(format: "locale == %@", locale.identifier)
+        let sortDescriptorByID = NSSortDescriptor(keyPath: \StorageBlazeTargetDevice.id, ascending: true)
+        let resultsController = ResultsController<StorageBlazeTargetDevice>(storageManager: storageManager,
+                                                                            matching: predicate,
+                                                                            sortedBy: [sortDescriptorByID])
+        return resultsController
+    }()
+
+    private let siteID: Int64
+    private let locale: Locale
+    private let stores: StoresManager
+    private let storageManager: StorageManagerType
+    private let onSelection: (Set<BlazeTargetDevice>?) -> Void
+
+    init(siteID: Int64,
+         locale: Locale = .current,
+         stores: StoresManager = ServiceLocator.stores,
+         storageManager: StorageManagerType = ServiceLocator.storageManager,
+         onSelection: @escaping (Set<BlazeTargetDevice>?) -> Void) {
+        self.siteID = siteID
+        self.locale = locale
+        self.stores = stores
+        self.storageManager = storageManager
+        self.onSelection = onSelection
+
+        configureResultsController()
+    }
+}
+
+private extension BlazeTargetDevicePickerViewModel {
+    /// Performs initial fetch from storage and updates results.
+    func configureResultsController() {
+        resultsController.onDidChangeContent = { [weak self] in
+            self?.updateResults()
+        }
+        resultsController.onDidResetContent = { [weak self] in
+            self?.updateResults()
+        }
+
+        do {
+            try resultsController.performFetch()
+            updateResults()
+        } catch {
+            ServiceLocator.crashLogging.logError(error)
+        }
+    }
+
+    func updateResults() {
+        devices = resultsController.fetchedObjects
+    }
+}

--- a/WooCommerce/Classes/ViewRelated/Blaze/TargetDevices/BlazeTargetDevicePickerViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Blaze/TargetDevices/BlazeTargetDevicePickerViewModel.swift
@@ -36,6 +36,28 @@ final class BlazeTargetDevicePickerViewModel: ObservableObject {
 
         configureResultsController()
     }
+
+    @MainActor
+    func syncDevices() async {
+        do {
+            try await withCheckedThrowingContinuation { continuation in
+                stores.dispatch(BlazeAction.synchronizeTargetDevices(siteID: siteID, locale: locale.identifier) { result in
+                    switch result {
+                    case .success:
+                        continuation.resume(returning: Void())
+                    case .failure(let error):
+                        continuation.resume(throwing: error)
+                    }
+                })
+            }
+        } catch {
+            DDLogError("⛔️ Error syncing Blaze target devices: \(error)")
+        }
+    }
+
+    func confirmSelection(_ selectedDevices: Set<BlazeTargetDevice>?) {
+        onSelection(selectedDevices)
+    }
 }
 
 private extension BlazeTargetDevicePickerViewModel {

--- a/WooCommerce/Classes/ViewRelated/Blaze/TargetLanguages/BlazeTargetLanguagePickerViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Blaze/TargetLanguages/BlazeTargetLanguagePickerViewModel.swift
@@ -18,8 +18,10 @@ final class BlazeTargetLanguagePickerViewModel: ObservableObject {
 
     /// Blaze target language ResultsController.
     private lazy var resultsController: ResultsController<StorageBlazeTargetLanguage> = {
+        let predicate = NSPredicate(format: "locale == %@", locale.identifier)
         let sortDescriptorByID = NSSortDescriptor(keyPath: \StorageBlazeTargetLanguage.id, ascending: true)
         let resultsController = ResultsController<StorageBlazeTargetLanguage>(storageManager: storageManager,
+                                                                              matching: predicate,
                                                                               sortedBy: [sortDescriptorByID])
         return resultsController
     }()

--- a/WooCommerce/Classes/ViewRelated/Blaze/TargetLanguages/BlazeTargetLanguagePickerViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Blaze/TargetLanguages/BlazeTargetLanguagePickerViewModel.swift
@@ -86,8 +86,18 @@ private extension BlazeTargetLanguagePickerViewModel {
         fetchedLanguages = resultsController.fetchedObjects
     }
 
+    /// Observes changes in the search query and filter the fetched results for display.
+    /// The debounce in search query messes with the initial state, so we ignore the initial query
+    /// and display the first fetch result immediately.
+    ///
     func configureDisplayedData() {
-        $searchQuery.debounce(for: .milliseconds(300), scheduler: DispatchQueue.main)
+        $fetchedLanguages
+            .prefix(1) // first fetch result is displayed immediately, ignoring the empty search query
+            .assign(to: &$languages)
+
+        $searchQuery
+            .dropFirst() // ignores initial value
+            .debounce(for: .milliseconds(300), scheduler: DispatchQueue.main)
             .combineLatest($fetchedLanguages)
             .map { query, languages in
                 guard query.isNotEmpty else {

--- a/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/MultiSelectionList.swift
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/MultiSelectionList.swift
@@ -48,7 +48,7 @@ struct MultiSelectionList<T: Hashable & Identifiable>: View {
         self.onQueryChanged = onQueryChanged
         self.onDismiss = onDismiss
         self.onCompletion = onCompletion
-        self.selectedItems = selectedItems ?? []
+        self.selectedItems = selectedItems ?? Set(contents)
     }
 
     var body: some View {

--- a/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/MultiSelectionList.swift
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/MultiSelectionList.swift
@@ -125,11 +125,11 @@ struct MultipleSelectionList_Previews: PreviewProvider {
             BlazeTargetLanguage(id: "2", name: "Vietnamese", locale: "vi")
         ]
         MultiSelectionList(title: "Languages",
-                              allOptionsTitle: "All languages",
-                              contents: languages,
-                              contentKeyPath: \.id,
-                              onQueryChanged: { _ in },
-                              onDismiss: {},
-                              onCompletion: { _ in })
+                           allOptionsTitle: "All languages",
+                           contents: languages,
+                           contentKeyPath: \.id,
+                           onQueryChanged: { _ in },
+                           onDismiss: {},
+                           onCompletion: { _ in })
     }
 }

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -2287,6 +2287,7 @@
 		DE7E5E812B4BCC06002E28D2 /* BlazeTargetLanguagePickerViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE7E5E802B4BCC06002E28D2 /* BlazeTargetLanguagePickerViewModel.swift */; };
 		DE7E5E832B4C1574002E28D2 /* BlazeTargetLanguagePickerViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE7E5E822B4C1574002E28D2 /* BlazeTargetLanguagePickerViewModelTests.swift */; };
 		DE7E5E862B4D11D7002E28D2 /* BlazeTargetDevicePickerViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE7E5E852B4D11D7002E28D2 /* BlazeTargetDevicePickerViewModel.swift */; };
+		DE7E5E882B4D16EB002E28D2 /* BlazeTargetDevicePickerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE7E5E872B4D16EB002E28D2 /* BlazeTargetDevicePickerView.swift */; };
 		DE85E4ED2AB416F5008789E1 /* AddProductWithAIActionSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE85E4EC2AB416F5008789E1 /* AddProductWithAIActionSheet.swift */; };
 		DE86E9272A4BEA2500A89A5B /* FeedbackView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE86E9262A4BEA2500A89A5B /* FeedbackView.swift */; };
 		DE86E9292A4C213A00A89A5B /* WooAnalyticsEvent+AIFeedback.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE86E9282A4C213A00A89A5B /* WooAnalyticsEvent+AIFeedback.swift */; };
@@ -4937,6 +4938,7 @@
 		DE7E5E802B4BCC06002E28D2 /* BlazeTargetLanguagePickerViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BlazeTargetLanguagePickerViewModel.swift; sourceTree = "<group>"; };
 		DE7E5E822B4C1574002E28D2 /* BlazeTargetLanguagePickerViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BlazeTargetLanguagePickerViewModelTests.swift; sourceTree = "<group>"; };
 		DE7E5E852B4D11D7002E28D2 /* BlazeTargetDevicePickerViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BlazeTargetDevicePickerViewModel.swift; sourceTree = "<group>"; };
+		DE7E5E872B4D16EB002E28D2 /* BlazeTargetDevicePickerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BlazeTargetDevicePickerView.swift; sourceTree = "<group>"; };
 		DE85E4E22AB2E79F008789E1 /* AddProductWithAIActionSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddProductWithAIActionSheet.swift; sourceTree = "<group>"; };
 		DE85E4EC2AB416F5008789E1 /* AddProductWithAIActionSheet.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AddProductWithAIActionSheet.swift; sourceTree = "<group>"; };
 		DE86E9262A4BEA2500A89A5B /* FeedbackView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedbackView.swift; sourceTree = "<group>"; };
@@ -11182,6 +11184,7 @@
 			isa = PBXGroup;
 			children = (
 				DE7E5E852B4D11D7002E28D2 /* BlazeTargetDevicePickerViewModel.swift */,
+				DE7E5E872B4D16EB002E28D2 /* BlazeTargetDevicePickerView.swift */,
 			);
 			path = TargetDevices;
 			sourceTree = "<group>";
@@ -13657,6 +13660,7 @@
 				AEB73C0C25CD734200A8454A /* AttributePickerViewModel.swift in Sources */,
 				D8752EF7265E60F4008ACC80 /* PaymentCaptureCelebration.swift in Sources */,
 				B98BA12D2AE90023006F1E4A /* OrderCustomAmountsSection.swift in Sources */,
+				DE7E5E882B4D16EB002E28D2 /* BlazeTargetDevicePickerView.swift in Sources */,
 				EE6B2AD129DC522300048A8F /* StoreCreationProgressView.swift in Sources */,
 				B58B4AB62108F11C00076FDD /* Notice.swift in Sources */,
 				2631D4F829ED0B5C00F13F20 /* WPComPlanNameSanitizer.swift in Sources */,

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -2288,6 +2288,7 @@
 		DE7E5E832B4C1574002E28D2 /* BlazeTargetLanguagePickerViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE7E5E822B4C1574002E28D2 /* BlazeTargetLanguagePickerViewModelTests.swift */; };
 		DE7E5E862B4D11D7002E28D2 /* BlazeTargetDevicePickerViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE7E5E852B4D11D7002E28D2 /* BlazeTargetDevicePickerViewModel.swift */; };
 		DE7E5E882B4D16EB002E28D2 /* BlazeTargetDevicePickerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE7E5E872B4D16EB002E28D2 /* BlazeTargetDevicePickerView.swift */; };
+		DE7E5E8A2B4D4015002E28D2 /* BlazeTargetDeviceViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE7E5E892B4D4015002E28D2 /* BlazeTargetDeviceViewModelTests.swift */; };
 		DE85E4ED2AB416F5008789E1 /* AddProductWithAIActionSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE85E4EC2AB416F5008789E1 /* AddProductWithAIActionSheet.swift */; };
 		DE86E9272A4BEA2500A89A5B /* FeedbackView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE86E9262A4BEA2500A89A5B /* FeedbackView.swift */; };
 		DE86E9292A4C213A00A89A5B /* WooAnalyticsEvent+AIFeedback.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE86E9282A4C213A00A89A5B /* WooAnalyticsEvent+AIFeedback.swift */; };
@@ -4939,6 +4940,7 @@
 		DE7E5E822B4C1574002E28D2 /* BlazeTargetLanguagePickerViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BlazeTargetLanguagePickerViewModelTests.swift; sourceTree = "<group>"; };
 		DE7E5E852B4D11D7002E28D2 /* BlazeTargetDevicePickerViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BlazeTargetDevicePickerViewModel.swift; sourceTree = "<group>"; };
 		DE7E5E872B4D16EB002E28D2 /* BlazeTargetDevicePickerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BlazeTargetDevicePickerView.swift; sourceTree = "<group>"; };
+		DE7E5E892B4D4015002E28D2 /* BlazeTargetDeviceViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BlazeTargetDeviceViewModelTests.swift; sourceTree = "<group>"; };
 		DE85E4E22AB2E79F008789E1 /* AddProductWithAIActionSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddProductWithAIActionSheet.swift; sourceTree = "<group>"; };
 		DE85E4EC2AB416F5008789E1 /* AddProductWithAIActionSheet.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AddProductWithAIActionSheet.swift; sourceTree = "<group>"; };
 		DE86E9262A4BEA2500A89A5B /* FeedbackView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedbackView.swift; sourceTree = "<group>"; };
@@ -5810,6 +5812,7 @@
 			children = (
 				024D4E962A2EC68B0090E0E6 /* BlazeWebViewModelTests.swift */,
 				DE7E5E822B4C1574002E28D2 /* BlazeTargetLanguagePickerViewModelTests.swift */,
+				DE7E5E892B4D4015002E28D2 /* BlazeTargetDeviceViewModelTests.swift */,
 				021EBB372A3076F4003634CA /* BlazeEligibilityCheckerTests.swift */,
 				DEA357122ADCC4C9006380BA /* BlazeCampaignListViewModelTests.swift */,
 				DE5746372B479CB80034B10D /* BlazeBudgetSettingViewModelTests.swift */,
@@ -14854,6 +14857,7 @@
 				02BC5AA524D27F8900C43326 /* ProductVariationFormViewModel+UpdatesTests.swift in Sources */,
 				D8736B5122EB69E300A14A29 /* OrderDetailsViewModelTests.swift in Sources */,
 				02C0CD2E23B5E3AE00F880B1 /* DefaultImageServiceTests.swift in Sources */,
+				DE7E5E8A2B4D4015002E28D2 /* BlazeTargetDeviceViewModelTests.swift in Sources */,
 				02E4FD812306AA890049610C /* StatsTimeRangeBarViewModelTests.swift in Sources */,
 				CCCFFC5D2934F0BA006130AF /* StatsIntervalDataParserTests.swift in Sources */,
 				953728F82B23635300FDF1D1 /* UIAlertController+helpers.swift in Sources */,

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -2286,6 +2286,7 @@
 		DE7E5E7F2B4BC52C002E28D2 /* MultiSelectionList.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE7E5E7E2B4BC52C002E28D2 /* MultiSelectionList.swift */; };
 		DE7E5E812B4BCC06002E28D2 /* BlazeTargetLanguagePickerViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE7E5E802B4BCC06002E28D2 /* BlazeTargetLanguagePickerViewModel.swift */; };
 		DE7E5E832B4C1574002E28D2 /* BlazeTargetLanguagePickerViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE7E5E822B4C1574002E28D2 /* BlazeTargetLanguagePickerViewModelTests.swift */; };
+		DE7E5E862B4D11D7002E28D2 /* BlazeTargetDevicePickerViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE7E5E852B4D11D7002E28D2 /* BlazeTargetDevicePickerViewModel.swift */; };
 		DE85E4ED2AB416F5008789E1 /* AddProductWithAIActionSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE85E4EC2AB416F5008789E1 /* AddProductWithAIActionSheet.swift */; };
 		DE86E9272A4BEA2500A89A5B /* FeedbackView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE86E9262A4BEA2500A89A5B /* FeedbackView.swift */; };
 		DE86E9292A4C213A00A89A5B /* WooAnalyticsEvent+AIFeedback.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE86E9282A4C213A00A89A5B /* WooAnalyticsEvent+AIFeedback.swift */; };
@@ -4935,6 +4936,7 @@
 		DE7E5E7E2B4BC52C002E28D2 /* MultiSelectionList.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MultiSelectionList.swift; sourceTree = "<group>"; };
 		DE7E5E802B4BCC06002E28D2 /* BlazeTargetLanguagePickerViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BlazeTargetLanguagePickerViewModel.swift; sourceTree = "<group>"; };
 		DE7E5E822B4C1574002E28D2 /* BlazeTargetLanguagePickerViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BlazeTargetLanguagePickerViewModelTests.swift; sourceTree = "<group>"; };
+		DE7E5E852B4D11D7002E28D2 /* BlazeTargetDevicePickerViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BlazeTargetDevicePickerViewModel.swift; sourceTree = "<group>"; };
 		DE85E4E22AB2E79F008789E1 /* AddProductWithAIActionSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddProductWithAIActionSheet.swift; sourceTree = "<group>"; };
 		DE85E4EC2AB416F5008789E1 /* AddProductWithAIActionSheet.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AddProductWithAIActionSheet.swift; sourceTree = "<group>"; };
 		DE86E9262A4BEA2500A89A5B /* FeedbackView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedbackView.swift; sourceTree = "<group>"; };
@@ -11176,6 +11178,14 @@
 			path = TargetLanguages;
 			sourceTree = "<group>";
 		};
+		DE7E5E842B4D11BD002E28D2 /* TargetDevices */ = {
+			isa = PBXGroup;
+			children = (
+				DE7E5E852B4D11D7002E28D2 /* BlazeTargetDevicePickerViewModel.swift */,
+			);
+			path = TargetDevices;
+			sourceTree = "<group>";
+		};
 		DE85E4EB2AB416F5008789E1 /* EntryPoint */ = {
 			isa = PBXGroup;
 			children = (
@@ -11264,6 +11274,7 @@
 		DED91DF72AD78A0C00CDCC53 /* Blaze */ = {
 			isa = PBXGroup;
 			children = (
+				DE7E5E842B4D11BD002E28D2 /* TargetDevices */,
 				DE7E5E7B2B4BB5F7002E28D2 /* TargetLanguages */,
 				DE5746322B4512750034B10D /* BudgetSetting */,
 				DE57462D2B43EAF20034B10D /* CampaignCreation */,
@@ -13537,6 +13548,7 @@
 				027A2E142513124E00DA6ACB /* Keychain+Entries.swift in Sources */,
 				B97C6E562B15E51A008A2BF2 /* UpdateProductInventoryView.swift in Sources */,
 				268EC45F26CEA50C00716F5C /* EditCustomerNote.swift in Sources */,
+				DE7E5E862B4D11D7002E28D2 /* BlazeTargetDevicePickerViewModel.swift in Sources */,
 				4535EE7E281BE04A004212B4 /* CouponAmountInputFormatter.swift in Sources */,
 				209AD3D22AC1EDF600825D76 /* WooPaymentsDepositsCurrencyOverviewView.swift in Sources */,
 				CE35F11B2343F3B1007B2A6B /* TwoColumnHeadlineFootnoteTableViewCell.swift in Sources */,

--- a/WooCommerce/WooCommerceTests/ViewRelated/Blaze/BlazeTargetDeviceViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Blaze/BlazeTargetDeviceViewModelTests.swift
@@ -1,0 +1,75 @@
+import XCTest
+import Yosemite
+import protocol Storage.StorageType
+@testable import WooCommerce
+
+@MainActor
+final class BlazeTargetDeviceViewModelTests: XCTestCase {
+
+    private let sampleSiteID: Int64 = 122
+    private let locale = Locale(identifier: "en_US")
+
+    private var stores: MockStoresManager!
+
+    /// Mock Storage: InMemory
+    private var storageManager: MockStorageManager!
+
+    /// View storage for tests
+    private var storage: StorageType {
+        storageManager.viewStorage
+    }
+
+    override func setUp() {
+        super.setUp()
+        stores = MockStoresManager(sessionManager: .testingInstance)
+        storageManager = MockStorageManager()
+    }
+
+    override func tearDown() {
+        storageManager = nil
+        stores = nil
+        super.tearDown()
+    }
+
+    func test_devices_contains_only_devices_matching_given_locale() async {
+        // Given
+        let mobile = BlazeTargetDevice(id: "mobile", name: "Mobile", locale: locale.identifier)
+        let mobileVi = BlazeTargetDevice(id: "mobile", name: "Mobile", locale: "vi")
+        insertDevice(mobile)
+        insertDevice(mobileVi)
+        let viewModel = BlazeTargetDevicePickerViewModel(siteID: sampleSiteID,
+                                                         locale: locale,
+                                                         storageManager: storageManager,
+                                                         onSelection: { _ in })
+
+        // Then
+        XCTAssertEqual(viewModel.devices, [mobile])
+    }
+
+    func test_confirmSelection_triggers_onSelection_correctly() {
+        // Given
+        let mobile = BlazeTargetDevice(id: "mobile", name: "Mobile", locale: locale.identifier)
+        var selectedItems: Set<BlazeTargetDevice>?
+        let viewModel = BlazeTargetDevicePickerViewModel(siteID: sampleSiteID,
+                                                         locale: locale,
+                                                         storageManager: storageManager,
+                                                         onSelection: { items in
+            selectedItems = items
+        })
+
+        // When
+        let expectedItems = Set([mobile])
+        viewModel.confirmSelection(expectedItems)
+
+        // Then
+        XCTAssertEqual(selectedItems, expectedItems)
+    }
+}
+
+private extension BlazeTargetDeviceViewModelTests {
+    func insertDevice(_ readOnlyDevice: BlazeTargetDevice) {
+        let newDevice = storage.insertNewObject(ofType: StorageBlazeTargetDevice.self)
+        newDevice.update(with: readOnlyDevice)
+        storage.saveIfNeeded()
+    }
+}

--- a/WooCommerce/WooCommerceTests/ViewRelated/Blaze/BlazeTargetLanguagePickerViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Blaze/BlazeTargetLanguagePickerViewModelTests.swift
@@ -36,7 +36,10 @@ final class BlazeTargetLanguagePickerViewModelTests: XCTestCase {
         let vietnamese = BlazeTargetLanguage(id: "vi", name: "Vietnamese", locale: locale)
         insertLanguage(english)
         insertLanguage(vietnamese)
-        let viewModel = BlazeTargetLanguagePickerViewModel(siteID: sampleSiteID, locale: Locale(identifier: locale), storageManager: storageManager, onSelection: { _ in })
+        let viewModel = BlazeTargetLanguagePickerViewModel(siteID: sampleSiteID, 
+                                                           locale: Locale(identifier: locale),
+                                                           storageManager: storageManager,
+                                                           onSelection: { _ in })
 
         // When
         viewModel.searchQuery = ""
@@ -54,7 +57,10 @@ final class BlazeTargetLanguagePickerViewModelTests: XCTestCase {
         let vietnamese = BlazeTargetLanguage(id: "vi", name: "Vietnamese", locale: locale)
         insertLanguage(english)
         insertLanguage(vietnamese)
-        let viewModel = BlazeTargetLanguagePickerViewModel(siteID: sampleSiteID, locale: Locale(identifier: locale), storageManager: storageManager, onSelection: { _ in })
+        let viewModel = BlazeTargetLanguagePickerViewModel(siteID: sampleSiteID, 
+                                                           locale: Locale(identifier: locale),
+                                                           storageManager: storageManager,
+                                                           onSelection: { _ in })
 
         // When
         viewModel.searchQuery = "vi"

--- a/WooCommerce/WooCommerceTests/ViewRelated/Blaze/BlazeTargetLanguagePickerViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Blaze/BlazeTargetLanguagePickerViewModelTests.swift
@@ -31,11 +31,12 @@ final class BlazeTargetLanguagePickerViewModelTests: XCTestCase {
 
     func test_languages_include_all_fetchedLanguages_if_searchQuery_is_empty() {
         // Given
-        let english = BlazeTargetLanguage(id: "en", name: "English", locale: "en")
-        let vietnamese = BlazeTargetLanguage(id: "vi", name: "Vietnamese", locale: "en")
+        let locale = "en_US"
+        let english = BlazeTargetLanguage(id: "en", name: "English", locale: locale)
+        let vietnamese = BlazeTargetLanguage(id: "vi", name: "Vietnamese", locale: locale)
         insertLanguage(english)
         insertLanguage(vietnamese)
-        let viewModel = BlazeTargetLanguagePickerViewModel(siteID: sampleSiteID, storageManager: storageManager, onSelection: { _ in })
+        let viewModel = BlazeTargetLanguagePickerViewModel(siteID: sampleSiteID, locale: Locale(identifier: locale), storageManager: storageManager, onSelection: { _ in })
 
         // When
         viewModel.searchQuery = ""
@@ -48,11 +49,12 @@ final class BlazeTargetLanguagePickerViewModelTests: XCTestCase {
 
     func test_languages_filters_matching_languages_if_searchQuery_is_not_empty() {
         // Given
-        let english = BlazeTargetLanguage(id: "en", name: "English", locale: "en")
-        let vietnamese = BlazeTargetLanguage(id: "vi", name: "Vietnamese", locale: "en")
+        let locale = "en_US"
+        let english = BlazeTargetLanguage(id: "en", name: "English", locale: locale)
+        let vietnamese = BlazeTargetLanguage(id: "vi", name: "Vietnamese", locale: locale)
         insertLanguage(english)
         insertLanguage(vietnamese)
-        let viewModel = BlazeTargetLanguagePickerViewModel(siteID: sampleSiteID, storageManager: storageManager, onSelection: { _ in })
+        let viewModel = BlazeTargetLanguagePickerViewModel(siteID: sampleSiteID, locale: Locale(identifier: locale), storageManager: storageManager, onSelection: { _ in })
 
         // When
         viewModel.searchQuery = "vi"
@@ -66,7 +68,6 @@ final class BlazeTargetLanguagePickerViewModelTests: XCTestCase {
     func test_confirmSelection_triggers_onSelection_correctly() {
         // Given
         let english = BlazeTargetLanguage(id: "en", name: "English", locale: "en")
-        let vietnamese = BlazeTargetLanguage(id: "vi", name: "Vietnamese", locale: "en")
         var selectedItems: Set<BlazeTargetLanguage>?
         let viewModel = BlazeTargetLanguagePickerViewModel(siteID: sampleSiteID, storageManager: storageManager, onSelection: { items in
             selectedItems = items

--- a/WooCommerce/WooCommerceTests/ViewRelated/Blaze/BlazeTargetLanguagePickerViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Blaze/BlazeTargetLanguagePickerViewModelTests.swift
@@ -36,7 +36,7 @@ final class BlazeTargetLanguagePickerViewModelTests: XCTestCase {
         let vietnamese = BlazeTargetLanguage(id: "vi", name: "Vietnamese", locale: locale)
         insertLanguage(english)
         insertLanguage(vietnamese)
-        let viewModel = BlazeTargetLanguagePickerViewModel(siteID: sampleSiteID, 
+        let viewModel = BlazeTargetLanguagePickerViewModel(siteID: sampleSiteID,
                                                            locale: Locale(identifier: locale),
                                                            storageManager: storageManager,
                                                            onSelection: { _ in })
@@ -57,7 +57,7 @@ final class BlazeTargetLanguagePickerViewModelTests: XCTestCase {
         let vietnamese = BlazeTargetLanguage(id: "vi", name: "Vietnamese", locale: locale)
         insertLanguage(english)
         insertLanguage(vietnamese)
-        let viewModel = BlazeTargetLanguagePickerViewModel(siteID: sampleSiteID, 
+        let viewModel = BlazeTargetLanguagePickerViewModel(siteID: sampleSiteID,
                                                            locale: Locale(identifier: locale),
                                                            storageManager: storageManager,
                                                            onSelection: { _ in })


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #11644 
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This PR adds a new screen for picking target devices for campaign creation. The screen uses the `MultiSelectionList` similar to the language picker but without the search bar.

Also: this PR adds some updates to the language picker:
- Query languages based on the current locale only.
- Ignore the initial value of the search query because the debounce messes up with the SwiftUI view state.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
- Log in to a store with at least one existing product and is eligible for Blaze.
- Navigate to the Products tab and select any public product.
- On the product form, select Promote with Blaze.
- Notice that the campaign creation form is presented. Select the device field.
- Notice that a new screen is displayed for selecting target devices. Confirm that the selection as expected.
- Select Cancel, the view should be dismissed without any changes to the campaign creation form.
- Select the device field again, this time select a different option(s) and tap Save. The device field in the creation form should be updated correctly.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

https://github.com/woocommerce/woocommerce-ios/assets/5533851/912376e8-1ae7-4d71-a62b-52717e01f9b7



---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
