### PR TITLE
Add a feature flag to use URLSession in WordPressKit

### DIFF
--- a/Experiments/Experiments/DefaultFeatureFlagService.swift
+++ b/Experiments/Experiments/DefaultFeatureFlagService.swift
@@ -91,6 +91,8 @@ public struct DefaultFeatureFlagService: FeatureFlagService {
             return buildConfig == .localDeveloper || buildConfig == .alpha
         case .splitViewInProductsTab:
             return false
+        case .useURLSessionInWordPressKit:
+            return buildConfig != .appStore
         default:
             return true
         }

--- a/Experiments/Experiments/FeatureFlag.swift
+++ b/Experiments/Experiments/FeatureFlag.swift
@@ -199,4 +199,8 @@ public enum FeatureFlag: Int {
     /// Displays the Products tab in a split view
     ///
     case splitViewInProductsTab
+
+    /// Configures WordPressKit to send HTTP requests using URLSession instead of Alamofire.
+    ///
+    case useURLSessionInWordPressKit
 }

--- a/Podfile
+++ b/Podfile
@@ -87,8 +87,9 @@ target 'WooCommerce' do
   # To allow pod to pick up beta versions use -beta. E.g., 1.1.7-beta.1
   # pod 'WordPressAuthenticator', '~> 9.0'
   # pod 'WordPressAuthenticator', git: 'https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git', branch: ''
-  pod 'WordPressAuthenticator', git: 'https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git', commit: '6312d0a91e709a4bae017e04f70e520199928928'
+  pod 'WordPressAuthenticator', git: 'https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git', commit: 'fa06fca7178b268d382d91861752b3be0729e8a8'
   # pod 'WordPressAuthenticator', path: '../WordPressAuthenticator-iOS'
+  pod 'WordPressKit', git: 'https://github.com/wordpress-mobile/WordPressKit-iOS.git', commit: 'b5c2bd39ec8f478dd53ecb7533ad025aad48f42e'
 
   wordpress_shared
 

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -28,14 +28,14 @@ PODS:
   - WordPress-Aztec-iOS (1.19.9)
   - WordPress-Editor-iOS (1.19.9):
     - WordPress-Aztec-iOS (= 1.19.9)
-  - WordPressAuthenticator (9.0.0):
+  - WordPressAuthenticator (9.0.1):
     - Gridicons (~> 1.0)
     - "NSURL+IDN (= 0.4)"
     - SVProgressHUD (~> 2.2.5)
-    - WordPressKit (~> 12.0)
+    - WordPressKit (~> 13.0)
     - WordPressShared (~> 2.1-beta)
     - WordPressUI (~> 1.7-beta)
-  - WordPressKit (12.0.0):
+  - WordPressKit (13.0.0):
     - Alamofire (~> 4.8.0)
     - NSObject-SafeExpectations (~> 0.0.4)
     - UIDeviceIdentifier (~> 2.0)
@@ -72,7 +72,8 @@ DEPENDENCIES:
   - StripeTerminal (~> 3.1.0)
   - WordPress-Aztec-iOS (from `https://github.com/wordpress-mobile/AztecEditor-iOS.git`, commit `950c7bc1bf98326986f10cccb2715ad86976f0fd`)
   - WordPress-Editor-iOS (from `https://github.com/wordpress-mobile/AztecEditor-iOS.git`, commit `950c7bc1bf98326986f10cccb2715ad86976f0fd`)
-  - WordPressAuthenticator (from `https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git`, commit `6312d0a91e709a4bae017e04f70e520199928928`)
+  - WordPressAuthenticator (from `https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git`, commit `fa06fca7178b268d382d91861752b3be0729e8a8`)
+  - WordPressKit (from `https://github.com/wordpress-mobile/WordPressKit-iOS.git`, commit `b5c2bd39ec8f478dd53ecb7533ad025aad48f42e`)
   - WordPressShared (~> 2.1)
   - WordPressUI (from `https://github.com/wordpress-mobile/WordPressUI-iOS.git`, commit `a0248ba6dabaed1d493416fd1273aa6718c76331`)
   - Wormholy (~> 1.6.6)
@@ -80,8 +81,6 @@ DEPENDENCIES:
   - ZendeskSupportSDK (~> 6.0)
 
 SPEC REPOS:
-  https://github.com/wordpress-mobile/cocoapods-specs.git:
-    - WordPressKit
   trunk:
     - Alamofire
     - Automattic-Tracks-iOS
@@ -117,8 +116,11 @@ EXTERNAL SOURCES:
     :commit: 950c7bc1bf98326986f10cccb2715ad86976f0fd
     :git: https://github.com/wordpress-mobile/AztecEditor-iOS.git
   WordPressAuthenticator:
