### PR TITLE
[Analytics Hub] Track analytics events for Jetpack Stats module CTA

### DIFF
--- a/WooCommerce/Classes/Analytics/WooAnalyticsEvent.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsEvent.swift
@@ -2563,6 +2563,30 @@ extension WooAnalyticsEvent {
                                                                                             Keys.calendar.rawValue: Locale.current.calendar.debugDescription,
                                                                                             Keys.timezone.rawValue: TimeZone.current.debugDescription])
         }
+
+        /// Tracks when the "Enable Jetpack Stats" call to action is shown.
+        ///
+        static func jetpackStatsCTAShown() -> WooAnalyticsEvent {
+            WooAnalyticsEvent(statName: .analyticsHubEnableJetpackStatsShown, properties: [:])
+        }
+
+        /// Tracks when the "Enable Jetpack Stats" call to action is tapped.
+        ///
+        static func jetpackStatsCTATapped() -> WooAnalyticsEvent {
+            WooAnalyticsEvent(statName: .analyticsHubEnableJetpackStatsTapped, properties: [:])
+        }
+
+        /// Tracks when the Jetpack Stats module is successfully enabled remotely.
+        ///
+        static func enableJetpackStatsSuccess() -> WooAnalyticsEvent {
+            WooAnalyticsEvent(statName: .analyticsHubEnableJetpackStatsSuccess, properties: [:])
+        }
+
+        /// Tracks when the Jetpack Stats module fails to be enabled remotely.
+        ///
+        static func enableJetpackStatsFailed(error: Error?) -> WooAnalyticsEvent {
+            WooAnalyticsEvent(statName: .analyticsHubEnableJetpackStatsFailed, properties: [:], error: error)
+        }
     }
 }
 

--- a/WooCommerce/Classes/Analytics/WooAnalyticsStat.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsStat.swift
@@ -171,6 +171,10 @@ public enum WooAnalyticsStat: String {
     case analyticsHubDateRangeOptionSelected = "analytics_hub_date_range_option_selected"
     case analyticsHubDateRangeSelectionFailed = "analytics_hub_date_range_selection_failed"
     case analyticsHubWaitingTimeLoaded = "analytics_hub_waiting_time_loaded"
+    case analyticsHubEnableJetpackStatsShown = "analytics_hub_enable_jetpack_stats_shown"
+    case analyticsHubEnableJetpackStatsTapped = "analytics_hub_enable_jetpack_stats_tapped"
+    case analyticsHubEnableJetpackStatsSuccess = "analytics_hub_enable_jetpack_stats_success"
+    case analyticsHubEnableJetpackStatsFailed = "analytics_hub_enable_jetpack_stats_failed"
 
     // MARK: Blaze Events
     //

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/AnalyticsHubViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/AnalyticsHubViewModel.swift
@@ -161,6 +161,8 @@ final class AnalyticsHubViewModel: ObservableObject {
     ///
     @MainActor
     func enableJetpackStats() async {
+        analytics.track(event: .AnalyticsHub.jetpackStatsCTATapped())
+
         do {
             try await remoteEnableJetpackStats()
             // Wait for backend to enable the module (it is not ready for stats to be requested immediately after a success response)
@@ -232,6 +234,9 @@ private extension AnalyticsHubViewModel {
         } catch SiteStatsStoreError.statsModuleDisabled {
             self.isJetpackStatsDisabled = true
             self.siteStats = nil
+            if showJetpackStatsCTA {
+                analytics.track(event: .AnalyticsHub.jetpackStatsCTAShown())
+            }
             DDLogError("⚠️ Analytics Hub Sessions card can't be loaded: Jetpack stats are disabled")
         } catch {
             self.siteStats = nil
@@ -308,9 +313,11 @@ private extension AnalyticsHubViewModel {
                 switch result {
                 case .success:
                     self?.isJetpackStatsDisabled = false
+                    self?.analytics.track(event: .AnalyticsHub.enableJetpackStatsSuccess())
                     continuation.resume()
                 case let .failure(error):
                     self?.isJetpackStatsDisabled = true
+                    self?.analytics.track(event: .AnalyticsHub.enableJetpackStatsFailed(error: error))
                     continuation.resume(throwing: error)
                 }
             }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #10338
⚠️ Depends on https://github.com/woocommerce/woocommerce-ios/pull/11708 ⚠️ 
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
Jetpack Stats aren’t activated by default on Woo Express stores, which means the Sessions card doesn’t load in the Analytics Hub. https://github.com/woocommerce/woocommerce-ios/pull/11708 adds a call to action to enable Jetpack Stats if they are disabled on the store. This PR adds the following Tracks events for that CTA:

* When the Jetpack Stats CTA is shown: `analytics_hub_enable_jetpack_stats_shown`
* When the Jetpack Stats CTA is tapped: `analytics_hub_enable_jetpack_stats_tapped`
* Jetpack Stats successfully enabled: `analytics_hub_enable_jetpack_stats_success`
* Jetpack Stats failed to be enabled: `analytics_hub_enable_jetpack_stats_failed`

## Event registration

- [x] `analytics_hub_enable_jetpack_stats_shown`: Automattic/tracks-events-registration#2150
- [x] `analytics_hub_enable_jetpack_stats_tapped`: Automattic/tracks-events-registration#2151
- [x] `analytics_hub_enable_jetpack_stats_success`: Automattic/tracks-events-registration#2152
- [x] `analytics_hub_enable_jetpack_stats_failed`: Automattic/tracks-events-registration#2153

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

I have tested the following scenarios:

### Expected events

Prerequisite: Create a new Woo Express store or disable Jetpack Stats on an existing store (at example.com/wp-admin/admin.php?page=jetpack_modules in wp-admin).

1. Build and run the app. Select the store from the prerequisite.
2. On the My Store tab, select "See More" to open the Analytics Hub.
3. Scroll down to the Sessions card where the Jetpack Stats CTA appears. Confirm the event `analytics_hub_enable_jetpack_stats_shown` is tracked.
4. Disable your internet connection (to force a failure).
5. Tap the button. Confirm the event `analytics_hub_enable_jetpack_stats_tapped` is tracked.
6. When the error notice appears, confirm the event `analytics_hub_enable_jetpack_stats_failed` is tracked.
7. Enable your internet connection.
8. Tap the button. Confirm the event `analytics_hub_enable_jetpack_stats_tapped` is tracked.
9. When the view reloads, confirm the event `analytics_hub_enable_jetpack_stats_success` is tracked.

### Jetpack stats call to action not shown

I confirmed these events are not triggered when:

* The sessions card loads data as usual (stats module is already enabled).
* The sessions card is hidden (e.g. shop manager on store where stats module is disabled).

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.