### PR TITLE
[Analytics Hub] Add logic to create analytics web report URLs

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/AnalyticsHubWebReport.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/AnalyticsHubWebReport.swift
@@ -1,0 +1,87 @@
+import Foundation
+
+/// Represents analytics reports the app can link to on the store's web admin
+struct AnalyticsHubWebReport {
+
+    /// Supported types of analytics reports
+    enum ReportType {
+        case revenue
+        case orders
+        case products
+    }
+
+    /// Provides the URL for a web analytics report
+    /// - Parameters:
+    ///   - report: Type of analytics report
+    ///   - period: Time range for the report
+    ///   - storeAdminURL: The store's wp-admin URL
+    ///
+    static func getUrl(for report: ReportType,
+                       timeRange: AnalyticsHubTimeRangeSelection.SelectionType?,
+                       storeAdminURL: String? = ServiceLocator.stores.sessionManager.defaultSite?.adminURL) -> URL? {
+        guard let storeAdminURL else {
+            return nil
+        }
+
+        let path = getPath(for: report)
+        let defaultReportString = storeAdminURL + "admin.php?page=wc-admin&path=\(path)"
+
+        // Build the web report URL based on the time range
+        // Note: the `compare` parameter only applies if the period is also specified
+        let period = getPeriod(for: timeRange)
+        switch (timeRange, period) {
+        case let (.custom(startDate, endDate), .some(period)):
+            let after = DateFormatter.Defaults.yearMonthDayDateFormatter.string(from: startDate)
+            let before = DateFormatter.Defaults.yearMonthDayDateFormatter.string(from: endDate)
+            return URL(string: defaultReportString + "&period=\(period)&after=\(after)&before=\(before)&compare=previous_period")
+        case let (_, .some(period)):
+            return URL(string: defaultReportString + "&period=\(period)&compare=previous_period")
+        default:
+            return URL(string: defaultReportString)
+        }
+    }
+
+    /// Gets the path parameter for the web report, based on the provided report type
+    ///
+    private static func getPath(for reportType: ReportType) -> String {
+        switch reportType {
+        case .revenue:
+            return "%2Fanalytics%2Frevenue"
+        case .orders:
+            return "%2Fanalytics%2Forders"
+        case .products:
+            return "%2Fanalytics%2Fproducts"
+        }
+    }
+
+    /// Gets the period parameter for the web report, based on the provided time range
+    ///
+    private static func getPeriod(for timeRange: AnalyticsHubTimeRangeSelection.SelectionType?) -> String? {
+        switch timeRange {
+        case .custom:
+            return "custom"
+        case .today:
+            return "today"
+        case .yesterday:
+            return "yesterday"
+        case .lastWeek:
+            return "last_week"
+        case .lastMonth:
+            return "last_month"
+        case .lastQuarter:
+            return "last_quarter"
+        case .lastYear:
+            return "last_year"
+        case .weekToDate:
+            return "week"
+        case .monthToDate:
+            return "month"
+        case .quarterToDate:
+            return "quarter"
+        case .yearToDate:
+            return "year"
+        default:
+            return nil
+        }
+    }
+}

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/AnalyticsHubWebReport.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/AnalyticsHubWebReport.swift
@@ -18,7 +18,8 @@ struct AnalyticsHubWebReport {
     ///
     static func getUrl(for report: ReportType,
                        timeRange: AnalyticsHubTimeRangeSelection.SelectionType?,
-                       storeAdminURL: String? = ServiceLocator.stores.sessionManager.defaultSite?.adminURL) -> URL? {
+                       storeAdminURL: String? = ServiceLocator.stores.sessionManager.defaultSite?.adminURL,
+                       timeZone: TimeZone = .siteTimezone) -> URL? {
         guard let storeAdminURL else {
             return nil
         }
@@ -31,8 +32,10 @@ struct AnalyticsHubWebReport {
         let period = getPeriod(for: timeRange)
         switch (timeRange, period) {
         case let (.custom(startDate, endDate), .some(period)):
-            let after = DateFormatter.Defaults.yearMonthDayDateFormatter.string(from: startDate)
-            let before = DateFormatter.Defaults.yearMonthDayDateFormatter.string(from: endDate)
+            let dateFormatter = DateFormatter.Defaults.yearMonthDayDateFormatter
+            dateFormatter.timeZone = timeZone
+            let after = dateFormatter.string(from: startDate)
+            let before = dateFormatter.string(from: endDate)
             return URL(string: defaultReportString + "&period=\(period)&after=\(after)&before=\(before)&compare=previous_period")
         case let (_, .some(period)):
             return URL(string: defaultReportString + "&period=\(period)&compare=previous_period")

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -2037,6 +2037,7 @@
 		CE8CCD44239AC06E009DBD22 /* RefundDetailsViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = CE8CCD42239AC06E009DBD22 /* RefundDetailsViewController.xib */; };
 		CE91BEA029FBE9E100B6E1AF /* QuantityRulesViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE91BE9F29FBE9E100B6E1AF /* QuantityRulesViewModelTests.swift */; };
 		CEA16F3A20FD0C8C0061B4E1 /* WooAnalytics.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEA16F3920FD0C8C0061B4E1 /* WooAnalytics.swift */; };
+		CEA9C8E02B6D323A000FE114 /* AnalyticsHubWebReportTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEA9C8DF2B6D323A000FE114 /* AnalyticsHubWebReportTests.swift */; };
 		CEC8188C2A3B7C8B00459843 /* AppStartupWaitingTimeTracker.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEC8188B2A3B7C8B00459843 /* AppStartupWaitingTimeTracker.swift */; };
 		CEC8188E2A3C75DD00459843 /* AppStartupWaitingTimeTrackerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEC8188D2A3C75DD00459843 /* AppStartupWaitingTimeTrackerTests.swift */; };
 		CECC758623D21AC200486676 /* AggregateOrderItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = CECC758523D21AC200486676 /* AggregateOrderItem.swift */; };
@@ -2045,6 +2046,7 @@
 		CECC759723D607C900486676 /* OrderItemRefund+Woo.swift in Sources */ = {isa = PBXBuildFile; fileRef = CECC759623D607C900486676 /* OrderItemRefund+Woo.swift */; };
 		CECC759923D6160000486676 /* AggregateDataHelperTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CECC759823D6160000486676 /* AggregateDataHelperTests.swift */; };
 		CECC759C23D61C1400486676 /* AggregateDataHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = CECC759B23D61C1400486676 /* AggregateDataHelper.swift */; };
