### PR TITLE
[Order Attribution] Upsert Order attribution information

### DIFF
--- a/Storage/Storage/Tools/StorageType+Extensions.swift
+++ b/Storage/Storage/Tools/StorageType+Extensions.swift
@@ -721,4 +721,11 @@ public extension StorageType {
         let descriptor = NSSortDescriptor(keyPath: \InboxNote.dateCreated, ascending: false)
         return allObjects(ofType: InboxNote.self, matching: predicate, sortedBy: [descriptor])
     }
+
+    /// Retrieves the Stored Order Attribution Info.
+    ///
+    func loadOrderAttributionInfo(siteID: Int64, orderID: Int64) -> OrderAttributionInfo? {
+        let predicate = \OrderAttributionInfo.order?.siteID == siteID && \OrderAttributionInfo.order?.orderID == orderID
+        return firstObject(ofType: OrderAttributionInfo.self, matching: predicate)
+    }
 }

--- a/Storage/StorageTests/Tools/StorageTypeExtensionsTests.swift
+++ b/Storage/StorageTests/Tools/StorageTypeExtensionsTests.swift
@@ -1344,4 +1344,22 @@ final class StorageTypeExtensionsTests: XCTestCase {
         XCTAssertEqual(foundTopics.count, 1)
         XCTAssertEqual(foundTopics.first, topic1)
     }
+
+    func test_loadOrderAttributionInfo_by_siteID_orderID() throws {
+        // Given
+        let orderAttributionInfo = storage.insertNewObject(ofType: OrderAttributionInfo.self)
+        orderAttributionInfo.source = "Organic"
+        let orderID: Int64 = 11
+
+        let order = storage.insertNewObject(ofType: Order.self)
+        order.orderID = orderID
+        order.siteID = sampleSiteID
+        order.attributionInfo = orderAttributionInfo
+
+        // When
+        let storedOrderAttributionInfo = try XCTUnwrap(storage.loadOrderAttributionInfo(siteID: sampleSiteID, orderID: orderID))
+
+        // Then
+        XCTAssertEqual(orderAttributionInfo, storedOrderAttributionInfo)
+    }
 }

--- a/Yosemite/Yosemite/Stores/Order/OrdersUpsertUseCase.swift
+++ b/Yosemite/Yosemite/Stores/Order/OrdersUpsertUseCase.swift
@@ -60,6 +60,7 @@ struct OrdersUpsertUseCase {
         handleOrderTaxes(readOnlyOrder, storageOrder, storage)
         handleOrderCustomFields(readOnlyOrder, storageOrder, storage)
         handleOrderGiftCards(readOnlyOrder, storageOrder, storage)
+        handleOrderAttributionInfo(readOnlyOrder, storageOrder, storage)
 
         return storageOrder
     }
@@ -340,6 +341,25 @@ struct OrdersUpsertUseCase {
             let newStorageGiftCard = storage.insertNewObject(ofType: Storage.OrderGiftCard.self)
             newStorageGiftCard.update(with: readOnlyGiftCard)
             storageOrder.addToAppliedGiftCards(newStorageGiftCard)
+        }
+    }
+
+    /// Updates, inserts, or prunes the provided StorageOrder's attribution info using the provided read-only Order's attribution info
+    ///
+    private func handleOrderAttributionInfo(_ readOnlyOrder: Networking.Order, _ storageOrder: Storage.Order, _ storage: StorageType) {
+        guard let readOnlyOrderAttributionInfo = readOnlyOrder.attributionInfo else {
+            if let existingStorageOrderAttributionInfo = storageOrder.attributionInfo {
+                storage.deleteObject(existingStorageOrderAttributionInfo)
+            }
+            return
+        }
+
+        if let existingStorageOrderAttributionInfo = storageOrder.attributionInfo {
+            existingStorageOrderAttributionInfo.update(with: readOnlyOrderAttributionInfo)
+        } else {
+            let newStorageOrderAttributionInfo = storage.insertNewObject(ofType: Storage.OrderAttributionInfo.self)
+            newStorageOrderAttributionInfo.update(with: readOnlyOrderAttributionInfo)
+            storageOrder.attributionInfo = newStorageOrderAttributionInfo
         }
     }
 }

