### PR TITLE
[Backend Receipts] Network layer for `receipt` endpoint

### DIFF
--- a/Networking/Networking.xcodeproj/project.pbxproj
+++ b/Networking/Networking.xcodeproj/project.pbxproj
@@ -399,6 +399,12 @@
 		6888A2C62A650FD00026F5C0 /* iap-transaction-not-handled.json in Resources */ = {isa = PBXBuildFile; fileRef = 6888A2C52A650FD00026F5C0 /* iap-transaction-not-handled.json */; };
 		688908AE28FF920C0081A07E /* customer-2.json in Resources */ = {isa = PBXBuildFile; fileRef = 688908AD28FF920C0081A07E /* customer-2.json */; };
 		68BD37B328D9B8BD00C2A517 /* CustomerRemoteTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 68BD37B228D9B8BD00C2A517 /* CustomerRemoteTests.swift */; };
+		68BFF8FA2B67679700B15FF2 /* ReceiptRemote.swift in Sources */ = {isa = PBXBuildFile; fileRef = 68BFF8F92B67679700B15FF2 /* ReceiptRemote.swift */; };
+		68BFF8FC2B6767FA00B15FF2 /* ReceiptMapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 68BFF8FB2B6767FA00B15FF2 /* ReceiptMapper.swift */; };
+		68BFF8FE2B676A9F00B15FF2 /* Receipt.swift in Sources */ = {isa = PBXBuildFile; fileRef = 68BFF8FD2B676A9F00B15FF2 /* Receipt.swift */; };
+		68BFF9022B677F1D00B15FF2 /* ReceiptRemoteTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 68BFF9012B677F1D00B15FF2 /* ReceiptRemoteTests.swift */; };
+		68BFF9042B6780AA00B15FF2 /* receipt.json in Resources */ = {isa = PBXBuildFile; fileRef = 68BFF9032B6780AA00B15FF2 /* receipt.json */; };
+		68BFF9062B6785C700B15FF2 /* receipt-without-data-envelope.json in Resources */ = {isa = PBXBuildFile; fileRef = 68BFF9052B6785C700B15FF2 /* receipt-without-data-envelope.json */; };
 		68C87B342862D40E00A99054 /* setting-all-except-countries.json in Resources */ = {isa = PBXBuildFile; fileRef = 68C87B332862D40E00A99054 /* setting-all-except-countries.json */; };
 		68CB800C28D87BC800E169F8 /* Customer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 68CB800B28D87BC800E169F8 /* Customer.swift */; };
 		68CB800E28D8901B00E169F8 /* CustomerMapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 68CB800D28D8901B00E169F8 /* CustomerMapper.swift */; };
@@ -1454,6 +1460,12 @@
 		6888A2C52A650FD00026F5C0 /* iap-transaction-not-handled.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "iap-transaction-not-handled.json"; sourceTree = "<group>"; };
 		688908AD28FF920C0081A07E /* customer-2.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "customer-2.json"; sourceTree = "<group>"; };
 		68BD37B228D9B8BD00C2A517 /* CustomerRemoteTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomerRemoteTests.swift; sourceTree = "<group>"; };
+		68BFF8F92B67679700B15FF2 /* ReceiptRemote.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReceiptRemote.swift; sourceTree = "<group>"; };
+		68BFF8FB2B6767FA00B15FF2 /* ReceiptMapper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReceiptMapper.swift; sourceTree = "<group>"; };
+		68BFF8FD2B676A9F00B15FF2 /* Receipt.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Receipt.swift; sourceTree = "<group>"; };
+		68BFF9012B677F1D00B15FF2 /* ReceiptRemoteTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReceiptRemoteTests.swift; sourceTree = "<group>"; };
+		68BFF9032B6780AA00B15FF2 /* receipt.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = receipt.json; sourceTree = "<group>"; };
+		68BFF9052B6785C700B15FF2 /* receipt-without-data-envelope.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "receipt-without-data-envelope.json"; sourceTree = "<group>"; };
 		68C87B332862D40E00A99054 /* setting-all-except-countries.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "setting-all-except-countries.json"; sourceTree = "<group>"; };
 		68CB800B28D87BC800E169F8 /* Customer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Customer.swift; sourceTree = "<group>"; };
 		68CB800D28D8901B00E169F8 /* CustomerMapper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomerMapper.swift; sourceTree = "<group>"; };
@@ -2347,6 +2359,7 @@
 				26E5A08B25A66FD3000DF8F6 /* ProductAttributeTermRemoteTests.swift */,
 				4599FC6524A633A10056157A /* ProductTagsRemoteTests.swift */,
 				CE71E2382A4C594600DB5376 /* ProductsReportsRemoteTests.swift */,