-    :commit: 6312d0a91e709a4bae017e04f70e520199928928
+    :commit: fa06fca7178b268d382d91861752b3be0729e8a8
     :git: https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git
+  WordPressKit:
+    :commit: b5c2bd39ec8f478dd53ecb7533ad025aad48f42e
+    :git: https://github.com/wordpress-mobile/WordPressKit-iOS.git
   WordPressUI:
     :commit: a0248ba6dabaed1d493416fd1273aa6718c76331
     :git: https://github.com/wordpress-mobile/WordPressUI-iOS.git
@@ -134,8 +136,11 @@ CHECKOUT OPTIONS:
     :commit: 950c7bc1bf98326986f10cccb2715ad86976f0fd
     :git: https://github.com/wordpress-mobile/AztecEditor-iOS.git
   WordPressAuthenticator:
-    :commit: 6312d0a91e709a4bae017e04f70e520199928928
+    :commit: fa06fca7178b268d382d91861752b3be0729e8a8
     :git: https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git
+  WordPressKit:
+    :commit: b5c2bd39ec8f478dd53ecb7533ad025aad48f42e
+    :git: https://github.com/wordpress-mobile/WordPressKit-iOS.git
   WordPressUI:
     :commit: a0248ba6dabaed1d493416fd1273aa6718c76331
     :git: https://github.com/wordpress-mobile/WordPressUI-iOS.git
@@ -161,8 +166,8 @@ SPEC CHECKSUMS:
   UIDeviceIdentifier: 442b65b4ff1832d4ca9c2a157815cb29ad981b17
   WordPress-Aztec-iOS: fbebd569c61baa252b3f5058c0a2a9a6ada686bb
   WordPress-Editor-iOS: bda9f7f942212589b890329a0cb22547311749ef
-  WordPressAuthenticator: ce9688b78d71e296ea54159c4eef3a1ea5cc1838
-  WordPressKit: 55d1abb019a150a59ede51ace089cb148a4375a0
+  WordPressAuthenticator: ba69878bfa1368636e92d29fcfb5bd1e0a11a3ef
+  WordPressKit: 7e5250e9e28fcdca787f8d313a7dc89a8571d774
   WordPressShared: 0aa459e5257a77184db87805a998f447443c9706
   WordPressUI: a491454affda3b0fb812812e637dc5e8f8f6bd06
   Wormholy: 09da0b876f9276031fd47383627cb75e194fc068
@@ -176,6 +181,6 @@ SPEC CHECKSUMS:
   ZendeskSupportProvidersSDK: 685b5d185af47ced0ec40564ec46355c838bbd06
   ZendeskSupportSDK: 92e6f9d334e81e9186f8a17583862350460a5393
 
-PODFILE CHECKSUM: c50079091c181e58300147498f7da908f851f899
+PODFILE CHECKSUM: 3df76e94250950bcf9e09f321a83183a1ce7c288
 
 COCOAPODS: 1.14.0

--- a/WooCommerce/Classes/AppDelegate.swift
+++ b/WooCommerce/Classes/AppDelegate.swift
@@ -10,6 +10,7 @@ import KeychainAccess
 import WordPressUI
 import WordPressAuthenticator
 import AutomatticTracks
+import WordPressKit
 
 import class Yosemite.ScreenshotStoresManager
 
@@ -101,6 +102,8 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         setupNoticePresenter()
         setupUniversalLinkRouter()
         disableAnimationsIfNeeded()
+
+        configureWordPressKit()
 
         // Don't track startup waiting time if user starts logged out
         if !ServiceLocator.stores.isAuthenticated {
@@ -457,6 +460,13 @@ private extension AppDelegate {
             ServiceLocator.analytics.track(event: .Widgets.widgetTapped(name: .appLink))
         default:
             break
+        }
+    }
+
+    func configureWordPressKit() {
+        if ServiceLocator.featureFlagService.isFeatureFlagEnabled(.useURLSessionInWordPressKit) {
+            WordPressOrgXMLRPCApi.useURLSession = true
+            WordPressComRestApi.useURLSession = true
         }
     }
 }


### PR DESCRIPTION
## Description

What says in the title. By default, WordPressKit sends HTTP requests using Alamofire. This PR adds a feature flag to configure WordPressKit sends HTTP requests using URLSession for all non-production builds.

With the new feature flag, we can test the new implementation during development. After the testing is done, we can switch WordPressKit over to URLSession completely and remove the new code in this PR.

## Testing instructions

Try features that involves different kinds of HTTP requests (GET, POST, upload files, etc). Testing error cases would be super valuable too.

## Screenshots

N/A


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
