### PR TITLE
[Tablet Orders] Set max width on billing information

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Customer Section/Billing Information/BillingInformationViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Customer Section/Billing Information/BillingInformationViewController.swift
@@ -48,6 +48,7 @@ final class BillingInformationViewController: UIViewController {
         super.viewDidLoad()
         setupNavigationItem()
         setupMainView()
+        constrainToMaxWidth()
         registerTableViewCells()
         registerTableViewHeaderFooters()
         reloadSections()
@@ -79,6 +80,16 @@ private extension BillingInformationViewController {
         tableView.estimatedSectionHeaderHeight = Constants.sectionHeight
         tableView.estimatedRowHeight = Constants.rowHeight
         tableView.rowHeight = UITableView.automaticDimension
+    }
+
+    func constrainToMaxWidth() {
+        guard ServiceLocator.featureFlagService.isFeatureFlagEnabled(.splitViewInOrdersTab) else {
+            return
+        }
+
+        let maxWidthConstraint = tableView.widthAnchor.constraint(lessThanOrEqualToConstant: Constants.maxWidth)
+        maxWidthConstraint.priority = .required
+        NSLayoutConstraint.activate([maxWidthConstraint])
     }
 
     /// Registers all of the available TableViewCells
@@ -588,5 +599,6 @@ private extension BillingInformationViewController {
         static let rowHeight = CGFloat(38)
         static let sectionHeight = CGFloat(44)
         static let footerHeight = CGFloat(0)
+        static let maxWidth = CGFloat(525)
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Customer Section/Billing Information/BillingInformationViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Customer Section/Billing Information/BillingInformationViewController.swift
@@ -60,6 +60,8 @@ final class BillingInformationViewController: UIViewController {
 
     private let messageComposerPresenter: MessageComposerPresenter = ServiceLocator.messageComposerPresenter
 
+    private let isSplitViewInOrdersTabEnabled: Bool = ServiceLocator.featureFlagService.isFeatureFlagEnabled(.splitViewInOrdersTab)
+
 }
 
 // MARK: - Interface Initialization
@@ -83,7 +85,7 @@ private extension BillingInformationViewController {
     }
 
     func constrainToMaxWidth() {
-        guard ServiceLocator.featureFlagService.isFeatureFlagEnabled(.splitViewInOrdersTab) else {
+        guard isSplitViewInOrdersTabEnabled else {
             return
         }
 
@@ -409,6 +411,11 @@ private extension BillingInformationViewController {
         }
 
         cell.accessibilityCustomActions = [callAccessibilityAction, messageAccessibilityAction, copyAccessibilityAction]
+
+        guard isSplitViewInOrdersTabEnabled else {
+            return
+        }
+        cell.showSideBorders(fromWidth: Constants.maxWidth)
     }
 
     func setupBillingEmail(cell: WooBasicTableViewCell) {
@@ -441,6 +448,11 @@ private extension BillingInformationViewController {
         }
 
         cell.accessibilityCustomActions = [emailAccessibilityAction, copyEmailAccessibilityAction]
+        
+        guard isSplitViewInOrdersTabEnabled else {
+            return
+        }
+        cell.showSideBorders(fromWidth: Constants.maxWidth)
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Customer Section/Billing Information/BillingInformationViewController.xib
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Customer Section/Billing Information/BillingInformationViewController.xib
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="17701" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="22505" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina4_7" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="17703"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="22504"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
@@ -20,7 +20,7 @@
             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
             <subviews>
                 <tableView clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" style="grouped" separatorStyle="default" rowHeight="-1" estimatedRowHeight="114" sectionHeaderHeight="18" sectionFooterHeight="18" translatesAutoresizingMaskIntoConstraints="NO" id="eXD-Va-gYx">
-                    <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
+                    <rect key="frame" x="0.0" y="20" width="375" height="647"/>
                     <color key="backgroundColor" systemColor="groupTableViewBackgroundColor"/>
                     <inset key="separatorInset" minX="16" minY="0.0" maxX="0.0" maxY="0.0"/>
                     <connections>
@@ -32,10 +32,11 @@
             <viewLayoutGuide key="safeArea" id="fnl-2z-Ty3"/>
             <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
             <constraints>
+                <constraint firstItem="eXD-Va-gYx" firstAttribute="centerX" secondItem="fnl-2z-Ty3" secondAttribute="centerX" id="0bk-D8-Lho"/>
                 <constraint firstItem="fnl-2z-Ty3" firstAttribute="bottom" secondItem="eXD-Va-gYx" secondAttribute="bottom" id="0wn-I6-XCt"/>
-                <constraint firstItem="eXD-Va-gYx" firstAttribute="trailing" secondItem="i5M-Pr-FkT" secondAttribute="trailing" id="11e-rx-0Y6"/>
+                <constraint firstItem="eXD-Va-gYx" firstAttribute="trailing" secondItem="i5M-Pr-FkT" secondAttribute="trailing" priority="750" id="11e-rx-0Y6"/>
                 <constraint firstItem="eXD-Va-gYx" firstAttribute="top" secondItem="fnl-2z-Ty3" secondAttribute="top" id="O0D-w3-dKV"/>
-                <constraint firstItem="eXD-Va-gYx" firstAttribute="leading" secondItem="i5M-Pr-FkT" secondAttribute="leading" id="zc8-ku-cRM"/>
+                <constraint firstItem="eXD-Va-gYx" firstAttribute="leading" secondItem="i5M-Pr-FkT" secondAttribute="leading" priority="750" id="zc8-ku-cRM"/>
             </constraints>
             <point key="canvasLocation" x="-4" y="154"/>
         </view>

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Customer Section/Billing Information/Cells/BillingAddressTableViewCell.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Customer Section/Billing Information/Cells/BillingAddressTableViewCell.swift
@@ -52,6 +52,9 @@ final class BillingAddressTableViewCell: UITableViewCell {
         }
     }
 
+    var rightBorder: CALayer?
+    var leftBorder: CALayer?
+
     override func awakeFromNib() {
         super.awakeFromNib()
         configureBackground()
@@ -66,6 +69,30 @@ final class BillingAddressTableViewCell: UITableViewCell {
         onEditTapped = nil
         editButton.accessibilityLabel = nil
     }
+
+    override func layoutSubviews() {
+        super.layoutSubviews()
+
+        guard bounds.width >= Constants.widthForSideBorders else {
+            removeSideBorders()
+            return
+        }
+
+        if leftBorder == nil || rightBorder == nil {
+            addSideBorders()
+        }
+
+        leftBorder?.frame = CGRect(x: 0.0,
+                                   y: 0.0,
+                                   width: Constants.borderWidth,
+                                   height: bounds.maxY)
+
+        rightBorder?.frame = CGRect(x: bounds.maxX - Constants.borderWidth,
+                                    y: 0.0,
+                                    width: Constants.borderWidth,
+                                    height: bounds.maxY)
+    }
+
 }
 
 /// MARK: - Private Methods
@@ -94,6 +121,26 @@ private extension BillingAddressTableViewCell {
     @objc func editButtonTapped() {
         onEditTapped?()
     }
+
+    func addSideBorders() {
+        let leftBorder = CALayer()
+        leftBorder.backgroundColor = UIColor.border.cgColor
+
+        let rightBorder = CALayer()
+        rightBorder.backgroundColor = UIColor.border.cgColor
+
+        contentView.layer.addSublayer(leftBorder)
+        contentView.layer.addSublayer(rightBorder)
+        self.leftBorder = leftBorder
+        self.rightBorder = rightBorder
+    }
+
+    func removeSideBorders() {
+        leftBorder?.removeFromSuperlayer()
+        rightBorder?.removeFromSuperlayer()
+        leftBorder = nil
+        rightBorder = nil
+    }
 }
 
 /// MARK: - Testability
@@ -105,5 +152,12 @@ extension BillingAddressTableViewCell {
 
     func getAddressLabel() -> UILabel {
         return addressLabel
+    }
+}
+
+private extension BillingAddressTableViewCell {
+    enum Constants {
+        static let borderWidth: CGFloat = 0.5
+        static let widthForSideBorders: CGFloat = 525
     }
 }

--- a/WooCommerce/Classes/ViewRelated/ReusableViews/WooBasicTableViewCell.swift
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/WooBasicTableViewCell.swift
@@ -65,6 +65,68 @@ class WooBasicTableViewCell: UITableViewCell {
         accessoryImageView.tintColor = .primaryButtonBackground
         accessoryView = accessoryImageView
     }
+
+    // MARK: - Side borders used in wider table views when max-width used to ensure readability.
+
+    private var rightBorder: CALayer?
+    private var leftBorder: CALayer?
+    private var shouldShowSideBorders = false
+    private var minimumWidthForSideBorders: CGFloat?
+
+    func showSideBorders(fromWidth minimumWidth: CGFloat) {
+        shouldShowSideBorders = true
+        minimumWidthForSideBorders = minimumWidth
+    }
+
+
+    override func layoutSubviews() {
+        super.layoutSubviews()
+
+        guard shouldShowSideBorders,
+              let minimumWidthForSideBorders else {
+            return
+        }
+
+        guard bounds.width >= minimumWidthForSideBorders else {
+            removeSideBorders()
+            return
+        }
+
+        if leftBorder == nil || rightBorder == nil {
+            removeSideBorders() // to prevent any double-border issues!
+            addSideBorders()
+        }
+
+        leftBorder?.frame = CGRect(x: 0.0,
+                                   y: 0.0,
+                                   width: Constants.borderWidth,
+                                   height: bounds.maxY)
+
+        rightBorder?.frame = CGRect(x: bounds.maxX - Constants.borderWidth,
+                                    y: 0.0,
+                                    width: Constants.borderWidth,
+                                    height: bounds.maxY)
+    }
+
+    private func addSideBorders() {
+        let leftBorder = CALayer()
+        leftBorder.backgroundColor = UIColor.border.cgColor
+
+        let rightBorder = CALayer()
+        rightBorder.backgroundColor = UIColor.border.cgColor
+
+        layer.addSublayer(leftBorder)
+        layer.addSublayer(rightBorder)
+        self.leftBorder = leftBorder
+        self.rightBorder = rightBorder
+    }
+
+    private func removeSideBorders() {
+        leftBorder?.removeFromSuperlayer()
+        rightBorder?.removeFromSuperlayer()
+        leftBorder = nil
+        rightBorder = nil
+    }
 }
 
 extension WooBasicTableViewCell {
@@ -86,5 +148,11 @@ extension WooBasicTableViewCell {
     func applySecondaryTextStyle() {
         bodyLabel.applySecondaryBodyStyle()
         bodyLabelTopMarginConstraint.constant = 8
+    }
+}
+
+private extension WooBasicTableViewCell {
+    enum Constants {
+        static let borderWidth: CGFloat = 0.5
     }
 }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #11767
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

On wider displays, we show the Order Details with a max-width of 525, to keep it readable.

The BillingInformationViewController is pushed from Order Details, so it makes sense to apply the same constraint to this view.

This PR adds the max width constraint, and side borders to the cells when the max-width comes in to play.

CC. @iamgabrielma perhaps we want to use this approach for side borders on the Order Details too; do you want to take a look at that? Fun with `CALayer`.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

1. Launch the app on a device which can show in a horizontally regular size class. (iPad or large iPhone)
2. Tap `Orders`
3. Select an Order with billing information set
4. Tap `View Billing Information`
5. Rotate the device so the view has more than 525 points of width
6. Observe that when the display is wide, the cells are shown with a margin around the left and right sides
7. Observe that the cells have side borders in this mode
8. Change the size so that the view has less than 525 points of width, or is compact
9. Observe that the cells fill the width and don't have side borders.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->


https://github.com/woocommerce/woocommerce-ios/assets/2472348/2172fa27-0ec0-44ec-8b5f-a030d972d470


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