+				68BFF9012B677F1D00B15FF2 /* ReceiptRemoteTests.swift */,
 				7412A8F121B6E47A005D182A /* ReportRemoteTests.swift */,
 				743E84F9221742E300FAC9D7 /* ShipmentsRemoteTests.swift */,
 				74AB5B5021AF426D00859C12 /* SiteAPIRemoteTests.swift */,
@@ -2505,6 +2518,7 @@
 				CE0A0F1A223989670075ED8D /* ProductsRemote.swift */,
 				CE71E22A2A4C363E00DB5376 /* ProductsReportsRemote.swift */,
 				025CA2C3238EBC4300B05C81 /* ProductShippingClassRemote.swift */,
+				68BFF8F92B67679700B15FF2 /* ReceiptRemote.swift */,
 				CE43066F234B99F50073CBFF /* RefundsRemote.swift */,
 				7412A8E921B6E192005D182A /* ReportRemote.swift */,
 				743E84E922171C5800FAC9D7 /* ShipmentsRemote.swift */,
@@ -2617,6 +2631,7 @@
 				267313302559CC930026F7EF /* PaymentGateway.swift */,
 				314703072670222500EF253A /* PaymentGatewayAccount.swift */,
 				D89A01D326D3F8D8008195BE /* ReaderLocation.swift */,
+				68BFF8FD2B676A9F00B15FF2 /* Receipt.swift */,
 				743E84EB22171F4600FAC9D7 /* ShipmentTracking.swift */,
 				D823D90C2237784A00C90817 /* ShipmentTrackingProvider.swift */,
 				D823D90F22377B4F00C90817 /* ShipmentTrackingProviderGroup.swift */,
@@ -2948,6 +2963,7 @@
 				EE4D51B42ACD331300783D77 /* product-categories-created-without-data.json */,
 				EE4D51B32ACD331300783D77 /* product-categories-created.json */,
 				020EF5EC2A8C8F4F009D2169 /* products-total.json */,
+				68BFF9032B6780AA00B15FF2 /* receipt.json */,
 				CEC4BF90234E40B5008D9195 /* refund-single.json */,
 				CEC4BF92234E7EE0008D9195 /* refunds-all.json */,
 				7412A8EF21B6E415005D182A /* report-orders.json */,
@@ -3085,6 +3101,7 @@
 				684AB6D72AC2E93100106D7C /* order-with-special-character-currency.json */,
 				20D210C22B1780CE0099E517 /* deposits-overview-all.json */,
 				20D210C42B1788E60099E517 /* deposits-overview-all-no-default-currency.json */,
+				68BFF9052B6785C700B15FF2 /* receipt-without-data-envelope.json */,
 			);
 			path = Responses;
 			sourceTree = "<group>";
@@ -3176,6 +3193,7 @@
 				311D412D2783C07D00052F64 /* StripeAccountMapper.swift */,
 				3192F21B260D32550067FEF9 /* WCPayAccountMapper.swift */,
 				D8EDFE2525EE8A60003D2213 /* ReaderConnectionTokenMapper.swift */,
+				68BFF8FB2B6767FA00B15FF2 /* ReceiptMapper.swift */,
 				3178A49E2703E5CF00A8B4CA /* RemoteReaderLocationMapper.swift */,
 				31054701262E04F700C5C02B /* RemotePaymentIntentMapper.swift */,
 				45A4B84D25D2E11300776FB4 /* ShippingLabelAddressValidationSuccessMapper.swift */,
@@ -3782,6 +3800,7 @@
 				EE66BB062B29791500518DAF /* theme-activate-success.json in Resources */,
 				CE6B969A2A0BCD09003C4B27 /* order-with-bundled-line-items.json in Resources */,
 				3158FE6026129ADD00E566B9 /* wcpay-account-none.json in Resources */,
+				68BFF9042B6780AA00B15FF2 /* receipt.json in Resources */,
 				743E84FC22174CE100FAC9D7 /* restnoroute_error.json in Resources */,
 				CE20179320E3EFA7005B4C18 /* broken-orders.json in Resources */,
 				D8FBFF2722D529F2006E3336 /* order-stats-v4-month.json in Resources */,
