### PR TITLE
[Blaze] Campaign form - Cover no product image case and add unit tests

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Blaze/BlazeEditAd/BlazeEditAdHostingController.swift
+++ b/WooCommerce/Classes/ViewRelated/Blaze/BlazeEditAd/BlazeEditAdHostingController.swift
@@ -4,7 +4,7 @@ import Yosemite
 
 /// Blaze ad data for the "Edit Ad Screen" form
 struct BlazeEditAdData: Equatable {
-    let image: MediaPickerImage
+    let image: MediaPickerImage?
     let tagline: String
     let description: String
 }

--- a/WooCommerce/Classes/ViewRelated/Blaze/BlazeEditAd/BlazeEditAdViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Blaze/BlazeEditAd/BlazeEditAdViewModel.swift
@@ -95,7 +95,11 @@ final class BlazeEditAdViewModel: ObservableObject {
 
         self.adData = adData
         self.suggestions = suggestions
-        self.imageState = .success(adData.image)
+        if let image = adData.image {
+            self.imageState = .success(image)
+        } else {
+            self.imageState = .empty
+        }
         self.tagline = adData.tagline
         self.description = adData.description
 

--- a/WooCommerce/Classes/ViewRelated/Blaze/CampaignCreation/BlazeCampaignCreationForm.swift
+++ b/WooCommerce/Classes/ViewRelated/Blaze/CampaignCreation/BlazeCampaignCreationForm.swift
@@ -25,11 +25,7 @@ final class BlazeCampaignCreationFormHostingController: UIHostingController<Blaz
 
 private extension BlazeCampaignCreationFormHostingController {
     func navigateToEditAd() {
-        guard let viewModel = viewModel.editAdViewModel else {
-            assertionFailure("Edit ad button should be disabled until image is ready.")
-            return
-        }
-        let vc = BlazeEditAdHostingController(viewModel: viewModel)
+        let vc = BlazeEditAdHostingController(viewModel: viewModel.editAdViewModel)
         present(vc, animated: true)
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Blaze/CampaignCreation/BlazeCampaignCreationFormViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Blaze/CampaignCreation/BlazeCampaignCreationFormViewModel.swift
@@ -23,9 +23,6 @@ final class BlazeCampaignCreationFormViewModel: ObservableObject {
 
     var onEditAd: (() -> Void)?
 
-    var productImage: URL? {
-        product?.imageURL
-    }
     @Published private(set) var image: MediaPickerImage?
     @Published private(set) var tagline: String = ""
     @Published private(set) var description: String = ""

--- a/WooCommerce/Classes/ViewRelated/Blaze/CampaignCreation/BlazeCampaignCreationFormViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Blaze/CampaignCreation/BlazeCampaignCreationFormViewModel.swift
@@ -62,11 +62,7 @@ final class BlazeCampaignCreationFormViewModel: ObservableObject {
         }
     }
 
-    var editAdViewModel: BlazeEditAdViewModel? {
-        guard let image else {
-            assertionFailure("Product image is not downloaded. Edit ad button should be disabled.")
-            return nil
-        }
+    var editAdViewModel: BlazeEditAdViewModel {
         let adData = BlazeEditAdData(image: image,
                                      tagline: tagline,
                                      description: description)

--- a/WooCommerce/Classes/ViewRelated/Blaze/CampaignCreation/BlazeCampaignCreationFormViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Blaze/CampaignCreation/BlazeCampaignCreationFormViewModel.swift
@@ -113,6 +113,8 @@ final class BlazeCampaignCreationFormViewModel: ObservableObject {
     @Published private(set) var error: BlazeCampaignCreationError?
     private var suggestions: [BlazeAISuggestion] = []
 
+    @Published private var isLoadingProductImage: Bool = true
+
     var canEditAd: Bool {
         image != nil && !isLoadingAISuggestions
     }
@@ -160,7 +162,9 @@ final class BlazeCampaignCreationFormViewModel: ObservableObject {
 // MARK: Image download
 extension BlazeCampaignCreationFormViewModel {
     func downloadProductImage() async {
+        isLoadingProductImage = true
         image = await loadProductImage()
+        isLoadingProductImage = false
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Blaze/CampaignCreation/BlazeCampaignCreationFormViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Blaze/CampaignCreation/BlazeCampaignCreationFormViewModel.swift
@@ -116,7 +116,7 @@ final class BlazeCampaignCreationFormViewModel: ObservableObject {
     @Published private var isLoadingProductImage: Bool = true
 
     var canEditAd: Bool {
-        image != nil && !isLoadingAISuggestions
+        !(isLoadingProductImage || isLoadingAISuggestions)
     }
 
     var canConfirmDetails: Bool {

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -2440,6 +2440,7 @@
 		E1F52DC62668E03B00349D75 /* CardPresentModalBluetoothRequired.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1F52DC52668E03B00349D75 /* CardPresentModalBluetoothRequired.swift */; };
 		EE0EE7A628B7415200F6061E /* CustomHelpCenterContent.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE0EE7A528B7415200F6061E /* CustomHelpCenterContent.swift */; };
 		EE0EE7A828B74EF300F6061E /* CustomHelpCenterContentTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE0EE7A728B74EF300F6061E /* CustomHelpCenterContentTests.swift */; };
+		EE1905822B50289100617C53 /* BlazeCampaignCreationFormViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE1905812B50289100617C53 /* BlazeCampaignCreationFormViewModelTests.swift */; };
 		EE28CF852B233AC40056D96E /* ProductCreationAISurveyConfirmationViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE28CF842B233AC40056D96E /* ProductCreationAISurveyConfirmationViewModelTests.swift */; };
 		EE2A57D729E399CC009F61E1 /* CaseIterable+Helpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE2A57D629E399CC009F61E1 /* CaseIterable+Helpers.swift */; };
 		EE2A57D929E39A9C009F61E1 /* CaseIterable+HelpersTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE2A57D829E39A9C009F61E1 /* CaseIterable+HelpersTests.swift */; };
@@ -5097,6 +5098,7 @@
 		E1F52DC52668E03B00349D75 /* CardPresentModalBluetoothRequired.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardPresentModalBluetoothRequired.swift; sourceTree = "<group>"; };
 		EE0EE7A528B7415200F6061E /* CustomHelpCenterContent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomHelpCenterContent.swift; sourceTree = "<group>"; };
 		EE0EE7A728B74EF300F6061E /* CustomHelpCenterContentTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomHelpCenterContentTests.swift; sourceTree = "<group>"; };
+		EE1905812B50289100617C53 /* BlazeCampaignCreationFormViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BlazeCampaignCreationFormViewModelTests.swift; sourceTree = "<group>"; };
 		EE28CF842B233AC40056D96E /* ProductCreationAISurveyConfirmationViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductCreationAISurveyConfirmationViewModelTests.swift; sourceTree = "<group>"; };
 		EE2A57D629E399CC009F61E1 /* CaseIterable+Helpers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "CaseIterable+Helpers.swift"; sourceTree = "<group>"; };
 		EE2A57D829E39A9C009F61E1 /* CaseIterable+HelpersTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "CaseIterable+HelpersTests.swift"; sourceTree = "<group>"; };
@@ -5829,6 +5831,7 @@
 				DEA357122ADCC4C9006380BA /* BlazeCampaignListViewModelTests.swift */,
 				DE5746372B479CB80034B10D /* BlazeBudgetSettingViewModelTests.swift */,
 				EE572A202B4684FF00B74B2E /* BlazeEditAdViewModelTests.swift */,
+				EE1905812B50289100617C53 /* BlazeCampaignCreationFormViewModelTests.swift */,
 			);
 			path = Blaze;
 			sourceTree = "<group>";
@@ -14844,6 +14847,7 @@
 				02E493EF245C1087000AEA9E /* ProductFormBottomSheetListSelectorCommandTests.swift in Sources */,
 				B90DACC22A31BBC800365897 /* BarcodeSKUScannerProductFinderTests.swift in Sources */,
 				D88D5A3B230B5D63007B6E01 /* MockAnalyticsProvider.swift in Sources */,
+				EE1905822B50289100617C53 /* BlazeCampaignCreationFormViewModelTests.swift in Sources */,
 				B9C4AB29280031AB007008B8 /* PaymentReceiptEmailParameterDeterminerTests.swift in Sources */,
 				029A9C672535873000BECEC5 /* AppCoordinatorTests.swift in Sources */,
 				DEDA8D9F2B16D56A0076BF0F /* UserDefaultsBlazeTests.swift in Sources */,

--- a/WooCommerce/WooCommerceTests/ViewRelated/Blaze/BlazeCampaignCreationFormViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Blaze/BlazeCampaignCreationFormViewModelTests.swift
@@ -26,9 +26,12 @@ final class BlazeCampaignCreationFormViewModelTests: XCTestCase {
         storageManager.viewStorage
     }
 
+    private var stores: MockStoresManager!
+
     override func setUp() {
         super.setUp()
         storageManager = MockStorageManager()
+        stores = MockStoresManager(sessionManager: .testingInstance)
     }
 
     // MARK: Initial values
@@ -71,16 +74,7 @@ final class BlazeCampaignCreationFormViewModelTests: XCTestCase {
                                    productID: sampleProductID,
                                    statusKey: (ProductStatus.published.rawValue),
                                    images: [sampleProductImage]))
-        let stores = MockStoresManager(sessionManager: .testingInstance)
-        stores.whenReceivingAction(ofType: BlazeAction.self) { [weak self] action in
-            guard let self = self else { return }
-            switch action {
-            case let .fetchAISuggestions(_, _, completion):
-                completion(.success(sampleAISuggestions))
-            default:
-                XCTFail("Unexpected action: \(action)")
-            }
-        }
+        mockAISuggestionsSuccess(sampleAISuggestions)
         let imageLoader = MockProductUIImageLoader()
         let sampleImage = UIImage.addOutlineImage
         imageLoader.requestImageStubbedResponse = sampleImage
@@ -107,16 +101,7 @@ final class BlazeCampaignCreationFormViewModelTests: XCTestCase {
                                    productID: sampleProductID,
                                    statusKey: (ProductStatus.published.rawValue),
                                    images: [.fake()]))
-        let stores = MockStoresManager(sessionManager: .testingInstance)
-        stores.whenReceivingAction(ofType: BlazeAction.self) { [weak self] action in
-            guard let self = self else { return }
-            switch action {
-            case let .fetchAISuggestions(_, _, completion):
-                completion(.success(sampleAISuggestions))
-            default:
-                XCTFail("Unexpected action: \(action)")
-            }
-        }
+        mockAISuggestionsSuccess(sampleAISuggestions)
         let imageLoader = MockProductUIImageLoader()
         let sampleImage = UIImage.addOutlineImage
         imageLoader.requestImageStubbedResponse = sampleImage
@@ -145,16 +130,7 @@ final class BlazeCampaignCreationFormViewModelTests: XCTestCase {
                                    productID: sampleProductID,
                                    statusKey: (ProductStatus.published.rawValue),
                                    images: [.fake()]))
