### PR TITLE
[My store - Analytics] Add new enum case to handle custom date range

### DIFF
--- a/Networking/Networking/Model/Stats/StatGranularity.swift
+++ b/Networking/Networking/Model/Stats/StatGranularity.swift
@@ -4,8 +4,10 @@ import Codegen
 /// Represents data granularity for stats (e.g. day, week, month, year)
 ///
 public enum StatGranularity: String, Decodable, GeneratedFakeable {
+    case hour
     case day
     case week
     case month
+    case quarter
     case year
 }

--- a/Networking/Networking/Model/Stats/StatsGranularityV4.swift
+++ b/Networking/Networking/Model/Stats/StatsGranularityV4.swift
@@ -8,5 +8,6 @@ public enum StatsGranularityV4: String, Decodable, GeneratedFakeable {
     case daily = "day"
     case weekly = "week"
     case monthly = "month"
+    case quarterly = "quarter"
     case yearly = "year"
 }

--- a/WooCommerce/Classes/Analytics/WooAnalyticsEvent+Dashboard.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsEvent+Dashboard.swift
@@ -58,6 +58,9 @@ private extension StatsTimeRangeV4 {
             return "months"
         case .thisYear:
             return "years"
+        case .custom:
+            // TODO: 11935 Update analytics value
+            return "custom"
         }
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/Time Range/AnalyticsHubTimeRangeSelection.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/Time Range/AnalyticsHubTimeRangeSelection.swift
@@ -164,6 +164,8 @@ extension AnalyticsHubTimeRangeSelection {
                 self = .monthToDate
             case .thisYear:
                 self = .yearToDate
+            case .custom(let start, let end):
+                self = .custom(start: start, end: end)
             }
         }
     }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/MyStore/TopPerformerDataViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/MyStore/TopPerformerDataViewController.swift
@@ -59,6 +59,9 @@ final class TopPerformerDataViewController: UIViewController {
             return NSLocalizedString("This Month", comment: "Top Performers section title - this month")
         case .year:
             return NSLocalizedString("This Year", comment: "Top Performers section title - this year")
+        case .hour, .quarter:
+            // TODO: 11935 I think we should calculate this based on `timeRange: StatsTimeRangeV4`?
+            return NSLocalizedString("Custom", comment: "Top Performers section title - Custom")
         }
     }
 

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Stats v4/StatsTimeRangeBarViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Stats v4/StatsTimeRangeBarViewModel.swift
@@ -17,6 +17,12 @@ private extension StatsTimeRangeV4 {
             let endDateString = dateFormatter.string(from: endDate)
             let format = NSLocalizedString("%1$@ - %2$@", comment: "Displays a date range for a stats interval")
             return String.localizedStringWithFormat(format, startDateString, endDateString)
+        case .custom:
+            // TODO: 11935 Update label count
+            let startDateString = dateFormatter.string(from: startDate)
+            let endDateString = dateFormatter.string(from: endDate)
+            let format = NSLocalizedString("%1$@ - %2$@", comment: "Displays a date range for a stats interval")
+            return String.localizedStringWithFormat(format, startDateString, endDateString)
         }
     }
 
@@ -33,6 +39,9 @@ private extension StatsTimeRangeV4 {
             dateFormatter = DateFormatter.Charts.chartAxisFullMonthFormatter
         case .thisYear:
             dateFormatter = DateFormatter.Charts.chartAxisYearFormatter
+        case .custom:
+            // TODO: 11935 Set chart axis formatter based on interval
+            dateFormatter = DateFormatter.Charts.chartAxisYearFormatter
         }
         dateFormatter.timeZone = timezone
         return dateFormatter
@@ -48,6 +57,9 @@ private extension StatsTimeRangeV4 {
             dateFormatter = DateFormatter.Charts.chartAxisDayFormatter
         case .thisYear:
             dateFormatter = DateFormatter.Charts.chartAxisFullMonthFormatter
+        case .custom:
+            // TODO: 11935 Set chart axis formatter based on interval
+            dateFormatter = DateFormatter.Charts.chartAxisYearFormatter
         }
         dateFormatter.timeZone = timezone
         return dateFormatter

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Stats v4/StatsTimeRangeV4+UI.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Stats v4/StatsTimeRangeV4+UI.swift
@@ -12,6 +12,9 @@ extension StatsTimeRangeV4 {
             return 31
         case .thisYear:
             return 12
+        case .custom:
+            // TODO: 11935 Calculate number of intervals
+            return 7
         }
     }
 
@@ -26,6 +29,12 @@ extension StatsTimeRangeV4 {
             return NSLocalizedString("This Month", comment: "Tab selector title that shows the statistics for this month")
         case .thisYear:
             return NSLocalizedString("This Year", comment: "Tab selector title that shows the statistics for this year")
+        case .custom:
+            return NSLocalizedString(
+                "statsTimeRangeV4.tabTitle.custom",
+                value: "Custom Range",
+                comment: "Tab selector title that shows the statistics for today"
+            )
         }
     }
 
