### PR TITLE
Blaze: Add support tag and handle result of support requests

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Blaze/ConfirmPayment/BlazeCampaignCreationErrorView.swift
+++ b/WooCommerce/Classes/ViewRelated/Blaze/ConfirmPayment/BlazeCampaignCreationErrorView.swift
@@ -6,6 +6,8 @@ struct BlazeCampaignCreationErrorView: View {
     @ScaledMetric private var scale: CGFloat = 1.0
 
     @State private var isShowingSupport = false
+    @State private var supportRequestSentNotice: Notice?
+    @State private var shouldShowSupportRequestError = false
 
     private let onTryAgain: () -> Void
     private let onCancel: () -> Void
@@ -66,22 +68,37 @@ struct BlazeCampaignCreationErrorView: View {
         .sheet(isPresented: $isShowingSupport) {
             supportForm
         }
+        .notice($supportRequestSentNotice)
     }
 }
 
 private extension BlazeCampaignCreationErrorView {
     var supportForm: some View {
         NavigationView {
-            SupportForm(viewModel: SupportFormViewModel(sourceTag: Constants.supportTag))
-                .toolbar {
-                    ToolbarItem(placement: .confirmationAction) {
-                        Button(Localization.done) {
-                            isShowingSupport = false
-                        }
+            SupportForm(viewModel: SupportFormViewModel(sourceTag: Constants.supportTag, onCompletion: { result in
+                switch result {
+                case .success:
+                    isShowingSupport = false
+                    supportRequestSentNotice = Notice(title: Localization.supportRequestSent)
+                case .failure:
+                    shouldShowSupportRequestError = true
+                }
+            }))
+            .toolbar {
+                ToolbarItem(placement: .confirmationAction) {
+                    Button(Localization.done) {
+                        isShowingSupport = false
                     }
                 }
+            }
         }
         .navigationViewStyle(.stack)
+        .alert(isPresented: $shouldShowSupportRequestError) {
+            Alert(title: Text(Localization.supportRequestFailed),
+                  dismissButton: .default(Text(Localization.gotIt), action: {
+                shouldShowSupportRequestError = false
+            }))
+        }
     }
 }
 
@@ -138,6 +155,21 @@ private extension BlazeCampaignCreationErrorView {
             "blazeCampaignCreationErrorView.done",
             value: "Done",
             comment: "Button to dismiss the support form from the Blaze campaign creation error screen."
+        )
+        static let supportRequestSent = NSLocalizedString(
+            "blazeCampaignCreationErrorView.supportRequestSent",
+            value: "Your support request has landed safely in our inbox. We will reply via email as quickly as we can.",
+            comment: "Message for the alert after the support request is created from the Blaze campaign creation error screen."
+        )
+        static let supportRequestFailed = NSLocalizedString(
+            "blazeCampaignCreationErrorView.supportRequestFailed",
+            value: "Sorry, we cannot create support requests right now, please try again later.",
+            comment: "Error message when the app can't create a support request from the Blaze campaign creation error screen."
+        )
+        static let gotIt = NSLocalizedString(
+            "blazeCampaignCreationErrorView.gotIt",
+            value: "Got It",
+            comment: "Button to dismiss the alert when the app can't create a support request from the Blaze campaign creation error screen."
         )
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Blaze/ConfirmPayment/BlazeCampaignCreationErrorView.swift
+++ b/WooCommerce/Classes/ViewRelated/Blaze/ConfirmPayment/BlazeCampaignCreationErrorView.swift
@@ -72,7 +72,7 @@ struct BlazeCampaignCreationErrorView: View {
 private extension BlazeCampaignCreationErrorView {
     var supportForm: some View {
         NavigationView {
-            SupportForm(viewModel: SupportFormViewModel())
+            SupportForm(viewModel: SupportFormViewModel(sourceTag: Constants.supportTag))
                 .toolbar {
                     ToolbarItem(placement: .confirmationAction) {
                         Button(Localization.done) {
@@ -91,6 +91,10 @@ private extension BlazeCampaignCreationErrorView {
         static let errorIconSize: CGFloat = 56
         static let contentPadding: CGFloat = 12
         static let titlePadding: CGFloat = 24
+    }
+
+    enum Constants {
+        static let supportTag = "origin:blaze-native-campaign-creation"
     }
 
     enum Localization {

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Help/SupportForm/SupportFormViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Help/SupportForm/SupportFormViewModel.swift
@@ -66,11 +66,13 @@ public final class SupportFormViewModel: ObservableObject {
     init(areas: [Area] = wooSupportAreas(),
          sourceTag: String? = nil,
          zendeskProvider: ZendeskManagerProtocol = ZendeskProvider.shared,
-         analyticsProvider: Analytics = ServiceLocator.analytics) {
+         analyticsProvider: Analytics = ServiceLocator.analytics,
+         onCompletion: ((Result<Void, Error>) -> Void)? = nil) {
         self.areas = areas
         self.sourceTag = sourceTag
         self.zendeskProvider = zendeskProvider
         self.analyticsProvider = analyticsProvider
+        self.onCompletion = onCompletion
     }
 
     /// Tracks when the support form is viewed.

--- a/WooCommerce/WooCommerceTests/Authentication/Store Creation/Profiler/StoreCreationProfilerUploadAnswersUseCaseTests.swift
+++ b/WooCommerce/WooCommerceTests/Authentication/Store Creation/Profiler/StoreCreationProfilerUploadAnswersUseCaseTests.swift
@@ -25,8 +25,9 @@ final class StoreCreationProfilerUploadAnswersUseCaseTests: XCTestCase {
 
         // Then
         let answers = try XCTUnwrap(userDefaults[.storeProfilerAnswers] as? [String: Data])
-        let receivedSiteID = try XCTUnwrap(answers["\(siteID)"])
-        XCTAssertEqual(receivedSiteID, answerEncoded)
+        let receivedData = try XCTUnwrap(answers["\(siteID)"])
+        let receivedAnswer = try JSONDecoder().decode(StoreProfilerAnswers.self, from: receivedData)
+        assertEqual(answer, receivedAnswer)
     }
 
     func test_it_uploads_answers_if_stored_answers_available() async throws {


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #11745 
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This PR updates the support request handling in the error screen of the Blaze campaign creation flow:
- Added a new support tag `origin:blaze-native-campaign-creation` for tickets created from this screen.
- Observe the result of the support request and display a notice when the request succeeds, or show an error alert when the request fails.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
- Update the method `submitCampaign` in `BlazeConfirmPaymentViewModel` to force `shouldDisplayCampaignCreationError` to be true and build the app.
- Log in to a store that's eligible for Blaze.
- Select Promote in the Blaze section on the dashboard screen to start campaign creation.
- Select Confirm Details > Submit Campaign.
- When the error screen is displayed, tap Get Support.
- Enter a non-A8C email address if an alert for the contact info is displayed, then fill the support form. Please note in the request that this is a test ticket and it should be closed.
- Disable the Internet connection on your machine and send the request. Notice an error alert after the request fails.
- Enable the connection and try again. After the request succeeds, the support form should be dismissed, and a notice should be displayed confirming the success.
- Go to Zendesk and look for your ticket by your email address. You should be able to find it with the new support tag `origin:blaze-native-campaign-creation`.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->
Success | Failure
--- | ---
<img src="https://github.com/woocommerce/woocommerce-ios/assets/5533851/22215abd-16ba-4a0e-a708-a642ce2fead4" width=320 /> | <img src="https://github.com/woocommerce/woocommerce-ios/assets/5533851/efbd2941-4c58-42e3-bbdc-7fb881e62edd" width=320 />

New support tag in the tag list:

<img width="276" alt="Screenshot 2024-01-22 at 15 53 02" src="https://github.com/woocommerce/woocommerce-ios/assets/5533851/9f1924ae-f190-4a41-8146-30a0b42f1f04">


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
