### PR TITLE
[Analytics Hub] Add analytics report URLs to Analytics Hub card view models

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/AnalyticsProductCardViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/AnalyticsProductCardViewModel.swift
@@ -20,6 +20,10 @@ struct AnalyticsProductsStatsCardViewModel {
     /// Indicates if there was an error loading stats part of the card.
     ///
     let showStatsError: Bool
+
+    /// URL for the corresponding web analytics report
+    ///
+    let reportURL: URL?
 }
 
 /// Analytics Hub Items Sold ViewModel.
@@ -49,7 +53,8 @@ extension AnalyticsProductsStatsCardViewModel {
         .init(itemsSold: "1000",
               delta: DeltaPercentage(string: "0%", direction: .zero),
               isRedacted: true,
-              showStatsError: false)
+              showStatsError: false,
+              reportURL: reportURL)
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/AnalyticsReportCardViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/AnalyticsReportCardViewModel.swift
@@ -52,6 +52,10 @@ struct AnalyticsReportCardViewModel {
     /// Message to display if there was an error loading the data for the card
     ///
     let syncErrorMessage: String
+
+    /// URL for the corresponding web analytics report
+    ///
+    let reportURL: URL?
 }
 
 extension AnalyticsReportCardViewModel {
@@ -71,7 +75,8 @@ extension AnalyticsReportCardViewModel {
               trailingChartData: [],
               isRedacted: true,
               showSyncError: false,
-              syncErrorMessage: "")
+              syncErrorMessage: "",
+              reportURL: reportURL)
     }
 }
 

--- a/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Analytics Hub/AnalyticsHubViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Analytics Hub/AnalyticsHubViewModelTests.swift
@@ -449,4 +449,128 @@ final class AnalyticsHubViewModelTests: XCTestCase {
             XCTAssert(analyticsProvider.receivedEvents.contains(event.rawValue), "Did not receive expected event: \(event.rawValue)")
         }
     }
