### PR TITLE
[Backend Receipts] Add backend vs local receipt eligibility usecase checks

### DIFF
--- a/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsDataSource.swift
+++ b/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsDataSource.swift
@@ -1507,7 +1507,7 @@ extension OrderDetailsDataSource {
         static let reprintShippingLabel = NSLocalizedString("Print Shipping Label", comment: "Text on the button that prints a shipping label")
         static let seeReceipt = NSLocalizedString(
             "OrderDetailsDataSource.configureSeeReceipt.button.title",
-            value: "[Debug] See Backed Receipt",
+            value: "[Debug] See Backend Receipt",
             comment: "Text on the button title to see the order's receipt")
         static let seeLegacyReceipt = NSLocalizedString("See Receipt", comment: "Text on the button to see a saved receipt")
     }

--- a/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsDataSource.swift
+++ b/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsDataSource.swift
@@ -106,7 +106,7 @@ final class OrderDetailsDataSource: NSObject {
 
     /// Whether the order has a locally-generated receipt associated.
     ///
-    var shouldShowLegacyReceipts: Bool = false
+    var orderHasLocalReceipt: Bool = false
 
     /// Closure to be executed when the cell was tapped.
     ///
@@ -1235,12 +1235,15 @@ extension OrderDetailsDataSource {
                 rows.append(.collectCardPaymentButton)
             }
 
-            if featureFlags.isFeatureFlagEnabled(.backendReceipts) {
-                rows.append(.seeReceipt)
-            }
-
-            if shouldShowLegacyReceipts {
+            switch orderHasLocalReceipt {
+            case true:
                 rows.append(.seeLegacyReceipt)
+            case false:
+                ReceiptEligibilityUseCase().isEligibleForBackendReceipts { isEligible in
+                    if isEligible {
+                        rows.append(.seeReceipt)
+                    }
+                }
             }
 
             if isEligibleForRefund {

--- a/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsDataSource.swift
+++ b/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsDataSource.swift
@@ -1239,7 +1239,7 @@ extension OrderDetailsDataSource {
             case true:
                 rows.append(.seeLegacyReceipt)
             case false:
-                ReceiptEligibilityUseCase().isEligibleForBackendReceipts { isEligible in
+                isEligibleForBackendReceipt { isEligible in
                     if isEligible {
                         rows.append(.seeReceipt)
                     }
@@ -1338,6 +1338,15 @@ extension OrderDetailsDataSource {
         }
 
         return refundFound
+    }
+
+    private func isEligibleForBackendReceipt(completion: @escaping (Bool) -> Void) {
+        guard !isEligibleForPayment else {
+            return completion(false)
+        }
+        ReceiptEligibilityUseCase().isEligibleForBackendReceipts { isEligibleForReceipt in
+            completion(isEligibleForReceipt)
+        }
     }
 
     private func updateOrderNoteAsyncDictionary(orderNotes: [OrderNote]) {

--- a/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsDataSource.swift
+++ b/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsDataSource.swift
@@ -622,7 +622,6 @@ private extension OrderDetailsDataSource {
         cell.leftText = Titles.seeReceipt
         cell.rightText = nil
         cell.hideFootnote()
-        cell.hideSeparator()
     }
 
     private func configureSeeLegacyReceipt(cell: TwoColumnHeadlineFootnoteTableViewCell) {
@@ -1516,7 +1515,7 @@ extension OrderDetailsDataSource {
         static let reprintShippingLabel = NSLocalizedString("Print Shipping Label", comment: "Text on the button that prints a shipping label")
         static let seeReceipt = NSLocalizedString(
             "OrderDetailsDataSource.configureSeeReceipt.button.title",
-            value: "[Debug] See Backend Receipt",
+            value: "See Receipt",
             comment: "Text on the button title to see the order's receipt")
         static let seeLegacyReceipt = NSLocalizedString("See Receipt", comment: "Text on the button to see a saved receipt")
     }

--- a/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsViewModel.swift
+++ b/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsViewModel.swift
@@ -636,9 +636,9 @@ extension OrderDetailsViewModel {
             switch result {
             case .success(let parameters):
                 self?.receipt = parameters
-                self?.dataSource.shouldShowLegacyReceipts = true
+                self?.dataSource.orderHasLocalReceipt = true
             case .failure:
-                self?.dataSource.shouldShowLegacyReceipts = false
+                self?.dataSource.orderHasLocalReceipt = false
             }
             onCompletion?(nil)
         }

--- a/WooCommerce/Classes/ViewModels/Order Details/Receipts/ReceiptEligibilityUseCase.swift
+++ b/WooCommerce/Classes/ViewModels/Order Details/Receipts/ReceiptEligibilityUseCase.swift
@@ -43,8 +43,7 @@ final class ReceiptEligibilityUseCase {
 private extension ReceiptEligibilityUseCase {
     enum Constants {
         static let wcPluginName = "WooCommerce"
-        // Minimum version is higher on purpose, temporary value until we actually know the version.
-        static let wcPluginMinimumVersion = "9.0.0"
+        static let wcPluginMinimumVersion = "8.7.0"
         static let wcPluginDevVersion = "8.6.0-dev-7625495467-gf50cc6b"
     }
 }

--- a/WooCommerce/Classes/ViewModels/Order Details/Receipts/ReceiptEligibilityUseCase.swift
+++ b/WooCommerce/Classes/ViewModels/Order Details/Receipts/ReceiptEligibilityUseCase.swift
@@ -1,0 +1,50 @@
+import Yosemite
+import Experiments
+
+final class ReceiptEligibilityUseCase {
+    private let stores: StoresManager
+    private let featureFlagService: FeatureFlagService
+    
+    private var siteID: Int64 {
+        stores.sessionManager.defaultStoreID ?? 0
+    }
+    
+    init(stores: StoresManager = ServiceLocator.stores,
+         featureFlagService: FeatureFlagService = ServiceLocator.featureFlagService) {
+        self.stores = stores
+        self.featureFlagService = featureFlagService
+    }
+
+    func isEligibleForBackendReceipts(onCompletion: @escaping (Bool) -> Void) {
+        guard featureFlagService.isFeatureFlagEnabled(.backendReceipts) else {
+            onCompletion(false)
+            return
+        }
+        
+        let action = SystemStatusAction.fetchSystemPlugin(siteID: siteID, systemPluginName: Constants.wcPluginName) { wcPlugin in
+            // 1. WooCommerce must be installed and active
+            guard let wcPlugin = wcPlugin, wcPlugin.active else {
+                return onCompletion(false)
+            }
+            // 2. If WooCommerce version is the specific API development branch, mark as eligible
+            if wcPlugin.version == Constants.wcPluginDevVersion {
+                onCompletion(true)
+            } else {
+                // 3. Else, if WooCommerce version is higher than minimum required version, mark as eligible
+                let isSupported = VersionHelpers.isVersionSupported(version: wcPlugin.version,
+                                                                    minimumRequired: Constants.wcPluginMinimumVersion)
+                onCompletion(isSupported)
+            }
+        }
+        stores.dispatch(action)
+    }
+}
+
+private extension ReceiptEligibilityUseCase {
+    enum Constants {
+        static let wcPluginName = "WooCommerce"
+        // Minimum version is higher on purpose, temporary value until we actually know the version.
+        static let wcPluginMinimumVersion = "9.0.0"
+        static let wcPluginDevVersion = "8.6.0-dev-7625495467-gf50cc6b"
+    }
+}

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -1331,6 +1331,7 @@
 		6856DB2E741639716E149967 /* KeyboardStateProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6856D02484A69911F2B91714 /* KeyboardStateProvider.swift */; };
 		6856DE479EC3B2265AC1F775 /* Calendar+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6856D66A1963092C34D20674 /* Calendar+Extensions.swift */; };
 		6856DF20E1BDCC391635F707 /* AgeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6856D1A5F72A36AB3704D19D /* AgeTests.swift */; };
+		68674D312B6C895D00E93FBD /* ReceiptEligibilityUseCaseTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 68674D302B6C895D00E93FBD /* ReceiptEligibilityUseCaseTests.swift */; };
 		68709D3D2A2ED94900A7FA6C /* UpgradesView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 68709D3C2A2ED94900A7FA6C /* UpgradesView.swift */; };
 		68709D402A2EE2DC00A7FA6C /* UpgradesViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 68709D3F2A2EE2DC00A7FA6C /* UpgradesViewModel.swift */; };
 		6879B8DB287AFFA100A0F9A8 /* CardReaderManualsViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6879B8DA287AFFA100A0F9A8 /* CardReaderManualsViewModelTests.swift */; };
@@ -3986,6 +3987,7 @@
 		6856D66A1963092C34D20674 /* Calendar+Extensions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Calendar+Extensions.swift"; sourceTree = "<group>"; };
 		6856D7981E11F85D5E4EFED7 /* NSMutableAttributedStringHelperTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NSMutableAttributedStringHelperTests.swift; sourceTree = "<group>"; };
 		6856DCE1638958DA296D690F /* KeyboardStateProviderTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = KeyboardStateProviderTests.swift; sourceTree = "<group>"; };
+		68674D302B6C895D00E93FBD /* ReceiptEligibilityUseCaseTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReceiptEligibilityUseCaseTests.swift; sourceTree = "<group>"; };
 		68709D3C2A2ED94900A7FA6C /* UpgradesView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UpgradesView.swift; sourceTree = "<group>"; };
 		68709D3F2A2EE2DC00A7FA6C /* UpgradesViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UpgradesViewModel.swift; sourceTree = "<group>"; };
 		6879B8DA287AFFA100A0F9A8 /* CardReaderManualsViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardReaderManualsViewModelTests.swift; sourceTree = "<group>"; };
@@ -8342,6 +8344,7 @@
 			isa = PBXGroup;
 			children = (
 				6850C5F32B6A11CA0026A93B /* ReceiptViewModelTests.swift */,
+				68674D302B6C895D00E93FBD /* ReceiptEligibilityUseCaseTests.swift */,
 			);
 			path = Receipts;
 			sourceTree = "<group>";
