### PR TITLE
[Analytics Hub] Store Analytics Hub cards with their enabled status and order

### DIFF
--- a/Storage/Storage.xcodeproj/project.pbxproj
+++ b/Storage/Storage.xcodeproj/project.pbxproj
@@ -207,6 +207,7 @@
 		CE4FD44C2350EB7600A16B31 /* OrderItemTaxRefund+CoreDataProperties.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE4FD4442350EB7600A16B31 /* OrderItemTaxRefund+CoreDataProperties.swift */; };
 		CE4FD44D2350EB7600A16B31 /* Refund+CoreDataClass.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE4FD4452350EB7600A16B31 /* Refund+CoreDataClass.swift */; };
 		CE4FD44E2350EB7600A16B31 /* Refund+CoreDataProperties.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE4FD4462350EB7600A16B31 /* Refund+CoreDataProperties.swift */; };
+		CEE482D32B83753100FAC8C5 /* AnalyticsCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEE482D22B83753100FAC8C5 /* AnalyticsCard.swift */; };
 		CEE9188929F7E8D2004B23FF /* OrderGiftCard+CoreDataClass.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEE9188729F7E8D2004B23FF /* OrderGiftCard+CoreDataClass.swift */; };
 		CEE9188A29F7E8D2004B23FF /* OrderGiftCard+CoreDataProperties.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEE9188829F7E8D2004B23FF /* OrderGiftCard+CoreDataProperties.swift */; };
 		CEF88DB2233EAAF100BED485 /* OrderRefundCondensed+CoreDataClass.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEF88DB0233EAAF000BED485 /* OrderRefundCondensed+CoreDataClass.swift */; };
@@ -510,6 +511,7 @@
 		CE831FE12A14F6C800E8BEFB /* Model 87.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = "Model 87.xcdatamodel"; sourceTree = "<group>"; };
 		CEC963062B173F4700688EA3 /* Model 104.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = "Model 104.xcdatamodel"; sourceTree = "<group>"; };
 		CEDA78632B31D0E00076AA09 /* Model 105.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = "Model 105.xcdatamodel"; sourceTree = "<group>"; };
+		CEE482D22B83753100FAC8C5 /* AnalyticsCard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnalyticsCard.swift; sourceTree = "<group>"; };
 		CEE9188229F7E60C004B23FF /* Model 85.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = "Model 85.xcdatamodel"; sourceTree = "<group>"; };
 		CEE9188729F7E8D2004B23FF /* OrderGiftCard+CoreDataClass.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "OrderGiftCard+CoreDataClass.swift"; sourceTree = "<group>"; };
 		CEE9188829F7E8D2004B23FF /* OrderGiftCard+CoreDataProperties.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "OrderGiftCard+CoreDataProperties.swift"; sourceTree = "<group>"; };
@@ -762,6 +764,7 @@
 				746A9D20214078080013F6FF /* TopEarnerStatsItem+CoreDataProperties.swift */,
 				02DA64182313C2AA00284168 /* StatsVersion.swift */,
 				02D45648231CFB27008CF0A9 /* StatsVersionBannerVisibility.swift */,
+				CEE482D22B83753100FAC8C5 /* AnalyticsCard.swift */,
 			);
 			name = Stats;
 			sourceTree = "<group>";
@@ -1437,6 +1440,7 @@
 				077F39C6269F1F7C00ABEADC /* SystemPlugin+CoreDataProperties.swift in Sources */,
 				CC2C0309262DCC6900928C9C /* ShippingLabelAccountSettings+CoreDataProperties.swift in Sources */,
 				31D9C8C826684AEC000AC134 /* PaymentGatewayAccount+CoreDataClass.swift in Sources */,
+				CEE482D32B83753100FAC8C5 /* AnalyticsCard.swift in Sources */,
 				B505F6DA20BEEA3200BB1B69 /* Account+CoreDataProperties.swift in Sources */,
 				CE4FD44D2350EB7600A16B31 /* Refund+CoreDataClass.swift in Sources */,
 				45E4620A2684BCEE00011BF2 /* Country+CoreDataClass.swift in Sources */,

--- a/Storage/Storage/Model/AnalyticsCard.swift
+++ b/Storage/Storage/Model/AnalyticsCard.swift
@@ -18,6 +18,7 @@ public struct AnalyticsCard: Codable, Hashable, Equatable, Comparable {
     }
 
     /// Types of report cards to display in the Analytics Hub.
