### PR TITLE
[Analytics Hub] Add basic UI to customize (select and reorder) analytics cards

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/AnalyticsHubView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/AnalyticsHubView.swift
@@ -164,7 +164,7 @@ struct AnalyticsHubView: View {
         }
         .sheet(isPresented: $isCustomizingAnalyticsCards) {
             NavigationView {
-                AnalyticsHubManageView()
+                AnalyticsHubCustomizeView()
             }
         }
     }
@@ -188,7 +188,7 @@ private extension AnalyticsHubView {
                                                          comment: "Label for button to enable Jetpack Stats")
         static let editButton = NSLocalizedString("analyticsHub.editButton.label",
                                                   value: "Edit",
-                                                  comment: "Label for button that opens a screen to customize the sections in the Analytics Hub")
+                                                  comment: "Label for button that opens a screen to customize the Analytics Hub")
     }
 
     struct Layout {

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/AnalyticsHubView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/AnalyticsHubView.swift
@@ -59,6 +59,7 @@ struct AnalyticsHubView: View {
     @StateObject var viewModel: AnalyticsHubViewModel
 
     @State private var isEnablingJetpackStats = false
+    @State private var isCustomizingAnalyticsCards = false
 
     var body: some View {
         RefreshablePlainList(action: {
@@ -151,6 +152,21 @@ struct AnalyticsHubView: View {
                 viewModel.trackAnalyticsInteraction()
             })
         )
+        .toolbar {
+            ToolbarItem(placement: .topBarTrailing) {
+                Button {
+                    isCustomizingAnalyticsCards.toggle()
+                } label: {
+                    Text(Localization.editButton)
+                }
+                .renderedIf(ServiceLocator.featureFlagService.isFeatureFlagEnabled(.customizeAnalyticsHub))
+            }
+        }
+        .sheet(isPresented: $isCustomizingAnalyticsCards) {
+            NavigationView {
+                AnalyticsHubManageView()
+            }
+        }
     }
 }
 
@@ -170,6 +186,9 @@ private extension AnalyticsHubView {
         static let sessionsCTAButton = NSLocalizedString("analyticsHub.jetpackStatsCTA.buttonLabel",
                                                          value: "Enable Jetpack Stats",
                                                          comment: "Label for button to enable Jetpack Stats")
+        static let editButton = NSLocalizedString("analyticsHub.editButton.label",
+                                                  value: "Edit",
+                                                  comment: "Label for button that opens a screen to customize the sections in the Analytics Hub")
     }
 
     struct Layout {

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/Customize/AnalyticsHubCustomizeView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/Customize/AnalyticsHubCustomizeView.swift
@@ -1,6 +1,6 @@
 import SwiftUI
 
-struct AnalyticsHubManageView: View {
+struct AnalyticsHubCustomizeView: View {
     // TODO: Add view model to contain view data
 
     // TODO: Replace with dynamic data (all available cards)
@@ -48,19 +48,19 @@ struct AnalyticsHubManageView: View {
 }
 
 // MARK: - Constants
-private extension AnalyticsHubManageView {
+private extension AnalyticsHubCustomizeView {
     enum Localization {
-        static let title = NSLocalizedString("analyticsHub.manageAnalyticsCards.title",
-                                             value: "Manage Analytics Cards",
-                                             comment: "Title for the screen to manage the analytics cards in the Analytics Hub")
-        static let saveButton = NSLocalizedString("analyticsHub.manageAnalytics.saveButton",
+        static let title = NSLocalizedString("analyticsHub.customizeAnalytics.title",
+                                             value: "Customize Analytics",
+                                             comment: "Title for the screen to customize the analytics cards in the Analytics Hub")
+        static let saveButton = NSLocalizedString("analyticsHub.customizeAnalytics.saveButton",
                                                   value: "Save",
-                                                  comment: "Button to save changes on the Manage Analytics screen")
+                                                  comment: "Button to save changes on the Customize Analytics screen")
     }
 }
 
 #Preview {
     NavigationView {
-        AnalyticsHubManageView()
+        AnalyticsHubCustomizeView()
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/Manage/AnalyticsHubManageView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/Manage/AnalyticsHubManageView.swift
@@ -1,0 +1,66 @@
+import SwiftUI
+
+struct AnalyticsHubManageView: View {
+    // TODO: Add view model to contain view data
+
+    // TODO: Replace with dynamic data (all available cards)
+    @State private var allCards: [String] = [
+        "Revenue",
+        "Orders",
+        "Products",
+        "Sessions"
+    ]
+
+    // TODO: Replace with dynamic data (all selected/enabled cards)
+    @State private var selectedCards: Set<String> = [
+        "Revenue",
+        "Orders"
+    ]
+
+    /// Dismisses the view.
+    ///
+    @Environment(\.dismiss) private var dismiss
+
+    var body: some View {
+        MultiSelectionReorderableList(contents: $allCards, contentKeyPath: \.self, selectedItems: $selectedCards)
+            .toolbar(content: {
+                ToolbarItem(placement: .cancellationAction) {
+                    Button(action: {
+                        dismiss() // TODO: Show discard changes prompt when there are changes
+                    }, label: {
+                        Image(uiImage: .closeButton)
+                            .secondaryBodyStyle()
+                    })
+                }
+                ToolbarItem(placement: .confirmationAction) {
+                    Button {
+                        dismiss() // TODO: Save changes
+                    } label: {
+                        Text(Localization.saveButton)
+                    } // TODO: Disable when there are no changes to save
+                }
+            })
+            .navigationTitle(Localization.title)
+            .navigationBarTitleDisplayMode(.inline)
+            .background(Color(uiColor: .listBackground))
+            .wooNavigationBarStyle()
+    }
+}
+
+// MARK: - Constants
+private extension AnalyticsHubManageView {
+    enum Localization {
+        static let title = NSLocalizedString("analyticsHub.manageAnalyticsCards.title",
+                                             value: "Manage Analytics Cards",
+                                             comment: "Title for the screen to manage the analytics cards in the Analytics Hub")
+        static let saveButton = NSLocalizedString("analyticsHub.manageAnalytics.saveButton",
+                                                  value: "Save",
+                                                  comment: "Button to save changes on the Manage Analytics screen")
+    }
+}
+
+#Preview {
+    NavigationView {
+        AnalyticsHubManageView()
+    }
+}

--- a/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/MultiSelectionReorderableList.swift
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/MultiSelectionReorderableList.swift
@@ -23,13 +23,14 @@ struct MultiSelectionReorderableList<T: Hashable>: View {
         List {
             ForEach(contents, id: contentKeyPath) { item in
                 SelectableItemRow(title: item[keyPath: contentKeyPath],
-                                  selected: selectedItems.contains(item),
+                                  selected: isSelected(item),
                                   displayMode: .compact,
                                   selectionStyle: .checkcircle)
                     .listRowInsets(.zero)
                     .onTapGesture {
                         toggleItem(item)
                     }
+                    .disabled(isLastSelected(item))
             }
             .onMove(perform: moveItem)
         }
@@ -45,6 +46,17 @@ private extension MultiSelectionReorderableList {
         contents.move(fromOffsets: source, toOffset: destination)
     }
 
+    /// Checks if the given item is selected.
+    func isSelected(_ item: T) -> Bool {
+        selectedItems.contains(item)
+    }
+
+    /// Checks if the given item is the last selected item.
+    /// This is used to disable that row, so it can't be deselected.
+    func isLastSelected(_ item: T) -> Bool {
+        isSelected(item) && selectedItems.count == 1
+    }
+
     /// Selects or deselects the given item.
     func toggleItem(_ item: T) {
         if selectedItems.contains(item) {
@@ -55,8 +67,14 @@ private extension MultiSelectionReorderableList {
     }
 }
 
-#Preview {
-    return MultiSelectionReorderableList(contents: .constant(["🥪", "🥓", "🥗"]),
-                                         contentKeyPath: \.self,
-                                         selectedItems: .constant(["🥓"]))
+#Preview("List") {
+    MultiSelectionReorderableList(contents: .constant(["🥪", "🥓", "🥗"]),
+                                  contentKeyPath: \.self,
+                                  selectedItems: .constant(["🥗", "🥓"]))
+}
+
+#Preview("Last selected item") {
+    MultiSelectionReorderableList(contents: .constant(["🥪", "🥓", "🥗"]),
+                                  contentKeyPath: \.self,
+                                  selectedItems: .constant(["🥓"]))
 }

--- a/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/MultiSelectionReorderableList.swift
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/MultiSelectionReorderableList.swift
@@ -1,0 +1,62 @@
+import SwiftUI
+
+/// View to select multiple items from a list and drag-and-drop to reorder them.
+struct MultiSelectionReorderableList<T: Hashable>: View {
+    /// Ordered array of contents to be displayed in the list.
+    @Binding private var contents: [T]
+
+    /// Key path to find the content to be displayed.
+    private let contentKeyPath: KeyPath<T, String>
+
+    /// Items selected from the list of `contents`.
+    @Binding private var selectedItems: Set<T>
+
+    init(contents: Binding<[T]>,
+         contentKeyPath: KeyPath<T, String>,
+         selectedItems: Binding<Set<T>>) {
+        self._contents = contents
+        self.contentKeyPath = contentKeyPath
+        self._selectedItems = selectedItems
+    }
+
+    var body: some View {
+        List {
+            ForEach(contents, id: contentKeyPath) { item in
+                SelectableItemRow(title: item[keyPath: contentKeyPath],
+                                  selected: selectedItems.contains(item),
+                                  displayMode: .compact,
+                                  selectionStyle: .checkcircle)
+                    .listRowInsets(.zero)
+                    .onTapGesture {
+                        toggleItem(item)
+                    }
+            }
+            .onMove(perform: moveItem)
+        }
+        .listStyle(.plain)
+        .environment(\.editMode, .constant(.active)) // Always allow reordering
+    }
+}
+
+// MARK: - Helper methods for selection and ordering
+private extension MultiSelectionReorderableList {
+    /// Moves an item within the list of contents.
+    func moveItem(fromOffsets source: IndexSet, toOffset destination: Int) {
+        contents.move(fromOffsets: source, toOffset: destination)
+    }
+
+    /// Selects or deselects the given item.
+    func toggleItem(_ item: T) {
+        if selectedItems.contains(item) {
+            selectedItems.remove(item)
+        } else {
+            selectedItems.insert(item)
+        }
+    }
+}
+
+#Preview {
+    return MultiSelectionReorderableList(contents: .constant(["🥪", "🥓", "🥗"]),
+                                         contentKeyPath: \.self,
+                                         selectedItems: .constant(["🥓"]))
+}

--- a/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/SelectableItemRow.swift
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/SelectableItemRow.swift
@@ -7,19 +7,26 @@ struct SelectableItemRow: View {
     private let selected: Bool
     private let displayMode: DisplayMode
     private let alignment: Alignment
+    private let selectionStyle: SelectionStyle
     @Environment(\.isEnabled) private var isEnabled
 
-    init(title: String, subtitle: String? = nil, selected: Bool, displayMode: DisplayMode = .full, alignment: Alignment = .leading) {
+    init(title: String,
+         subtitle: String? = nil,
+         selected: Bool,
+         displayMode: DisplayMode = .full,
+         alignment: Alignment = .leading,
+         selectionStyle: SelectionStyle = .checkmark) {
         self.title = title
         self.subtitle = subtitle
         self.selected = selected
         self.displayMode = displayMode
         self.alignment = alignment
+        self.selectionStyle = selectionStyle
     }
     var body: some View {
         HStack(spacing: 0) {
             if alignment == .leading {
-                checkmark
+                selectionIcon
             }
 
             VStack(alignment: .leading) {
@@ -38,7 +45,7 @@ struct SelectableItemRow: View {
             Spacer()
 
             if alignment == .trailing {
-                checkmark
+                selectionIcon
             }
         }
         .padding([.top, .bottom], Constants.hStackPadding)
@@ -46,10 +53,12 @@ struct SelectableItemRow: View {
         .contentShape(Rectangle())
     }
 
-    private var checkmark: some View {
+    private var selectionIcon: some View {
         ZStack {
-            if selected, isEnabled {
-                Image(uiImage: .checkmarkStyledImage).frame(width: Constants.imageSize, height: Constants.imageSize)
+            if let image = selectionStyle.image(selected: selected, isEnabled: isEnabled) {
+                Image(uiImage: image)
+                    .frame(width: Constants.imageSize, height: Constants.imageSize)
+                    .iconStyle(isEnabled)
             }
         }
         .frame(width: Constants.zStackWidth)
@@ -93,6 +102,24 @@ extension SelectableItemRow {
             }
         }
     }
+
+    enum SelectionStyle {
+        case checkmark
+        case checkcircle
+
+        func image(selected: Bool, isEnabled: Bool) -> UIImage? {
+            switch (self, selected, isEnabled) {
+            case (.checkmark, true, true):
+                return .checkmarkStyledImage
+            case (.checkmark, _, _):
+                return nil
+            case (.checkcircle, true, _):
+                return .checkCircleImage.withRenderingMode(.alwaysTemplate)
+            case (.checkcircle, false, _):
+                return .checkEmptyCircleImage
+            }
+        }
+    }
 }
 
 private extension SelectableItemRow {
@@ -110,13 +137,25 @@ struct SelectableItemRow_Previews: PreviewProvider {
     static var previews: some View {
         SelectableItemRow(title: "Title", subtitle: "My subtitle", selected: true)
             .previewLayout(.fixed(width: 375, height: 100))
+            .previewDisplayName("Selected")
 
         SelectableItemRow(title: "Title", subtitle: "My subtitle", selected: false)
             .previewLayout(.fixed(width: 375, height: 100))
+            .previewDisplayName("Unselected")
 
         SelectableItemRow(title: "Title", subtitle: "My subtitle", selected: true)
             .disabled(true)
             .previewLayout(.fixed(width: 375, height: 100))
             .previewDisplayName("Disabled state")
+
+        SelectableItemRow(title: "Title", subtitle: "My subtitle", selected: true, selectionStyle: .checkcircle)
+            .previewDisplayName("Check Circle Selected")
+
+        SelectableItemRow(title: "Title", subtitle: "My subtitle", selected: false, selectionStyle: .checkcircle)
+            .previewDisplayName("Check Circle Unselected")
+
+        SelectableItemRow(title: "Title", subtitle: "My subtitle", selected: true, selectionStyle: .checkcircle)
+            .disabled(true)
+            .previewDisplayName("Check Circle Disabled")
     }
 }

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -2063,6 +2063,7 @@
 		CEF5A2952A68469B0059CFD3 /* stats_summary_month.json in Resources */ = {isa = PBXBuildFile; fileRef = CEF5A2942A68469B0059CFD3 /* stats_summary_month.json */; };
 		CEF5A2972A6846A50059CFD3 /* stats_summary_year.json in Resources */ = {isa = PBXBuildFile; fileRef = CEF5A2962A6846A50059CFD3 /* stats_summary_year.json */; };
 		CEF5A29B2A6849DB0059CFD3 /* reports_products.json in Resources */ = {isa = PBXBuildFile; fileRef = CEF5A29A2A6849DB0059CFD3 /* reports_products.json */; };
+		CEFA16F12B74F64D00512782 /* AnalyticsHubManageView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEFA16F02B74F64D00512782 /* AnalyticsHubManageView.swift */; };
 		D41C9F2E26D9A0E900993558 /* WhatsNewViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = D41C9F2D26D9A0E900993558 /* WhatsNewViewModel.swift */; };
 		D41C9F3126D9A43200993558 /* WhatsNewViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D41C9F3026D9A43200993558 /* WhatsNewViewModelTests.swift */; };
 		D449C51B26DE6B5000D75B02 /* ReportList.swift in Sources */ = {isa = PBXBuildFile; fileRef = D449C51826DE6B5000D75B02 /* ReportList.swift */; };
@@ -4768,6 +4769,7 @@
 		CEF5A2942A68469B0059CFD3 /* stats_summary_month.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = stats_summary_month.json; sourceTree = "<group>"; };
 		CEF5A2962A6846A50059CFD3 /* stats_summary_year.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = stats_summary_year.json; sourceTree = "<group>"; };
 		CEF5A29A2A6849DB0059CFD3 /* reports_products.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = reports_products.json; sourceTree = "<group>"; };
+		CEFA16F02B74F64D00512782 /* AnalyticsHubManageView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnalyticsHubManageView.swift; sourceTree = "<group>"; };
 		D41C9F2426D97D5400993558 /* IconListItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IconListItem.swift; sourceTree = "<group>"; };
 		D41C9F2626D994CD00993558 /* ReportListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReportListView.swift; sourceTree = "<group>"; };
 		D41C9F2826D99E9700993558 /* LargeTitleView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LargeTitleView.swift; sourceTree = "<group>"; };
@@ -7143,6 +7145,7 @@
 			isa = PBXGroup;
 			children = (
 				B6F379662937831D00718561 /* Time Range */,
+				CEFA16F22B75042300512782 /* Manage */,
 				2647F7B429280A7F00D59FDF /* AnalyticsHubView.swift */,
 				26E7EE69292D688900793045 /* AnalyticsHubViewModel.swift */,
 				2647F7B9292BE2F900D59FDF /* AnalyticsReportCard.swift */,
@@ -10875,6 +10878,14 @@
 			path = AppRatings;
 			sourceTree = "<group>";
 		};
+		CEFA16F22B75042300512782 /* Manage */ = {
+			isa = PBXGroup;
+			children = (
+				CEFA16F02B74F64D00512782 /* AnalyticsHubManageView.swift */,
+			);
+			path = Manage;
+			sourceTree = "<group>";
+		};
 		D41C9F2A26D9A04A00993558 /* WhatsNew */ = {
 			isa = PBXGroup;
 			children = (
@@ -13608,6 +13619,7 @@
 				DE3650682B5128CE001569A7 /* BlazeTargetLocationPickerViewModel.swift in Sources */,
 				B958640C2A66847B002C4C6E /* CouponListView.swift in Sources */,
 				DEDA8DBE2B19952B0076BF0F /* ThemeSettingViewModel.swift in Sources */,
+				CEFA16F12B74F64D00512782 /* AnalyticsHubManageView.swift in Sources */,
 				68C31B712A8617C500AE5C5A /* NewNoteViewModel.swift in Sources */,
 				D41C9F2E26D9A0E900993558 /* WhatsNewViewModel.swift in Sources */,
 				02ECD1E424FF5E0B00735BE5 /* AddProductCoordinator.swift in Sources */,

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -2063,7 +2063,7 @@
 		CEF5A2952A68469B0059CFD3 /* stats_summary_month.json in Resources */ = {isa = PBXBuildFile; fileRef = CEF5A2942A68469B0059CFD3 /* stats_summary_month.json */; };
 		CEF5A2972A6846A50059CFD3 /* stats_summary_year.json in Resources */ = {isa = PBXBuildFile; fileRef = CEF5A2962A6846A50059CFD3 /* stats_summary_year.json */; };
 		CEF5A29B2A6849DB0059CFD3 /* reports_products.json in Resources */ = {isa = PBXBuildFile; fileRef = CEF5A29A2A6849DB0059CFD3 /* reports_products.json */; };
-		CEFA16F12B74F64D00512782 /* AnalyticsHubManageView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEFA16F02B74F64D00512782 /* AnalyticsHubManageView.swift */; };
+		CEFA16F12B74F64D00512782 /* AnalyticsHubCustomizeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEFA16F02B74F64D00512782 /* AnalyticsHubCustomizeView.swift */; };
 		D41C9F2E26D9A0E900993558 /* WhatsNewViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = D41C9F2D26D9A0E900993558 /* WhatsNewViewModel.swift */; };
 		D41C9F3126D9A43200993558 /* WhatsNewViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D41C9F3026D9A43200993558 /* WhatsNewViewModelTests.swift */; };
 		D449C51B26DE6B5000D75B02 /* ReportList.swift in Sources */ = {isa = PBXBuildFile; fileRef = D449C51826DE6B5000D75B02 /* ReportList.swift */; };
@@ -4769,7 +4769,7 @@
 		CEF5A2942A68469B0059CFD3 /* stats_summary_month.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = stats_summary_month.json; sourceTree = "<group>"; };
 		CEF5A2962A6846A50059CFD3 /* stats_summary_year.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = stats_summary_year.json; sourceTree = "<group>"; };
 		CEF5A29A2A6849DB0059CFD3 /* reports_products.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = reports_products.json; sourceTree = "<group>"; };
-		CEFA16F02B74F64D00512782 /* AnalyticsHubManageView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnalyticsHubManageView.swift; sourceTree = "<group>"; };
+		CEFA16F02B74F64D00512782 /* AnalyticsHubCustomizeView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnalyticsHubCustomizeView.swift; sourceTree = "<group>"; };
 		D41C9F2426D97D5400993558 /* IconListItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IconListItem.swift; sourceTree = "<group>"; };
 		D41C9F2626D994CD00993558 /* ReportListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReportListView.swift; sourceTree = "<group>"; };
 		D41C9F2826D99E9700993558 /* LargeTitleView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LargeTitleView.swift; sourceTree = "<group>"; };
@@ -7145,7 +7145,7 @@
 			isa = PBXGroup;
 			children = (
 				B6F379662937831D00718561 /* Time Range */,
-				CEFA16F22B75042300512782 /* Manage */,
+				CEFA16F22B75042300512782 /* Customize */,
 				2647F7B429280A7F00D59FDF /* AnalyticsHubView.swift */,
 				26E7EE69292D688900793045 /* AnalyticsHubViewModel.swift */,
 				2647F7B9292BE2F900D59FDF /* AnalyticsReportCard.swift */,
@@ -10878,12 +10878,12 @@
 			path = AppRatings;
 			sourceTree = "<group>";
 		};
-		CEFA16F22B75042300512782 /* Manage */ = {
+		CEFA16F22B75042300512782 /* Customize */ = {
 			isa = PBXGroup;
 			children = (
-				CEFA16F02B74F64D00512782 /* AnalyticsHubManageView.swift */,
+				CEFA16F02B74F64D00512782 /* AnalyticsHubCustomizeView.swift */,
 			);
-			path = Manage;
+			path = Customize;
 			sourceTree = "<group>";
 		};
 		D41C9F2A26D9A04A00993558 /* WhatsNew */ = {
@@ -13619,7 +13619,7 @@
 				DE3650682B5128CE001569A7 /* BlazeTargetLocationPickerViewModel.swift in Sources */,
 				B958640C2A66847B002C4C6E /* CouponListView.swift in Sources */,
 				DEDA8DBE2B19952B0076BF0F /* ThemeSettingViewModel.swift in Sources */,
-				CEFA16F12B74F64D00512782 /* AnalyticsHubManageView.swift in Sources */,
+				CEFA16F12B74F64D00512782 /* AnalyticsHubCustomizeView.swift in Sources */,
 				68C31B712A8617C500AE5C5A /* NewNoteViewModel.swift in Sources */,
 				D41C9F2E26D9A0E900993558 /* WhatsNewViewModel.swift in Sources */,
 				02ECD1E424FF5E0B00735BE5 /* AddProductCoordinator.swift in Sources */,

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -2015,6 +2015,7 @@
 		CE4296B920A5E9E400B2AFBD /* CNContact+Helpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE4296B820A5E9E400B2AFBD /* CNContact+Helpers.swift */; };
 		CE4DA5C821DD759400074607 /* CurrencyFormatterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE4DA5C721DD759400074607 /* CurrencyFormatterTests.swift */; };
 		CE4DDB7B20DD312400D32EC8 /* DateFormatter+Helpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE4DDB7A20DD312400D32EC8 /* DateFormatter+Helpers.swift */; };
+		CE4FE7D82B7D306200F66DD5 /* MultiSelectionReorderableList.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE4FE7D72B7D306200F66DD5 /* MultiSelectionReorderableList.swift */; };
 		CE55F2D42B238C04005D53D7 /* CollapsibleProductCardPriceSummaryViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE55F2D32B238C04005D53D7 /* CollapsibleProductCardPriceSummaryViewModel.swift */; };
 		CE55F2D62B23941D005D53D7 /* CollapsibleProductCardPriceSummary.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE55F2D52B23941D005D53D7 /* CollapsibleProductCardPriceSummary.swift */; };
 		CE55F2D82B23961B005D53D7 /* CollapsibleProductCardPriceSummaryViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE55F2D72B23961B005D53D7 /* CollapsibleProductCardPriceSummaryViewModelTests.swift */; };
