### PR TITLE
[Blaze] Stop showing Blaze in dashboard when site not eligible

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -2,8 +2,7 @@
 
 17.1
 -----
-- [*] Blaze: Stop showing Blaze in dashboard when site not eligible. [https://github.com/woocommerce/woocommerce-ios/pull/11797]
-
+- [*] Blaze: Hide the Blaze section on the Dashboard screen when logged in without WPCom. [https://github.com/woocommerce/woocommerce-ios/pull/11797]
 
 17.0
 -----

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -2,6 +2,7 @@
 
 17.1
 -----
+- [*] Blaze: Stop showing Blaze in dashboard when site not eligible. [https://github.com/woocommerce/woocommerce-ios/pull/11797]
 
 
 17.0

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Blaze/BlazeCampaignDashboardViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Blaze/BlazeCampaignDashboardViewModel.swift
@@ -49,8 +49,10 @@ final class BlazeCampaignDashboardViewModel: ObservableObject {
     private let stores: StoresManager
     private let storageManager: StorageManagerType
     private let analytics: Analytics
-    private let blazeEligibilityChecker: BlazeEligibilityCheckerProtocol
     private let userDefaults: UserDefaults
+
+    private var isSiteEligibleForBlaze = false
+    private let blazeEligibilityChecker: BlazeEligibilityCheckerProtocol
 
     /// Blaze campaign ResultsController.
     private lazy var blazeCampaignResultsController: ResultsController<StorageBlazeCampaign> = {
@@ -102,8 +104,10 @@ final class BlazeCampaignDashboardViewModel: ObservableObject {
     @MainActor
     func reload() async {
         update(state: .loading)
+        isSiteEligibleForBlaze = await blazeEligibilityChecker.isSiteEligible()
+
         guard !userDefaults.hasDismissedBlazeSectionOnMyStore(for: siteID),
-              await blazeEligibilityChecker.isSiteEligible() else {
+              isSiteEligibleForBlaze else {
             update(state: .empty)
             return
         }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Blaze/BlazeCampaignDashboardViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Blaze/BlazeCampaignDashboardViewModel.swift
@@ -212,6 +212,10 @@ private extension BlazeCampaignDashboardViewModel {
     }
 
     func updateResults() {
+        guard isSiteEligibleForBlaze else {
+            return update(state: .empty)
+        }
+
         if let campaign = blazeCampaignResultsController.fetchedObjects.first {
             update(state: .showCampaign(campaign: campaign))
         } else if let product = latestPublishedProduct {

--- a/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Blaze/BlazeCampaignDashboardViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Blaze/BlazeCampaignDashboardViewModelTests.swift
@@ -103,6 +103,28 @@ final class BlazeCampaignDashboardViewModelTests: XCTestCase {
         XCTAssertFalse(sut.shouldShowInDashboard)
     }
 
+    func test_it_hides_from_dashboard_if_a_product_gets_published_while_site_not_eligible_for_blaze() async {
+        // Given
+        let checker = MockBlazeEligibilityChecker(isSiteEligible: false)
+        let sut = BlazeCampaignDashboardViewModel(siteID: sampleSiteID,
+                                                  stores: stores,
+                                                  storageManager: storageManager,
+                                                  blazeEligibilityChecker: checker)
+
+        mockSynchronizeProducts()
+
+        mockSynchronizeCampaigns()
+
+        // When
+        await sut.reload()
+
+        insertProduct(.fake().copy(siteID: sampleSiteID,
+                                   statusKey: (ProductStatus.published.rawValue)))
+
+        // Then
+        XCTAssertFalse(sut.shouldShowInDashboard)
+    }
+
     // MARK: Blaze campaigns
 
     func test_it_shows_in_dashboard_if_blaze_campaign_available() async {

--- a/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Blaze/BlazeCampaignDashboardViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Blaze/BlazeCampaignDashboardViewModelTests.swift
@@ -618,7 +618,11 @@ final class BlazeCampaignDashboardViewModelTests: XCTestCase {
     func test_checkIfIntroViewIsNeeded_sets_shouldShowIntroView_to_false_if_there_exists_at_least_one_campaign() {
         // Given
         let campaign = BlazeCampaign.fake().copy(siteID: sampleSiteID)
-        let viewModel = BlazeCampaignDashboardViewModel(siteID: sampleSiteID, storageManager: storageManager)
+        let checker = MockBlazeEligibilityChecker(isSiteEligible: true)
+        let viewModel = BlazeCampaignDashboardViewModel(siteID: sampleSiteID,
+                                                        stores: stores,
+                                                        storageManager: storageManager,
+                                                        blazeEligibilityChecker: checker)
 
         // Confidence check
         XCTAssertFalse(viewModel.shouldShowIntroView)
@@ -633,8 +637,11 @@ final class BlazeCampaignDashboardViewModelTests: XCTestCase {
 
     func test_checkIfIntroViewIsNeeded_sets_shouldShowIntroView_to_true_if_there_is_no_existing_campaign() {
         // Given
-        let viewModel = BlazeCampaignDashboardViewModel(siteID: sampleSiteID, storageManager: storageManager)
-
+        let checker = MockBlazeEligibilityChecker(isSiteEligible: true)
+        let viewModel = BlazeCampaignDashboardViewModel(siteID: sampleSiteID,
+                                                        stores: stores,
+                                                        storageManager: storageManager,
+                                                        blazeEligibilityChecker: checker)
         // Confidence check
         XCTAssertFalse(viewModel.shouldShowIntroView)
 
@@ -662,8 +669,11 @@ final class BlazeCampaignDashboardViewModelTests: XCTestCase {
                                           statusKey: (ProductStatus.published.rawValue),
                                           purchasable: true))
 
-        let viewModel = BlazeCampaignDashboardViewModel(siteID: sampleSiteID, storageManager: storageManager)
-
+        let checker = MockBlazeEligibilityChecker(isSiteEligible: true)
+        let viewModel = BlazeCampaignDashboardViewModel(siteID: sampleSiteID,
+                                                        stores: stores,
+                                                        storageManager: storageManager,
+                                                        blazeEligibilityChecker: checker)
         // Then
         let product = try XCTUnwrap(viewModel.latestPublishedProduct)
         XCTAssertEqual(product.productID, 3)
@@ -676,8 +686,11 @@ final class BlazeCampaignDashboardViewModelTests: XCTestCase {
                                           statusKey: (ProductStatus.draft.rawValue),
                                           purchasable: true))
 
-        let viewModel = BlazeCampaignDashboardViewModel(siteID: sampleSiteID, storageManager: storageManager)
-
+        let checker = MockBlazeEligibilityChecker(isSiteEligible: true)
+        let viewModel = BlazeCampaignDashboardViewModel(siteID: sampleSiteID,
+                                                        stores: stores,
+                                                        storageManager: storageManager,
+                                                        blazeEligibilityChecker: checker)
         // Then
         XCTAssertNil(viewModel.latestPublishedProduct)
     }
@@ -688,8 +701,12 @@ final class BlazeCampaignDashboardViewModelTests: XCTestCase {
         // Given
         let testURL = "https://example.com"
         let campaign = BlazeCampaign.fake().copy(siteID: sampleSiteID, campaignID: 123)
-        let viewModel = BlazeCampaignDashboardViewModel(siteID: sampleSiteID, siteURL: testURL)
-
+        let checker = MockBlazeEligibilityChecker(isSiteEligible: true)
+        let viewModel = BlazeCampaignDashboardViewModel(siteID: sampleSiteID,
+                                                        siteURL: testURL,
+                                                        stores: stores,
+                                                        storageManager: storageManager,
+                                                        blazeEligibilityChecker: checker)
         // Confidence check
         XCTAssertNil(viewModel.selectedCampaignURL)
 
@@ -704,7 +721,12 @@ final class BlazeCampaignDashboardViewModelTests: XCTestCase {
 
     func test_blazeEntryPointDisplayed_is_tracked_when_shouldShowIntroView_is_set_to_true() throws {
         // Given
-        let viewModel = BlazeCampaignDashboardViewModel(siteID: sampleSiteID, analytics: analytics)
+        let checker = MockBlazeEligibilityChecker(isSiteEligible: true)
+        let viewModel = BlazeCampaignDashboardViewModel(siteID: sampleSiteID,
+                                                        stores: stores,
+                                                        storageManager: storageManager,
+                                                        analytics: analytics,
+                                                        blazeEligibilityChecker: checker)
 
         // When
         viewModel.shouldShowIntroView = true
@@ -718,7 +740,12 @@ final class BlazeCampaignDashboardViewModelTests: XCTestCase {
 
     func test_didSelectCampaignList_tracks_blazeCampaignListEntryPointSelected_with_the_correct_source() throws {
         // Given
-        let viewModel = BlazeCampaignDashboardViewModel(siteID: sampleSiteID, analytics: analytics)
+        let checker = MockBlazeEligibilityChecker(isSiteEligible: true)
+        let viewModel = BlazeCampaignDashboardViewModel(siteID: sampleSiteID,
+                                                        stores: stores,
+                                                        storageManager: storageManager,
+                                                        analytics: analytics,
+                                                        blazeEligibilityChecker: checker)
 
         // When
         viewModel.didSelectCampaignList()
@@ -732,7 +759,12 @@ final class BlazeCampaignDashboardViewModelTests: XCTestCase {
 
     func test_didSelectCampaignDetails_tracks_blazeCampaignDetailSelected_with_the_correct_source() throws {
         // Given
-        let viewModel = BlazeCampaignDashboardViewModel(siteID: sampleSiteID, analytics: analytics)
+        let checker = MockBlazeEligibilityChecker(isSiteEligible: true)
+        let viewModel = BlazeCampaignDashboardViewModel(siteID: sampleSiteID,
+                                                        stores: stores,
+                                                        storageManager: storageManager,
+                                                        analytics: analytics,
+                                                        blazeEligibilityChecker: checker)
 
         // When
         viewModel.didSelectCampaignDetails(.fake())
@@ -746,7 +778,12 @@ final class BlazeCampaignDashboardViewModelTests: XCTestCase {
 
     func test_didSelectCreateCampaign_tracks_blazeEntryPointTapped() throws {
         // Given
-        let viewModel = BlazeCampaignDashboardViewModel(siteID: sampleSiteID, analytics: analytics)
+        let checker = MockBlazeEligibilityChecker(isSiteEligible: true)
+        let viewModel = BlazeCampaignDashboardViewModel(siteID: sampleSiteID,
+                                                        stores: stores,
+                                                        storageManager: storageManager,
+                                                        analytics: analytics,
+                                                        blazeEligibilityChecker: checker)
 
         // When
         viewModel.didSelectCreateCampaign(source: .introView)

--- a/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Blaze/BlazeCampaignDashboardViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Blaze/BlazeCampaignDashboardViewModelTests.swift
@@ -2,6 +2,7 @@ import Foundation
 import XCTest
 import Yosemite
 import protocol Storage.StorageType
+import WordPressAuthenticator
 
 @testable import WooCommerce
 
@@ -26,6 +27,7 @@ final class BlazeCampaignDashboardViewModelTests: XCTestCase {
 
     override func setUp() {
         super.setUp()
+        WordPressAuthenticator.initializeAuthenticator()
         stores = MockStoresManager(sessionManager: .testingInstance)
         storageManager = MockStorageManager()
         analyticsProvider = MockAnalyticsProvider()

--- a/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Blaze/BlazeCampaignDashboardViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Blaze/BlazeCampaignDashboardViewModelTests.swift
@@ -44,7 +44,7 @@ final class BlazeCampaignDashboardViewModelTests: XCTestCase {
 
     // MARK: `shouldShowInDashboard`
 
-    func test_shouldShowInDashboard_is_true_by_default() async {
+    func test_shouldShowInDashboard_is_false_by_default() async {
         // Given
         let checker = MockBlazeEligibilityChecker(isSiteEligible: true)
         insertProduct(.fake().copy(siteID: sampleSiteID,
@@ -57,7 +57,7 @@ final class BlazeCampaignDashboardViewModelTests: XCTestCase {
                                                   blazeEligibilityChecker: checker)
 
         // Then
-        XCTAssertTrue(sut.shouldShowInDashboard)
+        XCTAssertFalse(sut.shouldShowInDashboard)
     }
 
     // MARK: Blaze eligibility


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #11782
<!-- Id number of the GitHub issue this PR addresses. -->

## Description

Fix a bug in which we displayed the Blaze view in the My Store tab (Dashboard) even though the current user is not eligible for Blaze. 

I added code to store the blaze eligibility check value and use the results from the storage layer only if the blaze eligibility check value is `true`. 

## Testing instructions
- Create a JN site with Woo but no Jetpack.
- Log in to the app using site credentials or application password.
- Switch to the Products tab, create a new product, and publish it.
- Switch to the My Store tab (Dashboard) and validate that the Blaze section is not displayed.
- Pull to refresh the dashboard and validate that the Blaze section is not displayed.

## Screenshots

https://github.com/woocommerce/woocommerce-ios/assets/524475/5db6dc7f-0476-4e03-bc4a-5b383c5d0c86



---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
