### PR TITLE
[Analytics Hub] Track when an analytics report is opened from an analytics card

### DIFF
--- a/WooCommerce/Classes/Analytics/WooAnalyticsEvent.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsEvent.swift
@@ -2593,6 +2593,9 @@ extension WooAnalyticsEvent {
             case option
             case calendar
             case timezone
+            case report
+            case period
+            case compare
         }
 
         /// Tracks when the "See more" button is tapped in My Store, to open the Analytics Hub.
@@ -2644,6 +2647,17 @@ extension WooAnalyticsEvent {
         ///
         static func enableJetpackStatsFailed(error: Error?) -> WooAnalyticsEvent {
             WooAnalyticsEvent(statName: .analyticsHubEnableJetpackStatsFailed, properties: [:], error: error)
+        }
+
+        /// Tracks when the link to view a full analytics report is tapped on a card in the Analytics Hub.
+        ///
+        static func viewFullReportTapped(for report: AnalyticsWebReport.ReportType,
+                                         period: AnalyticsHubTimeRangeSelection.SelectionType) -> WooAnalyticsEvent {
+            WooAnalyticsEvent(statName: .analyticsHubViewFullReportTapped, properties: [
+                Keys.report.rawValue: report.rawValue,
+                Keys.period.rawValue: period.tracksIdentifier,
+                Keys.compare.rawValue: "previous_period" // For now this is the only compare option in the app
+            ])
         }
     }
 }

