### PR TITLE
Fix arrow directions on the app to support RTL locales.

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -2,6 +2,7 @@
 
 17.2
 -----
+- [*] Fixed arrow directions for RTL locales. [https://github.com/woocommerce/woocommerce-ios/pull/11833]
 
 
 17.1

--- a/WooCommerce/Classes/Authentication/Store Creation/Profiler/Country/StoreCreationCountryQuestionView.swift
+++ b/WooCommerce/Classes/Authentication/Store Creation/Profiler/Country/StoreCreationCountryQuestionView.swift
@@ -21,7 +21,7 @@ struct StoreCreationCountryQuestionView: View {
                         Text(viewModel.selectedCountryCode?.readableCountry ?? Localization.selectCountry)
                             .bodyStyle()
                         Spacer()
-                        Image(systemName: "chevron.right")
+                        Image(systemName: "chevron.forward")
                             .secondaryBodyStyle()
                     }
                 })

--- a/WooCommerce/Classes/ViewRelated/Blaze/AdDestination/BlazeAdDestinationSettingView.swift
+++ b/WooCommerce/Classes/ViewRelated/Blaze/AdDestination/BlazeAdDestinationSettingView.swift
@@ -137,7 +137,7 @@ struct BlazeAdDestinationSettingView: View {
             HStack {
                 Text(parameter.key)
                 Spacer()
-                Image(systemName: "chevron.right")
+                Image(systemName: "chevron.forward")
                     .foregroundColor(.secondary)
                     .padding(.leading, Layout.contentHorizontalSpacing)
             }

--- a/WooCommerce/Classes/ViewRelated/Blaze/BlazeCampaignList/BlazeCampaignItemView.swift
+++ b/WooCommerce/Classes/ViewRelated/Blaze/BlazeCampaignList/BlazeCampaignItemView.swift
@@ -49,7 +49,7 @@ struct BlazeCampaignItemView: View {
                 Spacer()
 
                 // disclosure indicator
-                Image(systemName: "chevron.right")
+                Image(systemName: "chevron.forward")
                     .foregroundColor(.secondary)
                     .font(.headline)
             }

--- a/WooCommerce/Classes/ViewRelated/Blaze/CampaignCreation/BlazeCampaignCreationForm.swift
+++ b/WooCommerce/Classes/ViewRelated/Blaze/CampaignCreation/BlazeCampaignCreationForm.swift
@@ -272,7 +272,7 @@ private extension BlazeCampaignCreationForm {
                         .lineLimit(isContentSingleLine ? 1 : nil)
                 }
                 Spacer()
-                Image(systemName: "chevron.right")
+                Image(systemName: "chevron.forward")
                     .secondaryBodyStyle()
             }
             .padding(.horizontal, Layout.contentPadding)

--- a/WooCommerce/Classes/ViewRelated/Blaze/ConfirmPayment/BlazeConfirmPaymentView.swift
+++ b/WooCommerce/Classes/ViewRelated/Blaze/ConfirmPayment/BlazeConfirmPaymentView.swift
@@ -163,7 +163,7 @@ private extension BlazeConfirmPaymentView {
 
             Spacer()
 
-            Image(systemName: "chevron.right")
+            Image(systemName: "chevron.forward")
                 .secondaryBodyStyle()
         }
     }
@@ -175,7 +175,7 @@ private extension BlazeConfirmPaymentView {
             HStack {
                 Text(Localization.addPaymentMethod)
                 Spacer()
-                Image(systemName: "chevron.right")
+                Image(systemName: "chevron.forward")
                     .secondaryBodyStyle()
             }
         }

--- a/WooCommerce/Classes/ViewRelated/Hub Menu/HubMenu.swift
+++ b/WooCommerce/Classes/ViewRelated/Hub Menu/HubMenu.swift
@@ -192,7 +192,7 @@ private extension HubMenu {
                 case .down:
                     return .chevronDownImage
                 case .leading:
-                    return .chevronImage.withHorizontallyFlippedOrientation()
+                    return .chevronImage
                 }
             }
         }
@@ -296,6 +296,7 @@ private extension HubMenu {
                 Image(uiImage: chevron.asset)
                     .resizable()
                     .frame(width: HubMenu.Constants.chevronSize, height: HubMenu.Constants.chevronSize)
+                    .flipsForRightToLeftLayoutDirection(true)
                     .foregroundColor(Color(.textSubtle))
                     .accessibilityIdentifier(chevronAccessibilityID ?? "")
                     .renderedIf(chevron != .none)

--- a/WooCommerce/Classes/ViewRelated/Hub Menu/HubMenu.swift
+++ b/WooCommerce/Classes/ViewRelated/Hub Menu/HubMenu.swift
@@ -192,7 +192,7 @@ private extension HubMenu {
                 case .down:
                     return .chevronDownImage
                 case .leading:
-                    return .chevronImage.imageFlippedForRightToLeftLayoutDirection()
+                    return .chevronImage.withHorizontallyFlippedOrientation()
                 }
             }
         }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/ProductsSection/ProductDiscountView.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/ProductsSection/ProductDiscountView.swift
