### PR TITLE
[Tablet Products] Add a feature flag with barebone split view support

### DIFF
--- a/Experiments/Experiments/DefaultFeatureFlagService.swift
+++ b/Experiments/Experiments/DefaultFeatureFlagService.swift
@@ -87,6 +87,8 @@ public struct DefaultFeatureFlagService: FeatureFlagService {
             return buildConfig == .localDeveloper || buildConfig == .alpha
         case .backendReceipts:
             return buildConfig == .localDeveloper || buildConfig == .alpha
+        case .splitViewInProductsTab:
+            return false
         default:
             return true
         }

--- a/Experiments/Experiments/FeatureFlag.swift
+++ b/Experiments/Experiments/FeatureFlag.swift
@@ -191,4 +191,8 @@ public enum FeatureFlag: Int {
     /// Enables backend receipt generation for all payment methods
     ///
     case backendReceipts
+
+    /// Displays the Products tab in a split view
+    ///
+    case splitViewInProductsTab
 }

--- a/WooCommerce/Classes/Analytics/WooAnalyticsStat.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsStat.swift
@@ -586,8 +586,6 @@ public enum WooAnalyticsStat: String {
 
     // MARK: Notification View Events
     //
-    case notificationsSelected = "main_tab_notifications_selected"
-    case notificationsReselected = "main_tab_notifications_reselected"
     case notificationOpened = "notification_open"
     case notificationsListPulledToRefresh = "notifications_list_pulled_to_refresh"
     case notificationsListReadAllTapped = "notifications_list_menu_mark_read_button_tapped"

--- a/WooCommerce/Classes/ViewRelated/MainTabBarController.swift
+++ b/WooCommerce/Classes/ViewRelated/MainTabBarController.swift
@@ -21,10 +21,6 @@ enum WooTab {
     ///
     case products
 
-    /// Reviews Tab
-    ///
-    case reviews
-
     /// Hub Menu Tab
     ///
     case hubMenu
@@ -274,8 +270,6 @@ private extension MainTabBarController {
             ServiceLocator.analytics.track(.ordersSelected)
         case .products:
             ServiceLocator.analytics.track(.productListSelected)
-        case .reviews:
-            ServiceLocator.analytics.track(.notificationsSelected)
         case .hubMenu:
             ServiceLocator.analytics.track(.hubMenuTabSelected)
             break
@@ -292,8 +286,6 @@ private extension MainTabBarController {
             ServiceLocator.analytics.track(.ordersReselected)
         case .products:
             ServiceLocator.analytics.track(.productListReselected)
-        case .reviews:
-            ServiceLocator.analytics.track(.notificationsReselected)
         case .hubMenu:
             ServiceLocator.analytics.track(.hubMenuTabReselected)
             break
@@ -316,12 +308,6 @@ extension MainTabBarController {
     ///
     static func switchToOrdersTab(completion: (() -> Void)? = nil) {
         navigateTo(.orders, completion: completion)
-    }
-
-    /// Switches to the Reviews tab and pops to the root view controller
-    ///
-    static func switchToReviewsTab(completion: (() -> Void)? = nil) {
-        navigateTo(.reviews, completion: completion)
     }
 
     /// Switches to the Products tab and pops to the root view controller

--- a/WooCommerce/Classes/ViewRelated/Products/ProductsSplitViewWrapperController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductsSplitViewWrapperController.swift
@@ -1,0 +1,72 @@
+import UIKit
+import Yosemite
+
+/// Controller to wrap the products split view
+///
+final class ProductsSplitViewWrapperController: UIViewController {
+    private let siteID: Int64
+
+    private lazy var productsSplitViewController = WooSplitViewController(columnForCollapsingHandler: handleCollapsingSplitView)
+    private lazy var productsViewController = ProductsViewController(siteID: siteID)
+
+    init(siteID: Int64) {
+        self.siteID = siteID
+        super.init(nibName: nil, bundle: nil)
+        configureTabBarItem()
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        configureSplitView()
+        configureChildViewController()
+    }
+
+    override var shouldShowOfflineBanner: Bool {
+        return true
+    }
+}
+
+private extension ProductsSplitViewWrapperController {
+    func handleCollapsingSplitView(splitViewController: UISplitViewController) -> UISplitViewController.Column {
+        // TODO: update the collapsing logic
+        .secondary
+    }
+}
+
+private extension ProductsSplitViewWrapperController {
+    func configureSplitView() {
+        let productsNavigationController = WooTabNavigationController()
+        productsNavigationController.viewControllers = [productsViewController]
+        productsSplitViewController.setViewController(productsNavigationController, for: .primary)
+    }
+
+    func configureTabBarItem() {
+        tabBarItem.title = Localization.tabTitle
+        tabBarItem.image = .productImage
+        tabBarItem.accessibilityIdentifier = "tab-bar-products-item"
+    }
+
+    func configureChildViewController() {
+        guard let contentView = productsSplitViewController.view else {
+            return assertionFailure("Split view not available")
+        }
+        addChild(productsSplitViewController)
+        view.addSubview(contentView)
+        productsSplitViewController.didMove(toParent: self)
+
+        contentView.translatesAutoresizingMaskIntoConstraints = false
+        view.pinSubviewToAllEdges(contentView)
+    }
+}
+
+extension ProductsSplitViewWrapperController {
+    private enum Localization {
+        static let tabTitle = NSLocalizedString("productsTab.tabTitle",
+                                                value: "Products",
+                                                comment: "Title of the Products tab — plural form of Product")
+    }
+}

--- a/WooCommerce/Classes/ViewRelated/TabBar/WooTab+Tag.swift
+++ b/WooCommerce/Classes/ViewRelated/TabBar/WooTab+Tag.swift
@@ -10,10 +10,8 @@ extension WooTab {
             return 1
         case .products:
             return 2
-        case .reviews:
-            return 3
         case .hubMenu:
-            return 4
+            return 3
         }
     }
 }

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -242,6 +242,7 @@
 		0258B4D82B1590A3008FEA07 /* ConfigurableBundleNoticeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0258B4D72B1590A3008FEA07 /* ConfigurableBundleNoticeView.swift */; };
 		0258B4DA2B159A0F008FEA07 /* Publisher+WithPrevious.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0258B4D92B159A0F008FEA07 /* Publisher+WithPrevious.swift */; };
 		0258B66D2518778300EB5CF2 /* ProductFormViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0258B66C2518778300EB5CF2 /* ProductFormViewModelTests.swift */; };
