### PR TITLE
[Tablet Orders] Update order list disclosure indicator

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Orders/Cells/OrderListCellViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Cells/OrderListCellViewModel.swift
@@ -58,6 +58,17 @@ struct OrderListCellViewModel {
     var statusString: String {
         return orderStatus?.name ?? order.status.rawValue
     }
+
+    /// Accessory view that renders the cell's disclosure indicator
+    ///
+    var accessoryView: UIImageView? {
+        guard let image = UIImage(systemName: "chevron.right") else {
+            return nil
+        }
+        let accessoryView = UIImageView(image: image, highlightedImage: nil)
+        accessoryView.tintColor = .tertiaryLabel
+        return accessoryView
+    }
 }
 
 // MARK: - Constants

--- a/WooCommerce/Classes/ViewRelated/Orders/Cells/OrderTableViewCell.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Cells/OrderTableViewCell.swift
@@ -53,6 +53,9 @@ final class OrderTableViewCell: UITableViewCell & SearchResultCell {
         paymentStatusLabel.applyStyle(for: viewModel.status)
         paymentStatusLabel.text = viewModel.statusString
 
+        accessoryType = .none
+        accessoryView = viewModel.accessoryView
+
         // From iOS 15.0, a focus effect will be applied automatically to a selected cell
         // modifying its style (e.g: by adding a border)
         focusEffect = nil

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/OrderListCellViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/OrderListCellViewModelTests.swift
@@ -61,4 +61,20 @@ final class OrderListCellViewModelTests: XCTestCase {
         XCTAssertEqual(viewModel.status, order.status)
         XCTAssertEqual(viewModel.statusString, order.status.rawValue)
     }
+
+    func test_OrderListCell_accessoryView_uses_chevron_with_tertiaryLabel_tint_as_disclosure_indicator() {
+        // Given
+        let order = MockOrders().sampleOrder()
+        let expectedImage = UIImage(systemName: "chevron.right")
+
+        // When
+        let viewModel = OrderListCellViewModel(order: order, status: nil)
+
+        // Then
+        guard let accessoryView = viewModel.accessoryView else {
+            return XCTFail("Cell does not have an accessory view.")
+        }
+        XCTAssertEqual(accessoryView.image, expectedImage)
+        XCTAssertEqual(accessoryView.tintColor, .tertiaryLabel)
+    }
 }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #11679
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
This PR updates the disclosure indicator shown in the `OrderTableViewCell` in order to match the designs for tablet support. Figma: 6kkCwI9VOEYcidp6UT5bln-fi-192_26616 . This is necessary because the default chevron we were using up until now is not visible after we've changed the background colour to `wooPurple`.

<img width="800" alt="20240115-chevron-design-update" src="https://github.com/woocommerce/woocommerce-ios/assets/3812076/4b775f75-6f74-4a16-8f3e-f42f6bb9ef6b">

## Changes:
* We set the cell's `accessoryType` from the default `.disclosureIndicator` to `.none`
* We set the cell's `accessoryView` to the chevron SFSymbol with the `tertiaryLabel` tint applied to it.

| Before | After |
|--------|--------|
| ![20240115-chevron-design-update_before](https://github.com/woocommerce/woocommerce-ios/assets/3812076/2988a66b-309c-4d3a-8e31-c2fdadf582bb) | ![Simulator Screenshot - iPad Pro (12 9-inch) (6th generation) - 2024-01-15 at 14 04 00](https://github.com/woocommerce/woocommerce-ios/assets/3812076/233e9bae-0b08-4481-bea2-8795e628b1e4) | 

## Testing instructions
* Switch the `.splitViewInOrdersTab` feature flag to `true`
* Run the app on a simulator or device that support split views. eg: `iPad Pro 12.9 inch`
* Observe that the chevron is visible when the cell is selected