### PR TITLE
[Analytics Hub] Handle logic/interactions for basic Customize Analytics UI

### DIFF
--- a/WooCommerce/Classes/View Modifiers/View+DiscardChanges.swift
+++ b/WooCommerce/Classes/View Modifiers/View+DiscardChanges.swift
@@ -82,6 +82,11 @@ struct DiscardChangesWrapper<Content: View>: UIViewControllerRepresentable {
 }
 
 struct CloseButtonWithDiscardPrompt: ViewModifier {
+    let title: String
+    let message: String
+    let discardButtonTitle: String
+    let cancelButtonTitle: String
+
     let showPrompt: Bool
     let didDismiss: (() -> Void)?
 
@@ -106,14 +111,14 @@ struct CloseButtonWithDiscardPrompt: ViewModifier {
                 }
             })
             .interactiveDismissDisabled()
-            .confirmationDialog("", isPresented: $isShowingPrompt) {
-                Button(Localization.discard, role: .destructive, action: {
+            .confirmationDialog(title, isPresented: $isShowingPrompt) {
+                Button(discardButtonTitle, role: .destructive, action: {
                     didDismiss?()
                     dismiss()
                 })
-                Button(Localization.cancel, role: .cancel, action: {})
+                Button(cancelButtonTitle, role: .cancel, action: {})
             } message: {
-                Text(Localization.message)
+                Text(message)
             }
     }
 }
@@ -145,11 +150,24 @@ extension View {
 
     /// Adds a close button with a discard changes prompt, and disables the dismiss drag gesture.
     /// - Parameters:
+    ///   - title: Title for the discard changes action sheet. Defaults to empty string.
+    ///   - message: Message for the discard changes action sheet. Defaults to "Are you sure you want to discard these changes?"
+    ///   - discardButtonTitle: Title for the discard changes button on the action sheet. Defaults to "Discard changes".
+    ///   - cancelButtonTitle: Title for the cancel button on the action sheet. Defaults to "Cancel".
     ///   - hasChanges: Whether there are changes to be discarded.
     ///   - didDismiss: Optional method to be invoked when the view is dismissed.
-    func closeButtonWithDiscardChangesPrompt(hasChanges: Bool,
+    func closeButtonWithDiscardChangesPrompt(title: String = "",
+                                             message: String = Localization.message,
+                                             discardButtonTitle: String = Localization.discard,
+                                             cancelButtonTitle: String = Localization.cancel,
+                                             hasChanges: Bool,
                                              didDismiss: (() -> Void)? = nil) -> some View {
-        ModifiedContent(content: self, modifier: CloseButtonWithDiscardPrompt(showPrompt: hasChanges, didDismiss: didDismiss))
+        ModifiedContent(content: self, modifier: CloseButtonWithDiscardPrompt(title: title,
+                                                                              message: message,
+                                                                              discardButtonTitle: discardButtonTitle,
+                                                                              cancelButtonTitle: cancelButtonTitle,
+                                                                              showPrompt: hasChanges,
+                                                                              didDismiss: didDismiss))
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/Customize/AnalyticsHubCustomizeView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/Customize/AnalyticsHubCustomizeView.swift
@@ -1,28 +1,23 @@
 import SwiftUI
 
 struct AnalyticsHubCustomizeView: View {
-    // TODO: Add view model to contain view data
-
-    // TODO: Replace with dynamic data (all available cards)
-    @State private var allCards: [String] = [
+    // TODO: Initialize with real data
+    @ObservedObject var viewModel = AnalyticsHubCustomizeViewModel(allCards: [
         "Revenue",
         "Orders",
         "Products",
         "Sessions"
-    ]
-
-    // TODO: Replace with dynamic data (all selected/enabled cards)
-    @State private var selectedCards: Set<String> = [
+    ], selectedCards: [
         "Revenue",
         "Orders"
-    ]
+    ])
 
     /// Dismisses the view.
     ///
     @Environment(\.dismiss) private var dismiss
 
     var body: some View {
-        MultiSelectionReorderableList(contents: $allCards, contentKeyPath: \.self, selectedItems: $selectedCards)
+        MultiSelectionReorderableList(contents: $viewModel.allCards, contentKeyPath: \.self, selectedItems: $viewModel.selectedCards)
             .toolbar(content: {
                 ToolbarItem(placement: .cancellationAction) {
                     Button(action: {

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/Customize/AnalyticsHubCustomizeView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/Customize/AnalyticsHubCustomizeView.swift
@@ -9,7 +9,7 @@ struct AnalyticsHubCustomizeView: View {
         "Sessions"
     ], selectedCards: [
         "Revenue",
-        "Orders"
+        "Products"
     ])
 
     /// Dismisses the view.

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/Customize/AnalyticsHubCustomizeView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/Customize/AnalyticsHubCustomizeView.swift
@@ -19,26 +19,20 @@ struct AnalyticsHubCustomizeView: View {
     var body: some View {
         MultiSelectionReorderableList(contents: $viewModel.allCards, contentKeyPath: \.self, selectedItems: $viewModel.selectedCards)
             .toolbar(content: {
-                ToolbarItem(placement: .cancellationAction) {
-                    Button(action: {
-                        dismiss() // TODO: Show discard changes prompt when there are changes
-                    }, label: {
-                        Image(uiImage: .closeButton)
-                            .secondaryBodyStyle()
-                    })
-                }
                 ToolbarItem(placement: .confirmationAction) {
                     Button {
                         dismiss() // TODO: Save changes
                     } label: {
                         Text(Localization.saveButton)
-                    } // TODO: Disable when there are no changes to save
+                    }
+                    .disabled(!viewModel.hasChanges)
                 }
             })
             .navigationTitle(Localization.title)
             .navigationBarTitleDisplayMode(.inline)
             .background(Color(uiColor: .listBackground))
             .wooNavigationBarStyle()
+            .closeButtonWithDiscardChangesPrompt(hasChanges: viewModel.hasChanges)
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/Customize/AnalyticsHubCustomizeViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/Customize/AnalyticsHubCustomizeViewModel.swift
@@ -27,9 +27,20 @@ final class AnalyticsHubCustomizeViewModel: ObservableObject {
 
     init(allCards: [String],
          selectedCards: Set<String>) {
-        self.allCards = allCards
-        self.originalCards = allCards
+        self.allCards = AnalyticsHubCustomizeViewModel.groupAllCards(allCards, by: selectedCards)
+        self.originalCards = AnalyticsHubCustomizeViewModel.groupAllCards(allCards, by: selectedCards)
         self.selectedCards = selectedCards
         self.originalSelection = selectedCards
+    }
+}
+
+private extension AnalyticsHubCustomizeViewModel {
+    /// Groups the selected cards at the start of the list of all cards.
+    /// This preserves the relative order of selected and unselected cards.
+    ///
+    static func groupAllCards(_ allCards: [String], by selectedCards: Set<String>) -> [String] {
+        var groupedCards = allCards
+        _ = groupedCards.stablePartition(by: { !selectedCards.contains($0) })
+        return groupedCards
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/Customize/AnalyticsHubCustomizeViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/Customize/AnalyticsHubCustomizeViewModel.swift
@@ -1,0 +1,19 @@
+import Foundation
+
+/// View model for `AnalyticsHubCustomizeView`.
+final class AnalyticsHubCustomizeViewModel: ObservableObject {
+
+    /// Ordered array of all available analytics cards.
+    ///
+    @Published var allCards: [String]
+
+    /// Set of selected analytics cards, to be enabled in the Analytics Hub.
+    ///
+    @Published var selectedCards: Set<String>
+
+    init(allCards: [String],
+         selectedCards: Set<String>) {
+        self.allCards = allCards
+        self.selectedCards = selectedCards
+    }
+}

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/Customize/AnalyticsHubCustomizeViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/Customize/AnalyticsHubCustomizeViewModel.swift
@@ -11,9 +11,25 @@ final class AnalyticsHubCustomizeViewModel: ObservableObject {
     ///
     @Published var selectedCards: Set<String>
 
+    /// Original ordered array of analytics cards. Used to track if there are order changes to be saved.
+    ///
+    private let originalCards: [String]
+
+    /// Original set of selected cards. Used to track if there are selection changes to be saved.
+    ///
+    private let originalSelection: Set<String>?
+
+    /// Whether there are changes to be saved (card order or selection has changed).
+    ///
+    var hasChanges: Bool {
+        allCards != originalCards || selectedCards != originalSelection
+    }
+
     init(allCards: [String],
          selectedCards: Set<String>) {
         self.allCards = allCards
+        self.originalCards = allCards
         self.selectedCards = selectedCards
+        self.originalSelection = selectedCards
     }
 }

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -2016,10 +2016,12 @@
 		CE4DA5C821DD759400074607 /* CurrencyFormatterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE4DA5C721DD759400074607 /* CurrencyFormatterTests.swift */; };
 		CE4DDB7B20DD312400D32EC8 /* DateFormatter+Helpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE4DDB7A20DD312400D32EC8 /* DateFormatter+Helpers.swift */; };
 		CE4FE7D82B7D306200F66DD5 /* MultiSelectionReorderableList.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE4FE7D72B7D306200F66DD5 /* MultiSelectionReorderableList.swift */; };
+		CE4FE7DA2B7E2E9400F66DD5 /* AnalyticsHubCustomizeViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE4FE7D92B7E2E9400F66DD5 /* AnalyticsHubCustomizeViewModel.swift */; };
 		CE55F2D42B238C04005D53D7 /* CollapsibleProductCardPriceSummaryViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE55F2D32B238C04005D53D7 /* CollapsibleProductCardPriceSummaryViewModel.swift */; };
 		CE55F2D62B23941D005D53D7 /* CollapsibleProductCardPriceSummary.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE55F2D52B23941D005D53D7 /* CollapsibleProductCardPriceSummary.swift */; };
 		CE55F2D82B23961B005D53D7 /* CollapsibleProductCardPriceSummaryViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE55F2D72B23961B005D53D7 /* CollapsibleProductCardPriceSummaryViewModelTests.swift */; };
 		CE55F2DA2B28796E005D53D7 /* ProductDiscountViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE55F2D92B28796E005D53D7 /* ProductDiscountViewModel.swift */; };
+		CE5757AF2B7E7F7400AEEB6D /* AnalyticsHubCustomizeViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE5757AE2B7E7F7400AEEB6D /* AnalyticsHubCustomizeViewModelTests.swift */; };
 		CE583A0421076C0100D73C1C /* NewNoteViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE583A0321076C0100D73C1C /* NewNoteViewController.swift */; };
 		CE583A072107849F00D73C1C /* SwitchTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE583A052107849F00D73C1C /* SwitchTableViewCell.swift */; };
 		CE583A082107849F00D73C1C /* SwitchTableViewCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = CE583A062107849F00D73C1C /* SwitchTableViewCell.xib */; };
@@ -4721,10 +4723,12 @@
 		CE4DA5C721DD759400074607 /* CurrencyFormatterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CurrencyFormatterTests.swift; sourceTree = "<group>"; };
 		CE4DDB7A20DD312400D32EC8 /* DateFormatter+Helpers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "DateFormatter+Helpers.swift"; sourceTree = "<group>"; };
 		CE4FE7D72B7D306200F66DD5 /* MultiSelectionReorderableList.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MultiSelectionReorderableList.swift; sourceTree = "<group>"; };
+		CE4FE7D92B7E2E9400F66DD5 /* AnalyticsHubCustomizeViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnalyticsHubCustomizeViewModel.swift; sourceTree = "<group>"; };
 		CE55F2D32B238C04005D53D7 /* CollapsibleProductCardPriceSummaryViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CollapsibleProductCardPriceSummaryViewModel.swift; sourceTree = "<group>"; };
 		CE55F2D52B23941D005D53D7 /* CollapsibleProductCardPriceSummary.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CollapsibleProductCardPriceSummary.swift; sourceTree = "<group>"; };
 		CE55F2D72B23961B005D53D7 /* CollapsibleProductCardPriceSummaryViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CollapsibleProductCardPriceSummaryViewModelTests.swift; sourceTree = "<group>"; };
 		CE55F2D92B28796E005D53D7 /* ProductDiscountViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductDiscountViewModel.swift; sourceTree = "<group>"; };
+		CE5757AE2B7E7F7400AEEB6D /* AnalyticsHubCustomizeViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnalyticsHubCustomizeViewModelTests.swift; sourceTree = "<group>"; };
 		CE583A0321076C0100D73C1C /* NewNoteViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NewNoteViewController.swift; sourceTree = "<group>"; };
 		CE583A052107849F00D73C1C /* SwitchTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SwitchTableViewCell.swift; sourceTree = "<group>"; };
 		CE583A062107849F00D73C1C /* SwitchTableViewCell.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = SwitchTableViewCell.xib; sourceTree = "<group>"; };
@@ -9547,6 +9551,7 @@
 				B6440FB8292E74230012D506 /* AnalyticsHubTimeRangeSelectionTests.swift */,
 				CEA9C8DF2B6D323A000FE114 /* AnalyticsWebReportTests.swift */,
 				CE6A8FB72B7291760063564D /* AnalyticsReportLinkViewModelTests.swift */,
+				CE5757AE2B7E7F7400AEEB6D /* AnalyticsHubCustomizeViewModelTests.swift */,
 			);
 			path = "Analytics Hub";
 			sourceTree = "<group>";