--- a/WooCommerce/Classes/Analytics/WooAnalyticsStat.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsStat.swift
@@ -175,6 +175,7 @@ public enum WooAnalyticsStat: String {
     case analyticsHubEnableJetpackStatsTapped = "analytics_hub_enable_jetpack_stats_tapped"
     case analyticsHubEnableJetpackStatsSuccess = "analytics_hub_enable_jetpack_stats_success"
     case analyticsHubEnableJetpackStatsFailed = "analytics_hub_enable_jetpack_stats_failed"
+    case analyticsHubViewFullReportTapped = "analytics_hub_view_full_report_tapped"
 
     // MARK: Blaze Events
     //

--- a/WooCommerce/Classes/Authentication/WPAdminWebViewModel.swift
+++ b/WooCommerce/Classes/Authentication/WPAdminWebViewModel.swift
@@ -3,7 +3,7 @@ import WebKit
 
 /// A view model for authenticated web view for a wp-admin URL in self-hosted sites when WPCOM login is enabled as a Jetpack feature at
 /// `/wp-admin/admin.php?page=jetpack#/settings`.
-final class WPAdminWebViewModel: AuthenticatedWebViewModel, WebviewReloadable {
+class WPAdminWebViewModel: AuthenticatedWebViewModel, WebviewReloadable {
     /// Set in `AuthenticatedWebViewController`.
     var reloadWebview: () -> Void = {}
 

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/AnalyticsHubViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/AnalyticsHubViewModel.swift
@@ -412,7 +412,7 @@ private extension AnalyticsHubViewModel {
 
     static func revenueCard(currentPeriodStats: OrderStatsV4?,
                             previousPeriodStats: OrderStatsV4?,
-                            webReportViewModel: WPAdminWebViewModel?) -> AnalyticsReportCardViewModel {
+                            webReportViewModel: AnalyticsReportLinkViewModel?) -> AnalyticsReportCardViewModel {
         let showSyncError = currentPeriodStats == nil || previousPeriodStats == nil
 
         return AnalyticsReportCardViewModel(title: Localization.RevenueCard.title,
@@ -428,12 +428,12 @@ private extension AnalyticsHubViewModel {
                                             isRedacted: false,
                                             showSyncError: showSyncError,
                                             syncErrorMessage: Localization.RevenueCard.noRevenue,
-                                            reportWebSheetViewModel: webReportViewModel)
+                                            reportViewModel: webReportViewModel)
     }
 
     static func ordersCard(currentPeriodStats: OrderStatsV4?,
                            previousPeriodStats: OrderStatsV4?,
-                           webReportViewModel: WPAdminWebViewModel?) -> AnalyticsReportCardViewModel {
+                           webReportViewModel: AnalyticsReportLinkViewModel?) -> AnalyticsReportCardViewModel {
         let showSyncError = currentPeriodStats == nil || previousPeriodStats == nil
 
         return AnalyticsReportCardViewModel(title: Localization.OrderCard.title,
@@ -450,14 +450,14 @@ private extension AnalyticsHubViewModel {
                                             isRedacted: false,
                                             showSyncError: showSyncError,
                                             syncErrorMessage: Localization.OrderCard.noOrders,
-                                            reportWebSheetViewModel: webReportViewModel)
+                                            reportViewModel: webReportViewModel)
     }
 
     /// Helper function to create a `AnalyticsProductsStatsCardViewModel` from the fetched stats.
     ///
     static func productsStatsCard(currentPeriodStats: OrderStatsV4?,
                                   previousPeriodStats: OrderStatsV4?,
-                                  webReportViewModel: WPAdminWebViewModel?) -> AnalyticsProductsStatsCardViewModel {
+                                  webReportViewModel: AnalyticsReportLinkViewModel?) -> AnalyticsProductsStatsCardViewModel {
         let showStatsError = currentPeriodStats == nil || previousPeriodStats == nil
         let itemsSold = StatsDataTextFormatter.createItemsSoldText(orderStats: currentPeriodStats)
         let itemsSoldDelta = StatsDataTextFormatter.createOrderItemsSoldDelta(from: previousPeriodStats, to: currentPeriodStats)
@@ -466,7 +466,7 @@ private extension AnalyticsHubViewModel {
                                                    delta: itemsSoldDelta,
                                                    isRedacted: false,
                                                    showStatsError: showStatsError,
-                                                   reportWebSheetViewModel: webReportViewModel)
+                                                   reportViewModel: webReportViewModel)
     }
 
     /// Helper function to create a `AnalyticsItemsSoldViewModel` from the fetched stats.
@@ -524,17 +524,17 @@ private extension AnalyticsHubViewModel {
         })
     }
 
-    /// Gets the webview view model to show a web analytics report, based on the provided report type and currently selected time range
+    /// Gets the view model to show a web analytics report, based on the provided report type and currently selected time range
     ///
-    func webReportVM(for report: AnalyticsWebReport.ReportType) -> WPAdminWebViewModel? {
+    func webReportVM(for report: AnalyticsWebReport.ReportType) -> AnalyticsReportLinkViewModel? {
         return AnalyticsHubViewModel.webReportVM(for: report, timeRange: timeRangeSelectionType, storeAdminURL: stores.sessionManager.defaultSite?.adminURL)
     }
 
-    /// Gets the webview view model to show a web analytics report, based on the provided report type, time range, and store admin URL
+    /// Gets the view model to show a web analytics report, based on the provided report type, time range, and store admin URL
     ///
     static func webReportVM(for report: AnalyticsWebReport.ReportType,
                             timeRange: AnalyticsHubTimeRangeSelection.SelectionType,
-                            storeAdminURL: String?) -> WPAdminWebViewModel? {
+                            storeAdminURL: String?) -> AnalyticsReportLinkViewModel? {
         guard let url = AnalyticsWebReport.getUrl(for: report, timeRange: timeRange, storeAdminURL: storeAdminURL) else {
             return nil
         }
@@ -548,7 +548,7 @@ private extension AnalyticsHubViewModel {
                 return Localization.ProductCard.reportTitle
             }
         }()
-        return WPAdminWebViewModel(title: title, initialURL: url)
+        return AnalyticsReportLinkViewModel(reportType: report, period: timeRange, webViewTitle: title, reportURL: url)
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/AnalyticsProductCard.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/AnalyticsProductCard.swift
@@ -39,7 +39,7 @@ struct AnalyticsProductCard: View {
 
     /// URL for the products analytics web report
     ///
-    let reportViewModel: WPAdminWebViewModel?
+    let reportViewModel: AnalyticsReportLinkViewModel?
     @State private var showingWebReport: Bool = false
 
     var body: some View {
@@ -138,7 +138,10 @@ struct AnalyticsProductCardPreviews: PreviewProvider {
                              ],
                              isItemsSoldRedacted: false,
                              showItemsSoldError: false,
-                             reportViewModel: .init(title: "Products Report", initialURL: URL(string: "https://woo.com/")!))
+                             reportViewModel: .init(reportType: .products,
+                                                    period: .today,
+                                                    webViewTitle: "Products Report",
+                                                    reportURL: URL(string: "https://woo.com")!))
             .previewLayout(.sizeThatFits)
 
         AnalyticsProductCard(itemsSold: "-",
@@ -150,7 +153,10 @@ struct AnalyticsProductCardPreviews: PreviewProvider {
                              itemsSoldData: [],
                              isItemsSoldRedacted: false,
                              showItemsSoldError: true,
-                             reportViewModel: .init(title: "Products Report", initialURL: URL(string: "https://woo.com/")!))
+                             reportViewModel: .init(reportType: .products,
+                                                    period: .today,
+                                                    webViewTitle: "Products Report",
+                                                    reportURL: URL(string: "https://woo.com")!))
             .previewLayout(.sizeThatFits)
             .previewDisplayName("No data")
     }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/AnalyticsProductCardViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/AnalyticsProductCardViewModel.swift
@@ -21,9 +21,9 @@ struct AnalyticsProductsStatsCardViewModel {
     ///
     let showStatsError: Bool
 
-    /// WebViewSheetViewModel for the web analytics report
+    /// View model for the web analytics report link
     ///
-    let reportWebSheetViewModel: WPAdminWebViewModel?
+    let reportViewModel: AnalyticsReportLinkViewModel?
 }
 
 /// Analytics Hub Items Sold ViewModel.
@@ -54,7 +54,7 @@ extension AnalyticsProductsStatsCardViewModel {
               delta: DeltaPercentage(string: "0%", direction: .zero),
               isRedacted: true,
               showStatsError: false,
-              reportWebSheetViewModel: reportWebSheetViewModel)
+              reportViewModel: reportViewModel)
     }
 }
 
