### PR TITLE
Adds Connectivity Tool UI Mockup

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Connectivity Tool/ConnectivityTool.swift
+++ b/WooCommerce/Classes/ViewRelated/Connectivity Tool/ConnectivityTool.swift
@@ -1,0 +1,155 @@
+import SwiftUI
+
+/// View for the Connectivity Tool.
+///
+struct ConnectivityTool: View {
+
+    /// Dependency object.
+    ///
+    struct Card {
+        let title: String
+        let icon: ConnectivityToolCard.Icon
+        let state: ConnectivityToolCard.State
+    }
+
+    /// Tool cards.
+    ///
+    let cards: [Card]
+
+    var body: some View {
+        VStack(alignment: .center, spacing: .zero) {
+
+            ForEach(cards, id: \.title) { card in
+                ConnectivityToolCard(icon: card.icon, title: card.title, state: card.state)
+            }
+
+            Spacer()
+
+            Button(Localization.contactSupport) {
+                print()
+            }
+            .buttonStyle(PrimaryButtonStyle())
+        }
+        .frame(maxWidth: .greatestFiniteMagnitude, maxHeight: .greatestFiniteMagnitude, alignment: .topLeading)
+        .padding()
+        .background(Color(uiColor: .listBackground))
+    }
+}
+
+private extension ConnectivityTool {
+    enum Localization {
+        static let contactSupport = NSLocalizedString("Contact Support",
+                                                      comment: "Contact support button in the connectivity tool screen")
+    }
+}
+
+/// Reusable connectivity card.
+///
+struct ConnectivityToolCard: View {
+
+    /// Represents the state of the card.
+    ///
+    enum State {
+        case inProgress
+        case success
+        case error(String)
+
+        /// Builds the icon based on the state
+        ///
+        @ViewBuilder func buildIcon() -> some View {
+            switch self {
+            case .inProgress:
+                ProgressView()
+            case .success:
+                Image(uiImage: .checkCircleImage)
+            case .error:
+                Image(uiImage: .checkPartialCircleImage.withRenderingMode(.alwaysTemplate))
+                    .foregroundColor(Color.init(uiColor: .error))
+            }
+        }
+    }
+
+    /// Represents the icon of the card
+    ///
+    enum Icon {
+        case system(String)
+        case uiImage(UIImage)
+
+        /// Builds the asset based on the icon
+        ///
+        func buildAsset() -> Image {
+            switch self {
+            case .system(let name):
+                return Image(systemName: name)
+            case .uiImage(let uiImage):
+                return Image(uiImage: uiImage)
+            }
+        }
+    }
+
+    /// Card icon
+    ///
+    let icon: Icon
+
+    /// Card title
+    ///
+    let title: String
+
+    /// Card state
+    ///
+    let state: State
+
+    /// Internal layout values
+    ///
+    @ScaledMetric private var iconSize = 40.0
+    private static let cornerRadius = 4.0
+
+    var body: some View {
+        VStack {
+            HStack {
+
+                Circle()
+                    .fill(Color(uiColor: .listBackground))
+                    .overlay {
+                        icon.buildAsset()
+                            .foregroundColor(Color(uiColor: .primary))
+                    }
+                    .frame(width: iconSize, height: iconSize)
+
+                Text(title)
+                    .bodyStyle()
+
+                Spacer()
+
+                state.buildIcon()
+            }
+
+            if case let .error(message) = state {
+                Text(message)
+                    .foregroundColor(Color(uiColor: .error))
+                    .subheadlineStyle()
+                    .padding(.horizontal, 6)
+            }
+        }
+        .padding()
+        .background(Color(uiColor: .listForeground(modal: false)))
+        .cornerRadius(Self.cornerRadius)
+        .padding()
+    }
+}
+
+
+#Preview("Tool") {
+    NavigationView {
+        ConnectivityTool(cards: [
+            .init(title: "Internet Connection", icon: .system("wifi"), state: .success),
+            .init(title: "WordPress.com servers", icon: .system("server.rack"), state: .success),
+            .init(title: "Your Site",
+                  icon: .system("storefront"),
+                  state: .error("Your site is not responding properly\nPlease reach out to your host for further assistance")),
+            .init(title: "Your site orders", icon: .system("list.clipboard"), state: .inProgress)
+        ])
+            .navigationTitle("Connectivity Test")
+            .navigationBarTitleDisplayMode(.inline)
+    }
+}

