### PR TITLE
[Blaze] Retrieve Media or Upload asset before submitting campaign

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Blaze/CampaignCreation/BlazeCampaignCreationForm.swift
+++ b/WooCommerce/Classes/ViewRelated/Blaze/CampaignCreation/BlazeCampaignCreationForm.swift
@@ -186,9 +186,11 @@ struct BlazeCampaignCreationForm: View {
         .task {
             await viewModel.onLoad()
         }
-        LazyNavigationLink(destination: BlazeConfirmPaymentView(viewModel: viewModel.confirmPaymentViewModel),
-                           isActive: $viewModel.isShowingPaymentInfo) {
-            EmptyView()
+        if let confirmPaymentViewModel = viewModel.confirmPaymentViewModel {
+            LazyNavigationLink(destination: BlazeConfirmPaymentView(viewModel: confirmPaymentViewModel),
+                               isActive: $viewModel.isShowingPaymentInfo) {
+                EmptyView()
+            }
         }
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Blaze/CampaignCreation/BlazeCampaignCreationFormViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Blaze/CampaignCreation/BlazeCampaignCreationFormViewModel.swift
@@ -107,11 +107,19 @@ final class BlazeCampaignCreationFormViewModel: ObservableObject {
         }
     }()
 
-    lazy private(set) var confirmPaymentViewModel: BlazeConfirmPaymentViewModel = {
-        BlazeConfirmPaymentViewModel(siteID: siteID, campaignInfo: campaignInfo, onCompletion: { [weak self] in
+    var confirmPaymentViewModel: BlazeConfirmPaymentViewModel? {
+        guard let image else {
+            DDLogError("Image is required to confirm payment and submit Blaze campaign.")
+            return nil
+        }
+        return BlazeConfirmPaymentViewModel(productID: productID,
+                                            siteID: siteID,
+                                            campaignInfo: campaignInfo,
+                                            image: image,
+                                            onCompletion: { [weak self] in
             self?.completionHandler()
         })
-    }()
+    }
 
     var adDestinationViewModel: BlazeAdDestinationSettingViewModel? {
         // Only create viewModel (and thus show the ad destination setting) if these two URLs exist.
@@ -193,7 +201,7 @@ final class BlazeCampaignCreationFormViewModel: ObservableObject {
                             textSnippet: description,
                             targetUrl: "", // TODO: update this
                             urlParams: "", // TODO: update this
-                            mainImage: CreateBlazeCampaign.Image(url: "", mimeType: ""), // TODO: update this
+                            mainImage: CreateBlazeCampaign.Image(url: "", mimeType: ""), // Image info will be added by `BlazeConfirmPaymentViewModel`.
                             targeting: targetOptions,
                             targetUrn: targetUrn,
                             type: Constants.campaignType)

--- a/WooCommerce/Classes/ViewRelated/Blaze/CampaignCreation/BlazeCampaignCreationFormViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Blaze/CampaignCreation/BlazeCampaignCreationFormViewModel.swift
@@ -109,7 +109,6 @@ final class BlazeCampaignCreationFormViewModel: ObservableObject {
 
     var confirmPaymentViewModel: BlazeConfirmPaymentViewModel? {
         guard let image else {
-            DDLogError("Image is required to confirm payment and submit Blaze campaign.")
             return nil
         }
         return BlazeConfirmPaymentViewModel(productID: productID,

--- a/WooCommerce/Classes/ViewRelated/Blaze/ConfirmPayment/BlazeCampaignCreationErrorView.swift
+++ b/WooCommerce/Classes/ViewRelated/Blaze/ConfirmPayment/BlazeCampaignCreationErrorView.swift
@@ -7,11 +7,14 @@ struct BlazeCampaignCreationErrorView: View {
 
     @State private var isShowingSupport = false
 
+    private let error: BlazeCampaignCreationError
     private let onTryAgain: () -> Void
     private let onCancel: () -> Void
 
-    init(onTryAgain: @escaping () -> Void,
+    init(error: BlazeCampaignCreationError,
+         onTryAgain: @escaping () -> Void,
          onCancel: @escaping () -> Void) {
+        self.error = error
         self.onTryAgain = onTryAgain
         self.onCancel = onCancel
     }
@@ -30,7 +33,7 @@ struct BlazeCampaignCreationErrorView: View {
                     .largeTitleStyle()
 
                 VStack(alignment: .leading, spacing: Layout.contentPadding) {
-                    Text(Localization.message)
+                    Text(error.message)
                         .bodyStyle()
 
                     Text(Localization.noPaymentTaken)
@@ -104,12 +107,6 @@ private extension BlazeCampaignCreationErrorView {
             value: "Error creating campaign",
             comment: "Title of the Blaze campaign creation error screen."
         )
-        static let message = NSLocalizedString(
-            "blazeCampaignCreationErrorView.message",
-            value: "Something's not quite right.\nWe couldn't create your campaign.",
-            comment: "Message on the Blaze campaign creation error screen. " +
-            "Keep '\n' as-is as it signals a line break."
-        )
         static let noPaymentTaken = NSLocalizedString(
             "blazeCampaignCreationErrorView.noPaymentTaken",
             value: "No payment has been taken.",
@@ -143,6 +140,54 @@ private extension BlazeCampaignCreationErrorView {
     }
 }
 
-#Preview {
-    BlazeCampaignCreationErrorView(onTryAgain: {}, onCancel: {})
+enum BlazeCampaignCreationError: Error {
+    case failedToFetchCampaignImage
+    case failedToUploadCampaignImage
+    case failedToCreateCampaign
+
+    var message: String {
+        switch self {
+        case .failedToFetchCampaignImage:
+            NSLocalizedString(
+                "blazeCampaignCreationError.failedToFetchCampaignImage",
+                value: "Failed to fetch campaign image details.",
+                comment: "Message on the Blaze campaign creation error screen."
+            )
+        case .failedToUploadCampaignImage:
+            NSLocalizedString(
+                "blazeCampaignCreationError.failedToUploadCampaignImage",
+                value: "Failed to upload campaign image.",
+                comment: "Message on the Blaze campaign creation error screen."
+            )
+        case .failedToCreateCampaign:
+            NSLocalizedString(
+                "blazeCampaignCreationError.failedToCreateCampaign",
+                value: "Something's not quite right.\nWe couldn't create your campaign.",
+                comment: "Message on the Blaze campaign creation error screen. " +
+                "Keep '\n' as-is as it signals a line break."
+            )
+        }
+    }
+}
+
+extension BlazeCampaignCreationError: Identifiable {
+    var id: Self { self }
+}
+
+#Preview("Failed to fetch campaign image") {
+    BlazeCampaignCreationErrorView(error: .failedToFetchCampaignImage,
+                                   onTryAgain: {},
+                                   onCancel: {})
+}
+
+#Preview("Failed to upload campaign image") {
+    BlazeCampaignCreationErrorView(error: .failedToUploadCampaignImage,
+                                   onTryAgain: {},
+                                   onCancel: {})
+}
+
+#Preview("Failed to create campaign") {
+    BlazeCampaignCreationErrorView(error: .failedToCreateCampaign,
+                                   onTryAgain: {},
+                                   onCancel: {})
 }

--- a/WooCommerce/Classes/ViewRelated/Blaze/ConfirmPayment/BlazeConfirmPaymentView.swift
+++ b/WooCommerce/Classes/ViewRelated/Blaze/ConfirmPayment/BlazeConfirmPaymentView.swift
@@ -1,4 +1,5 @@
 import SwiftUI
+import class Photos.PHAsset
 
 /// View to confirm the payment method before creating a Blaze campaign.
 struct BlazeConfirmPaymentView: View {
@@ -81,14 +82,15 @@ struct BlazeConfirmPaymentView: View {
             BlazeCampaignCreationLoadingView()
                 .interactiveDismissDisabled()
         }
-        .sheet(isPresented: $viewModel.shouldDisplayCampaignCreationError) {
-            BlazeCampaignCreationErrorView(onTryAgain: {
-                viewModel.shouldDisplayCampaignCreationError = false
+        .sheet(item: $viewModel.campaignCreationError) { error in
+            BlazeCampaignCreationErrorView(error: error,
+                                           onTryAgain: {
+                viewModel.campaignCreationError = nil
                 Task {
                     await viewModel.submitCampaign()
                 }
             }, onCancel: {
-                viewModel.shouldDisplayCampaignCreationError = false
+                viewModel.campaignCreationError = nil
                 dismiss()
             })
             .interactiveDismissDisabled()
@@ -309,6 +311,7 @@ private extension BlazeConfirmPaymentView {
 
 #Preview {
     BlazeConfirmPaymentView(viewModel: BlazeConfirmPaymentViewModel(
+        productID: 123,
         siteID: 123,
         campaignInfo: .init(origin: "test",
                             originVersion: "1.0",
@@ -325,5 +328,6 @@ private extension BlazeConfirmPaymentView {
                             targeting: nil,
                             targetUrn: "",
                             type: "product"),
+        image: .init(image: .iconBolt, source: .asset(asset: PHAsset())),
         onCompletion: {}))
 }

--- a/WooCommerce/Classes/ViewRelated/Blaze/ConfirmPayment/BlazeConfirmPaymentViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Blaze/ConfirmPayment/BlazeConfirmPaymentViewModel.swift
@@ -1,11 +1,14 @@
 import Foundation
 import Yosemite
+import class Photos.PHAsset
 
 /// View model for `BlazeConfirmPaymentView`
 final class BlazeConfirmPaymentViewModel: ObservableObject {
 
+    private let productID: Int64
     private let siteID: Int64
     private let campaignInfo: CreateBlazeCampaign
+    private let image: MediaPickerImage
     private let stores: StoresManager
     private let analytics: Analytics
     private let completionHandler: () -> Void
@@ -76,13 +79,17 @@ final class BlazeConfirmPaymentViewModel: ObservableObject {
 
     @Published var isCreatingCampaign = false
 
-    init(siteID: Int64,
+    init(productID: Int64,
+         siteID: Int64,
          campaignInfo: CreateBlazeCampaign,
+         image: MediaPickerImage,
          stores: StoresManager = ServiceLocator.stores,
          analytics: Analytics = ServiceLocator.analytics,
          onCompletion: @escaping () -> Void) {
+        self.productID = productID
         self.siteID = siteID
         self.campaignInfo = campaignInfo
+        self.image = image
         self.stores = stores
         self.analytics = analytics
         self.completionHandler = onCompletion

--- a/WooCommerce/Classes/ViewRelated/Blaze/ConfirmPayment/BlazeConfirmPaymentViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Blaze/ConfirmPayment/BlazeConfirmPaymentViewModel.swift
@@ -143,11 +143,10 @@ final class BlazeConfirmPaymentViewModel: ObservableObject {
                 }
             }
 
-            var updatedDetails = campaignInfo
-            // Set image URL and mimeType
-            updatedDetails = updatedDetails.copy(mainImage: .init(url: campaignMedia.src, mimeType: campaignMedia.mimeType))
-            // Set payment method ID
-            updatedDetails = updatedDetails.copy(paymentMethodID: selectedPaymentMethod.id)
+            // Set payment method ID, image URL and mimeType
+            let updatedDetails = campaignInfo
+                .copy(paymentMethodID: selectedPaymentMethod.id,
+                      mainImage: .init(url: campaignMedia.src, mimeType: campaignMedia.mimeType))
 
             do {
                 try await requestCampaignCreation(details: updatedDetails)

--- a/WooCommerce/Classes/ViewRelated/Blaze/ConfirmPayment/BlazeConfirmPaymentViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Blaze/ConfirmPayment/BlazeConfirmPaymentViewModel.swift
@@ -136,7 +136,7 @@ final class BlazeConfirmPaymentViewModel: ObservableObject {
                 campaignMedia = media
             case .productImage(let image):
                 do {
-                    campaignMedia = try await fetchMedia(mediaID: image.imageID)
+                    campaignMedia = try await retrieveMedia(mediaID: image.imageID)
                 } catch {
                     DDLogError("⛔️ Error fetching product image's Media: \(error)")
                     throw BlazeCampaignCreationError.failedToFetchCampaignImage
@@ -176,7 +176,7 @@ private extension BlazeConfirmPaymentViewModel {
     }
 
     @MainActor
-    func fetchMedia(mediaID: Int64) async throws -> Media {
+    func retrieveMedia(mediaID: Int64) async throws -> Media {
         try await withCheckedThrowingContinuation { continuation in
             stores.dispatch(MediaAction.retrieveMedia(siteID: siteID,
                                                       mediaID: mediaID,

--- a/WooCommerce/WooCommerceTests/ViewRelated/Blaze/BlazeConfirmPaymentViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Blaze/BlazeConfirmPaymentViewModelTests.swift
@@ -305,7 +305,7 @@ final class BlazeConfirmPaymentViewModelTests: XCTestCase {
         XCTAssertEqual(campaign.mainImage.mimeType, media.mimeType)
     }
 
-    func test_upload_image_is_retired_one_time_if_upload_fails() async throws {
+    func test_upload_image_is_retried_one_time_if_upload_fails() async throws {
         // Given
         let viewModel = BlazeConfirmPaymentViewModel(productID: sampleProductID,
                                                      siteID: sampleSiteID,

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/Media/ProductUIImageLoaderTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/Media/ProductUIImageLoaderTests.swift
@@ -97,7 +97,7 @@ final class ProductUIImageLoaderTests: XCTestCase {
                                         alt: nil)
 
         // When
-        let image = try await imageLoader.requestImage(productImage: productImage)
+        _ = try await imageLoader.requestImage(productImage: productImage)
 
         // Then
         XCTAssertTrue(mockImageService.downloadImageCalled)
@@ -120,7 +120,7 @@ final class ProductUIImageLoaderTests: XCTestCase {
                                         alt: nil)
 
         // When
-        let image = try await imageLoader.requestImage(productImage: productImage)
+        _ = try await imageLoader.requestImage(productImage: productImage)
 
         // Then
         XCTAssertFalse(mockImageService.downloadImageCalled)


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #11984
<!-- Id number of the GitHub issue this PR addresses. -->

## Description

This PR prepares the Blaze campaign image before sending a create campaign request.

Blaze campaign's image can come from the following sources,
1. The promoted product's image
3. From camera/device
4. From the WP Media library

This PR handles the above image types in the following ways,
1. The promoted product's image doesn't need to be uploaded. But, a `ProductImage` doesn't have a `mimeType` value. 
    - So, we send a separate API request to retrieve the corresponding `Media` from the WP Media library. The retrieved Media contains the `mimeType`. 
    - Internal - p1707828165902379-slack-C03L1NF1EA3
2. The image selected from the camera/device is uploaded before submitting the Blaze campaign. 
    - The upload request is tried once again upon failure as the image upload could fail due to network issues. 
    - Internal - p1707821290862699/1704188207.780169-slack-C03L1NF1EA3
3. The image selected from WP Media can be used directly. 

We have also started showing custom error messages for image-related failures. Internal - p1707896051842299-slack-C03L1NF1EA3

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

**Prerequisites**
- Create JN site with Woo and Jetpack
- Publish a product with an image
- Login into the app using the JN site

#### Using product image for campaign
- Open product details page and tap "Promote with Blaze" -> "Create Your Campaign"
- From the Blaze preview screen tap "Confirm Details"
- You will land on the "Payment" screen
- Tap "Submit Campaign"
- The campaign should be submitted successfully.

#### Using image from camera/device for campaign
- Open product details page and tap "Promote with Blaze" -> "Create Your Campaign"
- Tap "Edit ad" -> "Change image"
- Take a photo or choose an image from the device library
- From the Blaze preview screen tap "Confirm Details"
- You will land on the "Payment" screen
- Tap "Submit Campaign"
- The campaign should be submitted successfully
- Check that the selected image is added to your site's WP Media library from the `wp-admin` page

#### Using an image from the WP Media library
- Open product details page and tap "Promote with Blaze" -> "Create Your Campaign"
- Tap "Edit ad" -> "Change image"
- Tap "WordPress Media Library" and choose an image from your site's library
- From the Blaze preview screen tap "Confirm Details"
- You will land on the "Payment" screen
- Tap "Submit Campaign"
- The campaign should be submitted successfully

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

| Using product image for campaign | Using image from camera/device for campaign | Using an image from the WP Media library |
|--------|--------|--------|
| ![Simulator Screen Recording - iPhone 15 Pro Max - 2024-02-15 at 08 38 11](https://github.com/woocommerce/woocommerce-ios/assets/524475/028fbdf2-f279-4c88-95e1-5c6ce97251ce) | ![Simulator Screen Recording - iPhone 15 Pro Max - 2024-02-15 at 08 39 00](https://github.com/woocommerce/woocommerce-ios/assets/524475/27c18496-efe0-479f-b214-4beb08c63662) | ![Simulator Screen Recording - iPhone 15 Pro Max - 2024-02-15 at 08 40 02](https://github.com/woocommerce/woocommerce-ios/assets/524475/556ce811-11fd-4abd-b5e6-1900a6d76962) | 

#### Error messages
| Campaign creation failed  | Unable to load `ProductImage`'s `Media` | Upload image failed |
|--------|--------|--------|
| ![GenericError](https://github.com/woocommerce/woocommerce-ios/assets/524475/eee30781-d2e3-4875-b0f4-9818de6fab1a) | ![UnableToLoadMedia](https://github.com/woocommerce/woocommerce-ios/assets/524475/52a22dfb-3f39-4792-8bc5-b64a0ec14067) | ![UploadImage](https://github.com/woocommerce/woocommerce-ios/assets/524475/e4c17831-6a11-452e-a6f8-f56891bd332f) | 

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.