@@ -10882,6 +10887,7 @@
 			isa = PBXGroup;
 			children = (
 				CEFA16F02B74F64D00512782 /* AnalyticsHubCustomizeView.swift */,
+				CE4FE7D92B7E2E9400F66DD5 /* AnalyticsHubCustomizeViewModel.swift */,
 			);
 			path = Customize;
 			sourceTree = "<group>";
@@ -13589,6 +13595,7 @@
 				451A04F02386F7B500E368C9 /* ProductImageCollectionViewCell.swift in Sources */,
 				AEACCB6D2785FF4A000D01F0 /* NavigationRow.swift in Sources */,
 				DE50294928BEF4CF00551736 /* WordPressOrgCredentials+Authenticator.swift in Sources */,
+				CE4FE7DA2B7E2E9400F66DD5 /* AnalyticsHubCustomizeViewModel.swift in Sources */,
 				CC857C7529B23AE100E19D1E /* BundledProductsListViewModel.swift in Sources */,
 				02E8B17E23E2C8D900A43403 /* ProductImageActionHandler.swift in Sources */,
 				03076D3A290C22BE008EE839 /* WebView.swift in Sources */,
@@ -15129,6 +15136,7 @@
 				02E493EF245C1087000AEA9E /* ProductFormBottomSheetListSelectorCommandTests.swift in Sources */,
 				B90DACC22A31BBC800365897 /* BarcodeSKUScannerProductFinderTests.swift in Sources */,
 				D88D5A3B230B5D63007B6E01 /* MockAnalyticsProvider.swift in Sources */,