@@ -4718,6 +4719,7 @@
 		CE4296B820A5E9E400B2AFBD /* CNContact+Helpers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "CNContact+Helpers.swift"; sourceTree = "<group>"; };
 		CE4DA5C721DD759400074607 /* CurrencyFormatterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CurrencyFormatterTests.swift; sourceTree = "<group>"; };
 		CE4DDB7A20DD312400D32EC8 /* DateFormatter+Helpers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "DateFormatter+Helpers.swift"; sourceTree = "<group>"; };
+		CE4FE7D72B7D306200F66DD5 /* MultiSelectionReorderableList.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MultiSelectionReorderableList.swift; sourceTree = "<group>"; };
 		CE55F2D32B238C04005D53D7 /* CollapsibleProductCardPriceSummaryViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CollapsibleProductCardPriceSummaryViewModel.swift; sourceTree = "<group>"; };
 		CE55F2D52B23941D005D53D7 /* CollapsibleProductCardPriceSummary.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CollapsibleProductCardPriceSummary.swift; sourceTree = "<group>"; };
 		CE55F2D72B23961B005D53D7 /* CollapsibleProductCardPriceSummaryViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CollapsibleProductCardPriceSummaryViewModelTests.swift; sourceTree = "<group>"; };
@@ -8041,6 +8043,7 @@
 				E1BAAE9F26BBECEF00F2C037 /* ButtonStyles.swift */,
 				DE19BB0B26C2688B00AB70D9 /* SingleSelectionList.swift */,
 				DE7E5E7E2B4BC52C002E28D2 /* MultiSelectionList.swift */,