@@ -4066,6 +4085,7 @@
 				B918DDF12A3C960000E74DE5 /* products-sku-search-variation.json in Resources */,
 				03EB99982907F4AA00F06A39 /* just-in-time-message-list-multiple.json in Resources */,
 				EE80A25029556FBD003591E4 /* coupon-reports-without-data.json in Resources */,
+				68BFF9062B6785C700B15FF2 /* receipt-without-data-envelope.json in Resources */,
 				451A97DE260B59870059D135 /* shipping-label-packages-success.json in Resources */,
 				2676F4D0290B0EC800C7A15B /* product-id-only.json in Resources */,
 				31D27C8F2602B553002EDB1D /* plugins.json in Resources */,
@@ -4194,6 +4214,7 @@
 				74ABA1CF213F1D1600FFAD30 /* TopEarnerStatsItem.swift in Sources */,
 				FE28F6E6268429B6004465C7 /* UserRemote.swift in Sources */,
 				02AD47702A6EB71100E652D6 /* URLRequestConvertible+Path.swift in Sources */,
+				68BFF8FE2B676A9F00B15FF2 /* Receipt.swift in Sources */,
 				7452387421124B7700A973CD /* AnyDecodable.swift in Sources */,
 				DE4D23B829B5F909003A4B5D /* Announcement.swift in Sources */,
 				CEF88DAD233E95B000BED485 /* OrderRefundCondensed.swift in Sources */,
@@ -4301,6 +4322,7 @@
 				DE74F29A27E08F5A0002FE59 /* SiteSettingMapper.swift in Sources */,
 				CC33754E29C884000006A538 /* ProductCompositeComponent.swift in Sources */,
 				450106852399A7CB00E24722 /* TaxClass.swift in Sources */,
+				68BFF8FA2B67679700B15FF2 /* ReceiptRemote.swift in Sources */,
 				CC0786612677B2DA00BA9AC1 /* ShippingLabelPurchaseMapper.swift in Sources */,
 				456930AB264EB85A009ED69D /* ShippingLabelCarriersAndRatesMapper.swift in Sources */,
 				CCF48AD4262864CB0034EA83 /* ShippingLabelAccountSettings.swift in Sources */,
@@ -4445,6 +4467,7 @@
 				4515280D257A7EEC0076B03C /* ProductAttributeListMapper.swift in Sources */,
 				93D8BBFD226BBEE800AD2EB3 /* AccountSettingsMapper.swift in Sources */,
 				31D27C8726028CE9002EDB1D /* SitePluginsMapper.swift in Sources */,
+				68BFF8FC2B6767FA00B15FF2 /* ReceiptMapper.swift in Sources */,
 				74D522B62113607F00042831 /* StatGranularity.swift in Sources */,
 				02C2549A25636E1500A04423 /* ShippingLabelAddress.swift in Sources */,
 				03DCB786262739D200C8953D /* CouponMapper.swift in Sources */,
@@ -4798,6 +4821,7 @@
 				B567AF3020A0FB8F00AB6C62 /* DotcomRequestTests.swift in Sources */,
 				EE57C138297F9AC900BC31E7 /* ProductVariationsBulkUpdateMapperTests.swift in Sources */,
 				E18152C428F85E5C0011A0EC /* InAppPurchasesProductsMapperTests.swift in Sources */,
+				68BFF9022B677F1D00B15FF2 /* ReceiptRemoteTests.swift in Sources */,
 				CCE5F39729F00B5200087332 /* SubscriptionsRemoteTests.swift in Sources */,
 				DED91DE72AD64ED500CDCC53 /* BlazeRemoteTests.swift in Sources */,
 				D8A2849A25FBB2E70019A84B /* ProductAttributeTermListMapperTests.swift in Sources */,

--- a/Networking/Networking/Mapper/ReceiptMapper.swift
+++ b/Networking/Networking/Mapper/ReceiptMapper.swift
@@ -1,0 +1,20 @@
+import Foundation
+
+struct ReceiptMapper: Mapper {
+    /// (Attempts) to convert a dictionary into `Receipt`.
+    ///
+    func map(response: Data) throws -> Receipt {
+        let decoder = JSONDecoder()
+        if hasDataEnvelope(in: response) {
+            return try decoder.decode(ReceiptEnvelope.self, from: response).data
+        } else {
+            return try decoder.decode(Receipt.self, from: response)
+        }
+    }
+}
+
+/// `ReceiptEnvelope` allows us to parse all the things with JSONDecoder.
+///
+private struct ReceiptEnvelope: Decodable {
+    let data: Receipt
+}

