### PR TITLE
[Analytics Hub] Count tapping on analytics report link in used_analytics event

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/AnalyticsHubViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/AnalyticsHubViewModel.swift
@@ -53,17 +53,26 @@ final class AnalyticsHubViewModel: ObservableObject {
         self.usageTracksEventEmitter = usageTracksEventEmitter
 
         let storeAdminURL = stores.sessionManager.defaultSite?.adminURL
-        let revenueWebReportVM = AnalyticsHubViewModel.webReportVM(for: .revenue, timeRange: selectedType, storeAdminURL: storeAdminURL)
+        let revenueWebReportVM = AnalyticsHubViewModel.webReportVM(for: .revenue,
+                                                                   timeRange: selectedType,
+                                                                   storeAdminURL: storeAdminURL,
+                                                                   usageTracksEventEmitter: usageTracksEventEmitter)
         self.revenueCard = AnalyticsHubViewModel.revenueCard(currentPeriodStats: nil,
                                                              previousPeriodStats: nil,
                                                              webReportViewModel: revenueWebReportVM)
 
-        let ordersWebReportVM = AnalyticsHubViewModel.webReportVM(for: .orders, timeRange: selectedType, storeAdminURL: storeAdminURL)
+        let ordersWebReportVM = AnalyticsHubViewModel.webReportVM(for: .orders,
+                                                                  timeRange: selectedType,
+                                                                  storeAdminURL: storeAdminURL,
+                                                                  usageTracksEventEmitter: usageTracksEventEmitter)
         self.ordersCard = AnalyticsHubViewModel.ordersCard(currentPeriodStats: nil,
                                                            previousPeriodStats: nil,
                                                            webReportViewModel: ordersWebReportVM)
 
-        let productsWebReportVM = AnalyticsHubViewModel.webReportVM(for: .products, timeRange: selectedType, storeAdminURL: storeAdminURL)
+        let productsWebReportVM = AnalyticsHubViewModel.webReportVM(for: .products,
+                                                                    timeRange: selectedType,
+                                                                    storeAdminURL: storeAdminURL,
+                                                                    usageTracksEventEmitter: usageTracksEventEmitter)
         self.productsStatsCard = AnalyticsHubViewModel.productsStatsCard(currentPeriodStats: nil,
                                                                          previousPeriodStats: nil,
                                                                          webReportViewModel: productsWebReportVM)
@@ -527,14 +536,18 @@ private extension AnalyticsHubViewModel {
     /// Gets the view model to show a web analytics report, based on the provided report type and currently selected time range
     ///
     func webReportVM(for report: AnalyticsWebReport.ReportType) -> AnalyticsReportLinkViewModel? {
-        return AnalyticsHubViewModel.webReportVM(for: report, timeRange: timeRangeSelectionType, storeAdminURL: stores.sessionManager.defaultSite?.adminURL)
+        return AnalyticsHubViewModel.webReportVM(for: report,
+                                                 timeRange: timeRangeSelectionType,
+                                                 storeAdminURL: stores.sessionManager.defaultSite?.adminURL,
+                                                 usageTracksEventEmitter: usageTracksEventEmitter)
     }
 
     /// Gets the view model to show a web analytics report, based on the provided report type, time range, and store admin URL
     ///
     static func webReportVM(for report: AnalyticsWebReport.ReportType,
                             timeRange: AnalyticsHubTimeRangeSelection.SelectionType,
-                            storeAdminURL: String?) -> AnalyticsReportLinkViewModel? {
+                            storeAdminURL: String?,
+                            usageTracksEventEmitter: StoreStatsUsageTracksEventEmitter) -> AnalyticsReportLinkViewModel? {
         guard let url = AnalyticsWebReport.getUrl(for: report, timeRange: timeRange, storeAdminURL: storeAdminURL) else {
             return nil
         }
@@ -548,7 +561,11 @@ private extension AnalyticsHubViewModel {
                 return Localization.ProductCard.reportTitle
             }
         }()
-        return AnalyticsReportLinkViewModel(reportType: report, period: timeRange, webViewTitle: title, reportURL: url)
+        return AnalyticsReportLinkViewModel(reportType: report,
+                                            period: timeRange,
+                                            webViewTitle: title,
+                                            reportURL: url,
+                                            usageTracksEventEmitter: usageTracksEventEmitter)
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/AnalyticsProductCard.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/AnalyticsProductCard.swift
@@ -141,7 +141,8 @@ struct AnalyticsProductCardPreviews: PreviewProvider {
                              reportViewModel: .init(reportType: .products,
                                                     period: .today,
                                                     webViewTitle: "Products Report",
-                                                    reportURL: URL(string: "https://woo.com")!))
+                                                    reportURL: URL(string: "https://woo.com")!,
+                                                    usageTracksEventEmitter: StoreStatsUsageTracksEventEmitter()))
             .previewLayout(.sizeThatFits)
 
         AnalyticsProductCard(itemsSold: "-",
@@ -156,7 +157,8 @@ struct AnalyticsProductCardPreviews: PreviewProvider {
                              reportViewModel: .init(reportType: .products,
                                                     period: .today,
                                                     webViewTitle: "Products Report",
-                                                    reportURL: URL(string: "https://woo.com")!))
+                                                    reportURL: URL(string: "https://woo.com")!,
+                                                    usageTracksEventEmitter: StoreStatsUsageTracksEventEmitter()))
             .previewLayout(.sizeThatFits)
             .previewDisplayName("No data")
     }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/AnalyticsReportCard.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/AnalyticsReportCard.swift