+				CE4FE7D72B7D306200F66DD5 /* MultiSelectionReorderableList.swift */,
 				CC254F2C26C17AB5005F3C82 /* BottomButtonView.swift */,
 				DE19BB1126C3811100AB70D9 /* LearnMoreRow.swift */,
 				E10BC15D26CC06970064F5E2 /* ScrollableVStack.swift */,
@@ -13672,6 +13675,7 @@
 				0262DA5323A238460029AF30 /* UnitInputTableViewCell.swift in Sources */,
 				D8EE9692264D328A0033B2F9 /* LegacyReceiptViewController.swift in Sources */,
 				68AC9D292ACE598B0042F784 /* ProductImageThumbnail.swift in Sources */,
+				CE4FE7D82B7D306200F66DD5 /* MultiSelectionReorderableList.swift in Sources */,
 				02E4FD7C2306A04C0049610C /* StatsTimeRangeBarView.swift in Sources */,
 				864213022AE77C730036E5A6 /* UIImage+Resizing.swift in Sources */,
 				DE61978B28991F0E005E4362 /* WKWebView+Authenticated.swift in Sources */,

--- a/WooFoundation/WooFoundation/ViewModifiers/WooStyleModifiers.swift
+++ b/WooFoundation/WooFoundation/ViewModifiers/WooStyleModifiers.swift
@@ -159,6 +159,19 @@ public struct LinkStyle: ViewModifier {
     }
 }
 
