### PR TITLE
In the initial products tab launch, the first product is shown in the secondary view but the row is selected later

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Products/ProductsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductsViewController.swift
@@ -244,6 +244,10 @@ final class ProductsViewController: UIViewController, GhostableViewController {
         showTopBannerViewIfNeeded()
         syncProductsSettings()
         observeSelectedProductAndDataLoadedStateToUpdateSelectedRow()
+
+        if !isEmpty {
+            tableView.selectRow(at: IndexPath(row: 0, section: 0), animated: true, scrollPosition: UITableView.ScrollPosition.none)
+        }
     }
 
     override func viewWillAppear(_ animated: Bool) {

--- a/WooCommerce/Classes/ViewRelated/Products/ProductsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductsViewController.swift
@@ -245,7 +245,7 @@ final class ProductsViewController: UIViewController, GhostableViewController {
         syncProductsSettings()
         observeSelectedProductAndDataLoadedStateToUpdateSelectedRow()
 
-        if !isEmpty {
+        if splitViewController?.isCollapsed == false, !isEmpty {
             tableView.selectRow(at: IndexPath(row: 0, section: 0), animated: true, scrollPosition: UITableView.ScrollPosition.none)
         }
     }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #11915
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
- Select first table view cell on `viewDidLoad`

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
- Make sure `splitViewInProductsTab` is turned on

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

![Simulator Screenshot - iPad Pro (11-inch) (4th generation) - 2024-02-16 at 11 19 15](https://github.com/woocommerce/woocommerce-ios/assets/6242034/365ededf-bb04-47c7-9274-6224e4e929ed)

---
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
