### PR TITLE
Blaze: Fix state change warnings when editing ads

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Blaze/BlazeEditAd/BlazeEditAdView.swift
+++ b/WooCommerce/Classes/ViewRelated/Blaze/BlazeEditAd/BlazeEditAdView.swift
@@ -115,7 +115,7 @@ private extension BlazeEditAdView {
             )
 
             Text(viewModel.taglineFooterText)
-                .foregroundStyle(viewModel.taglineRemainingLength >= 0 ? .secondary : Color(.error))
+                .foregroundStyle(viewModel.isTaglineValidated ? .secondary : Color(.error))
                 .footnoteStyle()
         }
     }
@@ -149,7 +149,7 @@ private extension BlazeEditAdView {
             )
 
             Text(viewModel.descriptionFooterText)
-                .foregroundStyle(viewModel.descriptionRemainingLength >= 0 ? .secondary : Color(.error))
+                .foregroundStyle(viewModel.isDescriptionValidated ? .secondary : Color(.error))
                 .footnoteStyle()
         }
     }

--- a/WooCommerce/Classes/ViewRelated/Blaze/BlazeEditAd/BlazeEditAdView.swift
+++ b/WooCommerce/Classes/ViewRelated/Blaze/BlazeEditAd/BlazeEditAdView.swift
@@ -94,9 +94,6 @@ private extension BlazeEditAdView {
 
             ZStack(alignment: .topLeading) {
                 TextEditor(text: $viewModel.tagline)
-                    .onChange(of: viewModel.tagline) { newValue in
-                        viewModel.tagline = viewModel.formatTagline(newValue)
-                    }
                     .bodyStyle()
                     .foregroundColor(.secondary)
                     .padding(insets: Layout.textFieldContentInsets)
@@ -118,6 +115,7 @@ private extension BlazeEditAdView {
             )
 
             Text(viewModel.taglineFooterText)
+                .foregroundStyle(viewModel.taglineRemainingLength >= 0 ? .secondary : Color(.error))
                 .footnoteStyle()
         }
     }
@@ -130,9 +128,6 @@ private extension BlazeEditAdView {
 
             ZStack(alignment: .topLeading) {
                 TextEditor(text: $viewModel.description)
-                    .onChange(of: viewModel.description) { newValue in
-                        viewModel.description = viewModel.formatDescription(newValue)
-                    }
                     .bodyStyle()
                     .foregroundColor(.secondary)
                     .padding(insets: Layout.textFieldContentInsets)
@@ -154,6 +149,7 @@ private extension BlazeEditAdView {
             )
 
             Text(viewModel.descriptionFooterText)
+                .foregroundStyle(viewModel.descriptionRemainingLength >= 0 ? .secondary : Color(.error))
                 .footnoteStyle()
         }
     }

--- a/WooCommerce/Classes/ViewRelated/Blaze/BlazeEditAd/BlazeEditAdViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Blaze/BlazeEditAd/BlazeEditAdViewModel.swift
@@ -1,5 +1,4 @@
 import Foundation
-import Combine
 import struct Networking.BlazeAISuggestion
 
 /// View model for `BlazeEditAdView`
