### PR TITLE
[Order Creation] Fix Collect Payment from Order Form when Split View enabled

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/EditableOrderViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/EditableOrderViewModel.swift
@@ -376,10 +376,6 @@ final class EditableOrderViewModel: ObservableObject {
 
     @Published private(set) var orderTotal: String = ""
 
-    @Published var collectPaymentViewModel: PaymentMethodsViewModel? = nil
-
-    @Published var shouldPresentCollectPayment: Bool = false
-
     /// Saves a shipping line.
     ///
     /// - Parameter shippingLine: Optional shipping line object to save. `nil` will remove existing shipping line.
@@ -795,14 +791,14 @@ final class EditableOrderViewModel: ObservableObject {
     func collectPayment(for order: Order) {
         let formattedTotal = currencyFormatter.formatAmount(order.total, with: order.currency) ?? String()
 
-        self.collectPaymentViewModel = PaymentMethodsViewModel(
+        let collectPaymentViewModel = PaymentMethodsViewModel(
             siteID: siteID,
             orderID: order.orderID,
             paymentLink: order.paymentURL,
             formattedTotal: formattedTotal,
             flow: .orderCreation)
 
-        self.shouldPresentCollectPayment = true
+        onFinishAndCollectPayment(order, collectPaymentViewModel)
     }
 
     /// Action triggered on `Done` button tap in order editing flow.
@@ -816,6 +812,8 @@ final class EditableOrderViewModel: ObservableObject {
     /// For edition it means that the merchant has finished editing the order.
     ///
     var onFinished: (Order) -> Void = { _ in }
+
+    var onFinishAndCollectPayment: (Order, PaymentMethodsViewModel) -> Void = { _, _ in }
 
     /// Updates the order status & tracks its event
     ///
@@ -895,7 +893,6 @@ final class EditableOrderViewModel: ObservableObject {
             guard let self else { return }
             self.collectPayment(for: order)
             self.trackCreateOrderSuccess(usesGiftCard: usesGiftCard)
-            self.onFinished(order)
         } onFailure: { [weak self] error, usesGiftCard in
             guard let self else { return }
             self.fixedNotice = NoticeFactory.createOrderErrorNotice(error, order: self.orderSynchronizer.order)

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/OrderForm.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/OrderForm.swift
@@ -261,14 +261,6 @@ struct OrderForm: View {
                     completedButton
                         .padding()
                 }
-                .sheet(isPresented: $viewModel.shouldPresentCollectPayment) {
-                    if let collectPaymentViewModel = viewModel.collectPaymentViewModel {
-                        PaymentMethodsHostingView(parentController: rootViewController,
-                                                  viewModel: collectPaymentViewModel)
-                    } else {
-                        EmptyView()
-                    }
-                }
             } expandableContent: {
                 OrderPaymentSection(
                     viewModel: viewModel.paymentDataViewModel,

--- a/WooCommerce/Classes/ViewRelated/Orders/OrderListViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrderListViewController.swift
@@ -112,7 +112,9 @@ final class OrderListViewController: UIViewController, GhostableViewController {
 
     /// Callback closure when an order is selected
     ///
-    private var switchDetailsHandler: (_ allViewModels: [OrderDetailsViewModel], _ index: Int) -> Void
+    private var switchDetailsHandler: (_ allViewModels: [OrderDetailsViewModel], _
+                                       index: Int, _
+                                       onCompletion: (() -> Void)?) -> Void
 
     /// Currently selected index path in the table view
     ///
@@ -148,7 +150,7 @@ final class OrderListViewController: UIViewController, GhostableViewController {
     init(siteID: Int64,
          title: String,
          viewModel: OrderListViewModel,
-         switchDetailsHandler: @escaping ([OrderDetailsViewModel], Int) -> Void) {
+         switchDetailsHandler: @escaping ([OrderDetailsViewModel], Int, (() -> Void)?) -> Void) {
         self.siteID = siteID
         self.viewModel = viewModel
         self.switchDetailsHandler = switchDetailsHandler
@@ -529,11 +531,11 @@ private extension OrderListViewController {
                 state != .empty else {
             selectedOrderID = nil
             selectedIndexPath = nil
-            return switchDetailsHandler([], 0)
+            return switchDetailsHandler([], 0, nil)
         }
         selectedOrderID = orderDetailsViewModel.order.orderID
         selectedIndexPath = firstIndexPath
-        switchDetailsHandler([orderDetailsViewModel], 0)
+        switchDetailsHandler([orderDetailsViewModel], 0, nil)
         highlightSelectedRowIfNeeded()
     }
 }
@@ -709,8 +711,8 @@ extension OrderListViewController: UITableViewDelegate {
             // There is no point of having order navigation in the order details view when we have a split screen,
             // because orders can be easily selected in the left view (orders list).
             // Passing just one order (the selected one) disables navigation
-            allowOrderNavigation ? switchDetailsHandler(allViewModels, currentIndex) :
-            switchDetailsHandler([orderDetailsViewModel], 0)
+            allowOrderNavigation ? switchDetailsHandler(allViewModels, currentIndex, nil) :
+            switchDetailsHandler([orderDetailsViewModel], 0, nil)
         } else {
             let viewController = OrderDetailsViewController(viewModels: allViewModels, currentIndex: currentIndex)
             navigationController?.pushViewController(viewController, animated: true)

--- a/WooCommerce/Classes/ViewRelated/Orders/OrdersRootViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrdersRootViewController.swift
@@ -188,6 +188,20 @@ final class OrdersRootViewController: UIViewController {
             }
         }
 
+        viewModel.onFinishAndCollectPayment = { [weak self] order, paymentMethodsViewModel in
+            self?.dismiss(animated: true) {
+                self?.navigateToOrderDetail(order) { [weak self] in
+                    guard let self,
+                          let orderDetailsViewController = self.orderDetailsViewController else {
+                        return
+                    }
+                    let paymentMethodsViewController = PaymentMethodsHostingController(viewModel: paymentMethodsViewModel)
+                    paymentMethodsViewController.parentController = orderDetailsViewController
+                    orderDetailsViewController.present(paymentMethodsViewController, animated: true)
+                }
+            }
+        }
+
         if ServiceLocator.featureFlagService.isFeatureFlagEnabled(.splitViewInOrdersTab) {
             let newOrderNavigationController = WooNavigationController(rootViewController: viewController)
             navigationController.present(newOrderNavigationController, animated: true)
@@ -522,7 +536,17 @@ private extension OrdersRootViewController {
             show(orderViewController, sender: self)
         }
         onCompletion?()
+    }
 
+    var orderDetailsViewController: OrderDetailsViewController? {
+        guard featureFlagService.isFeatureFlagEnabled(.splitViewInOrdersTab) else {
+            return navigationController?.topViewController as? OrderDetailsViewController
+        }
+
+        guard let secondaryViewNavigationController = splitViewController?.viewController(for: .secondary) as? UINavigationController else {
+            return nil
+        }
+        return secondaryViewNavigationController.topViewController as? OrderDetailsViewController
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/OrdersRootViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrdersRootViewController.swift
@@ -503,6 +503,7 @@ private extension OrdersRootViewController {
     /// Pushes an `OrderDetailsViewController` onto the navigation stack.
     ///
     private func navigateToOrderDetail(_ order: Order) {
+        analytics.track(event: WooAnalyticsEvent.Orders.orderOpen(order: order))
         let viewModel = OrderDetailsViewModel(order: order)
         guard !featureFlagService.isFeatureFlagEnabled(.splitViewInOrdersTab) else {
             return handleSwitchingDetails(viewModels: [viewModel], currentIndex: 0)
@@ -518,7 +519,6 @@ private extension OrdersRootViewController {
             show(orderViewController, sender: self)
         }
 
-        analytics.track(event: WooAnalyticsEvent.Orders.orderOpen(order: order))
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/OrdersRootViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrdersRootViewController.swift
@@ -291,8 +291,9 @@ final class OrdersRootViewController: UIViewController {
 
     /// This is to update the order detail in split view
     ///
-    private func handleSwitchingDetails(viewModels: [OrderDetailsViewModel], currentIndex: Int) {
+    private func handleSwitchingDetails(viewModels: [OrderDetailsViewModel], currentIndex: Int, onCompletion: (() -> Void)? = nil) {
         guard let splitViewController else {
+            onCompletion?()
             return
         }
 
@@ -305,6 +306,7 @@ final class OrdersRootViewController: UIViewController {
             emptyStateViewController.configure(config)
             splitViewController.setViewController(UINavigationController(rootViewController: emptyStateViewController), for: .secondary)
             splitViewController.show(.secondary)
+            onCompletion?()
             return
         }
 
@@ -313,6 +315,7 @@ final class OrdersRootViewController: UIViewController {
 
         splitViewController.setViewController(orderDetailsNavigationController, for: .secondary)
         splitViewController.show(.secondary)
+        onCompletion?()
     }
 }
 
@@ -502,11 +505,11 @@ private extension OrdersRootViewController {
 
     /// Pushes an `OrderDetailsViewController` onto the navigation stack.
     ///
-    private func navigateToOrderDetail(_ order: Order) {
+    private func navigateToOrderDetail(_ order: Order, onCompletion: (() -> Void)? = nil) {
         analytics.track(event: WooAnalyticsEvent.Orders.orderOpen(order: order))
         let viewModel = OrderDetailsViewModel(order: order)
         guard !featureFlagService.isFeatureFlagEnabled(.splitViewInOrdersTab) else {
-            return handleSwitchingDetails(viewModels: [viewModel], currentIndex: 0)
+            return handleSwitchingDetails(viewModels: [viewModel], currentIndex: 0, onCompletion: onCompletion)
         }
 
         let orderViewController = OrderDetailsViewController(viewModel: viewModel)
@@ -518,6 +521,7 @@ private extension OrdersRootViewController {
         } else {
             show(orderViewController, sender: self)
         }
+        onCompletion?()
 
     }
 }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #11676
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

The `Collect Payment` button on the Order Form was broken with the Orders Split View feature flag set to `true`.

This was due to the different view lifecycle, when the Order Form is presented from a `UISplitViewController`. The previous implementation relied on the Order Details becoming visible before the sheet was presented by the OrderForm (and frankly, I'm surprised it ever worked!)

This PR delegates the presentation of the Payment Method screen to the `OrdersRootViewController`, which handles the transition and can wait until the Order Details screen is shown, before telling it to present the payment screen.

The same approach is used with the feature flag on and off, but that's required a change to the code with the feature flag set to `false` as well. Both should be tested.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

1. Set the feature flag to your test variant
2. Launch the app
3. Tap the Orders tab
4. Tap +
5. Add a product to the order
6. Tap `Collect Payment`
7. Observe that the form is dismissed, Order Details are shown, and then the Payment Methods screen is presented on top.
8. Complete a payment flow.

- [ ] Feature flag `true`, iPad full-screen (split view visible)
- [ ] Feature flag `true`, iPad with app in slide-over (split view collapsed)
- [ ] Feature flag `true`, iPhone in portrait
- [ ] Feature flag `false`, iPad full-screen (split view visible)
- [ ] Feature flag `false`, iPad with app in slide-over (split view collapsed)
- [ ] Feature flag `false`, iPhone in portrait

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

### iPad: feature flag on



https://github.com/woocommerce/woocommerce-ios/assets/2472348/6479a279-6cd5-4aa7-94e9-80b2afa81c55




### iPad: feature flag off



https://github.com/woocommerce/woocommerce-ios/assets/2472348/9a9664a3-1400-4df0-a61b-1c63b7712aec





---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
