### PR TITLE
Product scanner: Missing cancel button to dismiss the view

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Products/SKU Scanner/CodeScannerViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/SKU Scanner/CodeScannerViewController.swift
@@ -26,6 +26,7 @@ final class CodeScannerViewController: UIViewController {
     @IBOutlet private weak var scanAreaView: UIView!
     @IBOutlet private weak var instructionLabel: PaddedLabel!
     @IBOutlet private weak var bottomDimmingView: UIView!
+    @IBOutlet private weak var cancelButton: UIButton!
 
     // > Delegate any interaction with the AVCaptureSession—including its inputs and outputs—to a
     // > dedicated serial dispatch queue, so that the interaction doesn’t block the main queue.
@@ -60,7 +61,19 @@ final class CodeScannerViewController: UIViewController {
 
         configureBarcodeDetection()
 
+        configureCancelButton()
+
         startLiveVideo()
+    }
+
+    private func configureCancelButton() {
+        cancelButton.setTitle(Localization.cancel, for: .normal)
+        cancelButton.tintColor = UIColor.white
+        cancelButton.addTarget(self, action: #selector(cancelButtonTapped), for: .touchUpInside)
+    }
+
+    @objc func cancelButtonTapped() {
+        dismiss(animated: true)
     }
 
     override func viewDidLayoutSubviews() {
@@ -312,5 +325,9 @@ private extension CodeScannerViewController {
     enum Constants {
         static let dimmingColor = UIColor(white: 0.0, alpha: 0.5)
         static let instructionTextInsets = UIEdgeInsets(top: 11, left: 0, bottom: 11, right: 0)
+    }
+
+    enum Localization {
+        static let cancel = NSLocalizedString("Cancel", comment: "Button to dismiss the screen")
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Products/SKU Scanner/CodeScannerViewController.xib
+++ b/WooCommerce/Classes/ViewRelated/Products/SKU Scanner/CodeScannerViewController.xib
@@ -1,8 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="21701" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="22505" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="21679"/>
+        <deployment identifier="iOS"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="22504"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
@@ -11,6 +12,7 @@
         <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner" customClass="CodeScannerViewController" customModule="WooCommerce" customModuleProvider="target">
             <connections>
                 <outlet property="bottomDimmingView" destination="XpR-Bg-LX0" id="b5g-m9-dBW"/>
+                <outlet property="cancelButton" destination="wCb-QS-xTf" id="JVx-sG-Ov0"/>
                 <outlet property="instructionLabel" destination="WDY-yE-Pa7" id="lA1-tM-wwa"/>
                 <outlet property="scanAreaView" destination="h26-0r-6H1" id="WNx-bS-KMX"/>
                 <outlet property="topDimmingView" destination="6Ui-xi-Quc" id="oPy-7r-UvD"/>
@@ -31,7 +33,18 @@
                     <subviews>
                         <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="6Ui-xi-Quc">
                             <rect key="frame" x="0.0" y="0.0" width="414" height="269"/>
+                            <subviews>
+                                <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="wCb-QS-xTf">
+                                    <rect key="frame" x="20" y="20" width="75" height="34.5"/>
+                                    <state key="normal" title="Button"/>
+                                    <buttonConfiguration key="configuration" style="plain" title="Button"/>
+                                </button>
+                            </subviews>
                             <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                            <constraints>
+                                <constraint firstItem="wCb-QS-xTf" firstAttribute="top" secondItem="6Ui-xi-Quc" secondAttribute="top" constant="20" id="aDv-QY-Sew"/>
+                                <constraint firstItem="wCb-QS-xTf" firstAttribute="leading" secondItem="6Ui-xi-Quc" secondAttribute="leading" constant="20" id="edO-za-6W1"/>
+                            </constraints>
                         </view>
                         <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="h26-0r-6H1">
                             <rect key="frame" x="0.0" y="269" width="414" height="358"/>


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #11811
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
- added cancel button for code scanner

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
- open Products or Orders tab
- tap on the scanner button in top left
- check that there is a Cancel button on top left (of the scanner view) and check that tapping on it dismisses the scanner
- test it in both portrait and landscape and both dark and light mode

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

| Portrait      | Landscape |
| ----------- | ----------- |
| ![Simulator Screenshot - iPhone 15 Pro - 2024-02-07 at 10 50 25](https://github.com/woocommerce/woocommerce-ios/assets/6242034/668c9c09-78c9-43b1-9011-04fb6e771361)      | ![Simulator Screenshot - iPhone 15 Pro - 2024-02-07 at 10 50 22](https://github.com/woocommerce/woocommerce-ios/assets/6242034/7a390b2d-6905-48df-bf8a-f5c3fe8e53da)       |

---
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
