### PR TITLE
Blaze: Allow campaign editing when image not loaded yet.

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Blaze/CampaignCreation/BlazeCampaignCreationForm.swift
+++ b/WooCommerce/Classes/ViewRelated/Blaze/CampaignCreation/BlazeCampaignCreationForm.swift
@@ -223,6 +223,7 @@ private extension BlazeCampaignCreationForm {
                     .foregroundColor(.accentColor)
             })
             .buttonStyle(.plain)
+            .disabled(!viewModel.canEditAd)
             .redacted(reason: !viewModel.canEditAd ? .placeholder : [])
             .shimmering(active: !viewModel.canEditAd)
         }

--- a/WooCommerce/Classes/ViewRelated/Blaze/CampaignCreation/BlazeCampaignCreationFormViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Blaze/CampaignCreation/BlazeCampaignCreationFormViewModel.swift
@@ -127,7 +127,7 @@ final class BlazeCampaignCreationFormViewModel: ObservableObject {
     @Published private var isLoadingProductImage: Bool = true
 
     var canEditAd: Bool {
-        !(isLoadingProductImage || isLoadingAISuggestions)
+        !isLoadingAISuggestions
     }
 
     var canConfirmDetails: Bool {

--- a/WooCommerce/WooCommerceTests/ViewRelated/Blaze/BlazeCampaignCreationFormViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Blaze/BlazeCampaignCreationFormViewModelTests.swift
@@ -125,32 +125,6 @@ final class BlazeCampaignCreationFormViewModelTests: XCTestCase {
         XCTAssertTrue(viewModel.canEditAd)
     }
 
-    func test_ad_can_be_edited_while_image_is_downloaded() async throws {
-        // Given
-        insertProduct(sampleProduct)
-        mockAISuggestionsSuccess(sampleAISuggestions)
-        mockDownloadImage(sampleImage)
-
-        let viewModel = BlazeCampaignCreationFormViewModel(siteID: sampleSiteID,
-                                                           productID: sampleProductID,
-                                                           stores: stores,
-                                                           storage: storageManager,
-                                                           productImageLoader: imageLoader,
-                                                           onCompletion: {})
-
-        // When
-        await viewModel.loadAISuggestions()
-        XCTAssertTrue(viewModel.canEditAd)
-
-        // Start downloading the product image without waiting for it to finish.
-        Task {
-            await viewModel.downloadProductImage()
-        }
-
-        // Then
-        XCTAssertTrue(viewModel.canEditAd)
-    }
-
     func test_ad_can_be_edited_if_suggestions_failed_to_load() async throws {
         // Given
         insertProduct(sampleProduct)

--- a/WooCommerce/WooCommerceTests/ViewRelated/Blaze/BlazeCampaignCreationFormViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Blaze/BlazeCampaignCreationFormViewModelTests.swift
@@ -125,7 +125,7 @@ final class BlazeCampaignCreationFormViewModelTests: XCTestCase {
         XCTAssertTrue(viewModel.canEditAd)
     }
 
-    func test_ad_cannot_be_edited_until_image_is_downloaded() async throws {
+    func test_ad_can_be_edited_while_image_is_downloaded() async throws {
         // Given
         insertProduct(sampleProduct)
         mockAISuggestionsSuccess(sampleAISuggestions)
@@ -137,12 +137,15 @@ final class BlazeCampaignCreationFormViewModelTests: XCTestCase {
                                                            storage: storageManager,
                                                            productImageLoader: imageLoader,
                                                            onCompletion: {})
-        // Load suggestions and ensure that ad cannot be edited
-        await viewModel.loadAISuggestions()
-        XCTAssertFalse(viewModel.canEditAd)
 
         // When
-        await viewModel.downloadProductImage()
+        await viewModel.loadAISuggestions()
+        XCTAssertTrue(viewModel.canEditAd)
+
+        // Start downloading the product image without waiting for it to finish.
+        Task {
+            await viewModel.downloadProductImage()
+        }
 
         // Then
         XCTAssertTrue(viewModel.canEditAd)


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #11721
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing 
“See original issue” – clarify what the problem was and how you’ve fixed it. -->

This PR enables "Edit ad" button on the campaign creation form, while the product image is still being downloaded.

It also adds a small fix to disable the button while in `.redacted` state, because otherwise it is redacted but still tappable.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

To simulate download process, set very slow connection in Simulator using Network Link Conditioner  (available from Additional Tools for Xcode 15). I find "3G" profile to be usable in this scenario.
![Screenshot 2024-01-18 at 13 57 19](https://github.com/woocommerce/woocommerce-ios/assets/266376/cbc79c41-f7db-46b8-b04d-e8ccfda5b80c)

Then, do below:
1. Go to products,
2. Pick a product with existing product image,
3. Tap "Promote with Blaze" as soon as it appears,
4. Note that "Edit Ad" button is available and tappable while the image is still showing placeholder.

