### PR TITLE
[Backend receipts] Error handling

### DIFF
--- a/WooCommerce/Classes/ViewModels/CardPresentPayments/PaymentCaptureOrchestrator.swift
+++ b/WooCommerce/Classes/ViewModels/CardPresentPayments/PaymentCaptureOrchestrator.swift
@@ -33,7 +33,7 @@ protocol PaymentCaptureOrchestrating {
 
     func saveReceipt(for order: Order, params: CardPresentReceiptParameters)
 
-    func presentBackendReceipt(for order: Order, onCompletion: @escaping (Receipt) -> Void)
+    func presentBackendReceipt(for order: Order, onCompletion: @escaping (Result<Receipt, Error>) -> Void)
 }
 
 
@@ -181,15 +181,13 @@ final class PaymentCaptureOrchestrator: PaymentCaptureOrchestrating {
         stores.dispatch(action)
     }
 
-    func presentBackendReceipt(for order: Order, onCompletion: @escaping (Receipt) -> Void) {
+    func presentBackendReceipt(for order: Order, onCompletion: @escaping (Result<Receipt, Error>) -> Void) {
         let action = ReceiptAction.retrieveReceipt(order: order) { result in
             switch result {
             case let .success(receipt):
-                onCompletion(receipt)
-            case .failure:
-                // TODO: Error handling. Propagate error.
-                DDLogError("Unable to retrieve receipt for site \(order.siteID) - order \(order.orderID)")
-                break
+                onCompletion(.success(receipt))
+            case let .failure(error):
+                onCompletion(.failure(error))
             }
         }
         stores.dispatch(action)

--- a/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsViewModel.swift
+++ b/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsViewModel.swift
@@ -480,7 +480,7 @@ extension OrderDetailsViewModel {
                     let receiptViewController = ReceiptViewController(viewModel: receiptViewModel)
                     viewController.navigationController?.pushViewController(receiptViewController, animated: true)
                 case let .failure(error):
-                    debugPrint("\(error)")
+                    self.displayReceiptRetrievalErrorNotice(for: order, with: error, in: viewController)
                 }
             }
             ServiceLocator.stores.dispatch(action)
@@ -799,5 +799,28 @@ private extension OrderDetailsViewModel {
     enum SyncState {
         case notSynced
         case synced
+    }
+}
+
+// MARK: - Notices
+private extension OrderDetailsViewModel {
+    func displayReceiptRetrievalErrorNotice(for order: Order,
+                                            with error: Error?,
+                                            in viewController: UIViewController) {
+        
+        let noticePresenter = DefaultNoticePresenter()
+        let notice = Notice(title: Localization.failedReceiptRetrievalNoticeText,
+                            feedbackType: .error)
+        noticePresenter.presentingViewController = viewController
+        noticePresenter.enqueue(notice: notice)
+
+        DDLogError("Failed to retrieve receipt for: \(order.orderID). Site \(order.siteID). Error: \(String(describing: error))")
+    }
+    
+    enum Localization {
+        static let failedReceiptRetrievalNoticeText = NSLocalizedString(
+            "OrderDetailsViewModel.displayReceiptRetrievalErrorNotice.notice",
+            value: "Unable to retrieve receipt.",
+            comment: "Notice that appears when no receipt can be retrieved upon tapping on 'See receipt' in the Order Details view.")
     }
 }

--- a/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsViewModel.swift
+++ b/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsViewModel.swift
@@ -807,16 +807,15 @@ private extension OrderDetailsViewModel {
     func displayReceiptRetrievalErrorNotice(for order: Order,
                                             with error: Error?,
                                             in viewController: UIViewController) {
-        
         let noticePresenter = DefaultNoticePresenter()
         let notice = Notice(title: Localization.failedReceiptRetrievalNoticeText,
                             feedbackType: .error)
         noticePresenter.presentingViewController = viewController
         noticePresenter.enqueue(notice: notice)
 
-        DDLogError("Failed to retrieve receipt for: \(order.orderID). Site \(order.siteID). Error: \(String(describing: error))")
+        DDLogError("Failed to retrieve receipt for order: \(order.orderID). Site \(order.siteID). Error: \(String(describing: error))")
     }
-    
+
     enum Localization {
         static let failedReceiptRetrievalNoticeText = NSLocalizedString(
             "OrderDetailsViewModel.displayReceiptRetrievalErrorNotice.notice",

--- a/WooCommerce/Classes/ViewModels/Order Details/Receipts/ReceiptEligibilityUseCase.swift
+++ b/WooCommerce/Classes/ViewModels/Order Details/Receipts/ReceiptEligibilityUseCase.swift
@@ -44,6 +44,10 @@ private extension ReceiptEligibilityUseCase {
     enum Constants {
         static let wcPluginName = "WooCommerce"
         static let wcPluginMinimumVersion = "8.7.0"
-        static let wcPluginDevVersion: [String] = ["8.6.0-dev-7625495467-gf50cc6b", "8.6.0-dev-7708067547-g87e8c5f"]
+        static let wcPluginDevVersion: [String] = ["8.7.0-dev",
+                                                   "8.6.0-dev",
+                                                   "8.5.0-beta.1",
+                                                   "8.6.0-dev-7625495467-gf50cc6b",
+                                                   "8.6.0-dev-7708067547-g87e8c5f"]
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Orders/Collect Payments/CollectOrderPaymentUseCase.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Collect Payments/CollectOrderPaymentUseCase.swift
@@ -510,9 +510,15 @@ private extension CollectOrderPaymentUseCase {
         // Handles receipt presentation for both print and email actions
         let receiptPresentationCompletionAction: () -> Void = { [weak self] in
             guard let self else { return }
-            self.paymentOrchestrator.presentBackendReceipt(for: self.order, onCompletion: { [weak self] receipt in
+            self.paymentOrchestrator.presentBackendReceipt(for: self.order, onCompletion: { [weak self] result in
                 guard let self else { return }
-                self.presentBackendReceiptModally(receipt: receipt, onCompleted: onCompleted)
+                switch result {
+                case let .success(receipt):
+                    self.presentBackendReceiptModally(receipt: receipt, onCompleted: onCompleted)
+                case let .failure(error):
+                    DDLogError("Failed to present receipt for order: \(order.orderID). Site \(order.siteID). Error: \(String(describing: error))")
+                    onCompleted()
+                }
             })
         }
         // Presents receipt alert

--- a/WooCommerce/WooCommerceTests/Mocks/MockPaymentCaptureOrchestrator.swift
+++ b/WooCommerce/WooCommerceTests/Mocks/MockPaymentCaptureOrchestrator.swift
@@ -72,7 +72,7 @@ final class MockPaymentCaptureOrchestrator: PaymentCaptureOrchestrating {
         spySaveReceiptParams = params
     }
 
-    func presentBackendReceipt(for order: Yosemite.Order, onCompletion: @escaping (Yosemite.Receipt) -> Void) {
+    func presentBackendReceipt(for order: Yosemite.Order, onCompletion: @escaping (Result<Yosemite.Receipt, Error>) -> Void) {
         // no implemented
     }
 }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes #11829

## Description
This PR adds error handling by logging the error internally as well as displaying a user-facing notification for the cases when this could fail, that is:
- We fail to fetch a receipt via tapping on `See receipt``
- We fail to print a receipt via "print or share" receipt when performing a card present payment.

| See Receipt failed | Print receipt failed |
|--------|--------|
| <img width=300 src="https://github.com/woocommerce/woocommerce-ios/assets/3812076/26f61358-670d-4d67-aef1-a342844ec833"> | <img width="302" alt="Screenshot 2024-02-06 at 16 22 10" src="https://github.com/woocommerce/woocommerce-ios/assets/3812076/fe6f35cc-7e90-4fbf-9c2b-7286a6beff0d"> | 

## Testing instructions
Return early with an error in `ReceiptStore.retrieveReceipt(:)` method, 
```diff
func retrieveReceipt(order: Order, onCompletion: @escaping (Result<Receipt, Error>) -> Void) {
+ onCompletion(.failure(NSError(domain: "oopsie", code: 123)))
+ return
remote.retrieveReceipt(siteID: order.siteID,
... 
```

As well as in `PaymentCaptureOrchestrator.presentBackendReceipt(:)`
```diff
func presentBackendReceipt(for order: Order, onCompletion: @escaping (Result<Receipt, Error>) -> Void) {
+        onCompletion(.failure(NSError(domain: "oopsie", code: 123)))
+        return
```
This way we can be sure that we're getting an error in both flows. Now, on a eligible store (woo-dev plugin with receipts API, you can use [indiemelon.mystagingwebsite.com](indiemelon.mystagingwebsite.com), since this one has WCPay enabled for testing):
1. Proceed to create an order. Collect cash payment. Tap on "See receipt". Observe that we fail to fetch the receipt and the notice appears in the bottom of the view.
2. Proceed to create a new order. Collect payment via card present. Tap on "Print receipt". Observe the notice appears in the bottom of the view.

### Caveats
If the 2nd flow goes fast enough, the user won't see the notice since we navigate them automatically to the order details upon completion, I don't think is worth to alter the whole navigation so they can see the notice, specially since the "See receipt" button will appear immediately after as well so they can try again. We can attempt to improve this in the future, but for the moment, if you need to slow it down for testing, we can delay the completion in the `presentBackedReceiptFailedNotice()` call as such:
```diff
-onCompleted()
+DispatchQueue.main.asyncAfter(deadline: .now() + 3) {
+	onCompleted()
+}
```
![Simulator Screen Recording - iPhone 15 - 2024-02-06 at 16 05 24](https://github.com/woocommerce/woocommerce-ios/assets/3812076/e955b4da-4655-4efc-bbf7-ba20c034aa07)