### PR TITLE
[Tablet Orders] Block selection when syncing

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/EditableOrderViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/EditableOrderViewModel.swift
@@ -1739,6 +1739,7 @@ private extension EditableOrderViewModel {
                     stores: stores,
                     toggleAllVariationsOnSelection: false,
                     topProductsProvider: TopProductsFromCachedOrdersProvider(),
+                    orderSyncState: orderSynchronizer.statePublisher,
                     onProductSelectionStateChanged: { [weak self] product in
                         guard let self = self else { return }
                         self.changeSelectionStateForProduct(product)
@@ -1809,7 +1810,7 @@ private extension EditableOrderViewModel {
             hasCustomerDetails: hasCustomerDetails,
             hasFees: orderSynchronizer.order.fees.isNotEmpty,
             hasShippingMethod: orderSynchronizer.order.shippingLines.isNotEmpty,
-            products: Array(allProducts), 
+            products: Array(allProducts),
             horizontalSizeClass: UITraitCollection.current.horizontalSizeClass))
     }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/ProductsSection/ConfigurableBundleItemView.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/ProductsSection/ConfigurableBundleItemView.swift
@@ -78,7 +78,7 @@ struct ConfigurableBundleItemView: View {
             .renderedIf(viewModel.isVariable && viewModel.isIncludedInBundle && viewModel.quantity > 0)
 
             if let variationSelectorViewModel = viewModel.variationSelectorViewModel {
-                LazyNavigationLink(destination: ProductVariationSelector(
+                LazyNavigationLink(destination: ProductVariationSelectorView(
                     isPresented: $showsVariationSelector,
                     viewModel: variationSelectorViewModel,
                     onMultipleSelections: { _ in }),

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/ProductsSection/ConfigurableBundleItemViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/ProductsSection/ConfigurableBundleItemViewModel.swift
@@ -145,6 +145,7 @@ final class ConfigurableBundleItemViewModel: ObservableObject, Identifiable {
                                            product: product,
                                            allowedProductVariationIDs: allowedProductVariationIDs,
                                            selectedProductVariationIDs: selectedVariation.map { [$0.variationID] } ?? [],
+                                           orderSyncState: nil,
                                            onVariationSelectionStateChanged: { [weak self] variation, _ in
             guard let self else { return }
             self.selectedVariation = .init(variationID: variation.productVariationID, attributes: variation.attributes)

--- a/WooCommerce/Classes/ViewRelated/Products/ProductSelector/ProductSelectorView.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductSelector/ProductSelectorView.swift
@@ -228,6 +228,8 @@ struct ProductSelectorView: View {
                     isShowingVariationList.toggle()
                     self.variationListViewModel = variationListViewModel
                 }
+                .redacted(reason: viewModel.selectionDisabled ? .placeholder : [])
+                .disabled(viewModel.selectionDisabled)
 
                 DisclosureIndicator()
             }
@@ -267,6 +269,8 @@ struct ProductSelectorView: View {
                     viewModel.changeSelectionStateForProduct(with: rowViewModel.productOrVariationID)
                 }
             }
+            .redacted(reason: viewModel.selectionDisabled ? .placeholder : [])
+            .disabled(viewModel.selectionDisabled)
         }
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Products/ProductSelector/ProductSelectorView.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductSelector/ProductSelectorView.swift
@@ -151,7 +151,7 @@ struct ProductSelectorView: View {
                     .renderedIf(configuration.multipleSelectionEnabled && !viewModel.syncChangesImmediately)
 
                     if let variationListViewModel = variationListViewModel {
-                        LazyNavigationLink(destination: ProductVariationSelector(
+                        LazyNavigationLink(destination: ProductVariationSelectorView(
                             isPresented: $isPresented,
                             viewModel: variationListViewModel,
                             onMultipleSelections: { selectedIDs in

--- a/WooCommerce/Classes/ViewRelated/Products/ProductSelector/ProductSelectorView.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductSelector/ProductSelectorView.swift
@@ -95,7 +95,7 @@ struct ProductSelectorView: View {
                 }
                 .buttonStyle(LinkButtonStyle())
                 .fixedSize()
-                .disabled(viewModel.totalSelectedItemsCount == 0 || viewModel.syncStatus != .results)
+                .disabled(viewModel.totalSelectedItemsCount == 0 || viewModel.syncStatus != .results || viewModel.selectionDisabled)
                 .renderedIf(configuration.multipleSelectionEnabled)
 
                 Spacer()

--- a/WooCommerce/Classes/ViewRelated/Products/ProductSelector/ProductSelectorView.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductSelector/ProductSelectorView.swift
@@ -62,6 +62,14 @@ struct ProductSelectorView: View {
 
     @Environment(\.adaptiveModalContainerPresentationStyle) var presentationStyle
 
+    /// Tracks the state for the 'Clear Selection' button
+    ///
+    private var isClearSelectionDisabled: Bool {
+        viewModel.totalSelectedItemsCount == 0 ||
+        viewModel.syncStatus != .results ||
+        viewModel.selectionDisabled
+    }
+
     /// Title for the multi-selection button
     ///
     private var doneButtonTitle: String {
@@ -95,7 +103,7 @@ struct ProductSelectorView: View {
                 }
                 .buttonStyle(LinkButtonStyle())
                 .fixedSize()
-                .disabled(viewModel.totalSelectedItemsCount == 0 || viewModel.syncStatus != .results || viewModel.selectionDisabled)
+                .disabled(isClearSelectionDisabled)
                 .renderedIf(configuration.multipleSelectionEnabled)
 
                 Spacer()

--- a/WooCommerce/Classes/ViewRelated/Products/ProductSelector/ProductSelectorViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductSelector/ProductSelectorViewModel.swift
@@ -199,6 +199,8 @@ final class ProductSelectorViewModel: ObservableObject {
 
     @Published var syncChangesImmediately: Bool
 
+    private var orderSyncState: Published<OrderSyncState>.Publisher?
+
     init(siteID: Int64,
          selectedItemIDs: [Int64] = [],
          purchasableItemsOnly: Bool = false,
@@ -212,6 +214,7 @@ final class ProductSelectorViewModel: ObservableObject {
          pageFirstIndex: Int = PaginationTracker.Defaults.pageFirstIndex,
          pageSize: Int = PaginationTracker.Defaults.pageSize,
          syncChangesImmediately: Bool = false,
+         orderSyncState: Published<OrderSyncState>.Publisher? = nil,
          onProductSelectionStateChanged: ((Product) -> Void)? = nil,
          onVariationSelectionStateChanged: ((ProductVariation, Product) -> Void)? = nil,
          onMultipleSelectionCompleted: (([Int64]) -> Void)? = nil,
@@ -233,6 +236,7 @@ final class ProductSelectorViewModel: ObservableObject {
         self.shouldDeleteStoredProductsOnFirstPage = shouldDeleteStoredProductsOnFirstPage
         self.paginationTracker = PaginationTracker(pageFirstIndex: pageFirstIndex, pageSize: pageSize)
         self.syncChangesImmediately = syncChangesImmediately
+        self.orderSyncState = orderSyncState
         self.onAllSelectionsCleared = onAllSelectionsCleared
         self.onSelectedVariationsCleared = onSelectedVariationsCleared
         self.onCloseButtonTapped = onCloseButtonTapped
@@ -246,6 +250,21 @@ final class ProductSelectorViewModel: ObservableObject {
         refreshDataAndSync()
         configureFirstPageLoad()
         synchronizeProductFilterSearch()
+        bindSelectionDisabledState()
+    }
+
+    @Published var selectionDisabled: Bool = false
+
+    private func bindSelectionDisabledState() {
+        orderSyncState?.map({ state in
+            switch state {
+            case .syncing(blocking: true):
+                return true
+            default:
+                return false
+            }
+        })
+        .assign(to: &$selectionDisabled)
     }
 
     /// Selects or unselects a product to add to the order
@@ -302,6 +321,7 @@ final class ProductSelectorViewModel: ObservableObject {
                                                  product: variableProduct,
                                                  selectedProductVariationIDs: selectedItems,
                                                  purchasableItemsOnly: purchasableItemsOnly,
+                                                 orderSyncState: orderSyncState,
                                                  onVariationSelectionStateChanged: { [weak self] productVariation, product in
             guard let self else { return }
             onVariationSelectionStateChanged?(productVariation, product)

--- a/WooCommerce/Classes/ViewRelated/Products/ProductSelector/ProductVariationSelector.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductSelector/ProductVariationSelector.swift
@@ -37,7 +37,7 @@ struct ProductVariationSelector: View {
                     }
                     .buttonStyle(LinkButtonStyle())
                     .fixedSize()
-                    .disabled(viewModel.selectedProductVariationIDs.isEmpty || viewModel.syncStatus != .results)
+                    .disabled(viewModel.selectedProductVariationIDs.isEmpty || viewModel.syncStatus != .results || viewModel.selectionDisabled)
 
                     InfiniteScrollList(isLoading: viewModel.shouldShowScrollIndicator,
                                        loadAction: viewModel.syncNextPage) {

--- a/WooCommerce/Classes/ViewRelated/Products/ProductSelector/ProductVariationSelector.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductSelector/ProductVariationSelector.swift
@@ -46,6 +46,8 @@ struct ProductVariationSelector: View {
                                        viewModel: rowViewModel)
                                 .accessibilityHint(Localization.productRowAccessibilityHint)
                                 .padding(Constants.defaultPadding)
+                                .redacted(reason: viewModel.selectionDisabled ? .placeholder : [])
+                                .disabled(viewModel.selectionDisabled)
                                 .onTapGesture {
                                     viewModel.changeSelectionStateForVariation(with: rowViewModel.productOrVariationID)
                                 }

--- a/WooCommerce/Classes/ViewRelated/Products/ProductSelector/ProductVariationSelectorView.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductSelector/ProductVariationSelectorView.swift
@@ -15,6 +15,14 @@ struct ProductVariationSelectorView: View {
 
     private let onMultipleSelections: (([Int64]) -> Void)?
 
+    /// Tracks the state for the 'Clear Selection' button
+    ///
+    private var isClearSelectionDisabled: Bool {
+        viewModel.selectedProductVariationIDs.isEmpty ||
+        viewModel.syncStatus != .results ||
+        viewModel.selectionDisabled
+    }
+
     ///   Environment safe areas
     ///
     @Environment(\.safeAreaInsets) private var safeAreaInsets: EdgeInsets
@@ -37,7 +45,7 @@ struct ProductVariationSelectorView: View {
                     }
                     .buttonStyle(LinkButtonStyle())
                     .fixedSize()
-                    .disabled(viewModel.selectedProductVariationIDs.isEmpty || viewModel.syncStatus != .results || viewModel.selectionDisabled)
+                    .disabled(isClearSelectionDisabled)
 
                     InfiniteScrollList(isLoading: viewModel.shouldShowScrollIndicator,
                                        loadAction: viewModel.syncNextPage) {

--- a/WooCommerce/Classes/ViewRelated/Products/ProductSelector/ProductVariationSelectorView.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductSelector/ProductVariationSelectorView.swift
@@ -2,7 +2,7 @@ import SwiftUI
 
 /// View showing a list of product variations to select.
 ///
-struct ProductVariationSelector: View {
+struct ProductVariationSelectorView: View {
     @Environment(\.presentationMode) private var presentation
 
     /// Defines whether the view is presented.
@@ -102,7 +102,7 @@ struct ProductVariationSelector: View {
     }
 }
 
-private extension ProductVariationSelector {
+private extension ProductVariationSelectorView {
     enum Constants {
         static let dividerHeight: CGFloat = 1
         static let defaultPadding: CGFloat = 16
@@ -131,6 +131,6 @@ struct AddProductVariationToOrder_Previews: PreviewProvider {
             selectedProductVariationIDs: []
         )
 
-        ProductVariationSelector(isPresented: .constant(true), viewModel: viewModel)
+        ProductVariationSelectorView(isPresented: .constant(true), viewModel: viewModel)
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Products/ProductSelector/ProductVariationSelectorViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductSelector/ProductVariationSelectorViewModel.swift
@@ -119,6 +119,8 @@ final class ProductVariationSelectorViewModel: ObservableObject {
     ///
     private let purchasableItemsOnly: Bool
 
+    private var orderSyncState: Published<OrderSyncState>.Publisher?
+
     init(siteID: Int64,
          productID: Int64,
          productName: String,
@@ -126,6 +128,7 @@ final class ProductVariationSelectorViewModel: ObservableObject {
          allowedProductVariationIDs: [Int64] = [],
          selectedProductVariationIDs: [Int64] = [],
          purchasableItemsOnly: Bool = false,
+         orderSyncState: Published<OrderSyncState>.Publisher? = nil,
          storageManager: StorageManagerType = ServiceLocator.storageManager,
          stores: StoresManager = ServiceLocator.stores,
          onVariationSelectionStateChanged: ((ProductVariation, Product) -> Void)? = nil,
@@ -134,6 +137,7 @@ final class ProductVariationSelectorViewModel: ObservableObject {
         self.productID = productID
         self.productName = productName
         self.productAttributes = productAttributes
+        self.orderSyncState = orderSyncState
         self.storageManager = storageManager
         self.stores = stores
         self.onVariationSelectionStateChanged = onVariationSelectionStateChanged
@@ -145,6 +149,7 @@ final class ProductVariationSelectorViewModel: ObservableObject {
         configureSyncingCoordinator()
         configureProductVariationsResultsController()
         configureFirstPageLoad()
+        bindSelectionDisabledState()
     }
 
     convenience init(siteID: Int64,
@@ -152,6 +157,7 @@ final class ProductVariationSelectorViewModel: ObservableObject {
                      allowedProductVariationIDs: [Int64] = [],
                      selectedProductVariationIDs: [Int64] = [],
                      purchasableItemsOnly: Bool = false,
+                     orderSyncState: Published<OrderSyncState>.Publisher? = nil,
                      storageManager: StorageManagerType = ServiceLocator.storageManager,
                      stores: StoresManager = ServiceLocator.stores,
                      onVariationSelectionStateChanged: ((ProductVariation, Product) -> Void)? = nil,
@@ -163,10 +169,25 @@ final class ProductVariationSelectorViewModel: ObservableObject {
                   allowedProductVariationIDs: allowedProductVariationIDs,
                   selectedProductVariationIDs: selectedProductVariationIDs,
                   purchasableItemsOnly: purchasableItemsOnly,
+                  orderSyncState: orderSyncState,
                   storageManager: storageManager,
                   stores: stores,
                   onVariationSelectionStateChanged: onVariationSelectionStateChanged,
                   onSelectionsCleared: onSelectionsCleared)
+    }
+
+    @Published var selectionDisabled: Bool = false
+
+    private func bindSelectionDisabledState() {
+        orderSyncState?.map({ state in
+            switch state {
+            case .syncing(blocking: true):
+                return true
+            default:
+                return false
+            }
+        })
+        .assign(to: &$selectionDisabled)
     }
 
     /// Select a product variation to add to the order

--- a/WooCommerce/Classes/ViewRelated/Products/ProductSelector/ProductVariationSelectorViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductSelector/ProductVariationSelectorViewModel.swift
@@ -3,7 +3,7 @@ import protocol Storage.StorageManagerType
 import Combine
 import WooFoundation
 
-/// View model for `ProductVariationSelector`.
+/// View model for `ProductVariationSelectorView`.
 ///
 final class ProductVariationSelectorViewModel: ObservableObject {
     private let siteID: Int64

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -1927,7 +1927,7 @@
 		CCF27B35280EF69700B755E1 /* orders_3337_add_product.json in Resources */ = {isa = PBXBuildFile; fileRef = CCF27B33280EF69600B755E1 /* orders_3337_add_product.json */; };
 		CCF27B3A280EF98F00B755E1 /* orders_3337.json in Resources */ = {isa = PBXBuildFile; fileRef = CCF27B39280EF98F00B755E1 /* orders_3337.json */; };
 		CCF87BBE279047BC00461C43 /* InfiniteScrollList.swift in Sources */ = {isa = PBXBuildFile; fileRef = CCF87BBD279047BC00461C43 /* InfiniteScrollList.swift */; };
-		CCF87BC02790582500461C43 /* ProductVariationSelector.swift in Sources */ = {isa = PBXBuildFile; fileRef = CCF87BBF2790582400461C43 /* ProductVariationSelector.swift */; };
+		CCF87BC02790582500461C43 /* ProductVariationSelectorView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CCF87BBF2790582400461C43 /* ProductVariationSelectorView.swift */; };
 		CCFBBCF429C4B8AF0081B595 /* ComponentsList.swift in Sources */ = {isa = PBXBuildFile; fileRef = CCFBBCF329C4B8AF0081B595 /* ComponentsList.swift */; };
 		CCFBBCF629C4B9A30081B595 /* ComponentsListViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = CCFBBCF529C4B9A30081B595 /* ComponentsListViewModel.swift */; };
 		CCFBBCF829C4C8010081B595 /* ComponentSettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = CCFBBCF729C4C8010081B595 /* ComponentSettings.swift */; };
@@ -4623,7 +4623,7 @@
 		CCF27B33280EF69600B755E1 /* orders_3337_add_product.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = orders_3337_add_product.json; sourceTree = "<group>"; };
 		CCF27B39280EF98F00B755E1 /* orders_3337.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = orders_3337.json; sourceTree = "<group>"; };
 		CCF87BBD279047BC00461C43 /* InfiniteScrollList.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InfiniteScrollList.swift; sourceTree = "<group>"; };
-		CCF87BBF2790582400461C43 /* ProductVariationSelector.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductVariationSelector.swift; sourceTree = "<group>"; };
+		CCF87BBF2790582400461C43 /* ProductVariationSelectorView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductVariationSelectorView.swift; sourceTree = "<group>"; };
 		CCFBBCF329C4B8AF0081B595 /* ComponentsList.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ComponentsList.swift; sourceTree = "<group>"; };
 		CCFBBCF529C4B9A30081B595 /* ComponentsListViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ComponentsListViewModel.swift; sourceTree = "<group>"; };
 		CCFBBCF729C4C8010081B595 /* ComponentSettings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ComponentSettings.swift; sourceTree = "<group>"; };
@@ -11297,7 +11297,7 @@
 				CC53FB372755213900C4CA4F /* ProductSelectorView.swift */,
 				CC53FB3B2757EC7200C4CA4F /* ProductSelectorViewModel.swift */,
 				022CE91929BB143000F210E0 /* ProductSelectorNavigationView.swift */,
-				CCF87BBF2790582400461C43 /* ProductVariationSelector.swift */,
+				CCF87BBF2790582400461C43 /* ProductVariationSelectorView.swift */,
 				CC13C0CA278E021300C0B5B5 /* ProductVariationSelectorViewModel.swift */,
 				CC53FB3427551A6E00C4CA4F /* ProductRow.swift */,
 				CC53FB39275697B000C4CA4F /* ProductRowViewModel.swift */,
@@ -13934,7 +13934,7 @@
 				B958A7CB28B3D4A100823EEF /* RouteMatcher.swift in Sources */,
 				0279F0E4252DC9670098D7DE /* ProductVariationLoadUseCase.swift in Sources */,
 				0366EAE12909A37800B51755 /* JustInTimeMessageViewModel.swift in Sources */,
-				CCF87BC02790582500461C43 /* ProductVariationSelector.swift in Sources */,
+				CCF87BC02790582500461C43 /* ProductVariationSelectorView.swift in Sources */,
 				02CA63DC23D1ADD100BBF148 /* DeviceMediaLibraryPicker.swift in Sources */,
 				021A84E0257DFC2A00BC71D1 /* RefundShippingLabelViewController.swift in Sources */,
 				0373A12F2A1D1F2100731236 /* DotView.swift in Sources */,


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #11907
Merge after: #11917
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

In Order Creation before Project Lily Pad, we blocked people from tapping the `+ Add products` button when there is a blocking order sync ongoing.

This PR adds the same behaviour to side-by-side order creation. It's not ideal, but it may help reduce the sync issues, by forcing people to wait for sync to happen before adding more products.

As mentioned in #11917, this also shows the priority we need to give to having a single source of truth for the order creation process.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

1. Enable the `sideBySideViewForOrderForm`
2. Launch the app on an iPad or large iPhone
3. Go to the Orders tab (check that you're seeing it in split view)
4. Tap `+`
5. Tap on a product on the left
6. Observe that all the products are disabled while the sync is ongoing
7. Deselect a product
8. Observe that the products are not disabled after removing a product
9. Repeat with a variation

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->


https://github.com/woocommerce/woocommerce-ios/assets/2472348/8a32b499-fd90-4aa5-898f-760cf8af2fee


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
