### PR TITLE
[Tablet Orders] Fix both columns showing order details after quick navigation (up and down arrows in order details)

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/OrderDetailsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/OrderDetailsViewController.swift
@@ -170,7 +170,6 @@ private extension OrderDetailsViewController {
         editButton.isEnabled = viewModel.editButtonIsEnabled
         navigationItem.rightBarButtonItems = [editButton] + orderNavigationRightBarButtonItems()
 
-        // Disables large title.
         navigationItem.largeTitleDisplayMode = .never
     }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/OrderDetailsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/OrderDetailsViewController.swift
@@ -62,15 +62,20 @@ final class OrderDetailsViewController: UIViewController {
 
     private let isSplitViewInOrdersTabEnabled: Bool = ServiceLocator.featureFlagService.isFeatureFlagEnabled(.splitViewInOrdersTab)
 
+    /// Callback closure when a different order is selected like from the quick navigation arrows.
+    private let switchDetailsHandler: OrderListViewController.SelectOrderDetails
+
     // MARK: - View Lifecycle
-    init(viewModels: [OrderDetailsViewModel], currentIndex: Int) {
+    init(viewModels: [OrderDetailsViewModel], currentIndex: Int, switchDetailsHandler: @escaping OrderListViewController.SelectOrderDetails) {
         self.viewModels = viewModels
         self.currentIndex = currentIndex
+        self.switchDetailsHandler = switchDetailsHandler
         super.init(nibName: Self.nibName, bundle: nil)
     }
 
+    /// Used for screens that show order details always in a single-column view.
     convenience init(viewModel: OrderDetailsViewModel) {
-        self.init(viewModels: [viewModel], currentIndex: 0)
+        self.init(viewModels: [viewModel], currentIndex: 0, switchDetailsHandler: { _, _, _, _ in })
     }
 
     required init?(coder: NSCoder) {
@@ -164,6 +169,9 @@ private extension OrderDetailsViewController {
         editButton.accessibilityIdentifier = "order-details-edit-button"
         editButton.isEnabled = viewModel.editButtonIsEnabled
         navigationItem.rightBarButtonItems = [editButton] + orderNavigationRightBarButtonItems()
+
+        // Disables large title.
+        navigationItem.largeTitleDisplayMode = .never
     }
 
     func orderNavigationRightBarButtonItems() -> [UIBarButtonItem] {
@@ -201,15 +209,12 @@ private extension OrderDetailsViewController {
     }
 
     func loadOrder(with index: Int) {
-        let splitViewNavigationController = splitViewController?.viewControllers.first as? UINavigationController
-        let usingNavigationController = isSplitViewInOrdersTabEnabled ? splitViewNavigationController : navigationController
-
-        guard let usingNavigationController = usingNavigationController else {
+        guard isSplitViewInOrdersTabEnabled else {
+            let viewController = OrderDetailsViewController(viewModels: viewModels, currentIndex: index, switchDetailsHandler: switchDetailsHandler)
+            navigationController?.replaceTopViewController(with: viewController, animated: false)
             return
         }
-
-        let viewController = OrderDetailsViewController(viewModels: viewModels, currentIndex: index)
-        usingNavigationController.replaceTopViewController(with: viewController, animated: false)
+        switchDetailsHandler(viewModels, index, true, nil)
     }
 
     /// Setup: EntityListener

--- a/WooCommerce/Classes/ViewRelated/Orders/OrderListViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrderListViewController.swift
@@ -234,6 +234,14 @@ final class OrderListViewController: UIViewController, GhostableViewController {
         }
     }
 
+    /// Called when an order is shown and the order should be selected in the order list.
+    /// - Parameter orderID: ID of the order to be selected in the order list.
+    func onOrderSelected(id orderID: Int64) {
+        selectedOrderID = orderID
+        selectedIndexPath = indexPath(for: orderID)
+        highlightSelectedRowIfNeeded()
+    }
+
     /// Returns a function that creates cells for `dataSource`.
     private func makeCellProvider() -> UITableViewDiffableDataSource<String, FetchResultSnapshotObjectID>.CellProvider {
         return { [weak self] tableView, indexPath, objectID in
@@ -555,12 +563,6 @@ private extension OrderListViewController {
         }
     }
 
-    func onOrderSelected(id orderID: Int64) {
-        selectedOrderID = orderID
-        selectedIndexPath = indexPath(for: orderID)
-        highlightSelectedRowIfNeeded()
-    }
-
     func indexPath(for orderID: Int64) -> IndexPath? {
         for identifier in dataSource.snapshot().itemIdentifiers {
             if let detailsViewModel = viewModel.detailsViewModel(withID: identifier),
@@ -780,7 +782,9 @@ extension OrderListViewController: UITableViewDelegate {
             allowOrderNavigation ? switchDetailsHandler(allViewModels, currentIndex, true, nil) :
             switchDetailsHandler([orderDetailsViewModel], 0, true, nil)
         } else {
-            let viewController = OrderDetailsViewController(viewModels: allViewModels, currentIndex: currentIndex)
+            let viewController = OrderDetailsViewController(viewModels: allViewModels,
+                                                            currentIndex: currentIndex,
+                                                            switchDetailsHandler: { _, _, _, _ in })
             navigationController?.pushViewController(viewController, animated: true)
         }
     }

--- a/WooCommerce/Classes/ViewRelated/Orders/OrdersRootViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrdersRootViewController.swift
@@ -171,6 +171,13 @@ final class OrdersRootViewController: UIViewController {
         selectOrderFromListIfPossible(for: orderID)
     }
 
+    /// Called when an order is shown externally (outside of `OrderListViewController`) and the order should be
+    /// selected in the order list.
+    /// - Parameter orderID: ID of the order to be selected in the order list.
+    func onOrderSelected(id orderID: Int64) {
+        ordersViewController.onOrderSelected(id: orderID)
+    }
+
     /// Presents the Order Creation flow.
     ///
     @objc func presentOrderCreationFlow() {

--- a/WooCommerce/Classes/ViewRelated/Orders/OrdersSplitViewWrapperController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrdersSplitViewWrapperController.swift
@@ -107,9 +107,10 @@ private extension OrdersSplitViewWrapperController {
                                              onCompletion: completion)
             })
 
-        // When showing an order with multiple order view models to support quick navigation (up and down arrows),
-        // subsequent order details should replace the top order details view controller to avoid multiple order details
-        // in the navigation stack.
+        // When navigating between orders using up and down arrows, each new Order Details screen shown
+        // should replace the topViewController, to avoid having to tap back through several Order Details
+        // screens in the navigation stack. The back button should always go to the Order List.
+        // The up and down arrows are enabled when there is more than one item in `viewModels`.
         guard viewModels.count > 1,
               let viewModel = viewModels[safe: currentIndex],
               let secondaryNavigationController = ordersSplitViewController.viewController(for: .secondary) as? UINavigationController,

--- a/WooCommerce/Classes/ViewRelated/Orders/OrdersSplitViewWrapperController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrdersSplitViewWrapperController.swift
@@ -107,11 +107,11 @@ private extension OrdersSplitViewWrapperController {
                                              onCompletion: completion)
             })
 
-        // When navigating between orders using up and down arrows, each new Order Details screen shown
-        // should replace the topViewController, to avoid having to tap back through several Order Details
+        // When navigating between orders using up and down arrows (referred to "quick order navigation" in code), each new Order Details screen
+        // shown should replace the topViewController, to avoid having to tap back through several Order Details
         // screens in the navigation stack. The back button should always go to the Order List.
         // The up and down arrows are enabled when there is more than one item in `viewModels`.
-        guard viewModels.count > 1,
+        guard isQuickOrderNavigationSupported(viewModels: viewModels),
               let viewModel = viewModels[safe: currentIndex],
               let secondaryNavigationController = ordersSplitViewController.viewController(for: .secondary) as? UINavigationController,
               secondaryNavigationController.topViewController is OrderDetailsViewController else {
@@ -126,6 +126,10 @@ private extension OrdersSplitViewWrapperController {
         ordersViewController.onOrderSelected(id: viewModel.order.orderID)
         ordersSplitViewController.show(.secondary)
         onCompletion?(true)
+    }
+
+    func isQuickOrderNavigationSupported(viewModels: [OrderDetailsViewModel]) -> Bool {
+        viewModels.count > 1
     }
 }
 


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #11794 
<!-- Id number of the GitHub issue this PR addresses. -->

## Why

In the order details collapsed mode, there's another way to show a different order by tapping the 🔼 and 🔽 arrows in the navigation bar. After tapping to a different order this way and then expanding to the multi-column state, the new order details view controller [replaces the top of the **primary navigation controller**](https://github.com/woocommerce/woocommerce-ios/blob/98a17f93778443ec01ce53895008656de438d9a0/WooCommerce/Classes/ViewRelated/Orders/Order%20Details/OrderDetailsViewController.swift#L204) while the secondary navigation controller still contains the first order details. Therefore, when transitioning from collapsed to multi-column state, the primary view is showing the latest order details while the secondary view shows the first order details.

## How

To properly fix it and also highlight the latest selected order in the order list in multi-column state, the order details presentation logic was moved from `OrderDetailsViewController` to `OrdersSplitViewWrapperController` so that this special case logic for "quick navigation" (top/down arrows) is handled altogether in `OrdersSplitViewWrapperController.handleSwitchingDetails`. This way, we can also sync the selected order/index path states in the order list by calling the now public `onOrderSelected`.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

Prerequisite: please test this on a wide device where it can switch between collapsed & expanded states. the store has at least 2 orders to test quick navigation

- Start split view with the Woo app open to the orders tab in the **collapsed mode**
- Tap on an order
- Use the arrow buttons in the header to navigate to another order
- Expand the split view to the multi-column state --> the secondary view should show the last selected order, and the primary view should highlight the selected order

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->


https://github.com/woocommerce/woocommerce-ios/assets/1945542/491ae4ab-be2c-4a5c-b291-4c05b13bb2b5



---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
