### PR TITLE
[Tablet Orders] Render product selection text based on product selection count

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/OrderForm.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/OrderForm.swift
@@ -789,6 +789,7 @@ private extension ProductSelectorView.Configuration {
 
     static func splitViewAddProductToOrder() -> ProductSelectorView.Configuration {
         ProductSelectorView.Configuration(
+            productHeaderTextEnabled: true,
             searchHeaderBackgroundColor: .listBackground,
             prefersLargeTitle: false,
             doneButtonTitleSingularFormat: "",

--- a/WooCommerce/Classes/ViewRelated/Products/ProductSelector/ProductSelectorView.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductSelector/ProductSelectorView.swift
@@ -98,6 +98,8 @@ struct ProductSelectorView: View {
                         .padding(.trailing)
                         .renderedIf(searchHeaderisBeingEdited)
             HStack {
+                Text(viewModel.selectProductsTitle)
+                    .renderedIf(true) // TODO: Render on split view configuration
                 Button(Localization.clearSelection) {
                     viewModel.clearSelection()
                 }

--- a/WooCommerce/Classes/ViewRelated/Products/ProductSelector/ProductSelectorView.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductSelector/ProductSelectorView.swift
@@ -99,7 +99,9 @@ struct ProductSelectorView: View {
                         .renderedIf(searchHeaderisBeingEdited)
             HStack {
                 Text(viewModel.selectProductsTitle)
-                    .renderedIf(true) // TODO: Render on split view configuration
+                    .renderedIf(configuration.productHeaderTextEnabled)
+                    .fixedSize()
+                    .padding(.leading)
                 Button(Localization.clearSelection) {
                     viewModel.clearSelection()
                 }
@@ -294,6 +296,7 @@ extension ProductSelectorView {
         /// Otherwise, the product itself is selected immediately.
         var treatsAllProductsAsSimple: Bool = false
 
+        var productHeaderTextEnabled: Bool = false
         var searchHeaderBackgroundColor: UIColor = .listForeground(modal: false)
         var prefersLargeTitle: Bool = true
         var doneButtonTitleSingularFormat: String = ""

--- a/WooCommerce/Classes/ViewRelated/Products/ProductSelector/ProductSelectorViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductSelector/ProductSelectorViewModel.swift
@@ -841,17 +841,17 @@ private extension ProductSelectorViewModel {
         static let lastSoldProductsSectionTitle = NSLocalizedString("Last Sold", comment: "Section title for last sold products on the Select Product screen.")
         static let productsSectionTitle = NSLocalizedString("Products", comment: "Section title for products on the Select Product screen.")
         static let selectProductsTitle = NSLocalizedString(
-            "",
+            "productSelectorViewModel.selectProductsTitle.selectProductsTitle",
             value: "Select products",
-            comment: "")
+            comment: "Text on the header of the Select Product screen when no products are selected.")
         static let singularProductSelectedFormattedText = NSLocalizedString(
-            "",
+            "productSelectorViewModel.selectProductsTitle.singularProductSelectedFormattedText",
             value: "%ld product selected",
-            comment: "")
+            comment: "Text on the header of the Select Product screen when one product is selected.")
         static let pluralProductSelectedFormattedText = NSLocalizedString(
-            "",
+            "productSelectorViewModel.selectProductsTitle.pluralProductSelectedFormattedText",
             value: "%ld products selected",
-            comment: "")
+            comment: "Text on the header of the Select Product screen when more than one products are selected.")
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Products/ProductSelector/ProductSelectorViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductSelector/ProductSelectorViewModel.swift
@@ -80,6 +80,19 @@ final class ProductSelectorViewModel: ObservableObject {
     ///
     @Published var filterButtonTitle: String = Localization.filterButtonWithoutActiveFilters
 
+    /// Outputs a "x products selected" title in the header, based on the number of selected products in the order
+    ///
+    var selectProductsTitle: String {
+        if totalSelectedItemsCount == 0 {
+            return Localization.selectProductsTitle
+        } else {
+            let title = String.pluralize(totalSelectedItemsCount,
+                                         singular: Localization.singularProductSelectedFormattedText,
+                                         plural: Localization.pluralProductSelectedFormattedText)
+            return String.localizedStringWithFormat(title, totalSelectedItemsCount)
+        }
+    }
+
     /// Defines the current notice that should be shown.
     /// Defaults to `nil`.
     ///
@@ -827,6 +840,18 @@ private extension ProductSelectorViewModel {
         static let popularProductsSectionTitle = NSLocalizedString("Popular", comment: "Section title for popular products on the Select Product screen.")
         static let lastSoldProductsSectionTitle = NSLocalizedString("Last Sold", comment: "Section title for last sold products on the Select Product screen.")
         static let productsSectionTitle = NSLocalizedString("Products", comment: "Section title for products on the Select Product screen.")
+        static let selectProductsTitle = NSLocalizedString(
+            "",
+            value: "Select products",
+            comment: "")
+        static let singularProductSelectedFormattedText = NSLocalizedString(
+            "",
+            value: "%ld product selected",
+            comment: "")
+        static let pluralProductSelectedFormattedText = NSLocalizedString(
+            "",
+            value: "%ld products selected",
+            comment: "")
     }
 }
 

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/ProductSelectorViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/ProductSelectorViewModelTests.swift
@@ -44,6 +44,24 @@ final class ProductSelectorViewModelTests: XCTestCase {
         XCTAssertEqual(viewModel.totalSelectedItemsCount, 0)
     }
 
+    func test_selectProductsTitle_when_changeSelectionStateForProduct_then_updates_text_reflecting_number_of_products_selected() {
+        // Given
+        let product1 = Product.fake().copy(siteID: sampleSiteID, productID: 1, purchasable: true)
+        let product2 = Product.fake().copy(siteID: sampleSiteID, productID: 2, purchasable: true)
+        insert(product1)
+        insert(product2)
+        let viewModel = ProductSelectorViewModel(siteID: sampleSiteID,
+                                                 storageManager: storageManager)
+        // When, Then
+        assertEqual("Select products", viewModel.selectProductsTitle)
+
+        viewModel.changeSelectionStateForProduct(with: product1.productID)
+        assertEqual("1 product selected", viewModel.selectProductsTitle)
+
+        viewModel.changeSelectionStateForProduct(with: product2.productID)
+        assertEqual("2 products selected", viewModel.selectProductsTitle)
+    }
+
     func test_view_model_adds_product_rows() {
         // Given
         let product = Product.fake().copy(siteID: sampleSiteID, purchasable: true)


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #11846 

## Description
This PR updates the header on the product selection screen when we run the app on split view, in order to show the number of selected products.

<img width="481" alt="Screenshot 2024-02-13 at 15 11 15" src="https://github.com/woocommerce/woocommerce-ios/assets/3812076/c2d18584-c8c2-4e95-a324-0fbd63d20713">

## Changes
We pass a new `productHeaderTextEnabled` property to the split view configuration "file", so we're sure to only render the text when this is used. Defaults to `false` for all other configurations.

## Testing instructions
1. Enable the `. sideBySideViewForOrderForm` feature flag
2. Run the app on an iPad or other device where you can use split views
3. Go to Orders > Tap `+` to create a new order
4. Observe that there's a `Select products` text in the top left corner. Upon selecting products, variations, or clearing the selection the text will be updated accordingly to reflect the number of selected products:
- No products renders `Select products`
- 1 selected product renders ` 1 product selected`
- n selected product renders ` n products selected`
5. Confirm that this text only appears in the product selector through order creation flow by: Go to Menu > Coupons > Tap `+` > Tap `Percentage discount` > Tap `All products`. Observe that the product selector that appears here does not have the `Select products` text.

## Screenshots
![Simulator Screen Recording - iPad Pro (12 9-inch) (6th generation) - 2024-02-13 at 15 02 37](https://github.com/woocommerce/woocommerce-ios/assets/3812076/10558f76-679b-4511-9cc8-74afd0f676c2)
