### PR TITLE
[Tablet orders] Fix deep-linked order overridden by the auto-selected first order

### DIFF
--- a/WooCommerce/Classes/ViewRelated/MainTabBarController.swift
+++ b/WooCommerce/Classes/ViewRelated/MainTabBarController.swift
@@ -586,7 +586,7 @@ private extension MainTabBarController {
         if isOrdersSplitViewFeatureFlagOn {
             return OrdersSplitViewWrapperController(siteID: siteID)
         } else {
-            return OrdersRootViewController(siteID: siteID)
+            return OrdersRootViewController(siteID: siteID, switchDetailsHandler: { _, _, _, _ in })
         }
     }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/OrderListViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrderListViewController.swift
@@ -550,11 +550,15 @@ private extension OrderListViewController {
         switchDetailsHandler([orderDetailsViewModel], 0, false) { [weak self] hasBeenSelected in
             guard let self else { return }
             if hasBeenSelected {
-                selectedOrderID = orderDetailsViewModel.order.orderID
-                selectedIndexPath = indexPath(for: orderDetailsViewModel.order.orderID)
-                highlightSelectedRowIfNeeded()
+                onOrderSelected(id: orderDetailsViewModel.order.orderID)
             }
         }
+    }
+
+    func onOrderSelected(id orderID: Int64) {
+        selectedOrderID = orderID
+        selectedIndexPath = indexPath(for: orderID)
+        highlightSelectedRowIfNeeded()
     }
 
     func indexPath(for orderID: Int64) -> IndexPath? {
@@ -590,6 +594,16 @@ extension OrderListViewController {
             }
         }
         return false
