### PR TITLE
[Analytics Hub] Add link to analytics reports in Analytics Hub

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -3,6 +3,7 @@
 17.3
 -----
 - [***] Products: Cache product images to reduce network requests. [https://github.com/woocommerce/woocommerce-ios/pull/11902]
+- [***] Stats: The Analytics Hub now includes links to the full analytics report for each supported analytics card (Revenue, Orders, Products). [https://github.com/woocommerce/woocommerce-ios/pull/11920]
 
 17.2
 -----

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/AnalyticsHubReportLink.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/AnalyticsHubReportLink.swift
@@ -5,15 +5,13 @@ struct AnalyticsHubReportLink: View {
     let reportViewModel: WPAdminWebViewModel
 
     var body: some View {
-        VStack(spacing: Layout.spacing) {
-            Divider()
-            Button {
-                showingWebReport = true
-            } label: {
-                Text(Localization.seeReport)
-                    .frame(maxWidth: .infinity, alignment: .leading)
-                DisclosureIndicator()
-            }
+        Button {
+            showingWebReport = true
+        } label: {
+            Text(Localization.seeReport)
+                .bodyStyle()
+                .frame(maxWidth: .infinity, alignment: .leading)
+            DisclosureIndicator()
         }
         .sheet(isPresented: $showingWebReport) {
             WooNavigationSheet(viewModel: .init(navigationTitle: reportViewModel.title, done: {
@@ -32,13 +30,9 @@ private extension AnalyticsHubReportLink {
                                                  value: "See Report",
                                                  comment: "Button label to show an analytics report in the Analytics Hub")
     }
-
-    enum Layout {
-        static let spacing: CGFloat = 16
-    }
 }
 
 #Preview {
-    AnalyticsHubReportLink(showingWebReport: .constant(true), reportViewModel: .init(initialURL: URL(string: "https://example.com/")!))
+    AnalyticsHubReportLink(showingWebReport: .constant(false), reportViewModel: .init(initialURL: URL(string: "https://woo.com/")!))
         .previewLayout(.sizeThatFits)
 }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/AnalyticsHubReportLink.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/AnalyticsHubReportLink.swift
@@ -1,0 +1,44 @@
+import SwiftUI
+
+struct AnalyticsHubReportLink: View {
+    @Binding var showingWebReport: Bool
+    let reportViewModel: WPAdminWebViewModel
+
+    var body: some View {
+        VStack(spacing: Layout.spacing) {
+            Divider()
+            Button {
+                showingWebReport = true
+            } label: {
+                Text(Localization.seeReport)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                DisclosureIndicator()
+            }
+        }
+        .sheet(isPresented: $showingWebReport) {
+            WooNavigationSheet(viewModel: .init(navigationTitle: reportViewModel.title, done: {
+                showingWebReport = false
+            })) {
+                AuthenticatedWebView(isPresented: $showingWebReport, viewModel: reportViewModel)
+            }
+        }
+    }
+}
+
+// MARK: Constants
+private extension AnalyticsHubReportLink {
+    enum Localization {
+        static let seeReport = NSLocalizedString("analyticsHub.reportCard.webReport",
+                                                 value: "See Report",
+                                                 comment: "Button label to show an analytics report in the Analytics Hub")
+    }
+
+    enum Layout {
+        static let spacing: CGFloat = 16
+    }
+}
+
+#Preview {
+    AnalyticsHubReportLink(showingWebReport: .constant(true), reportViewModel: .init(initialURL: URL(string: "https://example.com/")!))
+        .previewLayout(.sizeThatFits)
+}

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/AnalyticsHubViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/AnalyticsHubViewModel.swift
@@ -526,16 +526,16 @@ private extension AnalyticsHubViewModel {
 
     /// Gets the webview view model to show a web analytics report, based on the provided report type and currently selected time range
     ///
-    func webReportVM(for report: AnalyticsHubWebReport.ReportType) -> WPAdminWebViewModel? {
+    func webReportVM(for report: AnalyticsWebReport.ReportType) -> WPAdminWebViewModel? {
         return AnalyticsHubViewModel.webReportVM(for: report, timeRange: timeRangeSelectionType, storeAdminURL: stores.sessionManager.defaultSite?.adminURL)
     }
 
     /// Gets the webview view model to show a web analytics report, based on the provided report type, time range, and store admin URL
     ///
-    static func webReportVM(for report: AnalyticsHubWebReport.ReportType,
+    static func webReportVM(for report: AnalyticsWebReport.ReportType,
                             timeRange: AnalyticsHubTimeRangeSelection.SelectionType,
                             storeAdminURL: String?) -> WPAdminWebViewModel? {
-        guard let url = AnalyticsHubWebReport.getUrl(for: report, timeRange: timeRange, storeAdminURL: storeAdminURL) else {
+        guard let url = AnalyticsWebReport.getUrl(for: report, timeRange: timeRange, storeAdminURL: storeAdminURL) else {
             return nil
         }
         let title = {

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/AnalyticsHubViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/AnalyticsHubViewModel.swift
@@ -53,21 +53,20 @@ final class AnalyticsHubViewModel: ObservableObject {
         self.usageTracksEventEmitter = usageTracksEventEmitter
 
         let storeAdminURL = stores.sessionManager.defaultSite?.adminURL
+        let revenueWebReportVM = AnalyticsHubViewModel.webReportVM(for: .revenue, timeRange: selectedType, storeAdminURL: storeAdminURL)
         self.revenueCard = AnalyticsHubViewModel.revenueCard(currentPeriodStats: nil,
                                                              previousPeriodStats: nil,
-                                                             webReportURL: AnalyticsHubWebReport.getUrl(for: .revenue,
-                                                                                                        timeRange: selectedType,
-                                                                                                        storeAdminURL: storeAdminURL))
+                                                             webReportViewModel: revenueWebReportVM)
+
+        let ordersWebReportVM = AnalyticsHubViewModel.webReportVM(for: .orders, timeRange: selectedType, storeAdminURL: storeAdminURL)
         self.ordersCard = AnalyticsHubViewModel.ordersCard(currentPeriodStats: nil,
                                                            previousPeriodStats: nil,
-                                                           webReportURL: AnalyticsHubWebReport.getUrl(for: .orders,
-                                                                                                      timeRange: selectedType,
-                                                                                                      storeAdminURL: storeAdminURL))
+                                                           webReportViewModel: ordersWebReportVM)
+
+        let productsWebReportVM = AnalyticsHubViewModel.webReportVM(for: .products, timeRange: selectedType, storeAdminURL: storeAdminURL)
         self.productsStatsCard = AnalyticsHubViewModel.productsStatsCard(currentPeriodStats: nil,
                                                                          previousPeriodStats: nil,
-                                                                         webReportURL: AnalyticsHubWebReport.getUrl(for: .products,
-                                                                                                                    timeRange: selectedType,
-                                                                                                                    storeAdminURL: storeAdminURL))
+                                                                         webReportViewModel: productsWebReportVM)
 
         bindViewModelsWithData()
     }
@@ -370,13 +369,13 @@ private extension AnalyticsHubViewModel {
 
                 self.revenueCard = AnalyticsHubViewModel.revenueCard(currentPeriodStats: currentOrderStats,
                                                                      previousPeriodStats: previousOrderStats,
-                                                                     webReportURL: analyticsReportURL(for: .revenue))
+                                                                     webReportViewModel: webReportVM(for: .revenue))
                 self.ordersCard = AnalyticsHubViewModel.ordersCard(currentPeriodStats: currentOrderStats,
                                                                    previousPeriodStats: previousOrderStats,
-                                                                   webReportURL: analyticsReportURL(for: .orders))
+                                                                   webReportViewModel: webReportVM(for: .orders))
                 self.productsStatsCard = AnalyticsHubViewModel.productsStatsCard(currentPeriodStats: currentOrderStats,
                                                                                  previousPeriodStats: previousOrderStats,
-                                                                                 webReportURL: analyticsReportURL(for: .products))
+                                                                                 webReportViewModel: webReportVM(for: .products))
 
             }.store(in: &subscriptions)
 
@@ -413,7 +412,7 @@ private extension AnalyticsHubViewModel {
 
     static func revenueCard(currentPeriodStats: OrderStatsV4?,
                             previousPeriodStats: OrderStatsV4?,
-                            webReportURL: URL?) -> AnalyticsReportCardViewModel {
+                            webReportViewModel: WebViewSheetViewModel?) -> AnalyticsReportCardViewModel {
         let showSyncError = currentPeriodStats == nil || previousPeriodStats == nil
 
         return AnalyticsReportCardViewModel(title: Localization.RevenueCard.title,
@@ -429,12 +428,12 @@ private extension AnalyticsHubViewModel {
                                             isRedacted: false,
                                             showSyncError: showSyncError,
                                             syncErrorMessage: Localization.RevenueCard.noRevenue,
-                                            reportURL: webReportURL)
+                                            reportWebSheetViewModel: webReportViewModel)
     }
 
     static func ordersCard(currentPeriodStats: OrderStatsV4?,
                            previousPeriodStats: OrderStatsV4?,
-                           webReportURL: URL?) -> AnalyticsReportCardViewModel {
+                           webReportViewModel: WebViewSheetViewModel?) -> AnalyticsReportCardViewModel {
         let showSyncError = currentPeriodStats == nil || previousPeriodStats == nil
 
         return AnalyticsReportCardViewModel(title: Localization.OrderCard.title,
@@ -451,14 +450,14 @@ private extension AnalyticsHubViewModel {
                                             isRedacted: false,
                                             showSyncError: showSyncError,
                                             syncErrorMessage: Localization.OrderCard.noOrders,
-                                            reportURL: webReportURL)
+                                            reportWebSheetViewModel: webReportViewModel)
     }
 
     /// Helper function to create a `AnalyticsProductsStatsCardViewModel` from the fetched stats.
     ///
     static func productsStatsCard(currentPeriodStats: OrderStatsV4?,
                                   previousPeriodStats: OrderStatsV4?,
-                                  webReportURL: URL?) -> AnalyticsProductsStatsCardViewModel {
+                                  webReportViewModel: WebViewSheetViewModel?) -> AnalyticsProductsStatsCardViewModel {
         let showStatsError = currentPeriodStats == nil || previousPeriodStats == nil
         let itemsSold = StatsDataTextFormatter.createItemsSoldText(orderStats: currentPeriodStats)
         let itemsSoldDelta = StatsDataTextFormatter.createOrderItemsSoldDelta(from: previousPeriodStats, to: currentPeriodStats)
@@ -467,7 +466,7 @@ private extension AnalyticsHubViewModel {
                                                    delta: itemsSoldDelta,
                                                    isRedacted: false,
                                                    showStatsError: showStatsError,
-                                                   reportURL: webReportURL)
+                                                   reportWebSheetViewModel: webReportViewModel)
     }
 
     /// Helper function to create a `AnalyticsItemsSoldViewModel` from the fetched stats.
@@ -525,10 +524,31 @@ private extension AnalyticsHubViewModel {
         })
     }
 
-    /// Gets the URL for the provided analytics report type, based on the currently selected time range
+    /// Gets the webview view model to show a web analytics report, based on the provided report type and currently selected time range
     ///
-    func analyticsReportURL(for report: AnalyticsHubWebReport.ReportType) -> URL? {
-        return AnalyticsHubWebReport.getUrl(for: report, timeRange: timeRangeSelectionType, storeAdminURL: stores.sessionManager.defaultSite?.adminURL)
+    func webReportVM(for report: AnalyticsHubWebReport.ReportType) -> WebViewSheetViewModel? {
+        return AnalyticsHubViewModel.webReportVM(for: report, timeRange: timeRangeSelectionType, storeAdminURL: stores.sessionManager.defaultSite?.adminURL)
+    }
+
+    /// Gets the webview view model to show a web analytics report, based on the provided report type, time range, and store admin URL
+    ///
+    static func webReportVM(for report: AnalyticsHubWebReport.ReportType,
+                            timeRange: AnalyticsHubTimeRangeSelection.SelectionType,
+                            storeAdminURL: String?) -> WebViewSheetViewModel? {
+        guard let url = AnalyticsHubWebReport.getUrl(for: report, timeRange: timeRange, storeAdminURL: storeAdminURL) else {
+            return nil
+        }
+        let title = {
+            switch report {
+            case .revenue:
+                return Localization.RevenueCard.reportTitle
+            case .orders:
+                return Localization.OrderCard.reportTitle
+            case .products:
+                return Localization.ProductCard.reportTitle
+            }
+        }()
+        return WebViewSheetViewModel(url: url, navigationTitle: title, authenticated: true)
     }
 }
 
@@ -545,6 +565,9 @@ private extension AnalyticsHubViewModel {
             static let trailingTitle = NSLocalizedString("Net Sales", comment: "Label for net sales (net revenue) in the Analytics Hub")
             static let noRevenue = NSLocalizedString("Unable to load revenue analytics",
                                                      comment: "Text displayed when there is an error loading revenue stats data.")
+            static let reportTitle = NSLocalizedString("analyticsHub.revenueCard.reportTitle",
+                                                       value: "Revenue Report",
+                                                       comment: "Title for the revenue analytics report linked in the Analytics Hub")
         }
 
         enum OrderCard {
@@ -553,6 +576,9 @@ private extension AnalyticsHubViewModel {
             static let trailingTitle = NSLocalizedString("Average Order Value", comment: "Label for average value of orders in the Analytics Hub")
             static let noOrders = NSLocalizedString("Unable to load order analytics",
                                                     comment: "Text displayed when there is an error loading order stats data.")
+            static let reportTitle = NSLocalizedString("analyticsHub.orderCard.reportTitle",
+                                                       value: "Orders Report",
+                                                       comment: "Title for the orders analytics report linked in the Analytics Hub")
         }
 
         enum ProductCard {
@@ -560,6 +586,9 @@ private extension AnalyticsHubViewModel {
                 String.localizedStringWithFormat(NSLocalizedString("Net sales: %@", comment: "Label for the total sales of a product in the Analytics Hub"),
                                                  value)
             }
+            static let reportTitle = NSLocalizedString("analyticsHub.productCard.reportTitle",
+                                                       value: "Products Report",
+                                                       comment: "Title for the products analytics report linked in the Analytics Hub")
         }
 
         enum SessionsCard {

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/AnalyticsHubViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/AnalyticsHubViewModel.swift
@@ -412,7 +412,7 @@ private extension AnalyticsHubViewModel {
 
     static func revenueCard(currentPeriodStats: OrderStatsV4?,
                             previousPeriodStats: OrderStatsV4?,
-                            webReportViewModel: WebViewSheetViewModel?) -> AnalyticsReportCardViewModel {
+                            webReportViewModel: WPAdminWebViewModel?) -> AnalyticsReportCardViewModel {
         let showSyncError = currentPeriodStats == nil || previousPeriodStats == nil
 
         return AnalyticsReportCardViewModel(title: Localization.RevenueCard.title,
@@ -433,7 +433,7 @@ private extension AnalyticsHubViewModel {
 
     static func ordersCard(currentPeriodStats: OrderStatsV4?,
                            previousPeriodStats: OrderStatsV4?,
-                           webReportViewModel: WebViewSheetViewModel?) -> AnalyticsReportCardViewModel {
+                           webReportViewModel: WPAdminWebViewModel?) -> AnalyticsReportCardViewModel {
         let showSyncError = currentPeriodStats == nil || previousPeriodStats == nil
 
         return AnalyticsReportCardViewModel(title: Localization.OrderCard.title,
@@ -457,7 +457,7 @@ private extension AnalyticsHubViewModel {
     ///
     static func productsStatsCard(currentPeriodStats: OrderStatsV4?,
                                   previousPeriodStats: OrderStatsV4?,
-                                  webReportViewModel: WebViewSheetViewModel?) -> AnalyticsProductsStatsCardViewModel {
+                                  webReportViewModel: WPAdminWebViewModel?) -> AnalyticsProductsStatsCardViewModel {
         let showStatsError = currentPeriodStats == nil || previousPeriodStats == nil
         let itemsSold = StatsDataTextFormatter.createItemsSoldText(orderStats: currentPeriodStats)
         let itemsSoldDelta = StatsDataTextFormatter.createOrderItemsSoldDelta(from: previousPeriodStats, to: currentPeriodStats)
@@ -526,7 +526,7 @@ private extension AnalyticsHubViewModel {
 
     /// Gets the webview view model to show a web analytics report, based on the provided report type and currently selected time range
     ///
-    func webReportVM(for report: AnalyticsHubWebReport.ReportType) -> WebViewSheetViewModel? {
+    func webReportVM(for report: AnalyticsHubWebReport.ReportType) -> WPAdminWebViewModel? {
         return AnalyticsHubViewModel.webReportVM(for: report, timeRange: timeRangeSelectionType, storeAdminURL: stores.sessionManager.defaultSite?.adminURL)
     }
 
@@ -534,7 +534,7 @@ private extension AnalyticsHubViewModel {
     ///
     static func webReportVM(for report: AnalyticsHubWebReport.ReportType,
                             timeRange: AnalyticsHubTimeRangeSelection.SelectionType,
-                            storeAdminURL: String?) -> WebViewSheetViewModel? {
+                            storeAdminURL: String?) -> WPAdminWebViewModel? {
         guard let url = AnalyticsHubWebReport.getUrl(for: report, timeRange: timeRange, storeAdminURL: storeAdminURL) else {
             return nil
         }
@@ -548,7 +548,7 @@ private extension AnalyticsHubViewModel {
                 return Localization.ProductCard.reportTitle
             }
         }()
-        return WebViewSheetViewModel(url: url, navigationTitle: title, authenticated: true)
+        return WPAdminWebViewModel(title: title, initialURL: url)
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/AnalyticsProductCard.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/AnalyticsProductCard.swift
@@ -39,7 +39,7 @@ struct AnalyticsProductCard: View {
 
     /// URL for the products analytics web report
     ///
-    let reportViewModel: WebViewSheetViewModel?
+    let reportViewModel: WPAdminWebViewModel?
 
     var body: some View {
         VStack(alignment: .leading) {

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/AnalyticsProductCard.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/AnalyticsProductCard.swift
@@ -92,7 +92,7 @@ struct AnalyticsProductCard: View {
                 VStack(spacing: Layout.cardPadding) {
                     Divider()
                         .padding(.horizontal, Layout.dividerPadding)
-                    AnalyticsHubReportLink(showingWebReport: $showingWebReport, reportViewModel: reportViewModel)
+                    AnalyticsReportLink(showingWebReport: $showingWebReport, reportViewModel: reportViewModel)
                 }
             }
         }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/AnalyticsProductCard.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/AnalyticsProductCard.swift
@@ -78,18 +78,22 @@ struct AnalyticsProductCard: View {
                               valueTitle: Localization.itemsSold,
                               rows: itemsSoldData,
                               isRedacted: isItemsSoldRedacted)
-                .padding(.top, Layout.columnSpacing)
+                .padding(.vertical, Layout.columnSpacing)
 
             if showItemsSoldError {
                 Text(Localization.noItemsSold)
                     .foregroundColor(Color(.text))
                     .subheadlineStyle()
                     .frame(maxWidth: .infinity, alignment: .leading)
-                    .padding(.top, Layout.columnSpacing)
+                    .padding(.vertical, Layout.columnSpacing)
             }
 
             if let reportViewModel {
-                AnalyticsHubReportLink(showingWebReport: $showingWebReport, reportViewModel: reportViewModel)
+                VStack(spacing: Layout.cardPadding) {
+                    Divider()
+                        .padding(.horizontal, Layout.dividerPadding)
+                    AnalyticsHubReportLink(showingWebReport: $showingWebReport, reportViewModel: reportViewModel)
+                }
             }
         }
         .padding(Layout.cardPadding)
@@ -111,6 +115,7 @@ private extension AnalyticsProductCard {
         static let titleSpacing: CGFloat = 24
         static let cardPadding: CGFloat = 16
         static let columnSpacing: CGFloat = 10
+        static let dividerPadding: CGFloat = -16
     }
 }
 
@@ -133,7 +138,7 @@ struct AnalyticsProductCardPreviews: PreviewProvider {
                              ],
                              isItemsSoldRedacted: false,
                              showItemsSoldError: false,
-                             reportViewModel: nil)
+                             reportViewModel: .init(title: "Products Report", initialURL: URL(string: "https://woo.com/")!))
             .previewLayout(.sizeThatFits)
 
         AnalyticsProductCard(itemsSold: "-",
@@ -145,7 +150,7 @@ struct AnalyticsProductCardPreviews: PreviewProvider {
                              itemsSoldData: [],
                              isItemsSoldRedacted: false,
                              showItemsSoldError: true,
-                             reportViewModel: nil)
+                             reportViewModel: .init(title: "Products Report", initialURL: URL(string: "https://woo.com/")!))
             .previewLayout(.sizeThatFits)
             .previewDisplayName("No data")
     }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/AnalyticsProductCard.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/AnalyticsProductCard.swift
@@ -88,29 +88,11 @@ struct AnalyticsProductCard: View {
                     .padding(.top, Layout.columnSpacing)
             }
 
-            if reportViewModel != nil {
-                VStack(spacing: Layout.cardPadding) {
-                    Divider()
-                    Button {
-                        showingWebReport = true
-                    } label: {
-                        Text(Localization.seeReport)
-                            .frame(maxWidth: .infinity, alignment: .leading)
-                        DisclosureIndicator()
-                    }
-                }
+            if let reportViewModel {
+                AnalyticsHubReportLink(showingWebReport: $showingWebReport, reportViewModel: reportViewModel)
             }
         }
         .padding(Layout.cardPadding)
-        .sheet(isPresented: $showingWebReport) {
-            if let reportViewModel {
-                WooNavigationSheet(viewModel: .init(navigationTitle: reportViewModel.title, done: {
-                    showingWebReport = false
-                })) {
-                    AuthenticatedWebView(isPresented: $showingWebReport, viewModel: reportViewModel)
-                }
-            }
-        }
     }
 }
 
@@ -123,9 +105,6 @@ private extension AnalyticsProductCard {
                                                   comment: "Text displayed when there is an error loading product stats data.")
         static let noItemsSold = NSLocalizedString("Unable to load product items sold analytics",
                                                    comment: "Text displayed when there is an error loading items sold stats data.")
-        static let seeReport = NSLocalizedString("analyticsHub.reportCard.webReport",
-                                                 value: "See Report",
-                                                 comment: "Button label to show an analytics report in the Analytics Hub")
     }
 
     enum Layout {

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/AnalyticsProductCard.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/AnalyticsProductCard.swift
@@ -39,7 +39,7 @@ struct AnalyticsProductCard: View {
 
     /// URL for the products analytics web report
     ///
-    let reportURL: URL?
+    let reportViewModel: WebViewSheetViewModel?
 
     var body: some View {
         VStack(alignment: .leading) {
@@ -128,7 +128,7 @@ struct AnalyticsProductCardPreviews: PreviewProvider {
                              ],
                              isItemsSoldRedacted: false,
                              showItemsSoldError: false,
-                             reportURL: URL(string: "https://example.com"))
+                             reportViewModel: nil)
             .previewLayout(.sizeThatFits)
 
         AnalyticsProductCard(itemsSold: "-",
@@ -140,7 +140,7 @@ struct AnalyticsProductCardPreviews: PreviewProvider {
                              itemsSoldData: [],
                              isItemsSoldRedacted: false,
                              showItemsSoldError: true,
-                             reportURL: URL(string: "https://example.com"))
+                             reportViewModel: nil)
             .previewLayout(.sizeThatFits)
             .previewDisplayName("No data")
     }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/AnalyticsProductCard.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/AnalyticsProductCard.swift
@@ -37,6 +37,10 @@ struct AnalyticsProductCard: View {
     ///
     let showItemsSoldError: Bool
 
+    /// URL for the products analytics web report
+    ///
+    let reportURL: URL?
+
     var body: some View {
         VStack(alignment: .leading) {
 
@@ -123,7 +127,8 @@ struct AnalyticsProductCardPreviews: PreviewProvider {
                                 .init(imageURL: imageURL, name: "Bird Of Paradise", details: "Net Sales: $23.50", value: "2"),
                              ],
                              isItemsSoldRedacted: false,
-                             showItemsSoldError: false)
+                             showItemsSoldError: false,
+                             reportURL: URL(string: "https://example.com"))
             .previewLayout(.sizeThatFits)
 
         AnalyticsProductCard(itemsSold: "-",
@@ -134,7 +139,8 @@ struct AnalyticsProductCardPreviews: PreviewProvider {
                              showStatsError: true,
                              itemsSoldData: [],
                              isItemsSoldRedacted: false,
-                             showItemsSoldError: true)
+                             showItemsSoldError: true,
+                             reportURL: URL(string: "https://example.com"))
             .previewLayout(.sizeThatFits)
             .previewDisplayName("No data")
     }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/AnalyticsProductCard.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/AnalyticsProductCard.swift
@@ -40,6 +40,7 @@ struct AnalyticsProductCard: View {
     /// URL for the products analytics web report
     ///
     let reportViewModel: WPAdminWebViewModel?
+    @State private var showingWebReport: Bool = false
 
     var body: some View {
         VStack(alignment: .leading) {
@@ -86,8 +87,30 @@ struct AnalyticsProductCard: View {
                     .frame(maxWidth: .infinity, alignment: .leading)
                     .padding(.top, Layout.columnSpacing)
             }
+
+            if reportViewModel != nil {
+                VStack(spacing: Layout.cardPadding) {
+                    Divider()
+                    Button {
+                        showingWebReport = true
+                    } label: {
+                        Text(Localization.seeReport)
+                            .frame(maxWidth: .infinity, alignment: .leading)
+                        DisclosureIndicator()
+                    }
+                }
+            }
         }
         .padding(Layout.cardPadding)
+        .sheet(isPresented: $showingWebReport) {
+            if let reportViewModel {
+                WooNavigationSheet(viewModel: .init(navigationTitle: reportViewModel.title, done: {
+                    showingWebReport = false
+                })) {
+                    AuthenticatedWebView(isPresented: $showingWebReport, viewModel: reportViewModel)
+                }
+            }
+        }
     }
 }
 
@@ -100,6 +123,9 @@ private extension AnalyticsProductCard {
                                                   comment: "Text displayed when there is an error loading product stats data.")
         static let noItemsSold = NSLocalizedString("Unable to load product items sold analytics",
                                                    comment: "Text displayed when there is an error loading items sold stats data.")
+        static let seeReport = NSLocalizedString("analyticsHub.reportCard.webReport",
+                                                 value: "See Report",
+                                                 comment: "Button label to show an analytics report in the Analytics Hub")
     }
 
     enum Layout {

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/AnalyticsProductCardViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/AnalyticsProductCardViewModel.swift
@@ -23,7 +23,7 @@ struct AnalyticsProductsStatsCardViewModel {
 
     /// WebViewSheetViewModel for the web analytics report
     ///
-    let reportWebSheetViewModel: WebViewSheetViewModel?
+    let reportWebSheetViewModel: WPAdminWebViewModel?
 }
 
 /// Analytics Hub Items Sold ViewModel.

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/AnalyticsProductCardViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/AnalyticsProductCardViewModel.swift
@@ -81,6 +81,7 @@ extension AnalyticsProductCard {
         self.deltaTextColor = statsViewModel.delta.direction.deltaTextColor
         self.isStatsRedacted = statsViewModel.isRedacted
         self.showStatsError = statsViewModel.showStatsError
+        self.reportURL = statsViewModel.reportURL
 
         // Top performers list
         self.itemsSoldData = itemsViewModel.itemsSoldData

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/AnalyticsProductCardViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/AnalyticsProductCardViewModel.swift
@@ -21,9 +21,9 @@ struct AnalyticsProductsStatsCardViewModel {
     ///
     let showStatsError: Bool
 
-    /// URL for the corresponding web analytics report
+    /// WebViewSheetViewModel for the web analytics report
     ///
-    let reportURL: URL?
+    let reportWebSheetViewModel: WebViewSheetViewModel?
 }
 
 /// Analytics Hub Items Sold ViewModel.
@@ -54,7 +54,7 @@ extension AnalyticsProductsStatsCardViewModel {
               delta: DeltaPercentage(string: "0%", direction: .zero),
               isRedacted: true,
               showStatsError: false,
-              reportURL: reportURL)
+              reportWebSheetViewModel: reportWebSheetViewModel)
     }
 }
 
@@ -81,7 +81,7 @@ extension AnalyticsProductCard {
         self.deltaTextColor = statsViewModel.delta.direction.deltaTextColor
         self.isStatsRedacted = statsViewModel.isRedacted
         self.showStatsError = statsViewModel.showStatsError
-        self.reportURL = statsViewModel.reportURL
+        self.reportViewModel = statsViewModel.reportWebSheetViewModel
 
         // Top performers list
         self.itemsSoldData = itemsViewModel.itemsSoldData

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/AnalyticsReportCard.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/AnalyticsReportCard.swift
@@ -20,6 +20,9 @@ struct AnalyticsReportCard: View {
     let trailingChartData: [Double]
     let trailingChartColor: UIColor?
 
+    let reportViewModel: WebViewSheetViewModel?
+    @State private var showingWebReport: Bool = false
+
     let isRedacted: Bool
 
     let showSyncError: Bool
@@ -97,13 +100,33 @@ struct AnalyticsReportCard: View {
             }
 
             if showSyncError {
-               Text(syncErrorMessage)
-                   .foregroundColor(Color(.text))
-                   .subheadlineStyle()
-                   .frame(maxWidth: .infinity, alignment: .leading)
-           }
+                Text(syncErrorMessage)
+                    .foregroundColor(Color(.text))
+                    .subheadlineStyle()
+                    .frame(maxWidth: .infinity, alignment: .leading)
+            }
+
+            if reportViewModel != nil {
+                VStack(spacing: Layout.cardPadding) {
+                    Divider()
+                    Button {
+                        showingWebReport = true
+                    } label: {
+                        Text(Localization.seeReport)
+                            .frame(maxWidth: .infinity, alignment: .leading)
+                        DisclosureIndicator()
+                    }
+                }
+            }
         }
         .padding(Layout.cardPadding)
+        .sheet(isPresented: $showingWebReport) {
+            if let reportViewModel {
+                WebViewSheet(viewModel: reportViewModel) {
+                    showingWebReport = false
+                }
+            }
+        }
     }
 }
 
@@ -117,6 +140,12 @@ private extension AnalyticsReportCard {
         static let chartHeight: CGFloat = 32
         static let chartWidth: CGFloat = 72
         static let chartAspectRatio: CGFloat = 2.25
+    }
+
+    enum Localization {
+        static let seeReport = NSLocalizedString("analyticsHub.reportCard.webReport",
+                                                 value: "See Report",
+                                                 comment: "Button label to show an analytics report in the Analytics Hub")
     }
 }
 
@@ -138,6 +167,7 @@ struct Previews: PreviewProvider {
                             trailingDeltaTextColor: .textInverted,
                             trailingChartData: [50.0, 15.0, 20.0, 2.0, 10.0, 0.0, 40.0, 15.0, 20.0, 2.0, 10.0, 0.0],
                             trailingChartColor: .withColorStudio(.red, shade: .shade40),
+                            reportViewModel: WebViewSheetViewModel(url: URL(string: "https://example.com/")!, navigationTitle: "", authenticated: false),
                             isRedacted: false,
                             showSyncError: false,
                             syncErrorMessage: "")
@@ -158,6 +188,7 @@ struct Previews: PreviewProvider {
                             trailingDeltaTextColor: .text,
                             trailingChartData: [],
                             trailingChartColor: .withColorStudio(.gray, shade: .shade30),
+                            reportViewModel: WebViewSheetViewModel(url: URL(string: "https://example.com/")!, navigationTitle: "", authenticated: false),
                             isRedacted: false,
                             showSyncError: true,
                             syncErrorMessage: "Error loading revenue analytics")
@@ -179,6 +210,7 @@ struct Previews: PreviewProvider {
                             trailingDeltaTextColor: nil,
                             trailingChartData: [],
                             trailingChartColor: nil,
+                            reportViewModel: nil,
                             isRedacted: false,
                             showSyncError: true,
                             syncErrorMessage: "")

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/AnalyticsReportCard.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/AnalyticsReportCard.swift
@@ -110,7 +110,7 @@ struct AnalyticsReportCard: View {
                 VStack(spacing: Layout.cardPadding) {
                     Divider()
                         .padding(.horizontal, Layout.dividerPadding)
-                    AnalyticsHubReportLink(showingWebReport: $showingWebReport, reportViewModel: reportViewModel)
+                    AnalyticsReportLink(showingWebReport: $showingWebReport, reportViewModel: reportViewModel)
                 }
             }
         }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/AnalyticsReportCard.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/AnalyticsReportCard.swift
@@ -106,29 +106,11 @@ struct AnalyticsReportCard: View {
                     .frame(maxWidth: .infinity, alignment: .leading)
             }
 
-            if reportViewModel != nil {
-                VStack(spacing: Layout.cardPadding) {
-                    Divider()
-                    Button {
-                        showingWebReport = true
-                    } label: {
-                        Text(Localization.seeReport)
-                            .frame(maxWidth: .infinity, alignment: .leading)
-                        DisclosureIndicator()
-                    }
-                }
+            if let reportViewModel {
+                AnalyticsHubReportLink(showingWebReport: $showingWebReport, reportViewModel: reportViewModel)
             }
         }
         .padding(Layout.cardPadding)
-        .sheet(isPresented: $showingWebReport) {
-            if let reportViewModel {
-                WooNavigationSheet(viewModel: .init(navigationTitle: reportViewModel.title, done: {
-                    showingWebReport = false
-                })) {
-                    AuthenticatedWebView(isPresented: $showingWebReport, viewModel: reportViewModel)
-                }
-            }
-        }
     }
 }
 
@@ -142,12 +124,6 @@ private extension AnalyticsReportCard {
         static let chartHeight: CGFloat = 32
         static let chartWidth: CGFloat = 72
         static let chartAspectRatio: CGFloat = 2.25
-    }
-
-    enum Localization {
-        static let seeReport = NSLocalizedString("analyticsHub.reportCard.webReport",
-                                                 value: "See Report",
-                                                 comment: "Button label to show an analytics report in the Analytics Hub")
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/AnalyticsReportCard.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/AnalyticsReportCard.swift
@@ -20,7 +20,7 @@ struct AnalyticsReportCard: View {
     let trailingChartData: [Double]
     let trailingChartColor: UIColor?
 
-    let reportViewModel: WebViewSheetViewModel?
+    let reportViewModel: WPAdminWebViewModel?
     @State private var showingWebReport: Bool = false
 
     let isRedacted: Bool
@@ -122,8 +122,10 @@ struct AnalyticsReportCard: View {
         .padding(Layout.cardPadding)
         .sheet(isPresented: $showingWebReport) {
             if let reportViewModel {
-                WebViewSheet(viewModel: reportViewModel) {
+                WooNavigationSheet(viewModel: .init(navigationTitle: reportViewModel.title, done: {
                     showingWebReport = false
+                })) {
+                    AuthenticatedWebView(isPresented: $showingWebReport, viewModel: reportViewModel)
                 }
             }
         }
@@ -167,7 +169,7 @@ struct Previews: PreviewProvider {
                             trailingDeltaTextColor: .textInverted,
                             trailingChartData: [50.0, 15.0, 20.0, 2.0, 10.0, 0.0, 40.0, 15.0, 20.0, 2.0, 10.0, 0.0],
                             trailingChartColor: .withColorStudio(.red, shade: .shade40),
-                            reportViewModel: WebViewSheetViewModel(url: URL(string: "https://example.com/")!, navigationTitle: "", authenticated: false),
+                            reportViewModel: WPAdminWebViewModel(title: "", initialURL: URL(string: "https://example.com/")!),
                             isRedacted: false,
                             showSyncError: false,
                             syncErrorMessage: "")
@@ -188,7 +190,7 @@ struct Previews: PreviewProvider {
                             trailingDeltaTextColor: .text,
                             trailingChartData: [],
                             trailingChartColor: .withColorStudio(.gray, shade: .shade30),
-                            reportViewModel: WebViewSheetViewModel(url: URL(string: "https://example.com/")!, navigationTitle: "", authenticated: false),
+                            reportViewModel: WPAdminWebViewModel(title: "", initialURL: URL(string: "https://example.com/")!),
                             isRedacted: false,
                             showSyncError: true,
                             syncErrorMessage: "Error loading revenue analytics")

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/AnalyticsReportCard.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/AnalyticsReportCard.swift
@@ -107,7 +107,11 @@ struct AnalyticsReportCard: View {
             }
 
             if let reportViewModel {
-                AnalyticsHubReportLink(showingWebReport: $showingWebReport, reportViewModel: reportViewModel)
+                VStack(spacing: Layout.cardPadding) {
+                    Divider()
+                        .padding(.horizontal, Layout.dividerPadding)
+                    AnalyticsHubReportLink(showingWebReport: $showingWebReport, reportViewModel: reportViewModel)
+                }
             }
         }
         .padding(Layout.cardPadding)
@@ -124,6 +128,7 @@ private extension AnalyticsReportCard {
         static let chartHeight: CGFloat = 32
         static let chartWidth: CGFloat = 72
         static let chartAspectRatio: CGFloat = 2.25
+        static let dividerPadding: CGFloat = -16
     }
 }
 
@@ -145,7 +150,7 @@ struct Previews: PreviewProvider {
                             trailingDeltaTextColor: .textInverted,
                             trailingChartData: [50.0, 15.0, 20.0, 2.0, 10.0, 0.0, 40.0, 15.0, 20.0, 2.0, 10.0, 0.0],
                             trailingChartColor: .withColorStudio(.red, shade: .shade40),
-                            reportViewModel: WPAdminWebViewModel(title: "", initialURL: URL(string: "https://example.com/")!),
+                            reportViewModel: WPAdminWebViewModel(title: "", initialURL: URL(string: "https://woo.com/")!),
                             isRedacted: false,
                             showSyncError: false,
                             syncErrorMessage: "")

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/AnalyticsReportCardCurrentPeriodViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/AnalyticsReportCardCurrentPeriodViewModel.swift
@@ -73,6 +73,7 @@ extension AnalyticsReportCard {
         self.trailingDeltaTextColor = nil
         self.trailingChartData = []
         self.trailingChartColor = nil
+        self.reportViewModel = nil
         self.isRedacted = viewModel.isRedacted
         self.showSyncError = viewModel.showSyncError
         self.syncErrorMessage = viewModel.syncErrorMessage

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/AnalyticsReportCardViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/AnalyticsReportCardViewModel.swift
@@ -53,9 +53,9 @@ struct AnalyticsReportCardViewModel {
     ///
     let syncErrorMessage: String
 
-    /// URL for the corresponding web analytics report
+    /// WebViewSheetViewModel for the web analytics report
     ///
-    let reportURL: URL?
+    let reportWebSheetViewModel: WebViewSheetViewModel?
 }
 
 extension AnalyticsReportCardViewModel {
@@ -76,7 +76,7 @@ extension AnalyticsReportCardViewModel {
               isRedacted: true,
               showSyncError: false,
               syncErrorMessage: "",
-              reportURL: reportURL)
+              reportWebSheetViewModel: reportWebSheetViewModel)
     }
 }
 
@@ -102,19 +102,6 @@ extension AnalyticsReportCard {
         self.isRedacted = viewModel.isRedacted
         self.showSyncError = viewModel.showSyncError
         self.syncErrorMessage = viewModel.syncErrorMessage
-        self.reportViewModel = {
-            guard let reportURL = viewModel.reportURL else {
-                return nil
-            }
-            return WebViewSheetViewModel(url: reportURL, navigationTitle: Localization.reportTitle, authenticated: true)
-        }()
-    }
-}
-
-private extension AnalyticsReportCard {
-    enum Localization {
-        static let reportTitle = NSLocalizedString("analyticsHub.reportCard.reportTitle",
-                                                   value: "Analytics Report",
-                                                   comment: "Title for the webview displaying a web analytics report")
+        self.reportViewModel = viewModel.reportWebSheetViewModel
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/AnalyticsReportCardViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/AnalyticsReportCardViewModel.swift
@@ -102,5 +102,19 @@ extension AnalyticsReportCard {
         self.isRedacted = viewModel.isRedacted
         self.showSyncError = viewModel.showSyncError
         self.syncErrorMessage = viewModel.syncErrorMessage
+        self.reportViewModel = {
+            guard let reportURL = viewModel.reportURL else {
+                return nil
+            }
+            return WebViewSheetViewModel(url: reportURL, navigationTitle: Localization.reportTitle, authenticated: true)
+        }()
+    }
+}
+
+private extension AnalyticsReportCard {
+    enum Localization {
+        static let reportTitle = NSLocalizedString("analyticsHub.reportCard.reportTitle",
+                                                   value: "Analytics Report",
+                                                   comment: "Title for the webview displaying a web analytics report")
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/AnalyticsReportCardViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/AnalyticsReportCardViewModel.swift
@@ -55,7 +55,7 @@ struct AnalyticsReportCardViewModel {
 
     /// WebViewSheetViewModel for the web analytics report
     ///
-    let reportWebSheetViewModel: WebViewSheetViewModel?
+    let reportWebSheetViewModel: WPAdminWebViewModel?
 }
 
 extension AnalyticsReportCardViewModel {

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/AnalyticsReportLink.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/AnalyticsReportLink.swift
@@ -1,6 +1,6 @@
 import SwiftUI
 
-struct AnalyticsHubReportLink: View {
+struct AnalyticsReportLink: View {
     @Binding var showingWebReport: Bool
     let reportViewModel: WPAdminWebViewModel
 
@@ -24,7 +24,7 @@ struct AnalyticsHubReportLink: View {
 }
 
 // MARK: Constants
-private extension AnalyticsHubReportLink {
+private extension AnalyticsReportLink {
     enum Localization {
         static let seeReport = NSLocalizedString("analyticsHub.reportCard.webReport",
                                                  value: "See Report",
@@ -33,6 +33,6 @@ private extension AnalyticsHubReportLink {
 }
 
 #Preview {
-    AnalyticsHubReportLink(showingWebReport: .constant(false), reportViewModel: .init(initialURL: URL(string: "https://woo.com/")!))
+    AnalyticsReportLink(showingWebReport: .constant(false), reportViewModel: .init(initialURL: URL(string: "https://woo.com/")!))
         .previewLayout(.sizeThatFits)
 }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/AnalyticsWebReport.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/AnalyticsWebReport.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 /// Represents analytics reports the app can link to on the store's web admin
-struct AnalyticsHubWebReport {
+struct AnalyticsWebReport {
 
     /// Supported types of analytics reports
     enum ReportType {

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -2027,7 +2027,7 @@
 		CE5F462723AAC8C0006B1A5C /* RefundDetailsViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE5F462623AAC8C0006B1A5C /* RefundDetailsViewModel.swift */; };
 		CE5F462A23AACA0A006B1A5C /* RefundDetailsDataSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE5F462923AACA0A006B1A5C /* RefundDetailsDataSource.swift */; };
 		CE5F462C23AACBC4006B1A5C /* RefundDetailsResultController.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE5F462B23AACBC4006B1A5C /* RefundDetailsResultController.swift */; };
-		CE6A8FB42B724D7C0063564D /* AnalyticsHubReportLink.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE6A8FB32B724D7C0063564D /* AnalyticsHubReportLink.swift */; };
+		CE6A8FB42B724D7C0063564D /* AnalyticsReportLink.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE6A8FB32B724D7C0063564D /* AnalyticsReportLink.swift */; };
 		CE85535D209B5BB700938BDC /* OrderDetailsViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE85535C209B5BB700938BDC /* OrderDetailsViewModel.swift */; };
 		CE855365209BA6A700938BDC /* CustomerInfoTableViewCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = CE855361209BA6A700938BDC /* CustomerInfoTableViewCell.xib */; };
 		CE855366209BA6A700938BDC /* CustomerInfoTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE855362209BA6A700938BDC /* CustomerInfoTableViewCell.swift */; };
@@ -2047,7 +2047,7 @@
 		CECC759723D607C900486676 /* OrderItemRefund+Woo.swift in Sources */ = {isa = PBXBuildFile; fileRef = CECC759623D607C900486676 /* OrderItemRefund+Woo.swift */; };
 		CECC759923D6160000486676 /* AggregateDataHelperTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CECC759823D6160000486676 /* AggregateDataHelperTests.swift */; };
 		CECC759C23D61C1400486676 /* AggregateDataHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = CECC759B23D61C1400486676 /* AggregateDataHelper.swift */; };
-		CEDBDA472B6BEF2E002047D4 /* AnalyticsHubWebReport.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEDBDA462B6BEF2E002047D4 /* AnalyticsHubWebReport.swift */; };
+		CEDBDA472B6BEF2E002047D4 /* AnalyticsWebReport.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEDBDA462B6BEF2E002047D4 /* AnalyticsWebReport.swift */; };
 		CEE006052077D1280079161F /* SummaryTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEE006032077D1280079161F /* SummaryTableViewCell.swift */; };
 		CEE006062077D1280079161F /* SummaryTableViewCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = CEE006042077D1280079161F /* SummaryTableViewCell.xib */; };
 		CEE006082077D14C0079161F /* OrderDetailsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEE006072077D14C0079161F /* OrderDetailsViewController.swift */; };