@@ -92,7 +91,6 @@ final class BlazeEditAdViewModel: ObservableObject {
 
     private let onSave: (BlazeEditAdData) -> Void
     private let analytics: Analytics
-    private var subscriptions: Set<AnyCancellable> = []
 
     init(siteID: Int64,
          adData: BlazeEditAdData,

--- a/WooCommerce/Classes/ViewRelated/Blaze/BlazeEditAd/BlazeEditAdViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Blaze/BlazeEditAd/BlazeEditAdViewModel.swift
@@ -18,7 +18,13 @@ final class BlazeEditAdViewModel: ObservableObject {
     // Tagline
     @Published var tagline: String = ""
     var taglineFooterText: String {
-        tagline.isEmpty ? Localization.taglineEmpty : taglineLengthLimitLabel
+        if tagline.isEmpty {
+            Localization.taglineEmpty
+        } else if tagline.count > Constants.taglineMaxLength {
+            String.localizedStringWithFormat(Localization.taglineLengthExceedsLimit, Constants.taglineMaxLength)
+        } else {
+            taglineLengthLimitLabel
+        }
     }
 
     var isTaglineValidated: Bool {
@@ -36,7 +42,13 @@ final class BlazeEditAdViewModel: ObservableObject {
     // Description
     @Published var description: String = ""
     var descriptionFooterText: String {
-        description.isEmpty ? Localization.descriptionEmpty : descriptionLengthLimitLabel
+        if description.isEmpty {
+            Localization.descriptionEmpty
+        } else if description.count > Constants.descriptionMaxLength {
+            String.localizedStringWithFormat(Localization.descriptionLengthExceedsLimit, Constants.descriptionMaxLength)
+        } else {
+            descriptionLengthLimitLabel
+        }
     }
 
     var isDescriptionValidated: Bool {
@@ -251,6 +263,16 @@ extension BlazeEditAdViewModel {
             "blazeEditAdViewModel.description.emptyError",
             value: "Description cannot be empty",
             comment: "Edit Blaze Ad screen: Error message if Description field is empty."
+        )
+        static let taglineLengthExceedsLimit = NSLocalizedString(
+            "blazeEditAdViewModel.tagline.lengthExceedsLimit",
+            value: "Tagline cannot exceed %1$d characters",
+            comment: "Edit Blaze Ad screen: Error message if Tagline exceeds the character limit."
+        )
+        static let descriptionLengthExceedsLimit = NSLocalizedString(
+            "blazeEditAdViewModel.description.lengthExceedsLimit",
+            value: "Description cannot exceed %1$d characters",
+            comment: "Edit Blaze Ad screen: Error message if Description exceeds the character limit."
         )
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Blaze/BlazeEditAd/BlazeEditAdViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Blaze/BlazeEditAd/BlazeEditAdViewModel.swift
@@ -22,7 +22,7 @@ final class BlazeEditAdViewModel: ObservableObject {
         taglineEmptyError ?? taglineLengthLimitLabel
     }
 
-    @Published private var taglineRemainingLength: Int
+    @Published private(set) var taglineRemainingLength: Int
     private var taglineLengthLimitLabel: String {
         let lengthText = String.pluralize(taglineRemainingLength,
                                           singular: Localization.LengthLimit.singular,
@@ -38,7 +38,7 @@ final class BlazeEditAdViewModel: ObservableObject {
         descriptionEmptyError ?? descriptionLengthLimitLabel
     }
 
-    @Published private var descriptionRemainingLength: Int
+    @Published private(set) var descriptionRemainingLength: Int
     private var descriptionLengthLimitLabel: String {
         let lengthText = String.pluralize(descriptionRemainingLength,
                                           singular: Localization.LengthLimit.singular,
@@ -49,7 +49,9 @@ final class BlazeEditAdViewModel: ObservableObject {
     @Published private var descriptionEmptyError: String?
 
     var isSaveButtonEnabled: Bool {
-        guard let editedAdData else {
+        guard let editedAdData,
+                taglineRemainingLength >= 0,
+                descriptionRemainingLength >= 0 else {
             return false
         }
 
@@ -188,11 +190,7 @@ extension BlazeEditAdViewModel {
     private func watchCharacterLimit() {
         $tagline
             .map { text -> Int in
-                if text.count >= Constants.taglineMaxLength {
-                    return 0
-                } else {
-                    return Constants.taglineMaxLength - text.count
-                }
+                Constants.taglineMaxLength - text.count
             }
             .assign(to: &$taglineRemainingLength)
 
@@ -204,11 +202,7 @@ extension BlazeEditAdViewModel {
 
         $description
             .map { text -> Int in
-                if text.count >= Constants.descriptionMaxLength {
-                    return 0
-                } else {
-                    return Constants.descriptionMaxLength - text.count
-                }
+                Constants.descriptionMaxLength - text.count
             }
             .assign(to: &$descriptionRemainingLength)
 
@@ -217,20 +211,6 @@ extension BlazeEditAdViewModel {
                 text.isEmpty ? Localization.descriptionEmpty : nil
             }
             .assign(to: &$descriptionEmptyError)
-    }
-
-    func formatTagline(_ newValue: String) -> String {
-        guard newValue.count > Constants.taglineMaxLength else {
-            return newValue
-        }
-        return String(newValue.prefix(Constants.taglineMaxLength))
-    }
-
-    func formatDescription(_ newValue: String) -> String {
-        guard newValue.count > Constants.descriptionMaxLength else {
-            return newValue
-        }
-        return String(newValue.prefix(Constants.descriptionMaxLength))
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Blaze/BlazeEditAd/BlazeEditAdViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Blaze/BlazeEditAd/BlazeEditAdViewModel.swift
@@ -19,7 +19,7 @@ final class BlazeEditAdViewModel: ObservableObject {
     // Tagline
     @Published var tagline: String = ""
     var taglineFooterText: String {
-        taglineEmptyError ?? taglineLengthLimitLabel
+        tagline.isEmpty ? Localization.taglineEmpty : taglineLengthLimitLabel
     }
 
     var isTaglineValidated: Bool {
@@ -34,12 +34,10 @@ final class BlazeEditAdViewModel: ObservableObject {
         return String(format: lengthText, taglineRemainingLength)
     }
 
-    @Published private var taglineEmptyError: String?
-
     // Description
     @Published var description: String = ""
     var descriptionFooterText: String {
-        descriptionEmptyError ?? descriptionLengthLimitLabel
+        description.isEmpty ? Localization.descriptionEmpty : descriptionLengthLimitLabel
     }
 
     var isDescriptionValidated: Bool {
@@ -53,8 +51,6 @@ final class BlazeEditAdViewModel: ObservableObject {
                                           plural: Localization.LengthLimit.plural)
         return String(format: lengthText, descriptionRemainingLength)
     }
-
-    @Published private var descriptionEmptyError: String?
 
     var isSaveButtonEnabled: Bool {
         guard let editedAdData,
@@ -202,23 +198,11 @@ extension BlazeEditAdViewModel {
             }
             .assign(to: &$taglineRemainingLength)
 
-        $tagline
-            .map { text -> String? in
-                text.isEmpty ? Localization.taglineEmpty : nil
-            }
-            .assign(to: &$taglineEmptyError)
-
         $description
             .map { text -> Int in
                 Constants.descriptionMaxLength - text.count
             }
             .assign(to: &$descriptionRemainingLength)
-
-        $description
-            .map { text -> String? in
-                text.isEmpty ? Localization.descriptionEmpty : nil
-            }
-            .assign(to: &$descriptionEmptyError)
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Blaze/BlazeEditAd/BlazeEditAdViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Blaze/BlazeEditAd/BlazeEditAdViewModel.swift
@@ -22,7 +22,11 @@ final class BlazeEditAdViewModel: ObservableObject {
         taglineEmptyError ?? taglineLengthLimitLabel
     }
 
-    @Published private(set) var taglineRemainingLength: Int
+    var isTaglineValidated: Bool {
+        tagline.isNotEmpty && tagline.count <= Constants.taglineMaxLength
+    }
+
+    @Published private var taglineRemainingLength: Int
     private var taglineLengthLimitLabel: String {
         let lengthText = String.pluralize(taglineRemainingLength,
                                           singular: Localization.LengthLimit.singular,
@@ -38,7 +42,11 @@ final class BlazeEditAdViewModel: ObservableObject {
         descriptionEmptyError ?? descriptionLengthLimitLabel
     }
 
-    @Published private(set) var descriptionRemainingLength: Int
+    var isDescriptionValidated: Bool {
+        description.isNotEmpty && description.count <= Constants.descriptionMaxLength
+    }
+
+    @Published private var descriptionRemainingLength: Int
     private var descriptionLengthLimitLabel: String {
         let lengthText = String.pluralize(descriptionRemainingLength,
                                           singular: Localization.LengthLimit.singular,

--- a/WooCommerce/WooCommerceTests/ViewRelated/Blaze/BlazeEditAdViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Blaze/BlazeEditAdViewModelTests.swift
@@ -72,6 +72,21 @@ final class BlazeEditAdViewModelTests: XCTestCase {
         XCTAssertEqual(sut.taglineFooterText, BlazeEditAdViewModel.Localization.taglineEmpty)
     }
 
+    func test_tagline_footer_text_shows_error_when_tagline_exceeds_limit() {
+        // Given
+        let sut = BlazeEditAdViewModel(siteID: 123,
+                                       adData: sampleAdData,
+                                       suggestions: [.fake()],
+                                       onSave: { _ in })
+
+        // When
+        sut.tagline = String(repeating: "a", count: BlazeEditAdViewModel.Constants.taglineMaxLength + 1)
+
+        // Then
+        let expectedMessage = String(format: BlazeEditAdViewModel.Localization.taglineLengthExceedsLimit, BlazeEditAdViewModel.Constants.taglineMaxLength)
+        XCTAssertEqual(sut.taglineFooterText, expectedMessage)
+    }
+
     // MARK: Description
 
     func test_description_footer_text_is_plural_when_multiple_characters_remaining() {
@@ -128,6 +143,24 @@ final class BlazeEditAdViewModelTests: XCTestCase {
 
         // Then
         XCTAssertEqual(sut.descriptionFooterText, BlazeEditAdViewModel.Localization.descriptionEmpty)
+    }
+
+    func test_description_footer_text_shows_error_when_description_exceeds_limit() {
+        // Given
+        let sut = BlazeEditAdViewModel(siteID: 123,
+                                       adData: sampleAdData,
+                                       suggestions: [.fake()],
+                                       onSave: { _ in })
+
+        // When
+        sut.description = String(repeating: "a", count: BlazeEditAdViewModel.Constants.descriptionMaxLength + 1)
+
+        // Then
+        let expectedMessage = String(
+            format: BlazeEditAdViewModel.Localization.descriptionLengthExceedsLimit,
+            BlazeEditAdViewModel.Constants.descriptionMaxLength
+        )
+        XCTAssertEqual(sut.descriptionFooterText, expectedMessage)
     }
 
     // MARK: Save button

--- a/WooCommerce/WooCommerceTests/ViewRelated/Blaze/BlazeEditAdViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Blaze/BlazeEditAdViewModelTests.swift
@@ -190,6 +190,34 @@ final class BlazeEditAdViewModelTests: XCTestCase {
         XCTAssertTrue(sut.isSaveButtonEnabled)
     }
 
+    func test_save_button_is_disabled_when_tagline_exceeds_character_limit() {
+        // Given
+        let sut = BlazeEditAdViewModel(siteID: 123,
+                                       adData: sampleAdData,
+                                       suggestions: [.fake()],
+                                       onSave: { _ in })
+
+        // When
+        sut.tagline = String(repeating: "a", count: BlazeEditAdViewModel.Constants.taglineMaxLength + 1)
+
+        // Then
+        XCTAssertFalse(sut.isSaveButtonEnabled)
+    }
+
+    func test_save_button_is_disabled_when_description_exceeds_character_limit() {
+        // Given
+        let sut = BlazeEditAdViewModel(siteID: 123,
+                                       adData: sampleAdData,
+                                       suggestions: [.fake()],
+                                       onSave: { _ in })
+
+        // When
+        sut.description = String(repeating: "a", count: BlazeEditAdViewModel.Constants.descriptionMaxLength + 1)
+
+        // Then
+        XCTAssertFalse(sut.isSaveButtonEnabled)
+    }
+
     // MARK: Can select previous suggestions
 
     func test_canSelectPreviousSuggestion_is_false_initially() {

--- a/WooCommerce/WooCommerceTests/ViewRelated/Blaze/BlazeEditAdViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Blaze/BlazeEditAdViewModelTests.swift
@@ -396,6 +396,60 @@ final class BlazeEditAdViewModelTests: XCTestCase {
         XCTAssertTrue(sut.canSelectPreviousSuggestion)
         XCTAssertTrue(sut.canSelectNextSuggestion)
     }
+
+    // MARK: - isTaglineValidated and isDescriptionValidated
+
+    func test_isTaglineValidated_is_updated_correctly_depending_on_tagline_length() {
+        // Given
+        let sut = BlazeEditAdViewModel(siteID: 123,
+                                       adData: sampleAdData,
+                                       suggestions: sampleAISuggestions,
+                                       onSave: { _ in })
+
+        // When
+        sut.tagline = ""
+
+        // Then
+        XCTAssertFalse(sut.isTaglineValidated)
+
+        // When
+        sut.tagline = String(repeating: "a", count: BlazeEditAdViewModel.Constants.taglineMaxLength)
+
+        // Then
+        XCTAssertTrue(sut.isTaglineValidated)
+
+        // When
+        sut.tagline = String(repeating: "a", count: BlazeEditAdViewModel.Constants.taglineMaxLength + 1)
+
+        // Then
+        XCTAssertFalse(sut.isTaglineValidated)
+    }
+
+    func test_isDescriptionValidated_is_updated_correctly_depending_on_description_length() {
+        // Given
+        let sut = BlazeEditAdViewModel(siteID: 123,
+                                       adData: sampleAdData,
+                                       suggestions: sampleAISuggestions,
+                                       onSave: { _ in })
+
+        // When
+        sut.description = ""
+
+        // Then
+        XCTAssertFalse(sut.isDescriptionValidated)
+
+        // When
+        sut.description = String(repeating: "a", count: BlazeEditAdViewModel.Constants.descriptionMaxLength)
+
+        // Then
+        XCTAssertTrue(sut.isDescriptionValidated)
+
+        // When
+        sut.description = String(repeating: "a", count: BlazeEditAdViewModel.Constants.descriptionMaxLength + 1)
+
+        // Then
+        XCTAssertFalse(sut.isDescriptionValidated)
+    }
 }
 
 private extension BlazeEditAdViewModelTests {


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #11780 
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
In SwiftUI, if we try to change a view's state just before it's about to change, we get the warning "Publishing changes from within view updates is not allowed".

In `BlazeEditAdViewModel`, we violated this in two places:
- We observe `tagline` to change `taglineRemainingLength` immediately. Please note, we get a signal for change of `tagline` just before the value is changed. When we change `taglineRemainingLength` in `sink`, we are triggering an update to the SwiftUI view that listens to the property, before the the view even updates following the change to `tagline`.
- On `BlazeEditAdView`, we observe `tagline` with `onChange` and trigger the update to the value if the text exceeds the character limit. This again triggers state change even before the view is updated for `tagline`.


Solution:
- Updated `taglineRemainingLength` and `taglineEmptyError` using `map` instead of `sink` when observing `tagline`. 
- Added a similar fix for `descriptionRemainingLength` and `descriptionEmptyError`.
- Removed the forced formatting of tagline and description. Instead, we should let the user continue typing, while displaying the character count in red to signal an error.


## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
- Build the app and log in to a store eligible for Blaze.
- Select Promote in the Blaze secion on the Dashboard screen.
- Select Edit Ad to change the content.
- Type in the tagline and description fields until you exceed the character limits. Confirm the following:
  - The text should be displayed as is
  - The character count should be red when the text length exceeds the limit.
  - No warnings on Xcode regarding `Publishing changes from within view updates is not allowed`.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

https://github.com/woocommerce/woocommerce-ios/assets/5533851/071cb827-f5b7-49d5-ae18-32c664367dde



---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
