### PR TITLE
[Order Attribution] Show order attribution info

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -4,6 +4,7 @@
 -----
 - [***] Products: Cache product images to reduce network requests. [https://github.com/woocommerce/woocommerce-ios/pull/11902]
 - [***] Stats: The Analytics Hub now includes links to the full analytics report for each supported analytics card (Revenue, Orders, Products). [https://github.com/woocommerce/woocommerce-ios/pull/11920]
+- [*] Orders: Show the order attribution info in the order detail screen. [https://github.com/woocommerce/woocommerce-ios/pull/11963]
 
 17.2
 -----

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -4,7 +4,7 @@
 -----
 - [***] Products: Cache product images to reduce network requests. [https://github.com/woocommerce/woocommerce-ios/pull/11902]
 - [***] Stats: The Analytics Hub now includes links to the full analytics report for each supported analytics card (Revenue, Orders, Products). [https://github.com/woocommerce/woocommerce-ios/pull/11920]
-- [*] Orders: Show the order attribution info in the order detail screen. [https://github.com/woocommerce/woocommerce-ios/pull/11963]
+- [**] Orders: Show the order attribution info in the order detail screen. [https://github.com/woocommerce/woocommerce-ios/pull/11963]
 - [*] Products > product scanning: in wider devices, the product details after scanning a barcode does not show in split view with an empty secondary view anymore. Camera capture is also enabled when the app is in split mode with another app in iOS 16+ for supported devices. [https://github.com/woocommerce/woocommerce-ios/pull/11931]
 
 17.2

--- a/WooCommerce/Classes/Extensions/OrderAttributionInfo+Origin.swift
+++ b/WooCommerce/Classes/Extensions/OrderAttributionInfo+Origin.swift
@@ -22,8 +22,10 @@ extension OrderAttributionInfo {
             return Localization.unknown
         }
     }
+}
 
-    private enum Localization {
+extension OrderAttributionInfo {
+    enum Localization {
         static let source = NSLocalizedString(
             "orderAttributionInfo.source",
             value: "Source: %1$@",

--- a/WooCommerce/Classes/Extensions/OrderAttributionInfo+Origin.swift
+++ b/WooCommerce/Classes/Extensions/OrderAttributionInfo+Origin.swift
@@ -9,11 +9,11 @@ extension OrderAttributionInfo {
     var origin: String {
         switch sourceType {
         case "utm":
-            return String.localizedStringWithFormat(Localization.source, source ?? "")
+            return String.localizedStringWithFormat(Localization.source, source ?? Localization.unknown)
         case "organic":
-            return String.localizedStringWithFormat(Localization.organic, source ?? "")
+            return String.localizedStringWithFormat(Localization.organic, source ?? Localization.unknown)
         case "referral":
-            return String.localizedStringWithFormat(Localization.referral, source ?? "")
+            return String.localizedStringWithFormat(Localization.referral, source ?? Localization.unknown)
         case "typein":
             return Localization.direct
         case "admin":

--- a/WooCommerce/Classes/Extensions/OrderAttributionInfo+Origin.swift
+++ b/WooCommerce/Classes/Extensions/OrderAttributionInfo+Origin.swift
@@ -1,0 +1,69 @@
+import Foundation
+import struct Yosemite.OrderAttributionInfo
+
+/// Provides `Origin` value for order attribution
+///
+/// Implementation based on https://github.com/woocommerce/woocommerce/blob/trunk/plugins/woocommerce/src/Internal/Traits/OrderAttributionMeta.php#L276-L314
+///
+extension OrderAttributionInfo {
+    var origin: String {
+        switch sourceType {
+        case "utm":
+            return String.localizedStringWithFormat(Localization.source, source ?? "")
+        case "organic":
+            return String.localizedStringWithFormat(Localization.organic, source ?? "")
+        case "referral":
+            return String.localizedStringWithFormat(Localization.referral, source ?? "")
+        case "typein":
+            return Localization.direct
+        case "admin":
+            return Localization.webAdmin
+        default:
+            return Localization.unknown
+        }
+    }
+
+    private enum Localization {
+        static let source = NSLocalizedString(
+            "orderAttributionInfo.source",
+            value: "Source: %1$@",
+            comment: "Origin in Order Attribution Section on Order Details screen." +
+            "The placeholder is the source." +
+            "Reads like: Source: woo.com"
+        )
+
+        static let organic = NSLocalizedString(
+            "orderAttributionInfo.organic",
+            value: "Organic: %1$@",
+            comment: "Origin in Order Attribution Section on Order Details screen." +
+            "The placeholder is the source." +
+            "Reads like: Organic: woo.com"
+        )
+
+        static let referral = NSLocalizedString(
+            "orderAttributionInfo.referral",
+            value: "Referral: %1$@",
+            comment: "Origin in Order Attribution Section on Order Details screen." +
+            "The placeholder is the source." +
+            "Reads like: Referral: woo.com"
+        )
+
+        static let direct = NSLocalizedString(
+            "orderAttributionInfo.direct",
+            value: "Direct",
+            comment: "Origin in Order Attribution Section on Order Details screen."
+        )
+
+        static let webAdmin = NSLocalizedString(
+            "orderAttributionInfo.webAdmin",
+            value: "Web admin",
+            comment: "Origin in Order Attribution Section on Order Details screen."
+        )
+
+        static let unknown = NSLocalizedString(
+            "orderAttributionInfo.unknown",
+            value: "Unknown",
+            comment: "Origin in Order Attribution Section on Order Details screen."
+        )
+    }
+}

--- a/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsDataSource.swift
+++ b/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsDataSource.swift
@@ -1308,6 +1308,45 @@ extension OrderDetailsDataSource {
             return Section(category: .notes, title: Title.notes, rows: rows)
         }()
 
+        let attribution: Section? = {
+
+            let rows: [Row] = {
+                var rows: [Row] = [.attributionOrigin]
+
+                guard let orderAttributionInfo = order.attributionInfo else {
+                    return rows
+                }
+
+                if let _ = orderAttributionInfo.sourceType {
+                    rows.append(.attributionSourceType)
+                }
+
+                if let _ = orderAttributionInfo.campaign {
+                    rows.append(.attributionCampaign)
+                }
+
+                if let _ = orderAttributionInfo.source {
+                    rows.append(.attributionSource)
+                }
+
+                if let _ = orderAttributionInfo.medium {
+                    rows.append(.attributionMedium)
+                }
+
+                if let _ = orderAttributionInfo.deviceType {
+                    rows.append(.attributionDeviceType)
+                }
+
+                if let _ = orderAttributionInfo.sessionPageViews {
+                    rows.append(.attributionSessionPageViews)
+                }
+
+                return rows
+            }()
+
+            return Section(category: .attribution, title: Title.orderInformation, rows: rows)
+        }()
+
         sections = ([summary,
                      shippingNotice,
                      products,
@@ -1318,6 +1357,7 @@ extension OrderDetailsDataSource {
                     shippingLabelSections +
                     [payment,
                      customerInformation,
+                     attribution,
                      subscriptions,
                      giftCards,
                      tracking,
@@ -1818,6 +1858,14 @@ extension OrderDetailsDataSource {
             case .subscriptions:
                 return OrderSubscriptionTableViewCell.reuseIdentifier
             case .giftCards:
+                return TitleAndValueTableViewCell.reuseIdentifier
+            case .attributionOrigin,
+                    .attributionSourceType,
+                    .attributionCampaign,
+                    .attributionSource,
+                    .attributionMedium,
+                    .attributionDeviceType,
+                    .attributionSessionPageViews:
                 return TitleAndValueTableViewCell.reuseIdentifier
             }
         }

--- a/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsDataSource.swift
+++ b/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsDataSource.swift
@@ -1501,6 +1501,51 @@ extension OrderDetailsDataSource {
 
 // MARK: - Constants
 extension OrderDetailsDataSource {
+    enum Localization {
+        enum AttributionInfo {
+            static let origin = NSLocalizedString(
+                "orderDetailsDataSource.attributionInfo.origin",
+                value: "Origin",
+                comment: "Title in Order Attribution Section on Order Details screen."
+            )
+            static let unknown = NSLocalizedString(
+                "orderDetailsDataSource.attributionInfo.unknown",
+                value: "Unknown",
+                comment: "Origin in Order Attribution Section on Order Details screen."
+            )
+            static let sourceType = NSLocalizedString(
+                "orderDetailsDataSource.attributionInfo.sourceType",
+                value: "Source type",
+                comment: "Title in Order Attribution Section on Order Details screen."
+            )
+            static let campaign = NSLocalizedString(
+                "orderDetailsDataSource.attributionInfo.campaign",
+                value: "Campaign",
+                comment: "Title in Order Attribution Section on Order Details screen."
+            )
+            static let source = NSLocalizedString(
+                "orderDetailsDataSource.attributionInfo.source",
+                value: "Source",
+                comment: "Title in Order Attribution Section on Order Details screen."
+            )
+            static let medium = NSLocalizedString(
+                "orderDetailsDataSource.attributionInfo.medium",
+                value: "Medium",
+                comment: "Title in Order Attribution Section on Order Details screen."
+            )
+            static let deviceType = NSLocalizedString(
+                "orderDetailsDataSource.attributionInfo.deviceType",
+                value: "Device type",
+                comment: "Title in Order Attribution Section on Order Details screen."
+            )
+            static let sessionPageViews = NSLocalizedString(
+                "orderDetailsDataSource.attributionInfo.sessionPageViews",
+                value: "Session page views",
+                comment: "Title in Order Attribution Section on Order Details screen."
+            )
+        }
+    }
+
     enum Titles {
         static let markComplete = NSLocalizedString("Mark Order Complete", comment: "Fulfill Order Action Button")
         static let addNoteText = NSLocalizedString("Add a note",
@@ -1559,6 +1604,11 @@ extension OrderDetailsDataSource {
             NSLocalizedString("Don’t know how to print from your mobile device?",
                               comment: "Title of button in order details > shipping label that shows the instructions on how to print " +
                                 "a shipping label on the mobile device.")
+        static let orderInformation = NSLocalizedString(
+            "orderDetailsDataSource.attributionInfo.orderInformation",
+            value: "Order Information",
+            comment: "Title of Order Attribution Section in Order Details screen."
+        )
     }
 
     enum Footer {

--- a/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsDataSource.swift
+++ b/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsDataSource.swift
@@ -463,6 +463,20 @@ private extension OrderDetailsDataSource {
             configureSubscriptions(cell: cell, at: indexPath)
         case let cell as TitleAndValueTableViewCell where row == .giftCards:
             configureGiftCards(cell: cell, at: indexPath)
+        case let cell as TitleAndValueTableViewCell where row == .attributionOrigin:
+            configureAttributionOrigin(cell: cell, at: indexPath)
+        case let cell as TitleAndValueTableViewCell where row == .attributionSourceType:
+            configureAttributionSourceType(cell: cell, at: indexPath)
+        case let cell as TitleAndValueTableViewCell where row == .attributionCampaign:
+            configureAttributionCampaign(cell: cell, at: indexPath)
+        case let cell as TitleAndValueTableViewCell where row == .attributionSource:
+            configureAttributionSource(cell: cell, at: indexPath)
+        case let cell as TitleAndValueTableViewCell where row == .attributionMedium:
+            configureAttributionMedium(cell: cell, at: indexPath)
+        case let cell as TitleAndValueTableViewCell where row == .attributionDeviceType:
+            configureAttributionDeviceType(cell: cell, at: indexPath)
+        case let cell as TitleAndValueTableViewCell where row == .attributionSessionPageViews:
+            configureAttributionSessionPageViews(cell: cell, at: indexPath)
         default:
             fatalError("Unidentified customer info row type")
         }
@@ -1015,6 +1029,57 @@ private extension OrderDetailsDataSource {
             return []
         }
         return AddOnCrossreferenceUseCase(orderItemAttributes: item.attributes, product: product, addOnGroups: addOnGroups).addOns()
+    }
+}
+
+// MARK: - Attribution section
+private extension OrderDetailsDataSource {
+    func configureAttributionOrigin(cell: TitleAndValueTableViewCell, at indexPath: IndexPath) {
+        let origin: String = {
+            guard let orderAttributionInfo = order.attributionInfo else {
+                return Localization.AttributionInfo.unknown
+            }
+            return orderAttributionInfo.origin
+        }()
+
+        cell.updateUI(title: Localization.AttributionInfo.origin, value: origin)
+        cell.apply(style: .regular)
+    }
+
+    func configureAttributionSourceType(cell: TitleAndValueTableViewCell, at indexPath: IndexPath) {
+        cell.updateUI(title: Localization.AttributionInfo.sourceType,
+                      value: order.attributionInfo?.sourceType ?? "")
+        cell.apply(style: .regular)
+    }
+
+    func configureAttributionCampaign(cell: TitleAndValueTableViewCell, at indexPath: IndexPath) {
+        cell.updateUI(title: Localization.AttributionInfo.campaign,
+                      value: order.attributionInfo?.campaign ?? "")
+        cell.apply(style: .regular)
+    }
+
+    func configureAttributionSource(cell: TitleAndValueTableViewCell, at indexPath: IndexPath) {
+        cell.updateUI(title: Localization.AttributionInfo.source,
+                      value: order.attributionInfo?.source ?? "")
+        cell.apply(style: .regular)
+    }
+
+    func configureAttributionMedium(cell: TitleAndValueTableViewCell, at indexPath: IndexPath) {
+        cell.updateUI(title: Localization.AttributionInfo.medium,
+                      value: order.attributionInfo?.medium ?? "")
+        cell.apply(style: .regular)
+    }
+
+    func configureAttributionDeviceType(cell: TitleAndValueTableViewCell, at indexPath: IndexPath) {
+        cell.updateUI(title: Localization.AttributionInfo.deviceType,
+                      value: order.attributionInfo?.deviceType ?? "")
+        cell.apply(style: .regular)
+    }
+
+    func configureAttributionSessionPageViews(cell: TitleAndValueTableViewCell, at indexPath: IndexPath) {
+        cell.updateUI(title: Localization.AttributionInfo.sessionPageViews,
+                      value: order.attributionInfo?.sessionPageViews ?? "")
+        cell.apply(style: .regular)
     }
 }
 

--- a/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsDataSource.swift
+++ b/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsDataSource.swift
@@ -1585,6 +1585,7 @@ extension OrderDetailsDataSource {
             case addTracking
             case notes
             case customFields
+            case attribution
         }
 
         /// The table header style of a `Section`.
@@ -1690,6 +1691,13 @@ extension OrderDetailsDataSource {
         case orderNoteHeader
         case orderNote
         case customFields
+        case attributionOrigin
+        case attributionSourceType
+        case attributionCampaign
+        case attributionSource
+        case attributionMedium
+        case attributionDeviceType
+        case attributionSessionPageViews
 
         var reuseIdentifier: String {
             switch self {

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -2541,6 +2541,8 @@
 		EE7707CB2ABC4C8E009FD564 /* AIToneVoiceViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE7707CA2ABC4C8E009FD564 /* AIToneVoiceViewModelTests.swift */; };
 		EE81B1382865BB0B0032E0D4 /* ProductImagesProductIDUpdaterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE81B1372865BB0B0032E0D4 /* ProductImagesProductIDUpdaterTests.swift */; };
 		EE8A302B2B70B63E001D7C66 /* MockImageService.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE8A302A2B70B63E001D7C66 /* MockImageService.swift */; };
+		EE8A30452B74948C001D7C66 /* OrderAttributionInfo+Origin.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE8A30442B74948C001D7C66 /* OrderAttributionInfo+Origin.swift */; };
+		EE8A30472B74F3A8001D7C66 /* OrderAttributionInfo+OriginTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE8A30462B74F3A8001D7C66 /* OrderAttributionInfo+OriginTests.swift */; };
 		EE8DCA8028BF964700F23B23 /* MockAuthentication.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE8DCA7F28BF964700F23B23 /* MockAuthentication.swift */; };
 		EE94258F29DDA49E0063B499 /* StoreCreationProgressViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE94258E29DDA49E0063B499 /* StoreCreationProgressViewModelTests.swift */; };
 		EEA1E2042AC1D22600A37ADD /* ProductDetailPreviewViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EEA1E2032AC1D22600A37ADD /* ProductDetailPreviewViewModelTests.swift */; };
@@ -5248,6 +5250,8 @@
 		EE7707CA2ABC4C8E009FD564 /* AIToneVoiceViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AIToneVoiceViewModelTests.swift; sourceTree = "<group>"; };
 		EE81B1372865BB0B0032E0D4 /* ProductImagesProductIDUpdaterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductImagesProductIDUpdaterTests.swift; sourceTree = "<group>"; };
 		EE8A302A2B70B63E001D7C66 /* MockImageService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockImageService.swift; sourceTree = "<group>"; };
+		EE8A30442B74948C001D7C66 /* OrderAttributionInfo+Origin.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "OrderAttributionInfo+Origin.swift"; sourceTree = "<group>"; };
+		EE8A30462B74F3A8001D7C66 /* OrderAttributionInfo+OriginTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "OrderAttributionInfo+OriginTests.swift"; sourceTree = "<group>"; };
 		EE8DCA7F28BF964700F23B23 /* MockAuthentication.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockAuthentication.swift; sourceTree = "<group>"; };
 		EE94258E29DDA49E0063B499 /* StoreCreationProgressViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StoreCreationProgressViewModelTests.swift; sourceTree = "<group>"; };
 		EEA1E2032AC1D22600A37ADD /* ProductDetailPreviewViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductDetailPreviewViewModelTests.swift; sourceTree = "<group>"; };
@@ -9343,6 +9347,7 @@
 				DE50295628BF595200551736 /* WordPressOrgCredentialsAuthenticatorTests.swift */,
 				026D4653295D79230037F59A /* CountryCode+FlagEmojiTests.swift */,
 				EE2A57D829E39A9C009F61E1 /* CaseIterable+HelpersTests.swift */,
+				EE8A30462B74F3A8001D7C66 /* OrderAttributionInfo+OriginTests.swift */,
 			);
 			path = Extensions;
 			sourceTree = "<group>";
@@ -10440,6 +10445,7 @@
 				B98C6D4F2B149C3900A243E1 /* UINavigationItem+Configuration.swift */,
 				02FCA5532B54FC8C0097BFB8 /* CardPresentPaymentOnboardingState+Analytics.swift */,
 				204C9C732B6BDFFB007A94E0 /* UIUserInterfaceSizeClass+Helpers.swift */,
+				EE8A30442B74948C001D7C66 /* OrderAttributionInfo+Origin.swift */,
 			);
 			path = Extensions;
 			sourceTree = "<group>";
@@ -14251,6 +14257,7 @@
 				029D444922F13F8A00DEFA8A /* DashboardUI.swift in Sources */,
 				D8C2A28F231BD00500F503E9 /* ReviewsViewModel.swift in Sources */,
 				20E188842AD059A50053E945 /* AboutTapToPayView.swift in Sources */,
+				EE8A30452B74948C001D7C66 /* OrderAttributionInfo+Origin.swift in Sources */,
 				026D4652295D763B0037F59A /* CountryCode+FlagEmoji.swift in Sources */,
 				B9F3DAAD29BB71B100DDD545 /* CollectPaymentAppIntent.swift in Sources */,
 				EEBDF7DF2A2F674100EFEF47 /* ShareProductAIEligibilityChecker.swift in Sources */,
@@ -14986,6 +14993,7 @@
 				DE3877E4283E35E80075D87E /* DiscountTypeBottomSheetListSelectorCommandTests.swift in Sources */,
 				025678C725773399009D7E6C /* Collection+ShippingLabelTests.swift in Sources */,
 				02BC5AA624D27F8900C43326 /* ProductVariationFormViewModel+ChangesTests.swift in Sources */,
+				EE8A30472B74F3A8001D7C66 /* OrderAttributionInfo+OriginTests.swift in Sources */,
 				03A6C18428B52B1500AADF23 /* InPersonPaymentsCashOnDeliveryPaymentGatewayNotSetUpViewModelTests.swift in Sources */,
 				DE279BAD26E9CBEA002BA963 /* ShippingLabelPackagesFormViewModelTests.swift in Sources */,
 				DE36E09C2A89EEA400B98496 /* StoreNameSetupViewModelTests.swift in Sources */,

--- a/WooCommerce/WooCommerceTests/Extensions/OrderAttributionInfo+OriginTests.swift
+++ b/WooCommerce/WooCommerceTests/Extensions/OrderAttributionInfo+OriginTests.swift
@@ -1,0 +1,61 @@
+import XCTest
+@testable import WooCommerce
+import struct Yosemite.OrderAttributionInfo
+
+final class OrderAttributionInfo_OriginTests: XCTestCase {
+    func test_origin_when_source_type_is_utm() {
+        // Given
+        let sut = OrderAttributionInfo.fake().copy(sourceType: "utm", source: "example.com")
+
+        // Then
+        XCTAssertEqual(sut.origin, String.localizedStringWithFormat(OrderAttributionInfo.Localization.source, "example.com"))
+    }
+
+    func test_origin_when_source_type_is_organic() {
+        // Given
+        let sut = OrderAttributionInfo.fake().copy(sourceType: "organic", source: "example.com")
+
+        // Then
+        XCTAssertEqual(sut.origin, String.localizedStringWithFormat(OrderAttributionInfo.Localization.organic, "example.com"))
+    }
+
+    func test_origin_when_source_type_is_referral() {
+        // Given
+        let sut = OrderAttributionInfo.fake().copy(sourceType: "referral", source: "example.com")
+
+        // Then
+        XCTAssertEqual(sut.origin, String.localizedStringWithFormat(OrderAttributionInfo.Localization.referral, "example.com"))
+    }
+
+    func test_origin_when_source_type_is_typein() {
+        // Given
+        let sut = OrderAttributionInfo.fake().copy(sourceType: "typein", source: "example.com")
+
+        // Then
+        XCTAssertEqual(sut.origin, OrderAttributionInfo.Localization.direct)
+    }
+
+    func test_origin_when_source_type_is_admin() {
+        // Given
+        let sut = OrderAttributionInfo.fake().copy(sourceType: "admin", source: "example.com")
+
+        // Then
+        XCTAssertEqual(sut.origin, OrderAttributionInfo.Localization.webAdmin)
+    }
+
+    func test_origin_when_source_type_is_empty() {
+        // Given
+        let sut = OrderAttributionInfo.fake().copy(sourceType: "", source: "example.com")
+
+        // Then
+        XCTAssertEqual(sut.origin, OrderAttributionInfo.Localization.unknown)
+    }
+
+    func test_origin_when_source_type_is_unknown() {
+        // Given
+        let sut = OrderAttributionInfo.fake().copy(sourceType: "Random unknown source type", source: "example.com")
+
+        // Then
+        XCTAssertEqual(sut.origin, OrderAttributionInfo.Localization.unknown)
+    }
+}

--- a/WooCommerce/WooCommerceTests/Extensions/OrderAttributionInfo+OriginTests.swift
+++ b/WooCommerce/WooCommerceTests/Extensions/OrderAttributionInfo+OriginTests.swift
@@ -11,6 +11,14 @@ final class OrderAttributionInfo_OriginTests: XCTestCase {
         XCTAssertEqual(sut.origin, String.localizedStringWithFormat(OrderAttributionInfo.Localization.source, "example.com"))
     }
 
+    func test_origin_when_source_type_is_utm_and_source_nil() {
+        // Given
+        let sut = OrderAttributionInfo.fake().copy(sourceType: "utm", source: nil)
+
+        // Then
+        XCTAssertEqual(sut.origin, String.localizedStringWithFormat(OrderAttributionInfo.Localization.source, OrderAttributionInfo.Localization.unknown))
+    }
+
     func test_origin_when_source_type_is_organic() {
         // Given
         let sut = OrderAttributionInfo.fake().copy(sourceType: "organic", source: "example.com")
@@ -19,12 +27,28 @@ final class OrderAttributionInfo_OriginTests: XCTestCase {
         XCTAssertEqual(sut.origin, String.localizedStringWithFormat(OrderAttributionInfo.Localization.organic, "example.com"))
     }
 
+    func test_origin_when_source_type_is_organic_and_source_nil() {
+        // Given
+        let sut = OrderAttributionInfo.fake().copy(sourceType: "organic", source: nil)
+
+        // Then
+        XCTAssertEqual(sut.origin, String.localizedStringWithFormat(OrderAttributionInfo.Localization.organic, OrderAttributionInfo.Localization.unknown))
+    }
+
     func test_origin_when_source_type_is_referral() {
         // Given
         let sut = OrderAttributionInfo.fake().copy(sourceType: "referral", source: "example.com")
 
         // Then
         XCTAssertEqual(sut.origin, String.localizedStringWithFormat(OrderAttributionInfo.Localization.referral, "example.com"))
+    }
+
+    func test_origin_when_source_type_is_referral_and_source_nil() {
+        // Given
+        let sut = OrderAttributionInfo.fake().copy(sourceType: "referral", source: nil)
+
+        // Then
+        XCTAssertEqual(sut.origin, String.localizedStringWithFormat(OrderAttributionInfo.Localization.referral, OrderAttributionInfo.Localization.unknown))
     }
 
     func test_origin_when_source_type_is_typein() {

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Details/OrderDetailsDataSourceTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Details/OrderDetailsDataSourceTests.swift
@@ -57,6 +57,7 @@ final class OrderDetailsDataSourceTests: XCTestCase {
             Title.refundedProducts,
             Title.payment,
             Title.information,
+            Title.orderInformation,
             Title.notes
         ]
 
@@ -669,6 +670,193 @@ final class OrderDetailsDataSourceTests: XCTestCase {
         let paymentSection = try section(withTitle: Title.payment, from: dataSource)
         let receiptsRow = row(row: .seeReceipt, in: paymentSection)
         XCTAssertNil(receiptsRow)
+    }
+
+    // MARK: Order Attribution
+
+    func test_order_attribution_section_is_shown_with_origin_row_even_if_order_has_no_attribution_info() throws {
+        // Given
+        let order = Order.fake().copy(attributionInfo: .some(nil))
+        let dataSource = OrderDetailsDataSource(order: order,
+                                                storageManager: storageManager,
+                                                cardPresentPaymentsConfiguration: Mocks.configuration,
+                                                featureFlags: MockFeatureFlagService(isReadOnlyGiftCardsEnabled: true))
+
+        // When
+        dataSource.reloadSections()
+
+        // Then
+        let attributionSection = try section(withTitle: Title.orderInformation, from: dataSource)
+        let originRow = row(row: .attributionOrigin, in: attributionSection)
+        XCTAssertNotNil(originRow)
+    }
+
+    func test_order_attribution_section_hides_source_type_row_when_sourceType_is_nil() throws {
+        // Given
+        let order = Order.fake().copy(attributionInfo: .fake().copy(sourceType: .some(nil)))
+        let dataSource = OrderDetailsDataSource(order: order, storageManager: storageManager, cardPresentPaymentsConfiguration: Mocks.configuration)
+
+        // When
+        dataSource.reloadSections()
+
+        // Then
+        let attributionSection = try section(withTitle: Title.orderInformation, from: dataSource)
+        let row = row(row: .attributionSourceType, in: attributionSection)
+        XCTAssertNil(row)
+    }
+
+    func test_order_attribution_section_shows_source_type_row_when_sourceType_is_not_nil() throws {
+        // Given
+        let order = Order.fake().copy(attributionInfo: .fake().copy(sourceType: "Source type"))
+        let dataSource = OrderDetailsDataSource(order: order, storageManager: storageManager, cardPresentPaymentsConfiguration: Mocks.configuration)
+
+        // When
+        dataSource.reloadSections()
+
+        // Then
+        let attributionSection = try section(withTitle: Title.orderInformation, from: dataSource)
+        let row = row(row: .attributionSourceType, in: attributionSection)
+        XCTAssertNotNil(row)
+    }
+
+    func test_order_attribution_section_hides_campaign_row_when_campaign_is_nil() throws {
+        // Given
+        let order = Order.fake().copy(attributionInfo: .fake().copy(campaign: .some(nil)))
+        let dataSource = OrderDetailsDataSource(order: order, storageManager: storageManager, cardPresentPaymentsConfiguration: Mocks.configuration)
+
+        // When
+        dataSource.reloadSections()
+
+        // Then
+        let attributionSection = try section(withTitle: Title.orderInformation, from: dataSource)
+        let row = row(row: .attributionCampaign, in: attributionSection)
+        XCTAssertNil(row)
+    }
+
+    func test_order_attribution_section_shows_campaign_row_when_campaign_is_not_nil() throws {
+        // Given
+        let order = Order.fake().copy(attributionInfo: .fake().copy(campaign: "Campaign"))
+        let dataSource = OrderDetailsDataSource(order: order, storageManager: storageManager, cardPresentPaymentsConfiguration: Mocks.configuration)
+
+        // When
+        dataSource.reloadSections()
+
+        // Then
+        let attributionSection = try section(withTitle: Title.orderInformation, from: dataSource)
+        let row = row(row: .attributionCampaign, in: attributionSection)
+        XCTAssertNotNil(row)
+    }
+
+    func test_order_attribution_section_hides_source_row_when_source_is_nil() throws {
+        // Given
+        let order = Order.fake().copy(attributionInfo: .fake().copy(source: .some(nil)))
+        let dataSource = OrderDetailsDataSource(order: order, storageManager: storageManager, cardPresentPaymentsConfiguration: Mocks.configuration)
+
+        // When
+        dataSource.reloadSections()
+
+        // Then
+        let attributionSection = try section(withTitle: Title.orderInformation, from: dataSource)
+        let row = row(row: .attributionSource, in: attributionSection)
+        XCTAssertNil(row)
+    }
+
+    func test_order_attribution_section_shows_source_row_when_source_is_not_nil() throws {
+        // Given
+        let order = Order.fake().copy(attributionInfo: .fake().copy(source: "Source"))
+        let dataSource = OrderDetailsDataSource(order: order, storageManager: storageManager, cardPresentPaymentsConfiguration: Mocks.configuration)
+
+        // When
+        dataSource.reloadSections()
+
+        // Then
+        let attributionSection = try section(withTitle: Title.orderInformation, from: dataSource)
+        let row = row(row: .attributionSource, in: attributionSection)
+        XCTAssertNotNil(row)
+    }
+
+    func test_order_attribution_section_hides_medium_row_when_medium_is_nil() throws {
+        // Given
+        let order = Order.fake().copy(attributionInfo: .fake().copy(medium: .some(nil)))
+        let dataSource = OrderDetailsDataSource(order: order, storageManager: storageManager, cardPresentPaymentsConfiguration: Mocks.configuration)
+
+        // When
+        dataSource.reloadSections()
+
+        // Then
+        let attributionSection = try section(withTitle: Title.orderInformation, from: dataSource)
+        let row = row(row: .attributionMedium, in: attributionSection)
+        XCTAssertNil(row)
+    }
+
+    func test_order_attribution_section_shows_medium_row_when_medium_is_not_nil() throws {
+        // Given
+        let order = Order.fake().copy(attributionInfo: .fake().copy(medium: "Medium"))
+        let dataSource = OrderDetailsDataSource(order: order, storageManager: storageManager, cardPresentPaymentsConfiguration: Mocks.configuration)
+
+        // When
+        dataSource.reloadSections()
+
+        // Then
+        let attributionSection = try section(withTitle: Title.orderInformation, from: dataSource)
+        let row = row(row: .attributionMedium, in: attributionSection)
+        XCTAssertNotNil(row)
+    }
+
+    func test_order_attribution_section_hides_deviceType_row_when_deviceType_is_nil() throws {
+        // Given
+        let order = Order.fake().copy(attributionInfo: .fake().copy(deviceType: .some(nil)))
+        let dataSource = OrderDetailsDataSource(order: order, storageManager: storageManager, cardPresentPaymentsConfiguration: Mocks.configuration)
+
+        // When
+        dataSource.reloadSections()
+
+        // Then
+        let attributionSection = try section(withTitle: Title.orderInformation, from: dataSource)
+        let row = row(row: .attributionDeviceType, in: attributionSection)
+        XCTAssertNil(row)
+    }
+
+    func test_order_attribution_section_shows_deviceType_row_when_deviceType_is_not_nil() throws {
+        // Given
+        let order = Order.fake().copy(attributionInfo: .fake().copy(deviceType: "Device type"))
+        let dataSource = OrderDetailsDataSource(order: order, storageManager: storageManager, cardPresentPaymentsConfiguration: Mocks.configuration)
+
+        // When
+        dataSource.reloadSections()
+
+        // Then
+        let attributionSection = try section(withTitle: Title.orderInformation, from: dataSource)
+        let row = row(row: .attributionDeviceType, in: attributionSection)
+        XCTAssertNotNil(row)
+    }
+
+    func test_order_attribution_section_hides_sessionPageViews_row_when_sessionPageViews_is_nil() throws {
+        // Given
+        let order = Order.fake().copy(attributionInfo: .fake().copy(sessionPageViews: .some(nil)))
+        let dataSource = OrderDetailsDataSource(order: order, storageManager: storageManager, cardPresentPaymentsConfiguration: Mocks.configuration)
+
+        // When
+        dataSource.reloadSections()
+
+        // Then
+        let attributionSection = try section(withTitle: Title.orderInformation, from: dataSource)
+        let row = row(row: .attributionSessionPageViews, in: attributionSection)
+        XCTAssertNil(row)
+    }
+
+    func test_order_attribution_section_shows_sessionPageViews_row_when_sessionPageViews_is_not_nil() throws {
+        // Given
+        let order = Order.fake().copy(attributionInfo: .fake().copy(sessionPageViews: "3"))
+        let dataSource = OrderDetailsDataSource(order: order, storageManager: storageManager, cardPresentPaymentsConfiguration: Mocks.configuration)
+
+        // When
+        dataSource.reloadSections()
+
+        // Then
+        let attributionSection = try section(withTitle: Title.orderInformation, from: dataSource)
+        let row = row(row: .attributionSessionPageViews, in: attributionSection)
+        XCTAssertNotNil(row)
     }
 }
 


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #11958
<!-- Id number of the GitHub issue this PR addresses. -->

## Description

Shows order attribution info in the order detail screen.

## Testing instructions

#### Existing orders
1. Login into the app with your existing store
2. Open an old existing order with no attribution info
3. Under the "ORDER INFORMATION" section, the "Origin" row with the value "Unkown" should be displayed.

#### Orders with attribution info
1. Create a JN site
1. Enable Order Attribution for the store. ([Setting](https://private-user-images.githubusercontent.com/228780/285548505-80da5f97-1e15-4c8f-ba8c-301c015ef13d.png?jwt=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJnaXRodWIuY29tIiwiYXVkIjoicmF3LmdpdGh1YnVzZXJjb250ZW50LmNvbSIsImtleSI6ImtleTUiLCJleHAiOjE3MDczOTk4NTIsIm5iZiI6MTcwNzM5OTU1MiwicGF0aCI6Ii8yMjg3ODAvMjg1NTQ4NTA1LTgwZGE1Zjk3LTFlMTUtNGM4Zi1iYThjLTMwMWMwMTVlZjEzZC5wbmc_WC1BbXotQWxnb3JpdGhtPUFXUzQtSE1BQy1TSEEyNTYmWC1BbXotQ3JlZGVudGlhbD1BS0lBVkNPRFlMU0E1M1BRSzRaQSUyRjIwMjQwMjA4JTJGdXMtZWFzdC0xJTJGczMlMkZhd3M0X3JlcXVlc3QmWC1BbXotRGF0ZT0yMDI0MDIwOFQxMzM5MTJaJlgtQW16LUV4cGlyZXM9MzAwJlgtQW16LVNpZ25hdHVyZT0yMjVhMjZmMzc1ZDlmZDllYzEwMzlhOTM2ODA1NzIyOGI3NzU4NTQyNTdkNThlODA4NTQ2Yjk0Nzc2Mzg5MDY3JlgtQW16LVNpZ25lZEhlYWRlcnM9aG9zdCZhY3Rvcl9pZD0wJmtleV9pZD0wJnJlcG9faWQ9MCJ9.QbivwpIB81FRza6vH-AnjWApOZXwT59KKyBEGK9zqfA))
3. Login into the app
4. Create orders from the browser (Details below)
5. Open the order from the mobile app
6. Validate that the order attribution info is displayed.
7. Open the order from `wp-admin` page and validate that the order attribution values displayed in the mobile app match.



#### Creating orders with different attribution values

Internal - p1707390894816719/1707387041.549409-slack-C06FSDTSN82

Web PR: https://github.com/woocommerce/woocommerce/pull/39701

There’s a JavaScript snippet on the above Web PR that injects an <a> tag on the current webpage, and then clicks it. Use that to go from certain pages to the shop.

1. Enable Order Attribution for the store. ([Setting](https://private-user-images.githubusercontent.com/228780/285548505-80da5f97-1e15-4c8f-ba8c-301c015ef13d.png?jwt=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJnaXRodWIuY29tIiwiYXVkIjoicmF3LmdpdGh1YnVzZXJjb250ZW50LmNvbSIsImtleSI6ImtleTUiLCJleHAiOjE3MDczOTk4NTIsIm5iZiI6MTcwNzM5OTU1MiwicGF0aCI6Ii8yMjg3ODAvMjg1NTQ4NTA1LTgwZGE1Zjk3LTFlMTUtNGM4Zi1iYThjLTMwMWMwMTVlZjEzZC5wbmc_WC1BbXotQWxnb3JpdGhtPUFXUzQtSE1BQy1TSEEyNTYmWC1BbXotQ3JlZGVudGlhbD1BS0lBVkNPRFlMU0E1M1BRSzRaQSUyRjIwMjQwMjA4JTJGdXMtZWFzdC0xJTJGczMlMkZhd3M0X3JlcXVlc3QmWC1BbXotRGF0ZT0yMDI0MDIwOFQxMzM5MTJaJlgtQW16LUV4cGlyZXM9MzAwJlgtQW16LVNpZ25hdHVyZT0yMjVhMjZmMzc1ZDlmZDllYzEwMzlhOTM2ODA1NzIyOGI3NzU4NTQyNTdkNThlODA4NTQ2Yjk0Nzc2Mzg5MDY3JlgtQW16LVNpZ25lZEhlYWRlcnM9aG9zdCZhY3Rvcl9pZD0wJmtleV9pZD0wJnJlcG9faWQ9MCJ9.QbivwpIB81FRza6vH-AnjWApOZXwT59KKyBEGK9zqfA))
8. Open an incognito window and browse to a source site. Example: woo.com, google.com
9. Use the JS snippet from the Web PR https://github.com/woocommerce/woocommerce/pull/39701 to inject a link to your shop, and auto click it.
10. Go through the checkout process
11. Check the results on the Order Edit page and the Woo Mobile App.
12. Repeat 2-5 with several sources:
    - [Woo.com](http://woo.com/) -> should be just a referral
    - [Google.com](http://google.com/) -> should be classed as organic
    - Navigate directly to the shop URL -> should be typein/direct
    - Navigate directly to the shop URL, but include UTM params (?utm_source=FAKESOURCE&utm_medium=mediumparam&utm_campaign=campaignparam) -> should be utm
    - Create an order in the WP dashboard -> should be web admin

## Screenshots

| Web | App | No attribution info |
|--------|--------|--------|
| ![Cell](https://github.com/woocommerce/woocommerce-ios/assets/524475/78713ffa-15cb-4a7f-834c-d8808bc38c77) | ![Cell](https://github.com/woocommerce/woocommerce-ios/assets/524475/23f1754d-f0a8-4667-b7f6-70068a16235d) | ![image](https://github.com/woocommerce/woocommerce-ios/assets/524475/7dae5bae-e403-45f0-9eac-bf25d32870fa) |

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.