@@ -4726,7 +4726,7 @@
 		CE5F462623AAC8C0006B1A5C /* RefundDetailsViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RefundDetailsViewModel.swift; sourceTree = "<group>"; };
 		CE5F462923AACA0A006B1A5C /* RefundDetailsDataSource.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RefundDetailsDataSource.swift; sourceTree = "<group>"; };
 		CE5F462B23AACBC4006B1A5C /* RefundDetailsResultController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RefundDetailsResultController.swift; sourceTree = "<group>"; };
-		CE6A8FB32B724D7C0063564D /* AnalyticsHubReportLink.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnalyticsHubReportLink.swift; sourceTree = "<group>"; };
+		CE6A8FB32B724D7C0063564D /* AnalyticsReportLink.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnalyticsReportLink.swift; sourceTree = "<group>"; };
 		CE85535C209B5BB700938BDC /* OrderDetailsViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OrderDetailsViewModel.swift; sourceTree = "<group>"; };
 		CE855361209BA6A700938BDC /* CustomerInfoTableViewCell.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = CustomerInfoTableViewCell.xib; sourceTree = "<group>"; };
 		CE855362209BA6A700938BDC /* CustomerInfoTableViewCell.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CustomerInfoTableViewCell.swift; sourceTree = "<group>"; };
@@ -4747,7 +4747,7 @@
 		CECC759623D607C900486676 /* OrderItemRefund+Woo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "OrderItemRefund+Woo.swift"; sourceTree = "<group>"; };
 		CECC759823D6160000486676 /* AggregateDataHelperTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AggregateDataHelperTests.swift; sourceTree = "<group>"; };
 		CECC759B23D61C1400486676 /* AggregateDataHelper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AggregateDataHelper.swift; sourceTree = "<group>"; };
-		CEDBDA462B6BEF2E002047D4 /* AnalyticsHubWebReport.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnalyticsHubWebReport.swift; sourceTree = "<group>"; };
+		CEDBDA462B6BEF2E002047D4 /* AnalyticsWebReport.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnalyticsWebReport.swift; sourceTree = "<group>"; };
 		CEE006032077D1280079161F /* SummaryTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SummaryTableViewCell.swift; sourceTree = "<group>"; };
 		CEE006042077D1280079161F /* SummaryTableViewCell.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = SummaryTableViewCell.xib; sourceTree = "<group>"; };
 		CEE006072077D14C0079161F /* OrderDetailsViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OrderDetailsViewController.swift; sourceTree = "<group>"; };
@@ -7145,8 +7145,8 @@
 				CEF2DD852B558E3E00A3DD0B /* AnalyticsCTACard.swift */,
 				CC41E70B29310C1F008B3FB9 /* AnalyticsLineChart.swift */,
 				CCA1D5FD293F537400B40560 /* DeltaPercentage.swift */,
