### PR TITLE
[Blaze] Intro screen - Analytics

### DIFF
--- a/WooCommerce/Classes/Analytics/WooAnalyticsEvent+Blaze.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsEvent+Blaze.swift
@@ -59,14 +59,19 @@ extension WooAnalyticsEvent {
                               properties: [Key.source: source.rawValue])
         }
 
-        /// Tracked when the intro screen for Blaze is displayed.
-        static func blazeIntroDisplayed() -> WooAnalyticsEvent {
-            WooAnalyticsEvent(statName: .blazeIntroDisplayed, properties: [:])
-        }
-
         /// Tracked when an entry point to Blaze is dismissed.
         static func blazeViewDismissed(source: BlazeSource) -> WooAnalyticsEvent {
             WooAnalyticsEvent(statName: .blazeViewDismissed, properties: [Key.source: source.analyticsValue])
+        }
+
+        /// Tracked when the intro screen for Blaze is displayed.
+        static func introDisplayed() -> WooAnalyticsEvent {
+            WooAnalyticsEvent(statName: .blazeIntroDisplayed, properties: [:])
+        }
+
+        /// Tracked upon tapping "Learn how Blaze works" in Intro screen
+        static func introLearnMoreTapped() -> WooAnalyticsEvent {
+            WooAnalyticsEvent(statName: .blazeIntroLearnMoreTapped, properties: [:])
         }
     }
 }

--- a/WooCommerce/Classes/Analytics/WooAnalyticsStat.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsStat.swift
@@ -186,8 +186,9 @@ public enum WooAnalyticsStat: String {
     case blazeFlowError = "blaze_flow_error"
     case blazeCampaignListEntryPointSelected = "blaze_campaign_list_entry_point_selected"
     case blazeCampaignDetailSelected = "blaze_campaign_detail_selected"
-    case blazeIntroDisplayed = "blaze_intro_displayed"
     case blazeViewDismissed = "blaze_view_dismissed"
+    case blazeIntroDisplayed = "blaze_intro_displayed"
+    case blazeIntroLearnMoreTapped = "blaze_intro_learn_more_tapped"
 
     // MARK: Store Onboarding Events
     //

--- a/WooCommerce/Classes/ViewRelated/Blaze/BlazeIntro/BlazeCreateCampaignIntroView.swift
+++ b/WooCommerce/Classes/ViewRelated/Blaze/BlazeIntro/BlazeCreateCampaignIntroView.swift
@@ -95,7 +95,7 @@ struct BlazeCreateCampaignIntroView: View {
                     .padding(.horizontal, Layout.CTAStack.buttonHPadding)
 
                     Button(Localization.learnHowBlazeWorks) {
-                        viewModel.onLearnHowBlazeWorks()
+                        viewModel.didTapLearnHowBlazeWorks()
                     }
                     .buttonStyle(LinkButtonStyle())
                     .padding(.horizontal, Layout.CTAStack.buttonHPadding)
@@ -111,6 +111,9 @@ struct BlazeCreateCampaignIntroView: View {
                     BlazeLearnHowView(isPresented: $viewModel.showLearnHowSheet)
                 }
             }
+        }
+        .onAppear() {
+            viewModel.onAppear()
         }
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Blaze/BlazeIntro/BlazeCreateCampaignIntroViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Blaze/BlazeIntro/BlazeCreateCampaignIntroViewModel.swift
@@ -10,8 +10,12 @@ final class BlazeCreateCampaignIntroViewModel: ObservableObject {
         self.analytics = analytics
     }
 
-    func onLearnHowBlazeWorks() {
+    func onAppear() {
+        analytics.track(event: .Blaze.introDisplayed())
+    }
+
+    func didTapLearnHowBlazeWorks() {
         showLearnHowSheet = true
-        // TODO: 11512 Track Learn how button tap
+        analytics.track(event: .Blaze.introLearnMoreTapped())
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Blaze/BlazeCampaignDashboardView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Blaze/BlazeCampaignDashboardView.swift
@@ -131,6 +131,7 @@ struct BlazeCampaignDashboardView: View {
         }
         .sheet(isPresented: $viewModel.shouldShowIntroView) {
             let onCreateCampaignClosure = {
+                viewModel.didTapCreateYourCampaignButtonFromIntroView()
                 viewModel.shouldShowIntroView = false
                 startCampaignFromIntroTapped?(selectedProductID)
             }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Blaze/BlazeCampaignDashboardViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Blaze/BlazeCampaignDashboardViewModel.swift
@@ -129,6 +129,10 @@ final class BlazeCampaignDashboardViewModel: ObservableObject {
         }
     }
 
+    func didTapCreateYourCampaignButtonFromIntroView() {
+        analytics.track(event: .Blaze.blazeEntryPointTapped(source: .introView))
+    }
+
     func didSelectCampaignList() {
         analytics.track(event: .Blaze.blazeCampaignListEntryPointSelected(source: .myStoreSection))
     }

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -2470,6 +2470,7 @@
 		EE19058C2B5F744300617C53 /* BlazeAddPaymentMethodWebView.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE19058B2B5F744300617C53 /* BlazeAddPaymentMethodWebView.swift */; };
 		EE19058E2B5F747200617C53 /* BlazeAddPaymentMethodWebViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE19058D2B5F747200617C53 /* BlazeAddPaymentMethodWebViewModel.swift */; };
 		EE1905902B5F83BB00617C53 /* BlazeAddPaymentMethodWebViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE19058F2B5F83BB00617C53 /* BlazeAddPaymentMethodWebViewModelTests.swift */; };