@@ -14628,6 +14631,7 @@
 				DE279BAF26EA03EA002BA963 /* ShippingLabelSinglePackageViewModelTests.swift in Sources */,
 				DEEDA23D298A22180088256B /* SiteCredentialLoginUseCaseTests.swift in Sources */,
 				02FADAA52A607CEE00FE8683 /* MockImageTextScanner.swift in Sources */,
+				68674D312B6C895D00E93FBD /* ReceiptEligibilityUseCaseTests.swift in Sources */,
 				CE4DA5C821DD759400074607 /* CurrencyFormatterTests.swift in Sources */,
 				DE61979528A25842005E4362 /* StorePickerViewModelTests.swift in Sources */,
 				027385B02A17093C00835889 /* StoreCreationStatusCheckerTests.swift in Sources */,

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -1321,6 +1321,7 @@
 		6850C5EE2B69E6580026A93B /* ReceiptViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6850C5ED2B69E6580026A93B /* ReceiptViewModel.swift */; };
 		6850C5F12B69E74D0026A93B /* ReceiptViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6850C5F02B69E74D0026A93B /* ReceiptViewController.swift */; };
 		6850C5F42B6A11CA0026A93B /* ReceiptViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6850C5F32B6A11CA0026A93B /* ReceiptViewModelTests.swift */; };
