### PR TITLE
[Tablet products] Enable large title in products tab in split view

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Products/ProductsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductsViewController.swift
@@ -582,6 +582,7 @@ private extension ProductsViewController {
 
         configureNavigationBarLeftButtonItems()
         configureNavigationBarRightButtonItems()
+        navigationController?.navigationBar.prefersLargeTitles = true
     }
 
     func configureNavigationBarLeftButtonItems() {


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #11869 
<!-- Id number of the GitHub issue this PR addresses. -->

## Why

When split view is disabled (production), `ProductsViewController` is the root view controller of `WooTabNavigationController` which has [large title enabled by default](https://github.com/woocommerce/woocommerce-ios/blob/7d4331bda3e3d13ad309463ca51a7b82f95e7981/WooCommerce/Classes/System/WooTabNavigationController.swift#L10). However, when split view is enabled (under the feature flag), the tab container isn't a `WooTabNavigationController` anymore and the large title is back to the default (disabled).

## How

To always enable large title despite the navigation controller configuration, `navigationBar.prefersLargeTitles = true` is called in `ProductsViewController.viewDidLoad`.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

- In code, enable `splitViewInProductsTab` feature flag in `DefaultFeatureFlagService`
- Launch the app
- Log in if needed
- Go to the products tab --> the product list should have a large title in the navigation bar

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

before | after | after - scrolling down
-- | -- | --
<img src="https://github.com/woocommerce/woocommerce-ios/assets/1945542/349dddcd-1149-4711-8b9d-2c142797b2ef" width="500" /> | <img src="https://github.com/woocommerce/woocommerce-ios/assets/1945542/788d71ba-6254-477a-be6a-e9899e14a9fd" width="500" /> | <img src="https://github.com/woocommerce/woocommerce-ios/assets/1945542/dfc7e671-9f47-4d73-a245-e4a09a157469" width="500" />

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
