### PR TITLE
[Tablet orders] Add feature flag for M3 of Project Lily Pad

### DIFF
--- a/Experiments/Experiments/DefaultFeatureFlagService.swift
+++ b/Experiments/Experiments/DefaultFeatureFlagService.swift
@@ -15,6 +15,8 @@ public struct DefaultFeatureFlagService: FeatureFlagService {
             return buildConfig == .localDeveloper || buildConfig == .alpha
         case .splitViewInOrdersTab:
             return true
+        case .sideBySideViewForOrderForm:
+            return false
         case .updateOrderOptimistically:
             return buildConfig == .localDeveloper || buildConfig == .alpha
         case .shippingLabelsOnboardingM1:

--- a/Experiments/Experiments/FeatureFlag.swift
+++ b/Experiments/Experiments/FeatureFlag.swift
@@ -22,6 +22,10 @@ public enum FeatureFlag: Int {
     ///
     case splitViewInOrdersTab
 
+    /// Displays the OrderForm side by side with the Product Selector
+    ///
+    case sideBySideViewForOrderForm
+
     /// Enable optimistic updates for orders
     ///
     case updateOrderOptimistically


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #11844
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

This PR adds a feature flag ready for M3 development of Project Lily Pad.

This feature flag will be used to decide whether to show the existing single-view Order Creation / Order Editing flow, or the new side-by-side view with both the OrderForm and the Product Selector.

The feature flag is not yet in use.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

Check unit tests pass

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