-				CEDBDA462B6BEF2E002047D4 /* AnalyticsHubWebReport.swift */,
-				CE6A8FB32B724D7C0063564D /* AnalyticsHubReportLink.swift */,
+				CEDBDA462B6BEF2E002047D4 /* AnalyticsWebReport.swift */,
+				CE6A8FB32B724D7C0063564D /* AnalyticsReportLink.swift */,
 			);
 			path = "Analytics Hub";
 			sourceTree = "<group>";
@@ -13407,7 +13407,7 @@
 				B58B4AB32108F01700076FDD /* DefaultNoticePresenter.swift in Sources */,
 				4512055224655FB6005D68DE /* TitleAndTextFieldWithImageTableViewCell.swift in Sources */,
 				57448D28242E775000A56A74 /* EmptyStateViewController.swift in Sources */,
-				CE6A8FB42B724D7C0063564D /* AnalyticsHubReportLink.swift in Sources */,
+				CE6A8FB42B724D7C0063564D /* AnalyticsReportLink.swift in Sources */,
 				CE21B3D720FE669A00A259D5 /* BasicTableViewCell.swift in Sources */,
 				451A04EA2386D28300E368C9 /* ProductImagesHeaderViewModel.swift in Sources */,
 				02307924258731B2008EADEE /* PrintShippingLabelViewModel.swift in Sources */,
