### PR TITLE
[Tablet Products] Show selected product and support product creation in the secondary view

### DIFF
--- a/WooCommerce/Classes/ViewRelated/MainTabBarController.swift
+++ b/WooCommerce/Classes/ViewRelated/MainTabBarController.swift
@@ -562,7 +562,9 @@ private extension MainTabBarController {
         if isProductsSplitViewFeatureFlagOn {
             productsContainerController.wrappedController = ProductsSplitViewWrapperController(siteID: siteID)
         } else {
-            productsNavigationController.viewControllers = [ProductsViewController(siteID: siteID)]
+            productsNavigationController.viewControllers = [ProductsViewController(siteID: siteID,
+                                                                                   navigationControllerToAddProduct: productsNavigationController,
+                                                                                   navigateToContent: { _ in })]
         }
 
         // Configure hub menu tab coordinator once per logged in session potentially with multiple sites.

--- a/WooCommerce/Classes/ViewRelated/Products/ProductsSplitViewCoordinator.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductsSplitViewCoordinator.swift
@@ -1,0 +1,26 @@
+import UIKit
+
+/// Coordinates the state of multiple columns (product list and secondary view) based on the secondary view.
+final class ProductsSplitViewCoordinator {
+    private let siteID: Int64
+    private let splitViewController: UISplitViewController
+    private lazy var productsViewController = ProductsViewController(siteID: siteID)
+
+    init(siteID: Int64, splitViewController: UISplitViewController) {
+        self.siteID = siteID
+        self.splitViewController = splitViewController
+    }
+
+    /// Called when the split view is ready to be shown, like after the split view is added to the view hierarchy.
+    func start() {
+        configureSplitView()
+    }
+}
+
+private extension ProductsSplitViewCoordinator {
+    func configureSplitView() {
+        let productsNavigationController = WooTabNavigationController()
+        productsNavigationController.viewControllers = [productsViewController]
+        splitViewController.setViewController(productsNavigationController, for: .primary)
+    }
+}

--- a/WooCommerce/Classes/ViewRelated/Products/ProductsSplitViewWrapperController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductsSplitViewWrapperController.swift
@@ -5,9 +5,9 @@ import Yosemite
 ///
 final class ProductsSplitViewWrapperController: UIViewController {
     private let siteID: Int64
-
+    private lazy var coordinator: ProductsSplitViewCoordinator = ProductsSplitViewCoordinator(siteID: siteID,
+                                                                                              splitViewController: productsSplitViewController)
     private lazy var productsSplitViewController = WooSplitViewController(columnForCollapsingHandler: handleCollapsingSplitView)
-    private lazy var productsViewController = ProductsViewController(siteID: siteID)
 
     init(siteID: Int64) {
         self.siteID = siteID
@@ -21,8 +21,8 @@ final class ProductsSplitViewWrapperController: UIViewController {
 
     override func viewDidLoad() {
         super.viewDidLoad()
-        configureSplitView()
         configureChildViewController()
+        coordinator.start()
     }
 
     override var shouldShowOfflineBanner: Bool {
@@ -38,12 +38,6 @@ private extension ProductsSplitViewWrapperController {
 }
 
 private extension ProductsSplitViewWrapperController {
-    func configureSplitView() {
-        let productsNavigationController = WooTabNavigationController()
-        productsNavigationController.viewControllers = [productsViewController]
-        productsSplitViewController.setViewController(productsNavigationController, for: .primary)
-    }
-
     func configureTabBarItem() {
         tabBarItem.title = Localization.tabTitle
         tabBarItem.image = .productImage

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -508,6 +508,7 @@
 		02D7E7C72A4CBC620003049A /* LocalAnnouncementViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02D7E7C62A4CBC620003049A /* LocalAnnouncementViewModel.swift */; };
 		02D7E7C92A4CBEEC0003049A /* LocalAnnouncementModal.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02D7E7C82A4CBEEC0003049A /* LocalAnnouncementModal.swift */; };
 		02D7E7CC2A4CE5060003049A /* LocalAnnouncementsProviderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02D7E7CB2A4CE5060003049A /* LocalAnnouncementsProviderTests.swift */; };
+		02D9EFCB2B69F91B00AE8968 /* ProductsSplitViewCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02D9EFCA2B69F91B00AE8968 /* ProductsSplitViewCoordinator.swift */; };
 		02DAE7FC291B7B8B009342B7 /* DomainSelectorViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02DAE7FB291B7B8B009342B7 /* DomainSelectorViewModel.swift */; };
 		02DAE7FF291B8C8A009342B7 /* FreeDomainSelectorViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02DAE7FE291B8C8A009342B7 /* FreeDomainSelectorViewModelTests.swift */; };
 		02DC2ED2242061BF002F9676 /* ProductPriceSettingsViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02DC2ED1242061BE002F9676 /* ProductPriceSettingsViewModel.swift */; };
