### PR TITLE
[Blaze] Image missing alert

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Blaze/BlazeEditAd/BlazeEditAdViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Blaze/BlazeEditAd/BlazeEditAdViewModel.swift
@@ -55,8 +55,7 @@ final class BlazeEditAdViewModel: ObservableObject {
     }
 
     private var editedAdData: BlazeEditAdData? {
-        guard let image,
-              tagline.isNotEmpty,
+        guard tagline.isNotEmpty,
               description.isNotEmpty else {
             return nil
         }

--- a/WooCommerce/Classes/ViewRelated/Blaze/CampaignCreation/BlazeCampaignCreationForm.swift
+++ b/WooCommerce/Classes/ViewRelated/Blaze/CampaignCreation/BlazeCampaignCreationForm.swift
@@ -178,8 +178,8 @@ struct BlazeCampaignCreationForm: View {
             Alert(title: Text(Localization.NoImageErrorAlert.noImageFound),
                   dismissButton: .default(Text(Localization.NoImageErrorAlert.ok)))
         })
-        .onAppear() {
-            viewModel.onAppear()
+        .task {
+            await viewModel.onLoad()
         }
         LazyNavigationLink(destination: BlazeConfirmPaymentView(viewModel: viewModel.confirmPaymentViewModel),
                            isActive: $viewModel.isShowingPaymentInfo) {

--- a/WooCommerce/Classes/ViewRelated/Blaze/CampaignCreation/BlazeCampaignCreationForm.swift
+++ b/WooCommerce/Classes/ViewRelated/Blaze/CampaignCreation/BlazeCampaignCreationForm.swift
@@ -174,10 +174,13 @@ struct BlazeCampaignCreationForm: View {
             }),
                   secondaryButton: .cancel())
         })
-        .alert(isPresented: $viewModel.isShowingMissingImageErrorAlert, content: {
-            Alert(title: Text(Localization.NoImageErrorAlert.noImageFound),
-                  dismissButton: .default(Text(Localization.NoImageErrorAlert.ok)))
-        })
+        .alert(Localization.NoImageErrorAlert.noImageFound, isPresented: $viewModel.isShowingMissingImageErrorAlert) {
+            Button(Localization.NoImageErrorAlert.cancel, role: .cancel) { }
+
+            Button(Localization.NoImageErrorAlert.addImage) {
+                viewModel.didTapEditAd()
+            }
+        }
         .task {
             await viewModel.onLoad()
         }
@@ -384,13 +387,18 @@ private extension BlazeCampaignCreationForm {
         enum NoImageErrorAlert {
             static let noImageFound = NSLocalizedString(
                 "blazeCampaignCreationForm.noImageErrorAlert.noImageFound",
-                value: "Please set an image for the Blaze campaign by tapping Edit ad",
+                value: "Please add an image for the Blaze campaign",
                 comment: "Message asking to select an image for the Blaze campaign"
             )
-            static let ok = NSLocalizedString(
-                "blazeCampaignCreationForm.noImageErrorAlert.ok",
-                value: "OK",
-                comment: "Dismiss button on the error alert asking to select a image for the Blaze campaign"
+            static let cancel = NSLocalizedString(
+                "blazeCampaignCreationForm.noImageErrorAlert.cancel",
+                value: "Cancel",
+                comment: "Dismiss button on the alert asking to add an image for the Blaze campaign"
+            )
+            static let addImage = NSLocalizedString(
+                "blazeCampaignCreationForm.noImageErrorAlert.addImage",
+                value: "Add Image",
+                comment: "Button on the alert to add an image for the Blaze campaign"
             )
         }
     }

--- a/WooCommerce/Classes/ViewRelated/Blaze/CampaignCreation/BlazeCampaignCreationForm.swift
+++ b/WooCommerce/Classes/ViewRelated/Blaze/CampaignCreation/BlazeCampaignCreationForm.swift
@@ -178,6 +178,9 @@ struct BlazeCampaignCreationForm: View {
             Alert(title: Text(Localization.NoImageErrorAlert.noImageFound),
                   dismissButton: .default(Text(Localization.NoImageErrorAlert.ok)))
         })