@@ -81,7 +81,7 @@ extension AnalyticsProductCard {
         self.deltaTextColor = statsViewModel.delta.direction.deltaTextColor
         self.isStatsRedacted = statsViewModel.isRedacted
         self.showStatsError = statsViewModel.showStatsError
-        self.reportViewModel = statsViewModel.reportWebSheetViewModel
+        self.reportViewModel = statsViewModel.reportViewModel
 
         // Top performers list
         self.itemsSoldData = itemsViewModel.itemsSoldData

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/AnalyticsReportCard.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/AnalyticsReportCard.swift
@@ -20,7 +20,7 @@ struct AnalyticsReportCard: View {
     let trailingChartData: [Double]
     let trailingChartColor: UIColor?
 
-    let reportViewModel: WPAdminWebViewModel?
+    let reportViewModel: AnalyticsReportLinkViewModel?
     @State private var showingWebReport: Bool = false
 
     let isRedacted: Bool
@@ -150,7 +150,10 @@ struct Previews: PreviewProvider {
                             trailingDeltaTextColor: .textInverted,
                             trailingChartData: [50.0, 15.0, 20.0, 2.0, 10.0, 0.0, 40.0, 15.0, 20.0, 2.0, 10.0, 0.0],
                             trailingChartColor: .withColorStudio(.red, shade: .shade40),
-                            reportViewModel: WPAdminWebViewModel(title: "", initialURL: URL(string: "https://woo.com/")!),
+                            reportViewModel: .init(reportType: .revenue, 
+                                                   period: .today,
+                                                   webViewTitle: "Revenue Report",
+                                                   reportURL: URL(string: "https://woo.com")!),
                             isRedacted: false,
                             showSyncError: false,
                             syncErrorMessage: "")
@@ -171,7 +174,10 @@ struct Previews: PreviewProvider {
                             trailingDeltaTextColor: .text,
                             trailingChartData: [],
                             trailingChartColor: .withColorStudio(.gray, shade: .shade30),
-                            reportViewModel: WPAdminWebViewModel(title: "", initialURL: URL(string: "https://example.com/")!),
+                            reportViewModel: .init(reportType: .revenue,
+                                                   period: .today,
+                                                   webViewTitle: "Revenue Report",
+                                                   reportURL: URL(string: "https://woo.com")!),
                             isRedacted: false,
                             showSyncError: true,
                             syncErrorMessage: "Error loading revenue analytics")

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/AnalyticsReportCardViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/AnalyticsReportCardViewModel.swift
@@ -53,9 +53,9 @@ struct AnalyticsReportCardViewModel {
     ///
     let syncErrorMessage: String
 
-    /// WebViewSheetViewModel for the web analytics report
+    /// View model for the web analytics report link
     ///
-    let reportWebSheetViewModel: WPAdminWebViewModel?
+    let reportViewModel: AnalyticsReportLinkViewModel?
 }
 
 extension AnalyticsReportCardViewModel {
@@ -76,7 +76,7 @@ extension AnalyticsReportCardViewModel {
               isRedacted: true,
               showSyncError: false,
               syncErrorMessage: "",
-              reportWebSheetViewModel: reportWebSheetViewModel)
+              reportViewModel: reportViewModel)
     }
 }
 