@@ -13875,7 +13875,7 @@
 				B946881229B8DD41000646B0 /* DashboardViewController+Activity.swift in Sources */,
 				579CDEFF274D7E7900E8903D /* StoreStatsUsageTracksEventEmitter.swift in Sources */,
 				74F9E9CE214C036400A3F2D2 /* NoPeriodDataTableViewCell.swift in Sources */,
-				CEDBDA472B6BEF2E002047D4 /* AnalyticsHubWebReport.swift in Sources */,
+				CEDBDA472B6BEF2E002047D4 /* AnalyticsWebReport.swift in Sources */,
 				314DC4BD268D158F00444C9E /* CardReaderSettingsKnownReadersProvider.swift in Sources */,
 				264957A329C520860095AA4C /* SubscriptionsView.swift in Sources */,
 				02DE39D92968647100BB31D4 /* DomainSettingsViewModel.swift in Sources */,

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -2027,6 +2027,7 @@
 		CE5F462723AAC8C0006B1A5C /* RefundDetailsViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE5F462623AAC8C0006B1A5C /* RefundDetailsViewModel.swift */; };
 		CE5F462A23AACA0A006B1A5C /* RefundDetailsDataSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE5F462923AACA0A006B1A5C /* RefundDetailsDataSource.swift */; };
 		CE5F462C23AACBC4006B1A5C /* RefundDetailsResultController.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE5F462B23AACBC4006B1A5C /* RefundDetailsResultController.swift */; };