--- a/WooCommerce/Classes/ViewRelated/Connectivity Tool/ConnectivityTool.swift
+++ b/WooCommerce/Classes/ViewRelated/Connectivity Tool/ConnectivityTool.swift
@@ -62,6 +62,7 @@ struct ConnectivityToolCard: View {
                 ProgressView()
             case .success:
                 Image(uiImage: .checkCircleImage)
+                    .environment(\.colorScheme, .light)
             case .error:
                 Image(uiImage: .checkPartialCircleImage.withRenderingMode(.alwaysTemplate))
                     .foregroundColor(Color.init(uiColor: .error))

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -920,6 +920,7 @@
 		26CCBE0B2523B3650073F94D /* RefundProductsTotalTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26CCBE0A2523B3650073F94D /* RefundProductsTotalTableViewCell.swift */; };
 		26CCBE0D2523C2560073F94D /* RefundProductsTotalTableViewCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = 26CCBE0C2523C2560073F94D /* RefundProductsTotalTableViewCell.xib */; };
 		26CE6F342B7D4C27008DB858 /* Error+Timeout.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26CE6F332B7D4C27008DB858 /* Error+Timeout.swift */; };
+		26CE6F392B7E71AA008DB858 /* ConnectivityTool.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26CE6F382B7E71AA008DB858 /* ConnectivityTool.swift */; };
 		26CFDB2727357E8000AB940B /* SimplePaymentsSummary.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26CFDB2627357E8000AB940B /* SimplePaymentsSummary.swift */; };
 		26D1E9E82949818B00A7DC62 /* AnalyticsHubTimeRageAdapter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26D1E9E72949818B00A7DC62 /* AnalyticsHubTimeRageAdapter.swift */; };
 		26D57CF72B59820600E8EFB8 /* View+ContainerBackground.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26D57CF62B59820600E8EFB8 /* View+ContainerBackground.swift */; };
@@ -3609,6 +3610,7 @@
 		26CCBE0A2523B3650073F94D /* RefundProductsTotalTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RefundProductsTotalTableViewCell.swift; sourceTree = "<group>"; };
 		26CCBE0C2523C2560073F94D /* RefundProductsTotalTableViewCell.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = RefundProductsTotalTableViewCell.xib; sourceTree = "<group>"; };
 		26CE6F332B7D4C27008DB858 /* Error+Timeout.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Error+Timeout.swift"; sourceTree = "<group>"; };
+		26CE6F382B7E71AA008DB858 /* ConnectivityTool.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConnectivityTool.swift; sourceTree = "<group>"; };
 		26CFDB2627357E8000AB940B /* SimplePaymentsSummary.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SimplePaymentsSummary.swift; sourceTree = "<group>"; };
 		26D1E9E72949818B00A7DC62 /* AnalyticsHubTimeRageAdapter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnalyticsHubTimeRageAdapter.swift; sourceTree = "<group>"; };
 		26D57CF62B59820600E8EFB8 /* View+ContainerBackground.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "View+ContainerBackground.swift"; sourceTree = "<group>"; };
@@ -7405,6 +7407,14 @@
 			path = "Free Trial";
 			sourceTree = "<group>";
 		};
+		26CE6F372B7E7198008DB858 /* Connectivity Tool */ = {
+			isa = PBXGroup;
+			children = (
+				26CE6F382B7E71AA008DB858 /* ConnectivityTool.swift */,
+			);
+			path = "Connectivity Tool";
+			sourceTree = "<group>";
+		};
 		26DB7E3228636CF200506173 /* Order Edition */ = {
 			isa = PBXGroup;
 			children = (
@@ -9182,6 +9192,7 @@
 				571B850024CF7E1600CF58A7 /* InAppFeedback */,
 				0235594024496414004BE2B8 /* BottomSheet */,
 				D8815ADC26383E3E00EDAD62 /* CardPresentPayments */,
+				26CE6F372B7E7198008DB858 /* Connectivity Tool */,
 				02564A8F246CEBCB00D6DB2A /* Containers */,
 				027D67CF245ADDCC0036B8DB /* Filters */,
 				02645D7727BA02460065DC68 /* Inbox */,
@@ -13262,6 +13273,7 @@
 				02063C8929260AA000130906 /* StoreCreationSuccessView.swift in Sources */,
 				EEBA02A52ADD606D001FE8E4 /* BlazeCampaignDashboardViewModel.swift in Sources */,
 				77E53EB8250E6A4E003D385F /* ProductDownloadListViewController.swift in Sources */,
+				26CE6F392B7E71AA008DB858 /* ConnectivityTool.swift in Sources */,
 				020EF5EB2A8C7105009D2169 /* SiteSnapshotTracker.swift in Sources */,
 				E1325EFB28FD544E00EC9B2A /* InAppPurchasesDebugView.swift in Sources */,
 				74460D4022289B7600D7316A /* Coordinator.swift in Sources */,


### PR DESCRIPTION
Closes: #11993 

This PR Adds the connectivity tool UI mockup.

<img width="421" alt="screenshot" src="https://github.com/woocommerce/woocommerce-ios/assets/562080/4f19eb99-c261-4356-9a03-343b2c425330">


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
