### PR TITLE
Blaze: Synchronize products upon first login

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Dashboard/Blaze/BlazeCampaignDashboardViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Blaze/BlazeCampaignDashboardViewModel.swift
@@ -111,10 +111,11 @@ final class BlazeCampaignDashboardViewModel: ObservableObject {
         // Load Blaze campaigns
         await synchronizeBlazeCampaigns()
 
-        if blazeCampaignResultsController.fetchedObjects.isEmpty {
-            // Load published product as Blaze campaigns not available
-            await synchronizeFirstPublishedProduct()
-        }
+        // Load all products
+        // In case there are no campaigns, this helps decide whether to show a Product on the Blaze dashboard.
+        // It also helps determine whether the "Promote" button opens to product selector first (if the site has multiple
+        // products) or straight to campaign creation form (if there is only one product).
+        await synchronizePublishedProducts()
 
         updateResults()
     }
@@ -168,11 +169,10 @@ private extension BlazeCampaignDashboardViewModel {
 // MARK: - Products
 private extension BlazeCampaignDashboardViewModel {
     @MainActor
-    func synchronizeFirstPublishedProduct() async {
+    func synchronizePublishedProducts() async {
         await withCheckedContinuation { continuation in
             stores.dispatch(ProductAction.synchronizeProducts(siteID: siteID,
                                                               pageNumber: Store.Default.firstPageNumber,
-                                                              pageSize: 1,
                                                               stockStatus: nil,
                                                               productStatus: .published,
                                                               productType: nil,

--- a/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Blaze/BlazeCampaignDashboardViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Blaze/BlazeCampaignDashboardViewModelTests.swift
@@ -122,6 +122,8 @@ final class BlazeCampaignDashboardViewModelTests: XCTestCase {
             }
         }
 
+        mockSynchronizeProducts()
+
         // When
         await sut.reload()
 
@@ -273,6 +275,7 @@ final class BlazeCampaignDashboardViewModelTests: XCTestCase {
                                                   blazeEligibilityChecker: checker)
 
         mockSynchronizeCampaigns(insertCampaignToStorage: fakeBlazeCampaign)
+        mockSynchronizeProducts()
 
         // When
         await sut.reload()
@@ -404,6 +407,7 @@ final class BlazeCampaignDashboardViewModelTests: XCTestCase {
                                                   blazeEligibilityChecker: checker)
 
         mockSynchronizeCampaigns(insertCampaignToStorage: fakeBlazeCampaign)
+        mockSynchronizeProducts()
 
         // When
         await sut.reload()
@@ -498,7 +502,7 @@ final class BlazeCampaignDashboardViewModelTests: XCTestCase {
                                                   blazeEligibilityChecker: checker)
 
         mockSynchronizeCampaigns(insertCampaignToStorage: fakeBlazeCampaign)
-
+        mockSynchronizeProducts()
         // When
         await sut.reload()
 
@@ -767,6 +771,7 @@ final class BlazeCampaignDashboardViewModelTests: XCTestCase {
                                                   blazeEligibilityChecker: checker)
 
         mockSynchronizeCampaigns(insertCampaignToStorage: fakeBlazeCampaign)
+        mockSynchronizeProducts()
 
         // When
         await sut.reload()
@@ -856,6 +861,7 @@ final class BlazeCampaignDashboardViewModelTests: XCTestCase {
                                                   blazeEligibilityChecker: checker)
 
         mockSynchronizeCampaigns(insertCampaignToStorage: fakeBlazeCampaign)
+        mockSynchronizeProducts()
 
         // When
         await sut.reload()
@@ -883,6 +889,8 @@ final class BlazeCampaignDashboardViewModelTests: XCTestCase {
 
         let fakeBlazeCampaign = BlazeCampaign.fake().copy(siteID: sampleSiteID)
         mockSynchronizeCampaigns(insertCampaignToStorage: fakeBlazeCampaign)
+        mockSynchronizeProducts()
+
         await viewModel.reload()
         // confidence check
         XCTAssertEqual(viewModel.state, .showCampaign(campaign: fakeBlazeCampaign))

--- a/Yosemite/Yosemite/Actions/ProductAction.swift
+++ b/Yosemite/Yosemite/Actions/ProductAction.swift
@@ -44,7 +44,7 @@ public enum ProductAction: Action {
     ///
     case synchronizeProducts(siteID: Int64,
                              pageNumber: Int,
-                             pageSize: Int,
+                             pageSize: Int = ProductsRemote.Default.pageSize,
                              stockStatus: ProductStockStatus?,
                              productStatus: ProductStatus?,
                              productType: ProductType?,

--- a/Yosemite/Yosemite/Stores/ProductStore.swift
+++ b/Yosemite/Yosemite/Stores/ProductStore.swift
@@ -243,7 +243,7 @@ private extension ProductStore {
     ///
     func synchronizeProducts(siteID: Int64,
                              pageNumber: Int,
-                             pageSize: Int,
+                             pageSize: Int = ProductsRemote.Default.pageSize,
                              stockStatus: ProductStockStatus?,
                              productStatus: ProductStatus?,
                              productType: ProductType?,


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #11756
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

The "Promote" button on the Blaze dashboard uses a navigation Coordinator, `BlazeCampaignCreationCoordinator`, to decide what to open when it is tapped. 

The Coordinator, in turn, checks local storage for existing products, so that the button behavior is correct when tapped. If there are existing multiple products, it should open product selector, or if there is only one product, then open campaign creation directly.

This PR changes the `BlazeCampaignDashboardViewModel` `reload()` function to always synchronize all products instead of just one. This helps populate the products local storage so that the Coordinator can later use it.


## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

1. Log out of the app.
2. Log back into a store eligible for Blaze with more than one published product.
3. After the login succeeds, tap the Promote button in the Blaze section on the Dashboard screen.
4. Ensure product selector opens correctly.