--- a/Networking/Networking/Model/Receipt.swift
+++ b/Networking/Networking/Model/Receipt.swift
@@ -1,0 +1,27 @@
+import Foundation
+
+public struct Receipt: Decodable {
+    public let receiptURL: String
+    public let expirationDate: String
+
+    init(receiptURL: String, expirationDate: String) {
+        self.receiptURL = receiptURL
+        self.expirationDate = expirationDate
+    }
+
+    public init(from decoder: Decoder) throws {
+         let container = try decoder.container(keyedBy: CodingKeys.self)
+
+         let decodedReceiptURL = try container.decode(String.self, forKey: .receiptURL)
+         let decodedExpirationDate = try container.decode(String.self, forKey: .expirationDate)
+
+         self.init(receiptURL: decodedReceiptURL, expirationDate: decodedExpirationDate)
+     }
+}
+
+extension Receipt {
+    enum CodingKeys: String, CodingKey {
+        case receiptURL = "receipt_url"
+        case expirationDate = "expiration_date"
+    }
+}

--- a/Networking/Networking/Remote/ReceiptRemote.swift
+++ b/Networking/Networking/Remote/ReceiptRemote.swift
@@ -1,0 +1,15 @@
+import Foundation
+
+public class ReceiptRemote: Remote {
+    public func retrieveReceipt(siteID: Int64 = 121710041, orderID: Int64 = 7002, completion: @escaping (Result<Receipt, Error>) -> Void) {
+        let request = JetpackRequest(wooApiVersion: .mark3,
+                                     method: .post,
+                                     siteID: 121710041,
+                                     path: "orders/\(orderID)/receipt",
+                                     parameters: [:],
+                                     availableAsRESTRequest: true)
+        let mapper = ReceiptMapper()
+
+        enqueue(request, mapper: mapper, completion: completion)
+    }
+}

--- a/Networking/Networking/Remote/ReceiptRemote.swift
+++ b/Networking/Networking/Remote/ReceiptRemote.swift
@@ -1,15 +1,36 @@
 import Foundation
 
