### PR TITLE
Support form: Handle creating identity without UIKit

### DIFF
--- a/WooCommerce/Classes/Tools/Zendesk/ZendeskManager.swift
+++ b/WooCommerce/Classes/Tools/Zendesk/ZendeskManager.swift
@@ -273,7 +273,7 @@ private extension ZendeskManager {
         return try await withCheckedThrowingContinuation { continuation in
             createZendeskIdentity { [weak self] success in
                 guard let self, success else {
-                    DDLogInfo("Creating Zendesk identity failed.")
+                    DDLogError("⛔️ Creating Zendesk identity failed.")
                     return continuation.resume(throwing: ZendeskError.failedToCreateIdentity)
                 }
                 DDLogDebug("Using User Defaults for Zendesk identity.")

--- a/WooCommerce/Classes/Tools/Zendesk/ZendeskManager.swift
+++ b/WooCommerce/Classes/Tools/Zendesk/ZendeskManager.swift
@@ -40,7 +40,9 @@ protocol ZendeskManagerProtocol {
     var zendeskEnabled: Bool { get }
     var haveUserIdentity: Bool { get }
 
-    func userSupportIdentity() -> (name: String?, emailAddress: String?)
+    /// Returns the user's name and email from saved identity or login credentials.
+    ///
+    func retrieveUserInfoIfAvailable() -> (name: String?, emailAddress: String?)
     func showHelpCenter(from controller: UIViewController)
     func showSupportEmailPrompt(from controller: UIViewController, completion: @escaping onUserInformationCompletion)
     func initialize()
@@ -69,7 +71,7 @@ struct NoZendeskManager: ZendeskManagerProtocol {
 
     let haveUserIdentity = false
 
-    func userSupportIdentity() -> (name: String?, emailAddress: String?) {
+    func retrieveUserInfoIfAvailable() -> (name: String?, emailAddress: String?) {
         return (nil, nil)
     }
 
@@ -253,9 +255,9 @@ final class ZendeskManager: NSObject, ZendeskManagerProtocol {
 
     // MARK: - Helpers
 
-    /// Returns the user's Support email address.
+    /// Returns the user's name and email from saved identity or login credentials.
     ///
-    func userSupportIdentity() -> (name: String?, emailAddress: String?) {
+    func retrieveUserInfoIfAvailable() -> (name: String?, emailAddress: String?) {
         if getUserProfile() {
             return (userName, userEmail)
         }

--- a/WooCommerce/Classes/ViewRelated/Blaze/ConfirmPayment/BlazeCampaignCreationErrorView.swift
+++ b/WooCommerce/Classes/ViewRelated/Blaze/ConfirmPayment/BlazeCampaignCreationErrorView.swift
@@ -6,8 +6,6 @@ struct BlazeCampaignCreationErrorView: View {
     @ScaledMetric private var scale: CGFloat = 1.0
 
     @State private var isShowingSupport = false
-    @State private var supportRequestSentNotice: Notice?
-    @State private var shouldShowSupportRequestError = false
 
     private let onTryAgain: () -> Void
     private let onCancel: () -> Void
@@ -68,21 +66,14 @@ struct BlazeCampaignCreationErrorView: View {
         .sheet(isPresented: $isShowingSupport) {
             supportForm
         }
-        .notice($supportRequestSentNotice)
     }
 }
 
 private extension BlazeCampaignCreationErrorView {
     var supportForm: some View {
         NavigationView {
-            SupportForm(viewModel: SupportFormViewModel(sourceTag: Constants.supportTag, onCompletion: { result in
-                switch result {
-                case .success:
-                    isShowingSupport = false
-                    supportRequestSentNotice = Notice(title: Localization.supportRequestSent)
-                case .failure:
-                    shouldShowSupportRequestError = true
-                }
+            SupportForm(viewModel: SupportFormViewModel(sourceTag: Constants.supportTag, shouldHandleIdentity: true, onDismiss: {
+                isShowingSupport = false
             }))
             .toolbar {
                 ToolbarItem(placement: .confirmationAction) {
@@ -93,12 +84,6 @@ private extension BlazeCampaignCreationErrorView {
             }
         }
         .navigationViewStyle(.stack)
-        .alert(isPresented: $shouldShowSupportRequestError) {
-            Alert(title: Text(Localization.supportRequestFailed),
-                  dismissButton: .default(Text(Localization.gotIt), action: {
-                shouldShowSupportRequestError = false
-            }))
-        }
     }
 }
 
@@ -155,21 +140,6 @@ private extension BlazeCampaignCreationErrorView {
             "blazeCampaignCreationErrorView.done",
             value: "Done",
             comment: "Button to dismiss the support form from the Blaze campaign creation error screen."
-        )
-        static let supportRequestSent = NSLocalizedString(
-            "blazeCampaignCreationErrorView.supportRequestSent",
-            value: "Your support request has landed safely in our inbox. We will reply via email as quickly as we can.",
-            comment: "Message for the alert after the support request is created from the Blaze campaign creation error screen."
-        )
-        static let supportRequestFailed = NSLocalizedString(
-            "blazeCampaignCreationErrorView.supportRequestFailed",
-            value: "Sorry, we cannot create support requests right now, please try again later.",
-            comment: "Error message when the app can't create a support request from the Blaze campaign creation error screen."
-        )
-        static let gotIt = NSLocalizedString(
-            "blazeCampaignCreationErrorView.gotIt",
-            value: "Got It",
-            comment: "Button to dismiss the alert when the app can't create a support request from the Blaze campaign creation error screen."
         )
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Blaze/ConfirmPayment/BlazeCampaignCreationErrorView.swift
+++ b/WooCommerce/Classes/ViewRelated/Blaze/ConfirmPayment/BlazeCampaignCreationErrorView.swift
@@ -72,9 +72,8 @@ struct BlazeCampaignCreationErrorView: View {
 private extension BlazeCampaignCreationErrorView {
     var supportForm: some View {
         NavigationView {
-            SupportForm(viewModel: SupportFormViewModel(sourceTag: Constants.supportTag, shouldHandleIdentity: true, onDismiss: {
-                isShowingSupport = false
-            }))
+            SupportForm(isPresented: $isShowingSupport,
+                        viewModel: SupportFormViewModel(sourceTag: Constants.supportTag, shouldHandleIdentity: true))
             .toolbar {
                 ToolbarItem(placement: .confirmationAction) {
                     Button(Localization.done) {

--- a/WooCommerce/Classes/ViewRelated/Blaze/ConfirmPayment/BlazeCampaignCreationErrorView.swift
+++ b/WooCommerce/Classes/ViewRelated/Blaze/ConfirmPayment/BlazeCampaignCreationErrorView.swift
@@ -73,7 +73,7 @@ private extension BlazeCampaignCreationErrorView {
     var supportForm: some View {
         NavigationView {
             SupportForm(isPresented: $isShowingSupport,
-                        viewModel: SupportFormViewModel(sourceTag: Constants.supportTag, shouldHandleIdentity: true))
+                        viewModel: SupportFormViewModel(sourceTag: Constants.supportTag))
             .toolbar {
                 ToolbarItem(placement: .confirmationAction) {
                     Button(Localization.done) {

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Help/HelpAndSupportViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Help/HelpAndSupportViewController.swift
@@ -17,7 +17,7 @@ final class HelpAndSupportViewController: UIViewController {
     ///
     private var accountEmail: String {
         // A stored Zendesk email address is preferred
-        if let zendeskEmail = ZendeskProvider.shared.userSupportIdentity().emailAddress {
+        if let zendeskEmail = ZendeskProvider.shared.retrieveUserInfoIfAvailable().emailAddress {
             return zendeskEmail
         }
 

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Help/HelpAndSupportViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Help/HelpAndSupportViewController.swift
@@ -17,7 +17,7 @@ final class HelpAndSupportViewController: UIViewController {
     ///
     private var accountEmail: String {
         // A stored Zendesk email address is preferred
-        if let zendeskEmail = ZendeskProvider.shared.userSupportEmail() {
+        if let zendeskEmail = ZendeskProvider.shared.userSupportIdentity().emailAddress {
             return zendeskEmail
         }
 

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Help/SupportForm/SupportForm.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Help/SupportForm/SupportForm.swift
@@ -16,7 +16,7 @@ final class SupportFormHostingController: UIHostingController<SupportForm> {
 
     init(viewModel: SupportFormViewModel) {
         super.init(rootView: SupportForm(viewModel: viewModel))
-        handleSupportRequestCompletion(viewModel: viewModel)
+        handleSupportRequestDismissal(viewModel: viewModel)
         hidesBottomBarWhenPushed = true
     }
 
@@ -37,9 +37,9 @@ final class SupportFormHostingController: UIHostingController<SupportForm> {
         }
     }
 
-    /// Registers a completion block on the view model to properly show alerts and notices.
+    /// Registers a dismiss block on the view model to properly dismiss the view.
     ///
-    func handleSupportRequestCompletion(viewModel: SupportFormViewModel) {
+    func handleSupportRequestDismissal(viewModel: SupportFormViewModel) {
         viewModel.onDismiss = { [weak self] in
             self?.dismissView()
         }
@@ -186,13 +186,16 @@ struct SupportForm: View {
         .onAppear {
             viewModel.onViewAppear()
         }
-        .alert(isPresented: $viewModel.shouldShowErrorAlert) {
-            Alert(title: Text(viewModel.errorMessage),
-                  dismissButton: .default(Text(Localization.gotIt)))
+        .alert(viewModel.errorMessage, isPresented: $viewModel.shouldShowErrorAlert) {
+            Button(Localization.gotIt) {
+                viewModel.shouldShowErrorAlert = false
+            }
         }
-        .alert(isPresented: $viewModel.shouldShowSuccessAlert) {
-            Alert(title: Text(Localization.supportRequestSent),
-                  dismissButton: .default(Text(Localization.gotIt), action: viewModel.dismissView))
+        .alert(Localization.supportRequestSent, isPresented: $viewModel.shouldShowSuccessAlert) {
+            Button(Localization.gotIt) {
+                viewModel.shouldShowSuccessAlert = false
+                viewModel.dismissView()
+            }
         }
         .alert(Localization.IdentityInput.title, isPresented: $viewModel.shouldShowIdentityInput) {
             TextField(Localization.IdentityInput.email, text: $viewModel.contactEmailAddress)

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Help/SupportForm/SupportForm.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Help/SupportForm/SupportForm.swift
@@ -197,6 +197,8 @@ struct SupportForm: View {
                 isPresented = false
                 onDismiss?()
             }
+        } message: {
+            Text(Localization.supportRequestSentMessage)
         }
         .alert(Localization.IdentityInput.title, isPresented: $viewModel.shouldShowIdentityInput) {
             TextField(Localization.IdentityInput.email, text: $viewModel.contactEmailAddress)
@@ -228,12 +230,12 @@ private extension SupportForm {
         static let message = NSLocalizedString("Message", comment: "Message on the support form")
         static let submitRequest = NSLocalizedString("Submit Support Request", comment: "Button title to submit a support request.")
 
-        static let requestSent = NSLocalizedString(
+        static let supportRequestSent = NSLocalizedString(
             "supportForm.supportRequestSent",
             value: "Request Sent!",
             comment: "Title for the alert after the support request is created."
         )
-        static let supportRequestSent = NSLocalizedString(
+        static let supportRequestSentMessage = NSLocalizedString(
             "supportForm.supportRequestSentMessage",
             value: "Your support request has landed safely in our inbox. We will reply via email as quickly as we can.",
             comment: "Message for the alert after the support request is created."

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Help/SupportForm/SupportForm.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Help/SupportForm/SupportForm.swift
@@ -302,6 +302,7 @@ struct SupportFormProvider: PreviewProvider {
     }
 }
 
+@available(*, deprecated, message: "Please use `SupportForm` directly with `shouldHandleIdentity` for the view model instead.")
 struct HostedSupportForm: UIViewControllerRepresentable {
     typealias UIViewControllerType = SupportFormHostingController
 

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Help/SupportForm/SupportForm.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Help/SupportForm/SupportForm.swift
@@ -21,45 +21,8 @@ final class SupportFormHostingController: UIHostingController<SupportForm> {
         hidesBottomBarWhenPushed = true
     }
 
-    override func viewWillAppear(_ animated: Bool) {
-        super.viewWillAppear(animated)
-        createZendeskIdentity()
-    }
-
-    /// Creates the Zendesk Identity if needed.
-    /// If it fails, it dismisses the view and informs the user.
-    ///
-    func createZendeskIdentity() {
-        // TODO: We should consider refactoring this to present the email alert using SwiftUI.
-        ZendeskProvider.shared.createIdentity(presentIn: self) { [weak self] identityCreated in
-            if !identityCreated {
-                self?.logIdentityErrorAndPopBack()
-            }
-        }
-    }
-
     required dynamic init?(coder aDecoder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
-    }
-}
-
-private extension SupportFormHostingController {
-
-    /// Informs user about identity error and pop back
-    ///
-    func logIdentityErrorAndPopBack() {
-        let notice = Notice(title: Localization.badIdentityError, feedbackType: .error)
-        noticePresenter.enqueue(notice: notice)
-
-        dismissView()
-        DDLogError("⛔️ Zendesk Identity could not be created.")
-    }
-}
-
-private extension SupportFormHostingController {
-    enum Localization {
-        static let badIdentityError = NSLocalizedString("Sorry, we cannot create support requests right now, please try again later.",
-                                                        comment: "Error message when the app can't create a zendesk identity.")
     }
 }
 
@@ -308,7 +271,7 @@ struct SupportFormProvider: PreviewProvider {
     }
 }
 
-@available(*, deprecated, message: "Please use `SupportForm` directly with `shouldHandleIdentity` for the view model instead.")
+@available(*, deprecated, message: "Please use `SupportForm` directly instead.")
 struct HostedSupportForm: UIViewControllerRepresentable {
     typealias UIViewControllerType = SupportFormHostingController
 

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Help/SupportForm/SupportForm.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Help/SupportForm/SupportForm.swift
@@ -270,16 +270,3 @@ struct SupportFormProvider: PreviewProvider {
         }
     }
 }
-
-@available(*, deprecated, message: "Please use `SupportForm` directly instead.")
-struct HostedSupportForm: UIViewControllerRepresentable {
-    typealias UIViewControllerType = SupportFormHostingController
-
-    let viewModel: SupportFormViewModel
-
-    func makeUIViewController(context: Context) -> SupportFormHostingController {
-        SupportFormHostingController(viewModel: viewModel)
-    }
-
-    func updateUIViewController(_ uiViewController: SupportFormHostingController, context: Context) { }
-}

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Help/SupportForm/SupportFormViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Help/SupportForm/SupportFormViewModel.swift
@@ -54,11 +54,6 @@ public final class SupportFormViewModel: ObservableObject {
     ///
     private let analyticsProvider: Analytics
 
-    /// Closure to be triggered when the form should be dismissed.
-    /// Assign this closure to get notified when integrated in UIKit.
-    ///
-    var onDismiss: (() -> Void)?
-
     /// Defines when the submit button should be enabled or not.
     ///
     var submitButtonDisabled: Bool {
@@ -94,14 +89,12 @@ public final class SupportFormViewModel: ObservableObject {
          sourceTag: String? = nil,
          zendeskProvider: ZendeskManagerProtocol = ZendeskProvider.shared,
          shouldHandleIdentity: Bool = false,
-         analyticsProvider: Analytics = ServiceLocator.analytics,
-         onDismiss: (() -> Void)? = nil) {
+         analyticsProvider: Analytics = ServiceLocator.analytics) {
         self.areas = areas
         self.sourceTag = sourceTag
         self.zendeskProvider = zendeskProvider
         self.analyticsProvider = analyticsProvider
         self.shouldHandleIdentity = shouldHandleIdentity
-        self.onDismiss = onDismiss
     }
 
     /// Tracks when the support form is viewed.
@@ -168,10 +161,6 @@ public final class SupportFormViewModel: ObservableObject {
             self.error = error
             shouldShowErrorAlert = true
         }
-    }
-
-    func dismissView() {
-        onDismiss?()
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Help/SupportForm/SupportFormViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Help/SupportForm/SupportFormViewModel.swift
@@ -81,20 +81,14 @@ public final class SupportFormViewModel: ObservableObject {
         }
     }
 
-    /// Whether identity creation should be handled by the view model.
-    /// This should be enabled if you wish to use `SupportForm` directly from a SwiftUI view.
-    private let shouldHandleIdentity: Bool
-
     init(areas: [Area] = wooSupportAreas(),
          sourceTag: String? = nil,
          zendeskProvider: ZendeskManagerProtocol = ZendeskProvider.shared,
-         shouldHandleIdentity: Bool = false,
          analyticsProvider: Analytics = ServiceLocator.analytics) {
         self.areas = areas
         self.sourceTag = sourceTag
         self.zendeskProvider = zendeskProvider
         self.analyticsProvider = analyticsProvider
-        self.shouldHandleIdentity = shouldHandleIdentity
     }
 
     /// Tracks when the support form is viewed.
@@ -194,10 +188,6 @@ extension SupportFormViewModel {
 // MARK: Private helpers
 private extension SupportFormViewModel {
     func handleZendeskIdentityIfNeeded() {
-        guard shouldHandleIdentity else {
-            return
-        }
-
         guard !zendeskProvider.haveUserIdentity else {
             DDLogDebug("Using existing Zendesk identity")
             return

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Help/SupportForm/SupportFormViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Help/SupportForm/SupportFormViewModel.swift
@@ -193,7 +193,7 @@ private extension SupportFormViewModel {
             return
         }
 
-        let identity = zendeskProvider.userSupportIdentity()
+        let identity = zendeskProvider.retrieveUserInfoIfAvailable()
         contactName = identity.name ?? ""
         contactEmailAddress = identity.emailAddress ?? ""
         shouldShowIdentityInput = true

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Help/SupportForm/SupportFormViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Help/SupportForm/SupportFormViewModel.swift
@@ -95,7 +95,7 @@ public final class SupportFormViewModel: ObservableObject {
     ///
     func onViewAppear() {
         analyticsProvider.track(.supportNewRequestViewed)
-        handleZendeskIdentityIfNeeded()
+        requestZendeskIdentityIfNeeded()
     }
 
     /// Selects an area.
@@ -187,7 +187,7 @@ extension SupportFormViewModel {
 
 // MARK: Private helpers
 private extension SupportFormViewModel {
-    func handleZendeskIdentityIfNeeded() {
+    func requestZendeskIdentityIfNeeded() {
         guard !zendeskProvider.haveUserIdentity else {
             DDLogDebug("Using existing Zendesk identity")
             return

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Help/SupportForm/SupportFormViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Help/SupportForm/SupportFormViewModel.swift
@@ -1,4 +1,5 @@
 import Foundation
+import class WordPressShared.EmailFormatValidator
 
 /// Data Source for the Support Request
 ///
@@ -53,9 +54,10 @@ public final class SupportFormViewModel: ObservableObject {
     ///
     private let analyticsProvider: Analytics
 
-    /// Assign this closure to get notified when a support request creation finishes.
+    /// Closure to be triggered when the form should be dismissed.
+    /// Assign this closure to get notified when integrated in UIKit.
     ///
-    var onCompletion: ((Result<Void, Error>) -> Void)?
+    var onDismiss: (() -> Void)?
 
     /// Defines when the submit button should be enabled or not.
     ///
@@ -63,22 +65,50 @@ public final class SupportFormViewModel: ObservableObject {
         area == nil || subject.isEmpty || description.isEmpty
     }
 
+    var identitySubmitButtonDisabled: Bool {
+        !EmailFormatValidator.validate(string: contactEmailAddress)
+    }
+
+    @Published var contactName: String = ""
+    @Published var contactEmailAddress: String = ""
+    @Published var shouldShowIdentityInput = false
+    @Published var shouldShowErrorAlert = false
+    @Published var shouldShowSuccessAlert = false
+
+    private var error: Error?
+
+    var errorMessage: String {
+        switch error {
+        case .some(ZendeskError.failedToCreateIdentity):
+            return Localization.badIdentityError
+        default:
+            return Localization.supportRequestFailed
+        }
+    }
+
+    /// Whether identity creation should be handled by the view model.
+    /// This should be enabled if you wish to use `SupportForm` directly from a SwiftUI view.
+    private let shouldHandleIdentity: Bool
+
     init(areas: [Area] = wooSupportAreas(),
          sourceTag: String? = nil,
          zendeskProvider: ZendeskManagerProtocol = ZendeskProvider.shared,
+         shouldHandleIdentity: Bool = false,
          analyticsProvider: Analytics = ServiceLocator.analytics,
-         onCompletion: ((Result<Void, Error>) -> Void)? = nil) {
+         onDismiss: (() -> Void)? = nil) {
         self.areas = areas
         self.sourceTag = sourceTag
         self.zendeskProvider = zendeskProvider
         self.analyticsProvider = analyticsProvider
-        self.onCompletion = onCompletion
+        self.shouldHandleIdentity = shouldHandleIdentity
+        self.onDismiss = onDismiss
     }
 
     /// Tracks when the support form is viewed.
     ///
-    func trackSupportFormViewed() {
+    func onViewAppear() {
         analyticsProvider.track(.supportNewRequestViewed)
+        handleZendeskIdentityIfNeeded()
     }
 
     /// Selects an area.
@@ -106,14 +136,16 @@ public final class SupportFormViewModel: ObservableObject {
                                              description: description) { [weak self] result in
             guard let self else { return }
             self.showLoadingIndicator = false
-            self.onCompletion?(result)
 
             // Analytics
             switch result {
             case .success:
                 self.analyticsProvider.track(.supportNewRequestCreated)
-            case .failure:
+                self.shouldShowSuccessAlert = true
+            case .failure(let error):
                 self.analyticsProvider.track(.supportNewRequestFailed)
+                self.error = error
+                self.shouldShowErrorAlert = true
             }
         }
     }
@@ -126,6 +158,20 @@ public final class SupportFormViewModel: ObservableObject {
             return area.datasource.tags
         }
         return area.datasource.tags + [sourceTag]
+    }
+
+    @MainActor
+    func submitIdentityInfo() async {
+        do {
+            try await zendeskProvider.createIdentity(name: contactName, email: contactEmailAddress)
+        } catch {
+            self.error = error
+            shouldShowErrorAlert = true
+        }
+    }
+
+    func dismissView() {
+        onDismiss?()
     }
 }
 
@@ -156,6 +202,25 @@ extension SupportFormViewModel {
     }
 }
 
+// MARK: Private helpers
+private extension SupportFormViewModel {
+    func handleZendeskIdentityIfNeeded() {
+        guard shouldHandleIdentity else {
+            return
+        }
+
+        guard !zendeskProvider.haveUserIdentity else {
+            DDLogDebug("Using existing Zendesk identity")
+            return
+        }
+
+        let identity = zendeskProvider.userSupportIdentity()
+        contactName = identity.name ?? ""
+        contactEmailAddress = identity.emailAddress ?? ""
+        shouldShowIdentityInput = true
+    }
+}
+
 // MARK: Constants
 private extension SupportFormViewModel {
 
@@ -178,5 +243,15 @@ private extension SupportFormViewModel {
         static let wcPayments = NSLocalizedString("WooCommerce Payments", comment: "Title of the WooCommerce Payments support area option")
         static let wcPlugin = NSLocalizedString("WooCommerce Plugin", comment: "Title of the WooCommerce Plugin support area option")
         static let otherPlugin = NSLocalizedString("Other Extension / Plugin", comment: "Title of the Other Plugin support area option")
+        static let badIdentityError = NSLocalizedString(
+            "supportFormViewModel.badIdentityError",
+            value: "Sorry, we cannot create support requests right now, please try again later.",
+            comment: "Error message when the app can't create a zendesk identity."
+        )
+        static let supportRequestFailed = NSLocalizedString(
+            "supportFormViewModel.supportRequestFailed",
+            value: "Sorry, we cannot create support requests right now, please try again later.",
+            comment: "Error message when the app can't create a support request."
+        )
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Payments Menu/InPersonPaymentsMenu.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Payments Menu/InPersonPaymentsMenu.swift
@@ -193,7 +193,8 @@ struct InPersonPaymentsMenu: View {
             if let onboardingNotice = viewModel.cardPresentPaymentsOnboardingNotice {
                 PermanentNoticeView(notice: onboardingNotice)
                     .transition(.opacity.animation(.easeInOut))
-                LazyNavigationLink(destination: HostedSupportForm(viewModel: .init()),
+                LazyNavigationLink(destination: SupportForm(isPresented: $viewModel.presentSupport,
+                                                            viewModel: .init()),
                                    isActive: $viewModel.presentSupport) {
                     EmptyView()
                 }

--- a/WooCommerce/WooCommerceTests/Testing/MockZendeskManager.swift
+++ b/WooCommerce/WooCommerceTests/Testing/MockZendeskManager.swift
@@ -48,7 +48,7 @@ final class MockZendeskManager: ZendeskManagerProtocol {
     private var stubbedCreateIdentityResult: Result<Void, Error>?
     private var stubbedCreateSupportRequestResult: Result<Void, Error>?
 
-    func userSupportIdentity() -> (name: String?, emailAddress: String?) {
+    func retrieveUserInfoIfAvailable() -> (name: String?, emailAddress: String?) {
         (stubbedName, stubbedEmailAddress)
     }
 

--- a/WooCommerce/WooCommerceTests/Testing/MockZendeskManager.swift
+++ b/WooCommerce/WooCommerceTests/Testing/MockZendeskManager.swift
@@ -1,10 +1,12 @@
 
 import Foundation
 import UIKit
+import enum Networking.NetworkError
 
 @testable import WooCommerce
 
 final class MockZendeskManager: ZendeskManagerProtocol {
+
     struct NewRequestIfPossibleInvocation {
         let controller: UIViewController
         let sourceTag: String?
@@ -38,10 +40,28 @@ final class MockZendeskManager: ZendeskManagerProtocol {
         showNewWCPayRequestIfPossible(from: controller, with: nil)
     }
 
-    var zendeskEnabled = false
+    let zendeskEnabled = false
 
-    func userSupportEmail() -> String? {
-        return nil
+    private(set) var haveUserIdentity: Bool = false
+    private var stubbedName: String?
+    private var stubbedEmailAddress: String?
+    private var stubbedCreateIdentityResult: Result<Void, Error>?
+    private var stubbedCreateSupportRequestResult: Result<Void, Error>?
+
+    func userSupportIdentity() -> (name: String?, emailAddress: String?) {
+        (stubbedName, stubbedEmailAddress)
+    }
+
+    func createIdentity(name: String, email: String) async throws {
+        guard let stubbedCreateIdentityResult else {
+            throw NetworkError.notFound()
+        }
+        switch stubbedCreateIdentityResult {
+        case .success:
+            return
+        case .failure(let error):
+            throw error
+        }
     }
 
     func showHelpCenter(from controller: UIViewController) {
@@ -59,6 +79,20 @@ final class MockZendeskManager: ZendeskManagerProtocol {
     func reset() {
         // no-op
     }
+
+    func mockIdentity(name: String?, email: String?, haveUserIdentity: Bool) {
+        stubbedName = name
+        stubbedEmailAddress = email
+        self.haveUserIdentity = haveUserIdentity
+    }
+
+    func whenCreateIdentity(thenReturn result: Result<Void, Error>) {
+        stubbedCreateIdentityResult = result
+    }
+
+    func whenCreateSupportRequest(thenReturn result: Result<Void, Error>) {
+        stubbedCreateSupportRequestResult = result
+    }
 }
 
 extension MockZendeskManager {
@@ -73,5 +107,8 @@ extension MockZendeskManager {
                               description: String,
                               onCompletion: @escaping (Result<Void, Error>) -> Void) {
         latestInvokedTags = tags
+        if let stubbedCreateSupportRequestResult {
+            onCompletion(stubbedCreateSupportRequestResult)
+        }
     }
 }

--- a/WooCommerce/WooCommerceTests/Tools/Support/SupportFormViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/Tools/Support/SupportFormViewModelTests.swift
@@ -1,6 +1,7 @@
 import XCTest
 @testable import WooCommerce
 
+@MainActor
 final class SupportFormViewModelTests: XCTestCase {
 
     func test_submit_button_is_disabled_when_area_and_subject_and_description_are_empty() {
@@ -67,6 +68,98 @@ final class SupportFormViewModelTests: XCTestCase {
 
         // Then
         XCTAssertTrue(zendesk.latestInvokedTags.contains(sourceTag))
+    }
+
+    func test_shouldShowIdentityInput_is_false_when_triggering_onViewAppear_with_shouldHandleIdentity_being_false() {
+        // Given
+        let zendesk = MockZendeskManager()
+        let viewModel = SupportFormViewModel(zendeskProvider: zendesk,
+                                             shouldHandleIdentity: false)
+
+        // When
+        viewModel.onViewAppear()
+
+        // Then
+        XCTAssertFalse(viewModel.shouldShowIdentityInput)
+    }
+
+    func test_shouldShowIdentityInput_is_true_when_triggering_onViewAppear_with_shouldHandleIdentity_being_true_and_no_identity_is_found() {
+        // Given
+        let zendesk = MockZendeskManager()
+        let viewModel = SupportFormViewModel(zendeskProvider: zendesk,
+                                             shouldHandleIdentity: true)
+
+        // When
+        zendesk.mockIdentity(name: "Test", email: "test@example.com", haveUserIdentity: false)
+        viewModel.onViewAppear()
+
+        // Then
+        XCTAssertTrue(viewModel.shouldShowIdentityInput)
+        XCTAssertEqual(viewModel.contactName, "Test")
+        XCTAssertEqual(viewModel.contactEmailAddress, "test@example.com")
+    }
+
+    func test_shouldShowIdentityInput_is_false_when_triggering_onViewAppear_with_shouldHandleIdentity_being_true_and_identity_already_exists() {
+        // Given
+        let zendesk = MockZendeskManager()
+        let viewModel = SupportFormViewModel(zendeskProvider: zendesk,
+                                             shouldHandleIdentity: true)
+
+        // When
+        zendesk.mockIdentity(name: "Test", email: "test@example.com", haveUserIdentity: true)
+        viewModel.onViewAppear()
+
+        // Then
+        XCTAssertFalse(viewModel.shouldShowIdentityInput)
+    }
+
+    func test_submitIdentityInfo_sets_shouldShowErrorAlert_to_true_when_fails() async {
+        // Given
+        let zendesk = MockZendeskManager()
+        let viewModel = SupportFormViewModel(zendeskProvider: zendesk)
+
+        // When
+        zendesk.whenCreateIdentity(thenReturn: .failure(NSError(domain: "Test", code: 500)))
+        await viewModel.submitIdentityInfo()
+
+        // Then
+        XCTAssertTrue(viewModel.shouldShowErrorAlert)
+    }
+
+    func test_submitSupportRequest_sets_shouldShowSuccessAlert_to_true_when_succeeds() {
+        // Given
+        let zendesk = MockZendeskManager()
+        let area = SupportFormViewModel.Area(title: "Area 1", datasource: MockDataSource())
+        let viewModel = SupportFormViewModel(zendeskProvider: zendesk)
+        XCTAssertFalse(viewModel.shouldShowSuccessAlert)
+
+        // When
+        zendesk.whenCreateSupportRequest(thenReturn: .success(()))
+        viewModel.selectArea(area)
+        viewModel.submitSupportRequest()
+
+        // Then
+        waitUntil {
+            viewModel.shouldShowSuccessAlert == true
+        }
+    }
+
+    func test_submitSupportRequest_sets_shouldShowErrorAlert_to_true_when_fails() {
+        // Given
+        let zendesk = MockZendeskManager()
+        let area = SupportFormViewModel.Area(title: "Area 1", datasource: MockDataSource())
+        let viewModel = SupportFormViewModel(zendeskProvider: zendesk)
+        XCTAssertFalse(viewModel.shouldShowErrorAlert)
+
+        // When
+        zendesk.whenCreateSupportRequest(thenReturn: .failure(NSError(domain: "Test", code: 500)))
+        viewModel.selectArea(area)
+        viewModel.submitSupportRequest()
+
+        // Then
+        waitUntil {
+            viewModel.shouldShowErrorAlert == true
+        }
     }
 }
 

--- a/WooCommerce/WooCommerceTests/Tools/Support/SupportFormViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/Tools/Support/SupportFormViewModelTests.swift
@@ -70,24 +70,10 @@ final class SupportFormViewModelTests: XCTestCase {
         XCTAssertTrue(zendesk.latestInvokedTags.contains(sourceTag))
     }
 
-    func test_shouldShowIdentityInput_is_false_when_triggering_onViewAppear_with_shouldHandleIdentity_being_false() {
+    func test_shouldShowIdentityInput_is_true_when_triggering_onViewAppear_no_existing_identity() {
         // Given
         let zendesk = MockZendeskManager()
-        let viewModel = SupportFormViewModel(zendeskProvider: zendesk,
-                                             shouldHandleIdentity: false)
-
-        // When
-        viewModel.onViewAppear()
-
-        // Then
-        XCTAssertFalse(viewModel.shouldShowIdentityInput)
-    }
-
-    func test_shouldShowIdentityInput_is_true_when_triggering_onViewAppear_with_shouldHandleIdentity_being_true_and_no_identity_is_found() {
-        // Given
-        let zendesk = MockZendeskManager()
-        let viewModel = SupportFormViewModel(zendeskProvider: zendesk,
-                                             shouldHandleIdentity: true)
+        let viewModel = SupportFormViewModel(zendeskProvider: zendesk)
 
         // When
         zendesk.mockIdentity(name: "Test", email: "test@example.com", haveUserIdentity: false)
@@ -99,11 +85,10 @@ final class SupportFormViewModelTests: XCTestCase {
         XCTAssertEqual(viewModel.contactEmailAddress, "test@example.com")
     }
 
-    func test_shouldShowIdentityInput_is_false_when_triggering_onViewAppear_with_shouldHandleIdentity_being_true_and_identity_already_exists() {
+    func test_shouldShowIdentityInput_is_false_when_triggering_onViewAppear_with_existing_identity() {
         // Given
         let zendesk = MockZendeskManager()
-        let viewModel = SupportFormViewModel(zendeskProvider: zendesk,
-                                             shouldHandleIdentity: true)
+        let viewModel = SupportFormViewModel(zendeskProvider: zendesk)
 
         // When
         zendesk.mockIdentity(name: "Test", email: "test@example.com", haveUserIdentity: true)


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #11758 
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
Previously, we required using `SupportFormHostingController` to handle creating an identity for the support form. `HostedSupportForm` was created after that to add a SwiftUI wrapper around `SupportFormHostingController,` but this is not a nice solution and has some navigation glitches around the identity input alert.

This PR updates the support form and `ZendeskManager` to get contact details without the requirement for UIKit and marks `HostedSupportForm` as deprecated.

Changes:
- Updated `ZendeskManager`:
  - Added a new async method `createIdentity`.
  - Made `haveUserIdentity` accessible.
  - Replaced `userSupportEmail` with `userSupportIdentity`.
  - Added new error type `ZendeskError`.
- SupportForm:
  - Added an option closure `onDismiss` and update dismiss handling for `SupportFormHostingController`.
  - Added alerts for success, failure, and identity input.
- SupportFormViewModel:
  -  Removed `onCompletion`.
  - Added `shouldHandleIdentity` to handle identity input.
- BlazeCampaignCreationErrorView: Update the latest integration for `SupportForm`.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
Testing from a SwiftUI view:
- Update the method submitCampaign in BlazeConfirmPaymentViewModel to force shouldDisplayCampaignCreationError to be true and build the app.
- Log out of the store if you already entered an email address for the support form before.
- Log in to a store that's eligible for Blaze.
- Select Promote in the Blaze section on the dashboard screen to start campaign creation.
- Select Confirm Details > Submit Campaign.
- When the error screen is displayed, tap Get Support.
- Notice an alert is displayed for entering name and email address. Tap Cancel, the support form should be dismissed.
- Tap Get Support again. Enter a non-A8C email address for this alert. Notice that the OK button is only enabled when a correct form of the address is entered.
- Fill the support form. Please note in the request that this is a test ticket and it should be closed.
- Disable the Internet connection on your machine and send the request. Notice an error alert after the request fails.
- Enable the connection and try again. After the request succeeds, notice an alert for the success. Tapping Got It should dismiss the support form.

Testing from a UIKit view:
- Navigate to the Menu tab.
- Select Subscriptions > Report subscription issue.
- Repeat the testing steps for the support form to confirm that everything works exactly the same.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->
 

Identity Input | Success | Failure
--- | --- | ---
<img src="https://github.com/woocommerce/woocommerce-ios/assets/5533851/f8617115-af34-4025-865b-fb5904920403" width=320 /> | <img src="https://github.com/woocommerce/woocommerce-ios/assets/5533851/ea07923c-5824-42f0-8c30-583d2cb57be9" width=320 /> | <img src="https://github.com/woocommerce/woocommerce-ios/assets/5533851/c9b790d6-6e24-4d2e-84e1-04d4b42835dc" width=320 />

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
