### PR TITLE
Blaze: Restore product ID and remove product URL for BlazeCampaign model

### DIFF
--- a/Fakes/Fakes/Networking.generated.swift
+++ b/Fakes/Fakes/Networking.generated.swift
@@ -174,7 +174,6 @@ extension Networking.BlazeCampaign {
             siteID: .fake(),
             campaignID: .fake(),
             productID: .fake(),
-            productURL: .fake(),
             name: .fake(),
             uiStatus: .fake(),
             contentImageURL: .fake(),

--- a/Fakes/Fakes/Networking.generated.swift
+++ b/Fakes/Fakes/Networking.generated.swift
@@ -173,6 +173,7 @@ extension Networking.BlazeCampaign {
         .init(
             siteID: .fake(),
             campaignID: .fake(),
+            productID: .fake(),
             productURL: .fake(),
             name: .fake(),
             uiStatus: .fake(),

--- a/Networking/Networking/Model/Blaze/BlazeCampaign.swift
+++ b/Networking/Networking/Model/Blaze/BlazeCampaign.swift
@@ -15,9 +15,6 @@ public struct BlazeCampaign: Decodable, Equatable, GeneratedFakeable, GeneratedC
     /// ID of the product in the campaign
     public let productID: Int64?
 
-    /// URL of the product in the campaign
-    public let productURL: String
-
     /// Name of the campaign
     public let name: String
 
@@ -42,7 +39,6 @@ public struct BlazeCampaign: Decodable, Equatable, GeneratedFakeable, GeneratedC
     public init(siteID: Int64,
                 campaignID: Int64,
                 productID: Int64?,
-                productURL: String,
                 name: String,
                 uiStatus: String,
                 contentImageURL: String?,
@@ -53,7 +49,6 @@ public struct BlazeCampaign: Decodable, Equatable, GeneratedFakeable, GeneratedC
         self.siteID = siteID
         self.campaignID = campaignID
         self.productID = productID
-        self.productURL = productURL
         self.name = name
         self.uiStatus = uiStatus
         self.contentImageURL = contentImageURL
@@ -75,7 +70,6 @@ public struct BlazeCampaign: Decodable, Equatable, GeneratedFakeable, GeneratedC
         name = try container.decode(String.self, forKey: .name)
         uiStatus = try container.decode(String.self, forKey: .uiStatus)
         budgetCents = try container.decode(Double.self, forKey: .budgetCents)
-        productURL = try container.decode(String.self, forKey: .targetUrl)
 
         let targetUrn = try container.decode(String.self, forKey: .targetUrn)
         productID = Int64(String(targetUrn.split(separator: ":").last ?? ""))
@@ -118,7 +112,6 @@ private extension BlazeCampaign {
         case campaignId
         case name
         case targetUrn
-        case targetUrl
         case uiStatus
         case contentConfig
         case campaignStats

--- a/Networking/Networking/Model/Blaze/BlazeCampaign.swift
+++ b/Networking/Networking/Model/Blaze/BlazeCampaign.swift
@@ -12,6 +12,9 @@ public struct BlazeCampaign: Decodable, Equatable, GeneratedFakeable, GeneratedC
     /// ID of the campaign
     public let campaignID: Int64
 
+    /// ID of the product in the campaign
+    public let productID: Int64?
+
     /// URL of the product in the campaign
     public let productURL: String
 
@@ -38,6 +41,7 @@ public struct BlazeCampaign: Decodable, Equatable, GeneratedFakeable, GeneratedC
 
     public init(siteID: Int64,
                 campaignID: Int64,
+                productID: Int64?,
                 productURL: String,
                 name: String,
                 uiStatus: String,
@@ -48,6 +52,7 @@ public struct BlazeCampaign: Decodable, Equatable, GeneratedFakeable, GeneratedC
                 budgetCents: Double) {
         self.siteID = siteID
         self.campaignID = campaignID
+        self.productID = productID
         self.productURL = productURL
         self.name = name
         self.uiStatus = uiStatus
@@ -71,6 +76,9 @@ public struct BlazeCampaign: Decodable, Equatable, GeneratedFakeable, GeneratedC
         uiStatus = try container.decode(String.self, forKey: .uiStatus)
         budgetCents = try container.decode(Double.self, forKey: .budgetCents)
         productURL = try container.decode(String.self, forKey: .targetUrl)
+
+        let targetUrn = try container.decode(String.self, forKey: .targetUrn)
+        productID = Int64(String(targetUrn.split(separator: ":").last ?? ""))
 
         let content = try container.decode(ContentConfig.self, forKey: .contentConfig)
         contentImageURL = content.imageURL
@@ -109,6 +117,7 @@ private extension BlazeCampaign {
     enum CodingKeys: String, CodingKey {
         case campaignId
         case name
+        case targetUrn
         case targetUrl
         case uiStatus
         case contentConfig

--- a/Networking/Networking/Model/Blaze/BlazeCampaign.swift
+++ b/Networking/Networking/Model/Blaze/BlazeCampaign.swift
@@ -72,6 +72,10 @@ public struct BlazeCampaign: Decodable, Equatable, GeneratedFakeable, GeneratedC
         budgetCents = try container.decode(Double.self, forKey: .budgetCents)
 
         let targetUrn = try container.decode(String.self, forKey: .targetUrn)
+        /// Extracts the product ID from the `target_urn` response.
+        /// The response looks like the following: `urn:wpcom:post:1:134`
+        /// The product ID is the last number following the colon in the response (`134`).
+        /// If the product ID cannot be extracted, it returns null instead.
         productID = Int64(String(targetUrn.split(separator: ":").last ?? ""))
 
         let content = try container.decode(ContentConfig.self, forKey: .contentConfig)

--- a/Networking/Networking/Model/Copiable/Models+Copiable.generated.swift
+++ b/Networking/Networking/Model/Copiable/Models+Copiable.generated.swift
@@ -179,6 +179,7 @@ extension Networking.BlazeCampaign {
     public func copy(
         siteID: CopiableProp<Int64> = .copy,
         campaignID: CopiableProp<Int64> = .copy,
+        productID: NullableCopiableProp<Int64> = .copy,
         productURL: CopiableProp<String> = .copy,
         name: CopiableProp<String> = .copy,
         uiStatus: CopiableProp<String> = .copy,
@@ -190,6 +191,7 @@ extension Networking.BlazeCampaign {
     ) -> Networking.BlazeCampaign {
         let siteID = siteID ?? self.siteID
         let campaignID = campaignID ?? self.campaignID
+        let productID = productID ?? self.productID
         let productURL = productURL ?? self.productURL
         let name = name ?? self.name
         let uiStatus = uiStatus ?? self.uiStatus
@@ -202,6 +204,7 @@ extension Networking.BlazeCampaign {
         return Networking.BlazeCampaign(
             siteID: siteID,
             campaignID: campaignID,
+            productID: productID,
             productURL: productURL,
             name: name,
             uiStatus: uiStatus,

--- a/Networking/Networking/Model/Copiable/Models+Copiable.generated.swift
+++ b/Networking/Networking/Model/Copiable/Models+Copiable.generated.swift
@@ -180,7 +180,6 @@ extension Networking.BlazeCampaign {
         siteID: CopiableProp<Int64> = .copy,
         campaignID: CopiableProp<Int64> = .copy,
         productID: NullableCopiableProp<Int64> = .copy,
-        productURL: CopiableProp<String> = .copy,
         name: CopiableProp<String> = .copy,
         uiStatus: CopiableProp<String> = .copy,
         contentImageURL: NullableCopiableProp<String> = .copy,
@@ -192,7 +191,6 @@ extension Networking.BlazeCampaign {
         let siteID = siteID ?? self.siteID
         let campaignID = campaignID ?? self.campaignID
         let productID = productID ?? self.productID
-        let productURL = productURL ?? self.productURL
         let name = name ?? self.name
         let uiStatus = uiStatus ?? self.uiStatus
         let contentImageURL = contentImageURL ?? self.contentImageURL
@@ -205,7 +203,6 @@ extension Networking.BlazeCampaign {
             siteID: siteID,
             campaignID: campaignID,
             productID: productID,
-            productURL: productURL,
             name: name,
             uiStatus: uiStatus,
             contentImageURL: contentImageURL,

--- a/Networking/NetworkingTests/Mapper/BlazeCampaignListMapperTests.swift
+++ b/Networking/NetworkingTests/Mapper/BlazeCampaignListMapperTests.swift
@@ -17,7 +17,6 @@ final class BlazeCampaignListMapperTests: XCTestCase {
         XCTAssertEqual(item.siteID, dummySiteID)
         XCTAssertEqual(item.campaignID, 34518)
         XCTAssertEqual(item.productID, 134)
-        XCTAssertEqual(item.productURL, "https://example.com/product/fried-egg-bacon-bagel/")
         XCTAssertEqual(item.name, "Fried-egg Bacon Bagel")
         XCTAssertEqual(item.uiStatus, "rejected")
         XCTAssertEqual(item.contentClickURL, "https://example.com/product/fried-egg-bacon-bagel/")

--- a/Networking/NetworkingTests/Mapper/BlazeCampaignListMapperTests.swift
+++ b/Networking/NetworkingTests/Mapper/BlazeCampaignListMapperTests.swift
@@ -16,6 +16,7 @@ final class BlazeCampaignListMapperTests: XCTestCase {
         let item = try XCTUnwrap(campaigns.first)
         XCTAssertEqual(item.siteID, dummySiteID)
         XCTAssertEqual(item.campaignID, 34518)
+        XCTAssertEqual(item.productID, 134)
         XCTAssertEqual(item.productURL, "https://example.com/product/fried-egg-bacon-bagel/")
         XCTAssertEqual(item.name, "Fried-egg Bacon Bagel")
         XCTAssertEqual(item.uiStatus, "rejected")

--- a/Networking/NetworkingTests/Remote/BlazeRemoteTests.swift
+++ b/Networking/NetworkingTests/Remote/BlazeRemoteTests.swift
@@ -152,7 +152,6 @@ final class BlazeRemoteTests: XCTestCase {
         XCTAssertEqual(item.budgetCents, 500)
         XCTAssertEqual(item.totalClicks, 0)
         XCTAssertEqual(item.totalImpressions, 0)
-        XCTAssertEqual(item.productURL, "https://example.com/product/fried-egg-bacon-bagel/")
     }
 
     /// Verifies that loadCampaigns sends the correct parameters.

--- a/Networking/NetworkingTests/Responses/blaze-campaigns-success.json
+++ b/Networking/NetworkingTests/Responses/blaze-campaigns-success.json
@@ -20,6 +20,7 @@
             "avatar_url": "https://0.gravatar.com/avatar/1?s=96&d=identicon",
             "budget_cents": 500,
             "format": "html5",
+            "target_urn": "urn:wpcom:post:1:134",
             "target_url": "https://example.com/product/fried-egg-bacon-bagel/",
             "user_target_language": "0",
             "user_target_geo": "0",

--- a/WooCommerce/Classes/ViewRelated/Blaze/BlazeCampaignList/BlazeCampaignItemView.swift
+++ b/WooCommerce/Classes/ViewRelated/Blaze/BlazeCampaignList/BlazeCampaignItemView.swift
@@ -139,6 +139,7 @@ private extension BlazeCampaignItemView {
 struct BlazeCampaignItemView_Previews: PreviewProvider {
     static let campaign: BlazeCampaign = .init(siteID: 123,
                                                campaignID: 11,
+                                               productID: 33,
                                                productURL: "https://example.com",
                                                name: "Fluffy bunny pouch",
                                                uiStatus: BlazeCampaign.Status.finished.rawValue,

--- a/WooCommerce/Classes/ViewRelated/Blaze/BlazeCampaignList/BlazeCampaignItemView.swift
+++ b/WooCommerce/Classes/ViewRelated/Blaze/BlazeCampaignList/BlazeCampaignItemView.swift
@@ -140,7 +140,6 @@ struct BlazeCampaignItemView_Previews: PreviewProvider {
     static let campaign: BlazeCampaign = .init(siteID: 123,
                                                campaignID: 11,
                                                productID: 33,
-                                               productURL: "https://example.com",
                                                name: "Fluffy bunny pouch",
                                                uiStatus: BlazeCampaign.Status.finished.rawValue,
                                                contentImageURL: nil,

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewModel.swift
@@ -823,7 +823,7 @@ private extension ProductFormViewModel {
     func hasBlazeCampaign() -> Bool {
         let campaigns = blazeCampaignResultsController.fetchedObjects
         return campaigns.contains(where: {
-            ($0.productURL == product.permalink || $0.productID == product.productID) &&
+            ($0.productID == product.productID) &&
             ($0.status == .created || $0.status == .approved || $0.status == .scheduled || $0.status == .active)
         })
     }

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewModel.swift
@@ -823,7 +823,7 @@ private extension ProductFormViewModel {
     func hasBlazeCampaign() -> Bool {
         let campaigns = blazeCampaignResultsController.fetchedObjects
         return campaigns.contains(where: {
-            ($0.productURL == product.permalink) &&
+            ($0.productURL == product.permalink || $0.productID == product.productID) &&
             ($0.status == .created || $0.status == .approved || $0.status == .scheduled || $0.status == .active)
         })
     }

--- a/Yosemite/Yosemite/Model/Storage/BlazeCampaign+ReadOnlyConvertible.swift
+++ b/Yosemite/Yosemite/Model/Storage/BlazeCampaign+ReadOnlyConvertible.swift
@@ -9,7 +9,12 @@ extension Storage.BlazeCampaign: ReadOnlyConvertible {
     public func update(with campaign: Yosemite.BlazeCampaign) {
         siteID = campaign.siteID
         campaignID = campaign.campaignID
-        productID = campaign.productID != nil ? NSNumber(value: campaign.productID!) : nil
+        productID = {
+            guard let id = campaign.productID else {
+                return nil
+            }
+            return NSNumber(value: id)
+        }()
         name = campaign.name
         rawStatus = campaign.uiStatus
         contentClickURL = campaign.contentClickURL

--- a/Yosemite/Yosemite/Model/Storage/BlazeCampaign+ReadOnlyConvertible.swift
+++ b/Yosemite/Yosemite/Model/Storage/BlazeCampaign+ReadOnlyConvertible.swift
@@ -14,7 +14,7 @@ extension Storage.BlazeCampaign: ReadOnlyConvertible {
         rawStatus = campaign.uiStatus
         contentClickURL = campaign.contentClickURL
         contentImageURL = campaign.contentImageURL
-        totalBudget = campaign.budgetCents // TODO-11532: update the storage model property name
+        totalBudget = campaign.budgetCents
         totalClicks = campaign.totalClicks
         totalImpressions = campaign.totalImpressions
     }
@@ -25,7 +25,6 @@ extension Storage.BlazeCampaign: ReadOnlyConvertible {
         BlazeCampaign(siteID: siteID,
                       campaignID: campaignID,
                       productID: productID?.int64Value,
-                      productURL: "", // TODO-11532: map the new attribute `productURL` here
                       name: name,
                       uiStatus: rawStatus,
                       contentImageURL: contentImageURL,

--- a/Yosemite/Yosemite/Model/Storage/BlazeCampaign+ReadOnlyConvertible.swift
+++ b/Yosemite/Yosemite/Model/Storage/BlazeCampaign+ReadOnlyConvertible.swift
@@ -9,7 +9,7 @@ extension Storage.BlazeCampaign: ReadOnlyConvertible {
     public func update(with campaign: Yosemite.BlazeCampaign) {
         siteID = campaign.siteID
         campaignID = campaign.campaignID
-        productID = nil // TODO: add a new attribute `productURL` and remove `productID`
+        productID = campaign.productID != nil ? NSNumber(value: campaign.productID!) : nil
         name = campaign.name
         rawStatus = campaign.uiStatus
         contentClickURL = campaign.contentClickURL
@@ -24,6 +24,7 @@ extension Storage.BlazeCampaign: ReadOnlyConvertible {
     public func toReadOnly() -> BlazeCampaign {
         BlazeCampaign(siteID: siteID,
                       campaignID: campaignID,
+                      productID: productID?.int64Value,
                       productURL: "", // TODO-11532: map the new attribute `productURL` here
                       name: name,
                       uiStatus: rawStatus,


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Related to #11526 
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify the problem and how you’ve fixed it. -->
Previously in #11530, we replaced product ID with product URL to fix issue decoding Blaze campaigns. After that, the backend team has restored `target_urn` field, so we want to revert the change for parity with the Android app [p1703657179333409/1703656773.384589-slack-C03L1NF1EA3].

We also logged #11532 to update the storage model, but I think we can skip this because of this revert, and the renaming from totalBudget to budgetCents is not necessary. Unless there's any concern, I'll close that issue after this PR is merged.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
Build the app and smoke test the features related to Blaze to make sure that everything works properly. 

Also, make sure that Promote with Blaze button is not present on the detail screen of any product with an active campaign.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->
N/A

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.