### PR TITLE
[Tablet products] Disable large title in product form

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Products/ProductsSplitViewCoordinator.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductsSplitViewCoordinator.swift
@@ -15,7 +15,7 @@ final class ProductsSplitViewCoordinator {
     init(siteID: Int64, splitViewController: UISplitViewController) {
         self.siteID = siteID
         self.splitViewController = splitViewController
-        self.primaryNavigationController = WooNavigationController()
+        self.primaryNavigationController = WooTabNavigationController()
         self.secondaryNavigationController = WooNavigationController()
     }
 


### PR DESCRIPTION

<!-- Remember about a good descriptive title. -->

Closes: #11936

<!-- Id number of the GitHub issue this PR addresses. -->

## Why

The issue (large title being shown in product form) is specific to split view collapsed mode and with the feature flag enabled, because the secondary navigation controller is added to the primary navigation stack in split view collapsed mode and the primary navigation controller doesn't have the special logic in `WooTabNavigationController` to disable large title for view controllers after the first one.

## How

This PR updates the products tab primary navigation controller to be `WooTabNavigationController` so that any other secondary view controllers won't have the large title by default in the split view collapsed state.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

Prerequisite: the device/simulator allows switching between expanded and collapsed states like a tablet

- In code, enable `splitViewInProductsTab` feature flag in `DefaultFeatureFlagService`
- Launch the app
- Update the app window so that it's in collapsed state
- Go to the products tab, navigate back to the product list (it's a known issue where the secondary view is shown by default https://github.com/woocommerce/woocommerce-ios/issues/11911)
- Tap on a product --> the product form should not have a large title space in the navigation bar

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

before | after
-- | --
<img src="https://github.com/woocommerce/woocommerce-ios/assets/1945542/f3472262-6ecf-419f-9c27-1e7973544de0" width="500" /> | <img src="https://github.com/woocommerce/woocommerce-ios/assets/1945542/6ecfcdcd-486b-4c26-9e47-7b882779327a" width="500" /> 


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