@@ -102,6 +102,6 @@ extension AnalyticsReportCard {
         self.isRedacted = viewModel.isRedacted
         self.showSyncError = viewModel.showSyncError
         self.syncErrorMessage = viewModel.syncErrorMessage
-        self.reportViewModel = viewModel.reportWebSheetViewModel
+        self.reportViewModel = viewModel.reportViewModel
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/AnalyticsReportLink.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/AnalyticsReportLink.swift
@@ -2,10 +2,13 @@ import SwiftUI
 
 struct AnalyticsReportLink: View {
     @Binding var showingWebReport: Bool
-    let reportViewModel: WPAdminWebViewModel
+
+    /// View model for the report webview
+    let reportViewModel: AnalyticsReportLinkViewModel
 
     var body: some View {
         Button {
+            reportViewModel.onWebViewOpen()
             showingWebReport = true
         } label: {
             Text(Localization.seeReport)
@@ -33,6 +36,10 @@ private extension AnalyticsReportLink {
 }
 
 #Preview {
-    AnalyticsReportLink(showingWebReport: .constant(false), reportViewModel: .init(initialURL: URL(string: "https://woo.com/")!))
+    AnalyticsReportLink(showingWebReport: .constant(false),
+                        reportViewModel: .init(reportType: .revenue,
+                                               period: .today,
+                                               webViewTitle: "Revenue Report",
+                                               reportURL: URL(string: "https://woo.com/")!))
         .previewLayout(.sizeThatFits)
 }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/AnalyticsReportLinkViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/AnalyticsReportLinkViewModel.swift
@@ -1,0 +1,31 @@
+import Foundation
+
+/// A view model for `AnalyticsReportLink`, which opens an authenticated webview to show an analytics report in wp-admin.
+final class AnalyticsReportLinkViewModel: WPAdminWebViewModel {
+    /// Type of report being linked to
+    ///
+    let reportType: AnalyticsWebReport.ReportType
+
+    /// Selected time range for the report
+    ///
+    let period: AnalyticsHubTimeRangeSelection.SelectionType
+
+    private let analytics: Analytics
+
+    init(reportType: AnalyticsWebReport.ReportType,
+         period: AnalyticsHubTimeRangeSelection.SelectionType,
+         webViewTitle: String,
+         reportURL: URL,
+         analytics: Analytics = ServiceLocator.analytics) {
+        self.reportType = reportType
+        self.period = period
+        self.analytics = analytics
+        super.init(title: webViewTitle, initialURL: reportURL)
+    }
+
+    /// Action to take when the report webview is opened
+    ///
+    func onWebViewOpen() {
+        // no-op
+    }
+}

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/AnalyticsReportLinkViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/AnalyticsReportLinkViewModel.swift
@@ -26,6 +26,6 @@ final class AnalyticsReportLinkViewModel: WPAdminWebViewModel {
     /// Action to take when the report webview is opened
     ///
     func onWebViewOpen() {
-        // no-op
+        analytics.track(event: .AnalyticsHub.viewFullReportTapped(for: reportType, period: period))
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/AnalyticsWebReport.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/AnalyticsWebReport.swift
@@ -4,7 +4,7 @@ import Foundation
 struct AnalyticsWebReport {
 
     /// Supported types of analytics reports
-    enum ReportType {
+    enum ReportType: String {
         case revenue
         case orders
         case products

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -2028,6 +2028,7 @@
 		CE5F462A23AACA0A006B1A5C /* RefundDetailsDataSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE5F462923AACA0A006B1A5C /* RefundDetailsDataSource.swift */; };
 		CE5F462C23AACBC4006B1A5C /* RefundDetailsResultController.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE5F462B23AACBC4006B1A5C /* RefundDetailsResultController.swift */; };
 		CE6A8FB42B724D7C0063564D /* AnalyticsReportLink.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE6A8FB32B724D7C0063564D /* AnalyticsReportLink.swift */; };
+		CE6A8FB62B725A690063564D /* AnalyticsReportLinkViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE6A8FB52B725A690063564D /* AnalyticsReportLinkViewModel.swift */; };
 		CE85535D209B5BB700938BDC /* OrderDetailsViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE85535C209B5BB700938BDC /* OrderDetailsViewModel.swift */; };
 		CE855365209BA6A700938BDC /* CustomerInfoTableViewCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = CE855361209BA6A700938BDC /* CustomerInfoTableViewCell.xib */; };
 		CE855366209BA6A700938BDC /* CustomerInfoTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE855362209BA6A700938BDC /* CustomerInfoTableViewCell.swift */; };
@@ -4727,6 +4728,7 @@
 		CE5F462923AACA0A006B1A5C /* RefundDetailsDataSource.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RefundDetailsDataSource.swift; sourceTree = "<group>"; };
 		CE5F462B23AACBC4006B1A5C /* RefundDetailsResultController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RefundDetailsResultController.swift; sourceTree = "<group>"; };
 		CE6A8FB32B724D7C0063564D /* AnalyticsReportLink.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnalyticsReportLink.swift; sourceTree = "<group>"; };
+		CE6A8FB52B725A690063564D /* AnalyticsReportLinkViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnalyticsReportLinkViewModel.swift; sourceTree = "<group>"; };
 		CE85535C209B5BB700938BDC /* OrderDetailsViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OrderDetailsViewModel.swift; sourceTree = "<group>"; };
 		CE855361209BA6A700938BDC /* CustomerInfoTableViewCell.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = CustomerInfoTableViewCell.xib; sourceTree = "<group>"; };
 		CE855362209BA6A700938BDC /* CustomerInfoTableViewCell.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CustomerInfoTableViewCell.swift; sourceTree = "<group>"; };
@@ -7147,6 +7149,7 @@
 				CCA1D5FD293F537400B40560 /* DeltaPercentage.swift */,
 				CEDBDA462B6BEF2E002047D4 /* AnalyticsWebReport.swift */,
 				CE6A8FB32B724D7C0063564D /* AnalyticsReportLink.swift */,
+				CE6A8FB52B725A690063564D /* AnalyticsReportLinkViewModel.swift */,
 			);
 			path = "Analytics Hub";
 			sourceTree = "<group>";
