### PR TITLE
[Tablet Orders] Update selected products and product selector when changing size class

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/EditableOrderViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/EditableOrderViewModel.swift
@@ -1748,6 +1748,7 @@ private extension EditableOrderViewModel {
                     stores: stores,
                     toggleAllVariationsOnSelection: false,
                     topProductsProvider: TopProductsFromCachedOrdersProvider(),
+                    syncApproach: initialProductSelectionSyncApproach,
                     orderSyncState: orderSynchronizer.statePublisher,
                     onProductSelectionStateChanged: { [weak self] product in
                         guard let self = self else { return }
@@ -1779,6 +1780,21 @@ private extension EditableOrderViewModel {
                     })
             }
             .assign(to: &$productSelectorViewModel)
+    }
+
+    var initialProductSelectionSyncApproach: ProductSelectorViewModel.SyncApproach {
+        guard featureFlagService.isFeatureFlagEnabled(.sideBySideViewForOrderForm) else {
+            return .onButtonTap
+        }
+        switch UITraitCollection.current.horizontalSizeClass {
+        case .regular:
+            return .immediate
+        case .compact, .unspecified:
+            return .onButtonTap
+        @unknown default:
+            DDLogWarn("Unknown horizontalSizeClass used to determine initialProductSelectionSyncApproach.")
+            return .onButtonTap
+        }
     }
 
     /// Tracks when customer details have been added

--- a/WooCommerce/Classes/ViewRelated/Products/ProductSelector/ProductSelectorViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductSelector/ProductSelectorViewModel.swift
@@ -408,7 +408,7 @@ final class ProductSelectorViewModel: ObservableObject {
         if newSyncApproach == .immediate {
             onMultipleSelectionCompleted?(selectedItemsIDs)
         }
-        
+
         syncApproach = newSyncApproach
     }
 

