### PR TITLE
Dangermattic checks update

### DIFF
--- a/.github/workflows/run-danger.yml
+++ b/.github/workflows/run-danger.yml
@@ -6,6 +6,6 @@ on:
 
 jobs:
   dangermattic:
-    uses: Automattic/dangermattic/.github/workflows/reusable-run-danger.yml@trunk
+    uses: Automattic/dangermattic/.github/workflows/reusable-run-danger.yml@v1.0.0
     secrets:
       github-token: ${{ secrets.DANGERMATTIC_GITHUB_TOKEN }}

--- a/.github/workflows/run-danger.yml
+++ b/.github/workflows/run-danger.yml
@@ -2,10 +2,12 @@ name: ☢️ Danger
 
 on:
   pull_request:
-    types: [opened, synchronize, edited, review_requested, review_request_removed, labeled, unlabeled, milestoned, demilestoned]
+    types: [opened, reopened, ready_for_review, synchronize, edited, labeled, unlabeled, milestoned, demilestoned]
 
 jobs:
   dangermattic:
+    # runs on draft PRs only for opened / synchronize events
+    if: ${{ (github.event.pull_request.draft == false) || (github.event.pull_request.draft == true && contains(fromJSON('["opened", "synchronize"]'), github.event.action)) }}
     uses: Automattic/dangermattic/.github/workflows/reusable-run-danger.yml@v1.0.0
     secrets:
       github-token: ${{ secrets.DANGERMATTIC_GITHUB_TOKEN }}

--- a/Dangerfile
+++ b/Dangerfile
@@ -46,4 +46,4 @@ labels_checker.check(
 )
 
 # skip check for draft PRs and for WIP features unless the PR is against the main branch or release branch
-milestone_checker.check_milestone_due_date(days_before_due: 2) unless github_utils.wip_feature? && !(github_utils.release_branch? || github_utils.main_branch?)
+milestone_checker.check_milestone_due_date(days_before_due: 2) if (github_utils.main_branch? || github_utils.release_branch?) && !github_utils.wip_feature?

