### PR TITLE
Blaze: Remove stubbed response for forecasted impressions

### DIFF
--- a/Fakes/Fakes/Networking.generated.swift
+++ b/Fakes/Fakes/Networking.generated.swift
@@ -204,7 +204,7 @@ extension Networking.BlazeForecastedImpressionsInput {
             endDate: .fake(),
             timeZone: .fake(),
             totalBudget: .fake(),
-            targetings: .fake()
+            targeting: .fake()
         )
     }
 }

--- a/Networking/Networking/Model/Copiable/Models+Copiable.generated.swift
+++ b/Networking/Networking/Model/Copiable/Models+Copiable.generated.swift
@@ -1,6 +1,5 @@
 // Generated using Sourcery 1.0.3 — https://github.com/krzysztofzablocki/Sourcery
 // DO NOT EDIT
-import Alamofire
 import Codegen
 import Foundation
 

--- a/Networking/Networking/Model/Copiable/Models+Copiable.generated.swift
+++ b/Networking/Networking/Model/Copiable/Models+Copiable.generated.swift
@@ -1,5 +1,6 @@
 // Generated using Sourcery 1.0.3 — https://github.com/krzysztofzablocki/Sourcery
 // DO NOT EDIT
+import Alamofire
 import Codegen
 import Foundation
 

--- a/Networking/Networking/Remote/BlazeRemote.swift
+++ b/Networking/Networking/Remote/BlazeRemote.swift
@@ -1,4 +1,5 @@
 import Codegen
+import Alamofire
 import Foundation
 
 /// Protocol for `BlazeRemote` mainly used for mocking.
@@ -86,7 +87,11 @@ public final class BlazeRemote: Remote, BlazeRemoteProtocol {
             .compactMapValues { $0 } // filters out any field with nil value
 
 
-        let request = DotcomRequest(wordpressApiVersion: .wpcomMark2, method: .post, path: path, parameters: parameters)
+        let request = DotcomRequest(wordpressApiVersion: .wpcomMark2,
+                                    method: .post,
+                                    path: path,
+                                    parameters: parameters,
+                                    encoding: JSONEncoding.default)
         let mapper = CreateBlazeCampaignMapper()
         try await enqueue(request, mapper: mapper)
     }
@@ -158,8 +163,13 @@ public final class BlazeRemote: Remote, BlazeRemoteProtocol {
         dateFormatter.dateFormat = Constants.dateFormat
 
         let parameters = try input.toDictionary(keyEncodingStrategy: .convertToSnakeCase, dateFormatter: dateFormatter)
+            .compactMapValues { $0 } // filters out any field with nil value
 
-        let request = DotcomRequest(wordpressApiVersion: .wpcomMark2, method: .post, path: path, parameters: parameters)
+        let request = DotcomRequest(wordpressApiVersion: .wpcomMark2,
+                                    method: .post,
+                                    path: path,
+                                    parameters: parameters,
+                                    encoding: JSONEncoding.default)
         let mapper = BlazeImpressionsMapper()
         return try await enqueue(request, mapper: mapper)
     }

