### PR TITLE
Remove `addProductToOrderViaSKUScanner` feature flag

### DIFF
--- a/Experiments/Experiments/DefaultFeatureFlagService.swift
+++ b/Experiments/Experiments/DefaultFeatureFlagService.swift
@@ -43,8 +43,6 @@ public struct DefaultFeatureFlagService: FeatureFlagService {
             return true
         case .dashboardOnboarding:
             return true
-        case .addProductToOrderViaSKUScanner:
-            return true
         case .productBundles:
             return true
         case .manualErrorHandlingForSiteCredentialLogin:

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/EditableOrderViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/EditableOrderViewModel.swift
@@ -108,12 +108,6 @@ final class EditableOrderViewModel: ObservableObject {
         !featureFlagService.isFeatureFlagEnabled(.betterCustomerSelectionInOrder)
     }
 
-    /// Indicates whether adding a product to the order via SKU scanning is enabled
-    ///
-    var isAddProductToOrderViaSKUScannerEnabled: Bool {
-        featureFlagService.isFeatureFlagEnabled(.addProductToOrderViaSKUScanner)
-    }
-
     var enableAddingCustomAmountViaOrderTotalPercentage: Bool {
         orderSynchronizer.order.items.isNotEmpty || orderSynchronizer.order.fees.isNotEmpty
     }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/OrderForm.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/OrderForm.swift
@@ -554,7 +554,6 @@ private struct ProductsSection: View {
 
                     HStack(spacing: OrderForm.Layout.productsHeaderButtonsSpacing) {
                         scanProductButton
-                        .renderedIf(viewModel.isAddProductToOrderViaSKUScannerEnabled)
 
                         if let presentProductSelector {
                             Button(action: {
@@ -612,9 +611,7 @@ private struct ProductsSection: View {
                         .accessibilityIdentifier(OrderForm.Accessibility.addProductButtonIdentifier)
                         .buttonStyle(PlusButtonStyle())
                     }
-
                     scanProductButton
-                    .renderedIf(viewModel.isAddProductToOrderViaSKUScannerEnabled)
                 }
                 .renderedIf(viewModel.shouldShowAddProductsButton)
             }

--- a/WooCommerce/Classes/ViewRelated/Orders/OrdersRootViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrdersRootViewController.swift
@@ -351,15 +351,9 @@ private extension OrdersRootViewController {
     }
 
     /// Sets navigation buttons.
-    /// Scan: Present when `.addProductToOrderViaSKUScanner` flag is enabled
-    /// Search: Always present.
-    /// Add: Always present.
     ///
     func configureNavigationButtons() {
-        if featureFlagService.isFeatureFlagEnabled(.addProductToOrderViaSKUScanner) {
-            configureLeftButtonItemAsProductScanningButton()
-        }
-
+        configureLeftButtonItemAsProductScanningButton()
         navigationItem.rightBarButtonItems = [
             createAddOrderItem(),
             createSearchBarButtonItem()

--- a/WooCommerce/Classes/ViewRelated/Orders/OrdersRootViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrdersRootViewController.swift
@@ -256,7 +256,6 @@ final class OrdersRootViewController: UIViewController {
             self?.navigationItem.configureLeftBarButtonItemAsLoader()
             self?.handleScannedBarcode(scannedBarcode) { [weak self] result in
                 guard let self = self else { return }
-                self.configureLeftButtonItemAsProductScanningButton()
                 switch result {
                 case let .success(product):
                     self.analytics.track(event: WooAnalyticsEvent.Orders.orderProductAdd(flow: .creation,
@@ -353,15 +352,11 @@ private extension OrdersRootViewController {
     /// Sets navigation buttons.
     ///
     func configureNavigationButtons() {
-        configureLeftButtonItemAsProductScanningButton()
+        navigationItem.leftBarButtonItem = createAddOrderByProductScanningButtonItem()
         navigationItem.rightBarButtonItems = [
             createAddOrderItem(),
             createSearchBarButtonItem()
         ]
-    }
-
-    func configureLeftButtonItemAsProductScanningButton() {
-        navigationItem.leftBarButtonItem = createAddOrderByProductScanningButtonItem()
     }
 
     func configureFiltersBar() {

--- a/WooCommerce/WooCommerceTests/Mocks/MockFeatureFlagService.swift
+++ b/WooCommerce/WooCommerceTests/Mocks/MockFeatureFlagService.swift
@@ -14,7 +14,6 @@ struct MockFeatureFlagService: FeatureFlagService {
     private let isProductDescriptionAIFromStoreOnboardingEnabled: Bool
     private let isReadOnlyGiftCardsEnabled: Bool
     private let isHideStoreOnboardingTaskListFeatureEnabled: Bool
-    private let isAddProductToOrderViaSKUScannerEnabled: Bool
     private let isBlazeEnabled: Bool
     private let isShareProductAIEnabled: Bool
     private let betterCustomerSelectionInOrder: Bool
@@ -37,7 +36,6 @@ struct MockFeatureFlagService: FeatureFlagService {
          isProductDescriptionAIFromStoreOnboardingEnabled: Bool = false,
          isReadOnlyGiftCardsEnabled: Bool = false,
          isHideStoreOnboardingTaskListFeatureEnabled: Bool = false,
-         isAddProductToOrderViaSKUScannerEnabled: Bool = false,
          isBlazeEnabled: Bool = false,
          isShareProductAIEnabled: Bool = false,
          betterCustomerSelectionInOrder: Bool = false,
@@ -59,7 +57,6 @@ struct MockFeatureFlagService: FeatureFlagService {
         self.isProductDescriptionAIFromStoreOnboardingEnabled = isProductDescriptionAIFromStoreOnboardingEnabled
         self.isReadOnlyGiftCardsEnabled = isReadOnlyGiftCardsEnabled
         self.isHideStoreOnboardingTaskListFeatureEnabled = isHideStoreOnboardingTaskListFeatureEnabled
-        self.isAddProductToOrderViaSKUScannerEnabled = isAddProductToOrderViaSKUScannerEnabled
         self.isBlazeEnabled = isBlazeEnabled
         self.isShareProductAIEnabled = isShareProductAIEnabled
         self.betterCustomerSelectionInOrder = betterCustomerSelectionInOrder
@@ -97,8 +94,6 @@ struct MockFeatureFlagService: FeatureFlagService {
             return isReadOnlyGiftCardsEnabled
         case .hideStoreOnboardingTaskList:
             return isHideStoreOnboardingTaskListFeatureEnabled
-        case .addProductToOrderViaSKUScanner:
-            return isAddProductToOrderViaSKUScannerEnabled
         case .shareProductAI:
             return isShareProductAIEnabled
         case .betterCustomerSelectionInOrder:

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/EditableOrderViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/EditableOrderViewModelTests.swift
@@ -766,22 +766,6 @@ final class EditableOrderViewModelTests: XCTestCase {
         XCTAssertEqual(analytics.receivedProperties.first?["source"] as? String, "order_creation")
     }
 
-    func test_add_product_to_order_via_sku_scanner_when_feature_flag_is_enabled_then_feature_support_returns_true() {
-        // Given
-        let viewModel = EditableOrderViewModel(siteID: sampleSiteID, featureFlagService: MockFeatureFlagService(isAddProductToOrderViaSKUScannerEnabled: true))
-
-        // Then
-        XCTAssertTrue(viewModel.isAddProductToOrderViaSKUScannerEnabled)
-    }
-
-    func test_add_product_to_order_via_sku_scanner_feature_flag_is_disabled_then_feature_support_returns_false() {
-        // Given
-        let viewModel = EditableOrderViewModel(siteID: sampleSiteID, featureFlagService: MockFeatureFlagService(isAddProductToOrderViaSKUScannerEnabled: false))
-
-        // Then
-        XCTAssertFalse(viewModel.isAddProductToOrderViaSKUScannerEnabled)
-    }
-
     // MARK: - Payment Section Tests
 
     func test_payment_section_when_products_and_custom_amounts_are_added_then_paymentDataViewModel_is_updated() throws {


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

## Description
This PR removes the feature flag for `addProductToOrderViaSKUScanner`, which has been in production for several months now.

## Testing instructions
- Go to Orders > Observe that the scanning button appears in the left top corner. Tapping on it opens the barcode scanner.
- Still in Orders > tap `+` > Observe the button `+ Add Products [Scanner icon]`. Tapping on it opens the barcode scanner.
- Bonus points for testing the scanner, but is not necessary since we don't change its behaviour (you'll need a physical device, it doesn't work on simulated devices).

## Screenshots
| Order list | Order creation |
|--------|--------|
| ![__20240216-scanner-order-view](https://github.com/woocommerce/woocommerce-ios/assets/3812076/1031369c-7331-42f6-8001-1ac9ef3ac9f0) | ![__20240216-scanner-orderdetails-view](https://github.com/woocommerce/woocommerce-ios/assets/3812076/33cb160f-87db-44c8-9541-14160a2d78b6) |
