### PR TITLE
Blaze: Only force dismissing presented views before starting campaign creation

### DIFF
--- a/WooCommerce/Classes/Blaze/BlazeCampaignCreationCoordinator.swift
+++ b/WooCommerce/Classes/Blaze/BlazeCampaignCreationCoordinator.swift
@@ -100,8 +100,7 @@ private extension BlazeCampaignCreationCoordinator {
     }
 
     func startCreationFlow(from source: BlazeSource) {
-        /// Force dismissing any presented view to avoid issue presenting the creation flow.
-        navigationController.dismiss(animated: true) { [weak self] in
+        let navigationHandler = { [weak self] in
             guard let self else { return }
             switch blazeCreationEntryDestination {
             case .productSelector:
@@ -113,6 +112,13 @@ private extension BlazeCampaignCreationCoordinator {
             case .noProductAvailable:
                 presentNoProductAlert()
             }
+        }
+
+        /// Force dismissing any presented view to avoid issue presenting the creation flow.
+        if navigationController.presentedViewController != nil {
+            navigationController.dismiss(animated: true, completion: navigationHandler)
+        } else {
+             navigationHandler()
         }
     }
 


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #12015 
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
Before starting campaign creation, we are force-dismissing any presented view controller with `navigationController.dismiss`. This works for dismissing the intro modal, but there's an edge case when campaign creation is started from the product detail screen if that screen is opened from the My Store screen. In this case, calling `dismiss` will dismiss the whole navigation stack of product loader, and the navigation controller will then be deallocated which causes the navigation to Blaze campaign creation to fail.

This PR fixes this by checking for any presented view controller to dismiss instead of calling dismiss regardless.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

1. Place an order to your test store.
2. Log in to that store on the app and open the My Store tab.
3. Select any product on the product leaderboard and tap Promote on the presented detail screen.
4. Notice that the product detail screen is not dismissed, and the campaign creation flow is presented without any issue.

Please feel free to confirm that campaign creation is still presented properly if the intro screen is displayed. This can be tested by switching to a store without any campaign in the past.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

https://github.com/woocommerce/woocommerce-ios/assets/5533851/14d838ce-c47a-42ed-8815-cb0925573879



---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
