### PR TITLE
[Tablet Products] Enable product selection before the first data reload

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Products/ProductsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductsViewController.swift
@@ -945,7 +945,8 @@ private extension ProductsViewController {
 
     func observeSelectedProductAndDataLoadedStateToUpdateSelectedRow() {
         Publishers.CombineLatest3(selectedProduct,
-                                  onDataReloaded,
+                                  // Giving it an initial value to enable the combined publisher from the beginning.
+                                  onDataReloaded.merge(with: Just<Void>(())),
                                   // Giving it an initial value to enable the combined publisher from the beginning.
                                   onTableViewEditingEnd.merge(with: Just<Void>(())))
             .sink { [weak self] selectedProduct, _, _ in


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #11915 
<!-- Id number of the GitHub issue this PR addresses. -->

## Why

I was looking into why there was a delay after a product is shown in the secondary view and before it is selected in the product list in `ProductsViewController.observeSelectedProductAndDataLoadedStateToUpdateSelectedRow`. It was because after the table view configuration, `onDataReloaded` was emitted only when the data were reloaded while some data might have existed locally.

## How

By providing an initial value with Combine `merge` for the `onDataReloaded` publisher, the product row selection/deselection will be executed if there are any products locally when `observeSelectedProductAndDataLoadedStateToUpdateSelectedRow` is called in `viewDidLoad`.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

Prerequisite: the device/simulator supports split view. the store has at least 1 product

- In code, enable `splitViewInProductsTab` feature flag in `DefaultFeatureFlagService`
- Launch the app
- Switch to a store with non-zero products if needed
- Go to the products tab --> when the first product is shown in the secondary view, the same product should also be selected in the product list in the primary view

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

https://github.com/woocommerce/woocommerce-ios/assets/1945542/7120c79a-31fd-4269-a8fa-cc3e3f8f0841




---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
