### PR TITLE
[Backend Receipts] Update store and actions to account for backend receipts

### DIFF
--- a/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsDataSource.swift
+++ b/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsDataSource.swift
@@ -615,7 +615,7 @@ private extension OrderDetailsDataSource {
     }
 
     private func configureSeeReceipt(cell: TwoColumnHeadlineFootnoteTableViewCell) {
-        guard ServiceLocator.featureFlagService.isFeatureFlagEnabled(.backendReceipts) else {
+        guard featureFlags.isFeatureFlagEnabled(.backendReceipts) else {
             return
         }
         cell.setLeftTitleToLinkStyle(true)
@@ -1235,7 +1235,7 @@ extension OrderDetailsDataSource {
                 rows.append(.collectCardPaymentButton)
             }
 
-            if ServiceLocator.featureFlagService.isFeatureFlagEnabled(.backendReceipts) {
+            if featureFlags.isFeatureFlagEnabled(.backendReceipts) {
                 rows.append(.seeReceipt)
             }
 

--- a/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsDataSource.swift
+++ b/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsDataSource.swift
@@ -414,6 +414,8 @@ private extension OrderDetailsDataSource {
             configureOrderNote(cell: cell, at: indexPath)
         case let cell as LedgerTableViewCell:
             configurePayment(cell: cell)
+        case let cell as TwoColumnHeadlineFootnoteTableViewCell where row == .seeReceipt:
+            configureSeeReceipt(cell: cell)
         case let cell as TwoColumnHeadlineFootnoteTableViewCell where row == .seeLegacyReceipt:
             configureSeeLegacyReceipt(cell: cell)
         case let cell as TwoColumnHeadlineFootnoteTableViewCell where row == .customerPaid:
@@ -610,6 +612,17 @@ private extension OrderDetailsDataSource {
         cell.leftText = Titles.paidByCustomer
         cell.rightText = order.paymentTotal
         cell.updateFootnoteText(paymentViewModel.paymentSummary)
+    }
+
+    private func configureSeeReceipt(cell: TwoColumnHeadlineFootnoteTableViewCell) {
+        guard ServiceLocator.featureFlagService.isFeatureFlagEnabled(.backendReceipts) else {
+            return
+        }
+        cell.setLeftTitleToLinkStyle(true)
+        cell.leftText = Titles.seeReceipt
+        cell.rightText = nil
+        cell.hideFootnote()
+        cell.hideSeparator()
     }
 
     private func configureSeeLegacyReceipt(cell: TwoColumnHeadlineFootnoteTableViewCell) {
@@ -1222,6 +1235,10 @@ extension OrderDetailsDataSource {
                 rows.append(.collectCardPaymentButton)
             }
 
+            if ServiceLocator.featureFlagService.isFeatureFlagEnabled(.backendReceipts) {
+                rows.append(.seeReceipt)
+            }
+
             if shouldShowLegacyReceipts {
                 rows.append(.seeLegacyReceipt)
             }
@@ -1485,6 +1502,10 @@ extension OrderDetailsDataSource {
         static let collectPayment = NSLocalizedString("Collect Payment", comment: "Text on the button that starts collecting a card present payment.")
         static let createShippingLabel = NSLocalizedString("Create Shipping Label", comment: "Text on the button that starts shipping label creation")
         static let reprintShippingLabel = NSLocalizedString("Print Shipping Label", comment: "Text on the button that prints a shipping label")
+        static let seeReceipt = NSLocalizedString(
+            "OrderDetailsDataSource.configureSeeReceipt.button.title",
+            value: "[Debug] See Backed Receipt",
+            comment: "Text on the button title to see the order's receipt")
         static let seeLegacyReceipt = NSLocalizedString("See Receipt", comment: "Text on the button to see a saved receipt")
     }
 
@@ -1635,6 +1656,7 @@ extension OrderDetailsDataSource {
         case billingDetail
         case payment
         case customerPaid
+        case seeReceipt
         case seeLegacyReceipt
         case refund
         case netAmount
@@ -1683,6 +1705,8 @@ extension OrderDetailsDataSource {
             case .payment:
                 return LedgerTableViewCell.reuseIdentifier
             case .customerPaid:
+                return TwoColumnHeadlineFootnoteTableViewCell.reuseIdentifier
+            case .seeReceipt:
                 return TwoColumnHeadlineFootnoteTableViewCell.reuseIdentifier
             case .seeLegacyReceipt:
                 return TwoColumnHeadlineFootnoteTableViewCell.reuseIdentifier

--- a/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsViewModel.swift
+++ b/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsViewModel.swift
@@ -467,6 +467,16 @@ extension OrderDetailsViewModel {
             }
             let customFieldsView = UIHostingController(rootView: OrderCustomFieldsDetails(customFields: customFields))
             viewController.present(customFieldsView, animated: true)
+        case .seeReceipt:
+            let action = ReceiptAction.retrieveReceipt(order: order) { result in
+                switch result {
+                case let .success(receipt):
+                    debugPrint("\(receipt)")
+                case let .failure(error):
+                    debugPrint("\(error)")
+                }
+            }
+            ServiceLocator.stores.dispatch(action)
         case .seeLegacyReceipt:
             let countryCode = configurationLoader.configuration.countryCode
             ServiceLocator.analytics.track(event: .InPersonPayments.receiptViewTapped(countryCode: countryCode))

--- a/WooCommerce/WooCommerceTests/Mocks/MockFeatureFlagService.swift
+++ b/WooCommerce/WooCommerceTests/Mocks/MockFeatureFlagService.swift
@@ -23,6 +23,7 @@ struct MockFeatureFlagService: FeatureFlagService {
     private let productBundlesInOrderForm: Bool
     private let isScanToUpdateInventoryEnabled: Bool
     private let blazei3NativeCampaignCreation: Bool
+    private let isBackendReceiptsEnabled: Bool
 
     init(isInboxOn: Bool = false,
          isSplitViewInOrdersTabOn: Bool = false,
@@ -44,7 +45,8 @@ struct MockFeatureFlagService: FeatureFlagService {
          productBundles: Bool = false,
          productBundlesInOrderForm: Bool = false,
          isScanToUpdateInventoryEnabled: Bool = false,
-         blazei3NativeCampaignCreation: Bool = false) {
+         blazei3NativeCampaignCreation: Bool = false,
+         isBackendReceiptsEnabled: Bool = false) {
         self.isInboxOn = isInboxOn
         self.isSplitViewInOrdersTabOn = isSplitViewInOrdersTabOn
         self.isUpdateOrderOptimisticallyOn = isUpdateOrderOptimisticallyOn
@@ -66,6 +68,7 @@ struct MockFeatureFlagService: FeatureFlagService {
         self.productBundlesInOrderForm = productBundlesInOrderForm
         self.isScanToUpdateInventoryEnabled = isScanToUpdateInventoryEnabled
         self.blazei3NativeCampaignCreation = blazei3NativeCampaignCreation
+        self.isBackendReceiptsEnabled = isBackendReceiptsEnabled
     }
 
     func isFeatureFlagEnabled(_ featureFlag: FeatureFlag) -> Bool {
@@ -110,6 +113,8 @@ struct MockFeatureFlagService: FeatureFlagService {
             return isScanToUpdateInventoryEnabled
         case .blazei3NativeCampaignCreation:
             return blazei3NativeCampaignCreation
+        case .backendReceipts:
+            return isBackendReceiptsEnabled
         default:
             return false
         }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Details/OrderDetailsDataSourceTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Details/OrderDetailsDataSourceTests.swift
@@ -653,6 +653,40 @@ final class OrderDetailsDataSourceTests: XCTestCase {
         let giftCardsSection = section(withCategory: .giftCards, from: dataSource)
         XCTAssertNil(giftCardsSection)
     }
+
+    func test_receipts_row_is_hidden_when_feature_flag_is_false() throws {
+        // Given
+        let order = Order.fake()
+        let dataSource = OrderDetailsDataSource(order: order,
+                                                storageManager: storageManager,
+                                                cardPresentPaymentsConfiguration: Mocks.configuration,
+                                                featureFlags: MockFeatureFlagService(isBackendReceiptsEnabled: false))
+
+        // When
+        dataSource.reloadSections()
+
+        // Then
+        let paymentSection = try section(withTitle: Title.payment, from: dataSource)
+        let receiptsRow = row(row: .seeReceipt, in: paymentSection)
+        XCTAssertNil(receiptsRow)
+    }
+
+    func test_receipts_row_is_visible_in_payments_section_when_feature_flag_is_true() throws {
+        // Given
+        let order = Order.fake()
+        let dataSource = OrderDetailsDataSource(order: order,
+                                                storageManager: storageManager,
+                                                cardPresentPaymentsConfiguration: Mocks.configuration,
+                                                featureFlags: MockFeatureFlagService(isBackendReceiptsEnabled: true))
+
+        // When
+        dataSource.reloadSections()
+
+        // Then
+        let paymentSection = try section(withTitle: Title.payment, from: dataSource)
+        let receiptsRow = row(row: .seeReceipt, in: paymentSection)
+        XCTAssertNotNil(receiptsRow)
+    }
 }
 
 // MARK: - Test Data

--- a/Yosemite/Yosemite/Actions/ReceiptAction.swift
+++ b/Yosemite/Yosemite/Actions/ReceiptAction.swift
@@ -15,5 +15,5 @@ public enum ReceiptAction: Action {
     case loadReceipt(order: Order, onCompletion: (Result<CardPresentReceiptParameters, Error>) -> Void)
 
     /// Retrieves a receipt from the backend for a given `Order`
-    case retrieveReceipt(order:Order, onCompletion: (Result<Receipt, Error>) -> Void)
+    case retrieveReceipt(order: Order, onCompletion: (Result<Receipt, Error>) -> Void)
 }

--- a/Yosemite/Yosemite/Actions/ReceiptAction.swift
+++ b/Yosemite/Yosemite/Actions/ReceiptAction.swift
@@ -1,16 +1,19 @@
-/// RefundAction: Defines all of the Actions supported by the ReceiptStore.
+/// ReceiptAction: Defines all of the Actions supported by the ReceiptStore.
 ///
 public enum ReceiptAction: Action {
-    /// Prints a receipt for a given `Order` with the given `CardPresentReceiptParameters`
+    /// Prints a locally-generated receipt for a given `Order` with the given `CardPresentReceiptParameters`
     case print(order: Order, parameters: CardPresentReceiptParameters, completion: (PrintingResult) -> Void)
 
-    /// Generates content for a receipt for a given `Order` with the given `CardPresentReceiptParameters`
+    /// Generates content for a locally-generated receipt for a given `Order` with the given `CardPresentReceiptParameters`
     /// The content is a String containing HTML
     case generateContent(order: Order, parameters: CardPresentReceiptParameters, onContent: (String) -> Void)
 
-    /// Saves the metadata necessary to render a receipt
+    /// Saves the metadata necessary to render a locally-generated receipt
     case saveReceipt(order: Order, parameters: CardPresentReceiptParameters)
 
-    /// Loads the metadata necessary to render a receipt
+    /// Loads the metadata necessary to render a locally-generated receipt
     case loadReceipt(order: Order, onCompletion: (Result<CardPresentReceiptParameters, Error>) -> Void)
+
+    /// Retrieves a receipt from the backend for a given `Order`
+    case retrieveReceipt(order:Order, onCompletion: (Result<Receipt, Error>) -> Void)
 }

--- a/Yosemite/Yosemite/Model/Model.swift
+++ b/Yosemite/Yosemite/Model/Model.swift
@@ -106,6 +106,7 @@ public typealias ProductDownloadDragAndDrop = Networking.ProductDownloadDragAndD
 public typealias ProductVariation = Networking.ProductVariation
 public typealias ProductVariationAttribute = Networking.ProductVariationAttribute
 public typealias ReaderLocation = Networking.ReaderLocation
+public typealias Receipt = Networking.Receipt
 public typealias Refund = Networking.Refund
 public typealias RemoteFeatureFlag = Networking.RemoteFeatureFlag
 public typealias StatGranularity = Networking.StatGranularity

--- a/Yosemite/Yosemite/Stores/ReceiptStore.swift
+++ b/Yosemite/Yosemite/Stores/ReceiptStore.swift
@@ -9,7 +9,7 @@ import WooFoundation
 public class ReceiptStore: Store {
     private let receiptPrinterService: PrinterService
     private let fileStorage: FileStorage
-    private lazy var remote: ReceiptRemote = ReceiptRemote(network: network)
+    private let remote: ReceiptRemote
 
     private lazy var sharedDerivedStorage: StorageType = {
         storageManager.writerDerivedStorage
@@ -22,6 +22,7 @@ public class ReceiptStore: Store {
     public init(dispatcher: Dispatcher, storageManager: StorageManagerType, network: Network, receiptPrinterService: PrinterService, fileStorage: FileStorage) {
         self.receiptPrinterService = receiptPrinterService
         self.fileStorage = fileStorage
+        self.remote = ReceiptRemote(network: network)
         super.init(dispatcher: dispatcher, storageManager: storageManager, network: network)
     }
 

--- a/Yosemite/YosemiteTests/Stores/ReceiptStoreTests.swift
+++ b/Yosemite/YosemiteTests/Stores/ReceiptStoreTests.swift
@@ -462,6 +462,59 @@ final class ReceiptStoreTests: XCTestCase {
         // Then
         XCTAssertEqual(receiptPrinterService.contentProvided?.orderNote, "This note has a link")
     }
+
+    func test_retrieveReceipt_when_orderID_exists_then_returns_valid_receipt_with_expected_fields() throws {
+        // Given
+        let sampleOrderID: Int64 = 123
+        let mockOrder = Order.fake().copy(orderID: sampleOrderID)
+        let receiptStore = ReceiptStore(dispatcher: dispatcher,
+                                        storageManager: storageManager,
+                                        network: network,
+                                        receiptPrinterService: receiptPrinterService,
+                                        fileStorage: MockInMemoryStorage())
+        let expectedReceiptURL = "https://mywootestingstore.com/wc/file/transient/7e811be40195b17f82604592ed26b694868807"
+        let expectedReceiptExpirationDate = "2024-01-27"
+
+        network.simulateResponse(requestUrlSuffix: "orders/\(sampleOrderID)/receipt", filename: "receipt")
+
+        // When
+        let expectedResult: Result<Receipt, Error> = waitFor { promise in
+            let action = ReceiptAction.retrieveReceipt(order: mockOrder, onCompletion: { result in
+                promise(result)
+            })
+            receiptStore.onAction(action)
+        }
+
+        // Then
+        let expectedReceipt = try expectedResult.get()
+        assertEqual(expectedReceiptURL, expectedReceipt.receiptURL)
+        assertEqual(expectedReceiptExpirationDate, expectedReceipt.expirationDate)
+    }
+
+    func test_retrieveReceipt_when_orderID_does_not_match_route_then_returns_error() throws {
+        // Given
+        let sampleOrderID: Int64 = 987
+        let mockOrder = Order.fake().copy(orderID: sampleOrderID)
+        let receiptStore = ReceiptStore(dispatcher: dispatcher,
+                                        storageManager: storageManager,
+                                        network: network,
+                                        receiptPrinterService: receiptPrinterService,
+                                        fileStorage: MockInMemoryStorage())
+
+        network.simulateResponse(requestUrlSuffix: "orders/123/receipt", filename: "receipt")
+
+        // When
+        let expectedResult: Result<Receipt, Error> = waitFor { promise in
+            let action = ReceiptAction.retrieveReceipt(order: mockOrder, onCompletion: { result in
+                promise(result)
+            })
+            receiptStore.onAction(action)
+        }
+
+        // Then
+        let expectedError = expectedResult.failure
+        XCTAssertNotNil(expectedError)
+    }
 }
 
 

--- a/Yosemite/YosemiteTests/Stores/ReceiptStoreTests.swift
+++ b/Yosemite/YosemiteTests/Stores/ReceiptStoreTests.swift
@@ -463,7 +463,7 @@ final class ReceiptStoreTests: XCTestCase {
         XCTAssertEqual(receiptPrinterService.contentProvided?.orderNote, "This note has a link")
     }
 
-    func test_retrieveReceipt_when_orderID_exists_then_returns_valid_receipt_with_expected_fields() throws {
+    func test_retrieveReceipt_when_orderID_matches_route_then_returns_valid_receipt_with_expected_fields() throws {
         // Given
         let sampleOrderID: Int64 = 123
         let mockOrder = Order.fake().copy(orderID: sampleOrderID)


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes #11828
#11847 must be merged first.

## Description
This PR updates the business logic in order to fetch a receipt from the new API endpoint when the proper action is invoked.

We also update the UI to display a temporary `[Debug] See Backend Receipt` button for all orders for developer builds. The existing `See Receipt` will be displayed as always, this means that if the local-generated receipt exists on the device, then its row will also be shown below (we don't change the legacy logic for locally-generated receipts).

This is only for testing purposes and to keep changes small, in following PRs we'll add further validation (feature flag + Woo version) and display only the local receipt or the backend receipt, but not both.

| If local receipt doesn't exist | If local receipt does exist |
|--------|--------|
| ![Simulator Screenshot - iPhone 15 - 2024-01-30 at 17 11 17](https://github.com/woocommerce/woocommerce-ios/assets/3812076/241ef845-e804-4463-b579-c53dd1c278d5) | ![Simulator Screenshot - iPhone 15 - 2024-01-30 at 17 11 24](https://github.com/woocommerce/woocommerce-ios/assets/3812076/5aae8ac4-40fa-4c15-866c-be2d18cf561c) | 

## Changes
- Added a new `ReceiptAction` which will either return a `Receipt` or an `Error` from the remote.
- Added an additional `seeReceipt` row to the tableview datasource, this is feature flagged so will only be shown in dev builds.
- When the button is tapped, we will reach the new endpoint and return either a `Receipt` or an `Error`. At the moment we just log the result to the console.
- Updated unit tests

## Testing instructions
Success:
* In the app, log into mywootestingstore.mystagingwebsite.com (you will find the credentials in your email). This is necessary since the site runs a developer branch of WooCommerce needed to use the new receipts endpoint.
* Go to Orders > tap on any order (at the moment doesn't matter it's status) > tap on `[Debug] See Backend Receipt`
* Observe that Xcode console logs the receipt:
```
"Receipt(receiptURL: \"https://mywootestingstore.mystagingwebsite.com/wc/file/transient/7e811fa568e1102fe3bec19f0a2441cf116bf4\", expirationDate: \"2024-01-31\")"
```
Failure:
* In the app, log into any other site that runs a production version of WooCommerce
* Go to Orders > tap on any order > tap on `[Debug] See Backend Receipt`
* Observe that Xcode console logs the error:
```
"Dotcom Invalid REST Route"
```

## Screenshots
![2024-01-30 debug new receipt button](https://github.com/woocommerce/woocommerce-ios/assets/3812076/e645afec-54a9-4fc6-9c6d-2c0a281684a9)

