### PR TITLE
Blaze: Add parameter view should keep entered value after rotating device

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Blaze/AdDestination/BlazeAddParameterView.swift
+++ b/WooCommerce/Classes/ViewRelated/Blaze/AdDestination/BlazeAddParameterView.swift
@@ -5,10 +5,10 @@ import SwiftUI
 struct BlazeAddParameterView: View {
     @Environment(\.dismiss) private var dismiss
 
-    @ObservedObject private var viewModel: BlazeAddParameterViewModel
+    @StateObject private var viewModel: BlazeAddParameterViewModel
 
     init(viewModel: BlazeAddParameterViewModel) {
-        self.viewModel = viewModel
+        self._viewModel = StateObject(wrappedValue: viewModel)
     }
 
     var body: some View {


### PR DESCRIPTION
Fixes #11809 

### Description:

This fixes the bug where entered user value in Ad Destination > Add Parameter setting disappears after rotation.

### The issue:

While this fix works, I must say that my understanding of `@ObservedObject` vs `@StateObject` might still be lacking. But here's my best attempt to explain the issue:

Previously, `BlazeAddParameterView` uses `@ObservedObject` to observe its view model, as the viewmodel is created by the parent  view's`BlazeAdDestinationSettingViewModel`. During rotation, the underlying parent viewmodel is recreated, which in turn also recreates the `BlazeAddParameterViewModel`.

Inside the initialization for `BlazeAddParameterViewModel`, it checks for empty `parameter` value and if it is, sets `key` and `value` as empty:

```
    init(remainingCharacters: Int,
         parameter: BlazeAdURLParameter? = nil,
         onCancel: @escaping () -> Void,
         onCompletion: @escaping BlazeAddParameterCompletionHandler) {
        self.remainingCharacters = remainingCharacters
        self.parameter = parameter
        self.cancellationHandler = onCancel
        self.completionHandler = onCompletion

        key = parameter?.key ?? ""
        value = parameter?.value ?? ""
    }
```

Thus, during rotation, the `key` and `value`  are reset to empty String again, creating the issue.

### The fix:

The fix now uses `@StateObject`, which lets the view to take over responsibility to manage the viewmodel's lifecycle. Thus, as long as the view is visible, when it is rotated, it keeps the existing viewmodel. This in turns makes sure that the entered values in the viewmodel are preserved.

### To test:

To Reproduce

1. Log in to a store eligible for Blaze.
2. Go to Dashboard > Promote.
3. Select a product to promote if asked.
4. Select Ad Destination > Add parameter.
5. Type some contents in the key and value fields, then rotate the device.
6. Ensure the entered contents are not removed.