+				CE5757AF2B7E7F7400AEEB6D /* AnalyticsHubCustomizeViewModelTests.swift in Sources */,
 				EE1905822B50289100617C53 /* BlazeCampaignCreationFormViewModelTests.swift in Sources */,
 				B9C4AB29280031AB007008B8 /* PaymentReceiptEmailParameterDeterminerTests.swift in Sources */,
 				029A9C672535873000BECEC5 /* AppCoordinatorTests.swift in Sources */,

--- a/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Analytics Hub/AnalyticsHubCustomizeViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Analytics Hub/AnalyticsHubCustomizeViewModelTests.swift
@@ -12,6 +12,29 @@ final class AnalyticsHubCustomizeViewModelTests: XCTestCase {
         // Then
         assertEqual(allCards, vm.allCards)
         assertEqual(selectedCards, vm.selectedCards)
+        XCTAssertFalse(vm.hasChanges)
+    }
+
+    func test_hasChanges_is_true_when_card_order_changes() {
+        // Given
+        let vm = AnalyticsHubCustomizeViewModel(allCards: ["First", "Second"], selectedCards: [])
+
+        // When
+        vm.allCards = ["Second", "First"]
+
+        // Then
+        XCTAssertTrue(vm.hasChanges)
+    }
+
+    func test_hasChanges_is_true_when_selection_changes() {
+        // Given
+        let vm = AnalyticsHubCustomizeViewModel(allCards: ["First", "Second"], selectedCards: ["Second"])
+
+        // When
+        vm.selectedCards = ["First", "Second"]
+
+        // Then
+        XCTAssertTrue(vm.hasChanges)
     }
 
 }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Analytics Hub/AnalyticsHubCustomizeViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Analytics Hub/AnalyticsHubCustomizeViewModelTests.swift
