### PR TITLE
Order List: Update Networking and Yosemite to support filtering by customer and product

### DIFF
--- a/Networking/Networking/Remote/OrdersRemote.swift
+++ b/Networking/Networking/Remote/OrdersRemote.swift
@@ -13,8 +13,10 @@ public class OrdersRemote: Remote {
     ///               method will convert it to UTC ISO 8601 before calling the REST API.
     ///     - before: If given, limit response to resources published before a given compliant date.. Passing a local date is fine. This
     ///               method will convert it to UTC ISO 8601 before calling the REST API.
-    ///     - modifiedAfter: If given, limit response to resources modified after a given compliant date. Passing a local date is fine. This
-    ///               method will convert it to UTC ISO 8601 before calling the REST API.
+    ///     - modifiedAfter: If given, limit response to resources modified after a given compliant date. Passing a local date is fine.
+    ///     This method will convert it to UTC ISO 8601 before calling the REST API.
+    ///     - customerID: If given, limit response to orders placed by a customer.
+    ///     - productID: If given, limit response to orders including the given product.
     ///     - pageNumber: Number of page that should be retrieved.
     ///     - pageSize: Number of Orders to be retrieved per page.
     ///     - completion: Closure to be executed upon completion.
@@ -24,6 +26,8 @@ public class OrdersRemote: Remote {
                               after: Date? = nil,
                               before: Date? = nil,
                               modifiedAfter: Date? = nil,
+                              customerID: Int64? = nil,
+                              productID: Int64? = nil,
                               pageNumber: Int = Defaults.pageNumber,
                               pageSize: Int = Defaults.pageSize,
                               completion: @escaping (Result<[Order], Error>) -> Void) {
@@ -47,6 +51,14 @@ public class OrdersRemote: Remote {
             }
             if let modifiedAfter {
                 parameters[ParameterKeys.modifiedAfter] = utcDateFormatter.string(from: modifiedAfter)
+            }
+
+            if let customerID {
+                parameters[ParameterKeys.customer] = customerID
+            }
+
+            if let productID {
+                parameters[ParameterKeys.product] = productID
             }
 
             return parameters
@@ -399,6 +411,8 @@ public extension OrdersRemote {
         static let modifiedAfter: String    = "modified_after"
         /// Whether to consider the published or modified dates in GMT. When `false`, the local date field is used for filtering orders.
         static let usesGMTDates: String     = "dates_are_gmt"
+        static let customer = "customer"
+        static let product = "product"
     }
 
     enum ParameterValues {

--- a/Networking/NetworkingTests/Remote/OrdersRemoteTests.swift
+++ b/Networking/NetworkingTests/Remote/OrdersRemoteTests.swift
@@ -114,6 +114,56 @@ final class OrdersRemoteTests: XCTestCase {
         XCTAssertTrue(queryParameters.contains(expectedParam), "Expected to have param: \(expectedParam)")
     }
 
+    func test_loadAllOrders_includes_customer_parameter_when_provided() {
+        // Given
+        let remote = OrdersRemote(network: network)
+        let modifiedAfter = Date()
+        network.simulateResponse(requestUrlSuffix: "orders", filename: "orders-load-all")
+        let expectedCustomerID: Int64 = 123
+
+        // When
+        _ = waitFor { promise in
+            remote.loadAllOrders(for: self.sampleSiteID, customerID: expectedCustomerID) { result in
+                promise(result)
+            }
+        }
+
+        // Then
+        guard let queryParameters = network.queryParameters else {
+            XCTFail("Cannot parse query from the API request")
+            return
+        }
+
+        let dateFormatter = DateFormatter.Defaults.iso8601
+        let expectedParam = "customer=\(expectedCustomerID)"
+        XCTAssertTrue(queryParameters.contains(expectedParam), "Expected to have param: \(expectedParam)")
+    }
+
+    func test_loadAllOrders_includes_product_parameter_when_provided() {
+        // Given
+        let remote = OrdersRemote(network: network)
+        let modifiedAfter = Date()
+        network.simulateResponse(requestUrlSuffix: "orders", filename: "orders-load-all")
+        let expectedProductID: Int64 = 13
+
+        // When
+        _ = waitFor { promise in
+            remote.loadAllOrders(for: self.sampleSiteID, productID: expectedProductID) { result in
+                promise(result)
+            }
+        }
+
+        // Then
+        guard let queryParameters = network.queryParameters else {
+            XCTFail("Cannot parse query from the API request")
+            return
+        }
+
+        let dateFormatter = DateFormatter.Defaults.iso8601
+        let expectedParam = "product=\(expectedProductID)"
+        XCTAssertTrue(queryParameters.contains(expectedParam), "Expected to have param: \(expectedParam)")
+    }
+
     // MARK: - Load Order Tests
 
     /// Verifies that loadOrder properly parses the `order` sample response.

--- a/Networking/NetworkingTests/Remote/OrdersRemoteTests.swift
+++ b/Networking/NetworkingTests/Remote/OrdersRemoteTests.swift
@@ -117,7 +117,6 @@ final class OrdersRemoteTests: XCTestCase {
     func test_loadAllOrders_includes_customer_parameter_when_provided() {
         // Given
         let remote = OrdersRemote(network: network)
-        let modifiedAfter = Date()
         network.simulateResponse(requestUrlSuffix: "orders", filename: "orders-load-all")
         let expectedCustomerID: Int64 = 123
 
@@ -134,7 +133,6 @@ final class OrdersRemoteTests: XCTestCase {
             return
         }
 
-        let dateFormatter = DateFormatter.Defaults.iso8601
         let expectedParam = "customer=\(expectedCustomerID)"
         XCTAssertTrue(queryParameters.contains(expectedParam), "Expected to have param: \(expectedParam)")
     }
@@ -142,7 +140,6 @@ final class OrdersRemoteTests: XCTestCase {
     func test_loadAllOrders_includes_product_parameter_when_provided() {
         // Given
         let remote = OrdersRemote(network: network)
-        let modifiedAfter = Date()
         network.simulateResponse(requestUrlSuffix: "orders", filename: "orders-load-all")
         let expectedProductID: Int64 = 13
 
@@ -159,7 +156,6 @@ final class OrdersRemoteTests: XCTestCase {
             return
         }
 
-        let dateFormatter = DateFormatter.Defaults.iso8601
         let expectedParam = "product=\(expectedProductID)"
         XCTAssertTrue(queryParameters.contains(expectedParam), "Expected to have param: \(expectedParam)")
     }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/OrderListSyncActionUseCaseTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/OrderListSyncActionUseCaseTests.swift
@@ -144,7 +144,7 @@ final class OrderListSyncActionUseCaseTests: XCTestCase {
                                        completionHandler: unimportantCompletionHandler)
 
         // Assert
-        guard case .synchronizeOrders(_, let statuses, _, _, _, let pageNumber, let pageSize, _) = action else {
+        guard case .synchronizeOrders(_, let statuses, _, _, _, _, _, let pageNumber, let pageSize, _) = action else {
             XCTFail("Unexpected OrderAction type: \(action)")
             return
         }
@@ -167,7 +167,7 @@ final class OrderListSyncActionUseCaseTests: XCTestCase {
                                        completionHandler: unimportantCompletionHandler)
 
         // Assert
-        guard case .synchronizeOrders(_, let statuses, _, _, _, let pageNumber, let pageSize, _) = action else {
+        guard case .synchronizeOrders(_, let statuses, _, _, _, _, _, let pageNumber, let pageSize, _) = action else {
             XCTFail("Unexpected OrderAction type: \(action)")
             return
         }

--- a/Yosemite/Yosemite/Actions/OrderAction.swift
+++ b/Yosemite/Yosemite/Actions/OrderAction.swift
@@ -46,12 +46,16 @@ public enum OrderAction: Action {
     ///               doesn't matter. It will be converted to UTC later.
     ///     - modifiedAfter: Only include orders modified after this date. The time zone of the `Date`
     ///               doesn't matter. It will be converted to UTC later.
+    ///     - customerID: Only include orders placed by the given customer.
+    ///     - productID: Only include orders with `lineItems` including the given product.
     ///
     case synchronizeOrders(siteID: Int64,
                            statuses: [String]?,
                            after: Date? = nil,
                            before: Date? = nil,
                            modifiedAfter: Date? = nil,
+                           customerID: Int64? = nil,
+                           productID: Int64? = nil,
                            pageNumber: Int,
                            pageSize: Int,
                            onCompletion: (TimeInterval, Error?) -> Void)

--- a/Yosemite/Yosemite/Stores/OrderStore.swift
+++ b/Yosemite/Yosemite/Stores/OrderStore.swift
@@ -50,12 +50,14 @@ public class OrderStore: Store {
                                 deleteAllBeforeSaving: deleteAllBeforeSaving,
                                 pageSize: pageSize,
                                 onCompletion: onCompletion)
-        case let .synchronizeOrders(siteID, statuses, after, before, modifiedAfter, pageNumber, pageSize, onCompletion):
+        case let .synchronizeOrders(siteID, statuses, after, before, modifiedAfter, customerID, productID, pageNumber, pageSize, onCompletion):
             synchronizeOrders(siteID: siteID,
                               statuses: statuses,
                               after: after,
                               before: before,
                               modifiedAfter: modifiedAfter,
+                              customerID: customerID,
+                              productID: productID,
                               pageNumber: pageNumber,
                               pageSize: pageSize,
                               onCompletion: onCompletion)
@@ -240,6 +242,8 @@ private extension OrderStore {
                            after: Date?,
                            before: Date?,
                            modifiedAfter: Date?,
+                           customerID: Int64?,
+                           productID: Int64?,
                            pageNumber: Int,
                            pageSize: Int,
                            onCompletion: @escaping (TimeInterval, Error?) -> Void) {
@@ -249,6 +253,8 @@ private extension OrderStore {
                              after: after,
                              before: before,
                              modifiedAfter: modifiedAfter,
+                             customerID: customerID,
+                             productID: productID,
                              pageNumber: pageNumber,
                              pageSize: pageSize) { [weak self] result in
             switch result {


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of #12059
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This PR adds the parameters to the order syncing methods in Networking and Yosemite layers to support filtering orders by customer and product.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
The order list should still work as before. The new parameters haven't been used, so just CI passing is sufficient.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->
N/A

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
