### PR TITLE
[Tablet Orders] Call onCompletion with split view flag true

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Orders/OrdersRootViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrdersRootViewController.swift
@@ -515,7 +515,9 @@ private extension OrdersRootViewController {
         analytics.track(event: WooAnalyticsEvent.Orders.orderOpen(order: order))
         let viewModel = OrderDetailsViewModel(order: order)
         guard !featureFlagService.isFeatureFlagEnabled(.splitViewInOrdersTab) else {
-            return ordersViewController.showOrderDetails(order)
+            ordersViewController.showOrderDetails(order)
+            onCompletion?(true)
+            return
         }
 
         let orderViewController = OrderDetailsViewController(viewModel: viewModel)


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #11863 #11854
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

This PR fixes the Collect Payment button on Order Creation. In the 17.1 beta, it was broken and only showed Order Details.

Previously we failed to call this `onCompletion` handler in this navigate method. We didn’t initially use it after tapping `Collect Payment`, however a change in f49f3e4 meant that we started to use this route.

Because we didn’t call `onCompletion`, the caller (`OrderDetailsRootViewController.setupNavigation`) didn’t get a chance to show the payment methods screen

This change makes sure we notify the caller of completion even when the feature flag is on, and fixes the presentation of the Payment Methods screen from Order Creation.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

1. Launch the app
2. Go to the Orders Tab
3. Tap `+`
4. Add a product
5. Tap Collect Payment

Observe that the payment methods screen is shown, and you can take a payment.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

Uploading fix-collect-payment.mp4…



---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
