### PR TITLE
Update SwiftLint setup to be managed via CocoaPods 

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -1,39 +1,27 @@
-# Project configuration
-included:
-  - WooCommerce
-  - Networking
-  - Storage
-  - Yosemite
-  - WooFoundation
+excluded:
+  - DerivedData
+  - fastlane
+  - Pods
+  - Scripts
+  # Automattic's CI caching setup may generate this in the project folder
+  - Users/builder/Library/Caches/CocoaPods/Pods
+  - vendor
 
-# Rules
-whitelist_rules:
-  # Closing brace with closing parenthesis should not have any whitespaces in
-  # the middle.
-  # - closing_brace
-
+# Rules – Opt-in only, so we can progressively introduce new ones
+#
+only_rules:
   # Colons should be next to the identifier when specifying a type.
   - colon
 
   # There should be no space before and one after any comma.
   - comma
 
-  # Repeated `let` statements in conditional binding cascade should be avoided.
-  # - conditional_binding_cascade
-
   # if,for,while,do statements shouldn't wrap their conditionals in parentheses.
   - control_statement
 
-  # Create custom rules by providing a regex string. Optionally specify what
-  # syntax kinds to match against, the severity level, and what message to
-  # display.
-  # - custom_rules
+  - discarded_notification_center_observer
 
-  # Complexity of function bodies should be limited.
-  # - cyclomatic_complexity
-
-  # Prefer checking `isEmpty` over comparing `count` to zero.
-  # - empty_count
+  - duplicate_imports
 
   # Arguments can be omitted when matching enums with associated types if they
   # are not used.
@@ -42,69 +30,16 @@ whitelist_rules:
   # Prefer `() -> ` over `Void -> `.
   - empty_parameters
 
-  # Files should not span too many lines.
-  # - file_length
-
-  # Force casts should be avoided.
-  # - force_cast
-
-  # Force tries should be avoided.
-  # - force_try
-
-  # Force unwrapping should be avoided.
-  # - force_unwrapping
-
-  # Functions bodies should not span too many lines.
-  # - function_body_length
-
-  # Number of function parameters should be low.
-  # - function_parameter_count
-
-  # Files should not contain leading whitespace.
-  # - leading_whitespace
-
-  # Struct extension properties and methods are preferred over legacy functions
-  # - legacy_cggeometry_functions
-
-  # Struct-scoped constants are preferred over legacy global constants.
-  # - legacy_constant
-
-  # Swift constructors are preferred over legacy convenience functions.
-  # - legacy_constructor
-
-  # Lines should not span too many characters.
   - line_length
 
   # MARK comment should be in valid format.
   - mark
 
-  # Public declarations should be documented.
-  # - missing_docs
-
-  # Types should be nested at most 1 level deep, and statements should be nested
-  # at most 5 levels deep.
-  # - nesting
-
   # Opening braces should be preceded by a single space and on the same line as
   # the declaration.
   - opening_brace
 
-  # Operators should be surrounded by a single whitespace when defining them.
-  # - operator_whitespace
-
-  # Return arrow and return type should be separated by a single space or on a
-  # separate line.
-  # - return_arrow_whitespace
-
-  # Else and catch should be on the same line, one space after the previous
-  # declaration.
-  # - statement_position
-
-  # TODOs and FIXMEs should be avoided.
-  # - todo
-
-  # Limit vertical whitespace to a three empty lines (rule configuration is below)
-  - vertical_whitespace
+  - overridden_super_call
 
   # Files should have a single trailing newline.
   - trailing_newline
@@ -115,38 +50,40 @@ whitelist_rules:
   # Lines should not have trailing whitespace.
   - trailing_whitespace
 
-  # Type bodies should not span too many lines.
-  # - type_body_length
+  - vertical_whitespace
 
-  # Type name should only contain alphanumeric characters, start with an
-  # uppercase character and span between 3 and 40 characters in length.
-  # - type_name
-
-  # Documented declarations should be valid.
-  # - valid_docs
-
-  # Variable names should only contain alphanumeric characters and start with a
-  # lowercase character or should only contain capital letters. In an exception
-  # to the above, variable names may start with a capital letter when they are
-  # declared static and immutable. Variable names should not be too long or too
-  # short.
-  # - variable_name
+  - weak_delegate
 
   - custom_rules
 
 # Rules configuration