@@ -150,10 +150,11 @@ struct Previews: PreviewProvider {
                             trailingDeltaTextColor: .textInverted,
                             trailingChartData: [50.0, 15.0, 20.0, 2.0, 10.0, 0.0, 40.0, 15.0, 20.0, 2.0, 10.0, 0.0],
                             trailingChartColor: .withColorStudio(.red, shade: .shade40),
-                            reportViewModel: .init(reportType: .revenue, 
+                            reportViewModel: .init(reportType: .revenue,
                                                    period: .today,
                                                    webViewTitle: "Revenue Report",
-                                                   reportURL: URL(string: "https://woo.com")!),
+                                                   reportURL: URL(string: "https://woo.com")!,
+                                                   usageTracksEventEmitter: StoreStatsUsageTracksEventEmitter()),
                             isRedacted: false,
                             showSyncError: false,
                             syncErrorMessage: "")
@@ -177,7 +178,8 @@ struct Previews: PreviewProvider {
                             reportViewModel: .init(reportType: .revenue,
                                                    period: .today,
                                                    webViewTitle: "Revenue Report",
-                                                   reportURL: URL(string: "https://woo.com")!),
+                                                   reportURL: URL(string: "https://woo.com")!,
+                                                   usageTracksEventEmitter: StoreStatsUsageTracksEventEmitter()),
                             isRedacted: false,
                             showSyncError: true,
                             syncErrorMessage: "Error loading revenue analytics")

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/AnalyticsReportLink.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/AnalyticsReportLink.swift
@@ -40,6 +40,7 @@ private extension AnalyticsReportLink {
                         reportViewModel: .init(reportType: .revenue,
                                                period: .today,
                                                webViewTitle: "Revenue Report",
-                                               reportURL: URL(string: "https://woo.com/")!))
+                                               reportURL: URL(string: "https://woo.com/")!,
+                                               usageTracksEventEmitter: StoreStatsUsageTracksEventEmitter()))
         .previewLayout(.sizeThatFits)
 }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/AnalyticsReportLinkViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/AnalyticsReportLinkViewModel.swift
