### PR TITLE
[Tablet Products] Fix product list scrolled to the selected product when loading new products from infinite scroll

### DIFF
--- a/Experiments/Experiments/DefaultFeatureFlagService.swift
+++ b/Experiments/Experiments/DefaultFeatureFlagService.swift
@@ -88,7 +88,7 @@ public struct DefaultFeatureFlagService: FeatureFlagService {
         case .backendReceipts:
             return true
         case .splitViewInProductsTab:
-            return false
+            return buildConfig == .localDeveloper || buildConfig == .alpha
         case .customRangeInMyStoreAnalytics:
             return buildConfig == .localDeveloper || buildConfig == .alpha
         case .customizeAnalyticsHub:

--- a/Experiments/Experiments/DefaultFeatureFlagService.swift
+++ b/Experiments/Experiments/DefaultFeatureFlagService.swift
@@ -88,7 +88,7 @@ public struct DefaultFeatureFlagService: FeatureFlagService {
         case .backendReceipts:
             return true
         case .splitViewInProductsTab:
-            return buildConfig == .localDeveloper || buildConfig == .alpha
+            return false
         case .customRangeInMyStoreAnalytics:
             return buildConfig == .localDeveloper || buildConfig == .alpha
         case .customizeAnalyticsHub:

--- a/WooCommerce/Classes/ViewRelated/Products/ProductsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductsViewController.swift
@@ -977,8 +977,9 @@ private extension ProductsViewController {
 
                     let scrollPosition: UITableView.ScrollPosition = {
                         let hasSelectedProductChanged = (selectedProduct != previousSelectedProduct)
-                        let isSelectedIndexPathVisible = self.tableView.indexPathsForVisibleRows?.contains(selectedIndexPath) == true
-                        return hasSelectedProductChanged && !isSelectedIndexPathVisible ? .middle : .none
+                        guard hasSelectedProductChanged else { return .none }
+                        let isSelectedIndexPathVisible = self.isIndexPathVisible(selectedIndexPath)
+                        return isSelectedIndexPathVisible ? .none : .middle
                     }()
 
                     tableView.selectRow(at: selectedIndexPath, animated: false, scrollPosition: scrollPosition)
@@ -1002,12 +1003,18 @@ private extension ProductsViewController {
         selectedProductListener?.onUpsert = { [weak self] product in
             guard let self,
                   let selectedIndexPath = tableView.indexPathForSelectedRow,
-                  let visibleIndexPaths = tableView.indexPathsForVisibleRows,
-                  !visibleIndexPaths.contains(selectedIndexPath) else {
+                  !isIndexPathVisible(selectedIndexPath) else {
                 return
             }
             tableView.scrollToRow(at: selectedIndexPath, at: .middle, animated: false)
         }
+    }
+
+    func isIndexPathVisible(_ indexPath: IndexPath) -> Bool {
+        guard let indexPathsForVisibleRows = tableView.indexPathsForVisibleRows else {
+            return false
+        }
+        return indexPathsForVisibleRows.contains(indexPath)
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Products/ProductsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductsViewController.swift
@@ -969,9 +969,7 @@ private extension ProductsViewController {
                     if let currentSelectedIndexPath {
                         tableView.deselectRow(at: currentSelectedIndexPath, animated: false)
                     }
-                    let scrollPosition: UITableView.ScrollPosition = tableView.indexPathsForVisibleRows?.contains(selectedIndexPath) == true ?
-                        .none: .middle
-                    tableView.selectRow(at: selectedIndexPath, animated: false, scrollPosition: scrollPosition)
+                    tableView.selectRow(at: selectedIndexPath, animated: false, scrollPosition: .none)
                 } else if let currentSelectedIndexPath {
                     tableView.deselectRow(at: currentSelectedIndexPath, animated: false)
                 }

--- a/WooCommerce/Classes/ViewRelated/Products/ProductsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductsViewController.swift
@@ -958,11 +958,10 @@ private extension ProductsViewController {
                                   onDataReloaded.merge(with: Just<Void>(())),
                                   // Giving it an initial value to enable the combined publisher from the beginning.
                                   onTableViewEditingEnd.merge(with: Just<Void>(())))
+            .map { $0.0 }
             .withPrevious()
-            .sink { [weak self] previous, current in
+            .sink { [weak self] previousSelectedProduct, selectedProduct in
                 guard let self else { return }
-
-                let selectedProduct = current.0
 
                 let currentSelectedIndexPath = tableView.indexPathForSelectedRow
                 let selectedIndexPath = selectedProduct != nil ? resultsController.indexPath(forObjectMatching: {
@@ -977,7 +976,7 @@ private extension ProductsViewController {
                     }
 
                     let scrollPosition: UITableView.ScrollPosition = {
-                        let hasSelectedProductChanged = (selectedProduct != previous?.0)
+                        let hasSelectedProductChanged = (selectedProduct != previousSelectedProduct)
                         let isSelectedIndexPathVisible = self.tableView.indexPathsForVisibleRows?.contains(selectedIndexPath) == true
                         return hasSelectedProductChanged && !isSelectedIndexPathVisible ? .middle : .none
                     }()


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #12050
<!-- Id number of the GitHub issue this PR addresses. -->

## Why

In the product list selection/deselection logic `ProductsViewController.observeSelectedProductAndDataLoadedStateToUpdateSelectedRow`, the `tableView.selectRow` call currently sets the flag to scroll to the selected row in the middle if it's not visible. This is useful when the product name changes from the product form in the secondary view and the selected product's index path becomes invisible, but this becomes an issue when the merchant does an infinite scroll (new data loaded when scrolling near the bottom). Because the data for the next page are reloaded, it triggers the selection/deselection logic to scroll to the selected row while the merchant intends to see new data toward the bottom of the list.

## How

It prompted me to revisit the question: when do we want to scroll to the selected product?

I think we'd only want to do this when: (open to feedback here)
- The selected product changes, which includes the following scenarios:
  - After publishing a new product
  - The product in the secondary view is deleted, the first product becomes auto-selected, then the table view should be scrolled back to the top (this will be implemented in https://github.com/woocommerce/woocommerce-ios/issues/12067)
- For the same selected product, its position (index path) in the product list changes from the product updates in the secondary view (e.g. the product name)

This PR updates the scroll position in `ProductsViewController.observeSelectedProductAndDataLoadedStateToUpdateSelectedRow` so that the table view is scrolled to the selected row only when it's not visible and the selected product changes. To implement the second scenario where the selected product's properties change, it observes the `selectedProduct` (`Product`) and uses `EntityListener` to listen to any changes of this product in storage (like from any save actions). `EntityListener` still uses a callback closure so it's not the prettiest with Combine.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

Prerequisite: the device/simulator allows switching between expanded and collapsed states like a tablet

- [ ] @jaclync makes sure the product form works as expected when the feature flag is off
- [ ] @jaclync tests on iPhone

---

### Scenario 1: creating a new product

- In code, enable `splitViewInProductsTab` feature flag in `DefaultFeatureFlagService`
- Launch the app
- Go to the products tab
- Tap + to create a product
- Enter a product name that won't show up in the currently visible section of the product list (depending on the sort order)
- Publish the product --> the product list should be scrolled to the updated position (🗒️ from my testing, there's a scenario when the the updated position is toward the bottom of the table view which triggers infinite scroll, then the selected row isn't visible anymore. I think this is likely an edge case, we can handle it if we hear from the merchants)

### Scenario 1: updating a product's name

- Go to the products tab
- Select a product from the list
- In the secondary view product form, change the product name so that the product won't show up in the currently visible section of the product list (depending on the sort order)
- Save the product --> the product list should be scrolled to the updated position

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

Scenario 1: creating a new product


https://github.com/woocommerce/woocommerce-ios/assets/1945542/69eb5d90-5d3b-4cef-8a5c-7fd773a45826


Scenario 2: updating a product's name


https://github.com/woocommerce/woocommerce-ios/assets/1945542/afd28875-2869-4491-a00b-78f8f2c04e0d



---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.