### PR TITLE
Blaze: Remove the stubbed response for AI suggestion request

### DIFF
--- a/Networking/Networking/Remote/BlazeRemote.swift
+++ b/Networking/Networking/Remote/BlazeRemote.swift
@@ -187,7 +187,7 @@ public final class BlazeRemote: Remote, BlazeRemoteProtocol {
         ///
         let parameters = [Keys.AISuggestions.urn: "\(Keys.AISuggestions.urn):\(Keys.AISuggestions.wpcom):\(Keys.AISuggestions.post):\(siteID):\(productID)"]
 
-        let request = DotcomRequest(wordpressApiVersion: .wpcomMark2, method: .get, path: path, parameters: parameters)
+        let request = DotcomRequest(wordpressApiVersion: .wpcomMark2, method: .post, path: path, parameters: parameters, encoding: JSONEncoding.default)
         let mapper = BlazeAISuggestionListMapper()
         return try await enqueue(request, mapper: mapper)
     }

--- a/Yosemite/Yosemite/Stores/BlazeStore.swift
+++ b/Yosemite/Yosemite/Stores/BlazeStore.swift
@@ -316,13 +316,7 @@ private extension BlazeStore {
                             onCompletion: @escaping (Result<[BlazeAISuggestion], Error>) -> Void) {
         Task { @MainActor in
             do {
-                // TODO-11540: remove stubbed result when the API is ready.
-                let stubbedResult = [BlazeAISuggestion(siteName: "Shiny thing", textSnippet: "Get this new and shiny thing"),
-                                     BlazeAISuggestion(siteName: "New stuff", textSnippet: "Buy this new thing first"),
-                                     BlazeAISuggestion(siteName: "Exciting items", textSnippet: "Purchase these exciting items")]
-                let suggestions: [BlazeAISuggestion] = try await mockResponse(stubbedResult: stubbedResult, onExecution: {
-                    try await remote.fetchAISuggestions(siteID: siteID, productID: productID)
-                })
+                let suggestions: [BlazeAISuggestion] = try await remote.fetchAISuggestions(siteID: siteID, productID: productID)
                 onCompletion(.success(suggestions))
             } catch {
                 onCompletion(.failure(error))


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of: #11894 
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This PR updates the AI suggestion endpoint handling since the endpoint has been deployed [peeHDf-2fw-p2#comment-1851]. The endpoint in `BlazeRemote` has also been updated to use POST and JSON encoding following the remote endpoint specifications.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
- Log in to a store eligible for Blaze.
- On the Blaze section on the My Store screen, select Promote.
- Select any public product to start a Blaze campaign creation.
- Confirm that real AI suggestions are loaded successfully.
- Tap Edit Ad and switch between the suggestions. Confirm that the contents are correct.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

https://github.com/woocommerce/woocommerce-ios/assets/5533851/e29688c1-f1ce-4d24-a863-d25f8b88e1f2



---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.