+		EE1905942B62AE9100617C53 /* BlazeCreateCampaignIntroViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE1905932B62AE9100617C53 /* BlazeCreateCampaignIntroViewModelTests.swift */; };
 		EE28CF852B233AC40056D96E /* ProductCreationAISurveyConfirmationViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE28CF842B233AC40056D96E /* ProductCreationAISurveyConfirmationViewModelTests.swift */; };
 		EE2A57D729E399CC009F61E1 /* CaseIterable+Helpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE2A57D629E399CC009F61E1 /* CaseIterable+Helpers.swift */; };
 		EE2A57D929E39A9C009F61E1 /* CaseIterable+HelpersTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE2A57D829E39A9C009F61E1 /* CaseIterable+HelpersTests.swift */; };
@@ -5157,6 +5158,7 @@
 		EE19058B2B5F744300617C53 /* BlazeAddPaymentMethodWebView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BlazeAddPaymentMethodWebView.swift; sourceTree = "<group>"; };
 		EE19058D2B5F747200617C53 /* BlazeAddPaymentMethodWebViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BlazeAddPaymentMethodWebViewModel.swift; sourceTree = "<group>"; };
 		EE19058F2B5F83BB00617C53 /* BlazeAddPaymentMethodWebViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BlazeAddPaymentMethodWebViewModelTests.swift; sourceTree = "<group>"; };
+		EE1905932B62AE9100617C53 /* BlazeCreateCampaignIntroViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BlazeCreateCampaignIntroViewModelTests.swift; sourceTree = "<group>"; };
 		EE28CF842B233AC40056D96E /* ProductCreationAISurveyConfirmationViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductCreationAISurveyConfirmationViewModelTests.swift; sourceTree = "<group>"; };
 		EE2A57D629E399CC009F61E1 /* CaseIterable+Helpers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "CaseIterable+Helpers.swift"; sourceTree = "<group>"; };
 		EE2A57D829E39A9C009F61E1 /* CaseIterable+HelpersTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "CaseIterable+HelpersTests.swift"; sourceTree = "<group>"; };
@@ -5897,6 +5899,7 @@
 				EE1905892B590FF800617C53 /* BlazePaymentMethodsViewModelTests.swift */,
 				86E40AEC2B597DEC00990365 /* BlazeCampaignCreationCoordinatorTests.swift */,
 				EE19058F2B5F83BB00617C53 /* BlazeAddPaymentMethodWebViewModelTests.swift */,
+				EE1905932B62AE9100617C53 /* BlazeCreateCampaignIntroViewModelTests.swift */,
 			);
 			path = Blaze;
 			sourceTree = "<group>";
@@ -14507,6 +14510,7 @@
 				095A077E27CF486C007A61D2 /* ValueOneTableViewCellTests.swift in Sources */,
 				E17E3BF9266917C10009D977 /* CardPresentModalScanningFailedTests.swift in Sources */,
 				DE66C56F2978F24200DAA978 /* ApplicationPasswordDisabledViewModelTests.swift in Sources */,
+				EE1905942B62AE9100617C53 /* BlazeCreateCampaignIntroViewModelTests.swift in Sources */,
 				269098B627D2C09D001FEB07 /* ShippingInputTransformerTests.swift in Sources */,
 				02BA128B24616B48008D8325 /* ProductFormActionsFactory+VisibilityTests.swift in Sources */,
 				DEA88F522AAAC1180037273B /* AddEditProductCategoryViewModelTests.swift in Sources */,