+#
+control_statement:
+  severity: error
+
+discarded_notification_center_observer:
+  severity: error
+
+line_length: 163 # Max line length at the time of setup
+
+overridden_super_call:
+  severity: error
+
+trailing_whitespace:
+  ignores_empty_lines: false
+  ignores_comments: false
 
 vertical_whitespace:
   max_empty_lines: 3
   severity: error
 
-line_length: 160
-
-control_statement:
+weak_delegate:
   severity: error
+  excluded: .*Tests/.*
 
+# Custom rules
+#
 custom_rules:
-
   natural_content_alignment:
     name: "Natural Content Alignment"
     regex: '\.contentHorizontalAlignment(\s*)=(\s*)(\.left|\.right)'
@@ -164,6 +101,19 @@ custom_rules:
     regex: '\.textAlignment(\s*)=(\s*).right'
     message: "When forcing text alignment to the right, be sure to handle the Right-to-Left layout case properly, and then silence this warning with this line `// swiftlint:disable:next inverse_text_alignment`"
     severity: warning
+
+  localization_comment:
+    name: "Localization Comment"
+    regex: 'NSLocalizedString([^,]+,\s+comment:\s*"")'
+    message: "Localized strings should include a description giving context for how the string is used."
+    severity: warning
+    excluded: .*Tests/.* # We might want to remove this and add comments to tests, too
+
+  string_interpolation_in_localized_string:
+    name: "String Interpolation in Localized String"
+    regex: 'NSLocalizedString\("[^"]*\\\(\S*\)'
+    message: "Localized strings must not use interpolated variables. Instead, use `String(format:`"
+    severity: error
 
   swiftui_localization:
     name: "SwiftUI Localization"

--- a/Podfile
+++ b/Podfile
@@ -288,6 +288,10 @@ target 'ExperimentsTests' do
   experiments_pods
 end
 
+abstract_target 'Tools' do
+  pod 'SwiftLint', '~> 0.54'
+end
+
 # Workarounds:
 # ============
 #
@@ -385,4 +389,8 @@ post_install do |installer|
     end
   end
   # rubocop:enable Style/CombinableLoops
+
+  yellow_marker = "\033[33m"
+  reset_marker = "\033[0m"
+  puts "#{yellow_marker}The abstract target warning below is expected. Feel free to ignore it.#{reset_marker}"
 end

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -24,6 +24,7 @@ PODS:
   - Sourcery (1.0.3)
   - StripeTerminal (3.1.0)
   - SVProgressHUD (2.2.5)
+  - SwiftLint (0.54.0)
   - UIDeviceIdentifier (2.3.0)
   - WordPress-Aztec-iOS (1.19.9)
   - WordPress-Editor-iOS (1.19.9):
@@ -70,6 +71,7 @@ DEPENDENCIES:
   - Kingfisher (~> 7.6.2)
   - Sourcery (~> 1.0.3)
   - StripeTerminal (~> 3.1.0)
+  - SwiftLint (~> 0.54)
   - WordPress-Aztec-iOS (from `https://github.com/wordpress-mobile/AztecEditor-iOS.git`, commit `950c7bc1bf98326986f10cccb2715ad86976f0fd`)
   - WordPress-Editor-iOS (from `https://github.com/wordpress-mobile/AztecEditor-iOS.git`, commit `950c7bc1bf98326986f10cccb2715ad86976f0fd`)
   - WordPressAuthenticator (from `https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git`, commit `fa06fca7178b268d382d91861752b3be0729e8a8`)
@@ -96,6 +98,7 @@ SPEC REPOS:
     - Sourcery
     - StripeTerminal
     - SVProgressHUD
+    - SwiftLint
     - UIDeviceIdentifier
     - WordPressShared
     - WordPressUI
@@ -153,6 +156,7 @@ SPEC CHECKSUMS:
   Sourcery: 70a6048014bd4f37ea80e6bd4354d47bf3b760e1
   StripeTerminal: fa064cf68a7a3df7c2ee1b2e6d33c8866d1e6aef
   SVProgressHUD: 1428aafac632c1f86f62aa4243ec12008d7a51d6
