### PR TITLE
[Tablet Products] Fix 2 auto-selection issues

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Products/ProductsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductsViewController.swift
@@ -940,12 +940,12 @@ private extension ProductsViewController {
 
             if result.isFailure {
                 syncingCoordinator.resynchronize()
+            } else {
+                // Emits `onDataReloaded` when local product settings (filters & sort order) are loaded and synced, so that
+                // the first product selected in `selectFirstProductIfAvailable` is only triggered when the results match
+                // the product settings.
+                onDataReloaded.send(())
             }
-
-            // Emits `onDataReloaded` when local product settings (filters & sort order) are loaded and synced, so that
-            // the first product selected in `selectFirstProductIfAvailable` is only triggered when the results match
-            // the product settings.
-            onDataReloaded.send(())
         }
     }
 
@@ -1379,12 +1379,12 @@ extension ProductsViewController: SyncingCoordinatorDelegate {
                                                                  promotableProductType: promotableProductType,
                                                                  productCategory: settings.productCategoryFilter,
                                                                  numberOfActiveFilters: settings.numberOfActiveFilters())
-
+                    onCompletion(result)
                 }
             case let .failure(error):
                 DDLogError("⛔️ Error loading product settings: \(error)")
+                onCompletion(result)
             }
-            onCompletion(result)
         }
         ServiceLocator.stores.dispatch(action)
     }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #12045 
<!-- Id number of the GitHub issue this PR addresses. -->

## Why

Previously, there were two issues with the auto-selection in the products tab:

- When there's a filter applied to the product list, the selected product in the secondary view might not be in the product list ([screencast](https://github.com/woocommerce/woocommerce-ios/assets/1945542/c20e1965-d53c-48a7-9ae4-32dc01e5ec2b)) (This is mostly reproducible in app launch, where the store has more products than the filtered list)
  - This is because the filters/sort order (called "product settings" in code) in the products tab are loaded async after the [results controller is initialized](https://github.com/woocommerce/woocommerce-ios/blob/c2a0c09ccb29398dec6af66766da88d1fce18240/WooCommerce/Classes/ViewRelated/Products/ProductsViewController.swift#L897) which [triggers the auto-selection](https://github.com/woocommerce/woocommerce-ios/blob/c2a0c09ccb29398dec6af66766da88d1fce18240/WooCommerce/Classes/ViewRelated/Products/ProductsSplitViewCoordinator.swift#L139-L145) (based on the `onDataReloaded` observable), and thus the selected product might not be in the product list after the product settings are set

- When switching to a different store for the first time, the first product isn't selected ([screencast](https://github.com/woocommerce/woocommerce-ios/assets/1945542/6b3e4f96-ef2c-42d2-baa5-aa8a86ec5a59))
  - The cause is similar to the issue above, because the auto-selection is triggered when the results controller is initialized but no products are in the storage yet

## How

To fix these two issues, it's worth revisiting the question about when we want to auto-select the first product:

- When no product is selected
- When the split view is expanded (2 columns are shown)
- When the table view results are loaded initially:
    - Because product settings are loaded async, `onDataReloaded` is now only triggered after the product settings are loaded & synced

And the auto-selection should be **once** per store session, because the product in the secondary view can't be unselected. This "once" behavior is in `ProductsSplitViewCoordinator`.

When the merchant changes the filters/sort order where the product in the secondary view isn't in the product list anymore, I choose not to trigger auto-selection to replace the secondary view in case the merchant has some unsaved changes in the product form. Please feel free to 

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

Prerequisite: the device/simulator allows switching between expanded and collapsed states like a tablet. the account is connected to at least two stores

---

- In code, enable `splitViewInProductsTab` feature flag in `DefaultFeatureFlagService`
- Launch the app
- Go to the products tab --> the first product should be auto-selected shortly
- Switch to a different store whose products haven't been loaded before --> the first product should be auto-selected after the products are loaded
- Tap `Sort by` or `Filter` to apply a different product list setting --> the products should be reloaded, while the product in the secondary view remains the same
- Relaunch the app --> the first product should be auto-selected shortly

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->


https://github.com/woocommerce/woocommerce-ios/assets/1945542/60c631b9-7a3f-44d7-ae34-7f152b7fd8b8



---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