-        let stores = MockStoresManager(sessionManager: .testingInstance)
-        stores.whenReceivingAction(ofType: BlazeAction.self) { [weak self] action in
-            guard let self = self else { return }
-            switch action {
-            case let .fetchAISuggestions(_, _, completion):
-                completion(.success(sampleAISuggestions))
-            default:
-                XCTFail("Unexpected action: \(action)")
-            }
-        }
+        mockAISuggestionsSuccess(sampleAISuggestions)
         let imageLoader = MockProductUIImageLoader()
         let sampleImage = UIImage.addOutlineImage
         imageLoader.requestImageStubbedResponse = sampleImage
@@ -182,15 +158,7 @@ final class BlazeCampaignCreationFormViewModelTests: XCTestCase {
                                    productID: sampleProductID,
                                    statusKey: (ProductStatus.published.rawValue),
                                    images: [.fake()]))
-        let stores = MockStoresManager(sessionManager: .testingInstance)
-        stores.whenReceivingAction(ofType: BlazeAction.self) { action in
-            switch action {
-            case let .fetchAISuggestions(_, _, completion):
-                completion(.failure(MockError()))
-            default:
-                XCTFail("Unexpected action: \(action)")
-            }
-        }
+        mockDomainSuggestionsFailure(MockError())
         let imageLoader = MockProductUIImageLoader()
         let sampleImage = UIImage.addOutlineImage
         imageLoader.requestImageStubbedResponse = sampleImage
@@ -216,16 +184,7 @@ final class BlazeCampaignCreationFormViewModelTests: XCTestCase {
                                    productID: sampleProductID,
                                    statusKey: (ProductStatus.published.rawValue),
                                    images: [])) // Product has no image