@@ -14284,6 +14287,7 @@
 				0259D5F92581F0E6003B1CD6 /* ShippingLabelPaperSizeOptionView.swift in Sources */,
 				D81F2D37225F0D160084BF9C /* EmptyListMessageWithActionView.swift in Sources */,
 				B99B87A72AEFCF0A006B8AB1 /* Order+Empty.swift in Sources */,
+				CE6A8FB62B725A690063564D /* AnalyticsReportLinkViewModel.swift in Sources */,
 				684AB83C2873DF04003DFDD1 /* CardReaderManualsViewModel.swift in Sources */,
 				575472812452185300A94C3C /* PushNotification.swift in Sources */,
 				0396CFAD2981476900E91436 /* CardPresentModalBuiltInConnectingFailed.swift in Sources */,

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -2029,6 +2029,7 @@
 		CE5F462C23AACBC4006B1A5C /* RefundDetailsResultController.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE5F462B23AACBC4006B1A5C /* RefundDetailsResultController.swift */; };
 		CE6A8FB42B724D7C0063564D /* AnalyticsReportLink.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE6A8FB32B724D7C0063564D /* AnalyticsReportLink.swift */; };
 		CE6A8FB62B725A690063564D /* AnalyticsReportLinkViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE6A8FB52B725A690063564D /* AnalyticsReportLinkViewModel.swift */; };
+		CE6A8FB82B7291760063564D /* AnalyticsReportLinkViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE6A8FB72B7291760063564D /* AnalyticsReportLinkViewModelTests.swift */; };
 		CE85535D209B5BB700938BDC /* OrderDetailsViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE85535C209B5BB700938BDC /* OrderDetailsViewModel.swift */; };
 		CE855365209BA6A700938BDC /* CustomerInfoTableViewCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = CE855361209BA6A700938BDC /* CustomerInfoTableViewCell.xib */; };
 		CE855366209BA6A700938BDC /* CustomerInfoTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE855362209BA6A700938BDC /* CustomerInfoTableViewCell.swift */; };