@@ -1,0 +1,17 @@
+import XCTest
+@testable import WooCommerce
+
+final class AnalyticsHubCustomizeViewModelTests: XCTestCase {
+
+    func test_it_inits_with_expected_properties() {
+        // Given
+        let allCards = ["First", "Second"]
+        let selectedCards = Set(["Second"])
+        let vm = AnalyticsHubCustomizeViewModel(allCards: allCards, selectedCards: selectedCards)
+
+        // Then
+        assertEqual(allCards, vm.allCards)
+        assertEqual(selectedCards, vm.selectedCards)
+    }
+
+}

--- a/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Analytics Hub/AnalyticsHubCustomizeViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Analytics Hub/AnalyticsHubCustomizeViewModelTests.swift
@@ -6,13 +6,21 @@ final class AnalyticsHubCustomizeViewModelTests: XCTestCase {
     func test_it_inits_with_expected_properties() {
         // Given
         let allCards = ["First", "Second"]
-        let selectedCards = Set(["Second"])
+        let selectedCards = Set(["First"])
         let vm = AnalyticsHubCustomizeViewModel(allCards: allCards, selectedCards: selectedCards)
 
         // Then
         assertEqual(allCards, vm.allCards)
         assertEqual(selectedCards, vm.selectedCards)
         XCTAssertFalse(vm.hasChanges)
+    }
+
+    func test_it_groups_all_selected_cards_at_top_of_allCards_list_in_original_order() {
+        // Given
+        let vm = AnalyticsHubCustomizeViewModel(allCards: ["First", "Second", "Third"], selectedCards: ["Third", "Second"])
+
+        // Then
+        assertEqual(["Second", "Third", "First"], vm.allCards)
     }
 
     func test_hasChanges_is_true_when_card_order_changes() {


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #11946
⚠️ Depends on #12024 ⚠️ 
<!-- Id number of the GitHub issue this PR addresses. -->

## Why
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This adds a view model to handle basic logic and user interactions for the "Customize Analytics" UI added in #12024. These interactions include:

* Displays a discard changes prompt if there are unsaved changes when the close button is tapped.
* Disables the Save button if there are no changes to save.
* Groups selected analytics cards at the top of the list of cards when the view is opened, while otherwise preserving the order of selected and unselected cards. (We do this instead of moving the rows as they are selected/deselected.)

## How

* Adds a view model `AnalyticsHubCustomizeViewModel`:
   * Tracks if there are changes to the card order or selection in `hasChanges`.
   * Uses `stablePartition(by:)` to group the `allCards` array with selected cards at the start of the array. This is done when the view model is initialized, to ensure the view always shows selected cards first.
* Adds a reusable view modifier `closeButtonWithDiscardChangesPrompt(hasChanges: didDismiss:)` that adds a close button with a discard changes prompt when there are changes.
* Adds the new view model and discard changes modifier to the `AnalyticsHubCustomizeView`, and disables the Save button with the view model `hasChanges` property.
* Adds unit tests for the view model.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

1. Build and run the app.
2. On the My Store dashboard, tap "See More" to open the Analytics Hub.
3. Tap the "Edit" button in the navigation bar to open the Customize Analytics view.
4. Confirm the Save button is disabled by default, and all the selected rows are grouped at the top of the list.
5. Make a change (select/deselect or reorder rows) and confirm the Save button becomes enabled.
6. Confirm you can tap the close button to close the view when there are no changes, and it brings up a discard changes prompt if there are changes.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

https://github.com/woocommerce/woocommerce-ios/assets/8658164/8a477151-7501-4714-a636-f8153b12c39b



---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
