### PR TITLE
[Tablet Orders] Load product selector configuration based on size class

### DIFF
--- a/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/AdaptiveModalContainer.swift
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/AdaptiveModalContainer.swift
@@ -18,13 +18,22 @@ struct AdaptiveModalContainer<PrimaryView: View, SecondaryView: View>: View {
     @ViewBuilder let primaryView: (_ presentSecondaryView: (() -> Void)?) -> PrimaryView
     @ViewBuilder let secondaryView: (_ isPresented: Binding<Bool>) -> SecondaryView
 
+    /// Callback to notify of `UserInterfaceSizeClass` changes as soon as one of the views is rendered
+    var onSizeClassChange: ((UserInterfaceSizeClass?) -> Void)
+
     var body: some View {
         if horizontalSizeClass == .compact {
             ModalOnModalView(primaryView: primaryView, secondaryView: secondaryView)
                 .environment(\.adaptiveModalContainerPresentationStyle, .modalOnModal)
+                .onAppear {
+                    onSizeClassChange(horizontalSizeClass)
+                }
         } else {
             SideBySideView(primaryView: primaryView, secondaryView: secondaryView)
                 .environment(\.adaptiveModalContainerPresentationStyle, .sideBySide)
+                .onAppear {
+                    onSizeClassChange(horizontalSizeClass)
+                }
         }
     }
 


### PR DESCRIPTION
## Description

Closes #12012
Partially addresses https://github.com/woocommerce/woocommerce-ios/issues/11923

The current `OrderFormPresentationWrapper` only checks for feature flag when deciding which view we should render: Either the `AdaptiveModalContainer` if the feature flag is enabled, or the `OrderForm` if it's disabled

If the `AdaptiveModalContainer` is rendered, we always pass in the product selector configuration for split views, which will cause issues when the presented view is not a split view (eg: a regular iPhone in portrait mode) since will use the configuration details specific for split views. 

Examples of problems from using the incorrect configuration method:
* The text for the "done" button will not render, because there shouldn't be any text or button when using split views
* The top left corner shows "products selected" text, which only should happen on split views

| Incorrect configuration | Correct configuration |
|--------|--------|
| ![_20240214-bug](https://github.com/woocommerce/woocommerce-ios/assets/3812076/7cbaaa9b-9266-4d96-9a1d-8ca7bd5b2324) | ![_20240214-expected](https://github.com/woocommerce/woocommerce-ios/assets/3812076/7d4943f4-b696-45f3-a2df-271b160b5918) | 

The `AdaptiveModalContainer` view decides internally if should use either `ModalOnModalView` or `SideBySideView` based on the environment size class. This choice doesn't seem to be propagated to where we declare the `AdaptiveModalContainer`  (eg: using .onChange won't work, as won't be when a different view is used internally). The same applies to our custom `EnvironmentKey`, the notification doesn't seem to propagate as expected, which brings us to this alternative:

## Changes: 
- A callback is added to `AdaptiveModalContainer`, this closure will be invoked when either `ModalOnModalView` or `SideBySideView` appears as consequence of changes in the size class.
- This callback will trigger a state change in the `OrderFormPresentationWrapper`, which will either pass to the `ProductSelectorView` a `addProductToOrder` or `splitViewAddProductToOrder` configuration object, rendering the correct product selector view based on current class size.

| iPhone portrait | iPhone landscape |
|--------|--------|
| Cell | Cell |
![_20240214-fixed-compact](https://github.com/woocommerce/woocommerce-ios/assets/3812076/ddd219bc-3516-4b14-9cd0-68e4397a6553) | ![_20240214-fixed-iphone-landscape](https://github.com/woocommerce/woocommerce-ios/assets/3812076/7831d353-47e2-439e-8ffb-37b2a7d28bb8) |

| Tablet |
|--------|
| ![_20240214-fixed-tablet](https://github.com/woocommerce/woocommerce-ios/assets/3812076/88761bfa-a66c-4f1b-887d-7dc1bc289d41) |

## Caveats
Smaller devices that support split views (eg: iPhone 15 plus) might need further iteration, but this is outside of the scope of this PR.

## Testing instructions
- Enable the `sideBySideViewForOrderForm` feature flag
- Run the app on a device that does not support split views.
- Go to Orders > Tap `+` > Observe that the product selector view looks as the "iPhone portrait" screenshot above, that is: There's no text for "n selected products" in the upper left corner, and the button to complete the order renders adequately.
- Confirm portrait and landscape.
- Run the app on a tablet.
- Go to Orders > Tap `+` > Observe that the product selector has the "n selected products" in the upper left corner rather than a button.