### PR TITLE
[Mobile Payments] Pass gateway ID to existing IPP onboarding Tracks events

### DIFF
--- a/WooCommerce/Classes/Analytics/WooAnalyticsEvent.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsEvent.swift
@@ -1907,6 +1907,18 @@ extension WooAnalyticsEvent {
                               ])
         }
 
+        /// Tracked when the In-Person Payments onboarding completes.
+        ///
+        /// - Parameters:
+        ///   - gatewayID: the plugin (e.g. "woocommerce-payments" or "woocommerce-gateway-stripe") to be included in the event properties in Tracks.
+        ///
+        static func cardPresentOnboardingCompleted(gatewayID paymentGatewayID: String?) -> WooAnalyticsEvent {
+            WooAnalyticsEvent(statName: .cardPresentOnboardingCompleted,
+                              properties: [
+                                Keys.gatewayID: gatewayID(forGatewayID: paymentGatewayID)
+                              ])
+        }
+
         /// Tracked when the In-Person Payments onboarding cannot be completed for some reason.
         ///
         /// - Parameters:

--- a/WooCommerce/Classes/Analytics/WooAnalyticsEvent.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsEvent.swift
@@ -1924,12 +1924,14 @@ extension WooAnalyticsEvent {
         /// - Parameters:
         ///   - reason: the reason why the onboarding is not completed.
         ///   - countryCode: the country code of the store.
+        ///   - gatewayID: the plugin (e.g. "woocommerce-payments" or "woocommerce-gateway-stripe") to be included in the event properties in Tracks.
         ///
-        static func cardPresentOnboardingNotCompleted(reason: String, countryCode: CountryCode) -> WooAnalyticsEvent {
+        static func cardPresentOnboardingNotCompleted(reason: String, countryCode: CountryCode, gatewayID paymentGatewayID: String?) -> WooAnalyticsEvent {
             WooAnalyticsEvent(statName: .cardPresentOnboardingNotCompleted,
                               properties: [
                                 Keys.countryCode: countryCode.rawValue,
-                                Keys.reason: reason
+                                Keys.reason: reason,
+                                Keys.gatewayID: gatewayID(forGatewayID: paymentGatewayID)
                               ])
         }
 

--- a/WooCommerce/Classes/Analytics/WooAnalyticsEvent.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsEvent.swift
@@ -1962,12 +1962,16 @@ extension WooAnalyticsEvent {
         /// - Parameters:
         ///   - reason: the reason why the onboarding step was shown (effectively the name of the step.)
         ///   - countryCode: the country code of the store.
+        ///   - gatewayID: the plugin (e.g. "woocommerce-payments" or "woocommerce-gateway-stripe") to be included in the event properties in Tracks.
         ///
-        static func cardPresentOnboardingCtaTapped(reason: String, countryCode: CountryCode) -> WooAnalyticsEvent {
+        static func cardPresentOnboardingCtaTapped(reason: String,
+                                                   countryCode: CountryCode,
+                                                   gatewayID paymentGatewayID: String?) -> WooAnalyticsEvent {
             WooAnalyticsEvent(statName: .cardPresentOnboardingCtaTapped,
                               properties: [
                                 Keys.countryCode: countryCode.rawValue,
-                                Keys.reason: reason
+                                Keys.reason: reason,
+                                Keys.gatewayID: gatewayID(forGatewayID: paymentGatewayID)
                               ])
         }
 

--- a/WooCommerce/Classes/Analytics/WooAnalyticsEvent.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsEvent.swift
@@ -1957,7 +1957,8 @@ extension WooAnalyticsEvent {
                               properties: [
                                 Keys.countryCode: countryCode.rawValue,
                                 Keys.reason: reason,
-                                Keys.remindLater: remindLater
+                                Keys.remindLater: remindLater,
+                                Keys.gatewayID: gatewayID(forGatewayID: paymentGatewayID)
                               ])
         }
 

--- a/WooCommerce/Classes/Analytics/WooAnalyticsEvent.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsEvent.swift
@@ -1981,12 +1981,17 @@ extension WooAnalyticsEvent {
         ///   - reason: the reason why the onboarding step was shown (effectively the name of the step)
         ///   - countryCode: the country code of the store
         ///   - error: the logged error response from the API, if any.
+        ///   - gatewayID: the plugin (e.g. "woocommerce-payments" or "woocommerce-gateway-stripe") to be included in the event properties in Tracks.
         ///
-        static func cardPresentOnboardingCtaFailed(reason: String, countryCode: CountryCode, error: Error? = nil) -> WooAnalyticsEvent {
+        static func cardPresentOnboardingCtaFailed(reason: String,
+                                                   countryCode: CountryCode,
+                                                   error: Error? = nil,
+                                                   gatewayID paymentGatewayID: String?) -> WooAnalyticsEvent {
             WooAnalyticsEvent(statName: .cardPresentOnboardingCtaFailed,
                               properties: [
                                 Keys.countryCode: countryCode.rawValue,
                                 Keys.reason: reason,
+                                Keys.gatewayID: gatewayID(forGatewayID: paymentGatewayID)
                               ], error: error)
         }
 

--- a/WooCommerce/Classes/Analytics/WooAnalyticsEvent.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsEvent.swift
@@ -1947,8 +1947,12 @@ extension WooAnalyticsEvent {
         ///   - reason: the reason why the onboarding step was shown (effectively the name of the step.)
         ///   - remindLater: whether the user will see this onboarding step again
         ///   - countryCode: the country code of the store.
+        ///   - gatewayID: the plugin (e.g. "woocommerce-payments" or "woocommerce-gateway-stripe") to be included in the event properties in Tracks.
         ///
-        static func cardPresentOnboardingStepSkipped(reason: String, remindLater: Bool, countryCode: CountryCode) -> WooAnalyticsEvent {
+        static func cardPresentOnboardingStepSkipped(reason: String,
+                                                     remindLater: Bool,
+                                                     countryCode: CountryCode,
+                                                     gatewayID paymentGatewayID: String?) -> WooAnalyticsEvent {
             WooAnalyticsEvent(statName: .cardPresentOnboardingStepSkipped,
                               properties: [
                                 Keys.countryCode: countryCode.rawValue,

--- a/WooCommerce/Classes/Analytics/WooAnalyticsEvent.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsEvent.swift
@@ -1897,13 +1897,19 @@ extension WooAnalyticsEvent {
 
         /// Tracked when the "learn more" button in the In-Person Payments onboarding is tapped.
         ///
-        /// - Parameter countryCode: the country code of the store.
+        /// - Parameters:
+        ///   - reason: the reason for viewing the learn more page.
+        ///   - countryCode: the country code of the store.
+        ///   - gatewayID: the plugin (e.g. "woocommerce-payments" or "woocommerce-gateway-stripe") to be included in the event properties in Tracks.
         ///
-        static func cardPresentOnboardingLearnMoreTapped(reason: String, countryCode: CountryCode) -> WooAnalyticsEvent {
+        static func cardPresentOnboardingLearnMoreTapped(reason: String,
+                                                         countryCode: CountryCode,
+                                                         gatewayID paymentGatewayID: String?) -> WooAnalyticsEvent {
             WooAnalyticsEvent(statName: .cardPresentOnboardingLearnMoreTapped,
                               properties: [
                                 Keys.countryCode: countryCode.rawValue,
-                                Keys.reason: reason
+                                Keys.reason: reason,
+                                Keys.gatewayID: gatewayID(forGatewayID: paymentGatewayID)
                               ])
         }
 

--- a/WooCommerce/Classes/Analytics/WooAnalyticsEvent.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsEvent.swift
@@ -1365,7 +1365,7 @@ extension WooAnalyticsEvent {
 
         static let unknownGatewayID = "unknown"
 
-        static func gatewayID(forGatewayID gatewayID: String?) -> String {
+        private static func safeGatewayID(for gatewayID: String?) -> String {
             gatewayID ?? unknownGatewayID
         }
 
@@ -1386,7 +1386,7 @@ extension WooAnalyticsEvent {
             WooAnalyticsEvent(statName: .cardReaderSelectTypeShown,
                               properties: [
                                 Keys.countryCode: countryCode.rawValue,
-                                Keys.gatewayID: gatewayID(forGatewayID: forGatewayID)
+                                Keys.gatewayID: safeGatewayID(for: forGatewayID)
                               ]
             )
         }
@@ -1402,7 +1402,7 @@ extension WooAnalyticsEvent {
             WooAnalyticsEvent(statName: .cardReaderSelectTypeBuiltInTapped,
                               properties: [
                                 Keys.countryCode: countryCode.rawValue,
-                                Keys.gatewayID: gatewayID(forGatewayID: forGatewayID)
+                                Keys.gatewayID: safeGatewayID(for: forGatewayID)
                               ]
             )
         }
@@ -1418,7 +1418,7 @@ extension WooAnalyticsEvent {
             WooAnalyticsEvent(statName: .cardReaderSelectTypeBluetoothTapped,
                               properties: [
                                 Keys.countryCode: countryCode.rawValue,
-                                Keys.gatewayID: gatewayID(forGatewayID: forGatewayID)
+                                Keys.gatewayID: safeGatewayID(for: forGatewayID)
                               ]
             )
         }
@@ -1433,7 +1433,7 @@ extension WooAnalyticsEvent {
             WooAnalyticsEvent(statName: .manageCardReadersBuiltInReaderAutoDisconnect,
                               properties: [
                                 Keys.countryCode: countryCode.rawValue,
-                                Keys.gatewayID: gatewayID(forGatewayID: forGatewayID)
+                                Keys.gatewayID: safeGatewayID(for: forGatewayID)
                               ]
             )
         }
@@ -1452,7 +1452,7 @@ extension WooAnalyticsEvent {
                               properties: [
                                 Keys.cardReaderModel: readerModel(for: cardReaderModel),
                                 Keys.countryCode: countryCode.rawValue,
-                                Keys.gatewayID: gatewayID(forGatewayID: forGatewayID),
+                                Keys.gatewayID: safeGatewayID(for: forGatewayID),
                                 Keys.connectionType: connectionType
                               ]
             )
@@ -1473,7 +1473,7 @@ extension WooAnalyticsEvent {
             WooAnalyticsEvent(statName: .cardReaderDiscoveryFailed,
                               properties: [
                                 Keys.countryCode: countryCode.rawValue,
-                                Keys.gatewayID: gatewayID(forGatewayID: forGatewayID),
+                                Keys.gatewayID: safeGatewayID(for: forGatewayID),
                                 Keys.errorDescription: error.localizedDescription,
                                 Keys.siteID: siteID,
                                 Keys.connectionType: connectionType
@@ -1497,7 +1497,7 @@ extension WooAnalyticsEvent {
             var properties = [
                 Keys.cardReaderModel: readerModel(for: cardReaderModel),
                 Keys.countryCode: countryCode.rawValue,
-                Keys.gatewayID: gatewayID(forGatewayID: forGatewayID),
+                Keys.gatewayID: safeGatewayID(for: forGatewayID),
                 Keys.connectionType: connectionType
             ]
 
@@ -1526,7 +1526,7 @@ extension WooAnalyticsEvent {
                               properties: [
                                 Keys.cardReaderModel: readerModel(for: cardReaderModel),
                                 Keys.countryCode: countryCode.rawValue,
-                                Keys.gatewayID: gatewayID(forGatewayID: forGatewayID),
+                                Keys.gatewayID: safeGatewayID(for: forGatewayID),
                                 Keys.errorDescription: error.localizedDescription,
                                 Keys.siteID: siteID,
                                 Keys.connectionType: connectionType
@@ -1547,7 +1547,7 @@ extension WooAnalyticsEvent {
                               properties: [
                                 Keys.cardReaderModel: readerModel(for: cardReaderModel),
                                 Keys.countryCode: countryCode.rawValue,
-                                Keys.gatewayID: gatewayID(forGatewayID: forGatewayID)
+                                Keys.gatewayID: safeGatewayID(for: forGatewayID)
                               ]
             )
         }
@@ -1568,7 +1568,7 @@ extension WooAnalyticsEvent {
                               properties: [
                                 Keys.cardReaderModel: readerModel(for: cardReaderModel),
                                 Keys.countryCode: countryCode.rawValue,
-                                Keys.gatewayID: gatewayID(forGatewayID: forGatewayID),
+                                Keys.gatewayID: safeGatewayID(for: forGatewayID),
                                 Keys.softwareUpdateType: updateType.rawValue
                               ]
             )
@@ -1590,7 +1590,7 @@ extension WooAnalyticsEvent {
                               properties: [
                                 Keys.cardReaderModel: readerModel(for: cardReaderModel),
                                 Keys.countryCode: countryCode.rawValue,
-                                Keys.gatewayID: gatewayID(forGatewayID: forGatewayID),
+                                Keys.gatewayID: safeGatewayID(for: forGatewayID),
                                 Keys.softwareUpdateType: updateType.rawValue
                               ]
             )
@@ -1615,7 +1615,7 @@ extension WooAnalyticsEvent {
                               properties: [
                                 Keys.cardReaderModel: readerModel(for: cardReaderModel),
                                 Keys.countryCode: countryCode.rawValue,
-                                Keys.gatewayID: gatewayID(forGatewayID: forGatewayID),
+                                Keys.gatewayID: safeGatewayID(for: forGatewayID),
                                 Keys.softwareUpdateType: updateType.rawValue,
                                 Keys.errorDescription: error.localizedDescription
                               ]
@@ -1638,7 +1638,7 @@ extension WooAnalyticsEvent {
                               properties: [
                                 Keys.cardReaderModel: readerModel(for: cardReaderModel),
                                 Keys.countryCode: countryCode.rawValue,
-                                Keys.gatewayID: gatewayID(forGatewayID: forGatewayID),
+                                Keys.gatewayID: safeGatewayID(for: forGatewayID),
                                 Keys.softwareUpdateType: updateType.rawValue
                               ]
             )
@@ -1660,7 +1660,7 @@ extension WooAnalyticsEvent {
                               properties: [
                                 Keys.cardReaderModel: readerModel(for: cardReaderModel),
                                 Keys.countryCode: countryCode.rawValue,
-                                Keys.gatewayID: gatewayID(forGatewayID: forGatewayID),
+                                Keys.gatewayID: safeGatewayID(for: forGatewayID),
                                 Keys.softwareUpdateType: updateType.rawValue
                               ]
             )
@@ -1682,7 +1682,7 @@ extension WooAnalyticsEvent {
                               properties: [
                                 Keys.cardReaderModel: readerModel(for: cardReaderModel),
                                 Keys.countryCode: countryCode.rawValue,
-                                Keys.gatewayID: gatewayID(forGatewayID: forGatewayID),
+                                Keys.gatewayID: safeGatewayID(for: forGatewayID),
                                 Keys.softwareUpdateType: updateType.rawValue
                               ]
             )
@@ -1729,7 +1729,7 @@ extension WooAnalyticsEvent {
             let properties: [String: WooAnalyticsEventPropertyType] = [
                 Keys.cardReaderModel: cardReaderModel,
                 Keys.countryCode: countryCode.rawValue,
-                Keys.gatewayID: gatewayID(forGatewayID: forGatewayID),
+                Keys.gatewayID: safeGatewayID(for: forGatewayID),
                 Keys.paymentMethodType: paymentMethod?.analyticsValue,
                 Keys.errorDescription: errorDescription,
                 Keys.siteID: String(siteID)
@@ -1754,7 +1754,7 @@ extension WooAnalyticsEvent {
                               properties: [
                                 Keys.cardReaderModel: readerModel(for: cardReaderModel),
                                 Keys.countryCode: countryCode.rawValue,
-                                Keys.gatewayID: gatewayID(forGatewayID: forGatewayID),
+                                Keys.gatewayID: safeGatewayID(for: forGatewayID),
                                 Keys.cancellationSource: cancellationSource.rawValue,
                                 Keys.siteID: siteID
                               ]
@@ -1794,7 +1794,7 @@ extension WooAnalyticsEvent {
             var properties: [String: WooAnalyticsEventPropertyType] = [
                 Keys.cardReaderModel: readerModel(for: cardReaderModel),
                 Keys.countryCode: countryCode.rawValue,
-                Keys.gatewayID: gatewayID(forGatewayID: forGatewayID),
+                Keys.gatewayID: safeGatewayID(for: forGatewayID),
                 Keys.paymentMethodType: paymentMethod.analyticsValue,
                 Keys.siteID: siteID
             ]
@@ -1827,7 +1827,7 @@ extension WooAnalyticsEvent {
                               properties: [
                                 Keys.cardReaderModel: readerModel(for: cardReaderModel),
                                 Keys.countryCode: countryCode.rawValue,
-                                Keys.gatewayID: self.gatewayID(forGatewayID: gatewayID),
+                                Keys.gatewayID: safeGatewayID(for: gatewayID),
                                 Keys.siteID: siteID
                               ])
         }
@@ -1847,7 +1847,7 @@ extension WooAnalyticsEvent {
                               properties: [
                                 Keys.cardReaderModel: readerModel(for: cardReaderModel),
                                 Keys.countryCode: countryCode.rawValue,
-                                Keys.gatewayID: self.gatewayID(forGatewayID: gatewayID),
+                                Keys.gatewayID: safeGatewayID(for: gatewayID),
                                 Keys.siteID: siteID
                               ])
         }
@@ -1869,7 +1869,7 @@ extension WooAnalyticsEvent {
                               properties: [
                                 Keys.cardReaderModel: readerModel(for: cardReaderModel),
                                 Keys.countryCode: countryCode.rawValue,
-                                Keys.gatewayID: self.gatewayID(forGatewayID: gatewayID),
+                                Keys.gatewayID: safeGatewayID(for: gatewayID),
                                 Keys.siteID: siteID
                               ],
                               error: error)
@@ -1890,7 +1890,7 @@ extension WooAnalyticsEvent {
                               properties: [
                                 Keys.cardReaderModel: readerModel(for: cardReaderModel),
                                 Keys.countryCode: countryCode.rawValue,
-                                Keys.gatewayID: self.gatewayID(forGatewayID: gatewayID),
+                                Keys.gatewayID: safeGatewayID(for: gatewayID),
                                 Keys.siteID: siteID
                               ])
         }
@@ -1904,12 +1904,12 @@ extension WooAnalyticsEvent {
         ///
         static func cardPresentOnboardingLearnMoreTapped(reason: String,
                                                          countryCode: CountryCode,
-                                                         gatewayID paymentGatewayID: String?) -> WooAnalyticsEvent {
+                                                         gatewayID: String?) -> WooAnalyticsEvent {
             WooAnalyticsEvent(statName: .cardPresentOnboardingLearnMoreTapped,
                               properties: [
                                 Keys.countryCode: countryCode.rawValue,
                                 Keys.reason: reason,
-                                Keys.gatewayID: gatewayID(forGatewayID: paymentGatewayID)
+                                Keys.gatewayID: safeGatewayID(for: gatewayID)
                               ])
         }
 
@@ -1918,10 +1918,10 @@ extension WooAnalyticsEvent {
         /// - Parameters:
         ///   - gatewayID: the plugin (e.g. "woocommerce-payments" or "woocommerce-gateway-stripe") to be included in the event properties in Tracks.
         ///
-        static func cardPresentOnboardingCompleted(gatewayID paymentGatewayID: String?) -> WooAnalyticsEvent {
+        static func cardPresentOnboardingCompleted(gatewayID: String?) -> WooAnalyticsEvent {
             WooAnalyticsEvent(statName: .cardPresentOnboardingCompleted,
                               properties: [
-                                Keys.gatewayID: gatewayID(forGatewayID: paymentGatewayID)
+                                Keys.gatewayID: safeGatewayID(for: gatewayID)
                               ])
         }
 
@@ -1932,12 +1932,12 @@ extension WooAnalyticsEvent {
         ///   - countryCode: the country code of the store.
         ///   - gatewayID: the plugin (e.g. "woocommerce-payments" or "woocommerce-gateway-stripe") to be included in the event properties in Tracks.
         ///
-        static func cardPresentOnboardingNotCompleted(reason: String, countryCode: CountryCode, gatewayID paymentGatewayID: String?) -> WooAnalyticsEvent {
+        static func cardPresentOnboardingNotCompleted(reason: String, countryCode: CountryCode, gatewayID: String?) -> WooAnalyticsEvent {
             WooAnalyticsEvent(statName: .cardPresentOnboardingNotCompleted,
                               properties: [
                                 Keys.countryCode: countryCode.rawValue,
                                 Keys.reason: reason,
-                                Keys.gatewayID: gatewayID(forGatewayID: paymentGatewayID)
+                                Keys.gatewayID: safeGatewayID(for: gatewayID)
                               ])
         }
 
@@ -1952,13 +1952,13 @@ extension WooAnalyticsEvent {
         static func cardPresentOnboardingStepSkipped(reason: String,
                                                      remindLater: Bool,
                                                      countryCode: CountryCode,
-                                                     gatewayID paymentGatewayID: String?) -> WooAnalyticsEvent {
+                                                     gatewayID: String?) -> WooAnalyticsEvent {
             WooAnalyticsEvent(statName: .cardPresentOnboardingStepSkipped,
                               properties: [
                                 Keys.countryCode: countryCode.rawValue,
                                 Keys.reason: reason,
                                 Keys.remindLater: remindLater,
-                                Keys.gatewayID: gatewayID(forGatewayID: paymentGatewayID)
+                                Keys.gatewayID: safeGatewayID(for: gatewayID)
                               ])
         }
 
@@ -1971,12 +1971,12 @@ extension WooAnalyticsEvent {
         ///
         static func cardPresentOnboardingCtaTapped(reason: String,
                                                    countryCode: CountryCode,
-                                                   gatewayID paymentGatewayID: String?) -> WooAnalyticsEvent {
+                                                   gatewayID: String?) -> WooAnalyticsEvent {
             WooAnalyticsEvent(statName: .cardPresentOnboardingCtaTapped,
                               properties: [
                                 Keys.countryCode: countryCode.rawValue,
                                 Keys.reason: reason,
-                                Keys.gatewayID: gatewayID(forGatewayID: paymentGatewayID)
+                                Keys.gatewayID: safeGatewayID(for: gatewayID)
                               ])
         }
 
@@ -1991,12 +1991,12 @@ extension WooAnalyticsEvent {
         static func cardPresentOnboardingCtaFailed(reason: String,
                                                    countryCode: CountryCode,
                                                    error: Error? = nil,
-                                                   gatewayID paymentGatewayID: String?) -> WooAnalyticsEvent {
+                                                   gatewayID: String?) -> WooAnalyticsEvent {
             WooAnalyticsEvent(statName: .cardPresentOnboardingCtaFailed,
                               properties: [
                                 Keys.countryCode: countryCode.rawValue,
                                 Keys.reason: reason,
-                                Keys.gatewayID: gatewayID(forGatewayID: paymentGatewayID)
+                                Keys.gatewayID: safeGatewayID(for: gatewayID)
                               ], error: error)
         }
 

--- a/WooCommerce/Classes/Extensions/CardPresentPaymentOnboardingState+Analytics.swift
+++ b/WooCommerce/Classes/Extensions/CardPresentPaymentOnboardingState+Analytics.swift
@@ -1,0 +1,24 @@
+import enum Yosemite.CardPresentPaymentOnboardingState
+
+extension CardPresentPaymentOnboardingState {
+    /// Payment gateway ID for analytics.
+    public var gatewayID: String? {
+        switch self {
+            case let .completed(pluginState):
+                return pluginState.preferred.gatewayID
+            case let .pluginUnsupportedVersion(plugin: plugin),
+                let .pluginNotActivated(plugin),
+                let .pluginSetupNotCompleted(plugin),
+                let .pluginInTestModeWithLiveStripeAccount(plugin),
+                let .stripeAccountUnderReview(plugin),
+                let .stripeAccountOverdueRequirement(plugin),
+                let .stripeAccountRejected(plugin),
+                let .codPaymentGatewayNotSetUp(plugin),
+                let .stripeAccountPendingRequirement(plugin, _),
+                let .countryNotSupportedStripe(plugin, _):
+                return plugin.gatewayID
+            default:
+                return nil
+        }
+    }
+}

--- a/WooCommerce/Classes/Extensions/CardPresentPaymentOnboardingState+Analytics.swift
+++ b/WooCommerce/Classes/Extensions/CardPresentPaymentOnboardingState+Analytics.swift
@@ -17,7 +17,7 @@ extension CardPresentPaymentOnboardingState {
                 let .stripeAccountPendingRequirement(plugin, _),
                 let .countryNotSupportedStripe(plugin, _):
                 return plugin.gatewayID
-            default:
+            case .loading, .selectPlugin, .countryNotSupported, .pluginNotInstalled, .genericError, .noConnectionError:
                 return nil
         }
     }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/CardPresentPaymentsOnboardingUseCase.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/CardPresentPaymentsOnboardingUseCase.swift
@@ -560,7 +560,8 @@ private extension CardPresentPaymentsOnboardingUseCase {
     func trackCardPresentPluginActionFailed(_ error: Error, trigger: PluginFailureTrigger) {
         analytics.track(event: .InPersonPayments.cardPresentOnboardingCtaFailed(reason: trigger.rawValue,
                                                                                 countryCode: storeCountryCode,
-                                                                                error: error))
+                                                                                error: error,
+                                                                                gatewayID: preferredPluginLocal?.gatewayID))
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/CardPresentPaymentsOnboardingUseCase.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/CardPresentPaymentsOnboardingUseCase.swift
@@ -14,7 +14,7 @@ private typealias PaymentGatewayAccount = Yosemite.PaymentGatewayAccount
 protocol CardPresentPaymentsOnboardingUseCaseProtocol {
     /// Current store onboarding state.
     ///
-    var state: CardPresentPaymentOnboardingState { get set }
+    var state: CardPresentPaymentOnboardingState { get }
 
     /// Store onboarding state publisher.
     ///
@@ -62,7 +62,7 @@ final class CardPresentPaymentsOnboardingUseCase: CardPresentPaymentsOnboardingU
     private var wasCashOnDeliveryStepSkipped: Bool = false
     private var pendingRequirementsStepSkipped: Bool = false
 
-    @Published var state: CardPresentPaymentOnboardingState = .loading
+    @Published private(set) var state: CardPresentPaymentOnboardingState = .loading
 
     var statePublisher: Published<CardPresentPaymentOnboardingState>.Publisher {
         $state

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/InPersonPaymentsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/InPersonPaymentsViewModel.swift
@@ -174,6 +174,7 @@ private extension InPersonPaymentsViewModel {
             event: .InPersonPayments.cardPresentOnboardingStepSkipped(
                 reason: state.reasonForAnalytics,
                 remindLater: remindLater,
-                countryCode: countryCode))
+                countryCode: countryCode,
+                gatewayID: state.gatewayID))
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/InPersonPaymentsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/InPersonPaymentsViewModel.swift
@@ -153,14 +153,15 @@ private extension InPersonPaymentsViewModel {
             return
         }
         switch state {
-        case let .completed(pluginState):
+        case .completed:
             ServiceLocator.analytics
-                .track(event: .InPersonPayments.cardPresentOnboardingCompleted(gatewayID: pluginState.preferred.gatewayID))
+                .track(event: .InPersonPayments.cardPresentOnboardingCompleted(gatewayID: state.gatewayID))
         default:
             ServiceLocator.analytics
                 .track(event: .InPersonPayments
                     .cardPresentOnboardingNotCompleted(reason: state.reasonForAnalytics,
-                                                       countryCode: countryCode))
+                                                       countryCode: countryCode,
+                                                       gatewayID: state.gatewayID))
         }
     }
 

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/InPersonPaymentsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/InPersonPaymentsViewModel.swift
@@ -153,9 +153,9 @@ private extension InPersonPaymentsViewModel {
             return
         }
         switch state {
-        case .completed, .enabled:
+        case let .completed(pluginState):
             ServiceLocator.analytics
-                .track(.cardPresentOnboardingCompleted)
+                .track(event: .InPersonPayments.cardPresentOnboardingCompleted(gatewayID: pluginState.preferred.gatewayID))
         default:
             ServiceLocator.analytics
                 .track(event: .InPersonPayments

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Onboarding Errors/InPersonPaymentsCashOnDeliveryPaymentGatewayNotSetUpViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Onboarding Errors/InPersonPaymentsCashOnDeliveryPaymentGatewayNotSetUpViewModel.swift
@@ -130,7 +130,8 @@ extension InPersonPaymentsCashOnDeliveryPaymentGatewayNotSetUpViewModel {
 
     private func trackEnableTapped() {
         let event = Event.cardPresentOnboardingCtaTapped(reason: analyticReason,
-                                                         countryCode: cardPresentPaymentsConfiguration.countryCode)
+                                                         countryCode: cardPresentPaymentsConfiguration.countryCode,
+                                                         gatewayID: plugin.gatewayID)
         analytics.track(event: event)
     }
 

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Onboarding Errors/InPersonPaymentsCashOnDeliveryPaymentGatewayNotSetUpViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Onboarding Errors/InPersonPaymentsCashOnDeliveryPaymentGatewayNotSetUpViewModel.swift
@@ -41,6 +41,8 @@ final class InPersonPaymentsCashOnDeliveryPaymentGatewayNotSetUpViewModel: Obser
     // MARK: - Configuration properties
     private let cardPresentPaymentsConfiguration: CardPresentPaymentsConfiguration
 
+    private let plugin: CardPresentPaymentsPlugin
+
     private var siteID: Int64? {
         stores.sessionManager.defaultStoreID
     }
@@ -54,6 +56,7 @@ final class InPersonPaymentsCashOnDeliveryPaymentGatewayNotSetUpViewModel: Obser
          completion: @escaping () -> Void) {
         self.dependencies = dependencies
         self.cardPresentPaymentsConfiguration = configuration
+        self.plugin = plugin
         self.learnMoreURL = plugin.cashOnDeliveryLearnMoreURL
         self.analyticReason = analyticReason
         self.completion = completion
@@ -114,7 +117,8 @@ extension InPersonPaymentsCashOnDeliveryPaymentGatewayNotSetUpViewModel {
 
     var learnMoreEvent: WooAnalyticsEvent {
         Event.cardPresentOnboardingLearnMoreTapped(reason: analyticReason,
-                                                   countryCode: cardPresentPaymentsConfiguration.countryCode)
+                                                   countryCode: cardPresentPaymentsConfiguration.countryCode,
+                                                   gatewayID: plugin.gatewayID)
     }
 
     private func trackSkipTapped() {

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Onboarding Errors/InPersonPaymentsCashOnDeliveryPaymentGatewayNotSetUpViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Onboarding Errors/InPersonPaymentsCashOnDeliveryPaymentGatewayNotSetUpViewModel.swift
@@ -124,7 +124,8 @@ extension InPersonPaymentsCashOnDeliveryPaymentGatewayNotSetUpViewModel {
     private func trackSkipTapped() {
         let event = Event.cardPresentOnboardingStepSkipped(reason: analyticReason,
                                                            remindLater: false,
-                                                           countryCode: cardPresentPaymentsConfiguration.countryCode)
+                                                           countryCode: cardPresentPaymentsConfiguration.countryCode,
+                                                           gatewayID: plugin.gatewayID)
         analytics.track(event: event)
     }
 

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Onboarding Errors/InPersonPaymentsCountryNotSupported.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Onboarding Errors/InPersonPaymentsCountryNotSupported.swift
@@ -15,7 +15,8 @@ struct InPersonPaymentsCountryNotSupported: View {
             ),
             supportLink: true,
             learnMore: true,
-            analyticReason: analyticReason
+            analyticReason: analyticReason,
+            plugin: nil
         )
     }
 

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Onboarding Errors/InPersonPaymentsCountryNotSupportedStripe.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Onboarding Errors/InPersonPaymentsCountryNotSupportedStripe.swift
@@ -15,7 +15,8 @@ struct InPersonPaymentsCountryNotSupportedStripe: View {
             ),
             supportLink: true,
             learnMore: true,
-            analyticReason: analyticReason
+            analyticReason: analyticReason,
+            plugin: .stripe
         )
     }
 

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Onboarding Errors/InPersonPaymentsLiveSiteInTestModeView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Onboarding Errors/InPersonPaymentsLiveSiteInTestModeView.swift
@@ -17,6 +17,7 @@ struct InPersonPaymentsLiveSiteInTestMode: View {
             supportLink: false,
             learnMore: true,
             analyticReason: analyticReason,
+            plugin: plugin,
             buttonViewModel: InPersonPaymentsOnboardingErrorButtonViewModel(
                 text: Localization.primaryButton,
                 analyticReason: analyticReason,

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Onboarding Errors/InPersonPaymentsLiveSiteInTestModeView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Onboarding Errors/InPersonPaymentsLiveSiteInTestModeView.swift
@@ -21,6 +21,7 @@ struct InPersonPaymentsLiveSiteInTestMode: View {
             buttonViewModel: InPersonPaymentsOnboardingErrorButtonViewModel(
                 text: Localization.primaryButton,
                 analyticReason: analyticReason,
+                plugin: plugin,
                 action: onRefresh
             )
         )

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Onboarding Errors/InPersonPaymentsNoConnectionView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Onboarding Errors/InPersonPaymentsNoConnectionView.swift
@@ -19,6 +19,7 @@ struct InPersonPaymentsNoConnection: View {
             buttonViewModel: InPersonPaymentsOnboardingErrorButtonViewModel(
                 text: Localization.primaryButton,
                 analyticReason: analyticReason,
+                plugin: nil,
                 action: onRefresh
             )
         )

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Onboarding Errors/InPersonPaymentsNoConnectionView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Onboarding Errors/InPersonPaymentsNoConnectionView.swift
@@ -15,6 +15,7 @@ struct InPersonPaymentsNoConnection: View {
             supportLink: false,
             learnMore: false,
             analyticReason: analyticReason,
+            plugin: nil,
             buttonViewModel: InPersonPaymentsOnboardingErrorButtonViewModel(
                 text: Localization.primaryButton,
                 analyticReason: analyticReason,

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Onboarding Errors/InPersonPaymentsOnboardingError.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Onboarding Errors/InPersonPaymentsOnboardingError.swift
@@ -8,6 +8,7 @@ struct InPersonPaymentsOnboardingError: View {
     let supportLink: Bool
     let learnMore: Bool
     let analyticReason: String
+    let plugin: CardPresentPaymentsPlugin?
     var buttonViewModel: InPersonPaymentsOnboardingErrorButtonViewModel? = nil
     var secondaryButtonViewModel: InPersonPaymentsOnboardingErrorButtonViewModel? = nil
 
@@ -56,6 +57,7 @@ extension CardPresentPaymentsPlugin {
 private extension InPersonPaymentsOnboardingError {
     var learnMoreAnalyticEvent: WooAnalyticsEvent? {
         WooAnalyticsEvent.InPersonPayments.cardPresentOnboardingLearnMoreTapped(reason: analyticReason,
-                                                                                countryCode: CardPresentConfigurationLoader().configuration.countryCode)
+                                                                                countryCode: CardPresentConfigurationLoader().configuration.countryCode,
+                                                                                gatewayID: plugin?.gatewayID)
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Onboarding Errors/InPersonPaymentsOnboardingErrorButtonViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Onboarding Errors/InPersonPaymentsOnboardingErrorButtonViewModel.swift
@@ -13,6 +13,7 @@ struct InPersonPaymentsOnboardingErrorButtonViewModel {
     init(text: String,
          analyticReason: String,
          cardPresentConfiguration: CardPresentPaymentsConfiguration = CardPresentConfigurationLoader().configuration,
+         plugin: CardPresentPaymentsPlugin?,
          action: @escaping () -> Void) {
         self.text = text
         self.analyticReason = analyticReason
@@ -21,7 +22,9 @@ struct InPersonPaymentsOnboardingErrorButtonViewModel {
             ServiceLocator.analytics.track(
                 event: WooAnalyticsEvent.InPersonPayments.cardPresentOnboardingCtaTapped(
                     reason: analyticReason,
-                    countryCode: cardPresentConfiguration.countryCode))
+                    countryCode: cardPresentConfiguration.countryCode,
+                    gatewayID: plugin?.gatewayID
+                ))
             action()
         }
     }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Onboarding Errors/InPersonPaymentsPluginNotActivatedView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Onboarding Errors/InPersonPaymentsPluginNotActivatedView.swift
@@ -17,6 +17,7 @@ struct InPersonPaymentsPluginNotActivated: View {
             supportLink: false,
             learnMore: true,
             analyticReason: analyticReason,
+            plugin: plugin,
             buttonViewModel: InPersonPaymentsOnboardingErrorButtonViewModel(
                 text: Localization.primaryButton,
                 analyticReason: analyticReason,

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Onboarding Errors/InPersonPaymentsPluginNotActivatedView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Onboarding Errors/InPersonPaymentsPluginNotActivatedView.swift
@@ -21,6 +21,7 @@ struct InPersonPaymentsPluginNotActivated: View {
             buttonViewModel: InPersonPaymentsOnboardingErrorButtonViewModel(
                 text: Localization.primaryButton,
                 analyticReason: analyticReason,
+                plugin: plugin,
                 action: onActivate
             )
         )

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Onboarding Errors/InPersonPaymentsPluginNotInstalledView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Onboarding Errors/InPersonPaymentsPluginNotInstalledView.swift
@@ -19,6 +19,7 @@ struct InPersonPaymentsPluginNotInstalled: View {
             buttonViewModel: InPersonPaymentsOnboardingErrorButtonViewModel(
                 text: Localization.title,
                 analyticReason: analyticReason,
+                plugin: nil,
                 action: onInstall
             )
         )

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Onboarding Errors/InPersonPaymentsPluginNotInstalledView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Onboarding Errors/InPersonPaymentsPluginNotInstalledView.swift
@@ -15,6 +15,7 @@ struct InPersonPaymentsPluginNotInstalled: View {
             supportLink: false,
             learnMore: true,
             analyticReason: analyticReason,
+            plugin: nil,
             buttonViewModel: InPersonPaymentsOnboardingErrorButtonViewModel(
                 text: Localization.title,
                 analyticReason: analyticReason,

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Onboarding Errors/InPersonPaymentsPluginNotSetup.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Onboarding Errors/InPersonPaymentsPluginNotSetup.swift
@@ -90,7 +90,8 @@ struct InPersonPaymentsPluginNotSetup_Previews: PreviewProvider {
 private extension InPersonPaymentsPluginNotSetup {
     var learnMoreAnalyticEvent: WooAnalyticsEvent? {
         WooAnalyticsEvent.InPersonPayments.cardPresentOnboardingLearnMoreTapped(reason: analyticReason,
-                                                                                countryCode: cardPresentConfiguration.countryCode)
+                                                                                countryCode: cardPresentConfiguration.countryCode,
+                                                                                gatewayID: plugin.gatewayID)
     }
 
     private func trackPluginSetupTappedEvent() {

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Onboarding Errors/InPersonPaymentsPluginNotSetup.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Onboarding Errors/InPersonPaymentsPluginNotSetup.swift
@@ -30,7 +30,9 @@ struct InPersonPaymentsPluginNotSetup: View {
                 ServiceLocator.analytics.track(
                     event: WooAnalyticsEvent.InPersonPayments.cardPresentOnboardingCtaTapped(
                         reason: analyticReason,
-                        countryCode: cardPresentConfiguration.countryCode))
+                        countryCode: cardPresentConfiguration.countryCode,
+                        gatewayID: plugin.gatewayID
+                    ))
                 trackPluginSetupTappedEvent()
             } label: {
                 HStack {

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Onboarding Errors/InPersonPaymentsPluginNotSetup.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Onboarding Errors/InPersonPaymentsPluginNotSetup.swift
@@ -99,6 +99,8 @@ private extension InPersonPaymentsPluginNotSetup {
     private func trackPluginSetupTappedEvent() {
         ServiceLocator.analytics.track(event: WooAnalyticsEvent.InPersonPayments.cardPresentOnboardingCtaFailed(
             reason: "plugin_setup_tapped",
-            countryCode: cardPresentConfiguration.countryCode))
+            countryCode: cardPresentConfiguration.countryCode,
+            gatewayID: plugin.gatewayID
+        ))
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Onboarding Errors/InPersonPaymentsPluginNotSupportedVersionView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Onboarding Errors/InPersonPaymentsPluginNotSupportedVersionView.swift
@@ -17,6 +17,7 @@ struct InPersonPaymentsPluginNotSupportedVersion: View {
             supportLink: false,
             learnMore: true,
             analyticReason: analyticReason,
+            plugin: plugin,
             buttonViewModel: InPersonPaymentsOnboardingErrorButtonViewModel(
                 text: Localization.primaryButton,
                 analyticReason: analyticReason,

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Onboarding Errors/InPersonPaymentsPluginNotSupportedVersionView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Onboarding Errors/InPersonPaymentsPluginNotSupportedVersionView.swift
@@ -21,6 +21,7 @@ struct InPersonPaymentsPluginNotSupportedVersion: View {
             buttonViewModel: InPersonPaymentsOnboardingErrorButtonViewModel(
                 text: Localization.primaryButton,
                 analyticReason: analyticReason,
+                plugin: plugin,
                 action: onRefresh
             )
         )

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Onboarding Errors/InPersonPaymentsStripeAccountOverdueView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Onboarding Errors/InPersonPaymentsStripeAccountOverdueView.swift
@@ -48,7 +48,9 @@ private extension InPersonPaymentsStripeAccountOverdue {
     func trackPluginSetupTappedEvent() {
         ServiceLocator.analytics.track(event: WooAnalyticsEvent.InPersonPayments.cardPresentOnboardingCtaFailed(
             reason: "stripe_account_setup_tapped",
-            countryCode: CardPresentConfigurationLoader().configuration.countryCode))
+            countryCode: CardPresentConfigurationLoader().configuration.countryCode,
+            gatewayID: plugin.gatewayID
+        ))
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Onboarding Errors/InPersonPaymentsStripeAccountOverdueView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Onboarding Errors/InPersonPaymentsStripeAccountOverdueView.swift
@@ -1,9 +1,12 @@
 import SwiftUI
+import enum Yosemite.CardPresentPaymentsPlugin
 
 struct InPersonPaymentsStripeAccountOverdue: View {
     let analyticReason: String
     let onRefresh: () -> Void
     @State private var presentedSetupURL: URL? = nil
+
+    private let plugin: CardPresentPaymentsPlugin = .stripe
 
     var body: some View {
         InPersonPaymentsOnboardingError(
@@ -16,15 +19,17 @@ struct InPersonPaymentsStripeAccountOverdue: View {
             supportLink: true,
             learnMore: true,
             analyticReason: analyticReason,
-            plugin: .stripe,
+            plugin: plugin,
             buttonViewModel: InPersonPaymentsOnboardingErrorButtonViewModel(text: Localization.primaryButtonTitle,
                                                                             analyticReason: analyticReason,
+                                                                            plugin: plugin,
                                                                             action: {
                                                                                 presentedSetupURL = setupURL
                                                                                 trackPluginSetupTappedEvent()
                                                                             }),
             secondaryButtonViewModel: InPersonPaymentsOnboardingErrorButtonViewModel(text: Localization.secondaryButtonTitle,
                                                                                      analyticReason: analyticReason,
+                                                                                     plugin: plugin,
                                                                                      action: onRefresh)
         )
         .safariSheet(url: $presentedSetupURL, onDismiss: onRefresh)

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Onboarding Errors/InPersonPaymentsStripeAccountOverdueView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Onboarding Errors/InPersonPaymentsStripeAccountOverdueView.swift
@@ -16,6 +16,7 @@ struct InPersonPaymentsStripeAccountOverdue: View {
             supportLink: true,
             learnMore: true,
             analyticReason: analyticReason,
+            plugin: .stripe,
             buttonViewModel: InPersonPaymentsOnboardingErrorButtonViewModel(text: Localization.primaryButtonTitle,
                                                                             analyticReason: analyticReason,
                                                                             action: {

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Onboarding Errors/InPersonPaymentsStripeAccountPendingView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Onboarding Errors/InPersonPaymentsStripeAccountPendingView.swift
@@ -16,6 +16,7 @@ struct InPersonPaymentsStripeAccountPending: View {
             supportLink: true,
             learnMore: true,
             analyticReason: analyticReason,
+            plugin: .stripe,
             buttonViewModel: InPersonPaymentsOnboardingErrorButtonViewModel(
                 text: Localization.skipButton,
                 analyticReason: analyticReason,

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Onboarding Errors/InPersonPaymentsStripeAccountPendingView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Onboarding Errors/InPersonPaymentsStripeAccountPendingView.swift
@@ -1,9 +1,12 @@
 import SwiftUI
+import enum Yosemite.CardPresentPaymentsPlugin
 
 struct InPersonPaymentsStripeAccountPending: View {
     let deadline: Date?
     let analyticReason: String
     let onSkip: () -> ()
+
+    private let plugin: CardPresentPaymentsPlugin = .stripe
 
     var body: some View {
         InPersonPaymentsOnboardingError(
@@ -16,10 +19,11 @@ struct InPersonPaymentsStripeAccountPending: View {
             supportLink: true,
             learnMore: true,
             analyticReason: analyticReason,
-            plugin: .stripe,
+            plugin: plugin,
             buttonViewModel: InPersonPaymentsOnboardingErrorButtonViewModel(
                 text: Localization.skipButton,
                 analyticReason: analyticReason,
+                plugin: plugin,
                 action: onSkip
             )
         )

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Onboarding Errors/InPersonPaymentsStripeAcountReviewView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Onboarding Errors/InPersonPaymentsStripeAcountReviewView.swift
@@ -13,7 +13,8 @@ struct InPersonPaymentsStripeAccountReview: View {
             ),
             supportLink: true,
             learnMore: true,
-            analyticReason: analyticReason
+            analyticReason: analyticReason,
+            plugin: .stripe
         )
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Onboarding Errors/InPersonPaymentsStripeRejectedView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Onboarding Errors/InPersonPaymentsStripeRejectedView.swift
@@ -12,7 +12,8 @@ struct InPersonPaymentsStripeRejected: View {
             ),
             supportLink: true,
             learnMore: true,
-            analyticReason: analyticReason
+            analyticReason: analyticReason,
+            plugin: .stripe
         )
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Onboarding Errors/InPersonPaymentsUnavailableView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Onboarding Errors/InPersonPaymentsUnavailableView.swift
@@ -13,7 +13,8 @@ struct InPersonPaymentsUnavailable: View {
             ),
             supportLink: false,
             learnMore: true,
-            analyticReason: analyticReason
+            analyticReason: analyticReason,
+            plugin: nil
         )
     }
 }

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -585,6 +585,7 @@
 		02FADAA32A60759200FE8683 /* ImageTextScanner.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02FADAA22A60759200FE8683 /* ImageTextScanner.swift */; };
 		02FADAA52A607CEE00FE8683 /* MockImageTextScanner.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02FADAA42A607CEE00FE8683 /* MockImageTextScanner.swift */; };
 		02FADAA72A608F6B00FE8683 /* ImageTextScannerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02FADAA62A608F6B00FE8683 /* ImageTextScannerTests.swift */; };
+		02FCA5542B54FC8C0097BFB8 /* CardPresentPaymentOnboardingState+Analytics.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02FCA5532B54FC8C0097BFB8 /* CardPresentPaymentOnboardingState+Analytics.swift */; };
 		02FE1B9F287F51F400EC03B3 /* LoginOnboardingViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02FE1B9E287F51F400EC03B3 /* LoginOnboardingViewController.swift */; };
 		02FE734B2B21613D00CD486B /* ProductWithQuantityStepperView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02FE734A2B21613D00CD486B /* ProductWithQuantityStepperView.swift */; };
 		02FE89C7231FAA4100E85EF8 /* MainTabBarControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02FE89C6231FAA4100E85EF8 /* MainTabBarControllerTests.swift */; };
@@ -3240,6 +3241,7 @@
 		02FADAA22A60759200FE8683 /* ImageTextScanner.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageTextScanner.swift; sourceTree = "<group>"; };
 		02FADAA42A607CEE00FE8683 /* MockImageTextScanner.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockImageTextScanner.swift; sourceTree = "<group>"; };
 		02FADAA62A608F6B00FE8683 /* ImageTextScannerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageTextScannerTests.swift; sourceTree = "<group>"; };
+		02FCA5532B54FC8C0097BFB8 /* CardPresentPaymentOnboardingState+Analytics.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "CardPresentPaymentOnboardingState+Analytics.swift"; sourceTree = "<group>"; };
 		02FE1B9E287F51F400EC03B3 /* LoginOnboardingViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginOnboardingViewController.swift; sourceTree = "<group>"; };
 		02FE734A2B21613D00CD486B /* ProductWithQuantityStepperView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductWithQuantityStepperView.swift; sourceTree = "<group>"; };
 		02FE89C6231FAA4100E85EF8 /* MainTabBarControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainTabBarControllerTests.swift; sourceTree = "<group>"; };
@@ -10303,6 +10305,7 @@
 				DEDA8D982B04643E0076BF0F /* ProductSubscription+Empty.swift */,
 				0258B4D92B159A0F008FEA07 /* Publisher+WithPrevious.swift */,
 				B98C6D4F2B149C3900A243E1 /* UINavigationItem+Configuration.swift */,
+				02FCA5532B54FC8C0097BFB8 /* CardPresentPaymentOnboardingState+Analytics.swift */,
 			);
 			path = Extensions;
 			sourceTree = "<group>";
@@ -13115,6 +13118,7 @@
 				02305352237454C700487A64 /* AztecHorizontalRulerFormatBarCommand.swift in Sources */,
 				EE3B17AF2A9EFE97004D3E0C /* WooPaymentsSetupInstructionsView.swift in Sources */,
 				DEC1A3EA2ABC2C2E0022CC85 /* ProductDetailPreviewViewModel.swift in Sources */,
+				02FCA5542B54FC8C0097BFB8 /* CardPresentPaymentOnboardingState+Analytics.swift in Sources */,
 				B5DBF3C520E148E000B53AED /* DeauthenticatedState.swift in Sources */,
 				3190D61B26D6D82900EF364D /* CardPresentRetryableError.swift in Sources */,
 				021E2A1A23AA07F800B1DE07 /* Product+InventorySettingsViewModels.swift in Sources */,

--- a/Yosemite/Yosemite/Model/Enums/CardPresentPaymentsOnboardingState.swift
+++ b/Yosemite/Yosemite/Model/Enums/CardPresentPaymentsOnboardingState.swift
@@ -6,11 +6,6 @@ public enum CardPresentPaymentOnboardingState: Equatable {
     ///
     case loading
 
-    /// All the requirements are temporarily met and the feature is ready to use.
-    /// While the account is in good standing, additional information might be required if a payment volume threshold is reached
-    ///
-    case enabled
-
     /// All the requirements are met and the feature is ready to use
     ///
     case completed(plugin: CardPresentPaymentsPluginState)
@@ -87,8 +82,6 @@ extension CardPresentPaymentOnboardingState {
         switch self {
         case .loading:
             return "loading"
-        case .enabled:
-            return "enabled"
         case .completed:
             return "completed"
         case .selectPlugin:

--- a/Yosemite/Yosemite/Model/Enums/CardPresentPaymentsOnboardingState.swift
+++ b/Yosemite/Yosemite/Model/Enums/CardPresentPaymentsOnboardingState.swift
@@ -149,4 +149,25 @@ extension CardPresentPaymentOnboardingState {
             return false
         }
     }
+
+    /// Payment gateway ID for analytics.
+    public var gatewayID: String? {
+        switch self {
+            case let .completed(pluginState):
+                return pluginState.preferred.gatewayID
+            case let .pluginUnsupportedVersion(plugin: plugin),
+                let .pluginNotActivated(plugin),
+                let .pluginSetupNotCompleted(plugin),
+                let .pluginInTestModeWithLiveStripeAccount(plugin),
+                let .stripeAccountUnderReview(plugin),
+                let .stripeAccountOverdueRequirement(plugin),
+                let .stripeAccountRejected(plugin),
+                let .codPaymentGatewayNotSetUp(plugin),
+                let .stripeAccountPendingRequirement(plugin, _),
+                let .countryNotSupportedStripe(plugin, _):
+                return plugin.gatewayID
+            default:
+                return nil
+        }
+    }
 }

--- a/Yosemite/Yosemite/Model/Enums/CardPresentPaymentsOnboardingState.swift
+++ b/Yosemite/Yosemite/Model/Enums/CardPresentPaymentsOnboardingState.swift
@@ -1,6 +1,9 @@
 import WooFoundation
 
 /// Represents the possible states for onboarding to In-Person payments
+/// The states are specific to the onboarding UX in the app, and are based on the WooPayments onboarding state and the UI state determined in
+/// `CardPresentPaymentsOnboardingUseCaseProtocol`.
+/// The WooPayments onboarding state comes from the payments backend, and is represented by a different enum `WCPayAccountStatusEnum`.
 public enum CardPresentPaymentOnboardingState: Equatable {
     /// The app is loading the required data to check for the current state
     ///

--- a/Yosemite/Yosemite/Model/Enums/CardPresentPaymentsOnboardingState.swift
+++ b/Yosemite/Yosemite/Model/Enums/CardPresentPaymentsOnboardingState.swift
@@ -149,25 +149,4 @@ extension CardPresentPaymentOnboardingState {
             return false
         }
     }
-
-    /// Payment gateway ID for analytics.
-    public var gatewayID: String? {
-        switch self {
-            case let .completed(pluginState):
-                return pluginState.preferred.gatewayID
-            case let .pluginUnsupportedVersion(plugin: plugin),
-                let .pluginNotActivated(plugin),
-                let .pluginSetupNotCompleted(plugin),
-                let .pluginInTestModeWithLiveStripeAccount(plugin),
-                let .stripeAccountUnderReview(plugin),
-                let .stripeAccountOverdueRequirement(plugin),
-                let .stripeAccountRejected(plugin),
-                let .codPaymentGatewayNotSetUp(plugin),
-                let .stripeAccountPendingRequirement(plugin, _),
-                let .countryNotSupportedStripe(plugin, _):
-                return plugin.gatewayID
-            default:
-                return nil
-        }
-    }
 }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #10596 
<!-- Id number of the GitHub issue this PR addresses. -->

## Why

Based on the issue description:

We currently do not pass the _payment gateway ID_ as an explicit property to some IPP onboarding events, and rely on the event identifier itself to know if is WCPay or others. Ideally, we want to pass this explicitly into the event property list, for example as we do in `_card_present_collect_payment_success`. This PR adds `plugin_slug` property to all 6 `card_present_onboarding_*` events.

## How

The 6 `card_present_onboarding_*` events were updated to include a new `plugin_slug` (gateway ID) property. `gatewayID: String?` extension was added to `CardPresentPaymentOnboardingState` for easier access in a few events. The changes are a bit scattered as the plugin needs to be DI'ed or inferred by looking at the code. I also deleted `CardPresentPaymentOnboardingState.enabled` case because it's not used anymore.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

Hand-testing is optional, as it can be time-consuming to test all scenarios. There are also a lot of scenarios that could be hard to test like for a few error scenarios. I will make sure to ensure the event property `plugin_slug` is tracked for all 6 events.

- [x] @jaclync updates event registration in Tracks

---

- [x] `card_present_onboarding_step_skipped`
  - Find a store with the payment plugin all set up
  - In wp-admin > payment methods (`wp-admin/admin.php?page=wc-settings&tab=checkout`), disable `Cash on delivery` payment method and tap `Save changes`
  - In the app, switch to the store
  - Go to the Menu tab > Payments
  - Tap `Continue setup` --> should see a screen like in [this issue](https://github.com/woocommerce/woocommerce-ios/issues/7525))
  - Tap `Skip for now`
- [x] `card_present_onboarding_cta_tapped`, `card_present_onboarding_cta_failed`
  - Switch to a store with a payment plugin but not set up yet
  - Go to the Menu tab > Payments
  - Tap `Continue setup` 
  - Tap `Finish Setup in Store Admin` --> both events should be tracked with `plugin_slug`
- [x] `card_present_onboarding_learn_more_tapped`
  - Switch to a store with a payment plugin but not set up yet
  - Go to the Menu tab > Payments
  - Tap `Continue setup`
  - Tap `Learn more` --> the event should be tracked with `plugin_slug`
- [x] `card_present_onboarding_not_completed`
  - Switch to a store with a payment plugin but not set up yet
  - Go to the Menu tab > Payments
  - Tap `Continue setup`
  - Navigate back to the payments screen --> the event should be tracked with `plugin_slug`
- [x] `card_present_onboarding_completed`
  - Switch to a store with payments set up already
  - Go to the Menu tab > Payments --> the event should be tracked with `plugin_slug`

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
