### PR TITLE
[Order List] Update cell’s background configuration to `.listforeground`

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Orders/Cells/OrderTableViewCell.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Cells/OrderTableViewCell.swift
@@ -154,7 +154,7 @@ private extension OrderTableViewCell {
         } else {
             backgroundConfiguration = UIBackgroundConfiguration.listPlainCell()
         }
-        backgroundConfiguration.backgroundColor = .listBackground
+        backgroundConfiguration.backgroundColor = .listForeground(modal: false)
         self.backgroundConfiguration = backgroundConfiguration
     }
 


### PR DESCRIPTION

## Description
This PR addresses an UI bug introduced when updating `OrderTableViewCell` to use a background configuration object, rendering its colour as `.listBackground` rather than `.listForeground`

## Testing instructions
Go to Orders, observe that the foreground colour is correctly applied to the cells.

## Screenshots
| Before | After |
|--------|--------|
| ![Simulator Screenshot - iPhone 15 Plus - 2024-01-17 at 13 16 59](https://github.com/woocommerce/woocommerce-ios/assets/3812076/43a2731f-0f94-4d53-9ea2-091bd82b5849) | ![Simulator Screenshot - iPhone 15 Plus - 2024-01-17 at 13 15 49](https://github.com/woocommerce/woocommerce-ios/assets/3812076/328123db-f05c-442e-96ba-851af2311265) | 