### PR TITLE
Remove unnecessary switchDetailsHandler call

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Orders/OrderListViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrderListViewController.swift
@@ -506,7 +506,7 @@ private extension OrderListViewController {
         if splitViewController?.isCollapsed == true {
             tableView.deselectRow(at: selectedIndexPath, animated: false)
         } else {
-            tableView.selectRow(at: selectedIndexPath, animated: false, scrollPosition: .none)
+            tableView.selectRow(at: selectedIndexPath, animated: false, scrollPosition: .top)
         }
     }
 
@@ -560,7 +560,6 @@ extension OrderListViewController {
                let indexPath = dataSource.indexPath(for: identifier) {
                 selectedOrderID = orderID
                 selectedIndexPath = indexPath
-                switchDetailsHandler([detailsViewModel], 0, nil)
                 highlightSelectedRowIfNeeded()
                 break
             }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Continuation of https://github.com/woocommerce/woocommerce-ios/pull/11729
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
- continuation of fixes in https://github.com/woocommerce/woocommerce-ios/pull/11729
- removed unnecessary call of `switchDetailsHandler` since the `selectOrder(for orderID: Int64)` function was just selecting  the order (cell) and we already had logic/flow for showing the details or the order
- also when we are programatically highlighting/selecting the order cell I changed the `scrollPosition` to `.top` so our cell becomes visible when highlighted

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
- same as in https://github.com/woocommerce/woocommerce-ios/pull/11729
- test it on both iPad and iPhone (Plus/Max if you can) and test with `splitViewInOrdersTab` false and true

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

---
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
