### PR TITLE
[Tablet products] Fix product creation is no-op in collapsed mode

### DIFF
--- a/WooCommerce/Classes/ViewRelated/MainTabBarController.swift
+++ b/WooCommerce/Classes/ViewRelated/MainTabBarController.swift
@@ -565,7 +565,6 @@ private extension MainTabBarController {
             productsContainerController.wrappedController = ProductsSplitViewWrapperController(siteID: siteID)
         } else {
             productsNavigationController.viewControllers = [ProductsViewController(siteID: siteID,
-                                                                                   navigationControllerToAddProduct: productsNavigationController,
                                                                                    navigateToContent: { _ in })]
         }
 

--- a/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductCoordinator.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductCoordinator.swift
@@ -23,6 +23,12 @@ final class AddProductCoordinator: Coordinator {
         case blazeCampaignCreation
     }
 
+    /// Source view that initiates product creation for the action sheet to point to.
+    enum SourceView {
+        case barButtonItem(UIBarButtonItem)
+        case view(UIView)
+    }
+
     let navigationController: UINavigationController
 
     private let siteID: Int64
@@ -33,6 +39,7 @@ final class AddProductCoordinator: Coordinator {
     private let storage: StorageManagerType
     private let isFirstProduct: Bool
     private let analytics: Analytics
+    private let navigateToProductForm: ((UIViewController) -> Void)?
 
     /// ResultController to to track the current product count.
     ///
@@ -66,19 +73,31 @@ final class AddProductCoordinator: Coordinator {
 
     private var wooSubscriptionProductsEligibilityChecker: WooSubscriptionProductsEligibilityCheckerProtocol
 
+    /// - Parameters:
+    ///   - navigateToProductForm: Optional custom navigation when showing the product form for the new product.
     init(siteID: Int64,
          source: Source,
-         sourceBarButtonItem: UIBarButtonItem,
+         sourceView: SourceView?,
          sourceNavigationController: UINavigationController,
          storage: StorageManagerType = ServiceLocator.storageManager,
          addProductWithAIEligibilityChecker: ProductCreationAIEligibilityCheckerProtocol = ProductCreationAIEligibilityChecker(),
          productImageUploader: ProductImageUploaderProtocol = ServiceLocator.productImageUploader,
          analytics: Analytics = ServiceLocator.analytics,
-         isFirstProduct: Bool) {
+         isFirstProduct: Bool,
+         navigateToProductForm: ((UIViewController) -> Void)? = nil) {
         self.siteID = siteID
         self.source = source
-        self.sourceBarButtonItem = sourceBarButtonItem
-        self.sourceView = nil
+        switch sourceView {
+            case let .barButtonItem(barButtonItem):
+                self.sourceBarButtonItem = barButtonItem
+                self.sourceView = nil
+            case let .view(view):
+                self.sourceBarButtonItem = nil
+                self.sourceView = view
+            case .none:
+                self.sourceBarButtonItem = nil
+                self.sourceView = nil
+        }
         self.navigationController = sourceNavigationController
         self.productImageUploader = productImageUploader
         self.storage = storage
@@ -86,28 +105,7 @@ final class AddProductCoordinator: Coordinator {
         self.wooSubscriptionProductsEligibilityChecker = WooSubscriptionProductsEligibilityChecker(siteID: siteID, storage: storage)
         self.analytics = analytics
         self.isFirstProduct = isFirstProduct
-    }
-
-    init(siteID: Int64,
-         source: Source,
-         sourceView: UIView?,
-         sourceNavigationController: UINavigationController,
-         storage: StorageManagerType = ServiceLocator.storageManager,
-         addProductWithAIEligibilityChecker: ProductCreationAIEligibilityCheckerProtocol = ProductCreationAIEligibilityChecker(),
-         productImageUploader: ProductImageUploaderProtocol = ServiceLocator.productImageUploader,
-         analytics: Analytics = ServiceLocator.analytics,
-         isFirstProduct: Bool) {
-        self.siteID = siteID
-        self.source = source
-        self.sourceBarButtonItem = nil
-        self.sourceView = sourceView
-        self.navigationController = sourceNavigationController
-        self.productImageUploader = productImageUploader
-        self.storage = storage
-        self.addProductWithAIEligibilityChecker = addProductWithAIEligibilityChecker
-        self.wooSubscriptionProductsEligibilityChecker = WooSubscriptionProductsEligibilityChecker(siteID: siteID, storage: storage)
-        self.analytics = analytics
-        self.isFirstProduct = isFirstProduct
+        self.navigateToProductForm = navigateToProductForm
     }
 
     func start() {
@@ -371,7 +369,11 @@ private extension AddProductCoordinator {
                                                        presentationStyle: .navigationStack)
         // Since the Add Product UI could hold local changes, disables the bottom bar (tab bar) to simplify app states.
         viewController.hidesBottomBarWhenPushed = true
-        navigationController.pushViewController(viewController, animated: true)
+        if let navigateToProductForm {
+            navigateToProductForm(viewController)
+        } else {
+            navigationController.pushViewController(viewController, animated: true)
+        }
     }
 
     /// Presents AI Product Creation survey

--- a/WooCommerce/Classes/ViewRelated/Products/ProductsSplitViewCoordinator.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductsSplitViewCoordinator.swift
@@ -1,4 +1,5 @@
 import UIKit
+import Yosemite
 
 /// Coordinates the state of multiple columns (product list and secondary view) based on the secondary view.
 final class ProductsSplitViewCoordinator {
@@ -60,7 +61,7 @@ private extension ProductsSplitViewCoordinator {
                                                            sourceNavigationController: primaryNavigationController,
                                                            isFirstProduct: isFirstProduct,
                                                            navigateToProductForm: { [weak self] viewController in
-            self?.showSecondaryView(viewController: viewController, replacesNavigationStack: replacesNavigationStack)
+            self?.showSecondaryView(viewController: viewController, replacesNavigationStack: true)
         })
         addProductCoordinator.start()
         self.addProductCoordinator = addProductCoordinator

--- a/WooCommerce/Classes/ViewRelated/Products/ProductsSplitViewCoordinator.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductsSplitViewCoordinator.swift
@@ -7,8 +7,9 @@ final class ProductsSplitViewCoordinator {
     private let primaryNavigationController: UINavigationController
     private let secondaryNavigationController: UINavigationController
     private lazy var productsViewController = ProductsViewController(siteID: siteID,
-                                                                     navigationControllerToAddProduct: secondaryNavigationController,
                                                                      navigateToContent: showFromProductList)
+
+    private var addProductCoordinator: AddProductCoordinator?
 
     init(siteID: Int64, splitViewController: UISplitViewController) {
         self.siteID = siteID
@@ -27,28 +28,45 @@ private extension ProductsSplitViewCoordinator {
     func showFromProductList(content: ProductsViewController.NavigationContentType) {
         switch content {
             case let .productForm(product):
-                ProductDetailsFactory.productDetails(product: product,
-                                                     presentationStyle: .navigationStack,
-                                                     forceReadOnly: false) { [weak self] viewController in
-                    self?.showSecondaryView(viewController, replacesNavigationStack: true)
-                }
-            case let .other(viewController):
-                showSecondaryView(viewController, replacesNavigationStack: false)
+                showProductForm(product: product)
+            case let .addProduct(sourceView, isFirstProduct):
+                startProductCreation(sourceView: sourceView, isFirstProduct: isFirstProduct)
         }
     }
+}
 
+private extension ProductsSplitViewCoordinator {
     func showEmptyView() {
         let config = EmptyStateViewController.Config.simple(
             message: .init(string: Localization.emptyViewMessage),
             image: .emptyProductsTabImage
         )
         let emptyStateViewController = EmptyStateViewController(style: .basic, configuration: config)
-        showSecondaryView(emptyStateViewController, replacesNavigationStack: true)
+        showSecondaryView(viewController: emptyStateViewController, replacesNavigationStack: true)
     }
-}
 
-private extension ProductsSplitViewCoordinator {
-    func showSecondaryView(_ viewController: UIViewController, replacesNavigationStack: Bool) {
+    func showProductForm(product: Product) {
+        ProductDetailsFactory.productDetails(product: product,
+                                             presentationStyle: .navigationStack,
+                                             forceReadOnly: false) { [weak self] viewController in
+            self?.showSecondaryView(viewController: viewController, replacesNavigationStack: true)
+        }
+    }
+
+    func startProductCreation(sourceView: AddProductCoordinator.SourceView, isFirstProduct: Bool) {
+        let addProductCoordinator = AddProductCoordinator(siteID: siteID,
+                                                           source: .productsTab,
+                                                           sourceView: sourceView,
+                                                           sourceNavigationController: primaryNavigationController,
+                                                           isFirstProduct: isFirstProduct,
+                                                           navigateToProductForm: { [weak self] viewController in
+            self?.showSecondaryView(viewController: viewController, replacesNavigationStack: replacesNavigationStack)
+        })
+        addProductCoordinator.start()
+        self.addProductCoordinator = addProductCoordinator
+    }
+
+    func showSecondaryView(viewController: UIViewController, replacesNavigationStack: Bool) {
         if replacesNavigationStack {
             secondaryNavigationController.setViewControllers([viewController], animated: false)
         } else {

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/Add Product/AddProductCoordinatorTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/Add Product/AddProductCoordinatorTests.swift
@@ -128,7 +128,7 @@ private extension AddProductCoordinatorTests {
         let view = UIView()
         return AddProductCoordinator(siteID: sampleSiteID,
                                      source: source,
-                                     sourceView: view,
+                                     sourceView: .view(view),
                                      sourceNavigationController: navigationController,
                                      storage: storageManager,
                                      addProductWithAIEligibilityChecker: addProductWithAIEligibilityChecker,


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

⚠️ Please review https://github.com/woocommerce/woocommerce-ios/pull/11885 before this PR

Closes: #11899 
<!-- Id number of the GitHub issue this PR addresses. -->

## Why

Previously in https://github.com/woocommerce/woocommerce-ios/pull/11860, I set the **secondary navigation controller** to the product creation flow in `AddProductCoordinator`. Most of the navigation in product creation is modal-based which we actually want to show from the primary navigation controller to work in both split view collapsed & expanded modes. However, for the last step of the product creation flow, it shows the product form by pushing to the navigation stack which we want to use the secondary navigation controller. Because we currently pass the secondary navigation controller for the whole flow, when the split view is collapsed, the bottom sheet modal wouldn't show up in hte primary view.

## How

To fix this issue where we'd like to have different navigation controllers for presenting a modal and pushing the product form, I added an optional `navigateToProductForm` closure to `AddProductCoordinator` so that the navigation logic can be implemented in the split view coordinator `ProductsSplitViewCoordinator` while maintaining existing usage. This allows us to track the secondary content state that will be implemented in a future PR. `AddProductCoordinator`'s initializers were also refactored into one with an enum `SourceView` to make the code simpler now that we also start the product creation flow in `ProductsSplitViewCoordinator`. The primary navigation controller is now passed to `AddProductCoordinator`, and `ProductsViewController.navigationControllerToAddProduct` isn't needed anymore now that the logic was moved to `ProductsSplitViewCoordinator`.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

- [x] @jaclync tests that product creation works as before when the feature flag is off
---

- In code, enable `splitViewInProductsTab` feature flag in `DefaultFeatureFlagService`
- Go to the Products tab
  - 🗒️ There's a known issue where the products tab is showing the empty view in the collapsed mode. This will be fixed separately
- Collapse the split view if needed
- Tap + to create a product --> product creation flow should start

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->



https://github.com/woocommerce/woocommerce-ios/assets/1945542/4ea59c03-5a01-43be-a815-fe246e237073




---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