+		6850C5F62B6A51C90026A93B /* ReceiptEligibilityUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6850C5F52B6A51C90026A93B /* ReceiptEligibilityUseCase.swift */; };
 		6856D2A5C2076F5BF14F2C11 /* KeyboardStateProviderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6856DCE1638958DA296D690F /* KeyboardStateProviderTests.swift */; };
 		6856D31F941A33BAE66F394D /* KeyboardFrameAdjustmentProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6856D3846BBF078CB5D955B9 /* KeyboardFrameAdjustmentProvider.swift */; };
 		6856D49DB7DCF4D87745C0B1 /* MockPushNotificationsManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6856D249FD1702FE3864950A /* MockPushNotificationsManager.swift */; };
@@ -3973,6 +3974,7 @@
 		6850C5ED2B69E6580026A93B /* ReceiptViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReceiptViewModel.swift; sourceTree = "<group>"; };
 		6850C5F02B69E74D0026A93B /* ReceiptViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReceiptViewController.swift; sourceTree = "<group>"; };
 		6850C5F32B6A11CA0026A93B /* ReceiptViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReceiptViewModelTests.swift; sourceTree = "<group>"; };
+		6850C5F52B6A51C90026A93B /* ReceiptEligibilityUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReceiptEligibilityUseCase.swift; sourceTree = "<group>"; };
 		6856D02484A69911F2B91714 /* KeyboardStateProvider.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = KeyboardStateProvider.swift; sourceTree = "<group>"; };
 		6856D1A5F72A36AB3704D19D /* AgeTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AgeTests.swift; sourceTree = "<group>"; };
 		6856D249FD1702FE3864950A /* MockPushNotificationsManager.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MockPushNotificationsManager.swift; sourceTree = "<group>"; };
@@ -8318,6 +8320,7 @@
 			isa = PBXGroup;
 			children = (
 				6850C5ED2B69E6580026A93B /* ReceiptViewModel.swift */,
