### PR TITLE
[Tablet Orders] Add dividing line between side by side views

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Products/ProductSelector/ProductSelectorView.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductSelector/ProductSelectorView.swift
@@ -197,7 +197,6 @@ struct ProductSelectorView: View {
             }
         }
         .background(Color(configuration.searchHeaderBackgroundColor).ignoresSafeArea())
-        .ignoresSafeArea(.container, edges: .horizontal)
         .navigationTitle(configuration.title)
         .navigationBarTitleDisplayMode(configuration.prefersLargeTitle ? .large : .inline)
         .toolbar {

--- a/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/AdaptiveModalContainer.swift
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/AdaptiveModalContainer.swift
@@ -74,7 +74,7 @@ struct AdaptiveModalContainer<PrimaryView: View, SecondaryView: View>: View {
         @State var isShowingSecondaryView = true
 
         var body: some View {
-            HStack {
+            HStack(spacing: 0) {
                 NavigationView {
                     secondaryView($isShowingSecondaryView)
                         .toolbar {

--- a/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/AdaptiveModalContainer.swift
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/AdaptiveModalContainer.swift
@@ -90,6 +90,8 @@ struct AdaptiveModalContainer<PrimaryView: View, SecondaryView: View>: View {
                 .navigationViewStyle(.stack)
                 .layoutPriority(1)
 
+                Divider()
+
                 NavigationView {
                     primaryView(nil)
                 }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes #11906 

## Description
This PR adds a dividing line between each view when using the `SideBySideView` layout for split views.

## Testing instructions
- Switch `sideBySideViewForOrderForm` feature flag to `true`
- Go to Orders > Tap `+` to create a new order > observe that there's a vertical dividing line between the product selector and the order summary.

## Screenshots
![Simulator Screenshot - iPad Pro (12 9-inch) (6th generation) - 2024-02-20 at 14 06 11](https://github.com/woocommerce/woocommerce-ios/assets/3812076/ff5697d0-f8d0-402f-a813-5fc6860c600a)
