### PR TITLE
[Blaze] Payment and creation analytics

### DIFF
--- a/WooCommerce/Classes/Analytics/WooAnalyticsEvent+Blaze.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsEvent+Blaze.swift
@@ -173,12 +173,12 @@ extension WooAnalyticsEvent {
                 WooAnalyticsEvent(statName: .blazeAddPaymentMethodSuccess, properties: [:])
             }
 
-            /// Tracked upon adding a payment method
+            /// Tracked when campaign creation is successful
             static func campaignCreationSuccess() -> WooAnalyticsEvent {
                 WooAnalyticsEvent(statName: .blazeCampaignCreationSuccess, properties: [:])
             }
 
-            /// Tracked upon campaign creation fails
+            /// Tracked when campaign creation fails
             static func campaignCreationFailed() -> WooAnalyticsEvent {
                 WooAnalyticsEvent(statName: .blazeCampaignCreationFailed, properties: [:])
             }

--- a/WooCommerce/Classes/Analytics/WooAnalyticsEvent+Blaze.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsEvent+Blaze.swift
@@ -156,6 +156,33 @@ extension WooAnalyticsEvent {
                 WooAnalyticsEvent(statName: .blazeEditDestinationSaveTapped, properties: [:])
             }
         }
+
+        enum Payment {
+            /// Tracked upon tapping "Submit Campaign" in confirm payment screen
+            static func submitCampaignTapped() -> WooAnalyticsEvent {
+                WooAnalyticsEvent(statName: .blazeSubmitCampaignTapped, properties: [:])
+            }
+
+            /// Tracked upon displaying "Add payment method" web view screen
+            static func addPaymentMethodWebViewDisplayed() -> WooAnalyticsEvent {
+                WooAnalyticsEvent(statName: .blazeAddPaymentMethodWebViewDisplayed, properties: [:])
+            }
+
+            /// Tracked upon adding a payment method
+            static func addPaymentMethodSuccess() -> WooAnalyticsEvent {
+                WooAnalyticsEvent(statName: .blazeAddPaymentMethodSuccess, properties: [:])
+            }
+
+            /// Tracked upon adding a payment method
+            static func campaignCreationSuccess() -> WooAnalyticsEvent {
+                WooAnalyticsEvent(statName: .blazeCampaignCreationSuccess, properties: [:])
+            }
+
+            /// Tracked upon campaign creation fails
+            static func campaignCreationFailed() -> WooAnalyticsEvent {
+                WooAnalyticsEvent(statName: .blazeCampaignCreationFailed, properties: [:])
+            }
+        }
     }
 }
 

