### PR TITLE
[Tablet Orders] Remove duplicate cancel button

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/EditableOrderViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/EditableOrderViewModel.swift
@@ -83,7 +83,14 @@ final class EditableOrderViewModel: ObservableObject {
     /// Indicates whether the cancel button is visible.
     ///
     var shouldShowCancelButton: Bool {
-        featureFlagService.isFeatureFlagEnabled(.splitViewInOrdersTab) && flow == .creation
+        guard featureFlagService.isFeatureFlagEnabled(.splitViewInOrdersTab) else {
+            return false
+        }
+        // The cancel button is handled by the AdaptiveModalContainer with the side-by-side view enabled, so this one should not be shown.
+        guard !featureFlagService.isFeatureFlagEnabled(.sideBySideViewForOrderForm) else {
+            return false
+        }
+        return flow == .creation
     }
 
     /// Indicates the customer details screen to be shown. If there's no address added show the customer selector, otherwise the form so it can be edited


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #11888
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

When using the side-by-side (or modal-over-modal) Order form, the cancel button is handled by the AdaptiveModalContainer, as it gets moved between the two navigation bars depending which are visible.

This commit removes the extra Cancel button to ensure we don’t end up with two.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

1. Enable the `sideBySideViewForOrderForm` feature flag
2. Launch the app
3. Go to the Order tab
4. Tap `+`
5. Observe that there's a `x` cancel button, and no extra `Cancel` button shown.
6. Try with larger sizes and smaller sizes on iPad – observe that there's only one.

Repeat the test with the feature flag off – observe that only the `Cancel` button is shown.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->




https://github.com/woocommerce/woocommerce-ios/assets/2472348/a1ab83f4-5170-4171-b159-6947d9bf3878



---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