-public class ReceiptRemote: Remote {
-    public func retrieveReceipt(siteID: Int64 = 121710041, orderID: Int64 = 7002, completion: @escaping (Result<Receipt, Error>) -> Void) {
+public final class ReceiptRemote: Remote {
+    /// Retrieves a `Receipt`for a given `siteID`and `orderID`
+    ///
+    /// - Parameters:
+    ///    - siteID: site ID which contains the receipt
+    ///    - orderID: ID of the order that the receipt is associated to
+    ///    - forceRegenerate: whether a new receipt is generated. Defaults to `true`
+    ///    - completion: callback with the expected `Receipt` object, or an error.
+    ///
+    public func retrieveReceipt(siteID: Int64 = 121710041,
+                                orderID: Int64 = 7002,
+                                forceRegenerate: Bool = true,
+                                completion: @escaping (Result<Receipt, Error>) -> Void) {
+        let path = "orders/\(orderID)/receipt"
+        let parameters: [String: String] = [
+            ParameterKeys.forceRegenerate: String(forceRegenerate)
+        ]
         let request = JetpackRequest(wooApiVersion: .mark3,
                                      method: .post,
-                                     siteID: 121710041,
-                                     path: "orders/\(orderID)/receipt",
-                                     parameters: [:],
+                                     siteID: siteID,
+                                     path: path,
+                                     parameters: parameters,
                                      availableAsRESTRequest: true)
         let mapper = ReceiptMapper()
 
         enqueue(request, mapper: mapper, completion: completion)
+    }
+}
+
+private extension ReceiptRemote {
+    enum ParameterKeys {
+        static let forceRegenerate: String = "force_new"
     }
 }

--- a/Networking/Networking/Remote/ReceiptRemote.swift
+++ b/Networking/Networking/Remote/ReceiptRemote.swift
@@ -9,8 +9,8 @@ public final class ReceiptRemote: Remote {
     ///    - forceRegenerate: whether a new receipt is generated. Defaults to `true`
     ///    - completion: callback with the expected `Receipt` object, or an error.
     ///
-    public func retrieveReceipt(siteID: Int64 = 121710041,
-                                orderID: Int64 = 7002,
+    public func retrieveReceipt(siteID: Int64,
+                                orderID: Int64,
                                 forceRegenerate: Bool = true,
                                 completion: @escaping (Result<Receipt, Error>) -> Void) {
         let path = "orders/\(orderID)/receipt"

--- a/Networking/NetworkingTests/Remote/ReceiptRemoteTests.swift
+++ b/Networking/NetworkingTests/Remote/ReceiptRemoteTests.swift
@@ -1,0 +1,54 @@
+import XCTest
+
+@testable import Networking
+
+final class ReceiptRemoteTests: XCTestCase {
+
+    /// Dummy Network Wrapper
+    ///
+    let network = MockNetwork()
+
+    override func setUp() {
+        super.setUp()
+        network.removeAllSimulatedResponses()
+    }
+
+    func test_retrieveReceipt_when_there_is_data_envelope_then_returns_parsed_data() throws {
+        // Given
+        let remote = ReceiptRemote(network: network)
+
+        // When
+        network.simulateResponse(requestUrlSuffix: "orders/123/receipt",
+                                 filename: "receipt")
+        let result = waitFor { promise in
+            remote.retrieveReceipt(siteID: 123, orderID: 123) { result in
+                promise(result)
+            }
+        }
+        let receipt = try XCTUnwrap(result.get())
+
+        // Then
+        assertEqual("https://mywootestingstore.com/wc/file/transient/7e811be40195b17f82604592ed26b694868807", receipt.receiptURL)
+        assertEqual("2024-01-27", receipt.expirationDate)
+    }
+
+    func test_retrieveReceipt_when_there_is_no_data_envelope_then_returns_parsed_data() throws {
+        // Given
+        let remote = ReceiptRemote(network: network)
+
+        // When
+        network.simulateResponse(requestUrlSuffix: "orders/123/receipt",
+                                 filename: "receipt-without-data-envelope")
+        let result = waitFor { promise in
+            remote.retrieveReceipt(siteID: 123, orderID: 123) { result in
+                promise(result)
+            }
+        }
+        let receipt = try XCTUnwrap(result.get())
+
+        // Then
+        assertEqual("https://mywootestingstore.com/wc/file/transient/7e811be40195b17f82604592ed26b694868807", receipt.receiptURL)
+        assertEqual("2024-01-27", receipt.expirationDate)
+
+    }
+}

--- a/Networking/NetworkingTests/Remote/ReceiptRemoteTests.swift
+++ b/Networking/NetworkingTests/Remote/ReceiptRemoteTests.swift
@@ -49,6 +49,31 @@ final class ReceiptRemoteTests: XCTestCase {
         // Then
         assertEqual("https://mywootestingstore.com/wc/file/transient/7e811be40195b17f82604592ed26b694868807", receipt.receiptURL)
         assertEqual("2024-01-27", receipt.expirationDate)
+    }
 
+    func test_retrieveReceipt_when_invoked_then_includes_force_new_parameter_as_true_by_default() throws {
+        // Given
+        let remote = ReceiptRemote(network: network)
+
+        // When
+        remote.retrieveReceipt { _ in }
+
+        // Then
+        let request = try XCTUnwrap(network.requestsForResponseData.last as? JetpackRequest)
+        let received = try XCTUnwrap(request.parameters["force_new"] as? String)
+        assertEqual("true", received)
+    }
+
+    func test_retrieveReceipt_when_force_new_set_to_false_then_includes_force_new_parameter_as_false() throws {
+        // Given
+        let remote = ReceiptRemote(network: network)
+
+        // When
+        remote.retrieveReceipt(forceRegenerate: false) { _ in }
+
+        // Then
+        let request = try XCTUnwrap(network.requestsForResponseData.last as? JetpackRequest)
+        let received = try XCTUnwrap(request.parameters["force_new"] as? String)
+        assertEqual("false", received)
     }
 }

--- a/Networking/NetworkingTests/Remote/ReceiptRemoteTests.swift
+++ b/Networking/NetworkingTests/Remote/ReceiptRemoteTests.swift
@@ -6,7 +6,11 @@ final class ReceiptRemoteTests: XCTestCase {
 
     /// Dummy Network Wrapper
     ///
-    let network = MockNetwork()
+    private let network = MockNetwork()
+
+    private let sampleSiteID: Int64 = 12345
+
+    private let sampleOrderID: Int64 = 6789
 
     override func setUp() {
         super.setUp()
@@ -16,12 +20,14 @@ final class ReceiptRemoteTests: XCTestCase {
     func test_retrieveReceipt_when_there_is_data_envelope_then_returns_parsed_data() throws {
         // Given
         let remote = ReceiptRemote(network: network)
+        let endpoint = "orders/\(sampleOrderID)/receipt"
+        let filename = "receipt"
 
         // When
-        network.simulateResponse(requestUrlSuffix: "orders/123/receipt",
-                                 filename: "receipt")
+        network.simulateResponse(requestUrlSuffix: endpoint, filename: filename)
+
         let result = waitFor { promise in
-            remote.retrieveReceipt(siteID: 123, orderID: 123) { result in
+            remote.retrieveReceipt(siteID: self.sampleSiteID, orderID: self.sampleOrderID) { result in
                 promise(result)
             }
         }
@@ -35,12 +41,14 @@ final class ReceiptRemoteTests: XCTestCase {
     func test_retrieveReceipt_when_there_is_no_data_envelope_then_returns_parsed_data() throws {
         // Given
         let remote = ReceiptRemote(network: network)
+        let endpoint = "orders/\(sampleOrderID)/receipt"
+        let filename = "receipt-without-data-envelope"
 
         // When
-        network.simulateResponse(requestUrlSuffix: "orders/123/receipt",
-                                 filename: "receipt-without-data-envelope")
+        network.simulateResponse(requestUrlSuffix: endpoint, filename: filename)
+
         let result = waitFor { promise in
-            remote.retrieveReceipt(siteID: 123, orderID: 123) { result in
+            remote.retrieveReceipt(siteID: self.sampleSiteID, orderID: self.sampleOrderID) { result in
                 promise(result)
             }
         }
@@ -56,7 +64,7 @@ final class ReceiptRemoteTests: XCTestCase {
         let remote = ReceiptRemote(network: network)
 
         // When
-        remote.retrieveReceipt { _ in }
+        remote.retrieveReceipt(siteID: sampleSiteID, orderID: sampleOrderID) { _ in }
 
         // Then
         let request = try XCTUnwrap(network.requestsForResponseData.last as? JetpackRequest)
@@ -67,9 +75,10 @@ final class ReceiptRemoteTests: XCTestCase {
     func test_retrieveReceipt_when_force_new_set_to_false_then_includes_force_new_parameter_as_false() throws {
         // Given
         let remote = ReceiptRemote(network: network)
+        let forceRegenerate = false
 
         // When
-        remote.retrieveReceipt(forceRegenerate: false) { _ in }
+        remote.retrieveReceipt(siteID: sampleSiteID, orderID: sampleOrderID, forceRegenerate: forceRegenerate) { _ in }
 
         // Then
         let request = try XCTUnwrap(network.requestsForResponseData.last as? JetpackRequest)

--- a/Networking/NetworkingTests/Responses/receipt-without-data-envelope.json
+++ b/Networking/NetworkingTests/Responses/receipt-without-data-envelope.json
@@ -1,0 +1,4 @@
+{
+    "receipt_url":"https:\/\/mywootestingstore.com\/wc\/file\/transient\/7e811be40195b17f82604592ed26b694868807",
+    "expiration_date":"2024-01-27"
+}

--- a/Networking/NetworkingTests/Responses/receipt.json
+++ b/Networking/NetworkingTests/Responses/receipt.json
@@ -1,0 +1,6 @@
+{
+    "data": {
+        "receipt_url":"https:\/\/mywootestingstore.com\/wc\/file\/transient\/7e811be40195b17f82604592ed26b694868807",
+        "expiration_date":"2024-01-27"
+    }
+}


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #11825 

## Description
This PR adds the necessary network layer for the new `wc/v3/orders/<order-id>/receipt` endpoint, part of the Backend Receipts project ( pfoUAQ-b9-p2 ). 

The endpoint has not yet landed in WooCommerce core, but it's being worked on a development branch: https://github.com/woocommerce/woocommerce/pull/43502 using `WooCommerce Version 8.6.0-dev-7625495467-gf50cc6b`

From the app, we intend to submit a POST request to the endpoint, such as:
```
curl -X POST "https://mywootestingstore.mystagingwebsite.com/wp-json/wc/v3/orders/<order-id>/receipt?<consumer-key>&consumer_secret=<consumer-secret>"
```
And expect a response that contains a `receipt_url` with an URL to the order receipt, as well as an `expiration_date`.
```
{
    "receipt_url":"https:\/\/mywootestingstore.com\/wc\/file\/transient\/7e811be40195b17f82604592ed26b694868807",
    "expiration_date":"2024-01-27"
}
```

## Testing instructions
Still not being used. Unit tests should pass.