+		CE6A8FB42B724D7C0063564D /* AnalyticsHubReportLink.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE6A8FB32B724D7C0063564D /* AnalyticsHubReportLink.swift */; };
 		CE85535D209B5BB700938BDC /* OrderDetailsViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE85535C209B5BB700938BDC /* OrderDetailsViewModel.swift */; };
 		CE855365209BA6A700938BDC /* CustomerInfoTableViewCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = CE855361209BA6A700938BDC /* CustomerInfoTableViewCell.xib */; };
 		CE855366209BA6A700938BDC /* CustomerInfoTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE855362209BA6A700938BDC /* CustomerInfoTableViewCell.swift */; };
@@ -4725,6 +4726,7 @@
 		CE5F462623AAC8C0006B1A5C /* RefundDetailsViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RefundDetailsViewModel.swift; sourceTree = "<group>"; };
 		CE5F462923AACA0A006B1A5C /* RefundDetailsDataSource.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RefundDetailsDataSource.swift; sourceTree = "<group>"; };
 		CE5F462B23AACBC4006B1A5C /* RefundDetailsResultController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RefundDetailsResultController.swift; sourceTree = "<group>"; };
+		CE6A8FB32B724D7C0063564D /* AnalyticsHubReportLink.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnalyticsHubReportLink.swift; sourceTree = "<group>"; };
 		CE85535C209B5BB700938BDC /* OrderDetailsViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OrderDetailsViewModel.swift; sourceTree = "<group>"; };
 		CE855361209BA6A700938BDC /* CustomerInfoTableViewCell.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = CustomerInfoTableViewCell.xib; sourceTree = "<group>"; };
 		CE855362209BA6A700938BDC /* CustomerInfoTableViewCell.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CustomerInfoTableViewCell.swift; sourceTree = "<group>"; };
@@ -7144,6 +7146,7 @@
 				CC41E70B29310C1F008B3FB9 /* AnalyticsLineChart.swift */,
 				CCA1D5FD293F537400B40560 /* DeltaPercentage.swift */,
 				CEDBDA462B6BEF2E002047D4 /* AnalyticsHubWebReport.swift */,
