### PR TITLE
[Mobile Payments] Track `country` and `currency` properties in `payments_flow` failed and canceled events

### DIFF
--- a/WooCommerce/Classes/Analytics/WooAnalyticsEvent.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsEvent.swift
@@ -1261,8 +1261,12 @@ extension WooAnalyticsEvent {
             return WooAnalyticsEvent(statName: .paymentsFlowCompleted, properties: properties)
         }
 
-        static func paymentsFlowCanceled(flow: Flow) -> WooAnalyticsEvent {
-            WooAnalyticsEvent(statName: .paymentsFlowCanceled, properties: [Keys.flow: flow.rawValue])
+        static func paymentsFlowCanceled(flow: Flow, country: CountryCode, currency: String) -> WooAnalyticsEvent {
+            WooAnalyticsEvent(statName: .paymentsFlowCanceled, properties: [
+                Keys.flow: flow.rawValue,
+                Keys.country: country.rawValue,
+                Keys.currency: currency
+            ])
         }
 
         static func paymentsFlowFailed(flow: Flow, source: Source, country: CountryCode, currency: String) -> WooAnalyticsEvent {

--- a/WooCommerce/Classes/Analytics/WooAnalyticsEvent.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsEvent.swift
@@ -1265,9 +1265,13 @@ extension WooAnalyticsEvent {
             WooAnalyticsEvent(statName: .paymentsFlowCanceled, properties: [Keys.flow: flow.rawValue])
         }
 
-        static func paymentsFlowFailed(flow: Flow, source: Source) -> WooAnalyticsEvent {
-            WooAnalyticsEvent(statName: .paymentsFlowFailed, properties: [Keys.flow: flow.rawValue,
-                                                                          Keys.source: source.rawValue])
+        static func paymentsFlowFailed(flow: Flow, source: Source, country: CountryCode, currency: String) -> WooAnalyticsEvent {
+            WooAnalyticsEvent(statName: .paymentsFlowFailed, properties: [
+                Keys.flow: flow.rawValue,
+                Keys.source: source.rawValue,
+                Keys.country: country.rawValue,
+                Keys.currency: currency
+            ])
         }
 
         static func paymentsFlowCollect(flow: Flow,

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/SetUpTapToPayTryPaymentPromptViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/SetUpTapToPayTryPaymentPromptViewController.swift
@@ -126,8 +126,7 @@ struct SetUpTapToPayPaymentPromptView: View {
         .toolbar {
             ToolbarItem(placement: .confirmationAction) {
                 Button(action: {
-                    paymentFlowDismissed()
-                    viewModel.dismiss?()
+                    viewModel.onDismiss()
                 },
                        label: {
                     Text(Localization.doneButton)
@@ -135,10 +134,6 @@ struct SetUpTapToPayPaymentPromptView: View {
             }
         }
         .navigationBarHidden(false)
-    }
-
-    private func paymentFlowDismissed() {
-        ServiceLocator.analytics.track(event: WooAnalyticsEvent.PaymentsFlow.paymentsFlowCanceled(flow: .tapToPayTryAPayment))
     }
 
     private func completedOrder(summaryViewModel: TryAPaymentSummaryViewModel) -> some View {

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/SetUpTapToPayTryPaymentPromptViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/SetUpTapToPayTryPaymentPromptViewModel.swift
@@ -64,6 +64,15 @@ final class SetUpTapToPayTryPaymentPromptViewModel: PaymentSettingsFlowPresented
         observePaymentFlowFinishedToAttemptRefund()
     }
 
+    /// Called when the user dismisses the prompt view.
+    func onDismiss() {
+        analytics.track(event: WooAnalyticsEvent.PaymentsFlow
+            .paymentsFlowCanceled(flow: .tapToPayTryAPayment,
+                                  country: configuration.countryCode,
+                                  currency: currencySettings.currencyCode.rawValue))
+        dismiss?()
+    }
+
     /// Set up to observe readers connecting / disconnecting
     ///
     private func beginConnectedReaderObservation() {

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/SetUpTapToPayTryPaymentPromptViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/SetUpTapToPayTryPaymentPromptViewModel.swift
@@ -42,18 +42,21 @@ final class SetUpTapToPayTryPaymentPromptViewModel: PaymentSettingsFlowPresented
     }
 
     private let currencyFormatter: CurrencyFormatter
+    private let currencySettings: CurrencySettings
     private let trialPaymentAmount: String
 
     init(didChangeShouldShow: ((CardReaderSettingsTriState) -> Void)?,
          connectionAnalyticsTracker: CardReaderConnectionAnalyticsTracker,
          configuration: CardPresentPaymentsConfiguration = CardPresentConfigurationLoader().configuration,
-         stores: StoresManager = ServiceLocator.stores) {
+         stores: StoresManager = ServiceLocator.stores,
+         currencySettings: CurrencySettings = ServiceLocator.currencySettings) {
         self.didChangeShouldShow = didChangeShouldShow
         self.connectionAnalyticsTracker = connectionAnalyticsTracker
         self.configuration = configuration
         self.stores = stores
-        let currencyFormatter = CurrencyFormatter(currencySettings: ServiceLocator.currencySettings)
+        let currencyFormatter = CurrencyFormatter(currencySettings: currencySettings)
         self.currencyFormatter = currencyFormatter
+        self.currencySettings = currencySettings
         self.trialPaymentAmount = currencyFormatter.formatAmount(configuration.minimumAllowedChargeAmount) ?? "0.50"
 
         beginConnectedReaderObservation()
@@ -108,7 +111,10 @@ final class SetUpTapToPayTryPaymentPromptViewModel: PaymentSettingsFlowPresented
             case .failure(let error):
                 self.presentNoticeSubject.send(.error(Localization.errorCreatingTestPayment))
                 self.analytics.track(event: WooAnalyticsEvent.PaymentsFlow.paymentsFlowFailed(flow: .tapToPayTryAPayment,
-                                                                                              source: .tapToPayTryAPaymentPrompt))
+                                                                                              source: .tapToPayTryAPaymentPrompt,
+                                                                                              country: configuration.countryCode,
+                                                                                              currency: currencySettings.currencyCode.rawValue))
+
                 DDLogError("⛔️ Error creating Tap to Pay try a payment order: \(error)")
             }
         }

--- a/WooCommerce/Classes/ViewRelated/Orders/Payment Methods/PaymentMethodsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Payment Methods/PaymentMethodsViewModel.swift
@@ -388,7 +388,9 @@ private extension PaymentMethodsViewModel {
     /// Tracks the `paymentsFlowCanceled` event.
     ///
     func trackFlowCanceled() {
-        analytics.track(event: WooAnalyticsEvent.PaymentsFlow.paymentsFlowCanceled(flow: flow))
+        analytics.track(event: WooAnalyticsEvent.PaymentsFlow.paymentsFlowCanceled(flow: flow,
+                                                                                   country: cardPresentPaymentsConfiguration.countryCode,
+                                                                                   currency: currencySettings.currencyCode.rawValue))
     }
 
     /// Tracks `paymentsFlowCollect` event.

--- a/WooCommerce/Classes/ViewRelated/Orders/Payment Methods/PaymentMethodsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Payment Methods/PaymentMethodsViewModel.swift
@@ -379,7 +379,10 @@ private extension PaymentMethodsViewModel {
     /// Tracks the `paymentsFlowFailed` event.
     ///
     func trackFlowFailed() {
-        analytics.track(event: WooAnalyticsEvent.PaymentsFlow.paymentsFlowFailed(flow: flow, source: .paymentMethod))
+        analytics.track(event: WooAnalyticsEvent.PaymentsFlow.paymentsFlowFailed(flow: flow,
+                                                                                 source: .paymentMethod,
+                                                                                 country: cardPresentPaymentsConfiguration.countryCode,
+                                                                                 currency: currencySettings.currencyCode.rawValue))
     }
 
     /// Tracks the `paymentsFlowCanceled` event.

--- a/WooCommerce/Classes/ViewRelated/Orders/Simple Payments/Amount/SimplePaymentsAmountViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Simple Payments/Amount/SimplePaymentsAmountViewModel.swift
@@ -71,6 +71,9 @@ final class SimplePaymentsAmountViewModel: ObservableObject {
     ///
     private var initialOrderStatus: OrderStatusEnum = .pending
 
+    /// Store country code for analytics.
+    private let countryCode: CountryCode
+
     /// Analytics tracker.
     ///
     private let analytics: Analytics
@@ -80,12 +83,14 @@ final class SimplePaymentsAmountViewModel: ObservableObject {
          locale: Locale = Locale.autoupdatingCurrent,
          presentNoticeSubject: PassthroughSubject<SimplePaymentsNotice, Never> = PassthroughSubject(),
          storeCurrencySettings: CurrencySettings = ServiceLocator.currencySettings,
+         countryCode: CountryCode = SiteAddress().countryCode,
          analytics: Analytics = ServiceLocator.analytics) {
         self.siteID = siteID
         self.stores = stores
         self.formattableAmountTextFieldViewModel = FormattableAmountTextFieldViewModel(locale: locale, storeCurrencySettings: storeCurrencySettings)
         self.presentNoticeSubject = presentNoticeSubject
         self.currencySettings = storeCurrencySettings
+        self.countryCode = countryCode
         self.analytics = analytics
 
         updateInitialOrderStatus()
@@ -115,7 +120,7 @@ final class SimplePaymentsAmountViewModel: ObservableObject {
                 self.presentNoticeSubject.send(.error(Localization.creationError))
                 self.analytics.track(event: WooAnalyticsEvent.PaymentsFlow.paymentsFlowFailed(flow: .simplePayment,
                                                                                               source: .amount,
-                                                                                              country: SiteAddress().countryCode,
+                                                                                              country: countryCode,
                                                                                               currency: currencySettings.currencyCode.rawValue))
                 DDLogError("⛔️ Error creating simple payments order: \(error)")
             }
@@ -127,7 +132,7 @@ final class SimplePaymentsAmountViewModel: ObservableObject {
     ///
     func userDidCancelFlow() {
         analytics.track(event: WooAnalyticsEvent.PaymentsFlow.paymentsFlowCanceled(flow: .simplePayment,
-                                                                                   country: SiteAddress().countryCode,
+                                                                                   country: countryCode,
                                                                                    currency: currencySettings.currencyCode.rawValue))
     }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Simple Payments/Amount/SimplePaymentsAmountViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Simple Payments/Amount/SimplePaymentsAmountViewModel.swift
@@ -126,7 +126,9 @@ final class SimplePaymentsAmountViewModel: ObservableObject {
     /// Track the flow cancel scenario.
     ///
     func userDidCancelFlow() {
-        analytics.track(event: WooAnalyticsEvent.PaymentsFlow.paymentsFlowCanceled(flow: .simplePayment))
+        analytics.track(event: WooAnalyticsEvent.PaymentsFlow.paymentsFlowCanceled(flow: .simplePayment,
+                                                                                   country: SiteAddress().countryCode,
+                                                                                   currency: currencySettings.currencyCode.rawValue))
     }
 
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Simple Payments/Amount/SimplePaymentsAmountViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Simple Payments/Amount/SimplePaymentsAmountViewModel.swift
@@ -61,6 +61,8 @@ final class SimplePaymentsAmountViewModel: ObservableObject {
     ///
     private let presentNoticeSubject: PassthroughSubject<SimplePaymentsNotice, Never>
 
+    private let currencySettings: CurrencySettings
+
     lazy var presentNoticePublisher: AnyPublisher<SimplePaymentsNotice, Never> = {
         presentNoticeSubject.eraseToAnyPublisher()
     }()
@@ -83,6 +85,7 @@ final class SimplePaymentsAmountViewModel: ObservableObject {
         self.stores = stores
         self.formattableAmountTextFieldViewModel = FormattableAmountTextFieldViewModel(locale: locale, storeCurrencySettings: storeCurrencySettings)
         self.presentNoticeSubject = presentNoticeSubject
+        self.currencySettings = storeCurrencySettings
         self.analytics = analytics
 
         updateInitialOrderStatus()
@@ -110,7 +113,10 @@ final class SimplePaymentsAmountViewModel: ObservableObject {
 
             case .failure(let error):
                 self.presentNoticeSubject.send(.error(Localization.creationError))
-                self.analytics.track(event: WooAnalyticsEvent.PaymentsFlow.paymentsFlowFailed(flow: .simplePayment, source: .amount))
+                self.analytics.track(event: WooAnalyticsEvent.PaymentsFlow.paymentsFlowFailed(flow: .simplePayment,
+                                                                                              source: .amount,
+                                                                                              country: SiteAddress().countryCode,
+                                                                                              currency: currencySettings.currencyCode.rawValue))
                 DDLogError("⛔️ Error creating simple payments order: \(error)")
             }
         }

--- a/WooCommerce/Classes/ViewRelated/Orders/Simple Payments/Summary/SimplePaymentsSummaryViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Simple Payments/Summary/SimplePaymentsSummaryViewModel.swift
@@ -250,7 +250,10 @@ final class SimplePaymentsSummaryViewModel: ObservableObject {
                 self.navigateToPaymentMethods = true
             case .failure(let error):
                 self.presentNoticeSubject.send(.error(Localization.updateError))
-                self.analytics.track(event: WooAnalyticsEvent.PaymentsFlow.paymentsFlowFailed(flow: self.flow, source: .summary))
+                self.analytics.track(event: WooAnalyticsEvent.PaymentsFlow.paymentsFlowFailed(flow: self.flow,
+                                                                                              source: .summary,
+                                                                                              country: SiteAddress().countryCode,
+                                                                                              currency: currencySettings.currencyCode.rawValue))
                 DDLogError("⛔️ Error updating simple payments order: \(error)")
             }
         }

--- a/WooCommerce/Classes/ViewRelated/Orders/Simple Payments/Summary/SimplePaymentsSummaryViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Simple Payments/Summary/SimplePaymentsSummaryViewModel.swift
@@ -107,11 +107,12 @@ final class SimplePaymentsSummaryViewModel: ObservableObject {
     ///
     private let currencyFormatter: CurrencyFormatter
 
+    /// Store country code for analytics.
+    private let countryCode: CountryCode
+
     /// Store Currency Settings
     ///
-    private var currencySettings: CurrencySettings {
-        ServiceLocator.currencySettings
-    }
+    private let currencySettings: CurrencySettings
 
     /// Store ID
     ///
@@ -158,6 +159,8 @@ final class SimplePaymentsSummaryViewModel: ObservableObject {
          presentNoticeSubject: PassthroughSubject<SimplePaymentsNotice, Never> = PassthroughSubject(),
          currencyFormatter: CurrencyFormatter = CurrencyFormatter(currencySettings: ServiceLocator.currencySettings),
          stores: StoresManager = ServiceLocator.stores,
+         countryCode: CountryCode = SiteAddress().countryCode,
+         currencySettings: CurrencySettings = ServiceLocator.currencySettings,
          analytics: Analytics = ServiceLocator.analytics,
          analyticsFlow: WooAnalyticsEvent.PaymentsFlow.Flow = .simplePayment) {
         self.siteID = siteID
@@ -167,6 +170,8 @@ final class SimplePaymentsSummaryViewModel: ObservableObject {
         self.presentNoticeSubject = presentNoticeSubject
         self.currencyFormatter = currencyFormatter
         self.stores = stores
+        self.countryCode = countryCode
+        self.currencySettings = currencySettings
         self.analytics = analytics
         self.flow = analyticsFlow
         self.providedAmount = currencyFormatter.formatAmount(providedAmount) ?? providedAmount
@@ -252,7 +257,7 @@ final class SimplePaymentsSummaryViewModel: ObservableObject {
                 self.presentNoticeSubject.send(.error(Localization.updateError))
                 self.analytics.track(event: WooAnalyticsEvent.PaymentsFlow.paymentsFlowFailed(flow: self.flow,
                                                                                               source: .summary,
-                                                                                              country: SiteAddress().countryCode,
+                                                                                              country: countryCode,
                                                                                               currency: currencySettings.currencyCode.rawValue))
                 DDLogError("⛔️ Error updating simple payments order: \(error)")
             }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Payment Methods/PaymentMethodsViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Payment Methods/PaymentMethodsViewModelTests.swift
@@ -386,8 +386,12 @@ final class PaymentMethodsViewModelTests: XCTestCase {
         }
 
         let analytics = MockAnalyticsProvider()
+        let currencySettings = CurrencySettings()
+        currencySettings.currencyCode = .JPY
         let dependencies = Dependencies(stores: stores,
-                                        analytics: WooAnalytics(analyticsProvider: analytics))
+                                        analytics: WooAnalytics(analyticsProvider: analytics),
+                                        cardPresentPaymentsConfiguration: .init(country: .GB),
+                                        currencySettings: currencySettings)
         let viewModel = PaymentMethodsViewModel(formattedTotal: "$12.00",
                                                 flow: .simplePayment,
                                                 dependencies: dependencies)
@@ -399,6 +403,8 @@ final class PaymentMethodsViewModelTests: XCTestCase {
         assertEqual(analytics.receivedEvents.first, WooAnalyticsStat.paymentsFlowFailed.rawValue)
         assertEqual(analytics.receivedProperties.first?["source"] as? String, "payment_method")
         assertEqual(analytics.receivedProperties.first?["flow"] as? String, "simple_payment")
+        assertEqual(analytics.receivedProperties.first?["country"] as? String, "GB")
+        assertEqual(analytics.receivedProperties.first?["currency"] as? String, "JPY")
     }
 
     func test_failed_event_is_tracked_after_failing_to_collect_payment() {

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Simple Payments/SimplePaymentsAmountViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Simple Payments/SimplePaymentsAmountViewModelTests.swift
@@ -256,7 +256,6 @@ final class SimplePaymentsAmountViewModelTests: XCTestCase {
         let analytics = MockAnalyticsProvider()
         let currencySettings = CurrencySettings()
         currencySettings.currencyCode = .JPY
-        let siteAddress = SiteAddress(siteSettings: [.fake().copy(settingID: "woocommerce_default_country", value: "US:PA")])
         let viewModel = SimplePaymentsAmountViewModel(siteID: sampleSiteID,
                                                       stores: testingStore,
                                                       storeCurrencySettings: currencySettings,

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Simple Payments/SimplePaymentsAmountViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Simple Payments/SimplePaymentsAmountViewModelTests.swift
@@ -254,7 +254,14 @@ final class SimplePaymentsAmountViewModelTests: XCTestCase {
         }
 
         let analytics = MockAnalyticsProvider()
-        let viewModel = SimplePaymentsAmountViewModel(siteID: sampleSiteID, stores: testingStore, analytics: WooAnalytics(analyticsProvider: analytics))
+        let currencySettings = CurrencySettings()
+        currencySettings.currencyCode = .JPY
+        let siteAddress = SiteAddress(siteSettings: [.fake().copy(settingID: "woocommerce_default_country", value: "US:PA")])
+        let viewModel = SimplePaymentsAmountViewModel(siteID: sampleSiteID,
+                                                      stores: testingStore,
+                                                      storeCurrencySettings: currencySettings,
+                                                      countryCode: .JP,
+                                                      analytics: WooAnalytics(analyticsProvider: analytics))
 
         // When
         viewModel.createSimplePaymentsOrder()
@@ -263,6 +270,8 @@ final class SimplePaymentsAmountViewModelTests: XCTestCase {
         assertEqual(analytics.receivedEvents, [WooAnalyticsStat.paymentsFlowFailed.rawValue])
         assertEqual(analytics.receivedProperties.first?["source"] as? String, "amount")
         assertEqual(analytics.receivedProperties.first?["flow"] as? String, "simple_payment")
+        assertEqual(analytics.receivedProperties.first?["country"] as? String, "JP")
+        assertEqual(analytics.receivedProperties.first?["currency"] as? String, "JPY")
     }
 
     func test_view_model_disable_cancel_button_while_creating_payment_order() {

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Simple Payments/SimplePaymentsSummaryViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Simple Payments/SimplePaymentsSummaryViewModelTests.swift
@@ -521,10 +521,14 @@ final class SimplePaymentsSummaryViewModelTests: XCTestCase {
         }
 
         let mockAnalytics = MockAnalyticsProvider()
+        let currencySettings = CurrencySettings()
+        currencySettings.currencyCode = .JPY
         let viewModel = SimplePaymentsSummaryViewModel(providedAmount: "1.0",
                                                        totalWithTaxes: "1.0",
                                                        taxLines: [],
                                                        stores: mockStores,
+                                                       countryCode: .JP,
+                                                       currencySettings: currencySettings,
                                                        analytics: WooAnalytics(analyticsProvider: mockAnalytics))
 
         // When
@@ -534,6 +538,8 @@ final class SimplePaymentsSummaryViewModelTests: XCTestCase {
         assertEqual(mockAnalytics.receivedEvents, [WooAnalyticsStat.paymentsFlowFailed.rawValue])
         assertEqual(mockAnalytics.receivedProperties.first?["source"] as? String, "summary")
         assertEqual(mockAnalytics.receivedProperties.first?["flow"] as? String, "simple_payment")
+        assertEqual(mockAnalytics.receivedProperties.first?["country"] as? String, "JP")
+        assertEqual(mockAnalytics.receivedProperties.first?["currency"] as? String, "JPY")
     }
 
     func test_taxes_toggle_state_is_properly_loaded() {


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #11654
<!-- Id number of the GitHub issue this PR addresses. -->

## Why

From TTP analysis p1704815317432349-slack-C06C3CZFHGD, it'd be helpful if we have `country` and `currency` properties in all `payments_flow_` events including the remaining `payments_flow_failed` and `payments_flow_canceled` Tracks events. This PR ensures that these two properties are tracked in the two events.

## How

When `cardPresentPaymentsConfiguration` is available, it uses the country code from the configuration. Otherwise, the country code from `SiteAddress` is DI'ed for unit testing. The currency code is from `ServiceLocator.currencySettings` that is also DI'ed for unit testing.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

- [x] @jaclync test the scenarios below
- [x] @jaclync tests a different currency/country
- [x] @jaclync adds the event properties to Tracks

Hand testing is optional, since it can be time consuming to go through every payment flow. Feel free to pick one flow if you'd like to test.

Make sure `payments_flow_canceled` / `payments_flow_failed` events include the correct `country` and `currency` properties when canceling the payment flow / an error occurs (e.g. when switching to offline mode when an API request is expected) respectively in the following flows:

- Simple payment:
  - Go to the menu tab
  - Tap on `Payments`
  - Tap `Collect Payment` and enter an amount
- Order payment:
  - Prerequisite: the store has at least one order that is eligible for payment
  - Go to the orders tab
  - Tap on an order in the prerequisite
  - Tap `Collect Payment`
  - Tap on a method
- Tap-to-pay:
  - Additional prerequisite: the device is eligible for Apple Pay Tap-to-Pay feature
  - Repeat the steps above, then select `Tap to Pay on iPhone`

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
