### PR TITLE
Attempted alleviation of `ServiceLocator._stores.unsafeMutableAddressor` crash on app launch

### DIFF
--- a/WooCommerce/Classes/Yosemite/DefaultStoresManager.swift
+++ b/WooCommerce/Classes/Yosemite/DefaultStoresManager.swift
@@ -237,7 +237,7 @@ class DefaultStoresManager: StoresManager {
         applicationPasswordGenerationFailureObserver = nil
 
         let resetAction = CardPresentPaymentAction.reset
-        ServiceLocator.stores.dispatch(resetAction)
+        dispatch(resetAction)
 
         state = DeauthenticatedState()
 


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Attempted alleviation of crash related to #3376
<!-- Id number of the GitHub issue this PR addresses. -->

## Why

In the last 2 weeks at least (maybe for much longer), the top crash (312 devices that opted in) in Xcode Organizer is on `ServiceLocator._stores.unsafeMutableAddressor` with a stack trace like the following:

```
Exception Type:  EXC_BREAKPOINT (SIGTRAP)
Exception Codes: 0x0000000000000001, 0x00000001b7866d94
Termination Reason: SIGNAL 5 Trace/BPT trap: 5
Terminating Process: exc handler [2819]

Thread 0 name:
Thread 0 Crashed:
0   libdispatch.dylib             	0x00000001b7866d94 _dispatch_once_wait.cold.1 + 28 (lock.c:676)
1   libdispatch.dylib             	0x00000001b7831c68 _dispatch_once_wait + 184 (lock.c:676)
2   WooCommerce                   	0x00000001052334d0 ServiceLocator._stores.unsafeMutableAddressor + 20 (ServiceLocator.swift:22)
3   WooCommerce                   	0x00000001052334d0 static ServiceLocator.stores.getter + 20 (ServiceLocator.swift:132)
4   WooCommerce                   	0x00000001052334d0 DefaultStoresManager.deauthenticate() + 800 (DefaultStoresManager.swift:240)
5   WooCommerce                   	0x0000000105233190 DefaultStoresManager.fullyDeauthenticateIfNeeded() + 296 (DefaultStoresManager.swift:230)
6   WooCommerce                   	0x0000000104bc33cc specialized DefaultStoresManager.init(sessionManager:notificationCenter:defaults:) + 1068 (DefaultStoresManager.swift:131)
7   WooCommerce                   	0x0000000104bc0b94 specialized DefaultStoresManager.init(sessionManager:notificationCenter:defaults:) + 16 (<compiler-generated>:121)
8   WooCommerce                   	0x0000000104bc0b94 DefaultStoresManager.init(sessionManager:notificationCenter:defaults:) + 16 (DefaultStoresManager.swift:0)
9   WooCommerce                   	0x0000000104bc0b94 specialized DefaultStoresManager.__allocating_init(sessionManager:notificationCenter:defaults:) + 16 (<compiler-generated>:121)
10  WooCommerce                   	0x0000000104bc0b94 DefaultStoresManager.__allocating_init(sessionManager:notificationCenter:defaults:) + 16 (ServiceLocator.swift:22)
11  WooCommerce                   	0x0000000104bc0b94 one-time initialization function for _stores + 240
12  libdispatch.dylib             	0x00000001b7831300 _dispatch_client_callout + 20 (object.m:561)
13  libdispatch.dylib             	0x00000001b7832b3c _dispatch_once_callout + 32 (once.c:52)
14  WooCommerce                   	0x0000000104da41f0 ServiceLocator._stores.unsafeMutableAddressor + 20 (ServiceLocator.swift:22)
15  WooCommerce                   	0x0000000104da41f0 static ServiceLocator.stores.getter + 20 (ServiceLocator.swift:132)
... // This can be triggered from `AppDelegate.setupPushNotificationsManagerIfPossible` or `AppDelegate.setupAnalytics`
19  WooCommerce                   	0x0000000104da29b4 @objc AppDelegate.application(_:willFinishLaunchingWithOptions:) + 140
```
Example stack traces can be found by right clicking on the crash in Xcode Organizer > show in Finder, then right click to Show Package Contents.

I happened to be able to reproduce this crash consistently (cannot recover on the next launch) in an iOS 17.0.1 iPad simulator in Xcode 15.0.1/15.1/15.2. After taking a look at the code, it looks like the issue is from referencing `ServiceLocator.stores` in `DefaultStoresManager` itself while `ServiceLocator.stores` itself is being initialized:

<img width="1624" alt="Screenshot 2024-01-17 at 11 48 38 AM" src="https://github.com/woocommerce/woocommerce-ios/assets/1945542/c6f5eb0e-7016-447d-ac06-3f95c3489d0a">

## How

I tried updating this line to use `self` instead of `ServiceLocator.stores`, it still crashed on the next launch with the following stack trace, but it stopped crashing after that.

<details><summary>Stack trace of the following crash:</summary>
<code>
#2	0x0000000104ba9ce4 in ServiceLocator._stores.unsafeMutableAddressor at /Users/jaclynchen/Developer/testing/woocommerce-ios/WooCommerce/Classes/ServiceLocator/ServiceLocator.swift:22
#3	0x0000000104baaf9c in static ServiceLocator.stores.getter at /Users/jaclynchen/Developer/testing/woocommerce-ios/WooCommerce/Classes/ServiceLocator/ServiceLocator.swift:132
#4	0x0000000105b213d8 in WooAnalytics.refreshUserData() at /Users/jaclynchen/Developer/testing/woocommerce-ios/WooCommerce/Classes/Analytics/WooAnalytics.swift:67
#5	0x0000000105b21334 in protocol witness for Analytics.refreshUserData() in conformance WooAnalytics ()
#6	0x0000000105aac534 in DefaultStoresManager.deauthenticate() at /Users/jaclynchen/Developer/testing/woocommerce-ios/WooCommerce/Classes/Yosemite/DefaultStoresManager.swift:245
#7	0x0000000105aac358 in DefaultStoresManager.fullyDeauthenticateIfNeeded() at /Users/jaclynchen/Developer/testing/woocommerce-ios/WooCommerce/Classes/Yosemite/DefaultStoresManager.swift:230
#8	0x0000000105aaa1f4 in DefaultStoresManager.init(sessionManager:notificationCenter:defaults:) at /Users/jaclynchen/Developer/testing/woocommerce-ios/WooCommerce/Classes/Yosemite/DefaultStoresManager.swift:131
#9	0x0000000105aa9df8 in DefaultStoresManager.__allocating_init(sessionManager:notificationCenter:defaults:) ()
#10	0x0000000104ba9c64 in one-time initialization function for _stores at /Users/jaclynchen/Developer/testing/woocommerce-ios/WooCommerce/Classes/ServiceLocator/ServiceLocator.swift:22
#11	0x000000010ac8993c in _dispatch_client_callout ()
#12	0x000000010ac8b3dc in _dispatch_once_callout ()
#13	0x0000000104ba9ce4 in ServiceLocator._stores.unsafeMutableAddressor at /Users/jaclynchen/Developer/testing/woocommerce-ios/WooCommerce/Classes/ServiceLocator/ServiceLocator.swift:22
#14	0x0000000104baaf9c in static ServiceLocator.stores.getter at /Users/jaclynchen/Developer/testing/woocommerce-ios/WooCommerce/Classes/ServiceLocator/ServiceLocator.swift:132
#15	0x0000000105b213d8 in WooAnalytics.refreshUserData() at /Users/jaclynchen/Developer/testing/woocommerce-ios/WooCommerce/Classes/Analytics/WooAnalytics.swift:67
#16	0x0000000105b20f94 in WooAnalytics.initialize() at /Users/jaclynchen/Developer/testing/woocommerce-ios/WooCommerce/Classes/Analytics/WooAnalytics.swift:53
#18	0x0000000104ffdbc0 in AppDelegate.setupAnalytics() at /Users/jaclynchen/Developer/testing/woocommerce-ios/WooCommerce/Classes/AppDelegate.swift:293
#19	0x0000000104ffda18 in AppDelegate.application(_:willFinishLaunchingWithOptions:) at /Users/jaclynchen/Developer/testing/woocommerce-ios/WooCommerce/Classes/AppDelegate.swift:61
</code>
</details>

The next crash is a similar circular reference between `WooAnalytics` and `DefaultStoresManager` in their initialization:

- App launch --> `AppDelegate.setupAnalytics` --> `WooAnalytics.refreshUserData` --> referencing `ServiceLocator.stores.isAuthenticatedWithoutWPCom` --> initializing `DefaultStoresManager` as the static singleton in `ServiceLocator`
  - `DefaultStoresManager` finds that it's not authenticated --> `DefaultStoresManager.deauthenticate` --> `ServiceLocator.analytics.refreshUserData` which is what initiates the `DefaultStoresManager` initialization 😅 

I'm not sure why this crash can be resolved in the next launch though. We probably want to also fix this circular reference but it might involve bigger changes. I was hoping to see if this first change can alleviate the crash.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

I haven't found a way to reproduce this crash on any device, it just happens probably due to some race condition in the particular device. But when it can be reproduced on a device, it happens repeatedly on app launch.

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
