### PR TITLE
[Tablet Orders] Fix deeplink to Order Details when SplitViewOrders is enabled

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Dashboard/DashboardViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/DashboardViewController.swift
@@ -487,7 +487,7 @@ private extension DashboardViewController {
 
     /// Starts the Add Product flow to showcase the product description AI feature.
     private func startAddProductFlowFromProductDescriptionAIModal() {
-        AppDelegate.shared.tabBarController?.navigateToTabWithNavigationController(.products, animated: true) { [weak self] tabViewController in
+        AppDelegate.shared.tabBarController?.navigateToTabWithViewController(.products, animated: true) { [weak self] tabViewController in
             guard let self else { return }
             guard let navigationController = tabViewController as? UINavigationController else {
                 return assertionFailure("`AddProductCoordinator` currently expects the source to be `UINavigationController`. " +

--- a/WooCommerce/Classes/ViewRelated/Dashboard/DashboardViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/DashboardViewController.swift
@@ -487,8 +487,12 @@ private extension DashboardViewController {
 
     /// Starts the Add Product flow to showcase the product description AI feature.
     private func startAddProductFlowFromProductDescriptionAIModal() {
-        AppDelegate.shared.tabBarController?.navigateToTabWithNavigationController(.products, animated: true) { [weak self] navigationController in
+        AppDelegate.shared.tabBarController?.navigateToTabWithNavigationController(.products, animated: true) { [weak self] tabViewController in
             guard let self else { return }
+            guard let navigationController = tabViewController as? UINavigationController else {
+                return assertionFailure("`AddProductCoordinator` currently expects the source to be `UINavigationController`. " +
+                                        "When we support split view in the products tab, update the source to be `UIViewController`")
+            }
             let coordinator = AddProductCoordinator(siteID: self.siteID,
                                                     source: .productDescriptionAIAnnouncementModal,
                                                     sourceView: nil,

--- a/WooCommerce/Classes/ViewRelated/MainTabBarController.swift
+++ b/WooCommerce/Classes/ViewRelated/MainTabBarController.swift
@@ -190,18 +190,18 @@ final class MainTabBarController: UITabBarController {
     /// Switches the TabBarController to the specified Tab
     ///
     func navigateTo(_ tab: WooTab, animated: Bool = false, completion: (() -> Void)? = nil) {
-        navigateToTabWithNavigationController(tab, animated: animated) { _ in
+        navigateToTabWithViewController(tab, animated: animated) { _ in
             completion?()
         }
     }
 
-    /// Switches the TabBarController to the specified tab and pops to root of the tab.
+    /// Switches the TabBarController to the specified tab and pops to root of the tab if the root is a `UINavigationController`.
     ///
     /// - Parameters:
     ///   - tab: The tab to switch to.
     ///   - animated: Whether the tab switch is animated.
-    ///   - completion: Invoked when switching to the tab's root screen is complete.
-    func navigateToTabWithNavigationController(_ tab: WooTab, animated: Bool = false, completion: ((UIViewController) -> Void)? = nil) {
+    ///   - completion: Invoked when switching to the tab's root screen is complete with the root view controller.
+    func navigateToTabWithViewController(_ tab: WooTab, animated: Bool = false, completion: ((UIViewController) -> Void)? = nil) {
         dismiss(animated: animated) { [weak self] in
             guard let self else { return }
             selectedIndex = tab.visibleIndex()

--- a/WooCommerce/Classes/ViewRelated/MainTabBarController.swift
+++ b/WooCommerce/Classes/ViewRelated/MainTabBarController.swift
@@ -201,13 +201,19 @@ final class MainTabBarController: UITabBarController {
     ///   - tab: The tab to switch to.
     ///   - animated: Whether the tab switch is animated.
     ///   - completion: Invoked when switching to the tab's root screen is complete.
-    func navigateToTabWithNavigationController(_ tab: WooTab, animated: Bool = false, completion: ((UINavigationController) -> Void)? = nil) {
+    func navigateToTabWithNavigationController(_ tab: WooTab, animated: Bool = false, completion: ((UIViewController) -> Void)? = nil) {
         dismiss(animated: animated) { [weak self] in
-            self?.selectedIndex = tab.visibleIndex()
-            if let navController = self?.selectedViewController as? UINavigationController {
+            guard let self else { return }
+            selectedIndex = tab.visibleIndex()
+            guard let selectedViewController else {
+                return
+            }
+            if let navController = selectedViewController as? UINavigationController {
                 navController.popToRootViewController(animated: animated) {
                     completion?(navController)
                 }
+            } else {
+                completion?(selectedViewController)
             }
         }
     }
@@ -444,7 +450,10 @@ extension MainTabBarController {
 
     private static func presentDetails(for orderID: Int64, siteID: Int64) {
         if ServiceLocator.featureFlagService.isFeatureFlagEnabled(.splitViewInOrdersTab) {
-            (childViewController() as? OrdersSplitViewWrapperController)?.presentDetails(for: orderID, siteID: siteID)
+            guard let ordersSplitViewWrapperController = (childViewController() as? TabContainerController)?.wrappedController as? OrdersSplitViewWrapperController else {
+                return assertionFailure("Unexpected orders tab root view controller: \(String(describing: childViewController()))")
+            }
+            ordersSplitViewWrapperController.presentDetails(for: orderID, siteID: siteID)
         } else {
             (childViewController() as? OrdersRootViewController)?.presentDetails(for: orderID, siteID: siteID)
         }

--- a/WooCommerce/Classes/ViewRelated/MainTabBarController.swift
+++ b/WooCommerce/Classes/ViewRelated/MainTabBarController.swift
@@ -450,7 +450,8 @@ extension MainTabBarController {
 
     private static func presentDetails(for orderID: Int64, siteID: Int64) {
         if ServiceLocator.featureFlagService.isFeatureFlagEnabled(.splitViewInOrdersTab) {
-            guard let ordersSplitViewWrapperController = (childViewController() as? TabContainerController)?.wrappedController as? OrdersSplitViewWrapperController else {
+            guard let ordersTabController = childViewController() as? TabContainerController,
+                  let ordersSplitViewWrapperController = ordersTabController.wrappedController as? OrdersSplitViewWrapperController else {
                 return assertionFailure("Unexpected orders tab root view controller: \(String(describing: childViewController()))")
             }
             ordersSplitViewWrapperController.presentDetails(for: orderID, siteID: siteID)

--- a/WooCommerce/Classes/ViewRelated/MainTabBarController.swift
+++ b/WooCommerce/Classes/ViewRelated/MainTabBarController.swift
@@ -386,7 +386,7 @@ extension MainTabBarController {
         case .storeOrder:
             switchToOrdersTab {
                 if ServiceLocator.featureFlagService.isFeatureFlagEnabled(.splitViewInOrdersTab) {
-                    (childViewController() as? OrdersSplitViewWrapperController)?.presentDetails(for: note)
+                    ordersTabSplitViewWrapper()?.presentDetails(for: note)
                 } else {
                     (childViewController() as? OrdersRootViewController)?.presentDetails(for: note)
                 }
@@ -450,14 +450,18 @@ extension MainTabBarController {
 
     private static func presentDetails(for orderID: Int64, siteID: Int64) {
         if ServiceLocator.featureFlagService.isFeatureFlagEnabled(.splitViewInOrdersTab) {
-            guard let ordersTabController = childViewController() as? TabContainerController,
-                  let ordersSplitViewWrapperController = ordersTabController.wrappedController as? OrdersSplitViewWrapperController else {
-                return assertionFailure("Unexpected orders tab root view controller: \(String(describing: childViewController()))")
-            }
-            ordersSplitViewWrapperController.presentDetails(for: orderID, siteID: siteID)
+            ordersTabSplitViewWrapper()?.presentDetails(for: orderID, siteID: siteID)
         } else {
             (childViewController() as? OrdersRootViewController)?.presentDetails(for: orderID, siteID: siteID)
         }
+    }
+
+    private static func ordersTabSplitViewWrapper() -> OrdersSplitViewWrapperController? {
+        guard let ordersTabController = childViewController() as? TabContainerController,
+              let ordersSplitViewWrapperController = ordersTabController.wrappedController as? OrdersSplitViewWrapperController else {
+            return nil
+        }
+        return ordersSplitViewWrapperController
     }
 
     static func presentPayments() {

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -500,6 +500,7 @@
 		02D3B68529657061009BF0BC /* SupportButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02D3B68429657061009BF0BC /* SupportButton.swift */; };
 		02D4472C2A4D29930040D72D /* WooAnalyticsEvent+LocalAnnouncement.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02D4472B2A4D29930040D72D /* WooAnalyticsEvent+LocalAnnouncement.swift */; };
 		02D45647231CB1FB008CF0A9 /* UIImage+Dot.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02D45646231CB1FB008CF0A9 /* UIImage+Dot.swift */; };
+		02D635792B58071C00B1CBF6 /* MockNote.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02D635782B58071C00B1CBF6 /* MockNote.swift */; };
 		02D681A929C358BA00348510 /* StoreOnboardingPaymentsSetupView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02D681A829C358BA00348510 /* StoreOnboardingPaymentsSetupView.swift */; };
 		02D681AB29C3F8AC00348510 /* StoreOnboardingPaymentsSetupCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02D681AA29C3F8AC00348510 /* StoreOnboardingPaymentsSetupCoordinator.swift */; };
 		02D7E7C12A4CA9030003049A /* LocalAnnouncementsProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02D7E7C02A4CA9030003049A /* LocalAnnouncementsProvider.swift */; };
@@ -3159,6 +3160,7 @@
 		02D3B68429657061009BF0BC /* SupportButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SupportButton.swift; sourceTree = "<group>"; };
 		02D4472B2A4D29930040D72D /* WooAnalyticsEvent+LocalAnnouncement.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "WooAnalyticsEvent+LocalAnnouncement.swift"; sourceTree = "<group>"; };
 		02D45646231CB1FB008CF0A9 /* UIImage+Dot.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIImage+Dot.swift"; sourceTree = "<group>"; };
+		02D635782B58071C00B1CBF6 /* MockNote.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockNote.swift; sourceTree = "<group>"; };
 		02D681A829C358BA00348510 /* StoreOnboardingPaymentsSetupView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StoreOnboardingPaymentsSetupView.swift; sourceTree = "<group>"; };
 		02D681AA29C3F8AC00348510 /* StoreOnboardingPaymentsSetupCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StoreOnboardingPaymentsSetupCoordinator.swift; sourceTree = "<group>"; };
 		02D7E7C02A4CA9030003049A /* LocalAnnouncementsProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocalAnnouncementsProvider.swift; sourceTree = "<group>"; };
@@ -8397,6 +8399,7 @@
 				68A38DF42B293B030090C263 /* MockProductListViewModel.swift */,
 				EE66BB112B29D65400518DAF /* MockThemeInstaller.swift */,
 				EEFF47312B309221009BF302 /* MockStoreCreationStoreSwitchScheduler.swift */,
+				02D635782B58071C00B1CBF6 /* MockNote.swift */,
 			);
 			path = Mocks;
 			sourceTree = "<group>";
@@ -14821,6 +14824,7 @@
 				AEB6903729770B1D00872FE0 /* ProductListViewModelTests.swift in Sources */,
 				03B9E52B2A1505A7005C77F5 /* TapToPayReconnectionControllerTests.swift in Sources */,
 				314DC4C1268D28B100444C9E /* CardReaderSettingsKnownReadersStorageTests.swift in Sources */,
+				02D635792B58071C00B1CBF6 /* MockNote.swift in Sources */,
 				262AF38A2713B67600E39AFF /* SimplePaymentsAmountViewModelTests.swift in Sources */,
 				93FA787221CD2A1A00B663E5 /* CurrencySettingsTests.swift in Sources */,
 				45FBDF2D238BF8BF00127F77 /* AddProductImageCollectionViewCellTests.swift in Sources */,

--- a/WooCommerce/WooCommerceTests/Mocks/MockNote.swift
+++ b/WooCommerce/WooCommerceTests/Mocks/MockNote.swift
@@ -1,0 +1,46 @@
+import Foundation
+import XCTest
+
+import Networking
+
+/// Note: based on `YosemiteTests.MockNote`.
+/// Provides builders for `Note` to use as test data since `MetaContainer` cannot be initialized easily.
+///
+struct MockNote {
+    func makeOrderNote(noteID: Int64 = 0,
+                       metaSiteID: Int64,
+                       metaOrderID: Int64) -> Note {
+        let metaAsData: Data = {
+            var ids = [String: Int64]()
+            ids[MetaContainer.Keys.site.rawValue] = metaSiteID
+            ids[MetaContainer.Keys.order.rawValue] = metaOrderID
+
+            if ids.isEmpty {
+                return Data()
+            } else {
+                var metaAsJSON = [String: [String: Int64]]()
+                metaAsJSON[MetaContainer.Containers.ids.rawValue] = ids
+                do {
+                    return try JSONEncoder().encode(metaAsJSON)
+                } catch {
+                    fatalError("Expected to convert MetaContainer JSON to Data. \(error)")
+                }
+            }
+        }()
+
+        return Note(noteID: noteID,
+                    hash: 0,
+                    read: false,
+                    icon: nil,
+                    noticon: nil,
+                    timestamp: "",
+                    type: Note.Kind.storeOrder.rawValue,
+                    subtype: nil,
+                    url: nil,
+                    title: nil,
+                    subject: Data(),
+                    header: Data(),
+                    body: Data(),
+                    meta: metaAsData)
+    }
+}

--- a/WooCommerce/WooCommerceTests/System/TestingAppDelegate.swift
+++ b/WooCommerce/WooCommerceTests/System/TestingAppDelegate.swift
@@ -3,6 +3,12 @@ import UIKit
 
 @objc(TestingAppDelegate)
 class TestingAppDelegate: AppDelegate {
+    /// Enables mocking of `tabBarController` property in unit tests. It is strongly recommended to reset it back to `nil` after each test case that sets this.
+    static var mockTabBarController: MainTabBarController?
+
+    override var tabBarController: MainTabBarController? {
+        Self.mockTabBarController ?? super.tabBarController
+    }
 
     override func application(_ application: UIApplication,
                               willFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]? = nil) -> Bool {

--- a/WooCommerce/WooCommerceTests/ViewRelated/MainTabBarControllerTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/MainTabBarControllerTests.swift
@@ -475,7 +475,7 @@ final class MainTabBarControllerTests: XCTestCase {
         assertEqual("product", analyticsProvider.receivedProperties[safe: 1]?["type"] as? String)
     }
 
-    func test_navigateToTabWithNavigationController_returns_UINavigationController_of_the_newly_selected_tab() throws {
+    func test_navigateToTabWithNavigationController_returns_UIViewController_of_the_newly_selected_tab() throws {
         // Given
         stores.updateDefaultStore(storeID: 134)
 
@@ -486,7 +486,7 @@ final class MainTabBarControllerTests: XCTestCase {
 
         // When
         let navigationController = waitFor { promise in
-            tabBarController.navigateToTabWithNavigationController(.products, animated: false) { navigationController in
+            tabBarController.navigateToTabWithViewController(.products, animated: false) { navigationController in
                 promise(navigationController)
             }
         }

--- a/WooCommerce/WooCommerceTests/ViewRelated/MainTabBarControllerTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/MainTabBarControllerTests.swift
@@ -527,6 +527,49 @@ final class MainTabBarControllerTests: XCTestCase {
         // Resets the tab bar controller mock at the end of the test.
         TestingAppDelegate.mockTabBarController = nil
     }
+
+    func test_presentNotificationDetails_for_the_same_store_switches_to_orders_tab_and_opens_order() throws {
+        // Given
+        let stores = MockStoresManager(sessionManager: .testingInstance)
+        ServiceLocator.setStores(stores)
+
+        let siteID: Int64 = 256
+        stores.updateDefaultStore(storeID: siteID)
+
+        stores.whenReceivingAction(ofType: NotificationAction.self) { action in
+            guard case let .synchronizeNotification(_, completion) = action else {
+                return
+            }
+            let note = MockNote().makeOrderNote(metaSiteID: siteID, metaOrderID: 612)
+            completion(note, nil)
+        }
+
+        let mockFeatureFlagService = MockFeatureFlagService(isSplitViewInOrdersTabOn: true)
+        ServiceLocator.setFeatureFlagService(mockFeatureFlagService)
+
+        let tabBarController = try XCTUnwrap(UIStoryboard(name: "Main", bundle: nil).instantiateInitialViewController() as? MainTabBarController)
+        TestingAppDelegate.mockTabBarController = tabBarController
+
+        // Trigger `viewDidLoad`
+        XCTAssertNotNil(tabBarController.view)
+
+        // When
+        MainTabBarController.presentNotificationDetails(for: 1)
+        waitUntil {
+            tabBarController.selectedViewController is TabContainerController
+        }
+
+        // Then
+        XCTAssertEqual(tabBarController.selectedIndex, WooTab.orders.visibleIndex())
+        let tabContainerController = try XCTUnwrap(tabBarController.selectedViewController as? TabContainerController)
+        let ordersSplitViewWrapper = try XCTUnwrap(tabContainerController.wrappedController as? OrdersSplitViewWrapperController)
+        let splitViewController = try XCTUnwrap(ordersSplitViewWrapper.children.first as? UISplitViewController)
+        let secondaryViewController = try XCTUnwrap((splitViewController.viewController(for: .secondary) as? UINavigationController)?.topViewController)
+        assertThat(secondaryViewController, isAnInstanceOf: OrderLoaderViewController.self)
+
+        // Resets the tab bar controller mock at the end of the test.
+        TestingAppDelegate.mockTabBarController = nil
+    }
 }
 
 private extension MainTabBarController {


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of #11674 
<!-- Id number of the GitHub issue this PR addresses. -->

⚠️ Please notice there are two related known issues in https://github.com/woocommerce/woocommerce-ios/issues/11674

## Why

Based on the description in #11674:

> When the `splitViewInOrdersTab` feature flag is enabled, Universal URLs such as `https://woo.com/mobile/orders/details?blog_id={id}&order_id={id}` only navigate to the Orders tab, but don't open the specific order. This also affects order notifications, both displayed as a Notice in the app, or as a system notification when backgrounded.

This is because the orders tab's root view controller is now `TabContainerController` and not `UINavigationController` (with `OrdersRootViewController` as the top view controller) anymore with the split view support. When receiving the order universal link in `OrderDetailsRoute.perform`, it calls `MainTabBarController.navigateToOrderDetails` to:
1. Switch to the target store if it's different from the current store
2. Switch to the orders tab: this logic previously assumes the orders tab's root view controller to be `UINavigationController` instead of `TabContainerController`
3. Present the order details: this logic previously assumes the orders tab's root view controller to be `OrdersSplitViewWrapperController` instead of `TabContainerController`

## How

To fix the issue from the outdated assumption of the view controller type:

- Switch to the orders tab: this logic was updated in `MainTabBarController.navigateToTabWithNavigationController` (renamed to `navigateToTabWithNavigationController`) to call the completion block not only for `UINavigationController` tab root view controller but also any `UIViewController`. It now returns `UIViewController` in the completion block. This requires updating `DashboardViewController.startAddProductFlowFromProductDescriptionAIModal` to cast the view controller to `UINavigationController` because `AddProductCoordinator` expects the source view controller to be `UINavigationController` and it takes many diffs to fix this assumption. We can tackle this when we implement split view support for the products tab
- Present the order details: this logic was updated in `MainTabBarController.presentDetails` to get `OrdersSplitViewWrapperController` (which can present the order details) from the root `TabContainerController`. The same change was applied to the order notification tap handling. I tried adding some test cases for it to ensure the order universal link behavior, though the static usage makes it quite tricky. Lemme know if the test cases are too hacky 😬 

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

- [x] @jaclync tests that order deep links work as before when `splitViewInOrdersTab` feature flag is off
- [x] @jaclync tests that adding product from the AI modal works as before
- [x] @jaclync tests that tapping on a new order push notification opens the app, switches to the store, and opens the order

Hand-testing is optional, as I can reproduce the issue before and it's straightforward to verify.

- In code, update `splitViewInOrdersTab` feature flag to return `true` in `DefaultFeatureFlagService`
- In another app, paste an order URL that can deep link to the app (`https://woo.com/mobile/orders/details?blog_id={id}&order_id={id}`)
- In the app, switch to a different store from the store in the URL in the previous step
- Background the app
- Tap on the order URL --> it should deep link to the app, switch to the store in the URL, then open the order details for the order ID in the URL

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
