### PR TITLE
Fix issue parsing system status report

### DIFF
--- a/Networking/Networking/Model/SystemStatusDetails/SystemStatus+Theme.swift
+++ b/Networking/Networking/Model/SystemStatusDetails/SystemStatus+Theme.swift
@@ -4,15 +4,14 @@ public extension SystemStatus {
     /// Details about a store's theme in its system status report.
     ///
     struct Theme: Decodable {
-        public let name, version, versionLatest: String
+        public let name, version: String
         public let authorURL: String
         public let isChildTheme, hasWoocommerceSupport, hasWoocommerceFile, hasOutdatedTemplates: Bool
         public let overrides: [[String: String]]
-        public let parentName, parentVersion, parentVersionLatest, parentAuthorURL: String
+        public let parentName, parentVersion, parentAuthorURL: String
 
         enum CodingKeys: String, CodingKey {
             case name, version
-            case versionLatest = "version_latest"
             case authorURL = "author_url"
             case isChildTheme = "is_child_theme"
             case hasWoocommerceSupport = "has_woocommerce_support"
@@ -21,7 +20,6 @@ public extension SystemStatus {
             case overrides
             case parentName = "parent_name"
             case parentVersion = "parent_version"
-            case parentVersionLatest = "parent_version_latest"
             case parentAuthorURL = "parent_author_url"
         }
     }

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -2,6 +2,7 @@
 
 17.1
 -----
+- [*] Fixed issue loading system status report for sites using faulty themes. [https://github.com/woocommerce/woocommerce-ios/pull/11798]
 
 
 17.0


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #11757 
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This PR fixes error parsing system status report when a site installs a theme with no information about latest version. This happened when I installed [Maywood](https://wordpress.com/theme/maywood) theme to my test store.

The fix is to remove the properties `versionLatest` and `parentVersionLatest` from the `Theme` struct to stop parsing these fields. These are not used in the report so this is the simplest solution.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
- Install [Maywood](https://wordpress.com/theme/maywood) theme to your test store or use my test store Good Mood Bistro if you have access to it.
- Log in to the store on the app and navigate to Menu > Settings > Help & Support > System Status Report.
- Confirm that the report can be loaded successfully.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->
N/A

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
