### PR TITLE
[Custom Range] Reorder enum case to fix unit tests

### DIFF
--- a/Networking/Networking/Model/Stats/StatGranularity.swift
+++ b/Networking/Networking/Model/Stats/StatGranularity.swift
@@ -4,10 +4,10 @@ import Codegen
 /// Represents data granularity for stats (e.g. day, week, month, year)
 ///
 public enum StatGranularity: String, Decodable, GeneratedFakeable {
-    case hour
     case day
     case week
     case month
     case quarter
     case year
+    case hour
 }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of: #11971
<!-- Id number of the GitHub issue this PR addresses. -->

## Description

In #11975 I added a new enum case `hour` to `StatGranularity` for the "Custom Range" project. https://github.com/woocommerce/woocommerce-ios/issues/11935

But, the newly added enum case causes unit test failures when we generate fake files using `rake generate`. 
(I missed to generate fake files in the original PR #11975).

I haven't looked into the exact reason for the unit test failures. To avoid causing unit test failures for other devs (after one generates fakes), I changed the new enum case order to avoid using the new `hour` value for fake.

We can figure out the exact cause while working on the Custom Range project. Added a subtask under the Misc section to track this. https://github.com/woocommerce/woocommerce-ios/issues/11935

## Testing instructions
- Run `rake generate` and ensure no changes available to commit.
- CI should pass.

## Screenshots
NA

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.