@@ -2039,7 +2040,7 @@
 		CE8CCD44239AC06E009DBD22 /* RefundDetailsViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = CE8CCD42239AC06E009DBD22 /* RefundDetailsViewController.xib */; };
 		CE91BEA029FBE9E100B6E1AF /* QuantityRulesViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE91BE9F29FBE9E100B6E1AF /* QuantityRulesViewModelTests.swift */; };
 		CEA16F3A20FD0C8C0061B4E1 /* WooAnalytics.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEA16F3920FD0C8C0061B4E1 /* WooAnalytics.swift */; };
-		CEA9C8E02B6D323A000FE114 /* AnalyticsHubWebReportTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEA9C8DF2B6D323A000FE114 /* AnalyticsHubWebReportTests.swift */; };
+		CEA9C8E02B6D323A000FE114 /* AnalyticsWebReportTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEA9C8DF2B6D323A000FE114 /* AnalyticsWebReportTests.swift */; };
 		CEC8188C2A3B7C8B00459843 /* AppStartupWaitingTimeTracker.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEC8188B2A3B7C8B00459843 /* AppStartupWaitingTimeTracker.swift */; };
 		CEC8188E2A3C75DD00459843 /* AppStartupWaitingTimeTrackerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEC8188D2A3C75DD00459843 /* AppStartupWaitingTimeTrackerTests.swift */; };
 		CECC758623D21AC200486676 /* AggregateOrderItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = CECC758523D21AC200486676 /* AggregateOrderItem.swift */; };
@@ -4729,6 +4730,7 @@
 		CE5F462B23AACBC4006B1A5C /* RefundDetailsResultController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RefundDetailsResultController.swift; sourceTree = "<group>"; };
 		CE6A8FB32B724D7C0063564D /* AnalyticsReportLink.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnalyticsReportLink.swift; sourceTree = "<group>"; };
 		CE6A8FB52B725A690063564D /* AnalyticsReportLinkViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnalyticsReportLinkViewModel.swift; sourceTree = "<group>"; };
+		CE6A8FB72B7291760063564D /* AnalyticsReportLinkViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnalyticsReportLinkViewModelTests.swift; sourceTree = "<group>"; };
 		CE85535C209B5BB700938BDC /* OrderDetailsViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OrderDetailsViewModel.swift; sourceTree = "<group>"; };
 		CE855361209BA6A700938BDC /* CustomerInfoTableViewCell.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = CustomerInfoTableViewCell.xib; sourceTree = "<group>"; };
 		CE855362209BA6A700938BDC /* CustomerInfoTableViewCell.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CustomerInfoTableViewCell.swift; sourceTree = "<group>"; };
@@ -4739,7 +4741,7 @@
 		CE8CCD42239AC06E009DBD22 /* RefundDetailsViewController.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = RefundDetailsViewController.xib; sourceTree = "<group>"; };
 		CE91BE9F29FBE9E100B6E1AF /* QuantityRulesViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QuantityRulesViewModelTests.swift; sourceTree = "<group>"; };
 		CEA16F3920FD0C8C0061B4E1 /* WooAnalytics.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WooAnalytics.swift; sourceTree = "<group>"; };
-		CEA9C8DF2B6D323A000FE114 /* AnalyticsHubWebReportTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnalyticsHubWebReportTests.swift; sourceTree = "<group>"; };
+		CEA9C8DF2B6D323A000FE114 /* AnalyticsWebReportTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnalyticsWebReportTests.swift; sourceTree = "<group>"; };
 		CEC8188B2A3B7C8B00459843 /* AppStartupWaitingTimeTracker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppStartupWaitingTimeTracker.swift; sourceTree = "<group>"; };
 		CEC8188D2A3C75DD00459843 /* AppStartupWaitingTimeTrackerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppStartupWaitingTimeTrackerTests.swift; sourceTree = "<group>"; };
 		CECA64B020D9990E005A44C4 /* WooCommerce-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "WooCommerce-Bridging-Header.h"; sourceTree = "<group>"; };
@@ -9532,7 +9534,8 @@
 			children = (
 				AE4CCCEA29365CFD00B47EE8 /* AnalyticsHubViewModelTests.swift */,
 				B6440FB8292E74230012D506 /* AnalyticsHubTimeRangeSelectionTests.swift */,
-				CEA9C8DF2B6D323A000FE114 /* AnalyticsHubWebReportTests.swift */,
+				CEA9C8DF2B6D323A000FE114 /* AnalyticsWebReportTests.swift */,
+				CE6A8FB72B7291760063564D /* AnalyticsReportLinkViewModelTests.swift */,
 			);
 			path = "Analytics Hub";
 			sourceTree = "<group>";
