### PR TITLE
[Blaze] Way to retrieve `Media` of Product's image using ID

### DIFF
--- a/Networking/Networking.xcodeproj/project.pbxproj
+++ b/Networking/Networking.xcodeproj/project.pbxproj
@@ -1031,6 +1031,7 @@
 		EECB7EE8286555180028C888 /* media-update-product-id.json in Resources */ = {isa = PBXBuildFile; fileRef = EECB7EE7286555180028C888 /* media-update-product-id.json */; };
 		EECDBEDE296845F400293C4E /* RESTRequestConvertible.swift in Sources */ = {isa = PBXBuildFile; fileRef = EECDBEDD296845F400293C4E /* RESTRequestConvertible.swift */; };
 		EECDBEE029684AC500293C4E /* WordPressAPIVersionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EECDBEDF29684AC500293C4E /* WordPressAPIVersionTests.swift */; };
+		EEDADD282B7C6A5E00F7302B /* media.json in Resources */ = {isa = PBXBuildFile; fileRef = EEDADD272B7C6A5E00F7302B /* media.json */; };
 		EEE846A22A54745F005239B6 /* identify-language-success.json in Resources */ = {isa = PBXBuildFile; fileRef = EEE846A02A54745F005239B6 /* identify-language-success.json */; };
 		EEE846A32A54745F005239B6 /* identify-language-failure.json in Resources */ = {isa = PBXBuildFile; fileRef = EEE846A12A54745F005239B6 /* identify-language-failure.json */; };
 		EEFAA579295D2FC7003583BE /* RESTRequestTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EEFAA578295D2FC7003583BE /* RESTRequestTests.swift */; };
@@ -2103,6 +2104,7 @@
 		EECB7EE7286555180028C888 /* media-update-product-id.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "media-update-product-id.json"; sourceTree = "<group>"; };
 		EECDBEDD296845F400293C4E /* RESTRequestConvertible.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RESTRequestConvertible.swift; sourceTree = "<group>"; };
 		EECDBEDF29684AC500293C4E /* WordPressAPIVersionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WordPressAPIVersionTests.swift; sourceTree = "<group>"; };
+		EEDADD272B7C6A5E00F7302B /* media.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = media.json; sourceTree = "<group>"; };
 		EEE846A02A54745F005239B6 /* identify-language-success.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "identify-language-success.json"; sourceTree = "<group>"; };
 		EEE846A12A54745F005239B6 /* identify-language-failure.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "identify-language-failure.json"; sourceTree = "<group>"; };
 		EEFAA578295D2FC7003583BE /* RESTRequestTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RESTRequestTests.swift; sourceTree = "<group>"; };
@@ -2856,6 +2858,7 @@
 				02EF1671292F0D1900D90AD6 /* load-plan-success.json */,
 				B505F6D420BEE4E600BB1B69 /* me.json */,
 				93D8BBFE226BC1DA00AD2EB3 /* me-settings.json */,
+				EEDADD272B7C6A5E00F7302B /* media.json */,
 				02F096C12406691100C0C1D5 /* media-library.json */,
 				02AF07EB27492FDD00B2D81E /* media-library-from-wordpress-site.json */,
 				EECB7EE7286555180028C888 /* media-update-product-id.json */,
@@ -3807,6 +3810,7 @@
 				EE28C7DB2AC17961004A69F4 /* generate-product-invalid-token.json in Resources */,
 				DEA493752B3997ED00EED015 /* blaze-target-locations.json in Resources */,
 				EE66BB062B29791500518DAF /* theme-activate-success.json in Resources */,
+				EEDADD282B7C6A5E00F7302B /* media.json in Resources */,
 				CE6B969A2A0BCD09003C4B27 /* order-with-bundled-line-items.json in Resources */,
 				3158FE6026129ADD00E566B9 /* wcpay-account-none.json in Resources */,
 				68BFF9042B6780AA00B15FF2 /* receipt.json in Resources */,

