### PR TITLE
[Backend Receipts] Enable backend receipts on release builds

### DIFF
--- a/Experiments/Experiments/DefaultFeatureFlagService.swift
+++ b/Experiments/Experiments/DefaultFeatureFlagService.swift
@@ -88,7 +88,7 @@ public struct DefaultFeatureFlagService: FeatureFlagService {
         case .blazei3NativeCampaignCreation:
             return buildConfig == .localDeveloper || buildConfig == .alpha
         case .backendReceipts:
-            return buildConfig == .localDeveloper || buildConfig == .alpha
+            return true
         case .splitViewInProductsTab:
             return false
         case .customizeAnalyticsHub:

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -4,6 +4,7 @@
 -----
 - [***] Products: Cache product images to reduce network requests. [https://github.com/woocommerce/woocommerce-ios/pull/11902]
 - [***] Stats: The Analytics Hub now includes links to the full analytics report for each supported analytics card (Revenue, Orders, Products). [https://github.com/woocommerce/woocommerce-ios/pull/11920]
+- [**] Orders: Orders have an associated receipt now. Receipts can be printed, or shared via other apps installed on device. The feature will become available for merchants with WooCommerce version of 8.7.0+. [https://github.com/woocommerce/woocommerce-ios/pull/11956]
 
 17.2
 -----

--- a/WooCommerce/Classes/ViewModels/Order Details/Receipts/ReceiptEligibilityUseCase.swift
+++ b/WooCommerce/Classes/ViewModels/Order Details/Receipts/ReceiptEligibilityUseCase.swift
@@ -44,10 +44,6 @@ private extension ReceiptEligibilityUseCase {
     enum Constants {
         static let wcPluginName = "WooCommerce"
         static let wcPluginMinimumVersion = "8.7.0"
-        static let wcPluginDevVersion: [String] = ["8.7.0-dev",
-                                                   "8.6.0-dev",
-                                                   "8.5.0-beta.1",
-                                                   "8.6.0-dev-7625495467-gf50cc6b",
-                                                   "8.6.0-dev-7708067547-g87e8c5f"]
+        static let wcPluginDevVersion: [String] = ["8.7.0-dev","8.6.0-dev"]
     }
 }

--- a/WooCommerce/WooCommerceTests/ViewModels/Receipts/ReceiptEligibilityUseCaseTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewModels/Receipts/ReceiptEligibilityUseCaseTests.swift
@@ -55,7 +55,7 @@ final class ReceiptEligibilityUseCaseTests: XCTestCase {
         let featureFlag = MockFeatureFlagService(isBackendReceiptsEnabled: true)
         let stores = MockStoresManager(sessionManager: .makeForTesting())
         let plugin = SystemPlugin.fake().copy(name: "WooCommerce",
-                                              version: "8.6.0-dev-7625495467-gf50cc6b",
+                                              version: "8.6.0-dev",
                                               active: true)
 
         stores.whenReceivingAction(ofType: SystemStatusAction.self) { action in


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes #11952 
Closes #11879

## Description
This PR enables the backend receipts feature on release builds for stores running WooCommerce 8.7.0+ (or dev versions 8.6.0-dev or 8.7.0-dev)

## Testing instructions
* Switch Xcode's scheme to run the app on a release build configuration:
<img width="956" alt="Screenshot 2024-02-08 at 11 52 58" src="https://github.com/woocommerce/woocommerce-ios/assets/3812076/7aeb527a-bea8-4452-a223-782635457dfd">

* In the app, confirm under Menu > Settings > that the version check is correct (I found some cases when this doesn't update properly, perhaps because we're using dev versions for testing?). You can use the site credentials here pfoUAQ-eW-p2 if you're having troubles with this.
<img width="649" alt="Screenshot 2024-02-08 at 11 53 53" src="https://github.com/woocommerce/woocommerce-ios/assets/3812076/b5787ca5-cc3a-4e45-927b-d36c389022f4">

* Go to Orders > select any paid order (eg: `Completed` via cash) and observe that the `See receipt` link appears, can be tapped, and a receipt can be shared/printed.

|  |  |
|--------|--------|
| ![Simulator Screenshot - iPad Pro (12 9-inch) (6th generation) - 2024-02-08 at 11 35 39](https://github.com/woocommerce/woocommerce-ios/assets/3812076/ad774de0-6665-4e60-8777-91c2c67f329b) | ![Simulator Screenshot - iPad Pro (12 9-inch) (6th generation) - 2024-02-08 at 11 36 04](https://github.com/woocommerce/woocommerce-ios/assets/3812076/651dde44-43c4-4a2d-9b37-54b0721b736f) | 