+public struct IconStyle: ViewModifier {
+    /// Environment `enabled` state.
+    ///
+    @Environment(\.isEnabled) var isEnabled
+
+    public init() {}
+
+    public func body(content: Content) -> some View {
+        content
+            .foregroundColor(isEnabled ? Color(.accent) : Color(.textTertiary))
+    }
+}
+
 public struct HeadlineLinkStyle: ViewModifier {
     /// Environment `enabled` state.
     ///
@@ -238,5 +251,9 @@ public extension View {
 
     func captionStyle() -> some View {
         self.modifier(CaptionStyle())
+    }
+
+    func iconStyle(_ isEnabled: Bool = true) -> some View {
+        self.modifier(IconStyle())
     }
 }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of: #11946
Closes: #11947
<!-- Id number of the GitHub issue this PR addresses. -->

## Why
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
We want to add support for customizing the analytics cards in the Analytics Hub, to show/hide cards and reorder them.

This PR adds the basic UI for the screen to customize the analytics cards. From the Analytics Hub, you can use the "Edit" button (behind a feature flag) to open a new "Customize Analytics" view with a list of cards that can be selected and reordered.

Note: For now, this new view contains preset data, and changes aren't saved/reflected in the Analytics Hub. This will be added in later PRs.

## How

* Updates the `SelectableItemRow` reusable component:
   * It now includes a `SelectionStyle` (checkmark or a check circle for the row selection).
   * Adds an `iconStyle(isEnabled:)` view modifier to change the selection icon color when disabled.
* Adds a new, reusable SwiftUI component `MultiSelectionReorderableList`. Key features:
   * It supports reordering the contents list, using SwiftUI's built-in `EditMode` and the `onMove(perform:)` modifier.
   * It supports multi-selection, saving the selected items in the `selectedItems` set.
   * It disables the last selected row, so the last selected item can't be deselected. (This will prevent deselecting all items and creating an empty state, which is how we intend to use this component at this point.)
* Adds `AnalyticsHubCustomizeView` to customize the analytics cards.
   * For now, this view has private variables `allCards` and `selectedCards` to create a `MultiSelectionReorderableList` with temporary data. These will be replaced with a view model containing real data later on.
   * The view has a close button and a Save button; for now, these just dismiss the view. (A discard changes prompt and save action will be added later.)

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

1. Build and run the app.
2. On the My Store dashboard, tap "See More" to open the Analytics Hub.
3. Tap the "Edit" button in the navigation bar.
4. Confirm the "Customize Analytics" screen opens modally and the first two list items ("Revenue" and "Orders") are preselected.
5. Confirm you can select/deselect and reorder the items in the list.
6. Try to deselect all the items in the list, and confirm the last selected item can't be deselected and appears disabled (selection icon is grey).
7. Confirm tapping the close button ("X") or Save button closes the modal view.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

https://github.com/woocommerce/woocommerce-ios/assets/8658164/4c21619c-564c-441e-9623-5233544e744c



---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