--- a/Networking/Networking/Remote/MediaRemote.swift
+++ b/Networking/Networking/Remote/MediaRemote.swift
@@ -2,6 +2,9 @@ import Foundation
 
 /// Protocol for `MediaRemote` mainly used for mocking.
 public protocol MediaRemoteProtocol {
+    func loadMedia(siteID: Int64,
+                   mediaID: Int64,
+                   completion: @escaping (Result<WordPressMedia, Error>) -> Void)
     func loadMediaLibrary(for siteID: Int64,
                           imagesOnly: Bool,
                           pageNumber: Int,
@@ -34,6 +37,36 @@ public protocol MediaRemoteProtocol {
 /// Media: Remote Endpoints
 ///
 public class MediaRemote: Remote, MediaRemoteProtocol {
+    /// Loads media from the site's WP Media library
+    /// API reference - https://developer.wordpress.org/rest-api/reference/media/#retrieve-a-media-item
+    /// 
+    /// - Parameters:
+    ///   - siteID: site ID for which to load Media
+    ///   - mediaID: ID of the Media to load
+    ///   - completion: Closure to be executed upon completion.
+    ///
+    public func loadMedia(siteID: Int64,
+                          mediaID: Int64,
+                          completion: @escaping (Result<WordPressMedia, Error>) -> Void) {
+        let parameters: [String: Any] = [
+            ParameterKey.fieldsWordPressSite: ParameterValue.wordPressMediaFields,
+        ].compactMapValues { $0 }
+
+        let path = "sites/\(siteID)/media/\(mediaID)"
+        do {
+            let request = try DotcomRequest(wordpressApiVersion: .wpMark2,
+                                            method: .get,
+                                            path: path,
+                                            parameters: parameters,
+                                            availableAsRESTRequest: true)
+            let mapper = WordPressMediaMapper()
+
+            enqueue(request, mapper: mapper, completion: completion)
+        } catch {
+            completion(.failure(error))
+        }
+    }
+
     /// Loads an array of media from the site's WP Media Library.
     /// API reference: https://developer.wordpress.com/docs/api/1.2/get/sites/%24site/media/
     ///

--- a/Networking/NetworkingTests/Responses/media.json
+++ b/Networking/NetworkingTests/Responses/media.json
@@ -1,0 +1,132 @@
+{
+    "id": 22,
+    "date_gmt": "2021-11-22T01:55:57",
+    "slug": "img_0111-2",
+    "title": {
+        "rendered": "img_0111-2"
+    },
+    "alt_text": "Floral",
+    "mime_type": "image/jpeg",
+    "media_details": {
+        "width": 2560,
+        "height": 1920,
+        "file": "2021/11/img_0111-2-scaled.jpeg",
+        "sizes": {
+            "medium": {
+                "file": "img_0111-2-300x225.jpeg",
+                "width": 300,
+                "height": 225,
+                "mime_type": "image/jpeg",
+                "source_url": "https://ninja.media/wp-content/uploads/2021/11/img_0111-2-300x225.jpeg"
+            },
+            "large": {
+                "file": "img_0111-2-1024x768.jpeg",
+                "width": 1024,
+                "height": 768,
+                "mime_type": "image/jpeg",
+                "source_url": "https://ninja.media/wp-content/uploads/2021/11/img_0111-2-1024x768.jpeg"
+            },
+            "thumbnail": {
+                "file": "img_0111-2-150x150.jpeg",
+                "width": 150,
+                "height": 150,
+                "mime_type": "image/jpeg",
+                "source_url": "https://ninja.media/wp-content/uploads/2021/11/img_0111-2-150x150.jpeg"
+            },
+            "medium_large": {
+                "file": "img_0111-2-768x576.jpeg",
+                "width": 768,
+                "height": 576,
+                "mime_type": "image/jpeg",
+                "source_url": "https://ninja.media/wp-content/uploads/2021/11/img_0111-2-768x576.jpeg"
+            },
+            "1536x1536": {
+                "file": "img_0111-2-1536x1152.jpeg",
+                "width": 1536,
+                "height": 1152,
+                "mime_type": "image/jpeg",
+                "source_url": "https://ninja.media/wp-content/uploads/2021/11/img_0111-2-1536x1152.jpeg"
+            },
+            "2048x2048": {
+                "file": "img_0111-2-2048x1536.jpeg",
+                "width": 2048,
+                "height": 1536,
+                "mime_type": "image/jpeg",
+                "source_url": "https://ninja.media/wp-content/uploads/2021/11/img_0111-2-2048x1536.jpeg"
+            },
+            "post-thumbnail": {
+                "file": "img_0111-2-1568x1176.jpeg",
+                "width": 1568,
+                "height": 1176,
+                "mime_type": "image/jpeg",
+                "source_url": "https://ninja.media/wp-content/uploads/2021/11/img_0111-2-1568x1176.jpeg"
+            },
+            "woocommerce_thumbnail": {
+                "file": "img_0111-2-450x450.jpeg",
+                "width": 450,
+                "height": 450,
+                "uncropped": false,
+                "mime_type": "image/jpeg",
+                "source_url": "https://ninja.media/wp-content/uploads/2021/11/img_0111-2-450x450.jpeg"
+            },
+            "woocommerce_single": {
+                "file": "img_0111-2-600x450.jpeg",
+                "width": 600,
+                "height": 450,
+                "mime_type": "image/jpeg",
+                "source_url": "https://ninja.media/wp-content/uploads/2021/11/img_0111-2-600x450.jpeg"
+            },
+            "woocommerce_gallery_thumbnail": {
+                "file": "img_0111-2-100x100.jpeg",
+                "width": 100,
+                "height": 100,
+                "mime_type": "image/jpeg",
+                "source_url": "https://ninja.media/wp-content/uploads/2021/11/img_0111-2-100x100.jpeg"
+            },
+            "shop_catalog": {
+                "file": "img_0111-2-450x450.jpeg",
+                "width": 450,
+                "height": 450,
+                "mime_type": "image/jpeg",
+                "source_url": "https://ninja.media/wp-content/uploads/2021/11/img_0111-2-450x450.jpeg"
+            },
+            "shop_single": {
+                "file": "img_0111-2-600x450.jpeg",
+                "width": 600,
+                "height": 450,
+                "mime_type": "image/jpeg",
+                "source_url": "https://ninja.media/wp-content/uploads/2021/11/img_0111-2-600x450.jpeg"
+            },
+            "shop_thumbnail": {
+                "file": "img_0111-2-100x100.jpeg",
+                "width": 100,
+                "height": 100,
+                "mime_type": "image/jpeg",
+                "source_url": "https://ninja.media/wp-content/uploads/2021/11/img_0111-2-100x100.jpeg"
+            },
+            "full": {
+                "file": "img_0111-2-scaled.jpeg",
+                "width": 2560,
+                "height": 1920,
+                "mime_type": "image/jpeg",
+                "source_url": "https://ninja.media/wp-content/uploads/2021/11/img_0111-2-scaled.jpeg"
+            }
+        },
+        "image_meta": {
+            "aperture": "2.4",
+            "credit": "",
+            "camera": "iPhone X",
+            "caption": "",
+            "created_timestamp": "1522412059",
+            "copyright": "",
+            "focal_length": "6",
+            "iso": "16",
+            "shutter_speed": "0.0047846889952153",
+            "title": "",
+            "orientation": "1",
+            "keywords": []
+        },
+        "original_image": "img_0111-2.jpeg"
+    },
+    "source_url": "https://ninja.media/wp-content/uploads/2021/11/img_0111-2-scaled.jpeg"
+}

--- a/WooCommerce/WooCommerceTests/Mocks/MockMediaStoresManager.swift
+++ b/WooCommerce/WooCommerceTests/Mocks/MockMediaStoresManager.swift
@@ -26,6 +26,12 @@ final class MockMediaStoresManager: DefaultStoresManager {
 
     private func onMediaAction(action: MediaAction) {
         switch action {
+        case .retrieveMedia(_, _, let onCompletion):
+            guard let media = media else {
+                onCompletion(.failure(MediaActionError.unknown))
+                return
+            }
+            onCompletion(.success(media))
         case .uploadMedia(_, _, _, _, _, let onCompletion):
             guard let media = media else {
                 onCompletion(.failure(MediaActionError.unknown))

--- a/Yosemite/Yosemite/Actions/MediaAction.swift
+++ b/Yosemite/Yosemite/Actions/MediaAction.swift
@@ -3,6 +3,17 @@ import Foundation
 // MARK: - MediaAction: Defines media operations (supported by the MediaStore).
 //
 public enum MediaAction: Action {
+    /// Retrieves single Media item from the site's WP Media Library.
+    ///
+    /// - Parameters:
+    ///   - siteID: Site for which we'll load the media from.
+    ///   - mediaID: ID of Media to be retrieved
+    ///   - onCompletion: Closure to be executed upon completion.
+    ///
+    case retrieveMedia(siteID: Int64,
+                       mediaID: Int64,
+                       onCompletion: (Result<Media, Error>) -> Void)
+
     /// Retrieves media from the site's WP Media Library.
     ///
     /// - Parameters:

--- a/Yosemite/Yosemite/Stores/MediaStore.swift
+++ b/Yosemite/Yosemite/Stores/MediaStore.swift
@@ -51,6 +51,10 @@ public final class MediaStore: Store {
         }
 
         switch action {
+        case .retrieveMedia(let siteID,
+                            let mediaID,
+                            let onCompletion):
+            retrieveMedia(siteID: siteID, mediaID: mediaID, onCompletion: onCompletion)
         case let .retrieveMediaLibrary(siteID, imagesOnly, pageNumber, pageSize, onCompletion):
             retrieveMediaLibrary(siteID: siteID,
                                  imagesOnly: imagesOnly,
@@ -75,6 +79,21 @@ public final class MediaStore: Store {
 }
 
 private extension MediaStore {
+    /// Retrieves single Media item from the site's WP Media Library.
+    ///
+    /// - Parameters:
+    ///   - siteID: Site for which we'll load the media from.
+    ///   - mediaID: ID of Media to be retrieved
+    ///   - onCompletion: Closure to be executed upon completion.
+    ///
+    func retrieveMedia(siteID: Int64,
+                       mediaID: Int64,
+                       onCompletion: @escaping (Result<Media, Error>) -> Void) {
+        remote.loadMedia(siteID: siteID, mediaID: mediaID) { result in
+            onCompletion(result.map { $0.toMedia() })
+        }
+    }
+
     func retrieveMediaLibrary(siteID: Int64,
                               imagesOnly: Bool,
                               pageNumber: Int,


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of: #11984 
<!-- Id number of the GitHub issue this PR addresses. -->

## Description

To create a Blaze campaign we need the `mimeType` of a `ProductImage`. But [the ProductImage model](https://github.com/woocommerce/woocommerce-ios/blob/trunk/Networking/Networking/Model/Product/ProductImage.swift) doesn't provide a way to get `mimeType`. 

To get the `mimeType` of a `ProductImage` we need to get the corresponding `Media` of the product image using [this WordPress endpoint](https://developer.wordpress.org/rest-api/reference/media/#retrieve-a-media-item).

This PR adds a way to get a site's `Media` using media ID. In a future PR, we will use this new `MediaAction` to get a product image's `Media` using the product image's `imageID`. 

Internal - p1707828165902379-slack-C03L1NF1EA3

## Testing instructions
CI passing should be enough.

## Screenshots
NA

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.