### PR TITLE
Add activity indicator to TwoColumnHeadlineFootnoteTableViewCell

### DIFF
--- a/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsViewModel.swift
+++ b/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsViewModel.swift
@@ -468,6 +468,11 @@ extension OrderDetailsViewModel {
             let customFieldsView = UIHostingController(rootView: OrderCustomFieldsDetails(customFields: customFields))
             viewController.present(customFieldsView, animated: true)
         case .seeReceipt:
+            guard let cell = tableView.cellForRow(at: indexPath) as? TwoColumnHeadlineFootnoteTableViewCell else {
+                return
+            }
+            cell.startLoading()
+
             let action = ReceiptAction.retrieveReceipt(order: order) { [weak self] result in
                 guard let self else { return }
                 switch result {
@@ -482,6 +487,7 @@ extension OrderDetailsViewModel {
                 case let .failure(error):
                     debugPrint("\(error)")
                 }
+                cell.stopLoading()
             }
             ServiceLocator.stores.dispatch(action)
         case .seeLegacyReceipt:

--- a/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsViewModel.swift
+++ b/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsViewModel.swift
@@ -487,11 +487,12 @@ extension OrderDetailsViewModel {
                                                             siteName: siteName)
                     let receiptViewController = ReceiptViewController(viewModel: receiptViewModel)
                     viewController.navigationController?.pushViewController(receiptViewController, animated: true)
+                    cell.stopLoading()
                 case let .failure(error):
                     ServiceLocator.analytics.track(event: .InPersonPayments.receiptFetchFailed(error: error))
                     self.displayReceiptRetrievalErrorNotice(for: order, with: error, in: viewController)
+                    cell.stopLoading()
                 }
-                cell.stopLoading()
             }
             ServiceLocator.stores.dispatch(action)
         case .seeLegacyReceipt:

--- a/WooCommerce/Classes/ViewRelated/ReusableViews/TwoColumnHeadlineFootnoteTableViewCell.swift
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/TwoColumnHeadlineFootnoteTableViewCell.swift
@@ -12,7 +12,7 @@ final class TwoColumnHeadlineFootnoteTableViewCell: UITableViewCell {
     @IBOutlet private weak var rightTitleLabel: UILabel!
     @IBOutlet private weak var footnoteLabel: UILabel!
     
-    let activityIndicator: UIActivityIndicatorView = {
+    private let activityIndicator: UIActivityIndicatorView = {
         let indicator = UIActivityIndicatorView(style: .medium)
         indicator.translatesAutoresizingMaskIntoConstraints = false
         return indicator
@@ -108,10 +108,14 @@ final class TwoColumnHeadlineFootnoteTableViewCell: UITableViewCell {
 
     func startLoading() {
         activityIndicator.startAnimating()
+        isUserInteractionEnabled = false
+        alpha = 0.5
     }
 
     func stopLoading() {
         activityIndicator.stopAnimating()
+        isUserInteractionEnabled = true
+        alpha = 1
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/ReusableViews/TwoColumnHeadlineFootnoteTableViewCell.swift
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/TwoColumnHeadlineFootnoteTableViewCell.swift
@@ -11,6 +11,12 @@ final class TwoColumnHeadlineFootnoteTableViewCell: UITableViewCell {
     @IBOutlet private weak var leftTitleLabel: UILabel!
     @IBOutlet private weak var rightTitleLabel: UILabel!
     @IBOutlet private weak var footnoteLabel: UILabel!
+    
+    let activityIndicator: UIActivityIndicatorView = {
+        let indicator = UIActivityIndicatorView(style: .medium)
+        indicator.translatesAutoresizingMaskIntoConstraints = false
+        return indicator
+    }()
 
     /// Left title label text
     ///
@@ -83,6 +89,7 @@ final class TwoColumnHeadlineFootnoteTableViewCell: UITableViewCell {
 
         configureBackground()
         configureLabels()
+        configureActivityIndicator()
     }
 
     /// Reset the cell when it's recycled
@@ -97,6 +104,14 @@ final class TwoColumnHeadlineFootnoteTableViewCell: UITableViewCell {
     override func updateConfiguration(using state: UICellConfigurationState) {
         super.updateConfiguration(using: state)
         updateDefaultBackgroundConfiguration(using: state)
+    }
+
+    func startLoading() {
+        activityIndicator.startAnimating()
+    }
+
+    func stopLoading() {
+        activityIndicator.stopAnimating()
     }
 }
 
@@ -116,5 +131,13 @@ private extension TwoColumnHeadlineFootnoteTableViewCell {
         leftTitleLabel.applyHeadlineStyle()
         rightTitleLabel.applyHeadlineStyle()
         footnoteLabel.applyFootnoteStyle()
+    }
+
+    func configureActivityIndicator() {
+        addSubview(activityIndicator)
+        NSLayoutConstraint.activate([
+            activityIndicator.centerYAnchor.constraint(equalTo: centerYAnchor),
+            activityIndicator.centerXAnchor.constraint(equalTo: centerXAnchor),
+        ])
     }
 }


### PR DESCRIPTION
Improves #11857, from review https://github.com/woocommerce/woocommerce-ios/pull/11914#pullrequestreview-1867228461

## Description
At the moment, when tapping on "See receipt", the loading indicator only appears when we've already pushed the view controller into the navigation stack, but nothing happens in the time between a merchant presses the button and the action is dispatched, which may lead to confusion or multiple tapping.

This PR adds a simple loading state to the existing cell: Upon tapping, the cell starts animating by disabling user interaction, reducing its alpha, and making a loading indicator appear. Once we get a result from the store, we stop animating.

The solution is not perfect, sometimes we might still see a small gap between the loading and the view, but I opted from the simplest approach since improves the current implementation until the next project iteration.

## Testing instructions
1. On a backend-receipt eligible store ( you can use mywootestingstore.mystagingwebsite.com ) open an order that has an existing backend-generated receipt, or create a new order > collect payment by cash (old receipt generation do not have this, since are loaded from device).
2. Tap on the "See receipt" cell
3. Observe that the animation starts, then the receipt web view is pushed into the stack.

## Screenshots

| Normal state | Loading |
|--------|--------|
| <img width="298" alt="Screenshot 2024-02-13 at 10 15 35" src="https://github.com/woocommerce/woocommerce-ios/assets/3812076/7a63b3cb-b01f-40f7-b3d4-27560babb0d3"> | <img width="296" alt="Screenshot 2024-02-13 at 10 15 02" src="https://github.com/woocommerce/woocommerce-ios/assets/3812076/137f3f35-4651-40ba-b42b-42baf44f565d"> | 
