### PR TITLE
[Mobile Payments] Stop treating discovery success as an error

### DIFF
--- a/Hardware/Hardware/CardReader/StripeCardReader/StripeCardReaderService.swift
+++ b/Hardware/Hardware/CardReader/StripeCardReader/StripeCardReaderService.swift
@@ -170,16 +170,16 @@ extension StripeCardReaderService: CardReaderService {
          * https://stripe.com/docs/terminal/references/sdk-migration-guide#update-your-discoverreaders-and-connectreader-usage
          */
         discoveryCancellable = Terminal.shared.discoverReaders(config, delegate: self, completion: { [weak self] receivedError in
-            switch receivedError {
-            case .none:
-                let error = NSError(domain: "DiscoveryCancellable received nil error on completion", code: 0)
-                DDLogError(error.localizedDescription)
-                self?.switchStatusToFault(error: error)
+            guard let receivedError else {
+                // Discovery completed successfully
                 return
+            }
+
+            switch receivedError {
             case let error as ErrorCode where error.code == .canceled:
                 self?.switchStatusToIdle()
                 return
-            case let .some(error):
+            case let error:
                 self?.switchStatusToFault(error: error)
                 return
             }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #11648
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

This PR cherry picks previously merged changes, which were lost when the 16.7 beta fix changes were merged back to trunk. Previous review was #11519

---

As of SDK version 3, the discovery completion handler behaviour has changed.

Previously, we treated any `nil` property for `recievedError` in this completion handler as an indication that discovery had been canceled. Since the SDK migration, we’ve been look for the specific SCPErrorCanceled to check that.

However, we also started to treat `nil` as an error, as we weren’t expecting it to happen, and we were a little confused by discrepancies in Stripe’s documentation, which said that it indicated cancelation in one place.

This quote appears to be key:
> discoverReaders is now completed successfully when connectReader is called.
– https://stripe.com/docs/terminal/references/sdk-migration-guide#update-your-discoverreaders-and-connectreader-usage

i.e. the completion handler is called. And there’s no error. So the property is nil.

I’ve confirmed that we get the call every time `connect` is called on a card reader, and previously that meant momentarily showing an error.

This commit removes that incorrect handling of `nil` and instead does nothing for discovery completion. The momentary errors no longer show during connection

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

1. Ensure you're disconnected from any card readers
2. Launch the app
3. Navigate to `Menu > Payments > Collect Payment`
4. Take a payment for some amount – pick card reader for payment
5. Observe that the reader connects without showing an error

Repeat the above with Tap to Pay, observe that the TTP connection flow also completes without showing an error.

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
