### PR TITLE
[Tablet Orders] show shipping label flow modally

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -4,6 +4,7 @@
 -----
 - [*] Fixed issue loading system status report for sites using faulty themes. [https://github.com/woocommerce/woocommerce-ios/pull/11798]
 - [*] Blaze: Hide the Blaze section on the Dashboard screen when logged in without WPCom. [https://github.com/woocommerce/woocommerce-ios/pull/11797]
+- [*] Shipping labels: Show the purchase and print flows in modal screens [https://github.com/woocommerce/woocommerce-ios/pull/11815]
 
 17.0
 -----

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/OrderDetailsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/OrderDetailsViewController.swift
@@ -439,14 +439,13 @@ private extension OrderDetailsViewController {
             }
             collectPaymentTapped()
         case .reprintShippingLabel(let shippingLabel):
-            guard let navigationController = navigationController else {
-                assertionFailure("Cannot reprint a shipping label because `navigationController` is nil")
-                return
-            }
+            let printNavigationController = WooNavigationController()
             let coordinator = PrintShippingLabelCoordinator(shippingLabels: [shippingLabel],
                                                             printType: .reprint,
-                                                            sourceNavigationController: navigationController)
-            coordinator.showPrintUI()
+                                                            sourceNavigationController: printNavigationController)
+            let printViewController = coordinator.createPrintViewController()
+            printNavigationController.viewControllers = [printViewController]
+            present(printNavigationController, animated: true)
         case .createShippingLabel:
             navigateToCreateShippingLabelForm()
         case .shippingLabelTrackingMenu(let shippingLabel, let sourceView):
@@ -475,7 +474,7 @@ private extension OrderDetailsViewController {
                 }
                 return
             }
-
+            syncEverything()
             self.dismiss(animated: true)
         }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/OrderDetailsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/OrderDetailsViewController.swift
@@ -476,10 +476,11 @@ private extension OrderDetailsViewController {
                 return
             }
 
-            navigationController.popToViewController(self, animated: true)
+            self.dismiss(animated: true)
         }