+		CEDBDA472B6BEF2E002047D4 /* AnalyticsHubWebReport.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEDBDA462B6BEF2E002047D4 /* AnalyticsHubWebReport.swift */; };
 		CEE006052077D1280079161F /* SummaryTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEE006032077D1280079161F /* SummaryTableViewCell.swift */; };
 		CEE006062077D1280079161F /* SummaryTableViewCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = CEE006042077D1280079161F /* SummaryTableViewCell.xib */; };
 		CEE006082077D14C0079161F /* OrderDetailsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEE006072077D14C0079161F /* OrderDetailsViewController.swift */; };
@@ -4732,6 +4734,7 @@
 		CE8CCD42239AC06E009DBD22 /* RefundDetailsViewController.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = RefundDetailsViewController.xib; sourceTree = "<group>"; };
 		CE91BE9F29FBE9E100B6E1AF /* QuantityRulesViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QuantityRulesViewModelTests.swift; sourceTree = "<group>"; };
 		CEA16F3920FD0C8C0061B4E1 /* WooAnalytics.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WooAnalytics.swift; sourceTree = "<group>"; };
+		CEA9C8DF2B6D323A000FE114 /* AnalyticsHubWebReportTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnalyticsHubWebReportTests.swift; sourceTree = "<group>"; };
 		CEC8188B2A3B7C8B00459843 /* AppStartupWaitingTimeTracker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppStartupWaitingTimeTracker.swift; sourceTree = "<group>"; };
 		CEC8188D2A3C75DD00459843 /* AppStartupWaitingTimeTrackerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppStartupWaitingTimeTrackerTests.swift; sourceTree = "<group>"; };
 		CECA64B020D9990E005A44C4 /* WooCommerce-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "WooCommerce-Bridging-Header.h"; sourceTree = "<group>"; };
@@ -4741,6 +4744,7 @@
 		CECC759623D607C900486676 /* OrderItemRefund+Woo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "OrderItemRefund+Woo.swift"; sourceTree = "<group>"; };
 		CECC759823D6160000486676 /* AggregateDataHelperTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AggregateDataHelperTests.swift; sourceTree = "<group>"; };
 		CECC759B23D61C1400486676 /* AggregateDataHelper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AggregateDataHelper.swift; sourceTree = "<group>"; };
+		CEDBDA462B6BEF2E002047D4 /* AnalyticsHubWebReport.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnalyticsHubWebReport.swift; sourceTree = "<group>"; };
 		CEE006032077D1280079161F /* SummaryTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SummaryTableViewCell.swift; sourceTree = "<group>"; };
 		CEE006042077D1280079161F /* SummaryTableViewCell.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = SummaryTableViewCell.xib; sourceTree = "<group>"; };
 		CEE006072077D14C0079161F /* OrderDetailsViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OrderDetailsViewController.swift; sourceTree = "<group>"; };
@@ -7137,6 +7141,7 @@
 				CEF2DD852B558E3E00A3DD0B /* AnalyticsCTACard.swift */,
 				CC41E70B29310C1F008B3FB9 /* AnalyticsLineChart.swift */,
 				CCA1D5FD293F537400B40560 /* DeltaPercentage.swift */,
+				CEDBDA462B6BEF2E002047D4 /* AnalyticsHubWebReport.swift */,
 			);
 			path = "Analytics Hub";
 			sourceTree = "<group>";
@@ -9518,6 +9523,7 @@
 			children = (
 				AE4CCCEA29365CFD00B47EE8 /* AnalyticsHubViewModelTests.swift */,
 				B6440FB8292E74230012D506 /* AnalyticsHubTimeRangeSelectionTests.swift */,
+				CEA9C8DF2B6D323A000FE114 /* AnalyticsHubWebReportTests.swift */,
 			);
 			path = "Analytics Hub";
 			sourceTree = "<group>";
@@ -13862,6 +13868,7 @@
 				B946881229B8DD41000646B0 /* DashboardViewController+Activity.swift in Sources */,
 				579CDEFF274D7E7900E8903D /* StoreStatsUsageTracksEventEmitter.swift in Sources */,
 				74F9E9CE214C036400A3F2D2 /* NoPeriodDataTableViewCell.swift in Sources */,
+				CEDBDA472B6BEF2E002047D4 /* AnalyticsHubWebReport.swift in Sources */,
 				314DC4BD268D158F00444C9E /* CardReaderSettingsKnownReadersProvider.swift in Sources */,
 				264957A329C520860095AA4C /* SubscriptionsView.swift in Sources */,
 				02DE39D92968647100BB31D4 /* DomainSettingsViewModel.swift in Sources */,
@@ -14890,6 +14897,7 @@
 				DEF36DEC2898D64600178AC2 /* JetpackSetupWebViewModelTests.swift in Sources */,
 				023EC2E424DA95DB0021DA91 /* ProductInventorySettingsViewModel+VariationTests.swift in Sources */,
 				CCB366AF274518EC007D437A /* EditableOrderViewModelTests.swift in Sources */,
+				CEA9C8E02B6D323A000FE114 /* AnalyticsHubWebReportTests.swift in Sources */,
 				020BE76B23B4A380007FE54C /* AztecUnderlineFormatBarCommandTests.swift in Sources */,
 				2631D4FA29ED108400F13F20 /* WPComPlanNameSanitizer.swift in Sources */,
 				D83F5937225B402E00626E75 /* TitleAndEditableValueTableViewCellTests.swift in Sources */,