+        .onAppear() {
+            viewModel.onAppear()
+        }
         LazyNavigationLink(destination: BlazeConfirmPaymentView(viewModel: viewModel.confirmPaymentViewModel),
                            isActive: $viewModel.isShowingPaymentInfo) {
             EmptyView()

--- a/WooCommerce/Classes/ViewRelated/Blaze/CampaignCreation/BlazeCampaignCreationForm.swift
+++ b/WooCommerce/Classes/ViewRelated/Blaze/CampaignCreation/BlazeCampaignCreationForm.swift
@@ -53,7 +53,6 @@ struct BlazeCampaignCreationForm: View {
     @State private var isShowingTopicPicker = false
     @State private var isShowingLocationPicker = false
     @State private var isShowingAISuggestionsErrorAlert: Bool = false
-    @State private var isShowingPaymentInfo = false
 
     init(viewModel: BlazeCampaignCreationFormViewModel) {
         self.viewModel = viewModel
@@ -124,12 +123,9 @@ struct BlazeCampaignCreationForm: View {
                 Divider()
 
                 Button {
-                    // TODO: track tap
-                    isShowingPaymentInfo = true
+                    viewModel.didTapConfirmDetails()
                 } label: {
-                    LazyNavigationLink(destination: BlazeConfirmPaymentView(viewModel: viewModel.confirmPaymentViewModel), isActive: $isShowingPaymentInfo) {
-                        Text(Localization.confirmDetails)
-                    }
+                    Text(Localization.confirmDetails)
                 }
                 .buttonStyle(PrimaryButtonStyle())
                 .padding(Layout.contentPadding)
@@ -169,9 +165,9 @@ struct BlazeCampaignCreationForm: View {
             isShowingAISuggestionsErrorAlert = newValue == .failedToLoadAISuggestions
         }
         .alert(isPresented: $isShowingAISuggestionsErrorAlert, content: {
-            Alert(title: Text(Localization.ErrorAlert.title),
-                  message: Text(Localization.ErrorAlert.ErrorMessage.fetchingAISuggestions),
-                  primaryButton: .default(Text(Localization.ErrorAlert.retry), action: {
+            Alert(title: Text(Localization.AISuggestionsErrorAlert.title),
+                  message: Text(Localization.AISuggestionsErrorAlert.ErrorMessage.fetchingAISuggestions),
+                  primaryButton: .default(Text(Localization.AISuggestionsErrorAlert.retry), action: {
                 Task {
                     await viewModel.loadAISuggestions()
                 }
@@ -183,6 +179,14 @@ struct BlazeCampaignCreationForm: View {
         }
         .task {
             await viewModel.downloadProductImage()
+        }
+        .alert(isPresented: $viewModel.isShowingMissingImageErrorAlert, content: {
+            Alert(title: Text(Localization.NoImageErrorAlert.noImageFound),
+                  dismissButton: .default(Text(Localization.NoImageErrorAlert.ok)))
+        })
+        LazyNavigationLink(destination: BlazeConfirmPaymentView(viewModel: viewModel.confirmPaymentViewModel),
+                           isActive: $viewModel.isShowingPaymentInfo) {
+            EmptyView()
         }
     }
 }
@@ -361,7 +365,7 @@ private extension BlazeCampaignCreationForm {
             value: "Confirm Details",
             comment: "Button to confirm ad details on the Blaze campaign creation screen"
         )
-        enum ErrorAlert {
+        enum AISuggestionsErrorAlert {
             enum ErrorMessage {
                 static let fetchingAISuggestions = NSLocalizedString(
                     "blazeCampaignCreationForm.errorAlert.errorMessage.fetchingAISuggestions",
@@ -378,6 +382,18 @@ private extension BlazeCampaignCreationForm {
                 "blazeCampaignCreationForm.errorAlert.retry",
                 value: "Retry",
                 comment: "Button on the error alert displayed on the Blaze campaign creation screen"
+            )
+        }
+        enum NoImageErrorAlert {
+            static let noImageFound = NSLocalizedString(
+                "blazeCampaignCreationForm.noImageErrorAlert.noImageFound",
+                value: "Please set an image for the Blaze campaign by tapping Edit ad",
+                comment: "Message asking to select an image for the Blaze campaign"
+            )
+            static let ok = NSLocalizedString(
+                "blazeCampaignCreationForm.noImageErrorAlert.ok",
+                value: "OK",
+                comment: "Dismiss button on the error alert asking to select a image for the Blaze campaign"
             )
         }
     }

--- a/WooCommerce/Classes/ViewRelated/Blaze/CampaignCreation/BlazeCampaignCreationForm.swift
+++ b/WooCommerce/Classes/ViewRelated/Blaze/CampaignCreation/BlazeCampaignCreationForm.swift
@@ -164,16 +164,15 @@ struct BlazeCampaignCreationForm: View {
         .onChange(of: viewModel.error) { newValue in
             isShowingAISuggestionsErrorAlert = newValue == .failedToLoadAISuggestions
         }
-        .alert(isPresented: $isShowingAISuggestionsErrorAlert, content: {
-            Alert(title: Text(Localization.AISuggestionsErrorAlert.title),
-                  message: Text(Localization.AISuggestionsErrorAlert.ErrorMessage.fetchingAISuggestions),
-                  primaryButton: .default(Text(Localization.AISuggestionsErrorAlert.retry), action: {
+        .alert(Localization.AISuggestionsErrorAlert.fetchingAISuggestions, isPresented: $isShowingAISuggestionsErrorAlert) {
+            Button(Localization.AISuggestionsErrorAlert.cancel, role: .cancel) { }
+
+            Button(Localization.AISuggestionsErrorAlert.retry) {
                 Task {
                     await viewModel.loadAISuggestions()
                 }
-            }),
-                  secondaryButton: .cancel())
-        })
+            }
+        }
         .alert(Localization.NoImageErrorAlert.noImageFound, isPresented: $viewModel.isShowingMissingImageErrorAlert) {
             Button(Localization.NoImageErrorAlert.cancel, role: .cancel) { }
 
@@ -366,20 +365,18 @@ private extension BlazeCampaignCreationForm {
             comment: "Button to confirm ad details on the Blaze campaign creation screen"
         )
         enum AISuggestionsErrorAlert {
-            enum ErrorMessage {
-                static let fetchingAISuggestions = NSLocalizedString(
-                    "blazeCampaignCreationForm.errorAlert.errorMessage.fetchingAISuggestions",
-                    value: "Failed to load suggestions for tagline and description",
-                    comment: "Error message indicating that loading suggestions for tagline and description failed"
-                )
-            }
-            static let title = NSLocalizedString(
-                "blazeCampaignCreationForm.errorAlert.title",
-                value: "Oops! We've hit a snag",
-                comment: "Title on the error alert displayed on the Blaze campaign creation screen"
+            static let fetchingAISuggestions = NSLocalizedString(
+                "blazeCampaignCreationForm.aiSuggestionsErrorAlert.fetchingAISuggestions",
+                value: "Failed to load suggestions for tagline and description",
+                comment: "Error message indicating that loading suggestions for tagline and description failed"
+            )
+            static let cancel = NSLocalizedString(
+                "blazeCampaignCreationForm.aiSuggestionsErrorAlert.cancel",
+                value: "Cancel",
+                comment: "Dismiss button on the error alert displayed on the Blaze campaign creation screen"
             )
             static let retry = NSLocalizedString(
-                "blazeCampaignCreationForm.errorAlert.retry",
+                "blazeCampaignCreationForm.aiSuggestionsErrorAlert.retry",
                 value: "Retry",
                 comment: "Button on the error alert displayed on the Blaze campaign creation screen"
             )

--- a/WooCommerce/Classes/ViewRelated/Blaze/CampaignCreation/BlazeCampaignCreationForm.swift
+++ b/WooCommerce/Classes/ViewRelated/Blaze/CampaignCreation/BlazeCampaignCreationForm.swift
@@ -174,12 +174,6 @@ struct BlazeCampaignCreationForm: View {
             }),
                   secondaryButton: .cancel())
         })
-        .task {
-            await viewModel.loadAISuggestions()
-        }
-        .task {
-            await viewModel.downloadProductImage()
-        }
         .alert(isPresented: $viewModel.isShowingMissingImageErrorAlert, content: {
             Alert(title: Text(Localization.NoImageErrorAlert.noImageFound),
                   dismissButton: .default(Text(Localization.NoImageErrorAlert.ok)))

--- a/WooCommerce/Classes/ViewRelated/Blaze/CampaignCreation/BlazeCampaignCreationFormViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Blaze/CampaignCreation/BlazeCampaignCreationFormViewModel.swift
@@ -220,16 +220,18 @@ final class BlazeCampaignCreationFormViewModel: ObservableObject {
         initializeAdFinalDestination()
     }
 
-    func onAppear() {
-        if suggestions.isEmpty {
-            Task {
-                await loadAISuggestions()
+    func onLoad() async {
+        await withTaskGroup(of: Void.self) { group in
+            if suggestions.isEmpty {
+                group.addTask {
+                    await self.loadAISuggestions()
+                }
             }
-        }
 
-        if image == nil {
-            Task {
-                await downloadProductImage()
+            if image == nil {
+                group.addTask {
+                    await self.downloadProductImage()
+                }
             }
         }
     }

--- a/WooCommerce/Classes/ViewRelated/Blaze/CampaignCreation/BlazeCampaignCreationFormViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Blaze/CampaignCreation/BlazeCampaignCreationFormViewModel.swift
@@ -139,7 +139,7 @@ final class BlazeCampaignCreationFormViewModel: ObservableObject {
     @Published private(set) var finalDestinationURL: String = ""
 
     // AI Suggestions
-    @Published private(set) var isLoadingAISuggestions: Bool = true
+    @Published private(set) var isLoadingAISuggestions: Bool = false
     private let storage: StorageManagerType
     private var product: Product? {
         guard let product = productsResultsController.fetchedObjects.first else {
@@ -152,7 +152,7 @@ final class BlazeCampaignCreationFormViewModel: ObservableObject {
     @Published private(set) var error: BlazeCampaignCreationError?
     private var suggestions: [BlazeAISuggestion] = []
 
-    @Published private var isLoadingProductImage: Bool = true
+    @Published private var isLoadingProductImage: Bool = false
 
     var canEditAd: Bool {
         !isLoadingAISuggestions
@@ -202,7 +202,7 @@ final class BlazeCampaignCreationFormViewModel: ObservableObject {
          productID: Int64,
          stores: StoresManager = ServiceLocator.stores,
          storage: StorageManagerType = ServiceLocator.storageManager,
-    productImageLoader: ProductUIImageLoader = DefaultProductUIImageLoader(phAssetImageLoaderProvider: { PHImageManager.default() }),
+         productImageLoader: ProductUIImageLoader = DefaultProductUIImageLoader(phAssetImageLoaderProvider: { PHImageManager.default() }),
          onCompletion: @escaping () -> Void) {
         self.siteID = siteID
         self.productID = productID
@@ -218,13 +218,19 @@ final class BlazeCampaignCreationFormViewModel: ObservableObject {
         updateTargetTopicText()
         updateTargetLocationText()
         initializeAdFinalDestination()
+    }
 
-        Task {
-            await loadAISuggestions()
+    func onAppear() {
+        if suggestions.isEmpty {
+            Task {
+                await loadAISuggestions()
+            }
         }
 
-        Task {
-            await downloadProductImage()
+        if image == nil {
+            Task {
+                await downloadProductImage()
+            }
         }
     }
 

--- a/WooCommerce/Classes/ViewRelated/Blaze/CampaignCreation/BlazeCampaignCreationFormViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Blaze/CampaignCreation/BlazeCampaignCreationFormViewModel.swift
@@ -218,6 +218,14 @@ final class BlazeCampaignCreationFormViewModel: ObservableObject {
         updateTargetTopicText()
         updateTargetLocationText()
         initializeAdFinalDestination()
+
+        Task {
+            await loadAISuggestions()
+        }
+
+        Task {
+            await downloadProductImage()
+        }
     }
 
     func didTapEditAd() {

--- a/WooCommerce/WooCommerceTests/ViewRelated/Blaze/BlazeCampaignCreationFormViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Blaze/BlazeCampaignCreationFormViewModelTests.swift
@@ -96,11 +96,12 @@ final class BlazeCampaignCreationFormViewModelTests: XCTestCase {
         XCTAssertEqual(viewModel.description, "")
     }
 
-    // MARK: On appear
+    // MARK: On load
 
-    func test_on_appear_fetches_AI_suggestions() async throws {
+    func test_onLoad_fetches_AI_suggestions() async throws {
         // Given
         insertProduct(sampleProduct)
+        mockDownloadImage(sampleImage)
         var triggeredFetchAISuggestions = false
         stores.whenReceivingAction(ofType: BlazeAction.self) { action in
             switch action {
@@ -119,17 +120,17 @@ final class BlazeCampaignCreationFormViewModelTests: XCTestCase {
                                                onCompletion: {})
 
         // When
-        viewModel.onAppear()
+        await viewModel.onLoad()
 
         // Then
-        waitUntil {
-            triggeredFetchAISuggestions == true
-        }
+        XCTAssertTrue(triggeredFetchAISuggestions)
     }
 
-    func test_on_appear_downloads_image() async throws {
+    func test_onLoad_downloads_image() async throws {
         // Given
         insertProduct(sampleProduct)
+        mockAISuggestionsSuccess(sampleAISuggestions)
+        mockDownloadImage(sampleImage)
         let viewModel = BlazeCampaignCreationFormViewModel(siteID: sampleSiteID,
                                                productID: sampleProductID,
                                                stores: stores,
@@ -138,12 +139,10 @@ final class BlazeCampaignCreationFormViewModelTests: XCTestCase {
                                                onCompletion: {})
 
         // When
-        viewModel.onAppear()
+        await viewModel.onLoad()
 
         // Then
-        waitUntil {
-            self.imageLoader.imageRequestedForProductImage != nil
-        }
+        XCTAssertNotNil(imageLoader.imageRequestedForProductImage)
     }
 
     // MARK: Download product image

--- a/WooCommerce/WooCommerceTests/ViewRelated/Blaze/BlazeEditAdViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Blaze/BlazeEditAdViewModelTests.swift
@@ -162,6 +162,22 @@ final class BlazeEditAdViewModelTests: XCTestCase {
         }
     }
 
+    func test_save_button_is_enabled_when_tagline_is_changed_even_though_image_is_nil() {
+        // Given
+        let sut = BlazeEditAdViewModel(siteID: 123,
+                                       adData: BlazeEditAdData(image: nil,
+                                                               tagline: "Sample Tagline",
+                                                               description: "Sample description"),
+                                       suggestions: [.fake()],
+                                       onSave: { _ in })
+
+        // When
+        sut.tagline = "Test"
+
+        // Then
+        XCTAssertTrue(sut.isSaveButtonEnabled)
+    }
+
     func test_save_button_is_enabled_when_tagline_is_changed() {
         // Given
         let sut = BlazeEditAdViewModel(siteID: 123,
@@ -180,6 +196,22 @@ final class BlazeEditAdViewModelTests: XCTestCase {
         // Given
         let sut = BlazeEditAdViewModel(siteID: 123,
                                        adData: sampleAdData,
+                                       suggestions: [.fake()],
+                                       onSave: { _ in })
+
+        // When
+        sut.description = "Test"
+
+        // Then
+        XCTAssertTrue(sut.isSaveButtonEnabled)
+    }
+
+    func test_save_button_is_enabled_when_description_is_changed_even_though_image_is_nil() {
+        // Given
+        let sut = BlazeEditAdViewModel(siteID: 123,
+                                       adData: BlazeEditAdData(image: nil,
+                                                               tagline: "Sample Tagline",
+                                                               description: "Sample description"),
                                        suggestions: [.fake()],
                                        onSave: { _ in })
 


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #11761 
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

This PR adds an alert to ask user to add image to submit a campaign. It also fixes some issues that I found the no image flow.

Changes
- Show an alert if the user tries to submit a campaign without adding an image.
- Move the initial AI suggestions and product image loading work into the view model and condition checks to avoid reloading upon navigating back. 
- Allow editing tagline and description without selecting an image. 

## Testing instructions

#### No product image
- Log in to a store eligible for Blaze with a public product.
- Open a product without an image and tap "Promote with Blaze" from the product detail screen
- In the Blaze creation form, tap on validate that the "Confirm Details" button is enabled even though the product has no image
- Tap on the "Confirm Details" button, and you should see an alert asking you to add an image for the campaign
- Dismiss the alert and add an image
- Now tapping on the "Confirm Details" button should navigate to the next page

#### Navigating back
- Log in to a store eligible for Blaze with a public product.
- Open a product and tap "Promote with Blaze" from the product detail screen
- Tap "Edit ad" to enter custom tagline description and save it
- Tap on the "Confirm Details" button and navigate to the next page
- Now, navigate back and validate that the entered custom tagline and description are available. The screen shouldn't reload and reset those values. 

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->
| No product image | Navigate back |
|--------|--------|
| ![Simulator Screen Recording - iPhone 15 Pro - 2024-01-23 at 16 44 16](https://github.com/woocommerce/woocommerce-ios/assets/524475/63487cb8-f0fc-4eb7-a080-5efd92f85d9a) | ![Simulator Screen Recording - iPhone 15 Pro - 2024-01-23 at 17 21 27](https://github.com/woocommerce/woocommerce-ios/assets/524475/8a3c6008-7c87-41a6-8f28-0fb3203291b3) | 



---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
