### PR TITLE
[Tablet Orders] Sync product selections immediately when side by side

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Products/ProductSelector/ProductSelectorView.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductSelector/ProductSelectorView.swift
@@ -60,6 +60,8 @@ struct ProductSelectorView: View {
     /// Tracks whether the `orderFormBundleProductConfigureCTAShown` event has been tracked to prevent multiple events across view updates.
     @State private var hasTrackedBundleProductConfigureCTAShownEvent: Bool = false
 
+    @Environment(\.adaptiveModalContainerPresentationStyle) var presentationStyle
+
     /// Title for the multi-selection button
     ///
     private var doneButtonTitle: String {
@@ -138,7 +140,7 @@ struct ProductSelectorView: View {
                     .buttonStyle(PrimaryButtonStyle())
                     .padding(Constants.defaultPadding)
                     .accessibilityIdentifier(Constants.doneButtonAccessibilityIdentifier)
-                    .renderedIf(configuration.multipleSelectionEnabled)
+                    .renderedIf(configuration.multipleSelectionEnabled && !viewModel.syncChangesImmediately)
 
                     if let variationListViewModel = variationListViewModel {
                         LazyNavigationLink(destination: ProductVariationSelector(
@@ -188,6 +190,7 @@ struct ProductSelectorView: View {
         }
         .onAppear {
             viewModel.onLoadTrigger.send()
+            viewModel.syncChangesImmediately = presentationStyle == .sideBySide
         }
         .notice($viewModel.notice, autoDismiss: false)
         .sheet(isPresented: $showingFilters) {

--- a/WooCommerce/Classes/ViewRelated/Products/ProductSelector/ProductSelectorViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductSelector/ProductSelectorViewModel.swift
@@ -380,6 +380,9 @@ final class ProductSelectorViewModel: ObservableObject {
         selectedItemsIDs = []
 
         onAllSelectionsCleared?()
+        if syncChangesImmediately {
+            onMultipleSelectionCompleted?(selectedItemsIDs)
+        }
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Products/ProductSelector/ProductSelectorViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductSelector/ProductSelectorViewModel.swift
@@ -296,8 +296,22 @@ final class ProductSelectorViewModel: ObservableObject {
                                                  product: variableProduct,
                                                  selectedProductVariationIDs: selectedItems,
                                                  purchasableItemsOnly: purchasableItemsOnly,
-                                                 onVariationSelectionStateChanged: onVariationSelectionStateChanged,
-                                                 onSelectionsCleared: onSelectedVariationsCleared)
+                                                 onVariationSelectionStateChanged: { [weak self] productVariation, product in
+            guard let self else { return }
+            onVariationSelectionStateChanged?(productVariation, product)
+
+            if syncChangesImmediately {
+                onMultipleSelectionCompleted?(selectedItemsIDs)
+            }
+        },
+                                                 onSelectionsCleared: { [weak self] in
+            guard let self else { return }
+            onSelectedVariationsCleared?()
+
+            if syncChangesImmediately {
+                onMultipleSelectionCompleted?(selectedItemsIDs)
+            }
+        })
     }
 
     /// Clears the current search term and filters to display the full product list.

--- a/WooCommerce/Classes/ViewRelated/Products/ProductSelector/ProductSelectorViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductSelector/ProductSelectorViewModel.swift
@@ -197,6 +197,8 @@ final class ProductSelectorViewModel: ObservableObject {
 
     private let onConfigureProductRow: ((_ product: Product) -> Void)?
 
+    @Published var syncChangesImmediately: Bool
+
     init(siteID: Int64,
          selectedItemIDs: [Int64] = [],
          purchasableItemsOnly: Bool = false,
@@ -209,6 +211,7 @@ final class ProductSelectorViewModel: ObservableObject {
          topProductsProvider: ProductSelectorTopProductsProviderProtocol? = nil,
          pageFirstIndex: Int = PaginationTracker.Defaults.pageFirstIndex,
          pageSize: Int = PaginationTracker.Defaults.pageSize,
+         syncChangesImmediately: Bool = false,
          onProductSelectionStateChanged: ((Product) -> Void)? = nil,
          onVariationSelectionStateChanged: ((ProductVariation, Product) -> Void)? = nil,
          onMultipleSelectionCompleted: (([Int64]) -> Void)? = nil,
@@ -229,6 +232,7 @@ final class ProductSelectorViewModel: ObservableObject {
         self.purchasableItemsOnly = purchasableItemsOnly
         self.shouldDeleteStoredProductsOnFirstPage = shouldDeleteStoredProductsOnFirstPage
         self.paginationTracker = PaginationTracker(pageFirstIndex: pageFirstIndex, pageSize: pageSize)
+        self.syncChangesImmediately = syncChangesImmediately
         self.onAllSelectionsCleared = onAllSelectionsCleared
         self.onSelectedVariationsCleared = onSelectedVariationsCleared
         self.onCloseButtonTapped = onCloseButtonTapped
@@ -260,6 +264,10 @@ final class ProductSelectorViewModel: ObservableObject {
             onVariationSelectionStateChanged?(productVariation, selectedProduct.copy(productID: selectedProduct.parentID))
         } else {
             onProductSelectionStateChanged?(selectedProduct)
+        }
+
+        if syncChangesImmediately {
+            onMultipleSelectionCompleted?(selectedItemsIDs)
         }
     }
 

--- a/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/AdaptiveModalContainer.swift
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/AdaptiveModalContainer.swift
@@ -106,21 +106,3 @@ extension EnvironmentValues {
         set { self[AdaptiveModalContainerPresentationStyleKey.self] = newValue }
     }
 }
-
-
-class AdaptiveModalContainerPresentationContext: ObservableObject, Equatable {
-    static func == (lhs: AdaptiveModalContainerPresentationContext, rhs: AdaptiveModalContainerPresentationContext) -> Bool {
-        return lhs.presentationStyle == rhs.presentationStyle
-    }
-
-    @Published var presentationStyle: PresentationStyle
-
-    init(presentationStyle: PresentationStyle) {
-        self.presentationStyle = presentationStyle
-    }
-
-    enum PresentationStyle: Equatable {
-        case sideBySide
-        case modalOnModal
-    }
-}

--- a/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/AdaptiveModalContainer.swift
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/AdaptiveModalContainer.swift
@@ -21,8 +21,10 @@ struct AdaptiveModalContainer<PrimaryView: View, SecondaryView: View>: View {
     var body: some View {
         if horizontalSizeClass == .compact {
             ModalOnModalView(primaryView: primaryView, secondaryView: secondaryView)
+                .environment(\.adaptiveModalContainerPresentationStyle, .modalOnModal)
         } else {
             SideBySideView(primaryView: primaryView, secondaryView: secondaryView)
+                .environment(\.adaptiveModalContainerPresentationStyle, .sideBySide)
         }
     }
 
@@ -86,5 +88,39 @@ struct AdaptiveModalContainer<PrimaryView: View, SecondaryView: View>: View {
                 .frame(minWidth: 400)
             }
         }
+    }
+}
+
+enum AdaptiveModalContainerPresentationStyle {
+    case modalOnModal
+    case sideBySide
+}
+
+struct AdaptiveModalContainerPresentationStyleKey: EnvironmentKey {
+    static let defaultValue: AdaptiveModalContainerPresentationStyle = .modalOnModal
+}
+
+extension EnvironmentValues {
+    var adaptiveModalContainerPresentationStyle: AdaptiveModalContainerPresentationStyle {
+        get { self[AdaptiveModalContainerPresentationStyleKey.self] }
+        set { self[AdaptiveModalContainerPresentationStyleKey.self] = newValue }
+    }
+}
+
+
+class AdaptiveModalContainerPresentationContext: ObservableObject, Equatable {
+    static func == (lhs: AdaptiveModalContainerPresentationContext, rhs: AdaptiveModalContainerPresentationContext) -> Bool {
+        return lhs.presentationStyle == rhs.presentationStyle
+    }
+
+    @Published var presentationStyle: PresentationStyle
+
+    init(presentationStyle: PresentationStyle) {
+        self.presentationStyle = presentationStyle
+    }
+
+    enum PresentationStyle: Equatable {
+        case sideBySide
+        case modalOnModal
     }
 }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/ProductSelectorViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/ProductSelectorViewModelTests.swift
@@ -501,6 +501,25 @@ final class ProductSelectorViewModelTests: XCTestCase {
         XCTAssertEqual(selectedProduct, product.productID)
     }
 
+    func test_changeSelectionStateForProduct_when_syncImmediately_true_calls_multiple_selection_handler() {
+        // Given
+        var selectedProducts: [Int64] = []
+        let product = Product.fake().copy(siteID: sampleSiteID, productID: 1, purchasable: true)
+        insert(product)
+        let viewModel = ProductSelectorViewModel(siteID: sampleSiteID,
+                                                 storageManager: storageManager,
+                                                 syncChangesImmediately: true,
+                                                 onMultipleSelectionCompleted: { productIDs in
+            selectedProducts = productIDs
+        })
+
+        // When
+        viewModel.changeSelectionStateForProduct(with: product.productID)
+
+        // Then
+        XCTAssertEqual(selectedProducts, [product.productID])
+    }
+
     func test_getVariationsViewModel_returns_expected_view_model_for_variable_product() throws {
         // Given
         let product = Product.fake().copy(siteID: sampleSiteID, productID: 1, name: "Test Product", purchasable: true, variations: [1, 2])


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #11887 
Closes: #11760 
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

This updates the feature-flagged split-view order creation screen to remove the `Done` button, and immediately sync the product selection changes, when shown side-by-side with the Order Form.

Known issues:
- When you go back to a small view, with modal-on-modal presentation, the button is shown again, however it doesn't have a title. #11846 
- The selection/deselection is easy to get out of sync by rapidly changing selection of different products or variations. #11908 
- When there's a blocking sync in place (ghost products are shown) the `Add products` button would be disabled... but the product selection in side-by-side mode is not disabled. #11907 

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

1. Set the `sideBySideViewForOrderForm` feature flag to true
2. Launch the app on an iPad or large iPhone
3. Go to the `Orders` tab
4. Tap `+`
5. Add products to the order – observe that they're added straight away
6. Add a variable product to the order – observe that it works the same
7. Clear selected variations – observe that they're removed from the order form

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->


Uploading product-selections.mp4…


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
