### PR TITLE
[Backend Receipts] Add loading indicator when loading receipts

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Receipts/ReceiptViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Receipts/ReceiptViewController.swift
@@ -1,8 +1,16 @@
 import WebKit
 
 /// Previews a backend-generated receipt
-final class ReceiptViewController: UIViewController {
+final class ReceiptViewController: UIViewController, WKNavigationDelegate {
     @IBOutlet private weak var webView: WKWebView!
+
+    private lazy var activityIndicator: UIActivityIndicatorView = {
+        let indicator = UIActivityIndicatorView(style: .medium)
+        indicator.hidesWhenStopped = true
+        indicator.translatesAutoresizingMaskIntoConstraints = false
+        return indicator
+    }()
+
     private let viewModel: ReceiptViewModel
     
     var onDisappear: (() -> Void)?
@@ -27,6 +35,19 @@ final class ReceiptViewController: UIViewController {
 
         configureContent()
         configureNavigation()
+        configureActivityIndicator()
+
+        webView.navigationDelegate = self
+    }
+
+    func configureActivityIndicator() {
+        view.addSubview(activityIndicator)
+        NSLayoutConstraint.activate([
+            view.centerXAnchor.constraint(equalTo: activityIndicator.centerXAnchor),
+            view.centerYAnchor.constraint(equalTo: activityIndicator.centerYAnchor)
+        ])
+
+        activityIndicator.startAnimating()
     }
 
     private func configureContent() {
@@ -79,5 +100,12 @@ final class ReceiptViewController: UIViewController {
                 self?.dismiss(animated: true)
             }
         })
+    }
+}
+
+// MARK: - WKNavigation delegate
+extension ReceiptViewController {
+    func webView(_ webView: WKWebView, didFinish navigation: WKNavigation!) {
+        activityIndicator.stopAnimating()
     }
 }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes #11857 

## Description
This PR adds a loading indicator to ReceiptViewController, which will start running when the view loads, and will stop when the `didFinish` delegate is notified.

## Testing instructions
- On a store with the woo-dev receipt plugin ( you can use https://mywootestingstore.mystagingwebsite.com ), create an order, and collect payment (mark as paid by cash is fine)
- Observe the `See receipt` link in the order details, tap on it.
- Observe that the loading indicator runs with the view, and stops once the receipt is loaded.

## Screenshots
![Simulator Screen Recording - iPhone 15 - 2024-02-06 at 13 43 57](https://github.com/woocommerce/woocommerce-ios/assets/3812076/712a230a-f193-42b2-8c12-4d69681416d0)