@@ -11,21 +11,25 @@ final class AnalyticsReportLinkViewModel: WPAdminWebViewModel {
     let period: AnalyticsHubTimeRangeSelection.SelectionType
 
     private let analytics: Analytics
+    private let usageTracksEventEmitter: StoreStatsUsageTracksEventEmitter
 
     init(reportType: AnalyticsWebReport.ReportType,
          period: AnalyticsHubTimeRangeSelection.SelectionType,
          webViewTitle: String,
          reportURL: URL,
+         usageTracksEventEmitter: StoreStatsUsageTracksEventEmitter,
          analytics: Analytics = ServiceLocator.analytics) {
         self.reportType = reportType
         self.period = period
         self.analytics = analytics
+        self.usageTracksEventEmitter = usageTracksEventEmitter
         super.init(title: webViewTitle, initialURL: reportURL)
     }
 
     /// Action to take when the report webview is opened
     ///
-    func onWebViewOpen() {
+    func onWebViewOpen(at interactionTime: Date = Date()) {
         analytics.track(event: .AnalyticsHub.viewFullReportTapped(for: reportType, period: period))
+        usageTracksEventEmitter.interacted(at: interactionTime)
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Stats v4/StoreStatsUsageTracksEventEmitter.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Stats v4/StoreStatsUsageTracksEventEmitter.swift
@@ -16,6 +16,7 @@ import Foundation
 /// - Tapping on a product in the Top Performers list
 /// - Tapping on the Analytics date range
 /// - Selecting an Analytics date range option
+/// - Tapping on "See Report" on an Analytics Hub card
 ///
 /// If we ever change the algorithm in the future, we should probably consider renaming the Tracks event to avoid
 /// incorrect comparisons with old events. We should also make sure to change the Android code if we're changing anything
@@ -40,6 +41,7 @@ final class StoreStatsUsageTracksEventEmitter {
     /// - Tapping on a product in the Top Performers list
     /// - Tapping on the date range in the Analytics Hub
     /// - Selecting a date range option in the Analytics Hub
+    /// - Tapping on "See Report" on an Analytics Hub card
     private let interactionsThreshold = 5
 
     /// The maximum number of seconds in between interactions before we will consider the

--- a/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Analytics Hub/AnalyticsReportLinkViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Analytics Hub/AnalyticsReportLinkViewModelTests.swift
@@ -5,10 +5,12 @@ final class AnalyticsReportLinkViewModelTests: XCTestCase {
 
     private var analyticsProvider: MockAnalyticsProvider!
     private var analytics: Analytics!
+    private var eventEmitter: StoreStatsUsageTracksEventEmitter!
 
     override func setUp() {
         analyticsProvider = MockAnalyticsProvider()
         analytics = WooAnalytics(analyticsProvider: analyticsProvider)
+        eventEmitter = StoreStatsUsageTracksEventEmitter(analytics: analytics)
     }
 
     func test_onWebViewOpen_tracks_expected_events() throws {
@@ -17,6 +19,7 @@ final class AnalyticsReportLinkViewModelTests: XCTestCase {
                                               period: .weekToDate,
                                               webViewTitle: "",
                                               reportURL: try XCTUnwrap(URL(string: "https://woo.com/")),
+                                              usageTracksEventEmitter: eventEmitter,
                                               analytics: analytics)
 
         // When
@@ -30,4 +33,38 @@ final class AnalyticsReportLinkViewModelTests: XCTestCase {
         XCTAssertEqual(eventProperties["compare"] as? String, "previous_period")
     }
 
+    func test_onWebViewOpen_triggers_used_analytics_event_when_the_time_and_interaction_thresholds_are_reached() throws {
+        // Given
+        let vm = AnalyticsReportLinkViewModel(reportType: .revenue,
+                                              period: .weekToDate,
+                                              webViewTitle: "",
+                                              reportURL: try XCTUnwrap(URL(string: "https://woo.com/")),
+                                              usageTracksEventEmitter: eventEmitter,
+                                              analytics: analytics)
+
+        // Some analytics interactions have already been emitted
+        let firstInteraction = Date()
+        interacted(at: [
+            firstInteraction,
+            Date(timeInterval: 2, since: firstInteraction),
+            Date(timeInterval: 4, since: firstInteraction),
+            Date(timeInterval: 8, since: firstInteraction)
+        ])
+        XCTAssertFalse(try XCTUnwrap(analyticsProvider.receivedEvents.contains("used_analytics")))
+
+        // When
+        vm.onWebViewOpen(at: Date(timeInterval: 10, since: firstInteraction))
+
+        // Then
+        XCTAssertTrue(try XCTUnwrap(analyticsProvider.receivedEvents.contains("used_analytics")))
+    }
+}
+
+
+private extension AnalyticsReportLinkViewModelTests {
+    func interacted(at dates: [Date]) {
+        dates.forEach {
+            eventEmitter.interacted(at: $0)
+        }
+    }
 }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #11876
<!-- Id number of the GitHub issue this PR addresses. -->

## Why
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
We added a "See Report" button to cards in the Analytics Hub (#11920). This PR updates our `used_analytics` event to count taps on this button as as analytics usage.

## How

* `AnalyticsReportLinkViewModel` now accepts an instance of `StoreStatsUsageTracksEventEmitter`.
* When the "See Report" button is tapped (`AnalyticsReportLinkViewModel.onWebViewOpen()`), we track an interaction for `StoreStatsUsageTracksEventEmitter`.
* Also adds a unit test to confirm that this interaction is used for tracking `used_analytics`.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
If hand-testing this change, note that `used_analytics` is only tracked after 5 interactions and at least 10 seconds of interacting (with no more than 20 seconds of idle time between interactions). One way to test:

1. Build and run the app.
2. On the My Store tab, tap "See More."
3. In the Analytics Hub, spend at least 10 seconds doing 5 interactions among these: scrolling, pull to refresh, tap on the date range, select a new date range, tap on "See Report" on a card. Confirm that `used_analytics` is tracked when the tap on "See Report" is one of the 5 interactions.

This tracking is also checked with the new unit test.


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
