### PR TITLE
Fix widgets on iOS 17

### DIFF
--- a/WooCommerce.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/WooCommerce.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -84,7 +84,7 @@
       },
       {
         "package": "swift-numerics",
-        "repositoryURL": "https://github.com/apple/swift-numerics",
+        "repositoryURL": "https://github.com/apple/swift-numerics.git",
         "state": {
           "branch": null,
           "revision": "0a5bc04095a675662cf24757cc0640aa2204253b",

--- a/WooCommerce/StoreWidgets/Homescreen/StoreInfoView.swift
+++ b/WooCommerce/StoreWidgets/Homescreen/StoreInfoView.swift
@@ -36,6 +36,9 @@ private struct StoreInfoView: View {
     var body: some View {
         ZStack {
 
+            // Background
+            Color(.brand)
+
             VStack(alignment: .leading, spacing: Layout.sectionSpacing) {
                 VStack(alignment: .leading, spacing: Layout.cardSpacing) {
                     // Store Name
@@ -144,6 +147,9 @@ private struct AccessibilityStatsCard: View {
 private struct NotLoggedInView: View {
     var body: some View {
         ZStack {
+            // Background
+            Color(.brand)
+
             VStack {
                 Image(uiImage: .wooLogoWhite)
                     .resizable()
@@ -168,6 +174,9 @@ private struct NotLoggedInView: View {
 private struct UnableToFetchView: View {
     var body: some View {
         ZStack {
+            // Background
+            Color(.brand)
+
             VStack {
                 Image(uiImage: .wooLogoWhite)
                     .resizable()

--- a/WooCommerce/StoreWidgets/Homescreen/StoreInfoView.swift
+++ b/WooCommerce/StoreWidgets/Homescreen/StoreInfoView.swift
@@ -8,14 +8,15 @@ struct StoreInfoHomescreenWidget: View {
     let entry: StoreInfoEntry
 
     var body: some View {
-        switch entry {
-        case .notConnected:
-            NotLoggedInView()
-        case .error:
-            UnableToFetchView()
-        case .data(let data):
-            StoreInfoView(entryData: data)
-        }
+
+            switch entry {
+            case .notConnected:
+                NotLoggedInView()
+            case .error:
+                UnableToFetchView()
+            case .data(let data):
+                StoreInfoView(entryData: data)
+            }
     }
 }
 
@@ -34,8 +35,6 @@ private struct StoreInfoView: View {
 
     var body: some View {
         ZStack {
-            // Background
-            Color(.brand)
 
             VStack(alignment: .leading, spacing: Layout.sectionSpacing) {
                 VStack(alignment: .leading, spacing: Layout.cardSpacing) {
@@ -59,6 +58,7 @@ private struct StoreInfoView: View {
                 }
             }
             .padding(.horizontal)
+            .widgetBackground(backgroundView: Color(.brand))
         }
     }
 }
@@ -144,9 +144,6 @@ private struct AccessibilityStatsCard: View {
 private struct NotLoggedInView: View {
     var body: some View {
         ZStack {
-            // Background
-            Color(.brand)
-
             VStack {
                 Image(uiImage: .wooLogoWhite)
                     .resizable()
@@ -164,15 +161,13 @@ private struct NotLoggedInView: View {
             }
             .padding(.vertical, Layout.cardVerticalPadding)
         }
+        .widgetBackground(backgroundView: Color(.clear))
     }
 }
 
 private struct UnableToFetchView: View {
     var body: some View {
         ZStack {
-            // Background
-            Color(.brand)
-
             VStack {
                 Image(uiImage: .wooLogoWhite)
                     .resizable()
@@ -187,6 +182,7 @@ private struct UnableToFetchView: View {
             }
             .padding(.vertical, Layout.cardVerticalPadding)
         }
+        .widgetBackground(backgroundView: Color(.brand))
     }
 }
 

--- a/WooCommerce/StoreWidgets/Homescreen/StoreInfoView.swift
+++ b/WooCommerce/StoreWidgets/Homescreen/StoreInfoView.swift
@@ -8,15 +8,14 @@ struct StoreInfoHomescreenWidget: View {
     let entry: StoreInfoEntry
 
     var body: some View {
-
-            switch entry {
-            case .notConnected:
-                NotLoggedInView()
-            case .error:
-                UnableToFetchView()
-            case .data(let data):
-                StoreInfoView(entryData: data)
-            }
+        switch entry {
+        case .notConnected:
+            NotLoggedInView()
+        case .error:
+            UnableToFetchView()
+        case .data(let data):
+            StoreInfoView(entryData: data)
+        }
     }
 }
 
@@ -35,7 +34,6 @@ private struct StoreInfoView: View {
 
     var body: some View {
         ZStack {
-
             // Background
             Color(.brand)
 

--- a/WooCommerce/StoreWidgets/Homescreen/View+ContainerBackground.swift
+++ b/WooCommerce/StoreWidgets/Homescreen/View+ContainerBackground.swift
@@ -1,0 +1,17 @@
+import SwiftUI
+import WidgetKit
+
+extension View {
+    /// Adds backwards compatibility to the `containerBackground` API.
+    /// This API is needed to add support to stand by mode widgets.
+    ///
+    func widgetBackground(backgroundView: some View) -> some View {
+        if #available(iOSApplicationExtension 17.0, *) {
+            return containerBackground(for: .widget) {
+                backgroundView
+            }
+        } else {
+            return background(backgroundView)
+        }
+    }
+}

--- a/WooCommerce/StoreWidgets/Lockscreen/AppLinkWidget.swift
+++ b/WooCommerce/StoreWidgets/Lockscreen/AppLinkWidget.swift
@@ -57,6 +57,7 @@ private struct AppButtonView: View {
                 .scaledToFit()
                 .padding(10)
         }
+        .widgetBackground(backgroundView: Color(.clear))
     }
 }
 

--- a/WooCommerce/StoreWidgets/Lockscreen/StoreInfoCircularWidget.swift
+++ b/WooCommerce/StoreWidgets/Lockscreen/StoreInfoCircularWidget.swift
@@ -8,12 +8,15 @@ struct StoreInfoCircularWidget: View {
     let entry: StoreInfoEntry
 
     var body: some View {
-        switch entry {
-        case .data(let data):
-            StoreInfoCircularView(entryData: data)
-        case .notConnected, .error:
-            UnableToFetchView()
+        Group {
+            switch entry {
+            case .data(let data):
+                StoreInfoCircularView(entryData: data)
+            case .notConnected, .error:
+                UnableToFetchView()
+            }
         }
+        .widgetBackground(backgroundView: Color(.clear))
     }
 }
 

--- a/WooCommerce/StoreWidgets/Lockscreen/StoreInfoInlineWidget.swift
+++ b/WooCommerce/StoreWidgets/Lockscreen/StoreInfoInlineWidget.swift
@@ -8,12 +8,15 @@ struct StoreInfoInlineWidget: View {
     let entry: StoreInfoEntry
 
     var body: some View {
-        switch entry {
-        case .data(let data):
-            StoreInfoInlineView(entryData: data)
-        case .notConnected, .error:
-            UnableToFetchView()
+        Group {
+            switch entry {
+            case .data(let data):
+                StoreInfoInlineView(entryData: data)
+            case .notConnected, .error:
+                UnableToFetchView()
+            }
         }
+        .widgetBackground(backgroundView: Color(.clear))
     }
 }
 

--- a/WooCommerce/StoreWidgets/Lockscreen/StoreInfoRectangularWidget.swift
+++ b/WooCommerce/StoreWidgets/Lockscreen/StoreInfoRectangularWidget.swift
@@ -8,12 +8,15 @@ struct StoreInfoRectangularWidget: View {
     let entry: StoreInfoEntry
 
     var body: some View {
-        switch entry {
-        case .data(let data):
-            StoreInfoRectangularView(entryData: data)
-        case .notConnected, .error:
-            UnableToFetchView()
+        Group {
+            switch entry {
+            case .data(let data):
+                StoreInfoRectangularView(entryData: data)
+            case .notConnected, .error:
+                UnableToFetchView()
+            }
         }
+        .widgetBackground(backgroundView: Color(.clear))
     }
 }
 

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -917,6 +917,7 @@
 		26CCBE0D2523C2560073F94D /* RefundProductsTotalTableViewCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = 26CCBE0C2523C2560073F94D /* RefundProductsTotalTableViewCell.xib */; };
 		26CFDB2727357E8000AB940B /* SimplePaymentsSummary.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26CFDB2627357E8000AB940B /* SimplePaymentsSummary.swift */; };
 		26D1E9E82949818B00A7DC62 /* AnalyticsHubTimeRageAdapter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26D1E9E72949818B00A7DC62 /* AnalyticsHubTimeRageAdapter.swift */; };
+		26D57CF72B59820600E8EFB8 /* View+ContainerBackground.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26D57CF62B59820600E8EFB8 /* View+ContainerBackground.swift */; };
 		26D9E54428C107F80098DF26 /* WooFoundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 26D9E54328C107F80098DF26 /* WooFoundation.framework */; };
 		26D9E54828C10A3B0098DF26 /* Experiments.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 26D9E54728C10A3B0098DF26 /* Experiments.framework */; };
 		26DB7E3528636D2200506173 /* NonEditableOrderBanner.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26DB7E3428636D2200506173 /* NonEditableOrderBanner.swift */; };
@@ -3571,6 +3572,7 @@
 		26CCBE0C2523C2560073F94D /* RefundProductsTotalTableViewCell.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = RefundProductsTotalTableViewCell.xib; sourceTree = "<group>"; };
 		26CFDB2627357E8000AB940B /* SimplePaymentsSummary.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SimplePaymentsSummary.swift; sourceTree = "<group>"; };
 		26D1E9E72949818B00A7DC62 /* AnalyticsHubTimeRageAdapter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnalyticsHubTimeRageAdapter.swift; sourceTree = "<group>"; };
+		26D57CF62B59820600E8EFB8 /* View+ContainerBackground.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "View+ContainerBackground.swift"; sourceTree = "<group>"; };
 		26D9E54328C107F80098DF26 /* WooFoundation.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = WooFoundation.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		26D9E54728C10A3B0098DF26 /* Experiments.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = Experiments.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		26DB7E3428636D2200506173 /* NonEditableOrderBanner.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NonEditableOrderBanner.swift; sourceTree = "<group>"; };
@@ -8771,6 +8773,7 @@
 			isa = PBXGroup;
 			children = (
 				AEBFD13E28E7655F00F598C6 /* StoreInfoView.swift */,
+				26D57CF62B59820600E8EFB8 /* View+ContainerBackground.swift */,
 			);
 			path = Homescreen;
 			sourceTree = "<group>";
@@ -12832,6 +12835,7 @@
 			files = (
 				AED9012D28E5F517002B4572 /* AppLinkWidget.swift in Sources */,
 				2608C50728C941D600C9DFC0 /* UserDefaults+Woo.swift in Sources */,
+				26D57CF72B59820600E8EFB8 /* View+ContainerBackground.swift in Sources */,
 				265C99E628B9CB8E005E6117 /* StoreInfoViewModifiers.swift in Sources */,
 				2608C50628C93AB700C9DFC0 /* WooConstants.swift in Sources */,
 				260DE20A28CA7CFE009ECD7C /* StoreInfoDataService.swift in Sources */,


### PR DESCRIPTION
# Why

iOS 17 introduced a new background view API for widgets, this API is useful for removing the widget background when used in standby mode. 

This PR updates the widgets to use that new background API. 

Note: Our widget can't be rendered in standby mode because only small widgets can, so this PR does not add any extra functionality.

# Screenshots

| Home Screen | Lock Screen |
|--------|--------|
| ![IMG_9276](https://github.com/woocommerce/woocommerce-ios/assets/562080/1a6302ff-3f73-4c7a-a23d-22d45c98004d) | ![IMG_9277](https://github.com/woocommerce/woocommerce-ios/assets/562080/26c56f54-0df9-41fc-bd8a-0fcc2ab25a16) | 

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
