### PR TITLE
[Order Attrbution] Map and store attribution info in Order model (Networking layer)

### DIFF
--- a/Fakes/Fakes/Networking.generated.swift
+++ b/Fakes/Fakes/Networking.generated.swift
@@ -727,7 +727,22 @@ extension Networking.Order {
             taxes: .fake(),
             customFields: .fake(),
             renewalSubscriptionID: .fake(),
-            appliedGiftCards: .fake()
+            appliedGiftCards: .fake(),
+            attributionInfo: .fake()
+        )
+    }
+}
+extension Networking.OrderAttributionInfo {
+    /// Returns a "ready to use" type filled with fake values.
+    ///
+    public static func fake() -> Networking.OrderAttributionInfo {
+        .init(
+            sourceType: .fake(),
+            campaign: .fake(),
+            source: .fake(),
+            medium: .fake(),
+            deviceType: .fake(),
+            sessionPageViews: .fake()
         )
     }
 }

--- a/Networking/Networking.xcodeproj/project.pbxproj
+++ b/Networking/Networking.xcodeproj/project.pbxproj
@@ -1004,6 +1004,8 @@
 		EE80A25029556FBD003591E4 /* coupon-reports-without-data.json in Resources */ = {isa = PBXBuildFile; fileRef = EE80A24F29556FBD003591E4 /* coupon-reports-without-data.json */; };
 		EE839C262ABEF9C900049545 /* AIProductMapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE839C252ABEF9C900049545 /* AIProductMapper.swift */; };
 		EE84D62B2B0B46E7008EA80A /* product-variation-subscription-incomplete.json in Resources */ = {isa = PBXBuildFile; fileRef = EE84D62A2B0B46E7008EA80A /* product-variation-subscription-incomplete.json */; };
+		EE8A30302B72A3C8001D7C66 /* OrderAttributionInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE8A302F2B72A3C8001D7C66 /* OrderAttributionInfo.swift */; };
+		EE8A30322B72A521001D7C66 /* order-with-attribution-info.json in Resources */ = {isa = PBXBuildFile; fileRef = EE8A30312B72A521001D7C66 /* order-with-attribution-info.json */; };
 		EE8A86F1286C5226003E8AA4 /* media-update-product-id-in-wordpress-site.json in Resources */ = {isa = PBXBuildFile; fileRef = EE8A86F0286C5226003E8AA4 /* media-update-product-id-in-wordpress-site.json */; };
 		EE8C202B2B4786D500FE967B /* blaze-create-campaign-success.json in Resources */ = {isa = PBXBuildFile; fileRef = EE8C202A2B4786D500FE967B /* blaze-create-campaign-success.json */; };
 		EE8C202D2B47886500FE967B /* CreateBlazeCampaignMapperTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE8C202C2B47886500FE967B /* CreateBlazeCampaignMapperTests.swift */; };
@@ -2074,6 +2076,8 @@
 		EE80A24F29556FBD003591E4 /* coupon-reports-without-data.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "coupon-reports-without-data.json"; sourceTree = "<group>"; };
 		EE839C252ABEF9C900049545 /* AIProductMapper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AIProductMapper.swift; sourceTree = "<group>"; };
 		EE84D62A2B0B46E7008EA80A /* product-variation-subscription-incomplete.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "product-variation-subscription-incomplete.json"; sourceTree = "<group>"; };
+		EE8A302F2B72A3C8001D7C66 /* OrderAttributionInfo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OrderAttributionInfo.swift; sourceTree = "<group>"; };
+		EE8A30312B72A521001D7C66 /* order-with-attribution-info.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "order-with-attribution-info.json"; sourceTree = "<group>"; };
 		EE8A86F0286C5226003E8AA4 /* media-update-product-id-in-wordpress-site.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "media-update-product-id-in-wordpress-site.json"; sourceTree = "<group>"; };
 		EE8C202A2B4786D500FE967B /* blaze-create-campaign-success.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "blaze-create-campaign-success.json"; sourceTree = "<group>"; };
 		EE8C202C2B47886500FE967B /* CreateBlazeCampaignMapperTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CreateBlazeCampaignMapperTests.swift; sourceTree = "<group>"; };
@@ -2630,6 +2634,7 @@
 				CE12FBD8221F3A6F00C59248 /* OrderStatus.swift */,
 				B5BB1D1120A255EC00112D92 /* OrderStatusEnum.swift */,
 				BAB373712795A1FB00837B4A /* OrderTaxLine.swift */,
