### PR TITLE
[Backend Receipts] Handle card present payment flow. Use backend receipts on success

### DIFF
--- a/WooCommerce/Classes/ViewModels/CardPresentPayments/PaymentCaptureOrchestrator.swift
+++ b/WooCommerce/Classes/ViewModels/CardPresentPayments/PaymentCaptureOrchestrator.swift
@@ -188,6 +188,7 @@ final class PaymentCaptureOrchestrator: PaymentCaptureOrchestrating {
                 onCompletion(receipt)
             case .failure:
                 // TODO: Error handling. Propagate error.
+                DDLogError("Unable to retrieve receipt for site \(order.siteID) - order \(order.orderID)")
                 break
             }
         }

--- a/WooCommerce/Classes/ViewModels/CardPresentPayments/PaymentCaptureOrchestrator.swift
+++ b/WooCommerce/Classes/ViewModels/CardPresentPayments/PaymentCaptureOrchestrator.swift
@@ -32,6 +32,8 @@ protocol PaymentCaptureOrchestrating {
     func emailReceipt(for order: Order, params: CardPresentReceiptParameters, onContent: @escaping (String) -> Void)
 
     func saveReceipt(for order: Order, params: CardPresentReceiptParameters)
+
+    func shareOrPrintReceipt(for order: Order, onCompletion: @escaping (Receipt) -> Void)
 }
 
 
@@ -176,6 +178,22 @@ final class PaymentCaptureOrchestrator: PaymentCaptureOrchestrating {
             onContent(emailContent)
         }
 
+        stores.dispatch(action)
+    }
+
+    func shareOrPrintReceipt(for order: Order, onCompletion: @escaping (Receipt) -> Void) {
+        let action = ReceiptAction.retrieveReceipt(order: order) { result in
+            switch result {
+            case let .success(receipt):
+                onCompletion(receipt)
+            case .failure:
+                // TODO: Error handling: This should propagate an error.
+                // Temporary for testing. For sites using non woo-dev version.
+                let fakeReceipt = Receipt(receiptURL: "https://mywootestingstore.mystagingwebsite.com/wc/file/transient/7e820688af25a49c935bd1ea93b7e89c0bd207",
+                                          expirationDate: "2024-02-06")
+                onCompletion(fakeReceipt)
+            }
+        }
         stores.dispatch(action)
     }
 

--- a/WooCommerce/Classes/ViewModels/CardPresentPayments/PaymentCaptureOrchestrator.swift
+++ b/WooCommerce/Classes/ViewModels/CardPresentPayments/PaymentCaptureOrchestrator.swift
@@ -33,7 +33,7 @@ protocol PaymentCaptureOrchestrating {
 
     func saveReceipt(for order: Order, params: CardPresentReceiptParameters)
 
-    func shareOrPrintReceipt(for order: Order, onCompletion: @escaping (Receipt) -> Void)
+    func presentBackendReceipt(for order: Order, onCompletion: @escaping (Receipt) -> Void)
 }
 
 
@@ -181,17 +181,14 @@ final class PaymentCaptureOrchestrator: PaymentCaptureOrchestrating {
         stores.dispatch(action)
     }
 
