### PR TITLE
[Analytics Hub] Initialize AnalyticsHubCustomizeViewModel with AnalyticsCard

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/AnalyticsHubView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/AnalyticsHubView.swift
@@ -164,7 +164,7 @@ struct AnalyticsHubView: View {
         }
         .sheet(isPresented: $isCustomizingAnalyticsCards) {
             NavigationView {
-                AnalyticsHubCustomizeView()
+                AnalyticsHubCustomizeView(viewModel: viewModel.customizeAnalyticsViewModel)
             }
         }
     }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/AnalyticsHubViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/AnalyticsHubViewModel.swift
@@ -136,6 +136,10 @@ final class AnalyticsHubViewModel: ObservableObject {
     ///
     @Published var dismissNotice: Notice?
 
+    var customizeAnalyticsViewModel: AnalyticsHubCustomizeViewModel {
+        AnalyticsHubCustomizeViewModel(allCards: AnalyticsCard.defaultCards) // TODO: Use real data from storage
+    }
+
     // MARK: Private data
 
     /// Order stats for the current selected time period

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/Customize/AnalyticsCard+UI.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/Customize/AnalyticsCard+UI.swift
@@ -1,0 +1,37 @@
+import Foundation
+import Yosemite
+
+extension AnalyticsCard {
+    /// Localized name of the analytics card.
+    ///
+    var name: String {
+        switch type {
+        case .revenue:
+            return Localization.revenue
+        case .orders:
+            return Localization.orders
+        case .products:
+            return Localization.products
+        case .sessions:
+            return Localization.sessions
+        }
+    }
+}
+
+// MARK: - Localization
+private extension AnalyticsCard {
+    private enum Localization {
+        static let revenue = NSLocalizedString("analyticsHub.customize.revenue",
+                                               value: "Revenue",
+                                               comment: "Name for the Revenue analytics card in the Customize Analytics screen")
+        static let orders = NSLocalizedString("analyticsHub.customize.orders",
+                                              value: "Orders",
+                                              comment: "Name for the Orders analytics card in the Customize Analytics screen")
+        static let products = NSLocalizedString("analyticsHub.customize.products",
+                                                value: "Products",
+                                                comment: "Name for the Products analytics card in the Customize Analytics screen")
+        static let sessions = NSLocalizedString("analyticsHub.customize.sessions",
+                                                value: "Sessions",
+                                                comment: "Name for the Sessions analytics card in the Customize Analytics screen")
+    }
+}

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/Customize/AnalyticsHubCustomizeView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/Customize/AnalyticsHubCustomizeView.swift
@@ -2,22 +2,14 @@ import SwiftUI
 
 struct AnalyticsHubCustomizeView: View {
     // TODO: Initialize with real data
-    @ObservedObject var viewModel = AnalyticsHubCustomizeViewModel(allCards: [
-        "Revenue",
-        "Orders",
-        "Products",
-        "Sessions"
-    ], selectedCards: [
-        "Revenue",
-        "Products"
-    ])
+    @ObservedObject var viewModel: AnalyticsHubCustomizeViewModel
 
     /// Dismisses the view.
     ///
     @Environment(\.dismiss) private var dismiss
 
     var body: some View {
-        MultiSelectionReorderableList(contents: $viewModel.allCards, contentKeyPath: \.self, selectedItems: $viewModel.selectedCards)
+        MultiSelectionReorderableList(contents: $viewModel.allCards, contentKeyPath: \.name, selectedItems: $viewModel.selectedCards)
             .toolbar(content: {
                 ToolbarItem(placement: .confirmationAction) {
                     Button {
@@ -50,6 +42,6 @@ private extension AnalyticsHubCustomizeView {
 
 #Preview {
     NavigationView {
-        AnalyticsHubCustomizeView()
+        AnalyticsHubCustomizeView(viewModel: AnalyticsHubCustomizeViewModel(allCards: AnalyticsHubCustomizeViewModel.sampleCards))
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/Customize/AnalyticsHubCustomizeViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/Customize/AnalyticsHubCustomizeViewModel.swift
@@ -1,23 +1,24 @@
 import Foundation
+import Yosemite
 
 /// View model for `AnalyticsHubCustomizeView`.
 final class AnalyticsHubCustomizeViewModel: ObservableObject {
 
     /// Ordered array of all available analytics cards.
     ///
-    @Published var allCards: [String]
+    @Published var allCards: [AnalyticsCard]
 
     /// Set of selected analytics cards, to be enabled in the Analytics Hub.
     ///
-    @Published var selectedCards: Set<String>
+    @Published var selectedCards: Set<AnalyticsCard>
 
     /// Original ordered array of analytics cards. Used to track if there are order changes to be saved.
     ///
-    private let originalCards: [String]
+    private let originalCards: [AnalyticsCard]
 
     /// Original set of selected cards. Used to track if there are selection changes to be saved.
     ///
-    private let originalSelection: Set<String>?
+    private let originalSelection: Set<AnalyticsCard>?
 
     /// Whether there are changes to be saved (card order or selection has changed).
     ///
@@ -25,10 +26,11 @@ final class AnalyticsHubCustomizeViewModel: ObservableObject {
         allCards != originalCards || selectedCards != originalSelection
     }
 
-    init(allCards: [String],
-         selectedCards: Set<String>) {
-        self.allCards = AnalyticsHubCustomizeViewModel.groupAllCards(allCards, by: selectedCards)
-        self.originalCards = AnalyticsHubCustomizeViewModel.groupAllCards(allCards, by: selectedCards)
+    init(allCards: Set<AnalyticsCard>) {
+        self.allCards = AnalyticsHubCustomizeViewModel.groupAllCards(allCards)
+        self.originalCards = AnalyticsHubCustomizeViewModel.groupAllCards(allCards)
+
+        let selectedCards = allCards.filter { $0.enabled }
         self.selectedCards = selectedCards
         self.originalSelection = selectedCards
     }
@@ -38,9 +40,21 @@ private extension AnalyticsHubCustomizeViewModel {
     /// Groups the selected cards at the start of the list of all cards.
     /// This preserves the relative order of selected and unselected cards.
     ///
-    static func groupAllCards(_ allCards: [String], by selectedCards: Set<String>) -> [String] {
-        var groupedCards = allCards
-        _ = groupedCards.stablePartition(by: { !selectedCards.contains($0) })
+    static func groupAllCards(_ allCards: Set<AnalyticsCard>) -> [AnalyticsCard] {
+        var groupedCards = Array(allCards).sorted() // Sort cards by sort order
+        _ = groupedCards.stablePartition(by: { !$0.enabled }) // Group cards by enabled status
         return groupedCards
     }
+}
+
+// MARK: Data for SwiftUI previews
+extension AnalyticsHubCustomizeViewModel {
+    /// Sample cards to display in the SwiftUI preview
+    ///
+    static let sampleCards: Set<AnalyticsCard> = [
+        AnalyticsCard(type: .revenue, enabled: true, sortOrder: 0),
+        AnalyticsCard(type: .orders, enabled: false, sortOrder: 1),
+        AnalyticsCard(type: .products, enabled: true, sortOrder: 2),
+        AnalyticsCard(type: .sessions, enabled: false, sortOrder: 3)
+    ]
 }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/Customize/AnalyticsHubCustomizeViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/Customize/AnalyticsHubCustomizeViewModel.swift
@@ -18,7 +18,7 @@ final class AnalyticsHubCustomizeViewModel: ObservableObject {
 
     /// Original set of selected cards. Used to track if there are selection changes to be saved.
     ///
-    private let originalSelection: Set<AnalyticsCard>?
+    private let originalSelection: Set<AnalyticsCard>
 
     /// Whether there are changes to be saved (card order or selection has changed).
     ///

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/Customize/AnalyticsHubCustomizeViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/Customize/AnalyticsHubCustomizeViewModel.swift
@@ -27,8 +27,9 @@ final class AnalyticsHubCustomizeViewModel: ObservableObject {
     }
 
     init(allCards: Set<AnalyticsCard>) {
-        self.allCards = AnalyticsHubCustomizeViewModel.groupAllCards(allCards)
-        self.originalCards = AnalyticsHubCustomizeViewModel.groupAllCards(allCards)
+        let groupedCards = AnalyticsHubCustomizeViewModel.groupSelectedCards(in: allCards)
+        self.allCards = groupedCards
+        self.originalCards = groupedCards
 
         let selectedCards = allCards.filter { $0.enabled }
         self.selectedCards = selectedCards
@@ -40,7 +41,7 @@ private extension AnalyticsHubCustomizeViewModel {
     /// Groups the selected cards at the start of the list of all cards.
     /// This preserves the relative order of selected and unselected cards.
     ///
-    static func groupAllCards(_ allCards: Set<AnalyticsCard>) -> [AnalyticsCard] {
+    static func groupSelectedCards(in allCards: Set<AnalyticsCard>) -> [AnalyticsCard] {
         var groupedCards = Array(allCards).sorted() // Sort cards by sort order
         _ = groupedCards.stablePartition(by: { !$0.enabled }) // Group cards by enabled status
         return groupedCards

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -2061,6 +2061,7 @@
 		CEE006052077D1280079161F /* SummaryTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEE006032077D1280079161F /* SummaryTableViewCell.swift */; };
 		CEE006062077D1280079161F /* SummaryTableViewCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = CEE006042077D1280079161F /* SummaryTableViewCell.xib */; };
 		CEE006082077D14C0079161F /* OrderDetailsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEE006072077D14C0079161F /* OrderDetailsViewController.swift */; };
+		CEE482D52B83A9A300FAC8C5 /* AnalyticsCard+UI.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEE482D42B83A9A300FAC8C5 /* AnalyticsCard+UI.swift */; };
 		CEEC9B6021E79CAA0055EEF0 /* FeatureFlagTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEEC9B5F21E79CAA0055EEF0 /* FeatureFlagTests.swift */; };
 		CEEC9B6421E7AB850055EEF0 /* AppRatingManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEEC9B6221E79EE00055EEF0 /* AppRatingManager.swift */; };
 		CEEC9B6621E7C5200055EEF0 /* AppRatingManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEEC9B6521E7C5200055EEF0 /* AppRatingManagerTests.swift */; };
@@ -4774,6 +4775,7 @@
 		CEE006032077D1280079161F /* SummaryTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SummaryTableViewCell.swift; sourceTree = "<group>"; };
 		CEE006042077D1280079161F /* SummaryTableViewCell.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = SummaryTableViewCell.xib; sourceTree = "<group>"; };
 		CEE006072077D14C0079161F /* OrderDetailsViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OrderDetailsViewController.swift; sourceTree = "<group>"; };
+		CEE482D42B83A9A300FAC8C5 /* AnalyticsCard+UI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AnalyticsCard+UI.swift"; sourceTree = "<group>"; };
 		CEEC9B5F21E79CAA0055EEF0 /* FeatureFlagTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeatureFlagTests.swift; sourceTree = "<group>"; };
 		CEEC9B6221E79EE00055EEF0 /* AppRatingManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppRatingManager.swift; sourceTree = "<group>"; };
 		CEEC9B6521E7C5200055EEF0 /* AppRatingManagerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppRatingManagerTests.swift; sourceTree = "<group>"; };
@@ -10934,6 +10936,7 @@
 			children = (
 				CEFA16F02B74F64D00512782 /* AnalyticsHubCustomizeView.swift */,
 				CE4FE7D92B7E2E9400F66DD5 /* AnalyticsHubCustomizeViewModel.swift */,
+				CEE482D42B83A9A300FAC8C5 /* AnalyticsCard+UI.swift */,
 			);
 			path = Customize;
 			sourceTree = "<group>";
@@ -13917,6 +13920,7 @@
 				B946881A29BA2AC6000646B0 /* WooAnalyticsEvent+Spotlight.swift in Sources */,
 				0235BFD9246E959500778909 /* ProductFormActionsFactory.swift in Sources */,
 				024EFA6923FCC10B00F36918 /* Product+Media.swift in Sources */,
+				CEE482D52B83A9A300FAC8C5 /* AnalyticsCard+UI.swift in Sources */,
 				EE3E9E8F2B05FDD500985B2C /* SubscriptionExpiryViewController.swift in Sources */,
 				68B6F22B2ADE7ED500D171FC /* TooltipView.swift in Sources */,
 				02EAF5BE29FA04750058071C /* ProductDescriptionGenerationView.swift in Sources */,

--- a/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Analytics Hub/AnalyticsHubCustomizeViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Analytics Hub/AnalyticsHubCustomizeViewModelTests.swift
@@ -1,34 +1,40 @@
 import XCTest
 @testable import WooCommerce
+import Yosemite
 
 final class AnalyticsHubCustomizeViewModelTests: XCTestCase {
 
     func test_it_inits_with_expected_properties() {
         // Given
-        let allCards = ["First", "Second"]
-        let selectedCards = Set(["First"])
-        let vm = AnalyticsHubCustomizeViewModel(allCards: allCards, selectedCards: selectedCards)
+        let revenueCard = AnalyticsCard(type: .revenue, enabled: true, sortOrder: 0)
+        let ordersCard = AnalyticsCard(type: .orders, enabled: false, sortOrder: 1)
+        let vm = AnalyticsHubCustomizeViewModel(allCards: [revenueCard, ordersCard])
 
         // Then
-        assertEqual(allCards, vm.allCards)
-        assertEqual(selectedCards, vm.selectedCards)
+        assertEqual([revenueCard, ordersCard], vm.allCards)
+        assertEqual([revenueCard], vm.selectedCards)
         XCTAssertFalse(vm.hasChanges)
     }
 
     func test_it_groups_all_selected_cards_at_top_of_allCards_list_in_original_order() {
         // Given
-        let vm = AnalyticsHubCustomizeViewModel(allCards: ["First", "Second", "Third"], selectedCards: ["Third", "Second"])
+        let revenueCard = AnalyticsCard(type: .revenue, enabled: false, sortOrder: 0)
+        let ordersCard = AnalyticsCard(type: .orders, enabled: true, sortOrder: 1)
+        let productsCard = AnalyticsCard(type: .products, enabled: true, sortOrder: 2)
+        let vm = AnalyticsHubCustomizeViewModel(allCards: [revenueCard, ordersCard, productsCard])
 
         // Then
-        assertEqual(["Second", "Third", "First"], vm.allCards)
+        assertEqual([ordersCard, productsCard, revenueCard], vm.allCards)
     }
 
     func test_hasChanges_is_true_when_card_order_changes() {
         // Given
-        let vm = AnalyticsHubCustomizeViewModel(allCards: ["First", "Second"], selectedCards: [])
+        let revenueCard = AnalyticsCard(type: .revenue, enabled: false, sortOrder: 0)
+        let ordersCard = AnalyticsCard(type: .orders, enabled: false, sortOrder: 1)
+        let vm = AnalyticsHubCustomizeViewModel(allCards: [revenueCard, ordersCard])
 
         // When
-        vm.allCards = ["Second", "First"]
+        vm.allCards = [ordersCard, revenueCard]
 
         // Then
         XCTAssertTrue(vm.hasChanges)
@@ -36,10 +42,12 @@ final class AnalyticsHubCustomizeViewModelTests: XCTestCase {
 
     func test_hasChanges_is_true_when_selection_changes() {
         // Given
-        let vm = AnalyticsHubCustomizeViewModel(allCards: ["First", "Second"], selectedCards: ["Second"])
+        let revenueCard = AnalyticsCard(type: .revenue, enabled: false, sortOrder: 0)
+        let ordersCard = AnalyticsCard(type: .orders, enabled: true, sortOrder: 1)
+        let vm = AnalyticsHubCustomizeViewModel(allCards: [revenueCard, ordersCard])
 
         // When
-        vm.selectedCards = ["First", "Second"]
+        vm.selectedCards = [revenueCard, ordersCard]
 
         // Then
         XCTAssertTrue(vm.hasChanges)


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of #11948
<!-- Id number of the GitHub issue this PR addresses. -->

## Why
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This PR is a step toward connecting real data with the `AnalyticsHubCustomizeView` UI. It replaces the fake `String` data in that view with `AnalyticsCard` data (for now, displaying the default set of cards).

The next PR will add real data to this view by loading the analytics cards from storage, rather than showing the default cards.

## How
* Adds an extension for `AnalyticsCard` to display a localized name for each card in the list.
* Uses a set of `AnalyticsCards` to initialize `AnalyticsHubCustomizeViewModel`, and identifies the selected cards by their `enabled` property.
* Creates the view model in `AnalyticsHubViewModel`.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
Steps already tested:

1. Build and run the app.
2. On the My Store dashboard, tap "See More" to open the Analytics Hub.
3. Tap the "Edit" button in the navigation bar.
4. Confirm the "Customize Analytics" screen opens with the default set of cards preselected and in the default order (same as the cards visible in the Analytics Hub).

## Screenshot

<img src="https://github.com/woocommerce/woocommerce-ios/assets/8658164/f3130efe-f4c5-4b77-81d0-cb86924fa7b7" width="300px">



---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