+
+    @MainActor
+    func test_cards_viewmodels_contain_expected_reportURL_elements() async throws {
+        // Given
+        let sampleAdminURL = "https://example.com/wp-admin/"
+        let sessionManager = SessionManager.testingInstance
+        sessionManager.defaultSite = Site.fake().copy(adminURL: sampleAdminURL)
+        let stores = MockStoresManager(sessionManager: sessionManager)
+        let vm = AnalyticsHubViewModel(siteID: 123,
+                                       statsTimeRange: .thisMonth,
+                                       usageTracksEventEmitter: eventEmitter,
+                                       stores: stores)
+
+        // When
+        let revenueCardReportURL = try XCTUnwrap(vm.revenueCard.reportURL)
+        let ordersCardReportURL = try XCTUnwrap(vm.ordersCard.reportURL)
+        let productsCardReportURL = try XCTUnwrap(vm.productsStatsCard.reportURL)
+
+        let revenueCardURLQueryItems = try XCTUnwrap(URLComponents(url: revenueCardReportURL, resolvingAgainstBaseURL: false)?.queryItems)
+        let ordersCardURLQueryItems = try XCTUnwrap(URLComponents(url: ordersCardReportURL, resolvingAgainstBaseURL: false)?.queryItems)
+        let productsCardURLQueryItems = try XCTUnwrap(URLComponents(url: productsCardReportURL, resolvingAgainstBaseURL: false)?.queryItems)
+
+        // Then
+        // Report URL contains expected admin URL
+        XCTAssertTrue(revenueCardReportURL.relativeString.contains(sampleAdminURL))
+        XCTAssertTrue(ordersCardReportURL.relativeString.contains(sampleAdminURL))
+        XCTAssertTrue(productsCardReportURL.relativeString.contains(sampleAdminURL))
+
+        // Report URL contains expected report path
+        XCTAssertTrue(revenueCardURLQueryItems.contains(URLQueryItem(name: "path", value: "/analytics/revenue")))
+        XCTAssertTrue(ordersCardURLQueryItems.contains(URLQueryItem(name: "path", value: "/analytics/orders")))
+        XCTAssertTrue(productsCardURLQueryItems.contains(URLQueryItem(name: "path", value: "/analytics/products")))
+
+        // Report URL contains expected time range period
+        let expectedPeriodQueryItem = URLQueryItem(name: "period", value: "month")
+        XCTAssertTrue(revenueCardURLQueryItems.contains(expectedPeriodQueryItem))
+        XCTAssertTrue(ordersCardURLQueryItems.contains(expectedPeriodQueryItem))
+        XCTAssertTrue(productsCardURLQueryItems.contains(expectedPeriodQueryItem))
+    }
+
+    @MainActor
+    func test_cards_viewmodels_contain_expected_report_path_after_updating_from_network() async throws {
+        // Given
+        let sessionManager = SessionManager.testingInstance
+        sessionManager.defaultSite = Site.fake().copy(adminURL: "https://example.com/wp-admin/")
+        let stores = MockStoresManager(sessionManager: sessionManager)
+        let vm = AnalyticsHubViewModel(siteID: 123,
+                                       statsTimeRange: .thisMonth,
+                                       usageTracksEventEmitter: eventEmitter,
+                                       stores: stores)
+
+        stores.whenReceivingAction(ofType: StatsActionV4.self) { action in
+            switch action {
+            case let .retrieveCustomStats(_, _, _, _, _, _, _, completion):
+                let stats = OrderStatsV4.fake().copy(totals: .fake().copy(totalOrders: 15, totalItemsSold: 5, grossRevenue: 62))
+                completion(.success(stats))
+            case let .retrieveTopEarnerStats(_, _, _, _, _, _, _, _, completion):
+                let topEarners = TopEarnerStats.fake().copy(items: [.fake()])
+                completion(.success(topEarners))
+            case let .retrieveSiteSummaryStats(_, _, _, _, _, _, completion):
+                let siteStats = SiteSummaryStats.fake().copy(visitors: 30, views: 53)
+                completion(.success(siteStats))
+            default:
+                break
+            }
+        }
+
+        // When
+        await vm.updateData()
+
+        // Then
+        let revenueCardReportURL = try XCTUnwrap(vm.revenueCard.reportURL)
+        let ordersCardReportURL = try XCTUnwrap(vm.ordersCard.reportURL)
+        let productsCardReportURL = try XCTUnwrap(vm.productsStatsCard.reportURL)
+
+        let revenueCardURLQueryItems = try XCTUnwrap(URLComponents(url: revenueCardReportURL, resolvingAgainstBaseURL: false)?.queryItems)
+        let ordersCardURLQueryItems = try XCTUnwrap(URLComponents(url: ordersCardReportURL, resolvingAgainstBaseURL: false)?.queryItems)
+        let productsCardURLQueryItems = try XCTUnwrap(URLComponents(url: productsCardReportURL, resolvingAgainstBaseURL: false)?.queryItems)
+
+        // Report URL contains expected report path
+        XCTAssertTrue(revenueCardURLQueryItems.contains(URLQueryItem(name: "path", value: "/analytics/revenue")))
+        XCTAssertTrue(ordersCardURLQueryItems.contains(URLQueryItem(name: "path", value: "/analytics/orders")))
+        XCTAssertTrue(productsCardURLQueryItems.contains(URLQueryItem(name: "path", value: "/analytics/products")))
+    }
+
+    @MainActor
+    func test_cards_viewmodels_contain_non_nil_report_url_while_loading_and_after_error() async {
+        // Given
+        let sessionManager = SessionManager.testingInstance
+        sessionManager.defaultSite = Site.fake().copy(adminURL: "https://example.com/wp-admin/")
+        let stores = MockStoresManager(sessionManager: sessionManager)
+        let vm = AnalyticsHubViewModel(siteID: 123, statsTimeRange: .thisMonth, usageTracksEventEmitter: eventEmitter, stores: stores)
+
+        var loadingRevenueCard: AnalyticsReportCardViewModel?
+        var loadingOrdersCard: AnalyticsReportCardViewModel?
+        var loadingProductsCard: AnalyticsProductsStatsCardViewModel?
+        stores.whenReceivingAction(ofType: StatsActionV4.self) { action in
+            switch action {
+            case let .retrieveCustomStats(_, _, _, _, _, _, _, completion):
+                loadingRevenueCard = vm.revenueCard
+                loadingOrdersCard = vm.ordersCard
+                loadingProductsCard = vm.productsStatsCard
+                completion(.failure(NSError(domain: "Test", code: 1)))
+            case let .retrieveTopEarnerStats(_, _, _, _, _, _, _, _, completion):
+                completion(.failure(NSError(domain: "Test", code: 1)))
+            case let .retrieveSiteSummaryStats(_, _, _, _, _, _, completion):
+                completion(.failure(NSError(domain: "Test", code: 1)))
+            default:
+                break
+            }
+        }
+
+        // When
+        await vm.updateData()
+
+        // Then
+        XCTAssertNotNil(loadingRevenueCard?.reportURL)
+        XCTAssertNotNil(loadingOrdersCard?.reportURL)
+        XCTAssertNotNil(loadingProductsCard?.reportURL)
+
+        XCTAssertNotNil(vm.revenueCard.reportURL)
+        XCTAssertNotNil(vm.ordersCard.reportURL)
+        XCTAssertNotNil(vm.productsStatsCard.reportURL)
+    }
 }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of: #11874
<!-- Id number of the GitHub issue this PR addresses. -->

## Why
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
We plan to add full analytics reports to the Analytics Hub, by opening the web report in a webview. This PR adds the web report URL for each card in the Analytics Hub to the card's view model.

## How

* Adds the web report URL to the card view models (`AnalyticsReportCardViewModel` and `AnalyticsProductsStatsCardViewModel`), including the redacted view models.
* Initializes the revenue, orders, and product stats card view models in the `AnalyticsHubViewModel` init method, so we can use the selected time range and the store admin URL. This ensures the report link is immediately available, even while loading the stats data from remote (or if those requests fail).
* Adds a helper method to `AnalyticsHubViewModel` to get the web report URL for a given report, based on the currently selected time range. This helps set the report URL when the card view models are updated.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
Unit tests cover:

* `AnalyticsHubViewModelTests`:
   * The analytics card report URLs contain the expected store admin URL, time range period, and report path.
   * When the analytics cards are updated, each card's report URL still contains the expected report path.
   * The report URLs are not nil while loading remote data or after a remote request fails.

There are no changes to the UI in this PR.

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
