### PR TITLE
[Blaze] Read new payment method ID from web view success URL

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Blaze/ConfirmPayment/BlazeAddPaymentMethodWebView.swift
+++ b/WooCommerce/Classes/ViewRelated/Blaze/ConfirmPayment/BlazeAddPaymentMethodWebView.swift
@@ -15,7 +15,6 @@ struct BlazeAddPaymentMethodWebView: View {
                     AuthenticatedWebView(isPresented: .constant(true),
                                          url: addPaymentMethodURL,
                                          urlToTriggerExit: viewModel.addPaymentSuccessURL) { url in
-                        viewModel.notice = Notice(title: Localization.paymentMethodAddedNotice, feedbackType: .success)
                         viewModel.didAddNewPaymentMethod(successURL: url)
                         dismiss()
                     }
@@ -47,11 +46,6 @@ private extension BlazeAddPaymentMethodWebView {
             "blazeAddPaymentWebView.cancelButton",
             value: "Cancel",
             comment: "Title of the button to dismiss the Blaze Add Payment Method screen"
-        )
-        static let paymentMethodAddedNotice = NSLocalizedString(
-            "blazeAddPaymentWebView.paymentMethodAddedNotice",
-            value: "Payment method added",
-            comment: "Notice that will be displayed after adding a new Blaze payment method"
         )
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Blaze/ConfirmPayment/BlazeAddPaymentMethodWebView.swift
+++ b/WooCommerce/Classes/ViewRelated/Blaze/ConfirmPayment/BlazeAddPaymentMethodWebView.swift
@@ -1,0 +1,69 @@
+import SwiftUI
+
+struct BlazeAddPaymentMethodWebView: View {
+    @ObservedObject private var viewModel: BlazeAddPaymentMethodWebViewModel
+    @Environment(\.dismiss) private var dismiss
+
+    init(viewModel: BlazeAddPaymentMethodWebViewModel) {
+        self.viewModel = viewModel
+    }
+
+    var body: some View {
+        NavigationView {
+            Group {
+                if let addPaymentMethodURL = viewModel.addPaymentMethodURL {
+                    AuthenticatedWebView(isPresented: .constant(true),
+                                         url: addPaymentMethodURL,
+                                         urlToTriggerExit: viewModel.addPaymentSuccessURL) { url in
+                        viewModel.notice = Notice(title: Localization.paymentMethodAddedNotice, feedbackType: .success)
+                        viewModel.didAddNewPaymentMethod(successURL: url)
+                        dismiss()
+                    }
+                }
+            }
+            .toolbar {
+                ToolbarItem(placement: .cancellationAction) {
+                    Button(Localization.cancelButton) {
+                        dismiss()
+                    }
+                }
+            }
+            .navigationTitle(Localization.navigationBarTitle)
+            .wooNavigationBarStyle()
+            .navigationBarTitleDisplayMode(.inline)
+        }
+        .notice($viewModel.notice)
+    }
+}
+
+private extension BlazeAddPaymentMethodWebView {
+    enum Localization {
+        static let navigationBarTitle = NSLocalizedString(
+            "blazeAddPaymentWebView.navigationBarTitle",
+            value: "Payment Method",
+            comment: "Navigation bar title in the Blaze Add Payment Method screen"
+        )
+        static let cancelButton = NSLocalizedString(
+            "blazeAddPaymentWebView.cancelButton",
+            value: "Cancel",
+            comment: "Title of the button to dismiss the Blaze Add Payment Method screen"
+        )
+        static let paymentMethodAddedNotice = NSLocalizedString(
+            "blazeAddPaymentWebView.paymentMethodAddedNotice",
+            value: "Payment method added",
+            comment: "Notice that will be displayed after adding a new Blaze payment method"
+        )
+    }
+}
+
+struct BlazeAddPaymentWebView_Previews: PreviewProvider {
+    static var previews: some View {
+
+        let viewModel = BlazeAddPaymentMethodWebViewModel(siteID: 123,
+                                                    addPaymentMethodInfo: BlazePaymentMethodsViewModel.samplePaymentInfo().addPaymentMethod,
+                                                    completion: { newPaymentID in
+        })
+
+        BlazeAddPaymentMethodWebView(viewModel: viewModel)
+    }
+}

--- a/WooCommerce/Classes/ViewRelated/Blaze/ConfirmPayment/BlazeAddPaymentMethodWebViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Blaze/ConfirmPayment/BlazeAddPaymentMethodWebViewModel.swift
@@ -1,0 +1,40 @@
+import Yosemite
+
+/// View model for `BlazeAddPaymentMethodWebView`.
+///
+final class BlazeAddPaymentMethodWebViewModel: ObservableObject {
+    typealias Completion = (_ newPaymentMethodID: String) -> Void
+    private let onCompletion: Completion
+
+    private let siteID: Int64
+    private let addPaymentMethodInfo: BlazeAddPaymentInfo
+
+    @Published var notice: Notice?
+
+    var addPaymentMethodURL: URL? {
+        URL(string: addPaymentMethodInfo.formUrl)
+    }
+
+    var addPaymentSuccessURL: String {
+        addPaymentMethodInfo.successUrl
+    }
+
+    init(siteID: Int64,
+         addPaymentMethodInfo: BlazeAddPaymentInfo,
+         completion: @escaping Completion) {
+        self.siteID = siteID
+        self.addPaymentMethodInfo = addPaymentMethodInfo
+        self.onCompletion = completion
+    }
+
+    func didAddNewPaymentMethod(successURL: URL?) {
+        guard let successURL,
+              let urlComponents = URLComponents(url: successURL, resolvingAgainstBaseURL: true),
+              let newPaymentMethodID = urlComponents.queryItems?.first(where: { $0.name == addPaymentMethodInfo.idUrlParameter })?.value else {
+            DDLogError("⛔️ Failed to get newly added payment method ID from Blaze Add payment web view.")
+            return
+        }
+
+        onCompletion(newPaymentMethodID)
+    }
+}

--- a/WooCommerce/Classes/ViewRelated/Blaze/ConfirmPayment/BlazeAddPaymentMethodWebViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Blaze/ConfirmPayment/BlazeAddPaymentMethodWebViewModel.swift
@@ -28,6 +28,8 @@ final class BlazeAddPaymentMethodWebViewModel: ObservableObject {
     }
 
     func didAddNewPaymentMethod(successURL: URL?) {
+        notice = Notice(title: Localization.paymentMethodAddedNotice, feedbackType: .success)
+
         guard let successURL,
               let urlComponents = URLComponents(url: successURL, resolvingAgainstBaseURL: true),
               let newPaymentMethodID = urlComponents.queryItems?.first(where: { $0.name == addPaymentMethodInfo.idUrlParameter })?.value else {
@@ -36,5 +38,15 @@ final class BlazeAddPaymentMethodWebViewModel: ObservableObject {
         }
 
         onCompletion(newPaymentMethodID)
+    }
+}
+
+private extension BlazeAddPaymentMethodWebViewModel {
+    enum Localization {
+        static let paymentMethodAddedNotice = NSLocalizedString(
+            "blazeAddPaymentWebView.paymentMethodAddedNotice",
+            value: "Payment method added",
+            comment: "Notice that will be displayed after adding a new Blaze payment method"
+        )
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Blaze/ConfirmPayment/BlazeConfirmPaymentView.swift
+++ b/WooCommerce/Classes/ViewRelated/Blaze/ConfirmPayment/BlazeConfirmPaymentView.swift
@@ -8,7 +8,6 @@ struct BlazeConfirmPaymentView: View {
     @Environment(\.dismiss) private var dismiss
 
     @State private var externalURL: URL?
-    @State private var showAddPaymentSheet: Bool = false
 
     private let agreementText: NSAttributedString = {
         let content = String.localizedStringWithFormat(Localization.agreement, Localization.termsOfService, Localization.adPolicy, Localization.learnMore)
@@ -94,7 +93,7 @@ struct BlazeConfirmPaymentView: View {
             })
             .interactiveDismissDisabled()
         }
-        .sheet(isPresented: $showAddPaymentSheet) {
+        .sheet(isPresented: $viewModel.showAddPaymentSheet) {
             if let paymentMethodsViewModel = viewModel.paymentMethodsViewModel {
                 BlazePaymentMethodsView(viewModel: paymentMethodsViewModel)
             }
@@ -134,7 +133,7 @@ private extension BlazeConfirmPaymentView {
 
     var cardDetailView: some View {
         Button {
-            showAddPaymentSheet = true
+            viewModel.showAddPaymentSheet = true
         } label: {
             if let icon = viewModel.cardIcon {
                 Image(uiImage: icon)
@@ -165,7 +164,7 @@ private extension BlazeConfirmPaymentView {
 
     var addPaymentMethodButton: some View {
         Button {
-            showAddPaymentSheet = true
+            viewModel.showAddPaymentSheet = true
         } label: {
             HStack {
                 Text(Localization.addPaymentMethod)

--- a/WooCommerce/Classes/ViewRelated/Blaze/ConfirmPayment/BlazeConfirmPaymentView.swift
+++ b/WooCommerce/Classes/ViewRelated/Blaze/ConfirmPayment/BlazeConfirmPaymentView.swift
@@ -8,6 +8,7 @@ struct BlazeConfirmPaymentView: View {
     @Environment(\.dismiss) private var dismiss
 
     @State private var externalURL: URL?
+    @State private var showingAddPaymentWebView: Bool = false
 
     private let agreementText: NSAttributedString = {
         let content = String.localizedStringWithFormat(Localization.agreement, Localization.termsOfService, Localization.adPolicy, Localization.learnMore)
@@ -98,6 +99,11 @@ struct BlazeConfirmPaymentView: View {
                 BlazePaymentMethodsView(viewModel: paymentMethodsViewModel)
             }
         }
+        .sheet(isPresented: $showingAddPaymentWebView, content: {
+            if let viewModel = viewModel.addPaymentWebViewModel {
+                BlazeAddPaymentMethodWebView(viewModel: viewModel)
+            }
+        })
     }
 }
 
@@ -164,7 +170,7 @@ private extension BlazeConfirmPaymentView {
 
     var addPaymentMethodButton: some View {
         Button {
-            viewModel.showAddPaymentSheet = true
+            showingAddPaymentWebView = true
         } label: {
             HStack {
                 Text(Localization.addPaymentMethod)

--- a/WooCommerce/Classes/ViewRelated/Blaze/ConfirmPayment/BlazeConfirmPaymentViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Blaze/ConfirmPayment/BlazeConfirmPaymentViewModel.swift
@@ -21,6 +21,8 @@ final class BlazeConfirmPaymentViewModel: ObservableObject {
         isFetchingPaymentInfo || selectedPaymentMethod == nil
     }
 
+    @Published var showAddPaymentSheet: Bool = false
+
     var paymentMethodsViewModel: BlazePaymentMethodsViewModel? {
         guard let paymentInfo else {
             DDLogError("⛔️ No payment info available to list in payment methods screen.")
@@ -28,7 +30,8 @@ final class BlazeConfirmPaymentViewModel: ObservableObject {
         }
         return BlazePaymentMethodsViewModel(siteID: siteID,
                                             paymentInfo: paymentInfo,
-                                            selectedPaymentMethodID: selectedPaymentMethod?.id, completion: { paymentID in
+                                            selectedPaymentMethodID: selectedPaymentMethod?.id,
+                                            completion: { paymentID in
             Task { @MainActor [weak self] in
                 guard let self else { return }
                 await updatePaymentInfo()

--- a/WooCommerce/Classes/ViewRelated/Blaze/ConfirmPayment/BlazeConfirmPaymentViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Blaze/ConfirmPayment/BlazeConfirmPaymentViewModel.swift
@@ -46,6 +46,23 @@ final class BlazeConfirmPaymentViewModel: ObservableObject {
         })
     }
 
+    var addPaymentWebViewModel: BlazeAddPaymentMethodWebViewModel? {
+        guard let paymentInfo else {
+            DDLogError("⛔️ No add payment info available to initiate Add payment method flow.")
+            return nil
+        }
+
+        return BlazeAddPaymentMethodWebViewModel(siteID: siteID,
+                                                 addPaymentMethodInfo: paymentInfo.addPaymentMethod) { [weak self] newPaymentMethodID in
+            Task { @MainActor [weak self] in
+                guard let self else { return }
+
+                await updatePaymentInfo()
+                selectedPaymentMethod = paymentInfo.savedPaymentMethods.first(where: { $0.id == newPaymentMethodID })
+            }
+        }
+    }
+
     let totalAmount: String
 
     @Published private(set) var isFetchingPaymentInfo = false

--- a/WooCommerce/Classes/ViewRelated/Blaze/ConfirmPayment/BlazeConfirmPaymentViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Blaze/ConfirmPayment/BlazeConfirmPaymentViewModel.swift
@@ -36,8 +36,8 @@ final class BlazeConfirmPaymentViewModel: ObservableObject {
                 guard let self else { return }
                 showAddPaymentSheet = false
 
-                if let paymentIDExisting = paymentInfo.savedPaymentMethods.first(where: { $0.id == paymentID }) {
-                    selectedPaymentMethod = paymentIDExisting
+                if let existingPaymentMethod = paymentInfo.savedPaymentMethods.first(where: { $0.id == paymentID }) {
+                    selectedPaymentMethod = existingPaymentMethod
                 } else {
                     await updatePaymentInfo()
                     selectedPaymentMethod = paymentInfo.savedPaymentMethods.first(where: { $0.id == paymentID })

--- a/WooCommerce/Classes/ViewRelated/Blaze/ConfirmPayment/BlazeConfirmPaymentViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Blaze/ConfirmPayment/BlazeConfirmPaymentViewModel.swift
@@ -34,8 +34,14 @@ final class BlazeConfirmPaymentViewModel: ObservableObject {
                                             completion: { paymentID in
             Task { @MainActor [weak self] in
                 guard let self else { return }
-                await updatePaymentInfo()
-                selectedPaymentMethod = paymentInfo.savedPaymentMethods.first(where: { $0.id == paymentID })
+                showAddPaymentSheet = false
+
+                if let paymentIDExisting = paymentInfo.savedPaymentMethods.first(where: { $0.id == paymentID }) {
+                    selectedPaymentMethod = paymentIDExisting
+                } else {
+                    await updatePaymentInfo()
+                    selectedPaymentMethod = paymentInfo.savedPaymentMethods.first(where: { $0.id == paymentID })
+                }
             }
         })
     }

--- a/WooCommerce/Classes/ViewRelated/Blaze/ConfirmPayment/BlazePaymentMethodsView.swift
+++ b/WooCommerce/Classes/ViewRelated/Blaze/ConfirmPayment/BlazePaymentMethodsView.swift
@@ -5,7 +5,6 @@ struct BlazePaymentMethodsView: View {
     @ScaledMetric private var scale: CGFloat = 1.0
     @ObservedObject private var viewModel: BlazePaymentMethodsViewModel
     @Environment(\.dismiss) private var dismiss
-    @State private var showingAddPaymentWebView: Bool = false
 
     init(viewModel: BlazePaymentMethodsViewModel) {
         self.viewModel = viewModel
@@ -28,7 +27,7 @@ struct BlazePaymentMethodsView: View {
                 Group {
                     let buttonText = viewModel.paymentMethods.isEmpty ? Localization.addCreditCardButton : Localization.addAnotherCreditCardButton
                     Button(action: {
-                        showingAddPaymentWebView = true
+                        viewModel.showingAddPaymentWebView = true
                     }) {
                         Text(buttonText)
                     }
@@ -48,7 +47,7 @@ struct BlazePaymentMethodsView: View {
             .wooNavigationBarStyle()
             .navigationBarTitleDisplayMode(.inline)
         }
-        .sheet(isPresented: $showingAddPaymentWebView, content: {
+        .sheet(isPresented: $viewModel.showingAddPaymentWebView, content: {
             webView
         })
         .notice($viewModel.notice)
@@ -141,10 +140,10 @@ struct BlazePaymentMethodsView: View {
         if let addPaymentMethodURL = viewModel.addPaymentMethodURL,
            let fetchPaymentMethodURLPath = viewModel.addPaymentSuccessURL {
             NavigationView {
-                AuthenticatedWebView(isPresented: $showingAddPaymentWebView,
+                AuthenticatedWebView(isPresented: $viewModel.showingAddPaymentWebView,
                                      url: addPaymentMethodURL,
                                      urlToTriggerExit: fetchPaymentMethodURLPath) { url in
-                    showingAddPaymentWebView = false
+                    viewModel.showingAddPaymentWebView = false
                     viewModel.notice = Notice(title: Localization.paymentMethodAddedNotice, feedbackType: .success)
                     viewModel.didAddNewPaymentMethod(successURL: url)
                 }
@@ -153,7 +152,7 @@ struct BlazePaymentMethodsView: View {
                                      .toolbar {
                                          ToolbarItem(placement: .confirmationAction) {
                                              Button(action: {
-                                                 showingAddPaymentWebView = false
+                                                 viewModel.showingAddPaymentWebView = false
                                              }, label: {
                                                  Text(Localization.doneButtonAddPayment)
                                              })

--- a/WooCommerce/Classes/ViewRelated/Blaze/ConfirmPayment/BlazePaymentMethodsView.swift
+++ b/WooCommerce/Classes/ViewRelated/Blaze/ConfirmPayment/BlazePaymentMethodsView.swift
@@ -136,34 +136,6 @@ struct BlazePaymentMethodsView: View {
         }
         .padding(.top, Layout.noPaymentsViewTopPadding)
     }
-
-    @ViewBuilder
-    private var webView: some View {
-        if let addPaymentMethodURL = viewModel.addPaymentMethodURL,
-           let fetchPaymentMethodURLPath = viewModel.addPaymentSuccessURL {
-            NavigationView {
-                AuthenticatedWebView(isPresented: $viewModel.showingAddPaymentWebView,
-                                     url: addPaymentMethodURL,
-                                     urlToTriggerExit: fetchPaymentMethodURLPath) { url in
-                    viewModel.showingAddPaymentWebView = false
-                    viewModel.notice = Notice(title: Localization.paymentMethodAddedNotice, feedbackType: .success)
-                    viewModel.didAddNewPaymentMethod(successURL: url)
-                }
-                                     .navigationTitle(Localization.paymentMethodWebViewTitle)
-                                     .navigationBarTitleDisplayMode(.inline)
-                                     .toolbar {
-                                         ToolbarItem(placement: .confirmationAction) {
-                                             Button(action: {
-                                                 viewModel.showingAddPaymentWebView = false
-                                             }, label: {
-                                                 Text(Localization.doneButtonAddPayment)
-                                             })
-                                         }
-                                     }
-            }
-            .wooNavigationBarStyle()
-        }
-    }
 }
 
 private extension BlazePaymentMethodsView {
@@ -192,39 +164,32 @@ private extension BlazePaymentMethodsView {
             value: "Credits cards are retrieved from the following WordPress.com account: %1$@ <%2$@>",
             comment: "Footer for list of payment methods in Payment Method screen."
             + " %1$@ is a placeholder for the WordPress.com username."
-            + " %2$@ is a placeholder for the WordPress.com email address.")
+            + " %2$@ is a placeholder for the WordPress.com email address."
+        )
         static let emailReceipt = NSLocalizedString(
             "blazePaymentMethodsView.emailReceipt",
             value: "Email the label purchase receipts to %1$@ (%2$@) at %3$@",
             comment: "Label for the email receipts toggle in Payment Method screen."
             + " %1$@ is a placeholder for the account display name."
             + " %2$@ is a placeholder for the username."
-            + " %3$@ is a placeholder for the WordPress.com email address.")
+            + " %3$@ is a placeholder for the WordPress.com email address."
+        )
         static let addCreditCardButton = NSLocalizedString(
             "blazePaymentMethodsView.addCreditCardButton",
             value: "Add credit card",
-            comment: "Button title in the Blaze Payment Method screen")
+            comment: "Button title in the Blaze Payment Method screen"
+        )
         static let addAnotherCreditCardButton = NSLocalizedString(
             "blazePaymentMethodsView.addAnotherCreditCardButton",
             value: "Add another credit card",
             comment: "Button title in the Blaze Payment Method" +
-            " screen if there is an existing payment method")
-        static let paymentMethodWebViewTitle = NSLocalizedString(
-            "blazePaymentMethodsView.paymentMethodWebViewTitle",
-            value: "Payment method",
-            comment: "Title of the web view of adding a payment method in Blaze")
-        static let doneButtonAddPayment = NSLocalizedString(
-            "blazePaymentMethodsView.doneButtonAddPayment",
-            value: "Done",
-            comment: "Done navigation button in Blaze add payment web view")
-        static let paymentMethodAddedNotice = NSLocalizedString(
-            "blazePaymentMethodsView.paymentMethodAddedNotice",
-            value: "Payment method added",
-            comment: "Notice that will be displayed after adding a new Blaze payment method")
+            " screen if there is an existing payment method"
+        )
         static let pleaseAddPaymentMethodMessage = NSLocalizedString(
             "blazePaymentMethodsView.pleaseAddPaymentMethodMessage",
             value: "Please add a new payment method",
-            comment: "Message that will be displayed if there are no Blaze payment methods.")
+            comment: "Message that will be displayed if there are no Blaze payment methods."
+        )
     }
 
     enum Layout {

--- a/WooCommerce/Classes/ViewRelated/Blaze/ConfirmPayment/BlazePaymentMethodsView.swift
+++ b/WooCommerce/Classes/ViewRelated/Blaze/ConfirmPayment/BlazePaymentMethodsView.swift
@@ -27,7 +27,6 @@ struct BlazePaymentMethodsView: View {
                 // Add new method button
                 Group {
                     let buttonText = viewModel.paymentMethods.isEmpty ? Localization.addCreditCardButton : Localization.addAnotherCreditCardButton
-                    
                     Button(action: {
                         showingAddPaymentWebView = true
                     }) {
@@ -44,20 +43,6 @@ struct BlazePaymentMethodsView: View {
                         dismiss()
                     }
                 }
-
-                ToolbarItem(placement: .confirmationAction) {
-                    Button(action: {
-                        viewModel.saveSelection()
-                        dismiss()
-                    }, label: {
-                        if viewModel.isFetchingPaymentInfo {
-                            ProgressView()
-                        } else {
-                            Text(Localization.doneButton)
-                        }
-                    })
-                    .disabled(!viewModel.isDoneButtonEnabled)
-                }
             }
             .navigationTitle(Localization.navigationBarTitle)
             .wooNavigationBarStyle()
@@ -65,13 +50,6 @@ struct BlazePaymentMethodsView: View {
         }
         .sheet(isPresented: $showingAddPaymentWebView, content: {
             webView
-        })
-        .alert(Text(Localization.errorMessage), isPresented: $viewModel.shouldDisplayPaymentErrorAlert, actions: {
-            Button(Localization.tryAgain) {
-                Task {
-                    await viewModel.syncPaymentInfo()
-                }
-            }
         })
         .notice($viewModel.notice)
     }
@@ -165,12 +143,10 @@ struct BlazePaymentMethodsView: View {
             NavigationView {
                 AuthenticatedWebView(isPresented: $showingAddPaymentWebView,
                                      url: addPaymentMethodURL,
-                                     urlToTriggerExit: fetchPaymentMethodURLPath) {
+                                     urlToTriggerExit: fetchPaymentMethodURLPath) { url in
                     showingAddPaymentWebView = false
-                    Task {
-                        await viewModel.syncPaymentInfo()
-                    }
                     viewModel.notice = Notice(title: Localization.paymentMethodAddedNotice, feedbackType: .success)
+                    viewModel.didAddNewPaymentMethod(successURL: url)
                 }
                                      .navigationTitle(Localization.paymentMethodWebViewTitle)
                                      .navigationBarTitleDisplayMode(.inline)
@@ -199,11 +175,6 @@ private extension BlazePaymentMethodsView {
             "blazePaymentMethodsView.cancelButton",
             value: "Cancel",
             comment: "Title of the button to dismiss the Blaze payment method list screen"
-        )
-        static let doneButton = NSLocalizedString(
-            "blazePaymentMethodsView.doneButton",
-            value: "Done",
-            comment: "Done navigation button in the Blaze Payment Method screen"
         )
         static let transactionsSecure = NSLocalizedString(
             "blazePaymentMethodsView.transactionsSecure",
@@ -253,16 +224,6 @@ private extension BlazePaymentMethodsView {
             "blazePaymentMethodsView.pleaseAddPaymentMethodMessage",
             value: "Please add a new payment method",
             comment: "Message that will be displayed if there are no Blaze payment methods.")
-        static let errorMessage = NSLocalizedString(
-            "blazePaymentMethodsView.errorMessage",
-            value: "Error loading your payment methods",
-            comment: "Error message displayed when fetching payment methods failed on the Payment screen in the Blaze campaign creation flow."
-        )
-        static let tryAgain = NSLocalizedString(
-            "blazePaymentMethodsView.tryAgain",
-            value: "Try Again",
-            comment: "Button to retry when fetching payment methods failed on the Payment screen in the Blaze campaign creation flow."
-        )
     }
 
     enum Layout {

--- a/WooCommerce/Classes/ViewRelated/Blaze/ConfirmPayment/BlazePaymentMethodsView.swift
+++ b/WooCommerce/Classes/ViewRelated/Blaze/ConfirmPayment/BlazePaymentMethodsView.swift
@@ -5,6 +5,7 @@ struct BlazePaymentMethodsView: View {
     @ScaledMetric private var scale: CGFloat = 1.0
     @ObservedObject private var viewModel: BlazePaymentMethodsViewModel
     @Environment(\.dismiss) private var dismiss
+    @State private var showingAddPaymentWebView: Bool = false
 
     init(viewModel: BlazePaymentMethodsViewModel) {
         self.viewModel = viewModel
@@ -27,7 +28,7 @@ struct BlazePaymentMethodsView: View {
                 Group {
                     let buttonText = viewModel.paymentMethods.isEmpty ? Localization.addCreditCardButton : Localization.addAnotherCreditCardButton
                     Button(action: {
-                        viewModel.showingAddPaymentWebView = true
+                        showingAddPaymentWebView = true
                     }) {
                         Text(buttonText)
                     }
@@ -47,7 +48,7 @@ struct BlazePaymentMethodsView: View {
             .wooNavigationBarStyle()
             .navigationBarTitleDisplayMode(.inline)
         }
-        .sheet(isPresented: $viewModel.showingAddPaymentWebView, content: {
+        .sheet(isPresented: $showingAddPaymentWebView, content: {
             if let viewModel = viewModel.addPaymentWebViewModel {
                 BlazeAddPaymentMethodWebView(viewModel: viewModel)
             }

--- a/WooCommerce/Classes/ViewRelated/Blaze/ConfirmPayment/BlazePaymentMethodsView.swift
+++ b/WooCommerce/Classes/ViewRelated/Blaze/ConfirmPayment/BlazePaymentMethodsView.swift
@@ -52,7 +52,6 @@ struct BlazePaymentMethodsView: View {
                 BlazeAddPaymentMethodWebView(viewModel: viewModel)
             }
         })
-        .notice($viewModel.notice)
     }
 
     @ViewBuilder

--- a/WooCommerce/Classes/ViewRelated/Blaze/ConfirmPayment/BlazePaymentMethodsView.swift
+++ b/WooCommerce/Classes/ViewRelated/Blaze/ConfirmPayment/BlazePaymentMethodsView.swift
@@ -48,7 +48,9 @@ struct BlazePaymentMethodsView: View {
             .navigationBarTitleDisplayMode(.inline)
         }
         .sheet(isPresented: $viewModel.showingAddPaymentWebView, content: {
-            webView
+            if let viewModel = viewModel.addPaymentWebViewModel {
+                BlazeAddPaymentMethodWebView(viewModel: viewModel)
+            }
         })
         .notice($viewModel.notice)
     }

--- a/WooCommerce/Classes/ViewRelated/Blaze/ConfirmPayment/BlazePaymentMethodsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Blaze/ConfirmPayment/BlazePaymentMethodsViewModel.swift
@@ -12,7 +12,6 @@ final class BlazePaymentMethodsViewModel: ObservableObject {
     private let defaultAccount: Account?
 
     private let paymentInfo: BlazePaymentInfo?
-    @Published var notice: Notice?
     @Published var showingAddPaymentWebView: Bool
 
     var paymentMethods: [BlazePaymentMethod] {

--- a/WooCommerce/Classes/ViewRelated/Blaze/ConfirmPayment/BlazePaymentMethodsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Blaze/ConfirmPayment/BlazePaymentMethodsViewModel.swift
@@ -19,7 +19,7 @@ final class BlazePaymentMethodsViewModel: ObservableObject {
 
     var addPaymentWebViewModel: BlazeAddPaymentMethodWebViewModel? {
         guard let paymentInfo else {
-            DDLogError("⛔️ No add payment info available to initiate Add payment methods flow.")
+            DDLogError("⛔️ No add payment info available to initiate Add payment method flow.")
             return nil
         }
 

--- a/WooCommerce/Classes/ViewRelated/Blaze/ConfirmPayment/BlazePaymentMethodsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Blaze/ConfirmPayment/BlazePaymentMethodsViewModel.swift
@@ -12,7 +12,6 @@ final class BlazePaymentMethodsViewModel: ObservableObject {
     private let defaultAccount: Account?
 
     private let paymentInfo: BlazePaymentInfo?
-    @Published private(set) var isFetchingPaymentInfo = false
     @Published var notice: Notice?
 
     var paymentMethods: [BlazePaymentMethod] {

--- a/WooCommerce/Classes/ViewRelated/Blaze/ConfirmPayment/BlazePaymentMethodsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Blaze/ConfirmPayment/BlazePaymentMethodsViewModel.swift
@@ -12,7 +12,6 @@ final class BlazePaymentMethodsViewModel: ObservableObject {
     private let defaultAccount: Account?
 
     private let paymentInfo: BlazePaymentInfo?
-    @Published var showingAddPaymentWebView: Bool
 
     var paymentMethods: [BlazePaymentMethod] {
         paymentInfo?.savedPaymentMethods ?? []
@@ -56,7 +55,6 @@ final class BlazePaymentMethodsViewModel: ObservableObject {
         self.stores = stores
         self.onCompletion = completion
         self.defaultAccount = stores.sessionManager.defaultAccount
-        self.showingAddPaymentWebView = paymentInfo.savedPaymentMethods.isEmpty
     }
 
     func didSelectPaymentMethod(withID paymentMethodID: String) {

--- a/WooCommerce/Classes/ViewRelated/Blaze/ConfirmPayment/BlazePaymentMethodsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Blaze/ConfirmPayment/BlazePaymentMethodsViewModel.swift
@@ -19,6 +19,18 @@ final class BlazePaymentMethodsViewModel: ObservableObject {
         paymentInfo?.savedPaymentMethods ?? []
     }
 
+    var addPaymentWebViewModel: BlazeAddPaymentMethodWebViewModel? {
+        guard let paymentInfo else {
+            return nil
+        }
+
+        return BlazeAddPaymentMethodWebViewModel(siteID: siteID,
+                                                 addPaymentMethodInfo: paymentInfo.addPaymentMethod) { [weak self] newPaymentMethodID in
+            guard let self else { return }
+            didSelectPaymentMethod(withID: newPaymentMethodID)
+        }
+    }
+
     @Published private(set) var selectedPaymentMethodID: String?
 
     var userEmail: String {
@@ -31,17 +43,6 @@ final class BlazePaymentMethodsViewModel: ObservableObject {
 
     var WPCOMEmail: String {
         defaultAccount?.email ?? ""
-    }
-
-    var addPaymentMethodURL: URL? {
-        guard let paymentInfo else {
-            return nil
-        }
-        return URL(string: paymentInfo.addPaymentMethod.formUrl)
-    }
-
-    var addPaymentSuccessURL: String? {
-        paymentInfo?.addPaymentMethod.successUrl
     }
 
     init(siteID: Int64,
@@ -61,19 +62,6 @@ final class BlazePaymentMethodsViewModel: ObservableObject {
 
     func didSelectPaymentMethod(withID paymentMethodID: String) {
         selectedPaymentMethodID = paymentMethodID
-        saveSelection()
-    }
-
-    func didAddNewPaymentMethod(successURL: URL?) {
-        guard let successURL,
-              let urlComponents = URLComponents(url: successURL, resolvingAgainstBaseURL: true),
-              let idUrlParameter = paymentInfo?.addPaymentMethod.idUrlParameter,
-              let newPaymentMethodID = urlComponents.queryItems?.first(where: { $0.name == idUrlParameter })?.value else {
-            DDLogError("⛔️ Failed to get newly added payment method ID from Blaze Add payment web view.")
-            return
-        }
-
-        selectedPaymentMethodID = newPaymentMethodID
         saveSelection()
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Blaze/ConfirmPayment/BlazePaymentMethodsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Blaze/ConfirmPayment/BlazePaymentMethodsViewModel.swift
@@ -19,6 +19,7 @@ final class BlazePaymentMethodsViewModel: ObservableObject {
 
     var addPaymentWebViewModel: BlazeAddPaymentMethodWebViewModel? {
         guard let paymentInfo else {
+            DDLogError("⛔️ No add payment info available to initiate Add payment methods flow.")
             return nil
         }
 

--- a/WooCommerce/Classes/ViewRelated/Blaze/ConfirmPayment/BlazePaymentMethodsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Blaze/ConfirmPayment/BlazePaymentMethodsViewModel.swift
@@ -13,6 +13,7 @@ final class BlazePaymentMethodsViewModel: ObservableObject {
 
     private let paymentInfo: BlazePaymentInfo?
     @Published var notice: Notice?
+    @Published var showingAddPaymentWebView: Bool = false
 
     var paymentMethods: [BlazePaymentMethod] {
         paymentInfo?.savedPaymentMethods ?? []
@@ -55,6 +56,7 @@ final class BlazePaymentMethodsViewModel: ObservableObject {
         self.stores = stores
         self.onCompletion = completion
         self.defaultAccount = stores.sessionManager.defaultAccount
+        self.showingAddPaymentWebView = paymentInfo.savedPaymentMethods.isEmpty
     }
 
     func didSelectPaymentMethod(withID paymentMethodID: String) {

--- a/WooCommerce/Classes/ViewRelated/Blaze/ConfirmPayment/BlazePaymentMethodsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Blaze/ConfirmPayment/BlazePaymentMethodsViewModel.swift
@@ -13,7 +13,7 @@ final class BlazePaymentMethodsViewModel: ObservableObject {
 
     private let paymentInfo: BlazePaymentInfo?
     @Published var notice: Notice?
-    @Published var showingAddPaymentWebView: Bool = false
+    @Published var showingAddPaymentWebView: Bool
 
     var paymentMethods: [BlazePaymentMethod] {
         paymentInfo?.savedPaymentMethods ?? []

--- a/WooCommerce/Classes/ViewRelated/Inbox/InboxNoteRow.swift
+++ b/WooCommerce/Classes/ViewRelated/Inbox/InboxNoteRow.swift
@@ -105,7 +105,7 @@ struct InboxNoteRow: View {
         NavigationView {
             AuthenticatedWebView(isPresented: .constant(tappedAction != nil),
                                  url: url,
-                                 urlToTriggerExit: nil) {
+                                 urlToTriggerExit: nil) { _ in
 
             }
              .navigationTitle(Localization.inboxWebViewTitle)

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Payment Methods/ShippingLabelPaymentMethods.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Payment Methods/ShippingLabelPaymentMethods.swift
@@ -141,7 +141,7 @@ struct ShippingLabelPaymentMethods: View {
         NavigationView {
             AuthenticatedWebView(isPresented: $showingAddPaymentWebView,
                                  url: WooConstants.URLs.addPaymentMethodWCShip.asURL(),
-                                 urlToTriggerExit: viewModel.fetchPaymentMethodURLPath) {
+                                 urlToTriggerExit: viewModel.fetchPaymentMethodURLPath) { _ in
                 showingAddPaymentWebView = false
                 viewModel.syncShippingLabelAccountSettings()
                 ServiceLocator.analytics.track(.shippingLabelPaymentMethodAdded)

--- a/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/AuthenticatedWebView.swift
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/AuthenticatedWebView.swift
@@ -7,12 +7,12 @@ final class DefaultAuthenticatedWebViewModel: AuthenticatedWebViewModel {
     let title: String
     let initialURL: URL?
     let urlToTriggerExit: String?
-    let exitTrigger: (() -> Void)?
+    let exitTrigger: ((URL?) -> Void)?
 
     init(title: String = "",
          initialURL: URL,
          urlToTriggerExit: String? = nil,
-         exitTrigger: (() -> Void)? = nil) {
+         exitTrigger: ((URL?) -> Void)? = nil) {
         self.title = title
         self.initialURL = initialURL
         self.urlToTriggerExit = urlToTriggerExit
@@ -27,7 +27,7 @@ final class DefaultAuthenticatedWebViewModel: AuthenticatedWebViewModel {
         if let urlToTriggerExit,
             let url,
             url.absoluteString.contains(urlToTriggerExit) {
-            exitTrigger?()
+            exitTrigger?(url)
         }
     }
 
@@ -59,7 +59,7 @@ struct AuthenticatedWebView: UIViewControllerRepresentable {
     init(isPresented: Binding<Bool>,
              url: URL,
              urlToTriggerExit: String? = nil,
-             exitTrigger: (() -> Void)? = nil) {
+             exitTrigger: ((URL?) -> Void)? = nil) {
             self._isPresented = isPresented
             viewModel = DefaultAuthenticatedWebViewModel(initialURL: url,
                                                          urlToTriggerExit: urlToTriggerExit,

--- a/WooCommerce/Classes/ViewRelated/Upgrades/UpgradePlanCoordinatingController.swift
+++ b/WooCommerce/Classes/ViewRelated/Upgrades/UpgradePlanCoordinatingController.swift
@@ -44,7 +44,7 @@ final class UpgradePlanCoordinatingController: WooNavigationController {
         guard let upgradeURL = Constants.upgradeURL(siteID: siteID) else { return }
         let viewModel = DefaultAuthenticatedWebViewModel(title: Localization.upgradeNow,
                                                          initialURL: upgradeURL,
-                                                         urlToTriggerExit: Constants.exitTrigger) { [weak self] in
+                                                         urlToTriggerExit: Constants.exitTrigger) { [weak self] _ in
             self?.exitUpgradeFreeTrialFlowAfterUpgrade()
         }
 

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -2467,6 +2467,9 @@
 		EE1905862B57BBE300617C53 /* BlazePaymentMethodsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE1905852B57BBE300617C53 /* BlazePaymentMethodsView.swift */; };
 		EE1905882B57BBEC00617C53 /* BlazePaymentMethodsViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE1905872B57BBEC00617C53 /* BlazePaymentMethodsViewModel.swift */; };
 		EE19058A2B590FF800617C53 /* BlazePaymentMethodsViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE1905892B590FF800617C53 /* BlazePaymentMethodsViewModelTests.swift */; };
+		EE19058C2B5F744300617C53 /* BlazeAddPaymentMethodWebView.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE19058B2B5F744300617C53 /* BlazeAddPaymentMethodWebView.swift */; };
+		EE19058E2B5F747200617C53 /* BlazeAddPaymentMethodWebViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE19058D2B5F747200617C53 /* BlazeAddPaymentMethodWebViewModel.swift */; };
+		EE1905902B5F83BB00617C53 /* BlazeAddPaymentMethodWebViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE19058F2B5F83BB00617C53 /* BlazeAddPaymentMethodWebViewModelTests.swift */; };
 		EE28CF852B233AC40056D96E /* ProductCreationAISurveyConfirmationViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE28CF842B233AC40056D96E /* ProductCreationAISurveyConfirmationViewModelTests.swift */; };
 		EE2A57D729E399CC009F61E1 /* CaseIterable+Helpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE2A57D629E399CC009F61E1 /* CaseIterable+Helpers.swift */; };
 		EE2A57D929E39A9C009F61E1 /* CaseIterable+HelpersTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE2A57D829E39A9C009F61E1 /* CaseIterable+HelpersTests.swift */; };
@@ -5151,6 +5154,9 @@
 		EE1905852B57BBE300617C53 /* BlazePaymentMethodsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BlazePaymentMethodsView.swift; sourceTree = "<group>"; };
 		EE1905872B57BBEC00617C53 /* BlazePaymentMethodsViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BlazePaymentMethodsViewModel.swift; sourceTree = "<group>"; };
 		EE1905892B590FF800617C53 /* BlazePaymentMethodsViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BlazePaymentMethodsViewModelTests.swift; sourceTree = "<group>"; };
+		EE19058B2B5F744300617C53 /* BlazeAddPaymentMethodWebView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BlazeAddPaymentMethodWebView.swift; sourceTree = "<group>"; };
+		EE19058D2B5F747200617C53 /* BlazeAddPaymentMethodWebViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BlazeAddPaymentMethodWebViewModel.swift; sourceTree = "<group>"; };
+		EE19058F2B5F83BB00617C53 /* BlazeAddPaymentMethodWebViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BlazeAddPaymentMethodWebViewModelTests.swift; sourceTree = "<group>"; };
 		EE28CF842B233AC40056D96E /* ProductCreationAISurveyConfirmationViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductCreationAISurveyConfirmationViewModelTests.swift; sourceTree = "<group>"; };
 		EE2A57D629E399CC009F61E1 /* CaseIterable+Helpers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "CaseIterable+Helpers.swift"; sourceTree = "<group>"; };
 		EE2A57D829E39A9C009F61E1 /* CaseIterable+HelpersTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "CaseIterable+HelpersTests.swift"; sourceTree = "<group>"; };
@@ -5890,6 +5896,7 @@
 				EE1905812B50289100617C53 /* BlazeCampaignCreationFormViewModelTests.swift */,
 				EE1905892B590FF800617C53 /* BlazePaymentMethodsViewModelTests.swift */,
 				86E40AEC2B597DEC00990365 /* BlazeCampaignCreationCoordinatorTests.swift */,
+				EE19058F2B5F83BB00617C53 /* BlazeAddPaymentMethodWebViewModelTests.swift */,
 			);
 			path = Blaze;
 			sourceTree = "<group>";
@@ -11062,6 +11069,8 @@
 				DE02ABBB2B56984A008E0AC4 /* BlazeConfirmPaymentViewModel.swift */,
 				EE1905852B57BBE300617C53 /* BlazePaymentMethodsView.swift */,
 				EE1905872B57BBEC00617C53 /* BlazePaymentMethodsViewModel.swift */,
+				EE19058B2B5F744300617C53 /* BlazeAddPaymentMethodWebView.swift */,
+				EE19058D2B5F747200617C53 /* BlazeAddPaymentMethodWebViewModel.swift */,
 			);
 			path = ConfirmPayment;
 			sourceTree = "<group>";
@@ -13522,6 +13531,7 @@
 				B541B2172189EED4008FE7C1 /* NSMutableAttributedString+Helpers.swift in Sources */,
 				26F94E2E267A96A000DB6CCF /* ProductAddOnViewModel.swift in Sources */,
 				02A9BCD42737DE0D00159C79 /* JetpackBenefitsView.swift in Sources */,
+				EE19058E2B5F747200617C53 /* BlazeAddPaymentMethodWebViewModel.swift in Sources */,
 				20D5CB512AFCF856009A39C3 /* PaymentsRow.swift in Sources */,
 				E10459C627BBC22E00C1DCBA /* CardPresentConfigurationLoader.swift in Sources */,
 				B586906621A5F4B1001F1EFC /* UINavigationController+Woo.swift in Sources */,
@@ -13641,6 +13651,7 @@
 				02AAD54525023A8300BA1E26 /* ProductFormRemoteActionUseCase.swift in Sources */,
 				B9DC770329F18A8D0013B191 /* TopProductsFromCachedOrdersProvider.swift in Sources */,
 				86023FB12B199F6200A28F07 /* ThemesCarouselView.swift in Sources */,
+				EE19058C2B5F744300617C53 /* BlazeAddPaymentMethodWebView.swift in Sources */,
 				D83F5933225B2EB900626E75 /* ManualTrackingViewController.swift in Sources */,
 				3142663F2645E2AB00500598 /* PaymentSettingsFlowViewModelPresenter.swift in Sources */,
 				DEDB886B26E8531E00981595 /* ShippingLabelPackageAttributes.swift in Sources */,
@@ -14768,6 +14779,7 @@
 				2667BFE72530E78F008099D4 /* RefundItemsValuesCalculationUseCaseTests.swift in Sources */,
 				02AA586628531D0E0068B6F0 /* CloseAccountCoordinatorTests.swift in Sources */,
 				E12AF69B26BA8B2000C371C1 /* CardPresentPaymentsOnboardingUseCaseTests.swift in Sources */,
+				EE1905902B5F83BB00617C53 /* BlazeAddPaymentMethodWebViewModelTests.swift in Sources */,
 				D802549B265531D4001B2CC1 /* CardPresentModalConnectingToReaderTests.swift in Sources */,
 				EEBDF7E22A2F685C00EFEF47 /* DefaultShareProductAIEligibilityCheckerTests.swift in Sources */,
 				4572641B27F1FDF2004E1F95 /* AddEditCouponViewModelTests.swift in Sources */,

--- a/WooCommerce/WooCommerceTests/ViewRelated/Blaze/BlazeAddPaymentMethodWebViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Blaze/BlazeAddPaymentMethodWebViewModelTests.swift
@@ -38,4 +38,17 @@ final class BlazeAddPaymentMethodWebViewModelTests: XCTestCase {
         // Then
         XCTAssertEqual(selectedPaymentID, "123")
     }
+
+    func test_didAddNewPaymentMethod_sets_notice() async throws {
+        // Given
+        let viewModel = BlazeAddPaymentMethodWebViewModel(siteID: sampleSiteID,
+                                                          addPaymentMethodInfo: samplePaymentInfo.addPaymentMethod) { _ in }
+        XCTAssertNil(viewModel.notice)
+
+        let successURL = try XCTUnwrap(URL(string: "\(samplePaymentInfo.addPaymentMethod.successUrl)?\(samplePaymentInfo.addPaymentMethod.idUrlParameter)=123"))
+        viewModel.didAddNewPaymentMethod(successURL: successURL)
+
+        // Then
+        XCTAssertNotNil(viewModel.notice)
+    }
 }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Blaze/BlazeAddPaymentMethodWebViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Blaze/BlazeAddPaymentMethodWebViewModelTests.swift
@@ -1,0 +1,41 @@
+import XCTest
+import Yosemite
+@testable import WooCommerce
+
+final class BlazeAddPaymentMethodWebViewModelTests: XCTestCase {
+    private let sampleSiteID: Int64 = 322
+    private let samplePaymentInfo: BlazePaymentInfo = BlazePaymentMethodsViewModel.samplePaymentInfo()
+
+    func test_addPaymentMethodURL_returns_formUrl() async throws {
+        // Given
+        let viewModel = BlazeAddPaymentMethodWebViewModel(siteID: sampleSiteID,
+                                                          addPaymentMethodInfo: samplePaymentInfo.addPaymentMethod) { _ in }
+
+        // Then
+        XCTAssertEqual(viewModel.addPaymentMethodURL, try XCTUnwrap(URL(string: "https://example.com/blaze-pm-add")))
+    }
+
+    func test_addPaymentSuccessURL_returns_successUrl() async throws {
+        // Given
+        let viewModel = BlazeAddPaymentMethodWebViewModel(siteID: sampleSiteID,
+                                                          addPaymentMethodInfo: samplePaymentInfo.addPaymentMethod) { _ in }
+
+        // Then
+        XCTAssertEqual(viewModel.addPaymentSuccessURL, "https://example.com/blaze-pm-success")
+    }
+
+    func test_didAddNewPaymentMethod_sends_newly_added_payment_id_via_completion_handler() async throws {
+        // Given
+        var selectedPaymentID = ""
+        let viewModel = BlazeAddPaymentMethodWebViewModel(siteID: sampleSiteID,
+                                                          addPaymentMethodInfo: samplePaymentInfo.addPaymentMethod) { id in
+            selectedPaymentID = id
+        }
+
+        let successURL = try XCTUnwrap(URL(string: "\(samplePaymentInfo.addPaymentMethod.successUrl)?\(samplePaymentInfo.addPaymentMethod.idUrlParameter)=123"))
+        viewModel.didAddNewPaymentMethod(successURL: successURL)
+
+        // Then
+        XCTAssertEqual(selectedPaymentID, "123")
+    }
+}

--- a/WooCommerce/WooCommerceTests/ViewRelated/Blaze/BlazeConfirmPaymentViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Blaze/BlazeConfirmPaymentViewModelTests.swift
@@ -179,33 +179,6 @@ final class BlazeConfirmPaymentViewModelTests: XCTestCase {
         }
     }
 
-    func test_payment_info_is_not_fetched_when_existing_payment_method_selected() async {
-        // Given
-        let viewModel = BlazeConfirmPaymentViewModel(siteID: sampleSiteID, campaignInfo: .fake(), stores: stores) {}
-        viewModel.showAddPaymentSheet = true
-        let samplePaymentInfo: BlazePaymentInfo = BlazePaymentMethodsViewModel.samplePaymentInfo()
-        mockPaymentFetch(with: .success(samplePaymentInfo))
-        await viewModel.updatePaymentInfo()
-        var didTriggerFetchPaymentInfo = false
-        stores.whenReceivingAction(ofType: BlazeAction.self) { action in
-            switch action {
-            case let .fetchPaymentInfo(_, onCompletion):
-                didTriggerFetchPaymentInfo = true
-                onCompletion(.success(.fake()))
-            default:
-                break
-            }
-        }
-
-        // When
-        viewModel.paymentMethodsViewModel?.didSelectPaymentMethod(withID: "payment-method-1")
-
-        // Then
-        waitUntil {
-            didTriggerFetchPaymentInfo == false
-        }
-    }
-
     func test_payment_info_is_fetched_when_new_payment_method_added() async {
         // Given
         let viewModel = BlazeConfirmPaymentViewModel(siteID: sampleSiteID, campaignInfo: .fake(), stores: stores) {}

--- a/WooCommerce/WooCommerceTests/ViewRelated/Blaze/BlazePaymentMethodsViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Blaze/BlazePaymentMethodsViewModelTests.swift
@@ -91,48 +91,6 @@ final class BlazePaymentMethodsViewModelTests: XCTestCase {
         XCTAssertEqual(viewModel.addPaymentSuccessURL, "https://example.com/blaze-pm-success")
     }
 
-    // MARK: `isDoneButtonEnabled`
-    func test_isDoneButtonEnabled_is_false_if_no_payment_methods_available() async throws {
-        // Given
-        let viewModel = BlazePaymentMethodsViewModel(siteID: sampleSiteID,
-                                                     paymentInfo: samplePaymentInfo.copy(savedPaymentMethods: []),
-                                                     selectedPaymentMethodID: nil,
-                                                     stores: stores) { _ in }
-
-        // Then
-        XCTAssertFalse(viewModel.isDoneButtonEnabled)
-    }
-
-    func test_isDoneButtonEnabled_is_false_if_selection_not_changed() async throws {
-        // Given
-        let viewModel = BlazePaymentMethodsViewModel(siteID: sampleSiteID,
-                                                     paymentInfo: samplePaymentInfo,
-                                                     selectedPaymentMethodID: "payment-method-1",
-                                                     stores: stores) { _ in }
-
-        // When
-        viewModel.didSelectPaymentMethod(withID: "payment-method-2")
-        // Restore original selection
-        viewModel.didSelectPaymentMethod(withID: "payment-method-1")
-
-        // Then
-        XCTAssertFalse(viewModel.isDoneButtonEnabled)
-    }
-
-    func test_isDoneButtonEnabled_is_true_if_selection_not_changed() async throws {
-        // Given
-        let viewModel = BlazePaymentMethodsViewModel(siteID: sampleSiteID,
-                                                     paymentInfo: samplePaymentInfo,
-                                                     selectedPaymentMethodID: "payment-method-1",
-                                                     stores: stores) { _ in }
-
-        // When
-        viewModel.didSelectPaymentMethod(withID: "payment-method-2")
-
-        // Then
-        XCTAssertTrue(viewModel.isDoneButtonEnabled)
-    }
-
     // MARK: `didSelectPaymentMethod`
 
     func test_didSelectPaymentMethod_updates_selected_payment_method_id() async throws {
@@ -149,70 +107,8 @@ final class BlazePaymentMethodsViewModelTests: XCTestCase {
         XCTAssertEqual(viewModel.selectedPaymentMethodID, "payment-method-2")
     }
 
-    // MARK: Sync payments
-
-    func test_isFetchingPaymentInfo_is_updated_correctly_when_fetching_payment_info() async {
-        // Given
-        let viewModel = BlazePaymentMethodsViewModel(siteID: sampleSiteID,
-                                                     paymentInfo: samplePaymentInfo,
-                                                     selectedPaymentMethodID: "payment-method-1",
-                                                     stores: stores) { _ in }
-        var fetchingStates: [Bool] = []
-        subscription = viewModel.$isFetchingPaymentInfo
-            .sink { isFetching in
-                fetchingStates.append(isFetching)
-            }
-
-        // When
-        mockPaymentFetch(with: .success(.fake()))
-        await viewModel.syncPaymentInfo()
-
-        // Then
-        XCTAssertEqual(fetchingStates, [false, true, false])
-    }
-
-    func test_shouldDisplayPaymentErrorAlert_is_true_when_fetching_payment_info_fails() async {
-        // Given
-        let viewModel = BlazePaymentMethodsViewModel(siteID: sampleSiteID,
-                                                     paymentInfo: samplePaymentInfo,
-                                                     selectedPaymentMethodID: "payment-method-1",
-                                                     stores: stores) { _ in }
-        XCTAssertFalse(viewModel.shouldDisplayPaymentErrorAlert)
-
-        // When
-        mockPaymentFetch(with: .failure(NSError(domain: "Test", code: 500)))
-        await viewModel.syncPaymentInfo()
-
-        // Then
-        XCTAssertTrue(viewModel.shouldDisplayPaymentErrorAlert)
-    }
-
-    func test_syncPaymentInfo_refreshes_payment_methods_on_success() async {
-        // Given
-        let viewModel = BlazePaymentMethodsViewModel(siteID: sampleSiteID,
-                                                     paymentInfo: samplePaymentInfo.copy(savedPaymentMethods: []),
-                                                     selectedPaymentMethodID: nil,
-                                                     stores: stores) { _ in }
-        let paymentMethod = BlazePaymentMethod(id: "test-id",
-                                               rawType: "credit-card",
-                                               name: "Card ending in 7284",
-                                               info: .init(lastDigits: "7284",
-                                                           expiring: .fake(),
-                                                           type: "Mastercard",
-                                                           nickname: nil,
-                                                           cardholderName: "Jane Doe"))
-        XCTAssertTrue(viewModel.paymentMethods.isEmpty)
-
-        // When
-        mockPaymentFetch(with: .success(samplePaymentInfo))
-        await viewModel.syncPaymentInfo()
-
-        // Then
-        XCTAssertEqual(viewModel.paymentMethods, samplePaymentInfo.savedPaymentMethods)
-    }
-
     // MARK: Save selection
-    func test_saveSelection_send_selected_payment_id_via_completion_handler() async throws {
+    func test_didSelectPaymentMethod_sends_selected_payment_id_via_completion_handler() async throws {
         // Given
         var selectedPaymentID = ""
         let viewModel = BlazePaymentMethodsViewModel(siteID: sampleSiteID,
@@ -223,11 +119,51 @@ final class BlazePaymentMethodsViewModelTests: XCTestCase {
         }
         viewModel.didSelectPaymentMethod(withID: "payment-method-2")
 
-        // When
-        viewModel.saveSelection()
-
         // Then
         XCTAssertEqual(selectedPaymentID, "payment-method-2")
+    }
+
+    // MARK: Add new payment method
+
+    func test_addPaymentMethodURL_has_correct_value() async throws {
+        // Given
+        let viewModel = BlazePaymentMethodsViewModel(siteID: sampleSiteID,
+                                                     paymentInfo: samplePaymentInfo,
+                                                     selectedPaymentMethodID: "payment-method-1",
+                                                     stores: stores) { _ in }
+
+        // Then
+        let url = try XCTUnwrap(URL(string: samplePaymentInfo.addPaymentMethod.formUrl))
+        XCTAssertEqual(viewModel.addPaymentMethodURL, url)
+    }
+
+    func test_addPaymentSuccessURL_has_correct_value() async throws {
+        // Given
+        let viewModel = BlazePaymentMethodsViewModel(siteID: sampleSiteID,
+                                                     paymentInfo: samplePaymentInfo,
+                                                     selectedPaymentMethodID: "payment-method-1",
+                                                     stores: stores) { _ in }
+
+        // Then
+        let url = try XCTUnwrap(samplePaymentInfo.addPaymentMethod.successUrl)
+        XCTAssertEqual(viewModel.addPaymentSuccessURL, url)
+    }
+
+    func test_didAddNewPaymentMethod_sends_newly_added_payment_id_via_completion_handler() async throws {
+        // Given
+        var selectedPaymentID = ""
+        let viewModel = BlazePaymentMethodsViewModel(siteID: sampleSiteID,
+                                                     paymentInfo: samplePaymentInfo,
+                                                     selectedPaymentMethodID: "payment-method-1",
+                                                     stores: stores) { id in
+            selectedPaymentID = id
+        }
+
+        let successURL = try XCTUnwrap(URL(string: "\(samplePaymentInfo.addPaymentMethod.successUrl)?\(samplePaymentInfo.addPaymentMethod.idUrlParameter)=123"))
+        viewModel.didAddNewPaymentMethod(successURL: successURL)
+
+        // Then
+        XCTAssertEqual(selectedPaymentID, "123")
     }
 }
 

--- a/WooCommerce/WooCommerceTests/ViewRelated/Blaze/BlazePaymentMethodsViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Blaze/BlazePaymentMethodsViewModelTests.swift
@@ -67,29 +67,6 @@ final class BlazePaymentMethodsViewModelTests: XCTestCase {
         XCTAssertEqual(viewModel.WPCOMEmail, sampleEmail)
     }
 
-    // MARK: `showingAddPaymentWebView`
-    func test_showingAddPaymentWebView_is_false_if_saved_payment_methods_not_empty() async throws {
-        // Given
-        let viewModel = BlazePaymentMethodsViewModel(siteID: sampleSiteID,
-                                                     paymentInfo: samplePaymentInfo, // Non empty saved payments
-                                                     selectedPaymentMethodID: "payment-method-1",
-                                                     stores: stores) { _ in }
-
-        // Then
-        XCTAssertFalse(viewModel.showingAddPaymentWebView)
-    }
-
-    func test_showingAddPaymentWebView_is_true_if_saved_payment_methods_empty() async throws {
-        // Given
-        let viewModel = BlazePaymentMethodsViewModel(siteID: sampleSiteID,
-                                                     paymentInfo: samplePaymentInfo.copy(savedPaymentMethods: []), // No saved payments
-                                                     selectedPaymentMethodID: "payment-method-1",
-                                                     stores: stores) { _ in }
-
-        // Then
-        XCTAssertTrue(viewModel.showingAddPaymentWebView)
-    }
-
     // MARK: `didSelectPaymentMethod`
 
     func test_didSelectPaymentMethod_updates_selected_payment_method_id() async throws {

--- a/WooCommerce/WooCommerceTests/ViewRelated/Blaze/BlazePaymentMethodsViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Blaze/BlazePaymentMethodsViewModelTests.swift
@@ -91,7 +91,7 @@ final class BlazePaymentMethodsViewModelTests: XCTestCase {
         XCTAssertFalse(viewModel.showingAddPaymentWebView)
     }
 
-    func test_showingAddPaymentWebView_is_true_if_saved_payment_methods_not_empty() async throws {
+    func test_showingAddPaymentWebView_is_true_if_saved_payment_methods_empty() async throws {
         // Given
         let viewModel = BlazePaymentMethodsViewModel(siteID: sampleSiteID,
                                                      paymentInfo: samplePaymentInfo.copy(savedPaymentMethods: []), // No saved payments

--- a/WooCommerce/WooCommerceTests/ViewRelated/Blaze/BlazePaymentMethodsViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Blaze/BlazePaymentMethodsViewModelTests.swift
@@ -79,6 +79,29 @@ final class BlazePaymentMethodsViewModelTests: XCTestCase {
         XCTAssertEqual(viewModel.addPaymentMethodURL, try XCTUnwrap(URL(string: "https://example.com/blaze-pm-add")))
     }
 
+    // MARK: `showingAddPaymentWebView`
+    func test_showingAddPaymentWebView_is_false_if_saved_payment_methods_not_empty() async throws {
+        // Given
+        let viewModel = BlazePaymentMethodsViewModel(siteID: sampleSiteID,
+                                                     paymentInfo: samplePaymentInfo, // Non empty saved payments
+                                                     selectedPaymentMethodID: "payment-method-1",
+                                                     stores: stores) { _ in }
+
+        // Then
+        XCTAssertFalse(viewModel.showingAddPaymentWebView)
+    }
+
+    func test_showingAddPaymentWebView_is_true_if_saved_payment_methods_not_empty() async throws {
+        // Given
+        let viewModel = BlazePaymentMethodsViewModel(siteID: sampleSiteID,
+                                                     paymentInfo: samplePaymentInfo.copy(savedPaymentMethods: []), // No saved payments
+                                                     selectedPaymentMethodID: "payment-method-1",
+                                                     stores: stores) { _ in }
+
+        // Then
+        XCTAssertTrue(viewModel.showingAddPaymentWebView)
+    }
+
     // MARK: `fetchPaymentMethodURLPath`
     func test_fetchPaymentMethodURLPath_returns_successUrl() async throws {
         // Given

--- a/WooCommerce/WooCommerceTests/ViewRelated/Blaze/BlazePaymentMethodsViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Blaze/BlazePaymentMethodsViewModelTests.swift
@@ -35,7 +35,7 @@ final class BlazePaymentMethodsViewModelTests: XCTestCase {
         let viewModel = BlazePaymentMethodsViewModel(siteID: sampleSiteID,
                                                      paymentInfo: samplePaymentInfo,
                                                      selectedPaymentMethodID: "payment-method-1",
-                                                     stores: stores) { _ in}
+                                                     stores: stores) { _ in }
 
         // Then
         XCTAssertEqual(viewModel.paymentMethods, samplePaymentInfo.savedPaymentMethods)
@@ -67,18 +67,6 @@ final class BlazePaymentMethodsViewModelTests: XCTestCase {
         XCTAssertEqual(viewModel.WPCOMEmail, sampleEmail)
     }
 
-    // MARK: `addPaymentMethodURL`
-    func test_addPaymentMethodURL_returns_formUrl() async throws {
-        // Given
-        let viewModel = BlazePaymentMethodsViewModel(siteID: sampleSiteID,
-                                                     paymentInfo: samplePaymentInfo,
-                                                     selectedPaymentMethodID: "payment-method-1",
-                                                     stores: stores) { _ in }
-
-        // Then
-        XCTAssertEqual(viewModel.addPaymentMethodURL, try XCTUnwrap(URL(string: "https://example.com/blaze-pm-add")))
-    }
-
     // MARK: `showingAddPaymentWebView`
     func test_showingAddPaymentWebView_is_false_if_saved_payment_methods_not_empty() async throws {
         // Given
@@ -102,18 +90,6 @@ final class BlazePaymentMethodsViewModelTests: XCTestCase {
         XCTAssertTrue(viewModel.showingAddPaymentWebView)
     }
 
-    // MARK: `fetchPaymentMethodURLPath`
-    func test_fetchPaymentMethodURLPath_returns_successUrl() async throws {
-        // Given
-        let viewModel = BlazePaymentMethodsViewModel(siteID: sampleSiteID,
-                                                     paymentInfo: samplePaymentInfo,
-                                                     selectedPaymentMethodID: "payment-method-1",
-                                                     stores: stores) { _ in }
-
-        // Then
-        XCTAssertEqual(viewModel.addPaymentSuccessURL, "https://example.com/blaze-pm-success")
-    }
-
     // MARK: `didSelectPaymentMethod`
 
     func test_didSelectPaymentMethod_updates_selected_payment_method_id() async throws {
@@ -131,6 +107,7 @@ final class BlazePaymentMethodsViewModelTests: XCTestCase {
     }
 
     // MARK: Save selection
+
     func test_didSelectPaymentMethod_sends_selected_payment_id_via_completion_handler() async throws {
         // Given
         var selectedPaymentID = ""
@@ -144,49 +121,6 @@ final class BlazePaymentMethodsViewModelTests: XCTestCase {
 
         // Then
         XCTAssertEqual(selectedPaymentID, "payment-method-2")
-    }
-
-    // MARK: Add new payment method
-
-    func test_addPaymentMethodURL_has_correct_value() async throws {
-        // Given
-        let viewModel = BlazePaymentMethodsViewModel(siteID: sampleSiteID,
-                                                     paymentInfo: samplePaymentInfo,
-                                                     selectedPaymentMethodID: "payment-method-1",
-                                                     stores: stores) { _ in }
-
-        // Then
-        let url = try XCTUnwrap(URL(string: samplePaymentInfo.addPaymentMethod.formUrl))
-        XCTAssertEqual(viewModel.addPaymentMethodURL, url)
-    }
-
-    func test_addPaymentSuccessURL_has_correct_value() async throws {
-        // Given
-        let viewModel = BlazePaymentMethodsViewModel(siteID: sampleSiteID,
-                                                     paymentInfo: samplePaymentInfo,
-                                                     selectedPaymentMethodID: "payment-method-1",
-                                                     stores: stores) { _ in }
-
-        // Then
-        let url = try XCTUnwrap(samplePaymentInfo.addPaymentMethod.successUrl)
-        XCTAssertEqual(viewModel.addPaymentSuccessURL, url)
-    }
-
-    func test_didAddNewPaymentMethod_sends_newly_added_payment_id_via_completion_handler() async throws {
-        // Given
-        var selectedPaymentID = ""
-        let viewModel = BlazePaymentMethodsViewModel(siteID: sampleSiteID,
-                                                     paymentInfo: samplePaymentInfo,
-                                                     selectedPaymentMethodID: "payment-method-1",
-                                                     stores: stores) { id in
-            selectedPaymentID = id
-        }
-
-        let successURL = try XCTUnwrap(URL(string: "\(samplePaymentInfo.addPaymentMethod.successUrl)?\(samplePaymentInfo.addPaymentMethod.idUrlParameter)=123"))
-        viewModel.didAddNewPaymentMethod(successURL: successURL)
-
-        // Then
-        XCTAssertEqual(selectedPaymentID, "123")
     }
 }
 


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of: #11737 
<!-- Id number of the GitHub issue this PR addresses. -->

## Description

These are changes to how we handle adding new Blaze payment methods.

- Parse the URL from the web view and find the newly added payment method's ID. 
- Remove the "Done" button and dismiss the payment methods screen after selection.
- From payment method list screen, auto-present web view if no saved payments are available. 
- Reload payment methods from the payment confirmation view only if a new payment method is added. 

## Testing instructions
- There is no straightforward way to test this without changing code until the API is ready. We can revisit this once the API is ready. (Added a subtask under #11737 to keep track)
- CI passing is sufficient for now. 

## Screenshots
| Existing payment method selected | Empty payment methods  | New payment method added |
|--------|--------|--------|
| ![Simulator Screen Recording - iPhone 15 Pro - 2024-01-22 at 22 43 46](https://github.com/woocommerce/woocommerce-ios/assets/524475/b1d80c2d-0c86-4a94-8c72-80e523ffea85) | ![Simulator Screen Recording - iPhone 15 Pro - 2024-01-23 at 05 49 11](https://github.com/woocommerce/woocommerce-ios/assets/524475/5ffc495f-0681-4b6e-892a-cef863294d0d)  | ![Simulator Screen Recording - iPhone 15 Pro - 2024-01-22 at 22 42 52](https://github.com/woocommerce/woocommerce-ios/assets/524475/5a0bad2c-5e44-4b0d-a6ae-bc986cb2ce54) | 

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
