### PR TITLE
[Tablet Orders] Use grouped bg configuration in iOS15

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Orders/Cells/OrderTableViewCell.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Cells/OrderTableViewCell.swift
@@ -105,7 +105,7 @@ final class OrderTableViewCell: UITableViewCell & SearchResultCell {
         if #available(iOS 16.0, *) {
             backgroundConfiguration = defaultBackgroundConfiguration().updated(for: state)
         } else {
-            backgroundConfiguration = UIBackgroundConfiguration.listPlainCell().updated(for: state)
+            backgroundConfiguration = UIBackgroundConfiguration.listGroupedCell().updated(for: state)
         }
 
         if state.isSelected || state.isHighlighted {


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #11768
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

The OrderList is a grouped table; using a `listPlainCell` configuration resulted in incorrect selection/highlight/normal state colours. This meant it was difficult to discerning which order was selected when shown in a splitview. This was particularly an issue in dark mode.

Using the correct configuration initialiser for the table resolves the issue.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

1. Launch the app on an iOS 15 iPad or large iPhone, using dark mode
2. Navigate to the `Orders` tab
3. Select an order in the list
4. Observe that the selected row is highlighted, and the unselected rows match the table view cells in the Order Details pane.

Repeat the test in light mode

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

https://github.com/woocommerce/woocommerce-ios/assets/2472348/3bf7e55a-9cdb-4a0a-aab9-4ffa376193c5




---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
