### PR TITLE
[Blaze] Add Help button on creation form and payment confirmation screen.

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Blaze/CampaignCreation/BlazeCampaignCreationForm.swift
+++ b/WooCommerce/Classes/ViewRelated/Blaze/CampaignCreation/BlazeCampaignCreationForm.swift
@@ -38,15 +38,8 @@ private extension BlazeCampaignCreationFormHostingController {
     }
 
     @objc func helpButtonWasPressed() {
-        guard let navigationController else {
-            return
-        }
-        showSupport(from: navigationController)
-    }
-
-    func showSupport(from navigationController: UINavigationController) {
         let supportForm = SupportFormHostingController(viewModel: .init(sourceTag: Constants.supportTag))
-        supportForm.show(from: navigationController)
+        supportForm.show(from: self)
     }
 
     func navigateToEditAd() {

--- a/WooCommerce/Classes/ViewRelated/Blaze/CampaignCreation/BlazeCampaignCreationForm.swift
+++ b/WooCommerce/Classes/ViewRelated/Blaze/CampaignCreation/BlazeCampaignCreationForm.swift
@@ -26,20 +26,6 @@ final class BlazeCampaignCreationFormHostingController: UIHostingController<Blaz
 private extension BlazeCampaignCreationFormHostingController {
     func configureNavigation() {
         title = Localization.title
-        addHelpButtonToNavigationItem()
-    }
-
-    func addHelpButtonToNavigationItem() {
-        let helpBarButtonItem = UIBarButtonItem(title: Localization.help,
-                                                style: .plain,
-                                                target: self,
-                                                action: #selector(helpButtonWasPressed))
-        navigationItem.rightBarButtonItem = helpBarButtonItem
-    }
-
-    @objc func helpButtonWasPressed() {
-        let supportForm = SupportFormHostingController(viewModel: .init(sourceTag: Constants.supportTag))
-        supportForm.show(from: self)
     }
 
     func navigateToEditAd() {
@@ -54,12 +40,6 @@ private extension BlazeCampaignCreationFormHostingController {
             "blazeCampaignCreationForm.title",
             value: "Preview",
             comment: "Title of the Blaze campaign creation screen"
-        )
-
-        static let help = NSLocalizedString(
-            "blazeCampaignCreationForm.help",
-            value: "Help",
-            comment: "Button to contact support on the Blaze campaign creation screen"
         )
     }
 
@@ -81,6 +61,7 @@ struct BlazeCampaignCreationForm: View {
     @State private var isShowingTopicPicker = false
     @State private var isShowingLocationPicker = false
     @State private var isShowingAISuggestionsErrorAlert: Bool = false
+    @State private var isShowingSupport: Bool = false
 
     init(viewModel: BlazeCampaignCreationFormViewModel) {
         self.viewModel = viewModel
@@ -160,6 +141,16 @@ struct BlazeCampaignCreationForm: View {
                 .disabled(!viewModel.canConfirmDetails)
             }
             .background(Constants.backgroundViewColor)
+        }
+        .toolbar {
+            ToolbarItem(placement: .navigationBarTrailing) {
+                Button(Localization.help) {
+                    isShowingSupport = true
+                }
+            }
+        }
+        .sheet(isPresented: $isShowingSupport) {
+            supportForm
         }
         .sheet(isPresented: $isShowingBudgetSetting) {
             BlazeBudgetSettingView(viewModel: viewModel.budgetSettingViewModel)
@@ -321,6 +312,23 @@ private extension BlazeCampaignCreationForm {
 }
 
 private extension BlazeCampaignCreationForm {
+    var supportForm: some View {
+        NavigationView {
+            SupportForm(isPresented: $isShowingSupport,
+                        viewModel: SupportFormViewModel(sourceTag: Constants.supportTag))
+            .toolbar {
+                ToolbarItem(placement: .confirmationAction) {
+                    Button(Localization.done) {
+                        isShowingSupport = false
+                    }
+                }
+            }
+        }
+        .navigationViewStyle(.stack)
+    }
+}
+
+private extension BlazeCampaignCreationForm {
     enum Layout {
         static let contentMargin: CGFloat = 8
         static let contentPadding: CGFloat = 16
@@ -337,6 +345,8 @@ private extension BlazeCampaignCreationForm {
                                                dark: .init(uiColor: .secondarySystemBackground))
         static let cellColor = Color(light: .init(uiColor: .systemBackground),
                                      dark: .init(uiColor: .tertiarySystemBackground))
+
+        static let supportTag = "origin:blaze-native-campaign-creation"
     }
 
     enum Localization {
@@ -429,6 +439,20 @@ private extension BlazeCampaignCreationForm {
                 comment: "Button on the alert to add an image for the Blaze campaign"
             )
         }
+
+
+        static let help = NSLocalizedString(
+            "blazeCampaignCreationForm.help",
+            value: "Help",
+            comment: "Button to contact support on the Blaze campaign form screen."
+        )
+
+        static let done = NSLocalizedString(
+            "blazeCampaignCreationForm.done",
+            value: "Done",
+            comment: "Button to dismiss the support form from the Blaze campaign form screen."
+        )
+
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Blaze/CampaignCreation/BlazeCampaignCreationForm.swift
+++ b/WooCommerce/Classes/ViewRelated/Blaze/CampaignCreation/BlazeCampaignCreationForm.swift
@@ -19,11 +19,36 @@ final class BlazeCampaignCreationFormHostingController: UIHostingController<Blaz
 
     override func viewDidLoad() {
         super.viewDidLoad()
-        title = Localization.title
+        configureNavigation()
     }
 }
 
 private extension BlazeCampaignCreationFormHostingController {
+    func configureNavigation() {
+        title = Localization.title
+        addHelpButtonToNavigationItem()
+    }
+
+    func addHelpButtonToNavigationItem() {
+        let helpBarButtonItem = UIBarButtonItem(title: Localization.help,
+                                                style: .plain,
+                                                target: self,
+                                                action: #selector(helpButtonWasPressed))
+        navigationItem.rightBarButtonItem = helpBarButtonItem
+    }
+
+    @objc func helpButtonWasPressed() {
+        guard let navigationController else {
+            return
+        }
+        showSupport(from: navigationController)
+    }
+
+    func showSupport(from navigationController: UINavigationController) {
+        let supportForm = SupportFormHostingController(viewModel: .init(sourceTag: Constants.supportTag))
+        supportForm.show(from: navigationController)
+    }
+
     func navigateToEditAd() {
         let vc = BlazeEditAdHostingController(viewModel: viewModel.editAdViewModel)
         present(vc, animated: true)
@@ -37,6 +62,16 @@ private extension BlazeCampaignCreationFormHostingController {
             value: "Preview",
             comment: "Title of the Blaze campaign creation screen"
         )
+
+        static let help = NSLocalizedString(
+            "blazeCampaignCreationForm.help",
+            value: "Help",
+            comment: "Button to contact support on the Blaze campaign creation screen"
+        )
+    }
+
+    enum Constants {
+        static let supportTag = "origin:blaze-native-campaign-creation"
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Blaze/ConfirmPayment/BlazeConfirmPaymentView.swift
+++ b/WooCommerce/Classes/ViewRelated/Blaze/ConfirmPayment/BlazeConfirmPaymentView.swift
@@ -9,6 +9,7 @@ struct BlazeConfirmPaymentView: View {
 
     @State private var externalURL: URL?
     @State private var showingAddPaymentWebView: Bool = false
+    @State private var isShowingSupport = false
 
     private let agreementText: NSAttributedString = {
         let content = String.localizedStringWithFormat(Localization.agreement, Localization.termsOfService, Localization.adPolicy, Localization.learnMore)
@@ -64,6 +65,13 @@ struct BlazeConfirmPaymentView: View {
         }
         .navigationTitle(Localization.title)
         .navigationBarTitleDisplayMode(.inline)
+        .toolbar {
+            ToolbarItem(placement: .navigationBarTrailing) {
+                Button(Localization.help) {
+                    isShowingSupport = true
+                }
+            }
+        }
         .safeAreaInset(edge: .bottom) {
             footerView
         }
@@ -103,8 +111,29 @@ struct BlazeConfirmPaymentView: View {
                 BlazeAddPaymentMethodWebView(viewModel: viewModel)
             }
         })
+        .sheet(isPresented: $isShowingSupport) {
+            supportForm
+        }
     }
 }
+
+private extension BlazeConfirmPaymentView {
+    var supportForm: some View {
+        NavigationView {
+            SupportForm(isPresented: $isShowingSupport,
+                        viewModel: SupportFormViewModel(sourceTag: Constants.supportTag))
+            .toolbar {
+                ToolbarItem(placement: .confirmationAction) {
+                    Button(Localization.done) {
+                        isShowingSupport = false
+                    }
+                }
+            }
+        }
+        .navigationViewStyle(.stack)
+    }
+}
+
 
 private extension BlazeConfirmPaymentView {
     var totalAmountView: some View {
@@ -225,6 +254,7 @@ private extension BlazeConfirmPaymentView {
         static let termsLink = "https://wordpress.com/tos/"
         static let adPolicyLink = "https://automattic.com/advertising-policy/"
         static let learnMoreLink = "https://wordpress.com/support/promote-a-post/"
+        static let supportTag = "origin:blaze-native-campaign-creation"
     }
 
     enum Localization {
@@ -303,6 +333,18 @@ private extension BlazeConfirmPaymentView {
             "blazeConfirmPaymentView.tryAgain",
             value: "Try Again",
             comment: "Button to retry when fetching payment methods failed on the Payment screen in the Blaze campaign creation flow."
+        )
+
+        static let help = NSLocalizedString(
+            "blazeConfirmPaymentView.help",
+            value: "Help",
+            comment: "Button to contact support on the Blaze confirm payment view screen."
+        )
+
+        static let done = NSLocalizedString(
+            "blazeConfirmPaymentView.done",
+            value: "Done",
+            comment: "Button to dismiss the support form from the Blaze confirm payment view screen."
         )
     }
 }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #12010 
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This adds Help button on two screens:
- Blaze campaign creation form
- Blaze payment confirmation screen

This is to match the Android counterpart:

https://github.com/woocommerce/woocommerce-android/pull/10793



## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

1. With a Blaze-eligible site, create a new Blaze campaign (can be from dashboard),
2. On the campaign creation form, ensure "Help" button appears on top right,
3. Test the button, ensure support form is shown,
4. Go back to campaign creation form,
5. Tap "Confirm details",
6. On the payment confirmation screen, ensure "Help" button appears on top right,
7. Test the button, ensure support form is shown,

## Video


https://github.com/woocommerce/woocommerce-ios/assets/266376/91cf4893-036b-49b9-86ae-bf2641e89d35


## Discussion

As shown in the video above, the way support form is shown is inconsistent between campaign form and payment screen.
- campaign form: normal navigation
- payment screen: sheet

The main difference is because campaign form uses UIKit, while payment screen is SwiftUI.

- The campaign form behavior matches other uses of `SupportFormHostingController` in the codebase.
- The payment screen behavior matches the `SupportForm` use in `BlazeCampaignCreationErrorView`

I chose to do the above since we're close to launch and they're the simplest way to do things.

Technically it should be possible to make the campaign form show the support form in a sheet, but the paths that I looked at seem to require a non-trivial amount of changes, so it might be good for future iterations. For now, at least the functionality is available to merchants and the difference in presentation should not stop them from contacting support.

Let me know if it's worth figuring it out now, though.


---
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
