### PR TITLE
Login: Fix regression issue for JCP site login

### DIFF
--- a/WooCommerce/Classes/Authentication/AuthenticationManager.swift
+++ b/WooCommerce/Classes/Authentication/AuthenticationManager.swift
@@ -390,11 +390,6 @@ extension AuthenticationManager: WordPressAuthenticatorDelegate {
                                        in: navigationController)
         }
 
-        /// Jetpack is required. Present an error if we don't detect a valid installation for a self-hosted site.
-        if isJetpackInvalidForSelfHostedSite(url: siteURL) {
-            return presentJetpackError(for: siteURL, with: credentials, in: navigationController, onDismiss: onDismiss)
-        }
-
         let matcher = ULAccountMatcher(storageManager: storageManager)
         matcher.refreshStoredSites()
 
@@ -597,14 +592,6 @@ private extension AuthenticationManager {
         }
 
         return sites
-    }
-
-    func isJetpackInvalidForSelfHostedSite(url: String) -> Bool {
-        if let site = currentSelfHostedSite, site.url == url,
-            (!site.hasJetpack || !site.isJetpackActive) {
-            return true
-        }
-        return false
     }
 
     /// Presents an error if the user tries to log in to a site without Jetpack.


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #11919 
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
There's a piece of outdated code back in 2022 when we added a [check](https://github.com/woocommerce/woocommerce-ios/commit/028c8bb) for Jetpack for site credential login in #7847. This check has never been removed since we disabled WPCom login for self-hosted sites without a working Jetpack connection. This check has caused the login for JCP sites to fail.

This PR removes this check and fixes the login issue for JCP sites.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
- Create a JN site with Woo and no Jetpack.
- Install WCPay and connect your WPCom account with the plugin.
- Log in to the site on the app. You will then be asked for WPCom credentials.
- Notice that after WPCom login completes, you are redirected to the My Store screen without any error.

Please feel free to test for other edge cases like account mismatch (logging in with a WPCom account that was not connected to WCPay), or no Woo installed.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->
My Store screen after logging in to a JCP site:

<img src="https://github.com/woocommerce/woocommerce-ios/assets/5533851/c09ef4ce-ee35-4bed-bfa2-6580726ace46" width=320 />


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