--- a/WooCommerce/Classes/ViewRelated/Products/ProductSelector/ProductSelectorViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductSelector/ProductSelectorViewModel.swift
@@ -210,7 +210,7 @@ final class ProductSelectorViewModel: ObservableObject {
 
     private let onConfigureProductRow: ((_ product: Product) -> Void)?
 
-    @Published var syncChangesImmediately: Bool
+    @Published private(set) var syncApproach: SyncApproach
 
     private var orderSyncState: Published<OrderSyncState>.Publisher?
 
@@ -226,7 +226,7 @@ final class ProductSelectorViewModel: ObservableObject {
          topProductsProvider: ProductSelectorTopProductsProviderProtocol? = nil,
          pageFirstIndex: Int = PaginationTracker.Defaults.pageFirstIndex,
          pageSize: Int = PaginationTracker.Defaults.pageSize,
-         syncChangesImmediately: Bool = false,
+         syncApproach: SyncApproach = .onButtonTap,
          orderSyncState: Published<OrderSyncState>.Publisher? = nil,
          onProductSelectionStateChanged: ((Product) -> Void)? = nil,
          onVariationSelectionStateChanged: ((ProductVariation, Product) -> Void)? = nil,
@@ -248,7 +248,7 @@ final class ProductSelectorViewModel: ObservableObject {
         self.purchasableItemsOnly = purchasableItemsOnly
         self.shouldDeleteStoredProductsOnFirstPage = shouldDeleteStoredProductsOnFirstPage
         self.paginationTracker = PaginationTracker(pageFirstIndex: pageFirstIndex, pageSize: pageSize)
-        self.syncChangesImmediately = syncChangesImmediately
+        self.syncApproach = syncApproach
         self.orderSyncState = orderSyncState
         self.onAllSelectionsCleared = onAllSelectionsCleared
         self.onSelectedVariationsCleared = onSelectedVariationsCleared
@@ -298,7 +298,7 @@ final class ProductSelectorViewModel: ObservableObject {
             onProductSelectionStateChanged?(selectedProduct)
         }
 
-        if syncChangesImmediately {
+        if syncApproach == .immediate {
             onMultipleSelectionCompleted?(selectedItemsIDs)
         }
     }
@@ -339,7 +339,7 @@ final class ProductSelectorViewModel: ObservableObject {
             guard let self else { return }
             onVariationSelectionStateChanged?(productVariation, product)
 
-            if syncChangesImmediately {
+            if syncApproach == .immediate {
                 onMultipleSelectionCompleted?(selectedItemsIDs)
             }
         },
@@ -347,7 +347,7 @@ final class ProductSelectorViewModel: ObservableObject {
             guard let self else { return }
             onSelectedVariationsCleared?()
 
-            if syncChangesImmediately {
+            if syncApproach == .immediate {
                 onMultipleSelectionCompleted?(selectedItemsIDs)
             }
         })
@@ -400,6 +400,14 @@ final class ProductSelectorViewModel: ObservableObject {
         updateSelectedVariations(productID: productID, selectedVariationIDs: selectedIDs)
     }
 
+    func updateSyncApproach(to newSyncApproach: SyncApproach) {
+        guard newSyncApproach != syncApproach else {
+            return
+        }
+        onMultipleSelectionCompleted?(selectedItemsIDs)
+        syncApproach = newSyncApproach
+    }
+
     /// Triggers completion closure when the multiple selection completes.
     ///
     func completeMultipleSelection() {
@@ -419,9 +427,14 @@ final class ProductSelectorViewModel: ObservableObject {
         selectedItemsIDs = []
 
         onAllSelectionsCleared?()
-        if syncChangesImmediately {
+        if syncApproach == .immediate {
             onMultipleSelectionCompleted?(selectedItemsIDs)
         }
+    }
+
+    enum SyncApproach {
+        case immediate
+        case onButtonTap
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Products/ProductSelector/ProductSelectorViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductSelector/ProductSelectorViewModel.swift
@@ -404,7 +404,11 @@ final class ProductSelectorViewModel: ObservableObject {
         guard newSyncApproach != syncApproach else {
             return
         }
-        onMultipleSelectionCompleted?(selectedItemsIDs)
+
+        if newSyncApproach == .immediate {
+            onMultipleSelectionCompleted?(selectedItemsIDs)
+        }
+        
         syncApproach = newSyncApproach
     }
 

--- a/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/AdaptiveModalContainer.swift
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/AdaptiveModalContainer.swift
@@ -18,22 +18,13 @@ struct AdaptiveModalContainer<PrimaryView: View, SecondaryView: View>: View {
     @ViewBuilder let primaryView: (_ presentSecondaryView: (() -> Void)?) -> PrimaryView
     @ViewBuilder let secondaryView: (_ isPresented: Binding<Bool>) -> SecondaryView
 
-    /// Callback to notify of `UserInterfaceSizeClass` changes as soon as one of the views is rendered
-    var onSizeClassChange: ((UserInterfaceSizeClass?) -> Void)
-
     var body: some View {
         if horizontalSizeClass == .compact {
             ModalOnModalView(primaryView: primaryView, secondaryView: secondaryView)
                 .environment(\.adaptiveModalContainerPresentationStyle, .modalOnModal)
-                .onAppear {
-                    onSizeClassChange(horizontalSizeClass)
-                }
         } else {
             SideBySideView(primaryView: primaryView, secondaryView: secondaryView)
                 .environment(\.adaptiveModalContainerPresentationStyle, .sideBySide)
-                .onAppear {
-                    onSizeClassChange(horizontalSizeClass)
-                }
         }
     }
 

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/ProductSelectorViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/ProductSelectorViewModelTests.swift
@@ -526,7 +526,7 @@ final class ProductSelectorViewModelTests: XCTestCase {
         insert(product)
         let viewModel = ProductSelectorViewModel(siteID: sampleSiteID,
                                                  storageManager: storageManager,
-                                                 syncChangesImmediately: true,
+                                                 syncApproach: .immediate,
                                                  onMultipleSelectionCompleted: { productIDs in
             selectedProducts = productIDs
         })
@@ -1402,6 +1402,51 @@ final class ProductSelectorViewModelTests: XCTestCase {
 
         // Then
         assertEqual(bundleProduct, productToConfigure)
+    }
+
+    /// We call onMultipleSelectionCompleted to save the selections made on a modal product
+    /// selector, e.g. when an iPad is in split-screen mode and is rotated to landscape.
+    /// It's a blocking operation, so we only want to do it when required.
+    func test_updateSyncApproach_calls_onMultipleSelectionCompleted_when_approach_changes_to_immediate() {
+        // Given
+        let simpleProduct = Product.fake().copy(siteID: sampleSiteID, productID: 1, purchasable: true)
+        insert(simpleProduct)
+
+        let selectedItems = waitFor { promise in
+            let viewModel = ProductSelectorViewModel(siteID: self.sampleSiteID,
+                                                     selectedItemIDs: [],
+                                                     storageManager: self.storageManager,
+                                                     syncApproach: .onButtonTap,
+                                                     onMultipleSelectionCompleted: { selectedItems in
+                promise(selectedItems)
+            })
+
+            // When
+            viewModel.addSelection(id: 1)
+            viewModel.updateSyncApproach(to: .immediate)
+        }
+
+        // Then
+        assertEqual([1], selectedItems)
+    }
+
+    func test_updateSyncApproach_doesnt_call_onMultipleSelectionCompleted_when_approach_stays_on_immediate() {
+        // Given
+        let expectation = XCTestExpectation(description: "onMultipleSelectionCompleted called")
+        expectation.isInverted = true
+
+        let viewModel = ProductSelectorViewModel(siteID: self.sampleSiteID,
+                                                 syncApproach: .immediate,
+                                                 onMultipleSelectionCompleted: { selectedItems in
+            /// Since the expectation is inverted, the test will fail if this is called before the timeout.
+            expectation.fulfill()
+        })
+
+        // When
+        viewModel.updateSyncApproach(to: .immediate)
+
+        // Then
+        wait(for: [expectation], timeout: 0.5)
     }
 
     // MARK: - Pagination

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/ProductSelectorViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/ProductSelectorViewModelTests.swift
@@ -1449,6 +1449,25 @@ final class ProductSelectorViewModelTests: XCTestCase {
         wait(for: [expectation], timeout: 0.5)
     }
 
+    func test_updateSyncApproach_doesnt_call_onMultipleSelectionCompleted_when_approach_changes_to_onButtonTap() {
+        // Given
+        let expectation = XCTestExpectation(description: "onMultipleSelectionCompleted called")
+        expectation.isInverted = true
+
+        let viewModel = ProductSelectorViewModel(siteID: self.sampleSiteID,
+                                                 syncApproach: .immediate,
+                                                 onMultipleSelectionCompleted: { selectedItems in
+            /// Since the expectation is inverted, the test will fail if this is called before the timeout.
+            expectation.fulfill()
+        })
+
+        // When
+        viewModel.updateSyncApproach(to: .onButtonTap)
+
+        // Then
+        wait(for: [expectation], timeout: 0.5)
+    }
+
     // MARK: - Pagination
 
     func test_it_syncs_the_second_page_after_searching_and_selecting_a_product_not_in_the_first_page() {

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/ProductSelectorViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/ProductSelectorViewModelTests.swift
@@ -1446,7 +1446,7 @@ final class ProductSelectorViewModelTests: XCTestCase {
         viewModel.updateSyncApproach(to: .immediate)
 
         // Then
-        wait(for: [expectation], timeout: 0.5)
+        wait(for: [expectation], timeout: 0.1)
     }
 
     func test_updateSyncApproach_doesnt_call_onMultipleSelectionCompleted_when_approach_changes_to_onButtonTap() {
@@ -1465,7 +1465,7 @@ final class ProductSelectorViewModelTests: XCTestCase {
         viewModel.updateSyncApproach(to: .onButtonTap)
 
         // Then
-        wait(for: [expectation], timeout: 0.5)
+        wait(for: [expectation], timeout: 0.1)
     }
 
     // MARK: - Pagination

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/ProductSelectorViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/ProductSelectorViewModelTests.swift
@@ -1412,13 +1412,13 @@ final class ProductSelectorViewModelTests: XCTestCase {
         let simpleProduct = Product.fake().copy(siteID: sampleSiteID, productID: 1, purchasable: true)
         insert(simpleProduct)
 
-        let selectedItems = waitFor { promise in
+        let selectedItemIDs = waitFor { promise in
             let viewModel = ProductSelectorViewModel(siteID: self.sampleSiteID,
                                                      selectedItemIDs: [],
                                                      storageManager: self.storageManager,
                                                      syncApproach: .onButtonTap,
-                                                     onMultipleSelectionCompleted: { selectedItems in
-                promise(selectedItems)
+                                                     onMultipleSelectionCompleted: { selectedItemIDs in
+                promise(selectedItemIDs)
             })
 
             // When
@@ -1427,7 +1427,7 @@ final class ProductSelectorViewModelTests: XCTestCase {
         }
 
         // Then
-        assertEqual([1], selectedItems)
+        assertEqual([1], selectedItemIDs)
     }
 
     func test_updateSyncApproach_doesnt_call_onMultipleSelectionCompleted_when_approach_stays_on_immediate() {


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #11923
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

When the Product Selector is shown side-by-side with the Order Form on tablets and larger iPhones, selections are synced to the order immediately. When shown in a modal-on-modal context, the merchant has to tap a button to dismiss the selector before we sync their changes.

Both iPads and large iPhones can switch between these display approaches, by rotating the device or moving to a split view/slideover presentation.

Previously, when switching from modal-on-modal to side-by-side with the product selector visible, any unsynced selection changes would be lost. Additionally, the product selector would show an titleless button, and the merchant would have to tap that to sync their selections.

This PR fixes these issues, so any unsynced changes are saved to the order when we move from modal-on-modal to side-by-side.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

1. Enable the `sideBySideViewForOrderForm` feature flag
2. Launch the app on an iPad or large iPhone (in landscape)
3. Open the `Orders` tab, and then tap `+` to make a new order – it should be in side-by-side mode
4. Select a product
5. Rotate the iPhone or set a split view to put the order form in modal-on-modal mode
6. Tap `+` to open the product selector
7. Change your selections, but don't tap the button
8. Rotate the iPhone or expand the split view to put the screen in side-by-side mode
9. Observe that your changes are synced, not lost.

Repeat as closely as you can with the feature flag disabled – e.g. by closing the product selector, and looking for products that have been unexpectedly synced – there should be no change in behaviour.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->


https://github.com/woocommerce/woocommerce-ios/assets/2472348/4388d4c3-564f-4954-b7d8-1b1973e793a6


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