--- a/Yosemite/YosemiteTests/Stores/Order/OrdersUpsertUseCaseTests.swift
+++ b/Yosemite/YosemiteTests/Stores/Order/OrdersUpsertUseCaseTests.swift
@@ -357,6 +357,24 @@ final class OrdersUpsertUseCaseTests: XCTestCase {
         let storageAttributionInfo = try XCTUnwrap(viewStorage.loadOrder(siteID: 3, orderID: 11)?.attributionInfo)
         XCTAssertEqual(storageAttributionInfo.toReadOnly(), attributionInfo)
     }
+
+    func test_it_removes_existing_order_attribution_info_from_storage_if_removed_in_remote() throws {
+        // Given
+        let siteID: Int64 = 3
+        let orderID: Int64 = 11
+        let originalAttributionInfo = OrderAttributionInfo.fake().copy(source: "admin")
+        let order = makeOrder().copy(siteID: siteID, orderID: orderID, attributionInfo: originalAttributionInfo)
+        let useCase = OrdersUpsertUseCase(storage: viewStorage)
+        useCase.upsert([order])
+
+        // When
+        useCase.upsert([order.copy(attributionInfo: .some(nil))])
+
+        // Then
+        XCTAssertNil(viewStorage.loadOrderAttributionInfo(siteID: siteID, orderID: orderID))
+        let storageOrder = try XCTUnwrap(viewStorage.loadOrder(siteID: siteID, orderID: orderID))
+        XCTAssertNil(storageOrder.attributionInfo)
+    }
 }
 
 private extension OrdersUpsertUseCaseTests {

--- a/Yosemite/YosemiteTests/Stores/Order/OrdersUpsertUseCaseTests.swift
+++ b/Yosemite/YosemiteTests/Stores/Order/OrdersUpsertUseCaseTests.swift
@@ -327,6 +327,36 @@ final class OrdersUpsertUseCaseTests: XCTestCase {
         XCTAssertEqual(storageOrder.appliedGiftCards?.map { $0.toReadOnly() }.sorted(by: { $0.amount > $1.amount }),
                        [giftCard1, giftCard2])
     }
+
+    func test_it_persists_order_attribution_info_in_storage() throws {
+        // Given
+        let attributionInfo = OrderAttributionInfo.fake()
+        let order = makeOrder().copy(siteID: 3, orderID: 11, attributionInfo: attributionInfo)
+        let useCase = OrdersUpsertUseCase(storage: viewStorage)
+
+        // When
+        useCase.upsert([order])
+
+        // Then
+        let storageAttributionInfo = try XCTUnwrap(viewStorage.loadOrder(siteID: 3, orderID: 11)?.attributionInfo)
+        XCTAssertEqual(storageAttributionInfo.toReadOnly(), attributionInfo)
+    }
+
+    func test_it_replaces_existing_order_attribution_info_in_storage() throws {
+        // Given
+        let originalAttributionInfo = OrderAttributionInfo.fake().copy(source: "admin")
+        let order = makeOrder().copy(siteID: 3, orderID: 11, attributionInfo: originalAttributionInfo)
+        let useCase = OrdersUpsertUseCase(storage: viewStorage)
+        useCase.upsert([order])
+
+        // When
+        let attributionInfo = OrderAttributionInfo.fake().copy(source: "blaze")
+        useCase.upsert([order.copy(attributionInfo: attributionInfo)])
+
+        // Then
+        let storageAttributionInfo = try XCTUnwrap(viewStorage.loadOrder(siteID: 3, orderID: 11)?.attributionInfo)
+        XCTAssertEqual(storageAttributionInfo.toReadOnly(), attributionInfo)
+    }
 }
 
 private extension OrdersUpsertUseCaseTests {


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #11938
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
Upserts order attribution into the storage while processing orders in Yosemite layer. 

## Testing instructions
- Login into the app
- Navigate to the orders tab
- Adding, viewing or editing orders should work as before

## Screenshots
<img src="https://github.com/woocommerce/woocommerce-ios/assets/524475/ebf0bdcd-5a94-4e97-8f7a-cff453fa373c" width="320"/>


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
