### PR TITLE
Blaze: Fix incorrect site URL sent to dashboard section

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -6,7 +6,7 @@
 - [*] Orders: the placeholder cells shown in the loading state have the animated redacted content again. [https://github.com/woocommerce/woocommerce-ios/pull/11842]
 - [*] Fixed arrow directions for RTL locales. [https://github.com/woocommerce/woocommerce-ios/pull/11833]
 - [*] Update Product Creation AI prompt to avoid unexpected response from AI. [https://github.com/woocommerce/woocommerce-ios/pull/11853]
-
+- [*] Fixed incorrect site URL when creating Blaze campaigns after switching stores. [https://github.com/woocommerce/woocommerce-ios/pull/11868]
 - [*] Orders in split view: when the store has no orders and then an order is created, the order list is now shown instead of the empty view. [https://github.com/woocommerce/woocommerce-ios/pull/11849]
 
 17.1

--- a/WooCommerce/Classes/ViewRelated/Blaze/BlazeCampaignList/BlazeCampaignListViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Blaze/BlazeCampaignList/BlazeCampaignListViewModel.swift
@@ -49,7 +49,7 @@ final class BlazeCampaignListViewModel: ObservableObject {
     }()
 
     init(siteID: Int64,
-         siteURL: String = ServiceLocator.stores.sessionManager.defaultSite?.url ?? "",
+         siteURL: String,
          stores: StoresManager = ServiceLocator.stores,
          storageManager: StorageManagerType = ServiceLocator.storageManager,
          userDefaults: UserDefaults = .standard,

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Blaze/BlazeCampaignDashboardView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Blaze/BlazeCampaignDashboardView.swift
@@ -307,6 +307,6 @@ private struct ProductInfoView: View {
 
 struct BlazeCampaignDashboardView_Previews: PreviewProvider {
     static var previews: some View {
-        BlazeCampaignDashboardView(viewModel: .init(siteID: 0))
+        BlazeCampaignDashboardView(viewModel: .init(siteID: 0, siteURL: "https://example.com"))
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Blaze/BlazeCampaignDashboardView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Blaze/BlazeCampaignDashboardView.swift
@@ -60,7 +60,7 @@ private extension BlazeCampaignDashboardViewHostingController {
     /// Parameter isPostCreation: Whether the list is opened after creating a campaign successfully.
     ///
     func showCampaignList() {
-        let controller = BlazeCampaignListHostingController(viewModel: .init(siteID: viewModel.siteID))
+        let controller = BlazeCampaignListHostingController(viewModel: .init(siteID: viewModel.siteID, siteURL: viewModel.siteURL))
         parentNavigationController.show(controller, sender: self)
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Blaze/BlazeCampaignDashboardViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Blaze/BlazeCampaignDashboardViewModel.swift
@@ -79,7 +79,7 @@ final class BlazeCampaignDashboardViewModel: ObservableObject {
     private var subscriptions: Set<AnyCancellable> = []
 
     init(siteID: Int64,
-         siteURL: String = ServiceLocator.stores.sessionManager.defaultSite?.url ?? "",
+         siteURL: String,
          stores: StoresManager = ServiceLocator.stores,
          storageManager: StorageManagerType = ServiceLocator.storageManager,
          analytics: Analytics = ServiceLocator.analytics,

--- a/WooCommerce/Classes/ViewRelated/Dashboard/DashboardViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/DashboardViewController.swift
@@ -761,6 +761,14 @@ private extension DashboardViewController {
 // MARK: - Blaze campaign view
 extension DashboardViewController {
     func observeBlazeCampaignViewVisibility() {
+        ServiceLocator.stores.site
+            .compactMap { $0 }
+            .removeDuplicates()
+            .sink { [weak self] site in
+                self?.viewModel.updateBlazeCampaignView(with: site)
+            }
+            .store(in: &subscriptions)
+
         viewModel.$showBlazeCampaignView.removeDuplicates()
             .sink { [weak self] showBlazeCampaignView in
                 guard let self else { return }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/DashboardViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/DashboardViewController.swift
@@ -137,9 +137,9 @@ final class DashboardViewController: UIViewController {
 
     // MARK: View Lifecycle
 
-    init(siteID: Int64) {
+    init(siteID: Int64, siteURL: String) {
         self.siteID = siteID
-        self.viewModel = .init(siteID: siteID)
+        self.viewModel = .init(siteID: siteID, siteURL: siteURL)
         super.init(nibName: nil, bundle: nil)
         configureTabBarItem()
     }
@@ -761,14 +761,6 @@ private extension DashboardViewController {
 // MARK: - Blaze campaign view
 extension DashboardViewController {
     func observeBlazeCampaignViewVisibility() {
-        ServiceLocator.stores.site
-            .compactMap { $0 }
-            .removeDuplicates()
-            .sink { [weak self] site in
-                self?.viewModel.updateBlazeCampaignView(with: site)
-            }
-            .store(in: &subscriptions)
-
         viewModel.$showBlazeCampaignView.removeDuplicates()
             .sink { [weak self] showBlazeCampaignView in
                 guard let self else { return }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/DashboardViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/DashboardViewModel.swift
@@ -46,6 +46,7 @@ final class DashboardViewModel {
     }
 
     init(siteID: Int64,
+         siteURL: String,
          stores: StoresManager = ServiceLocator.stores,
          featureFlags: FeatureFlagService = ServiceLocator.featureFlagService,
          analytics: Analytics = ServiceLocator.analytics,
@@ -61,7 +62,7 @@ final class DashboardViewModel {
         self.justInTimeMessagesManager = JustInTimeMessagesProvider(stores: stores, analytics: analytics)
         self.localAnnouncementsProvider = .init(stores: stores, analytics: analytics, featureFlagService: featureFlags)
         self.storeOnboardingViewModel = .init(siteID: siteID, isExpanded: false, stores: stores, defaults: userDefaults)
-        self.blazeCampaignDashboardViewModel = .init(siteID: siteID, siteURL: ServiceLocator.stores.sessionManager.defaultSite?.url ?? "")
+        self.blazeCampaignDashboardViewModel = .init(siteID: siteID, siteURL: siteURL)
         self.storeCreationProfilerUploadAnswersUseCase = storeCreationProfilerUploadAnswersUseCase ?? StoreCreationProfilerUploadAnswersUseCase(siteID: siteID)
         self.themeInstaller = themeInstaller
         self.startupWaitingTimeTracker = startupWaitingTimeTracker
@@ -87,18 +88,6 @@ final class DashboardViewModel {
     func reloadBlazeCampaignView() async {
         await blazeCampaignDashboardViewModel.reload()
         startupWaitingTimeTracker.end(action: .syncBlazeCampaigns)
-    }
-
-    func updateBlazeCampaignView(with site: Site) {
-        guard site.siteID != blazeCampaignDashboardViewModel.siteID ||
-                site.url != blazeCampaignDashboardViewModel.siteURL else {
-            return
-        }
-        blazeCampaignDashboardViewModel = BlazeCampaignDashboardViewModel(siteID: site.siteID, siteURL: site.url)
-        setupObserverForBlazeCampaignView()
-        Task {
-            await blazeCampaignDashboardViewModel.reload()
-        }
     }
 
     /// Syncs store stats for dashboard UI.

--- a/WooCommerce/Classes/ViewRelated/Dashboard/DashboardViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/DashboardViewModel.swift
@@ -17,7 +17,7 @@ final class DashboardViewModel {
 
     let storeOnboardingViewModel: StoreOnboardingViewModel
 
-    private(set) var blazeCampaignDashboardViewModel: BlazeCampaignDashboardViewModel
+    let blazeCampaignDashboardViewModel: BlazeCampaignDashboardViewModel
 
     @Published private(set) var showWebViewSheet: WebViewSheetViewModel? = nil
 

--- a/WooCommerce/Classes/ViewRelated/Hub Menu/HubMenu.swift
+++ b/WooCommerce/Classes/ViewRelated/Hub Menu/HubMenu.swift
@@ -335,17 +335,39 @@ private extension HubMenu {
 
 struct HubMenu_Previews: PreviewProvider {
     static var previews: some View {
-        HubMenu(viewModel: .init(siteID: 123, tapToPayBadgePromotionChecker: TapToPayBadgePromotionChecker()))
+        let site = Site(siteID: 123,
+                        name: "Test",
+                        description: "Site for testing",
+                        url: "https://example.com",
+                        adminURL: "https://example.com/wp-admin",
+                        loginURL: "https://example.com/wp-login.php",
+                        isSiteOwner: true,
+                        frameNonce: "",
+                        plan: "",
+                        isAIAssistantFeatureActive: true,
+                        isJetpackThePluginInstalled: true,
+                        isJetpackConnected: true,
+                        isWooCommerceActive: true,
+                        isWordPressComStore: true,
+                        jetpackConnectionActivePlugins: [],
+                        timezone: "UTC",
+                        gmtOffset: 0,
+                        isPublic: true,
+                        canBlaze: true,
+                        isAdmin: true,
+                        wasEcommerceTrial: false)
+
+        HubMenu(viewModel: .init(site: site, tapToPayBadgePromotionChecker: TapToPayBadgePromotionChecker()))
             .environment(\.colorScheme, .light)
 
-        HubMenu(viewModel: .init(siteID: 123, tapToPayBadgePromotionChecker: TapToPayBadgePromotionChecker()))
+        HubMenu(viewModel: .init(site: site, tapToPayBadgePromotionChecker: TapToPayBadgePromotionChecker()))
             .environment(\.colorScheme, .dark)
 
-        HubMenu(viewModel: .init(siteID: 123, tapToPayBadgePromotionChecker: TapToPayBadgePromotionChecker()))
+        HubMenu(viewModel: .init(site: site, tapToPayBadgePromotionChecker: TapToPayBadgePromotionChecker()))
             .previewLayout(.fixed(width: 312, height: 528))
             .environment(\.sizeCategory, .accessibilityExtraExtraExtraLarge)
 
-        HubMenu(viewModel: .init(siteID: 123, tapToPayBadgePromotionChecker: TapToPayBadgePromotionChecker()))
+        HubMenu(viewModel: .init(site: site, tapToPayBadgePromotionChecker: TapToPayBadgePromotionChecker()))
             .previewLayout(.fixed(width: 1024, height: 768))
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Hub Menu/HubMenuCoordinator.swift
+++ b/WooCommerce/Classes/ViewRelated/Hub Menu/HubMenuCoordinator.swift
@@ -5,6 +5,7 @@ import UIKit
 import enum Yosemite.ProductReviewAction
 import enum Yosemite.NotificationAction
 import struct Yosemite.ProductReviewFromNoteParcel
+import struct Yosemite.Site
 import protocol Yosemite.StoresManager
 
 /// Coordinator for the HubMenu tab.
@@ -57,12 +58,12 @@ final class HubMenuCoordinator: Coordinator {
     }
 
     func start() {
-        // No-op: please call `activate(siteID:)` instead when the menu tab is configured.
+        // No-op: please call `activate(site:)` instead when the menu tab is configured.
     }
 
     /// Replaces `start()` because the menu tab's navigation stack could be updated multiple times when site ID changes.
-    func activate(siteID: Int64) {
-        hubMenuController = HubMenuViewController(siteID: siteID,
+    func activate(site: Site) {
+        hubMenuController = HubMenuViewController(site: site,
                                                   navigationController: navigationController,
                                                   tapToPayBadgePromotionChecker: tapToPayBadgePromotionChecker)
         if let hubMenuController = hubMenuController {

--- a/WooCommerce/Classes/ViewRelated/Hub Menu/HubMenuViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Hub Menu/HubMenuViewController.swift
@@ -7,10 +7,10 @@ final class HubMenuViewController: UIHostingController<HubMenu> {
     private let viewModel: HubMenuViewModel
     private let tapToPayBadgePromotionChecker: TapToPayBadgePromotionChecker
 
-    init(siteID: Int64,
+    init(site: Site,
          navigationController: UINavigationController?,
          tapToPayBadgePromotionChecker: TapToPayBadgePromotionChecker) {
-        self.viewModel = HubMenuViewModel(siteID: siteID,
+        self.viewModel = HubMenuViewModel(site: site,
                                           navigationController: navigationController,
                                           tapToPayBadgePromotionChecker: tapToPayBadgePromotionChecker)
         self.tapToPayBadgePromotionChecker = tapToPayBadgePromotionChecker

--- a/WooCommerce/Classes/ViewRelated/Hub Menu/HubMenuViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Hub Menu/HubMenuViewModel.swift
@@ -202,7 +202,7 @@ final class HubMenuViewModel: ObservableObject {
         }
 
         // shows campaign list for the new Blaze experience.
-        let controller = BlazeCampaignListHostingController(viewModel: .init(siteID: site.siteID))
+        let controller = BlazeCampaignListHostingController(viewModel: .init(siteID: site.siteID, siteURL: site.url))
         navigationController?.show(controller, sender: self)
         ServiceLocator.analytics.track(event: .Blaze.blazeCampaignListEntryPointSelected(source: .menu))
     }

--- a/WooCommerce/Classes/ViewRelated/MainTabBarController.swift
+++ b/WooCommerce/Classes/ViewRelated/MainTabBarController.swift
@@ -536,20 +536,20 @@ private extension MainTabBarController {
             guard let self, let site else {
                 return
             }
-            self.updateViewControllers(siteID: site.siteID, siteURL: site.url)
+            self.updateViewControllers(site: site)
         }
     }
 
-    func updateViewControllers(siteID: Int64, siteURL: String) {
+    func updateViewControllers(site: Site) {
 
         // Update view model with `siteID` to query correct Orders Status
-        viewModel.configureOrdersStatusesListener(for: siteID)
+        viewModel.configureOrdersStatusesListener(for: site.siteID)
 
         // Initialize each tab's root view controller
-        let dashboardViewController = createDashboardViewController(siteID: siteID, siteURL: siteURL)
+        let dashboardViewController = createDashboardViewController(siteID: site.siteID, siteURL: site.url)
         dashboardNavigationController.viewControllers = [dashboardViewController]
 
-        let ordersViewController = createOrdersViewController(siteID: siteID)
+        let ordersViewController = createOrdersViewController(siteID: site.siteID)
         if isOrdersSplitViewFeatureFlagOn {
             ordersContainerController.wrappedController = ordersViewController
         } else {
@@ -557,9 +557,9 @@ private extension MainTabBarController {
         }
 
         if isProductsSplitViewFeatureFlagOn {
-            productsContainerController.wrappedController = ProductsSplitViewWrapperController(siteID: siteID)
+            productsContainerController.wrappedController = ProductsSplitViewWrapperController(siteID: site.siteID)
         } else {
-            productsNavigationController.viewControllers = [ProductsViewController(siteID: siteID)]
+            productsNavigationController.viewControllers = [ProductsViewController(siteID: site.siteID)]
         }
 
         // Configure hub menu tab coordinator once per logged in session potentially with multiple sites.
@@ -568,7 +568,7 @@ private extension MainTabBarController {
             self.hubMenuTabCoordinator = hubTabCoordinator
             hubTabCoordinator.start()
         }
-        hubMenuTabCoordinator?.activate(siteID: siteID)
+        hubMenuTabCoordinator?.activate(site: site)
 
         viewModel.loadHubMenuTabBadge()
 

--- a/WooCommerce/Classes/ViewRelated/MainTabBarController.swift
+++ b/WooCommerce/Classes/ViewRelated/MainTabBarController.swift
@@ -540,10 +540,7 @@ private extension MainTabBarController {
         }
     }
 
-    func updateViewControllers(siteID: Int64?, siteURL: String) {
-        guard let siteID = siteID else {
-            return
-        }
+    func updateViewControllers(siteID: Int64, siteURL: String) {
 
         // Update view model with `siteID` to query correct Orders Status
         viewModel.configureOrdersStatusesListener(for: siteID)

--- a/WooCommerce/WooCommerceTests/ViewRelated/Blaze/BlazeCampaignListViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Blaze/BlazeCampaignListViewModelTests.swift
@@ -8,6 +8,7 @@ import protocol Storage.StorageType
 final class BlazeCampaignListViewModelTests: XCTestCase {
 
     private let sampleSiteID: Int64 = 322
+    private let sampleSiteURL = "https://example.com"
 
     private var subscriptions: [AnyCancellable] = []
 
@@ -42,7 +43,7 @@ final class BlazeCampaignListViewModelTests: XCTestCase {
             }
             invocationCountOfLoadCampaigns += 1
         }
-        let viewModel = BlazeCampaignListViewModel(siteID: sampleSiteID, stores: stores)
+        let viewModel = BlazeCampaignListViewModel(siteID: sampleSiteID, siteURL: sampleSiteURL, stores: stores)
 
         // Then
         XCTAssertEqual(viewModel.syncState, .empty)
@@ -59,7 +60,7 @@ final class BlazeCampaignListViewModelTests: XCTestCase {
             }
             invocationCountOfLoadCampaigns += 1
         }
-        let viewModel = BlazeCampaignListViewModel(siteID: sampleSiteID, stores: stores)
+        let viewModel = BlazeCampaignListViewModel(siteID: sampleSiteID, siteURL: sampleSiteURL, stores: stores)
 
         // When
         viewModel.loadCampaigns()
@@ -69,7 +70,7 @@ final class BlazeCampaignListViewModelTests: XCTestCase {
     }
 
     func test_state_is_syncingFirstPage_upon_loadCampaigns_if_there_is_no_existing_campaign_in_storage() {
-        let viewModel = BlazeCampaignListViewModel(siteID: sampleSiteID)
+        let viewModel = BlazeCampaignListViewModel(siteID: sampleSiteID, siteURL: sampleSiteURL)
 
         // When
         viewModel.loadCampaigns()
@@ -81,7 +82,7 @@ final class BlazeCampaignListViewModelTests: XCTestCase {
     func test_state_is_results_upon_loadCampaigns_if_there_are_existing_campaigns_in_storage() {
         let existingCampaign = BlazeCampaign.fake().copy(siteID: sampleSiteID, campaignID: 123)
         insertCampaigns([existingCampaign])
-        let viewModel = BlazeCampaignListViewModel(siteID: sampleSiteID, storageManager: storageManager)
+        let viewModel = BlazeCampaignListViewModel(siteID: sampleSiteID, siteURL: sampleSiteURL, storageManager: storageManager)
 
         // When
         viewModel.loadCampaigns()
@@ -103,7 +104,7 @@ final class BlazeCampaignListViewModelTests: XCTestCase {
             self.insertCampaigns([campaign])
             onCompletion(.success(true))
         }
-        let viewModel = BlazeCampaignListViewModel(siteID: sampleSiteID, stores: stores, storageManager: storageManager)
+        let viewModel = BlazeCampaignListViewModel(siteID: sampleSiteID, siteURL: sampleSiteURL, stores: stores, storageManager: storageManager)
 
         var states = [BlazeCampaignListViewModel.SyncState]()
         viewModel.$syncState
@@ -132,7 +133,7 @@ final class BlazeCampaignListViewModelTests: XCTestCase {
             syncPageNumber = pageNumber
             onCompletion(.success(false))
         }
-        let viewModel = BlazeCampaignListViewModel(siteID: sampleSiteID, stores: stores, storageManager: storageManager)
+        let viewModel = BlazeCampaignListViewModel(siteID: sampleSiteID, siteURL: sampleSiteURL, stores: stores, storageManager: storageManager)
 
         var states = [BlazeCampaignListViewModel.SyncState]()
         viewModel.$syncState
@@ -168,7 +169,7 @@ final class BlazeCampaignListViewModelTests: XCTestCase {
             onCompletion(.success(pageNumber == 1 ? true : false))
         }
 
-        let viewModel = BlazeCampaignListViewModel(siteID: sampleSiteID, stores: stores, storageManager: storageManager)
+        let viewModel = BlazeCampaignListViewModel(siteID: sampleSiteID, siteURL: sampleSiteURL, stores: stores, storageManager: storageManager)
 
         var states = [BlazeCampaignListViewModel.SyncState]()
         viewModel.$syncState
@@ -202,7 +203,7 @@ final class BlazeCampaignListViewModelTests: XCTestCase {
             self.insertCampaigns([campaign])
             onCompletion(.success(true))
         }
-        let viewModel = BlazeCampaignListViewModel(siteID: sampleSiteID, stores: stores, storageManager: storageManager)
+        let viewModel = BlazeCampaignListViewModel(siteID: sampleSiteID, siteURL: sampleSiteURL, stores: stores, storageManager: storageManager)
 
         // When
         viewModel.loadCampaigns()
@@ -220,7 +221,7 @@ final class BlazeCampaignListViewModelTests: XCTestCase {
             }
             onCompletion(.success(false))
         }
-        let viewModel = BlazeCampaignListViewModel(siteID: sampleSiteID, stores: stores, storageManager: storageManager)
+        let viewModel = BlazeCampaignListViewModel(siteID: sampleSiteID, siteURL: sampleSiteURL, stores: stores, storageManager: storageManager)
 
         // When
         viewModel.loadCampaigns()
@@ -242,7 +243,7 @@ final class BlazeCampaignListViewModelTests: XCTestCase {
             self.insertCampaigns(items)
             onCompletion(.success(false))
         }
-        let viewModel = BlazeCampaignListViewModel(siteID: sampleSiteID, stores: stores, storageManager: storageManager)
+        let viewModel = BlazeCampaignListViewModel(siteID: sampleSiteID, siteURL: sampleSiteURL, stores: stores, storageManager: storageManager)
 
         // When
         viewModel.loadCampaigns()
@@ -269,7 +270,7 @@ final class BlazeCampaignListViewModelTests: XCTestCase {
 
             onCompletion(.success(false))
         }
-        let viewModel = BlazeCampaignListViewModel(siteID: sampleSiteID, stores: stores)
+        let viewModel = BlazeCampaignListViewModel(siteID: sampleSiteID, siteURL: sampleSiteURL, stores: stores)
 
         // When
         waitFor { promise in
@@ -289,7 +290,7 @@ final class BlazeCampaignListViewModelTests: XCTestCase {
         // Given
         let stores = MockStoresManager(sessionManager: .testingInstance)
         let campaign = BlazeCampaign.fake().copy(siteID: sampleSiteID)
-        let viewModel = BlazeCampaignListViewModel(siteID: sampleSiteID, stores: stores, storageManager: storageManager)
+        let viewModel = BlazeCampaignListViewModel(siteID: sampleSiteID, siteURL: sampleSiteURL, stores: stores, storageManager: storageManager)
 
         // Confidence check
         XCTAssertFalse(viewModel.shouldShowIntroView)
@@ -311,7 +312,7 @@ final class BlazeCampaignListViewModelTests: XCTestCase {
     func test_shouldShowIntroView_is_true_only_when_loading_campaigns_for_the_first_time_and_there_are_no_existing_campaigns() {
         // Given
         let stores = MockStoresManager(sessionManager: .testingInstance)
-        let viewModel = BlazeCampaignListViewModel(siteID: sampleSiteID, stores: stores, storageManager: storageManager)
+        let viewModel = BlazeCampaignListViewModel(siteID: sampleSiteID, siteURL: sampleSiteURL, stores: stores, storageManager: storageManager)
 
         // Confidence check
         XCTAssertFalse(viewModel.shouldShowIntroView)
@@ -358,7 +359,7 @@ final class BlazeCampaignListViewModelTests: XCTestCase {
 
     func test_blazeEntryPointDisplayed_is_tracked_upon_view_appear() throws {
         // Given
-        let viewModel = BlazeCampaignListViewModel(siteID: sampleSiteID, analytics: analytics)
+        let viewModel = BlazeCampaignListViewModel(siteID: sampleSiteID, siteURL: sampleSiteURL, analytics: analytics)
 
         // Confidence check
         XCTAssertFalse(analyticsProvider.receivedEvents.contains("blaze_entry_point_displayed"))
@@ -375,7 +376,7 @@ final class BlazeCampaignListViewModelTests: XCTestCase {
 
     func test_didSelectCampaignDetails_tracks_blazeCampaignDetailSelected_with_correct_source() throws {
         // Given
-        let viewModel = BlazeCampaignListViewModel(siteID: sampleSiteID, analytics: analytics)
+        let viewModel = BlazeCampaignListViewModel(siteID: sampleSiteID, siteURL: sampleSiteURL, analytics: analytics)
 
         // When
         viewModel.didSelectCampaignDetails(.fake())
@@ -389,7 +390,7 @@ final class BlazeCampaignListViewModelTests: XCTestCase {
 
     func test_didSelectCreateCampaign_tracks_blazeEntryPointTapped() throws {
         // Given
-        let viewModel = BlazeCampaignListViewModel(siteID: sampleSiteID, analytics: analytics)
+        let viewModel = BlazeCampaignListViewModel(siteID: sampleSiteID, siteURL: sampleSiteURL, analytics: analytics)
 
         // When
         viewModel.didSelectCreateCampaign(source: .introView)

--- a/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Blaze/BlazeCampaignDashboardViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Blaze/BlazeCampaignDashboardViewModelTests.swift
@@ -11,6 +11,7 @@ import WordPressAuthenticator
 @MainActor
 final class BlazeCampaignDashboardViewModelTests: XCTestCase {
     private let sampleSiteID: Int64 = 122
+    private let sampleSiteURL = "https://example.com"
 
     private var stores: MockStoresManager!
 
@@ -52,6 +53,7 @@ final class BlazeCampaignDashboardViewModelTests: XCTestCase {
                                    purchasable: true))
 
         let sut = BlazeCampaignDashboardViewModel(siteID: sampleSiteID,
+                                                  siteURL: sampleSiteURL,
                                                   stores: stores,
                                                   storageManager: storageManager,
                                                   blazeEligibilityChecker: checker)
@@ -66,6 +68,7 @@ final class BlazeCampaignDashboardViewModelTests: XCTestCase {
         // Given
         let checker = MockBlazeEligibilityChecker(isSiteEligible: true)
         let sut = BlazeCampaignDashboardViewModel(siteID: sampleSiteID,
+                                                  siteURL: sampleSiteURL,
                                                   stores: stores,
                                                   storageManager: storageManager,
                                                   blazeEligibilityChecker: checker)
@@ -87,6 +90,7 @@ final class BlazeCampaignDashboardViewModelTests: XCTestCase {
         // Given
         let checker = MockBlazeEligibilityChecker(isSiteEligible: false)
         let sut = BlazeCampaignDashboardViewModel(siteID: sampleSiteID,
+                                                  siteURL: sampleSiteURL,
                                                   stores: stores,
                                                   storageManager: storageManager,
                                                   blazeEligibilityChecker: checker)
@@ -107,6 +111,7 @@ final class BlazeCampaignDashboardViewModelTests: XCTestCase {
         // Given
         let checker = MockBlazeEligibilityChecker(isSiteEligible: false)
         let sut = BlazeCampaignDashboardViewModel(siteID: sampleSiteID,
+                                                  siteURL: sampleSiteURL,
                                                   stores: stores,
                                                   storageManager: storageManager,
                                                   blazeEligibilityChecker: checker)
@@ -132,6 +137,7 @@ final class BlazeCampaignDashboardViewModelTests: XCTestCase {
         let checker = MockBlazeEligibilityChecker(isSiteEligible: true)
         let blazeCampaign = BlazeCampaign.fake().copy(siteID: sampleSiteID)
         let sut = BlazeCampaignDashboardViewModel(siteID: sampleSiteID,
+                                                  siteURL: sampleSiteURL,
                                                   stores: stores,
                                                   storageManager: storageManager,
                                                   blazeEligibilityChecker: checker)
@@ -159,6 +165,7 @@ final class BlazeCampaignDashboardViewModelTests: XCTestCase {
         // Given
         let checker = MockBlazeEligibilityChecker(isSiteEligible: true)
         let sut = BlazeCampaignDashboardViewModel(siteID: sampleSiteID,
+                                                  siteURL: sampleSiteURL,
                                                   stores: stores,
                                                   storageManager: storageManager,
                                                   blazeEligibilityChecker: checker)
@@ -179,6 +186,7 @@ final class BlazeCampaignDashboardViewModelTests: XCTestCase {
         // Given
         let checker = MockBlazeEligibilityChecker(isSiteEligible: true)
         let sut = BlazeCampaignDashboardViewModel(siteID: sampleSiteID,
+                                                  siteURL: sampleSiteURL,
                                                   stores: stores,
                                                   storageManager: storageManager,
                                                   blazeEligibilityChecker: checker)
@@ -200,6 +208,7 @@ final class BlazeCampaignDashboardViewModelTests: XCTestCase {
         let checker = MockBlazeEligibilityChecker(isSiteEligible: true)
 
         let sut = BlazeCampaignDashboardViewModel(siteID: sampleSiteID,
+                                                  siteURL: sampleSiteURL,
                                                   stores: stores,
                                                   storageManager: storageManager,
                                                   blazeEligibilityChecker: checker)
@@ -227,6 +236,7 @@ final class BlazeCampaignDashboardViewModelTests: XCTestCase {
                                              purchasable: true)
 
         let sut = BlazeCampaignDashboardViewModel(siteID: sampleSiteID,
+                                                  siteURL: sampleSiteURL,
                                                   stores: stores,
                                                   storageManager: storageManager,
                                                   blazeEligibilityChecker: checker)
@@ -251,6 +261,7 @@ final class BlazeCampaignDashboardViewModelTests: XCTestCase {
         // Given
         let checker = MockBlazeEligibilityChecker(isSiteEligible: true)
         let sut = BlazeCampaignDashboardViewModel(siteID: sampleSiteID,
+                                                  siteURL: sampleSiteURL,
                                                   stores: stores,
                                                   storageManager: storageManager,
                                                   blazeEligibilityChecker: checker)
@@ -294,6 +305,7 @@ final class BlazeCampaignDashboardViewModelTests: XCTestCase {
         let checker = MockBlazeEligibilityChecker(isSiteEligible: true)
         let fakeBlazeCampaign = BlazeCampaign.fake().copy(siteID: sampleSiteID)
         let sut = BlazeCampaignDashboardViewModel(siteID: sampleSiteID,
+                                                  siteURL: sampleSiteURL,
                                                   stores: stores,
                                                   storageManager: storageManager,
                                                   blazeEligibilityChecker: checker)
@@ -320,6 +332,7 @@ final class BlazeCampaignDashboardViewModelTests: XCTestCase {
                                               purchasable: true)
 
         let sut = BlazeCampaignDashboardViewModel(siteID: sampleSiteID,
+                                                  siteURL: sampleSiteURL,
                                                   stores: stores,
                                                   storageManager: storageManager,
                                                   blazeEligibilityChecker: checker)
@@ -345,6 +358,7 @@ final class BlazeCampaignDashboardViewModelTests: XCTestCase {
                                               statusKey: (ProductStatus.draft.rawValue))
 
         let sut = BlazeCampaignDashboardViewModel(siteID: sampleSiteID,
+                                                  siteURL: sampleSiteURL,
                                                   stores: stores,
                                                   storageManager: storageManager,
                                                   blazeEligibilityChecker: checker)
@@ -367,6 +381,7 @@ final class BlazeCampaignDashboardViewModelTests: XCTestCase {
         // Given
         let checker = MockBlazeEligibilityChecker(isSiteEligible: true)
         let sut = BlazeCampaignDashboardViewModel(siteID: sampleSiteID,
+                                                  siteURL: sampleSiteURL,
                                                   stores: stores,
                                                   storageManager: storageManager,
                                                   blazeEligibilityChecker: checker)
@@ -391,6 +406,7 @@ final class BlazeCampaignDashboardViewModelTests: XCTestCase {
         // Given
         let checker = MockBlazeEligibilityChecker(isSiteEligible: true)
         let sut = BlazeCampaignDashboardViewModel(siteID: sampleSiteID,
+                                                  siteURL: sampleSiteURL,
                                                   stores: stores,
                                                   storageManager: storageManager,
                                                   blazeEligibilityChecker: checker)
@@ -426,6 +442,7 @@ final class BlazeCampaignDashboardViewModelTests: XCTestCase {
         let checker = MockBlazeEligibilityChecker(isSiteEligible: true)
         let fakeBlazeCampaign = BlazeCampaign.fake().copy(siteID: sampleSiteID)
         let sut = BlazeCampaignDashboardViewModel(siteID: sampleSiteID,
+                                                  siteURL: sampleSiteURL,
                                                   stores: stores,
                                                   storageManager: storageManager,
                                                   blazeEligibilityChecker: checker)
@@ -448,6 +465,7 @@ final class BlazeCampaignDashboardViewModelTests: XCTestCase {
                                               purchasable: true)
 
         let sut = BlazeCampaignDashboardViewModel(siteID: sampleSiteID,
+                                                  siteURL: sampleSiteURL,
                                                   stores: stores,
                                                   storageManager: storageManager,
                                                   blazeEligibilityChecker: checker)
@@ -466,6 +484,7 @@ final class BlazeCampaignDashboardViewModelTests: XCTestCase {
         // Given
         let checker = MockBlazeEligibilityChecker(isSiteEligible: true)
         let sut = BlazeCampaignDashboardViewModel(siteID: sampleSiteID,
+                                                  siteURL: sampleSiteURL,
                                                   stores: stores,
                                                   storageManager: storageManager,
                                                   blazeEligibilityChecker: checker)
@@ -486,6 +505,7 @@ final class BlazeCampaignDashboardViewModelTests: XCTestCase {
         // Given
         let checker = MockBlazeEligibilityChecker(isSiteEligible: true)
         let sut = BlazeCampaignDashboardViewModel(siteID: sampleSiteID,
+                                                  siteURL: sampleSiteURL,
                                                   stores: stores,
                                                   storageManager: storageManager,
                                                   blazeEligibilityChecker: checker)
@@ -521,6 +541,7 @@ final class BlazeCampaignDashboardViewModelTests: XCTestCase {
         let checker = MockBlazeEligibilityChecker(isSiteEligible: true)
         let fakeBlazeCampaign = BlazeCampaign.fake().copy(siteID: sampleSiteID)
         let sut = BlazeCampaignDashboardViewModel(siteID: sampleSiteID,
+                                                  siteURL: sampleSiteURL,
                                                   stores: stores,
                                                   storageManager: storageManager,
                                                   blazeEligibilityChecker: checker)
@@ -541,6 +562,7 @@ final class BlazeCampaignDashboardViewModelTests: XCTestCase {
                                               statusKey: (ProductStatus.published.rawValue))
 
         let sut = BlazeCampaignDashboardViewModel(siteID: sampleSiteID,
+                                                  siteURL: sampleSiteURL,
                                                   stores: stores,
                                                   storageManager: storageManager,
                                                   blazeEligibilityChecker: checker)
@@ -559,6 +581,7 @@ final class BlazeCampaignDashboardViewModelTests: XCTestCase {
         // Given
         let checker = MockBlazeEligibilityChecker(isSiteEligible: true)
         let sut = BlazeCampaignDashboardViewModel(siteID: sampleSiteID,
+                                                  siteURL: sampleSiteURL,
                                                   stores: stores,
                                                   storageManager: storageManager,
                                                   blazeEligibilityChecker: checker)
@@ -580,6 +603,7 @@ final class BlazeCampaignDashboardViewModelTests: XCTestCase {
         let checker = MockBlazeEligibilityChecker(isSiteEligible: true)
         let fakeBlazeCampaign = BlazeCampaign.fake().copy(siteID: sampleSiteID)
         let sut = BlazeCampaignDashboardViewModel(siteID: sampleSiteID,
+                                                  siteURL: sampleSiteURL,
                                                   stores: stores,
                                                   storageManager: storageManager,
                                                   blazeEligibilityChecker: checker)
@@ -613,6 +637,7 @@ final class BlazeCampaignDashboardViewModelTests: XCTestCase {
                                               statusKey: (ProductStatus.published.rawValue),
                                               purchasable: true)
         let sut = BlazeCampaignDashboardViewModel(siteID: sampleSiteID,
+                                                  siteURL: sampleSiteURL,
                                                   stores: stores,
                                                   storageManager: storageManager,
                                                   blazeEligibilityChecker: checker)
@@ -658,6 +683,7 @@ final class BlazeCampaignDashboardViewModelTests: XCTestCase {
 
         let checker = MockBlazeEligibilityChecker(isSiteEligible: true)
         let viewModel = BlazeCampaignDashboardViewModel(siteID: sampleSiteID,
+                                                        siteURL: sampleSiteURL,
                                                         stores: stores,
                                                         storageManager: storageManager,
                                                         blazeEligibilityChecker: checker)
@@ -675,6 +701,7 @@ final class BlazeCampaignDashboardViewModelTests: XCTestCase {
 
         let checker = MockBlazeEligibilityChecker(isSiteEligible: true)
         let viewModel = BlazeCampaignDashboardViewModel(siteID: sampleSiteID,
+                                                        siteURL: sampleSiteURL,
                                                         stores: stores,
                                                         storageManager: storageManager,
                                                         blazeEligibilityChecker: checker)
@@ -710,6 +737,7 @@ final class BlazeCampaignDashboardViewModelTests: XCTestCase {
         // Given
         let checker = MockBlazeEligibilityChecker(isSiteEligible: true)
         let viewModel = BlazeCampaignDashboardViewModel(siteID: sampleSiteID,
+                                                        siteURL: sampleSiteURL,
                                                         stores: stores,
                                                         storageManager: storageManager,
                                                         analytics: analytics,
@@ -728,6 +756,7 @@ final class BlazeCampaignDashboardViewModelTests: XCTestCase {
         // Given
         let checker = MockBlazeEligibilityChecker(isSiteEligible: true)
         let viewModel = BlazeCampaignDashboardViewModel(siteID: sampleSiteID,
+                                                        siteURL: sampleSiteURL,
                                                         stores: stores,
                                                         storageManager: storageManager,
                                                         analytics: analytics,
@@ -747,6 +776,7 @@ final class BlazeCampaignDashboardViewModelTests: XCTestCase {
         // Given
         let checker = MockBlazeEligibilityChecker(isSiteEligible: true)
         let viewModel = BlazeCampaignDashboardViewModel(siteID: sampleSiteID,
+                                                        siteURL: sampleSiteURL,
                                                         stores: stores,
                                                         storageManager: storageManager,
                                                         analytics: analytics,
@@ -766,6 +796,7 @@ final class BlazeCampaignDashboardViewModelTests: XCTestCase {
         // Given
         let checker = MockBlazeEligibilityChecker(isSiteEligible: true)
         let viewModel = BlazeCampaignDashboardViewModel(siteID: sampleSiteID,
+                                                        siteURL: sampleSiteURL,
                                                         stores: stores,
                                                         storageManager: storageManager,
                                                         analytics: analytics,
@@ -786,6 +817,7 @@ final class BlazeCampaignDashboardViewModelTests: XCTestCase {
         let checker = MockBlazeEligibilityChecker(isSiteEligible: true)
         let fakeBlazeCampaign = BlazeCampaign.fake().copy(siteID: sampleSiteID)
         let sut = BlazeCampaignDashboardViewModel(siteID: sampleSiteID,
+                                                  siteURL: sampleSiteURL,
                                                   stores: stores,
                                                   storageManager: storageManager,
                                                   analytics: analytics,
@@ -812,6 +844,7 @@ final class BlazeCampaignDashboardViewModelTests: XCTestCase {
                                               purchasable: true)
 
         let sut = BlazeCampaignDashboardViewModel(siteID: sampleSiteID,
+                                                  siteURL: sampleSiteURL,
                                                   stores: stores,
                                                   storageManager: storageManager,
                                                   analytics: analytics,
@@ -837,6 +870,7 @@ final class BlazeCampaignDashboardViewModelTests: XCTestCase {
                                               statusKey: (ProductStatus.draft.rawValue))
 
         let sut = BlazeCampaignDashboardViewModel(siteID: sampleSiteID,
+                                                  siteURL: sampleSiteURL,
                                                   stores: stores,
                                                   storageManager: storageManager,
                                                   analytics: analytics,
@@ -856,6 +890,7 @@ final class BlazeCampaignDashboardViewModelTests: XCTestCase {
         // Given
         let checker = MockBlazeEligibilityChecker(isSiteEligible: true)
         let sut = BlazeCampaignDashboardViewModel(siteID: sampleSiteID,
+                                                  siteURL: sampleSiteURL,
                                                   stores: stores,
                                                   storageManager: storageManager,
                                                   analytics: analytics,
@@ -876,6 +911,7 @@ final class BlazeCampaignDashboardViewModelTests: XCTestCase {
         let checker = MockBlazeEligibilityChecker(isSiteEligible: true)
         let fakeBlazeCampaign = BlazeCampaign.fake().copy(siteID: sampleSiteID)
         let sut = BlazeCampaignDashboardViewModel(siteID: sampleSiteID,
+                                                  siteURL: sampleSiteURL,
                                                   stores: stores,
                                                   storageManager: storageManager,
                                                   analytics: analytics,
@@ -903,6 +939,7 @@ final class BlazeCampaignDashboardViewModelTests: XCTestCase {
         let uuid = UUID().uuidString
         let userDefaults = try XCTUnwrap(UserDefaults(suiteName: uuid))
         let viewModel = BlazeCampaignDashboardViewModel(siteID: sampleSiteID,
+                                                        siteURL: sampleSiteURL,
                                                         stores: stores,
                                                         storageManager: storageManager,
                                                         blazeEligibilityChecker: checker,

--- a/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/DashboardViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/DashboardViewModelTests.swift
@@ -14,6 +14,7 @@ import struct Yosemite.Site
 
 final class DashboardViewModelTests: XCTestCase {
     private let sampleSiteID: Int64 = 122
+    private let sampleSiteURL = "https://example.com"
 
     private var analytics: Analytics!
     private var analyticsProvider: MockAnalyticsProvider!
@@ -27,7 +28,7 @@ final class DashboardViewModelTests: XCTestCase {
 
     func test_default_statsVersion_is_v4() {
         // Given
-        let viewModel = DashboardViewModel(siteID: 0)
+        let viewModel = DashboardViewModel(siteID: 0, siteURL: sampleSiteURL)
 
         // Then
         XCTAssertEqual(viewModel.statsVersion, .v4)
@@ -40,7 +41,7 @@ final class DashboardViewModelTests: XCTestCase {
                 completion(.failure(DotcomError.noRestRoute))
             }
         }
-        let viewModel = DashboardViewModel(siteID: 0, stores: stores)
+        let viewModel = DashboardViewModel(siteID: 0, siteURL: sampleSiteURL, stores: stores)
         XCTAssertEqual(viewModel.statsVersion, .v4)
 
         // When
@@ -66,7 +67,7 @@ final class DashboardViewModelTests: XCTestCase {
                 XCTFail("Received unsupported action: \(action)")
             }
         }
-        let viewModel = DashboardViewModel(siteID: 0, stores: stores)
+        let viewModel = DashboardViewModel(siteID: 0, siteURL: sampleSiteURL, stores: stores)
         XCTAssertEqual(viewModel.statsVersion, .v4)
 
         // When
@@ -88,7 +89,7 @@ final class DashboardViewModelTests: XCTestCase {
                 completion(storeStatsResult)
             }
         }
-        let viewModel = DashboardViewModel(siteID: 0, stores: stores)
+        let viewModel = DashboardViewModel(siteID: 0, siteURL: sampleSiteURL, stores: stores)
         viewModel.syncStats(for: sampleSiteID, siteTimezone: .current, timeRange: .thisMonth, latestDateToInclude: .init(), forceRefresh: false)
         XCTAssertEqual(viewModel.statsVersion, .v3)
 
@@ -104,7 +105,7 @@ final class DashboardViewModelTests: XCTestCase {
         // Given
         let message = Yosemite.JustInTimeMessage.fake().copy(title: "JITM Message")
         prepareStoresToShowJustInTimeMessage(.success([message]))
-        let viewModel = DashboardViewModel(siteID: 0, stores: stores)
+        let viewModel = DashboardViewModel(siteID: 0, siteURL: sampleSiteURL, stores: stores)
 
         // When
         await viewModel.syncAnnouncements(for: sampleSiteID)
@@ -150,7 +151,7 @@ final class DashboardViewModelTests: XCTestCase {
                 XCTFail("Received unsupported action: \(action)")
             }
         }
-        let viewModel = DashboardViewModel(siteID: 0, stores: stores)
+        let viewModel = DashboardViewModel(siteID: 0, siteURL: sampleSiteURL, stores: stores)
 
         // When
         await viewModel.syncAnnouncements(for: sampleSiteID)
@@ -167,7 +168,7 @@ final class DashboardViewModelTests: XCTestCase {
         let secondMessage = Yosemite.JustInTimeMessage.fake().copy(messageID: "test-message-id-2",
                                                                    featureClass: "test-feature-class-2")
         prepareStoresToShowJustInTimeMessage(.success([message, secondMessage]))
-        let viewModel = DashboardViewModel(siteID: 0, stores: stores, analytics: analytics)
+        let viewModel = DashboardViewModel(siteID: 0, siteURL: sampleSiteURL, stores: stores, analytics: analytics)
 
         // When
         await viewModel.syncAnnouncements(for: sampleSiteID)
@@ -190,7 +191,7 @@ final class DashboardViewModelTests: XCTestCase {
 
         let secondMessage = Yosemite.JustInTimeMessage.fake().copy(title: "Lower priority JITM")
         prepareStoresToShowJustInTimeMessage(.success([message, secondMessage]))
-        let viewModel = DashboardViewModel(siteID: 0, stores: stores, analytics: analytics)
+        let viewModel = DashboardViewModel(siteID: 0, siteURL: sampleSiteURL, stores: stores, analytics: analytics)
 
         // When
         await viewModel.syncAnnouncements(for: sampleSiteID)
@@ -203,7 +204,7 @@ final class DashboardViewModelTests: XCTestCase {
         // Given
         let error = DotcomError.noRestRoute
         prepareStoresToShowJustInTimeMessage(.failure(error))
-        let viewModel = DashboardViewModel(siteID: 0, stores: stores, analytics: analytics)
+        let viewModel = DashboardViewModel(siteID: 0, siteURL: sampleSiteURL, stores: stores, analytics: analytics)
 
         // When
         await viewModel.syncAnnouncements(for: sampleSiteID)
@@ -224,7 +225,7 @@ final class DashboardViewModelTests: XCTestCase {
         // Given
         prepareStoresToShowJustInTimeMessage(.success([]))
 
-        let viewModel = DashboardViewModel(siteID: 0, stores: stores, analytics: analytics)
+        let viewModel = DashboardViewModel(siteID: 0, siteURL: sampleSiteURL, stores: stores, analytics: analytics)
         viewModel.announcementViewModel = JustInTimeMessageViewModel(
             justInTimeMessage: .fake(),
             screenName: "my_store",
@@ -249,7 +250,7 @@ final class DashboardViewModelTests: XCTestCase {
         stores.updateDefaultStore(.fake().copy(siteID: sampleSiteID, isWordPressComStore: true))
         let featureFlagService = MockFeatureFlagService(isProductDescriptionAIFromStoreOnboardingEnabled: true)
 
-        let viewModel = DashboardViewModel(siteID: 0, stores: stores, featureFlags: featureFlagService)
+        let viewModel = DashboardViewModel(siteID: 0, siteURL: sampleSiteURL, stores: stores, featureFlags: featureFlagService)
         stores.whenReceivingAction(ofType: AppSettingsAction.self) { action in
             switch action {
             case .getLocalAnnouncementVisibility(_, _):
@@ -277,7 +278,7 @@ final class DashboardViewModelTests: XCTestCase {
         stores.updateDefaultStore(.fake().copy(siteID: sampleSiteID, isWordPressComStore: true))
         let featureFlagService = MockFeatureFlagService(isProductDescriptionAIFromStoreOnboardingEnabled: true)
 
-        let viewModel = DashboardViewModel(siteID: 0, stores: stores, featureFlags: featureFlagService)
+        let viewModel = DashboardViewModel(siteID: 0, siteURL: sampleSiteURL, stores: stores, featureFlags: featureFlagService)
         stores.whenReceivingAction(ofType: AppSettingsAction.self) { action in
             switch action {
             case let .getLocalAnnouncementVisibility(_, completion):
@@ -303,6 +304,7 @@ final class DashboardViewModelTests: XCTestCase {
         let defaults = try XCTUnwrap(UserDefaults(suiteName: uuid))
         defaults[.completedAllStoreOnboardingTasks] = false
         let viewModel = DashboardViewModel(siteID: 0,
+                                           siteURL: sampleSiteURL,
                                            stores: stores,
                                            featureFlags: MockFeatureFlagService(isDashboardStoreOnboardingEnabled: false),
                                            userDefaults: defaults)
@@ -316,6 +318,7 @@ final class DashboardViewModelTests: XCTestCase {
         let defaults = try XCTUnwrap(UserDefaults(suiteName: uuid))
         defaults[.completedAllStoreOnboardingTasks] = true
         let viewModel = DashboardViewModel(siteID: 0,
+                                           siteURL: sampleSiteURL,
                                            stores: stores,
                                            featureFlags: MockFeatureFlagService(isDashboardStoreOnboardingEnabled: false),
                                            userDefaults: defaults)
@@ -329,6 +332,7 @@ final class DashboardViewModelTests: XCTestCase {
         let defaults = try XCTUnwrap(UserDefaults(suiteName: uuid))
         defaults[.completedAllStoreOnboardingTasks] = true
         let viewModel = DashboardViewModel(siteID: 0,
+                                           siteURL: sampleSiteURL,
                                            stores: stores,
                                            featureFlags: MockFeatureFlagService(isDashboardStoreOnboardingEnabled: true),
                                            userDefaults: defaults)
@@ -342,6 +346,7 @@ final class DashboardViewModelTests: XCTestCase {
         let defaults = try XCTUnwrap(UserDefaults(suiteName: uuid))
         defaults[.completedAllStoreOnboardingTasks] = false
         let viewModel = DashboardViewModel(siteID: 0,
+                                           siteURL: sampleSiteURL,
                                            stores: stores,
                                            featureFlags: MockFeatureFlagService(isDashboardStoreOnboardingEnabled: true),
                                            userDefaults: defaults)
@@ -354,6 +359,7 @@ final class DashboardViewModelTests: XCTestCase {
         let uuid = UUID().uuidString
         let defaults = try XCTUnwrap(UserDefaults(suiteName: uuid))
         let viewModel = DashboardViewModel(siteID: 0,
+                                           siteURL: sampleSiteURL,
                                            stores: stores,
                                            featureFlags: MockFeatureFlagService(isDashboardStoreOnboardingEnabled: true),
                                            userDefaults: defaults)
@@ -366,6 +372,7 @@ final class DashboardViewModelTests: XCTestCase {
         let uuid = UUID().uuidString
         let defaults = try XCTUnwrap(UserDefaults(suiteName: uuid))
         let viewModel = DashboardViewModel(siteID: 0,
+                                           siteURL: sampleSiteURL,
                                            stores: stores,
                                            featureFlags: MockFeatureFlagService(isDashboardStoreOnboardingEnabled: true),
                                            userDefaults: defaults)
@@ -384,6 +391,7 @@ final class DashboardViewModelTests: XCTestCase {
         let uuid = UUID().uuidString
         let defaults = try XCTUnwrap(UserDefaults(suiteName: uuid))
         let sut = DashboardViewModel(siteID: 0,
+                                     siteURL: sampleSiteURL,
                                      stores: stores,
                                      featureFlags: MockFeatureFlagService(isDashboardStoreOnboardingEnabled: true),
                                      userDefaults: defaults)
@@ -407,6 +415,7 @@ final class DashboardViewModelTests: XCTestCase {
         let uuid = UUID().uuidString
         let defaults = try XCTUnwrap(UserDefaults(suiteName: uuid))
         let sut = DashboardViewModel(siteID: 0,
+                                     siteURL: sampleSiteURL,
                                      stores: stores,
                                      featureFlags: MockFeatureFlagService(isDashboardStoreOnboardingEnabled: true),
                                      userDefaults: defaults)
@@ -430,6 +439,7 @@ final class DashboardViewModelTests: XCTestCase {
         let uuid = UUID().uuidString
         let defaults = try XCTUnwrap(UserDefaults(suiteName: uuid))
         let sut = DashboardViewModel(siteID: 0,
+                                     siteURL: sampleSiteURL,
                                      stores: stores,
                                      featureFlags: MockFeatureFlagService(isDashboardStoreOnboardingEnabled: true),
                                      userDefaults: defaults)
@@ -450,6 +460,7 @@ final class DashboardViewModelTests: XCTestCase {
         let uuid = UUID().uuidString
         let defaults = try XCTUnwrap(UserDefaults(suiteName: uuid))
         let sut = DashboardViewModel(siteID: 0,
+                                     siteURL: sampleSiteURL,
                                      stores: stores,
                                      featureFlags: MockFeatureFlagService(isDashboardStoreOnboardingEnabled: true),
                                      userDefaults: defaults)
@@ -467,7 +478,7 @@ final class DashboardViewModelTests: XCTestCase {
         let sessionManager = SessionManager.makeForTesting()
         sessionManager.defaultSite = Site.fake().copy(isPublic: false)
         let stores = MockStoresManager(sessionManager: sessionManager)
-        let viewModel = DashboardViewModel(siteID: 123, stores: stores)
+        let viewModel = DashboardViewModel(siteID: 123, siteURL: sampleSiteURL, stores: stores)
 
         // When
         let siteURLToShare = viewModel.siteURLToShare
@@ -482,7 +493,7 @@ final class DashboardViewModelTests: XCTestCase {
         let expectedURL = "https://example.com"
         sessionManager.defaultSite = Site.fake().copy(url: expectedURL, isPublic: true)
         let stores = MockStoresManager(sessionManager: sessionManager)
-        let viewModel = DashboardViewModel(siteID: 123, stores: stores)
+        let viewModel = DashboardViewModel(siteID: 123, siteURL: sampleSiteURL, stores: stores)
 
         // When
         let siteURLToShare = viewModel.siteURLToShare
@@ -495,7 +506,7 @@ final class DashboardViewModelTests: XCTestCase {
         // Given
         let localTimezone = TimeZone(secondsFromGMT: -3600)
         let siteGMTOffset = 0.0
-        let viewModel = DashboardViewModel(siteID: 0, stores: stores, analytics: analytics)
+        let viewModel = DashboardViewModel(siteID: 0, siteURL: sampleSiteURL, stores: stores, analytics: analytics)
 
         // When
         viewModel.trackStatsTimezone(localTimezone: localTimezone!, siteGMTOffset: siteGMTOffset)
@@ -515,7 +526,7 @@ final class DashboardViewModelTests: XCTestCase {
         // Given
         let localTimezone = TimeZone(secondsFromGMT: -5400)
         let siteGMTOffset = 2.50000
-        let viewModel = DashboardViewModel(siteID: 0, stores: stores, analytics: analytics)
+        let viewModel = DashboardViewModel(siteID: 0, siteURL: sampleSiteURL, stores: stores, analytics: analytics)
 
         // When
         viewModel.trackStatsTimezone(localTimezone: localTimezone!, siteGMTOffset: siteGMTOffset)
@@ -535,7 +546,7 @@ final class DashboardViewModelTests: XCTestCase {
         // Given
         let localTimezone = TimeZone(secondsFromGMT: -7200)
         let siteGMTOffset = -2.0
-        let viewModel = DashboardViewModel(siteID: 0, stores: stores, analytics: analytics)
+        let viewModel = DashboardViewModel(siteID: 0, siteURL: sampleSiteURL, stores: stores, analytics: analytics)
 
         // When
         viewModel.trackStatsTimezone(localTimezone: localTimezone!, siteGMTOffset: siteGMTOffset)
@@ -555,7 +566,7 @@ final class DashboardViewModelTests: XCTestCase {
                 XCTFail("Received unsupported action: \(action)")
             }
         }
-        let viewModel = DashboardViewModel(siteID: sampleSiteID, stores: stores)
+        let viewModel = DashboardViewModel(siteID: sampleSiteID, siteURL: sampleSiteURL, stores: stores)
 
         // When
         let siteVisitStatsResult: Result<Void, Error> = waitFor { promise in
@@ -579,6 +590,7 @@ final class DashboardViewModelTests: XCTestCase {
         // Given
         let usecase = MockStoreCreationProfilerUploadAnswersUseCase()
         let viewModel = DashboardViewModel(siteID: sampleSiteID,
+                                           siteURL: sampleSiteURL,
                                            storeCreationProfilerUploadAnswersUseCase: usecase)
 
         // When
@@ -593,6 +605,7 @@ final class DashboardViewModelTests: XCTestCase {
         // Given
         let themeInstaller = MockThemeInstaller()
         _ = DashboardViewModel(siteID: sampleSiteID,
+                               siteURL: sampleSiteURL,
                                themeInstaller: themeInstaller)
 
         waitUntil {
@@ -607,7 +620,7 @@ final class DashboardViewModelTests: XCTestCase {
     func test_it_tracks_end_of_blaze_campaign_sync_action_when_blaze_campaign_view_reloads() async {
         // Given
         let waitingTimeTracker = AppStartupWaitingTimeTracker()
-        let viewModel = DashboardViewModel(siteID: sampleSiteID, startupWaitingTimeTracker: waitingTimeTracker)
+        let viewModel = DashboardViewModel(siteID: sampleSiteID, siteURL: sampleSiteURL, startupWaitingTimeTracker: waitingTimeTracker)
         XCTAssertTrue(waitingTimeTracker.startupActionsPending.contains(.syncBlazeCampaigns))
 
         // Then

--- a/WooCommerce/WooCommerceTests/ViewRelated/HubMenu/HubMenuCoordinatorTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/HubMenu/HubMenuCoordinatorTests.swift
@@ -15,6 +15,7 @@ final class HubMenuCoordinatorTests: XCTestCase {
     private var switchStoreUseCase: MockSwitchStoreUseCase!
 
     private let siteID: Int64 = 1
+    private let sampleSite = Site.fake().copy(siteID: 1)
 
     override func setUp() {
         super.setUp()
@@ -46,7 +47,7 @@ final class HubMenuCoordinatorTests: XCTestCase {
         let pushNotification = PushNotification(noteID: 1_234, siteID: 1, kind: .storeOrder, title: "", subtitle: "", message: "")
 
         coordinator.start()
-        coordinator.activate(siteID: siteID)
+        coordinator.activate(site: sampleSite)
 
         XCTAssertEqual(coordinator.navigationController.viewControllers.count, 1)
 
@@ -67,7 +68,7 @@ final class HubMenuCoordinatorTests: XCTestCase {
         let pushNotification = PushNotification(noteID: 1_234, siteID: 1, kind: .comment, title: "", subtitle: "", message: "")
 
         coordinator.start()
-        coordinator.activate(siteID: siteID)
+        coordinator.activate(site: sampleSite)
 
         // When
         pushNotificationsManager.sendForegroundNotification(pushNotification)
@@ -86,7 +87,7 @@ final class HubMenuCoordinatorTests: XCTestCase {
         let pushNotification = PushNotification(noteID: 1_234, siteID: 1, kind: .comment, title: "", subtitle: "", message: "")
 
         coordinator.start()
-        coordinator.activate(siteID: siteID)
+        coordinator.activate(site: sampleSite)
 
         assertEmpty(noticePresenter.queuedNotices)
 

--- a/WooCommerce/WooCommerceTests/ViewRelated/HubMenu/HubMenuViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/HubMenu/HubMenuViewModelTests.swift
@@ -5,6 +5,7 @@ import XCTest
 
 final class HubMenuViewModelTests: XCTestCase {
     private let sampleSiteID: Int64 = 606
+    private let sampleSite = Site.fake().copy(siteID: 606)
 
     func test_viewDidAppear_then_posts_notification() {
         // Given

--- a/WooCommerce/WooCommerceTests/ViewRelated/HubMenu/HubMenuViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/HubMenu/HubMenuViewModelTests.swift
@@ -8,7 +8,7 @@ final class HubMenuViewModelTests: XCTestCase {
 
     func test_viewDidAppear_then_posts_notification() {
         // Given
-        let viewModel = HubMenuViewModel(siteID: sampleSiteID, tapToPayBadgePromotionChecker: TapToPayBadgePromotionChecker())
+        let viewModel = HubMenuViewModel(site: sampleSite, tapToPayBadgePromotionChecker: TapToPayBadgePromotionChecker())
         expectation(forNotification: .hubMenuViewDidAppear, object: nil, handler: nil)
 
         // When
@@ -23,7 +23,7 @@ final class HubMenuViewModelTests: XCTestCase {
         let featureFlagService = MockFeatureFlagService(isInboxOn: false)
 
         // When
-        let viewModel = HubMenuViewModel(siteID: sampleSiteID,
+        let viewModel = HubMenuViewModel(site: sampleSite,
                                          tapToPayBadgePromotionChecker: TapToPayBadgePromotionChecker(),
                                          featureFlagService: featureFlagService)
 
@@ -53,7 +53,7 @@ final class HubMenuViewModelTests: XCTestCase {
         }
 
         // When
-        let viewModel = HubMenuViewModel(siteID: sampleSiteID,
+        let viewModel = HubMenuViewModel(site: sampleSite,
                                          tapToPayBadgePromotionChecker: TapToPayBadgePromotionChecker(),
                                          featureFlagService: featureFlagService,
                                          stores: stores)
@@ -84,7 +84,7 @@ final class HubMenuViewModelTests: XCTestCase {
         }
 
         // When
-        let viewModel = HubMenuViewModel(siteID: sampleSiteID,
+        let viewModel = HubMenuViewModel(site: sampleSite,
                                          tapToPayBadgePromotionChecker: TapToPayBadgePromotionChecker(),
                                          featureFlagService: featureFlagService,
                                          stores: stores)
@@ -98,7 +98,7 @@ final class HubMenuViewModelTests: XCTestCase {
 
     func test_generalElements_does_not_include_blaze_when_default_site_is_not_set() {
         // When
-        let viewModel = HubMenuViewModel(siteID: sampleSiteID,
+        let viewModel = HubMenuViewModel(site: sampleSite,
                                          tapToPayBadgePromotionChecker: TapToPayBadgePromotionChecker())
         viewModel.setupMenuElements()
 
@@ -116,7 +116,7 @@ final class HubMenuViewModelTests: XCTestCase {
         let blazeEligibilityChecker = MockBlazeEligibilityChecker(isSiteEligible: false)
 
         // When
-        let viewModel = HubMenuViewModel(siteID: sampleSiteID,
+        let viewModel = HubMenuViewModel(site: sampleSite,
                                          tapToPayBadgePromotionChecker: TapToPayBadgePromotionChecker(),
                                          stores: stores,
                                          blazeEligibilityChecker: blazeEligibilityChecker)
@@ -136,7 +136,7 @@ final class HubMenuViewModelTests: XCTestCase {
         let blazeEligibilityChecker = MockBlazeEligibilityChecker(isSiteEligible: true)
 
         // When
-        let viewModel = HubMenuViewModel(siteID: sampleSiteID,
+        let viewModel = HubMenuViewModel(site: sampleSite,
                                          tapToPayBadgePromotionChecker: TapToPayBadgePromotionChecker(),
                                          stores: stores,
                                          blazeEligibilityChecker: blazeEligibilityChecker)
@@ -159,7 +159,7 @@ final class HubMenuViewModelTests: XCTestCase {
         let stores = MockStoresManager(sessionManager: sessionManager)
 
         // When
-        let viewModel = HubMenuViewModel(siteID: site.siteID,
+        let viewModel = HubMenuViewModel(site: sampleSite,
                                          tapToPayBadgePromotionChecker: TapToPayBadgePromotionChecker(),
                                          stores: stores)
 
@@ -171,11 +171,10 @@ final class HubMenuViewModelTests: XCTestCase {
         let sampleAdminURL = "https://testshop.com/wp-admin/"
         let sessionManager = SessionManager.testingInstance
         let site = Site.fake().copy(adminURL: sampleAdminURL)
-        sessionManager.defaultSite = site
         let stores = MockStoresManager(sessionManager: sessionManager)
 
         // When
-        let viewModel = HubMenuViewModel(siteID: site.siteID,
+        let viewModel = HubMenuViewModel(site: site,
                                          tapToPayBadgePromotionChecker: TapToPayBadgePromotionChecker(),
                                          stores: stores)
 
@@ -191,7 +190,7 @@ final class HubMenuViewModelTests: XCTestCase {
         let stores = MockStoresManager(sessionManager: sessionManager)
 
         // When
-        let viewModel = HubMenuViewModel(siteID: site.siteID,
+        let viewModel = HubMenuViewModel(site: sampleSite,
                                          tapToPayBadgePromotionChecker: TapToPayBadgePromotionChecker(),
                                          stores: stores)
         // Then
@@ -205,11 +204,10 @@ final class HubMenuViewModelTests: XCTestCase {
         let expectedAdminURL = "https://testshop.com/wp-admin"
         let sessionManager = SessionManager.testingInstance
         let site = Site.fake().copy(url: sampleStoreURL, adminURL: sampleAdminURL)
-        sessionManager.defaultSite = site
         let stores = MockStoresManager(sessionManager: sessionManager)
 
         // When
-        let viewModel = HubMenuViewModel(siteID: site.siteID,
+        let viewModel = HubMenuViewModel(site: site,
                                          tapToPayBadgePromotionChecker: TapToPayBadgePromotionChecker(),
                                          stores: stores)
         // Then
@@ -223,11 +221,10 @@ final class HubMenuViewModelTests: XCTestCase {
         let expectedAdminURL = "https://testshop.com/wp-admin"
         let sessionManager = SessionManager.testingInstance
         let site = Site.fake().copy(url: sampleStoreURL, adminURL: sampleAdminURL)
-        sessionManager.defaultSite = site
         let stores = MockStoresManager(sessionManager: sessionManager)
 
         // When
-        let viewModel = HubMenuViewModel(siteID: site.siteID,
+        let viewModel = HubMenuViewModel(site: site,
                                          tapToPayBadgePromotionChecker: TapToPayBadgePromotionChecker(),
                                          stores: stores)
         // Then
@@ -245,7 +242,7 @@ final class HubMenuViewModelTests: XCTestCase {
         let stores = MockStoresManager(sessionManager: sessionManager)
 
         // When
-        let viewModel = HubMenuViewModel(siteID: site.siteID,
+        let viewModel = HubMenuViewModel(site: sampleSite,
                                          tapToPayBadgePromotionChecker: TapToPayBadgePromotionChecker(),
                                          stores: stores)
 
@@ -263,7 +260,7 @@ final class HubMenuViewModelTests: XCTestCase {
         let stores = MockStoresManager(sessionManager: sessionManager)
 
         // When
-        let viewModel = HubMenuViewModel(siteID: site.siteID,
+        let viewModel = HubMenuViewModel(site: sampleSite,
                                          tapToPayBadgePromotionChecker: TapToPayBadgePromotionChecker(),
                                          stores: stores)
 
@@ -277,11 +274,10 @@ final class HubMenuViewModelTests: XCTestCase {
         let sampleAdminURL = ""
         let sessionManager = SessionManager.makeForTesting(authenticated: true, isWPCom: true)
         let site = Site.fake().copy(url: sampleStoreURL, adminURL: sampleAdminURL, isWordPressComStore: true)
-        sessionManager.defaultSite = site
         let stores = MockStoresManager(sessionManager: sessionManager)
 
         // When
-        let viewModel = HubMenuViewModel(siteID: site.siteID,
+        let viewModel = HubMenuViewModel(site: site,
                                          tapToPayBadgePromotionChecker: TapToPayBadgePromotionChecker(),
                                          stores: stores)
 
@@ -299,7 +295,7 @@ final class HubMenuViewModelTests: XCTestCase {
         let stores = MockStoresManager(sessionManager: sessionManager)
 
         // When
-        let viewModel = HubMenuViewModel(siteID: site.siteID,
+        let viewModel = HubMenuViewModel(site: sampleSite,
                                          tapToPayBadgePromotionChecker: TapToPayBadgePromotionChecker(),
                                          stores: stores)
 
@@ -317,7 +313,7 @@ final class HubMenuViewModelTests: XCTestCase {
         let stores = MockStoresManager(sessionManager: sessionManager)
 
         // When
-        let viewModel = HubMenuViewModel(siteID: site.siteID,
+        let viewModel = HubMenuViewModel(site: sampleSite,
                                          tapToPayBadgePromotionChecker: TapToPayBadgePromotionChecker(),
                                          stores: stores)
 
@@ -332,7 +328,7 @@ final class HubMenuViewModelTests: XCTestCase {
         let stores = MockStoresManager(sessionManager: sessionManager)
 
         // When
-        let viewModel = HubMenuViewModel(siteID: sampleSiteID,
+        let viewModel = HubMenuViewModel(site: sampleSite,
                                          tapToPayBadgePromotionChecker: TapToPayBadgePromotionChecker(),
                                          stores: stores)
         viewModel.setupMenuElements()
@@ -349,7 +345,7 @@ final class HubMenuViewModelTests: XCTestCase {
         let stores = MockStoresManager(sessionManager: sessionManager)
 
         // When
-        let viewModel = HubMenuViewModel(siteID: sampleSiteID,
+        let viewModel = HubMenuViewModel(site: sampleSite,
                                          tapToPayBadgePromotionChecker: TapToPayBadgePromotionChecker(),
                                          stores: stores)
         viewModel.setupMenuElements()


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #11187 
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
Currently, we are using the default value `ServiceLocator.stores.sessionManager.defaultSite` for the `siteURL` property in both Blaze section on the dashboard screen and the campaign list view. 

When switching sites, `defaultSiteID` is updated before `defaultSite`, and the dashboard screen is updated before the updated value for `defaultSite` is set, causing the Blaze section to keep the outdated URL of the selected site.

This PR fixes this issue by removing the default value for the site URL, and instead injecting the site URL into the dashboard screen, which will then be used to inject into the Blaze section. This makes sure that the section always has the most up-to-date value for the selected site URL.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
- Turn off the feature flag `blazei3NativeCampaignCreation`.
- Log in to a store eligible for Blaze. 
- Select the Promote button on the Blaze section in the My Store screen. Confirm that the correct product list is displayed for the selected store.
- Switch to a different store that's also eligible for Blaze.
- Select the Promote button again. Confirm that the correct product list is displayed for the selected store.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

https://github.com/woocommerce/woocommerce-ios/assets/5533851/8637727f-b27a-4a34-bc45-6b23f6b0b3b2



---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