-        let stores = MockStoresManager(sessionManager: .testingInstance)
-        stores.whenReceivingAction(ofType: BlazeAction.self) { [weak self] action in
-            guard let self = self else { return }
-            switch action {
-            case let .fetchAISuggestions(_, _, completion):
-                completion(.success(sampleAISuggestions))
-            default:
-                XCTFail("Unexpected action: \(action)")
-            }
-        }
+        mockAISuggestionsSuccess(sampleAISuggestions)
         let imageLoader = MockProductUIImageLoader()
         let viewModel = BlazeCampaignCreationFormViewModel(siteID: sampleSiteID,
                                                            productID: sampleProductID,
@@ -247,7 +206,6 @@ final class BlazeCampaignCreationFormViewModelTests: XCTestCase {
     func test_loadAISuggestions_sends_correct_product_ID_to_fetch() async throws {
         // Given
         var expectedProductID: Int64?
-        let stores = MockStoresManager(sessionManager: .testingInstance)
         stores.whenReceivingAction(ofType: BlazeAction.self) { [weak self] action in
             guard let self = self else { return }
             switch action {
@@ -272,16 +230,7 @@ final class BlazeCampaignCreationFormViewModelTests: XCTestCase {
 
     func test_loadAISuggestions_sets_tagline_and_description_upon_success() async throws {
         // Given
-        let stores = MockStoresManager(sessionManager: .testingInstance)
-        stores.whenReceivingAction(ofType: BlazeAction.self) { [weak self] action in
-            guard let self = self else { return }
-            switch action {
-            case let .fetchAISuggestions(_, _, completion):
-                completion(.success(sampleAISuggestions))
-            default:
-                XCTFail("Unexpected action: \(action)")
-            }
-        }
+        mockAISuggestionsSuccess(sampleAISuggestions)
         let viewModel = BlazeCampaignCreationFormViewModel(siteID: sampleSiteID,
                                                            productID: sampleProductID,
                                                            stores: stores,
@@ -298,15 +247,7 @@ final class BlazeCampaignCreationFormViewModelTests: XCTestCase {
 
     func test_loadAISuggestions_sets_error_if_request_fails() async throws {
         // Given
-        let stores = MockStoresManager(sessionManager: .testingInstance)
-        stores.whenReceivingAction(ofType: BlazeAction.self) { action in
-            switch action {
-            case let .fetchAISuggestions(_, _, completion):
-                completion(.failure(MockError()))
-            default:
-                XCTFail("Unexpected action: \(action)")
-            }
-        }
+        mockDomainSuggestionsFailure(MockError())
         let viewModel = BlazeCampaignCreationFormViewModel(siteID: sampleSiteID,
                                                            productID: sampleProductID,
                                                            stores: stores,
@@ -321,15 +262,7 @@ final class BlazeCampaignCreationFormViewModelTests: XCTestCase {
 
     func test_loadAISuggestions_sets_error_if_no_suggestions_available() async throws {
         // Given
-        let stores = MockStoresManager(sessionManager: .testingInstance)
-        stores.whenReceivingAction(ofType: BlazeAction.self) { action in
-            switch action {
-            case let .fetchAISuggestions(_, _, completion):
-                completion(.success([]))
-            default:
-                XCTFail("Unexpected action: \(action)")
-            }
-        }
+        mockAISuggestionsSuccess([])
         let viewModel = BlazeCampaignCreationFormViewModel(siteID: sampleSiteID,
                                                            productID: sampleProductID,
                                                            stores: stores,
@@ -350,16 +283,7 @@ final class BlazeCampaignCreationFormViewModelTests: XCTestCase {
                                    productID: sampleProductID,
                                    statusKey: (ProductStatus.published.rawValue),
                                    images: [])) // Product has no image
-        let stores = MockStoresManager(sessionManager: .testingInstance)
-        stores.whenReceivingAction(ofType: BlazeAction.self) { [weak self] action in
-            guard let self = self else { return }
-            switch action {
-            case let .fetchAISuggestions(_, _, completion):
-                completion(.success(sampleAISuggestions))
-            default:
-                XCTFail("Unexpected action: \(action)")
-            }
-        }
+        mockAISuggestionsSuccess(sampleAISuggestions)
         let imageLoader = MockProductUIImageLoader()
 
         let viewModel = BlazeCampaignCreationFormViewModel(siteID: sampleSiteID,
@@ -385,16 +309,8 @@ final class BlazeCampaignCreationFormViewModelTests: XCTestCase {
                                    productID: sampleProductID,
                                    statusKey: (ProductStatus.published.rawValue),
                                    images: [.fake()]))
-        let stores = MockStoresManager(sessionManager: .testingInstance)
-        stores.whenReceivingAction(ofType: BlazeAction.self) { action in
-            switch action {
-            case let .fetchAISuggestions(_, _, completion):
-                completion(.success([BlazeAISuggestion(siteName: "", // Empty tagline
-                                                       textSnippet: "Description")]))
-            default:
-                XCTFail("Unexpected action: \(action)")
-            }
-        }
+        mockAISuggestionsSuccess([BlazeAISuggestion(siteName: "", // Empty tagline
+                                                    textSnippet: "Description")])
         let imageLoader = MockProductUIImageLoader()
         let sampleImage = UIImage.addOutlineImage
         imageLoader.requestImageStubbedResponse = sampleImage
@@ -422,16 +338,8 @@ final class BlazeCampaignCreationFormViewModelTests: XCTestCase {
                                    productID: sampleProductID,
                                    statusKey: (ProductStatus.published.rawValue),
                                    images: [.fake()]))
-        let stores = MockStoresManager(sessionManager: .testingInstance)
-        stores.whenReceivingAction(ofType: BlazeAction.self) { action in
-            switch action {
-            case let .fetchAISuggestions(_, _, completion):
-                completion(.success([BlazeAISuggestion(siteName: "Tagline",
-                                                       textSnippet: "")]))  // Empty description
-            default:
-                XCTFail("Unexpected action: \(action)")
-            }
-        }
+        mockAISuggestionsSuccess([BlazeAISuggestion(siteName: "Tagline",
+                                                   textSnippet: "")])  // Empty description
         let imageLoader = MockProductUIImageLoader()
         let sampleImage = UIImage.addOutlineImage
         imageLoader.requestImageStubbedResponse = sampleImage
@@ -489,5 +397,30 @@ private class MockProductUIImageLoader: ProductUIImageLoader {
 
     func requestImage(asset: PHAsset, targetSize: CGSize, skipsDegradedImage: Bool, completion: @escaping (UIImage) -> Void) {
         // no-op
+    }
+}
+
+private extension BlazeCampaignCreationFormViewModelTests {
+    func mockAISuggestionsSuccess(_ suggestions: [BlazeAISuggestion]) {
+        stores.whenReceivingAction(ofType: BlazeAction.self) { [weak self] action in
+            guard let self = self else { return }
+            switch action {
+            case let .fetchAISuggestions(_, _, completion):
+                completion(.success(suggestions))
+            default:
+                XCTFail("Unexpected action: \(action)")
+            }
+        }
+    }
+
+    func mockDomainSuggestionsFailure(_ error: Error) {
+        stores.whenReceivingAction(ofType: BlazeAction.self) { action in
+            switch action {
+            case let .fetchAISuggestions(_, _, completion):
+                completion(.failure(error))
+            default:
+                XCTFail("Unexpected action: \(action)")
+            }
+        }
     }
 }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Blaze/BlazeCampaignCreationFormViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Blaze/BlazeCampaignCreationFormViewModelTests.swift
@@ -21,6 +21,8 @@ final class BlazeCampaignCreationFormViewModelTests: XCTestCase {
                      images: [.fake().copy(imageID: 1)])
     }
 
+    private let sampleImage = UIImage.addOutlineImage
+
     private let sampleAISuggestions = [BlazeAISuggestion(siteName: "First suggested tagline", textSnippet: "First suggested description"),
                                        BlazeAISuggestion(siteName: "Second suggested tagline", textSnippet: "Second suggested description"),
                                        BlazeAISuggestion(siteName: "Third suggested tagline", textSnippet: "Third suggested description")]
@@ -35,10 +37,13 @@ final class BlazeCampaignCreationFormViewModelTests: XCTestCase {
 
     private var stores: MockStoresManager!
 
+    private var imageLoader: MockProductUIImageLoader!
+
     override func setUp() {
         super.setUp()
         storageManager = MockStorageManager()
         stores = MockStoresManager(sessionManager: .testingInstance)
+        imageLoader = MockProductUIImageLoader()
     }
 
     // MARK: Initial values
@@ -78,9 +83,7 @@ final class BlazeCampaignCreationFormViewModelTests: XCTestCase {
         // Given
         insertProduct(sampleProduct)
         mockAISuggestionsSuccess(sampleAISuggestions)
-        let imageLoader = MockProductUIImageLoader()
-        let sampleImage = UIImage.addOutlineImage
-        imageLoader.requestImageStubbedResponse = sampleImage
+        mockDownloadImage(sampleImage)
         let viewModel = BlazeCampaignCreationFormViewModel(siteID: sampleSiteID,
                                                            productID: sampleProductID,
                                                            stores: stores,
@@ -102,9 +105,7 @@ final class BlazeCampaignCreationFormViewModelTests: XCTestCase {
         // Given
         insertProduct(sampleProduct)
         mockAISuggestionsSuccess(sampleAISuggestions)
-        let imageLoader = MockProductUIImageLoader()
-        let sampleImage = UIImage.addOutlineImage
-        imageLoader.requestImageStubbedResponse = sampleImage
+        mockDownloadImage(sampleImage)
 
         let viewModel = BlazeCampaignCreationFormViewModel(siteID: sampleSiteID,
                                                            productID: sampleProductID,
@@ -128,9 +129,7 @@ final class BlazeCampaignCreationFormViewModelTests: XCTestCase {
         // Given
         insertProduct(sampleProduct)
         mockAISuggestionsSuccess(sampleAISuggestions)
-        let imageLoader = MockProductUIImageLoader()
-        let sampleImage = UIImage.addOutlineImage
-        imageLoader.requestImageStubbedResponse = sampleImage
+        mockDownloadImage(sampleImage)
 
         let viewModel = BlazeCampaignCreationFormViewModel(siteID: sampleSiteID,
                                                            productID: sampleProductID,
@@ -153,9 +152,7 @@ final class BlazeCampaignCreationFormViewModelTests: XCTestCase {
         // Given
         insertProduct(sampleProduct)
         mockDomainSuggestionsFailure(MockError())
-        let imageLoader = MockProductUIImageLoader()
-        let sampleImage = UIImage.addOutlineImage
-        imageLoader.requestImageStubbedResponse = sampleImage
+        mockDownloadImage(sampleImage)
 
         let viewModel = BlazeCampaignCreationFormViewModel(siteID: sampleSiteID,
                                                            productID: sampleProductID,
@@ -302,9 +299,7 @@ final class BlazeCampaignCreationFormViewModelTests: XCTestCase {
         insertProduct(sampleProduct)
         mockAISuggestionsSuccess([BlazeAISuggestion(siteName: "", // Empty tagline
                                                     textSnippet: "Description")])
-        let imageLoader = MockProductUIImageLoader()
-        let sampleImage = UIImage.addOutlineImage
-        imageLoader.requestImageStubbedResponse = sampleImage
+        mockDownloadImage(sampleImage)
 
         let viewModel = BlazeCampaignCreationFormViewModel(siteID: sampleSiteID,
                                                            productID: sampleProductID,
@@ -328,9 +323,7 @@ final class BlazeCampaignCreationFormViewModelTests: XCTestCase {
         insertProduct(sampleProduct)
         mockAISuggestionsSuccess([BlazeAISuggestion(siteName: "Tagline",
                                                    textSnippet: "")])  // Empty description
-        let imageLoader = MockProductUIImageLoader()
-        let sampleImage = UIImage.addOutlineImage
-        imageLoader.requestImageStubbedResponse = sampleImage
+        mockDownloadImage(sampleImage)
 
         let viewModel = BlazeCampaignCreationFormViewModel(siteID: sampleSiteID,
                                                            productID: sampleProductID,
@@ -410,5 +403,9 @@ private extension BlazeCampaignCreationFormViewModelTests {
                 XCTFail("Unexpected action: \(action)")
             }
         }
+    }
+
+    func mockDownloadImage(_ image: UIImage?) {
+        imageLoader.requestImageStubbedResponse = image
     }
 }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Blaze/BlazeCampaignCreationFormViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Blaze/BlazeCampaignCreationFormViewModelTests.swift
@@ -1,0 +1,493 @@
+import Photos
+import Combine
+import XCTest
+import Yosemite
+import protocol Storage.StorageManagerType
+import protocol Storage.StorageType
+@testable import WooCommerce
+import struct Networking.BlazeAISuggestion
+
+@MainActor
+final class BlazeCampaignCreationFormViewModelTests: XCTestCase {
+
+    private let sampleSiteID: Int64 = 322
+
+    private let sampleProductID: Int64 = 433
+
+    private let sampleAISuggestions = [BlazeAISuggestion(siteName: "First suggested tagline", textSnippet: "First suggested description"),
+                                       BlazeAISuggestion(siteName: "Second suggested tagline", textSnippet: "Second suggested description"),
+                                       BlazeAISuggestion(siteName: "Third suggested tagline", textSnippet: "Third suggested description")]
+
+    /// Mock Storage: InMemory
+    private var storageManager: StorageManagerType!
+
+    /// View storage for tests
+    private var storage: StorageType {
+        storageManager.viewStorage
+    }
+
+    override func setUp() {
+        super.setUp()
+        storageManager = MockStorageManager()
+    }
+
+    // MARK: Initial values
+    func test_image_is_empty_initially() async throws {
+        // Given
+        let viewModel = BlazeCampaignCreationFormViewModel(siteID: sampleSiteID,
+                                                           productID: sampleProductID,
+                                                           onCompletion: {})
+
+        // Then
+        XCTAssertNil(viewModel.image)
+    }
+
+    func test_tagline_is_empty_initially() async throws {
+        // Given
+        let viewModel = BlazeCampaignCreationFormViewModel(siteID: sampleSiteID,
+                                                           productID: sampleProductID,
+                                                           onCompletion: {})
+
+        // Then
+        XCTAssertEqual(viewModel.tagline, "")
+    }
+
+    func test_description_is_empty_initially() async throws {
+        // Given
+        let viewModel = BlazeCampaignCreationFormViewModel(siteID: sampleSiteID,
+                                                           productID: sampleProductID,
+                                                           onCompletion: {})
+
+        // Then
+        XCTAssertEqual(viewModel.description, "")
+    }
+
+    // MARK: Download product image
+
+    func test_it_reads_product_from_storage_for_displaying_image() async throws {
+        // Given
+        let sampleProductImage = ProductImage.fake().copy(imageID: 1)
+        insertProduct(.fake().copy(siteID: sampleSiteID,
+                                   productID: sampleProductID,
+                                   statusKey: (ProductStatus.published.rawValue),
+                                   images: [sampleProductImage]))
+        let stores = MockStoresManager(sessionManager: .testingInstance)
+        stores.whenReceivingAction(ofType: BlazeAction.self) { [weak self] action in
+            guard let self = self else { return }
+            switch action {
+            case let .fetchAISuggestions(_, _, completion):
+                completion(.success(sampleAISuggestions))
+            default:
+                XCTFail("Unexpected action: \(action)")
+            }
+        }
+        let imageLoader = MockProductUIImageLoader()
+        let sampleImage = UIImage.addOutlineImage
+        imageLoader.requestImageStubbedResponse = sampleImage
+        let viewModel = BlazeCampaignCreationFormViewModel(siteID: sampleSiteID,
+                                                           productID: sampleProductID,
+                                                           stores: stores,
+                                                           storage: storageManager,
+                                                           productImageLoader: imageLoader,
+                                                           onCompletion: {})
+
+        // When
+        await viewModel.downloadProductImage()
+
+        // Then
+        XCTAssertEqual(imageLoader.imageRequestedForProductImage, sampleProductImage)
+        XCTAssertEqual(viewModel.image?.image, sampleImage)
+    }
+
+    // MARK: `canEditAd`
+
+    func test_ad_cannot_be_edited_until_suggestions_are_loaded() async throws {
+        // Given
+        insertProduct(.fake().copy(siteID: sampleSiteID,
+                                   productID: sampleProductID,
+                                   statusKey: (ProductStatus.published.rawValue),
+                                   images: [.fake()]))
+        let stores = MockStoresManager(sessionManager: .testingInstance)
+        stores.whenReceivingAction(ofType: BlazeAction.self) { [weak self] action in
+            guard let self = self else { return }
+            switch action {
+            case let .fetchAISuggestions(_, _, completion):
+                completion(.success(sampleAISuggestions))
+            default:
+                XCTFail("Unexpected action: \(action)")
+            }
+        }
+        let imageLoader = MockProductUIImageLoader()
+        let sampleImage = UIImage.addOutlineImage
+        imageLoader.requestImageStubbedResponse = sampleImage
+
+        let viewModel = BlazeCampaignCreationFormViewModel(siteID: sampleSiteID,
+                                                           productID: sampleProductID,
+                                                           stores: stores,
+                                                           storage: storageManager,
+                                                           productImageLoader: imageLoader,
+                                                           onCompletion: {})
+
+        // Download product and ensure that ad cannot be edited
+        await viewModel.downloadProductImage()
+        XCTAssertFalse(viewModel.canEditAd)
+
+        // When
+        await viewModel.loadAISuggestions()
+
+        // Then
+        XCTAssertTrue(viewModel.canEditAd)
+    }
+
+    func test_ad_cannot_be_edited_until_image_is_downloaded() async throws {
+        // Given
+        insertProduct(.fake().copy(siteID: sampleSiteID,
+                                   productID: sampleProductID,
+                                   statusKey: (ProductStatus.published.rawValue),
+                                   images: [.fake()]))
+        let stores = MockStoresManager(sessionManager: .testingInstance)
+        stores.whenReceivingAction(ofType: BlazeAction.self) { [weak self] action in
+            guard let self = self else { return }
+            switch action {
+            case let .fetchAISuggestions(_, _, completion):
+                completion(.success(sampleAISuggestions))
+            default:
+                XCTFail("Unexpected action: \(action)")
+            }
+        }
+        let imageLoader = MockProductUIImageLoader()
+        let sampleImage = UIImage.addOutlineImage
+        imageLoader.requestImageStubbedResponse = sampleImage
+
+        let viewModel = BlazeCampaignCreationFormViewModel(siteID: sampleSiteID,
+                                                           productID: sampleProductID,
+                                                           stores: stores,
+                                                           storage: storageManager,
+                                                           productImageLoader: imageLoader,
+                                                           onCompletion: {})
+        // Load suggestions and ensure that ad cannot be edited
+        await viewModel.loadAISuggestions()
+        XCTAssertFalse(viewModel.canEditAd)
+
+        // When
+        await viewModel.downloadProductImage()
+
+        // Then
+        XCTAssertTrue(viewModel.canEditAd)
+    }
+
+    func test_ad_can_be_edited_if_suggestions_failed_to_load() async throws {
+        // Given
+        insertProduct(.fake().copy(siteID: sampleSiteID,
+                                   productID: sampleProductID,
+                                   statusKey: (ProductStatus.published.rawValue),
+                                   images: [.fake()]))
+        let stores = MockStoresManager(sessionManager: .testingInstance)
+        stores.whenReceivingAction(ofType: BlazeAction.self) { action in
+            switch action {
+            case let .fetchAISuggestions(_, _, completion):
+                completion(.failure(MockError()))
+            default:
+                XCTFail("Unexpected action: \(action)")
+            }
+        }
+        let imageLoader = MockProductUIImageLoader()
+        let sampleImage = UIImage.addOutlineImage
+        imageLoader.requestImageStubbedResponse = sampleImage
+
+        let viewModel = BlazeCampaignCreationFormViewModel(siteID: sampleSiteID,
+                                                           productID: sampleProductID,
+                                                           stores: stores,
+                                                           storage: storageManager,
+                                                           productImageLoader: imageLoader,
+                                                           onCompletion: {})
+        await viewModel.downloadProductImage()
+
+        // When
+        await viewModel.loadAISuggestions()
+
+        // Then
+        XCTAssertTrue(viewModel.canEditAd)
+    }
+
+    func test_ad_can_be_edited_when_product_has_no_image() async throws {
+        // Given
+        insertProduct(.fake().copy(siteID: sampleSiteID,
+                                   productID: sampleProductID,
+                                   statusKey: (ProductStatus.published.rawValue),
+                                   images: [])) // Product has no image
+        let stores = MockStoresManager(sessionManager: .testingInstance)
+        stores.whenReceivingAction(ofType: BlazeAction.self) { [weak self] action in
+            guard let self = self else { return }
+            switch action {
+            case let .fetchAISuggestions(_, _, completion):
+                completion(.success(sampleAISuggestions))
+            default:
+                XCTFail("Unexpected action: \(action)")
+            }
+        }
+        let imageLoader = MockProductUIImageLoader()
+        let viewModel = BlazeCampaignCreationFormViewModel(siteID: sampleSiteID,
+                                                           productID: sampleProductID,
+                                                           stores: stores,
+                                                           storage: storageManager,
+                                                           productImageLoader: imageLoader,
+                                                           onCompletion: {})
+        await viewModel.loadAISuggestions()
+
+        // When
+        await viewModel.downloadProductImage()
+
+        // Then
+        XCTAssertTrue(viewModel.canEditAd)
+    }
+
+    // MARK: Load AI suggestions
+
+    func test_loadAISuggestions_sends_correct_product_ID_to_fetch() async throws {
+        // Given
+        var expectedProductID: Int64?
+        let stores = MockStoresManager(sessionManager: .testingInstance)
+        stores.whenReceivingAction(ofType: BlazeAction.self) { [weak self] action in
+            guard let self = self else { return }
+            switch action {
+            case let .fetchAISuggestions(_, productID, completion):
+                expectedProductID = productID
+                completion(.success(sampleAISuggestions))
+            default:
+                XCTFail("Unexpected action: \(action)")
+            }
+        }
+        let viewModel = BlazeCampaignCreationFormViewModel(siteID: sampleSiteID,
+                                                           productID: sampleProductID,
+                                                           stores: stores,
+                                                           onCompletion: {})
+
+        // When
+        await viewModel.loadAISuggestions()
+
+        // Then
+        XCTAssertEqual(expectedProductID, sampleProductID)
+    }
+
+    func test_loadAISuggestions_sets_tagline_and_description_upon_success() async throws {
+        // Given
+        let stores = MockStoresManager(sessionManager: .testingInstance)
+        stores.whenReceivingAction(ofType: BlazeAction.self) { [weak self] action in
+            guard let self = self else { return }
+            switch action {
+            case let .fetchAISuggestions(_, _, completion):
+                completion(.success(sampleAISuggestions))
+            default:
+                XCTFail("Unexpected action: \(action)")
+            }
+        }
+        let viewModel = BlazeCampaignCreationFormViewModel(siteID: sampleSiteID,
+                                                           productID: sampleProductID,
+                                                           stores: stores,
+                                                           onCompletion: {})
+
+        // When
+        await viewModel.loadAISuggestions()
+
+        // Then
+        let firstSuggestion = try XCTUnwrap(sampleAISuggestions.first)
+        XCTAssertEqual(viewModel.tagline, firstSuggestion.siteName)
+        XCTAssertEqual(viewModel.description, firstSuggestion.textSnippet)
+    }
+
+    func test_loadAISuggestions_sets_error_if_request_fails() async throws {
+        // Given
+        let stores = MockStoresManager(sessionManager: .testingInstance)
+        stores.whenReceivingAction(ofType: BlazeAction.self) { action in
+            switch action {
+            case let .fetchAISuggestions(_, _, completion):
+                completion(.failure(MockError()))
+            default:
+                XCTFail("Unexpected action: \(action)")
+            }
+        }
+        let viewModel = BlazeCampaignCreationFormViewModel(siteID: sampleSiteID,
+                                                           productID: sampleProductID,
+                                                           stores: stores,
+                                                           onCompletion: {})
+
+        // When
+        await viewModel.loadAISuggestions()
+
+        // Then
+        XCTAssertEqual(viewModel.error, .failedToLoadAISuggestions)
+    }
+
+    func test_loadAISuggestions_sets_error_if_no_suggestions_available() async throws {
+        // Given
+        let stores = MockStoresManager(sessionManager: .testingInstance)
+        stores.whenReceivingAction(ofType: BlazeAction.self) { action in
+            switch action {
+            case let .fetchAISuggestions(_, _, completion):
+                completion(.success([]))
+            default:
+                XCTFail("Unexpected action: \(action)")
+            }
+        }
+        let viewModel = BlazeCampaignCreationFormViewModel(siteID: sampleSiteID,
+                                                           productID: sampleProductID,
+                                                           stores: stores,
+                                                           onCompletion: {})
+
+        // When
+        await viewModel.loadAISuggestions()
+
+        // Then
+        XCTAssertEqual(viewModel.error, .failedToLoadAISuggestions)
+    }
+
+    // MARK: `canConfirmDetails`
+
+    func test_ad_cannot_be_confirmed_if_image_is_nil() async throws {
+        // Given
+        insertProduct(.fake().copy(siteID: sampleSiteID,
+                                   productID: sampleProductID,
+                                   statusKey: (ProductStatus.published.rawValue),
+                                   images: [])) // Product has no image
+        let stores = MockStoresManager(sessionManager: .testingInstance)
+        stores.whenReceivingAction(ofType: BlazeAction.self) { [weak self] action in
+            guard let self = self else { return }
+            switch action {
+            case let .fetchAISuggestions(_, _, completion):
+                completion(.success(sampleAISuggestions))
+            default:
+                XCTFail("Unexpected action: \(action)")
+            }
+        }
+        let imageLoader = MockProductUIImageLoader()
+
+        let viewModel = BlazeCampaignCreationFormViewModel(siteID: sampleSiteID,
+                                                           productID: sampleProductID,
+                                                           stores: stores,
+                                                           storage: storageManager,
+                                                           productImageLoader: imageLoader,
+                                                           onCompletion: {})
+        // Load suggestions to set tagline and description
+        await viewModel.loadAISuggestions()
+
+        // When
+        await viewModel.downloadProductImage()
+
+        // Then
+        XCTAssertNil(viewModel.image)
+        XCTAssertFalse(viewModel.canConfirmDetails)
+    }
+
+    func test_ad_cannot_be_confirmed_if_tagline_is_empty() async throws {
+        // Given
+        insertProduct(.fake().copy(siteID: sampleSiteID,
+                                   productID: sampleProductID,
+                                   statusKey: (ProductStatus.published.rawValue),
+                                   images: [.fake()]))
+        let stores = MockStoresManager(sessionManager: .testingInstance)
+        stores.whenReceivingAction(ofType: BlazeAction.self) { action in
+            switch action {
+            case let .fetchAISuggestions(_, _, completion):
+                completion(.success([BlazeAISuggestion(siteName: "", // Empty tagline
+                                                       textSnippet: "Description")]))
+            default:
+                XCTFail("Unexpected action: \(action)")
+            }
+        }
+        let imageLoader = MockProductUIImageLoader()
+        let sampleImage = UIImage.addOutlineImage
+        imageLoader.requestImageStubbedResponse = sampleImage
+
+        let viewModel = BlazeCampaignCreationFormViewModel(siteID: sampleSiteID,
+                                                           productID: sampleProductID,
+                                                           stores: stores,
+                                                           storage: storageManager,
+                                                           productImageLoader: imageLoader,
+                                                           onCompletion: {})
+        // Sets non-nil product image
+        await viewModel.downloadProductImage()
+
+        // Load suggestion with empty tagline
+        await viewModel.loadAISuggestions()
+
+        // Then
+        XCTAssertTrue(viewModel.tagline.isEmpty)
+        XCTAssertFalse(viewModel.canConfirmDetails)
+    }
+
+    func test_ad_cannot_be_confirmed_if_description_is_empty() async throws {
+        // Given
+        insertProduct(.fake().copy(siteID: sampleSiteID,
+                                   productID: sampleProductID,
+                                   statusKey: (ProductStatus.published.rawValue),
+                                   images: [.fake()]))
+        let stores = MockStoresManager(sessionManager: .testingInstance)
+        stores.whenReceivingAction(ofType: BlazeAction.self) { action in
+            switch action {
+            case let .fetchAISuggestions(_, _, completion):
+                completion(.success([BlazeAISuggestion(siteName: "Tagline",
+                                                       textSnippet: "")]))  // Empty description
+            default:
+                XCTFail("Unexpected action: \(action)")
+            }
+        }
+        let imageLoader = MockProductUIImageLoader()
+        let sampleImage = UIImage.addOutlineImage
+        imageLoader.requestImageStubbedResponse = sampleImage
+
+        let viewModel = BlazeCampaignCreationFormViewModel(siteID: sampleSiteID,
+                                                           productID: sampleProductID,
+                                                           stores: stores,
+                                                           storage: storageManager,
+                                                           productImageLoader: imageLoader,
+                                                           onCompletion: {})
+        // Sets non-nil product image
+        await viewModel.downloadProductImage()
+
+        // Load suggestion with empty description
+        await viewModel.loadAISuggestions()
+
+        // Then
+        XCTAssertTrue(viewModel.description.isEmpty)
+        XCTAssertFalse(viewModel.canConfirmDetails)
+    }
+}
+
+private extension BlazeCampaignCreationFormViewModelTests {
+    /// Insert a `Product` into storage.
+    /// 
+    func insertProduct(_ readOnlyProduct: Product) {
+        let product = storage.insertNewObject(ofType: StorageProduct.self)
+        product.update(with: readOnlyProduct)
+
+        for readOnlyImage in readOnlyProduct.images {
+            let productImage = storage.insertNewObject(ofType: StorageProductImage.self)
+            productImage.update(with: readOnlyImage)
+            productImage.product = product
+        }
+        storage.saveIfNeeded()
+    }
+
+    final class MockError: Error { }
+}
+
+private class MockProductUIImageLoader: ProductUIImageLoader {
+    var imageRequestedForProductImage: Yosemite.ProductImage?
+    var requestImageStubbedResponse: UIImage?
+    func requestImage(productImage: Yosemite.ProductImage, completion: @escaping (UIImage) -> Void) -> Cancellable? {
+        imageRequestedForProductImage = productImage
+        if let requestImageStubbedResponse {
+            completion(requestImageStubbedResponse)
+        }
+        return nil
+    }
+
+    func requestImage(asset: PHAsset, targetSize: CGSize, completion: @escaping (UIImage) -> Void) {
+        // no-op
+    }
+
+    func requestImage(asset: PHAsset, targetSize: CGSize, skipsDegradedImage: Bool, completion: @escaping (UIImage) -> Void) {
+        // no-op
+    }
+}

--- a/WooCommerce/WooCommerceTests/ViewRelated/Blaze/BlazeCampaignCreationFormViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Blaze/BlazeCampaignCreationFormViewModelTests.swift
@@ -14,6 +14,13 @@ final class BlazeCampaignCreationFormViewModelTests: XCTestCase {
 
     private let sampleProductID: Int64 = 433
 
+    private var sampleProduct: Product {
+        .fake().copy(siteID: sampleSiteID,
+                     productID: sampleProductID,
+                     statusKey: (ProductStatus.published.rawValue),
+                     images: [.fake().copy(imageID: 1)])
+    }
+
     private let sampleAISuggestions = [BlazeAISuggestion(siteName: "First suggested tagline", textSnippet: "First suggested description"),
                                        BlazeAISuggestion(siteName: "Second suggested tagline", textSnippet: "Second suggested description"),
                                        BlazeAISuggestion(siteName: "Third suggested tagline", textSnippet: "Third suggested description")]
@@ -69,11 +76,7 @@ final class BlazeCampaignCreationFormViewModelTests: XCTestCase {
 
     func test_it_reads_product_from_storage_for_displaying_image() async throws {
         // Given
-        let sampleProductImage = ProductImage.fake().copy(imageID: 1)
-        insertProduct(.fake().copy(siteID: sampleSiteID,
-                                   productID: sampleProductID,
-                                   statusKey: (ProductStatus.published.rawValue),
-                                   images: [sampleProductImage]))
+        insertProduct(sampleProduct)
         mockAISuggestionsSuccess(sampleAISuggestions)
         let imageLoader = MockProductUIImageLoader()
         let sampleImage = UIImage.addOutlineImage
@@ -89,7 +92,7 @@ final class BlazeCampaignCreationFormViewModelTests: XCTestCase {
         await viewModel.downloadProductImage()
 
         // Then
-        XCTAssertEqual(imageLoader.imageRequestedForProductImage, sampleProductImage)
+        XCTAssertEqual(imageLoader.imageRequestedForProductImage?.imageID, sampleProduct.images.first?.imageID)
         XCTAssertEqual(viewModel.image?.image, sampleImage)
     }
 
@@ -97,10 +100,7 @@ final class BlazeCampaignCreationFormViewModelTests: XCTestCase {
 
     func test_ad_cannot_be_edited_until_suggestions_are_loaded() async throws {
         // Given
-        insertProduct(.fake().copy(siteID: sampleSiteID,
-                                   productID: sampleProductID,
-                                   statusKey: (ProductStatus.published.rawValue),
-                                   images: [.fake()]))
+        insertProduct(sampleProduct)
         mockAISuggestionsSuccess(sampleAISuggestions)
         let imageLoader = MockProductUIImageLoader()
         let sampleImage = UIImage.addOutlineImage
@@ -126,10 +126,7 @@ final class BlazeCampaignCreationFormViewModelTests: XCTestCase {
 
     func test_ad_cannot_be_edited_until_image_is_downloaded() async throws {
         // Given
-        insertProduct(.fake().copy(siteID: sampleSiteID,
-                                   productID: sampleProductID,
-                                   statusKey: (ProductStatus.published.rawValue),
-                                   images: [.fake()]))
+        insertProduct(sampleProduct)
         mockAISuggestionsSuccess(sampleAISuggestions)
         let imageLoader = MockProductUIImageLoader()
         let sampleImage = UIImage.addOutlineImage
@@ -154,10 +151,7 @@ final class BlazeCampaignCreationFormViewModelTests: XCTestCase {
 
     func test_ad_can_be_edited_if_suggestions_failed_to_load() async throws {
         // Given
-        insertProduct(.fake().copy(siteID: sampleSiteID,
-                                   productID: sampleProductID,
-                                   statusKey: (ProductStatus.published.rawValue),
-                                   images: [.fake()]))
+        insertProduct(sampleProduct)
         mockDomainSuggestionsFailure(MockError())
         let imageLoader = MockProductUIImageLoader()
         let sampleImage = UIImage.addOutlineImage
@@ -305,10 +299,7 @@ final class BlazeCampaignCreationFormViewModelTests: XCTestCase {
 
     func test_ad_cannot_be_confirmed_if_tagline_is_empty() async throws {
         // Given
-        insertProduct(.fake().copy(siteID: sampleSiteID,
-                                   productID: sampleProductID,
-                                   statusKey: (ProductStatus.published.rawValue),
-                                   images: [.fake()]))
+        insertProduct(sampleProduct)
         mockAISuggestionsSuccess([BlazeAISuggestion(siteName: "", // Empty tagline
                                                     textSnippet: "Description")])
         let imageLoader = MockProductUIImageLoader()
@@ -334,10 +325,7 @@ final class BlazeCampaignCreationFormViewModelTests: XCTestCase {
 
     func test_ad_cannot_be_confirmed_if_description_is_empty() async throws {
         // Given
-        insertProduct(.fake().copy(siteID: sampleSiteID,
-                                   productID: sampleProductID,
-                                   statusKey: (ProductStatus.published.rawValue),
-                                   images: [.fake()]))
+        insertProduct(sampleProduct)
         mockAISuggestionsSuccess([BlazeAISuggestion(siteName: "Tagline",
                                                    textSnippet: "")])  // Empty description
         let imageLoader = MockProductUIImageLoader()

--- a/WooCommerce/WooCommerceTests/ViewRelated/Blaze/BlazeCampaignCreationFormViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Blaze/BlazeCampaignCreationFormViewModelTests.swift
@@ -176,7 +176,7 @@ final class BlazeCampaignCreationFormViewModelTests: XCTestCase {
                                    statusKey: (ProductStatus.published.rawValue),
                                    images: [])) // Product has no image
         mockAISuggestionsSuccess(sampleAISuggestions)
-        let imageLoader = MockProductUIImageLoader()
+
         let viewModel = BlazeCampaignCreationFormViewModel(siteID: sampleSiteID,
                                                            productID: sampleProductID,
                                                            stores: stores,
@@ -275,7 +275,6 @@ final class BlazeCampaignCreationFormViewModelTests: XCTestCase {
                                    statusKey: (ProductStatus.published.rawValue),
                                    images: [])) // Product has no image
         mockAISuggestionsSuccess(sampleAISuggestions)
-        let imageLoader = MockProductUIImageLoader()
 
         let viewModel = BlazeCampaignCreationFormViewModel(siteID: sampleSiteID,
                                                            productID: sampleProductID,

--- a/WooCommerce/WooCommerceTests/ViewRelated/Blaze/BlazeCampaignCreationFormViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Blaze/BlazeCampaignCreationFormViewModelTests.swift
@@ -382,8 +382,7 @@ private class MockProductUIImageLoader: ProductUIImageLoader {
 
 private extension BlazeCampaignCreationFormViewModelTests {
     func mockAISuggestionsSuccess(_ suggestions: [BlazeAISuggestion]) {
-        stores.whenReceivingAction(ofType: BlazeAction.self) { [weak self] action in
-            guard let self = self else { return }
+        stores.whenReceivingAction(ofType: BlazeAction.self) { action in
             switch action {
             case let .fetchAISuggestions(_, _, completion):
                 completion(.success(suggestions))

--- a/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Blaze/BlazeCampaignDashboardViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Blaze/BlazeCampaignDashboardViewModelTests.swift
@@ -721,7 +721,7 @@ final class BlazeCampaignDashboardViewModelTests: XCTestCase {
 
         // Then
         let product = try XCTUnwrap(viewModel.latestPublishedProduct)
-        XCTAssertEqual(viewModel.latestPublishedProduct?.productID, 3)
+        XCTAssertEqual(product.productID, 3)
     }
 
     func test_latestPublishedProduct_is_nil_when_no_published_product_available() throws {

--- a/Yosemite/Yosemite/Actions/BlazeAction.swift
+++ b/Yosemite/Yosemite/Actions/BlazeAction.swift
@@ -98,5 +98,5 @@ public enum BlazeAction: Action {
     ///
     case fetchAISuggestions(siteID: Int64,
                             productID: Int64,
-                              onCompletion: (Result<[BlazeAISuggestion], Error>) -> Void)
+                            onCompletion: (Result<[BlazeAISuggestion], Error>) -> Void)
 }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #11652 
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
This PR covers edge cases in the Blaze campaign edit flow. It also adds an initial round of unit tests for `BlazeCampaignCreationFormViewModel`. 

**Changes**
- Made the image optional in the Blaze campaign edit screen to allow creating a campaign for a product with no image.
- The `BlazeEditAdViewModel` is no longer optional as the edit screen can be displayed even if image is nil. 
- Add unit tests for `BlazeCampaignCreationFormViewModel`

## Testing instructions
- Follow instructions from #11658 and test that the flow works as before.
- Additionally, test with a product with no image. You should be able to pick an image for the campaign.

## Screenshots


https://github.com/woocommerce/woocommerce-ios/assets/524475/2a90bffb-9052-44d1-867d-9cd514622f3c



---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.