### PR TITLE
[Order List] Use chevron.forward for custom disclosure for RTL languages

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Orders/Cells/OrderListCellViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Cells/OrderListCellViewModel.swift
@@ -62,7 +62,7 @@ struct OrderListCellViewModel {
     /// Accessory view that renders the cell's disclosure indicator
     ///
     var accessoryView: UIImageView? {
-        guard let image = UIImage(systemName: "chevron.right") else {
+        guard let image = UIImage(systemName: "chevron.forward") else {
             return nil
         }
         let accessoryView = UIImageView(image: image, highlightedImage: nil)

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/OrderListCellViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/OrderListCellViewModelTests.swift
@@ -65,7 +65,7 @@ final class OrderListCellViewModelTests: XCTestCase {
     func test_OrderListCell_accessoryView_uses_chevron_with_tertiaryLabel_tint_as_disclosure_indicator() {
         // Given
         let order = MockOrders().sampleOrder()
-        let expectedImage = UIImage(systemName: "chevron.right")
+        let expectedImage = UIImage(systemName: "chevron.forward")
 
         // When
         let viewModel = OrderListCellViewModel(order: order, status: nil)


### PR DESCRIPTION
This ensures that the disclosure icon is in the correct orientation for both LTR and RTL languages.

<!-- Remember about a good descriptive title. -->

Closes: #11801
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

Previously, the custom disclosure indicator on the Order List cells pointed the wrong direction for RTL languages.

This PR updates to use the semantic symbol "chevron.forward" instead of "chevron.right", which adapts according to the text direction.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

1. Set your device language to an RTL language, e.g. Arabic. 
2. Launch the app
3. Tap the `Orders` tab
4. Observe that the disclosure indicators point left

Repeat the test using an LTR language, e.g. English, and observe that the indicators point right.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->
![rtl disclosure](https://github.com/woocommerce/woocommerce-ios/assets/2472348/2c37e6c4-beaa-4f0d-a8a9-a0e3d7ecea61)


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