+				CE6A8FB32B724D7C0063564D /* AnalyticsHubReportLink.swift */,
 			);
 			path = "Analytics Hub";
 			sourceTree = "<group>";
@@ -13404,6 +13407,7 @@
 				B58B4AB32108F01700076FDD /* DefaultNoticePresenter.swift in Sources */,
 				4512055224655FB6005D68DE /* TitleAndTextFieldWithImageTableViewCell.swift in Sources */,
 				57448D28242E775000A56A74 /* EmptyStateViewController.swift in Sources */,
+				CE6A8FB42B724D7C0063564D /* AnalyticsHubReportLink.swift in Sources */,
 				CE21B3D720FE669A00A259D5 /* BasicTableViewCell.swift in Sources */,
 				451A04EA2386D28300E368C9 /* ProductImagesHeaderViewModel.swift in Sources */,
 				02307924258731B2008EADEE /* PrintShippingLabelViewModel.swift in Sources */,

--- a/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Analytics Hub/AnalyticsHubViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Analytics Hub/AnalyticsHubViewModelTests.swift
@@ -463,9 +463,9 @@ final class AnalyticsHubViewModelTests: XCTestCase {
                                        stores: stores)
 
         // When
-        let revenueCardReportURL = try XCTUnwrap(vm.revenueCard.reportURL)
-        let ordersCardReportURL = try XCTUnwrap(vm.ordersCard.reportURL)
-        let productsCardReportURL = try XCTUnwrap(vm.productsStatsCard.reportURL)
+        let revenueCardReportURL = try XCTUnwrap(vm.revenueCard.reportWebSheetViewModel?.url)
+        let ordersCardReportURL = try XCTUnwrap(vm.ordersCard.reportWebSheetViewModel?.url)
+        let productsCardReportURL = try XCTUnwrap(vm.productsStatsCard.reportWebSheetViewModel?.url)
 
         let revenueCardURLQueryItems = try XCTUnwrap(URLComponents(url: revenueCardReportURL, resolvingAgainstBaseURL: false)?.queryItems)
         let ordersCardURLQueryItems = try XCTUnwrap(URLComponents(url: ordersCardReportURL, resolvingAgainstBaseURL: false)?.queryItems)
