### PR TITLE
Revert "[Performance] Include Blaze campaign syncing in waiting time tracker for app launch"

### DIFF
--- a/WooCommerce/Classes/Analytics/AppStartupWaitingTimeTracker.swift
+++ b/WooCommerce/Classes/Analytics/AppStartupWaitingTimeTracker.swift
@@ -13,7 +13,6 @@ class AppStartupWaitingTimeTracker: WaitingTimeTracker {
     enum StartupAction: CaseIterable {
         case syncDashboardStats
         case loadOnboardingTasks
-        case syncBlazeCampaigns
     }
 
     /// Represents all of the app startup actions waiting to be completed.

--- a/WooCommerce/Classes/ViewRelated/Dashboard/DashboardViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/DashboardViewModel.swift
@@ -34,7 +34,6 @@ final class DashboardViewModel {
     private let userDefaults: UserDefaults
     private let storeCreationProfilerUploadAnswersUseCase: StoreCreationProfilerUploadAnswersUseCaseProtocol
     private let themeInstaller: ThemeInstaller
-    private let startupWaitingTimeTracker: AppStartupWaitingTimeTracker
 
     var siteURLToShare: URL? {
         if let site = stores.sessionManager.defaultSite,
@@ -51,8 +50,7 @@ final class DashboardViewModel {
          analytics: Analytics = ServiceLocator.analytics,
          userDefaults: UserDefaults = .standard,
          storeCreationProfilerUploadAnswersUseCase: StoreCreationProfilerUploadAnswersUseCaseProtocol? = nil,
-         themeInstaller: ThemeInstaller = DefaultThemeInstaller(),
-         startupWaitingTimeTracker: AppStartupWaitingTimeTracker = ServiceLocator.startupWaitingTimeTracker) {
+         themeInstaller: ThemeInstaller = DefaultThemeInstaller()) {
         self.siteID = siteID
         self.stores = stores
         self.featureFlagService = featureFlags
@@ -64,7 +62,6 @@ final class DashboardViewModel {
         self.blazeCampaignDashboardViewModel = .init(siteID: siteID)
         self.storeCreationProfilerUploadAnswersUseCase = storeCreationProfilerUploadAnswersUseCase ?? StoreCreationProfilerUploadAnswersUseCase(siteID: siteID)
         self.themeInstaller = themeInstaller
-        self.startupWaitingTimeTracker = startupWaitingTimeTracker
         setupObserverForShowOnboarding()
         setupObserverForBlazeCampaignView()
         installPendingThemeIfNeeded()
@@ -86,7 +83,6 @@ final class DashboardViewModel {
     ///
     func reloadBlazeCampaignView() async {
         await blazeCampaignDashboardViewModel.reload()
-        startupWaitingTimeTracker.end(action: .syncBlazeCampaigns)
     }
 
     /// Syncs store stats for dashboard UI.

--- a/WooCommerce/WooCommerceTests/System/AppStartupWaitingTimeTrackerTests.swift
+++ b/WooCommerce/WooCommerceTests/System/AppStartupWaitingTimeTrackerTests.swift
@@ -29,7 +29,7 @@ final class AppStartupWaitingTimeTrackerTests: XCTestCase {
         XCTAssertEqual(analyticsProvider.receivedEvents.count, 0)
 
         // When all actions are ended
-        completeAllStartupActions()
+        tracker.end(action: .loadOnboardingTasks)
 
         // Then
         XCTAssertEqual(analyticsProvider.receivedEvents.count, 1)

--- a/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/DashboardViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/DashboardViewModelTests.swift
@@ -602,20 +602,6 @@ final class DashboardViewModelTests: XCTestCase {
         //  Then
         XCTAssertEqual(themeInstaller.installPendingThemeCalledForSiteID, sampleSiteID)
     }
-
-    // MARK: Blaze Campaigns
-    func test_it_tracks_end_of_blaze_campaign_sync_action_when_blaze_campaign_view_reloads() async {
-        // Given
-        let waitingTimeTracker = AppStartupWaitingTimeTracker()
-        let viewModel = DashboardViewModel(siteID: sampleSiteID, startupWaitingTimeTracker: waitingTimeTracker)
-        XCTAssertTrue(waitingTimeTracker.startupActionsPending.contains(.syncBlazeCampaigns))
-
-        // Then
-        await viewModel.reloadBlazeCampaignView()
-
-        // Then
-        XCTAssertFalse(waitingTimeTracker.startupActionsPending.contains(.syncBlazeCampaigns))
-    }
 }
 
 private extension DashboardViewModelTests {


### PR DESCRIPTION
Reverts: woocommerce/woocommerce-ios#11606
Closes: https://github.com/woocommerce/woocommerce-ios/issues/11962

## Why
We have a crash that looks like it's caused by a race condition when the array `AppStartupWaitingTimeTracker.startupActionsPending` is modified by different startup actions ending at the same time. I'll have a look at making this thread safe, and have that change reviewed, but in the meantime I will revert the change leading to the crash to prevent it affecting more users.

Note that this will affect the accuracy of our startup waiting time tracking (`application_opened_waiting_time_loaded`) until a solution is in place that tracks all actions that contribute to the perceived startup time.