### PR TITLE
[Tablet Orders] Add container for Order Form and Product Selector

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/EditableOrderViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/EditableOrderViewModel.swift
@@ -1724,7 +1724,7 @@ private extension EditableOrderViewModel {
         $isProductSelectorPresented
             .removeDuplicates()
             .map { [weak self] isPresented in
-                guard let self, isPresented else { return nil }
+                guard let self else { return nil }
                 return ProductSelectorViewModel(
                     siteID: siteID,
                     selectedItemIDs: selectedProductsAndVariationsIDs,

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/OrderForm.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/OrderForm.swift
@@ -167,7 +167,9 @@ struct OrderForm: View {
 
                             ProductsSection(scroll: scroll,
                                             flow: flow,
-                                            viewModel: viewModel, navigationButtonID: $navigationButtonID)
+                                            presentProductSelector: presentProductSelector,
+                                            viewModel: viewModel,
+                                            navigationButtonID: $navigationButtonID)
                             .disabled(viewModel.shouldShowNonEditableIndicators)
 
                             Group {
@@ -460,6 +462,8 @@ private struct ProductsSection: View {
 
     let flow: WooAnalyticsEvent.Orders.Flow
 
+    let presentProductSelector: (() -> Void)?
+
     /// View model to drive the view content
     @ObservedObject var viewModel: EditableOrderViewModel
 
@@ -510,14 +514,25 @@ private struct ProductsSection: View {
                         scanProductButton
                         .renderedIf(viewModel.isAddProductToOrderViaSKUScannerEnabled)
 
-                        Button(action: {
-                            viewModel.toggleProductSelectorVisibility()
-                        }) {
-                            Image(uiImage: .plusImage)
+                        if let presentProductSelector {
+                            Button(action: {
+                                presentProductSelector()
+                            }) {
+                                Image(uiImage: .plusImage)
+                            }
+                            .accessibilityLabel(OrderForm.Localization.addProductButtonAccessibilityLabel)
+                            .id(addProductButton)
+                            .accessibilityIdentifier(OrderForm.Accessibility.addProductButtonIdentifier)
+                        } else if !ServiceLocator.featureFlagService.isFeatureFlagEnabled(.sideBySideViewForOrderForm) {
+                            Button(action: {
+                                viewModel.toggleProductSelectorVisibility()
+                            }) {
+                                Image(uiImage: .plusImage)
+                            }
+                            .accessibilityLabel(OrderForm.Localization.addProductButtonAccessibilityLabel)
+                            .id(addProductButton)
+                            .accessibilityIdentifier(OrderForm.Accessibility.addProductButtonIdentifier)
                         }
-                        .accessibilityLabel(OrderForm.Localization.addProductButtonAccessibilityLabel)
-                        .id(addProductButton)
-                        .accessibilityIdentifier(OrderForm.Accessibility.addProductButtonIdentifier)
                     }
                     .scaledToFit()
                     .renderedIf(!viewModel.shouldShowNonEditableIndicators)
@@ -540,12 +555,21 @@ private struct ProductsSection: View {
                 }
 
                 HStack {
-                    Button(OrderForm.Localization.addProducts) {
-                        viewModel.toggleProductSelectorVisibility()
+                    if let presentProductSelector {
+                        Button(OrderForm.Localization.addProducts) {
+                            presentProductSelector()
+                        }
+                        .id(addProductButton)
+                        .accessibilityIdentifier(OrderForm.Accessibility.addProductButtonIdentifier)
+                        .buttonStyle(PlusButtonStyle())
+                    } else if !ServiceLocator.featureFlagService.isFeatureFlagEnabled(.sideBySideViewForOrderForm) {
+                        Button(OrderForm.Localization.addProducts) {
+                            viewModel.toggleProductSelectorVisibility()
+                        }
+                        .id(addProductButton)
+                        .accessibilityIdentifier(OrderForm.Accessibility.addProductButtonIdentifier)
+                        .buttonStyle(PlusButtonStyle())
                     }
-                    .id(addProductButton)
-                    .accessibilityIdentifier(OrderForm.Accessibility.addProductButtonIdentifier)
-                    .buttonStyle(PlusButtonStyle())
 
                     scanProductButton
                     .renderedIf(viewModel.isAddProductToOrderViaSKUScannerEnabled)

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/OrderForm.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/OrderForm.swift
@@ -129,6 +129,26 @@ struct OrderForm: View {
     @State private var shouldShowShippingLineDetails = false
 
     var body: some View {
+        if ServiceLocator.featureFlagService.isFeatureFlagEnabled(.sideBySideViewForOrderForm) {
+            AdaptiveModalContainer(primaryView: { presentProductSelector in
+                orderFormSummary(presentProductSelector)
+            }, secondaryView: { isShowingProductSelector in
+                if let productSelectorViewModel = viewModel.productSelectorViewModel {
+                    ProductSelectorView(configuration: ProductSelectorView.Configuration.splitViewAddProductToOrder(),
+                                        source: .orderForm(flow: flow),
+                                        isPresented: isShowingProductSelector,
+                                        viewModel: productSelectorViewModel)
+                    .sheet(item: $viewModel.productToConfigureViewModel) { viewModel in
+                        ConfigurableBundleProductView(viewModel: viewModel)
+                    }
+                }
+            })
+        } else {
+            orderFormSummary(nil)
+        }
+    }
+
+    @ViewBuilder private func orderFormSummary(_ presentProductSelector: (() -> Void)?) -> some View {
         GeometryReader { geometry in
             ScrollViewReader { scroll in
                 ScrollView {
@@ -719,6 +739,18 @@ private extension ProductSelectorView.Configuration {
             doneButtonTitlePluralFormat: Localization.doneButtonPlural,
             title: Localization.title,
             cancelButtonTitle: Localization.close,
+            productRowAccessibilityHint: Localization.productRowAccessibilityHint,
+            variableProductRowAccessibilityHint: Localization.variableProductRowAccessibilityHint)
+    }
+
+    static func splitViewAddProductToOrder() -> ProductSelectorView.Configuration {
+        ProductSelectorView.Configuration(
+            searchHeaderBackgroundColor: .listBackground,
+            prefersLargeTitle: false,
+            doneButtonTitleSingularFormat: "",
+            doneButtonTitlePluralFormat: "",
+            title: Localization.title,
+            cancelButtonTitle: nil,
             productRowAccessibilityHint: Localization.productRowAccessibilityHint,
             variableProductRowAccessibilityHint: Localization.variableProductRowAccessibilityHint)
     }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/OrderDetailsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/OrderDetailsViewController.swift
@@ -384,8 +384,13 @@ private extension OrderDetailsViewController {
     @objc private func editOrder() {
         let viewModel = EditableOrderViewModel(siteID: viewModel.order.siteID, flow: .editing(initialOrder: viewModel.order))
         let viewController = OrderFormHostingController(viewModel: viewModel)
-        let navController = UINavigationController(rootViewController: viewController)
-        present(navController, animated: true)
+        if ServiceLocator.featureFlagService.isFeatureFlagEnabled(.sideBySideViewForOrderForm) {
+            viewController.modalPresentationStyle = .overFullScreen
+            present(viewController, animated: true)
+        } else {
+            let navController = UINavigationController(rootViewController: viewController)
+            present(navController, animated: true)
+        }
 
         let hasMultipleShippingLines = self.viewModel.order.shippingLines.count > 1
         let hasMultipleFeeLines = self.viewModel.order.fees.count > 1

--- a/WooCommerce/Classes/ViewRelated/Orders/OrdersRootViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrdersRootViewController.swift
@@ -223,9 +223,14 @@ final class OrdersRootViewController: UIViewController {
             }
         }
 
-        if ServiceLocator.featureFlagService.isFeatureFlagEnabled(.splitViewInOrdersTab) {
-            let newOrderNavigationController = WooNavigationController(rootViewController: viewController)
-            navigationController.present(newOrderNavigationController, animated: true)
+        if featureFlagService.isFeatureFlagEnabled(.splitViewInOrdersTab) {
+            if featureFlagService.isFeatureFlagEnabled(.sideBySideViewForOrderForm) {
+                viewController.modalPresentationStyle = .overFullScreen
+                navigationController.present(viewController, animated: true)
+            } else {
+                let newOrderNavigationController = WooNavigationController(rootViewController: viewController)
+                navigationController.present(newOrderNavigationController, animated: true)
+            }
         } else {
             viewController.hidesBottomBarWhenPushed = true
             navigationController.pushViewController(viewController, animated: true)

--- a/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/AdaptiveModalContainer.swift
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/AdaptiveModalContainer.swift
@@ -1,5 +1,17 @@
 import SwiftUI
 
+/// `AdaptiveModalContainer` shows two views, primary and secondary
+/// In horizontally regular environments, they are shown side-by-side, with the primary on the right (in an LTR system.)
+/// In horizontally compact environments, the primary view is shown. 
+///
+/// In compact environments, the primary view can use the `presentSecondaryView` closure to trigger modal presentation of the secondary view.
+/// This closure is `nil` when the secondary view is shown side-by-side.
+///
+/// Each view is wrapped in its own Navigation Stack
+///
+/// Intended to be presented modally – a close button will be added to the leftmost navigation bar.
+///
+/// This was initially developed for the Order Form and Product Selector to be presented together on iPad.
 struct AdaptiveModalContainer<PrimaryView: View, SecondaryView: View>: View {
     @Environment(\.horizontalSizeClass) var horizontalSizeClass
 

--- a/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/AdaptiveModalContainer.swift
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/AdaptiveModalContainer.swift
@@ -1,0 +1,78 @@
+import SwiftUI
+
+struct AdaptiveModalContainer<PrimaryView: View, SecondaryView: View>: View {
+    @Environment(\.horizontalSizeClass) var horizontalSizeClass
+
+    @ViewBuilder let primaryView: (_ presentSecondaryView: (() -> Void)?) -> PrimaryView
+    @ViewBuilder let secondaryView: (_ isPresented: Binding<Bool>) -> SecondaryView
+
+    var body: some View {
+        if horizontalSizeClass == .compact {
+            ModalOnModalView(primaryView: primaryView, secondaryView: secondaryView)
+        } else {
+            SideBySideView(primaryView: primaryView, secondaryView: secondaryView)
+        }
+    }
+
+    private struct ModalOnModalView: View {
+        @ViewBuilder let primaryView: (_ presentSecondaryView: @escaping () -> Void) -> PrimaryView
+        @ViewBuilder let secondaryView: (_ isPresented: Binding<Bool>) -> SecondaryView
+        @State var isShowingSecondaryView = false
+        @Environment(\.dismiss) var dismiss
+
+        var body: some View {
+            NavigationView {
+                primaryView({
+                    isShowingSecondaryView = true
+                })
+                .toolbar {
+                    ToolbarItem(placement: .navigationBarLeading) {
+                        Button(action: {
+                            dismiss()
+                        }) {
+                            Image(systemName: "xmark")
+                        }
+                    }
+                }
+                .sheet(isPresented: $isShowingSecondaryView) {
+                    NavigationView {
+                        secondaryView($isShowingSecondaryView)
+                    }
+                }
+            }
+            .navigationViewStyle(.stack)
+        }
+    }
+
+    private struct SideBySideView: View {
+        @ViewBuilder let primaryView: (_ presentSecondaryView: (() -> Void)?) -> PrimaryView
+        @ViewBuilder let secondaryView: (_ isPresented: Binding<Bool>) -> SecondaryView
+        @Environment(\.dismiss) var dismiss
+        @State var isShowingSecondaryView = true
+
+        var body: some View {
+            HStack {
+                NavigationView {
+                    secondaryView($isShowingSecondaryView)
+                        .toolbar {
+                            ToolbarItem(placement: .navigationBarLeading) {
+                                Button(action: {
+                                    dismiss()
+                                }) {
+                                    Image(systemName: "xmark")
+                                }
+                            }
+                        }
+                }
+                .navigationViewStyle(.stack)
+                .layoutPriority(1)
+
+                NavigationView {
+                    primaryView(nil)
+                }
+                .navigationViewStyle(.stack)
+                .frame(minWidth: 400)
+            }
+        }
+    }
+}

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -747,6 +747,7 @@
 		20D210BE2B14C9B90099E517 /* WooPaymentsDepositStatusDisplayDetails.swift in Sources */ = {isa = PBXBuildFile; fileRef = 20D210BD2B14C9B90099E517 /* WooPaymentsDepositStatusDisplayDetails.swift */; };
 		20D5CB512AFCF856009A39C3 /* PaymentsRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 20D5CB502AFCF856009A39C3 /* PaymentsRow.swift */; };
 		20D5CB532AFCF8E7009A39C3 /* PaymentsToggleRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 20D5CB522AFCF8E7009A39C3 /* PaymentsToggleRow.swift */; };
+		20DA6DDB2B681175002AA0FB /* AdaptiveModalContainer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 20DA6DDA2B681175002AA0FB /* AdaptiveModalContainer.swift */; };
 		20E188842AD059A50053E945 /* AboutTapToPayView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 20E188832AD059A50053E945 /* AboutTapToPayView.swift */; };
 		247CE89C2583402A00F9D9D1 /* Embassy in Frameworks */ = {isa = PBXBuildFile; productRef = 247CE89B2583402A00F9D9D1 /* Embassy */; };
 		247CE8A6258340E600F9D9D1 /* ScreenshotImages.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 247CE8A5258340E600F9D9D1 /* ScreenshotImages.xcassets */; };
@@ -3428,6 +3429,7 @@
 		20D210BD2B14C9B90099E517 /* WooPaymentsDepositStatusDisplayDetails.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WooPaymentsDepositStatusDisplayDetails.swift; sourceTree = "<group>"; };
 		20D5CB502AFCF856009A39C3 /* PaymentsRow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaymentsRow.swift; sourceTree = "<group>"; };
 		20D5CB522AFCF8E7009A39C3 /* PaymentsToggleRow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaymentsToggleRow.swift; sourceTree = "<group>"; };
+		20DA6DDA2B681175002AA0FB /* AdaptiveModalContainer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AdaptiveModalContainer.swift; sourceTree = "<group>"; };
 		20E188832AD059A50053E945 /* AboutTapToPayView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AboutTapToPayView.swift; sourceTree = "<group>"; };
 		247CE8A5258340E600F9D9D1 /* ScreenshotImages.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = ScreenshotImages.xcassets; sourceTree = "<group>"; };
 		24C579D124F476300076E1B4 /* Woo-Alpha.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = "Woo-Alpha.entitlements"; sourceTree = "<group>"; };
@@ -8045,6 +8047,7 @@
 				68B6F22A2ADE7ED500D171FC /* TooltipView.swift */,
 				B9B7E37D2AF105EF00A959CA /* PencilEditButton.swift */,
 				20203AB12B31EEF1009D0C11 /* ExpandableBottomSheet.swift */,
+				20DA6DDA2B681175002AA0FB /* AdaptiveModalContainer.swift */,
 			);
 			path = "SwiftUI Components";
 			sourceTree = "<group>";
@@ -13392,6 +13395,7 @@
 				E1D4E84426776A6B00256B83 /* HeadlineTableViewCell.swift in Sources */,
 				B555530F21B57DE700449E71 /* ApplicationAdapter.swift in Sources */,
 				025C00682550DE4700FAC222 /* ProductSKUInputScannerViewController.swift in Sources */,
+				20DA6DDB2B681175002AA0FB /* AdaptiveModalContainer.swift in Sources */,
 				456BEFB626D912EC002AC16C /* AuthenticatedWebView.swift in Sources */,
 				310D1B482734919E001D55B4 /* InPersonPaymentsLiveSiteInTestModeView.swift in Sources */,
 				AE1CC33829129A010021C8EF /* LinkBehavior.swift in Sources */,

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/EditableOrderViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/EditableOrderViewModelTests.swift
@@ -2185,10 +2185,12 @@ final class EditableOrderViewModelTests: XCTestCase {
         let actionError = NSError(domain: "Error", code: 0)
         stores.whenReceivingAction(ofType: ProductAction.self, thenCall: { action in
             switch action {
+            case .synchronizeProducts:
+                return
             case .retrieveFirstPurchasableItemMatchFromSKU(_, _, let onCompletion):
                 onCompletion(.failure(actionError))
             default:
-                XCTFail("Expected failure, got success")
+                XCTFail("Unexpected ProductAction received")
             }
         })
 


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #11744
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

This PR adds a new `AdaptiveModalContainer` to contain the Order Form and Product Selector. 

The new container is responsible for showing these two views, and is specifically intended to be shown modally. This is due to the nav stack requirements of the Tablet Orders design. 

In LTR environments, the primary view is displayed on the right, and the secondary on the left – this is the reverse of the `UISplitViewController`. Each view is wrapped in a nav stack, with the `x` button to close the modal shown in the leftmost nav bar. Both these behaviours are reversed for RTL environments.

The wrapped views are displayed side by side when it's a horizontally regular environment. In a horizontally compact environment, we show the primary view, and provide it a closure to present the secondary view in a sheet on top.

It wasn't totally clear where to stop on this, so some stuff is in a very WIP state. The change is behind the `sideBySideViewForOrderForm` feature flag, which is still set to false. We won't turn this on in dev builds until it's more consistent/complete.

### Known issues
- The Product Selector still has a CTA button when shown in a horizontally regular environment. You have to tap this for changes to be synced to the Order Form. It has no title. – This should be removed and syncing happen automatically for every change.
- There's a Cancel button always shown on the Order Form – this should be removed when the feature flag is used.
- Changes in the Order Form side aren't synced to the Product Selector side.
- The `Collect Payment` button doesn't work. This is actually a pre-existing issue on trunk, unrelated to these changes. I'll fix it separately.
- The barcode scanning error notice is compressed and only on one side on iPad

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

### iPad, with changes

1. Change the `sideBySideViewForOrderForm` feature flag to `true`
2. Launch the app on an iPad
3. Go to the Orders tab
4. Tap `+`
5. Observe that the side-by-side view is shown for Order Creation.
6. Experiment with different split view/slide over sizes. 
7. Observe that the `Add Products` buttons only show when in a horizontally compact setting
8. Tap `Add Products` and see that the Product Selector is shown and can be used as normal.

### iPad or iPhone, without changes

1. Change the `sideBySideViewForOrderForm` feature flag to `false`
2. Launch the app on an iPad
3. Go to the Orders tab
4. Tap `+`
5. Observe that the Order Form is shown on its own in a modal sheet.

### iPhone, with changes

1. Change the `sideBySideViewForOrderForm` feature flag to `true`
2. Launch the app on an iPhone
3. Go to the Orders tab
4. Tap `+`
5. Observe that the Order Form is shown modally.
6. Tap `Add Products` – observe that you can do this as normal.
7. If using a large iPhone, flip it horizontally to see the side-by-side view

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

### iPad before (feature flag false)

https://github.com/woocommerce/woocommerce-ios/assets/2472348/a294c871-7d0b-47f0-9d55-5be25af5d9ed



### iPad after (feature flag true)


https://github.com/woocommerce/woocommerce-ios/assets/2472348/1d9bf0f2-78a4-43f1-af87-e02dcab3ccc6


### iPhone before (feature flag false)


https://github.com/woocommerce/woocommerce-ios/assets/2472348/08c6c9a7-69fa-4e13-99c9-604cc0f6cc37


### iPhone after (feature flag true)

https://github.com/woocommerce/woocommerce-ios/assets/2472348/236dabd6-1e5a-4e19-9444-881243dc83a2


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