+    }
+
+    func showOrderDetails(_ order: Order, onCompletion: ((Bool) -> Void)? = nil) {
+        let viewModel = OrderDetailsViewModel(order: order)
+        switchDetailsHandler([viewModel], 0, true) { [weak self] hasBeenSelected in
+            guard let self else { return }
+            if hasBeenSelected {
+                onOrderSelected(id: order.orderID)
+            }
+        }
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/OrderListViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrderListViewController.swift
@@ -575,10 +575,6 @@ extension OrderListViewController {
     /// - Parameter orderID: ID of the order to select in the list.
     /// - Returns: Whether the order to select is in the list already (i.e. the order has been fetched and exists locally).
     func selectOrderFromListIfPossible(for orderID: Int64) -> Bool {
-        // check if already selected
-        guard selectedOrderID != orderID else {
-            return true
-        }
         for identifier in dataSource.snapshot().itemIdentifiers {
             if let detailsViewModel = viewModel.detailsViewModel(withID: identifier),
                detailsViewModel.order.orderID == orderID {

--- a/WooCommerce/Classes/ViewRelated/Orders/OrdersRootViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrdersRootViewController.swift
@@ -540,7 +540,5 @@ private extension OrdersRootViewController {
             "Retrieves a list of orders that contain a given keyword.",
             comment: "VoiceOver accessibility hint, informing the user the button can be used to search orders."
         )
-        static let emptyOrderDetails = NSLocalizedString("No order selected",
-                                                         comment: "Message on the detail view of the Orders tab before any order is selected")
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Orders/OrdersRootViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrdersRootViewController.swift
@@ -508,7 +508,7 @@ private extension OrdersRootViewController {
         analytics.track(event: WooAnalyticsEvent.Orders.orderOpen(order: order))
         let viewModel = OrderDetailsViewModel(order: order)
         guard !featureFlagService.isFeatureFlagEnabled(.splitViewInOrdersTab) else {
-            return switchDetailsHandler([viewModel], 0, true, onCompletion)
+            return ordersViewController.showOrderDetails(order)
         }
 
         let orderViewController = OrderDetailsViewController(viewModel: viewModel)

--- a/WooCommerce/Classes/ViewRelated/Orders/OrdersSplitViewWrapperController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrdersSplitViewWrapperController.swift
@@ -66,7 +66,7 @@ private extension OrdersSplitViewWrapperController {
     }
 
     func isShowingEmptyView() -> Bool {
-        splitViewController?.viewController(for: .secondary) is EmptyStateViewController
+        ordersSplitViewController.viewController(for: .secondary) is EmptyStateViewController
     }
 
     func showSecondaryView(_ viewController: UIViewController) {

--- a/WooCommerce/Classes/ViewRelated/Orders/OrdersSplitViewWrapperController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrdersSplitViewWrapperController.swift
@@ -64,11 +64,13 @@ private extension OrdersSplitViewWrapperController {
             image: .emptySearchResultsImage
         )
         emptyStateViewController.configure(config)
-        showSecondaryView(emptyStateViewController)
+        let navigationController = WooNavigationController(rootViewController: emptyStateViewController)
+        showSecondaryView(navigationController)
     }
 
     func isShowingEmptyView() -> Bool {
-        ordersSplitViewController.viewController(for: .secondary) is EmptyStateViewController
+        (ordersSplitViewController.viewController(for: .secondary) as? UINavigationController)?
+            .viewControllers.contains(where: { $0 is EmptyStateViewController }) == true
     }
 
     func showSecondaryView(_ viewController: UIViewController) {


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #11674
Closes: #11795

<!-- Id number of the GitHub issue this PR addresses. -->

## Why

In the split view implementation, there's an auto-selection behavior where the first order is auto-selected in `viewDidLayoutSubviews` when the split view collapsed state is known. However, when a deep-linked order is also being shown while the orders tab is being shown for the first time (e.g. previously logged in to a different store), the auto-selected first order can override the deep-linked order so that the linked order is never shown. This PR fixes this race condition by only showing the auto-selected order if the secondary view is showing the empty view. If a non-empty view is being shown in the secondary view, I don't think we need to auto-select the first order but please lemme know if I missed anything.

## How

To fix the issue, the `switchDetailsHandler` callback was updated to include two info:

- `isSelectedManually`: whether the order details are selected manually (so that it's `false` for auto-selection in `viewDidLayoutSubviews`). When `isSelectedManually` is `true`, order details are always shown. But when `isSelectedManually` is `false`, it might not be shown depending on the secondary view state
- In `onCompletion`, a boolean was added that indicates if the selection is successful. This addition is for `OrderListViewController`'s `selectedIndexPath` and `selectedOrderID` to be set only if the order details presentation is successful 

Then, all the logic that shows the secondary view was moved to `OrdersSplitViewWrapperController` so that we can consolidate the secondary view presentation logic in one place. This includes `switchDetailsHandler`, which now skips order details presentation if `isSelectedManually` is `false` and the secondary view is not the empty view.

`OrderListViewController.highlightSelectedRowIfNeeded` was also updated to highlight the row based on the selected order instead of the index path state because the index path can get outdated.

🗒️ I've been struggling with fixes in the order split view - making one change breaks some other scenario 😓 . In a split view where the primary is a list and the secondary view is based on the selected row, the selected item & index path states in `OrderListViewController` can get out of sync from the secondary view like when the user navigates back from the order details in collapsed mode. The selected index path can also get outdated like when some orders are loaded individually, and the data source changes. I was inclined to remove `OrderListViewController.selectedIndexPath` but the changes would be out of scope and I'm sure something will break. We can consider a different approach when we implement split view for the products tab like with a source of truth of the secondary view state that works for both expanded and collapsed states.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

Prerequisite: the account is connected to more than one store

- Launch the app in the multi-column state in a wide device
- Prepare an order link in a separate app
- Switch to a different store from the store ID in the link
- Tap on an order universal link --> the order in the link should be shown. before this PR, the first order of the store is shown instead of the order ID in the link

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->


https://github.com/woocommerce/woocommerce-ios/assets/1945542/0ed7a942-4aec-438b-bd21-5b6a06cacc5f



---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
