### PR TITLE
[Product images] Cache images to reduce network requests

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -2,7 +2,7 @@
 
 17.3
 -----
-
+- [***] Products: Cache product images to reduce network requests. [https://github.com/woocommerce/woocommerce-ios/pull/11902]
 
 17.2
 -----

--- a/WooCommerce/Classes/System/SessionManager.swift
+++ b/WooCommerce/Classes/System/SessionManager.swift
@@ -5,6 +5,7 @@ import KeychainAccess
 import protocol Networking.ApplicationPasswordUseCase
 import class Networking.OneTimeApplicationPasswordUseCase
 import class Networking.DefaultApplicationPasswordUseCase
+import class Kingfisher.ImageCache
 
 // MARK: - SessionManager Notifications
 //
@@ -46,6 +47,10 @@ final class SessionManager: SessionManagerProtocol {
     /// KeychainAccess Wrapper.
     ///
     private let keychain: Keychain
+
+    /// Cache which stores product images
+    ///
+    private let imageCache: ImageCache
 
     /// Default Credentials.
     ///
@@ -146,9 +151,12 @@ final class SessionManager: SessionManagerProtocol {
 
     /// Designated Initializer.
     ///
-    init(defaults: UserDefaults, keychainServiceName: String) {
+    init(defaults: UserDefaults,
+         keychainServiceName: String,
+         imageCache: ImageCache = ImageCache.default) {
         self.defaults = defaults
         self.keychain = Keychain(service: keychainServiceName).accessibility(.afterFirstUnlock)
+        self.imageCache = imageCache
 
         defaultStoreIDSubject = .init(defaults[.defaultStoreID])
     }
@@ -177,6 +185,7 @@ final class SessionManager: SessionManagerProtocol {
         defaults[.themesPendingInstall] = nil
         defaults[.siteIDPendingStoreSwitch] = nil
         defaults[.expectedStoreNamePendingStoreSwitch] = nil
+        imageCache.clearCache()
     }
 
     /// Deletes application password

--- a/WooCommerce/Classes/ViewRelated/Blaze/BlazeEditAd/BlazeEditAdHostingController.swift
+++ b/WooCommerce/Classes/ViewRelated/Blaze/BlazeEditAd/BlazeEditAdHostingController.swift
@@ -97,15 +97,12 @@ private extension BlazeEditAdHostingController {
 private extension BlazeEditAdHostingController {
     @MainActor
     func onWPMediaPickerCompletion(mediaItems: [Media]) async -> MediaPickerImage? {
-        guard let media = mediaItems.first else {
+        guard let media = mediaItems.first,
+              let image = try? await productImageLoader.requestImage(productImage: media.toProductImage)else {
             return nil
         }
-        return await withCheckedContinuation { continuation in
-            let productImage = media.toProductImage
-            _ = productImageLoader.requestImage(productImage: productImage) { image in
-                continuation.resume(returning: .init(image: image, source: .media(media: media)))
-            }
-        }
+
+        return .init(image: image, source: .media(media: media))
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Blaze/CampaignCreation/BlazeCampaignCreationFormViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Blaze/CampaignCreation/BlazeCampaignCreationFormViewModel.swift
@@ -301,14 +301,11 @@ extension BlazeCampaignCreationFormViewModel {
 
 private extension BlazeCampaignCreationFormViewModel {
     func loadProductImage() async -> MediaPickerImage? {
-        await withCheckedContinuation({ continuation in
-            guard let firstImage = product?.images.first else {
-                return continuation.resume(returning: nil)
-            }
-            _ = productImageLoader.requestImage(productImage: firstImage) { image in
-                continuation.resume(returning: .init(image: image, source: .productImage(image: firstImage)))
-            }
-        })
+        guard let firstImage = product?.images.first,
+              let image = try? await productImageLoader.requestImage(productImage: firstImage) else {
+            return nil
+        }
+        return .init(image: image, source: .productImage(image: firstImage))
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductFromImage/AddProductFromImageCoordinator.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductFromImage/AddProductFromImageCoordinator.swift
@@ -125,15 +125,11 @@ private extension AddProductFromImageCoordinator {
 private extension AddProductFromImageCoordinator {
     @MainActor
     func onWPMediaPickerCompletion(mediaItems: [Media]) async -> MediaPickerImage? {
-        guard let media = mediaItems.first else {
+        guard let media = mediaItems.first,
+              let image = try? await productImageLoader.requestImage(productImage: media.toProductImage)else {
             return nil
         }
-        return await withCheckedContinuation { continuation in
-            let productImage = media.toProductImage
-            _ = productImageLoader.requestImage(productImage: productImage) { image in
-                continuation.resume(returning: .init(image: image, source: .media(media: media)))
-            }
-        }
+        return .init(image: image, source: .media(media: media))
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Products/Cells/Product Images/Collection View Cells/ProductImageCollectionViewCell.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Cells/Product Images/Collection View Cells/ProductImageCollectionViewCell.swift
@@ -5,7 +5,7 @@ final class ProductImageCollectionViewCell: UICollectionViewCell {
 
     @IBOutlet weak var imageView: UIImageView!
 
-    var cancellableTask: Cancellable?
+    var cancellableTask: Task<Void, Never>?
 
     override func awakeFromNib() {
         super.awakeFromNib()
@@ -21,6 +21,7 @@ final class ProductImageCollectionViewCell: UICollectionViewCell {
     }
 
     override func prepareForReuse() {
+        super.prepareForReuse()
         cancellableTask?.cancel()
         cancellableTask = nil
     }

--- a/WooCommerce/Classes/ViewRelated/Products/Cells/Product Images/Collection View Cells/ProductImageCollectionViewCell.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Cells/Product Images/Collection View Cells/ProductImageCollectionViewCell.swift
@@ -24,6 +24,7 @@ final class ProductImageCollectionViewCell: UICollectionViewCell {
         super.prepareForReuse()
         cancellableTask?.cancel()
         cancellableTask = nil
+        imageView.image = nil
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Products/Media/DefaultProductUIImageLoader.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Media/DefaultProductUIImageLoader.swift
@@ -9,6 +9,11 @@ import Combine
 /// - When updating from an asset to remote Product image, caches the asset image locally to avoid an extra API request
 ///
 final class DefaultProductUIImageLoader: ProductUIImageLoader {
+    enum ImageLoaderError: Error {
+        case invalidURL
+        case unableToLoadImage
+    }
+
     private var imagesByProductImageID: [Int64: UIImage] = [:]
     private let imageService: ImageService
 

--- a/WooCommerce/Classes/ViewRelated/Products/Media/DefaultProductUIImageLoader.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Media/DefaultProductUIImageLoader.swift
@@ -19,8 +19,6 @@ final class DefaultProductUIImageLoader: ProductUIImageLoader {
 
     private let productImageActionHandler: ProductImageActionHandler?
 
-    private var activeImageTasks = [ImageDownloadTask]()
-
     private let phAssetImageLoaderProvider: (() -> PHAssetImageLoader)?
     /// `PHAssetImageLoader` is lazy loaded to avoid triggering permission alert by initializing `PHImageManager` before it is used.
     private lazy var phAssetImageLoader: PHAssetImageLoader = {
@@ -56,31 +54,41 @@ final class DefaultProductUIImageLoader: ProductUIImageLoader {
         }
     }
 
-    deinit {
-        activeImageTasks.forEach { $0.cancel() }
-        activeImageTasks.removeAll()
-    }
-
-    func requestImage(productImage: ProductImage, completion: @escaping (UIImage) -> Void) -> Cancellable? {
+    func requestImage(productImage: ProductImage) async throws -> UIImage {
         if let image = imagesByProductImageID[productImage.imageID] {
-            completion(image)
-            return nil
+            return image
         }
+
         guard let encodedString = productImage.src.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed),
               let url = URL(string: encodedString) else {
-            return nil
+            throw ImageLoaderError.invalidURL
         }
-        let task = imageService.downloadImage(with: url, shouldCacheImage: true) { [weak self] (image, error) in
-            guard let image = image else {
-                return
+
+        if let imageFromCache = await withCheckedContinuation({ continuation in
+            imageService.retrieveImageFromCache(with: url) { image in
+                if let image = image {
+                    continuation.resume(returning: image)
+                } else {
+                    continuation.resume(returning: nil)
+                }
             }
-            self?.imagesByProductImageID[productImage.imageID] = image
-            completion(image)
+        }) {
+            return imageFromCache
         }
-        if let task = task {
-            activeImageTasks.append(task)
+
+        if let downloadedImage = await withCheckedContinuation({ continuation in
+            _ = imageService.downloadImage(with: url, shouldCacheImage: true) { (image, error) in
+                if let image = image {
+                    continuation.resume(returning: image)
+                } else {
+                    continuation.resume(returning: nil)
+                }
+            }
+        }) {
+            return downloadedImage
         }
-        return task
+
+        throw ImageLoaderError.unableToLoadImage
     }
 
     func requestImage(asset: PHAsset, targetSize: CGSize, completion: @escaping (UIImage) -> Void) {

--- a/WooCommerce/Classes/ViewRelated/Products/Media/ProductImagesCollectionViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Media/ProductImagesCollectionViewController.swift
@@ -102,11 +102,20 @@ private extension ProductImagesCollectionViewController {
         cell.imageView.contentMode = .center
         cell.imageView.image = .productsTabProductCellPlaceholderImage
 
-        let cancellable = productUIImageLoader.requestImage(productImage: productImage) { [weak cell] image in
-            cell?.imageView.contentMode = .scaleAspectFit
-            cell?.imageView.image = image
+        cell.cancellableTask = Task {
+            guard let image = try? await productUIImageLoader.requestImage(productImage: productImage) else {
+                return
+            }
+
+            /// `ProductImageCollectionViewCell` cancels the task while preparing the cell for reuse
+            /// Checking Task cancellation status prevents us from showing the downloaded image in a different product's cell
+            ///
+            guard !Task.isCancelled else {
+                return
+            }
+            cell.imageView.contentMode = .scaleAspectFit
+            cell.imageView.image = image
         }
-        cell.cancellableTask = cancellable
     }
 
     func configureUploadingImageCell(_ cell: UICollectionViewCell, asset: PHAsset) {

--- a/WooCommerce/Classes/ViewRelated/Products/Media/ProductImagesGalleryViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Media/ProductImagesGalleryViewController.swift
@@ -200,10 +200,19 @@ private extension ProductImagesGalleryViewController {
         cell.imageView.image = .productsTabProductCellPlaceholderImage
         cell.contentView.layer.borderWidth = 0
 
-        let cancellable = productUIImageLoader.requestImage(productImage: productImage) { [weak cell] image in
-            cell?.imageView.contentMode = .scaleAspectFit
-            cell?.imageView.image = image
+        cell.cancellableTask = Task {
+            guard let image = try? await productUIImageLoader.requestImage(productImage: productImage) else {
+                return
+            }
+
+            /// `ProductImageCollectionViewCell` cancels the task while preparing the cell for reuse
+            /// Checking Task cancellation status prevents us from showing the downloaded image in a different product's cell
+            ///
+            guard !Task.isCancelled else {
+                return
+            }
+            cell.imageView.contentMode = .scaleAspectFit
+            cell.imageView.image = image
         }
-        cell.cancellableTask = cancellable
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Products/Media/ProductUIImageLoader.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Media/ProductUIImageLoader.swift
@@ -7,7 +7,7 @@ import Combine
 protocol ProductUIImageLoader {
     /// Requests an image given a remote Product image asynchronously.
     ///
-    func requestImage(productImage: ProductImage, completion: @escaping (UIImage) -> Void) -> Cancellable?
+    func requestImage(productImage: ProductImage) async throws -> UIImage
 
     /// Requests an image given a `PHAsset` asynchronously, with a target size for optimization.
     ///

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -2535,6 +2535,7 @@
 		EE7707C82ABBF4BB009FD564 /* AIToneVoiceViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE7707C72ABBF4BB009FD564 /* AIToneVoiceViewModel.swift */; };
 		EE7707CB2ABC4C8E009FD564 /* AIToneVoiceViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE7707CA2ABC4C8E009FD564 /* AIToneVoiceViewModelTests.swift */; };
 		EE81B1382865BB0B0032E0D4 /* ProductImagesProductIDUpdaterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE81B1372865BB0B0032E0D4 /* ProductImagesProductIDUpdaterTests.swift */; };
+		EE8A302B2B70B63E001D7C66 /* MockImageService.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE8A302A2B70B63E001D7C66 /* MockImageService.swift */; };
 		EE8DCA8028BF964700F23B23 /* MockAuthentication.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE8DCA7F28BF964700F23B23 /* MockAuthentication.swift */; };
 		EE94258F29DDA49E0063B499 /* StoreCreationProgressViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE94258E29DDA49E0063B499 /* StoreCreationProgressViewModelTests.swift */; };
 		EEA1E2042AC1D22600A37ADD /* ProductDetailPreviewViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EEA1E2032AC1D22600A37ADD /* ProductDetailPreviewViewModelTests.swift */; };
@@ -5236,6 +5237,7 @@
 		EE7707C72ABBF4BB009FD564 /* AIToneVoiceViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AIToneVoiceViewModel.swift; sourceTree = "<group>"; };
 		EE7707CA2ABC4C8E009FD564 /* AIToneVoiceViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AIToneVoiceViewModelTests.swift; sourceTree = "<group>"; };
 		EE81B1372865BB0B0032E0D4 /* ProductImagesProductIDUpdaterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductImagesProductIDUpdaterTests.swift; sourceTree = "<group>"; };
+		EE8A302A2B70B63E001D7C66 /* MockImageService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockImageService.swift; sourceTree = "<group>"; };
 		EE8DCA7F28BF964700F23B23 /* MockAuthentication.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockAuthentication.swift; sourceTree = "<group>"; };
 		EE94258E29DDA49E0063B499 /* StoreCreationProgressViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StoreCreationProgressViewModelTests.swift; sourceTree = "<group>"; };
 		EEA1E2032AC1D22600A37ADD /* ProductDetailPreviewViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductDetailPreviewViewModelTests.swift; sourceTree = "<group>"; };
@@ -8501,6 +8503,7 @@
 				EE66BB112B29D65400518DAF /* MockThemeInstaller.swift */,
 				EEFF47312B309221009BF302 /* MockStoreCreationStoreSwitchScheduler.swift */,
 				02D635782B58071C00B1CBF6 /* MockNote.swift */,
+				EE8A302A2B70B63E001D7C66 /* MockImageService.swift */,
 			);
 			path = Mocks;
 			sourceTree = "<group>";
@@ -14887,6 +14890,7 @@
 				EEC2D27F292CF60E0072132E /* JetpackSetupHostingControllerTests.swift in Sources */,
 				4535EE82281BE726004212B4 /* CouponCodeInputFormatterTests.swift in Sources */,
 				EEB4E2D829B20F0F00371C3C /* StoreOnboardingTaskViewModel.swift in Sources */,
+				EE8A302B2B70B63E001D7C66 /* MockImageService.swift in Sources */,
 				DEF36DEC2898D64600178AC2 /* JetpackSetupWebViewModelTests.swift in Sources */,
 				023EC2E424DA95DB0021DA91 /* ProductInventorySettingsViewModel+VariationTests.swift in Sources */,
 				CCB366AF274518EC007D437A /* EditableOrderViewModelTests.swift in Sources */,

--- a/WooCommerce/WooCommerceTests/Mocks/MockImageCache.swift
+++ b/WooCommerce/WooCommerceTests/Mocks/MockImageCache.swift
@@ -38,4 +38,11 @@ final class MockImageCache: ImageCache {
                         completionHandler: ((CacheStoreResult) -> Void)? = nil) {
         imagesByKey[key] = image
     }
+
+    var clearCacheCalled = false
+
+    override func clearCache(completion handler: (() -> Void)? = nil) {
+        clearCacheCalled = true
+        super.clearCache(completion: handler)
+    }
 }

--- a/WooCommerce/WooCommerceTests/Mocks/MockImageService.swift
+++ b/WooCommerce/WooCommerceTests/Mocks/MockImageService.swift
@@ -1,7 +1,7 @@
 import UIKit
 @testable import WooCommerce
 
-class MockImageService {
+final class MockImageService {
     private(set) var retrieveImageFromCacheCalled = false
     private var retrieveImageFromCacheCompletionImage: UIImage?
 

--- a/WooCommerce/WooCommerceTests/Mocks/MockImageService.swift
+++ b/WooCommerce/WooCommerceTests/Mocks/MockImageService.swift
@@ -1,0 +1,48 @@
+import UIKit
+@testable import WooCommerce
+
+class MockImageService {
+    private(set) var retrieveImageFromCacheCalled = false
+    private var retrieveImageFromCacheCompletionImage: UIImage?
+
+    func whenRetrieveImageFromCache(thenReturn image: UIImage?) {
+        retrieveImageFromCacheCompletionImage = image
+    }
+
+    private(set) var downloadImageCalled = false
+    private(set) var shouldCacheImageValue = false
+    private var downloadImageValue: UIImage?
+    private var downloadImageError: ImageServiceError?
+
+    func whenDownloadImage(thenReturn image: UIImage) {
+        downloadImageValue = image
+    }
+
+    func whenDownloadImage(thenThrow error: ImageServiceError) {
+        downloadImageError = error
+    }
+}
+
+extension MockImageService: ImageService {
+
+    func retrieveImageFromCache(with url: URL, completion: @escaping ImageCacheRetrievalCompletion) {
+        retrieveImageFromCacheCalled = true
+        completion(retrieveImageFromCacheCompletionImage)
+    }
+
+
+    func downloadImage(with url: URL, shouldCacheImage: Bool, completion: ImageDownloadCompletion?) -> ImageDownloadTask? {
+        downloadImageCalled = true
+        shouldCacheImageValue = shouldCacheImage
+        completion?(downloadImageValue, downloadImageError)
+        return nil
+    }
+
+    func downloadAndCacheImageForImageView(_ imageView: UIImageView,
+                                           with url: String?,
+                                           placeholder: UIImage?,
+                                           progressBlock: ImageDownloadProgressBlock?,
+                                           completion: ImageDownloadCompletion?) {
+        // no-op
+    }
+}

--- a/WooCommerce/WooCommerceTests/Mocks/MockImageService.swift
+++ b/WooCommerce/WooCommerceTests/Mocks/MockImageService.swift
@@ -24,12 +24,10 @@ final class MockImageService {
 }
 
 extension MockImageService: ImageService {
-
     func retrieveImageFromCache(with url: URL, completion: @escaping ImageCacheRetrievalCompletion) {
         retrieveImageFromCacheCalled = true
         completion(retrieveImageFromCacheCompletionImage)
     }
-
 
     func downloadImage(with url: URL, shouldCacheImage: Bool, completion: ImageDownloadCompletion?) -> ImageDownloadTask? {
         downloadImageCalled = true

--- a/WooCommerce/WooCommerceTests/System/SessionManagerTests.swift
+++ b/WooCommerce/WooCommerceTests/System/SessionManagerTests.swift
@@ -6,7 +6,7 @@ import KeychainAccess
 
 /// SessionManager Unit Tests
 ///
-class SessionManagerTests: XCTestCase {
+final class SessionManagerTests: XCTestCase {
 
     /// Sample Application Password
     ///
@@ -402,6 +402,24 @@ class SessionManagerTests: XCTestCase {
 
         // Then
         XCTAssertNil(defaults[.expectedStoreNamePendingStoreSwitch])
+    }
+
+    /// Verifies that image cache is cleared upon reset
+    ///
+    func test_image_cache_is_cleared_upon_reset() throws {
+        // Given
+        let uuid = UUID().uuidString
+        let defaults = try XCTUnwrap(UserDefaults(suiteName: uuid))
+        let mockCache = MockImageCache(name: "Testing")
+        let sut = SessionManager(defaults: defaults,
+                                 keychainServiceName: Settings.keychainServiceName,
+                                 imageCache: mockCache)
+
+        // When
+        sut.reset()
+
+        // Then
+        XCTAssertTrue(mockCache.clearCacheCalled)
     }
 
     /// Verifies that `removeDefaultCredentials` effectively nukes everything from the keychain

--- a/WooCommerce/WooCommerceTests/ViewRelated/Blaze/BlazeCampaignCreationFormViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Blaze/BlazeCampaignCreationFormViewModelTests.swift
@@ -552,19 +552,21 @@ private extension BlazeCampaignCreationFormViewModelTests {
         }
         storage.saveIfNeeded()
     }
-
-    final class MockError: Error { }
 }
+
+private final class MockError: Error { }
 
 private class MockProductUIImageLoader: ProductUIImageLoader {
     var imageRequestedForProductImage: Yosemite.ProductImage?
     var requestImageStubbedResponse: UIImage?
-    func requestImage(productImage: Yosemite.ProductImage, completion: @escaping (UIImage) -> Void) -> Cancellable? {
+
+    func requestImage(productImage: ProductImage) async throws -> UIImage {
         imageRequestedForProductImage = productImage
         if let requestImageStubbedResponse {
-            completion(requestImageStubbedResponse)
+            return requestImageStubbedResponse
+        } else {
+            throw MockError()
         }
-        return nil
     }
 
     func requestImage(asset: PHAsset, targetSize: CGSize, completion: @escaping (UIImage) -> Void) {

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/Media/ProductUIImageLoaderTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/Media/ProductUIImageLoaderTests.swift
@@ -28,7 +28,7 @@ final class ProductUIImageLoaderTests: XCTestCase {
         super.tearDown()
     }
 
-    func testRequestingImageWithRemoteProductImage() async throws {
+    func test_requesting_image_with_remote_product_image() async throws {
         let mockPHAssetImageLoader = MockPHAssetImageLoader(imagesByAsset: [:])
         let imageLoader = DefaultProductUIImageLoader(imageService: imageService, phAssetImageLoaderProvider: { mockPHAssetImageLoader })
         let productImage = ProductImage(imageID: mockProductImageID,
@@ -42,7 +42,7 @@ final class ProductUIImageLoaderTests: XCTestCase {
         XCTAssertEqual(image, self.testImage)
     }
 
-    func testRequestingImageWithRemoteProductImageFromURLWithSpecialChars() async throws {
+    func test_requesting_image_with_remote_product_image_from_URL_with_special_chars() async throws {
         let mockPHAssetImageLoader = MockPHAssetImageLoader(imagesByAsset: [:])
         let imageLoader = DefaultProductUIImageLoader(imageService: imageService, phAssetImageLoaderProvider: { mockPHAssetImageLoader })
         let productImage = ProductImage(imageID: mockProductImageID,
@@ -152,7 +152,7 @@ final class ProductUIImageLoaderTests: XCTestCase {
         }
     }
 
-    func testRequestingImageWithPHAsset() {
+    func test_requesting_image_with_PHAsset() {
         let asset = PHAsset()
         let mockPHAssetImageLoader = MockPHAssetImageLoader(imagesByAsset: [asset: testImage])
         let imageLoader = DefaultProductUIImageLoader(imageService: imageService, phAssetImageLoaderProvider: { mockPHAssetImageLoader })

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/Media/ProductUIImageLoaderTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/Media/ProductUIImageLoaderTests.swift
@@ -28,7 +28,7 @@ final class ProductUIImageLoaderTests: XCTestCase {
         super.tearDown()
     }
 
-    func testRequestingImageWithRemoteProductImage() {
+    func testRequestingImageWithRemoteProductImage() async throws {
         let mockPHAssetImageLoader = MockPHAssetImageLoader(imagesByAsset: [:])
         let imageLoader = DefaultProductUIImageLoader(imageService: imageService, phAssetImageLoaderProvider: { mockPHAssetImageLoader })
         let productImage = ProductImage(imageID: mockProductImageID,
@@ -38,15 +38,11 @@ final class ProductUIImageLoaderTests: XCTestCase {
                                         name: "woo",
                                         alt: nil)
 
-        let expectation = self.expectation(description: "Wait for image request")
-        _ = imageLoader.requestImage(productImage: productImage) { image in
-            XCTAssertEqual(image, self.testImage)
-            expectation.fulfill()
-        }
-        waitForExpectations(timeout: Constants.expectationTimeout, handler: nil)
+        let image = try await imageLoader.requestImage(productImage: productImage)
+        XCTAssertEqual(image, self.testImage)
     }
 
-    func testRequestingImageWithRemoteProductImageFromURLWithSpecialChars() {
+    func testRequestingImageWithRemoteProductImageFromURLWithSpecialChars() async throws {
         let mockPHAssetImageLoader = MockPHAssetImageLoader(imagesByAsset: [:])
         let imageLoader = DefaultProductUIImageLoader(imageService: imageService, phAssetImageLoaderProvider: { mockPHAssetImageLoader })
         let productImage = ProductImage(imageID: mockProductImageID,
@@ -56,12 +52,104 @@ final class ProductUIImageLoaderTests: XCTestCase {
                                         name: "woo",
                                         alt: nil)
 
-        let expectation = self.expectation(description: "Wait for image request")
-        _ = imageLoader.requestImage(productImage: productImage) { image in
-            XCTAssertEqual(image, self.testImage)
-            expectation.fulfill()
+        let image = try await imageLoader.requestImage(productImage: productImage)
+        XCTAssertEqual(image, self.testImage)
+    }
+
+    func test_request_image_throws_error_if_product_image_has_invalid_url() async throws {
+        // Given
+        let mockPHAssetImageLoader = MockPHAssetImageLoader(imagesByAsset: [:])
+        let mockImageService = MockImageService()
+        mockImageService.whenRetrieveImageFromCache(thenReturn: nil)
+        mockImageService.whenDownloadImage(thenReturn: UIImage.checkmark)
+        let imageLoader = DefaultProductUIImageLoader(imageService: mockImageService,
+                                                      phAssetImageLoaderProvider: { mockPHAssetImageLoader })
+        let productImage = ProductImage(imageID: mockProductImageID,
+                                        dateCreated: Date(),
+                                        dateModified: Date(),
+                                        src: "invalid_url",
+                                        name: "woo",
+                                        alt: nil)
+
+        // When
+        do {
+            _ = try await imageLoader.requestImage(productImage: productImage)
+        } catch {
+            // Then
+            let error = try XCTUnwrap(error as? DefaultProductUIImageLoader.ImageLoaderError)
+            XCTAssertEqual(error, .invalidURL)
         }
-        waitForExpectations(timeout: Constants.expectationTimeout, handler: nil)
+    }
+
+    func test_request_image_caches_remote_image() async throws {
+        // Given
+        let mockPHAssetImageLoader = MockPHAssetImageLoader(imagesByAsset: [:])
+        let mockImageService = MockImageService()
+        mockImageService.whenRetrieveImageFromCache(thenReturn: nil)
+        mockImageService.whenDownloadImage(thenReturn: UIImage.checkmark)
+        let imageLoader = DefaultProductUIImageLoader(imageService: mockImageService,
+                                                      phAssetImageLoaderProvider: { mockPHAssetImageLoader })
+        let productImage = ProductImage(imageID: mockProductImageID,
+                                        dateCreated: Date(),
+                                        dateModified: Date(),
+                                        src: imageURL.absoluteString,
+                                        name: "woo",
+                                        alt: nil)
+
+        // When
+        let image = try await imageLoader.requestImage(productImage: productImage)
+
+        // Then
+        XCTAssertTrue(mockImageService.downloadImageCalled)
+        XCTAssertTrue(mockImageService.shouldCacheImageValue)
+    }
+
+    func test_request_image_retrieves_from_cache_if_available() async throws {
+        // Given
+        let mockPHAssetImageLoader = MockPHAssetImageLoader(imagesByAsset: [:])
+        let mockImageService = MockImageService()
+        mockImageService.whenRetrieveImageFromCache(thenReturn: UIImage.checkmark)
+        mockImageService.whenDownloadImage(thenReturn: UIImage.checkmark)
+        let imageLoader = DefaultProductUIImageLoader(imageService: mockImageService,
+                                                      phAssetImageLoaderProvider: { mockPHAssetImageLoader })
+        let productImage = ProductImage(imageID: mockProductImageID,
+                                        dateCreated: Date(),
+                                        dateModified: Date(),
+                                        src: imageURL.absoluteString,
+                                        name: "woo",
+                                        alt: nil)
+
+        // When
+        let image = try await imageLoader.requestImage(productImage: productImage)
+
+        // Then
+        XCTAssertFalse(mockImageService.downloadImageCalled)
+        XCTAssertTrue(mockImageService.retrieveImageFromCacheCalled)
+    }
+
+    func test_request_image_throws_error_if_image_cannot_be_loaded() async throws {
+        // Given
+        let mockPHAssetImageLoader = MockPHAssetImageLoader(imagesByAsset: [:])
+        let mockImageService = MockImageService()
+        mockImageService.whenRetrieveImageFromCache(thenReturn: nil)
+        mockImageService.whenDownloadImage(thenThrow: ImageServiceError.other(error: MockError()))
+        let imageLoader = DefaultProductUIImageLoader(imageService: mockImageService,
+                                                      phAssetImageLoaderProvider: { mockPHAssetImageLoader })
+        let productImage = ProductImage(imageID: mockProductImageID,
+                                        dateCreated: Date(),
+                                        dateModified: Date(),
+                                        src: imageURL.absoluteString,
+                                        name: "woo",
+                                        alt: nil)
+
+        // When
+        do {
+            _ = try await imageLoader.requestImage(productImage: productImage)
+        } catch {
+            // Then
+            let error = try XCTUnwrap(error as? DefaultProductUIImageLoader.ImageLoaderError)
+            XCTAssertEqual(error, .unableToLoadImage)
+        }
     }
 
     func testRequestingImageWithPHAsset() {
@@ -77,3 +165,5 @@ final class ProductUIImageLoaderTests: XCTestCase {
         waitForExpectations(timeout: Constants.expectationTimeout, handler: nil)
     }
 }
+
+private class MockError: Error {}


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #11898
<!-- Id number of the GitHub issue this PR addresses. -->

## Description

### What? 
We load the product images every time we open the product form. There are also multiple requests sent for the same image URL.

https://github.com/woocommerce/woocommerce-ios/assets/524475/bf013022-e568-4bae-9cff-45659a7cd1cd


I noticed this behaviour while investigating a `WatchdogTermination` Sentry issue. Internal - peaMlT-gA-p2#comment-851

### Why? 

- The repeated loading of images might create memory issues when loading a product with many large images.
- We should stop sending duplicate network requests for the same product image. 

### How? 
- Use `DefaultImageService`'s caching setup to store and reuse product images.
- Rewrite the request image into `async` for better error handling and cancellation. 
- Clear the image cache upon logout.

## Testing instructions

We need to test two things in this PR.
- Product images can be viewed/edited as before.
- Product images should not be fetched from the network each time the product form is opened. (Should be cached instead)

Recommended testing setup
- I recommend setting up [Proxyman](https://proxyman.io/) and running builds from `trunk` and this branch in two simulators. 
- Open a product from the `trunk` build. Check Proxyman to see the image-related network requests.
- Open the same product from this branch's build. Check Proxyman to see the image-related network requests. The images should be cached and reused.
- Follow the same process while testing other product image screens/features. 

Steps
- Create a JN site
- Add a few products with many images
- Login into the app
- Open the products tab and open product and ensure that product images can be viewed as before.
- Try adding/removing product images and validate that it works as before.

## Screenshots

https://github.com/woocommerce/woocommerce-ios/assets/524475/fa9f7052-6ec6-438c-8401-697b0dec505d


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.