### PR TITLE
Product creation AI: Reuse detected language on retries

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductWithAI/Preview/ProductDetailPreviewViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductWithAI/Preview/ProductDetailPreviewViewModel.swift
@@ -37,6 +37,7 @@ final class ProductDetailPreviewViewModel: ObservableObject {
     private var currency: String
     private var currencyFormatter: CurrencyFormatter
 
+    private var detectedLanguage: String?
     private var weightUnit: String?
     private var dimensionUnit: String?
     private let shippingValueLocalizer: ShippingValueLocalizer
@@ -286,6 +287,11 @@ private extension ProductDetailPreviewViewModel {
 
     @MainActor
     func identifyLanguage() async throws -> String {
+        if let detectedLanguage,
+           detectedLanguage.isNotEmpty {
+            return detectedLanguage
+        }
+
         do {
             let productInfo = {
                 guard let features = productFeatures,
@@ -302,6 +308,7 @@ private extension ProductDetailPreviewViewModel {
                     continuation.resume(with: result)
                 }))
             }
+            detectedLanguage = language
             return language
         } catch {
             throw IdentifyLanguageError.failedToIdentifyLanguage(underlyingError: error)

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/Add Product/AddProductWithAI/ProductDetailPreviewViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/Add Product/AddProductWithAI/ProductDetailPreviewViewModelTests.swift
@@ -5,6 +5,9 @@ import Yosemite
 
 @MainActor
 final class ProductDetailPreviewViewModelTests: XCTestCase {
+    private let sampleSiteID: Int64 = 123
+    private var stores: MockStoresManager!
+    private var storage: MockStorageManager!
     private var analyticsProvider: MockAnalyticsProvider!
     private var analytics: WooAnalytics!
 
@@ -13,24 +16,22 @@ final class ProductDetailPreviewViewModelTests: XCTestCase {
 
         analyticsProvider = MockAnalyticsProvider()
         analytics = WooAnalytics(analyticsProvider: analyticsProvider)
+        stores = MockStoresManager(sessionManager: .makeForTesting())
+        storage = MockStorageManager()
     }
 
     override func tearDown() {
         analytics = nil
         analyticsProvider = nil
+        stores = nil
+        storage = nil
         super.tearDown()
     }
 
     // MARK: `generateProductDetails`
 
-    func test_generateProductDetails_fetches_site_settings_if_weight_unit_is_nil() async throws {
+    func test_generateProductDetails_fetches_site_settings_if_weight_unit_is_nil() async {
         // Given
-        let sampleSiteID: Int64 = 123
-
-        let stores = MockStoresManager(sessionManager: .makeForTesting())
-        let storage = MockStorageManager()
-        storage.insertSampleSite(readOnlySite: Site.fake().copy(siteID: sampleSiteID))
-
         let productName = "Pen"
         let productFeatures = "Ballpoint, Blue ink, ABS plastic"
 
@@ -47,58 +48,27 @@ final class ProductDetailPreviewViewModelTests: XCTestCase {
             switch action {
             case let .synchronizeGeneralSiteSettings(siteID, completion):
                 // Then
-                XCTAssertEqual(siteID, sampleSiteID)
+                XCTAssertEqual(siteID, self.sampleSiteID)
                 completion(nil)
             case let .synchronizeProductSiteSettings(siteID, completion):
                 // Then
-                XCTAssertEqual(siteID, sampleSiteID)
+                XCTAssertEqual(siteID, self.sampleSiteID)
                 completion(nil)
             default:
                 break
             }
         }
 
-        stores.whenReceivingAction(ofType: ProductAction.self) { action in
-            switch action {
-            case let .generateAIProduct(_, _, _, _, _, _, _, _, _, _, completion):
-                completion(.success(.fake()))
-            case let .identifyLanguage(_, _, _, completion):
-                completion(.success("en"))
-            default:
-                break
-            }
-        }
-
-        stores.whenReceivingAction(ofType: ProductCategoryAction.self) { action in
-            switch action {
-            case let .synchronizeProductCategories(_, _, completion):
-                completion(nil)
-            default:
-                break
-            }
-        }
-
-        stores.whenReceivingAction(ofType: ProductTagAction.self) { action in
-            switch action {
-            case let .synchronizeAllProductTags(_, completion):
-                completion(nil)
-            default:
-                break
-            }
-        }
+        mockProductActions()
+        mockProductTagActions()
+        mockProductCategoryActions()
 
         // When
         await viewModel.generateProductDetails()
     }
 
-    func test_generateProductDetails_fetches_site_settings_if_dimension_unit_is_nil() async throws {
+    func test_generateProductDetails_fetches_site_settings_if_dimension_unit_is_nil() async {
         // Given
-        let sampleSiteID: Int64 = 123
-
-        let stores = MockStoresManager(sessionManager: .makeForTesting())
-        let storage = MockStorageManager()
-        storage.insertSampleSite(readOnlySite: Site.fake().copy(siteID: sampleSiteID))
-
         let productName = "Pen"
         let productFeatures = "Ballpoint, Blue ink, ABS plastic"
 
@@ -115,58 +85,27 @@ final class ProductDetailPreviewViewModelTests: XCTestCase {
             switch action {
             case let .synchronizeGeneralSiteSettings(siteID, completion):
                 // Then
-                XCTAssertEqual(siteID, sampleSiteID)
+                XCTAssertEqual(siteID, self.sampleSiteID)
                 completion(nil)
             case let .synchronizeProductSiteSettings(siteID, completion):
                 // Then
-                XCTAssertEqual(siteID, sampleSiteID)
+                XCTAssertEqual(siteID, self.sampleSiteID)
                 completion(nil)
             default:
                 break
             }
         }
 
-        stores.whenReceivingAction(ofType: ProductAction.self) { action in
-            switch action {
-            case let .generateAIProduct(_, _, _, _, _, _, _, _, _, _, completion):
-                completion(.success(.fake()))
-            case let .identifyLanguage(_, _, _, completion):
-                completion(.success("en"))
-            default:
-                break
-            }
-        }
-
-        stores.whenReceivingAction(ofType: ProductCategoryAction.self) { action in
-            switch action {
-            case let .synchronizeProductCategories(_, _, completion):
-                completion(nil)
-            default:
-                break
-            }
-        }
-
-        stores.whenReceivingAction(ofType: ProductTagAction.self) { action in
-            switch action {
-            case let .synchronizeAllProductTags(_, completion):
-                completion(nil)
-            default:
-                break
-            }
-        }
+        mockProductActions()
+        mockProductTagActions()
+        mockProductCategoryActions()
 
         // When
         await viewModel.generateProductDetails()
     }
 
-    func test_generateProductDetails_synchronizes_categories() async throws {
+    func test_generateProductDetails_synchronizes_categories() async {
         // Given
-        let sampleSiteID: Int64 = 123
-
-        let stores = MockStoresManager(sessionManager: .makeForTesting())
-        let storage = MockStorageManager()
-        storage.insertSampleSite(readOnlySite: Site.fake().copy(siteID: sampleSiteID))
-
         let productName = "Pen"
         let productFeatures = "Ballpoint, Blue ink, ABS plastic"
 
@@ -179,42 +118,15 @@ final class ProductDetailPreviewViewModelTests: XCTestCase {
                                                       storageManager: storage,
                                                       onProductCreated: { _ in })
 
-        stores.whenReceivingAction(ofType: SettingAction.self) { action in
-            switch action {
-            case let .synchronizeGeneralSiteSettings(_, completion):
-                completion(nil)
-            case let .synchronizeProductSiteSettings(_, completion):
-                completion(nil)
-            default:
-                break
-            }
-        }
-
-        stores.whenReceivingAction(ofType: ProductAction.self) { action in
-            switch action {
-            case let .generateAIProduct(_, _, _, _, _, _, _, _, _, _, completion):
-                completion(.success(.fake()))
-            case let .identifyLanguage(_, _, _, completion):
-                completion(.success("en"))
-            default:
-                break
-            }
-        }
+        mockSettingActions()
+        mockProductActions()
+        mockProductTagActions()
 
         stores.whenReceivingAction(ofType: ProductCategoryAction.self) { action in
             switch action {
             case let .synchronizeProductCategories(siteID, _, completion):
                 // Then
-                XCTAssertEqual(siteID, sampleSiteID)
-                completion(nil)
-            default:
-                break
-            }
-        }
-
-        stores.whenReceivingAction(ofType: ProductTagAction.self) { action in
-            switch action {
-            case let .synchronizeAllProductTags(_, completion):
+                XCTAssertEqual(siteID, self.sampleSiteID)
                 completion(nil)
             default:
                 break
@@ -225,14 +137,8 @@ final class ProductDetailPreviewViewModelTests: XCTestCase {
         await viewModel.generateProductDetails()
     }
 
-    func test_generateProductDetails_synchronizes_tags() async throws {
+    func test_generateProductDetails_synchronizes_tags() async {
         // Given
-        let sampleSiteID: Int64 = 123
-
-        let stores = MockStoresManager(sessionManager: .makeForTesting())
-        let storage = MockStorageManager()
-        storage.insertSampleSite(readOnlySite: Site.fake().copy(siteID: sampleSiteID))
-
         let productName = "Pen"
         let productFeatures = "Ballpoint, Blue ink, ABS plastic"
 
@@ -245,42 +151,15 @@ final class ProductDetailPreviewViewModelTests: XCTestCase {
                                                       storageManager: storage,
                                                       onProductCreated: { _ in })
 
-        stores.whenReceivingAction(ofType: SettingAction.self) { action in
-            switch action {
-            case let .synchronizeGeneralSiteSettings(_, completion):
-                completion(nil)
-            case let .synchronizeProductSiteSettings(_, completion):
-                completion(nil)
-            default:
-                break
-            }
-        }
-
-        stores.whenReceivingAction(ofType: ProductAction.self) { action in
-            switch action {
-            case let .generateAIProduct(_, _, _, _, _, _, _, _, _, _, completion):
-                completion(.success(.fake()))
-            case let .identifyLanguage(_, _, _, completion):
-                completion(.success("en"))
-            default:
-                break
-            }
-        }
-
-        stores.whenReceivingAction(ofType: ProductCategoryAction.self) { action in
-            switch action {
-            case let .synchronizeProductCategories(_, _, completion):
-                completion(nil)
-            default:
-                break
-            }
-        }
+        mockSettingActions()
+        mockProductActions()
+        mockProductCategoryActions()
 
         stores.whenReceivingAction(ofType: ProductTagAction.self) { action in
             switch action {
             case let .synchronizeAllProductTags(siteID, completion):
                 // Then
-                XCTAssertEqual(siteID, sampleSiteID)
+                XCTAssertEqual(siteID, self.sampleSiteID)
                 completion(nil)
             default:
                 break
@@ -293,20 +172,10 @@ final class ProductDetailPreviewViewModelTests: XCTestCase {
 
     func test_generateProductDetails_sends_name_and_features_to_identify_language() async throws {
         // Given
-        let siteID: Int64 = 123
-
-        let stores = MockStoresManager(sessionManager: .makeForTesting())
-        let storage = MockStorageManager()
-        storage.insertSampleSite(readOnlySite: Site.fake().copy(siteID: siteID))
-
-        let uuid = UUID().uuidString
-        let userDefaults = try XCTUnwrap(UserDefaults(suiteName: uuid))
-        userDefaults[.aiPromptTone] = ["\(siteID)": AIToneVoice.casual.rawValue]
-
         let productName = "Pen"
         let productFeatures = "Ballpoint, Blue ink, ABS plastic"
 
-        let viewModel = ProductDetailPreviewViewModel(siteID: 123,
+        let viewModel = ProductDetailPreviewViewModel(siteID: sampleSiteID,
                                                       productName: productName,
                                                       productDescription: nil,
                                                       productFeatures: productFeatures,
@@ -330,26 +199,53 @@ final class ProductDetailPreviewViewModelTests: XCTestCase {
             }
         }
 
-        stores.whenReceivingAction(ofType: ProductCategoryAction.self) { action in
-            switch action {
-            case let .synchronizeProductCategories(_, _, completion):
-                completion(nil)
-            default:
-                break
-            }
-        }
-
-        stores.whenReceivingAction(ofType: ProductTagAction.self) { action in
-            switch action {
-            case let .synchronizeAllProductTags(_, completion):
-                completion(nil)
-            default:
-                break
-            }
-        }
+        mockProductTagActions()
+        mockProductCategoryActions()
 
         // When
         await viewModel.generateProductDetails()
+    }
+
+    func test_identified_language_is_reused_when_generating_product_details_again() async {
+        // Given
+        let productName = "Pen"
+        let productFeatures = "Ballpoint, Blue ink, ABS plastic"
+        let expectedLanguage = "en"
+        var identifyingLanguageRequestCount = 0
+
+        let viewModel = ProductDetailPreviewViewModel(siteID: 123,
+                                                      productName: productName,
+                                                      productDescription: nil,
+                                                      productFeatures: productFeatures,
+                                                      weightUnit: "kg",
+                                                      dimensionUnit: "m",
+                                                      stores: stores,
+                                                      storageManager: storage,
+                                                      onProductCreated: { _ in })
+
+        stores.whenReceivingAction(ofType: ProductAction.self) { action in
+            switch action {
+            case let .generateAIProduct(_, _, _, language, _, _, _, _, _, _, completion):
+                XCTAssertEqual(language, expectedLanguage)
+                completion(.success(.fake()))
+            case let .identifyLanguage(_, _, _, completion):
+                identifyingLanguageRequestCount += 1
+                completion(.success(expectedLanguage))
+            default:
+                break
+            }
+        }
+
+        mockProductTagActions()
+        mockProductCategoryActions()
+
+        // When
+        await viewModel.generateProductDetails()
+        // Retry once
+        await viewModel.generateProductDetails()
+
+        // Then
+        XCTAssertEqual(identifyingLanguageRequestCount, 1)
     }
 
     func test_generateProductDetails_sends_correct_values_to_generate_product_details() async throws {
@@ -362,12 +258,6 @@ final class ProductDetailPreviewViewModelTests: XCTestCase {
         let sampleCurrency = "₹"
         let sampleWeightUnit = "kg"
         let sampleDimensionUnit = "cm"
-
-        let stores = MockStoresManager(sessionManager: .makeForTesting())
-        stores.sessionManager.setStoreId(sampleSiteID)
-
-        let storage = MockStorageManager()
-        storage.insertSampleSite(readOnlySite: Site.fake().copy(siteID: sampleSiteID))
 
         let uuid = UUID().uuidString
         let userDefaults = try XCTUnwrap(UserDefaults(suiteName: uuid))
@@ -428,42 +318,17 @@ final class ProductDetailPreviewViewModelTests: XCTestCase {
             }
         }
 
-        stores.whenReceivingAction(ofType: ProductCategoryAction.self) { action in
-            switch action {
-            case let .synchronizeProductCategories(_, _, completion):
-                completion(nil)
-            default:
-                break
-            }
-        }
-
-        stores.whenReceivingAction(ofType: ProductTagAction.self) { action in
-            switch action {
-            case let .synchronizeAllProductTags(_, completion):
-                completion(nil)
-            default:
-                break
-            }
-        }
+        mockProductTagActions()
+        mockProductCategoryActions()
 
         // When
         await viewModel.generateProductDetails()
     }
 
-    func test_generateProductDetails_sends_productDescription_if_available_to_generate_product_details() async throws {
+    func test_generateProductDetails_sends_productDescription_if_available_to_generate_product_details() async {
         // Given
-        let sampleSiteID: Int64 = 123
         let sampleProductName = "Pen"
         let sampleProductDescription = "Ballpoint, Blue ink, ABS plastic"
-
-        let stores = MockStoresManager(sessionManager: .makeForTesting())
-        stores.sessionManager.setStoreId(sampleSiteID)
-
-        let storage = MockStorageManager()
-        storage.insertSampleSite(readOnlySite: Site.fake().copy(siteID: sampleSiteID))
-
-        let uuid = UUID().uuidString
-        let userDefaults = try XCTUnwrap(UserDefaults(suiteName: uuid))
 
         let viewModel = ProductDetailPreviewViewModel(siteID: sampleSiteID,
                                                       productName: sampleProductName,
@@ -473,40 +338,12 @@ final class ProductDetailPreviewViewModelTests: XCTestCase {
                                                       dimensionUnit: "m",
                                                       stores: stores,
                                                       storageManager: storage,
-                                                      userDefaults: userDefaults,
                                                       onProductCreated: { _ in })
         XCTAssertFalse(viewModel.isGeneratingDetails)
 
-        stores.whenReceivingAction(ofType: ProductAction.self) { action in
-            switch action {
-            case let .generateAIProduct(_, _, keywords, _, _, _, _, _, _, _, completion):
-                // Then
-                XCTAssertEqual(keywords, sampleProductDescription)
-                completion(.success(.fake()))
-            case let .identifyLanguage(_, _, _, completion):
-                completion(.success("en"))
-            default:
-                break
-            }
-        }
-
-        stores.whenReceivingAction(ofType: ProductCategoryAction.self) { action in
-            switch action {
-            case let .synchronizeProductCategories(_, _, completion):
-                completion(nil)
-            default:
-                break
-            }
-        }
-
-        stores.whenReceivingAction(ofType: ProductTagAction.self) { action in
-            switch action {
-            case let .synchronizeAllProductTags(_, completion):
-                completion(nil)
-            default:
-                break
-            }
-        }
+        mockProductActions()
+        mockProductTagActions()
+        mockProductCategoryActions()
 
         // When
         await viewModel.generateProductDetails()
@@ -514,16 +351,6 @@ final class ProductDetailPreviewViewModelTests: XCTestCase {
 
     func test_generateProductDetails_updates_generationInProgress_correctly() async throws {
         // Given
-        let siteID: Int64 = 123
-
-        let stores = MockStoresManager(sessionManager: .makeForTesting())
-        let storage = MockStorageManager()
-        storage.insertSampleSite(readOnlySite: Site.fake().copy(siteID: siteID))
-
-        let uuid = UUID().uuidString
-        let userDefaults = try XCTUnwrap(UserDefaults(suiteName: uuid))
-        userDefaults[.aiPromptTone] = ["\(siteID)": AIToneVoice.casual.rawValue]
-
         let viewModel = ProductDetailPreviewViewModel(siteID: 123,
                                                       productName: "Pen",
                                                       productDescription: nil,
@@ -549,23 +376,8 @@ final class ProductDetailPreviewViewModelTests: XCTestCase {
             }
         }
 
-        stores.whenReceivingAction(ofType: ProductCategoryAction.self) { action in
-            switch action {
-            case let .synchronizeProductCategories(_, _, completion):
-                completion(nil)
-            default:
-                break
-            }
-        }
-
-        stores.whenReceivingAction(ofType: ProductTagAction.self) { action in
-            switch action {
-            case let .synchronizeAllProductTags(_, completion):
-                completion(nil)
-            default:
-                break
-            }
-        }
+        mockProductTagActions()
+        mockProductCategoryActions()
 
         await viewModel.generateProductDetails()
 
@@ -575,18 +387,7 @@ final class ProductDetailPreviewViewModelTests: XCTestCase {
 
     func test_errorState_is_updated_when_generateProductDetails_fails() async throws {
         // Given
-        let siteID: Int64 = 123
-
-        let stores = MockStoresManager(sessionManager: .makeForTesting())
-        let storage = MockStorageManager()
-        storage.insertSampleSite(readOnlySite: Site.fake().copy(siteID: siteID))
-
-        let uuid = UUID().uuidString
-        let userDefaults = try XCTUnwrap(UserDefaults(suiteName: uuid))
-        userDefaults[.aiPromptTone] = ["\(siteID)": AIToneVoice.casual.rawValue]
-
         let expectedError = NSError(domain: "test", code: 503)
-
         let viewModel = ProductDetailPreviewViewModel(siteID: 123,
                                                       productName: "Pen",
                                                       productDescription: nil,
@@ -598,23 +399,8 @@ final class ProductDetailPreviewViewModelTests: XCTestCase {
                                                       onProductCreated: { _ in })
         XCTAssertEqual(viewModel.errorState, .none)
 
-        stores.whenReceivingAction(ofType: ProductCategoryAction.self) { action in
-            switch action {
-            case let .synchronizeProductCategories(_, _, completion):
-                completion(nil)
-            default:
-                break
-            }
-        }
-
-        stores.whenReceivingAction(ofType: ProductTagAction.self) { action in
-            switch action {
-            case let .synchronizeAllProductTags(_, completion):
-                completion(nil)
-            default:
-                break
-            }
-        }
+        mockProductTagActions()
+        mockProductCategoryActions()
 
         // When
         stores.whenReceivingAction(ofType: ProductAction.self) { action in
@@ -656,13 +442,6 @@ final class ProductDetailPreviewViewModelTests: XCTestCase {
                                    tags: [],
                                    price: price,
                                    categories: [])
-        let stores = MockStoresManager(sessionManager: .makeForTesting())
-        let storage = MockStorageManager()
-        storage.insertSampleSite(readOnlySite: Site.fake().copy(siteID: siteID))
-
-        let uuid = UUID().uuidString
-        let userDefaults = try XCTUnwrap(UserDefaults(suiteName: uuid))
-        userDefaults[.aiPromptTone] = ["\(siteID)": AIToneVoice.casual.rawValue]
 
         let viewModel = ProductDetailPreviewViewModel(siteID: siteID,
                                                       productName: "Pen",
@@ -674,35 +453,11 @@ final class ProductDetailPreviewViewModelTests: XCTestCase {
                                                       storageManager: storage,
                                                       onProductCreated: { _ in })
 
-        stores.whenReceivingAction(ofType: ProductCategoryAction.self) { action in
-            switch action {
-            case let .synchronizeProductCategories(_, _, completion):
-                completion(nil)
-            default:
-                break
-            }
-        }
-
-        stores.whenReceivingAction(ofType: ProductTagAction.self) { action in
-            switch action {
-            case let .synchronizeAllProductTags(_, completion):
-                completion(nil)
-            default:
-                break
-            }
-        }
+        mockProductActions(aiGeneratedProductResult: .success(aiProduct))
+        mockProductTagActions()
+        mockProductCategoryActions()
 
         // When
-        stores.whenReceivingAction(ofType: ProductAction.self) { action in
-            switch action {
-            case let .generateAIProduct(_, _, _, _, _, _, _, _, _, _, completion):
-                completion(.success(aiProduct))
-            case let .identifyLanguage(_, _, _, completion):
-                completion(.success("en"))
-            default:
-                break
-            }
-        }
         await viewModel.generateProductDetails()
 
         // Then
@@ -724,9 +479,6 @@ final class ProductDetailPreviewViewModelTests: XCTestCase {
         let sampleSiteID: Int64 = 123
         let biscuit = ProductCategory.fake().copy(siteID: sampleSiteID, name: "Biscuits")
         let product = AIProduct.fake().copy(categories: [biscuit.name])
-        let stores = MockStoresManager(sessionManager: .makeForTesting())
-        let storage = MockStorageManager()
-        storage.insertSampleSite(readOnlySite: Site.fake().copy(siteID: sampleSiteID))
 
         let sampleCategories = [biscuit, ProductCategory.fake().copy(siteID: sampleSiteID)]
         sampleCategories.forEach { storage.insertSampleProductCategory(readOnlyProductCategory: $0) }
@@ -748,35 +500,11 @@ final class ProductDetailPreviewViewModelTests: XCTestCase {
                                                       storageManager: storage,
                                                       onProductCreated: { _ in })
 
-        stores.whenReceivingAction(ofType: ProductCategoryAction.self) { action in
-            switch action {
-            case let .synchronizeProductCategories(_, _, completion):
-                completion(nil)
-            default:
-                break
-            }
-        }
-
-        stores.whenReceivingAction(ofType: ProductTagAction.self) { action in
-            switch action {
-            case let .synchronizeAllProductTags(_, completion):
-                completion(nil)
-            default:
-                break
-            }
-        }
+        mockProductActions(aiGeneratedProductResult: .success(product))
+        mockProductTagActions()
+        mockProductCategoryActions()
 
         // When
-        stores.whenReceivingAction(ofType: ProductAction.self) { action in
-            switch action {
-            case let .generateAIProduct(_, _, _, _, _, _, _, _, _, _, completion):
-                completion(.success(product))
-            case let .identifyLanguage(_, _, _, completion):
-                completion(.success("en"))
-            default:
-                break
-            }
-        }
         await viewModel.generateProductDetails()
 
         // Then
@@ -786,13 +514,7 @@ final class ProductDetailPreviewViewModelTests: XCTestCase {
 
     func test_generateProductDetails_generates_product_with_new_categories_suggested_by_AI() async throws {
         // Given
-        let sampleSiteID: Int64 = 123
-
         let product = AIProduct.fake().copy(categories: ["Biscuits", "Cookies"])
-        let stores = MockStoresManager(sessionManager: .makeForTesting())
-        let storage = MockStorageManager()
-        storage.insertSampleSite(readOnlySite: Site.fake().copy(siteID: sampleSiteID))
-
         let viewModel = ProductDetailPreviewViewModel(siteID: sampleSiteID,
                                                       productName: "Pen",
                                                       productDescription: nil,
@@ -803,35 +525,11 @@ final class ProductDetailPreviewViewModelTests: XCTestCase {
                                                       storageManager: storage,
                                                       onProductCreated: { _ in })
 
-        stores.whenReceivingAction(ofType: ProductCategoryAction.self) { action in
-            switch action {
-            case let .synchronizeProductCategories(_, _, completion):
-                completion(nil)
-            default:
-                break
-            }
-        }
-
-        stores.whenReceivingAction(ofType: ProductTagAction.self) { action in
-            switch action {
-            case let .synchronizeAllProductTags(_, completion):
-                completion(nil)
-            default:
-                break
-            }
-        }
+        mockProductActions(aiGeneratedProductResult: .success(product))
+        mockProductTagActions()
+        mockProductCategoryActions()
 
         // When
-        stores.whenReceivingAction(ofType: ProductAction.self) { action in
-            switch action {
-            case let .generateAIProduct(_, _, _, _, _, _, _, _, _, _, completion):
-                completion(.success(product))
-            case let .identifyLanguage(_, _, _, completion):
-                completion(.success("en"))
-            default:
-                break
-            }
-        }
         await viewModel.generateProductDetails()
 
         // Then
@@ -842,12 +540,8 @@ final class ProductDetailPreviewViewModelTests: XCTestCase {
 
     func test_generateProductDetails_generates_product_with_matching_existing_tags() async throws {
         // Given
-        let sampleSiteID: Int64 = 123
         let food: ProductTag = .fake().copy(siteID: sampleSiteID, name: "Food")
         let product = AIProduct.fake().copy(tags: [food.name])
-        let stores = MockStoresManager(sessionManager: .makeForTesting())
-        let storage = MockStorageManager()
-        storage.insertSampleSite(readOnlySite: Site.fake().copy(siteID: sampleSiteID))
 
         let sampleCategories = [ProductCategory.fake().copy(siteID: sampleSiteID), ProductCategory.fake().copy(siteID: sampleSiteID)]
         sampleCategories.forEach { storage.insertSampleProductCategory(readOnlyProductCategory: $0) }
@@ -869,35 +563,11 @@ final class ProductDetailPreviewViewModelTests: XCTestCase {
                                                       storageManager: storage,
                                                       onProductCreated: { _ in })
 
-        stores.whenReceivingAction(ofType: ProductCategoryAction.self) { action in
-            switch action {
-            case let .synchronizeProductCategories(_, _, completion):
-                completion(nil)
-            default:
-                break
-            }
-        }
-
-        stores.whenReceivingAction(ofType: ProductTagAction.self) { action in
-            switch action {
-            case let .synchronizeAllProductTags(_, completion):
-                completion(nil)
-            default:
-                break
-            }
-        }
+        mockProductActions(aiGeneratedProductResult: .success(product))
+        mockProductTagActions()
+        mockProductCategoryActions()
 
         // When
-        stores.whenReceivingAction(ofType: ProductAction.self) { action in
-            switch action {
-            case let .generateAIProduct(_, _, _, _, _, _, _, _, _, _, completion):
-                completion(.success(product))
-            case let .identifyLanguage(_, _, _, completion):
-                completion(.success("en"))
-            default:
-                break
-            }
-        }
         await viewModel.generateProductDetails()
 
         // Then
@@ -907,12 +577,7 @@ final class ProductDetailPreviewViewModelTests: XCTestCase {
 
     func test_generateProductDetails_generates_product_with_new_tags_suggested_by_AI() async throws {
         // Given
-        let sampleSiteID: Int64 = 123
         let product = AIProduct.fake().copy(tags: ["Food", "Grocery"])
-        let stores = MockStoresManager(sessionManager: .makeForTesting())
-        let storage = MockStorageManager()
-        storage.insertSampleSite(readOnlySite: Site.fake().copy(siteID: sampleSiteID))
-
         let viewModel = ProductDetailPreviewViewModel(siteID: sampleSiteID,
                                                       productName: "Pen",
                                                       productDescription: nil,
@@ -923,35 +588,11 @@ final class ProductDetailPreviewViewModelTests: XCTestCase {
                                                       storageManager: storage,
                                                       onProductCreated: { _ in })
 
-        stores.whenReceivingAction(ofType: ProductCategoryAction.self) { action in
-            switch action {
-            case let .synchronizeProductCategories(_, _, completion):
-                completion(nil)
-            default:
-                break
-            }
-        }
-
-        stores.whenReceivingAction(ofType: ProductTagAction.self) { action in
-            switch action {
-            case let .synchronizeAllProductTags(_, completion):
-                completion(nil)
-            default:
-                break
-            }
-        }
+        mockProductActions(aiGeneratedProductResult: .success(product))
+        mockProductTagActions()
+        mockProductCategoryActions()
 
         // When
-        stores.whenReceivingAction(ofType: ProductAction.self) { action in
-            switch action {
-            case let .generateAIProduct(_, _, _, _, _, _, _, _, _, _, completion):
-                completion(.success(product))
-            case let .identifyLanguage(_, _, _, completion):
-                completion(.success("en"))
-            default:
-                break
-            }
-        }
         await viewModel.generateProductDetails()
 
         // Then
@@ -969,7 +610,6 @@ final class ProductDetailPreviewViewModelTests: XCTestCase {
                                       aiProduct: aiProduct,
                                       categories: [],
                                       tags: [])
-        let stores = MockStoresManager(sessionManager: .makeForTesting())
         let viewModel = ProductDetailPreviewViewModel(siteID: 123,
                                                       productName: "iPhone 15",
                                                       productDescription: nil,
@@ -979,23 +619,8 @@ final class ProductDetailPreviewViewModelTests: XCTestCase {
                                                       stores: stores,
                                                       onProductCreated: { _ in })
 
-        stores.whenReceivingAction(ofType: ProductCategoryAction.self) { action in
-            switch action {
-            case let .synchronizeProductCategories(_, _, completion):
-                completion(nil)
-            default:
-                break
-            }
-        }
-
-        stores.whenReceivingAction(ofType: ProductTagAction.self) { action in
-            switch action {
-            case let .synchronizeAllProductTags(_, completion):
-                completion(nil)
-            default:
-                break
-            }
-        }
+        mockProductTagActions()
+        mockProductCategoryActions()
 
         // When
         stores.whenReceivingAction(ofType: ProductAction.self) { action in
@@ -1028,7 +653,6 @@ final class ProductDetailPreviewViewModelTests: XCTestCase {
                                       aiProduct: aiProduct,
                                       categories: [],
                                       tags: [])
-        let stores = MockStoresManager(sessionManager: .makeForTesting())
         let viewModel = ProductDetailPreviewViewModel(siteID: 123,
                                                       productName: "iPhone 15",
                                                       productDescription: nil,
@@ -1038,37 +662,12 @@ final class ProductDetailPreviewViewModelTests: XCTestCase {
                                                       stores: stores,
                                                       onProductCreated: { createdProduct = $0 })
 
-        stores.whenReceivingAction(ofType: ProductCategoryAction.self) { action in
-            switch action {
-            case let .synchronizeProductCategories(_, _, completion):
-                completion(nil)
-            default:
-                break
-            }
-        }
-
-        stores.whenReceivingAction(ofType: ProductTagAction.self) { action in
-            switch action {
-            case let .synchronizeAllProductTags(_, completion):
-                completion(nil)
-            default:
-                break
-            }
-        }
+        mockProductTagActions()
+        mockProductCategoryActions()
+        mockProductActions(aiGeneratedProductResult: .success(aiProduct),
+                           addedProductResult: .success(expectedProduct))
 
         // When
-        stores.whenReceivingAction(ofType: ProductAction.self) { action in
-            switch action {
-            case let .generateAIProduct(_, _, _, _, _, _, _, _, _, _, completion):
-                completion(.success(aiProduct))
-            case let .identifyLanguage(_, _, _, completion):
-                completion(.success("en"))
-            case let .addProduct(_, onCompletion):
-                onCompletion(.success(expectedProduct))
-            default:
-                break
-            }
-        }
         await viewModel.generateProductDetails()
         await viewModel.saveProductAsDraft()
 
@@ -1079,7 +678,6 @@ final class ProductDetailPreviewViewModelTests: XCTestCase {
     func test_saveProductAsDraft_updates_errorState_upon_failure() async {
         // Given
         let aiProduct = AIProduct.fake().copy(name: "iPhone 15")
-        let stores = MockStoresManager(sessionManager: .makeForTesting())
         let viewModel = ProductDetailPreviewViewModel(siteID: 123,
                                                       productName: "iPhone 15",
                                                       productDescription: nil,
@@ -1090,37 +688,12 @@ final class ProductDetailPreviewViewModelTests: XCTestCase {
                                                       onProductCreated: { _ in })
         XCTAssertEqual(viewModel.errorState, .none)
 
-        stores.whenReceivingAction(ofType: ProductCategoryAction.self) { action in
-            switch action {
-            case let .synchronizeProductCategories(_, _, completion):
-                completion(nil)
-            default:
-                break
-            }
-        }
-
-        stores.whenReceivingAction(ofType: ProductTagAction.self) { action in
-            switch action {
-            case let .synchronizeAllProductTags(_, completion):
-                completion(nil)
-            default:
-                break
-            }
-        }
+        mockProductTagActions()
+        mockProductCategoryActions()
+        mockProductActions(aiGeneratedProductResult: .success(aiProduct),
+                           addedProductResult: .failure(.unexpected))
 
         // When
-        stores.whenReceivingAction(ofType: ProductAction.self) { action in
-            switch action {
-            case let .generateAIProduct(_, _, _, _, _, _, _, _, _, _, completion):
-                completion(.success(aiProduct))
-            case let .identifyLanguage(_, _, _, completion):
-                completion(.success("en"))
-            case let .addProduct(_, onCompletion):
-                onCompletion(.failure(.unexpected))
-            default:
-                break
-            }
-        }
         await viewModel.generateProductDetails()
         await viewModel.saveProductAsDraft()
 
@@ -1130,14 +703,9 @@ final class ProductDetailPreviewViewModelTests: XCTestCase {
 
     func test_saveProductAsDraft_saves_local_categories() async {
         // Given
-        let sampleSiteID: Int64 = 123
         let grocery = ProductCategory.fake().copy(siteID: sampleSiteID, name: "Groceries")
         let aiProduct = AIProduct.fake().copy(name: "iPhone 15",
                                               categories: ["Biscuits", "Cookies"])
-
-        let stores = MockStoresManager(sessionManager: .makeForTesting())
-        let storage = MockStorageManager()
-        storage.insertSampleSite(readOnlySite: Site.fake().copy(siteID: sampleSiteID))
 
         let sampleCategories = [grocery]
         sampleCategories.forEach { storage.insertSampleProductCategory(readOnlyProductCategory: $0) }
@@ -1158,7 +726,7 @@ final class ProductDetailPreviewViewModelTests: XCTestCase {
                 completion(nil)
             case let .addProductCategories(siteID, names, _, completion):
                 // Then
-                XCTAssertEqual(siteID, sampleSiteID)
+                XCTAssertEqual(siteID, self.sampleSiteID)
                 XCTAssertEqual(names, ["Biscuits", "Cookies"])
                 completion(.success([]))
             default:
@@ -1166,44 +734,19 @@ final class ProductDetailPreviewViewModelTests: XCTestCase {
             }
         }
 
-        stores.whenReceivingAction(ofType: ProductTagAction.self) { action in
-            switch action {
-            case let .synchronizeAllProductTags(_, completion):
-                completion(nil)
-            default:
-                break
-            }
-        }
-
-        stores.whenReceivingAction(ofType: ProductAction.self) { action in
-            switch action {
-            case let .generateAIProduct(_, _, _, _, _, _, _, _, _, _, completion):
-                completion(.success(aiProduct))
-            case let .identifyLanguage(_, _, _, completion):
-                completion(.success("en"))
-            case let .addProduct(_, onCompletion):
-                onCompletion(.success(.fake()))
-            default:
-                break
-            }
-        }
-
-        await viewModel.generateProductDetails()
+        mockProductTagActions()
+        mockProductActions(aiGeneratedProductResult: .success(aiProduct))
 
         // When
+        await viewModel.generateProductDetails()
         await viewModel.saveProductAsDraft()
     }
 
     func test_saveProductAsDraft_saves_local_tags() async {
         // Given
-        let sampleSiteID: Int64 = 123
         let existingTag = ProductTag.fake().copy(siteID: sampleSiteID, name: "Existing tag")
         let aiProduct = AIProduct.fake().copy(name: "iPhone 15",
                                               tags: ["Tag 1", "Tag 2"])
-
-        let stores = MockStoresManager(sessionManager: .makeForTesting())
-        let storage = MockStorageManager()
-        storage.insertSampleSite(readOnlySite: Site.fake().copy(siteID: sampleSiteID))
 
         let sampleTags = [existingTag, ProductTag.fake().copy(siteID: sampleSiteID)]
         sampleTags.forEach { storage.insertSampleProductTag(readOnlyProductTag: $0) }
@@ -1218,16 +761,8 @@ final class ProductDetailPreviewViewModelTests: XCTestCase {
                                                       storageManager: storage,
                                                       onProductCreated: { _ in })
 
-        stores.whenReceivingAction(ofType: ProductCategoryAction.self) { action in
-            switch action {
-            case let .synchronizeProductCategories(_, _, completion):
-                completion(nil)
-            case let .addProductCategories(_, _, _, completion):
-                completion(.success([]))
-            default:
-                break
-            }
-        }
+        mockProductCategoryActions()
+        mockProductActions(aiGeneratedProductResult: .success(aiProduct))
 
         stores.whenReceivingAction(ofType: ProductTagAction.self) { action in
             switch action {
@@ -1235,22 +770,9 @@ final class ProductDetailPreviewViewModelTests: XCTestCase {
                 completion(nil)
             case let .addProductTags(siteID, tags, completion):
                 // Then
-                XCTAssertEqual(siteID, sampleSiteID)
+                XCTAssertEqual(siteID, self.sampleSiteID)
                 XCTAssertEqual(tags, ["Tag 1", "Tag 2"])
                 completion(.success([]))
-            default:
-                break
-            }
-        }
-
-        stores.whenReceivingAction(ofType: ProductAction.self) { action in
-            switch action {
-            case let .generateAIProduct(_, _, _, _, _, _, _, _, _, _, completion):
-                completion(.success(aiProduct))
-            case let .identifyLanguage(_, _, _, completion):
-                completion(.success("en"))
-            case let .addProduct(_, onCompletion):
-                onCompletion(.success(.fake()))
             default:
                 break
             }
@@ -1266,13 +788,7 @@ final class ProductDetailPreviewViewModelTests: XCTestCase {
 
     func test_handleFeedback_sets_shouldShowFeedbackView_to_false() {
         // Given
-        let siteID: Int64 = 123
-
-        let stores = MockStoresManager(sessionManager: .makeForTesting())
-        let storage = MockStorageManager()
-        storage.insertSampleSite(readOnlySite: Site.fake().copy(siteID: siteID))
-
-        let viewModel = ProductDetailPreviewViewModel(siteID: siteID,
+        let viewModel = ProductDetailPreviewViewModel(siteID: sampleSiteID,
                                                       productName: "Pen",
                                                       productDescription: nil,
                                                       productFeatures: "Ballpoint, Blue ink, ABS plastic",
@@ -1294,13 +810,7 @@ final class ProductDetailPreviewViewModelTests: XCTestCase {
 
     func test_generateProductDetails_tracks_event_on_success() async throws {
         // Given
-        let siteID: Int64 = 123
-
-        let stores = MockStoresManager(sessionManager: .makeForTesting())
-        let storage = MockStorageManager()
-        storage.insertSampleSite(readOnlySite: Site.fake().copy(siteID: siteID))
-
-        let viewModel = ProductDetailPreviewViewModel(siteID: siteID,
+        let viewModel = ProductDetailPreviewViewModel(siteID: sampleSiteID,
                                                       productName: "Pen",
                                                       productDescription: nil,
                                                       productFeatures: "Ballpoint, Blue ink, ABS plastic",
@@ -1311,34 +821,9 @@ final class ProductDetailPreviewViewModelTests: XCTestCase {
                                                       analytics: analytics,
                                                       onProductCreated: { _ in })
 
-        stores.whenReceivingAction(ofType: ProductCategoryAction.self) { action in
-            switch action {
-            case let .synchronizeProductCategories(_, _, completion):
-                completion(nil)
-            default:
-                break
-            }
-        }
-
-        stores.whenReceivingAction(ofType: ProductTagAction.self) { action in
-            switch action {
-            case let .synchronizeAllProductTags(_, completion):
-                completion(nil)
-            default:
-                break
-            }
-        }
-
-        stores.whenReceivingAction(ofType: ProductAction.self) { action in
-            switch action {
-            case let .generateAIProduct(_, _, _, _, _, _, _, _, _, _, completion):
-                completion(.success(.fake()))
-            case let .identifyLanguage(_, _, _, completion):
-                completion(.success("en"))
-            default:
-                break
-            }
-        }
+        mockProductTagActions()
+        mockProductCategoryActions()
+        mockProductActions()
 
         // When
         await viewModel.generateProductDetails()
@@ -1349,15 +834,9 @@ final class ProductDetailPreviewViewModelTests: XCTestCase {
 
     func test_generateProductDetails_tracks_event_on_failure() async throws {
         // Given
-        let siteID: Int64 = 123
-
-        let stores = MockStoresManager(sessionManager: .makeForTesting())
-        let storage = MockStorageManager()
-        storage.insertSampleSite(readOnlySite: Site.fake().copy(siteID: siteID))
-
         let expectedError = NSError(domain: "test", code: 503)
 
-        let viewModel = ProductDetailPreviewViewModel(siteID: siteID,
+        let viewModel = ProductDetailPreviewViewModel(siteID: sampleSiteID,
                                                       productName: "Pen",
                                                       productDescription: nil,
                                                       productFeatures: "Ballpoint, Blue ink, ABS plastic",
@@ -1368,34 +847,9 @@ final class ProductDetailPreviewViewModelTests: XCTestCase {
                                                       analytics: analytics,
                                                       onProductCreated: { _ in })
 
-        stores.whenReceivingAction(ofType: ProductCategoryAction.self) { action in
-            switch action {
-            case let .synchronizeProductCategories(_, _, completion):
-                completion(nil)
-            default:
-                break
-            }
-        }
-
-        stores.whenReceivingAction(ofType: ProductTagAction.self) { action in
-            switch action {
-            case let .synchronizeAllProductTags(_, completion):
-                completion(nil)
-            default:
-                break
-            }
-        }
-
-        stores.whenReceivingAction(ofType: ProductAction.self) { action in
-            switch action {
-            case let .generateAIProduct(_, _, _, _, _, _, _, _, _, _, completion):
-                completion(.failure(expectedError))
-            case let .identifyLanguage(_, _, _, completion):
-                completion(.success("en"))
-            default:
-                break
-            }
-        }
+        mockProductTagActions()
+        mockProductCategoryActions()
+        mockProductActions(aiGeneratedProductResult: .failure(expectedError))
 
         // When
         await viewModel.generateProductDetails()
@@ -1409,15 +863,9 @@ final class ProductDetailPreviewViewModelTests: XCTestCase {
         XCTAssertEqual(errorEventProperties["error_domain"] as? String, "test")
     }
 
-    func test_saveProductAsDraft_tracks_tapped_event() async throws {
+    func test_saveProductAsDraft_tracks_tapped_event() async {
         // Given
-        let siteID: Int64 = 123
-
-        let stores = MockStoresManager(sessionManager: .makeForTesting())
-        let storage = MockStorageManager()
-        storage.insertSampleSite(readOnlySite: Site.fake().copy(siteID: siteID))
-
-        let viewModel = ProductDetailPreviewViewModel(siteID: siteID,
+        let viewModel = ProductDetailPreviewViewModel(siteID: sampleSiteID,
                                                       productName: "Pen",
                                                       productDescription: nil,
                                                       productFeatures: "Ballpoint, Blue ink, ABS plastic",
@@ -1428,16 +876,7 @@ final class ProductDetailPreviewViewModelTests: XCTestCase {
                                                       analytics: analytics,
                                                       onProductCreated: { _ in })
 
-        stores.whenReceivingAction(ofType: ProductAction.self) { action in
-            switch action {
-            case let .generateAIProduct(_, _, _, _, _, _, _, _, _, _, completion):
-                completion(.success(.fake()))
-            case let .identifyLanguage(_, _, _, completion):
-                completion(.success("en"))
-            default:
-                break
-            }
-        }
+        mockProductActions()
 
         // When
         await viewModel.saveProductAsDraft()
@@ -1448,13 +887,7 @@ final class ProductDetailPreviewViewModelTests: XCTestCase {
 
     func test_saveProductAsDraft_tracks_event_on_success() async throws {
         // Given
-        let siteID: Int64 = 123
-
-        let stores = MockStoresManager(sessionManager: .makeForTesting())
-        let storage = MockStorageManager()
-        storage.insertSampleSite(readOnlySite: Site.fake().copy(siteID: siteID))
-
-        let viewModel = ProductDetailPreviewViewModel(siteID: siteID,
+        let viewModel = ProductDetailPreviewViewModel(siteID: sampleSiteID,
                                                       productName: "Pen",
                                                       productDescription: nil,
                                                       productFeatures: "Ballpoint, Blue ink, ABS plastic",
@@ -1464,36 +897,9 @@ final class ProductDetailPreviewViewModelTests: XCTestCase {
                                                       storageManager: storage,
                                                       analytics: analytics,
                                                       onProductCreated: { _ in })
-        stores.whenReceivingAction(ofType: ProductAction.self) { action in
-            switch action {
-            case let .generateAIProduct(_, _, _, _, _, _, _, _, _, _, completion):
-                completion(.success(.fake()))
-            case let .identifyLanguage(_, _, _, completion):
-                completion(.success("en"))
-            case let .addProduct(product, completion):
-                completion(.success(product))
-            default:
-                break
-            }
-        }
-
-        stores.whenReceivingAction(ofType: ProductCategoryAction.self) { action in
-            switch action {
-            case let .synchronizeProductCategories(_, _, completion):
-                completion(nil)
-            default:
-                break
-            }
-        }
-
-        stores.whenReceivingAction(ofType: ProductTagAction.self) { action in
-            switch action {
-            case let .synchronizeAllProductTags(_, completion):
-                completion(nil)
-            default:
-                break
-            }
-        }
+        mockProductTagActions()
+        mockProductCategoryActions()
+        mockProductActions()
 
         await viewModel.generateProductDetails()
 
@@ -1506,15 +912,9 @@ final class ProductDetailPreviewViewModelTests: XCTestCase {
 
     func test_saveProductAsDraft_tracks_event_on_failure() async throws {
         // Given
-        let siteID: Int64 = 123
-
-        let stores = MockStoresManager(sessionManager: .makeForTesting())
-        let storage = MockStorageManager()
-        storage.insertSampleSite(readOnlySite: Site.fake().copy(siteID: siteID))
-
         let expectedError = ProductUpdateError(error: NSError(domain: "test", code: 503))
 
-        let viewModel = ProductDetailPreviewViewModel(siteID: siteID,
+        let viewModel = ProductDetailPreviewViewModel(siteID: sampleSiteID,
                                                       productName: "Pen",
                                                       productDescription: nil,
                                                       productFeatures: "Ballpoint, Blue ink, ABS plastic",
@@ -1524,36 +924,10 @@ final class ProductDetailPreviewViewModelTests: XCTestCase {
                                                       storageManager: storage,
                                                       analytics: analytics,
                                                       onProductCreated: { _ in })
-        stores.whenReceivingAction(ofType: ProductAction.self) { action in
-            switch action {
-            case let .generateAIProduct(_, _, _, _, _, _, _, _, _, _, completion):
-                completion(.success(.fake()))
-            case let .identifyLanguage(_, _, _, completion):
-                completion(.success("en"))
-            case let .addProduct(_, completion):
-                completion(.failure(expectedError))
-            default:
-                break
-            }
-        }
 
-        stores.whenReceivingAction(ofType: ProductCategoryAction.self) { action in
-            switch action {
-            case let .synchronizeProductCategories(_, _, completion):
-                completion(nil)
-            default:
-                break
-            }
-        }
-
-        stores.whenReceivingAction(ofType: ProductTagAction.self) { action in
-            switch action {
-            case let .synchronizeAllProductTags(_, completion):
-                completion(nil)
-            default:
-                break
-            }
-        }
+        mockProductTagActions()
+        mockProductCategoryActions()
+        mockProductActions(addedProductResult: .failure(expectedError))
 
         await viewModel.generateProductDetails()
 
@@ -1571,13 +945,7 @@ final class ProductDetailPreviewViewModelTests: XCTestCase {
 
     func test_handleFeedback_tracks_feedback_received()  throws {
         // Given
-        let siteID: Int64 = 123
-
-        let stores = MockStoresManager(sessionManager: .makeForTesting())
-        let storage = MockStorageManager()
-        storage.insertSampleSite(readOnlySite: Site.fake().copy(siteID: siteID))
-
-        let viewModel = ProductDetailPreviewViewModel(siteID: siteID,
+        let viewModel = ProductDetailPreviewViewModel(siteID: sampleSiteID,
                                                       productName: "Pen",
                                                       productDescription: nil,
                                                       productFeatures: "Ballpoint, Blue ink, ABS plastic",
@@ -1596,5 +964,61 @@ final class ProductDetailPreviewViewModelTests: XCTestCase {
         let eventProperties = analyticsProvider.receivedProperties[index]
         XCTAssertEqual(eventProperties["source"] as? String, "product_creation")
         XCTAssertEqual(eventProperties["is_useful"] as? Bool, true)
+    }
+}
+
+private extension ProductDetailPreviewViewModelTests {
+    func mockSettingActions() {
+        stores.whenReceivingAction(ofType: SettingAction.self) { action in
+            switch action {
+            case let .synchronizeGeneralSiteSettings(_, completion):
+                completion(nil)
+            case let .synchronizeProductSiteSettings(_, completion):
+                completion(nil)
+            default:
+                break
+            }
+        }
+    }
+
+    func mockProductCategoryActions() {
+        stores.whenReceivingAction(ofType: ProductCategoryAction.self) { action in
+            switch action {
+            case let .synchronizeProductCategories(_, _, completion):
+                completion(nil)
+            case let .addProductCategories(_, _, _, completion):
+                completion(.success([]))
+            default:
+                break
+            }
+        }
+    }
+
+    func mockProductTagActions() {
+        stores.whenReceivingAction(ofType: ProductTagAction.self) { action in
+            switch action {
+            case let .synchronizeAllProductTags(_, completion):
+                completion(nil)
+            default:
+                break
+            }
+        }
+    }
+
+    func mockProductActions(identifiedLanguage: String = "en",
+                            aiGeneratedProductResult: Result<AIProduct, Error> = .success(.fake()),
+                            addedProductResult: Result<Product, ProductUpdateError> = .success(.fake())) {
+        stores.whenReceivingAction(ofType: ProductAction.self) { action in
+            switch action {
+            case let .generateAIProduct(_, _, _, _, _, _, _, _, _, _, completion):
+                completion(aiGeneratedProductResult)
+            case let .identifyLanguage(_, _, _, completion):
+                completion(.success(identifiedLanguage))
+            case let .addProduct(_, onCompletion):
+                onCompletion(addedProductResult)
+            default:
+                break
+            }
+        }
     }
 }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #11653 
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This PR adds an improvement to only request language detection for product creation AI on first try. This will improve the response for subsequent requests.

Also: updated unit tests to make them shorter.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
It's not straightforward to replicate the case where the product generation fails. We can update the method `ProductDetailPreviewViewModel` to force the error state like so:

<img width="627" alt="image" src="https://github.com/woocommerce/woocommerce-ios/assets/5533851/e6141117-6a6e-4f79-a732-a10a856d7262">

- Build the app and log in to a store eligible for Jetpack AI.
- Navigate to the Products tab, select "+" then "Create a product with AI".
- Follow the steps to generate a product.
- After reaching the Preview screen, an alert should be displayed saying there was an error generating product details. Confirm in Proxyman that there was a request to identify the language in the title and keywords immediately before that.
- Tap Retry in the alert. Confirm in Proxyman that no other request to identify the language is sent. 
- Tap Cancel in the alert. Try generate the product again.
- Confirm in Proxyman that a request to identify the language is sent again.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->
N/A

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
