### PR TITLE
[Analytics Hub] Load and save analytics cards from storage in Customize Analytics screen

### DIFF
--- a/Storage/Storage/Model/AnalyticsCard.swift
+++ b/Storage/Storage/Model/AnalyticsCard.swift
@@ -1,7 +1,8 @@
 import Foundation
+import Codegen
 
 /// Represents an analytics report card in the Analytics Hub
-public struct AnalyticsCard: Codable, Hashable, Equatable {
+public struct AnalyticsCard: Codable, Hashable, Equatable, GeneratedCopiable {
     /// The type of analytics report card.
     public let type: CardType
 

--- a/Storage/Storage/Model/Copiable/Models+Copiable.generated.swift
+++ b/Storage/Storage/Model/Copiable/Models+Copiable.generated.swift
@@ -4,6 +4,21 @@ import Codegen
 import Foundation
 
 
+extension Storage.AnalyticsCard {
+    public func copy(
+        type: CopiableProp<AnalyticsCard.CardType> = .copy,
+        enabled: CopiableProp<Bool> = .copy
+    ) -> Storage.AnalyticsCard {
+        let type = type ?? self.type
+        let enabled = enabled ?? self.enabled
+
+        return Storage.AnalyticsCard(
+            type: type,
+            enabled: enabled
+        )
+    }
+}
+
 extension Storage.FeatureAnnouncementCampaignSettings {
     public func copy(
         dismissedDate: NullableCopiableProp<Date> = .copy,

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/AnalyticsHubView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/AnalyticsHubView.swift
@@ -59,6 +59,7 @@ struct AnalyticsHubView: View {
     @StateObject var viewModel: AnalyticsHubViewModel
 
     @State private var isEnablingJetpackStats = false
+    @State private var isCustomizingAnalyticsCards = false
 
     var body: some View {
         RefreshablePlainList(action: {
@@ -152,49 +153,21 @@ struct AnalyticsHubView: View {
                 viewModel.trackAnalyticsInteraction()
             })
         )
-        .customizeAnalyticsButton(viewModel: viewModel.customizeAnalyticsViewModel)
-    }
-}
-
-fileprivate extension View {
-    /// Adds a button to customize analytics if the provided view model is not nil
-    func customizeAnalyticsButton(viewModel: AnalyticsHubCustomizeViewModel?) -> some View {
-        self.modifier(ConditionalCustomizeAnalyticsButton(viewModel: viewModel))
-    }
-}
-
-fileprivate struct ConditionalCustomizeAnalyticsButton: ViewModifier {
-    let viewModel: AnalyticsHubCustomizeViewModel?
-
-    @State private var isCustomizingAnalyticsCards: Bool = false
-    private let featureFlagEnabled = ServiceLocator.featureFlagService.isFeatureFlagEnabled(.customizeAnalyticsHub)
-
-    func body(content: Content) -> some View {
-        if featureFlagEnabled, let viewModel {
-            content
-                .toolbar {
-                    ToolbarItem(placement: .topBarTrailing) {
-                        Button {
-                            isCustomizingAnalyticsCards.toggle()
-                        } label: {
-                            Text(Localization.editButton)
-                        }
-                    }
+        .toolbar {
+            ToolbarItem(placement: .topBarTrailing) {
+                Button {
+                    isCustomizingAnalyticsCards.toggle()
+                } label: {
+                    Text(Localization.editButton)
                 }
-                .sheet(isPresented: $isCustomizingAnalyticsCards) {
-                    NavigationView {
-                        AnalyticsHubCustomizeView(viewModel: viewModel)
-                    }
-                }
-        } else {
-            content
+                .renderedIf(ServiceLocator.featureFlagService.isFeatureFlagEnabled(.customizeAnalyticsHub))
+            }
         }
-    }
-
-    enum Localization {
-        static let editButton = NSLocalizedString("analyticsHub.editButton.label",
-                                                  value: "Edit",
-                                                  comment: "Label for button that opens a screen to customize the Analytics Hub")
+        .sheet(isPresented: $isCustomizingAnalyticsCards) {
+            NavigationView {
+                AnalyticsHubCustomizeView(viewModel: viewModel.customizeAnalyticsViewModel)
+            }
+        }
     }
 }
 
@@ -214,6 +187,9 @@ private extension AnalyticsHubView {
         static let sessionsCTAButton = NSLocalizedString("analyticsHub.jetpackStatsCTA.buttonLabel",
                                                          value: "Enable Jetpack Stats",
                                                          comment: "Label for button to enable Jetpack Stats")
+        static let editButton = NSLocalizedString("analyticsHub.editButton.label",
+                                                  value: "Edit",
+                                                  comment: "Label for button that opens a screen to customize the Analytics Hub")
     }
 
     struct Layout {

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/AnalyticsHubView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/AnalyticsHubView.swift
@@ -140,6 +140,7 @@ struct AnalyticsHubView: View {
         .background(Color(uiColor: .listBackground))
         .edgesIgnoringSafeArea(.horizontal)
         .task {
+            await viewModel.loadAnalyticsCardSettings()
             await viewModel.updateData()
         }
         .onReceive(viewModel.$dismissNotice) { notice in

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/AnalyticsHubViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/AnalyticsHubViewModel.swift
@@ -103,11 +103,7 @@ final class AnalyticsHubViewModel: ObservableObject {
     /// View model for `AnalyticsHubCustomizeView`, to customize the cards in the Analytics Hub.
     ///
     lazy private(set) var customizeAnalyticsViewModel: AnalyticsHubCustomizeViewModel = {
-        AnalyticsHubCustomizeViewModel(allCards: allCardsWithSettings) { [weak self] updatedCards in
-            guard let self else { return }
-            self.allCardsWithSettings = updatedCards
-            self.storeAnalyticsCardSettings(updatedCards)
-        }
+        AnalyticsHubCustomizeViewModel(allCards: allCardsWithSettings, onSave: onCustomizeCards)
     }()
 
     /// Sessions Card display state
@@ -432,6 +428,12 @@ private extension AnalyticsHubViewModel {
                     await self.updateData()
                 }
             }.store(in: &subscriptions)
+
+        $allCardsWithSettings
+            .sink { [weak self] analyticsCards in
+                guard let self else { return }
+                self.customizeAnalyticsViewModel = AnalyticsHubCustomizeViewModel(allCards: analyticsCards, onSave: onCustomizeCards)
+            }.store(in: &subscriptions)
     }
 
     static func revenueCard(currentPeriodStats: OrderStatsV4?,
@@ -581,6 +583,14 @@ private extension AnalyticsHubViewModel {
                                             webViewTitle: title,
                                             reportURL: url,
                                             usageTracksEventEmitter: usageTracksEventEmitter)
+    }
+
+    /// Updates and stores analytics card settings when cards are customized.
+    /// Passed to the `AnalyticsHubCustomizeViewModel` to be performed when changes are saved.
+    ///
+    func onCustomizeCards(_ updatedCards: [AnalyticsCard]) {
+        allCardsWithSettings = updatedCards
+        storeAnalyticsCardSettings(updatedCards)
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/AnalyticsHubViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/AnalyticsHubViewModel.swift
@@ -102,7 +102,13 @@ final class AnalyticsHubViewModel: ObservableObject {
 
     /// View model for `AnalyticsHubCustomizeView`, to customize the cards in the Analytics Hub.
     ///
-    @Published private(set) var customizeAnalyticsViewModel: AnalyticsHubCustomizeViewModel?
+    lazy private(set) var customizeAnalyticsViewModel: AnalyticsHubCustomizeViewModel = {
+        AnalyticsHubCustomizeViewModel(allCards: allCardsWithSettings) { [weak self] updatedCards in
+            guard let self else { return }
+            self.allCardsWithSettings = updatedCards
+            self.storeAnalyticsCardSettings(updatedCards)
+        }
+    }()
 
     /// Sessions Card display state
     ///
@@ -424,17 +430,6 @@ private extension AnalyticsHubViewModel {
                 // Update data on range selection change
                 Task.init {
                     await self.updateData()
-                }
-            }.store(in: &subscriptions)
-
-        $allCardsWithSettings
-            .sink { [weak self] analyticsCards in
-                guard let self else { return }
-
-                self.customizeAnalyticsViewModel = AnalyticsHubCustomizeViewModel(allCards: analyticsCards) { [weak self] updatedCards in
-                    guard let self else { return }
-                    self.allCardsWithSettings = updatedCards
-                    self.storeAnalyticsCardSettings(updatedCards)
                 }
             }.store(in: &subscriptions)
     }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/AnalyticsHubViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/AnalyticsHubViewModel.swift
@@ -143,8 +143,9 @@ final class AnalyticsHubViewModel: ObservableObject {
     // MARK: Private data
 
     /// All analytics cards with their enabled/disabled settings.
+    /// Defaults to all enabled cards in default order.
     ///
-    @Published private(set) var allCardsWithSettings: [AnalyticsCard]?
+    @Published private(set) var allCardsWithSettings = AnalyticsHubViewModel.defaultCards
 
     /// Order stats for the current selected time period
     ///
@@ -428,9 +429,7 @@ private extension AnalyticsHubViewModel {
 
         $allCardsWithSettings
             .sink { [weak self] analyticsCards in
-                guard let self, let analyticsCards else {
-                    return
-                }
+                guard let self else { return }
 
                 self.customizeAnalyticsViewModel = AnalyticsHubCustomizeViewModel(allCards: analyticsCards) { [weak self] updatedCards in
                     guard let self else { return }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/Customize/AnalyticsHubCustomizeView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/Customize/AnalyticsHubCustomizeView.swift
@@ -1,7 +1,6 @@
 import SwiftUI
 
 struct AnalyticsHubCustomizeView: View {
-    // TODO: Initialize with real data
     @ObservedObject var viewModel: AnalyticsHubCustomizeViewModel
 
     /// Dismisses the view.
@@ -13,7 +12,8 @@ struct AnalyticsHubCustomizeView: View {
             .toolbar(content: {
                 ToolbarItem(placement: .confirmationAction) {
                     Button {
-                        dismiss() // TODO: Save changes
+                        viewModel.saveChanges()
+                        dismiss()
                     } label: {
                         Text(Localization.saveButton)
                     }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/Customize/AnalyticsHubCustomizeViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/Customize/AnalyticsHubCustomizeViewModel.swift
@@ -47,7 +47,7 @@ final class AnalyticsHubCustomizeViewModel: ObservableObject {
     ///
     func saveChanges() {
         let updatedCards = allCards.map { card in
-            AnalyticsCard(type: card.type, enabled: selectedCards.contains(card))
+            card.copy(enabled: selectedCards.contains(card))
         }
         onSave?(updatedCards)
     }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/Customize/AnalyticsHubCustomizeViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/Customize/AnalyticsHubCustomizeViewModel.swift
@@ -26,7 +26,12 @@ final class AnalyticsHubCustomizeViewModel: ObservableObject {
         allCards != originalCards || selectedCards != originalSelection
     }
 
-    init(allCards: [AnalyticsCard]) {
+    /// Callback closure called when the changes are saved.
+    ///
+    private let onSave: (([AnalyticsCard]) -> Void)?
+
+    init(allCards: [AnalyticsCard],
+         onSave: (([AnalyticsCard]) -> Void)? = nil) {
         let groupedCards = AnalyticsHubCustomizeViewModel.groupSelectedCards(in: allCards)
         self.allCards = groupedCards
         self.originalCards = groupedCards
@@ -34,6 +39,17 @@ final class AnalyticsHubCustomizeViewModel: ObservableObject {
         let selectedCards = Set(allCards.filter { $0.enabled })
         self.selectedCards = selectedCards
         self.originalSelection = selectedCards
+
+        self.onSave = onSave
+    }
+
+    /// Assembles the new selections and order into an updated set of cards.
+    ///
+    func saveChanges() {
+        let updatedCards = allCards.map { card in
+            AnalyticsCard(type: card.type, enabled: selectedCards.contains(card))
+        }
+        onSave?(updatedCards)
     }
 }
 

--- a/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Analytics Hub/AnalyticsHubCustomizeViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Analytics Hub/AnalyticsHubCustomizeViewModelTests.swift
@@ -71,9 +71,7 @@ final class AnalyticsHubCustomizeViewModelTests: XCTestCase {
         }
 
         // Then
-        let expectedCards = [AnalyticsCard(type: .orders, enabled: true),
-                             AnalyticsCard(type: .revenue, enabled: true),
-                             AnalyticsCard(type: .products, enabled: false)]
+        let expectedCards = [ordersCard, revenueCard.copy(enabled: true), productsCard.copy(enabled: false)]
         assertEqual(expectedCards, actualCards)
     }
 

--- a/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Analytics Hub/AnalyticsHubCustomizeViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Analytics Hub/AnalyticsHubCustomizeViewModelTests.swift
@@ -53,4 +53,28 @@ final class AnalyticsHubCustomizeViewModelTests: XCTestCase {
         XCTAssertTrue(vm.hasChanges)
     }
 
+    func test_saveChanges_returns_updated_array_of_cards() {
+        // Given
+        let revenueCard = AnalyticsCard(type: .revenue, enabled: false)
+        let ordersCard = AnalyticsCard(type: .orders, enabled: true)
+        let productsCard = AnalyticsCard(type: .products, enabled: true)
+
+        // When
+        let actualCards = waitFor { promise in
+            let vm = AnalyticsHubCustomizeViewModel(allCards: [revenueCard, ordersCard, productsCard]) { updatedCards in
+                promise(updatedCards)
+            }
+
+            vm.allCards = [ordersCard, revenueCard, productsCard]
+            vm.selectedCards = [revenueCard, ordersCard]
+            vm.saveChanges()
+        }
+
+        // Then
+        let expectedCards = [AnalyticsCard(type: .orders, enabled: true),
+                             AnalyticsCard(type: .revenue, enabled: true),
+                             AnalyticsCard(type: .products, enabled: false)]
+        assertEqual(expectedCards, actualCards)
+    }
+
 }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Analytics Hub/AnalyticsHubViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Analytics Hub/AnalyticsHubViewModelTests.swift
@@ -577,7 +577,10 @@ final class AnalyticsHubViewModelTests: XCTestCase {
     func test_allCardsWithSettings_shows_correct_data_after_loading_from_storage() async {
         // Given
         let vm = AnalyticsHubViewModel(siteID: 123, statsTimeRange: .thisMonth, usageTracksEventEmitter: eventEmitter, stores: stores)
-        let expectedCards = defaultCards()
+        let expectedCards = [AnalyticsCard(type: .revenue, enabled: true),
+                             AnalyticsCard(type: .orders, enabled: false),
+                             AnalyticsCard(type: .products, enabled: false),
+                             AnalyticsCard(type: .sessions, enabled: false)]
         stores.whenReceivingAction(ofType: AppSettingsAction.self) { action in
             switch action {
             case let .loadAnalyticsHubCards(_, completion):
@@ -594,13 +597,13 @@ final class AnalyticsHubViewModelTests: XCTestCase {
         assertEqual(expectedCards, vm.allCardsWithSettings)
     }
 
-    func test_it_updates_allCardsWithSettings_when_saved() async throws {
+    func test_it_updates_allCardsWithSettings_when_saved() async {
         // Given
         let vm = AnalyticsHubViewModel(siteID: 123, statsTimeRange: .thisMonth, usageTracksEventEmitter: eventEmitter, stores: stores)
 
         // When
-        try XCTUnwrap (vm.customizeAnalyticsViewModel).selectedCards = [AnalyticsCard(type: .revenue, enabled: true)]
-        try XCTUnwrap (vm.customizeAnalyticsViewModel).saveChanges()
+        vm.customizeAnalyticsViewModel.selectedCards = [AnalyticsCard(type: .revenue, enabled: true)]
+        vm.customizeAnalyticsViewModel.saveChanges()
 
         // Then
         let expectedCards = [AnalyticsCard(type: .revenue, enabled: true),
@@ -610,12 +613,12 @@ final class AnalyticsHubViewModelTests: XCTestCase {
         assertEqual(expectedCards, vm.allCardsWithSettings)
     }
 
-    func test_it_stores_updated_analytics_cards_when_saved() async throws {
+    func test_it_stores_updated_analytics_cards_when_saved() async {
         // Given
         let vm = AnalyticsHubViewModel(siteID: 123, statsTimeRange: .thisMonth, usageTracksEventEmitter: eventEmitter, stores: stores)
 
         // When
-        let storedAnalyticsCards = try waitFor { promise in
+        let storedAnalyticsCards = waitFor { promise in
             self.stores.whenReceivingAction(ofType: AppSettingsAction.self) { action in
                 switch action {
                 case let .setAnalyticsHubCards(_, cards):
@@ -626,8 +629,8 @@ final class AnalyticsHubViewModelTests: XCTestCase {
             }
 
             // Only revenue card is selected and changes are saved
-            try XCTUnwrap (vm.customizeAnalyticsViewModel).selectedCards = [AnalyticsCard(type: .revenue, enabled: true)]
-            try XCTUnwrap (vm.customizeAnalyticsViewModel).saveChanges()
+            vm.customizeAnalyticsViewModel.selectedCards = [AnalyticsCard(type: .revenue, enabled: true)]
+            vm.customizeAnalyticsViewModel.saveChanges()
         }
 
         // Then
@@ -637,14 +640,5 @@ final class AnalyticsHubViewModelTests: XCTestCase {
                              AnalyticsCard(type: .products, enabled: false),
                              AnalyticsCard(type: .sessions, enabled: false)]
         assertEqual(expectedCards, storedAnalyticsCards)
-    }
-}
-
-private extension AnalyticsHubViewModelTests {
-    func defaultCards() -> [AnalyticsCard] {
-        return [AnalyticsCard(type: .revenue, enabled: true),
-                AnalyticsCard(type: .orders, enabled: false),
-                AnalyticsCard(type: .products, enabled: false),
-                AnalyticsCard(type: .sessions, enabled: false)]
     }
 }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Analytics Hub/AnalyticsHubViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Analytics Hub/AnalyticsHubViewModelTests.swift
@@ -596,25 +596,13 @@ final class AnalyticsHubViewModelTests: XCTestCase {
 
     func test_it_updates_allCardsWithSettings_when_saved() async throws {
         // Given
-        // VM loads default set of cards
         let vm = AnalyticsHubViewModel(siteID: 123, statsTimeRange: .thisMonth, usageTracksEventEmitter: eventEmitter, stores: stores)
-        stores.whenReceivingAction(ofType: AppSettingsAction.self) { action in
-            switch action {
-            case let .loadAnalyticsHubCards(_, completion):
-                completion(self.defaultCards())
-            default:
-                break
-            }
-        }
-        await vm.loadAnalyticsCardSettings()
 
         // When
-        // Only revenue card is selected and changes are saved
         try XCTUnwrap (vm.customizeAnalyticsViewModel).selectedCards = [AnalyticsCard(type: .revenue, enabled: true)]
         try XCTUnwrap (vm.customizeAnalyticsViewModel).saveChanges()
 
         // Then
-        // analyticsCardSet contains updated selection
         let expectedCards = [AnalyticsCard(type: .revenue, enabled: true),
                              AnalyticsCard(type: .orders, enabled: false),
                              AnalyticsCard(type: .products, enabled: false),
@@ -624,17 +612,7 @@ final class AnalyticsHubViewModelTests: XCTestCase {
 
     func test_it_stores_updated_analytics_cards_when_saved() async throws {
         // Given
-        // VM loads default set of cards
         let vm = AnalyticsHubViewModel(siteID: 123, statsTimeRange: .thisMonth, usageTracksEventEmitter: eventEmitter, stores: stores)
-        stores.whenReceivingAction(ofType: AppSettingsAction.self) { action in
-            switch action {
-            case let .loadAnalyticsHubCards(_, completion):
-                completion(self.defaultCards())
-            default:
-                break
-            }
-        }
-        await vm.loadAnalyticsCardSettings()
 
         // When
         let storedAnalyticsCards = try waitFor { promise in

--- a/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Analytics Hub/AnalyticsHubViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Analytics Hub/AnalyticsHubViewModelTests.swift
@@ -573,4 +573,28 @@ final class AnalyticsHubViewModelTests: XCTestCase {
         XCTAssertNotNil(vm.ordersCard.reportViewModel?.initialURL)
         XCTAssertNotNil(vm.productsStatsCard.reportViewModel?.initialURL)
     }
+
+    func test_analyticsCardSet_shows_correct_data_after_loading_from_storage() async {
+        // Given
+        let vm = AnalyticsHubViewModel(siteID: 123, statsTimeRange: .thisMonth, usageTracksEventEmitter: eventEmitter, stores: stores)
+        let expectedCards: Set<AnalyticsCard> = [
+            AnalyticsCard(type: .revenue, enabled: true, sortOrder: 0),
+            AnalyticsCard(type: .orders, enabled: false, sortOrder: 1)
+        ]
+
+        stores.whenReceivingAction(ofType: AppSettingsAction.self) { action in
+            switch action {
+            case let .loadAnalyticsHubCards(_, completion):
+                completion(expectedCards)
+            default:
+                break
+            }
+        }
+
+        // When
+        await vm.loadAnalyticsCardSettings()
+
+        // Then
+        assertEqual(expectedCards, vm.analyticsCardSet)
+    }
 }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Analytics Hub/AnalyticsHubViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Analytics Hub/AnalyticsHubViewModelTests.swift
@@ -574,14 +574,10 @@ final class AnalyticsHubViewModelTests: XCTestCase {
         XCTAssertNotNil(vm.productsStatsCard.reportViewModel?.initialURL)
     }
 
-    func test_analyticsCardSet_shows_correct_data_after_loading_from_storage() async {
+    func test_allCardsWithSettings_shows_correct_data_after_loading_from_storage() async {
         // Given
         let vm = AnalyticsHubViewModel(siteID: 123, statsTimeRange: .thisMonth, usageTracksEventEmitter: eventEmitter, stores: stores)
-        let expectedCards: Set<AnalyticsCard> = [
-            AnalyticsCard(type: .revenue, enabled: true, sortOrder: 0),
-            AnalyticsCard(type: .orders, enabled: false, sortOrder: 1)
-        ]
-
+        let expectedCards = defaultCards()
         stores.whenReceivingAction(ofType: AppSettingsAction.self) { action in
             switch action {
             case let .loadAnalyticsHubCards(_, completion):
@@ -595,6 +591,82 @@ final class AnalyticsHubViewModelTests: XCTestCase {
         await vm.loadAnalyticsCardSettings()
 
         // Then
-        assertEqual(expectedCards, vm.analyticsCardSet)
+        assertEqual(expectedCards, vm.allCardsWithSettings)
+    }
+
+    func test_it_updates_allCardsWithSettings_when_saved() async throws {
+        // Given
+        // VM loads default set of cards
+        let vm = AnalyticsHubViewModel(siteID: 123, statsTimeRange: .thisMonth, usageTracksEventEmitter: eventEmitter, stores: stores)
+        stores.whenReceivingAction(ofType: AppSettingsAction.self) { action in
+            switch action {
+            case let .loadAnalyticsHubCards(_, completion):
+                completion(self.defaultCards())
+            default:
+                break
+            }
+        }
+        await vm.loadAnalyticsCardSettings()
+
+        // When
+        // Only revenue card is selected and changes are saved
+        try XCTUnwrap (vm.customizeAnalyticsViewModel).selectedCards = [AnalyticsCard(type: .revenue, enabled: true)]
+        try XCTUnwrap (vm.customizeAnalyticsViewModel).saveChanges()
+
+        // Then
+        // analyticsCardSet contains updated selection
+        let expectedCards = [AnalyticsCard(type: .revenue, enabled: true),
+                             AnalyticsCard(type: .orders, enabled: false),
+                             AnalyticsCard(type: .products, enabled: false),
+                             AnalyticsCard(type: .sessions, enabled: false)]
+        assertEqual(expectedCards, vm.allCardsWithSettings)
+    }
+
+    func test_it_stores_updated_analytics_cards_when_saved() async throws {
+        // Given
+        // VM loads default set of cards
+        let vm = AnalyticsHubViewModel(siteID: 123, statsTimeRange: .thisMonth, usageTracksEventEmitter: eventEmitter, stores: stores)
+        stores.whenReceivingAction(ofType: AppSettingsAction.self) { action in
+            switch action {
+            case let .loadAnalyticsHubCards(_, completion):
+                completion(self.defaultCards())
+            default:
+                break
+            }
+        }
+        await vm.loadAnalyticsCardSettings()
+
+        // When
+        let storedAnalyticsCards = try waitFor { promise in
+            self.stores.whenReceivingAction(ofType: AppSettingsAction.self) { action in
+                switch action {
+                case let .setAnalyticsHubCards(_, cards):
+                    promise(cards)
+                default:
+                    break
+                }
+            }
+
+            // Only revenue card is selected and changes are saved
+            try XCTUnwrap (vm.customizeAnalyticsViewModel).selectedCards = [AnalyticsCard(type: .revenue, enabled: true)]
+            try XCTUnwrap (vm.customizeAnalyticsViewModel).saveChanges()
+        }
+
+        // Then
+        // Stored cards contain updated selection
+        let expectedCards = [AnalyticsCard(type: .revenue, enabled: true),
+                             AnalyticsCard(type: .orders, enabled: false),
+                             AnalyticsCard(type: .products, enabled: false),
+                             AnalyticsCard(type: .sessions, enabled: false)]
+        assertEqual(expectedCards, storedAnalyticsCards)
+    }
+}
+
+private extension AnalyticsHubViewModelTests {
+    func defaultCards() -> [AnalyticsCard] {
+        return [AnalyticsCard(type: .revenue, enabled: true),
+                AnalyticsCard(type: .orders, enabled: false),
+                AnalyticsCard(type: .products, enabled: false),
+                AnalyticsCard(type: .sessions, enabled: false)]
     }
 }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Analytics Hub/AnalyticsHubViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Analytics Hub/AnalyticsHubViewModelTests.swift
@@ -641,4 +641,33 @@ final class AnalyticsHubViewModelTests: XCTestCase {
                              AnalyticsCard(type: .sessions, enabled: false)]
         assertEqual(expectedCards, storedAnalyticsCards)
     }
+
+    func test_it_updates_customizeAnalyticsVM_when_analytics_cards_saved() async {
+        // Given
+        let vm = AnalyticsHubViewModel(siteID: 123, statsTimeRange: .thisMonth, usageTracksEventEmitter: eventEmitter, stores: stores)
+
+        // When
+        let storedAnalyticsCards = waitFor { promise in
+            self.stores.whenReceivingAction(ofType: AppSettingsAction.self) { action in
+                switch action {
+                case let .setAnalyticsHubCards(_, cards):
+                    promise(cards)
+                default:
+                    break
+                }
+            }
+
+            // Only orders card is selected and changes are saved
+            vm.customizeAnalyticsViewModel.selectedCards = [AnalyticsCard(type: .orders, enabled: true)]
+            vm.customizeAnalyticsViewModel.saveChanges()
+        }
+
+        // Then
+        // View model contains updated selection and order
+        let expectedCards = [AnalyticsCard(type: .orders, enabled: true),
+                             AnalyticsCard(type: .revenue, enabled: false),
+                             AnalyticsCard(type: .products, enabled: false),
+                             AnalyticsCard(type: .sessions, enabled: false)]
+        assertEqual(expectedCards, vm.customizeAnalyticsViewModel.allCards)
+    }
 }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #11948
<!-- Id number of the GitHub issue this PR addresses. -->

## Why
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This connects the new "Customize Analytics" screen with real data in the Storage layer:

* The view displays the actual list of analytics cards (including their order and selected status) loaded from storage.
* When the Save button is tapped, it saves the changes in storage.

## How

* Adds a save method and closure to `AnalyticsHubCustomizeViewModel` to handle saving the changes. This assembles the changes to the card order and selections into a new array of analytics cards.
* Calls the save method in `AnalyticsHubCustomizeView` on the Save button.
* The interactions with the Storage layer are done in `AnalyticsHubViewModel`, since that's where we'll be using these settings:
   * Adds a published `allCardsWithSettings` property. We'll use this to customize `AnalyticsHubView` in future PRs.
   * Makes `AnalyticsHubCustomizeViewModel` a lazy variable with a closure that stores the analytics cards in storage and updates `allCardsWithSettings` when changes are saved.
   * Binds `AnalyticsHubCustomizeViewModel` to `allCardsWithSettings` so the view model is updated when the cards change.
   * Adds an async method to load analytics cards from storage.
* Loads the analytics cards from storage when `AnalyticsHubView` is loaded.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

The changes have been hand tested with these steps:

1. Build and run the app.
2. On the My Store dashboard, tap "See More" to open the Analytics Hub.
3. Tap the "Edit" button in the navigation bar.
4. In the "Customize Analytics" screen, make changes to the card order and selections.
5. Tap "Save" to save the changes.
6. Tap "Edit" again and confirm the "Customize Analytics" screen opens with the changes made previously.
7. Go back to the My Store dashboard.
8. Open the Analytics Hub again, tap "Edit," and confirm the "Customize Analytics" screen opens with the changes made previously.

## Screenshots

https://github.com/woocommerce/woocommerce-ios/assets/8658164/283eb964-3eba-4439-89f5-73897c13f1a3



---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
