### PR TITLE
[Tablet Orders] Remove order status selector from order creation flow

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/EditableOrderViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/EditableOrderViewModel.swift
@@ -167,7 +167,7 @@ final class EditableOrderViewModel: ObservableObject {
 
     /// Indicates if the order status list (selector) should be shown or not.
     ///
-    @Published var shouldShowOrderStatusList: Bool = false
+    @Published var shouldShowOrderStatusListSheet: Bool = false
 
     /// Defines if the view should be disabled.
     @Published private(set) var disabled: Bool = false

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/OrderForm.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/OrderForm.swift
@@ -203,11 +203,16 @@ struct OrderForm: View {
                             }
                             .renderedIf(viewModel.shouldShowNonEditableIndicators)
 
-                            Group {
+                            if ServiceLocator.featureFlagService.isFeatureFlagEnabled(.sideBySideViewForOrderForm) {
+                                Group {
+                                    OrderStatusSection(viewModel: viewModel, topDivider: !viewModel.shouldShowNonEditableIndicators)
+                                    Spacer(minLength: Layout.sectionSpacing)
+                                }
+                                .renderedIf(flow == .editing)
+                            } else {
                                 OrderStatusSection(viewModel: viewModel, topDivider: !viewModel.shouldShowNonEditableIndicators)
                                 Spacer(minLength: Layout.sectionSpacing)
                             }
-                            .renderedIf(flow == .editing)
 
                             ProductsSection(scroll: scroll,
                                             flow: flow,

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/OrderForm.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/OrderForm.swift
@@ -203,9 +203,11 @@ struct OrderForm: View {
                             }
                             .renderedIf(viewModel.shouldShowNonEditableIndicators)
 
-                            OrderStatusSection(viewModel: viewModel, topDivider: !viewModel.shouldShowNonEditableIndicators)
-
-                            Spacer(minLength: Layout.sectionSpacing)
+                            Group {
+                                OrderStatusSection(viewModel: viewModel, topDivider: !viewModel.shouldShowNonEditableIndicators)
+                                Spacer(minLength: Layout.sectionSpacing)
+                            }
+                            .renderedIf(flow == .editing)
 
                             ProductsSection(scroll: scroll,
                                             flow: flow,

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/StatusSection/OrderStatusSection.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/StatusSection/OrderStatusSection.swift
@@ -36,11 +36,11 @@ struct OrderStatusSection: View {
                 Spacer()
 
                 PencilEditButton {
-                    viewModel.shouldShowOrderStatusList = true
+                    viewModel.shouldShowOrderStatusListSheet = true
                 }
                 .accessibilityLabel(Text(Localization.editButtonAccessibilityLabel))
                 .accessibilityIdentifier("order-status-section-edit-button")
-                .sheet(isPresented: $viewModel.shouldShowOrderStatusList) {
+                .sheet(isPresented: $viewModel.shouldShowOrderStatusListSheet) {
                     OrderStatusList(siteID: viewModel.siteID, status: viewModel.currentOrderStatus, autoConfirmSelection: true) { newStatus in
                         viewModel.updateOrderStatus(newStatus: newStatus)
                     }.ignoresSafeArea()

--- a/WooCommerce/WooCommerceUITests/Tests/OrdersTests.swift
+++ b/WooCommerce/WooCommerceUITests/Tests/OrdersTests.swift
@@ -32,7 +32,6 @@ final class OrdersTests: XCTestCase {
 
         try TabNavComponent().goToOrdersScreen()
             .startOrderCreation()
-            .editOrderStatus()
             .addProduct(byName: "Black Coral shades")
             .addCustomerDetails(name: order.billing.first_name)
             .addShipping(amount: order.shipping_lines[0].total, name: order.shipping_lines[0].method_title)


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes #11746
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
This PR removes the `OrderStatusSection` selector from orders in the `.creation` flow, as part of the UI updates from 6kkCwI9VOEYcidp6UT5bln-fi-192_25891

<img width="407" alt="Screenshot 2024-02-19 at 11 50 17" src="https://github.com/woocommerce/woocommerce-ios/assets/3812076/e9c1a892-d2ac-4ef0-9b7d-a7f0b6ce1a86">

## Changes
- We only render the component if the current order is on the `.editing` flow
- Removed the UI test regarding editing order status during order creation.
- Updated variable name of `shouldShowOrderStatusListSheet` for clarity.

## Testing instructions
1. Go to Orders > Create new order > Observe that the `OrderStatusSection` is not rendered. We cannot change the order status during creation.
2. Edit an existing order > Observe that the `OrderStatusSection` is rendered. Tapping the pencil button opens the selector, and the order status can be updated.

There's no specific testing for tablets-only since the logic is not affected by the size class, `creation` and `editing` should also hide/display the section appropriately in tablets.

| Order Creation | Order Editing |
|--------|--------|
| ![Simulator Screenshot - iPhone 15 Plus - 2024-02-19 at 11 48 05](https://github.com/woocommerce/woocommerce-ios/assets/3812076/09f1cb3b-1734-4e8c-8dcc-935a46f8e234) | ![Simulator Screenshot - iPhone 15 Plus - 2024-02-19 at 11 48 15](https://github.com/woocommerce/woocommerce-ios/assets/3812076/94f024a8-6406-4eb4-aae8-edb48508ebe4) | 
