### PR TITLE
[Tablet Products] Fix product scanning modal & support camera when the app is in split view

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -4,6 +4,7 @@
 -----
 - [***] Products: Cache product images to reduce network requests. [https://github.com/woocommerce/woocommerce-ios/pull/11902]
 - [***] Stats: The Analytics Hub now includes links to the full analytics report for each supported analytics card (Revenue, Orders, Products). [https://github.com/woocommerce/woocommerce-ios/pull/11920]
+- [*] Products > product scanning: in wider devices, the product details after scanning a barcode does not show in split view with an empty secondary view anymore. Camera capture is also enabled when the app is in split mode with another app in iOS 16+ for supported devices. [https://github.com/woocommerce/woocommerce-ios/pull/11931]
 
 17.2
 -----

--- a/WooCommerce/Classes/ViewRelated/Products/SKU Scanner/CodeScannerViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/SKU Scanner/CodeScannerViewController.swift
@@ -137,6 +137,11 @@ private extension CodeScannerViewController {
     /// Enables and starts live stream video, if available.
     func startLiveVideo() {
         session.sessionPreset = .photo
+        if #available(iOS 16.0, *) {
+            if session.isMultitaskingCameraAccessSupported {
+                session.isMultitaskingCameraAccessEnabled = true
+            }
+        }
 
         guard let captureDevice = AVCaptureDevice.default(for: .video),
             let deviceInput = try? AVCaptureDeviceInput(device: captureDevice) else {

--- a/WooCommerce/Classes/ViewRelated/Products/UpdateInventory/UpdateProductInventoryView.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/UpdateInventory/UpdateProductInventoryView.swift
@@ -161,6 +161,7 @@ struct UpdateProductInventoryView: View {
                 }
             }
         }
+        .navigationViewStyle(StackNavigationViewStyle())
     }
 }
 


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #11930

<!-- Id number of the GitHub issue this PR addresses. -->

## Why

There are two issues with the product scanning flow:

- On tablets, the product modal after scanning a barcode that matches the product SKU is currently shown in a split view with an empty secondary view
  - The reason for this is that the SwiftUI view `UpdateProductInventoryView` is using `NavigationView` which has `navigationViewStyle` default to split view on wider devices based on the [Apple documentation](https://developer.apple.com/documentation/swiftui/view/navigationviewstyle(_:)):

> Use this modifier to change the appearance and behavior of navigation views. For example, by default, navigation views appear with multiple columns in wider environments, like iPad in landscape orientation

- When the app is in split-over mode with another app, the camera is also stopped and available in fullscreen mode.
  - When the device has multiple apps running in parallel in split view (like Woo & Notes apps), `AVCaptureSession` is paused by default. In order to enable camera multitasking, we need to manually enable the camera session available in iOS 16+

## How

For the navigation view style issue, `StackNavigationViewStyle` is now set manually to ensure the style. For the camera multitasking issue, multitasking is now enabled for iOS 16+ following the [doc](https://developer.apple.com/documentation/avkit/accessing_the_camera_while_multitasking_on_ipad) (we're removing iOS 15 support very soon p91TBi-aVX-p2#comment-11811). 

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

- [x] @jaclync tests that the issues are fixed when the feature flag is off

---

Prerequisites: please test in a physical device for proper camera access. the store doesn't have the Square plugin (scanning products is disabled in this case). the store has a product that has the SKU set to a barcode (you can add it from product form > inventory > scan)

- In code, enable `splitViewInProductsTab` feature flag in `DefaultFeatureFlagService`
- Launch the app
- Put the app in split mode with another app
- Go to the products tab
- Tap on the scan button in the left navigation bar --> the camera should be available if the device is iOS 16+. if not, update the app to fullscreen mode
- Scan the barcode that's used for a product's SKU (see the prerequisites) --> the product modal should not be in a split view anymore


## Screenshots
<!-- Include before and after images or gifs when appropriate. -->



https://github.com/woocommerce/woocommerce-ios/assets/1945542/98963759-5ab5-4bba-bda6-eb84f1835402





---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.