+				6850C5F52B6A51C90026A93B /* ReceiptEligibilityUseCase.swift */,
 			);
 			path = Receipts;
 			sourceTree = "<group>";
@@ -14425,6 +14428,7 @@
 				DEDA8D9D2B1609DE0076BF0F /* UserDefaults+Blaze.swift in Sources */,
 				038BC37F29C37B0E00EAF565 /* SetUpTapToPayCompleteViewController.swift in Sources */,
 				E16715CB26663B0B00326230 /* CardPresentModalSuccessWithoutEmail.swift in Sources */,
+				6850C5F62B6A51C90026A93B /* ReceiptEligibilityUseCase.swift in Sources */,
 				028CB70F290138EF00331C09 /* Publisher+Concurrency.swift in Sources */,
 				311F827426CD897900DF5BAD /* CardReaderSettingsAlertsProvider.swift in Sources */,
 				020DD0AF294A06C400727BEF /* StoreCreationSellingStatusQuestionView.swift in Sources */,

--- a/WooCommerce/WooCommerceTests/ViewModels/Receipts/ReceiptEligibilityUseCaseTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewModels/Receipts/ReceiptEligibilityUseCaseTests.swift
@@ -1,0 +1,139 @@
+import XCTest
+import Yosemite
+@testable import WooCommerce
+
+final class ReceiptEligibilityUseCaseTests: XCTestCase {
+
+    func test_isEligibleForBackendReceipts_when_feature_flag_is_disabled_then_returns_false() {
+        // Given
+        let featureFlag = MockFeatureFlagService(isBackendReceiptsEnabled: false)
+        let stores = MockStoresManager(sessionManager: .makeForTesting())
+        let sut = ReceiptEligibilityUseCase(stores: stores, featureFlagService: featureFlag)
+
+        // When
+        let isEligible: Bool = waitFor { promise in
+            sut.isEligibleForBackendReceipts(onCompletion: { result in
+                promise(result)
+            })
+        }
+
+        // Then
+        XCTAssertFalse(isEligible)
+    }
+
+    func test_isEligibleForBackendReceipts_when_WooCommerce_version_is_incorrect_dev_version_then_returns_false() {
+        // Given
+        let featureFlag = MockFeatureFlagService(isBackendReceiptsEnabled: true)
+        let stores = MockStoresManager(sessionManager: .makeForTesting())
+        let plugin = SystemPlugin.fake().copy(name: "WooCommerce",
+                                              version: "8.6.0-dev-wrong-version",
+                                              active: true)
+
+        stores.whenReceivingAction(ofType: SystemStatusAction.self) { action in
+            switch action {
+            case let .fetchSystemPlugin(_, _, onCompletion):
+                onCompletion(plugin)
+            default:
+                XCTFail("Unexpected action")
+            }
+        }
+        let sut = ReceiptEligibilityUseCase(stores: stores, featureFlagService: featureFlag)
+
+        // When
+        let isEligible: Bool = waitFor { promise in
+            sut.isEligibleForBackendReceipts(onCompletion: { result in
+                promise(result)
+            })
+        }
+
+        // Then
+        XCTAssertFalse(isEligible)
+    }
+
+    func test_isEligibleForBackendReceipts_when_WooCommerce_version_is_correct_dev_version_then_returns_true() {
+        // Given
+        let featureFlag = MockFeatureFlagService(isBackendReceiptsEnabled: true)
+        let stores = MockStoresManager(sessionManager: .makeForTesting())
+        let plugin = SystemPlugin.fake().copy(name: "WooCommerce",
+                                              version: "8.6.0-dev-7625495467-gf50cc6b",
+                                              active: true)
+
+        stores.whenReceivingAction(ofType: SystemStatusAction.self) { action in
+            switch action {
+            case let .fetchSystemPlugin(_, _, onCompletion):
+                onCompletion(plugin)
+            default:
+                XCTFail("Unexpected action")
+            }
+        }
+        let sut = ReceiptEligibilityUseCase(stores: stores, featureFlagService: featureFlag)
+
+        // When
+        let isEligible: Bool = waitFor { promise in
+            sut.isEligibleForBackendReceipts(onCompletion: { result in
+                promise(result)
+            })
+        }
+
+        // Then
+        XCTAssertTrue(isEligible)
+    }
+
+    func test_isEligibleForBackendReceipts_when_WooCommerce_version_is_below_minimum_then_returns_false() {
+        // Given
+        let featureFlag = MockFeatureFlagService(isBackendReceiptsEnabled: true)
+        let stores = MockStoresManager(sessionManager: .makeForTesting())
+        let plugin = SystemPlugin.fake().copy(name: "WooCommerce",
+                                              version: "8.5",
+                                              active: true)
+
+        stores.whenReceivingAction(ofType: SystemStatusAction.self) { action in
+            switch action {
+            case let .fetchSystemPlugin(_, _, onCompletion):
+                onCompletion(plugin)
+            default:
+                XCTFail("Unexpected action")
+            }
+        }
+        let sut = ReceiptEligibilityUseCase(stores: stores, featureFlagService: featureFlag)
+
+        // When
+        let isEligible: Bool = waitFor { promise in
+            sut.isEligibleForBackendReceipts(onCompletion: { result in
+                promise(result)
+            })
+        }
+
+        // Then
+        XCTAssertFalse(isEligible)
+    }
+
+    func test_isEligibleForBackendReceipts_when_WooCommerce_version_is_equal_or_above_minimum_then_returns_true() {
+        // Given
+        let featureFlag = MockFeatureFlagService(isBackendReceiptsEnabled: true)
+        let stores = MockStoresManager(sessionManager: .makeForTesting())
+        let plugin = SystemPlugin.fake().copy(name: "WooCommerce",
+                                              version: "8.7.0",
+                                              active: true)
+
+        stores.whenReceivingAction(ofType: SystemStatusAction.self) { action in
+            switch action {
+            case let .fetchSystemPlugin(_, _, onCompletion):
+                onCompletion(plugin)
+            default:
+                XCTFail("Unexpected action")
+            }
+        }
+        let sut = ReceiptEligibilityUseCase(stores: stores, featureFlagService: featureFlag)
+
+        // When
+        let isEligible: Bool = waitFor { promise in
+            sut.isEligibleForBackendReceipts(onCompletion: { result in
+                promise(result)
+            })
+        }
+
+        // Then
+        XCTAssertTrue(isEligible)
+    }
+}

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Details/OrderDetailsDataSourceTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Details/OrderDetailsDataSourceTests.swift
@@ -670,23 +670,6 @@ final class OrderDetailsDataSourceTests: XCTestCase {
         let receiptsRow = row(row: .seeReceipt, in: paymentSection)
         XCTAssertNil(receiptsRow)
     }