-        shippingLabelFormVC.hidesBottomBarWhenPushed = true
-        navigationController?.show(shippingLabelFormVC, sender: self)
+
+        let shippingLabelNavigationController = WooNavigationController(rootViewController: shippingLabelFormVC)
+        navigationController?.present(shippingLabelNavigationController, animated: true)
     }
 
     func markOrderCompleteWasPressed() {

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/OrderDetailsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/OrderDetailsViewController.swift
@@ -477,6 +477,9 @@ private extension OrderDetailsViewController {
             syncEverything()
             self.dismiss(animated: true)
         }
+        shippingLabelFormVC.onCancel = { [weak self] in
+            self?.dismiss(animated: true)
+        }
 
         let shippingLabelNavigationController = WooNavigationController(rootViewController: shippingLabelFormVC)
         navigationController?.present(shippingLabelNavigationController, animated: true)

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Shipping Address Validation/ShippingLabelAddressFormViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Shipping Address Validation/ShippingLabelAddressFormViewController.swift
@@ -77,6 +77,14 @@ final class ShippingLabelAddressFormViewController: UIViewController {
         return topBanner
     }
 
+    /// Dedicated NoticePresenter (use this here instead of ServiceLocator.noticePresenter)
+    ///
+    private lazy var noticePresenter: DefaultNoticePresenter = {
+        let noticePresenter = DefaultNoticePresenter()
+        noticePresenter.presentingViewController = self
+        return noticePresenter
+    }()
+
     private let viewModel: ShippingLabelAddressFormViewModel
 
     /// Completion callback
@@ -273,7 +281,7 @@ private extension ShippingLabelAddressFormViewController {
     ///
     func displayErrorNotice(title: String) {
         let notice = Notice(title: title, feedbackType: .error, actionTitle: nil, actionHandler: nil)
-        ServiceLocator.noticePresenter.enqueue(notice: notice)
+        noticePresenter.enqueue(notice: notice)
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/ShippingLabelFormViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/ShippingLabelFormViewController.swift
@@ -566,15 +566,17 @@ private extension ShippingLabelFormViewController {
             return
         }
 
-        if let indexOfSelf = navigationController.viewControllers.firstIndex(of: self) {
-            let viewControllersExcludingSelf = Array(navigationController.viewControllers[0..<indexOfSelf])
-            navigationController.setViewControllers(viewControllersExcludingSelf, animated: false)
-        }
         let printCoordinator = PrintShippingLabelCoordinator(shippingLabels: viewModel.purchasedShippingLabels,
                                                              printType: .print,
                                                              sourceNavigationController: navigationController,
                                                              onCompletion: onLabelSave)
-        printCoordinator.showPrintUI()
+
+        let printViewController = printCoordinator.createPrintViewController()
+
+        if let indexOfSelf = navigationController.viewControllers.firstIndex(of: self) {
+            let viewControllersExcludingSelf = Array(navigationController.viewControllers[0..<indexOfSelf])
+            navigationController.setViewControllers(viewControllersExcludingSelf + [printViewController], animated: true)
+        }
     }
 
     /// Enqueues the `Label Purchase Error` Notice.

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/ShippingLabelFormViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/ShippingLabelFormViewController.swift
@@ -38,6 +38,10 @@ final class ShippingLabelFormViewController: UIViewController {
     ///
     var onLabelSave: (() -> Void)?
 
+    /// Assign this closure to be notified when the cancel button is tapped. If appropriate, this should dismiss the view.
+    ///
+    var onCancel: (() -> Void)?
+
     /// Dedicated NoticePresenter (use this here instead of ServiceLocator.noticePresenter)
     ///
     private lazy var noticePresenter: DefaultNoticePresenter = {
@@ -99,7 +103,7 @@ private extension ShippingLabelFormViewController {
     }
 
     @objc func cancelButtonTapped() {
-        presentingViewController?.dismiss(animated: true)
+        onCancel?()
     }
 
     func configureMainView() {

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/ShippingLabelFormViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/ShippingLabelFormViewController.swift
@@ -83,6 +83,15 @@ private extension ShippingLabelFormViewController {
 
     func configureNavigationBar() {
         title = Localization.titleView
+        navigationItem.leftBarButtonItem = UIBarButtonItem(title: Localization.cancelButtonTitle,
+                                                           style: .plain,
+                                                           target: self,
+                                                           action: #selector(cancelButtonTapped))
+        isModalInPresentation = true
+    }
+
+    @objc func cancelButtonTapped() {
+        presentingViewController?.dismiss(animated: true)
     }
 
     func configureMainView() {
@@ -705,6 +714,10 @@ private extension ShippingLabelFormViewController {
         static let noticeUnableToFetchCountries = NSLocalizedString("Unable to fetch countries.",
                                                                     comment: "Unable to fetch countries action failed in Shipping Label Form")
         static let noticeRetryAction = NSLocalizedString("Retry", comment: "Retry Action")
+        static let cancelButtonTitle = NSLocalizedString(
+            "shipping.label.navigationBar.cancel.button.title",
+            value: "Cancel",
+            comment: "Cancel button title for the Shipping Label purchase flow, shown in the nav bar")
     }
 
     enum Constants {

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/ShippingLabelFormViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/ShippingLabelFormViewController.swift
@@ -38,6 +38,14 @@ final class ShippingLabelFormViewController: UIViewController {
     ///
     var onLabelSave: (() -> Void)?
 
+    /// Dedicated NoticePresenter (use this here instead of ServiceLocator.noticePresenter)
+    ///
+    private lazy var noticePresenter: DefaultNoticePresenter = {
+        let noticePresenter = DefaultNoticePresenter()
+        noticePresenter.presentingViewController = self
+        return noticePresenter
+    }()
+
     /// Init
     ///
     init(order: Order) {
@@ -421,7 +429,7 @@ private extension ShippingLabelFormViewController {
                 [weak self] in
                 self?.viewModel.fetchCountries()
             }
-            ServiceLocator.noticePresenter.enqueue(notice: notice)
+            noticePresenter.enqueue(notice: notice)
             return
         }
         let isPhoneNumberRequired = viewModel.customsFormRequired || type == .origin
@@ -454,7 +462,7 @@ private extension ShippingLabelFormViewController {
                 [weak self] in
                 self?.viewModel.fetchCountries()
             }
-            ServiceLocator.noticePresenter.enqueue(notice: notice)
+            noticePresenter.enqueue(notice: notice)
             return
         }
         let vc = ShippingLabelSuggestedAddressViewController(siteID: viewModel.siteID,
@@ -575,7 +583,7 @@ private extension ShippingLabelFormViewController {
         let message = NSLocalizedString("Error purchasing the label", comment: "Notice displayed when the label purchase fails")
         let notice = Notice(title: message, feedbackType: .error)
 
-        ServiceLocator.noticePresenter.enqueue(notice: notice)
+        noticePresenter.enqueue(notice: notice)
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Print Customs Form/PrintCustomsFormsView.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Print Customs Form/PrintCustomsFormsView.swift
@@ -6,12 +6,15 @@ struct PrintCustomsFormsView: View {
 
     @State private var printingInvoicePath: String?
 
-    init(invoiceURLs: [String], showsSaveForLater: Bool = false) {
+    init(invoiceURLs: [String], showsSaveForLater: Bool = false, hostedDismiss: (() -> Void)? = nil) {
         self.invoiceURLs = invoiceURLs
         self.showsSaveForLater = showsSaveForLater
+        self.hostedDismiss = hostedDismiss
     }
 
-    @Environment(\.presentationMode) var presentationMode: Binding<PresentationMode>
+    @Environment(\.dismiss) var dismiss
+
+    var hostedDismiss: (() -> Void)?
 
     var body: some View {
         ScrollView {
@@ -81,7 +84,8 @@ struct PrintCustomsFormsView: View {
 
     private var saveForLaterButton: some View {
         Button(action: {
-            presentationMode.wrappedValue.dismiss()
+            dismiss()
+            hostedDismiss?()
         }, label: {
             Text(Localization.saveForLaterButton)
         })

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Print Shipping Label/PrintShippingLabelCoordinator.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Print Shipping Label/PrintShippingLabelCoordinator.swift
@@ -166,10 +166,14 @@ private extension PrintShippingLabelCoordinator {
             .compactMap { $0.commercialInvoiceURL }
             .filter { $0.isNotEmpty }
         guard urls.isNotEmpty, printType == .print else {
+            onCompletion?()
             return
         }
 
-        let printCustomsFormsView = PrintCustomsFormsView(invoiceURLs: urls, showsSaveForLater: true)
+        let printCustomsFormsView = PrintCustomsFormsView(invoiceURLs: urls,
+                                                          showsSaveForLater: true) {
+            self.onCompletion?()
+        }
         let hostingController = UIHostingController(rootView: printCustomsFormsView)
         hostingController.hidesBottomBarWhenPushed = true
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Print Shipping Label/PrintShippingLabelCoordinator.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Print Shipping Label/PrintShippingLabelCoordinator.swift
@@ -30,10 +30,10 @@ final class PrintShippingLabelCoordinator {
         self.onCompletion = onCompletion
     }
 
-    /// Shows the main screen for printing a shipping label.
+    /// Creates the main viewController for printing a shipping label.
     /// `self` is retained in the action callbacks so that the coordinator has the same life cycle as the main view controller
     /// (`PrintShippingLabelViewController`).
-    func showPrintUI() {
+    func createPrintViewController() -> PrintShippingLabelViewController {
         let printViewController = PrintShippingLabelViewController(shippingLabels: shippingLabels, printType: printType)
 
         printViewController.onAction = { actionType in
@@ -53,9 +53,7 @@ final class PrintShippingLabelCoordinator {
             }
         }
 
-        // Since the print UI could make an API request for printing data, disables the bottom bar (tab bar) to simplify app states.
-        printViewController.hidesBottomBarWhenPushed = true
-        sourceNavigationController.show(printViewController, sender: sourceNavigationController)
+        return printViewController
     }
 }
 
@@ -98,7 +96,7 @@ private extension PrintShippingLabelCoordinator {
         let viewProperties = InProgressViewProperties(title: Localization.inProgressTitle(labelCount: shippingLabels.count),
                                                       message: Localization.inProgressMessage)
         let inProgressViewController = InProgressViewController(viewProperties: viewProperties)
-        inProgressViewController.modalPresentationStyle = .overCurrentContext
+        inProgressViewController.modalPresentationStyle = .overFullScreen
         sourceNavigationController.present(inProgressViewController, animated: true, completion: nil)
     }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Print Shipping Label/PrintShippingLabelViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Print Shipping Label/PrintShippingLabelViewController.swift
@@ -115,7 +115,7 @@ private extension PrintShippingLabelViewController {
     }
 
     @objc func closeButtonTapped() {
-        onAction?(.saveLabelForLater)
+        saveLabelForLater()
         presentingViewController?.dismiss(animated: true)
     }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Print Shipping Label/PrintShippingLabelViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Print Shipping Label/PrintShippingLabelViewController.swift
@@ -107,6 +107,16 @@ private extension PrintShippingLabelViewController {
 private extension PrintShippingLabelViewController {
     func configureNavigationBar() {
         navigationItem.title = Localization.navigationBarTitle(labelCount: viewModel.shippingLabels.count)
+        navigationItem.leftBarButtonItem = UIBarButtonItem(title: Localization.closeButtonTitle,
+                                                           style: .plain,
+                                                           target: self,
+                                                           action: #selector(closeButtonTapped))
+        isModalInPresentation = true
+    }
+
+    @objc func closeButtonTapped() {
+        onAction?(.saveLabelForLater)
+        presentingViewController?.dismiss(animated: true)
     }
 
     func configureTableView() {
@@ -392,6 +402,10 @@ private extension PrintShippingLabelViewController {
         static let paperSizeOptionsButtonTitle = NSLocalizedString("See layout and paper sizes options", comment: "Link title to see all paper size options")
         static let printingInstructionsButtonTitle = NSLocalizedString("Don’t know how to print from your device?",
                                                                        comment: "Link title to see instructions for printing a shipping label on an iOS device")
+        static let closeButtonTitle = NSLocalizedString(
+            "print.shipping.label.close.button.title",
+            value: "Close",
+            comment: "Close title for the navigation bar button on the Print Shipping Label view.")
     }
 }
 

--- a/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/Reprint Shipping Label/PrintShippingLabelCoordinatorTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Shipping Label/Reprint Shipping Label/PrintShippingLabelCoordinatorTests.swift
@@ -4,20 +4,6 @@ import TestKit
 import Yosemite
 
 final class PrintShippingLabelCoordinatorTests: XCTestCase {
-    func test_showPrintUI_shows_PrintShippingLabelViewController() {
-        // Given
-        let viewController = MockSourceNavigationController()
-        let shippingLabel = MockShippingLabel.emptyLabel()
-        let coordinator = PrintShippingLabelCoordinator(shippingLabels: [shippingLabel], printType: .print, sourceNavigationController: viewController)
-
-        // When
-        coordinator.showPrintUI()
-
-        // Then
-        XCTAssertEqual(viewController.shownViewControllers.count, 1)
-        assertThat(viewController.shownViewControllers[0], isAnInstanceOf: PrintShippingLabelViewController.self)
-    }
-
     // MARK: `showPaperSizeSelector`
 
     func test_showPaperSizeSelector_shows_ListSelectorViewController() throws {
@@ -27,15 +13,15 @@ final class PrintShippingLabelCoordinatorTests: XCTestCase {
         let coordinator = PrintShippingLabelCoordinator(shippingLabels: [shippingLabel],
                                                         printType: .print,
                                                         sourceNavigationController: viewController)
-        coordinator.showPrintUI()
-        let printViewController = try XCTUnwrap(viewController.shownViewControllers.first as? PrintShippingLabelViewController)
+
+        let printViewController = coordinator.createPrintViewController()
 
         // When
         printViewController.onAction?(.showPaperSizeSelector(paperSizeOptions: [.label], selectedPaperSize: nil, onSelection: { _ in }))
 
         // Then
-        XCTAssertEqual(viewController.shownViewControllers.count, 2)
-        assertThat(viewController.shownViewControllers[1],
+        XCTAssertEqual(viewController.shownViewControllers.count, 1)
+        assertThat(viewController.shownViewControllers[0],
                    isAnInstanceOf: ListSelectorViewController<ShippingLabelPaperSizeListSelectorCommand, ShippingLabelPaperSize, BasicTableViewCell>.self)
     }
 
@@ -50,8 +36,8 @@ final class PrintShippingLabelCoordinatorTests: XCTestCase {
                                                         printType: .print,
                                                         sourceNavigationController: viewController,
                                                         stores: stores)
-        coordinator.showPrintUI()
-        let printViewController = try XCTUnwrap(viewController.shownViewControllers.first as? PrintShippingLabelViewController)
+
+        let printViewController = coordinator.createPrintViewController()
 
         // When
         printViewController.onAction?(.print(paperSize: .label))
@@ -80,8 +66,8 @@ final class PrintShippingLabelCoordinatorTests: XCTestCase {
                                                         printType: .print,
                                                         sourceNavigationController: viewController,
                                                         stores: stores)
-        coordinator.showPrintUI()
-        let printViewController = try XCTUnwrap(viewController.shownViewControllers.first as? PrintShippingLabelViewController)
+
+        let printViewController = coordinator.createPrintViewController()
 
         // When
         printViewController.onAction?(.print(paperSize: .label))
@@ -107,8 +93,8 @@ final class PrintShippingLabelCoordinatorTests: XCTestCase {
                                                         sourceNavigationController: viewController,
                                                         stores: stores,
                                                         analytics: analytics)
-        coordinator.showPrintUI()
-        let printViewController = try XCTUnwrap(viewController.shownViewControllers.first as? PrintShippingLabelViewController)
+
+        let printViewController = coordinator.createPrintViewController()
 
         // When
         printViewController.onAction?(.print(paperSize: .label))
@@ -127,8 +113,8 @@ final class PrintShippingLabelCoordinatorTests: XCTestCase {
         let coordinator = PrintShippingLabelCoordinator(shippingLabels: [shippingLabel],
                                                         printType: .print,
                                                         sourceNavigationController: viewController)
-        coordinator.showPrintUI()
-        let printViewController = try XCTUnwrap(viewController.shownViewControllers.first as? PrintShippingLabelViewController)
+
+        let printViewController = coordinator.createPrintViewController()
 
         // When
         printViewController.onAction?(.presentPaperSizeOptions)
@@ -148,8 +134,8 @@ final class PrintShippingLabelCoordinatorTests: XCTestCase {
         let coordinator = PrintShippingLabelCoordinator(shippingLabels: [shippingLabel],
                                                         printType: .print,
                                                         sourceNavigationController: viewController)
-        coordinator.showPrintUI()
-        let printViewController = try XCTUnwrap(viewController.shownViewControllers.first as? PrintShippingLabelViewController)
+
+        let printViewController = coordinator.createPrintViewController()
 
         // When
         printViewController.onAction?(.presentPrintingInstructions)


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #11805 
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

With Project Lily Pad, we've added a split view display for Orders on larger screens.

#7987 causes more significant problems when combined with the orders split view; now it has the potential to cause data loss.

The shipping label flow was presented in the navigation flow from Order Details. In a split view environment, that means it was presented in the right hand frame, while the keyboard is full width.

While typing in the form, when the validation status changed, the keyboard was momentarily dismissed. If you were about to tap a letter on the left of the keyboard, you instead find yourself selecting a different order.

This means you lose your selected order, and worse still, any text you've entered in the shipping label form.

As a workaround, we have changed the flow to be presented modally, which makes it impossible to accidentally select another order and lose your progress.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

1. Launch the app, and switch to a store which is eligible for shipping label purchase
2. Tap the Orders tab
3. Select an order which is eligible for shipping label purchase
4. Tap Create Shipping Label
5. Follow the flow through, including changing the phone number or another field with validation
6. Observe that while the keyboard is still momentarily dismissed, you can't accidentally select another order while it's off screen.

Ensure you test the printing, saving, and reprinting flows as well.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

https://github.com/woocommerce/woocommerce-ios/assets/2472348/78968540-c3bf-49c8-98d5-162a7b590f5e



---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
