### PR TITLE
[Tablet support] Add max width to order details

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/OrderDetailsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/OrderDetailsViewController.swift
@@ -133,6 +133,9 @@ private extension OrderDetailsViewController {
         tableView.estimatedRowHeight = Constants.rowHeight
         tableView.rowHeight = UITableView.automaticDimension
 
+        stackView.layer.borderWidth = 1.0
+        stackView.layer.borderColor = .init(red: 0.776, green: 0.776, blue: 0.784, alpha: 1)
+
         let maxWidthConstraint = stackView.widthAnchor.constraint(lessThanOrEqualToConstant: Constants.maxWidth)
         NSLayoutConstraint.activate([maxWidthConstraint])
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/OrderDetailsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/OrderDetailsViewController.swift
@@ -142,8 +142,10 @@ private extension OrderDetailsViewController {
         stackView.layer.borderWidth = 0.5
         stackView.layer.borderColor = UIColor.border.cgColor
 
-        let maxWidthConstraint = stackView.widthAnchor.constraint(lessThanOrEqualToConstant: Constants.maxWidth)
-        NSLayoutConstraint.activate([maxWidthConstraint])
+        if isSplitViewInOrdersTabEnabled {
+            let maxWidthConstraint = stackView.widthAnchor.constraint(lessThanOrEqualToConstant: Constants.maxWidth)
+            NSLayoutConstraint.activate([maxWidthConstraint])
+        }
     }
 
     /// Setup: Navigation

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/OrderDetailsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/OrderDetailsViewController.swift
@@ -82,6 +82,7 @@ final class OrderDetailsViewController: UIViewController {
         configureNavigationBar()
         configureTopLoaderView()
         configureTableView()
+        configureStackView()
         registerTableViewCells()
         registerTableViewHeaderFooters()
         configureEntityListener()
@@ -133,14 +134,16 @@ private extension OrderDetailsViewController {
         tableView.estimatedRowHeight = Constants.rowHeight
         tableView.rowHeight = UITableView.automaticDimension
 
-        stackView.layer.borderWidth = 1.0
-        stackView.layer.borderColor = .init(red: 0.776, green: 0.776, blue: 0.784, alpha: 1)
+        tableView.dataSource = viewModel.dataSource
+        tableView.accessibilityIdentifier = "order-details-table-view"
+    }
+
+    func configureStackView() {
+        stackView.layer.borderWidth = 0.5
+        stackView.layer.borderColor = UIColor.border.cgColor
 
         let maxWidthConstraint = stackView.widthAnchor.constraint(lessThanOrEqualToConstant: Constants.maxWidth)
         NSLayoutConstraint.activate([maxWidthConstraint])
-
-        tableView.dataSource = viewModel.dataSource
-        tableView.accessibilityIdentifier = "order-details-table-view"
     }
 
     /// Setup: Navigation

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/OrderDetailsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/OrderDetailsViewController.swift
@@ -905,7 +905,7 @@ private extension OrderDetailsViewController {
         static let headerContainerInsets = UIEdgeInsets(top: 0, left: 0, bottom: 8, right: 0)
         static let rowHeight = CGFloat(38)
         static let sectionHeight = CGFloat(44)
-        static let maxWidth = CGFloat(560)
+        static let maxWidth = CGFloat(450)
     }
 
     /// Mailing a receipt failed but the SDK didn't return a more specific error

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/OrderDetailsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/OrderDetailsViewController.swift
@@ -909,7 +909,7 @@ private extension OrderDetailsViewController {
         static let headerContainerInsets = UIEdgeInsets(top: 0, left: 0, bottom: 8, right: 0)
         static let rowHeight = CGFloat(38)
         static let sectionHeight = CGFloat(44)
-        static let maxWidth = CGFloat(450)
+        static let maxWidth = CGFloat(525)
         static let borderWidth = CGFloat(0.5)
     }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/OrderDetailsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/OrderDetailsViewController.swift
@@ -905,7 +905,7 @@ private extension OrderDetailsViewController {
         static let headerContainerInsets = UIEdgeInsets(top: 0, left: 0, bottom: 8, right: 0)
         static let rowHeight = CGFloat(38)
         static let sectionHeight = CGFloat(44)
-        static let maxWidth = CGFloat(540)
+        static let maxWidth = CGFloat(560)
     }
 
     /// Mailing a receipt failed but the SDK didn't return a more specific error

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/OrderDetailsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/OrderDetailsViewController.swift
@@ -139,14 +139,15 @@ private extension OrderDetailsViewController {
     }
 
     func configureStackView() {
+        guard isSplitViewInOrdersTabEnabled else {
+            return
+        }
         stackView.layer.borderWidth = Constants.borderWidth
         stackView.layer.borderColor = UIColor.border.cgColor
 
-        if isSplitViewInOrdersTabEnabled {
-            let maxWidthConstraint = stackView.widthAnchor.constraint(lessThanOrEqualToConstant: Constants.maxWidth)
-            maxWidthConstraint.priority = .required
-            NSLayoutConstraint.activate([maxWidthConstraint])
-        }
+        let maxWidthConstraint = stackView.widthAnchor.constraint(lessThanOrEqualToConstant: Constants.maxWidth)
+        maxWidthConstraint.priority = .required
+        NSLayoutConstraint.activate([maxWidthConstraint])
     }
 
     /// Setup: Navigation

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/OrderDetailsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/OrderDetailsViewController.swift
@@ -139,7 +139,7 @@ private extension OrderDetailsViewController {
     }
 
     func configureStackView() {
-        stackView.layer.borderWidth = 0.5
+        stackView.layer.borderWidth = Constants.borderWidth
         stackView.layer.borderColor = UIColor.border.cgColor
 
         if isSplitViewInOrdersTabEnabled {
@@ -908,6 +908,7 @@ private extension OrderDetailsViewController {
         static let rowHeight = CGFloat(38)
         static let sectionHeight = CGFloat(44)
         static let maxWidth = CGFloat(450)
+        static let borderWidth = CGFloat(0.5)
     }
 
     /// Mailing a receipt failed but the SDK didn't return a more specific error

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/OrderDetailsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/OrderDetailsViewController.swift
@@ -133,6 +133,9 @@ private extension OrderDetailsViewController {
         tableView.estimatedRowHeight = Constants.rowHeight
         tableView.rowHeight = UITableView.automaticDimension
 
+        let maxWidthConstraint = stackView.widthAnchor.constraint(lessThanOrEqualToConstant: Constants.maxWidth)
+        NSLayoutConstraint.activate([maxWidthConstraint])
+
         tableView.dataSource = viewModel.dataSource
         tableView.accessibilityIdentifier = "order-details-table-view"
     }
@@ -896,6 +899,7 @@ private extension OrderDetailsViewController {
         static let headerContainerInsets = UIEdgeInsets(top: 0, left: 0, bottom: 8, right: 0)
         static let rowHeight = CGFloat(38)
         static let sectionHeight = CGFloat(44)
+        static let maxWidth = CGFloat(540)
     }
 
     /// Mailing a receipt failed but the SDK didn't return a more specific error

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/OrderDetailsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/OrderDetailsViewController.swift
@@ -144,6 +144,7 @@ private extension OrderDetailsViewController {
 
         if isSplitViewInOrdersTabEnabled {
             let maxWidthConstraint = stackView.widthAnchor.constraint(lessThanOrEqualToConstant: Constants.maxWidth)
+            maxWidthConstraint.priority = .required
             NSLayoutConstraint.activate([maxWidthConstraint])
         }
     }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/OrderDetailsViewController.xib
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/OrderDetailsViewController.xib
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="19529" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="22154" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="19519"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="22130"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
@@ -22,10 +22,10 @@
             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
             <subviews>
                 <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="d22-mg-5dQ">
-                    <rect key="frame" x="0.0" y="44" width="414" height="818"/>
+                    <rect key="frame" x="0.0" y="48" width="414" height="814"/>
                     <subviews>
                         <tableView clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="grouped" separatorStyle="default" rowHeight="-1" estimatedRowHeight="114" sectionHeaderHeight="18" sectionFooterHeight="18" translatesAutoresizingMaskIntoConstraints="NO" id="svF-7x-weU">
-                            <rect key="frame" x="0.0" y="0.0" width="414" height="818"/>
+                            <rect key="frame" x="0.0" y="0.0" width="414" height="814"/>
                             <color key="backgroundColor" systemColor="groupTableViewBackgroundColor"/>
                             <inset key="separatorInset" minX="16" minY="0.0" maxX="0.0" maxY="0.0"/>
                             <connections>
@@ -40,8 +40,9 @@
             <constraints>
                 <constraint firstItem="d22-mg-5dQ" firstAttribute="top" secondItem="vUN-kp-3ea" secondAttribute="top" id="5ZE-aa-z8W"/>
                 <constraint firstItem="vUN-kp-3ea" firstAttribute="bottom" secondItem="d22-mg-5dQ" secondAttribute="bottom" id="5Zf-no-qjl"/>
-                <constraint firstAttribute="trailing" secondItem="d22-mg-5dQ" secondAttribute="trailing" id="5np-Rf-otN"/>
-                <constraint firstItem="d22-mg-5dQ" firstAttribute="leading" secondItem="iN0-l3-epB" secondAttribute="leading" id="Vck-kK-YlT"/>
+                <constraint firstAttribute="trailing" secondItem="d22-mg-5dQ" secondAttribute="trailing" priority="750" id="5np-Rf-otN"/>
+                <constraint firstItem="d22-mg-5dQ" firstAttribute="leading" secondItem="iN0-l3-epB" secondAttribute="leading" priority="750" id="Vck-kK-YlT"/>
+                <constraint firstItem="d22-mg-5dQ" firstAttribute="centerX" secondItem="iN0-l3-epB" secondAttribute="centerX" id="Z7Q-Q0-SKe"/>
             </constraints>
             <point key="canvasLocation" x="139" y="140"/>
         </view>

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/OrderDetailsViewController.xib
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/OrderDetailsViewController.xib
@@ -40,9 +40,9 @@
             <constraints>
                 <constraint firstItem="d22-mg-5dQ" firstAttribute="top" secondItem="vUN-kp-3ea" secondAttribute="top" id="5ZE-aa-z8W"/>
                 <constraint firstItem="vUN-kp-3ea" firstAttribute="bottom" secondItem="d22-mg-5dQ" secondAttribute="bottom" id="5Zf-no-qjl"/>
-                <constraint firstAttribute="trailing" secondItem="d22-mg-5dQ" secondAttribute="trailing" priority="750" id="5np-Rf-otN"/>
-                <constraint firstItem="d22-mg-5dQ" firstAttribute="leading" secondItem="iN0-l3-epB" secondAttribute="leading" priority="750" id="Vck-kK-YlT"/>
-                <constraint firstItem="d22-mg-5dQ" firstAttribute="centerX" secondItem="iN0-l3-epB" secondAttribute="centerX" id="Z7Q-Q0-SKe"/>
+                <constraint firstItem="vUN-kp-3ea" firstAttribute="trailing" secondItem="d22-mg-5dQ" secondAttribute="trailing" priority="750" id="5np-Rf-otN"/>
+                <constraint firstItem="d22-mg-5dQ" firstAttribute="leading" secondItem="vUN-kp-3ea" secondAttribute="leading" priority="750" id="Vck-kK-YlT"/>
+                <constraint firstItem="d22-mg-5dQ" firstAttribute="centerX" secondItem="vUN-kp-3ea" secondAttribute="centerX" id="Z7Q-Q0-SKe"/>
             </constraints>
             <point key="canvasLocation" x="139" y="140"/>
         </view>


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #11677 
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
This PR updates the order view design for larger screens, and sets a maximum fixed width to the Order Details view.

<img width=800 src="https://github.com/woocommerce/woocommerce-ios/assets/3812076/c71e7689-b42e-40c8-97cb-574900ef6b61"/>


Why do we use a fixed max-width rather than a proportional one? Context: p1705383120838949-slack-C025A8VV728 

> _the content works well up to this width, which is the widest it can be before it becomes too spaced out. With a fixed max width, you don’t need to worry about iPhones and iPads. On iPhone, the screen won’t ever be wide enough to exceed the max width. Same on iPad in portrait, or smaller multitasking Split View percentages, or the iPad mini._

## Changes
- Adds a new `configureStackView()` function to the view controller init, which sets the style and constraints specifics to the stack view.
- Adds a max-width constant constraint to the stack view, with a value of `450` (taken from designs 6kkCwI9VOEYcidp6UT5bln-fi-192_26916 , but perhaps is too small for bigger screens?)
- Updates the `OrderDetailsViewController.xib` file in order to adjust both leading and trailing priority constraints by reducing them. We also add a new constraint to center the view horizontally.

## Testing instructions
- Switch the `.splitViewInOrdersTab` flag to `true`
- Go to Orders
- Observe that if we run the app on a device that does not support split views (eg: iPhone 15), there are no differences. We will see the order list, and upon tapping on an order we'll navigate to the order details view.
- If we use a device that supports split views (eg: iPhone 15 plus, or iPad Pro), we'll see the dual view (order list to the left + order details to the right) where the order details screen will show visible margins both leading and trailing that will dynamically decrease/increase depending on device.
- Attempt to change orientation, enable apps side-by-side, use side-over, and observe how the view and margins are updated properly.

## Screenshots (iPhone)
| iPhone portrait | iPhone landscape (split view) | iPhone landscape (no split view) |
|--------|--------|--------|
| ![Simulator Screenshot - iPhone 15 Plus - 2024-01-17 at 12 46 08](https://github.com/woocommerce/woocommerce-ios/assets/3812076/c52bb8e6-8aed-40ce-830d-50b5e1d0bf63) | ![Simulator Screenshot - iPhone 15 Plus - 2024-01-17 at 12 45 57](https://github.com/woocommerce/woocommerce-ios/assets/3812076/b748c92a-ef6e-4ffb-8276-607b4f7e0aab) | ![Simulator Screenshot - iPhone 15 Plus - 2024-01-12 at 11 58 26](https://github.com/woocommerce/woocommerce-ios/assets/3812076/956f3a40-37fd-4fd4-9f3f-1aadc3d6bbdf) |

## Screenshots (iPad)
| Slide-over | Split view horizontal | Split view vertical |
|--------|--------|--------|
| ![Simulator Screenshot - iPad Pro (12 9-inch) (6th generation) - 2024-01-17 at 12 55 28](https://github.com/woocommerce/woocommerce-ios/assets/3812076/aa1cc82d-c1f2-4dc3-9dcc-c82ca93041d5) | ![simulator_screenshot_FC266E62-3C4F-4584-A1D2-BEFBE75C7AC5](https://github.com/woocommerce/woocommerce-ios/assets/3812076/f017df1a-04de-4cbd-982f-28687a630b3c) | ![simulator_screenshot_7B9AD14F-1DE3-4673-904F-67846A73B93F](https://github.com/woocommerce/woocommerce-ios/assets/3812076/940f3a8c-5b30-4844-9a02-7c22685937da) | 


I understand this is expected, but perhaps there's an improvement here we could attempt on a future PR, I'm not sure of the complexity or worthiness at the moment thought: When using slider-over being the other app the one that's been slide away, then it hides part of the order UI.

<img width=800 src="https://github.com/woocommerce/woocommerce-ios/assets/3812076/4cc4ad6d-8285-44dc-bd45-f080741b8f1b">