@@ -520,9 +520,9 @@ final class AnalyticsHubViewModelTests: XCTestCase {
         await vm.updateData()
 
         // Then
-        let revenueCardReportURL = try XCTUnwrap(vm.revenueCard.reportURL)
-        let ordersCardReportURL = try XCTUnwrap(vm.ordersCard.reportURL)
-        let productsCardReportURL = try XCTUnwrap(vm.productsStatsCard.reportURL)
+        let revenueCardReportURL = try XCTUnwrap(vm.revenueCard.reportWebSheetViewModel?.url)
+        let ordersCardReportURL = try XCTUnwrap(vm.ordersCard.reportWebSheetViewModel?.url)
+        let productsCardReportURL = try XCTUnwrap(vm.productsStatsCard.reportWebSheetViewModel?.url)
 
         let revenueCardURLQueryItems = try XCTUnwrap(URLComponents(url: revenueCardReportURL, resolvingAgainstBaseURL: false)?.queryItems)
         let ordersCardURLQueryItems = try XCTUnwrap(URLComponents(url: ordersCardReportURL, resolvingAgainstBaseURL: false)?.queryItems)
@@ -565,12 +565,12 @@ final class AnalyticsHubViewModelTests: XCTestCase {
         await vm.updateData()
 
         // Then
-        XCTAssertNotNil(loadingRevenueCard?.reportURL)
-        XCTAssertNotNil(loadingOrdersCard?.reportURL)
-        XCTAssertNotNil(loadingProductsCard?.reportURL)
+        XCTAssertNotNil(loadingRevenueCard?.reportWebSheetViewModel?.url)
+        XCTAssertNotNil(loadingOrdersCard?.reportWebSheetViewModel?.url)
+        XCTAssertNotNil(loadingProductsCard?.reportWebSheetViewModel?.url)
 
-        XCTAssertNotNil(vm.revenueCard.reportURL)
-        XCTAssertNotNil(vm.ordersCard.reportURL)
-        XCTAssertNotNil(vm.productsStatsCard.reportURL)
+        XCTAssertNotNil(vm.revenueCard.reportWebSheetViewModel?.url)
+        XCTAssertNotNil(vm.ordersCard.reportWebSheetViewModel?.url)
+        XCTAssertNotNil(vm.productsStatsCard.reportWebSheetViewModel?.url)
     }
 }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Analytics Hub/AnalyticsHubViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Analytics Hub/AnalyticsHubViewModelTests.swift
@@ -463,9 +463,9 @@ final class AnalyticsHubViewModelTests: XCTestCase {
                                        stores: stores)
 
         // When
-        let revenueCardReportURL = try XCTUnwrap(vm.revenueCard.reportWebSheetViewModel?.url)
-        let ordersCardReportURL = try XCTUnwrap(vm.ordersCard.reportWebSheetViewModel?.url)
-        let productsCardReportURL = try XCTUnwrap(vm.productsStatsCard.reportWebSheetViewModel?.url)
+        let revenueCardReportURL = try XCTUnwrap(vm.revenueCard.reportWebSheetViewModel?.initialURL)
+        let ordersCardReportURL = try XCTUnwrap(vm.ordersCard.reportWebSheetViewModel?.initialURL)
+        let productsCardReportURL = try XCTUnwrap(vm.productsStatsCard.reportWebSheetViewModel?.initialURL)
 
         let revenueCardURLQueryItems = try XCTUnwrap(URLComponents(url: revenueCardReportURL, resolvingAgainstBaseURL: false)?.queryItems)
         let ordersCardURLQueryItems = try XCTUnwrap(URLComponents(url: ordersCardReportURL, resolvingAgainstBaseURL: false)?.queryItems)
@@ -520,9 +520,9 @@ final class AnalyticsHubViewModelTests: XCTestCase {
         await vm.updateData()
 
         // Then
-        let revenueCardReportURL = try XCTUnwrap(vm.revenueCard.reportWebSheetViewModel?.url)
-        let ordersCardReportURL = try XCTUnwrap(vm.ordersCard.reportWebSheetViewModel?.url)
-        let productsCardReportURL = try XCTUnwrap(vm.productsStatsCard.reportWebSheetViewModel?.url)
+        let revenueCardReportURL = try XCTUnwrap(vm.revenueCard.reportWebSheetViewModel?.initialURL)
+        let ordersCardReportURL = try XCTUnwrap(vm.ordersCard.reportWebSheetViewModel?.initialURL)
+        let productsCardReportURL = try XCTUnwrap(vm.productsStatsCard.reportWebSheetViewModel?.initialURL)
 
         let revenueCardURLQueryItems = try XCTUnwrap(URLComponents(url: revenueCardReportURL, resolvingAgainstBaseURL: false)?.queryItems)
         let ordersCardURLQueryItems = try XCTUnwrap(URLComponents(url: ordersCardReportURL, resolvingAgainstBaseURL: false)?.queryItems)
@@ -565,12 +565,12 @@ final class AnalyticsHubViewModelTests: XCTestCase {
         await vm.updateData()
 
         // Then
-        XCTAssertNotNil(loadingRevenueCard?.reportWebSheetViewModel?.url)
-        XCTAssertNotNil(loadingOrdersCard?.reportWebSheetViewModel?.url)
-        XCTAssertNotNil(loadingProductsCard?.reportWebSheetViewModel?.url)
+        XCTAssertNotNil(loadingRevenueCard?.reportWebSheetViewModel?.initialURL)
+        XCTAssertNotNil(loadingOrdersCard?.reportWebSheetViewModel?.initialURL)
+        XCTAssertNotNil(loadingProductsCard?.reportWebSheetViewModel?.initialURL)
 
-        XCTAssertNotNil(vm.revenueCard.reportWebSheetViewModel?.url)
-        XCTAssertNotNil(vm.ordersCard.reportWebSheetViewModel?.url)
-        XCTAssertNotNil(vm.productsStatsCard.reportWebSheetViewModel?.url)
+        XCTAssertNotNil(vm.revenueCard.reportWebSheetViewModel?.initialURL)
+        XCTAssertNotNil(vm.ordersCard.reportWebSheetViewModel?.initialURL)
+        XCTAssertNotNil(vm.productsStatsCard.reportWebSheetViewModel?.initialURL)
     }
 }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Analytics Hub/AnalyticsHubWebReportTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Analytics Hub/AnalyticsHubWebReportTests.swift