+  SwiftLint: c1de071d9d08c8aba837545f6254315bc900e211
   UIDeviceIdentifier: 442b65b4ff1832d4ca9c2a157815cb29ad981b17
   WordPress-Aztec-iOS: fbebd569c61baa252b3f5058c0a2a9a6ada686bb
   WordPress-Editor-iOS: bda9f7f942212589b890329a0cb22547311749ef
@@ -171,6 +175,6 @@ SPEC CHECKSUMS:
   ZendeskSupportProvidersSDK: 685b5d185af47ced0ec40564ec46355c838bbd06
   ZendeskSupportSDK: 92e6f9d334e81e9186f8a17583862350460a5393
 
-PODFILE CHECKSUM: 07dd31cac4626d121176c18d27cb6db680e8632d
+PODFILE CHECKSUM: 1ea53ed3b2f86a30293a871c11dfb745ed4a469e
 
 COCOAPODS: 1.14.0

--- a/Rakefile
+++ b/Rakefile
@@ -1,16 +1,16 @@
 # frozen_string_literal: true
 
-SWIFTLINT_VERSION = '0.54.0'
-XCODE_WORKSPACE = 'WooCommerce.xcworkspace'
-XCODE_SCHEME = 'WooCommerce'
-XCODE_CONFIGURATION = 'Debug'
-
 require 'fileutils'
 require 'tmpdir'
 require 'rake/clean'
 require 'yaml'
 require 'digest'
+
 PROJECT_DIR = __dir__
+SWIFTLINT_BIN = File.join(PROJECT_DIR, 'Pods', 'SwiftLint', 'swiftlint')
+XCODE_WORKSPACE = 'WooCommerce.xcworkspace'
+XCODE_SCHEME = 'WooCommerce'
+XCODE_CONFIGURATION = 'Debug'
 
 task default: %w[test]
 
@@ -88,36 +88,9 @@ namespace :dependencies do
     task :check do
       if swiftlint_needs_install
         dependency_failed('SwiftLint')
-        Rake::Task['dependencies:lint:install'].invoke
+        Rake::Task['dependencies:pod:install'].invoke
       end
     end
-
-    task :install do
-      fold('install.swiftlint') do
-        puts "Installing SwiftLint #{SWIFTLINT_VERSION} into #{swiftlint_path}"
-        Dir.mktmpdir do |tmpdir|
-          # Try first using a binary release
-          zipfile = "#{tmpdir}/swiftlint-#{SWIFTLINT_VERSION}.zip"
-          sh "curl --fail --location -o #{zipfile} https://github.com/realm/SwiftLint/releases/download/#{SWIFTLINT_VERSION}/portable_swiftlint.zip || true"
-          if File.exist?(zipfile)
-            extracted_dir = "#{tmpdir}/swiftlint-#{SWIFTLINT_VERSION}"
-            sh "unzip #{zipfile} -d #{extracted_dir}"
-            FileUtils.mkdir_p("#{swiftlint_path}/bin")
-            FileUtils.cp("#{extracted_dir}/swiftlint", "#{swiftlint_path}/bin/swiftlint")
-          else
-            sh "git clone --quiet https://github.com/realm/SwiftLint.git #{tmpdir}"
-            Dir.chdir(tmpdir) do
-              sh "git checkout --quiet #{SWIFTLINT_VERSION}"
-              sh 'git submodule --quiet update --init --recursive'
-              FileUtils.rm_rf(swiftlint_path)
-              FileUtils.mkdir_p(swiftlint_path)
-              sh "make prefix_install PREFIX='#{swiftlint_path}'"
-            end
-          end
-        end
-      end
-    end
-    CLOBBER << 'vendor/swiftlint'
   end
 end
 
@@ -223,24 +196,16 @@ def podfile_locked?
   podfile_checksum == lockfile_checksum
 end
 