@@ -44,6 +53,8 @@ extension StatsTimeRangeV4 {
             return currentDate.endOfMonth(timezone: siteTimezone)!
         case .thisYear:
             return currentDate.endOfYear(timezone: siteTimezone)!
+        case .custom(_, let toDate):
+            return toDate.endOfDay(timezone: siteTimezone)
         }
     }
 
@@ -62,6 +73,8 @@ extension StatsTimeRangeV4 {
             return latestDate.startOfMonth(timezone: siteTimezone)!
         case .thisYear:
             return latestDate.startOfYear(timezone: siteTimezone)!
+        case .custom(let startDate, _):
+            return startDate.startOfDay(timezone: siteTimezone)
         }
     }
 
@@ -77,9 +90,9 @@ extension StatsTimeRangeV4 {
             dateFormatter = DateFormatter.Charts.chartAxisDayFormatter
         case .weekly:
             dateFormatter = DateFormatter.Charts.chartAxisDayFormatter
-        case .monthly:
+        case .monthly, .quarterly:
             dateFormatter = DateFormatter.Charts.chartAxisMonthFormatter
-        default:
+        case .yearly:
             fatalError("This case is not supported: \(intervalGranularity.rawValue)")
         }
         dateFormatter.timeZone = siteTimezone

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Stats v4/StoreStatsAndTopPerformersPeriodViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Stats v4/StoreStatsAndTopPerformersPeriodViewController.swift
@@ -48,6 +48,9 @@ final class StoreStatsAndTopPerformersPeriodViewController: UIViewController {
             return 60*60
         case .thisYear:
             return 60*60*12
+        case .custom:
+            // TODO: 11935 Specify refresh interval
+            return 60
         }
     }
 

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Stats v4/StoreStatsV4ChartAxisHelper.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Stats v4/StoreStatsV4ChartAxisHelper.swift
@@ -13,6 +13,9 @@ final class StoreStatsV4ChartAxisHelper {
             labelCount = 6
         case .thisWeek:
             labelCount = 7
+        case .custom:
+            // TODO: 11935 Update label count
+            labelCount = 5
         }
         return labelCount
     }

--- a/Yosemite/Yosemite/Model/Enums/StatsTimeRangeV4.swift
+++ b/Yosemite/Yosemite/Model/Enums/StatsTimeRangeV4.swift
@@ -1,3 +1,5 @@
+import Foundation
+
 /// Represents the time range for an Order Stats v4 model.
 /// This is a local property and not in the remote response.
 ///
@@ -5,11 +7,70 @@
 /// - thisWeek: daily data starting Sunday of this week until now.
 /// - thisMonth: daily data starting 1st of this month until now.
 /// - thisYear: monthly data starting January of this year until now.
-public enum StatsTimeRangeV4: String {
+/// - custom: Data for a custom range.
+public enum StatsTimeRangeV4 {
     case today
     case thisWeek
     case thisMonth
     case thisYear
+    case custom(from: Date, to: Date)
+}
+
+extension StatsTimeRangeV4: RawRepresentable, Hashable {
+
+    public init?(rawValue: String) {
+        switch rawValue {
+        case Value.today:
+            self = .today
+        case Value.thisWeek:
+            self = .thisWeek
+        case Value.thisMonth:
+            self = .thisMonth
+        case Value.thisYear:
+            self = .thisYear
+        default:
+            guard rawValue.starts(with: Value.custom) else {
+                return nil
+            }
+
+            let splits = rawValue.split(separator: "_")
+
+            guard let from = splits[safe: 1],
+                  let to = splits[safe: 2] else {
+                return nil
+            }
+
+            let dateFormatter = DateFormatter.Defaults.yearMonthDayDateFormatter
+            guard let fromDate = dateFormatter.date(from: String(from)),
+                  let toDate = dateFormatter.date(from: String(to)) else {
+                return nil
+            }
+
+            self = .custom(from: fromDate, to: toDate)
+        }
+    }
+
+    public var rawValue: String {
+        switch self {
+        case .today: return Value.today
+        case .thisWeek: return Value.thisWeek
+        case .thisMonth: return Value.thisMonth
+        case .thisYear: return Value.thisYear
+        case .custom(let from, let to):
+            let dateFormatter = DateFormatter.Defaults.yearMonthDayDateFormatter
+            return [Value.custom,
+                    dateFormatter.string(from: from),
+                    dateFormatter.string(from: to)].joined(separator: "_")
+        }
+    }
+
+    private enum Value {
+        static let today = "today"
+        static let thisWeek = "thisWeek"
+        static let thisMonth = "thisMonth"
+        static let thisYear = "thisYear"
+        static let custom = "custom"
+    }
 }
 
 extension StatsTimeRangeV4 {
@@ -24,6 +85,22 @@ extension StatsTimeRangeV4 {
             return .daily
         case .thisYear:
             return .monthly
+        case .custom(let from, let to):
+            guard let differenceInDays = StatsTimeRangeV4.differenceInDays(startDate: from, toDate: to) else {
+                return .hourly
+            }
+            switch differenceInDays {
+            case .lessThan1:
+                return .hourly
+            case .from1To28:
+                return .daily
+            case .from29To90:
+                return .weekly
+            case .from91to365:
+                return .monthly
+            case .greaterThanOrEqualTo365:
+                return .quarterly
+            }
         }
     }
 
@@ -34,6 +111,22 @@ extension StatsTimeRangeV4 {
             return .day
         case .thisYear:
             return .month
+        case .custom(let from, let to):
+            guard let differenceInDays = StatsTimeRangeV4.differenceInDays(startDate: from, toDate: to) else {
+                return .hour
+            }
+            switch differenceInDays {
+            case .lessThan1:
+                return .hour
+            case .from1To28:
+                return .day
+            case .from29To90:
+                return .week
+            case .from91to365:
+                return .month
+            case .greaterThanOrEqualTo365:
+                return .quarter
+            }
         }
     }
 