+    /// The order of the cases in this enum defines the default order of cards in the Analytics Hub.
     public enum CardType: Codable, CaseIterable {
         case revenue
         case orders

--- a/Storage/Storage/Model/AnalyticsCard.swift
+++ b/Storage/Storage/Model/AnalyticsCard.swift
@@ -1,0 +1,43 @@
+import Foundation
+
+/// Represents an analytics report card in the Analytics Hub
+public struct AnalyticsCard: Codable, Hashable, Equatable, Comparable {
+    /// The type of analytics report card.
+    public let type: CardType
+
+    /// Whether the card is enabled in the Analytics Hub.
+    public let enabled: Bool
+
+    /// The card's order in a sorted list of cards in the Analytics Hub.
+    public let sortOrder: Int
+
+    public init(type: CardType, enabled: Bool, sortOrder: Int) {
+        self.type = type
+        self.enabled = enabled
+        self.sortOrder = sortOrder
+    }
+
+    /// Types of report cards to display in the Analytics Hub.
+    public enum CardType: Codable, CaseIterable {
+        case revenue
+        case orders
+        case products
+        case sessions
+    }
+
+    /// The default set of cards for the Analytics Hub.
+    /// Provides all card types enabled in their default order.
+    public static let defaultCards: Set<AnalyticsCard> = {
+        let allCards = CardType.allCases.map { type in
+            AnalyticsCard(type: type, enabled: true, sortOrder: CardType.allCases.firstIndex(of: type) ?? 0)
+        }
+        return Set(allCards)
+    }()
+}
+
+// MARK: - Comparable conformance
+extension AnalyticsCard {
+    public static func < (lhs: AnalyticsCard, rhs: AnalyticsCard) -> Bool {
+        lhs.sortOrder < rhs.sortOrder
+    }
+}

--- a/Storage/Storage/Model/Copiable/Models+Copiable.generated.swift
+++ b/Storage/Storage/Model/Copiable/Models+Copiable.generated.swift
@@ -71,7 +71,8 @@ extension Storage.GeneralStoreSettings {
         skippedCashOnDeliveryOnboardingStep: CopiableProp<Bool> = .copy,
         lastSelectedStatsTimeRange: CopiableProp<String> = .copy,
         firstInPersonPaymentsTransactionsByReaderType: CopiableProp<[CardReaderType: Date]> = .copy,
-        selectedTaxRateID: NullableCopiableProp<Int64> = .copy
+        selectedTaxRateID: NullableCopiableProp<Int64> = .copy,
+        analyticsHubCards: CopiableProp<Set<AnalyticsCard>> = .copy
     ) -> Storage.GeneralStoreSettings {
         let storeID = storeID ?? self.storeID
         let isTelemetryAvailable = isTelemetryAvailable ?? self.isTelemetryAvailable
@@ -82,6 +83,7 @@ extension Storage.GeneralStoreSettings {
         let lastSelectedStatsTimeRange = lastSelectedStatsTimeRange ?? self.lastSelectedStatsTimeRange
         let firstInPersonPaymentsTransactionsByReaderType = firstInPersonPaymentsTransactionsByReaderType ?? self.firstInPersonPaymentsTransactionsByReaderType
         let selectedTaxRateID = selectedTaxRateID ?? self.selectedTaxRateID
+        let analyticsHubCards = analyticsHubCards ?? self.analyticsHubCards
 
         return Storage.GeneralStoreSettings(
             storeID: storeID,
@@ -92,7 +94,8 @@ extension Storage.GeneralStoreSettings {
             skippedCashOnDeliveryOnboardingStep: skippedCashOnDeliveryOnboardingStep,
             lastSelectedStatsTimeRange: lastSelectedStatsTimeRange,
             firstInPersonPaymentsTransactionsByReaderType: firstInPersonPaymentsTransactionsByReaderType,
-            selectedTaxRateID: selectedTaxRateID
+            selectedTaxRateID: selectedTaxRateID,
+            analyticsHubCards: analyticsHubCards
         )
     }
 }

--- a/Storage/Storage/Model/Copiable/Models+Copiable.generated.swift
+++ b/Storage/Storage/Model/Copiable/Models+Copiable.generated.swift
@@ -72,7 +72,7 @@ extension Storage.GeneralStoreSettings {
         lastSelectedStatsTimeRange: CopiableProp<String> = .copy,
         firstInPersonPaymentsTransactionsByReaderType: CopiableProp<[CardReaderType: Date]> = .copy,
         selectedTaxRateID: NullableCopiableProp<Int64> = .copy,
-        analyticsHubCards: CopiableProp<Set<AnalyticsCard>> = .copy
+        analyticsHubCards: NullableCopiableProp<Set<AnalyticsCard>> = .copy
     ) -> Storage.GeneralStoreSettings {
         let storeID = storeID ?? self.storeID
         let isTelemetryAvailable = isTelemetryAvailable ?? self.isTelemetryAvailable

--- a/Storage/Storage/Model/GeneralStoreSettings.swift
+++ b/Storage/Storage/Model/GeneralStoreSettings.swift
@@ -51,7 +51,7 @@ public struct GeneralStoreSettings: Codable, Equatable, GeneratedCopiable {
     public let selectedTaxRateID: Int64?
 
     /// The set of cards for the Analytics Hub, with their enabled status and sort order.
-    public let analyticsHubCards: Set<AnalyticsCard>
+    public let analyticsHubCards: Set<AnalyticsCard>?
 
     public init(storeID: String? = nil,
                 isTelemetryAvailable: Bool = false,
@@ -62,7 +62,7 @@ public struct GeneralStoreSettings: Codable, Equatable, GeneratedCopiable {
                 lastSelectedStatsTimeRange: String = "",
                 firstInPersonPaymentsTransactionsByReaderType: [CardReaderType: Date] = [:],
                 selectedTaxRateID: Int64? = nil,
-                analyticsHubCards: Set<AnalyticsCard> = AnalyticsCard.defaultCards) {
+                analyticsHubCards: Set<AnalyticsCard>? = nil) {
         self.storeID = storeID
         self.isTelemetryAvailable = isTelemetryAvailable
         self.telemetryLastReportedTime = telemetryLastReportedTime
@@ -106,7 +106,7 @@ extension GeneralStoreSettings {
         self.firstInPersonPaymentsTransactionsByReaderType = try container.decodeIfPresent([CardReaderType: Date].self,
                                                                                            forKey: .firstInPersonPaymentsTransactionsByReaderType) ?? [:]
         self.selectedTaxRateID = try container.decodeIfPresent(Int64.self, forKey: .selectedTaxRateID)
-        self.analyticsHubCards = try container.decodeIfPresent(Set<AnalyticsCard>.self, forKey: .analyticsHubCards) ?? AnalyticsCard.defaultCards
+        self.analyticsHubCards = try container.decodeIfPresent(Set<AnalyticsCard>.self, forKey: .analyticsHubCards)
 
         // Decode new properties with `decodeIfPresent` and provide a default value if necessary.
     }

--- a/Storage/Storage/Model/GeneralStoreSettings.swift
+++ b/Storage/Storage/Model/GeneralStoreSettings.swift
@@ -50,6 +50,9 @@ public struct GeneralStoreSettings: Codable, Equatable, GeneratedCopiable {
     /// The selected tax rate to apply to the orders
     public let selectedTaxRateID: Int64?
 
+    /// The set of cards for the Analytics Hub, with their enabled status and sort order.
+    public let analyticsHubCards: Set<AnalyticsCard>
+
     public init(storeID: String? = nil,
                 isTelemetryAvailable: Bool = false,
                 telemetryLastReportedTime: Date? = nil,
@@ -58,7 +61,8 @@ public struct GeneralStoreSettings: Codable, Equatable, GeneratedCopiable {
                 skippedCashOnDeliveryOnboardingStep: Bool = false,
                 lastSelectedStatsTimeRange: String = "",
                 firstInPersonPaymentsTransactionsByReaderType: [CardReaderType: Date] = [:],
-                selectedTaxRateID: Int64? = nil) {
+                selectedTaxRateID: Int64? = nil,
+                analyticsHubCards: Set<AnalyticsCard> = AnalyticsCard.defaultCards) {
         self.storeID = storeID
         self.isTelemetryAvailable = isTelemetryAvailable
         self.telemetryLastReportedTime = telemetryLastReportedTime
@@ -68,6 +72,7 @@ public struct GeneralStoreSettings: Codable, Equatable, GeneratedCopiable {
         self.lastSelectedStatsTimeRange = lastSelectedStatsTimeRange
         self.firstInPersonPaymentsTransactionsByReaderType = firstInPersonPaymentsTransactionsByReaderType
         self.selectedTaxRateID = selectedTaxRateID
+        self.analyticsHubCards = analyticsHubCards
     }
 
     public func erasingSelectedTaxRateID() -> GeneralStoreSettings {
@@ -79,7 +84,8 @@ public struct GeneralStoreSettings: Codable, Equatable, GeneratedCopiable {
                              skippedCashOnDeliveryOnboardingStep: skippedCashOnDeliveryOnboardingStep,
                              lastSelectedStatsTimeRange: lastSelectedStatsTimeRange,
                              firstInPersonPaymentsTransactionsByReaderType: firstInPersonPaymentsTransactionsByReaderType,
-                             selectedTaxRateID: nil)
+                             selectedTaxRateID: nil,
+                             analyticsHubCards: analyticsHubCards)
     }
 }
 
@@ -100,6 +106,7 @@ extension GeneralStoreSettings {
         self.firstInPersonPaymentsTransactionsByReaderType = try container.decodeIfPresent([CardReaderType: Date].self,
                                                                                            forKey: .firstInPersonPaymentsTransactionsByReaderType) ?? [:]
         self.selectedTaxRateID = try container.decodeIfPresent(Int64.self, forKey: .selectedTaxRateID)
+        self.analyticsHubCards = try container.decodeIfPresent(Set<AnalyticsCard>.self, forKey: .analyticsHubCards) ?? AnalyticsCard.defaultCards
 
         // Decode new properties with `decodeIfPresent` and provide a default value if necessary.
     }

--- a/Storage/StorageTests/Model/AppSettings/GeneralStoreSettingsTests.swift
+++ b/Storage/StorageTests/Model/AppSettings/GeneralStoreSettingsTests.swift
@@ -12,4 +12,13 @@ final class GeneralStoreSettingsTests: XCTestCase {
         let decoded = try JSONDecoder().decode(GeneralStoreSettings.self, from: encoded)
         XCTAssertEqual(expected, decoded)
     }
+
+    func test_it_returns_default_analytics_cards_when_none_set() {
+        // Given
+        let expectedCards = AnalyticsCard.defaultCards
+        let settings = GeneralStoreSettings()
+
+        // Then
+        assertEqual(expectedCards, settings.analyticsHubCards)
+    }
 }

--- a/Storage/StorageTests/Model/AppSettings/GeneralStoreSettingsTests.swift
+++ b/Storage/StorageTests/Model/AppSettings/GeneralStoreSettingsTests.swift
@@ -12,13 +12,4 @@ final class GeneralStoreSettingsTests: XCTestCase {
         let decoded = try JSONDecoder().decode(GeneralStoreSettings.self, from: encoded)
         XCTAssertEqual(expected, decoded)
     }
-
-    func test_it_returns_default_analytics_cards_when_none_set() {
-        // Given
-        let expectedCards = AnalyticsCard.defaultCards
-        let settings = GeneralStoreSettings()
-
-        // Then
-        assertEqual(expectedCards, settings.analyticsHubCards)
-    }
 }

--- a/Yosemite/Yosemite/Actions/AppSettingsAction.swift
+++ b/Yosemite/Yosemite/Actions/AppSettingsAction.swift
@@ -248,6 +248,7 @@ public enum AppSettingsAction: Action {
     case setAnalyticsHubCards(siteID: Int64, cards: Set<AnalyticsCard>)
 
     /// Loads the set of cards for the Analytics Hub with their enabled status and sort order.
+    /// Defaults to all cards enabled in a default order if no customized settings have been saved.
     ///
     case loadAnalyticsHubCards(siteID: Int64, onCompletion: (Set<AnalyticsCard>) -> Void)
 }

--- a/Yosemite/Yosemite/Actions/AppSettingsAction.swift
+++ b/Yosemite/Yosemite/Actions/AppSettingsAction.swift
@@ -240,4 +240,14 @@ public enum AppSettingsAction: Action {
 
     /// Loads the selected tax rate to be applied to orders. This is site-specific.
     case loadSelectedTaxRateID(siteID: Int64, onCompletion: (Int64?) -> Void)
+
+    // MARK: - Analytics Hub Cards
+
+    /// Stores the set of cards for the Analytics Hub with their updated enabled status and sort order.
+    ///
+    case setAnalyticsHubCards(siteID: Int64, cards: Set<AnalyticsCard>)
+
+    /// Loads the set of cards for the Analytics Hub with their enabled status and sort order.
+    ///
+    case loadAnalyticsHubCards(siteID: Int64, onCompletion: (Set<AnalyticsCard>) -> Void)
 }

--- a/Yosemite/Yosemite/Model/Model.swift
+++ b/Yosemite/Yosemite/Model/Model.swift
@@ -286,6 +286,7 @@ public typealias StorageWCPayCharge = Storage.WCPayCharge
 public typealias FeatureAnnouncementCampaign = Storage.FeatureAnnouncementCampaign
 public typealias FeatureAnnouncementCampaignSettings = Storage.FeatureAnnouncementCampaignSettings
 public typealias LocalAnnouncement = Storage.LocalAnnouncement
+public typealias AnalyticsCard = Storage.AnalyticsCard
 
 // MARK: - Internal ReadOnly Models
 

--- a/Yosemite/Yosemite/Stores/AppSettingsStore.swift
+++ b/Yosemite/Yosemite/Stores/AppSettingsStore.swift
@@ -204,6 +204,10 @@ public class AppSettingsStore: Store {
             setSelectedTaxRateID(with: taxRateId, siteID: siteID)
         case .loadSelectedTaxRateID(let siteID, let onCompletion):
             loadSelectedTaxRateID(with: siteID, onCompletion: onCompletion)
+        case .setAnalyticsHubCards(let siteID, let cards):
+            setAnalyticsHubCards(siteID: siteID, cards: cards)
+        case .loadAnalyticsHubCards(let siteID, let onCompletion):
+            loadAnalyticsHubCards(siteID: siteID, onCompletion: onCompletion)
         }
     }
 }
@@ -901,6 +905,20 @@ private extension AppSettingsStore {
 
     func loadSelectedTaxRateID(with siteID: Int64, onCompletion: (Int64?) -> Void) {
         onCompletion(getStoreSettings(for: siteID).selectedTaxRateID)
+    }
+}
+
+// MARK: - Analytics Hub Cards
+
+private extension AppSettingsStore {
+    func setAnalyticsHubCards(siteID: Int64, cards: Set<AnalyticsCard>) {
+        let storeSettings = getStoreSettings(for: siteID)
+        let updatedSettings = storeSettings.copy(analyticsHubCards: cards)
+        setStoreSettings(settings: updatedSettings, for: siteID)
+    }
+
+    func loadAnalyticsHubCards(siteID: Int64, onCompletion: (Set<AnalyticsCard>) -> Void) {
+        onCompletion(getStoreSettings(for: siteID).analyticsHubCards)
     }
 }
 

--- a/Yosemite/Yosemite/Stores/AppSettingsStore.swift
+++ b/Yosemite/Yosemite/Stores/AppSettingsStore.swift
@@ -918,7 +918,10 @@ private extension AppSettingsStore {
     }
 
     func loadAnalyticsHubCards(siteID: Int64, onCompletion: (Set<AnalyticsCard>) -> Void) {
-        onCompletion(getStoreSettings(for: siteID).analyticsHubCards)
+        guard let storedCards = getStoreSettings(for: siteID).analyticsHubCards else {
+            return onCompletion(AnalyticsCard.defaultCards)
+        }
+        onCompletion(storedCards)
     }
 }
 

--- a/Yosemite/YosemiteTests/Stores/AppSettingsStoreTests.swift
+++ b/Yosemite/YosemiteTests/Stores/AppSettingsStoreTests.swift
@@ -1264,8 +1264,14 @@ extension AppSettingsStoreTests {
 
     func test_loadAnalyticsHubCards_works_correctly() throws {
         // Given
-        let storedAnalyticsCards = AnalyticsCard.defaultCards
-        let existingSettings = GeneralStoreSettingsBySite(storeSettingsBySite: [TestConstants.siteID: GeneralStoreSettings()])
+        let storedAnalyticsCards: Set<AnalyticsCard> = [
+            AnalyticsCard(type: .revenue, enabled: true, sortOrder: 1),
+            AnalyticsCard(type: .orders, enabled: false, sortOrder: 3),
+            AnalyticsCard(type: .products, enabled: true, sortOrder: 0),
+            AnalyticsCard(type: .sessions, enabled: false, sortOrder: 2)
+        ]
+        let storeSettings = GeneralStoreSettings(analyticsHubCards: storedAnalyticsCards)
+        let existingSettings = GeneralStoreSettingsBySite(storeSettingsBySite: [TestConstants.siteID: storeSettings])
         try fileStorage?.write(existingSettings, to: expectedGeneralStoreSettingsFileURL)
 
         // When
@@ -1277,6 +1283,23 @@ extension AppSettingsStoreTests {
 
         // Then
         assertEqual(storedAnalyticsCards, loadedAnalyticsCards)
+    }
+
+    func test_loadAnalyticsHubCards_loads_default_cards_when_no_cards_are_saved() throws {
+        // Given
+        let existingSettings = GeneralStoreSettingsBySite(storeSettingsBySite: [TestConstants.siteID: GeneralStoreSettings()])
+        try fileStorage?.write(existingSettings, to: expectedGeneralStoreSettingsFileURL)
+
+        // When
+        var loadedAnalyticsCards: Set<AnalyticsCard> = []
+        let action = AppSettingsAction.loadAnalyticsHubCards(siteID: TestConstants.siteID) { cards in
+            loadedAnalyticsCards = cards
+        }
+        subject?.onAction(action)
+
+        // Then
+        let defaultAnalyticsCards = AnalyticsCard.defaultCards
+        assertEqual(defaultAnalyticsCards, loadedAnalyticsCards)
     }
 }
 

--- a/Yosemite/YosemiteTests/Stores/AppSettingsStoreTests.swift
+++ b/Yosemite/YosemiteTests/Stores/AppSettingsStoreTests.swift
@@ -1239,6 +1239,45 @@ extension AppSettingsStoreTests {
         // Then
         XCTAssertEqual(loadedTaxRateID, storedTaxRateID)
     }
+
+    func test_setAnalyticsHubCards_works_correctly() throws {
+        // Given
+        let analyticsCards: Set<AnalyticsCard> = [
+            AnalyticsCard(type: .revenue, enabled: true, sortOrder: 1),
+            AnalyticsCard(type: .orders, enabled: false, sortOrder: 3),
+            AnalyticsCard(type: .products, enabled: true, sortOrder: 0),
+            AnalyticsCard(type: .sessions, enabled: false, sortOrder: 2)
+        ]
+        let existingSettings = GeneralStoreSettingsBySite(storeSettingsBySite: [TestConstants.siteID: GeneralStoreSettings()])
+        try fileStorage?.write(existingSettings, to: expectedGeneralStoreSettingsFileURL)
+
+        // When
+        let action = AppSettingsAction.setAnalyticsHubCards(siteID: TestConstants.siteID, cards: analyticsCards)
+        subject?.onAction(action)
+
+        // Then
+        let savedSettings: GeneralStoreSettingsBySite = try XCTUnwrap(fileStorage?.data(for: expectedGeneralStoreSettingsFileURL))
+        let settingsForSite = savedSettings.storeSettingsBySite[TestConstants.siteID]
+
+        assertEqual(analyticsCards, settingsForSite?.analyticsHubCards)
+    }
+
+    func test_loadAnalyticsHubCards_works_correctly() throws {
+        // Given
+        let storedAnalyticsCards = AnalyticsCard.defaultCards
+        let existingSettings = GeneralStoreSettingsBySite(storeSettingsBySite: [TestConstants.siteID: GeneralStoreSettings()])
+        try fileStorage?.write(existingSettings, to: expectedGeneralStoreSettingsFileURL)
+
+        // When
+        var loadedAnalyticsCards: Set<AnalyticsCard> = []
+        let action = AppSettingsAction.loadAnalyticsHubCards(siteID: TestConstants.siteID) { cards in
+            loadedAnalyticsCards = cards
+        }
+        subject?.onAction(action)
+
+        // Then
+        assertEqual(storedAnalyticsCards, loadedAnalyticsCards)
+    }
 }
 
 // MARK: - Utils


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #12038
<!-- Id number of the GitHub issue this PR addresses. -->

## Why
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
We want to merchants to be able to customize the cards in the Analytics Hub (which cards are shown and in what order) for their stores. To do that, we need to store the customizations merchants make.

This PR adds support for storing the customized Analytics Hub cards for each store they manage in the app.

## How

* Adds an `AnalyticsCard` data model in the Storage layer:
   * Properties include the type of card, whether the card is enabled in the Analytics Hub, and its sort order.
   * A `defaultCards` property returns a default set of cards, for when there aren't any saved customizations. The default set has all the cards enabled and in the order they are defined in `AnalyticsCard.CardType`.
* Adds analytics cards to `GeneralStoreSettings`, so the customized set of cards can be saved in store settings.
* Adds methods to save and load analytics cards in `AppSettingsAction` and `AppSettingsStore`.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
These new storage methods aren't used yet, but we can check that other app settings continue to work as expected. (For example, confirm that the last selected time range tab in store stats is pre-selected when the app is force closed and reopened.)


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