-def swiftlint_path
-  "#{PROJECT_DIR}/vendor/swiftlint"
+def swiftlint_needs_install
+  # Notice that this doesn't check whether the local version is up-to-date.
+  # Given we are using CocoaPods to install SwiftLint, it's safe to assume SwiftLint will be up-to-date most of the time.
+  # We are trading being 100% sure we're up-to-date for a faster check.
+  File.exist?(SWIFTLINT_BIN) == false
 end
 
 def swiftlint(args)
-  args = [swiftlint_bin] + args
+  args = [SWIFTLINT_BIN] + args
   sh(*args)
-end
-
-def swiftlint_bin
-  "#{swiftlint_path}/bin/swiftlint"
-end
-
-def swiftlint_needs_install
-  return true unless File.exist?(swiftlint_bin)
-
-  installed_version = `"#{swiftlint_bin}" version`.chomp
-  (installed_version != SWIFTLINT_VERSION)
 end
 
 def xcodebuild(*build_cmds)

--- a/Rakefile
+++ b/Rakefile
@@ -140,7 +140,7 @@ end
 namespace :lint do
   desc 'Automatically corrects style errors where possible'
   task autocorrect: %w[dependencies:lint:check] do
-    swiftlint %w[autocorrect]
+    swiftlint %w[lint --autocorrect --quiet]
   end
 end
 

--- a/Scripts/build-phases/swiftlint.sh
+++ b/Scripts/build-phases/swiftlint.sh
@@ -18,14 +18,14 @@ DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 
 # Temporarily move to the root directory so that SwiftLint can correctly
 # find the paths returned from the `git` commands below.
-pushd $DIR/../../ > /dev/null
+pushd "$DIR/../../" > /dev/null || exit 1
 
 # Paths relative to the root directory
 SWIFTLINT="./vendor/swiftlint/bin/swiftlint"
 CONFIG_FILE=".swiftlint.yml"
 
 if ! which $SWIFTLINT >/dev/null; then
-  echo "error: SwiftLint is not installed. Install by running `rake dependencies`."
+  echo "error: SwiftLint is not installed. Install by running \`rake dependencies\`."
   exit 1
 fi
 
@@ -34,22 +34,22 @@ fi
 # The `|| true` at the end is to stop `grep` from returning a non-zero exit if there
 # are no matches. Xcode's build will fail if we don't do this.
 #
-MODIFIED_FILES=`git diff --name-only --diff-filter=d HEAD | grep -G "\.swift$" || true`
-echo $MODIFIED_FILES | xargs $SWIFTLINT --config $CONFIG_FILE --quiet
+MODIFIED_FILES=$(git diff --name-only --diff-filter=d HEAD | grep -G "\.swift$" || true)
+echo "$MODIFIED_FILES" | xargs $SWIFTLINT --config $CONFIG_FILE --quiet
 MODIFIED_FILES_LINT_RESULT=$?
 
 # Run SwiftLint on the added files
-ADDED_FILES=`git ls-files --others --exclude-standard | grep -G "\.swift$" || true`
-echo $ADDED_FILES | xargs $SWIFTLINT --config $CONFIG_FILE --quiet
+ADDED_FILES=$(git ls-files --others --exclude-standard | grep -G "\.swift$" || true)
+echo "$ADDED_FILES" | xargs $SWIFTLINT --config $CONFIG_FILE --quiet
 ADDED_FILES_LINT_RESULT=$?
 
 # Restore the previous directory
-popd > /dev/null
+popd > /dev/null || exit 1
 
-# Exit with non-zero if SwiftLint found a serious violation in the linted files. 
+# Exit with non-zero if SwiftLint found a serious violation in the linted files.
 #
 # This stops Xcode from complaining about "...did not return a nonzero exit code...".
 #
-if [ $MODIFIED_FILES_LINT_RESULT -ne 0 ] || [ $ADDED_FILES_LINT_RESULT -ne 0 ] ; then 
+if [ $MODIFIED_FILES_LINT_RESULT -ne 0 ] || [ $ADDED_FILES_LINT_RESULT -ne 0 ] ; then
   exit 1
 fi


### PR DESCRIPTION
## Description

This is simpler than running our own install and version check logic and simplifying addressing violations.

Builds on top of #12007 

## Testing instructions
This PR will still fail to lint in CI. See TBD for addressing the issues.

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary. — N.A.