@@ -3189,6 +3190,7 @@
 		02D7E7C62A4CBC620003049A /* LocalAnnouncementViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocalAnnouncementViewModel.swift; sourceTree = "<group>"; };
 		02D7E7C82A4CBEEC0003049A /* LocalAnnouncementModal.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocalAnnouncementModal.swift; sourceTree = "<group>"; };
 		02D7E7CB2A4CE5060003049A /* LocalAnnouncementsProviderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocalAnnouncementsProviderTests.swift; sourceTree = "<group>"; };
+		02D9EFCA2B69F91B00AE8968 /* ProductsSplitViewCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductsSplitViewCoordinator.swift; sourceTree = "<group>"; };
 		02DAE7FB291B7B8B009342B7 /* DomainSelectorViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DomainSelectorViewModel.swift; sourceTree = "<group>"; };
 		02DAE7FE291B8C8A009342B7 /* FreeDomainSelectorViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FreeDomainSelectorViewModelTests.swift; sourceTree = "<group>"; };
 		02DC2ED1242061BE002F9676 /* ProductPriceSettingsViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductPriceSettingsViewModel.swift; sourceTree = "<group>"; };
@@ -8534,6 +8536,7 @@
 				AEFF77A529783CA600667F7A /* PriceInputViewModel.swift */,
 				B946881729B8DDC2000646B0 /* ProductsViewController+Activity.swift */,
 				0258D9482B68E7FE00D280D0 /* ProductsSplitViewWrapperController.swift */,
+				02D9EFCA2B69F91B00AE8968 /* ProductsSplitViewCoordinator.swift */,
 			);
 			path = Products;
 			sourceTree = "<group>";
@@ -13261,6 +13264,7 @@
 				DE46133926B2BEB8001DE59C /* ShippingLabelCountryListSelectorCommand.swift in Sources */,
 				68E952D22875A44B0095A23D /* CardReaderType+Manual.swift in Sources */,
 				035DBA4B292E248C003E5125 /* CardPresentPaymentAlertsPresenter.swift in Sources */,
+				02D9EFCB2B69F91B00AE8968 /* ProductsSplitViewCoordinator.swift in Sources */,
 				0211259F2578DE310075AD2A /* ShippingLabelPrintingStepView.swift in Sources */,
 				B58B4AB22108F01700076FDD /* NoticeView.swift in Sources */,
 				74B5713621CD7604008F9B8E /* SharingHelper.swift in Sources */,


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Parat of #11852
<!-- Id number of the GitHub issue this PR addresses. -->

## Why

To support split view in the products tab, we want to show the main content in the secondary view. This PR does this for 2 navigation actions:

- Navigation bar - add product
- Product list - select a product

## How

Any feedback on the implementation is welcome! I decided to create `ProductsSplitViewCoordinator` to coordinate the primary/secondary view content in the split view, with a fixed navigation controller for each pane.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

🗒️ This is just the first step to show the secondary view. More details in pfoUAQ-cM-p2.

- [x] @jaclync tests when feature flag is disabled, all functionality in the products tab remains the same

### Feature flag enabled

- Enable the feature flag in code
- Go to the products tab
- Tap on a product in the list --> the product form should be shown in the secondary view
- Tap on + in the navigation bar in the list --> the product form should be shown eventually

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->


https://github.com/woocommerce/woocommerce-ios/assets/1945542/4b978caf-542b-4306-8a3b-4b5be8d54078



---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.