-
-    func test_receipts_row_is_visible_in_payments_section_when_feature_flag_is_true() throws {
-        // Given
-        let order = Order.fake()
-        let dataSource = OrderDetailsDataSource(order: order,
-                                                storageManager: storageManager,
-                                                cardPresentPaymentsConfiguration: Mocks.configuration,
-                                                featureFlags: MockFeatureFlagService(isBackendReceiptsEnabled: true))
-
-        // When
-        dataSource.reloadSections()
-
-        // Then
-        let paymentSection = try section(withTitle: Title.payment, from: dataSource)
-        let receiptsRow = row(row: .seeReceipt, in: paymentSection)
-        XCTAssertNotNil(receiptsRow)
-    }
 }
 
 // MARK: - Test Data


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes #11827
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
This PR introduces an eligibility check for backend receipts, so the option will be available for sites running WooCommerce 8.7.0+ (not launched yet).

We render either the legacy or the new `See receipt` based  the WooCommerce version, and if there are existing receipts already saved on device (only for paid orders): 
* If there are existing receipts on device, we just follow the existing logic and display locally-generated receipts.
* If there are no existing receipts on device, we display the new `See receipt` for eligible stores, in order to fetch one from the backend.

## Changes
- Updated `[Debug] See backend receipt` to `See Receipt`, and made them mutually exclusive: The row will either show a link to the old receipt, to the new one, or no row.
- Added an eligibility checker, we only show the new logic if: locally-generated receipt doesn't yet exist, feature flag is enabled, and WC version is supported. 

