### PR TITLE
[Coupons in Orders] Use NSDecimalNumber for discounts instead of Strings

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/EditableOrderViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/EditableOrderViewModel.swift
@@ -1567,7 +1567,7 @@ private extension EditableOrderViewModel {
                         return true
                     }
                     // If no coupons have been applied, but there are order discounts (discounts added directly to products of an order), disable coupons
-                    if order.coupons.isEmpty && order.discountTotal != "0.00" {
+                    if order.coupons.isEmpty && isDiscountBiggerThanZero {
                         return true
                     }
                     return false


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
Before, when checking whether the order has discounts other than coupons to disable adding coupons, we were comparing the string value of the discount total ("0.00") That's suboptimal, as the string value can change and still be 0: "0", "0.0", "0,00", etc. With this PR we use the NSDecimalNumber instead, same as we did in the same scope when ascertaining whether to show the discount total or not.
## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

1. Go to orders
2. See that adding coupons is disabled
3. Add a product
4. See that adding coupons is enabled
5. Add discount to the product
6. See that adding coupons is disabled

Btw, as you can see in the video, the ? info popover has a glitch when being shown and cannot be read, as it's covered by the Set New Tax Rate.


## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

https://github.com/woocommerce/woocommerce-ios/assets/1864060/29922774-b2b4-4f3d-83a0-f0ae5f7be4ae




---
- [X] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
