### PR TITLE
[Tablet Products] Show product form in-progress view overlay in fullscreen

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewController+Helpers.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewController+Helpers.swift
@@ -137,7 +137,8 @@ private extension ProductFormViewController {
     func displayInProgressView(title: String, message: String) {
         let viewProperties = InProgressViewProperties(title: title, message: message)
         let inProgressViewController = InProgressViewController(viewProperties: viewProperties)
-        inProgressViewController.modalPresentationStyle = .overCurrentContext
+        inProgressViewController.modalPresentationStyle = ServiceLocator.featureFlagService.isFeatureFlagEnabled(.splitViewInProductsTab) ?
+            .overFullScreen: .overCurrentContext
 
         navigationController?.present(inProgressViewController, animated: true, completion: nil)
     }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #11928
<!-- Id number of the GitHub issue this PR addresses. -->

## Why

As also noted in the design comment pfoUAQ-cM-p2#comment-121 (the last point), currently the product form in-progress overlay (shown when saving the product remotely) is only over the secondary column in the split view and issues arise when the user taps on a different product in the product list at the same time. With the split view support, it makes more sense to show the overlay in fullscreen.

## How

The in-progress modal style was updated from `overCurrentContext` to `overFullscreen` under the feature flag to avoid any potential edits on the same product elsewhere in the app (like from product search, products section in order details).

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

- [x] @jaclync makes sure the product form saving flow works as expected when the feature flag is off

---

- In code, enable `splitViewInProductsTab` feature flag in `DefaultFeatureFlagService`
- Launch the app
- Go to the products tab
- Tap on + or an existing product
- Update the name or any other product info
- Tap to save or publish the product --> the modal should be fullscreen

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->


https://github.com/woocommerce/woocommerce-ios/assets/1945542/f0628bf0-52f4-4b96-a9bb-c643b7c6450e



---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.