### PR TITLE
[Order Attribution] Source type for orders created in Mobile App

### DIFF
--- a/Networking/Networking/Model/OrderAttributionInfo.swift
+++ b/Networking/Networking/Model/OrderAttributionInfo.swift
@@ -69,3 +69,11 @@ extension OrderAttributionInfo {
         case sessionPageViews = "_wc_order_attribution_session_pages"
     }
 }
+
+public extension OrderAttributionInfo {
+    enum Values {
+        /// Sent in create order request to mark the order as created from mobile
+        ///
+        public static let mobileAppSourceType = "mobile_app"
+    }
+}

--- a/Networking/Networking/Model/OrderAttributionInfo.swift
+++ b/Networking/Networking/Model/OrderAttributionInfo.swift
@@ -59,7 +59,7 @@ public struct OrderAttributionInfo: Equatable, GeneratedFakeable, GeneratedCopia
     }
 }
 
-private extension OrderAttributionInfo {
+extension OrderAttributionInfo {
     enum Keys: String {
         case sourceType = "_wc_order_attribution_source_type"
         case campaign = "_wc_order_attribution_utm_campaign"

--- a/Networking/Networking/Model/OrderMetaData.swift
+++ b/Networking/Networking/Model/OrderMetaData.swift
@@ -4,7 +4,7 @@ import Codegen
 /// Represents the metadata within an Order
 /// Currently only handles `String` metadata values
 ///
-public struct OrderMetaData: Decodable, Equatable {
+public struct OrderMetaData: Codable, Equatable {
     public let metadataID: Int64
     public let key: String
     public let value: String

--- a/Networking/Networking/Remote/OrdersRemote.swift
+++ b/Networking/Networking/Remote/OrdersRemote.swift
@@ -188,6 +188,11 @@ public class OrdersRemote: Remote {
                     params[Order.CodingKeys.giftCards.rawValue] = try [[NestedFieldKeys.giftCardCode: giftCard].toDictionary()]
                 }
 
+                // Set source type to mark the order as created from mobile
+                params[Order.CodingKeys.metadata.rawValue] = try [OrderMetaData(metadataID: 0,
+                                                                                key: OrderAttributionInfo.Keys.sourceType.rawValue,
+                                                                                value: OrderAttributionInfo.Values.mobileAppSourceType).toDictionary()]
+
                 return params
             }()
 

--- a/Networking/NetworkingTests/Remote/OrdersRemoteTests.swift
+++ b/Networking/NetworkingTests/Remote/OrdersRemoteTests.swift
@@ -661,6 +661,23 @@ final class OrdersRemoteTests: XCTestCase {
         assertEqual(received, expected)
     }
 
+    func test_create_order_sets_mobile_app_as_source_type_meta_data() throws {
+        // Given
+        let remote = OrdersRemote(network: network)
+        let order = Order.fake()
+
+        // When
+        remote.createOrder(siteID: 123, order: order, giftCard: nil, fields: []) { result in }
+
+        // Then
+        let request = try XCTUnwrap(network.requestsForResponseData.last as? JetpackRequest)
+        let received = try XCTUnwrap(request.parameters["meta_data"] as? [[String: AnyHashable]])
+        let expected: [[String: AnyHashable]] = [["id": 0,
+                                                  "key": "_wc_order_attribution_source_type",
+                                                  "value": "mobile_app"]]
+        assertEqual(received, expected)
+    }
+
     // MARK: - Delete order tests
 
     func test_delete_order_properly_returns_parsed_order() throws {

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -4,7 +4,7 @@
 -----
 - [***] Products: Cache product images to reduce network requests. [https://github.com/woocommerce/woocommerce-ios/pull/11902]
 - [***] Stats: The Analytics Hub now includes links to the full analytics report for each supported analytics card (Revenue, Orders, Products). [https://github.com/woocommerce/woocommerce-ios/pull/11920]
-- [**] Orders: Show the order attribution info in the order detail screen. [https://github.com/woocommerce/woocommerce-ios/pull/11963]
+- [**] Orders: Show the order attribution info in the order detail screen. [https://github.com/woocommerce/woocommerce-ios/pull/11963, https://github.com/woocommerce/woocommerce-ios/pull/11966]
 - [**] Orders: Orders have an associated receipt now. Receipts can be printed, or shared via other apps installed on device. The feature will become available for merchants with WooCommerce version of 8.7.0+. [https://github.com/woocommerce/woocommerce-ios/pull/11956]
 - [*] Products > product scanning: in wider devices, the product details after scanning a barcode does not show in split view with an empty secondary view anymore. Camera capture is also enabled when the app is in split mode with another app in iOS 16+ for supported devices. [https://github.com/woocommerce/woocommerce-ios/pull/11931]
 

--- a/WooCommerce/Classes/Extensions/OrderAttributionInfo+Origin.swift
+++ b/WooCommerce/Classes/Extensions/OrderAttributionInfo+Origin.swift
@@ -18,6 +18,8 @@ extension OrderAttributionInfo {
             return Localization.direct
         case "admin":
             return Localization.webAdmin
+        case OrderAttributionInfo.Values.mobileAppSourceType:
+            return Localization.mobileApp
         default:
             return Localization.unknown
         }
@@ -59,6 +61,12 @@ extension OrderAttributionInfo {
         static let webAdmin = NSLocalizedString(
             "orderAttributionInfo.webAdmin",
             value: "Web admin",
+            comment: "Origin in Order Attribution Section on Order Details screen."
+        )
+
+        static let mobileApp = NSLocalizedString(
+            "orderAttributionInfo.mobileApp",
+            value: "Mobile App",
             comment: "Origin in Order Attribution Section on Order Details screen."
         )
 

--- a/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsDataSource.swift
+++ b/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsDataSource.swift
@@ -1409,7 +1409,7 @@ extension OrderDetailsDataSource {
                 return rows
             }()
 
-            return Section(category: .attribution, title: Title.orderInformation, rows: rows)
+            return Section(category: .attribution, title: Title.orderAttribution, rows: rows)
         }()
 
         sections = ([summary,
@@ -1709,9 +1709,9 @@ extension OrderDetailsDataSource {
             NSLocalizedString("Don’t know how to print from your mobile device?",
                               comment: "Title of button in order details > shipping label that shows the instructions on how to print " +
                                 "a shipping label on the mobile device.")
-        static let orderInformation = NSLocalizedString(
-            "orderDetailsDataSource.attributionInfo.orderInformation",
-            value: "Order Information",
+        static let orderAttribution = NSLocalizedString(
+            "orderDetailsDataSource.attributionInfo.orderAttribution",
+            value: "Order attribution",
             comment: "Title of Order Attribution Section in Order Details screen."
         )
     }

--- a/WooCommerce/WooCommerceTests/Extensions/OrderAttributionInfo+OriginTests.swift
+++ b/WooCommerce/WooCommerceTests/Extensions/OrderAttributionInfo+OriginTests.swift
@@ -67,6 +67,14 @@ final class OrderAttributionInfo_OriginTests: XCTestCase {
         XCTAssertEqual(sut.origin, OrderAttributionInfo.Localization.webAdmin)
     }
 
+    func test_origin_when_source_type_is_mobile_app() {
+        // Given
+        let sut = OrderAttributionInfo.fake().copy(sourceType: "mobile_app", source: "example.com")
+
+        // Then
+        XCTAssertEqual(sut.origin, OrderAttributionInfo.Localization.mobileApp)
+    }
+
     func test_origin_when_source_type_is_empty() {
         // Given
         let sut = OrderAttributionInfo.fake().copy(sourceType: "", source: "example.com")

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Details/OrderDetailsDataSourceTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Details/OrderDetailsDataSourceTests.swift
@@ -57,7 +57,7 @@ final class OrderDetailsDataSourceTests: XCTestCase {
             Title.refundedProducts,
             Title.payment,
             Title.information,
-            Title.orderInformation,
+            Title.orderAttribution,
             Title.notes
         ]
 
@@ -686,7 +686,7 @@ final class OrderDetailsDataSourceTests: XCTestCase {
         dataSource.reloadSections()
 
         // Then
-        let attributionSection = try section(withTitle: Title.orderInformation, from: dataSource)
+        let attributionSection = try section(withTitle: Title.orderAttribution, from: dataSource)
         let originRow = row(row: .attributionOrigin, in: attributionSection)
         XCTAssertNotNil(originRow)
     }
@@ -700,7 +700,7 @@ final class OrderDetailsDataSourceTests: XCTestCase {
         dataSource.reloadSections()
 
         // Then
-        let attributionSection = try section(withTitle: Title.orderInformation, from: dataSource)
+        let attributionSection = try section(withTitle: Title.orderAttribution, from: dataSource)
         let row = row(row: .attributionSourceType, in: attributionSection)
         XCTAssertNil(row)
     }
@@ -714,7 +714,7 @@ final class OrderDetailsDataSourceTests: XCTestCase {
         dataSource.reloadSections()
 
         // Then
-        let attributionSection = try section(withTitle: Title.orderInformation, from: dataSource)
+        let attributionSection = try section(withTitle: Title.orderAttribution, from: dataSource)
         let row = row(row: .attributionSourceType, in: attributionSection)
         XCTAssertNotNil(row)
     }
@@ -728,7 +728,7 @@ final class OrderDetailsDataSourceTests: XCTestCase {
         dataSource.reloadSections()
 
         // Then
-        let attributionSection = try section(withTitle: Title.orderInformation, from: dataSource)
+        let attributionSection = try section(withTitle: Title.orderAttribution, from: dataSource)
         let row = row(row: .attributionCampaign, in: attributionSection)
         XCTAssertNil(row)
     }
@@ -742,7 +742,7 @@ final class OrderDetailsDataSourceTests: XCTestCase {
         dataSource.reloadSections()
 
         // Then
-        let attributionSection = try section(withTitle: Title.orderInformation, from: dataSource)
+        let attributionSection = try section(withTitle: Title.orderAttribution, from: dataSource)
         let row = row(row: .attributionCampaign, in: attributionSection)
         XCTAssertNotNil(row)
     }
@@ -756,7 +756,7 @@ final class OrderDetailsDataSourceTests: XCTestCase {
         dataSource.reloadSections()
 
         // Then
-        let attributionSection = try section(withTitle: Title.orderInformation, from: dataSource)
+        let attributionSection = try section(withTitle: Title.orderAttribution, from: dataSource)
         let row = row(row: .attributionSource, in: attributionSection)
         XCTAssertNil(row)
     }
@@ -770,7 +770,7 @@ final class OrderDetailsDataSourceTests: XCTestCase {
         dataSource.reloadSections()
 
         // Then
-        let attributionSection = try section(withTitle: Title.orderInformation, from: dataSource)
+        let attributionSection = try section(withTitle: Title.orderAttribution, from: dataSource)
         let row = row(row: .attributionSource, in: attributionSection)
         XCTAssertNotNil(row)
     }
@@ -784,7 +784,7 @@ final class OrderDetailsDataSourceTests: XCTestCase {
         dataSource.reloadSections()
 
         // Then
-        let attributionSection = try section(withTitle: Title.orderInformation, from: dataSource)
+        let attributionSection = try section(withTitle: Title.orderAttribution, from: dataSource)
         let row = row(row: .attributionMedium, in: attributionSection)
         XCTAssertNil(row)
     }
@@ -798,7 +798,7 @@ final class OrderDetailsDataSourceTests: XCTestCase {
         dataSource.reloadSections()
 
         // Then
-        let attributionSection = try section(withTitle: Title.orderInformation, from: dataSource)
+        let attributionSection = try section(withTitle: Title.orderAttribution, from: dataSource)
         let row = row(row: .attributionMedium, in: attributionSection)
         XCTAssertNotNil(row)
     }
@@ -812,7 +812,7 @@ final class OrderDetailsDataSourceTests: XCTestCase {
         dataSource.reloadSections()
 
         // Then
-        let attributionSection = try section(withTitle: Title.orderInformation, from: dataSource)
+        let attributionSection = try section(withTitle: Title.orderAttribution, from: dataSource)
         let row = row(row: .attributionDeviceType, in: attributionSection)
         XCTAssertNil(row)
     }
@@ -826,7 +826,7 @@ final class OrderDetailsDataSourceTests: XCTestCase {
         dataSource.reloadSections()
 
         // Then
-        let attributionSection = try section(withTitle: Title.orderInformation, from: dataSource)
+        let attributionSection = try section(withTitle: Title.orderAttribution, from: dataSource)
         let row = row(row: .attributionDeviceType, in: attributionSection)
         XCTAssertNotNil(row)
     }
@@ -840,7 +840,7 @@ final class OrderDetailsDataSourceTests: XCTestCase {
         dataSource.reloadSections()
 
         // Then
-        let attributionSection = try section(withTitle: Title.orderInformation, from: dataSource)
+        let attributionSection = try section(withTitle: Title.orderAttribution, from: dataSource)
         let row = row(row: .attributionSessionPageViews, in: attributionSection)
         XCTAssertNil(row)
     }
@@ -854,7 +854,7 @@ final class OrderDetailsDataSourceTests: XCTestCase {
         dataSource.reloadSections()
 
         // Then
-        let attributionSection = try section(withTitle: Title.orderInformation, from: dataSource)
+        let attributionSection = try section(withTitle: Title.orderAttribution, from: dataSource)
         let row = row(row: .attributionSessionPageViews, in: attributionSection)
         XCTAssertNotNil(row)
     }

--- a/Yosemite/YosemiteTests/Stores/OrderStoreTests.swift
+++ b/Yosemite/YosemiteTests/Stores/OrderStoreTests.swift
@@ -1151,6 +1151,7 @@ final class OrderStoreTests: XCTestCase {
             "customer_note",
             "fee_lines",
             "line_items",
+            "meta_data",
             "shipping",
             "shipping_lines",
             "status"
@@ -1178,6 +1179,7 @@ final class OrderStoreTests: XCTestCase {
             "fee_lines",
             "gift_cards",
             "line_items",
+            "meta_data",
             "shipping",
             "shipping_lines",
             "status"


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #11964 
<!-- Id number of the GitHub issue this PR addresses. -->

## Description

The orders created from the `wp-admin` page are marked as `source_type` `admin` which lets us show the order source in the order attribution view. 

<img width="312" alt="image" src="https://github.com/woocommerce/woocommerce-ios/assets/524475/5857bc07-0682-40f9-845c-0e095f087a4a">


Similarly, this PR marks the orders created from the mobile app with `source_type` as `mobile_app`. Decision - Internal - p1707243205265609-slack-C06FSDTSN82


Changes
1. Send `meta_data` value in create order request . `source_type` as `mobile_app`
2. Handle the `mobile_app` source type and show the "Origin" value as "Mobile App" in the order detail screen.
3. Update section title as "ORDER ATTRIBUTION" to match web. 


Issue created to handle this new `mobile_app` source type in Web https://github.com/woocommerce/woocommerce/issues/44490

## Testing instructions
1. Create a JN site
2. Login into the app
4. Create a product
5. Create an order from the mobile app
6. Open the order detail screen
7. "ORDER ATTRIBUTION" section should show the following values.
<img width="320" alt="Screenshot 2024-02-09 at 9 45 01 AM" src="https://github.com/woocommerce/woocommerce-ios/assets/524475/278f0696-4aa1-4434-a5ca-e543c3f092e1">

If you have proxyman setup you can intercept the `/wc/v3/orders&_method=post` and validate that the `meta_data` field is added like below.
```
body={"fee_lines":[],"customer_id":0,"status":"pending","line_items":[],"coupon_lines":[],"meta_data":[{"id":0,"key":"_wc_order_attribution_source_type","value":"mobile_app"}],"customer_note":"","shipping_lines":[]}
```

## Screenshots

| Order from Web | Order from Mobile App |
|--------|--------|
| ![image](https://github.com/woocommerce/woocommerce-ios/assets/524475/640c8c22-e4b3-4b06-ad83-93c700dc8062) | ![image](https://github.com/woocommerce/woocommerce-ios/assets/524475/fcbcfdc5-b6fe-476b-8672-41d0770c0f39) | 

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.