### PR TITLE
Fix order list not automatically refreshed when going from 0 -> 1 order

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -3,7 +3,7 @@
 17.2
 -----
 - [*] Fixed arrow directions for RTL locales. [https://github.com/woocommerce/woocommerce-ios/pull/11833]
-
+- [*] Orders in split view: when the store has no orders and then an order is created, the order list is now shown instead of the empty view. [https://github.com/woocommerce/woocommerce-ios/pull/11849]
 
 17.1
 -----

--- a/WooCommerce/Classes/ViewRelated/Orders/OrderListViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrderListViewController.swift
@@ -288,6 +288,8 @@ private extension OrderListViewController {
             guard let self = self else { return }
             self.dataSource.apply(snapshot)
 
+            transitionToResultsUpdatedState()
+
             if self.isSplitViewInOrdersTabEnabled, self.splitViewController?.isCollapsed == false {
                 self.checkSelectedItem()
             }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #11820
<!-- Id number of the GitHub issue this PR addresses. -->

## Why

While debugging the issue #11820 where the empty view is shown even after an order is created without any filters (I can reproduce it), it turned out the call to transition to the results state `transitionToResultsUpdatedState` is only triggered after a remote sync:

https://github.com/woocommerce/woocommerce-ios/blob/a8cc07194bcb4ec8b96f5e8fcba0ba3654c566f6/WooCommerce/Classes/ViewRelated/Orders/OrderListViewController.swift#L445

After an order is created in the app, an order list remote sync isn't triggered. Instead, the created order comes through from the storage that is included in a fetched results controller snapshot to be applied to the table view

https://github.com/woocommerce/woocommerce-ios/blob/a8cc07194bcb4ec8b96f5e8fcba0ba3654c566f6/WooCommerce/Classes/ViewRelated/Orders/OrderListViewController.swift#L289

Because `transitionToResultsUpdatedState` is not triggered after the snapshot update, the UI state stays at the empty state. In the Xcode UI debugger, the order list includes the new order but is behind the empty view.

## How

The fix is to call `transitionToResultsUpdatedState` after each snapshot update.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

1. Create a new store (or setup a filter that will not match with any existing orders)
2. Create a new order (or create an order that will match your filter) --> if using phone or iPad without tablet orders project, the new order should be shown in the list. On devices with split view enabled, the empty view should transition to the order list

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->


https://github.com/woocommerce/woocommerce-ios/assets/1945542/7e72d777-250c-4a63-ad9c-8f9589dd9d9c



---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
