### PR TITLE
Fix crash when underlining special Glyph in Aztec

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -24,8 +24,8 @@ workspace 'WooCommerce.xcworkspace'
 ##
 def aztec
   # pod 'WordPress-Editor-iOS', '~> 1.19.9'
-  pod 'WordPress-Editor-iOS', git: 'https://github.com/wordpress-mobile/AztecEditor-iOS.git', commit: '4049aa539ff4d0f3ef304a16d002ad3470c03720'
-  pod 'WordPress-Aztec-iOS', git: 'https://github.com/wordpress-mobile/AztecEditor-iOS.git', commit: '4049aa539ff4d0f3ef304a16d002ad3470c03720'
+  pod 'WordPress-Editor-iOS', git: 'https://github.com/wordpress-mobile/AztecEditor-iOS.git', commit: '950c7bc1bf98326986f10cccb2715ad86976f0fd'
+  pod 'WordPress-Aztec-iOS', git: 'https://github.com/wordpress-mobile/AztecEditor-iOS.git', commit: '950c7bc1bf98326986f10cccb2715ad86976f0fd'
 end
 
 def tracks

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -70,8 +70,8 @@ DEPENDENCIES:
   - Kingfisher (~> 7.6.2)
   - Sourcery (~> 1.0.3)
   - StripeTerminal (~> 3.1.0)
-  - WordPress-Aztec-iOS (from `https://github.com/wordpress-mobile/AztecEditor-iOS.git`, commit `4049aa539ff4d0f3ef304a16d002ad3470c03720`)
-  - WordPress-Editor-iOS (from `https://github.com/wordpress-mobile/AztecEditor-iOS.git`, commit `4049aa539ff4d0f3ef304a16d002ad3470c03720`)
+  - WordPress-Aztec-iOS (from `https://github.com/wordpress-mobile/AztecEditor-iOS.git`, commit `950c7bc1bf98326986f10cccb2715ad86976f0fd`)
+  - WordPress-Editor-iOS (from `https://github.com/wordpress-mobile/AztecEditor-iOS.git`, commit `950c7bc1bf98326986f10cccb2715ad86976f0fd`)
   - WordPressAuthenticator (from `https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git`, commit `6312d0a91e709a4bae017e04f70e520199928928`)
   - WordPressShared (~> 2.1)
   - WordPressUI (from `https://github.com/wordpress-mobile/WordPressUI-iOS.git`, commit `a0248ba6dabaed1d493416fd1273aa6718c76331`)
@@ -111,10 +111,10 @@ SPEC REPOS:
 
 EXTERNAL SOURCES:
   WordPress-Aztec-iOS:
-    :commit: 4049aa539ff4d0f3ef304a16d002ad3470c03720
+    :commit: 950c7bc1bf98326986f10cccb2715ad86976f0fd
     :git: https://github.com/wordpress-mobile/AztecEditor-iOS.git
   WordPress-Editor-iOS:
-    :commit: 4049aa539ff4d0f3ef304a16d002ad3470c03720
+    :commit: 950c7bc1bf98326986f10cccb2715ad86976f0fd
     :git: https://github.com/wordpress-mobile/AztecEditor-iOS.git
   WordPressAuthenticator:
     :commit: 6312d0a91e709a4bae017e04f70e520199928928
@@ -128,10 +128,10 @@ EXTERNAL SOURCES:
 
 CHECKOUT OPTIONS:
   WordPress-Aztec-iOS:
-    :commit: 4049aa539ff4d0f3ef304a16d002ad3470c03720
+    :commit: 950c7bc1bf98326986f10cccb2715ad86976f0fd
     :git: https://github.com/wordpress-mobile/AztecEditor-iOS.git
   WordPress-Editor-iOS:
-    :commit: 4049aa539ff4d0f3ef304a16d002ad3470c03720
+    :commit: 950c7bc1bf98326986f10cccb2715ad86976f0fd
     :git: https://github.com/wordpress-mobile/AztecEditor-iOS.git
   WordPressAuthenticator:
     :commit: 6312d0a91e709a4bae017e04f70e520199928928
@@ -176,6 +176,6 @@ SPEC CHECKSUMS:
   ZendeskSupportProvidersSDK: 685b5d185af47ced0ec40564ec46355c838bbd06
   ZendeskSupportSDK: 92e6f9d334e81e9186f8a17583862350460a5393
 
-PODFILE CHECKSUM: f077dcc460d553950b5bf8664a2f02e4a5577eac
+PODFILE CHECKSUM: c50079091c181e58300147498f7da908f851f899
 
 COCOAPODS: 1.14.0


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #11866 
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This PR updates Aztec library to include the [crash fix](https://github.com/wordpress-mobile/AztecEditor-iOS/pull/1384) when underlining text with special glyphs.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
- In wp-admin, open an existing product or create a new one.
- In the product description field, switch the classic editor to the text mode and enter some link with special glyphs like this and save the product.

```html
<a href="https://example.com/">&nbsp;قسم شنط &nbsp;الكايلي &nbsp;</a>

<a href="https://www.wordpress.com/"><img class="alignnone wp-image-65" title="شنطة كايلي" src="https://www.wordpress.com/" alt="لوقو انستجرام" width="40" height="40" data-image-description="&lt;/p&gt; &lt;p&gt;لوقو انستجرام&lt;/p&gt; &lt;p&gt;" /></a>

```
- Open the app and select the updated product.
- Select product description and confirm that the app doesn't crash. The text link should be underlined correctly.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->
<img src="https://github.com/woocommerce/woocommerce-ios/assets/5533851/95833c1f-97bc-4146-b0d3-e2d6d6f8b3f8" width=320 />


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
