### PR TITLE
Blaze: Update duration and start date after tapping the Apply button

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Blaze/BudgetSetting/BlazeBudgetSettingView.swift
+++ b/WooCommerce/Classes/ViewRelated/Blaze/BudgetSetting/BlazeBudgetSettingView.swift
@@ -7,6 +7,8 @@ struct BlazeBudgetSettingView: View {
     @Environment(\.sizeCategory) private var sizeCategory
     @State private var showingImpressionInfo = false
     @State private var showingDurationSetting = false
+    @State private var duration: Double = 0
+    @State private var startDate = Date()
 
     @ObservedObject private var viewModel: BlazeBudgetSettingViewModel
 
@@ -43,6 +45,10 @@ struct BlazeBudgetSettingView: View {
             } else {
                 durationSettingView
             }
+        }
+        .onAppear {
+            duration = viewModel.dayCount
+            startDate = viewModel.startDate
         }
     }
 }
@@ -182,11 +188,11 @@ private extension BlazeBudgetSettingView {
             ScrollView {
                 // Duration slider
                 VStack(spacing: Layout.sectionContentSpacing) {
-                    Text(viewModel.formattedDayCount)
+                    Text(viewModel.formatDayCount(duration))
                         .fontWeight(.semibold)
                         .bodyStyle()
 
-                    Slider(value: $viewModel.dayCount,
+                    Slider(value: $duration,
                            in: viewModel.dayCountSliderRange,
                            step: Double(BlazeBudgetSettingViewModel.Constants.dayCountSliderStep))
                 }
@@ -201,7 +207,7 @@ private extension BlazeBudgetSettingView {
 
                         Spacer()
 
-                        DatePicker(selection: $viewModel.startDate, in: Date()..., displayedComponents: [.date]) {
+                        DatePicker(selection: $startDate, in: Date()..., displayedComponents: [.date]) {
                             EmptyView()
                         }
                         .datePickerStyle(.compact)
@@ -215,7 +221,7 @@ private extension BlazeBudgetSettingView {
 
                 // CTA
                 Button(Localization.apply) {
-                    viewModel.didTapApplyDuration()
+                    viewModel.didTapApplyDuration(dayCount: duration, since: startDate)
                     showingDurationSetting = false
                 }
                 .buttonStyle(PrimaryButtonStyle())

--- a/WooCommerce/Classes/ViewRelated/Blaze/BudgetSetting/BlazeBudgetSettingViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Blaze/BudgetSetting/BlazeBudgetSettingViewModel.swift
@@ -48,6 +48,7 @@ final class BlazeBudgetSettingViewModel: ObservableObject {
     }()
 
     private let siteID: Int64
+    private let locale: Locale
     private let timeZone: TimeZone
     private let targetOptions: BlazeTargetOptions?
     private let stores: StoresManager
@@ -62,6 +63,7 @@ final class BlazeBudgetSettingViewModel: ObservableObject {
          dailyBudget: Double,
          duration: Int,
          startDate: Date,
+         locale: Locale = .current,
          timeZone: TimeZone = .current,
          targetOptions: BlazeTargetOptions? = nil,
          stores: StoresManager = ServiceLocator.stores,
@@ -71,6 +73,7 @@ final class BlazeBudgetSettingViewModel: ObservableObject {
         self.dailyAmount = dailyBudget
         self.dayCount = Double(duration)
         self.startDate = startDate
+        self.locale = locale
         self.timeZone = timeZone
         self.targetOptions = targetOptions
         self.stores = stores
@@ -117,7 +120,10 @@ final class BlazeBudgetSettingViewModel: ObservableObject {
                                                     targeting: targetOptions)
         do {
             let result = try await fetchForecastedImpressions(input: input)
-            let formattedImpressions = String(format: "%d - %d", result.totalImpressionsMin, result.totalImpressionsMax)
+            let formattedImpressions = String(format: "%d - %d",
+                                              locale: locale,
+                                              result.totalImpressionsMin,
+                                              result.totalImpressionsMax)
             forecastedImpressionState = .result(formattedResult: formattedImpressions)
         } catch {
             DDLogError("⛔️ Error fetching forecasted impression: \(error)")

--- a/WooCommerce/Classes/ViewRelated/Blaze/BudgetSetting/BlazeBudgetSettingViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Blaze/BudgetSetting/BlazeBudgetSettingViewModel.swift
@@ -6,8 +6,11 @@ import Yosemite
 final class BlazeBudgetSettingViewModel: ObservableObject {
     @Published var dailyAmount: Double
     /// Using Double because Slider doesn't work with Int
-    @Published var dayCount: Double
-    @Published var startDate: Date
+    /// This is readonly and will be updated through `didTapApplyDuration`.
+    @Published private(set) var dayCount: Double
+
+    /// This is readonly and will be updated through `didTapApplyDuration`.
+    @Published private(set) var startDate: Date
 
     @Published private(set) var forecastedImpressionState = ForecastedImpressionState.loading
 
@@ -30,12 +33,6 @@ final class BlazeBudgetSettingViewModel: ObservableObject {
         String.pluralize(Int(dayCount),
                          singular: Localization.totalDurationSingleDay,
                          plural: Localization.totalDurationMultipleDays)
-    }
-
-    var formattedDayCount: String {
-        String.pluralize(Int(dayCount),
-                         singular: Localization.singleDay,
-                         plural: Localization.multipleDays)
     }
 
     var formattedDateRange: String {
@@ -83,8 +80,16 @@ final class BlazeBudgetSettingViewModel: ObservableObject {
         observeSettings()
     }
 
-    func didTapApplyDuration() {
+    func didTapApplyDuration(dayCount: Double, since startDate: Date) {
         analytics.track(event: .Blaze.Budget.changedDuration(Int(dayCount)))
+        self.dayCount = dayCount
+        self.startDate = startDate
+    }
+
+    func formatDayCount(_ count: Double) -> String {
+        String.pluralize(Int(count),
+                         singular: Localization.singleDay,
+                         plural: Localization.multipleDays)
     }
 
     func confirmSettings() {

--- a/WooCommerce/WooCommerceTests/ViewRelated/Blaze/BlazeBudgetSettingViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Blaze/BlazeBudgetSettingViewModelTests.swift
@@ -53,6 +53,7 @@ final class BlazeBudgetSettingViewModelTests: XCTestCase {
                                                     dailyBudget: 15,
                                                     duration: 3,
                                                     startDate: .now,
+                                                    locale: Locale(identifier: "en_US"),
                                                     stores: stores,
                                                     onCompletion: { _, _, _ in })
 
@@ -70,7 +71,7 @@ final class BlazeBudgetSettingViewModelTests: XCTestCase {
         await viewModel.updateImpressions(startDate: .now, dayCount: 3, dailyBudget: 15)
 
         // Then
-        XCTAssertEqual(viewModel.forecastedImpressionState, .result(formattedResult: "1000 - 5000"))
+        XCTAssertEqual(viewModel.forecastedImpressionState, .result(formattedResult: "1,000 - 5,000"))
     }
 
     func test_updateImpressions_updates_forecastedImpressionState_correctly_when_fetching_impression_fails() async {

--- a/WooCommerce/WooCommerceTests/ViewRelated/Blaze/BlazeBudgetSettingViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Blaze/BlazeBudgetSettingViewModelTests.swift
@@ -37,8 +37,7 @@ final class BlazeBudgetSettingViewModelTests: XCTestCase {
 
         // When
         viewModel.dailyAmount = 80
-        viewModel.dayCount = 7
-        viewModel.startDate = expectedStartDate
+        viewModel.didTapApplyDuration(dayCount: 7, since: expectedStartDate)
         viewModel.confirmSettings()
 
         // Then
@@ -128,8 +127,7 @@ final class BlazeBudgetSettingViewModelTests: XCTestCase {
             }
         }
         viewModel.dailyAmount = 20
-        viewModel.dayCount = 7
-        viewModel.startDate = expectedStartDate
+        viewModel.didTapApplyDuration(dayCount: 7, since: expectedStartDate)
         await viewModel.retryFetchingImpressions()
 
         // Then
@@ -173,8 +171,7 @@ final class BlazeBudgetSettingViewModelTests: XCTestCase {
 
 
         // When
-        viewModel.dayCount = 7
-        viewModel.didTapApplyDuration()
+        viewModel.didTapApplyDuration(dayCount: 7, since: .now)
 
         // Then
         let index = try XCTUnwrap(analyticsProvider.receivedEvents.firstIndex(of: "blaze_creation_edit_budget_set_duration_applied"))


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #12027 
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This PR follows the discussion in p1708002828270189-slack-C03L1NF1EA3 to update day count and start date on the budget settings screen only when the Apply button is tapped.

The solution is to keep separate states for the day count and start date on the SwiftUI view, and only update the values in the view model after tapping the Apply button.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
- Log in to a store eligible for Blaze.
- Select a product and tap Promote.
- On the Blaze campaign creation form, select the Budget field.
- Tap the Edit button on the footer of the screen to update the duration. Confirm that the initial states of the duration and start date are correct.
- Drag the duration slider and/or select different start dates. Confirm that the budget is not updated in the background.
- Tap the Apply button. Confirm that the budget and estimated impressions are updated correctly.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

https://github.com/woocommerce/woocommerce-ios/assets/5533851/e4041ac8-dc79-48c9-a011-e3f533fae3ed



---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.