### PR TITLE
Adds Connectivity Tool Logic

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Connectivity Tool/ConnectivityTool.swift
+++ b/WooCommerce/Classes/ViewRelated/Connectivity Tool/ConnectivityTool.swift
@@ -1,10 +1,33 @@
 import SwiftUI
+import Combine
 
 /// Connectivity Tool Hosting Controller
-/// 
+///
 final class ConnectivityToolViewController: UIHostingController<ConnectivityTool> {
-    override init(rootView: ConnectivityTool) {
-        super.init(rootView: rootView)
+
+    /// ConnectivityTool view model
+    ///
+    private let viewModel: ConnectivityToolViewModel
+
+    /// Combine subscriptions
+    ///
+    private var subscriptions: Set<AnyCancellable> = []
+
+
+    init() {
+        viewModel = ConnectivityToolViewModel()
+        let view = ConnectivityTool(cards: viewModel.cards)
+        super.init(rootView: view)
+        self.hidesBottomBarWhenPushed = true
+    }
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        // Bind cards to view
+        viewModel.$cards.sink { [weak self] cards in
+            self?.rootView.cards = cards
+        }
+        .store(in: &subscriptions)
     }
 
     required dynamic init?(coder aDecoder: NSCoder) {
@@ -26,7 +49,7 @@ struct ConnectivityTool: View {
 
     /// Tool cards.
     ///
-    let cards: [Card]
+    var cards: [Card]
 
     var body: some View {
         VStack(alignment: .center, spacing: .zero) {
@@ -150,7 +173,6 @@ struct ConnectivityToolCard: View {
         .padding()
     }
 }
-
 
 #Preview("Tool") {
     NavigationView {

--- a/WooCommerce/Classes/ViewRelated/Connectivity Tool/ConnectivityTool.swift
+++ b/WooCommerce/Classes/ViewRelated/Connectivity Tool/ConnectivityTool.swift
@@ -19,6 +19,7 @@ final class ConnectivityToolViewController: UIHostingController<ConnectivityTool
         let view = ConnectivityTool(cards: viewModel.cards)
         super.init(rootView: view)
         self.hidesBottomBarWhenPushed = true
+        self.title = NSLocalizedString("Connectivity Test", comment: "Screen title for the connectivity tool")
     }
 
     override func viewDidLoad() {

--- a/WooCommerce/Classes/ViewRelated/Connectivity Tool/ConnectivityTool.swift
+++ b/WooCommerce/Classes/ViewRelated/Connectivity Tool/ConnectivityTool.swift
@@ -1,5 +1,17 @@
 import SwiftUI
 
+/// Connectivity Tool Hosting Controller
+/// 
+final class ConnectivityToolViewController: UIHostingController<ConnectivityTool> {
+    override init(rootView: ConnectivityTool) {
+        super.init(rootView: rootView)
+    }
+
+    required dynamic init?(coder aDecoder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+}
+
 /// View for the Connectivity Tool.
 ///
 struct ConnectivityTool: View {

--- a/WooCommerce/Classes/ViewRelated/Connectivity Tool/ConnectivityToolViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Connectivity Tool/ConnectivityToolViewModel.swift
@@ -1,5 +1,23 @@
 import Foundation
 
 final class ConnectivityToolViewModel {
-    
+
+    @Published var cards: [ConnectivityTool.Card] = [.init(title: "Internet Connection",
+                                                           icon: .system("wifi"),
+                                                           state: .inProgress)]
+
+    init() {
+
+        DispatchQueue.main.asyncAfter(deadline: .now() + 2) {
+            self.cards = [
+                .init(title: "Internet Connection",
+                      icon: .system("wifi"),
+                      state: .success),
+                .init(title: "WordPress.com servers",
+                      icon: .system("server.rack"),
+                      state: .inProgress)
+            ]
+        }
+    }
+
 }

--- a/WooCommerce/Classes/ViewRelated/Connectivity Tool/ConnectivityToolViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Connectivity Tool/ConnectivityToolViewModel.swift
@@ -1,0 +1,5 @@
+import Foundation
+
+final class ConnectivityToolViewModel {
+    
+}

--- a/WooCommerce/Classes/ViewRelated/Connectivity Tool/ConnectivityToolViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Connectivity Tool/ConnectivityToolViewModel.swift
@@ -1,23 +1,185 @@
 import Foundation
+import Combine
+import Networking
+import Yosemite
 
 final class ConnectivityToolViewModel {
 
-    @Published var cards: [ConnectivityTool.Card] = [.init(title: "Internet Connection",
-                                                           icon: .system("wifi"),
-                                                           state: .inProgress)]
+    /// Cards to be rendered by the view.
+    ///
+    @Published var cards: [ConnectivityTool.Card] = []
 
-    init() {
+    /// Remote used to check the connection to WPCom servers.
+    ///
+    private let announcementsRemote: AnnouncementsRemote
 
-        DispatchQueue.main.asyncAfter(deadline: .now() + 2) {
-            self.cards = [
-                .init(title: "Internet Connection",
-                      icon: .system("wifi"),
-                      state: .success),
-                .init(title: "WordPress.com servers",
-                      icon: .system("server.rack"),
-                      state: .inProgress)
-            ]
+    /// Remote used to check the connection to the site.
+    ///
+    private let systemStatusRemote: SystemStatusRemote
+
+    /// Remote used to check the site orders.
+    ///
+    private let orderRemote: OrdersRemote?
+
+    /// Site to be tested.
+    ///
+    private let siteID: Int64
+
+    /// Combine subscriptions.
+    ///
+    private var subscriptions: Set<AnyCancellable> = []
+
+    init(session: SessionManagerProtocol = ServiceLocator.stores.sessionManager) {
+
+        let network = AlamofireNetwork(credentials: session.defaultCredentials)
+        self.announcementsRemote = AnnouncementsRemote(network: network)
+        self.systemStatusRemote = SystemStatusRemote(network: network)
+        self.orderRemote = OrdersRemote(network: network)
+        self.siteID = session.defaultStoreID ?? .zero
+
+        Task {
+            await startConnectivityTest()
         }
     }
 
+    /// Sequentially runs all connectivity tests defined in `ConnectivityTest`.
+    ///
+    private func startConnectivityTest() async {
+
+        for (index, testCase) in ConnectivityTest.allCases.enumerated() {
+
+            // Add an inProgress card for the current test.
+            cards.append(testCase.inProgressCard)
+
+            // Run the test.
+            let testResult = await runTest(for: testCase)
+
+            // Update the test card with the test result.
+            cards[index] = cards[index].updatingState(testResult)
+
+            // Only continue with another test if the current test was successful.
+            if case .error = testResult {
+                return // Exit connectivity test.
+            }
+        }
+    }
+
+    /// Perform the test for a provided test case.
+    ///
+    private func runTest(for connectivityTest: ConnectivityTest) async -> ConnectivityToolCard.State {
+        switch connectivityTest {
+        case .internetConnection:
+            return await testInternetConnectivity()
+        case .wpComServers:
+            return await testWPComServersConnectivity()
+        case .site:
+            return await testSiteConnectivity()
+        case .siteOrders:
+            return await testFetchingOrders()
+
+        }
+    }
+
+    /// Perform internet connectivity case using the `connectivityObserver`.
+    ///
+    private func testInternetConnectivity() async -> ConnectivityToolCard.State {
+        await withCheckedContinuation { continuation in
+            ServiceLocator.connectivityObserver.statusPublisher.first()
+                .sink { [weak self] status in
+                    guard let self else { return }
+
+                    let reachable = {
+                        if case .reachable = status {
+                            return true
+                        } else {
+                            return false
+                        }
+                    }()
+
+                    let state: ConnectivityToolCard.State = reachable ? .success : .error("No internet connection")
+                    continuation.resume(returning: state)
+                }
+                .store(in: &subscriptions)
+        }
+    }
+
+    /// Test WPCom connectivity by fetching the mobile announcements.
+    ///
+    func testWPComServersConnectivity() async -> ConnectivityToolCard.State {
+        await withCheckedContinuation { continuation in
+            announcementsRemote.loadAnnouncements(appVersion: UserAgent.bundleShortVersion, locale: Locale.current.identifier) { result in
+                let state: ConnectivityToolCard.State = result.isSuccess ? .success : .error("Can't reach WordPress.com servers")
+                continuation.resume(returning: state)
+            }
+        }
+    }
+
+    /// Test Site connectivity by fetching the status report..
+    ///
+    func testSiteConnectivity() async -> ConnectivityToolCard.State {
+        await withCheckedContinuation { continuation in
+            systemStatusRemote.fetchSystemStatusReport(for: siteID) { result in
+                let state: ConnectivityToolCard.State = result.isSuccess ? .success : .error("Can't reach your site servers")
+                continuation.resume(returning: state)
+            }
+        }
+    }
+
+    /// Test fetching the site orders by actually fetching orders.
+    ///
+    func testFetchingOrders() async -> ConnectivityToolCard.State {
+        await withCheckedContinuation { continuation in
+            orderRemote?.loadAllOrders(for: siteID) { result in
+                let state: ConnectivityToolCard.State = result.isSuccess ? .success : .error("Can't reach your site servers")
+                continuation.resume(returning: state)
+            }
+        }
+    }
+}
+
+private extension ConnectivityToolViewModel {
+    enum ConnectivityTest: CaseIterable {
+        case internetConnection
+        case wpComServers
+        case site
+        case siteOrders
+
+        var title: String {
+            switch self {
+            case .internetConnection:
+                NSLocalizedString("Internet Connection", comment: "Title for the internet connection connectivity tool card")
+            case .wpComServers:
+                NSLocalizedString("Connecting to WordPress.com Servers", comment: "Title for the WPCom servers connectivity tool card")
+            case .site:
+                NSLocalizedString("Connecting to your site", comment: "Title for the Your Site connectivity tool card")
+            case .siteOrders:
+                NSLocalizedString("Fetching your site orders", comment: "Title for the Your Site Orders connectivity tool card")
+            }
+        }
+
+        var icon: ConnectivityToolCard.Icon {
+            switch self {
+            case .internetConnection:
+                    .system("wifi")
+            case .wpComServers:
+                    .system("server.rack")
+            case .site:
+                    .system("storefront")
+            case .siteOrders:
+                    .system("list.clipboard")
+            }
+        }
+
+        var inProgressCard: ConnectivityTool.Card {
+            .init(title: title, icon: icon, state: .inProgress)
+        }
+    }
+}
+
+extension ConnectivityTool.Card {
+    /// Updates a card state to a new given state.
+    ///
+    func updatingState(_ newState: ConnectivityToolCard.State) -> ConnectivityTool.Card {
+        Self.init(title: title, icon: icon, state: newState)
+    }
 }

--- a/WooCommerce/Classes/ViewRelated/Connectivity Tool/ConnectivityToolViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Connectivity Tool/ConnectivityToolViewModel.swift
@@ -85,13 +85,13 @@ final class ConnectivityToolViewModel {
     private func testInternetConnectivity() async -> ConnectivityToolCard.State {
         await withCheckedContinuation { continuation in
             ServiceLocator.connectivityObserver.statusPublisher.first()
-                .sink { [weak self] status in
-                    guard let self else { return }
-
+                .sink { status in
                     let reachable = {
                         if case .reachable = status {
+                            DDLogInfo("Connectivity Tool: ✅ Internet Connection")
                             return true
                         } else {
+                            DDLogError("Connectivity Tool: ❌ Internet Connection")
                             return false
                         }
                     }()
@@ -108,6 +108,14 @@ final class ConnectivityToolViewModel {
     func testWPComServersConnectivity() async -> ConnectivityToolCard.State {
         await withCheckedContinuation { continuation in
             announcementsRemote.loadAnnouncements(appVersion: UserAgent.bundleShortVersion, locale: Locale.current.identifier) { result in
+
+                switch result {
+                case .success:
+                    DDLogInfo("Connectivity Tool: ✅ WPCom connection")
+                case .failure(let error):
+                    DDLogError("Connectivity Tool: ❌ WPCom connection\n\(error)")
+                }
+
                 let state: ConnectivityToolCard.State = result.isSuccess ? .success : .error("Can't reach WordPress.com servers")
                 continuation.resume(returning: state)
             }
@@ -119,6 +127,14 @@ final class ConnectivityToolViewModel {
     func testSiteConnectivity() async -> ConnectivityToolCard.State {
         await withCheckedContinuation { continuation in
             systemStatusRemote.fetchSystemStatusReport(for: siteID) { result in
+
+                switch result {
+                case .success:
+                    DDLogInfo("Connectivity Tool: ✅ Site connection")
+                case .failure(let error):
+                    DDLogError("Connectivity Tool: ❌ Site connection\n\(error)")
+                }
+
                 let state: ConnectivityToolCard.State = result.isSuccess ? .success : .error("Can't reach your site servers")
                 continuation.resume(returning: state)
             }
@@ -130,6 +146,14 @@ final class ConnectivityToolViewModel {
     func testFetchingOrders() async -> ConnectivityToolCard.State {
         await withCheckedContinuation { continuation in
             orderRemote?.loadAllOrders(for: siteID) { result in
+
+                switch result {
+                case .success:
+                    DDLogInfo("Connectivity Tool: ✅ Site Orders")
+                case .failure(let error):
+                    DDLogError("Connectivity Tool: ❌ Site Orders\n\(error)")
+                }
+
                 let state: ConnectivityToolCard.State = result.isSuccess ? .success : .error("Can't reach your site servers")
                 continuation.resume(returning: state)
             }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/DashboardViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/DashboardViewController.swift
@@ -171,11 +171,6 @@ final class DashboardViewController: UIViewController {
         Task { @MainActor in
             await viewModel.syncAnnouncements(for: siteID)
         }
-
-        DispatchQueue.main.asyncAfter(deadline: .now() + 2) {
-            let vc = ConnectivityToolViewController()
-            self.show(vc, sender: self)
-        }
     }
 
     override func viewWillAppear(_ animated: Bool) {

--- a/WooCommerce/Classes/ViewRelated/Dashboard/DashboardViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/DashboardViewController.swift
@@ -171,6 +171,11 @@ final class DashboardViewController: UIViewController {
         Task { @MainActor in
             await viewModel.syncAnnouncements(for: siteID)
         }
+
+        DispatchQueue.main.asyncAfter(deadline: .now() + 2) {
+            let vc = ConnectivityToolViewController()
+            self.show(vc, sender: self)
+        }
     }
 
     override func viewWillAppear(_ animated: Bool) {

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -762,6 +762,7 @@
 		2602A64627BDBEBA00B347F1 /* ProductInputTransformer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2602A64527BDBEBA00B347F1 /* ProductInputTransformer.swift */; };
 		2602A64827BDBF8000B347F1 /* ProductInputTransformerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2602A64727BDBF8000B347F1 /* ProductInputTransformerTests.swift */; };
 		2602A64A27BDC80200B347F1 /* RemoteOrderSynchronizerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2602A64927BDC80200B347F1 /* RemoteOrderSynchronizerTests.swift */; };
+		260520F22B83B1B7005D5D59 /* ConnectivityToolViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 260520F12B83B1B7005D5D59 /* ConnectivityToolViewModel.swift */; };
 		260837092AA66E4B0004A12B /* UserNotifications.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 260837082AA66E4A0004A12B /* UserNotifications.framework */; };
 		2608370B2AA66E4B0004A12B /* UserNotificationsUI.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 2608370A2AA66E4B0004A12B /* UserNotificationsUI.framework */; };
 		2608370E2AA66E4B0004A12B /* OrderNotificationViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2608370D2AA66E4B0004A12B /* OrderNotificationViewController.swift */; };
@@ -3471,6 +3472,7 @@
 		2602A64527BDBEBA00B347F1 /* ProductInputTransformer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductInputTransformer.swift; sourceTree = "<group>"; };
 		2602A64727BDBF8000B347F1 /* ProductInputTransformerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductInputTransformerTests.swift; sourceTree = "<group>"; };
 		2602A64927BDC80200B347F1 /* RemoteOrderSynchronizerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteOrderSynchronizerTests.swift; sourceTree = "<group>"; };
+		260520F12B83B1B7005D5D59 /* ConnectivityToolViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConnectivityToolViewModel.swift; sourceTree = "<group>"; };
 		260837072AA66E4A0004A12B /* NotificationExtension.appex */ = {isa = PBXFileReference; explicitFileType = "wrapper.app-extension"; includeInIndex = 0; path = NotificationExtension.appex; sourceTree = BUILT_PRODUCTS_DIR; };
 		260837082AA66E4A0004A12B /* UserNotifications.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = UserNotifications.framework; path = System/Library/Frameworks/UserNotifications.framework; sourceTree = SDKROOT; };
 		2608370A2AA66E4B0004A12B /* UserNotificationsUI.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = UserNotificationsUI.framework; path = System/Library/Frameworks/UserNotificationsUI.framework; sourceTree = SDKROOT; };
@@ -7423,6 +7425,7 @@
 			isa = PBXGroup;
 			children = (
 				26CE6F382B7E71AA008DB858 /* ConnectivityTool.swift */,
+				260520F12B83B1B7005D5D59 /* ConnectivityToolViewModel.swift */,
 			);
 			path = "Connectivity Tool";
 			sourceTree = "<group>";
@@ -13611,6 +13614,7 @@
 				0202B6922387AB0C00F3EBE0 /* WooTab+Tag.swift in Sources */,
 				D8736B5A22F07D7100A14A29 /* MainTabViewModel.swift in Sources */,
 				02619858256B53DD00E321E9 /* AggregatedShippingLabelOrderItems.swift in Sources */,
+				260520F22B83B1B7005D5D59 /* ConnectivityToolViewModel.swift in Sources */,
 				0235595024496853004BE2B8 /* BottomSheetListSelectorViewController.swift in Sources */,
 				57A49128250A7EB2000FEF21 /* OrderListViewController.swift in Sources */,
 				DE34771327F174C8009CA300 /* StatusView.swift in Sources */,


### PR DESCRIPTION
Closes: #11994 

# Why

This PR adds connectivity tool logic.

In particular, it tests for

- Internet connection
- Reaching wpcom servers by fetching the mobile announcements
- Reaching the site by fetching the system status
- Fetching orders by loading the first page of orders.

# Demo

### Success on a Jetpack Store

https://github.com/woocommerce/woocommerce-ios/assets/562080/2edb4ea9-981b-4f8e-947d-115176c53b20

### Success on a Non-Jetpack Store

https://github.com/woocommerce/woocommerce-ios/assets/562080/dddd984a-ef67-42af-a07c-d0b037804f55

### Failure on a Non-Jetpack Store

https://github.com/woocommerce/woocommerce-ios/assets/562080/bdd6a47b-fe15-491f-8e16-544cf39f314c



---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
