### PR TITLE
[Tablet Orders] Make order sync blocking in side-by-side mode to improve product selection sync reliability

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/EditableOrderViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/EditableOrderViewModel.swift
@@ -492,6 +492,7 @@ final class EditableOrderViewModel: ObservableObject {
         configureGiftCardSupport()
         observeGiftCardStatesForAnalytics()
         observeProductSelectorPresentationStateForViewModel()
+        forwardSyncApproachToSynchronizer()
     }
 
     /// Checks the latest Order sync, and returns the current items that are in the Order
@@ -1795,6 +1796,15 @@ private extension EditableOrderViewModel {
             DDLogWarn("Unknown horizontalSizeClass used to determine initialProductSelectionSyncApproach.")
             return .onButtonTap
         }
+    }
+
+    func forwardSyncApproachToSynchronizer() {
+        $syncChangesImmediately
+            .share()
+            .sink { [weak self] syncImmediately in
+                self?.orderSynchronizer.updateBlockingBehavior(syncImmediately ? .allUpdates : .majorUpdates)
+            }
+            .store(in: &cancellables)
     }
 
     /// Tracks when customer details have been added

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/Synchronizer/OrderSynchronizer.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/Synchronizer/OrderSynchronizer.swift
@@ -10,6 +10,11 @@ enum OrderSyncState {
     case error(Error, usesGiftCard: Bool)
 }
 
+enum OrderSyncBlockBehavior {
+    case allUpdates
+    case majorUpdates
+}
+
 /// Product input for an `OrderSynchronizer` type.
 ///
 struct OrderSyncProductInput {
@@ -150,4 +155,8 @@ protocol OrderSynchronizer {
     /// Commits all order changes to the remote source. State needs to be in `.synced` to initiate work.
     ///
     func commitAllChanges(onCompletion: @escaping (Result<Order, Error>, _ usesGiftCard: Bool) -> Void)
+
+    /// Sets the block behavior for sync requests
+    ///
+    func updateBlockingBehavior(_ behavior: OrderSyncBlockBehavior)
 }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of: #11908 
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

This isn't pretty.

With the side-by-side order creation process, we sync product selections and removals as soon as they are performed.

This makes it easy to rapidly make significant changes to the order, which is not reliable. In particular, by quickly selecting and deselecting multiple products, it's easy to get the product selector out of sync with the order.

This PR implements the simplest fix, which is to always block the UI when a change is in flight. We only block when the side-by-side mode is used.

Unfortunately, this currently includes quantity changes, which makes that part of order creation frustrating to use.

This PR may be OK for a temporary solution, or it may be better to allow the potential out-of-sync orders... but neither are good.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

1. Enable the `sideBySideViewForOrderForm` feature flag
2. Launch the app on an iPad, and go to the `Orders` tab. Tap `+`
3. Add a product to the order – observe that the UI is blocked while the sync completes
4. Add another – observe that it's blocked again
5. Remove a product – observe that the UI is blocked
6. Open a product card and change the quantity – observe that you get a moment to tap it multiple times, if you're fast, but then the UI is blocked for the sync.
7. Set a split view so that the screen shows in modal-on-modal
8. Change a product's quantity – observe that the UI is not blocked.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->


https://github.com/woocommerce/woocommerce-ios/assets/2472348/b0735067-f7e7-4a3b-945a-647173e91754


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
