### PR TITLE
[Tablet Products] Sync selected product state in product list (primary view) and product form (secondary view)

### DIFF
--- a/WooCommerce/Classes/System/WooSplitViewController.swift
+++ b/WooCommerce/Classes/System/WooSplitViewController.swift
@@ -11,10 +11,14 @@ final class WooSplitViewController: UISplitViewController {
 
     private let columnForCollapsingHandler: ColumnForCollapsingHandler?
 
+    private let didExpandHandler: ((UISplitViewController) -> Void)?
+
     /// Init a split view with an optional handler to decide which column to collapse the split view into.
     /// By default, always display the primary column when collapsed.
-    init(columnForCollapsingHandler: ColumnForCollapsingHandler? = nil) {
+    init(columnForCollapsingHandler: ColumnForCollapsingHandler? = nil,
+         didExpandHandler: ((UISplitViewController) -> Void)? = nil) {
         self.columnForCollapsingHandler = columnForCollapsingHandler
+        self.didExpandHandler = didExpandHandler
         super.init(style: .doubleColumn)
         configureCommonStyle()
     }
@@ -39,5 +43,9 @@ extension WooSplitViewController: UISplitViewControllerDelegate {
     func splitViewController(_ splitViewController: UISplitViewController, willChangeTo displayMode: UISplitViewController.DisplayMode) {
         // Automatically hides the default toggle button if displaying 2 columns.
         splitViewController.presentsWithGesture = displayMode != .oneBesideSecondary
+    }
+
+    func splitViewControllerDidExpand(_ svc: UISplitViewController) {
+        didExpandHandler?(svc)
     }
 }

--- a/WooCommerce/Classes/ViewRelated/MainTabBarController.swift
+++ b/WooCommerce/Classes/ViewRelated/MainTabBarController.swift
@@ -565,6 +565,7 @@ private extension MainTabBarController {
             productsContainerController.wrappedController = ProductsSplitViewWrapperController(siteID: siteID)
         } else {
             productsNavigationController.viewControllers = [ProductsViewController(siteID: siteID,
+                                                                                   selectedProduct: Empty().eraseToAnyPublisher(),
                                                                                    navigateToContent: { _ in })]
         }
 

--- a/WooCommerce/Classes/ViewRelated/Products/ProductsSplitViewCoordinator.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductsSplitViewCoordinator.swift
@@ -3,7 +3,7 @@ import UIKit
 import Yosemite
 
 /// Coordinates the state of multiple columns (product list and secondary view) based on the secondary view.
-final class ProductsSplitViewCoordinator {
+final class ProductsSplitViewCoordinator: NSObject {
     /// Content type that is shown in the secondary view.
     enum SecondaryViewContentType: Equatable {
         case empty

--- a/WooCommerce/Classes/ViewRelated/Products/ProductsSplitViewCoordinator.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductsSplitViewCoordinator.swift
@@ -13,10 +13,7 @@ final class ProductsSplitViewCoordinator: NSObject {
     @Published private var contentTypes: [SecondaryViewContentType] = []
     private var selectedProduct: AnyPublisher<Product?, Never> {
         $contentTypes.map { contentTypes -> Product? in
-            guard let contentType = contentTypes.last else {
-                return nil
-            }
-            guard case let .productForm(product) = contentType else {
+            guard let contentType = contentTypes.last, case let .productForm(product) = contentType else {
                 return nil
             }
             return product

--- a/WooCommerce/Classes/ViewRelated/Products/ProductsSplitViewCoordinator.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductsSplitViewCoordinator.swift
@@ -50,7 +50,7 @@ final class ProductsSplitViewCoordinator: NSObject {
         guard let lastContentType = contentTypes.last else {
             return .primary
         }
-        return lastContentType == .empty ? .primary: .secondary
+        return lastContentType == .empty ? .primary : .secondary
     }
 
     /// Called when the split view transitions from collapsed to expanded mode.

--- a/WooCommerce/Classes/ViewRelated/Products/ProductsSplitViewCoordinator.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductsSplitViewCoordinator.swift
@@ -29,6 +29,7 @@ final class ProductsSplitViewCoordinator {
     private let primaryNavigationController: UINavigationController
     private let secondaryNavigationController: UINavigationController
     private lazy var productsViewController = ProductsViewController(siteID: siteID,
+                                                                     selectedProduct: selectedProduct,
                                                                      navigateToContent: showFromProductList)
 
     private var addProductCoordinator: AddProductCoordinator?

--- a/WooCommerce/Classes/ViewRelated/Products/ProductsSplitViewCoordinator.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductsSplitViewCoordinator.swift
@@ -47,6 +47,15 @@ final class ProductsSplitViewCoordinator: NSObject {
         autoSelectProductOnInitialDataLoad()
     }
 
+    /// Called when the split view is collapsing from the expanded state to determine which column to show in the collapsed mode.
+    /// - Returns: The column to show when the split view is collapsed.
+    func columnToShowWhenSplitViewIsCollapsing() -> UISplitViewController.Column {
+        guard let lastContentType = contentTypes.last else {
+            return .primary
+        }
+        return lastContentType == .empty ? .primary: .secondary
+    }
+
     /// Called when the split view transitions from collapsed to expanded mode.
     func didExpand() {
         // Auto-selects the first product if there is no content to be shown.

--- a/WooCommerce/Classes/ViewRelated/Products/ProductsSplitViewWrapperController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductsSplitViewWrapperController.swift
@@ -38,6 +38,7 @@ private extension ProductsSplitViewWrapperController {
     }
 
     func handleDidExpand(splitViewController: UISplitViewController) {
+        coordinator.didExpand()
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Products/ProductsSplitViewWrapperController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductsSplitViewWrapperController.swift
@@ -33,8 +33,7 @@ final class ProductsSplitViewWrapperController: UIViewController {
 
 private extension ProductsSplitViewWrapperController {
     func handleCollapsingSplitView(splitViewController: UISplitViewController) -> UISplitViewController.Column {
-        // TODO: update the collapsing logic
-        .secondary
+        coordinator.columnToShowWhenSplitViewIsCollapsing()
     }
 
     func handleDidExpand(splitViewController: UISplitViewController) {

--- a/WooCommerce/Classes/ViewRelated/Products/ProductsSplitViewWrapperController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductsSplitViewWrapperController.swift
@@ -7,7 +7,8 @@ final class ProductsSplitViewWrapperController: UIViewController {
     private let siteID: Int64
     private lazy var coordinator: ProductsSplitViewCoordinator = ProductsSplitViewCoordinator(siteID: siteID,
                                                                                               splitViewController: productsSplitViewController)
-    private lazy var productsSplitViewController = WooSplitViewController(columnForCollapsingHandler: handleCollapsingSplitView)
+    private lazy var productsSplitViewController = WooSplitViewController(columnForCollapsingHandler: handleCollapsingSplitView,
+                                                                          didExpandHandler: handleDidExpand)
 
     init(siteID: Int64) {
         self.siteID = siteID
@@ -34,6 +35,9 @@ private extension ProductsSplitViewWrapperController {
     func handleCollapsingSplitView(splitViewController: UISplitViewController) -> UISplitViewController.Column {
         // TODO: update the collapsing logic
         .secondary
+    }
+
+    func handleDidExpand(splitViewController: UISplitViewController) {
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Products/ProductsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductsViewController.swift
@@ -278,6 +278,14 @@ final class ProductsViewController: UIViewController, GhostableViewController {
     override var shouldShowOfflineBanner: Bool {
         return true
     }
+
+    /// Selects the first product if one is available. Invoked when no product is selected when data is loaded in split view expanded mode.
+    func selectFirstProductIfAvailable() {
+        guard let firstProduct = resultsController.fetchedObjects.first else {
+            return
+        }
+        didSelectProduct(product: firstProduct)
+    }
 }
 
 // MARK: - Navigation Bar Actions

--- a/WooCommerce/Classes/ViewRelated/Products/ProductsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductsViewController.swift
@@ -998,11 +998,13 @@ extension ProductsViewController: UITableViewDelegate {
         estimatedRowHeights[indexPath] = cell.frame.height
 
         // Restore cell selection state
-        let product = resultsController.object(at: indexPath)
-        if self.viewModel.productIsSelected(product) {
-            tableView.selectRow(at: indexPath, animated: false, scrollPosition: .none)
-        } else {
-            tableView.deselectRow(at: indexPath, animated: false)
+        if tableView.isEditing {
+            let product = resultsController.object(at: indexPath)
+            if self.viewModel.productIsSelected(product) {
+                tableView.selectRow(at: indexPath, animated: false, scrollPosition: .none)
+            } else {
+                tableView.deselectRow(at: indexPath, animated: false)
+            }
         }
     }
 

--- a/Yosemite/Yosemite/Tools/ResultsController.swift
+++ b/Yosemite/Yosemite/Tools/ResultsController.swift
@@ -211,6 +211,17 @@ public class ResultsController<T: ResultsControllerMutableType> {
         return readOnlySections ?? []
     }
 
+    /// Returns an optional index path of the first matching object.
+    /// - Parameter objectMatching: Specifies the matching criteria.
+    /// - Returns: An optional index path of the first object that matches the given criteria.
+    public func indexPath(forObjectMatching objectMatching: (T) -> Bool) -> IndexPath? {
+        guard let fetchedObjects = controller.fetchedObjects,
+              let object = fetchedObjects.first(where: { objectMatching($0) }) else {
+            return nil
+        }
+        return controller.indexPath(forObject: object)
+    }
+
     /// Refreshes all of the Fetched Objects, so that the new criteria is met.
     ///
     private func refreshFetchedObjects(predicate: NSPredicate?) {

--- a/Yosemite/YosemiteTests/Tools/ResultsControllerTests.swift
+++ b/Yosemite/YosemiteTests/Tools/ResultsControllerTests.swift
@@ -425,6 +425,45 @@ final class ResultsControllerTests: XCTestCase {
         // Then
         XCTAssertEqual(resultsController.fetchedObjects.count, 3)
     }
+
+    // MARK: - `indexPath(forObjectMatching:)`
+
+    func test_indexPath_returns_index_path_for_the_first_matching_object() throws {
+        // Given
+        let _ = [
+            insertAccount(displayName: "A", username: "two"),
+            insertAccount(displayName: "A", username: "one"), // index path (0, 0) when sorted by username
+            insertAccount(displayName: "C", username: "three"),
+        ]
+
+        // When
+        let sortByUsername = NSSortDescriptor(key: #selector(getter: Storage.Account.username).description, ascending: true)
+        let resultsController = ResultsController<Storage.Account>(viewStorage: viewStorage,
+                                                                   sectionNameKeyPath: #keyPath(Storage.Account.displayName),
+                                                                   sortedBy: [sampleSortDescriptor, sortByUsername])
+        try resultsController.performFetch()
+
+        // Then
+        XCTAssertEqual(resultsController.indexPath(forObjectMatching: { $0.displayName == "A" }), .init(row: 0, section: 0))
+    }
+
+    func test_indexPath_returns_nil_when_there_is_no_matching_object() throws {
+        // Given
+        let _ = [
+            insertAccount(displayName: "A", username: "two"),
+            insertAccount(displayName: "A", username: "one"),
+            insertAccount(displayName: "C", username: "three"),
+        ]
+
+        // When
+        let resultsController = ResultsController<Storage.Account>(viewStorage: viewStorage,
+                                                                   sectionNameKeyPath: #keyPath(Storage.Account.displayName),
+                                                                   sortedBy: [sampleSortDescriptor])
+        try resultsController.performFetch()
+
+        // Then
+        XCTAssertNil(resultsController.indexPath(forObjectMatching: { $0.displayName == "B" }))
+    }
 }
 
 // MARK: - Utils


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #11901
Closes: #11910 
Closes: #11911
<!-- Id number of the GitHub issue this PR addresses. -->

## Why

The main objective of this PR is to come up with a way to track a centralized selected product state that is in sync with the secondary view and can be observed in the product list in the primary column. This enables easier implementation of https://github.com/woocommerce/woocommerce-ios/issues/11911 on the collapsing behavior, and auto-selection logic https://github.com/woocommerce/woocommerce-ios/issues/11910 doesn't need to be the product list view controller's `viewDidLayoutSubviews` like in the orders tab. I tried not adding any split view logic to the product list view controller and keeping most of the split view logic within the coorindator, please feel free to share any feedback on this implementation.

## How

First, the secondary column content is tracked by an observable array `contentTypes: [SecondaryViewContentType]` with a new enum `SecondaryViewContentType` that is currently either the empty view or product form (new or existing product). The array elements correspond to the view controllers in the secondary navigation stack that pushes the view controller using the coordinator. Just a note that there are still some push navigation actions within `ProductFormViewController` that we might also want to move to the coordinator later.

### Select/deselect the product that is shown in the secondary view

With the selected product state in `ProductsViewController`'s initializer (`Empty` is passed when the feature flag is off), `ProductsViewController` observes the selected product along with a passthrough signal (not persisting the current value) after each data load. This is because the same product can have a different index path after the data is reloaded using `NSFetchedResultsController` under the hood, like after the filters or pull-to-refresh. To know the latest index path given a product, `ResultsController.indexPath(forObjectMatching:)` was added.

### Showing newly created product as selected

In `ProductsSplitViewCoordinator`, it implements `addProductCoordinator.onProductCreated` and replaces the last content type value from `nil` product to the newly created product.

### Challenge: detecting when a view controller is popped from the secondary navigation stack

This is one of the trickiest issues I've encountered so far, as I wasn't able to find any other way to detect this scenario than conforming to `UINavigationControllerDelegate` of the secondary navigation controller to compare the navigation view controllers count with the current `contentTypes` state. I'd be really happy to know if there's a better way to do this! The implementation is in `ProductsSplitViewCoordinator`'s `UINavigationControllerDelegate.willShow` method (the coordinator has to be a NSObject subclass to conform to `UINavigationControllerDelegate`).

### Challenge: in collapsed mode, detecting when the last secondary view controller is popped

I got stuck on this for the longest time, as none of the `UISplitViewControllerDelegate` method is triggered when the last secondary view controller is popped and the product list is shown in the collapsed mode where the secondary navigation stack is added to the primary navigation stack. In the end, the workaround I came up with is in `ProductsSplitViewCoordinator.willNavigateFromTheLastSecondaryViewControllerToProductListInCollapsedMode` that I tried adding as many comments as possible.

### Updating collapsing behavior for https://github.com/woocommerce/woocommerce-ios/issues/11911

With the `contentTypes` state, it checks whether the last content type is an empty view. If not, the secondary column is returned as we only want to collapse to the primary column when there is no product selected.

### Auto-selection logic for https://github.com/woocommerce/woocommerce-ios/issues/11910

To auto-select a product when the data is loaded and no product is selected, I decided to break it into two parts given the available APIs:

- Initial data load & selected product state if the split view is in the expanded state
- `UISplitViewControllerDelegate.splitViewControllerDidExpand`

This way, we don't have to embed the split view logic inside the product list's `viewDidLayoutSubviews` similar to the orders tab.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

- [ ] @jaclync tests that the products tab is the same as before when the feature flag is off

---

Prerequisite: a large device/simulator that can be switched between expanded and collapsed states. In code, enable `splitViewInProductsTab` feature flag in `DefaultFeatureFlagService`.

### Auto-selection & collapsing behavior

- In expanded mode, launch the app
- Go to the products tab --> the first product should be selected (🗒️ the row is somehow selected a bit later, I left it as a separate task https://github.com/woocommerce/woocommerce-ios/issues/11915)
- Collapse the split view --> the first product form should be shown
- Tap < to go back to the product list --> no product should be selected
- Expand the split view --> the first product should be selected again

### Create product

- Make sure it's in expanded state
- In the product list, tap on any product
- Tap + in the product list, then proceed with the action sheets until the product form is shown --> the product form should be shown in the secondary column
- Enter some product details, then tap `Publish` to publish the product --> after it's saved remotely, the new product row should appear as selected in the product list
- Tap < to go back to the previously selected product form --> the selected product row in the product list should be updated

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->


https://github.com/woocommerce/woocommerce-ios/assets/1945542/4db55916-9915-44b5-994c-b841f574ee2b



---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.