### PR TITLE
My Store Analytics: Add feature flag and new button for custom range

### DIFF
--- a/Experiments/Experiments/DefaultFeatureFlagService.swift
+++ b/Experiments/Experiments/DefaultFeatureFlagService.swift
@@ -91,6 +91,8 @@ public struct DefaultFeatureFlagService: FeatureFlagService {
             return buildConfig == .localDeveloper || buildConfig == .alpha
         case .splitViewInProductsTab:
             return false
+        case .customRangeInMyStoreAnalytics:
+            return buildConfig == .localDeveloper || buildConfig == .alpha
         default:
             return true
         }

--- a/Experiments/Experiments/FeatureFlag.swift
+++ b/Experiments/Experiments/FeatureFlag.swift
@@ -199,4 +199,8 @@ public enum FeatureFlag: Int {
     /// Displays the Products tab in a split view
     ///
     case splitViewInProductsTab
+
+    /// Displays the option to add a custom date range in My Store Analytics
+    ///
+    case customRangeInMyStoreAnalytics
 }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Stats v4/StoreStatsAndTopPerformersViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Stats v4/StoreStatsAndTopPerformersViewController.swift
@@ -54,14 +54,7 @@ final class StoreStatsAndTopPerformersViewController: TabbedViewController {
     private var localOrdersSubscription: AnyCancellable?
     private var remoteOrdersSubscription: AnyCancellable?
 
-    private lazy var customRangeButton: UIButton = {
-        let button = UIButton(configuration: .plain())
-        button.setImage(UIImage(systemName: "calendar.badge.plus"), for: .normal)
-        button.tintColor = .accent
-        button.frame = CGRect(origin: .zero, size: TabBar.customRangeButtonSize)
-        button.backgroundColor = .listForeground(modal: false)
-        return button
-    }()
+    private lazy var customRangeButtonView = createCustomRangeButtonView()
 
     // MARK: - View Lifecycle
 
@@ -414,8 +407,29 @@ private extension StoreStatsAndTopPerformersViewController {
         /// TODO-11935: Check if a custom range has been added and hide this button.
         ///
         if featureFlagService.isFeatureFlagEnabled(.customRangeInMyStoreAnalytics) {
-            addCustomViewToTabBar(customRangeButton)
+            addCustomViewToTabBar(customRangeButtonView)
         }
+    }
+
+    func createCustomRangeButtonView() -> UIView {
+        let stackView = UIStackView()
+        stackView.translatesAutoresizingMaskIntoConstraints = false
+        stackView.axis = .vertical
+
+        // TODO-11935: handle button action
+        let button = UIButton(configuration: .plain())
+        button.setImage(UIImage(systemName: "calendar.badge.plus"), for: .normal)
+        button.tintColor = .accent
+        button.frame = CGRect(origin: .zero, size: TabBar.customRangeButtonSize)
+        button.backgroundColor = .listForeground(modal: false)
+
+        let separator = UIView()
+        separator.heightAnchor.constraint(equalToConstant: TabBar.customRangeViewSeparator).isActive = true
+        separator.backgroundColor = .systemColor(.separator)
+
+        stackView.addArrangedSubview(button)
+        stackView.addArrangedSubview(separator)
+        return stackView
     }
 }
 
@@ -486,6 +500,7 @@ private extension StoreStatsAndTopPerformersViewController {
         /// Setting a negative spacing offsets the default spacing to match the design more.
         static let tabSpacing: CGFloat = -8.0
         static let customRangeButtonSize = CGSize(width: 24, height: 24)
+        static let customRangeViewSeparator: CGFloat = 0.5
     }
 
     enum Constants {

--- a/WooCommerce/Classes/ViewRelated/FilterTabBar/TabbedViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/FilterTabBar/TabbedViewController.swift
@@ -26,6 +26,8 @@ class TabbedViewController: UIViewController {
     private let items: [TabbedItem]
     private let onDismiss: (() -> Void)?
 
+    private var customTabBarView: UIView?
+
     private(set) lazy var tabBar: FilterTabBar = {
         let bar = FilterTabBar()
         configureFilterTabBar(bar)
@@ -33,6 +35,13 @@ class TabbedViewController: UIViewController {
         bar.translatesAutoresizingMaskIntoConstraints = false
         bar.addTarget(self, action: #selector(changedItem(sender:)), for: .valueChanged)
         return bar
+    }()
+
+    private lazy var tabBarStackView: UIStackView = {
+        let stackView = UIStackView()
+        stackView.translatesAutoresizingMaskIntoConstraints = false
+        stackView.axis = .horizontal
+        return stackView
     }()
 
     private lazy var stackView: UIStackView = {
@@ -51,7 +60,8 @@ class TabbedViewController: UIViewController {
 
         navigationItem.rightBarButtonItem = UIBarButtonItem(barButtonSystemItem: .done, target: self, action: #selector(donePressed))
 
-        stackView.addArrangedSubview(tabBar)
+        tabBarStackView.addArrangedSubview(tabBar)
+        stackView.addArrangedSubview(tabBarStackView)
     }
 
     required init?(coder: NSCoder) {
@@ -80,6 +90,18 @@ class TabbedViewController: UIViewController {
     @objc func changedItem(sender: FilterTabBar) {
         updateVisibleChildViewController(at: sender.selectedIndex)
         selection = sender.selectedIndex
+    }
+
+    func addCustomViewToTabBar(_ customView: UIView) {
+        tabBarStackView.addArrangedSubview(customView)
+        customTabBarView = customView
+    }
+
+    func removeCustomViewFromTabBar() {
+        guard let customTabBarView else {
+            return
+        }
+        tabBarStackView.removeArrangedSubview(customTabBarView)
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/FilterTabBar/TabbedViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/FilterTabBar/TabbedViewController.swift
@@ -102,6 +102,7 @@ class TabbedViewController: UIViewController {
             return
         }
         tabBarStackView.removeArrangedSubview(customTabBarView)
+        self.customTabBarView = nil
     }
 }
 


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #11941 
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This PR adds a new button for adding a custom range on My Store analytics. This button is hidden behind a feature flag so it should not be displayed on production yet.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
- Enable the feature flag `customRangeInMyStoreAnalytics` and build the app.
- Notice on My Store there's a new button for adding a custom range. The tap action for this button has not been handled yet.
- Feel free to test again with the feature flag off to confirm that the button is not available.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->
| Light mode | Dark mode |
| --- | --- |
| <img src="https://github.com/woocommerce/woocommerce-ios/assets/5533851/fa97d400-15a0-4acd-95b4-3c0e7617a97f" width=320 /> | <img src="https://github.com/woocommerce/woocommerce-ios/assets/5533851/b3f32652-3c51-4b79-a66d-79807c66d491" width=320 /> |

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