--- a/WooCommerce/Classes/Analytics/WooAnalyticsStat.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsStat.swift
@@ -201,6 +201,11 @@ public enum WooAnalyticsStat: String {
     case blazeEditLocationSaveTapped = "blaze_creation_edit_location_save_tapped"
     case blazeEditInterestSaveTapped = "blaze_creation_edit_interest_save_tapped"
     case blazeEditDestinationSaveTapped = "blaze_creation_edit_destination_save_tapped"
+    case blazeSubmitCampaignTapped = "blaze_creation_payment_submit_campaign_tapped"
+    case blazeAddPaymentMethodWebViewDisplayed = "blaze_creation_add_payment_method_web_view_displayed"
+    case blazeAddPaymentMethodSuccess = "blaze_creation_add_payment_method_success"
+    case blazeCampaignCreationSuccess = "blaze_campaign_creation_success"
+    case blazeCampaignCreationFailed = "blaze_campaign_creation_failed"
 
     // MARK: Store Onboarding Events
     //

--- a/WooCommerce/Classes/ViewRelated/Blaze/ConfirmPayment/BlazeAddPaymentMethodWebView.swift
+++ b/WooCommerce/Classes/ViewRelated/Blaze/ConfirmPayment/BlazeAddPaymentMethodWebView.swift
@@ -31,6 +31,9 @@ struct BlazeAddPaymentMethodWebView: View {
             .wooNavigationBarStyle()
             .navigationBarTitleDisplayMode(.inline)
         }
+        .onAppear {
+            viewModel.onAppear()
+        }
         .notice($viewModel.notice)
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Blaze/ConfirmPayment/BlazeAddPaymentMethodWebViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Blaze/ConfirmPayment/BlazeAddPaymentMethodWebViewModel.swift
@@ -4,6 +4,7 @@ import Yosemite
 ///
 final class BlazeAddPaymentMethodWebViewModel: ObservableObject {
     typealias Completion = (_ newPaymentMethodID: String) -> Void
+    private let analytics: Analytics
     private let onCompletion: Completion
 
     private let siteID: Int64
@@ -21,10 +22,16 @@ final class BlazeAddPaymentMethodWebViewModel: ObservableObject {
 
     init(siteID: Int64,
          addPaymentMethodInfo: BlazeAddPaymentInfo,
+         analytics: Analytics = ServiceLocator.analytics,
          completion: @escaping Completion) {
         self.siteID = siteID
         self.addPaymentMethodInfo = addPaymentMethodInfo
+        self.analytics = analytics
         self.onCompletion = completion
+    }
+
+    func onAppear() {
+        analytics.track(event: .Blaze.Payment.addPaymentMethodWebViewDisplayed())
     }
 
     func didAddNewPaymentMethod(successURL: URL?) {
@@ -37,6 +44,7 @@ final class BlazeAddPaymentMethodWebViewModel: ObservableObject {
             return
         }
 
+        analytics.track(event: .Blaze.Payment.addPaymentMethodSuccess())
         onCompletion(newPaymentMethodID)
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Blaze/ConfirmPayment/BlazeConfirmPaymentView.swift
+++ b/WooCommerce/Classes/ViewRelated/Blaze/ConfirmPayment/BlazeConfirmPaymentView.swift
@@ -89,7 +89,6 @@ struct BlazeConfirmPaymentView: View {
                 }
             }, onCancel: {
                 viewModel.shouldDisplayCampaignCreationError = false
-                viewModel.cancelCampaignCreation()
                 dismiss()
             })
             .interactiveDismissDisabled()

--- a/WooCommerce/WooCommerceTests/ViewRelated/Blaze/BlazeAddPaymentMethodWebViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Blaze/BlazeAddPaymentMethodWebViewModelTests.swift
@@ -6,7 +6,22 @@ final class BlazeAddPaymentMethodWebViewModelTests: XCTestCase {
     private let sampleSiteID: Int64 = 322
     private let samplePaymentInfo: BlazePaymentInfo = BlazePaymentMethodsViewModel.samplePaymentInfo()
 
-    func test_addPaymentMethodURL_returns_formUrl() async throws {
+    private var analyticsProvider: MockAnalyticsProvider!
+    private var analytics: WooAnalytics!
+
+    override func setUp() {
+        super.setUp()
+        analyticsProvider = MockAnalyticsProvider()
+        analytics = WooAnalytics(analyticsProvider: analyticsProvider)
+    }
+
+    override func tearDown() {
+        analytics = nil
+        analyticsProvider = nil
+        super.tearDown()
+    }
+
+    func test_addPaymentMethodURL_returns_formUrl() throws {
         // Given
         let viewModel = BlazeAddPaymentMethodWebViewModel(siteID: sampleSiteID,
                                                           addPaymentMethodInfo: samplePaymentInfo.addPaymentMethod) { _ in }
@@ -24,7 +39,7 @@ final class BlazeAddPaymentMethodWebViewModelTests: XCTestCase {
         XCTAssertEqual(viewModel.addPaymentSuccessURL, "https://example.com/blaze-pm-success")
     }
 
-    func test_didAddNewPaymentMethod_sends_newly_added_payment_id_via_completion_handler() async throws {
+    func test_didAddNewPaymentMethod_sends_newly_added_payment_id_via_completion_handler() throws {
         // Given
         var selectedPaymentID = ""
         let viewModel = BlazeAddPaymentMethodWebViewModel(siteID: sampleSiteID,
@@ -39,7 +54,7 @@ final class BlazeAddPaymentMethodWebViewModelTests: XCTestCase {
         XCTAssertEqual(selectedPaymentID, "123")
     }
 
-    func test_didAddNewPaymentMethod_sets_notice() async throws {
+    func test_didAddNewPaymentMethod_sets_notice() throws {
         // Given
         let viewModel = BlazeAddPaymentMethodWebViewModel(siteID: sampleSiteID,
                                                           addPaymentMethodInfo: samplePaymentInfo.addPaymentMethod) { _ in }
@@ -50,5 +65,31 @@ final class BlazeAddPaymentMethodWebViewModelTests: XCTestCase {
 
         // Then
         XCTAssertNotNil(viewModel.notice)
+    }
+
+    // MARK: Analytics
+    func test_onAppear_tracks_event() throws {
+        // Given
+        let viewModel = BlazeAddPaymentMethodWebViewModel(siteID: sampleSiteID,
+                                                          addPaymentMethodInfo: samplePaymentInfo.addPaymentMethod,
+                                                          analytics: analytics) { _ in }
+        // When
+        viewModel.onAppear()
+
+        // Then
+        XCTAssertTrue(analyticsProvider.receivedEvents.contains("blaze_creation_add_payment_method_web_view_displayed"))
+    }
+
+    func test_didAddNewPaymentMethod_tracks_event() throws {
+        // Given
+        let viewModel = BlazeAddPaymentMethodWebViewModel(siteID: sampleSiteID,
+                                                          addPaymentMethodInfo: samplePaymentInfo.addPaymentMethod,
+                                                          analytics: analytics) { _ in }
+        // When
+        let successURL = try XCTUnwrap(URL(string: "\(samplePaymentInfo.addPaymentMethod.successUrl)?\(samplePaymentInfo.addPaymentMethod.idUrlParameter)=123"))
+        viewModel.didAddNewPaymentMethod(successURL: successURL)
+
+        // Then
+        XCTAssertTrue(analyticsProvider.receivedEvents.contains("blaze_creation_add_payment_method_success"))
     }
 }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #11835 
Closes: #11841
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
Adds analytics events for Blaze creation and payment. 

Tracking plan - pe5sF9-2mb-p2#metrics

## Testing instructions

The following steps assume that API is ready. We can use these steps to test once the API is ready. For now, please only look at the code. 

Prerequisites
- Create a JN site with Woo + Jetpack and publish a product.
- Log in to the app using WPCOM credentials.
- Create a new product and publish it.
- Switch to Products tab and open the product details screen
- Tap "Promote with Blaze" button
- Tap the "Create Your Campaign" button and navigate to Blaze creation form

No cards
- Tap "Confirm Details" and validate that `blaze_creation_confirm_details_tapped` event is tracked
- Launch the add payment method view from this screen and validate that `blaze_creation_add_payment_method_web_view_displayed` event is tracked.
- Add a payment view from the web view and validate that `blaze_creation_add_payment_method_success` event is tracked.

Existing cards
- Navigate back to the creation form
- Tap "Confirm Details"
- Tap on an existing card -> "Add another credit card" and validate that `blaze_creation_add_payment_method_web_view_displayed` event is tracked
- Add a payment view from the web view and validate that `blaze_creation_add_payment_method_success` event is tracked

Campaign creation
- Turn off internet
- Tap "Submit Campaign" and validate that `blaze_creation_payment_submit_campaign_tapped` is tracked
- You will see an error screen as campaign creation will fail due to no connection. Validate that `blaze_campaign_creation_failed` event is tracked.
- Try submitting campaign again after turning on internet. `blaze_campaign_creation_success` should be tracked after campaign creation is successful. 

## Screenshots
![Simulator Screen Recording - iPhone 15 Pro Max - 2024-01-29 at 16 28 19](https://github.com/woocommerce/woocommerce-ios/assets/524475/782d5b40-100e-4405-9d4b-553f073404d5)

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