+		0258D9492B68E7FE00D280D0 /* ProductsSplitViewWrapperController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0258D9482B68E7FE00D280D0 /* ProductsSplitViewWrapperController.swift */; };
 		0259D5F92581F0E6003B1CD6 /* ShippingLabelPaperSizeOptionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0259D5F82581F0E6003B1CD6 /* ShippingLabelPaperSizeOptionView.swift */; };
 		0259D5FF2581F3FA003B1CD6 /* ShippingLabelPaperSizeOptionsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0259D5FE2581F3FA003B1CD6 /* ShippingLabelPaperSizeOptionsViewController.swift */; };
 		0259D65D2582248D003B1CD6 /* PrintShippingLabelViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0259D65B2582248D003B1CD6 /* PrintShippingLabelViewController.swift */; };
@@ -2921,6 +2922,7 @@
 		0258B4D72B1590A3008FEA07 /* ConfigurableBundleNoticeView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConfigurableBundleNoticeView.swift; sourceTree = "<group>"; };
 		0258B4D92B159A0F008FEA07 /* Publisher+WithPrevious.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Publisher+WithPrevious.swift"; sourceTree = "<group>"; };
 		0258B66C2518778300EB5CF2 /* ProductFormViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductFormViewModelTests.swift; sourceTree = "<group>"; };
+		0258D9482B68E7FE00D280D0 /* ProductsSplitViewWrapperController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductsSplitViewWrapperController.swift; sourceTree = "<group>"; };
 		0259D5F82581F0E6003B1CD6 /* ShippingLabelPaperSizeOptionView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShippingLabelPaperSizeOptionView.swift; sourceTree = "<group>"; };
 		0259D5FE2581F3FA003B1CD6 /* ShippingLabelPaperSizeOptionsViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShippingLabelPaperSizeOptionsViewController.swift; sourceTree = "<group>"; };
 		0259D65B2582248D003B1CD6 /* PrintShippingLabelViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PrintShippingLabelViewController.swift; sourceTree = "<group>"; };
@@ -8531,6 +8533,7 @@
 				AEFF77A32978389400667F7A /* PriceInputViewController.swift */,
 				AEFF77A529783CA600667F7A /* PriceInputViewModel.swift */,
 				B946881729B8DDC2000646B0 /* ProductsViewController+Activity.swift */,
