### PR TITLE
Blaze: Show alert when attempting to start campaign creation without any published product

### DIFF
--- a/WooCommerce/Classes/Analytics/WooAnalyticsEvent+ProductCreation.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsEvent+ProductCreation.swift
@@ -41,6 +41,8 @@ extension AddProductCoordinator.Source {
                 return "store_onboarding"
             case .productDescriptionAIAnnouncementModal:
                 return "product_description_ai_announcement"
+            case .blazeCampaignCreation:
+                return "blaze_campaign_creation"
         }
     }
 }

--- a/WooCommerce/Classes/Blaze/BlazeCampaignCreationCoordinator.swift
+++ b/WooCommerce/Classes/Blaze/BlazeCampaignCreationCoordinator.swift
@@ -69,7 +69,7 @@ final class BlazeCampaignCreationCoordinator: Coordinator {
         case .webViewForm(let productID):
             navigateToWebCampaignCreation(source: source, productID: productID)
         case .noProductAvailable:
-            break // TODO 11685: add error alert.
+            presentNoProductAlert()
         }
     }
 }
@@ -183,6 +183,21 @@ private extension BlazeCampaignCreationCoordinator {
         blazeNavigationController.viewControllers = [controller]
         navigationController.present(blazeNavigationController, animated: true, completion: nil)
     }
+
+    func presentNoProductAlert() {
+        let alert = UIAlertController(title: Localization.NoProductAlert.title,
+                                      message: Localization.NoProductAlert.message,
+                                      preferredStyle: .alert)
+        let createAction = UIAlertAction(title: Localization.NoProductAlert.createProduct, style: .default) { _ in
+            // TODO: start product creation
+        }
+        let cancelAction = UIAlertAction(title: Localization.NoProductAlert.cancel, style: .cancel)
+        alert.addAction(createAction)
+        alert.addAction(cancelAction)
+        navigationController.dismiss(animated: true) { [weak self] in
+            self?.navigationController.present(alert, animated: true)
+        }
+    }
 }
 
 // MARK: - Completion handler
@@ -255,5 +270,27 @@ private extension BlazeCampaignCreationCoordinator {
             value: "Done",
             comment: "Button to dismiss the celebration view when a Blaze campaign is successfully created."
         )
+        enum NoProductAlert {
+            static let title = NSLocalizedString(
+                "blazeCampaignCreationCoordinator.NoProductAlert.title",
+                value: "No product found",
+                comment: "Title of the alert when attempting to start Blaze campaign creation flow without any product in the store"
+            )
+            static let message = NSLocalizedString(
+                "blazeCampaignCreationCoordinator.NoProductAlert.message",
+                value: "You currently don’t have a product available for promotion. Would you like to create a product now?",
+                comment: "Message of the alert when attempting to start Blaze campaign creation flow without any product in the store"
+            )
+            static let cancel = NSLocalizedString(
+                "blazeCampaignCreationCoordinator.NoProductAlert.cancel",
+                value: "Cancel",
+                comment: "Button to dismiss the alert when attempting to start Blaze campaign creation flow without any product in the store"
+            )
+            static let createProduct = NSLocalizedString(
+                "blazeCampaignCreationCoordinator.NoProductAlert.createProduct",
+                value: "Create Product",
+                comment: "Button to create a product when attempting to start Blaze campaign creation flow without any product in the store"
+            )
+        }
     }
 }

--- a/WooCommerce/Classes/Blaze/BlazeCampaignCreationCoordinator.swift
+++ b/WooCommerce/Classes/Blaze/BlazeCampaignCreationCoordinator.swift
@@ -206,7 +206,7 @@ private extension BlazeCampaignCreationCoordinator {
                                                 sourceView: nil,
                                                 sourceNavigationController: navigationController,
                                                 isFirstProduct: true)
-        self.addProductCoordinator = coordinator
+        addProductCoordinator = coordinator
         coordinator.start()
     }
 }