@@ -48,6 +141,22 @@ extension StatsTimeRangeV4 {
             return .month
         case .thisYear:
             return .year
+        case .custom(let from, let to):
+            guard let differenceInDays = StatsTimeRangeV4.differenceInDays(startDate: from, toDate: to) else {
+                return .hour
+            }
+            switch differenceInDays {
+            case .lessThan1:
+                return .hour
+            case .from1To28:
+                return .day
+            case .from29To90:
+                return .week
+            case .from91to365:
+                return .month
+            case .greaterThanOrEqualTo365:
+                return .quarter
+            }
         }
     }
 
@@ -62,6 +171,22 @@ extension StatsTimeRangeV4 {
             return .month
         case .thisYear:
             return .year
+        case .custom(let from, let to):
+            guard let differenceInDays = StatsTimeRangeV4.differenceInDays(startDate: from, toDate: to) else {
+                return .hour
+            }
+            switch differenceInDays {
+            case .lessThan1:
+                return .hour
+            case .from1To28:
+                return .day
+            case .from29To90:
+                return .week
+            case .from91to365:
+                return .month
+            case .greaterThanOrEqualTo365:
+                return .quarter
+            }
         }
     }
 
@@ -80,6 +205,46 @@ extension StatsTimeRangeV4 {
             return daysThisMonth?.count ?? 0
         case .thisYear:
             return 12
+        case .custom(let from, let to):
+            guard let differenceInDays = StatsTimeRangeV4.differenceInDays(startDate: from, toDate: to) else {
+                return 1
+            }
+            // TODO: 11935 Calculate interval units
+            return 1
+        }
+    }
+}
+
+private extension StatsTimeRangeV4 {
+    enum DifferenceInDays {
+        case greaterThanOrEqualTo365
+        case from91to365
+        case from29To90
+        case from1To28
+        case lessThan1
+    }
+
+    static func differenceInDays(startDate: Date, toDate: Date) -> DifferenceInDays? {
+        let components = [.day, .weekOfYear, .month] as Set<Calendar.Component>
+        let dateComponents = Calendar.current.dateComponents(components, from: startDate, to: toDate)
+
+        guard let day = dateComponents.day else {
+            return nil
+        }
+
+        switch day {
+        case 325...Int.max:
+            return .greaterThanOrEqualTo365
+        case 91...365:
+            return .from91to365
+        case 29...90:
+            return .from29To90
+        case 1...28:
+            return .from1To28
+        case 0:
+            return .lessThan1
+        default:
+            return nil
         }
     }
 }

--- a/Yosemite/Yosemite/Model/Enums/StatsTimeRangeV4.swift
+++ b/Yosemite/Yosemite/Model/Enums/StatsTimeRangeV4.swift
@@ -7,7 +7,7 @@ import Foundation
 /// - thisWeek: daily data starting Sunday of this week until now.
 /// - thisMonth: daily data starting 1st of this month until now.
 /// - thisYear: monthly data starting January of this year until now.