+				0258D9482B68E7FE00D280D0 /* ProductsSplitViewWrapperController.swift */,
 			);
 			path = Products;
 			sourceTree = "<group>";
@@ -13047,6 +13050,7 @@
 				B59D49CD219B587E006BF0AD /* UILabel+OrderStatus.swift in Sources */,
 				265BCA0C2430E741004E53EE /* ProductCategoryTableViewCell.swift in Sources */,
 				02ACD25A2852E11700EC928E /* CloseAccountCoordinator.swift in Sources */,
+				0258D9492B68E7FE00D280D0 /* ProductsSplitViewWrapperController.swift in Sources */,
 				036CA6F129229C9E00E4DF4F /* IndefiniteCircularProgressViewStyle.swift in Sources */,
 				451A9973260E39270059D135 /* ShippingLabelPackageNumberRow.swift in Sources */,
 				AEE2610F26E664CE00B142A0 /* EditOrderAddressFormViewModel.swift in Sources */,


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Prerequisite for #11852
<!-- Id number of the GitHub issue this PR addresses. -->

- [x] @jaclync marks the removed Tracks events as deprecated in Tracks

## Why

As Corvid is taking on tablet support for the products tab per pfoUAQ-9k-p2, we can come up with a POC (proof-of-concept) for design review like what Peacock did for the orders tab pdfdoF-4mI-p2. This PR adds a feature flag (default to `false`) and a barebone split wrapper similar to the orders tab.  The secondary view logic isn't implemented yet to make review easier, and we might explore different ways of syncing the table view primary view & secondary view when a row is selected.

## How

- A new feature flag `splitViewInProductsTab` was created, default to be `false`
- In `MainTabBarController`, a new `productsContainerController: TabContainerController` was added when the feature flag is enabled. It's shown similar to the orders tab
- `WooTab.reviews` enum case was removed since the reviews tab has been replaced with the menu tab in production for a while and we have plans to change it
- `ProductsSplitViewWrapperController` was added as a barebone split view wrapper based on the orders tab. Only the basic setup was implemented like the tab / child view controller configurations

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

Hand testing on the feature flag off case is recommended, just as a confidence test. The feature flag on case is optional, as it's still a WIP without a proper split view support yet.

### Feature flag off (no changes expected)

- Launch the app
- Log in if needed --> the 4 tabs should be the same as before
- Tap on each tab, and make sure each tab behaves the same as before

### Feature flag on

Please test on a wide device (tablets or large phones) for split view support.

- In code, return the `splitViewInProductsTab` feature flag as `true` in `DefaultFeatureFlagService`
- Launch the app
- Tap on the products tab --> the product list should be shown in the primary view

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

feature flag off (default) | feature flag on
-- | --
<img src="https://github.com/woocommerce/woocommerce-ios/assets/1945542/c3e04996-2697-4436-ab72-2e124925164d" width="500" /> | <img src="https://github.com/woocommerce/woocommerce-ios/assets/1945542/9bdfce97-aaff-4a0d-a66e-10cd76b08a9a" width="500" />


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.