--- a/WooCommerce/WooCommerceTests/ViewRelated/Blaze/BlazeCreateCampaignIntroViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Blaze/BlazeCreateCampaignIntroViewModelTests.swift
@@ -1,0 +1,41 @@
+import XCTest
+@testable import WooCommerce
+
+final class BlazeCreateCampaignIntroViewModelTests: XCTestCase {
+    private var analyticsProvider: MockAnalyticsProvider!
+    private var analytics: WooAnalytics!
+
+    override func setUp() {
+        super.setUp()
+        analyticsProvider = MockAnalyticsProvider()
+        analytics = WooAnalytics(analyticsProvider: analyticsProvider)
+    }
+
+    override func tearDown() {
+        analytics = nil
+        analyticsProvider = nil
+        super.tearDown()
+    }
+
+    func test_onAppear_tracks_introDisplayed() throws {
+        // Given
+        let viewModel = BlazeCreateCampaignIntroViewModel(analytics: analytics)
+
+        // When
+        viewModel.onAppear()
+
+        // Then
+        XCTAssertTrue(analyticsProvider.receivedEvents.contains("blaze_intro_displayed"))
+    }
+
+    func test_onLearnHowBlazeWorks_tracks_introLearnMoreTapped() throws {
+        // Given
+        let viewModel = BlazeCreateCampaignIntroViewModel(analytics: analytics)
+
+        // When
+        viewModel.didTapLearnHowBlazeWorks()
+
+        // Then
+        XCTAssertTrue(analyticsProvider.receivedEvents.contains("blaze_intro_learn_more_tapped"))
+    }
+}

--- a/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Blaze/BlazeCampaignDashboardViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Blaze/BlazeCampaignDashboardViewModelTests.swift
@@ -760,6 +760,24 @@ final class BlazeCampaignDashboardViewModelTests: XCTestCase {
         XCTAssertEqual(eventProperties["source"] as? String, "intro_view")
     }
 
+    func test_didTapCreateYourCampaignButtonFromIntroView_tracks_entry_point_tapped() throws {
+        // Given
+        let checker = MockBlazeEligibilityChecker(isSiteEligible: true)
+        let viewModel = BlazeCampaignDashboardViewModel(siteID: sampleSiteID,
+                                                        stores: stores,
+                                                        storageManager: storageManager,
+                                                        analytics: analytics,
+                                                        blazeEligibilityChecker: checker)
+
+        // When
+        viewModel.didTapCreateYourCampaignButtonFromIntroView()
+
+        // Then
+        let index = try XCTUnwrap(analyticsProvider.receivedEvents.firstIndex(of: "blaze_entry_point_tapped"))
+        let properties = try XCTUnwrap(analyticsProvider.receivedProperties[index])
+        XCTAssertEqual(properties["source"] as? String, "intro_view")
+    }
+
     func test_didSelectCampaignList_tracks_blazeCampaignListEntryPointSelected_with_the_correct_source() throws {
         // Given
         let checker = MockBlazeEligibilityChecker(isSiteEligible: true)


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #11804
<!-- Id number of the GitHub issue this PR addresses. -->

## Description

Adds tracking events for the Blaze intro view. 

Changes
- Add tracking events for the Intro view
- Track the missing entry point tapped event from the Blaze dashboard view. 

## Testing instructions

#### Prerequisites
- Create a JN site with Woo + Jetpack and publish a product.
- Log in to the app using WPCOM credentials.
- Create a new product and publish it.

#### Dashboard
- Switch to the My Store tab (Dashboard) and tap the "Promote" button from the Blaze section.
- You will see the Blaze Intro screen.
- Check Xcode logs and validate that the event `blaze_intro_displayed` is tracked.
- Tap "Learn how Blaze works" button and validate that `blaze_intro_learn_more_tapped` event is tracked.
- Tap "Create Your Campaign" button and validate that `blaze_entry_point_tapped` event is tracked with source as `intro_view`.

#### Product form
- Switch to Products tab and open the product details screen
- Tap "Promote with Blaze" button
- Check Xcode logs and validate that the event `blaze_intro_displayed` is tracked.
- Tap "Learn how Blaze works" button and validate that `blaze_intro_learn_more_tapped` event is tracked.
- Tap the "Create Your Campaign" button and validate that the `blaze_entry_point_tapped` event is tracked with the source as `intro_view`.

#### Menu -> Blaze
- Switch to the Menu tab and tap "Blaze"
- You will see the Blaze intro screen
- Check Xcode logs and validate that the event `blaze_intro_displayed` is tracked.
- Tap "Learn how Blaze works" button and validate that `blaze_intro_learn_more_tapped` event is tracked.
- Tap "Create Your Campaign" button and validate that `blaze_entry_point_tapped` event is tracked with source as `intro_view`.

## Screenshots
<img width="283" alt="image" src="https://github.com/woocommerce/woocommerce-ios/assets/524475/d58a480f-74de-4565-9b68-548fc485220f">

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