--- a/Dangerfile
+++ b/Dangerfile
@@ -22,12 +22,6 @@ common_release_checker.check_internal_release_notes_changed(report_type: :messag
 
 ios_release_checker.check_modified_translations_on_release_branch
 
-labels_checker.check(
-  do_not_merge_labels: ['status: do not merge'],
-  required_labels: [//],
-  required_labels_error: 'PR requires at least one label.'
-)
-
 tracks_checker.check_tracks_changes(
   tracks_files: [
     'WooAnalyticsStat.swift'
@@ -42,7 +36,14 @@ view_changes_checker.check
 
 pr_size_checker.check_diff_size(max_size: 500)
 
+# skip remaining checks if we have a Draft PR
+return if github.pr_draft?
+
+labels_checker.check(
+  do_not_merge_labels: ['status: do not merge'],
+  required_labels: [//],
+  required_labels_error: 'PR requires at least one label.'
+)
+
 # skip check for draft PRs and for WIP features unless the PR is against the main branch or release branch
-unless github.pr_draft? || (github_utils.wip_feature? && !(github_utils.release_branch? || github_utils.main_branch?))
-  milestone_checker.check_milestone_due_date(days_before_due: 2)
-end
+milestone_checker.check_milestone_due_date(days_before_due: 2) unless github_utils.wip_feature? && !(github_utils.release_branch? || github_utils.main_branch?)

--- a/Dangerfile
+++ b/Dangerfile
@@ -1,25 +1,26 @@
 # frozen_string_literal: true
 
-def release_branch?
-  danger.github.branch_for_base.start_with?('release/') || danger.github.branch_for_base.start_with?('hotfix/')
-end
-
-def main_branch?
-  danger.github.branch_for_base == 'trunk'
-end
-
-def wip_feature?
-  has_wip_label = github.pr_labels.any? { |label| label.include?('WIP') }
-  has_wip_title = github.pr_title.include?('WIP')
-
-  has_wip_label || has_wip_title
-end
-
-return if github.pr_labels.include?('Releases')
-
 github.dismiss_out_of_range_messages
 
+# `files: []` forces rubocop to scan all files, not just the ones modified in the PR
+rubocop.lint(files: [], force_exclusion: true, inline_comment: true, fail_on_inline_comment: true, include_cop_names: true)
+
 manifest_pr_checker.check_all_manifest_lock_updated
+
+podfile_checker.check_podfile_does_not_have_branch_references
+
+ios_release_checker.check_core_data_model_changed
+ios_release_checker.check_release_notes_and_app_store_strings
+
+# skip remaining checks if we're during the release process
+if github.pr_labels.include?('Releases')
+  message('This PR has the `Releases` label: some checks will be skipped.')
+  return
+end
+
+common_release_checker.check_internal_release_notes_changed(report_type: :message)
+
+ios_release_checker.check_modified_translations_on_release_branch
 
 labels_checker.check(
   do_not_merge_labels: ['status: do not merge'],
@@ -27,11 +28,21 @@ labels_checker.check(
   required_labels_error: 'PR requires at least one label.'
 )
 
-view_changes_need_screenshots.view_changes_need_screenshots
+tracks_checker.check_tracks_changes(
+  tracks_files: [
+    'WooAnalyticsStat.swift'
+  ],
+  tracks_usage_matchers: [
+    /AnalyticsTracker\.track/
+  ],
+  tracks_label: 'Tracks'
+)
 
-pr_size_checker.check_diff_size
+view_changes_checker.check
+
+pr_size_checker.check_diff_size(max_size: 500)
 
 # skip check for draft PRs and for WIP features unless the PR is against the main branch or release branch
-milestone_checker.check_milestone_due_date(days_before_due: 2) unless github.pr_draft? || (wip_feature? && !(release_branch? || main_branch?))
-
-rubocop.lint(inline_comment: true, fail_on_inline_comment: true, include_cop_names: true)
+unless github.pr_draft? || (github_utils.wip_feature? && !(github_utils.release_branch? || github_utils.main_branch?))
+  milestone_checker.check_milestone_due_date(days_before_due: 2)
+end

--- a/Dangerfile
+++ b/Dangerfile
@@ -12,7 +12,7 @@ podfile_checker.check_podfile_does_not_have_branch_references
 ios_release_checker.check_core_data_model_changed
 ios_release_checker.check_release_notes_and_app_store_strings
 
-# skip remaining checks if we're during the release process
+# skip remaining checks if we're in a release-process PR
 if github.pr_labels.include?('Releases')
   message('This PR has the `Releases` label: some checks will be skipped.')
   return
@@ -36,8 +36,11 @@ view_changes_checker.check
 
 pr_size_checker.check_diff_size(max_size: 500)
 
-# skip remaining checks if we have a Draft PR
-return if github.pr_draft?
+# skip remaining checks if the PR is still a Draft
+if github.pr_draft?
+  message('This PR is still a Draft: some checks will be skipped.')
+  return
+end
 
 labels_checker.check(
   do_not_merge_labels: ['status: do not merge'],
@@ -45,5 +48,5 @@ labels_checker.check(
   required_labels_error: 'PR requires at least one label.'
 )
 
-# skip check for draft PRs and for WIP features unless the PR is against the main branch or release branch
+# runs the milestone check if this is not a WIP feature and the PR is against the main branch or the release branch
 milestone_checker.check_milestone_due_date(days_before_due: 2) if (github_utils.main_branch? || github_utils.release_branch?) && !github_utils.wip_feature?

--- a/Gemfile
+++ b/Gemfile
@@ -27,4 +27,4 @@ gem 'rubocop-rake', '~> 0.6'
 gem 'xcode-install'
 gem 'xcpretty-travis-formatter'
 
-gem 'danger-dangermattic', git: 'https://github.com/Automattic/dangermattic'
+gem 'danger-dangermattic', git: 'https://github.com/Automattic/dangermattic', ref: 'iangmaia/common-utils'

--- a/Gemfile
+++ b/Gemfile
@@ -22,9 +22,9 @@ gem 'fastlane-plugin-sentry', '~> 1.0'
 # Using '~> 9.0.1' would resolve to 9.0.x compatible version, missing out on any new feature release.
 gem 'fastlane-plugin-wpmreleasetoolkit', '~> 9.3'
 gem 'rake', '~> 12.3'
-gem 'rubocop', '~> 1.56'
+gem 'rubocop', '~> 1.60'
 gem 'rubocop-rake', '~> 0.6'
 gem 'xcode-install'
 gem 'xcpretty-travis-formatter'
 
-gem 'danger-dangermattic', git: 'https://github.com/Automattic/dangermattic', ref: 'iangmaia/common-utils'
+gem 'danger-dangermattic', '~> 1.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,7 @@
 GIT
   remote: https://github.com/Automattic/dangermattic
-  revision: 06a54db4f546d20c0465e4d144049d061a2a1e20
+  revision: a05023fa2b877c0d778c14bfff891c1318dd9f63
+  ref: iangmaia/common-utils
   specs:
     danger-dangermattic (0.0.1)
       danger (~> 9.3)
@@ -109,7 +110,7 @@ GEM
     connection_pool (2.4.1)
     cork (0.3.0)
       colored2 (~> 3.1)
-    danger (9.3.2)
+    danger (9.4.3)
       claide (~> 1.0)
       claide-plugins (>= 0.9.2)
       colored2 (~> 3.1)
@@ -120,7 +121,7 @@ GEM
       kramdown (~> 2.3)
       kramdown-parser-gfm (~> 1.0)
       no_proxy_fix
-      octokit (~> 6.0)
+      octokit (>= 4.0)
       terminal-table (>= 1, < 4)
     danger-junit (1.0.2)
       danger (> 2.0)
@@ -130,10 +131,10 @@ GEM
     danger-rubocop (0.12.0)
       danger
       rubocop (~> 1.0)
-    danger-swiftlint (0.33.0)
+    danger-swiftlint (0.35.0)
       danger
       rake (> 10)
-      thor (~> 0.19)
+      thor (~> 1.0.0)
     danger-xcode_summary (1.2.0)
       danger-plugin-api (~> 1.0)
       xcresult (~> 0.2)
@@ -168,7 +169,7 @@ GEM
     faraday-em_http (1.0.0)
     faraday-em_synchrony (1.0.0)
     faraday-excon (1.1.0)
-    faraday-http-cache (2.5.0)
+    faraday-http-cache (2.5.1)
       faraday (>= 0.8)
     faraday-httpclient (1.0.1)
     faraday-multipart (1.0.4)
@@ -384,7 +385,7 @@ GEM
     terminal-notifier (2.0.0)
     terminal-table (3.0.2)
       unicode-display_width (>= 1.1.1, < 3)
-    thor (0.20.3)
+    thor (1.0.1)
     trailblazer-option (0.1.2)
     tty-cursor (0.7.1)
     tty-screen (0.8.1)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,17 +1,3 @@
-GIT
-  remote: https://github.com/Automattic/dangermattic
-  revision: a05023fa2b877c0d778c14bfff891c1318dd9f63
-  ref: iangmaia/common-utils
-  specs:
-    danger-dangermattic (0.0.1)
-      danger (~> 9.3)
-      danger-junit (~> 1.0)
-      danger-plugin-api (~> 1.0)
-      danger-rubocop (~> 0.11)
-      danger-swiftlint (~> 0.29)
-      danger-xcode_summary (~> 1.0)
-      rubocop (~> 1.56)
-
 GEM
   remote: https://rubygems.org/
   specs:
@@ -27,7 +13,7 @@ GEM
       minitest (>= 5.1)
       mutex_m
       tzinfo (~> 2.0)
-    addressable (2.8.5)
+    addressable (2.8.6)
       public_suffix (>= 2.0.2, < 6.0)
     algoliasearch (1.27.5)
       httpclient (~> 2.8, >= 2.8.3)
@@ -123,6 +109,14 @@ GEM
       no_proxy_fix
       octokit (>= 4.0)
       terminal-table (>= 1, < 4)
+    danger-dangermattic (1.0.0)
+      danger (~> 9.4)
+      danger-junit (~> 1.0)
+      danger-plugin-api (~> 1.0)
+      danger-rubocop (~> 0.12)
+      danger-swiftlint (~> 0.35)
+      danger-xcode_summary (~> 1.0)
+      rubocop (~> 1.60)
     danger-junit (1.0.2)
       danger (> 2.0)
       ox (~> 2.0)
@@ -246,7 +240,7 @@ GEM
     fourflusher (2.3.1)
     fuzzy_match (2.0.4)
     gh_inspector (1.1.3)
-    git (1.18.0)
+    git (1.19.1)
       addressable (~> 2.8)
       rchardet (~> 1.8)
     google-apis-androidpublisher_v3 (0.52.0)
@@ -294,7 +288,7 @@ GEM
       concurrent-ruby (~> 1.0)
     java-properties (0.3.0)
     jmespath (1.6.2)
-    json (2.6.3)
+    json (2.7.1)
     jwt (2.7.1)
     kramdown (2.4.0)
       rexml
@@ -307,7 +301,7 @@ GEM
     minitest (5.20.0)
     molinillo (0.8.0)
     multi_json (1.15.0)
-    multipart-post (2.3.0)
+    multipart-post (2.4.0)
     mutex_m (0.1.2)
     nanaimo (0.3.0)
     nap (1.1.0)
@@ -327,8 +321,8 @@ GEM
     optparse (0.1.1)
     os (1.1.4)
     ox (2.14.17)
-    parallel (1.23.0)
-    parser (3.2.2.4)
+    parallel (1.24.0)
+    parser (3.3.0.5)
       ast (~> 2.4.1)
       racc
     plist (3.7.0)
@@ -342,7 +336,7 @@ GEM
     rake-compiler (1.2.5)
       rake
     rchardet (1.8.0)
-    regexp_parser (2.8.2)
+    regexp_parser (2.9.0)
     representable (3.2.0)
       declarative (< 0.1.0)
       trailblazer-option (>= 0.1.1, < 0.2.0)
@@ -351,15 +345,15 @@ GEM
     rexml (3.2.6)
     rmagick (4.3.0)
     rouge (2.0.7)
-    rubocop (1.57.2)
+    rubocop (1.60.2)
       json (~> 2.3)
       language_server-protocol (>= 3.17.0)
       parallel (~> 1.10)
-      parser (>= 3.2.2.4)
+      parser (>= 3.3.0.2)
       rainbow (>= 2.2.2, < 4.0)
       regexp_parser (>= 1.8, < 3.0)
       rexml (>= 3.2.5, < 4.0)
-      rubocop-ast (>= 1.28.1, < 2.0)
+      rubocop-ast (>= 1.30.0, < 2.0)
       ruby-progressbar (~> 1.7)
       unicode-display_width (>= 2.4.0, < 3.0)
     rubocop-ast (1.30.0)
@@ -424,7 +418,7 @@ PLATFORMS
 DEPENDENCIES
   cocoapods (~> 1.14)
   cocoapods-catalyst-support (~> 0.1)
-  danger-dangermattic!
+  danger-dangermattic (~> 1.0)
   dotenv
   fastlane (~> 2.217)
   fastlane-plugin-appcenter (~> 2.0)
@@ -432,7 +426,7 @@ DEPENDENCIES
   fastlane-plugin-wpmreleasetoolkit (~> 9.3)
   rake (~> 12.3)
   rmagick (~> 4.1)
-  rubocop (~> 1.56)
+  rubocop (~> 1.60)
   rubocop-rake (~> 0.6)
   xcode-install
   xcpretty-travis-formatter


### PR DESCRIPTION
This PR adapts the `Dangerfile` to the latest [Dangermattic](https://github.com/Automattic/dangermattic) version, using newly added plugins, adapting the code as needed and implementing a few improvements.

The main changes:
- Improvements to the Rubocop check call
- Added Core Data model changed check
- Added Podfile branch references check
- Added Release Notes / Store strings check
- Added Tracks Check
- Added check for translations being changed only on the release branch
- Added check on the internal release notes being changed 
- Use `github_utils` plugin instead of locally declared functions
- Added message report when we're skipping checks due to the `Releases` label
- Use officially distributed `danger-dangermattic` Gem

## Testing
The main validation is to make sure CI is 🟢.

To run Danger yourself:
1. Checkout this branch 
2. Run `bundle install`
3. Run:
```ruby
DANGER_GITHUB_API_TOKEN=<github_token> bundle exec danger pr <PR_URL>
```
You should get in the console the same errors / warnings reported in the PR.