### PR TITLE
Blaze: Fix incorrect site URL sent to dashboard section

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -6,7 +6,7 @@
 - [*] Orders: the placeholder cells shown in the loading state have the animated redacted content again. [https://github.com/woocommerce/woocommerce-ios/pull/11842]
 - [*] Fixed arrow directions for RTL locales. [https://github.com/woocommerce/woocommerce-ios/pull/11833]
 - [*] Update Product Creation AI prompt to avoid unexpected response from AI. [https://github.com/woocommerce/woocommerce-ios/pull/11853]
-
+- [*] Fixed incorrect site URL when creating Blaze campaigns after switching stores. [https://github.com/woocommerce/woocommerce-ios/pull/11872]
 - [*] Orders in split view: when the store has no orders and then an order is created, the order list is now shown instead of the empty view. [https://github.com/woocommerce/woocommerce-ios/pull/11849]
 
 17.1

--- a/WooCommerce/Classes/ViewRelated/Blaze/BlazeCampaignList/BlazeCampaignListView.swift
+++ b/WooCommerce/Classes/ViewRelated/Blaze/BlazeCampaignList/BlazeCampaignListView.swift
@@ -165,6 +165,6 @@ private extension BlazeCampaignListView {
 
 struct BlazeCampaignListView_Previews: PreviewProvider {
     static var previews: some View {
-        BlazeCampaignListView(viewModel: .init(siteID: 123, siteURL: "https://example.com"))
+        BlazeCampaignListView(viewModel: .init(siteID: 123))
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Blaze/BlazeCampaignList/BlazeCampaignListViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Blaze/BlazeCampaignList/BlazeCampaignListViewModel.swift
@@ -22,7 +22,11 @@ final class BlazeCampaignListViewModel: ObservableObject {
     private var didShowIntroView = false
 
     let siteID: Int64
-    let siteURL: String
+
+    var siteURL: String {
+        stores.sessionManager.defaultSite?.url ?? ""
+    }
+
     private let stores: StoresManager
     private let storageManager: StorageManagerType
     private let userDefaults: UserDefaults
@@ -49,13 +53,11 @@ final class BlazeCampaignListViewModel: ObservableObject {
     }()
 
     init(siteID: Int64,
-         siteURL: String = ServiceLocator.stores.sessionManager.defaultSite?.url ?? "",
          stores: StoresManager = ServiceLocator.stores,
          storageManager: StorageManagerType = ServiceLocator.storageManager,
          userDefaults: UserDefaults = .standard,
          analytics: Analytics = ServiceLocator.analytics) {
         self.siteID = siteID
-        self.siteURL = siteURL
         self.stores = stores
         self.storageManager = storageManager
         self.userDefaults = userDefaults

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Blaze/BlazeCampaignDashboardViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Blaze/BlazeCampaignDashboardViewModel.swift
@@ -41,7 +41,11 @@ final class BlazeCampaignDashboardViewModel: ObservableObject {
     var onStateChange: (() -> Void)?
 
     let siteID: Int64
-    let siteURL: String
+
+    var siteURL: String {
+        stores.sessionManager.defaultSite?.url ?? ""
+    }
+
     private let stores: StoresManager
     private let storageManager: StorageManagerType
     private let analytics: Analytics
@@ -79,14 +83,12 @@ final class BlazeCampaignDashboardViewModel: ObservableObject {
     private var subscriptions: Set<AnyCancellable> = []
 
     init(siteID: Int64,
-         siteURL: String = ServiceLocator.stores.sessionManager.defaultSite?.url ?? "",
          stores: StoresManager = ServiceLocator.stores,
          storageManager: StorageManagerType = ServiceLocator.storageManager,
          analytics: Analytics = ServiceLocator.analytics,
          blazeEligibilityChecker: BlazeEligibilityCheckerProtocol = BlazeEligibilityChecker(),
          userDefaults: UserDefaults = .standard) {
         self.siteID = siteID
-        self.siteURL = siteURL
         self.stores = stores
         self.storageManager = storageManager
         self.analytics = analytics

--- a/WooCommerce/WooCommerceTests/ViewRelated/Blaze/BlazeCampaignListViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Blaze/BlazeCampaignListViewModelTests.swift
@@ -341,8 +341,10 @@ final class BlazeCampaignListViewModelTests: XCTestCase {
     func test_didSelectCampaignDetails_updates_selectedCampaignURL_correctly() {
         // Given
         let testURL = "https://example.com"
+        let site = Site.fake().copy(siteID: sampleSiteID, url: testURL)
+        let stores = MockStoresManager(sessionManager: .makeForTesting(authenticated: true, isWPCom: true, defaultSite: site))
         let campaign = BlazeCampaign.fake().copy(siteID: sampleSiteID, campaignID: 123)
-        let viewModel = BlazeCampaignListViewModel(siteID: sampleSiteID, siteURL: testURL)
+        let viewModel = BlazeCampaignListViewModel(siteID: sampleSiteID, stores: stores)
 
         // Confidence check
         XCTAssertNil(viewModel.selectedCampaignURL)

--- a/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Blaze/BlazeCampaignDashboardViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Blaze/BlazeCampaignDashboardViewModelTests.swift
@@ -687,10 +687,11 @@ final class BlazeCampaignDashboardViewModelTests: XCTestCase {
     func test_didSelectCampaignDetails_updates_selectedCampaignURL_correctly() {
         // Given
         let testURL = "https://example.com"
+        let site = Site.fake().copy(siteID: sampleSiteID, url: testURL)
+        let stores = MockStoresManager(sessionManager: .makeForTesting(authenticated: true, isWPCom: true, defaultSite: site))
         let campaign = BlazeCampaign.fake().copy(siteID: sampleSiteID, campaignID: 123)
         let checker = MockBlazeEligibilityChecker(isSiteEligible: true)
         let viewModel = BlazeCampaignDashboardViewModel(siteID: sampleSiteID,
-                                                        siteURL: testURL,
                                                         stores: stores,
                                                         storageManager: storageManager,
                                                         blazeEligibilityChecker: checker)


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #11187 
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
Currently, we are using the default value `ServiceLocator.stores.sessionManager.defaultSite` for the `siteURL` property in both Blaze section on the dashboard screen and the campaign list view. 

When switching sites, `defaultSiteID` is updated before `defaultSite`, and the dashboard screen is updated before the updated value for `defaultSite` is set, causing the Blaze section to keep the outdated URL of the selected site.

This PR fixes this issue by removing the site URL parameter from the initializer of `BlazeCampaignDashboardViewModel` and `BlazeCampaignListViewModel`. Instead, site URL is kept as a computed variable, determined by the default site in session manager to make sure that it's always up-to-date.

<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
- Turn off the feature flag `blazei3NativeCampaignCreation`.
- Log in to a store eligible for Blaze. 
- Select the Promote button on the Blaze section in the My Store screen. Confirm that the correct product list is displayed for the selected store.
- Switch to a different store that's also eligible for Blaze.
- Select the Promote button again. Confirm that the correct product list is displayed for the selected store.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

https://github.com/woocommerce/woocommerce-ios/assets/5533851/8637727f-b27a-4a34-bc45-6b23f6b0b3b2



---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
