### PR TITLE
Orders tab: fix placeholder cells losing animated content

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -90,8 +90,9 @@ target 'WooCommerce' do
 
   wordpress_shared
 
-  pod 'WordPressUI', '~> 1.13'
+  # pod 'WordPressUI', '~> 1.13'
   # pod 'WordPressUI', :git => 'https://github.com/wordpress-mobile/WordPressUI-iOS.git', :branch => ''
+  pod 'WordPressUI', git: 'https://github.com/wordpress-mobile/WordPressUI-iOS.git', commit: 'd1acf1e2693ccfdff58bef3e9ced38d3f00abfb0'
 
   aztec
 

--- a/Podfile
+++ b/Podfile
@@ -92,7 +92,7 @@ target 'WooCommerce' do
 
   # pod 'WordPressUI', '~> 1.13'
   # pod 'WordPressUI', :git => 'https://github.com/wordpress-mobile/WordPressUI-iOS.git', :branch => ''
-  pod 'WordPressUI', git: 'https://github.com/wordpress-mobile/WordPressUI-iOS.git', commit: '38da37f2d08d8628d5c065c652a80b1dda77677f'
+  pod 'WordPressUI', git: 'https://github.com/wordpress-mobile/WordPressUI-iOS.git', commit: 'a0248ba6dabaed1d493416fd1273aa6718c76331'
 
   aztec
 

--- a/Podfile
+++ b/Podfile
@@ -92,7 +92,7 @@ target 'WooCommerce' do
 
   # pod 'WordPressUI', '~> 1.13'
   # pod 'WordPressUI', :git => 'https://github.com/wordpress-mobile/WordPressUI-iOS.git', :branch => ''
-  pod 'WordPressUI', git: 'https://github.com/wordpress-mobile/WordPressUI-iOS.git', commit: 'd1acf1e2693ccfdff58bef3e9ced38d3f00abfb0'
+  pod 'WordPressUI', git: 'https://github.com/wordpress-mobile/WordPressUI-iOS.git', commit: '38da37f2d08d8628d5c065c652a80b1dda77677f'
 
   aztec
 

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -73,7 +73,7 @@ DEPENDENCIES:
   - WordPress-Editor-iOS (~> 1.19.9)
   - WordPressAuthenticator (~> 9.0)
   - WordPressShared (~> 2.1)
-  - WordPressUI (from `https://github.com/wordpress-mobile/WordPressUI-iOS.git`, commit `38da37f2d08d8628d5c065c652a80b1dda77677f`)
+  - WordPressUI (from `https://github.com/wordpress-mobile/WordPressUI-iOS.git`, commit `a0248ba6dabaed1d493416fd1273aa6718c76331`)
   - Wormholy (~> 1.6.6)
   - WPMediaPicker (~> 1.8.1)
   - ZendeskSupportSDK (~> 6.0)
@@ -114,12 +114,12 @@ SPEC REPOS:
 
 EXTERNAL SOURCES:
   WordPressUI:
-    :commit: 38da37f2d08d8628d5c065c652a80b1dda77677f
+    :commit: a0248ba6dabaed1d493416fd1273aa6718c76331
     :git: https://github.com/wordpress-mobile/WordPressUI-iOS.git
 
 CHECKOUT OPTIONS:
   WordPressUI:
-    :commit: 38da37f2d08d8628d5c065c652a80b1dda77677f
+    :commit: a0248ba6dabaed1d493416fd1273aa6718c76331
     :git: https://github.com/wordpress-mobile/WordPressUI-iOS.git
 
 SPEC CHECKSUMS:
@@ -155,6 +155,6 @@ SPEC CHECKSUMS:
   ZendeskSupportProvidersSDK: 685b5d185af47ced0ec40564ec46355c838bbd06
   ZendeskSupportSDK: 92e6f9d334e81e9186f8a17583862350460a5393
 
-PODFILE CHECKSUM: f1a3c646ae31dba245d6b6613b76f806c8589f08
+PODFILE CHECKSUM: 38f7d5d7246e7e947c3a5e2347c1b799c1a1ed4b
 
 COCOAPODS: 1.14.0

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -42,7 +42,7 @@ PODS:
     - WordPressShared (~> 2.0-beta)
     - wpxmlrpc (~> 0.10)
   - WordPressShared (2.1.0)