+				EE8A302F2B72A3C8001D7C66 /* OrderAttributionInfo.swift */,
 				267313302559CC930026F7EF /* PaymentGateway.swift */,
 				314703072670222500EF253A /* PaymentGatewayAccount.swift */,
 				D89A01D326D3F8D8008195BE /* ReaderLocation.swift */,
@@ -2891,6 +2896,7 @@
 				A69FE19C2588D70E0059A96B /* order-with-deleted-refunds.json */,
 				CE12AE9429F29F4F0056DD17 /* order-with-subscription-renewal.json */,
 				CEE9188029F7DC23004B23FF /* order-with-gift-cards.json */,
+				EE8A30312B72A521001D7C66 /* order-with-attribution-info.json */,
 				CE6B96992A0BCD09003C4B27 /* order-with-bundled-line-items.json */,
 				CE831FE62A17FC1800E8BEFB /* order-with-composite-product.json */,
 				261CF1B3255AD6B30090D8D3 /* payment-gateway-list.json */,
@@ -4045,6 +4051,7 @@
 				02050F57296FE90A00710E63 /* domain-suggestions-paid.json in Resources */,
 				31B8D6B626583970008E3DB2 /* wcpay-account-implicitly-not-eligible.json in Resources */,
 				EEFC4C9B2A5ED1F6004C5A83 /* identify-language-invalid-token.json in Resources */,
+				EE8A30322B72A521001D7C66 /* order-with-attribution-info.json in Resources */,
 				EE57C125297EB4E300BC31E7 /* product-attributes-all-without-data.json in Resources */,
 				31054714262E2F3B00C5C02B /* wcpay-payment-intent-requires-payment-method.json in Resources */,
 				EE57C134297F985A00BC31E7 /* product-variations-bulk-update-without-data.json in Resources */,
@@ -4629,6 +4636,7 @@
 				DE2E8EB329546501002E4B14 /* PlaceholderDataValidator.swift in Sources */,
 				2665032E261F4FBF0079A159 /* ProductAddOnOption.swift in Sources */,
 				E18152C028F85D4A0011A0EC /* InAppPurchasesProductMapper.swift in Sources */,
+				EE8A30302B72A3C8001D7C66 /* OrderAttributionInfo.swift in Sources */,
 				028296F7237D588700E84012 /* ProductVariation.swift in Sources */,
 				DE4D23BA29B5FB3E003A4B5D /* AnnouncementsRemote.swift in Sources */,
 				DEC51AEF2768A628009F3DF4 /* SystemStatus+Database.swift in Sources */,