## Testing instructions
* On any store with a current WooCommerce version, confirm that the legacy flow works as expected, that is: An unpaid order shows no "See receipt" row in order details. When paying for the order via a card present method, saving the receipt, and refreshing the order (either navigate back and in again, or use pull to refresh) shows the "See receipt" row. Tapping the row, displays the old receipt (screenshot for comparison below)
* On an eligible store (you can use https://mywootestingstore.mystagingwebsite.com/): 
  * Go to an unpaid order (eg: "Pending Payment"), and observe that we do not render a `See receipt` row.
  * Go to an paid order (eg: "Completed"), and observe that `See receipt` row is rendered and a backend receipt is shown (screenshot for comparison below).

## Screenshots
| Has local receipt | Eligible for backend receipt | Awaiting payment |
|--------|--------|--------|
| ![Simulator Screenshot - iPhone 15 - 2024-02-02 at 10 13 03](https://github.com/woocommerce/woocommerce-ios/assets/3812076/857fa3b6-3c65-4389-bb25-65176b69dd98) | ![simulator_screenshot_B629D3E8-A20A-4EF9-B3A1-E4943DD0D83B](https://github.com/woocommerce/woocommerce-ios/assets/3812076/e6bb04c7-c548-4ef6-b648-6a387b623f12) | ![2024-02-02 awaiting payment](https://github.com/woocommerce/woocommerce-ios/assets/3812076/37840bf6-6174-487c-81c0-4f078a227190) |

Note that there's no summary description under `Paid` for new receipts, this is expected since currently the `paymentSummary` performs a check on payment methods to see if a card present was used. We'll attempt to improve this separately. Logged at: https://github.com/woocommerce/woocommerce-ios/issues/11878.

| Old receipt | New receipt |
|--------|--------|
| ![Simulator Screenshot - iPhone 15 - 2024-02-02 at 12 02 00](https://github.com/woocommerce/woocommerce-ios/assets/3812076/529b7259-029d-4595-b8f4-7ac17265e4b5) | ![Simulator Screenshot - iPhone 15 - 2024-02-02 at 12 01 11](https://github.com/woocommerce/woocommerce-ios/assets/3812076/c27dc5cb-41fd-4278-a775-33c09e2f5c19) |