-  - WordPressUI (1.13.1)
+  - WordPressUI (1.15.0)
   - Wormholy (1.6.6)
   - WPMediaPicker (1.8.1)
   - wpxmlrpc (0.10.0)
@@ -73,7 +73,7 @@ DEPENDENCIES:
   - WordPress-Editor-iOS (~> 1.19.9)
   - WordPressAuthenticator (~> 9.0)
   - WordPressShared (~> 2.1)
-  - WordPressUI (~> 1.13)
+  - WordPressUI (from `https://github.com/wordpress-mobile/WordPressUI-iOS.git`, commit `d1acf1e2693ccfdff58bef3e9ced38d3f00abfb0`)
   - Wormholy (~> 1.6.6)
   - WPMediaPicker (~> 1.8.1)
   - ZendeskSupportSDK (~> 6.0)
@@ -101,7 +101,6 @@ SPEC REPOS:
     - WordPress-Aztec-iOS
     - WordPress-Editor-iOS
     - WordPressShared
-    - WordPressUI
     - Wormholy
     - WPMediaPicker
     - wpxmlrpc
@@ -112,6 +111,16 @@ SPEC REPOS:
     - ZendeskSDKConfigurationsSDK
     - ZendeskSupportProvidersSDK
     - ZendeskSupportSDK
+
+EXTERNAL SOURCES:
+  WordPressUI:
+    :commit: d1acf1e2693ccfdff58bef3e9ced38d3f00abfb0
+    :git: https://github.com/wordpress-mobile/WordPressUI-iOS.git
+
+CHECKOUT OPTIONS:
+  WordPressUI:
+    :commit: d1acf1e2693ccfdff58bef3e9ced38d3f00abfb0
+    :git: https://github.com/wordpress-mobile/WordPressUI-iOS.git
 
 SPEC CHECKSUMS:
   Alamofire: 3ec537f71edc9804815215393ae2b1a8ea33a844
@@ -134,7 +143,7 @@ SPEC CHECKSUMS:
   WordPressAuthenticator: e3c18f1b63222742a565fea3faf1a55a144ce8c4
   WordPressKit: 57712035a44595cf49b0c9f0ad5b8b899a8cbe6a
   WordPressShared: 0aa459e5257a77184db87805a998f447443c9706
-  WordPressUI: 7304a3a604b8dc582981e723e6d7caa9dd5a9f0e
+  WordPressUI: a491454affda3b0fb812812e637dc5e8f8f6bd06
   Wormholy: 09da0b876f9276031fd47383627cb75e194fc068
   WPMediaPicker: 9011a0ec1f468c039af7485c244576b4c9889a0f
   wpxmlrpc: 68db063041e85d186db21f674adf08d9c70627fd
@@ -146,6 +155,6 @@ SPEC CHECKSUMS:
   ZendeskSupportProvidersSDK: 685b5d185af47ced0ec40564ec46355c838bbd06
   ZendeskSupportSDK: 92e6f9d334e81e9186f8a17583862350460a5393
 
-PODFILE CHECKSUM: 8b4feca63e4816db58ab59b47cd31b94477c016a
+PODFILE CHECKSUM: 8c2967317ad3834cf0446af21ae357a4d197be72
 
 COCOAPODS: 1.14.0

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -73,7 +73,7 @@ DEPENDENCIES:
   - WordPress-Editor-iOS (~> 1.19.9)
   - WordPressAuthenticator (~> 9.0)
   - WordPressShared (~> 2.1)
-  - WordPressUI (from `https://github.com/wordpress-mobile/WordPressUI-iOS.git`, commit `d1acf1e2693ccfdff58bef3e9ced38d3f00abfb0`)
+  - WordPressUI (from `https://github.com/wordpress-mobile/WordPressUI-iOS.git`, commit `38da37f2d08d8628d5c065c652a80b1dda77677f`)
   - Wormholy (~> 1.6.6)
   - WPMediaPicker (~> 1.8.1)
   - ZendeskSupportSDK (~> 6.0)
@@ -114,12 +114,12 @@ SPEC REPOS:
 
 EXTERNAL SOURCES:
   WordPressUI:
