### PR TITLE
Fix weird animation on all products related menus

### DIFF
--- a/WooCommerce/Classes/ViewRelated/BottomSheet/ListSelector/BottomSheetListSelectorViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/BottomSheet/ListSelector/BottomSheetListSelectorViewController.swift
@@ -43,6 +43,11 @@ UIViewController, UITableViewDataSource, UITableViewDelegate where Command.Model
         configureTableView()
     }
 
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+        configurePreferredContentSize()
+    }
+
     override func viewDidAppear(_ animated: Bool) {
         super.viewDidAppear(animated)
         configurePreferredContentSize()

--- a/WooCommerce/Classes/ViewRelated/BottomSheet/ListSelector/BottomSheetListSelectorViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/BottomSheet/ListSelector/BottomSheetListSelectorViewController.swift
@@ -43,13 +43,8 @@ UIViewController, UITableViewDataSource, UITableViewDelegate where Command.Model
         configureTableView()
     }
 
-    override func viewWillAppear(_ animated: Bool) {
-        super.viewWillAppear(animated)
-        configurePreferredContentSize()
-    }
-
-    override func viewDidAppear(_ animated: Bool) {
-        super.viewDidAppear(animated)
+    override func viewDidLayoutSubviews() {
+        super.viewDidLayoutSubviews()
         configurePreferredContentSize()
     }
 

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewController.swift
@@ -924,7 +924,7 @@ private extension ProductFormViewController {
                                                                     }
         }
         let listSelectorPresenter = BottomSheetListSelectorPresenter(viewProperties: viewProperties, command: dataSource)
-        listSelectorPresenter.show(from: self, sourceView: button, arrowDirections: .down)
+        listSelectorPresenter.show(from: self, sourceView: button.titleLabel ?? button, arrowDirections: .down)
     }
 
     func updateMoreDetailsButtonVisibility() {


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #8405
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
- there was a problem with timing of calling/setting **preferredContentSize** which caused a "glitch" in presentation of a popover on iPad
- now **preferredContentSize** is properly set and the glitch is gone
- another thing added in this PR is usage of **button.titleLabel** as a **sourceView** when presenting the popover so the popover arrow points to the button content and not the middle of it

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
- Open products
- Tap on any Product
- Tap on "Add more details" button
- Check that popover immediately has proper dimensions and does not jump up and then back down

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

| Before      | After |
| ----------- | ----------- |
| ![before](https://github.com/woocommerce/woocommerce-ios/assets/6242034/0b26ff61-0803-4374-b1e2-fed248198c0d) | ![after](https://github.com/woocommerce/woocommerce-ios/assets/6242034/b7e59db3-93a5-4665-83f7-407e8b5d1668) |

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