--- a/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Analytics Hub/AnalyticsHubWebReportTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Analytics Hub/AnalyticsHubWebReportTests.swift
@@ -6,40 +6,60 @@ final class AnalyticsHubWebReportTests: XCTestCase {
 
     let exampleAdminURL = "https://example.com/wp-admin/"
 
-    func test_getURL_returns_expected_absolute_URL_string() {
+    func test_getURL_returns_expected_report_URL() throws {
+        // Given
+        let reportURL = try XCTUnwrap(AnalyticsHubWebReport.getUrl(for: .revenue, timeRange: .today, storeAdminURL: exampleAdminURL))
+
+        // Then
+        let expectedURL = try XCTUnwrap(URL(string: exampleAdminURL +
+                                            "admin.php?page=wc-admin&path=%2Fanalytics%2Frevenue&period=today&compare=previous_period"))
+
+        let expectedComponents = URLComponents(url: expectedURL, resolvingAgainstBaseURL: false)
+        let reportComponents = URLComponents(url: reportURL, resolvingAgainstBaseURL: false)
+
+        let expectedQueryItems = Set(try XCTUnwrap(expectedComponents?.queryItems))
+        let reportQueryItems = Set(try XCTUnwrap(reportComponents?.queryItems))
+
+        assertEqual(expectedComponents?.scheme, reportComponents?.scheme)
+        assertEqual(expectedComponents?.host, reportComponents?.host)
+        assertEqual(expectedComponents?.path, reportComponents?.path)
+        assertEqual(expectedQueryItems, reportQueryItems)
+    }
+
+    func test_getUrl_returns_URL_containing_expected_revenue_report_path() throws {
         // Given
         let reportURL = AnalyticsHubWebReport.getUrl(for: .revenue, timeRange: .today, storeAdminURL: exampleAdminURL)
 
-        // Then
-        let expectedURL = exampleAdminURL + "admin.php?page=wc-admin&path=%2Fanalytics%2Frevenue&period=today&compare=previous_period"
-        assertEqual(expectedURL, try XCTUnwrap(reportURL).absoluteString)
-    }
-
-    func test_getUrl_returns_URL_containing_expected_revenue_report_path() {
-        // Given
-        let reportURL = AnalyticsHubWebReport.getUrl(for: .revenue, timeRange: .today, storeAdminURL: exampleAdminURL)
+        // When
+        let reportQueryItems = URLComponents(url: try XCTUnwrap(reportURL), resolvingAgainstBaseURL: false)?.queryItems
 
         // Then
-        let expectedURLString = "&path=%2Fanalytics%2Frevenue"
-        XCTAssertTrue(try XCTUnwrap(reportURL).absoluteString.contains(expectedURLString))
+        let expectedQueryItem = URLQueryItem(name: "path", value: "/analytics/revenue")
+        XCTAssertTrue(try XCTUnwrap(reportQueryItems).contains(expectedQueryItem))
     }
 
-    func test_getUrl_returns_URL_containing_expected_orders_report_path() {
+    func test_getUrl_returns_URL_containing_expected_orders_report_path() throws {
         // Given
         let reportURL = AnalyticsHubWebReport.getUrl(for: .orders, timeRange: .today, storeAdminURL: exampleAdminURL)
 
+        // When
+        let reportQueryItems = URLComponents(url: try XCTUnwrap(reportURL), resolvingAgainstBaseURL: false)?.queryItems
+
         // Then
-        let expectedURLString = "&path=%2Fanalytics%2Forders"
-        XCTAssertTrue(try XCTUnwrap(reportURL).absoluteString.contains(expectedURLString))
+        let expectedQueryItem = URLQueryItem(name: "path", value: "/analytics/orders")
+        XCTAssertTrue(try XCTUnwrap(reportQueryItems).contains(expectedQueryItem))
     }
 
-    func test_getUrl_returns_URL_containing_expected_products_report_path() {
+    func test_getUrl_returns_URL_containing_expected_products_report_path() throws {
         // Given
         let reportURL = AnalyticsHubWebReport.getUrl(for: .products, timeRange: .today, storeAdminURL: exampleAdminURL)
 
+        // When
+        let reportQueryItems = URLComponents(url: try XCTUnwrap(reportURL), resolvingAgainstBaseURL: false)?.queryItems
+
         // Then
-        let expectedURLString = "&path=%2Fanalytics%2Fproducts"
-        XCTAssertTrue(try XCTUnwrap(reportURL).absoluteString.contains(expectedURLString))
+        let expectedQueryItem = URLQueryItem(name: "path", value: "/analytics/products")
+        XCTAssertTrue(try XCTUnwrap(reportQueryItems).contains(expectedQueryItem))
     }
 
     func test_getUrl_returns_URL_containing_expected_query_parameters_for_custom_time_range() throws {
@@ -53,11 +73,18 @@ final class AnalyticsHubWebReportTests: XCTestCase {
         let reportURL = AnalyticsHubWebReport.getUrl(for: .revenue, timeRange: timeRange, storeAdminURL: exampleAdminURL, timeZone: timeZone)
 
         // Then
-        let expectedURLString = "&period=custom&after=2024-01-01&before=2024-01-07&compare=previous_period"
-        XCTAssertTrue(try XCTUnwrap(reportURL).absoluteString.contains(expectedURLString))
+        let reportQueryItems = URLComponents(url: try XCTUnwrap(reportURL), resolvingAgainstBaseURL: false)?.queryItems
+        let expectedQueryItems = [
+            URLQueryItem(name: "period", value: "custom"),
+            URLQueryItem(name: "after", value: "2024-01-01"),
+            URLQueryItem(name: "compare", value: "previous_period")
+        ]
+        for expectedQueryItem in expectedQueryItems {
+            XCTAssertTrue(try XCTUnwrap(reportQueryItems).contains(expectedQueryItem))
+        }
     }
 
-    func test_getUrl_returns_URL_containing_expected_query_parameters_for_today_time_range() {
+    func test_getUrl_returns_URL_containing_expected_period_for_today_time_range() throws {
         // Given
         let timeRange: AnalyticsHubTimeRangeSelection.SelectionType = .today
 
@@ -65,11 +92,12 @@ final class AnalyticsHubWebReportTests: XCTestCase {
         let reportURL = AnalyticsHubWebReport.getUrl(for: .revenue, timeRange: timeRange, storeAdminURL: exampleAdminURL)
 
         // Then
-        let expectedURLString = "&period=today&compare=previous_period"
-        XCTAssertTrue(try XCTUnwrap(reportURL).absoluteString.contains(expectedURLString))
+        let reportQueryItems = URLComponents(url: try XCTUnwrap(reportURL), resolvingAgainstBaseURL: false)?.queryItems
+        let expectedQueryItem = URLQueryItem(name: "period", value: "today")
+        XCTAssertTrue(try XCTUnwrap(reportQueryItems).contains(expectedQueryItem))
     }
 
-    func test_getUrl_returns_URL_containing_expected_query_parameters_for_yesterday_time_range() {
+    func test_getUrl_returns_URL_containing_expected_period_for_yesterday_time_range() throws {
         // Given
         let timeRange: AnalyticsHubTimeRangeSelection.SelectionType = .yesterday
 
@@ -77,11 +105,12 @@ final class AnalyticsHubWebReportTests: XCTestCase {
         let reportURL = AnalyticsHubWebReport.getUrl(for: .revenue, timeRange: timeRange, storeAdminURL: exampleAdminURL)
 
         // Then
-        let expectedURLString = "&period=yesterday&compare=previous_period"
-        XCTAssertTrue(try XCTUnwrap(reportURL).absoluteString.contains(expectedURLString))
+        let reportQueryItems = URLComponents(url: try XCTUnwrap(reportURL), resolvingAgainstBaseURL: false)?.queryItems
+        let expectedQueryItem = URLQueryItem(name: "period", value: "yesterday")
+        XCTAssertTrue(try XCTUnwrap(reportQueryItems).contains(expectedQueryItem))
     }
 
-    func test_getUrl_returns_URL_containing_expected_query_parameters_for_last_week_time_range() {
+    func test_getUrl_returns_URL_containing_expected_period_for_last_week_time_range() throws {
         // Given
         let timeRange: AnalyticsHubTimeRangeSelection.SelectionType = .lastWeek
 
@@ -89,11 +118,12 @@ final class AnalyticsHubWebReportTests: XCTestCase {
         let reportURL = AnalyticsHubWebReport.getUrl(for: .revenue, timeRange: timeRange, storeAdminURL: exampleAdminURL)
 
         // Then
-        let expectedURLString = "&period=last_week&compare=previous_period"
-        XCTAssertTrue(try XCTUnwrap(reportURL).absoluteString.contains(expectedURLString))
+        let reportQueryItems = URLComponents(url: try XCTUnwrap(reportURL), resolvingAgainstBaseURL: false)?.queryItems
+        let expectedQueryItem = URLQueryItem(name: "period", value: "last_week")
+        XCTAssertTrue(try XCTUnwrap(reportQueryItems).contains(expectedQueryItem))
     }
 
-    func test_getUrl_returns_URL_containing_expected_query_parameters_for_last_month_time_range() {
+    func test_getUrl_returns_URL_containing_expected_period_for_last_month_time_range() throws {
         // Given
         let timeRange: AnalyticsHubTimeRangeSelection.SelectionType = .lastMonth
 
@@ -101,11 +131,12 @@ final class AnalyticsHubWebReportTests: XCTestCase {
         let reportURL = AnalyticsHubWebReport.getUrl(for: .revenue, timeRange: timeRange, storeAdminURL: exampleAdminURL)
 
         // Then
-        let expectedURLString = "&period=last_month&compare=previous_period"
-        XCTAssertTrue(try XCTUnwrap(reportURL).absoluteString.contains(expectedURLString))
+        let reportQueryItems = URLComponents(url: try XCTUnwrap(reportURL), resolvingAgainstBaseURL: false)?.queryItems
+        let expectedQueryItem = URLQueryItem(name: "period", value: "last_month")
+        XCTAssertTrue(try XCTUnwrap(reportQueryItems).contains(expectedQueryItem))
     }
 
-    func test_getUrl_returns_URL_containing_expected_query_parameters_for_last_quarter_time_range() {
+    func test_getUrl_returns_URL_containing_expected_period_for_last_quarter_time_range() throws {
         // Given
         let timeRange: AnalyticsHubTimeRangeSelection.SelectionType = .lastQuarter
 
@@ -113,11 +144,12 @@ final class AnalyticsHubWebReportTests: XCTestCase {
         let reportURL = AnalyticsHubWebReport.getUrl(for: .revenue, timeRange: timeRange, storeAdminURL: exampleAdminURL)
 
         // Then
-        let expectedURLString = "&period=last_quarter&compare=previous_period"
-        XCTAssertTrue(try XCTUnwrap(reportURL).absoluteString.contains(expectedURLString))
+        let reportQueryItems = URLComponents(url: try XCTUnwrap(reportURL), resolvingAgainstBaseURL: false)?.queryItems
+        let expectedQueryItem = URLQueryItem(name: "period", value: "last_quarter")
+        XCTAssertTrue(try XCTUnwrap(reportQueryItems).contains(expectedQueryItem))
     }
 
-    func test_getUrl_returns_URL_containing_expected_query_parameters_for_last_year_time_range() {
+    func test_getUrl_returns_URL_containing_expected_period_for_last_year_time_range() throws {
         // Given
         let timeRange: AnalyticsHubTimeRangeSelection.SelectionType = .lastYear
 
@@ -125,11 +157,12 @@ final class AnalyticsHubWebReportTests: XCTestCase {
         let reportURL = AnalyticsHubWebReport.getUrl(for: .revenue, timeRange: timeRange, storeAdminURL: exampleAdminURL)
 
         // Then
-        let expectedURLString = "&period=last_year&compare=previous_period"
-        XCTAssertTrue(try XCTUnwrap(reportURL).absoluteString.contains(expectedURLString))
+        let reportQueryItems = URLComponents(url: try XCTUnwrap(reportURL), resolvingAgainstBaseURL: false)?.queryItems
+        let expectedQueryItem = URLQueryItem(name: "period", value: "last_year")
+        XCTAssertTrue(try XCTUnwrap(reportQueryItems).contains(expectedQueryItem))
     }
 
-    func test_getUrl_returns_URL_containing_expected_query_parameters_for_week_to_date_time_range() {
+    func test_getUrl_returns_URL_containing_expected_period_for_week_to_date_time_range() throws {
         // Given
         let timeRange: AnalyticsHubTimeRangeSelection.SelectionType = .weekToDate
 
@@ -137,11 +170,12 @@ final class AnalyticsHubWebReportTests: XCTestCase {
         let reportURL = AnalyticsHubWebReport.getUrl(for: .revenue, timeRange: timeRange, storeAdminURL: exampleAdminURL)
 
         // Then
-        let expectedURLString = "&period=week&compare=previous_period"
-        XCTAssertTrue(try XCTUnwrap(reportURL).absoluteString.contains(expectedURLString))
+        let reportQueryItems = URLComponents(url: try XCTUnwrap(reportURL), resolvingAgainstBaseURL: false)?.queryItems
+        let expectedQueryItem = URLQueryItem(name: "period", value: "week")
+        XCTAssertTrue(try XCTUnwrap(reportQueryItems).contains(expectedQueryItem))
     }
 
-    func test_getUrl_returns_URL_containing_expected_query_parameters_for_month_to_date_time_range() {
+    func test_getUrl_returns_URL_containing_expected_period_for_month_to_date_time_range() throws {
         // Given
         let timeRange: AnalyticsHubTimeRangeSelection.SelectionType = .monthToDate
 
@@ -149,11 +183,12 @@ final class AnalyticsHubWebReportTests: XCTestCase {
         let reportURL = AnalyticsHubWebReport.getUrl(for: .revenue, timeRange: timeRange, storeAdminURL: exampleAdminURL)
 
         // Then
-        let expectedURLString = "&period=month&compare=previous_period"
-        XCTAssertTrue(try XCTUnwrap(reportURL).absoluteString.contains(expectedURLString))
+        let reportQueryItems = URLComponents(url: try XCTUnwrap(reportURL), resolvingAgainstBaseURL: false)?.queryItems
+        let expectedQueryItem = URLQueryItem(name: "period", value: "month")
+        XCTAssertTrue(try XCTUnwrap(reportQueryItems).contains(expectedQueryItem))
     }
 
-    func test_getUrl_returns_URL_containing_expected_query_parameters_for_quarter_to_date_time_range() {
+    func test_getUrl_returns_URL_containing_expected_period_for_quarter_to_date_time_range() throws {
         // Given
         let timeRange: AnalyticsHubTimeRangeSelection.SelectionType = .quarterToDate
 
@@ -161,11 +196,12 @@ final class AnalyticsHubWebReportTests: XCTestCase {
         let reportURL = AnalyticsHubWebReport.getUrl(for: .revenue, timeRange: timeRange, storeAdminURL: exampleAdminURL)
 
         // Then
-        let expectedURLString = "&period=quarter&compare=previous_period"
-        XCTAssertTrue(try XCTUnwrap(reportURL).absoluteString.contains(expectedURLString))
+        let reportQueryItems = URLComponents(url: try XCTUnwrap(reportURL), resolvingAgainstBaseURL: false)?.queryItems
+        let expectedQueryItem = URLQueryItem(name: "period", value: "quarter")
+        XCTAssertTrue(try XCTUnwrap(reportQueryItems).contains(expectedQueryItem))
     }
 
-    func test_getUrl_returns_URL_containing_expected_query_parameters_for_year_to_date_time_range() {
+    func test_getUrl_returns_URL_containing_expected_period_for_year_to_date_time_range() throws {
         // Given
         let timeRange: AnalyticsHubTimeRangeSelection.SelectionType = .yearToDate
 
@@ -173,8 +209,9 @@ final class AnalyticsHubWebReportTests: XCTestCase {
         let reportURL = AnalyticsHubWebReport.getUrl(for: .revenue, timeRange: timeRange, storeAdminURL: exampleAdminURL)
 
         // Then
-        let expectedURLString = "&period=year&compare=previous_period"
-        XCTAssertTrue(try XCTUnwrap(reportURL).absoluteString.contains(expectedURLString))
+        let reportQueryItems = URLComponents(url: try XCTUnwrap(reportURL), resolvingAgainstBaseURL: false)?.queryItems
+        let expectedQueryItem = URLQueryItem(name: "period", value: "year")
+        XCTAssertTrue(try XCTUnwrap(reportQueryItems).contains(expectedQueryItem))
     }
 
 }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Analytics Hub/AnalyticsHubWebReportTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Analytics Hub/AnalyticsHubWebReportTests.swift
@@ -1,0 +1,171 @@
+import XCTest
+import TestKit
+@testable import WooCommerce
+
+final class AnalyticsHubWebReportTests: XCTestCase {
+
+    let exampleAdminURL = "https://example.com/wp-admin/"
+    let exampleDefaultReport = "admin.php?page=wc-admin&path=%2Fanalytics%2Frevenue"
+
+    func test_getUrl_returns_expected_default_revenue_report_url() {
+        // Given
+        let reportURL = AnalyticsHubWebReport.getUrl(for: .revenue, timeRange: nil, storeAdminURL: exampleAdminURL)
+
+        // Then
+        let expectedURL = URL(string: exampleAdminURL + "admin.php?page=wc-admin&path=%2Fanalytics%2Frevenue")
+        assertEqual(expectedURL, reportURL)
+    }
+
+    func test_getUrl_returns_expected_default_orders_report_url() {
+        // Given
+        let reportURL = AnalyticsHubWebReport.getUrl(for: .orders, timeRange: nil, storeAdminURL: exampleAdminURL)
+
+        // Then
+        let expectedURL = URL(string: exampleAdminURL + "admin.php?page=wc-admin&path=%2Fanalytics%2Forders")
+        assertEqual(expectedURL, reportURL)
+    }
+
+    func test_getUrl_returns_expected_default_products_report_url() {
+        // Given
+        let reportURL = AnalyticsHubWebReport.getUrl(for: .products, timeRange: nil, storeAdminURL: exampleAdminURL)
+
+        // Then
+        let expectedURL = URL(string: exampleAdminURL + "admin.php?page=wc-admin&path=%2Fanalytics%2Fproducts")
+        assertEqual(expectedURL, reportURL)
+    }
+
+    func test_getUrl_returns_expected_URL_with_custom_time_range() throws {
+        // Given
+        let start = try XCTUnwrap(Date.dateWithISO8601String("2024-01-01T00:00:00Z"))
+        let end = try XCTUnwrap(Date.dateWithISO8601String("2024-01-07T00:00:00Z"))
+        let timeRange: AnalyticsHubTimeRangeSelection.SelectionType = .custom(start: start, end: end)
+
+        // When
+        let reportURL = AnalyticsHubWebReport.getUrl(for: .revenue, timeRange: timeRange, storeAdminURL: exampleAdminURL)
+
+        // Then
+        let expectedURL = URL(string: exampleAdminURL + exampleDefaultReport + "&period=custom&after=2024-01-01&before=2024-01-07&compare=previous_period")
+        assertEqual(expectedURL, reportURL)
+    }
+
+    func test_getUrl_returns_expected_URL_for_today_time_range() {
+        // Given
+        let timeRange: AnalyticsHubTimeRangeSelection.SelectionType = .today
+
+        // When
+        let reportURL = AnalyticsHubWebReport.getUrl(for: .revenue, timeRange: timeRange, storeAdminURL: exampleAdminURL)
+
+        // Then
+        let expectedURL = URL(string: exampleAdminURL + exampleDefaultReport + "&period=today&compare=previous_period")
+        assertEqual(expectedURL, reportURL)
+    }
+
+    func test_getUrl_returns_expected_URL_for_yesterday_time_range() {
+        // Given
+        let timeRange: AnalyticsHubTimeRangeSelection.SelectionType = .yesterday
+
+        // When
+        let reportURL = AnalyticsHubWebReport.getUrl(for: .revenue, timeRange: timeRange, storeAdminURL: exampleAdminURL)
+
+        // Then
+        let expectedURL = URL(string: exampleAdminURL + exampleDefaultReport + "&period=yesterday&compare=previous_period")
+        assertEqual(expectedURL, reportURL)
+    }
+
+    func test_getUrl_returns_expected_URL_for_last_week_time_range() {
+        // Given
+        let timeRange: AnalyticsHubTimeRangeSelection.SelectionType = .lastWeek
+
+        // When
+        let reportURL = AnalyticsHubWebReport.getUrl(for: .revenue, timeRange: timeRange, storeAdminURL: exampleAdminURL)
+
+        // Then
+        let expectedURL = URL(string: exampleAdminURL + exampleDefaultReport + "&period=last_week&compare=previous_period")
+        assertEqual(expectedURL, reportURL)
+    }
+
+    func test_getUrl_returns_expected_URL_for_last_month_time_range() {
+        // Given
+        let timeRange: AnalyticsHubTimeRangeSelection.SelectionType = .lastMonth
+
+        // When
+        let reportURL = AnalyticsHubWebReport.getUrl(for: .revenue, timeRange: timeRange, storeAdminURL: exampleAdminURL)
+
+        // Then
+        let expectedURL = URL(string: exampleAdminURL + exampleDefaultReport + "&period=last_month&compare=previous_period")
+        assertEqual(expectedURL, reportURL)
+    }
+
+    func test_getUrl_returns_expected_URL_for_last_quarter_time_range() {
+        // Given
+        let timeRange: AnalyticsHubTimeRangeSelection.SelectionType = .lastQuarter
+
+        // When
+        let reportURL = AnalyticsHubWebReport.getUrl(for: .revenue, timeRange: timeRange, storeAdminURL: exampleAdminURL)
+
+        // Then
+        let expectedURL = URL(string: exampleAdminURL + exampleDefaultReport + "&period=last_quarter&compare=previous_period")
+        assertEqual(expectedURL, reportURL)
+    }
+
+    func test_getUrl_returns_expected_URL_for_last_year_time_range() {
+        // Given
+        let timeRange: AnalyticsHubTimeRangeSelection.SelectionType = .lastYear
+
+        // When
+        let reportURL = AnalyticsHubWebReport.getUrl(for: .revenue, timeRange: timeRange, storeAdminURL: exampleAdminURL)
+
+        // Then
+        let expectedURL = URL(string: exampleAdminURL + exampleDefaultReport + "&period=last_year&compare=previous_period")
+        assertEqual(expectedURL, reportURL)
+    }
+
+    func test_getUrl_returns_expected_URL_for_week_to_date_time_range() {
+        // Given
+        let timeRange: AnalyticsHubTimeRangeSelection.SelectionType = .weekToDate
+
+        // When
+        let reportURL = AnalyticsHubWebReport.getUrl(for: .revenue, timeRange: timeRange, storeAdminURL: exampleAdminURL)
+
+        // Then
+        let expectedURL = URL(string: exampleAdminURL + exampleDefaultReport + "&period=week&compare=previous_period")
+        assertEqual(expectedURL, reportURL)
+    }
+
+    func test_getUrl_returns_expected_URL_for_month_to_date_time_range() {
+        // Given
+        let timeRange: AnalyticsHubTimeRangeSelection.SelectionType = .monthToDate
+
+        // When
+        let reportURL = AnalyticsHubWebReport.getUrl(for: .revenue, timeRange: timeRange, storeAdminURL: exampleAdminURL)
+
+        // Then
+        let expectedURL = URL(string: exampleAdminURL + exampleDefaultReport + "&period=month&compare=previous_period")
+        assertEqual(expectedURL, reportURL)
+    }
+
+    func test_getUrl_returns_expected_URL_for_quarter_to_date_time_range() {
+        // Given
+        let timeRange: AnalyticsHubTimeRangeSelection.SelectionType = .quarterToDate
+
+        // When
+        let reportURL = AnalyticsHubWebReport.getUrl(for: .revenue, timeRange: timeRange, storeAdminURL: exampleAdminURL)
+
+        // Then
+        let expectedURL = URL(string: exampleAdminURL + exampleDefaultReport + "&period=quarter&compare=previous_period")
+        assertEqual(expectedURL, reportURL)
+    }
+
+    func test_getUrl_returns_expected_URL_for_year_to_date_time_range() {
+        // Given
+        let timeRange: AnalyticsHubTimeRangeSelection.SelectionType = .yearToDate
+
+        // When
+        let reportURL = AnalyticsHubWebReport.getUrl(for: .revenue, timeRange: timeRange, storeAdminURL: exampleAdminURL)
+
+        // Then
+        let expectedURL = URL(string: exampleAdminURL + exampleDefaultReport + "&period=year&compare=previous_period")
+        assertEqual(expectedURL, reportURL)
+    }
+
+}

--- a/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Analytics Hub/AnalyticsHubWebReportTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Analytics Hub/AnalyticsHubWebReportTests.swift
@@ -39,9 +39,10 @@ final class AnalyticsHubWebReportTests: XCTestCase {
         let start = try XCTUnwrap(Date.dateWithISO8601String("2024-01-01T00:00:00Z"))
         let end = try XCTUnwrap(Date.dateWithISO8601String("2024-01-07T00:00:00Z"))
         let timeRange: AnalyticsHubTimeRangeSelection.SelectionType = .custom(start: start, end: end)
+        let timeZone = TimeZone(abbreviation: "GMT") ?? TimeZone.current
 
         // When
-        let reportURL = AnalyticsHubWebReport.getUrl(for: .revenue, timeRange: timeRange, storeAdminURL: exampleAdminURL)
+        let reportURL = AnalyticsHubWebReport.getUrl(for: .revenue, timeRange: timeRange, storeAdminURL: exampleAdminURL, timeZone: timeZone)
 
         // Then
         let expectedURL = URL(string: exampleAdminURL + exampleDefaultReport + "&period=custom&after=2024-01-01&before=2024-01-07&compare=previous_period")

--- a/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Analytics Hub/AnalyticsHubWebReportTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Analytics Hub/AnalyticsHubWebReportTests.swift
@@ -5,36 +5,44 @@ import TestKit
 final class AnalyticsHubWebReportTests: XCTestCase {
 
     let exampleAdminURL = "https://example.com/wp-admin/"
-    let exampleDefaultReport = "admin.php?page=wc-admin&path=%2Fanalytics%2Frevenue"
 
-    func test_getUrl_returns_expected_default_revenue_report_url() {
+    func test_getURL_returns_expected_absolute_URL_string() {
         // Given
-        let reportURL = AnalyticsHubWebReport.getUrl(for: .revenue, timeRange: nil, storeAdminURL: exampleAdminURL)
+        let reportURL = AnalyticsHubWebReport.getUrl(for: .revenue, timeRange: .today, storeAdminURL: exampleAdminURL)
 
         // Then
-        let expectedURL = URL(string: exampleAdminURL + "admin.php?page=wc-admin&path=%2Fanalytics%2Frevenue")
-        assertEqual(expectedURL, reportURL)
+        let expectedURL = exampleAdminURL + "admin.php?page=wc-admin&path=%2Fanalytics%2Frevenue&period=today&compare=previous_period"
+        assertEqual(expectedURL, try XCTUnwrap(reportURL).absoluteString)
     }
 
-    func test_getUrl_returns_expected_default_orders_report_url() {
+    func test_getUrl_returns_URL_containing_expected_revenue_report_path() {
         // Given
-        let reportURL = AnalyticsHubWebReport.getUrl(for: .orders, timeRange: nil, storeAdminURL: exampleAdminURL)
+        let reportURL = AnalyticsHubWebReport.getUrl(for: .revenue, timeRange: .today, storeAdminURL: exampleAdminURL)
 
         // Then
-        let expectedURL = URL(string: exampleAdminURL + "admin.php?page=wc-admin&path=%2Fanalytics%2Forders")
-        assertEqual(expectedURL, reportURL)
+        let expectedURLString = "&path=%2Fanalytics%2Frevenue"
+        XCTAssertTrue(try XCTUnwrap(reportURL).absoluteString.contains(expectedURLString))
     }
 
-    func test_getUrl_returns_expected_default_products_report_url() {
+    func test_getUrl_returns_URL_containing_expected_orders_report_path() {
         // Given
-        let reportURL = AnalyticsHubWebReport.getUrl(for: .products, timeRange: nil, storeAdminURL: exampleAdminURL)
+        let reportURL = AnalyticsHubWebReport.getUrl(for: .orders, timeRange: .today, storeAdminURL: exampleAdminURL)
 
         // Then
-        let expectedURL = URL(string: exampleAdminURL + "admin.php?page=wc-admin&path=%2Fanalytics%2Fproducts")
-        assertEqual(expectedURL, reportURL)
+        let expectedURLString = "&path=%2Fanalytics%2Forders"
+        XCTAssertTrue(try XCTUnwrap(reportURL).absoluteString.contains(expectedURLString))
     }
 
-    func test_getUrl_returns_expected_URL_with_custom_time_range() throws {
+    func test_getUrl_returns_URL_containing_expected_products_report_path() {
+        // Given
+        let reportURL = AnalyticsHubWebReport.getUrl(for: .products, timeRange: .today, storeAdminURL: exampleAdminURL)
+
+        // Then
+        let expectedURLString = "&path=%2Fanalytics%2Fproducts"
+        XCTAssertTrue(try XCTUnwrap(reportURL).absoluteString.contains(expectedURLString))
+    }
+
+    func test_getUrl_returns_URL_containing_expected_query_parameters_for_custom_time_range() throws {
         // Given
         let start = try XCTUnwrap(Date.dateWithISO8601String("2024-01-01T00:00:00Z"))
         let end = try XCTUnwrap(Date.dateWithISO8601String("2024-01-07T00:00:00Z"))
@@ -45,11 +53,11 @@ final class AnalyticsHubWebReportTests: XCTestCase {
         let reportURL = AnalyticsHubWebReport.getUrl(for: .revenue, timeRange: timeRange, storeAdminURL: exampleAdminURL, timeZone: timeZone)
 
         // Then
-        let expectedURL = URL(string: exampleAdminURL + exampleDefaultReport + "&period=custom&after=2024-01-01&before=2024-01-07&compare=previous_period")
-        assertEqual(expectedURL, reportURL)
+        let expectedURLString = "&period=custom&after=2024-01-01&before=2024-01-07&compare=previous_period"
+        XCTAssertTrue(try XCTUnwrap(reportURL).absoluteString.contains(expectedURLString))
     }
 
-    func test_getUrl_returns_expected_URL_for_today_time_range() {
+    func test_getUrl_returns_URL_containing_expected_query_parameters_for_today_time_range() {
         // Given
         let timeRange: AnalyticsHubTimeRangeSelection.SelectionType = .today
 
@@ -57,11 +65,11 @@ final class AnalyticsHubWebReportTests: XCTestCase {
         let reportURL = AnalyticsHubWebReport.getUrl(for: .revenue, timeRange: timeRange, storeAdminURL: exampleAdminURL)
 
         // Then
-        let expectedURL = URL(string: exampleAdminURL + exampleDefaultReport + "&period=today&compare=previous_period")
-        assertEqual(expectedURL, reportURL)
+        let expectedURLString = "&period=today&compare=previous_period"
+        XCTAssertTrue(try XCTUnwrap(reportURL).absoluteString.contains(expectedURLString))
     }
 
-    func test_getUrl_returns_expected_URL_for_yesterday_time_range() {
+    func test_getUrl_returns_URL_containing_expected_query_parameters_for_yesterday_time_range() {
         // Given
         let timeRange: AnalyticsHubTimeRangeSelection.SelectionType = .yesterday
 
@@ -69,11 +77,11 @@ final class AnalyticsHubWebReportTests: XCTestCase {
         let reportURL = AnalyticsHubWebReport.getUrl(for: .revenue, timeRange: timeRange, storeAdminURL: exampleAdminURL)
 
         // Then
-        let expectedURL = URL(string: exampleAdminURL + exampleDefaultReport + "&period=yesterday&compare=previous_period")
-        assertEqual(expectedURL, reportURL)
+        let expectedURLString = "&period=yesterday&compare=previous_period"
+        XCTAssertTrue(try XCTUnwrap(reportURL).absoluteString.contains(expectedURLString))
     }
 
-    func test_getUrl_returns_expected_URL_for_last_week_time_range() {
+    func test_getUrl_returns_URL_containing_expected_query_parameters_for_last_week_time_range() {
         // Given
         let timeRange: AnalyticsHubTimeRangeSelection.SelectionType = .lastWeek
 
@@ -81,11 +89,11 @@ final class AnalyticsHubWebReportTests: XCTestCase {
         let reportURL = AnalyticsHubWebReport.getUrl(for: .revenue, timeRange: timeRange, storeAdminURL: exampleAdminURL)
 
         // Then
-        let expectedURL = URL(string: exampleAdminURL + exampleDefaultReport + "&period=last_week&compare=previous_period")
-        assertEqual(expectedURL, reportURL)
+        let expectedURLString = "&period=last_week&compare=previous_period"
+        XCTAssertTrue(try XCTUnwrap(reportURL).absoluteString.contains(expectedURLString))
     }
 
-    func test_getUrl_returns_expected_URL_for_last_month_time_range() {
+    func test_getUrl_returns_URL_containing_expected_query_parameters_for_last_month_time_range() {
         // Given
         let timeRange: AnalyticsHubTimeRangeSelection.SelectionType = .lastMonth
 
@@ -93,11 +101,11 @@ final class AnalyticsHubWebReportTests: XCTestCase {
         let reportURL = AnalyticsHubWebReport.getUrl(for: .revenue, timeRange: timeRange, storeAdminURL: exampleAdminURL)
 
         // Then
-        let expectedURL = URL(string: exampleAdminURL + exampleDefaultReport + "&period=last_month&compare=previous_period")
-        assertEqual(expectedURL, reportURL)
+        let expectedURLString = "&period=last_month&compare=previous_period"
+        XCTAssertTrue(try XCTUnwrap(reportURL).absoluteString.contains(expectedURLString))
     }
 
-    func test_getUrl_returns_expected_URL_for_last_quarter_time_range() {
+    func test_getUrl_returns_URL_containing_expected_query_parameters_for_last_quarter_time_range() {
         // Given
         let timeRange: AnalyticsHubTimeRangeSelection.SelectionType = .lastQuarter
 
@@ -105,11 +113,11 @@ final class AnalyticsHubWebReportTests: XCTestCase {
         let reportURL = AnalyticsHubWebReport.getUrl(for: .revenue, timeRange: timeRange, storeAdminURL: exampleAdminURL)
 
         // Then
-        let expectedURL = URL(string: exampleAdminURL + exampleDefaultReport + "&period=last_quarter&compare=previous_period")
-        assertEqual(expectedURL, reportURL)
+        let expectedURLString = "&period=last_quarter&compare=previous_period"
+        XCTAssertTrue(try XCTUnwrap(reportURL).absoluteString.contains(expectedURLString))
     }
 
-    func test_getUrl_returns_expected_URL_for_last_year_time_range() {
+    func test_getUrl_returns_URL_containing_expected_query_parameters_for_last_year_time_range() {
         // Given
         let timeRange: AnalyticsHubTimeRangeSelection.SelectionType = .lastYear
 
@@ -117,11 +125,11 @@ final class AnalyticsHubWebReportTests: XCTestCase {
         let reportURL = AnalyticsHubWebReport.getUrl(for: .revenue, timeRange: timeRange, storeAdminURL: exampleAdminURL)
 
         // Then
-        let expectedURL = URL(string: exampleAdminURL + exampleDefaultReport + "&period=last_year&compare=previous_period")
-        assertEqual(expectedURL, reportURL)
+        let expectedURLString = "&period=last_year&compare=previous_period"
+        XCTAssertTrue(try XCTUnwrap(reportURL).absoluteString.contains(expectedURLString))
     }
 
-    func test_getUrl_returns_expected_URL_for_week_to_date_time_range() {
+    func test_getUrl_returns_URL_containing_expected_query_parameters_for_week_to_date_time_range() {
         // Given
         let timeRange: AnalyticsHubTimeRangeSelection.SelectionType = .weekToDate
 
@@ -129,11 +137,11 @@ final class AnalyticsHubWebReportTests: XCTestCase {
         let reportURL = AnalyticsHubWebReport.getUrl(for: .revenue, timeRange: timeRange, storeAdminURL: exampleAdminURL)
 
         // Then
-        let expectedURL = URL(string: exampleAdminURL + exampleDefaultReport + "&period=week&compare=previous_period")
-        assertEqual(expectedURL, reportURL)
+        let expectedURLString = "&period=week&compare=previous_period"
+        XCTAssertTrue(try XCTUnwrap(reportURL).absoluteString.contains(expectedURLString))
     }
 
-    func test_getUrl_returns_expected_URL_for_month_to_date_time_range() {
+    func test_getUrl_returns_URL_containing_expected_query_parameters_for_month_to_date_time_range() {
         // Given
         let timeRange: AnalyticsHubTimeRangeSelection.SelectionType = .monthToDate
 
@@ -141,11 +149,11 @@ final class AnalyticsHubWebReportTests: XCTestCase {
         let reportURL = AnalyticsHubWebReport.getUrl(for: .revenue, timeRange: timeRange, storeAdminURL: exampleAdminURL)
 
         // Then
-        let expectedURL = URL(string: exampleAdminURL + exampleDefaultReport + "&period=month&compare=previous_period")
-        assertEqual(expectedURL, reportURL)
+        let expectedURLString = "&period=month&compare=previous_period"
+        XCTAssertTrue(try XCTUnwrap(reportURL).absoluteString.contains(expectedURLString))
     }
 
-    func test_getUrl_returns_expected_URL_for_quarter_to_date_time_range() {
+    func test_getUrl_returns_URL_containing_expected_query_parameters_for_quarter_to_date_time_range() {
         // Given
         let timeRange: AnalyticsHubTimeRangeSelection.SelectionType = .quarterToDate
 
@@ -153,11 +161,11 @@ final class AnalyticsHubWebReportTests: XCTestCase {
         let reportURL = AnalyticsHubWebReport.getUrl(for: .revenue, timeRange: timeRange, storeAdminURL: exampleAdminURL)
 
         // Then
-        let expectedURL = URL(string: exampleAdminURL + exampleDefaultReport + "&period=quarter&compare=previous_period")
-        assertEqual(expectedURL, reportURL)
+        let expectedURLString = "&period=quarter&compare=previous_period"
+        XCTAssertTrue(try XCTUnwrap(reportURL).absoluteString.contains(expectedURLString))
     }
 
-    func test_getUrl_returns_expected_URL_for_year_to_date_time_range() {
+    func test_getUrl_returns_URL_containing_expected_query_parameters_for_year_to_date_time_range() {
         // Given
         let timeRange: AnalyticsHubTimeRangeSelection.SelectionType = .yearToDate
 
@@ -165,8 +173,8 @@ final class AnalyticsHubWebReportTests: XCTestCase {
         let reportURL = AnalyticsHubWebReport.getUrl(for: .revenue, timeRange: timeRange, storeAdminURL: exampleAdminURL)
 
         // Then
-        let expectedURL = URL(string: exampleAdminURL + exampleDefaultReport + "&period=year&compare=previous_period")
-        assertEqual(expectedURL, reportURL)
+        let expectedURLString = "&period=year&compare=previous_period"
+        XCTAssertTrue(try XCTUnwrap(reportURL).absoluteString.contains(expectedURLString))
     }
 
 }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #11873
<!-- Id number of the GitHub issue this PR addresses. -->

## Why
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
We plan to add full analytics reports to the Analytics Hub, by opening the web report in a webview. This PR adds the logic to create a web report URL based on:

* The Analytics Hub card (e.g. the Revenue card opens the revenue web report)
* The selected time range (e.g. while viewing analytics for Week to Date you will get the Week to Date web report)
* The store's admin URL
* The store's timezone

## How

* Adds `AnalyticsHubWebReport` to build the report URL:
   * If for some reason the store admin URL is nil, the report URL will be nil. (This shouldn't happen, but we can use this to hide the link to the report if we don't have the store admin URL.)
   * Adds query items for the specified report and time range. If there's a custom time range, it uses the store timezone to add the respective start and end dates.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
Unit tests cover:

* `AnalyticsHubWebReportTests`:
   * The report URL contains all the expected components (scheme, host, path, query items).
   * The report URL contains the expected path for the given report type.
   * The report URL contains the expected period for the given time range.
   * The report URL contains `before` and `after` parameters for custom time ranges.

There are no changes to the UI in this PR.

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
