### PR TITLE
[Analytics Hub] Hide sessions card for non-Jetpack stores

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -3,6 +3,7 @@
 17.0
 -----
 - [*] Payments: cash payment is now in fullscreen and supports entering a different amount paid by the customer with an option to record it in an order note. The calculated change due amount is also shown. [https://github.com/woocommerce/woocommerce-ios/pull/11365]
+- [internal] Analytics Hub: Sessions card (views and conversion rate) is now hidden for non-Jetpack stores, since they don't have those stats. [https://github.com/woocommerce/woocommerce-ios/pull/11694]
 
 16.9
 -----

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/AnalyticsHubViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/AnalyticsHubViewModel.swift
@@ -235,7 +235,7 @@ private extension AnalyticsHubViewModel {
     /// Retrieves site summary stats using the `retrieveSiteSummaryStats` action.
     ///
     func retrieveSiteSummaryStats(latestDateToInclude: Date) async throws -> SiteSummaryStats? {
-        guard let period = timeRangeSelectionType.period else {
+        guard !stores.isAuthenticatedWithoutWPCom, let period = timeRangeSelectionType.period else {
             return nil
         }
 

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/AnalyticsHubViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/AnalyticsHubViewModel.swift
@@ -64,6 +64,10 @@ final class AnalyticsHubViewModel: ObservableObject {
     /// Sessions Card display state
     ///
     var showSessionsCard: Bool {
+        guard !stores.isAuthenticatedWithoutWPCom else {
+            return false
+        }
+
         switch timeRangeSelectionType {
         case .custom:
             return false

--- a/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Analytics Hub/AnalyticsHubViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Analytics Hub/AnalyticsHubViewModelTests.swift
@@ -172,6 +172,15 @@ final class AnalyticsHubViewModelTests: XCTestCase {
         XCTAssertTrue(vm.showSessionsCard)
     }
 
+    func test_session_card_is_hidden_for_sites_without_jetpack() {
+        // Given
+        let stores = MockStoresManager(sessionManager: .makeForTesting(authenticated: true, isWPCom: false))
+        let vm = AnalyticsHubViewModel(siteID: 123, statsTimeRange: .today, usageTracksEventEmitter: eventEmitter, stores: stores)
+
+        // Then
+        XCTAssertFalse(vm.showSessionsCard)
+    }
+
     func test_time_range_card_tracks_expected_events() throws {
         // Given
         let vm = AnalyticsHubViewModel(siteID: 123, statsTimeRange: .today, usageTracksEventEmitter: eventEmitter, analytics: analytics)

--- a/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Analytics Hub/AnalyticsHubViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Analytics Hub/AnalyticsHubViewModelTests.swift
@@ -2,6 +2,7 @@ import XCTest
 import Yosemite
 import WooFoundation
 @testable import WooCommerce
+import enum Networking.DotcomError
 
 final class AnalyticsHubViewModelTests: XCTestCase {
 
@@ -216,5 +217,28 @@ final class AnalyticsHubViewModelTests: XCTestCase {
 
         // Then
         XCTAssert(analyticsProvider.receivedEvents.contains(WooAnalyticsStat.analyticsHubWaitingTimeLoaded.rawValue))
+    }
+
+    @MainActor
+    func test_retrieving_stats_skips_summary_stats_request_for_sites_without_jetpack() async {
+        // Given
+        let stores = MockStoresManager(sessionManager: .makeForTesting(authenticated: true, isWPCom: false))
+        let vm = AnalyticsHubViewModel(siteID: 123, statsTimeRange: .today, usageTracksEventEmitter: eventEmitter, stores: stores)
+        stores.whenReceivingAction(ofType: StatsActionV4.self) { action in
+            switch action {
+            case let .retrieveCustomStats(_, _, _, _, _, _, _, completion):
+                completion(.success(.fake()))
+            case let .retrieveTopEarnerStats(_, _, _, _, _, _, _, _, completion):
+                completion(.success(.fake()))
+            case let .retrieveSiteSummaryStats(_, _, _, _, _, _, completion):
+                XCTFail("Request to retrieve site summary stats should not be dispatched for sites without Jetpack")
+                completion(.failure(DotcomError.unknown(code: "unknown_blog", message: "Unknown blog")))
+            default:
+                break
+            }
+        }
+
+        // When
+        await vm.updateData()
     }
 }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of #10338
<!-- Id number of the GitHub issue this PR addresses. -->

## Why
Stores that aren't using Jetpack won't have any Jetpack stats. The Analytics Hub sessions card requires Jetpack stats, so instead of showing a generic error we are now hiding that card for non-Jetpack stores.

## How
* Sets `showSessionsCard` to `false` for stores authenticated without WPCom (hides the card).
* Doesn't dispatch the request to fetch site summary stats for stores authenticated without WPCom (avoids extraneous API request).

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

Store without Jetpack:

1. Log in to the app with a store not using Jetpack.
2. In the My Store dashboard, tap "See More" to open the Analytics Hub.
3. Scroll to the bottom and confirm the sessions card doesn't load.

Store with Jetpack:

1. Log in to the app with a store using Jetpack.
2. In the My Store dashboard, tap "See More" to open the Analytics Hub.
3. Scroll to the bottom and confirm the sessions card loads as usual, with the expected data.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->
Before|After
-|-
![Simulator Screenshot - iPhone 15 Pro - 2024-01-15 at 10 53 42](https://github.com/woocommerce/woocommerce-ios/assets/8658164/1746fe6b-6191-4990-9b04-582990723126)|![Simulator Screenshot - iPhone 15 Pro - 2024-01-15 at 10 57 21](https://github.com/woocommerce/woocommerce-ios/assets/8658164/cd423805-ffc8-4184-8a1f-f7f6179825f9)


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
