### PR TITLE
[Blaze] Edit Ad screen - Analytics

### DIFF
--- a/WooCommerce/Classes/Analytics/WooAnalyticsEvent+Blaze.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsEvent+Blaze.swift
@@ -73,6 +73,30 @@ extension WooAnalyticsEvent {
         static func introLearnMoreTapped() -> WooAnalyticsEvent {
             WooAnalyticsEvent(statName: .blazeIntroLearnMoreTapped, properties: [:])
         }
+
+        enum CreationForm {
+            /// Tracked when Blaze creation form is displayed
+            static func creationFormDisplayed() -> WooAnalyticsEvent {
+                WooAnalyticsEvent(statName: .blazeCreationFormDisplayed, properties: [:])
+            }
+
+            /// Tracked upon tapping "Edit ad" in Blaze creation form
+            static func editAdTapped() -> WooAnalyticsEvent {
+                WooAnalyticsEvent(statName: .blazeEditAdTapped, properties: [:])
+            }
+        }
+
+        enum EditAd {
+            /// Tracked upon selecting AI suggestion in Edit Ad screen
+            static func aiSuggestionTapped() -> WooAnalyticsEvent {
+                WooAnalyticsEvent(statName: .blazeEditAdAISuggestionTapped, properties: [:])
+            }
+
+            /// Tracked upon tapping "Save" in Edit Ad screen
+            static func saveTapped() -> WooAnalyticsEvent {
+                WooAnalyticsEvent(statName: .blazeEditAdSaveTapped, properties: [:])
+            }
+        }
     }
 }
 

--- a/WooCommerce/Classes/Analytics/WooAnalyticsStat.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsStat.swift
@@ -189,6 +189,10 @@ public enum WooAnalyticsStat: String {
     case blazeViewDismissed = "blaze_view_dismissed"
     case blazeIntroDisplayed = "blaze_intro_displayed"
     case blazeIntroLearnMoreTapped = "blaze_intro_learn_more_tapped"
+    case blazeCreationFormDisplayed = "blaze_creation_form_displayed"
+    case blazeEditAdTapped = "blaze_creation_edit_ad_tapped"
+    case blazeEditAdSaveTapped = "blaze_creation_edit_ad_save_tapped"
+    case blazeEditAdAISuggestionTapped = "blaze_creation_edit_ad_ai_suggestion_tapped"
 
     // MARK: Store Onboarding Events
     //

--- a/WooCommerce/Classes/ViewRelated/Blaze/BlazeEditAd/BlazeEditAdViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Blaze/BlazeEditAd/BlazeEditAdViewModel.swift
@@ -106,8 +106,8 @@ final class BlazeEditAdViewModel: ObservableObject {
     init(siteID: Int64,
          adData: BlazeEditAdData,
          suggestions: [BlazeAISuggestion],
-         onSave: @escaping (BlazeEditAdData) -> Void,
-         analytics: Analytics = ServiceLocator.analytics) {
+         analytics: Analytics = ServiceLocator.analytics,
+         onSave: @escaping (BlazeEditAdData) -> Void) {
         self.siteID = siteID
 
         self.adData = adData
@@ -130,7 +130,7 @@ final class BlazeEditAdViewModel: ObservableObject {
     }
 
     func didTapSave() {
-        // TODO: 11512 Track Save button tap
+        analytics.track(event: .Blaze.EditAd.saveTapped())
         guard let editedAdData else {
             assertionFailure("Save button shouldn't be enabled when edited ad is nil")
             return
@@ -159,6 +159,8 @@ final class BlazeEditAdViewModel: ObservableObject {
     }
 
     func didTapPrevious() {
+        analytics.track(event: .Blaze.EditAd.aiSuggestionTapped())
+
         guard let selectedSuggestionIndex,
               selectedSuggestionIndex > 0 else {
             return
@@ -174,6 +176,8 @@ final class BlazeEditAdViewModel: ObservableObject {
     }
 
     func didTapNext() {
+        analytics.track(event: .Blaze.EditAd.aiSuggestionTapped())
+
         let newIndex = {
             guard let selectedSuggestionIndex else {
                 // Select first item when no suggestion is selected previously

--- a/WooCommerce/Classes/ViewRelated/Blaze/CampaignCreation/BlazeCampaignCreationForm.swift
+++ b/WooCommerce/Classes/ViewRelated/Blaze/CampaignCreation/BlazeCampaignCreationForm.swift
@@ -180,6 +180,9 @@ struct BlazeCampaignCreationForm: View {
                 viewModel.didTapEditAd()
             }
         }
+        .onAppear() {
+            viewModel.onAppear()
+        }
         .task {
             await viewModel.onLoad()
         }

--- a/WooCommerce/Classes/ViewRelated/Blaze/CampaignCreation/BlazeCampaignCreationFormViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Blaze/CampaignCreation/BlazeCampaignCreationFormViewModel.swift
@@ -199,17 +199,21 @@ final class BlazeCampaignCreationFormViewModel: ObservableObject {
                             type: Constants.campaignType)
     }
 
+    private let analytics: Analytics
+
     init(siteID: Int64,
          productID: Int64,
          stores: StoresManager = ServiceLocator.stores,
          storage: StorageManagerType = ServiceLocator.storageManager,
          productImageLoader: ProductUIImageLoader = DefaultProductUIImageLoader(phAssetImageLoaderProvider: { PHImageManager.default() }),
+         analytics: Analytics = ServiceLocator.analytics,
          onCompletion: @escaping () -> Void) {
         self.siteID = siteID
         self.productID = productID
         self.stores = stores
         self.storage = storage
         self.productImageLoader = productImageLoader
+        self.analytics = analytics
         self.completionHandler = onCompletion
         self.targetUrn = String(format: Constants.targetUrnFormat, siteID, productID)
 
@@ -219,6 +223,10 @@ final class BlazeCampaignCreationFormViewModel: ObservableObject {
         updateTargetTopicText()
         updateTargetLocationText()
         initializeAdFinalDestination()
+    }
+
+    func onAppear() {
+        analytics.track(event: .Blaze.CreationForm.creationFormDisplayed())
     }
 
     func onLoad() async {
@@ -238,6 +246,7 @@ final class BlazeCampaignCreationFormViewModel: ObservableObject {
     }
 
     func didTapEditAd() {
+        analytics.track(event: .Blaze.CreationForm.editAdTapped())
         onEditAd?()
     }
 


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #11812
<!-- Id number of the GitHub issue this PR addresses. -->

## Description

Adds tracking events for the Blaze Edit Ad screen.

## Testing instructions

- Create a JN site with Woo + Jetpack and publish a product.
- Log in to the app using WPCOM credentials.
- Create a new product and publish it.
- Switch to Products tab and open the product details screen
- Tap "Promote with Blaze" button
- Tap the "Create Your Campaign" button and navigate to Blaze creation form
- Check Xcode logs and validate that `blaze_creation_form_displayed` event is tracked
- Tap "Edit ad" and navigate to edit screen
- From Xcode logs and validate that `blaze_creation_edit_ad_tapped` event is tracked
- In the edit ad screen tap on `<` or `>` arrows to switch between AI suggestions.
- Validate that `blaze_creation_edit_ad_ai_suggestion_tapped` event is tracked upon switching suggestions.
- Tap "Save" button and validate that `blaze_creation_edit_ad_save_tapped` is tracked. 


## Screenshots

<img width="283" alt="image" src="https://github.com/woocommerce/woocommerce-ios/assets/524475/edbbe132-8779-41be-a1d9-6af897885c7a">

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
