### PR TITLE
[Tablet Orders] Remove shimmering effect from `NewTaxRateSelectorView`

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/Taxes/NewTaxRateSelectorView.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/Taxes/NewTaxRateSelectorView.swift
@@ -98,7 +98,6 @@ struct NewTaxRateSelectorView: View {
                                 ForEach(viewModel.placeholderRowViewModels, id: \.id) { rowViewModel in
                                     TaxRateRow(viewModel: rowViewModel, onSelect: {})
                                         .redacted(reason: .placeholder)
-                                        .shimmering()
                                 }
                             }
                         }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #11764 

## Description
This PR addresses the odd effect caused by shimmering in the `NewTaxRateSelectorView` view by removing it.

![Simulator Screen Recording - iPad Pro (12 9-inch) (6th generation) - 2024-01-23 at 15 37 33](https://github.com/woocommerce/woocommerce-ios/assets/3812076/86a8e268-e073-4192-9c4a-d9e28affb4a2)


## Testing instructions
1. Go to Orders > Add a product (or more) to your order
2. Tap on "Set new tax rate"
3. Observe that the view doesn't behave like in the video

