### PR TITLE
[Tablet support] Use `defaultBackgroundConfiguration` for order list cell when available

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Orders/Cells/OrderTableViewCell.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Cells/OrderTableViewCell.swift
@@ -144,7 +144,13 @@ private extension OrderTableViewCell {
 
 private extension OrderTableViewCell {
     func configureBackground() {
-        var backgroundConfiguration = UIBackgroundConfiguration.listPlainCell()
+        var backgroundConfiguration: UIBackgroundConfiguration
+
+        if #available(iOS 16.0, *) {
+            backgroundConfiguration = defaultBackgroundConfiguration()
+        } else {
+            backgroundConfiguration = UIBackgroundConfiguration.listPlainCell()
+        }
         backgroundConfiguration.backgroundColor = .listBackground
         self.backgroundConfiguration = backgroundConfiguration
     }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

This is a follow-up from review https://github.com/woocommerce/woocommerce-ios/pull/11621#discussion_r1450016037

## Description
This PR updates the initial `OrderTableViewCell` background configuration to use `defaultBackgroundConfiguration` when available. More info: [WWDC's Modern cell configuration](https://developer.apple.com/videos/play/wwdc2020/10027/)

## Changes
We add an iOS16 availability check in the initial cell config, in which case we set the config to [defaultBackgroundConfiguration()](https://developer.apple.com/documentation/uikit/uitableviewcell/4013362-defaultbackgroundconfiguration)

## Testing instructions
- Add a breakpoint in the `configureBackground()` method, [line 156](https://github.com/woocommerce/woocommerce-ios/blob/b0e1e4cf63ccb34b9eeea4fcbf06b5bc7c093d7e/WooCommerce/Classes/ViewRelated/Orders/Cells/OrderTableViewCell.swift#L156)
- Run the app on < iOS16 
- Observe that the base style is `List Plain Cell` and  the background colour is `.listBackground` (light gray):

```
(lldb) po backgroundConfiguration
<UIBackgroundConfiguration: 0x6000039c56c0; 
  Base Style = List Plain Cell; 
  backgroundColor = <UIDynamicProviderColor: 0x60000034c620; provider = <__NSMallocBlock__: 0x600000d09230>>
>

(lldb) po backgroundConfiguration.backgroundColor?.accessibilityName
▿ Optional<String>
  - some : "light gray"
```
- Re-run the app on >= iOS16
- Observe that the applied background colour is also `.listBackground`

## Screenshots
There should be no visual difference before and after:
| Before | After |
|--------|--------|
| ![_before_UIBackgroundConfiguration_2024-01-11 at 09 48 13](https://github.com/woocommerce/woocommerce-ios/assets/3812076/66cbbcc2-a970-4fe2-9f12-f237f77f2faa) | ![_after_UIBackgroundConfiguration_2024-01-11 at 09 59 38](https://github.com/woocommerce/woocommerce-ios/assets/3812076/f8cfd1c5-b61b-407a-bae5-20c1a7dde53e) | 
