### PR TITLE
[Product List] Update selection colour to new design

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Products/Cells/ProductsTabProductTableViewCell.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Cells/ProductsTabProductTableViewCell.swift
@@ -97,8 +97,6 @@ extension ProductsTabProductTableViewCell {
             selectedProductImageOverlayView?.removeFromSuperview()
             selectedProductImageOverlayView = nil
         }
-        let selectedBackgroundColor = isSelected ? UIColor.primary.withAlphaComponent(0.2): .listForeground(modal: false)
-        backgroundColor = selectedBackgroundColor
     }
 
     func configureAccessoryDeleteButton(onTap: @escaping () -> Void) {
@@ -157,7 +155,7 @@ private extension ProductsTabProductTableViewCell {
 
         //Background when selected
         selectedBackgroundView = UIView()
-        selectedBackgroundView?.backgroundColor = .listBackground
+        selectedBackgroundView?.backgroundColor = Colors.selectedBackgroundColor
 
         // Prevents overflow of selectedBackgroundView above dividers from adjacent cells
         clipsToBounds = true
@@ -240,6 +238,7 @@ private extension ProductsTabProductTableViewCell {
         static let imageBorderColor = UIColor.border
         static let imagePlaceholderTintColor = UIColor.systemColor(.systemGray2)
         static let imageBackgroundColor = UIColor.listForeground(modal: false)
+        static let selectedBackgroundColor = UIColor.productsCellSelectedBackgroundColor
     }
 }
 

--- a/WooFoundation/WooFoundation/Colors/UIColor+SemanticColors.swift
+++ b/WooFoundation/WooFoundation/Colors/UIColor+SemanticColors.swift
@@ -427,6 +427,12 @@ public extension UIColor {
             return .secondarySystemGroupedBackground
         }
     }
+
+    /// Products tab list cell selected background color
+    ///
+    static var productsCellSelectedBackgroundColor: UIColor {
+        return UIColor.wooCommercePurple(.shade0)
+    }
 }
 
 


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #11659
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
- Add and use **productsCellSelectedBackgroundColor** (`wooCommercePurple(.shade0)`) for products list cell

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
- open Products tab
- tap on any product in the list and check that the selected background color is `wooCommercePurple(.shade0)`
- enter multiple selection mode and select multiple products, check that the selected background color is `wooCommercePurple(.shade0)`

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

|       | Now | Before     |
| :---        |    :----:   |           :----:  |
| Single selection      | ![Simulator Screen Recording - iPad Pro (11-inch) (4th generation) - 2024-01-16 at 15 23 57](https://github.com/woocommerce/woocommerce-ios/assets/6242034/7d5f6d71-1e8b-4c11-b934-e5a47b14b6b7)       | ![Simulator Screen Recording - iPad Pro (11-inch) (4th generation) - 2024-01-16 at 15 30 18](https://github.com/woocommerce/woocommerce-ios/assets/6242034/513dbd33-538d-4154-b0fb-741f72bd9969)   |
| Multiple selection   | ![Simulator Screen Recording - iPad Pro (11-inch) (4th generation) - 2024-01-16 at 15 23 43](https://github.com/woocommerce/woocommerce-ios/assets/6242034/772fd7dd-4012-40f3-b0d9-4227c811e80e)        | ![Simulator Screen Recording - iPad Pro (11-inch) (4th generation) - 2024-01-16 at 15 30 28](https://github.com/woocommerce/woocommerce-ios/assets/6242034/59a1c8ab-0ca2-4e42-b3e7-1e655507f7dd)      |

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
