### PR TITLE
[Product List: Selection] Do not deselect when the table view is in editing mode

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Products/ProductsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductsViewController.swift
@@ -1009,7 +1009,8 @@ extension ProductsViewController: UITableViewDelegate {
     }
 
     func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
-        if splitViewController?.isCollapsed == true || !isSplitViewEnabled {
+        if (splitViewController?.isCollapsed == true || !isSplitViewEnabled) &&
+            !tableView.isEditing {
             tableView.deselectRow(at: indexPath, animated: true)
         }
 


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #12041 
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
With this PR we fix the multiple product selection not working. This a regression from https://github.com/woocommerce/woocommerce-ios/pull/11918 , where we didn't take the editing mode exception into account when deselecting rows. Because of that, we deselected the selection right away for all cases.
With this PR we exclude the row deselection when the table view is in editing mode.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

1. Go to Products
2. Tap on the Editing mode button (checkmark navigation bar button, third from the right side)
3. Select several products. See how they stay selected.
4. Deselect them, See how they are deselected.
5. Perform an action with the selection. (Bulk update) See how they action is applied to all products.

Check also that the tablet support remains fully functional (`splitViewInProductsTab` feature flag to true)

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->


https://github.com/woocommerce/woocommerce-ios/assets/1864060/bea3075a-d0fc-4bb1-b2f8-f3f588ff1382




---
- [X] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.