-    :commit: d1acf1e2693ccfdff58bef3e9ced38d3f00abfb0
+    :commit: 38da37f2d08d8628d5c065c652a80b1dda77677f
     :git: https://github.com/wordpress-mobile/WordPressUI-iOS.git
 
 CHECKOUT OPTIONS:
   WordPressUI:
-    :commit: d1acf1e2693ccfdff58bef3e9ced38d3f00abfb0
+    :commit: 38da37f2d08d8628d5c065c652a80b1dda77677f
     :git: https://github.com/wordpress-mobile/WordPressUI-iOS.git
 
 SPEC CHECKSUMS:
@@ -155,6 +155,6 @@ SPEC CHECKSUMS:
   ZendeskSupportProvidersSDK: 685b5d185af47ced0ec40564ec46355c838bbd06
   ZendeskSupportSDK: 92e6f9d334e81e9186f8a17583862350460a5393
 
-PODFILE CHECKSUM: 8c2967317ad3834cf0446af21ae357a4d197be72
+PODFILE CHECKSUM: f1a3c646ae31dba245d6b6613b76f806c8589f08
 
 COCOAPODS: 1.14.0

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -2,7 +2,7 @@
 
 17.2
 -----
-
+- [*] Orders: the placeholder cells shown in the loading state have the animated redacted content again. [https://github.com/woocommerce/woocommerce-ios/pull/11842]
 
 17.1
 -----

--- a/WooCommerce/Classes/Authentication/WPComLogin/WPComPasswordLoginViewModel.swift
+++ b/WooCommerce/Classes/Authentication/WPComLogin/WPComPasswordLoginViewModel.swift
@@ -78,7 +78,7 @@ private extension WPComPasswordLoginViewModel {
         return email
             .lowercased()
             .trimmingCharacters(in: .whitespaces)
-            .md5Hash()
+            .sha256Hash()
     }
 
     func createLoginFields(with nonceInfo: SocialLogin2FANonceInfo? = nil, userID: Int = 0) -> LoginFields {

--- a/WooCommerce/WooCommerceTests/ViewRelated/JetpackSetup/WPComLogin/WPComPasswordLoginViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/JetpackSetup/WPComLogin/WPComPasswordLoginViewModelTests.swift
@@ -24,7 +24,7 @@ final class WPComPasswordLoginViewModelTests: XCTestCase {
         let url = try XCTUnwrap(viewModel.avatarURL)
 
         // Then
-        assertEqual("https://gravatar.com/avatar/55502f40dc8b7c769880b10874abc9d0?d=mp&s=80&r=g", url.absoluteString)
+        assertEqual("https://gravatar.com/avatar/973dfe463ec85785f5f95af5ba3906eedb2d931c24e69824a89ea65dba4e813b?d=mp&s=80&r=g", url.absoluteString)
     }
 
     func test_isLoggingIn_is_updated_correctly_and_onMultifactorCodeRequest_is_triggered_when_2FA_code_is_required() {


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #11701
Please review https://github.com/wordpress-mobile/WordPressUI-iOS/pull/138 first with testing steps in this PR

<!-- Id number of the GitHub issue this PR addresses. -->

Details about Why and How are in https://github.com/wordpress-mobile/WordPressUI-iOS/pull/138 as this PR just updates the `WordPressUI` library to the PR commit.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

- [x] @jaclync tests that all screens that conform to `GhostableViewController` look as before

---

Note: for easier testing on the loading state, you can add a filter to the order list that results in no orders. Alternatively, switching to another store also shows the loading state.

- Launch the app
- Go to the orders tab --> in the loading state, the cells should have animated content (redacted content) instead of the whole cell animated

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

before | after
-- | --
<img src="https://github.com/woocommerce/woocommerce-ios/assets/1945542/975fc95b-eae0-41e4-90dc-eaeff3069878" width="300" /> | <img src="https://github.com/woocommerce/woocommerce-ios/assets/1945542/bfa150a9-ba87-4b87-9d97-dc402e106bf1" width="300" />
<img src="https://github.com/woocommerce/woocommerce-ios/assets/1945542/733ce162-d2d9-4181-8f10-cbb689212d86" width="300" /> | <img src="https://github.com/woocommerce/woocommerce-ios/assets/1945542/cd0fa725-7360-4d4f-b2df-851302b2b5fc" width="300" />

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