--- a/Networking/Networking/Model/Copiable/Models+Copiable.generated.swift
+++ b/Networking/Networking/Model/Copiable/Models+Copiable.generated.swift
@@ -1092,7 +1092,8 @@ extension Networking.Order {
         taxes: CopiableProp<[OrderTaxLine]> = .copy,
         customFields: CopiableProp<[OrderMetaData]> = .copy,
         renewalSubscriptionID: NullableCopiableProp<String> = .copy,
-        appliedGiftCards: CopiableProp<[OrderGiftCard]> = .copy
+        appliedGiftCards: CopiableProp<[OrderGiftCard]> = .copy,
+        attributionInfo: NullableCopiableProp<OrderAttributionInfo> = .copy
     ) -> Networking.Order {
         let siteID = siteID ?? self.siteID
         let orderID = orderID ?? self.orderID
@@ -1131,6 +1132,7 @@ extension Networking.Order {
         let customFields = customFields ?? self.customFields
         let renewalSubscriptionID = renewalSubscriptionID ?? self.renewalSubscriptionID
         let appliedGiftCards = appliedGiftCards ?? self.appliedGiftCards
+        let attributionInfo = attributionInfo ?? self.attributionInfo
 
         return Networking.Order(
             siteID: siteID,
@@ -1169,7 +1171,35 @@ extension Networking.Order {
             taxes: taxes,
             customFields: customFields,
             renewalSubscriptionID: renewalSubscriptionID,
-            appliedGiftCards: appliedGiftCards
+            appliedGiftCards: appliedGiftCards,
+            attributionInfo: attributionInfo
+        )
+    }
+}
+
+extension Networking.OrderAttributionInfo {
+    public func copy(
+        sourceType: NullableCopiableProp<OrderAttributionInfo.SourceType> = .copy,
+        campaign: NullableCopiableProp<String> = .copy,
+        source: NullableCopiableProp<String> = .copy,
+        medium: NullableCopiableProp<String> = .copy,
+        deviceType: NullableCopiableProp<String> = .copy,
+        sessionPageViews: NullableCopiableProp<String> = .copy
+    ) -> Networking.OrderAttributionInfo {
+        let sourceType = sourceType ?? self.sourceType
+        let campaign = campaign ?? self.campaign
+        let source = source ?? self.source
+        let medium = medium ?? self.medium
+        let deviceType = deviceType ?? self.deviceType
+        let sessionPageViews = sessionPageViews ?? self.sessionPageViews
+
+        return Networking.OrderAttributionInfo(
+            sourceType: sourceType,
+            campaign: campaign,
+            source: source,
+            medium: medium,
+            deviceType: deviceType,
+            sessionPageViews: sessionPageViews
         )
     }
 }

--- a/Networking/Networking/Model/Copiable/Models+Copiable.generated.swift
+++ b/Networking/Networking/Model/Copiable/Models+Copiable.generated.swift
@@ -3,7 +3,6 @@
 import Codegen
 import Foundation
 
-
 extension Networking.AIProduct {
     public func copy(
         name: CopiableProp<String> = .copy,
@@ -1179,7 +1178,7 @@ extension Networking.Order {
 
 extension Networking.OrderAttributionInfo {
     public func copy(
-        sourceType: NullableCopiableProp<OrderAttributionInfo.SourceType> = .copy,
+        sourceType: NullableCopiableProp<String> = .copy,
         campaign: NullableCopiableProp<String> = .copy,
         source: NullableCopiableProp<String> = .copy,
         medium: NullableCopiableProp<String> = .copy,

--- a/Networking/Networking/Model/Order.swift
+++ b/Networking/Networking/Model/Order.swift
@@ -57,6 +57,10 @@ public struct Order: Decodable, GeneratedCopiable, GeneratedFakeable {
     ///
     public let appliedGiftCards: [OrderGiftCard]
 
+    /// Attribution info about the source of the order
+    ///
+    public let attributionInfo: OrderAttributionInfo?
+
     /// Order struct initializer.
     ///
     public init(siteID: Int64,
@@ -95,7 +99,8 @@ public struct Order: Decodable, GeneratedCopiable, GeneratedFakeable {
                 taxes: [OrderTaxLine],
                 customFields: [OrderMetaData],
                 renewalSubscriptionID: String?,
-                appliedGiftCards: [OrderGiftCard]) {
+                appliedGiftCards: [OrderGiftCard],
+                attributionInfo: OrderAttributionInfo?) {
 
         self.siteID = siteID
         self.orderID = orderID
@@ -139,6 +144,7 @@ public struct Order: Decodable, GeneratedCopiable, GeneratedFakeable {
         self.customFields = customFields
         self.renewalSubscriptionID = renewalSubscriptionID
         self.appliedGiftCards = appliedGiftCards
+        self.attributionInfo = attributionInfo
     }
 
 
@@ -224,6 +230,15 @@ public struct Order: Decodable, GeneratedCopiable, GeneratedFakeable {
         // Gift Cards extension
         let appliedGiftCards = try container.decodeIfPresent([OrderGiftCard].self, forKey: .giftCards) ?? []
 
+        // Attribution info
+        let attributionInfo: OrderAttributionInfo? = {
+            guard let allOrderMetaData else {
+                return nil
+            }
+
+            return OrderAttributionInfo(metaData: allOrderMetaData)
+        }()
+
         self.init(siteID: siteID,
                   orderID: orderID,
                   parentID: parentID,
@@ -260,7 +275,8 @@ public struct Order: Decodable, GeneratedCopiable, GeneratedFakeable {
                   taxes: taxes,
                   customFields: customFields,
                   renewalSubscriptionID: renewalSubscriptionID,
-                  appliedGiftCards: appliedGiftCards)
+                  appliedGiftCards: appliedGiftCards,
+                  attributionInfo: attributionInfo)
     }
 
     public static var empty: Order {
@@ -300,7 +316,8 @@ public struct Order: Decodable, GeneratedCopiable, GeneratedFakeable {
                   taxes: [],
                   customFields: [],
                   renewalSubscriptionID: nil,
-                  appliedGiftCards: [])
+                  appliedGiftCards: [],
+                  attributionInfo: nil)
     }
 }
 
@@ -389,7 +406,8 @@ extension Order: Equatable {
             lhs.refunds.sorted() == rhs.refunds.sorted() &&
             lhs.items.count == rhs.items.count &&
             lhs.items.sorted() == rhs.items.sorted() &&
-            lhs.customerNote == rhs.customerNote
+            lhs.customerNote == rhs.customerNote &&
+            lhs.attributionInfo == rhs.attributionInfo
     }
 }
 

--- a/Networking/Networking/Model/OrderAttributionInfo.swift
+++ b/Networking/Networking/Model/OrderAttributionInfo.swift
@@ -4,45 +4,14 @@ import Codegen
 /// Order's attribution info helps to know the source of the order
 ///
 public struct OrderAttributionInfo: Equatable, GeneratedFakeable, GeneratedCopiable {
-
-    // Source types based on
-    // swiftlint:disable:next line_length
-    // https://github.com/woocommerce/woocommerce/blob/4dcc7d8bf80dcd660e0e999ca84794ef61627d41/plugins/woocommerce/src/Internal/Traits/OrderAttributionMeta.php#L276-L314
-    //
-    public enum SourceType: Equatable {
-        case utm
-        case organic
-        case referral
-        case typein
-        case admin
-        case unknown(_ sourceType: String)
-
-        init(string: String) {
-            switch string {
-            case "utm":
-                self = .utm
-            case "organic":
-                self = .organic
-            case "referral":
-                self = .referral
-            case "typein":
-                self = .typein
-            case "admin":
-                self = .admin
-            default:
-                self = .unknown(string)
-            }
-        }
-    }
-
-    public let sourceType: SourceType?
+    public let sourceType: String?
     public let campaign: String?
     public let source: String?
     public let medium: String?
     public let deviceType: String?
     public let sessionPageViews: String?
 
-    public init(sourceType: SourceType?,
+    public init(sourceType: String?,
                 campaign: String?,
                 source: String?,
                 medium: String?,
@@ -57,7 +26,7 @@ public struct OrderAttributionInfo: Equatable, GeneratedFakeable, GeneratedCopia
     }
 
     public init(metaData: [OrderMetaData]) {
-        var sourceType: SourceType?
+        var sourceType: String?
         var campaign: String?
         var source: String?
         var medium: String?
@@ -66,7 +35,7 @@ public struct OrderAttributionInfo: Equatable, GeneratedFakeable, GeneratedCopia
         for item in metaData {
             switch item.key {
             case Keys.sourceType.rawValue:
-                sourceType = SourceType(string: item.value)
+                sourceType = item.value
             case Keys.campaign.rawValue:
                 campaign = item.value
             case Keys.source.rawValue:

--- a/Networking/Networking/Model/OrderAttributionInfo.swift
+++ b/Networking/Networking/Model/OrderAttributionInfo.swift
@@ -1,0 +1,102 @@
+import Foundation
+import Codegen
+
+/// Order's attribution info helps to know the source of the order
+///
+public struct OrderAttributionInfo: Equatable, GeneratedFakeable, GeneratedCopiable {
+
+    // Source types based on
+    // swiftlint:disable:next line_length
+    // https://github.com/woocommerce/woocommerce/blob/4dcc7d8bf80dcd660e0e999ca84794ef61627d41/plugins/woocommerce/src/Internal/Traits/OrderAttributionMeta.php#L276-L314
+    //
+    public enum SourceType: Equatable {
+        case utm
+        case organic
+        case referral
+        case typein
+        case admin
+        case unknown(_ sourceType: String)
+
+        init(string: String) {
+            switch string {
+            case "utm":
+                self = .utm
+            case "organic":
+                self = .organic
+            case "referral":
+                self = .referral
+            case "typein":
+                self = .typein
+            case "admin":
+                self = .admin
+            default:
+                self = .unknown(string)
+            }
+        }
+    }
+
+    public let sourceType: SourceType?
+    public let campaign: String?
+    public let source: String?
+    public let medium: String?
+    public let deviceType: String?
+    public let sessionPageViews: String?
+
+    public init(sourceType: SourceType?,
+                campaign: String?,
+                source: String?,
+                medium: String?,
+                deviceType: String?,
+                sessionPageViews: String?) {
+        self.sourceType = sourceType
+        self.campaign = campaign
+        self.source = source
+        self.medium = medium
+        self.deviceType = deviceType
+        self.sessionPageViews = sessionPageViews
+    }
+
+    public init(metaData: [OrderMetaData]) {
+        var sourceType: SourceType?
+        var campaign: String?
+        var source: String?
+        var medium: String?
+        var deviceType: String?
+        var sessionPageViews: String?
+        for item in metaData {
+            switch item.key {
+            case Keys.sourceType.rawValue:
+                sourceType = SourceType(string: item.value)
+            case Keys.campaign.rawValue:
+                campaign = item.value
+            case Keys.source.rawValue:
+                source = item.value
+            case Keys.medium.rawValue:
+                medium = item.value
+            case Keys.deviceType.rawValue:
+                deviceType = item.value
+            case Keys.sessionPageViews.rawValue:
+                sessionPageViews = item.value
+            default:
+                continue
+            }
+        }
+        self.init(sourceType: sourceType,
+                  campaign: campaign,
+                  source: source,
+                  medium: medium,
+                  deviceType: deviceType,
+                  sessionPageViews: sessionPageViews)
+    }
+}
+
+private extension OrderAttributionInfo {
+    enum Keys: String {
+        case sourceType = "_wc_order_attribution_source_type"
+        case campaign = "_wc_order_attribution_utm_campaign"
+        case source = "_wc_order_attribution_utm_source"
+        case medium = "_wc_order_attribution_utm_medium"
+        case deviceType = "_wc_order_attribution_device_type"
+        case sessionPageViews = "_wc_order_attribution_session_pages"
+    }
+}

--- a/Networking/NetworkingTests/Mapper/OrderMapperTests.swift
+++ b/Networking/NetworkingTests/Mapper/OrderMapperTests.swift
@@ -495,6 +495,22 @@ final class OrderMapperTests: XCTestCase {
             .init(addOnID: 1690786915, key: "Wrapping paper", value: "Yes"),
         ])
     }
+
+    func test_order_attribution_info_is_parsed_successfully() throws {
+        // Given
+        let order = try XCTUnwrap(mapLoadOrderWithAttributionInfo())
+
+        // When
+        let attributionInfo = try XCTUnwrap(order.attributionInfo)
+
+        // Then
+        XCTAssertEqual(attributionInfo.sourceType, .referral)
+        XCTAssertEqual(attributionInfo.campaign, "sale")
+        XCTAssertEqual(attributionInfo.source, "woo.com")
+        XCTAssertEqual(attributionInfo.medium, "referral")
+        XCTAssertEqual(attributionInfo.deviceType, "Desktop")
+        XCTAssertEqual(attributionInfo.sessionPageViews, "2")
+    }
 }
 
 
@@ -617,4 +633,9 @@ private extension OrderMapperTests {
         return mapOrder(from: "order-alternative-types")
     }
 
+    /// Returns the Order output upon receiving `order-with-attribution-info`
+    ///
+    func mapLoadOrderWithAttributionInfo() -> Order? {
+        return mapOrder(from: "order-with-attribution-info")
+    }
 }

--- a/Networking/NetworkingTests/Mapper/OrderMapperTests.swift
+++ b/Networking/NetworkingTests/Mapper/OrderMapperTests.swift
@@ -504,7 +504,7 @@ final class OrderMapperTests: XCTestCase {
         let attributionInfo = try XCTUnwrap(order.attributionInfo)
 
         // Then
-        XCTAssertEqual(attributionInfo.sourceType, .referral)
+        XCTAssertEqual(attributionInfo.sourceType, "referral")
         XCTAssertEqual(attributionInfo.campaign, "sale")
         XCTAssertEqual(attributionInfo.source, "woo.com")
         XCTAssertEqual(attributionInfo.medium, "referral")

--- a/Networking/NetworkingTests/Mapper/OrderMapperTests.swift
+++ b/Networking/NetworkingTests/Mapper/OrderMapperTests.swift
@@ -496,7 +496,7 @@ final class OrderMapperTests: XCTestCase {
         ])
     }
 
-    func test_order_attribution_info_is_parsed_successfully() throws {
+    func test_order_attribution_info_is_parsed_correctly() throws {
         // Given
         let order = try XCTUnwrap(mapLoadOrderWithAttributionInfo())
 

--- a/Networking/NetworkingTests/Responses/order-with-attribution-info.json
+++ b/Networking/NetworkingTests/Responses/order-with-attribution-info.json
@@ -1,0 +1,338 @@
+{
+    "data": {
+        "id": 459,
+        "parent_id": 0,
+        "status": "processing",
+        "currency": "USD",
+        "version": "7.5.1",
+        "prices_include_tax": false,
+        "date_created": "2023-03-29T04:21:20",
+        "date_modified": "2023-03-29T04:23:02",
+        "discount_total": "0.00",
+        "discount_tax": "0.00",
+        "shipping_total": "10.00",
+        "shipping_tax": "0.00",
+        "cart_tax": "0.00",
+        "total": "4.00",
+        "total_tax": "0.00",
+        "customer_id": 27375286,
+        "order_key": "wc_order_boLXJYDMOOhSp",
+        "billing": {
+            "first_name": "Tyrel",
+            "last_name": "Senger",
+            "company": "",
+            "address_1": "8412 Dicki Creek",
+            "address_2": "481 General Crossroad",
+            "city": "Denesikton",
+            "state": "Louisiana",
+            "postcode": "903851780",
+            "country": "BB",
+            "email": "your.email+fakedata99085@gmail.com",
+            "phone": "724-024-2595"
+        },
+        "shipping": {
+            "first_name": "Tyrel",
+            "last_name": "Senger",
+            "company": "",
+            "address_1": "8412 Dicki Creek",
+            "address_2": "481 General Crossroad",
+            "city": "Denesikton",
+            "state": "Louisiana",
+            "postcode": "903851780",
+            "country": "BB",
+            "phone": "1234567898"
+        },
+        "payment_method": "woocommerce_payments",
+        "payment_method_title": "Visa credit card",
+        "transaction_id": "pi_3MqpbEFmpgWy4Lrl0vJo4TIn",
+        "customer_ip_address": "189.147.41.13",
+        "customer_user_agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/111.0.0.0 Safari/537.36",
+        "created_via": "store-api",
+        "customer_note": "",
+        "date_completed": null,
+        "date_paid": "2023-03-29T04:23:02",
+        "cart_hash": "dde03e176e78380de9549352abdfbe4a",
+        "number": "459",
+        "meta_data": [
+            {
+                "id": 12849,
+                "key": "_shipping_hash",
+                "value": "9d4568c009d203ab10e33ea9953a0264"
+            },
+            {
+                "id": 12850,
+                "key": "_coupons_hash",
+                "value": "d751713988987e9331980363e24189ce"
+            },
+            {
+                "id": 12851,
+                "key": "_fees_hash",
+                "value": "d751713988987e9331980363e24189ce"
+            },
+            {
+                "id": 12852,
+                "key": "_taxes_hash",
+                "value": "d751713988987e9331980363e24189ce"
+            },
+            {
+                "id": 12853,
+                "key": "is_vat_exempt",
+                "value": "no"
+            },
+            {
+                "id": 12855,
+                "key": "_customer_ip_country",
+                "value": "MX"
+            },
+            {
+                "id": 12856,
+                "key": "_customer_self_declared_country",
+                "value": "false"
+            },
+            {
+                "id": 12858,
+                "key": "_payment_method_id",
+                "value": "pm_1MU8TnFmpgWy4LrlAwUzFd6t"
+            },
+            {
+                "id": 12859,
+                "key": "_stripe_customer_id",
+                "value": "cus_NEbhgaeylNVXDP"
+            },
+            {
+                "id": 12861,
+                "key": "_wcpay_mode",
+                "value": "test"
+            },
+            {
+                "id": 12862,
+                "key": "_intent_id",
+                "value": "pi_3MqpbEFmpgWy4Lrl0vJo4TIn"
+            },
+            {
+                "id": 12863,
+                "key": "_charge_id",
+                "value": "ch_3MqpbEFmpgWy4Lrl0XY98kur"
+            },
+            {
+                "id": 12864,
+                "key": "_intention_status",
+                "value": "succeeded"
+            },
+            {
+                "id": 12865,
+                "key": "_wcpay_intent_currency",
+                "value": "usd"
+            },
+            {
+                "id": 12869,
+                "key": "_wc_points_earned",
+                "value": "36"
+            },
+            {
+                "id": 12871,
+                "key": "_automatewoo_order_created",
+                "value": "1"
+            },
+            {
+                "id": 12872,
+                "key": "_new_order_tracking_complete",
+                "value": "yes"
+            },
+            {
+                "id": 12873,
+                "key": "_wc_connect_destination_normalized",
+                "value": "1"
+            },
+            {
+                "id": 4113,
+                "key": "_wc_order_attribution_device_type",
+                "value": "Desktop"
+            },
+            {
+                "id": 4104,
+                "key": "_wc_order_attribution_referrer",
+                "value": "https://woo.com/"
+            },
+            {
+                "id": 4111,
+                "key": "_wc_order_attribution_session_count",
+                "value": "1"
+            },
+            {
+                "id": 4108,
+                "key": "_wc_order_attribution_session_entry",
+                "value": "https://ddev.site/shop/"
+            },
+            {
+                "id": 4110,
+                "key": "_wc_order_attribution_session_pages",
+                "value": "2"
+            },
+            {
+                "id": 4109,
+                "key": "_wc_order_attribution_session_start_time",
+                "value": "2024-01-18 10:41:42"
+            },
+            {
+                "id": 4103,
+                "key": "_wc_order_attribution_source_type",
+                "value": "referral"
+            },
+            {
+                "id": 4112,
+                "key": "_wc_order_attribution_user_agent",
+                "value": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36"
+            },
+            {
+                "id": 4107,
+                "key": "_wc_order_attribution_utm_content",
+                "value": "/"
+            },
+            {
+                "id": 4106,
+                "key": "_wc_order_attribution_utm_medium",
+                "value": "referral"
+            },
+            {
+                "id": 4105,
+                "key": "_wc_order_attribution_utm_source",
+                "value": "woo.com"
+            },
+            {
+                "id": 4075,
+                "key": "_wc_order_attribution_utm_campaign",
+                "value": "sale"
+            }
+        ],
+        "line_items": [
+            {
+                "id": 921,
+                "name": "Beanie with Logo",
+                "product_id": 36,
+                "variation_id": 0,
+                "quantity": 1,
+                "tax_class": "clothing-20010",
+                "subtotal": "18.00",
+                "subtotal_tax": "0.00",
+                "total": "18.00",
+                "total_tax": "0.00",
+                "taxes": [],
+                "meta_data": [
+                    {
+                        "id": 8166,
+                        "key": "As a Gift",
+                        "value": "No",
+                        "display_key": "As a Gift",
+                        "display_value": "No"
+                    },
+                    {
+                        "id": 8167,
+                        "key": "_pao_ids",
+                        "value": [
+                            {
+                                "key": "As a Gift",
+                                "value": "No"
+                            }
+                        ],
+                        "display_key": "_pao_ids",
+                        "display_value": [
+                            {
+                                "key": "As a Gift",
+                                "value": "No"
+                            }
+                        ]
+                    },
+                    {
+                        "id": 8168,
+                        "key": "_wcsatt_scheme",
+                        "value": "0",
+                        "display_key": "_wcsatt_scheme",
+                        "display_value": "0"
+                    },
+                    {
+                        "id": 8189,
+                        "key": "_reduced_stock",
+                        "value": "1",
+                        "display_key": "_reduced_stock",
+                        "display_value": "1"
+                    }
+                ],
+                "sku": "Woo-beanie-logo",
+                "price": 18,
+                "image": {
+                    "id": "59",
+                    "src": "https://example.com/wp-content/uploads/2023/01/beanie-with-logo-1.jpg"
+                },
+                "parent_name": null,
+                "composite_parent": "",
+                "composite_children": [],
+                "bundled_by": "",
+                "bundled_item_title": "",
+                "bundled_items": []
+            }
+        ],
+        "tax_lines": [],
+        "shipping_lines": [
+            {
+                "id": 923,
+                "method_title": "Flat rate",
+                "method_id": "flat_rate",
+                "instance_id": "3",
+                "total": "10.00",
+                "total_tax": "0.00",
+                "taxes": [],
+                "meta_data": [
+                    {
+                        "id": 8180,
+                        "key": "Items",
+                        "value": "Beanie with Logo &times; 1",
+                        "display_key": "Items",
+                        "display_value": "Beanie with Logo &times; 1"
+                    }
+                ]
+            }
+        ],
+        "fee_lines": [],
+        "coupon_lines": [],
+        "refunds": [],
+        "payment_url": "https://example.com/checkout/order-pay/459/?pay_for_order=true&key=wc_order_boLXJYDMOOhSp",
+        "is_editable": false,
+        "needs_payment": false,
+        "needs_processing": true,
+        "date_created_gmt": "2023-03-29T03:21:20",
+        "date_modified_gmt": "2023-03-29T03:23:02",
+        "date_completed_gmt": null,
+        "date_paid_gmt": "2023-03-29T03:23:02",
+        "gift_cards": [
+            {
+                "id": 2,
+                "code": "SU9F-MGB5-KS5V-EZFT",
+                "amount": 20
+            },
+            {
+                "id": 4,
+                "code": "NZR8-BMP8-XJZ2-ZKS9",
+                "amount": 4
+            }
+        ],
+        "currency_symbol": "$",
+        "_links": {
+            "self": [
+                {
+                    "href": "https://example.com/wp-json/wc/v3/orders/459"
+                }
+            ],
+            "collection": [
+                {
+                    "href": "https://example.com/wp-json/wc/v3/orders"
+                }
+            ],
+            "customer": [
+                {
+                    "href": "https://example.com/wp-json/wc/v3/customers/27375286"
+                }
+            ]
+        }
+    }
+}

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Address Edit/EditOrderAddressForm.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Address Edit/EditOrderAddressForm.swift
@@ -504,7 +504,8 @@ struct EditAddressForm_Previews: PreviewProvider {
                                    taxes: [],
                                    customFields: [],
                                    renewalSubscriptionID: nil,
-                                   appliedGiftCards: [])
+                                   appliedGiftCards: [],
+                                   attributionInfo: nil)
 
     static let sampleAddress = Address(firstName: "Johnny",
                                        lastName: "Appleseed",

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Package Details/Multi-package/ShippingLabelPackagesFormViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Package Details/Multi-package/ShippingLabelPackagesFormViewModel.swift
@@ -487,7 +487,8 @@ extension ShippingLabelPackagesFormViewModel {
                      taxes: [],
                      customFields: [],
                      renewalSubscriptionID: nil,
-                     appliedGiftCards: [])
+                     appliedGiftCards: [],
+                     attributionInfo: nil)
     }
 
     static func sampleAddress() -> Address {

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Package Details/ShippingLabelSampleData.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Package Details/ShippingLabelSampleData.swift
@@ -42,7 +42,8 @@ enum ShippingLabelSampleData {
                      taxes: [],
                      customFields: [],
                      renewalSubscriptionID: nil,
-                     appliedGiftCards: [])
+                     appliedGiftCards: [],
+                     attributionInfo: nil)
     }
 
     static func samplePackageDetails() -> ShippingLabelPackagesResponse {

--- a/Yosemite/Yosemite/Model/Mocks/MockObjectGraph.swift
+++ b/Yosemite/Yosemite/Model/Mocks/MockObjectGraph.swift
@@ -376,7 +376,8 @@ extension MockObjectGraph {
             taxes: [],
             customFields: [],
             renewalSubscriptionID: nil,
-            appliedGiftCards: []
+            appliedGiftCards: [],
+            attributionInfo: nil
         )
     }
 }

--- a/Yosemite/Yosemite/Model/Storage/Order+ReadOnlyConvertible.swift
+++ b/Yosemite/Yosemite/Model/Storage/Order+ReadOnlyConvertible.swift
@@ -117,7 +117,7 @@ extension Storage.Order: ReadOnlyConvertible {
                      customFields: orderCustomFields,
                      renewalSubscriptionID: renewalSubscriptionID,
                      appliedGiftCards: orderGiftCards,
-                     attributionInfo: nil) // TODO: 11921
+                     attributionInfo: nil) // TODO: 11933
 
     }
 

--- a/Yosemite/Yosemite/Model/Storage/Order+ReadOnlyConvertible.swift
+++ b/Yosemite/Yosemite/Model/Storage/Order+ReadOnlyConvertible.swift
@@ -116,7 +116,8 @@ extension Storage.Order: ReadOnlyConvertible {
                      taxes: orderTaxLines,
                      customFields: orderCustomFields,
                      renewalSubscriptionID: renewalSubscriptionID,
-                     appliedGiftCards: orderGiftCards)
+                     appliedGiftCards: orderGiftCards,
+                     attributionInfo: nil) // TODO: 11921
 
     }
 

--- a/Yosemite/Yosemite/Stores/Order/OrderFactory.swift
+++ b/Yosemite/Yosemite/Stores/Order/OrderFactory.swift
@@ -44,7 +44,8 @@ public enum OrderFactory {
               taxes: [],
               customFields: [],
               renewalSubscriptionID: nil,
-              appliedGiftCards: [])
+              appliedGiftCards: [],
+              attributionInfo: nil)
     }
 
     /// Creates a fee line suitable to be used within a simple payments order.


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #11924 
<!-- Id number of the GitHub issue this PR addresses. -->

## Description

We will start showing the order attribution info in the order details screen.

To get an order's attribution info, this PR maps order attribution info and stores it in `Order` model in the networking layer. We will update the storage layer in a future PR.

## Testing instructions
CI passing is sufficient. 

## Screenshots
NA

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