--- a/Networking/Networking/Remote/BlazeRemote.swift
+++ b/Networking/Networking/Remote/BlazeRemote.swift
@@ -283,18 +283,18 @@ public struct BlazeForecastedImpressionsInput: Encodable, GeneratedFakeable {
     // Total budget of the campaign
     public let totalBudget: Double
     // Target options for the campaign. Optional.
-    public let targetings: BlazeTargetOptions?
+    public let targeting: BlazeTargetOptions?
 
     public init(startDate: Date,
                 endDate: Date,
                 timeZone: String,
                 totalBudget: Double,
-                targetings: BlazeTargetOptions? = nil) {
+                targeting: BlazeTargetOptions? = nil) {
         self.startDate = startDate
         self.endDate = endDate
         self.timeZone = timeZone
         self.totalBudget = totalBudget
-        self.targetings = targetings
+        self.targeting = targeting
     }
 
     private enum CodingKeys: String, CodingKey {
@@ -302,7 +302,7 @@ public struct BlazeForecastedImpressionsInput: Encodable, GeneratedFakeable {
         case endDate
         case timeZone
         case totalBudget
-        case targetings
+        case targeting
     }
 }
 

--- a/Networking/Networking/Remote/BlazeRemote.swift
+++ b/Networking/Networking/Remote/BlazeRemote.swift
@@ -83,6 +83,8 @@ public final class BlazeRemote: Remote, BlazeRemoteProtocol {
         let dateFormatter = DateFormatter()
         dateFormatter.dateFormat = Constants.dateFormat
         let parameters = try campaign.toDictionary(keyEncodingStrategy: .convertToSnakeCase, dateFormatter: dateFormatter)
+            .compactMapValues { $0 } // filters out any field with nil value
+
 
         let request = DotcomRequest(wordpressApiVersion: .wpcomMark2, method: .post, path: path, parameters: parameters)
         let mapper = CreateBlazeCampaignMapper()

--- a/Networking/Networking/Remote/BlazeRemote.swift
+++ b/Networking/Networking/Remote/BlazeRemote.swift
@@ -1,6 +1,6 @@
 import Codegen
-import Alamofire
 import Foundation
+import struct Alamofire.JSONEncoding
 
 /// Protocol for `BlazeRemote` mainly used for mocking.
 ///

--- a/Networking/NetworkingTests/Encoder/BlazeForecastedImpressionsInputEncoderTests.swift
+++ b/Networking/NetworkingTests/Encoder/BlazeForecastedImpressionsInputEncoderTests.swift
@@ -30,7 +30,7 @@ final class BlazeForecastedImpressionsInputEncoderTests: XCTestCase {
         XCTAssertEqual(parameters["total_budget"] as? Double, 35.00)
         XCTAssertEqual(parameters["time_zone"] as? String, timeZone)
 
-        let targetingsParams = try XCTUnwrap(parameters["targetings"] as? [String: Any])
+        let targetingsParams = try XCTUnwrap(parameters["targeting"] as? [String: Any])
         XCTAssertEqual(targetingsParams["locations"] as? [Int64], [29211, 42546])
         XCTAssertEqual(targetingsParams["languages"] as? [String], ["en", "de"])
         XCTAssertEqual(targetingsParams["devices"] as? [String], ["mobile"])

--- a/Networking/NetworkingTests/Encoder/BlazeForecastedImpressionsInputEncoderTests.swift
+++ b/Networking/NetworkingTests/Encoder/BlazeForecastedImpressionsInputEncoderTests.swift
@@ -19,7 +19,7 @@ final class BlazeForecastedImpressionsInputEncoderTests: XCTestCase {
                                                     endDate: endDate,
                                                     timeZone: timeZone,
                                                     totalBudget: totalBudget,
-                                                    targetings: targetOptions)
+                                                    targeting: targetOptions)
 
         // When
         let parameters = try input.toDictionary(keyEncodingStrategy: .convertToSnakeCase, dateFormatter: dateFormatter)

--- a/Networking/NetworkingTests/Remote/BlazeRemoteTests.swift
+++ b/Networking/NetworkingTests/Remote/BlazeRemoteTests.swift
@@ -57,7 +57,7 @@ final class BlazeRemoteTests: XCTestCase {
                                                   mimeType: "image/png")
         let targeting = BlazeTargetOptions(locations: [29211, 42546],
                                            languages: ["en", "de"],
-                                           devices: ["mobile"],
+                                           devices: nil,
                                            pageTopics: ["IAB3", "IAB4"])
         let campaign = CreateBlazeCampaign.fake().copy(origin: "WooMobile",
                                                        originVersion: "1.0.1",
@@ -99,7 +99,7 @@ final class BlazeRemoteTests: XCTestCase {
         let targetingDict = try XCTUnwrap(request.parameters?["targeting"] as? [String: Any])
         XCTAssertEqual(targetingDict["locations"] as? [Int64], targeting.locations)
         XCTAssertEqual(targetingDict["languages"] as? [String], targeting.languages)
-        XCTAssertEqual(targetingDict["devices"] as? [String], targeting.devices)
+        XCTAssertNil(targetingDict["devices"])
         XCTAssertEqual(targetingDict["page_topics"] as? [String], targeting.pageTopics)
 
         XCTAssertEqual(request.parameters?["target_urn"] as? String, campaign.targetUrn)

--- a/Networking/NetworkingTests/Remote/BlazeRemoteTests.swift
+++ b/Networking/NetworkingTests/Remote/BlazeRemoteTests.swift
@@ -431,6 +431,48 @@ final class BlazeRemoteTests: XCTestCase {
         XCTAssertEqual(result, .init(totalImpressionsMin: 17900, totalImpressionsMax: 24200))
     }
 
+    func test_fetchForecastedImpressions_correct_parameters() async throws {
+        // Given
+        let remote = BlazeRemote(network: network)
+        let suffix = "sites/\(sampleSiteID)/wordads/dsp/api/v1.1/forecast"
+        network.simulateResponse(requestUrlSuffix: suffix, filename: "blaze-impressions")
+
+        let dateFormatter = DateFormatter()
+        dateFormatter.dateFormat = "yyyy-MM-dd"
+
+        let startDateString = "2023-12-05"
+        let startDate = try XCTUnwrap(dateFormatter.date(from: startDateString))
+
+        let endDateString = "2023-12-11"
+        let endDate = try XCTUnwrap(dateFormatter.date(from: endDateString))
+
+        let targeting = BlazeTargetOptions(locations: nil,
+                                           languages: ["en", "de"],
+                                           devices: nil,
+                                           pageTopics: ["IAB3", "IAB4"])
+        let input = BlazeForecastedImpressionsInput(startDate: startDate,
+                                                    endDate: endDate,
+                                                    timeZone: "America/New_York",
+                                                    totalBudget: 35.00,
+                                                    targeting: targeting)
+
+        // When
+        _ = try await remote.fetchForecastedImpressions(for: sampleSiteID, with: input)
+
+        // Then
+        let request = try XCTUnwrap(network.requestsForResponseData.first as? DotcomRequest)
+        XCTAssertEqual(request.parameters?["start_date"] as? String, startDateString)
+        XCTAssertEqual(request.parameters?["end_date"] as? String, endDateString)
+        XCTAssertEqual(request.parameters?["time_zone"] as? String, input.timeZone)
+        XCTAssertEqual(request.parameters?["total_budget"] as? Double, input.totalBudget)
+
+        let targetingDict = try XCTUnwrap(request.parameters?["targeting"] as? [String: Any])
+        XCTAssertNil(targetingDict["locations"])
+        XCTAssertEqual(targetingDict["languages"] as? [String], targeting.languages)
+        XCTAssertNil(targetingDict["devices"])
+        XCTAssertEqual(targetingDict["page_topics"] as? [String], targeting.pageTopics)
+    }
+
     func test_fetchForecastedImpressions_properly_relays_networking_errors() async {
         // Given
         let remote = BlazeRemote(network: network)

--- a/WooCommerce/Classes/ViewRelated/Blaze/BudgetSetting/BlazeBudgetSettingViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Blaze/BudgetSetting/BlazeBudgetSettingViewModel.swift
@@ -99,7 +99,7 @@ final class BlazeBudgetSettingViewModel: ObservableObject {
                                                     endDate: endDate,
                                                     timeZone: timeZone.identifier,
                                                     totalBudget: totalBudget,
-                                                    targetings: targetOptions)
+                                                    targeting: targetOptions)
         do {
             let result = try await fetchForecastedImpressions(input: input)
             let formattedImpressions = String(format: "%d - %d", result.totalImpressionsMin, result.totalImpressionsMax)

--- a/WooCommerce/Classes/ViewRelated/Blaze/CampaignCreation/BlazeCampaignCreationFormViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Blaze/CampaignCreation/BlazeCampaignCreationFormViewModel.swift
@@ -49,7 +49,8 @@ final class BlazeCampaignCreationFormViewModel: ObservableObject {
                                   pageTopics: pageTopics?.map { $0.id })
     }
 
-    lazy private(set) var budgetSettingViewModel: BlazeBudgetSettingViewModel = {
+    /// We need to recreate the view model every time the budget screen is opened to get the updated target options.
+    var budgetSettingViewModel: BlazeBudgetSettingViewModel {
         BlazeBudgetSettingViewModel(siteID: siteID,
                                     dailyBudget: dailyBudget,
                                     duration: duration,
@@ -61,7 +62,7 @@ final class BlazeCampaignCreationFormViewModel: ObservableObject {
             self.dailyBudget = dailyBudget
             self.updateBudgetDetails()
         }
-    }()
+    }
 
     var editAdViewModel: BlazeEditAdViewModel {
         let adData = BlazeEditAdData(image: image,

--- a/WooCommerce/Classes/ViewRelated/Blaze/TargetDevices/BlazeTargetDevicePickerView.swift
+++ b/WooCommerce/Classes/ViewRelated/Blaze/TargetDevices/BlazeTargetDevicePickerView.swift
@@ -21,7 +21,8 @@ struct BlazeTargetDevicePickerView: View {
                 case .syncing:
                     ActivityIndicator(isAnimating: .constant(true), style: .medium)
                 case .result(let devices):
-                    MultiSelectionList(contents: devices,
+                    MultiSelectionList(allOptionsTitle: Localization.allTitle,
+                                       contents: devices,
                                        contentKeyPath: \.name,
                                        selectedItems: $viewModel.selectedDevices)
                 case .error:
@@ -63,6 +64,11 @@ private extension BlazeTargetDevicePickerView {
             "blazeTargetDevicePickerView.title",
             value: "Devices",
             comment: "Title of the target device picker view for Blaze campaign creation"
+        )
+        static let allTitle = NSLocalizedString(
+            "blazeTargetDevicePickerView.allTitle",
+            value: "All devices",
+            comment: "Title of the row to select all target devices for Blaze campaign creation"
         )
         static let cancelButtonTitle = NSLocalizedString(
             "blazeTargetDevicePickerView.cancel",

--- a/WooCommerce/WooCommerceTests/ViewRelated/Blaze/BlazeBudgetSettingViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Blaze/BlazeBudgetSettingViewModelTests.swift
@@ -123,6 +123,6 @@ final class BlazeBudgetSettingViewModelTests: XCTestCase {
         XCTAssertEqual(fetchInput?.endDate, Date(timeInterval: 7 * 86400, since: expectedStartDate))
         XCTAssertEqual(fetchInput?.totalBudget, 20 * 7)
         XCTAssertEqual(fetchInput?.timeZone, "Europe/London")
-        XCTAssertEqual(fetchInput?.targetings, targetOptions)
+        XCTAssertEqual(fetchInput?.targeting, targetOptions)
     }
 }

--- a/Yosemite/Yosemite/Stores/BlazeStore.swift
+++ b/Yosemite/Yosemite/Stores/BlazeStore.swift
@@ -297,11 +297,7 @@ private extension BlazeStore {
                                     onCompletion: @escaping (Result<BlazeImpressions, Error>) -> Void) {
         Task { @MainActor in
             do {
-                // TODO-11540: remove stubbed result when the API is ready.
-                let stubbedResult = BlazeImpressions(totalImpressionsMin: 5000, totalImpressionsMax: 10000)
-                let impressions: BlazeImpressions = try await mockResponse(stubbedResult: stubbedResult, onExecution: {
-                    try await remote.fetchForecastedImpressions(for: siteID, with: input)
-                })
+                let impressions = try await remote.fetchForecastedImpressions(for: siteID, with: input)
                 onCompletion(.success(impressions))
             } catch {
                 onCompletion(.failure(error))


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of #11622 
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
According to a recent update from the API team [peeHDf-2fw-p2#comment-1838], the forecasted impression API has been deployed, so this PR removes the stubbed response for the endpoint.

A few things have been fixed when testing the real endpoint:
- The POST request was sent with data in form, while the endpoint expects JSON. I updated the encoding to `JSONEncoding` to fix this (also applied to the campaign creation endpoint).
- The endpoint expects non-empty array for target options, so the fields with nil value have been filtered out from the requests for both forecasted impressions and campaign creation.
- The endpoint expects `targeting` instead of `targetings`, so the property's name has been updated for `BlazeForecastedImpressionsInput`.
- Since the targeting device endpoint no longer returns the All option, the all row has been restore for the device picker view.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
- Log in to a store eligible for Blaze.
- Select Promote in the Blaze section on the Dashboard screen to start campaign creation.
- Select the Device field, and notice that we now have the All row that works similarly to other target option picker views.
- Update any target options and then select the Budget field. Confirm that the real data for forecasted impressions are loaded properly.
- You can also open Proxyman/Charles Proxy while testing to confirm the correct requests and responses.


## Screenshots
<!-- Include before and after images or gifs when appropriate. -->


https://github.com/woocommerce/woocommerce-ios/assets/5533851/857f9c11-4ac5-434a-8e34-d1748e90af64



---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
