### PR TITLE
My Store Analytics: Custom Range tab creation UI flow

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Dashboard/Stats v4/CustomRangeTabCreationCoordinator.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Stats v4/CustomRangeTabCreationCoordinator.swift
@@ -1,0 +1,33 @@
+import Foundation
+import UIKit
+
+/// Coordinates navigation into Custom Range tab creation from the Stats dashboard.
+final class CustomRangeTabCreationCoordinator: Coordinator {
+    let navigationController: UINavigationController
+
+    init(navigationController: UINavigationController) {
+        self.navigationController = navigationController
+    }
+
+    func start() {
+        presentDateRangePicker()
+    }
+}
+
+private extension CustomRangeTabCreationCoordinator {
+    func presentDateRangePicker() {
+        let controller = RangedDatePickerHostingController(datesFormatter: DatesFormatter()) { [weak self] _, _ in
+            guard let self else { return }
+            // TODO call function to handle range selection.
+        }
+        navigationController.present(controller, animated: true)
+    }
+
+    /// Specific `DatesFormatter` for the `RangedDatePicker` when presented in the analytics hub module.
+    ///
+    struct DatesFormatter: RangedDateTextFormatter {
+        func format(start: Date, end: Date) -> String {
+            start.formatAsRange(with: end, timezone: .current, calendar: Locale.current.calendar)
+        }
+    }
+}

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Stats v4/CustomRangeTabCreationCoordinator.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Stats v4/CustomRangeTabCreationCoordinator.swift
@@ -4,9 +4,11 @@ import UIKit
 /// Coordinates navigation into Custom Range tab creation from the Stats dashboard.
 final class CustomRangeTabCreationCoordinator: Coordinator {
     let navigationController: UINavigationController
+    private let onDateRangeSelected: (_ start: Date, _ end: Date) -> Void
 
-    init(navigationController: UINavigationController) {
+    init(navigationController: UINavigationController, onDateRangeSelected: @escaping (_ start: Date, _ end: Date) -> Void) {
         self.navigationController = navigationController
+        self.onDateRangeSelected = onDateRangeSelected
     }
 
     func start() {
@@ -16,9 +18,9 @@ final class CustomRangeTabCreationCoordinator: Coordinator {
 
 private extension CustomRangeTabCreationCoordinator {
     func presentDateRangePicker() {
-        let controller = RangedDatePickerHostingController(datesFormatter: DatesFormatter()) { [weak self] _, _ in
+        let controller = RangedDatePickerHostingController(datesFormatter: DatesFormatter()) { [weak self] start, end in
             guard let self else { return }
-            // TODO call function to handle range selection.
+            self.onDateRangeSelected(start, end)
         }
         navigationController.present(controller, animated: true)
     }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Stats v4/CustomRangeTabCreationCoordinator.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Stats v4/CustomRangeTabCreationCoordinator.swift
@@ -18,10 +18,15 @@ final class CustomRangeTabCreationCoordinator: Coordinator {
 
 private extension CustomRangeTabCreationCoordinator {
     func presentDateRangePicker() {
-        let controller = RangedDatePickerHostingController(datesFormatter: DatesFormatter()) { [weak self] start, end in
-            guard let self else { return }
-            self.onDateRangeSelected(start, end)
-        }
+        let controller = RangedDatePickerHostingController(
+            datesFormatter: DatesFormatter(),
+            applyButtonTitle: Localization.add,
+            datesSelected: { [weak self] start, end in
+                guard let self else { return }
+                self.onDateRangeSelected(start, end)
+            }
+        )
+
         navigationController.present(controller, animated: true)
     }
 
@@ -31,5 +36,17 @@ private extension CustomRangeTabCreationCoordinator {
         func format(start: Date, end: Date) -> String {
             start.formatAsRange(with: end, timezone: .current, calendar: Locale.current.calendar)
         }
+    }
+}
+
+// MARK: Constant
+
+private extension CustomRangeTabCreationCoordinator {
+    enum Localization {
+        static let add = NSLocalizedString(
+            "customRangeTabCreationCoordinator.add",
+            value: "Add",
+            comment: "Button in date range picker to add a Custom Range tab"
+        )
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Stats v4/CustomRangeTabCreationCoordinator.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Stats v4/CustomRangeTabCreationCoordinator.swift
@@ -20,7 +20,7 @@ private extension CustomRangeTabCreationCoordinator {
     func presentDateRangePicker() {
         let controller = RangedDatePickerHostingController(
             datesFormatter: DatesFormatter(),
-            applyButtonTitle: Localization.add,
+            customApplyButtonTitle: Localization.add,
             datesSelected: { [weak self] start, end in
                 guard let self else { return }
                 self.onDateRangeSelected(start, end)

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Stats v4/StoreStatsAndTopPerformersViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Stats v4/StoreStatsAndTopPerformersViewController.swift
@@ -14,6 +14,8 @@ final class StoreStatsAndTopPerformersViewController: TabbedViewController {
 
     var onPullToRefresh: @MainActor () async -> Void = {}
 
+    private var customRangeCoordinator: CustomRangeTabCreationCoordinator?
+
     // MARK: - Subviews
 
     private lazy var buttonBarBottomBorder: UIView = {
@@ -25,7 +27,6 @@ final class StoreStatsAndTopPerformersViewController: TabbedViewController {
     private var visibleChildViewController: StoreStatsAndTopPerformersPeriodViewController {
         return periodVCs[selection]
     }
-
     // MARK: - Private Properties
 
     private let periodVCs: [StoreStatsAndTopPerformersPeriodViewController]
@@ -437,11 +438,19 @@ private extension StoreStatsAndTopPerformersViewController {
     }
 
     func startCustomRangeTabCreation() {
-        guard let navigationController else {
-            return
-        }
-        let coordinator = CustomRangeTabCreationCoordinator(navigationController: navigationController)
-        coordinator.start()
+        guard let navigationController else { return }
+        customRangeCoordinator = CustomRangeTabCreationCoordinator(
+            navigationController: navigationController,
+            onDateRangeSelected: { [weak self] start, end in
+                self?.createCustomRangeTab(start, end)
+            }
+        )
+        customRangeCoordinator?.start()
+    }
+
+    func createCustomRangeTab(_ start: Date, _ end: Date) {
+        // todo
+        print(start.description + end.description)
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Stats v4/StoreStatsAndTopPerformersViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Stats v4/StoreStatsAndTopPerformersViewController.swift
@@ -113,7 +113,9 @@ final class StoreStatsAndTopPerformersViewController: TabbedViewController {
         super.viewWillAppear(animated)
         ensureGhostContentIsAnimated()
     }
+}
 
+private extension StoreStatsAndTopPerformersViewController {
     func observeSelectedTimeRangeIndex() {
         let timeRangeCount = timeRanges.count
         selectedTimeRangeIndexSubscription = $selectedTimeRangeIndex

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Stats v4/StoreStatsAndTopPerformersViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Stats v4/StoreStatsAndTopPerformersViewController.swift
@@ -27,6 +27,11 @@ final class StoreStatsAndTopPerformersViewController: TabbedViewController {
     private var visibleChildViewController: StoreStatsAndTopPerformersPeriodViewController {
         return periodVCs[selection]
     }
+
+    var timeRangeCount: Int {
+        return timeRanges.count
+    }
+
     // MARK: - Private Properties
 
     private var periodVCs: [StoreStatsAndTopPerformersPeriodViewController]
@@ -134,11 +139,10 @@ extension StoreStatsAndTopPerformersViewController: DashboardUI {
 //
 private extension StoreStatsAndTopPerformersViewController {
     func observeSelectedTimeRangeIndex() {
-        let timeRangeCount = timeRanges.count
         selectedTimeRangeIndexSubscription = $selectedTimeRangeIndex
             .compactMap { $0 }
             // It's possible to reach an out-of-bound index by swipe gesture, thus checking the index range here.
-            .filter { $0 >= 0 && $0 < timeRangeCount }
+            .filter { $0 >= 0 && $0 < self.timeRangeCount }
             .removeDuplicates()
             // Tapping to change to a farther tab could result in `updateIndicator` callback to be triggered for the middle tabs.
             // A short debounce workaround is applied here to avoid making API requests for the middle tabs.

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Stats v4/StoreStatsAndTopPerformersViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Stats v4/StoreStatsAndTopPerformersViewController.swift
@@ -463,7 +463,8 @@ private extension StoreStatsAndTopPerformersViewController {
 
         let customRangeTabbedItem = TabbedItem(title: range.tabTitle,
                                                viewController: customRangeVC,
-                                               accessibilityIdentifier: Constants.customRangeTabAcessibilityIdentifier)
+                                               accessibilityIdentifier: "period-data-" + range.rawValue + "-tab")
+
         appendToTabBar(customRangeTabbedItem)
 
         // Once a custom range tab is created, do not show the "Custom Range" button anymore.
@@ -551,6 +552,5 @@ private extension StoreStatsAndTopPerformersViewController {
 
     enum Constants {
         static let backgroundColor: UIColor = .systemBackground
-        static let customRangeTabAcessibilityIdentifier: String = "period-data-custom-tab"
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Stats v4/StoreStatsAndTopPerformersViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Stats v4/StoreStatsAndTopPerformersViewController.swift
@@ -459,9 +459,9 @@ private extension StoreStatsAndTopPerformersViewController {
                                                                            usageTracksEventEmitter: usageTracksEventEmitter)
         periodVCs.append(customRangeVC)
 
-        let customRangeTabbedItem = TabbedItem(title: "Custom Range",
+        let customRangeTabbedItem = TabbedItem(title: Localization.customRangeTabTitle,
                                                viewController: customRangeVC,
-                                               accessibilityIdentifier: "todo-identifier")
+                                               accessibilityIdentifier: Constants.customRangeTabAcessibilityIdentifier)
         appendToTabBar(customRangeTabbedItem)
         removeCustomViewFromTabBar()
     }
@@ -539,5 +539,14 @@ private extension StoreStatsAndTopPerformersViewController {
 
     enum Constants {
         static let backgroundColor: UIColor = .systemBackground
+        static let customRangeTabAcessibilityIdentifier: String = "period-data-custom-tab"
+    }
+
+    enum Localization {
+        static let customRangeTabTitle = NSLocalizedString(
+            "storeStatsAndTopPerformersViewController.customRangeTabTitle",
+            value: "Custom Range",
+            comment: "Title of the Custom Range tab"
+        )
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Stats v4/StoreStatsAndTopPerformersViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Stats v4/StoreStatsAndTopPerformersViewController.swift
@@ -454,10 +454,11 @@ private extension StoreStatsAndTopPerformersViewController {
 
     func createCustomRangeTab(_ start: Date, _ end: Date) {
         let currentDate = Date()
+        let range = StatsTimeRangeV4.custom(from: start, to: end)
 
         // TODO: 11935 Add the correct data fetching and displaying based on custom range.
         let customRangeVC = StoreStatsAndTopPerformersPeriodViewController(siteID: siteID,
-                                                                           timeRange: .custom(from: start, to: end),
+                                                                           timeRange: range,
                                                                            currentDate: currentDate,
                                                                            canDisplayInAppFeedbackCard: false,
                                                                            usageTracksEventEmitter: usageTracksEventEmitter)
@@ -465,7 +466,7 @@ private extension StoreStatsAndTopPerformersViewController {
         periodVCs.append(customRangeVC)
         timeRanges.append(.custom(from: start, to: end))
 
-        let customRangeTabbedItem = TabbedItem(title: Localization.customRangeTabTitle,
+        let customRangeTabbedItem = TabbedItem(title: range.tabTitle,
                                                viewController: customRangeVC,
                                                accessibilityIdentifier: Constants.customRangeTabAcessibilityIdentifier)
         appendToTabBar(customRangeTabbedItem)
@@ -474,7 +475,7 @@ private extension StoreStatsAndTopPerformersViewController {
         removeCustomViewFromTabBar()
 
         // Get stats data for this tab
-        self.syncStats(forced: false, viewControllerToSync: customRangeVC)
+        syncStats(forced: false, viewControllerToSync: customRangeVC)
 
         // Add pull to refresh functionality
         customRangeVC.onPullToRefresh = { [weak self] in
@@ -556,13 +557,5 @@ private extension StoreStatsAndTopPerformersViewController {
     enum Constants {
         static let backgroundColor: UIColor = .systemBackground
         static let customRangeTabAcessibilityIdentifier: String = "period-data-custom-tab"
-    }
-
-    enum Localization {
-        static let customRangeTabTitle = NSLocalizedString(
-            "storeStatsAndTopPerformersViewController.customRangeTabTitle",
-            value: "Custom Range",
-            comment: "Title of the Custom Range tab"
-        )
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Stats v4/StoreStatsAndTopPerformersViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Stats v4/StoreStatsAndTopPerformersViewController.swift
@@ -452,10 +452,9 @@ private extension StoreStatsAndTopPerformersViewController {
         print(start.description + end.description)
         let currentDate = Date()
 
-        // TODO: 11935 Replace with the correct tab content
-        // Currently this is just a dummy content
+        // TODO: 11935 Do actual data fetching and displaying.
         let customRangeVC = StoreStatsAndTopPerformersPeriodViewController(siteID: siteID,
-                                                                           timeRange: .thisMonth,
+                                                                           timeRange: .custom(from: start, to: end),
                                                                            currentDate: currentDate,
                                                                            canDisplayInAppFeedbackCard: true,
                                                                            usageTracksEventEmitter: usageTracksEventEmitter)

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Stats v4/StoreStatsAndTopPerformersViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Stats v4/StoreStatsAndTopPerformersViewController.swift
@@ -29,7 +29,7 @@ final class StoreStatsAndTopPerformersViewController: TabbedViewController {
     }
     // MARK: - Private Properties
 
-    private let periodVCs: [StoreStatsAndTopPerformersPeriodViewController]
+    private var periodVCs: [StoreStatsAndTopPerformersPeriodViewController]
     private let siteID: Int64
     // A set of syncing time ranges is tracked instead of a single boolean so that the stats for each time range
     // can be synced when swiping or tapping to change the time range tab before the syncing finishes for the previously selected tab.
@@ -449,8 +449,22 @@ private extension StoreStatsAndTopPerformersViewController {
     }
 
     func createCustomRangeTab(_ start: Date, _ end: Date) {
-        // todo
         print(start.description + end.description)
+        let currentDate = Date()
+
+        // todo replace with the correct tab content
+        let customRangeVC = StoreStatsAndTopPerformersPeriodViewController(siteID: siteID,
+                                                                           timeRange: .thisMonth,
+                                                                           currentDate: currentDate,
+                                                                           canDisplayInAppFeedbackCard: true,
+                                                                           usageTracksEventEmitter: usageTracksEventEmitter)
+        periodVCs.append(customRangeVC)
+
+        let customRangeTabbedItem = TabbedItem(title: "Custom Range",
+                                               viewController: customRangeVC,
+                                               accessibilityIdentifier: "todo-identifier")
+        appendTabToTabBar(customRangeTabbedItem)
+        removeCustomViewFromTabBar()
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Stats v4/StoreStatsAndTopPerformersViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Stats v4/StoreStatsAndTopPerformersViewController.swift
@@ -449,7 +449,6 @@ private extension StoreStatsAndTopPerformersViewController {
     }
 
     func createCustomRangeTab(_ start: Date, _ end: Date) {
-        print(start.description + end.description)
         let currentDate = Date()
 
         // TODO: 11935 Do actual data fetching and displaying.

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Stats v4/StoreStatsAndTopPerformersViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Stats v4/StoreStatsAndTopPerformersViewController.swift
@@ -452,7 +452,8 @@ private extension StoreStatsAndTopPerformersViewController {
         print(start.description + end.description)
         let currentDate = Date()
 
-        // todo replace with the correct tab content
+        // TODO: 11935 Replace with the correct tab content
+        // Currently this is just a dummy content
         let customRangeVC = StoreStatsAndTopPerformersPeriodViewController(siteID: siteID,
                                                                            timeRange: .thisMonth,
                                                                            currentDate: currentDate,

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Stats v4/StoreStatsAndTopPerformersViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Stats v4/StoreStatsAndTopPerformersViewController.swift
@@ -423,6 +423,10 @@ private extension StoreStatsAndTopPerformersViewController {
         button.frame = CGRect(origin: .zero, size: TabBar.customRangeButtonSize)
         button.backgroundColor = .listForeground(modal: false)
 
+        button.on(.touchUpInside) { [weak self] _ in
+            self?.startCustomRangeTabCreation()
+        }
+
         let separator = UIView()
         separator.heightAnchor.constraint(equalToConstant: TabBar.customRangeViewSeparator).isActive = true
         separator.backgroundColor = .systemColor(.separator)
@@ -430,6 +434,14 @@ private extension StoreStatsAndTopPerformersViewController {
         stackView.addArrangedSubview(button)
         stackView.addArrangedSubview(separator)
         return stackView
+    }
+
+    func startCustomRangeTabCreation() {
+        guard let navigationController else {
+            return
+        }
+        let coordinator = CustomRangeTabCreationCoordinator(navigationController: navigationController)
+        coordinator.start()
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Stats v4/StoreStatsAndTopPerformersViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Stats v4/StoreStatsAndTopPerformersViewController.swift
@@ -464,7 +464,7 @@ private extension StoreStatsAndTopPerformersViewController {
         let customRangeTabbedItem = TabbedItem(title: "Custom Range",
                                                viewController: customRangeVC,
                                                accessibilityIdentifier: "todo-identifier")
-        appendTabToTabBar(customRangeTabbedItem)
+        appendToTabBar(customRangeTabbedItem)
         removeCustomViewFromTabBar()
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Stats v4/StoreStatsAndTopPerformersViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Stats v4/StoreStatsAndTopPerformersViewController.swift
@@ -459,7 +459,7 @@ private extension StoreStatsAndTopPerformersViewController {
         let customRangeVC = StoreStatsAndTopPerformersPeriodViewController(siteID: siteID,
                                                                            timeRange: .custom(from: start, to: end),
                                                                            currentDate: currentDate,
-                                                                           canDisplayInAppFeedbackCard: true,
+                                                                           canDisplayInAppFeedbackCard: false,
                                                                            usageTracksEventEmitter: usageTracksEventEmitter)
 
         periodVCs.append(customRangeVC)

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Stats v4/StoreStatsAndTopPerformersViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Stats v4/StoreStatsAndTopPerformersViewController.swift
@@ -28,10 +28,6 @@ final class StoreStatsAndTopPerformersViewController: TabbedViewController {
         return periodVCs[selection]
     }
 
-    var timeRangeCount: Int {
-        return timeRanges.count
-    }
-
     // MARK: - Private Properties
 
     private var periodVCs: [StoreStatsAndTopPerformersPeriodViewController]
@@ -142,7 +138,7 @@ private extension StoreStatsAndTopPerformersViewController {
         selectedTimeRangeIndexSubscription = $selectedTimeRangeIndex
             .compactMap { $0 }
             // It's possible to reach an out-of-bound index by swipe gesture, thus checking the index range here.
-            .filter { $0 >= 0 && $0 < self.timeRangeCount }
+            .filter { $0 >= 0 && $0 < self.timeRanges.count }
             .removeDuplicates()
             // Tapping to change to a farther tab could result in `updateIndicator` callback to be triggered for the middle tabs.
             // A short debounce workaround is applied here to avoid making API requests for the middle tabs.
@@ -313,7 +309,6 @@ private extension StoreStatsAndTopPerformersViewController {
             }
         }
     }
-
 
     func observeRemotelyCreatedOrdersToResetLastSyncTimestamp() {
         let siteID = self.siteID

--- a/WooCommerce/Classes/ViewRelated/FilterTabBar/TabbedViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/FilterTabBar/TabbedViewController.swift
@@ -102,6 +102,7 @@ class TabbedViewController: UIViewController {
             return
         }
         tabBarStackView.removeArrangedSubview(customTabBarView)
+        customTabBarView.removeFromSuperview()
         self.customTabBarView = nil
     }
 

--- a/WooCommerce/Classes/ViewRelated/FilterTabBar/TabbedViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/FilterTabBar/TabbedViewController.swift
@@ -110,12 +110,14 @@ class TabbedViewController: UIViewController {
         // Setup child view controller
         items.append(tab)
         tabBar.items = items
-        configureChildViewControllers()
+        addChild(tab.viewController)
+        stackView.addArrangedSubview(tab.viewController.view)
+        tab.viewController.didMove(toParent: self)
 
-        // Setup selected position
+        // Set the appended tab as selected
         let tabPosition = items.count-1
-        updateVisibleChildViewController(at: tabPosition)
         selection = tabPosition
+        updateVisibleChildViewController(at: tabPosition)
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/FilterTabBar/TabbedViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/FilterTabBar/TabbedViewController.swift
@@ -23,7 +23,7 @@ class TabbedViewController: UIViewController {
         }
     }
 
-    private let items: [TabbedItem]
+    private var items: [TabbedItem]
     private let onDismiss: (() -> Void)?
 
     private var customTabBarView: UIView?
@@ -103,6 +103,18 @@ class TabbedViewController: UIViewController {
         }
         tabBarStackView.removeArrangedSubview(customTabBarView)
         self.customTabBarView = nil
+    }
+
+    func appendTabToTabBar(_ tab: TabbedItem) {
+        // Setup child view controller
+        items.append(tab)
+        tabBar.items = items
+        configureChildViewControllers()
+
+        // Setup selected position
+        let tabPosition = items.count-1
+        updateVisibleChildViewController(at: tabPosition)
+        selection = tabPosition
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/FilterTabBar/TabbedViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/FilterTabBar/TabbedViewController.swift
@@ -106,7 +106,7 @@ class TabbedViewController: UIViewController {
         self.customTabBarView = nil
     }
 
-    func appendTabToTabBar(_ tab: TabbedItem) {
+    func appendToTabBar(_ tab: TabbedItem) {
         // Setup child view controller
         items.append(tab)
         tabBar.items = items

--- a/WooCommerce/Classes/ViewRelated/FilterTabBar/TabbedViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/FilterTabBar/TabbedViewController.swift
@@ -113,6 +113,7 @@ class TabbedViewController: UIViewController {
         addChild(tab.viewController)
         stackView.addArrangedSubview(tab.viewController.view)
         tab.viewController.didMove(toParent: self)
+        tab.viewController.view.isHidden = true
 
         // Set the appended tab as selected
         let tabPosition = items.count-1

--- a/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/RangedDatePicker.swift
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/RangedDatePicker.swift
@@ -7,6 +7,25 @@ protocol RangedDateTextFormatter {
     func format(start: Date, end: Date) -> String
 }
 
+/// Hosting controller for `RangedDatePicker`
+///
+final class RangedDatePickerHostingController: UIHostingController<RangedDatePicker> {
+    init(startDate: Date? = nil,
+         endDate: Date? = nil,
+         datesFormatter: RangedDateTextFormatter,
+         datesSelected: ((_ start: Date, _ end: Date) -> Void)? = nil) {
+        super.init(rootView: RangedDatePicker(startDate: startDate,
+                                              endDate: endDate,
+                                              datesFormatter: datesFormatter,
+                                              datesSelected: datesSelected))
+    }
+
+    @available(*, unavailable)
+    required dynamic init?(coder aDecoder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+}
+
 /// View to select a custom date range.
 /// Consists of two date pickers laid out vertically.
 ///

--- a/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/RangedDatePicker.swift
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/RangedDatePicker.swift
@@ -13,16 +13,26 @@ final class RangedDatePickerHostingController: UIHostingController<RangedDatePic
     init(startDate: Date? = nil,
          endDate: Date? = nil,
          datesFormatter: RangedDateTextFormatter,
+         applyButtonTitle: String = Localization.apply,
          datesSelected: ((_ start: Date, _ end: Date) -> Void)? = nil) {
         super.init(rootView: RangedDatePicker(startDate: startDate,
                                               endDate: endDate,
                                               datesFormatter: datesFormatter,
+                                              applyButtonTitle: applyButtonTitle,
                                               datesSelected: datesSelected))
     }
 
     @available(*, unavailable)
     required dynamic init?(coder aDecoder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
+    }
+}
+
+// MARK: Constant
+
+private extension RangedDatePickerHostingController {
+    enum Localization {
+        static let apply = NSLocalizedString("Apply", comment: "Apply navigation button in custom range date picker")
     }
 }
 
@@ -49,16 +59,22 @@ struct RangedDatePicker: View {
     ///
     private let datesFormatter: RangedDateTextFormatter
 
+    /// Custom text for the confirm button
+    ///
+    private let applyButtonTitle: String
+
     /// Custom `init` to provide intial start and end dates.
     ///
     init(startDate: Date? = nil,
          endDate: Date? = nil,
          datesFormatter: RangedDateTextFormatter,
+         applyButtonTitle: String = Localization.apply,
          datesSelected: ((_ start: Date, _ end: Date) -> Void)? = nil) {
         self._startDate = State(initialValue: startDate ?? Date())
         self._endDate = State(initialValue: endDate ?? Date())
         self.datesFormatter = datesFormatter
         self.datesSelected = datesSelected
+        self.applyButtonTitle = applyButtonTitle
     }
 
     var body: some View {
@@ -109,7 +125,7 @@ struct RangedDatePicker: View {
                         presentation.wrappedValue.dismiss()
                         datesSelected?(startDate, endDate)
                     }, label: {
-                        Text(Localization.apply)
+                        Text(applyButtonTitle)
                     })
                 }
                 ToolbarItem(placement: .cancellationAction) {

--- a/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/RangedDatePicker.swift
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/RangedDatePicker.swift
@@ -13,12 +13,12 @@ final class RangedDatePickerHostingController: UIHostingController<RangedDatePic
     init(startDate: Date? = nil,
          endDate: Date? = nil,
          datesFormatter: RangedDateTextFormatter,
-         applyButtonTitle: String = Localization.apply,
+         customApplyButtonTitle: String? = nil,
          datesSelected: ((_ start: Date, _ end: Date) -> Void)? = nil) {
         super.init(rootView: RangedDatePicker(startDate: startDate,
                                               endDate: endDate,
                                               datesFormatter: datesFormatter,
-                                              applyButtonTitle: applyButtonTitle,
+                                              customApplyButtonTitle: customApplyButtonTitle,
                                               datesSelected: datesSelected))
     }
 
@@ -68,13 +68,13 @@ struct RangedDatePicker: View {
     init(startDate: Date? = nil,
          endDate: Date? = nil,
          datesFormatter: RangedDateTextFormatter,
-         applyButtonTitle: String = Localization.apply,
+         customApplyButtonTitle: String? = nil,
          datesSelected: ((_ start: Date, _ end: Date) -> Void)? = nil) {
         self._startDate = State(initialValue: startDate ?? Date())
         self._endDate = State(initialValue: endDate ?? Date())
         self.datesFormatter = datesFormatter
         self.datesSelected = datesSelected
-        self.applyButtonTitle = applyButtonTitle
+        self.applyButtonTitle = customApplyButtonTitle ?? Localization.apply
     }
 
     var body: some View {

--- a/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/RangedDatePicker.swift
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/RangedDatePicker.swift
@@ -28,14 +28,6 @@ final class RangedDatePickerHostingController: UIHostingController<RangedDatePic
     }
 }
 
-// MARK: Constant
-
-private extension RangedDatePickerHostingController {
-    enum Localization {
-        static let apply = NSLocalizedString("Apply", comment: "Apply navigation button in custom range date picker")
-    }
-}
-
 /// View to select a custom date range.
 /// Consists of two date pickers laid out vertically.
 ///

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -1502,6 +1502,7 @@
 		866016512B47F8F800B4047E /* ProductSelector+Blaze.swift in Sources */ = {isa = PBXBuildFile; fileRef = 866016502B47F8F800B4047E /* ProductSelector+Blaze.swift */; };
 		867644A62B55121A0044ACAA /* BlazeCampaignCreationCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 867644A52B55121A0044ACAA /* BlazeCampaignCreationCoordinator.swift */; };
 		867B330F2B4D39B900DCBEA6 /* BlazeAddParameterView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 867B330E2B4D39B900DCBEA6 /* BlazeAddParameterView.swift */; };
+		8687FF492B7A003400D06633 /* CustomRangeTabCreationCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8687FF482B7A003400D06633 /* CustomRangeTabCreationCoordinator.swift */; };
 		86967D812B4E21C600C20CA8 /* BlazeAddParameterViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 86967D802B4E21C600C20CA8 /* BlazeAddParameterViewModel.swift */; };
 		86967D832B4E3EC300C20CA8 /* BlazeAdUrlParameter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 86967D822B4E3EC300C20CA8 /* BlazeAdUrlParameter.swift */; };
 		8697AFBD2B60F56A00EFAF21 /* BlazeAdDestinationSettingViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8697AFBC2B60F56A00EFAF21 /* BlazeAdDestinationSettingViewModelTests.swift */; };
@@ -4173,6 +4174,7 @@
 		866016502B47F8F800B4047E /* ProductSelector+Blaze.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ProductSelector+Blaze.swift"; sourceTree = "<group>"; };
 		867644A52B55121A0044ACAA /* BlazeCampaignCreationCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BlazeCampaignCreationCoordinator.swift; sourceTree = "<group>"; };
 		867B330E2B4D39B900DCBEA6 /* BlazeAddParameterView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BlazeAddParameterView.swift; sourceTree = "<group>"; };
+		8687FF482B7A003400D06633 /* CustomRangeTabCreationCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomRangeTabCreationCoordinator.swift; sourceTree = "<group>"; };
 		86967D802B4E21C600C20CA8 /* BlazeAddParameterViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BlazeAddParameterViewModel.swift; sourceTree = "<group>"; };
 		86967D822B4E3EC300C20CA8 /* BlazeAdUrlParameter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BlazeAdUrlParameter.swift; sourceTree = "<group>"; };
 		8697AFBC2B60F56A00EFAF21 /* BlazeAdDestinationSettingViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BlazeAdDestinationSettingViewModelTests.swift; sourceTree = "<group>"; };
@@ -6370,6 +6372,7 @@
 				DEC6C51727466B59006832D3 /* StoreStatsEmptyView.swift */,
 				579CDEFE274D7E7900E8903D /* StoreStatsUsageTracksEventEmitter.swift */,
 				020624EF27951113000D024C /* StoreStatsDataOrRedactedView.swift */,
+				8687FF482B7A003400D06633 /* CustomRangeTabCreationCoordinator.swift */,
 			);
 			path = "Stats v4";
 			sourceTree = "<group>";
@@ -13079,6 +13082,7 @@
 				B65C869A2AA6429700464D5B /* SinglePackageHazmatDeclaration.swift in Sources */,
 				CCA1D5FE293F537400B40560 /* DeltaPercentage.swift in Sources */,
 				4569D3C325DC008700CDC3E2 /* SiteAddress.swift in Sources */,
+				8687FF492B7A003400D06633 /* CustomRangeTabCreationCoordinator.swift in Sources */,
 				02BBD6E729A268F300243BE2 /* StoreOnboardingViewModel.swift in Sources */,
 				B9B0391828A6838400DC1C83 /* PermanentNoticeView.swift in Sources */,
 				20BCF6EE2B0E478B00954840 /* WooPaymentsDepositsOverviewViewModel.swift in Sources */,

--- a/Yosemite/YosemiteTests/Model/Enums/StatsTimeRangeTests.swift
+++ b/Yosemite/YosemiteTests/Model/Enums/StatsTimeRangeTests.swift
@@ -31,7 +31,7 @@ final class StatsTimeRangeTests: XCTestCase {
         // Given
         // GMT: Saturday, February 1, 2020 12:29:29 AM
         let fromDate = Date(timeIntervalSince1970: 1580516969)
-        let toDate = fromDate.addingDays(Int.random(in: 91...364))
+        let toDate = fromDate.addingDays(Int.random(in: 91...365))
 
         // When
         let range: StatsTimeRangeV4 = .custom(from: fromDate, to: toDate)


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #11971 

Please do not merge until #11975 is merged first. 

<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

This adds the following flow:
1. Tapping the "Custom Range" button will open the date range picker,
2. Tapping "Add" in the date range picker will create a new tab called "Custom Range" at the end of the analytics tab (with some dummy content). This new tab should be in selected state.
3. Doing the above will also remove the "Custom Range" button.

Note that this is purely UI flow PR. It does not include:

1. The actual content for the "Custom Range" tab.
2. Persistence (e.g: if the app is restarted, "Custom Range" tab will disappear).

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
1. Run app,
3. Tap the Custom Range button on the analytics tab area (the "calendar +" icon)
4. Ensure date range picker is shown,
5. Play around to make sure date selection functionality is working, then tap "Add",
6. Ensure that you're returned to the analytics area, and a new tab called "Custom Range" is shown.
7. Ensure that the Custom Range button is no longer shown.

## Video
<!-- Include before and after images or gifs when appropriate. -->

https://github.com/woocommerce/woocommerce-ios/assets/266376/f3bb9a96-6171-40f8-a639-cf54f72b4d26


