### PR TITLE
[Backend Receipts] Update remote with `expiration_days` property

### DIFF
--- a/Networking/Networking/Remote/ReceiptRemote.swift
+++ b/Networking/Networking/Remote/ReceiptRemote.swift
@@ -6,15 +6,18 @@ public final class ReceiptRemote: Remote {
     /// - Parameters:
     ///    - siteID: site ID which contains the receipt
     ///    - orderID: ID of the order that the receipt is associated to
+    ///    - expirationDays: validity of the receipt before a new one needs to be regenerated. Defaults to `2`
     ///    - forceRegenerate: whether a new receipt is generated. Defaults to `true`
     ///    - completion: callback with the expected `Receipt` object, or an error.
     ///
     public func retrieveReceipt(siteID: Int64,
                                 orderID: Int64,
+                                expirationDays: Int = 2,
                                 forceRegenerate: Bool = true,
                                 completion: @escaping (Result<Receipt, Error>) -> Void) {
         let path = "orders/\(orderID)/receipt"
         let parameters: [String: String] = [
+            ParameterKeys.expirationDays: String(expirationDays),
             ParameterKeys.forceRegenerate: String(forceRegenerate)
         ]
         let request = JetpackRequest(wooApiVersion: .mark3,
@@ -31,6 +34,7 @@ public final class ReceiptRemote: Remote {
 
 private extension ReceiptRemote {
     enum ParameterKeys {
+        static let expirationDays: String = "expiration_days"
         static let forceRegenerate: String = "force_new"
     }
 }

--- a/Networking/NetworkingTests/Remote/ReceiptRemoteTests.swift
+++ b/Networking/NetworkingTests/Remote/ReceiptRemoteTests.swift
@@ -86,7 +86,7 @@ final class ReceiptRemoteTests: XCTestCase {
         assertEqual("false", received)
     }
 
-    func test_retrieveReceipt_when_expiration_date_is_unset_then_returns_default_2_days() throws {
+    func test_retrieveReceipt_when_expiration_date_is_unset_then_sends_expiration_days_parameter_as_default_2_days() throws {
         // Given
         let remote = ReceiptRemote(network: network)
 
@@ -99,7 +99,7 @@ final class ReceiptRemoteTests: XCTestCase {
         assertEqual("2", received)
     }
 
-    func test_retrieveReceipt_when_expiration_date_is_set_then_returns_expirationDays_passed_in() throws {
+    func test_retrieveReceipt_when_expiration_date_is_set_then_sends_expiration_days_parameter_as_default_days_passed_in() throws {
         // Given
         let remote = ReceiptRemote(network: network)
         let expirationDays = 365

--- a/Networking/NetworkingTests/Remote/ReceiptRemoteTests.swift
+++ b/Networking/NetworkingTests/Remote/ReceiptRemoteTests.swift
@@ -85,4 +85,31 @@ final class ReceiptRemoteTests: XCTestCase {
         let received = try XCTUnwrap(request.parameters["force_new"] as? String)
         assertEqual("false", received)
     }
+
+    func test_retrieveReceipt_when_expiration_date_is_unset_then_returns_default_2_days() throws {
+        // Given
+        let remote = ReceiptRemote(network: network)
+
+        // When
+        remote.retrieveReceipt(siteID: sampleSiteID, orderID: sampleOrderID) { _ in }
+
+        // Then
+        let request = try XCTUnwrap(network.requestsForResponseData.last as? JetpackRequest)
+        let received = try XCTUnwrap(request.parameters["expiration_days"] as? String)
+        assertEqual("2", received)
+    }
+
+    func test_retrieveReceipt_when_expiration_date_is_set_then_returns_expirationDays_passed_in() throws {
+        // Given
+        let remote = ReceiptRemote(network: network)
+        let expirationDays = 365
+
+        // When
+        remote.retrieveReceipt(siteID: sampleSiteID, orderID: sampleOrderID, expirationDays: expirationDays) { _ in }
+
+        // Then
+        let request = try XCTUnwrap(network.requestsForResponseData.last as? JetpackRequest)
+        let received = try XCTUnwrap(request.parameters["expiration_days"] as? String)
+        assertEqual("365", received)
+    }
 }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #11855 
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
This PR adds support for the `expiration_days` property when calling the `orders/<order-id>/receipt` endpoint. By default the server will return a receipt that will expire X days later, but we adjust this to be shorter on mobile to 2 days by passing it explicitly in the POST request.

## Testing instructions
- Log into https://receipts-api.mystagingwebsite.com/ (you'll find the credentials in your email). This is necessary since the this feature is still not in core Woo. That site runs a plugin built from a development branch.
- Go to orders > create new order > add a product > Collect payment > Select cash
- Observe that a new `See receipt` appears in the order details (you may need to pull-to-refresh)
- Tap on it
- In Proxyman, observe the API call form contains:
```
body={"force_new":"true","expiration_days":"2"}
json=true
path=/wc/v3/orders/36/receipt&_method=post
```
And the response has a ~2 days expiration date:
```
{
  "data": {
    "receipt_url": "https://receipts-api.mystagingwebsite.com/wc/file/transient/7e820ae1127d8742463b546c1cb65a2da873b4",
    "expiration_date": "2024-02-10"
  }
}
```
### Known issues
You may see a 404 view when loading the receipt, rather than the receipt itself. This is a known issue that will be addressed in the woo-dev plugin itself, is outside of scope of this PR.

## Screenshots
![Simulator Screen Recording - iPhone 15 - 2024-02-08 at 12 47 47](https://github.com/woocommerce/woocommerce-ios/assets/3812076/cd978775-b1d7-4c99-a943-19f07a6138c5)