--- a/WooCommerce/Classes/Blaze/BlazeCampaignCreationCoordinator.swift
+++ b/WooCommerce/Classes/Blaze/BlazeCampaignCreationCoordinator.swift
@@ -37,6 +37,7 @@ final class BlazeCampaignCreationCoordinator: Coordinator {
     private let onCampaignCreated: () -> Void
 
     private var bottomSheetPresenter: BottomSheetPresenter?
+    private var addProductCoordinator: AddProductCoordinator?
 
     init(siteID: Int64,
          siteURL: String,
@@ -188,8 +189,8 @@ private extension BlazeCampaignCreationCoordinator {
         let alert = UIAlertController(title: Localization.NoProductAlert.title,
                                       message: Localization.NoProductAlert.message,
                                       preferredStyle: .alert)
-        let createAction = UIAlertAction(title: Localization.NoProductAlert.createProduct, style: .default) { _ in
-            // TODO: start product creation
+        let createAction = UIAlertAction(title: Localization.NoProductAlert.createProduct, style: .default) { [weak self] _ in
+            self?.startProductCreation()
         }
         let cancelAction = UIAlertAction(title: Localization.NoProductAlert.cancel, style: .cancel)
         alert.addAction(createAction)
@@ -197,6 +198,16 @@ private extension BlazeCampaignCreationCoordinator {
         navigationController.dismiss(animated: true) { [weak self] in
             self?.navigationController.present(alert, animated: true)
         }
+    }
+
+    func startProductCreation() {
+        let coordinator = AddProductCoordinator(siteID: siteID,
+                                                source: .blazeCampaignCreation,
+                                                sourceView: nil,
+                                                sourceNavigationController: navigationController,
+                                                isFirstProduct: true)
+        self.addProductCoordinator = coordinator
+        coordinator.start()
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Blaze/CampaignCreation/BlazeCampaignCreationFormViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Blaze/CampaignCreation/BlazeCampaignCreationFormViewModel.swift
@@ -111,7 +111,7 @@ final class BlazeCampaignCreationFormViewModel: ObservableObject {
             self?.completionHandler()
         })
     }()
-    
+
     var adDestinationViewModel: BlazeAdDestinationSettingViewModel? {
         // Only create viewModel (and thus show the ad destination setting) if these two URLs exist.
         guard let productURL, let siteURL else {

--- a/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductCoordinator.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductCoordinator.swift
@@ -19,6 +19,8 @@ final class AddProductCoordinator: Coordinator {
         case storeOnboarding
         /// Initiated from the product description AI announcement modal in the dashboard.
         case productDescriptionAIAnnouncementModal
+        /// Initiated from the campaign creation entry point when there is no product in the store.
+        case blazeCampaignCreation
     }
 
     let navigationController: UINavigationController

--- a/WooCommerce/WooCommerceTests/ViewRelated/Blaze/BlazeCampaignCreationCoordinatorTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Blaze/BlazeCampaignCreationCoordinatorTests.swift
@@ -127,6 +127,30 @@ final class BlazeCampaignCreationCoordinatorTests: XCTestCase {
         let viewController = try XCTUnwrap(presentedNavigationController.viewControllers.first)
         XCTAssertTrue(viewController is ProductSelectorViewController)
     }
+
+    func test_error_alert_is_displayed_if_i3_feature_flag_is_enabled_and_no_published_product_is_found() throws {
+        // Given
+        let featureFlagService = MockFeatureFlagService(blazei3NativeCampaignCreation: true)
+        insertProduct(.fake().copy(siteID: 1,
+                                   productID: 1,
+                                   statusKey: (ProductStatus.draft.rawValue)))
+
+        let sut = BlazeCampaignCreationCoordinator(siteID: 1,
+                                                   siteURL: "https://woo.com/",
+                                                   source: .campaignList,
+                                                   storageManager: storageManager,
+                                                   featureFlagService: featureFlagService,
+                                                   navigationController: navigationController,
+                                                   onCampaignCreated: { }
+        )
+
+        // When
+        sut.start()
+
+        // Then
+        let presentedController = try XCTUnwrap(sut.navigationController.presentedViewController)
+        XCTAssertTrue(presentedController is UIAlertController)
+    }
 }
 
 private extension BlazeCampaignCreationCoordinatorTests {

--- a/Yosemite/YosemiteTests/Mocks/Networking/Remote/MockBlazeRemote.swift
+++ b/Yosemite/YosemiteTests/Mocks/Networking/Remote/MockBlazeRemote.swift
@@ -52,7 +52,7 @@ final class MockBlazeRemote {
 }
 
 extension MockBlazeRemote: BlazeRemoteProtocol {
-    
+
     func createCampaign(_ campaign: CreateBlazeCampaign,
                         siteID: Int64) async throws {
         guard let result = creatingCampaignResult else {


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #11685 
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
As the title suggests, this PR updates the `BlazeCampaignCreationCoordinator` to present an alert when no published product is found in the store.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
- Log in to a store eligible for Blaze but without any published products.
- Switch to the Menu tab and select Blaze.
- Select Create campaign, notice that an alert is popped up suggesting to create a product.
- Tap Create product, the product creation flow should be presented.
- Tap Cancel, the alert should be dismissed and nothing else happens.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->
<img src="https://github.com/woocommerce/woocommerce-ios/assets/5533851/3bd3a337-105b-4701-a036-38f7cad8e009" width=320 />


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