@@ -14745,6 +14748,7 @@
 				0242CFB829F278B70080F500 /* ProductFormAIEligibilityCheckerTests.swift in Sources */,
 				E10DFC78267331590083AFF2 /* ApplicationLogViewModelTests.swift in Sources */,
 				0298431225936DFC00979CAE /* ShippingLabelsTopBannerFactoryTests.swift in Sources */,
+				CE6A8FB82B7291760063564D /* AnalyticsReportLinkViewModelTests.swift in Sources */,
 				B98968572A98F227007A2FBE /* TaxEducationalDialogViewModelTests.swift in Sources */,
 				57B374B6245B331100D58BE0 /* EmptyStateViewControllerTests.swift in Sources */,
 				EE6F08662A718DFB00AA9B88 /* FreeTrialSurveyViewModelTests.swift in Sources */,
@@ -14909,7 +14913,7 @@
 				DEF36DEC2898D64600178AC2 /* JetpackSetupWebViewModelTests.swift in Sources */,
 				023EC2E424DA95DB0021DA91 /* ProductInventorySettingsViewModel+VariationTests.swift in Sources */,
 				CCB366AF274518EC007D437A /* EditableOrderViewModelTests.swift in Sources */,
-				CEA9C8E02B6D323A000FE114 /* AnalyticsHubWebReportTests.swift in Sources */,
+				CEA9C8E02B6D323A000FE114 /* AnalyticsWebReportTests.swift in Sources */,
 				020BE76B23B4A380007FE54C /* AztecUnderlineFormatBarCommandTests.swift in Sources */,
 				2631D4FA29ED108400F13F20 /* WPComPlanNameSanitizer.swift in Sources */,
 				D83F5937225B402E00626E75 /* TitleAndEditableValueTableViewCellTests.swift in Sources */,

--- a/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Analytics Hub/AnalyticsHubViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Analytics Hub/AnalyticsHubViewModelTests.swift
@@ -463,9 +463,9 @@ final class AnalyticsHubViewModelTests: XCTestCase {
                                        stores: stores)
 
         // When
-        let revenueCardReportURL = try XCTUnwrap(vm.revenueCard.reportWebSheetViewModel?.initialURL)
-        let ordersCardReportURL = try XCTUnwrap(vm.ordersCard.reportWebSheetViewModel?.initialURL)
-        let productsCardReportURL = try XCTUnwrap(vm.productsStatsCard.reportWebSheetViewModel?.initialURL)
+        let revenueCardReportURL = try XCTUnwrap(vm.revenueCard.reportViewModel?.initialURL)
+        let ordersCardReportURL = try XCTUnwrap(vm.ordersCard.reportViewModel?.initialURL)
+        let productsCardReportURL = try XCTUnwrap(vm.productsStatsCard.reportViewModel?.initialURL)
 
         let revenueCardURLQueryItems = try XCTUnwrap(URLComponents(url: revenueCardReportURL, resolvingAgainstBaseURL: false)?.queryItems)
         let ordersCardURLQueryItems = try XCTUnwrap(URLComponents(url: ordersCardReportURL, resolvingAgainstBaseURL: false)?.queryItems)
