### PR TITLE
Ensure that an order remains selected after the list filter is changed

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Orders/OrderListViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrderListViewController.swift
@@ -546,6 +546,7 @@ private extension OrderListViewController {
 
 extension OrderListViewController {
     /// Adds ability to select any order
+    @discardableResult
     func selectOrder(for orderID: Int64) -> Bool {
         let itemIdentifiers = dataSource.snapshot().itemIdentifiers
         for identifier in itemIdentifiers {

--- a/WooCommerce/Classes/ViewRelated/Orders/OrderListViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrderListViewController.swift
@@ -514,7 +514,7 @@ private extension OrderListViewController {
         if splitViewController?.isCollapsed == true {
             tableView.deselectRow(at: orderIndexPath, animated: false)
         } else {
-            tableView.selectRow(at: orderIndexPath, animated: false, scrollPosition: .none)
+            tableView.selectRow(at: orderIndexPath, animated: false, scrollPosition: .middle)
         }
     }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/OrderListViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrderListViewController.swift
@@ -546,13 +546,14 @@ private extension OrderListViewController {
 
 extension OrderListViewController {
     /// Adds ability to select any order
-    func selectOrder(for orderID: Int64) -> Bool {
+    @discardableResult
+    func selectOrder(for orderID: Int64, canSwitchDetails: Bool = true) -> Bool {
         let itemIdentifiers = dataSource.snapshot().itemIdentifiers
         for identifier in itemIdentifiers {
             if let detailsViewModel = viewModel.detailsViewModel(withID: identifier),
                detailsViewModel.order.orderID == orderID,
                let indexPath = dataSource.indexPath(for: identifier) {
-                if selectedOrderID != orderID || selectedIndexPath != indexPath {
+                if canSwitchDetails && (selectedOrderID != orderID || selectedIndexPath != indexPath) {
                     switchDetailsHandler([detailsViewModel], 0, nil)
                 }
                 selectedOrderID = orderID

--- a/WooCommerce/Classes/ViewRelated/Orders/OrderListViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrderListViewController.swift
@@ -514,24 +514,22 @@ private extension OrderListViewController {
         if splitViewController?.isCollapsed == true {
             tableView.deselectRow(at: orderIndexPath, animated: false)
         } else {
-            tableView.selectRow(at: orderIndexPath, animated: false, scrollPosition: .middle)
+            tableView.selectRow(at: orderIndexPath, animated: false, scrollPosition: .none)
         }
     }
 
-    /// Checks to see if the selected item is still at the same index in the list and resets its state & auto-selects the first item if not.
-    ///
+    /// Checks to see if there is a selected order ID, and selects its order.
+    /// Otherwise, try to select first item.
+    /// 
     func checkSelectedItem() {
-        guard let indexPath = selectedIndexPath, let orderID = selectedOrderID else {
-            return selectFirstItemIfPossible()
-        }
-
-        guard let objectID = dataSource.itemIdentifier(for: indexPath),
-            let orderDetailsViewModel = viewModel.detailsViewModel(withID: objectID) else {
-            return selectFirstItemIfPossible()
-        }
-
-        if orderDetailsViewModel.order.orderID != orderID {
+        guard let orderID = selectedOrderID else {
             selectFirstItemIfPossible()
+            return
+        }
+        let selected = selectOrderFromListIfPossible(for: orderID)
+        if !selected {
+            selectedIndexPath = nil
+            switchDetailsHandler([], 0, true, nil)
         }
     }
 
@@ -582,13 +580,15 @@ extension OrderListViewController {
         for identifier in dataSource.snapshot().itemIdentifiers {
             if let detailsViewModel = viewModel.detailsViewModel(withID: identifier),
                detailsViewModel.order.orderID == orderID {
-                switchDetailsHandler([detailsViewModel], 0, true) { [weak self] hasBeenSelected in
-                    guard let self else { return }
-                    if hasBeenSelected {
-                        selectedOrderID = orderID
-                        selectedIndexPath = dataSource.indexPath(for: identifier)
-                        highlightSelectedRowIfNeeded()
-                    }
+                let orderNotAlreadySelected = selectedOrderID != orderID
+                let indexPath = dataSource.indexPath(for: identifier)
+                let indexPathNotAlreadySelected = selectedIndexPath != indexPath
+                let shouldSwitchDetails = orderNotAlreadySelected || indexPathNotAlreadySelected
+                if shouldSwitchDetails {
+                    showOrderDetails(detailsViewModel.order)
+                }
+                else {
+                    onOrderSelected(id: orderID)
                 }
                 return true
             }

--- a/WooCommerce/Classes/ViewRelated/Orders/OrderListViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrderListViewController.swift
@@ -520,6 +520,7 @@ private extension OrderListViewController {
         }
         let selected = selectOrder(for: orderID)
         if !selected {
+            selectedIndexPath = nil
             switchDetailsHandler([], 0, nil)
         }
     }
@@ -551,6 +552,9 @@ extension OrderListViewController {
             if let detailsViewModel = viewModel.detailsViewModel(withID: identifier),
                detailsViewModel.order.orderID == orderID,
                let indexPath = dataSource.indexPath(for: identifier) {
+                if selectedOrderID != orderID || selectedIndexPath != indexPath {
+                    switchDetailsHandler([detailsViewModel], 0, nil)
+                }
                 selectedOrderID = orderID
                 selectedIndexPath = indexPath
                 highlightSelectedRowIfNeeded()

--- a/WooCommerce/Classes/ViewRelated/Orders/OrderListViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrderListViewController.swift
@@ -510,21 +510,15 @@ private extension OrderListViewController {
         }
     }
 
-    /// Checks to see if the selected item is still at the same index in the list and resets its state if not.
+    /// Checks to see if there is a selected order ID, and selects its order.
+    /// Otherwise, try to select first item.
     ///
     func checkSelectedItem() {
-        guard let indexPath = selectedIndexPath, let orderID = selectedOrderID else {
-            return selectFirstItemIfPossible()
-        }
-
-        guard let objectID = dataSource.itemIdentifier(for: indexPath),
-            let orderDetailsViewModel = viewModel.detailsViewModel(withID: objectID) else {
-            return selectFirstItemIfPossible()
-        }
-
-        if orderDetailsViewModel.order.orderID != orderID {
+        guard let orderID = selectedOrderID else {
             selectFirstItemIfPossible()
+            return
         }
+        selectOrder(for: orderID)
     }
 
     /// Attempts setting the first item in the list as selected if there's any item at all.
@@ -548,12 +542,7 @@ private extension OrderListViewController {
 
 extension OrderListViewController {
     /// Adds ability to select any order
-    /// Used when opening an order with deep link
     func selectOrder(for orderID: Int64) {
-        // check if already selected
-        guard selectedOrderID != orderID else {
-            return
-        }
         for identifier in dataSource.snapshot().itemIdentifiers {
             if let detailsViewModel = viewModel.detailsViewModel(withID: identifier),
                detailsViewModel.order.orderID == orderID,

--- a/WooCommerce/Classes/ViewRelated/Orders/OrderListViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrderListViewController.swift
@@ -506,7 +506,7 @@ private extension OrderListViewController {
         if splitViewController?.isCollapsed == true {
             tableView.deselectRow(at: selectedIndexPath, animated: false)
         } else {
-            tableView.selectRow(at: selectedIndexPath, animated: false, scrollPosition: .none)
+            tableView.selectRow(at: selectedIndexPath, animated: false, scrollPosition: .middle)
         }
     }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/OrderListViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrderListViewController.swift
@@ -518,7 +518,10 @@ private extension OrderListViewController {
             selectFirstItemIfPossible()
             return
         }
-        selectOrder(for: orderID)
+        let selected = selectOrder(for: orderID)
+        if !selected {
+            switchDetailsHandler([], 0, nil)
+        }
     }
 
     /// Attempts setting the first item in the list as selected if there's any item at all.
@@ -542,18 +545,19 @@ private extension OrderListViewController {
 
 extension OrderListViewController {
     /// Adds ability to select any order
-    func selectOrder(for orderID: Int64) {
-        for identifier in dataSource.snapshot().itemIdentifiers {
+    func selectOrder(for orderID: Int64) -> Bool {
+        let itemIdentifiers = dataSource.snapshot().itemIdentifiers
+        for identifier in itemIdentifiers {
             if let detailsViewModel = viewModel.detailsViewModel(withID: identifier),
                detailsViewModel.order.orderID == orderID,
                let indexPath = dataSource.indexPath(for: identifier) {
                 selectedOrderID = orderID
                 selectedIndexPath = indexPath
-                switchDetailsHandler([detailsViewModel], 0, nil)
                 highlightSelectedRowIfNeeded()
-                break
+                return true
             }
         }
+        return false
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/OrderListViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrderListViewController.swift
@@ -518,7 +518,7 @@ private extension OrderListViewController {
             selectFirstItemIfPossible()
             return
         }
-        let selected = selectOrder(for: orderID)
+        let selected = selectOrder(for: orderID, canSwitchDetails: true)
         if !selected {
             selectedIndexPath = nil
             switchDetailsHandler([], 0, nil)
@@ -547,13 +547,13 @@ private extension OrderListViewController {
 extension OrderListViewController {
     /// Adds ability to select any order
     @discardableResult
-    func selectOrder(for orderID: Int64) -> Bool {
+    func selectOrder(for orderID: Int64, canSwitchDetails: Bool) -> Bool {
         let itemIdentifiers = dataSource.snapshot().itemIdentifiers
         for identifier in itemIdentifiers {
             if let detailsViewModel = viewModel.detailsViewModel(withID: identifier),
                detailsViewModel.order.orderID == orderID,
                let indexPath = dataSource.indexPath(for: identifier) {
-                if selectedOrderID != orderID || selectedIndexPath != indexPath {
+                if canSwitchDetails && (selectedOrderID != orderID || selectedIndexPath != indexPath) {
                     switchDetailsHandler([detailsViewModel], 0, nil)
                 }
                 selectedOrderID = orderID

--- a/WooCommerce/Classes/ViewRelated/Orders/OrderListViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrderListViewController.swift
@@ -546,14 +546,13 @@ private extension OrderListViewController {
 
 extension OrderListViewController {
     /// Adds ability to select any order
-    @discardableResult
-    func selectOrder(for orderID: Int64, canSwitchDetails: Bool = true) -> Bool {
+    func selectOrder(for orderID: Int64) -> Bool {
         let itemIdentifiers = dataSource.snapshot().itemIdentifiers
         for identifier in itemIdentifiers {
             if let detailsViewModel = viewModel.detailsViewModel(withID: identifier),
                detailsViewModel.order.orderID == orderID,
                let indexPath = dataSource.indexPath(for: identifier) {
-                if canSwitchDetails && (selectedOrderID != orderID || selectedIndexPath != indexPath) {
+                if selectedOrderID != orderID || selectedIndexPath != indexPath {
                     switchDetailsHandler([detailsViewModel], 0, nil)
                 }
                 selectedOrderID = orderID

--- a/WooCommerce/Classes/ViewRelated/Orders/OrderListViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrderListViewController.swift
@@ -553,7 +553,10 @@ extension OrderListViewController {
             if let detailsViewModel = viewModel.detailsViewModel(withID: identifier),
                detailsViewModel.order.orderID == orderID,
                let indexPath = dataSource.indexPath(for: identifier) {
-                if canSwitchDetails && (selectedOrderID != orderID || selectedIndexPath != indexPath) {
+                let orderNotAlreadySelected = selectedOrderID != orderID
+                let indexPathNotAlreadySelected = selectedIndexPath != indexPath
+                let shouldSwitchDetails = orderNotAlreadySelected || indexPathNotAlreadySelected
+                if canSwitchDetails && shouldSwitchDetails {
                     switchDetailsHandler([detailsViewModel], 0, nil)
                 }
                 selectedOrderID = orderID

--- a/WooCommerce/Classes/ViewRelated/Orders/OrdersRootViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrdersRootViewController.swift
@@ -153,7 +153,7 @@ final class OrdersRootViewController: UIViewController {
     }
 
     func selectOrder(for orderID: Int64) {
-        ordersViewController.selectOrder(for: orderID, canSwitchDetails: false)
+        ordersViewController.selectOrder(for: orderID)
     }
 
     func presentDetails(for orderID: Int64, siteID: Int64, note: Note? = nil) {

--- a/WooCommerce/Classes/ViewRelated/Orders/OrdersRootViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrdersRootViewController.swift
@@ -153,7 +153,7 @@ final class OrdersRootViewController: UIViewController {
     }
 
     func selectOrder(for orderID: Int64) {
-        ordersViewController.selectOrder(for: orderID)
+        ordersViewController.selectOrder(for: orderID, canSwitchDetails: false)
     }
 
     func presentDetails(for orderID: Int64, siteID: Int64, note: Note? = nil) {

--- a/WooCommerce/Classes/ViewRelated/Orders/OrdersSplitViewWrapperController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrdersSplitViewWrapperController.swift
@@ -45,6 +45,8 @@ final class OrdersSplitViewWrapperController: UIViewController {
         let loaderViewController = OrderLoaderViewController(orderID: orderID, siteID: Int64(siteID), note: note)
         let loaderNavigationController = WooNavigationController(rootViewController: loaderViewController)
 
+        ordersViewController.navigationController?.popToRootViewController(animated: false)
+
         ordersSplitViewController.setViewController(loaderNavigationController, for: .secondary)
         ordersSplitViewController.show(.secondary)
 

--- a/WooCommerce/Classes/ViewRelated/Orders/OrdersSplitViewWrapperController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrdersSplitViewWrapperController.swift
@@ -74,6 +74,10 @@ private extension OrdersSplitViewWrapperController {
     }
 
     func showSecondaryView(_ viewController: UIViewController) {
+        // added to remove double details presented bug #11752 https://github.com/woocommerce/woocommerce-ios/pull/11753#discussion_r1463020153
+        // - white debugging noticed that ordersViewController.navigationController had multiple orders in the view controllers list
+        ordersViewController.navigationController?.popToRootViewController(animated: false)
+
         ordersSplitViewController.setViewController(viewController, for: .secondary)
         ordersSplitViewController.show(.secondary)
     }

--- a/WooCommerce/Classes/ViewRelated/Orders/OrdersSplitViewWrapperController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrdersSplitViewWrapperController.swift
@@ -45,6 +45,8 @@ final class OrdersSplitViewWrapperController: UIViewController {
         let loaderViewController = OrderLoaderViewController(orderID: orderID, siteID: Int64(siteID), note: note)
         let loaderNavigationController = WooNavigationController(rootViewController: loaderViewController)
 
+        // added to remove double details presented bug #11752 https://github.com/woocommerce/woocommerce-ios/pull/11753#discussion_r1463020153
+        // - white debugging noticed that ordersViewController.navigationController had multiple orders in the view controllers list
         ordersViewController.navigationController?.popToRootViewController(animated: false)
 
         ordersSplitViewController.setViewController(loaderNavigationController, for: .secondary)


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #11750 
Closes: #11752
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
- Checks to see if there is a selected order ID, and selects its order
- calling `popToRootViewController` to make sure there are no multiple order details in the hierarchy

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

#11750
- make sure that you have at least 2 orders
- select any order except the first one
- open filters
- select different filter to achieve that the list is not showing previously selected order
- now reset the filter to show all orders
- observe that the previously selected order is selected again (and not the first order in the list)
- make sure to set `splitViewInOrdersTab` to `true`

#11752 
- repro instructions from https://github.com/woocommerce/woocommerce-ios/issues/11752

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

![Simulator Screen Recording - iPad Pro (11-inch) (4th generation) - 2024-01-22 at 17 26 32](https://github.com/woocommerce/woocommerce-ios/assets/6242034/7df9d0cd-94ba-454e-95d6-2047a409be99)

---
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