@@ -40,6 +40,7 @@ struct ProductDiscountView: View {
                     DiscountLineDetailsView(viewModel: discountDetailsViewModel)
                     HStack {
                         Image(systemName: "arrow.turn.down.right")
+                            .flipsForRightToLeftLayoutDirection(true)
                             .foregroundColor(.secondary)
                         Text(Localization.discountLabel)
                             .foregroundColor(.secondary)

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/Taxes/TaxRateRow.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/Taxes/TaxRateRow.swift
@@ -28,7 +28,7 @@ struct TaxRateRow: View {
                 .multilineTextAlignment(.trailing)
                 .frame(width: nil, alignment: .trailing)
 
-            Image(systemName: "chevron.right")
+            Image(systemName: "chevron.forward")
                 .font(.body)
                 .font(Font.title.weight(.semibold))
                 .foregroundColor(Color(.textTertiary))

--- a/WooCommerce/Classes/ViewRelated/Upgrades/FullFeatureListView.swift
+++ b/WooCommerce/Classes/ViewRelated/Upgrades/FullFeatureListView.swift
@@ -63,7 +63,7 @@ struct FullFeatureListView: View {
         .navigationBarItems(leading: Button(action: {
             presentationMode.wrappedValue.dismiss()
         }) {
-            Image(systemName: "chevron.left")
+            Image(systemName: "chevron.backward")
         })
         .background(Color(.secondarySystemBackground))
     }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #11807 
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This PR updates the arrow directions in multiple places of the app:
- Hub menu: `imageFlippedForRightToLeftLayoutDirection` doesn't work properly in SwiftUI, so it has been replaced with `flipsForRightToLeftLayoutDirection`.
- Product discount in order creation: there's an icon using a system image named `arrow.turn.down.right` - applying `flipsForRightToLeftLayoutDirection` makes sure the icon is flipped for RTL locales.
- Tax rate row in order creation, Upgrade, Store creation profiler, Blaze campaign creation: fixed the arrow direction by using the generic system image named `chevron.forward` or `chevron.backward` instead of `.left` or `.right`.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
Pre-condition: Switch your simulator language to Arabic to test the arrows.
1. Hub menu
- Log in to the app
- Switch to Menu tab.
- Confirm that the arrows face left instead of right.

<img src="https://github.com/woocommerce/woocommerce-ios/assets/5533851/83d6176e-9c2f-4931-80e6-73741811ab8a" width=320 />


2. Blaze campaign creation
- Log in to a store eligible for Blaze with at least one existing campaign.
- On the dashboard screen, notice the arrow on the campaign item faces left.
- Tap Promote. Confirm that the arrows in the creation form / ad destination / payment confirm screens are correct.

Creation form | Ad destination | Confirm payment | Campaign item
--- | --- | --- | ---
<img src="https://github.com/woocommerce/woocommerce-ios/assets/5533851/da76b21f-d686-4808-9ec5-ebb4b9388c23" width=320 /> | <img src="https://github.com/woocommerce/woocommerce-ios/assets/5533851/ce832bc2-4797-4b32-80f2-adcad15864da" width=320 /> | <img src="https://github.com/woocommerce/woocommerce-ios/assets/5533851/06018c59-683d-40ba-a754-1d27171c2545" width=320 /> | <img src="https://github.com/woocommerce/woocommerce-ios/assets/5533851/2fa0a054-68e1-4eaa-beb5-17c9615212c4" width=320 />


3. Order creation
- Log in to a store.
- Switch to Orders tab and select "+" to create a new order.
- Add a product to the order.
- Expand the product row, tap Add discount.
- Add an amount then save it.
- Tap the Pencil button next to the discount amount.
- Confirm that the arrow icon faces left.

<img src="https://github.com/woocommerce/woocommerce-ios/assets/5533851/4e8909aa-358b-48c0-b9a0-fff3f7135ed5" width=320 />

- Tax rate row: follow the steps in [this PR](https://github.com/woocommerce/woocommerce-ios/pull/11547) to set up Tax, then confirm that the arrow in the tax rate row faces left.

<img src="https://github.com/woocommerce/woocommerce-ios/assets/5533851/42305662-5ce8-4e81-a10b-0da523cfacd8" width=320 />


4. Store creation
- Open the store picker then select Add a store > Create a new store.
- Confirm that the country step of the profiler flow contains an arrow facing left

<img src="https://github.com/woocommerce/woocommerce-ios/assets/5533851/2729e4c7-0ce5-4576-af62-3de807759c72" width=320 />

- After store creation succeeds, tap Upgrade in the banner on Dashboard screen.
- Tap View complete list of features button.
- Confirm that the arrow on the feature list faces right.


<img src="https://github.com/woocommerce/woocommerce-ios/assets/5533851/201c2b0e-eff5-4f0a-8998-f8410a0e6d76" width=320 />




---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