@@ -520,9 +520,9 @@ final class AnalyticsHubViewModelTests: XCTestCase {
         await vm.updateData()
 
         // Then
-        let revenueCardReportURL = try XCTUnwrap(vm.revenueCard.reportWebSheetViewModel?.initialURL)
-        let ordersCardReportURL = try XCTUnwrap(vm.ordersCard.reportWebSheetViewModel?.initialURL)
-        let productsCardReportURL = try XCTUnwrap(vm.productsStatsCard.reportWebSheetViewModel?.initialURL)
+        let revenueCardReportURL = try XCTUnwrap(vm.revenueCard.reportViewModel?.initialURL)
+        let ordersCardReportURL = try XCTUnwrap(vm.ordersCard.reportViewModel?.initialURL)
+        let productsCardReportURL = try XCTUnwrap(vm.productsStatsCard.reportViewModel?.initialURL)
 
         let revenueCardURLQueryItems = try XCTUnwrap(URLComponents(url: revenueCardReportURL, resolvingAgainstBaseURL: false)?.queryItems)
         let ordersCardURLQueryItems = try XCTUnwrap(URLComponents(url: ordersCardReportURL, resolvingAgainstBaseURL: false)?.queryItems)
@@ -565,12 +565,12 @@ final class AnalyticsHubViewModelTests: XCTestCase {
         await vm.updateData()
 
         // Then
-        XCTAssertNotNil(loadingRevenueCard?.reportWebSheetViewModel?.initialURL)
-        XCTAssertNotNil(loadingOrdersCard?.reportWebSheetViewModel?.initialURL)
-        XCTAssertNotNil(loadingProductsCard?.reportWebSheetViewModel?.initialURL)
+        XCTAssertNotNil(loadingRevenueCard?.reportViewModel?.initialURL)
+        XCTAssertNotNil(loadingOrdersCard?.reportViewModel?.initialURL)
+        XCTAssertNotNil(loadingProductsCard?.reportViewModel?.initialURL)
 
-        XCTAssertNotNil(vm.revenueCard.reportWebSheetViewModel?.initialURL)
-        XCTAssertNotNil(vm.ordersCard.reportWebSheetViewModel?.initialURL)
-        XCTAssertNotNil(vm.productsStatsCard.reportWebSheetViewModel?.initialURL)
+        XCTAssertNotNil(vm.revenueCard.reportViewModel?.initialURL)
+        XCTAssertNotNil(vm.ordersCard.reportViewModel?.initialURL)
+        XCTAssertNotNil(vm.productsStatsCard.reportViewModel?.initialURL)
     }
 }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Analytics Hub/AnalyticsReportLinkViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Analytics Hub/AnalyticsReportLinkViewModelTests.swift
@@ -1,0 +1,33 @@
+import XCTest
+@testable import WooCommerce
+
+final class AnalyticsReportLinkViewModelTests: XCTestCase {
+
+    private var analyticsProvider: MockAnalyticsProvider!
+    private var analytics: Analytics!
+
+    override func setUp() {
+        analyticsProvider = MockAnalyticsProvider()
+        analytics = WooAnalytics(analyticsProvider: analyticsProvider)
+    }
+
+    func test_onWebViewOpen_tracks_expected_events() throws {
+        // Given
+        let vm = AnalyticsReportLinkViewModel(reportType: .revenue,
+                                              period: .weekToDate,
+                                              webViewTitle: "",
+                                              reportURL: try XCTUnwrap(URL(string: "https://woo.com/")),
+                                              analytics: analytics)
+
+        // When
+        vm.onWebViewOpen()
+
+        // Then
+        let indexOfEvent = try XCTUnwrap(analyticsProvider.receivedEvents.firstIndex(where: { $0 == "analytics_hub_view_full_report_tapped" }))
+        let eventProperties = try XCTUnwrap(analyticsProvider.receivedProperties[indexOfEvent])
+        XCTAssertEqual(eventProperties["report"] as? String, "revenue")
+        XCTAssertEqual(eventProperties["period"] as? String, "Week to Date")
+        XCTAssertEqual(eventProperties["compare"] as? String, "previous_period")
+    }
+
+}

--- a/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Analytics Hub/AnalyticsWebReportTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Analytics Hub/AnalyticsWebReportTests.swift
@@ -2,7 +2,7 @@ import XCTest
 import TestKit
 @testable import WooCommerce
 
-final class AnalyticsHubWebReportTests: XCTestCase {
+final class AnalyticsWebReportTests: XCTestCase {
 
     let exampleAdminURL = "https://example.com/wp-admin/"
 


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #11875
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This adds a new Tracks event:

- `analytics_hub_view_full_report_tapped` (Registration: https://github.com/Automattic/tracks-events-registration/pull/2222)
   - Custom prop `report` with value `revenue|orders|products` (the report that is opened)
   - Custom prop `period` with value set to the currently selected date range (e.g. `today|yesterday|custom`)
   - Custom prop `compare` with value `previous_period` (in the future this can be expanded to include `previous_year` when the app supports a previous year comparison)

The event is triggered when the user taps on "See Report" on a card to view the full analytics report, with the custom props reflecting the selected report and the currently selected date range and comparison period in the Analytics Hub.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
How to test:

1. Build and run the app.
2. On the My Store tab, tap the "See More" button.
3. Select "See Report" on any of the cards in the Analytics Hub.
4. Confirm the event is tracked with the expected `report`, `period`, and `compare` properties.


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
