### PR TITLE
[Tablet Products] Update products tab cell to have the same color as grouped style table view

### DIFF
--- a/WooCommerce/Classes/Extensions/UITableViewCell+Helpers.swift
+++ b/WooCommerce/Classes/Extensions/UITableViewCell+Helpers.swift
@@ -12,32 +12,19 @@ extension UITableViewCell {
         return classNameWithoutNamespaces
     }
 
-    private func defaultBackgroundConfiguration(style: UITableView.Style = .grouped) -> UIBackgroundConfiguration {
-        var backgroundConfiguration: UIBackgroundConfiguration
-
-        if #available(iOS 16.0, *) {
-            backgroundConfiguration = defaultBackgroundConfiguration()
-        } else {
-            if style == .plain {
-                backgroundConfiguration = UIBackgroundConfiguration.listPlainCell()
-            }
-            else {
-                backgroundConfiguration = UIBackgroundConfiguration.listGroupedCell()
-            }
-        }
-        return backgroundConfiguration
-    }
-
     /// Configures the default background configuration
-    func configureDefaultBackgroundConfiguration(style: UITableView.Style = .grouped) {
-        var backgroundConfiguration = defaultBackgroundConfiguration(style: style)
+    func configureDefaultBackgroundConfiguration() {
+        var backgroundConfiguration = defaultBackgroundConfiguration()
         backgroundConfiguration.backgroundColor = .listForeground(modal: false)
         self.backgroundConfiguration = backgroundConfiguration
     }
 
     /// Updates the default background configuration
     func updateDefaultBackgroundConfiguration(using state: UICellConfigurationState, style: UITableView.Style = .grouped) {
-        var backgroundConfiguration = defaultBackgroundConfiguration(style: style).updated(for: state)
+        var backgroundConfiguration = defaultBackgroundConfiguration().updated(for: state)
+        if style == .grouped {
+            backgroundConfiguration.backgroundColor = .listForeground(modal: false)
+        }
 
         if state.isSelected || state.isHighlighted {
             backgroundConfiguration.backgroundColor = .listSelectedBackground


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #12031 
<!-- Id number of the GitHub issue this PR addresses. -->

## Why

In iOS 16+, the cell's `defaultBackgroundConfiguration` has a different background color based on the table view style (plain vs. grouped). In `updateDefaultBackgroundConfiguration(using:style:)`, since it's just using `defaultBackgroundConfiguration` and only sets a different background color when the state is selected or highlighted, the cell's background color is different in the products tab where the table view style is set to plain (vs. grouped in the orders tab).

## How

First, since the app is now iOS 16+ after dropping iOS 15 support recently https://github.com/woocommerce/woocommerce-ios/pull/11965, we can directly use the native `defaultBackgroundConfiguration` without the iOS 15 fallback (nice naming on the custom function to make the removal easy).

Then, to fix the different background color when the table view style is plain, `listForeground` background color is applied when the table view style is grouped in the `updateDefaultBackgroundConfiguration` function. I was thinking about setting `listForeground` regardless of the table view style because it's also in `configureDefaultBackgroundConfiguration`, but I thought I'd keep the scope of changes minimal.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

Prerequisite: the device/simulator allows switching between expanded and collapsed states like a tablet. the store should have at least 2 products.

- In code, enable `splitViewInProductsTab` feature flag in `DefaultFeatureFlagService`
- Launch the app
- Go to the products tab --> the first product should be selected
- Change the device to dark mode if needed --> the selected product row should be distinguishable from the non-selected row(s) like in the orders tab
- Change the device to light mode --> the selected product row should be distinguishable from the non-selected row(s) like in the orders tab

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

light | dark
-- | --
<img src="https://github.com/woocommerce/woocommerce-ios/assets/1945542/1334c451-56d8-4843-bfba-d0d9c1ee8ecc" width="300" /> | <img src="https://github.com/woocommerce/woocommerce-ios/assets/1945542/d7e673f8-5dcd-4844-afe9-83e59cfecee3" width="300" />

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