-/// - custom: Data for a custom range.
+/// - custom: Data for a custom date range.
 public enum StatsTimeRangeV4 {
     case today
     case thisWeek

--- a/Yosemite/Yosemite/Model/Enums/StatsTimeRangeV4.swift
+++ b/Yosemite/Yosemite/Model/Enums/StatsTimeRangeV4.swift
@@ -239,6 +239,12 @@ private extension StatsTimeRangeV4 {
         case lessThan1
     }
 
+    /// Based on WooCommerce Core
+    ///
+    /// https://github.com/woocommerce/woocommerce/blob/e863c02551e94d928d3873131ff2f4ab61d0ff66/packages/js/date/src/index.ts#L626
+    /// 
+    /// More details at pe5sF9-2ri-p2
+    ///
     static func differenceInDays(startDate: Date, toDate: Date) -> DifferenceInDays? {
         let components = [.day, .weekOfYear, .month] as Set<Calendar.Component>
         let dateComponents = Calendar.current.dateComponents(components, from: startDate, to: toDate)

--- a/Yosemite/Yosemite/Model/Enums/StatsTimeRangeV4.swift
+++ b/Yosemite/Yosemite/Model/Enums/StatsTimeRangeV4.swift
@@ -101,7 +101,7 @@ extension StatsTimeRangeV4 {
         case .thisYear:
             return .monthly
         case .custom(let from, let to):
-            guard let differenceInDays = StatsTimeRangeV4.differenceInDays(startDate: from, toDate: to) else {
+            guard let differenceInDays = StatsTimeRangeV4.differenceInDays(startDate: from, endDate: to) else {
                 return .hourly
             }
             switch differenceInDays {
@@ -127,7 +127,7 @@ extension StatsTimeRangeV4 {
         case .thisYear:
             return .month
         case .custom(let from, let to):
-            guard let differenceInDays = StatsTimeRangeV4.differenceInDays(startDate: from, toDate: to) else {
+            guard let differenceInDays = StatsTimeRangeV4.differenceInDays(startDate: from, endDate: to) else {
                 return .hour
             }
             switch differenceInDays {
@@ -187,7 +187,7 @@ extension StatsTimeRangeV4 {
         case .thisYear:
             return .year
         case .custom(let from, let to):
-            guard let differenceInDays = StatsTimeRangeV4.differenceInDays(startDate: from, toDate: to) else {
+            guard let differenceInDays = StatsTimeRangeV4.differenceInDays(startDate: from, endDate: to) else {
                 return .hour
             }
             switch differenceInDays {
@@ -220,10 +220,7 @@ extension StatsTimeRangeV4 {
             return daysThisMonth?.count ?? 0
         case .thisYear:
             return 12
-        case .custom(let from, let to):
-            guard let differenceInDays = StatsTimeRangeV4.differenceInDays(startDate: from, toDate: to) else {
-                return 1
-            }
+        case .custom:
             // TODO: 11935 Calculate interval units
             return 1
         }
@@ -245,9 +242,8 @@ private extension StatsTimeRangeV4 {
     /// 
     /// More details at pe5sF9-2ri-p2
     ///
-    static func differenceInDays(startDate: Date, toDate: Date) -> DifferenceInDays? {
-        let components = [.day, .weekOfYear, .month] as Set<Calendar.Component>
-        let dateComponents = Calendar.current.dateComponents(components, from: startDate, to: toDate)
+    static func differenceInDays(startDate: Date, endDate: Date) -> DifferenceInDays? {
+        let dateComponents = Calendar.current.dateComponents([.day], from: startDate, to: endDate)
 
         guard let day = dateComponents.day else {
             return nil

--- a/Yosemite/Yosemite/Model/Enums/StatsTimeRangeV4.swift
+++ b/Yosemite/Yosemite/Model/Enums/StatsTimeRangeV4.swift
@@ -113,7 +113,7 @@ extension StatsTimeRangeV4 {
                 return .weekly
             case .from91to365:
                 return .monthly
-            case .greaterThanOrEqualTo365:
+            case .greaterThan365:
                 return .quarterly
             }
         }
@@ -139,7 +139,7 @@ extension StatsTimeRangeV4 {
                 return .week
             case .from91to365:
                 return .month
-            case .greaterThanOrEqualTo365:
+            case .greaterThan365:
                 return .quarter
             }
         }
@@ -157,7 +157,7 @@ extension StatsTimeRangeV4 {
         case .thisYear:
             return .year
         case .custom(let from, let to):
-            guard let differenceInDays = StatsTimeRangeV4.differenceInDays(startDate: from, toDate: to) else {
+            guard let differenceInDays = StatsTimeRangeV4.differenceInDays(startDate: from, endDate: to) else {
                 return .hour
             }
             switch differenceInDays {
@@ -169,7 +169,7 @@ extension StatsTimeRangeV4 {
                 return .week
             case .from91to365:
                 return .month
-            case .greaterThanOrEqualTo365:
+            case .greaterThan365:
                 return .quarter
             }
         }
@@ -199,7 +199,7 @@ extension StatsTimeRangeV4 {
                 return .week
             case .from91to365:
                 return .month
-            case .greaterThanOrEqualTo365:
+            case .greaterThan365:
                 return .quarter
             }
         }
@@ -229,7 +229,7 @@ extension StatsTimeRangeV4 {
 
 private extension StatsTimeRangeV4 {
     enum DifferenceInDays {
-        case greaterThanOrEqualTo365
+        case greaterThan365
         case from91to365
         case from29To90
         case from1To28
@@ -250,8 +250,8 @@ private extension StatsTimeRangeV4 {
         }
 
         switch day {
-        case 325...Int.max:
-            return .greaterThanOrEqualTo365
+        case 366...Int.max:
+            return .greaterThan365
         case 91...365:
             return .from91to365
         case 29...90:

--- a/Yosemite/Yosemite/Model/Mocks/ActionHandlers/MockStatsActionV4Handler.swift
+++ b/Yosemite/Yosemite/Model/Mocks/ActionHandlers/MockStatsActionV4Handler.swift
@@ -33,6 +33,8 @@ struct MockStatsActionV4Handler: MockActionHandler {
                 onCompletion(.success(()))
             case .thisYear:
                 success(onCompletion)
+            case .custom(_, _):
+                success(onCompletion)
         }
     }
 
@@ -49,6 +51,8 @@ struct MockStatsActionV4Handler: MockActionHandler {
                 onCompletion(.success(()))
             case .thisYear:
                 success(onCompletion)
+            case .custom(_, _):
+                success(onCompletion)
         }
     }
 
@@ -64,6 +68,8 @@ struct MockStatsActionV4Handler: MockActionHandler {
             store.upsertStoredTopEarnerStats(readOnlyStats: objectGraph.thisMonthTopProducts)
             onCompletion(.success(objectGraph.thisMonthTopProducts))
         case .thisYear:
+            onCompletion(.success(objectGraph.thisMonthTopProducts))
+        case .custom(_, _):
             onCompletion(.success(objectGraph.thisMonthTopProducts))
         }
     }

--- a/Yosemite/Yosemite/Model/Mocks/MockObjectGraph.swift
+++ b/Yosemite/Yosemite/Model/Mocks/MockObjectGraph.swift
@@ -460,6 +460,7 @@ extension MockObjectGraph {
     static func createVisitStats(siteID: Int64, granularity: StatGranularity, items: [SiteVisitStatsItem]) -> SiteVisitStats {
 
         switch granularity {
+            case .hour: preconditionFailure("Not implemented")
             case .day: preconditionFailure("Not implemented")
             case .week: preconditionFailure("Not implemented")
             case .month:
@@ -469,6 +470,7 @@ extension MockObjectGraph {
                 granularity: .day,
                 items: items
             )
+            case .quarter: preconditionFailure("Not implemented")
             case .year: preconditionFailure("Not implemented")
         }
     }

--- a/Yosemite/Yosemite/Stores/StatsStoreV4.swift
+++ b/Yosemite/Yosemite/Stores/StatsStoreV4.swift
@@ -487,11 +487,17 @@ public extension StatsStoreV4 {
     ///
     static func buildDateString(from date: Date, with granularity: StatGranularity) -> String {
         switch granularity {
+        case .hour:
+            // TODO: 11935 Check and update date formatter
+            return DateFormatter.Defaults.dateTimeFormatter.string(from: date)
         case .day:
             return DateFormatter.Stats.statsDayFormatter.string(from: date)
         case .week:
             return DateFormatter.Stats.statsWeekFormatter.string(from: date)
         case .month:
+            return DateFormatter.Stats.statsMonthFormatter.string(from: date)
+        case .quarter:
+            // TODO: 11935 Check and update date formatter
             return DateFormatter.Stats.statsMonthFormatter.string(from: date)
         case .year:
             return DateFormatter.Stats.statsYearFormatter.string(from: date)

--- a/Yosemite/YosemiteTests/Model/Enums/StatsTimeRangeTests.swift
+++ b/Yosemite/YosemiteTests/Model/Enums/StatsTimeRangeTests.swift
@@ -1,7 +1,7 @@
 import XCTest
 @testable import Yosemite
 
-class StatsTimeRangeTests: XCTestCase {
+final class StatsTimeRangeTests: XCTestCase {
 
     func testVisitStatsQuantityOnFebInLeapYear() {
         // GMT: Saturday, February 1, 2020 12:29:29 AM
@@ -10,5 +10,43 @@ class StatsTimeRangeTests: XCTestCase {
         let quantity = StatsTimeRangeV4.thisMonth.siteVisitStatsQuantity(date: date,
                                                                          siteTimezone: timezone)
         XCTAssertEqual(quantity, 29)
+    }
+
+    // MARK: Custom range
+
+    func test_initializing_custom_range_from_rawValue() {
+        // Given
+
+        // GMT: Saturday, February 1, 2020 12:29:29 AM
+        let fromDate = Date(timeIntervalSince1970: 1580516969)
+        let fromDateString = DateFormatter.Defaults.yearMonthDayDateFormatter.string(from: fromDate)
+
+        // GMT: Tuesday, February 13, 2024 2:47:04 AM
+        let toDate = Date(timeIntervalSince1970: 1707792424)
+        let toDateString = DateFormatter.Defaults.yearMonthDayDateFormatter.string(from: toDate)
+
+        // When
+        let range = StatsTimeRangeV4(rawValue: "custom_\(fromDateString)_\(toDateString)")
+
+        // Then
+        XCTAssertEqual(range, .custom(from: fromDate, to: toDate))
+    }
+
+    func test_getting_rawValue_from_custom_range() {
+        // Given
+
+        // GMT: Saturday, February 1, 2020 12:29:29 AM
+        let fromDate = Date(timeIntervalSince1970: 1580516969)
+        let fromDateString = DateFormatter.Defaults.yearMonthDayDateFormatter.string(from: fromDate)
+
+        // GMT: Tuesday, February 13, 2024 2:47:04 AM
+        let toDate = Date(timeIntervalSince1970: 1707792424)
+        let toDateString = DateFormatter.Defaults.yearMonthDayDateFormatter.string(from: toDate)
+
+        // When
+        let range: StatsTimeRangeV4 = .custom(from: fromDate, to: toDate)
+
+        // Then
+        XCTAssertEqual(range.rawValue, "custom_\(fromDateString)_\(toDateString)")
     }
 }

--- a/Yosemite/YosemiteTests/Model/Enums/StatsTimeRangeTests.swift
+++ b/Yosemite/YosemiteTests/Model/Enums/StatsTimeRangeTests.swift
@@ -31,7 +31,7 @@ final class StatsTimeRangeTests: XCTestCase {
         // Given
         // GMT: Saturday, February 1, 2020 12:29:29 AM
         let fromDate = Date(timeIntervalSince1970: 1580516969)
-        let toDate = fromDate.addingDays(Int.random(in: 91...364))
+        let toDate = fromDate.addingDays(Int.random(in: 91...365))
 
         // When
         let range: StatsTimeRangeV4 = .custom(from: fromDate, to: toDate)
@@ -98,7 +98,7 @@ final class StatsTimeRangeTests: XCTestCase {
         // Given
         // GMT: Saturday, February 1, 2020 12:29:29 AM
         let fromDate = Date(timeIntervalSince1970: 1580516969)
-        let toDate = fromDate.addingDays(Int.random(in: 91...364))
+        let toDate = fromDate.addingDays(Int.random(in: 91...365))
 
         // When
         let range: StatsTimeRangeV4 = .custom(from: fromDate, to: toDate)
@@ -165,7 +165,7 @@ final class StatsTimeRangeTests: XCTestCase {
         // Given
         // GMT: Saturday, February 1, 2020 12:29:29 AM
         let fromDate = Date(timeIntervalSince1970: 1580516969)
-        let toDate = fromDate.addingDays(Int.random(in: 91...364))
+        let toDate = fromDate.addingDays(Int.random(in: 91...365))
 
         // When
         let range: StatsTimeRangeV4 = .custom(from: fromDate, to: toDate)
@@ -232,7 +232,7 @@ final class StatsTimeRangeTests: XCTestCase {
         // Given
         // GMT: Saturday, February 1, 2020 12:29:29 AM
         let fromDate = Date(timeIntervalSince1970: 1580516969)
-        let toDate = fromDate.addingDays(Int.random(in: 91...364))
+        let toDate = fromDate.addingDays(Int.random(in: 91...365))
 
         // When
         let range: StatsTimeRangeV4 = .custom(from: fromDate, to: toDate)

--- a/Yosemite/YosemiteTests/Model/Enums/StatsTimeRangeTests.swift
+++ b/Yosemite/YosemiteTests/Model/Enums/StatsTimeRangeTests.swift
@@ -12,6 +12,273 @@ final class StatsTimeRangeTests: XCTestCase {
         XCTAssertEqual(quantity, 29)
     }
 
+    // MARK: `intervalGranularity` for custom range
+
+    func test_intervalGranularity_for_dates_with_days_difference_greater_than_365() {
+        // Given
+        // GMT: Saturday, February 1, 2020 12:29:29 AM
+        let fromDate = Date(timeIntervalSince1970: 1580516969)
+        let toDate = fromDate.addingDays(366)
+
+        // When
+        let range: StatsTimeRangeV4 = .custom(from: fromDate, to: toDate)
+
+        // Then
+        XCTAssertEqual(range.intervalGranularity, .quarterly)
+    }
+
+    func test_intervalGranularity_for_dates_with_days_difference_from_91_to_365() {
+        // Given
+        // GMT: Saturday, February 1, 2020 12:29:29 AM
+        let fromDate = Date(timeIntervalSince1970: 1580516969)
+        let toDate = fromDate.addingDays(Int.random(in: 91...364))
+
+        // When
+        let range: StatsTimeRangeV4 = .custom(from: fromDate, to: toDate)
+
+        // Then
+        XCTAssertEqual(range.intervalGranularity, .monthly)
+    }
+
+    func test_intervalGranularity_for_dates_with_days_difference_from_29_to_90() {
+        // Given
+        // GMT: Saturday, February 1, 2020 12:29:29 AM
+        let fromDate = Date(timeIntervalSince1970: 1580516969)
+        let toDate = fromDate.addingDays(Int.random(in: 29...90))
+
+        // When
+        let range: StatsTimeRangeV4 = .custom(from: fromDate, to: toDate)
+
+        // Then
+        XCTAssertEqual(range.intervalGranularity, .weekly)
+    }
+
+    func test_intervalGranularity_for_dates_with_days_difference_from_1_to_28() {
+        // Given
+        // GMT: Saturday, February 1, 2020 12:29:29 AM
+        let fromDate = Date(timeIntervalSince1970: 1580516969)
+        let toDate = fromDate.addingDays(Int.random(in: 1...28))
+
+        // When
+        let range: StatsTimeRangeV4 = .custom(from: fromDate, to: toDate)
+
+        // Then
+        XCTAssertEqual(range.intervalGranularity, .daily)
+    }
+
+    func test_intervalGranularity_for_dates_with_days_difference_less_than_1() {
+        // Given
+        // GMT: Saturday, February 1, 2020 12:29:29 AM
+        let fromDate = Date(timeIntervalSince1970: 1580516969)
+        let toDate = fromDate.addingDays(0)
+
+        // When
+        let range: StatsTimeRangeV4 = .custom(from: fromDate, to: toDate)
+
+        // Then
+        XCTAssertEqual(range.intervalGranularity, .hourly)
+    }
+
+    // MARK: `siteVisitStatsGranularity` for custom range
+
+    func test_siteVisitStatsGranularity_for_dates_with_days_difference_greater_than_365() {
+        // Given
+        // GMT: Saturday, February 1, 2020 12:29:29 AM
+        let fromDate = Date(timeIntervalSince1970: 1580516969)
+        let toDate = fromDate.addingDays(366)
+
+        // When
+        let range: StatsTimeRangeV4 = .custom(from: fromDate, to: toDate)
+
+        // Then
+        XCTAssertEqual(range.siteVisitStatsGranularity, .quarter)
+    }
+
+    func test_siteVisitStatsGranularity_for_dates_with_days_difference_from_91_to_365() {
+        // Given
+        // GMT: Saturday, February 1, 2020 12:29:29 AM
+        let fromDate = Date(timeIntervalSince1970: 1580516969)
+        let toDate = fromDate.addingDays(Int.random(in: 91...364))
+
+        // When
+        let range: StatsTimeRangeV4 = .custom(from: fromDate, to: toDate)
+
+        // Then
+        XCTAssertEqual(range.siteVisitStatsGranularity, .month)
+    }
+
+    func test_siteVisitStatsGranularity_for_dates_with_days_difference_from_29_to_90() {
+        // Given
+        // GMT: Saturday, February 1, 2020 12:29:29 AM
+        let fromDate = Date(timeIntervalSince1970: 1580516969)
+        let toDate = fromDate.addingDays(Int.random(in: 29...90))
+
+        // When
+        let range: StatsTimeRangeV4 = .custom(from: fromDate, to: toDate)
+
+        // Then
+        XCTAssertEqual(range.siteVisitStatsGranularity, .week)
+    }
+
+    func test_siteVisitStatsGranularity_for_dates_with_days_difference_from_1_to_28() {
+        // Given
+        // GMT: Saturday, February 1, 2020 12:29:29 AM
+        let fromDate = Date(timeIntervalSince1970: 1580516969)
+        let toDate = fromDate.addingDays(Int.random(in: 1...28))
+
+        // When
+        let range: StatsTimeRangeV4 = .custom(from: fromDate, to: toDate)
+
+        // Then
+        XCTAssertEqual(range.siteVisitStatsGranularity, .day)
+    }
+
+    func test_siteVisitStatsGranularity_for_dates_with_days_difference_less_than_1() {
+        // Given
+        // GMT: Saturday, February 1, 2020 12:29:29 AM
+        let fromDate = Date(timeIntervalSince1970: 1580516969)
+        let toDate = fromDate.addingDays(0)
+
+        // When
+        let range: StatsTimeRangeV4 = .custom(from: fromDate, to: toDate)
+
+        // Then
+        XCTAssertEqual(range.siteVisitStatsGranularity, .hour)
+    }
+
+    // MARK: `topEarnerStatsGranularity` for custom range
+
+    func test_topEarnerStatsGranularity_for_dates_with_days_difference_greater_than_365() {
+        // Given
+        // GMT: Saturday, February 1, 2020 12:29:29 AM
+        let fromDate = Date(timeIntervalSince1970: 1580516969)
+        let toDate = fromDate.addingDays(366)
+
+        // When
+        let range: StatsTimeRangeV4 = .custom(from: fromDate, to: toDate)
+
+        // Then
+        XCTAssertEqual(range.topEarnerStatsGranularity, .quarter)
+    }
+
+    func test_topEarnerStatsGranularity_for_dates_with_days_difference_from_91_to_365() {
+        // Given
+        // GMT: Saturday, February 1, 2020 12:29:29 AM
+        let fromDate = Date(timeIntervalSince1970: 1580516969)
+        let toDate = fromDate.addingDays(Int.random(in: 91...364))
+
+        // When
+        let range: StatsTimeRangeV4 = .custom(from: fromDate, to: toDate)
+
+        // Then
+        XCTAssertEqual(range.topEarnerStatsGranularity, .month)
+    }
+
+    func test_topEarnerStatsGranularity_for_dates_with_days_difference_from_29_to_90() {
+        // Given
+        // GMT: Saturday, February 1, 2020 12:29:29 AM
+        let fromDate = Date(timeIntervalSince1970: 1580516969)
+        let toDate = fromDate.addingDays(Int.random(in: 29...90))
+
+        // When
+        let range: StatsTimeRangeV4 = .custom(from: fromDate, to: toDate)
+
+        // Then
+        XCTAssertEqual(range.topEarnerStatsGranularity, .week)
+    }
+
+    func test_topEarnerStatsGranularity_for_dates_with_days_difference_from_1_to_28() {
+        // Given
+        // GMT: Saturday, February 1, 2020 12:29:29 AM
+        let fromDate = Date(timeIntervalSince1970: 1580516969)
+        let toDate = fromDate.addingDays(Int.random(in: 1...28))
+
+        // When
+        let range: StatsTimeRangeV4 = .custom(from: fromDate, to: toDate)
+
+        // Then
+        XCTAssertEqual(range.topEarnerStatsGranularity, .day)
+    }
+
+    func test_topEarnerStatsGranularity_for_dates_with_days_difference_less_than_1() {
+        // Given
+        // GMT: Saturday, February 1, 2020 12:29:29 AM
+        let fromDate = Date(timeIntervalSince1970: 1580516969)
+        let toDate = fromDate.addingDays(0)
+
+        // When
+        let range: StatsTimeRangeV4 = .custom(from: fromDate, to: toDate)
+
+        // Then
+        XCTAssertEqual(range.topEarnerStatsGranularity, .hour)
+    }
+
+    // MARK: `summaryStatsGranularity` for custom range
+
+    func test_summaryStatsGranularity_for_dates_with_days_difference_greater_than_365() {
+        // Given
+        // GMT: Saturday, February 1, 2020 12:29:29 AM
+        let fromDate = Date(timeIntervalSince1970: 1580516969)
+        let toDate = fromDate.addingDays(366)
+
+        // When
+        let range: StatsTimeRangeV4 = .custom(from: fromDate, to: toDate)
+
+        // Then
+        XCTAssertEqual(range.summaryStatsGranularity, .quarter)
+    }
+
+    func test_summaryStatsGranularity_for_dates_with_days_difference_from_91_to_365() {
+        // Given
+        // GMT: Saturday, February 1, 2020 12:29:29 AM
+        let fromDate = Date(timeIntervalSince1970: 1580516969)
+        let toDate = fromDate.addingDays(Int.random(in: 91...364))
+
+        // When
+        let range: StatsTimeRangeV4 = .custom(from: fromDate, to: toDate)
+
+        // Then
+        XCTAssertEqual(range.summaryStatsGranularity, .month)
+    }
+
+    func test_summaryStatsGranularity_for_dates_with_days_difference_from_29_to_90() {
+        // Given
+        // GMT: Saturday, February 1, 2020 12:29:29 AM
+        let fromDate = Date(timeIntervalSince1970: 1580516969)
+        let toDate = fromDate.addingDays(Int.random(in: 29...90))
+
+        // When
+        let range: StatsTimeRangeV4 = .custom(from: fromDate, to: toDate)
+
+        // Then
+        XCTAssertEqual(range.summaryStatsGranularity, .week)
+    }
+
+    func test_summaryStatsGranularity_for_dates_with_days_difference_from_1_to_28() {
+        // Given
+        // GMT: Saturday, February 1, 2020 12:29:29 AM
+        let fromDate = Date(timeIntervalSince1970: 1580516969)
+        let toDate = fromDate.addingDays(Int.random(in: 1...28))
+
+        // When
+        let range: StatsTimeRangeV4 = .custom(from: fromDate, to: toDate)
+
+        // Then
+        XCTAssertEqual(range.summaryStatsGranularity, .day)
+    }
+
+    func test_summaryStatsGranularity_for_dates_with_days_difference_less_than_1() {
+        // Given
+        // GMT: Saturday, February 1, 2020 12:29:29 AM
+        let fromDate = Date(timeIntervalSince1970: 1580516969)
+        let toDate = fromDate.addingDays(0)
+
+        // When
+        let range: StatsTimeRangeV4 = .custom(from: fromDate, to: toDate)
+
+        // Then
+        XCTAssertEqual(range.summaryStatsGranularity, .hour)
+    }
     // MARK: Custom range
 
     func test_initializing_custom_range_from_rawValue() {


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of: #11973 
<!-- Id number of the GitHub issue this PR addresses. -->

## Description

Adds new enum cases to support the custom date range selection. 
This PR just adds the new case to unblock development for UI and API. We have added TODOs in order to update the code accordingly in future UI or API related PRs.

## Testing instructions
We need to test that analytics works as before.
1. Login into the app
2. In the "My Store" tab, ensure that the analytics section works data as before.
3. Switch between "Today", "This Week", "This Month", This Year" and tabs and UI works as before.
4. Tap on "See more", and the analytics detail screen should work as before.


## Screenshots
<!-- Include before and after images or gifs when appropriate. -->
![Simulator Screen Recording - iPhone 15 Pro Max - 2024-02-13 at 07 55 47](https://github.com/woocommerce/woocommerce-ios/assets/524475/5b2f5df3-05f7-4b5d-a6fe-49051a3309a5)


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