-    func shareOrPrintReceipt(for order: Order, onCompletion: @escaping (Receipt) -> Void) {
+    func presentBackendReceipt(for order: Order, onCompletion: @escaping (Receipt) -> Void) {
         let action = ReceiptAction.retrieveReceipt(order: order) { result in
             switch result {
             case let .success(receipt):
                 onCompletion(receipt)
             case .failure:
-                // TODO: Error handling: This should propagate an error.
-                // Temporary for testing. For sites using non woo-dev version.
-                let fakeReceipt = Receipt(receiptURL: "https://mywootestingstore.mystagingwebsite.com/wc/file/transient/7e820688af25a49c935bd1ea93b7e89c0bd207",
-                                          expirationDate: "2024-02-06")
-                onCompletion(fakeReceipt)
+                // TODO: Error handling. Propagate error.
+                break
             }
         }
         stores.dispatch(action)

--- a/WooCommerce/Classes/ViewModels/Order Details/Receipts/ReceiptEligibilityUseCase.swift
+++ b/WooCommerce/Classes/ViewModels/Order Details/Receipts/ReceiptEligibilityUseCase.swift
@@ -26,8 +26,8 @@ final class ReceiptEligibilityUseCase {
             guard let wcPlugin = wcPlugin, wcPlugin.active else {
                 return onCompletion(false)
             }
-            // 2. If WooCommerce version is the specific API development branch, mark as eligible
-            if wcPlugin.version == Constants.wcPluginDevVersion {
+            // 2. If WooCommerce version is any of the specific API development branches, mark as eligible
+            if Constants.wcPluginDevVersion.contains(wcPlugin.version) {
                 onCompletion(true)
             } else {
                 // 3. Else, if WooCommerce version is higher than minimum required version, mark as eligible
@@ -44,6 +44,6 @@ private extension ReceiptEligibilityUseCase {
     enum Constants {
         static let wcPluginName = "WooCommerce"
         static let wcPluginMinimumVersion = "8.7.0"
-        static let wcPluginDevVersion = "8.6.0-dev-7625495467-gf50cc6b"
+        static let wcPluginDevVersion: [String] = ["8.6.0-dev-7625495467-gf50cc6b", "8.6.0-dev-7708067547-g87e8c5f"]
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/BluetoothCardReaderPaymentAlertsProvider.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/BluetoothCardReaderPaymentAlertsProvider.swift
@@ -9,6 +9,14 @@ final class BluetoothCardReaderPaymentAlertsProvider: CardReaderTransactionAlert
     var amount: String = ""
     var transactionType: CardPresentTransactionType
 
+    var isEligibleForBackendReceipts: Bool {
+        // TODO: feature flag check is not enough, we need to also confirm is the correct WC version
+        guard ServiceLocator.featureFlagService.isFeatureFlagEnabled(.backendReceipts) else {
+            return false
+        }
+        return true
+    }
+
     init(transactionType: CardPresentTransactionType) {
         self.transactionType = transactionType
     }
@@ -49,13 +57,20 @@ final class BluetoothCardReaderPaymentAlertsProvider: CardReaderTransactionAlert
     func success(printReceipt: @escaping () -> Void,
                  emailReceipt: @escaping () -> Void,
                  noReceiptAction: @escaping () -> Void) -> CardPresentPaymentsModalViewModel {
-        if MFMailComposeViewController.canSendMail() {
-            return CardPresentModalSuccess(printReceipt: printReceipt,
-                                           emailReceipt: emailReceipt,
-                                           noReceiptAction: noReceiptAction)
-        } else {
-            return CardPresentModalSuccessWithoutEmail(printReceipt: printReceipt, noReceiptAction: noReceiptAction)
+        guard isEligibleForBackendReceipts else {
+            // Legacy flow:
+            if MFMailComposeViewController.canSendMail() {
+                return CardPresentModalSuccess(printReceipt: printReceipt,
+                                               emailReceipt: emailReceipt,
+                                               noReceiptAction: noReceiptAction)
+            } else {
+                return CardPresentModalSuccessWithoutEmail(printReceipt: printReceipt, noReceiptAction: noReceiptAction)
+            }
         }
+        // New flow:
+        return CardPresentModalSuccess(printReceipt: printReceipt,
+                                       emailReceipt: emailReceipt,
+                                       noReceiptAction: noReceiptAction)
     }
 
     func error(error: Error, tryAgain: @escaping () -> Void, dismissCompletion: @escaping () -> Void) -> CardPresentPaymentsModalViewModel {

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/BluetoothCardReaderPaymentAlertsProvider.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/BluetoothCardReaderPaymentAlertsProvider.swift
@@ -9,14 +9,6 @@ final class BluetoothCardReaderPaymentAlertsProvider: CardReaderTransactionAlert
     var amount: String = ""
     var transactionType: CardPresentTransactionType
 
-    var isEligibleForBackendReceipts: Bool {
-        // TODO: feature flag check is not enough, we need to also confirm is the correct WC version
-        guard ServiceLocator.featureFlagService.isFeatureFlagEnabled(.backendReceipts) else {
-            return false
-        }
-        return true
-    }
-
     init(transactionType: CardPresentTransactionType) {
         self.transactionType = transactionType
     }
@@ -57,18 +49,13 @@ final class BluetoothCardReaderPaymentAlertsProvider: CardReaderTransactionAlert
     func success(printReceipt: @escaping () -> Void,
                  emailReceipt: @escaping () -> Void,
                  noReceiptAction: @escaping () -> Void) -> CardPresentPaymentsModalViewModel {
-        guard isEligibleForBackendReceipts else {
-            if MFMailComposeViewController.canSendMail() {
-                return CardPresentModalSuccess(printReceipt: printReceipt,
-                                               emailReceipt: emailReceipt,
-                                               noReceiptAction: noReceiptAction)
-            } else {
-                return CardPresentModalSuccessWithoutEmail(printReceipt: printReceipt, noReceiptAction: noReceiptAction)
-            }
+        if MFMailComposeViewController.canSendMail() {
+            return CardPresentModalSuccess(printReceipt: printReceipt,
+                                           emailReceipt: emailReceipt,
+                                           noReceiptAction: noReceiptAction)
+        } else {
+            return CardPresentModalSuccessWithoutEmail(printReceipt: printReceipt, noReceiptAction: noReceiptAction)
         }
-        return CardPresentModalSuccess(printReceipt: printReceipt,
-                                       emailReceipt: emailReceipt,
-                                       noReceiptAction: noReceiptAction)
     }
 
     func error(error: Error, tryAgain: @escaping () -> Void, dismissCompletion: @escaping () -> Void) -> CardPresentPaymentsModalViewModel {

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/BluetoothCardReaderPaymentAlertsProvider.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/BluetoothCardReaderPaymentAlertsProvider.swift
@@ -58,7 +58,6 @@ final class BluetoothCardReaderPaymentAlertsProvider: CardReaderTransactionAlert
                  emailReceipt: @escaping () -> Void,
                  noReceiptAction: @escaping () -> Void) -> CardPresentPaymentsModalViewModel {
         guard isEligibleForBackendReceipts else {
-            // Legacy flow:
             if MFMailComposeViewController.canSendMail() {
                 return CardPresentModalSuccess(printReceipt: printReceipt,
                                                emailReceipt: emailReceipt,
@@ -67,7 +66,6 @@ final class BluetoothCardReaderPaymentAlertsProvider: CardReaderTransactionAlert
                 return CardPresentModalSuccessWithoutEmail(printReceipt: printReceipt, noReceiptAction: noReceiptAction)
             }
         }
-        // New flow:
         return CardPresentModalSuccess(printReceipt: printReceipt,
                                        emailReceipt: emailReceipt,
                                        noReceiptAction: noReceiptAction)

--- a/WooCommerce/Classes/ViewRelated/Orders/Collect Payments/CollectOrderPaymentUseCase.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Collect Payments/CollectOrderPaymentUseCase.swift
@@ -592,7 +592,7 @@ private extension CollectOrderPaymentUseCase {
         let receiptViewModel = ReceiptViewModel(receipt: receipt,
                                                 orderID: order.orderID,
                                                 siteName: stores.sessionManager.defaultSite?.name)
-        let receiptViewController = ReceiptViewController(viewModel: receiptViewModel, onDismiss: {
+        let receiptViewController = ReceiptViewController(viewModel: receiptViewModel, onDisappear: {
             onCompleted()
         })
         let navigationController = UINavigationController(rootViewController: receiptViewController)

--- a/WooCommerce/Classes/ViewRelated/Orders/Collect Payments/CollectOrderPaymentUseCase.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Collect Payments/CollectOrderPaymentUseCase.swift
@@ -503,7 +503,7 @@ private extension CollectOrderPaymentUseCase {
     ///
     func presentBackendReceiptAlert(alertProvider paymentAlerts: CardReaderTransactionAlertsProviding, onCompleted: @escaping () -> ()) {
         alertsPresenter.present(viewModel: paymentAlerts.success(printReceipt: {
-            self.paymentOrchestrator.shareOrPrintReceipt(for: self.order, onCompletion: { receipt in
+            self.paymentOrchestrator.presentBackendReceipt(for: self.order, onCompletion: { receipt in
                 let receiptViewModel = ReceiptViewModel(receipt: receipt,
                                                         orderID: self.order.orderID,
                                                         siteName: self.stores.sessionManager.defaultSite?.name)
@@ -514,7 +514,7 @@ private extension CollectOrderPaymentUseCase {
                 self.rootViewController.present(navigationController, animated: true)
             })
         }, emailReceipt: {
-            self.paymentOrchestrator.shareOrPrintReceipt(for: self.order, onCompletion: { receipt in
+            self.paymentOrchestrator.presentBackendReceipt(for: self.order, onCompletion: { receipt in
                 let receiptViewModel = ReceiptViewModel(receipt: receipt,
                                                         orderID: self.order.orderID,
                                                         siteName: self.stores.sessionManager.defaultSite?.name)

--- a/WooCommerce/Classes/ViewRelated/Orders/Collect Payments/CollectOrderPaymentUseCase.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Collect Payments/CollectOrderPaymentUseCase.swift
@@ -509,16 +509,18 @@ private extension CollectOrderPaymentUseCase {
     func presentBackendReceiptAlert(alertProvider paymentAlerts: CardReaderTransactionAlertsProviding, onCompleted: @escaping () -> ()) {
         // Present receipt alert
         alertsPresenter.present(viewModel: paymentAlerts.success(printReceipt: { [weak self] in
-            guard let self = self else { return }
+            guard let self else { return }
 
-            self.paymentOrchestrator.presentBackendReceipt(for: self.order, onCompletion: { receipt in
+            self.paymentOrchestrator.presentBackendReceipt(for: self.order, onCompletion: { [weak self] receipt in
+                guard let self else { return }
                 self.presentBackendReceiptModally(receipt: receipt, onCompleted: onCompleted)
             })
 
         }, emailReceipt: { [weak self] in
-            guard let self = self else { return }
+            guard let self else { return }
 
-            self.paymentOrchestrator.presentBackendReceipt(for: self.order, onCompletion: { receipt in
+            self.paymentOrchestrator.presentBackendReceipt(for: self.order, onCompletion: { [weak self] receipt in
+                guard let self else { return }
                 self.presentBackendReceiptModally(receipt: receipt, onCompleted: onCompleted)
             })
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Collect Payments/CollectOrderPaymentUseCase.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Collect Payments/CollectOrderPaymentUseCase.swift
@@ -157,12 +157,10 @@ final class CollectOrderPaymentUseCase: NSObject, CollectOrderPaymentProtocol {
                         // Handle payment receipt
                         self.storeInPersonPaymentsTransactionDateIfFirst(using: reader.readerType)
                         guard ServiceLocator.featureFlagService.isFeatureFlagEnabled(.backendReceipts) else {
-                            // Legacy flow:
                             return self.presentLocalReceiptAlert(receiptParameters: paymentData.receiptParameters,
                                                      alertProvider: paymentAlertProvider,
                                                      onCompleted: onCompleted)
                         }
-                        // New flow:
                         self.presentBackendReceiptAlert(alertProvider: paymentAlertProvider, onCompleted: onCompleted)
                     }
                     onPaymentCompletion()

--- a/WooCommerce/Classes/ViewRelated/Orders/Collect Payments/CollectOrderPaymentUseCase.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Collect Payments/CollectOrderPaymentUseCase.swift
@@ -505,17 +505,23 @@ private extension CollectOrderPaymentUseCase {
     }
     /// Allow merchants to print or email backend-generated receipts.
     /// The alerts presenter can be simplified once we remove legacy receipts: https://github.com/woocommerce/woocommerce-ios/issues/11897
+    ///
     func presentBackendReceiptAlert(alertProvider paymentAlerts: CardReaderTransactionAlertsProviding, onCompleted: @escaping () -> ()) {
+        // Present receipt alert
         alertsPresenter.present(viewModel: paymentAlerts.success(printReceipt: { [weak self] in
             guard let self = self else { return }
+
             self.paymentOrchestrator.presentBackendReceipt(for: self.order, onCompletion: { receipt in
                 self.presentBackendReceiptModally(receipt: receipt, onCompleted: onCompleted)
             })
+
         }, emailReceipt: { [weak self] in
             guard let self = self else { return }
+
             self.paymentOrchestrator.presentBackendReceipt(for: self.order, onCompletion: { receipt in
                 self.presentBackendReceiptModally(receipt: receipt, onCompleted: onCompleted)
             })
+
         }, noReceiptAction: {
             // Do nothing, confirm the receipt link appears now on OrderDetails
             onCompleted()

--- a/WooCommerce/Classes/ViewRelated/Orders/Collect Payments/CollectOrderPaymentUseCase.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Collect Payments/CollectOrderPaymentUseCase.swift
@@ -500,11 +500,13 @@ private extension CollectOrderPaymentUseCase {
     /// Allow merchants to print or email backend-generated receipts.
     /// The alerts presenter can be simplified once we remove legacy receipts: https://github.com/woocommerce/woocommerce-ios/issues/11897
     func presentBackendReceiptAlert(alertProvider paymentAlerts: CardReaderTransactionAlertsProviding, onCompleted: @escaping () -> ()) {
-        alertsPresenter.present(viewModel: paymentAlerts.success(printReceipt: {
+        alertsPresenter.present(viewModel: paymentAlerts.success(printReceipt: { [weak self] in
+            guard let self = self else { return }
             self.paymentOrchestrator.presentBackendReceipt(for: self.order, onCompletion: { receipt in
                 self.presentBackendReceiptModally(receipt: receipt, onCompleted: onCompleted)
             })
-        }, emailReceipt: {
+        }, emailReceipt: { [weak self] in
+            guard let self = self else { return }
             self.paymentOrchestrator.presentBackendReceipt(for: self.order, onCompletion: { receipt in
                 self.presentBackendReceiptModally(receipt: receipt, onCompleted: onCompleted)
             })

--- a/WooCommerce/Classes/ViewRelated/Orders/Collect Payments/CollectOrderPaymentUseCase.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Collect Payments/CollectOrderPaymentUseCase.swift
@@ -588,13 +588,13 @@ private extension CollectOrderPaymentUseCase {
     ///
     func presentBackendReceiptModally(receipt: Receipt, onCompleted: @escaping (() -> Void)) {
         let receiptViewModel = ReceiptViewModel(receipt: receipt,
-                                                orderID: self.order.orderID,
-                                                siteName: self.stores.sessionManager.defaultSite?.name)
+                                                orderID: order.orderID,
+                                                siteName: stores.sessionManager.defaultSite?.name)
         let receiptViewController = ReceiptViewController(viewModel: receiptViewModel, onDismiss: {
             onCompleted()
         })
         let navigationController = UINavigationController(rootViewController: receiptViewController)
-        self.rootViewController.present(navigationController, animated: true)
+        rootViewController.present(navigationController, animated: true)
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Receipts/ReceiptViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Receipts/ReceiptViewController.swift
@@ -5,17 +5,17 @@ final class ReceiptViewController: UIViewController {
     @IBOutlet private weak var webView: WKWebView!
     private let viewModel: ReceiptViewModel
     
-    var onDismiss: (() -> Void)?
+    var onDisappear: (() -> Void)?
 
-    init(viewModel: ReceiptViewModel, onDismiss: (() -> Void)? = nil) {
+    init(viewModel: ReceiptViewModel, onDisappear: (() -> Void)? = nil) {
         self.viewModel = viewModel
-        self.onDismiss = onDismiss
+        self.onDisappear = onDisappear
         super.init(nibName: "LegacyReceiptViewController", bundle: nil)
     }
     
     override func viewWillDisappear(_ animated: Bool) {
         super.viewWillDisappear(animated)
-        onDismiss?()
+        onDisappear?()
     }
 
     required init?(coder: NSCoder) {

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Receipts/ReceiptViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Receipts/ReceiptViewController.swift
@@ -4,10 +4,18 @@ import WebKit
 final class ReceiptViewController: UIViewController {
     @IBOutlet private weak var webView: WKWebView!
     private let viewModel: ReceiptViewModel
+    
+    var onDismiss: (() -> Void)?
 
-    init(viewModel: ReceiptViewModel) {
+    init(viewModel: ReceiptViewModel, onDismiss: (() -> Void)? = nil) {
         self.viewModel = viewModel
+        self.onDismiss = onDismiss
         super.init(nibName: "LegacyReceiptViewController", bundle: nil)
+    }
+    
+    override func viewWillDisappear(_ animated: Bool) {
+        super.viewWillDisappear(animated)
+        onDismiss?()
     }
 
     required init?(coder: NSCoder) {

--- a/WooCommerce/WooCommerceTests/Mocks/MockPaymentCaptureOrchestrator.swift
+++ b/WooCommerce/WooCommerceTests/Mocks/MockPaymentCaptureOrchestrator.swift
@@ -71,4 +71,8 @@ final class MockPaymentCaptureOrchestrator: PaymentCaptureOrchestrating {
         spySaveReceiptOrder = order
         spySaveReceiptParams = params
     }
+
+    func presentBackendReceipt(for order: Yosemite.Order, onCompletion: @escaping (Yosemite.Receipt) -> Void) {
+        // no implemented
+    }
 }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes #11831 

## Description
This PR addresses adding backend receipts support for the card present payment flow: Upon successful payment collection via a card reader, the merchant is presented with a modal view in order to print, share, or save their receipt. On eligible stores now the receipt will be backend-generated.

| Options | Upon tapping |
|--------|--------|
| <img width="296" alt="Screenshot 2024-02-05 at 15 20 24" src="https://github.com/woocommerce/woocommerce-ios/assets/3812076/021ef279-3945-46db-86ee-067eda949d98"> | <img width=300 src="https://github.com/woocommerce/woocommerce-ios/assets/3812076/6d93ee18-a12e-4049-a075-8e36bc3319c6"> | 



## Changes
- Upon `collectPayment` success, we perform an eligibility check for backend receipts (feature flag must be enabled, and WC version must be a specific developer branch or 8.7+) in order to display the legacy alert, or the new one.
- If the eligibility check passes, we reuse the existing payments orchestrator and modal presentation to give the merchant options regarding printing, sharing, or saving the receipt. This can be simplified once we remove the legacy code, for the time being we call the same method in both the `printReceipt` and `emailReceipt` closures, since both are presented through the same webview.
- Once the modal is dismissed, the completion handler is called and the flow is finished.

## Testing instructions
You will need a WooCommerce store running the backend receipts branch, and WCPay dev enabled. 
### Site
* If login doesn't act up, the easier way is to use the site and credentials here: pfoUAQ-da-p2
* If you're unable to login, you can use your own store. Be sure to install the WooCommerce branch as the instructions here: https://github.com/woocommerce/woocommerce-ios/pull/11848#issuecomment-1918194890 

 
Since the plugin could be updated when this is reviewed, be sure that the plugin version is included in the [eligibility check here](https://github.com/woocommerce/woocommerce-ios/blob/e41eb9bf10ecd8fbdf4696d998b37ecf1623ee28/WooCommerce/Classes/ViewModels/Order%20Details/Receipts/ReceiptEligibilityUseCase.swift#L47), or add it just for the testing. Let me know if you have troubles setting up the site, I'll attempt to set a new one.

### Flow
- Add a breakpoint in the `isEligible` switch [here](https://github.com/woocommerce/woocommerce-ios/blob/e41eb9bf10ecd8fbdf4696d998b37ecf1623ee28/WooCommerce/Classes/ViewRelated/Orders/Collect%20Payments/CollectOrderPaymentUseCase.swift#L162).
- Go through the order creation flow > collect a payment using a physical or simulated card reader > observe that upon finishing collection, eligibility will be true and `presentBackendReceiptAlert(:)` will be called, which will show the modal for the backend receipt.
- Upon dismissing the modal, the order will be marked as completed shortly after.
- Set the `.backendReceipts` feature flag to `false`. Go through the same flow. This time observe how eligibility will not pass and `presentLocalReceiptAlert(:)` will be called instead, displaying the legacy modal and local receipt.

### Known issues:
- Error handling will be added here: https://github.com/woocommerce/woocommerce-ios/issues/11829
- Loading indicator while loading the web view will be added here: https://github.com/woocommerce/woocommerce-ios/issues/11857
- "Saving the receipt" does nothing at the moment, since we're always fetching the latest from the API, so if the merchant goes to Order details to see the receipt will be a fresh one. We might add some sort of persistence later on, but is outside of scope for this iteration.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->
![Simulator Screen Recording - iPhone 15 - 2024-02-05 at 14 26 48](https://github.com/woocommerce/woocommerce-ios/assets/3812076/55684cd1-eb21-4429-8b34-05c1c80f2077)