### PR TITLE
[Orders] Track horizontal size class for some order events

### DIFF
--- a/WooCommerce/Classes/Analytics/WooAnalyticsEvent.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsEvent.swift
@@ -779,7 +779,8 @@ extension WooAnalyticsEvent {
                                                       hasCustomerDetails: Bool,
                                                       hasFees: Bool,
                                                       hasShippingMethod: Bool,
-                                                      products: [Product]) -> WooAnalyticsEvent {
+                                                      products: [Product],
+                                                      horizontalSizeClass: UIUserInterfaceSizeClass) -> WooAnalyticsEvent {
             WooAnalyticsEvent(statName: .collectPaymentTapped, properties: [
                 Keys.flow: Flow.creation.rawValue,
                 Keys.orderStatus: status.rawValue,
@@ -788,7 +789,8 @@ extension WooAnalyticsEvent {
                 Keys.hasCustomerDetails: hasCustomerDetails,
                 Keys.hasFees: hasFees,
                 Keys.hasShippingMethod: hasShippingMethod,
-                Keys.productTypes: productTypes(order: order, products: products)
+                Keys.productTypes: productTypes(order: order, products: products),
+                Keys.horizontalSizeClass: horizontalSizeClass.nameForAnalytics
             ])
         }
 

--- a/WooCommerce/Classes/Analytics/WooAnalyticsEvent.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsEvent.swift
@@ -558,14 +558,34 @@ extension WooAnalyticsEvent {
             static let usesGiftCard = "use_gift_card"
             static let taxStatus = "tax_status"
             static let expanded = "expanded"
+            static let horizontalSizeClass = "horizontal_size_class"
         }
 
-        static func orderOpen(order: Order) -> WooAnalyticsEvent {
+        static func ordersSelected(horizontalSizeClass: UIUserInterfaceSizeClass) -> WooAnalyticsEvent {
+            return WooAnalyticsEvent(statName: .ordersSelected,
+                                     properties: [
+                                        Keys.horizontalSizeClass: horizontalSizeClass.nameForAnalytics
+                                     ])
+        }
+
+        static func ordersReselected(horizontalSizeClass: UIUserInterfaceSizeClass) -> WooAnalyticsEvent {
+            return WooAnalyticsEvent(statName: .ordersReselected,
+                                     properties: [
+                                        Keys.horizontalSizeClass: horizontalSizeClass.nameForAnalytics
+                                     ])
+        }
+
+        static func orderOpen(order: Order,
+                              horizontalSizeClass: UIUserInterfaceSizeClass) -> WooAnalyticsEvent {
             let customFieldsSize = order.customFields.map { $0.value.utf8.count }.reduce(0, +) // Total byte size of custom field values
-            return WooAnalyticsEvent(statName: .orderOpen, properties: ["id": order.orderID,
-                                                                        "status": order.status.rawValue,
-                                                                        "custom_fields_count": Int64(order.customFields.count),
-                                                                        "custom_fields_size": Int64(customFieldsSize)])
+            return WooAnalyticsEvent(statName: .orderOpen, 
+                                     properties: [
+                                        "id": order.orderID,
+                                        "status": order.status.rawValue,
+                                        "custom_fields_count": Int64(order.customFields.count),
+                                        "custom_fields_size": Int64(customFieldsSize),
+                                        Keys.horizontalSizeClass: horizontalSizeClass.nameForAnalytics
+                                     ])
         }
 
         static func orderAddNew() -> WooAnalyticsEvent {
@@ -738,7 +758,8 @@ extension WooAnalyticsEvent {
                                             hasCustomerDetails: Bool,
                                             hasFees: Bool,
                                             hasShippingMethod: Bool,
-                                            products: [Product]) -> WooAnalyticsEvent {
+                                            products: [Product],
+                                            horizontalSizeClass: UIUserInterfaceSizeClass) -> WooAnalyticsEvent {
             WooAnalyticsEvent(statName: .orderCreateButtonTapped, properties: [
                 Keys.orderStatus: status.rawValue,
                 Keys.productCount: Int64(productCount),
@@ -746,7 +767,8 @@ extension WooAnalyticsEvent {
                 Keys.hasCustomerDetails: hasCustomerDetails,
                 Keys.hasFees: hasFees,
                 Keys.hasShippingMethod: hasShippingMethod,
-                Keys.productTypes: productTypes(order: order, products: products)
+                Keys.productTypes: productTypes(order: order, products: products),
+                Keys.horizontalSizeClass: horizontalSizeClass.nameForAnalytics
             ])
         }
 

--- a/WooCommerce/Classes/Extensions/UIUserInterfaceSizeClass+Helpers.swift
+++ b/WooCommerce/Classes/Extensions/UIUserInterfaceSizeClass+Helpers.swift
@@ -1,0 +1,16 @@
+import UIKit
+
+extension UIUserInterfaceSizeClass {
+    var nameForAnalytics: String {
+        switch self {
+        case .unspecified:
+            return "unspecified"
+        case .compact:
+            return "compact"
+        case .regular:
+            return "regular"
+        @unknown default:
+            return "unknown"
+        }
+    }
+}

--- a/WooCommerce/Classes/ViewRelated/MainTabBarController.swift
+++ b/WooCommerce/Classes/ViewRelated/MainTabBarController.swift
@@ -271,7 +271,8 @@ private extension MainTabBarController {
         case .myStore:
             ServiceLocator.analytics.track(.dashboardSelected)
         case .orders:
-            ServiceLocator.analytics.track(.ordersSelected)
+            ServiceLocator.analytics.track(
+                event: .Orders.ordersSelected(horizontalSizeClass: UITraitCollection.current.horizontalSizeClass))
         case .products:
             ServiceLocator.analytics.track(.productListSelected)
         case .reviews:
@@ -289,7 +290,8 @@ private extension MainTabBarController {
         case .myStore:
             ServiceLocator.analytics.track(.dashboardReselected)
         case .orders:
-            ServiceLocator.analytics.track(.ordersReselected)
+            ServiceLocator.analytics.track(
+                event: .Orders.ordersReselected(horizontalSizeClass: UITraitCollection.current.horizontalSizeClass))
         case .products:
             ServiceLocator.analytics.track(.productListReselected)
         case .reviews:

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/EditableOrderViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/EditableOrderViewModel.swift
@@ -1795,14 +1795,16 @@ private extension EditableOrderViewModel {
     ///
     func trackCreateButtonTapped() {
         let hasCustomerDetails = customerDataViewModel.isDataAvailable
-        analytics.track(event: WooAnalyticsEvent.Orders.orderCreateButtonTapped(order: orderSynchronizer.order,
-                                                                                status: orderSynchronizer.order.status,
-                                                                                productCount: orderSynchronizer.order.items.count,
-                                                                                customAmountsCount: orderSynchronizer.order.fees.count,
-                                                                                hasCustomerDetails: hasCustomerDetails,
-                                                                                hasFees: orderSynchronizer.order.fees.isNotEmpty,
-                                                                                hasShippingMethod: orderSynchronizer.order.shippingLines.isNotEmpty,
-                                                                                products: Array(allProducts)))
+        analytics.track(event: WooAnalyticsEvent.Orders.orderCreateButtonTapped(
+            order: orderSynchronizer.order,
+            status: orderSynchronizer.order.status,
+            productCount: orderSynchronizer.order.items.count,
+            customAmountsCount: orderSynchronizer.order.fees.count,
+            hasCustomerDetails: hasCustomerDetails,
+            hasFees: orderSynchronizer.order.fees.isNotEmpty,
+            hasShippingMethod: orderSynchronizer.order.shippingLines.isNotEmpty,
+            products: Array(allProducts), 
+            horizontalSizeClass: UITraitCollection.current.horizontalSizeClass))
     }
 
     func trackCollectPaymentTapped() {

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/EditableOrderViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/EditableOrderViewModel.swift
@@ -1809,14 +1809,16 @@ private extension EditableOrderViewModel {
 
     func trackCollectPaymentTapped() {
         let hasCustomerDetails = customerDataViewModel.isDataAvailable
-        analytics.track(event: WooAnalyticsEvent.Orders.orderCreationCollectPaymentTapped(order: orderSynchronizer.order,
-                                                                                          status: orderSynchronizer.order.status,
-                                                                                          productCount: orderSynchronizer.order.items.count,
-                                                                                          customAmountsCount: orderSynchronizer.order.fees.count,
-                                                                                          hasCustomerDetails: hasCustomerDetails,
-                                                                                          hasFees: orderSynchronizer.order.fees.isNotEmpty,
-                                                                                          hasShippingMethod: orderSynchronizer.order.shippingLines.isNotEmpty,
-                                                                                          products: Array(allProducts)))
+        analytics.track(event: WooAnalyticsEvent.Orders.orderCreationCollectPaymentTapped(
+            order: orderSynchronizer.order,
+            status: orderSynchronizer.order.status,
+            productCount: orderSynchronizer.order.items.count,
+            customAmountsCount: orderSynchronizer.order.fees.count,
+            hasCustomerDetails: hasCustomerDetails,
+            hasFees: orderSynchronizer.order.fees.isNotEmpty,
+            hasShippingMethod: orderSynchronizer.order.shippingLines.isNotEmpty,
+            products: Array(allProducts),
+            horizontalSizeClass: UITraitCollection.current.horizontalSizeClass))
     }
 
     /// Tracks an order creation success

--- a/WooCommerce/Classes/ViewRelated/Orders/OrderListViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrderListViewController.swift
@@ -767,7 +767,7 @@ extension OrderListViewController: UITableViewDelegate {
 
         selectedIndexPath = indexPath
         let order = orderDetailsViewModel.order
-        ServiceLocator.analytics.track(event: WooAnalyticsEvent.Orders.orderOpen(order: order))
+        ServiceLocator.analytics.track(event: WooAnalyticsEvent.Orders.orderOpen(order: order, horizontalSizeClass: UITraitCollection.current.horizontalSizeClass))
         selectedOrderID = order.orderID
         let allViewModels = allViewModels()
         let currentIndex = allViewModels.firstIndex(where: { $0.order.orderID == order.orderID })

--- a/WooCommerce/Classes/ViewRelated/Orders/OrdersRootViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrdersRootViewController.swift
@@ -512,7 +512,10 @@ private extension OrdersRootViewController {
     /// Pushes an `OrderDetailsViewController` onto the navigation stack.
     ///
     private func navigateToOrderDetail(_ order: Order, onCompletion: ((Bool) -> Void)? = nil) {
-        analytics.track(event: WooAnalyticsEvent.Orders.orderOpen(order: order))
+        analytics.track(event: WooAnalyticsEvent.Orders.orderOpen(
+            order: order,
+            horizontalSizeClass: UITraitCollection.current.horizontalSizeClass
+        ))
         let viewModel = OrderDetailsViewModel(order: order)
         guard !featureFlagService.isFeatureFlagEnabled(.splitViewInOrdersTab) else {
             ordersViewController.showOrderDetails(order)

--- a/WooCommerce/Classes/ViewRelated/Search/Order/OrderSearchUICommand.swift
+++ b/WooCommerce/Classes/ViewRelated/Search/Order/OrderSearchUICommand.swift
@@ -80,7 +80,9 @@ final class OrderSearchUICommand: SearchUICommand {
         let detailsViewController = OrderDetailsViewController(viewModel: viewModel)
 
         viewController.navigationController?.pushViewController(detailsViewController, animated: true)
-        ServiceLocator.analytics.track(event: WooAnalyticsEvent.Orders.orderOpen(order: model))
+        ServiceLocator.analytics.track(event: WooAnalyticsEvent.Orders.orderOpen(
+            order: model,
+            horizontalSizeClass: UITraitCollection.current.horizontalSizeClass))
     }
 
     /// Removes the `#` from the start of the search keyword, if present.

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -727,6 +727,7 @@
 		2024966A2B0CC97100EE527D /* MockWooPaymentsDepositService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 202496692B0CC97100EE527D /* MockWooPaymentsDepositService.swift */; };
 		202D2A5A2AC5933100E4ABC0 /* TopTabView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 202D2A592AC5933100E4ABC0 /* TopTabView.swift */; };
 		203A5C312AC5ADD700BF29A1 /* WooPaymentsDepositsOverviewView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 203A5C302AC5ADD700BF29A1 /* WooPaymentsDepositsOverviewView.swift */; };
+		204C9C742B6BDFFB007A94E0 /* UIUserInterfaceSizeClass+Helpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 204C9C732B6BDFFB007A94E0 /* UIUserInterfaceSizeClass+Helpers.swift */; };
 		209AD3D02AC1EDDA00825D76 /* WooPaymentsDepositsCurrencyOverviewViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 209AD3CF2AC1EDDA00825D76 /* WooPaymentsDepositsCurrencyOverviewViewModel.swift */; };
 		209AD3D22AC1EDF600825D76 /* WooPaymentsDepositsCurrencyOverviewView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 209AD3D12AC1EDF600825D76 /* WooPaymentsDepositsCurrencyOverviewView.swift */; };
 		209B15672AD85F070094152A /* OperatingSystemVersion+Localization.swift in Sources */ = {isa = PBXBuildFile; fileRef = 209B15662AD85F070094152A /* OperatingSystemVersion+Localization.swift */; };
@@ -3408,6 +3409,7 @@
 		202496692B0CC97100EE527D /* MockWooPaymentsDepositService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockWooPaymentsDepositService.swift; sourceTree = "<group>"; };
 		202D2A592AC5933100E4ABC0 /* TopTabView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TopTabView.swift; sourceTree = "<group>"; };
 		203A5C302AC5ADD700BF29A1 /* WooPaymentsDepositsOverviewView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WooPaymentsDepositsOverviewView.swift; sourceTree = "<group>"; };
+		204C9C732B6BDFFB007A94E0 /* UIUserInterfaceSizeClass+Helpers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIUserInterfaceSizeClass+Helpers.swift"; sourceTree = "<group>"; };
 		209AD3CF2AC1EDDA00825D76 /* WooPaymentsDepositsCurrencyOverviewViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WooPaymentsDepositsCurrencyOverviewViewModel.swift; sourceTree = "<group>"; };
 		209AD3D12AC1EDF600825D76 /* WooPaymentsDepositsCurrencyOverviewView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WooPaymentsDepositsCurrencyOverviewView.swift; sourceTree = "<group>"; };
 		209B15662AD85F070094152A /* OperatingSystemVersion+Localization.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "OperatingSystemVersion+Localization.swift"; sourceTree = "<group>"; };
@@ -10367,6 +10369,7 @@
 				0258B4D92B159A0F008FEA07 /* Publisher+WithPrevious.swift */,
 				B98C6D4F2B149C3900A243E1 /* UINavigationItem+Configuration.swift */,
 				02FCA5532B54FC8C0097BFB8 /* CardPresentPaymentOnboardingState+Analytics.swift */,
+				204C9C732B6BDFFB007A94E0 /* UIUserInterfaceSizeClass+Helpers.swift */,
 			);
 			path = Extensions;
 			sourceTree = "<group>";
@@ -13442,6 +13445,7 @@
 				B5A56BF0219F2CE90065A902 /* VerticalButton.swift in Sources */,
 				D831E2DC230E0558000037D0 /* Authentication.swift in Sources */,
 				26DB7E3528636D2200506173 /* NonEditableOrderBanner.swift in Sources */,
+				204C9C742B6BDFFB007A94E0 /* UIUserInterfaceSizeClass+Helpers.swift in Sources */,
 				028A4657295B2CF4001CF6CE /* StoreCreationSellingPlatformsQuestionView.swift in Sources */,
 				314DC4BF268D183600444C9E /* CardReaderSettingsKnownReaderStorage.swift in Sources */,
 				2662D90826E15D6E00E25611 /* AreaSelectorCommand.swift in Sources */,


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

We have recently made changes to the Orders tab to benefit iPad users. In 17.1, we add a UISplitViewController for the root of the Orders tab. To analyse the impact of these changes, it would be useful to know when the split view is in use.

We can do that by tracking the horizontal size class – this will be either `compact` (no split) or `regular` (split view shown)

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

1. Launch the app
2. Tap the Orders tab
3. Observe that the `main_tab_orders_selected` event is tracked with a `horizontal_size_class` property, matching your current size class.
4. Repeat for the `main_tab_orders_reselected` event (tap the `Orders` tab again)

Also check `order_open` (select an order), `order_create_button_tapped` (create an order), and `payments_flow_order_collect_payment_tapped` (create an order by tapping `Collect Payment`).

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->
![CleanShot 2024-02-01 at 16 12 04@2x](https://github.com/woocommerce/woocommerce-ios/assets/2472348/7c46ff2b-fa70-42eb-acc1-f7ad330ea827)
![CleanShot 2024-02-01 at 16 11 57@2x](https://github.com/woocommerce/woocommerce-ios/assets/2472348/c3655575-0e9a-4a9e-840e-c4812799302b)
![CleanShot 2024-02-01 at 16 11 36@2x](https://github.com/woocommerce/woocommerce-ios/assets/2472348/6dee4778-8b15-408d-afff-7d47a492b869)
![CleanShot 2024-02-01 at 16 22 01@2x](https://github.com/woocommerce/woocommerce-ios/assets/2472348/030c540c-4343-43a2-b57e-bc7892bdb1c9)



---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
