### PR TITLE
Update the selected row style for products list

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Products/Cells/ProductsTabProductTableViewCell.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Cells/ProductsTabProductTableViewCell.swift
@@ -37,6 +37,9 @@ final class ProductsTabProductTableViewCell: UITableViewCell {
         configureDetailsLabel()
         configureProductImageView()
         configureBottomBorderView()
+        // From iOS 15.0, a focus effect will be applied automatically to a selected cell
+        // modifying its style (e.g: by adding a border)
+        focusEffect = nil
     }
 
     required init?(coder aDecoder: NSCoder) {
@@ -239,7 +242,6 @@ private extension ProductsTabProductTableViewCell {
         static let imageBorderColor = UIColor.border
         static let imagePlaceholderTintColor = UIColor.systemColor(.systemGray2)
         static let imageBackgroundColor = UIColor.listForeground(modal: false)
-        static let selectedBackgroundColor = UIColor.productsCellSelectedBackgroundColor
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Products/ProductsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductsViewController.swift
@@ -962,14 +962,16 @@ extension ProductsViewController: UITableViewDelegate {
     }
 
     func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
+        if splitViewController?.isCollapsed == true || !isSplitViewEnabled {
+            tableView.deselectRow(at: indexPath, animated: true)
+        }
+
         let product = resultsController.object(at: indexPath)
 
         if tableView.isEditing {
             viewModel.selectProduct(product)
             updatedSelectedItems()
         } else {
-            tableView.deselectRow(at: indexPath, animated: true)
-
             ServiceLocator.analytics.track(.productListProductTapped)
 
             didSelectProduct(product: product)


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #11903
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
- setting `focusEffect = nil` to avoid the selection frame in the products cell (same as in https://github.com/woocommerce/woocommerce-ios/pull/11621)

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
- make sure `splitViewInProductsTab` is enabled in `DefaultFeatureFlagService`
- open Products tab
- tap on different products in the list and check that the selection style (background color) is ok, same as in Orders

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->
![Simulator Screenshot - iPad Pro (11-inch) (4th generation) - 2024-02-06 at 12 05 44](https://github.com/woocommerce/woocommerce-ios/assets/6242034/1ad6f269-d5ba-4a8c-83ed-a079761974fe)

---
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