@@ -8,7 +8,7 @@ final class AnalyticsHubWebReportTests: XCTestCase {
 
     func test_getURL_returns_expected_report_URL() throws {
         // Given
-        let reportURL = try XCTUnwrap(AnalyticsHubWebReport.getUrl(for: .revenue, timeRange: .today, storeAdminURL: exampleAdminURL))
+        let reportURL = try XCTUnwrap(AnalyticsWebReport.getUrl(for: .revenue, timeRange: .today, storeAdminURL: exampleAdminURL))
 
         // Then
         let expectedURL = try XCTUnwrap(URL(string: exampleAdminURL +
@@ -28,7 +28,7 @@ final class AnalyticsHubWebReportTests: XCTestCase {
 
     func test_getUrl_returns_URL_containing_expected_revenue_report_path() throws {
         // Given
-        let reportURL = AnalyticsHubWebReport.getUrl(for: .revenue, timeRange: .today, storeAdminURL: exampleAdminURL)
+        let reportURL = AnalyticsWebReport.getUrl(for: .revenue, timeRange: .today, storeAdminURL: exampleAdminURL)
 
         // When
         let reportQueryItems = URLComponents(url: try XCTUnwrap(reportURL), resolvingAgainstBaseURL: false)?.queryItems
@@ -40,7 +40,7 @@ final class AnalyticsHubWebReportTests: XCTestCase {
 
     func test_getUrl_returns_URL_containing_expected_orders_report_path() throws {
         // Given
-        let reportURL = AnalyticsHubWebReport.getUrl(for: .orders, timeRange: .today, storeAdminURL: exampleAdminURL)
+        let reportURL = AnalyticsWebReport.getUrl(for: .orders, timeRange: .today, storeAdminURL: exampleAdminURL)
 
         // When
         let reportQueryItems = URLComponents(url: try XCTUnwrap(reportURL), resolvingAgainstBaseURL: false)?.queryItems
@@ -52,7 +52,7 @@ final class AnalyticsHubWebReportTests: XCTestCase {
 
     func test_getUrl_returns_URL_containing_expected_products_report_path() throws {
         // Given
-        let reportURL = AnalyticsHubWebReport.getUrl(for: .products, timeRange: .today, storeAdminURL: exampleAdminURL)
+        let reportURL = AnalyticsWebReport.getUrl(for: .products, timeRange: .today, storeAdminURL: exampleAdminURL)
 
         // When
         let reportQueryItems = URLComponents(url: try XCTUnwrap(reportURL), resolvingAgainstBaseURL: false)?.queryItems
@@ -70,7 +70,7 @@ final class AnalyticsHubWebReportTests: XCTestCase {
         let timeZone = TimeZone(abbreviation: "GMT") ?? TimeZone.current
 
         // When
-        let reportURL = AnalyticsHubWebReport.getUrl(for: .revenue, timeRange: timeRange, storeAdminURL: exampleAdminURL, timeZone: timeZone)
+        let reportURL = AnalyticsWebReport.getUrl(for: .revenue, timeRange: timeRange, storeAdminURL: exampleAdminURL, timeZone: timeZone)
 
         // Then
         let reportQueryItems = URLComponents(url: try XCTUnwrap(reportURL), resolvingAgainstBaseURL: false)?.queryItems
@@ -89,7 +89,7 @@ final class AnalyticsHubWebReportTests: XCTestCase {
         let timeRange: AnalyticsHubTimeRangeSelection.SelectionType = .today
 
         // When
-        let reportURL = AnalyticsHubWebReport.getUrl(for: .revenue, timeRange: timeRange, storeAdminURL: exampleAdminURL)
+        let reportURL = AnalyticsWebReport.getUrl(for: .revenue, timeRange: timeRange, storeAdminURL: exampleAdminURL)
 
         // Then
         let reportQueryItems = URLComponents(url: try XCTUnwrap(reportURL), resolvingAgainstBaseURL: false)?.queryItems
@@ -102,7 +102,7 @@ final class AnalyticsHubWebReportTests: XCTestCase {
         let timeRange: AnalyticsHubTimeRangeSelection.SelectionType = .yesterday
 
         // When
-        let reportURL = AnalyticsHubWebReport.getUrl(for: .revenue, timeRange: timeRange, storeAdminURL: exampleAdminURL)
+        let reportURL = AnalyticsWebReport.getUrl(for: .revenue, timeRange: timeRange, storeAdminURL: exampleAdminURL)
 
         // Then
         let reportQueryItems = URLComponents(url: try XCTUnwrap(reportURL), resolvingAgainstBaseURL: false)?.queryItems
@@ -115,7 +115,7 @@ final class AnalyticsHubWebReportTests: XCTestCase {
         let timeRange: AnalyticsHubTimeRangeSelection.SelectionType = .lastWeek
 
         // When
-        let reportURL = AnalyticsHubWebReport.getUrl(for: .revenue, timeRange: timeRange, storeAdminURL: exampleAdminURL)
+        let reportURL = AnalyticsWebReport.getUrl(for: .revenue, timeRange: timeRange, storeAdminURL: exampleAdminURL)
 
         // Then
         let reportQueryItems = URLComponents(url: try XCTUnwrap(reportURL), resolvingAgainstBaseURL: false)?.queryItems
@@ -128,7 +128,7 @@ final class AnalyticsHubWebReportTests: XCTestCase {
         let timeRange: AnalyticsHubTimeRangeSelection.SelectionType = .lastMonth
 
         // When
-        let reportURL = AnalyticsHubWebReport.getUrl(for: .revenue, timeRange: timeRange, storeAdminURL: exampleAdminURL)
+        let reportURL = AnalyticsWebReport.getUrl(for: .revenue, timeRange: timeRange, storeAdminURL: exampleAdminURL)
 
         // Then
         let reportQueryItems = URLComponents(url: try XCTUnwrap(reportURL), resolvingAgainstBaseURL: false)?.queryItems
@@ -141,7 +141,7 @@ final class AnalyticsHubWebReportTests: XCTestCase {
         let timeRange: AnalyticsHubTimeRangeSelection.SelectionType = .lastQuarter
 
         // When
-        let reportURL = AnalyticsHubWebReport.getUrl(for: .revenue, timeRange: timeRange, storeAdminURL: exampleAdminURL)
+        let reportURL = AnalyticsWebReport.getUrl(for: .revenue, timeRange: timeRange, storeAdminURL: exampleAdminURL)
 
         // Then
         let reportQueryItems = URLComponents(url: try XCTUnwrap(reportURL), resolvingAgainstBaseURL: false)?.queryItems
@@ -154,7 +154,7 @@ final class AnalyticsHubWebReportTests: XCTestCase {
         let timeRange: AnalyticsHubTimeRangeSelection.SelectionType = .lastYear
 
         // When
-        let reportURL = AnalyticsHubWebReport.getUrl(for: .revenue, timeRange: timeRange, storeAdminURL: exampleAdminURL)
+        let reportURL = AnalyticsWebReport.getUrl(for: .revenue, timeRange: timeRange, storeAdminURL: exampleAdminURL)
 
         // Then
         let reportQueryItems = URLComponents(url: try XCTUnwrap(reportURL), resolvingAgainstBaseURL: false)?.queryItems
@@ -167,7 +167,7 @@ final class AnalyticsHubWebReportTests: XCTestCase {
         let timeRange: AnalyticsHubTimeRangeSelection.SelectionType = .weekToDate
 
         // When
-        let reportURL = AnalyticsHubWebReport.getUrl(for: .revenue, timeRange: timeRange, storeAdminURL: exampleAdminURL)
+        let reportURL = AnalyticsWebReport.getUrl(for: .revenue, timeRange: timeRange, storeAdminURL: exampleAdminURL)
 
         // Then
         let reportQueryItems = URLComponents(url: try XCTUnwrap(reportURL), resolvingAgainstBaseURL: false)?.queryItems
@@ -180,7 +180,7 @@ final class AnalyticsHubWebReportTests: XCTestCase {
         let timeRange: AnalyticsHubTimeRangeSelection.SelectionType = .monthToDate
 
         // When
-        let reportURL = AnalyticsHubWebReport.getUrl(for: .revenue, timeRange: timeRange, storeAdminURL: exampleAdminURL)
+        let reportURL = AnalyticsWebReport.getUrl(for: .revenue, timeRange: timeRange, storeAdminURL: exampleAdminURL)
 
         // Then
         let reportQueryItems = URLComponents(url: try XCTUnwrap(reportURL), resolvingAgainstBaseURL: false)?.queryItems
@@ -193,7 +193,7 @@ final class AnalyticsHubWebReportTests: XCTestCase {
         let timeRange: AnalyticsHubTimeRangeSelection.SelectionType = .quarterToDate
 
         // When
-        let reportURL = AnalyticsHubWebReport.getUrl(for: .revenue, timeRange: timeRange, storeAdminURL: exampleAdminURL)
+        let reportURL = AnalyticsWebReport.getUrl(for: .revenue, timeRange: timeRange, storeAdminURL: exampleAdminURL)
 
         // Then
         let reportQueryItems = URLComponents(url: try XCTUnwrap(reportURL), resolvingAgainstBaseURL: false)?.queryItems
@@ -206,7 +206,7 @@ final class AnalyticsHubWebReportTests: XCTestCase {
         let timeRange: AnalyticsHubTimeRangeSelection.SelectionType = .yearToDate
 
         // When
-        let reportURL = AnalyticsHubWebReport.getUrl(for: .revenue, timeRange: timeRange, storeAdminURL: exampleAdminURL)
+        let reportURL = AnalyticsWebReport.getUrl(for: .revenue, timeRange: timeRange, storeAdminURL: exampleAdminURL)
 
         // Then
         let reportQueryItems = URLComponents(url: try XCTUnwrap(reportURL), resolvingAgainstBaseURL: false)?.queryItems


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #11874
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This adds a "See Report" link to cards in the Analytics Hub, to open the full corresponding analytics report in a webview. It respects the selected time range, opening the web report with the matching time range.

Note: If the merchant hasn't ever logged in to wp-admin in a webview, they will see a login page the first time:

* On stores with Jetpack SSO login, merchants can log in by tapping a button.
* On stores without Jetpack, merchants need to enter their site credentials but can select "Remember me" to stay logged in.

This should only be required once. Opening webviews after the initial login will keep the merchant logged in, even when the app is relaunched.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
I have tested the following scenarios:

- [x] Stores using Jetpack, hosted on WordPress.com.
- [x] Self-hosted stores connected via Jetpack.
- [x] Self-hosted stores without Jetpack.
- [x] Opening an analytics report immediately after logging in to the app.
- [x] Opening an analytics report after relaunching the app.
- [x] Opening each analytics report type (revenue, orders, products).
- [x] Opening analytics reports with different time ranges.
- [x] Dark mode
- [x] Landscape orientation
- [x] Opening a report on iPad

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->


https://github.com/woocommerce/woocommerce-ios/assets/8658164/097dc129-6b65-42e3-b106-9c3bd29d18f0





---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
