### PR TITLE
[Tablet Orders] Design tweaks

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/OrderForm.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/OrderForm.swift
@@ -728,7 +728,6 @@ private extension ProductsSection {
             } else {
                 HStack() {
                     Image(uiImage: .scanImage.withRenderingMode(.alwaysTemplate))
-                        .foregroundColor(Color(.brand))
                     Text(Localization.scanProductRowTitle)
                         .frame(maxWidth: .infinity, alignment: .leading)
                 }
@@ -752,7 +751,6 @@ private extension ProductsSection {
                 ProgressView()
             } else {
                 Image(uiImage: .scanImage.withRenderingMode(.alwaysTemplate))
-                .foregroundColor(Color(.brand))
             }
         })
         .accessibilityLabel(OrderForm.Localization.scanProductButtonAccessibilityLabel)

--- a/WooCommerce/Classes/ViewRelated/Products/ProductSelector/ProductSelectorView.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductSelector/ProductSelectorView.swift
@@ -89,6 +89,8 @@ struct ProductSelectorView: View {
                 horizontalSizeClass == .regular {
                 productSelectorHeaderTitleRow
                 productSelectorHeaderSearchRow
+                    .padding(.bottom, Constants.defaultPadding)
+                    .background(Color(.listForeground(modal: false)))
             } else {
                 productSelectorHeaderSearchRow
                 productSelectorHeaderTitleRow
@@ -323,7 +325,6 @@ private extension ProductSelectorView {
             }
         }
         .frame(height: Constants.minimumRowHeight * scale)
-        .padding(.bottom, Constants.defaultPadding)
         .background(Color(.listForeground(modal: false)))
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Products/ProductSelector/ProductSelectorView.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductSelector/ProductSelectorView.swift
@@ -62,6 +62,8 @@ struct ProductSelectorView: View {
 
     @Environment(\.horizontalSizeClass) var horizontalSizeClass
 
+    @ScaledMetric private var scale: CGFloat = 1.0
+
     /// Tracks the state for the 'Clear Selection' button
     ///
     private var isClearSelectionDisabled: Bool {
@@ -318,15 +320,15 @@ private extension ProductSelectorView {
                 Picker(selection: $viewModel.productSearchFilter, label: EmptyView()) {
                     ForEach(ProductSearchFilter.allCases, id: \.self) { option in Text(option.title) }
                 }
-                .if(horizontalSizeClass == .regular && geometry.size.width < 450) { $0.pickerStyle(.menu) }
-                .if(horizontalSizeClass == .compact || geometry.size.width > 450) { $0.pickerStyle(.segmented) }
+                .if(horizontalSizeClass == .regular && geometry.size.width < Constants.headerSearchRowWidth) { $0.pickerStyle(.menu) }
+                .if(horizontalSizeClass == .compact || geometry.size.width > Constants.headerSearchRowWidth) { $0.pickerStyle(.segmented) }
                 .padding(.leading)
                 .padding(.trailing)
                 .renderedIf(searchHeaderisBeingEdited)
             }
             .background(Color(.listForeground(modal: false)))
         }
-        .frame(height: 48)
+        .frame(height: Constants.minimumRowHeight * scale)
     }
 }
 
@@ -355,6 +357,8 @@ private extension ProductSelectorView {
     enum Constants {
         static let dividerHeight: CGFloat = 1
         static let defaultPadding: CGFloat = 16
+        static let minimumRowHeight: CGFloat = 48
+        static let headerSearchRowWidth: CGFloat = 450
         static let doneButtonAccessibilityIdentifier: String = "product-multiple-selection-done-button"
         static let productRowAccessibilityIdentifier: String = "product-item"
     }

--- a/WooCommerce/Classes/ViewRelated/Products/ProductSelector/ProductSelectorView.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductSelector/ProductSelectorView.swift
@@ -319,7 +319,6 @@ private extension ProductSelectorView {
                 }
                 .if(horizontalSizeClass == .regular && geometry.size.width < Constants.headerSearchRowWidth) { $0.pickerStyle(.menu) }
                 .if(horizontalSizeClass == .compact || geometry.size.width > Constants.headerSearchRowWidth) { $0.pickerStyle(.segmented) }
-                .padding(.leading)
                 .padding(.trailing)
                 .renderedIf(searchHeaderisBeingEdited)
             }

--- a/WooCommerce/Classes/ViewRelated/Products/ProductSelector/ProductSelectorView.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductSelector/ProductSelectorView.swift
@@ -287,13 +287,11 @@ private extension ProductSelectorView {
         HStack {
             Text(viewModel.selectProductsTitle)
                 .renderedIf(configuration.productHeaderTextEnabled)
-                .fixedSize()
                 .padding(.leading)
             Button(Localization.clearSelection) {
                 viewModel.clearSelection()
             }
             .buttonStyle(LinkButtonStyle())
-            .fixedSize()
             .disabled(isClearSelectionDisabled)
             .renderedIf(configuration.multipleSelectionEnabled)
 
@@ -304,7 +302,6 @@ private extension ProductSelectorView {
                 ServiceLocator.analytics.track(event: .ProductListFilter.productListViewFilterOptionsTapped(source: source.filterAnalyticsSource))
             }
             .buttonStyle(LinkButtonStyle())
-            .fixedSize()
         }
         .padding(.horizontal, insets: safeAreaInsets)
         .background(Color(.listForeground(modal: false)))

--- a/WooCommerce/Classes/ViewRelated/Products/ProductSelector/ProductSelectorView.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductSelector/ProductSelectorView.swift
@@ -326,9 +326,10 @@ private extension ProductSelectorView {
                 .padding(.trailing)
                 .renderedIf(searchHeaderisBeingEdited)
             }
-            .background(Color(.listForeground(modal: false)))
         }
         .frame(height: Constants.minimumRowHeight * scale)
+        .padding(.bottom, Constants.defaultPadding)
+        .background(Color(.listForeground(modal: false)))
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Products/ProductSelector/ProductSelectorView.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductSelector/ProductSelectorView.swift
@@ -318,8 +318,8 @@ private extension ProductSelectorView {
                 Picker(selection: $viewModel.productSearchFilter, label: EmptyView()) {
                     ForEach(ProductSearchFilter.allCases, id: \.self) { option in Text(option.title) }
                 }
-                .if(horizontalSizeClass == .regular && geometry.size.width < Constants.headerSearchRowWidth) { $0.pickerStyle(.menu) }
-                .if(horizontalSizeClass == .compact || geometry.size.width > Constants.headerSearchRowWidth) { $0.pickerStyle(.segmented) }
+                .if(geometry.size.width <= Constants.headerSearchRowWidth) { $0.pickerStyle(.menu) }
+                .if(geometry.size.width > Constants.headerSearchRowWidth) { $0.pickerStyle(.segmented) }
                 .padding(.trailing)
                 .renderedIf(searchHeaderisBeingEdited)
             }

--- a/WooCommerce/Classes/ViewRelated/Products/ProductSelector/ProductSelectorView.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductSelector/ProductSelectorView.swift
@@ -91,6 +91,7 @@ struct ProductSelectorView: View {
                 productSelectorHeaderSearchRow
                 productSelectorHeaderTitleRow
             }
+            Divider()
 
             switch viewModel.syncStatus {
             case .results:

--- a/WooCommerce/Classes/ViewRelated/Products/ProductSelector/ProductSelectorView.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductSelector/ProductSelectorView.swift
@@ -313,12 +313,12 @@ private extension ProductSelectorView {
             SearchHeader(text: $viewModel.searchTerm, placeholder: Localization.searchPlaceholder, onEditingChanged: { isEditing in
                 searchHeaderisBeingEdited = isEditing
             })
-            .padding(.horizontal, insets: safeAreaInsets)
             .accessibilityIdentifier("product-selector-search-bar")
             Picker(selection: $viewModel.productSearchFilter, label: EmptyView()) {
                 ForEach(ProductSearchFilter.allCases, id: \.self) { option in Text(option.title) }
             }
-            .pickerStyle(.segmented)
+            .if(horizontalSizeClass == .compact) { $0.pickerStyle(.segmented) }
+            .if(horizontalSizeClass == .regular) { $0.pickerStyle(.menu) }
             .padding(.leading)
             .padding(.trailing)
             .renderedIf(searchHeaderisBeingEdited)

--- a/WooCommerce/Classes/ViewRelated/Products/ProductSelector/ProductSelectorView.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductSelector/ProductSelectorView.swift
@@ -324,6 +324,8 @@ private extension ProductSelectorView {
                 .renderedIf(searchHeaderisBeingEdited)
             }
         }
+        // The GeometryReader will take all available space if not constrained vertically, while adjusting automatically horizontally,
+        // so we need to set a desired height for this view.
         .frame(height: Constants.minimumRowHeight * scale)
         .background(Color(.listForeground(modal: false)))
     }

--- a/WooCommerce/Classes/ViewRelated/Products/ProductSelector/ProductSelectorView.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductSelector/ProductSelectorView.swift
@@ -299,9 +299,9 @@ private extension ProductSelectorView {
                 .fixedSize()
                 .disabled(isClearSelectionDisabled)
                 .renderedIf(configuration.multipleSelectionEnabled)
-                
+
                 Spacer()
-                
+
                 Button(viewModel.filterButtonTitle) {
                     showingFilters.toggle()
                     ServiceLocator.analytics.track(event: .ProductListFilter.productListViewFilterOptionsTapped(source: source.filterAnalyticsSource))

--- a/WooCommerce/Classes/ViewRelated/Products/ProductSelector/ProductSelectorView.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductSelector/ProductSelectorView.swift
@@ -303,7 +303,6 @@ private extension ProductSelectorView {
             }
             .buttonStyle(LinkButtonStyle())
         }
-        .padding(.horizontal, insets: safeAreaInsets)
         .background(Color(.listForeground(modal: false)))
     }
 

--- a/WooCommerce/Classes/ViewRelated/Products/ProductSelector/ProductSelectorView.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductSelector/ProductSelectorView.swift
@@ -304,7 +304,9 @@ private extension ProductSelectorView {
                 ServiceLocator.analytics.track(event: .ProductListFilter.productListViewFilterOptionsTapped(source: source.filterAnalyticsSource))
             }
             .buttonStyle(LinkButtonStyle())
+            .fixedSize()
         }
+        .padding(.horizontal, insets: safeAreaInsets)
         .background(Color(.listForeground(modal: false)))
     }
 

--- a/WooCommerce/Classes/ViewRelated/Products/ProductSelector/ProductSelectorView.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductSelector/ProductSelectorView.swift
@@ -286,27 +286,32 @@ struct ProductSelectorView: View {
 
 private extension ProductSelectorView {
     @ViewBuilder private var productSelectorHeaderTitleRow: some View {
-        HStack {
-            Text(viewModel.selectProductsTitle)
-                .renderedIf(configuration.productHeaderTextEnabled)
-                .padding(.leading)
-            Button(Localization.clearSelection) {
-                viewModel.clearSelection()
+        GeometryReader { geometry in
+            HStack {
+                Text(viewModel.selectProductsTitle)
+                    .renderedIf(configuration.productHeaderTextEnabled && geometry.size.width > Constants.headerSearchRowWidth)
+                    .fixedSize()
+                    .padding(.leading)
+                Button(Localization.clearSelection) {
+                    viewModel.clearSelection()
+                }
+                .buttonStyle(LinkButtonStyle())
+                .fixedSize()
+                .disabled(isClearSelectionDisabled)
+                .renderedIf(configuration.multipleSelectionEnabled)
+                
+                Spacer()
+                
+                Button(viewModel.filterButtonTitle) {
+                    showingFilters.toggle()
+                    ServiceLocator.analytics.track(event: .ProductListFilter.productListViewFilterOptionsTapped(source: source.filterAnalyticsSource))
+                }
+                .buttonStyle(LinkButtonStyle())
+                .fixedSize()
             }
-            .buttonStyle(LinkButtonStyle())
-            .disabled(isClearSelectionDisabled)
-            .renderedIf(configuration.multipleSelectionEnabled)
-
-            Spacer()
-
-            Button(viewModel.filterButtonTitle) {
-                showingFilters.toggle()
-                ServiceLocator.analytics.track(event: .ProductListFilter.productListViewFilterOptionsTapped(source: source.filterAnalyticsSource))
-            }
-            .buttonStyle(LinkButtonStyle())
-            .fixedSize()
+            .padding(.horizontal, insets: safeAreaInsets)
         }
-        .padding(.horizontal, insets: safeAreaInsets)
+        .frame(height: Constants.minimumRowHeight * scale)
         .background(Color(.listForeground(modal: false)))
     }
 

--- a/WooCommerce/Classes/ViewRelated/Products/ProductSelector/ProductSelectorView.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductSelector/ProductSelectorView.swift
@@ -309,21 +309,24 @@ private extension ProductSelectorView {
     }
 
     @ViewBuilder private var productSelectorHeaderSearchRow: some View {
-        HStack {
-            SearchHeader(text: $viewModel.searchTerm, placeholder: Localization.searchPlaceholder, onEditingChanged: { isEditing in
-                searchHeaderisBeingEdited = isEditing
-            })
-            .accessibilityIdentifier("product-selector-search-bar")
-            Picker(selection: $viewModel.productSearchFilter, label: EmptyView()) {
-                ForEach(ProductSearchFilter.allCases, id: \.self) { option in Text(option.title) }
+        GeometryReader { geometry in
+            HStack {
+                SearchHeader(text: $viewModel.searchTerm, placeholder: Localization.searchPlaceholder, onEditingChanged: { isEditing in
+                    searchHeaderisBeingEdited = isEditing
+                })
+                .accessibilityIdentifier("product-selector-search-bar")
+                Picker(selection: $viewModel.productSearchFilter, label: EmptyView()) {
+                    ForEach(ProductSearchFilter.allCases, id: \.self) { option in Text(option.title) }
+                }
+                .if(horizontalSizeClass == .regular && geometry.size.width < 450) { $0.pickerStyle(.menu) }
+                .if(horizontalSizeClass == .compact || geometry.size.width > 450) { $0.pickerStyle(.segmented) }
+                .padding(.leading)
+                .padding(.trailing)
+                .renderedIf(searchHeaderisBeingEdited)
             }
-            .if(horizontalSizeClass == .compact) { $0.pickerStyle(.segmented) }
-            .if(horizontalSizeClass == .regular) { $0.pickerStyle(.menu) }
-            .padding(.leading)
-            .padding(.trailing)
-            .renderedIf(searchHeaderisBeingEdited)
+            .background(Color(.listForeground(modal: false)))
         }
-        .background(Color(.listForeground(modal: false)))
+        .frame(height: 48)
     }
 }
 


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Partially addresses #12057

## Description
This PR addresses the design issues raised on a previous review here: https://github.com/woocommerce/woocommerce-ios/pull/12033#pullrequestreview-1891221396

## Changes:
- Added a divider to the `ProductSelectorView`, between the header (clear selection, filter, ... ) and the product list. There's an additional divider on the top, separating the navigation controls from the rest of the view. This seems to be added by default from iOS16+, I was unable to remove it so far, needs more research.
<img width="421" alt="Screenshot 2024-02-22 at 10 01 13" src="https://github.com/woocommerce/woocommerce-ios/assets/3812076/6cb910c7-93d2-4202-976f-b439fdc03e3b">

- Addressed the segmented controls when searching products, and the search bar size itself being truncated on smaller screens: We will use either a `.segmented` or a `.menu` control type based on the screen size class and a minimum screen width (currently set to 450, happy to change this as you see fit).

![Simulator Screenshot - iPhone 15 Plus - 2024-02-22 at 08 48 08](https://github.com/woocommerce/woocommerce-ios/assets/3812076/71462bb0-8538-42c7-9f1f-5d866c7e47f8)

- Adjusted the product selector header in split views, the combination of padding and using `.fixedSize()` for some of their components made the controls overflow the available view. There's some improvements that could be done here regarding spacing and padding on smaller screens, currently we allow the HStack to grow vertically if needed, rather than forcing a fixed size and cutting out button text.

| Before | After |
|--------|--------|
| <img width="585" alt="Screenshot 2024-02-22 at 10 04 06" src="https://github.com/woocommerce/woocommerce-ios/assets/3812076/601a24d3-585e-4965-b336-a2a16148b408"> | ![simulator_screenshot_C3FC513A-6B66-4F5B-B34F-1C0D1559B52C](https://github.com/woocommerce/woocommerce-ios/assets/3812076/3d3e97b2-42b2-4831-a9fd-649aa7ca04ba) | 

- Addressed using the wrong tint on dark mode for the scanner button icon.

<img width="195" alt="Screenshot 2024-02-22 at 10 06 32" src="https://github.com/woocommerce/woocommerce-ios/assets/3812076/af189c95-5402-486a-9243-f591edc0ec21">

## Testing instructions
- Switch `sideBySideViewForOrderForm ` to `true`
- Navigate to the Order > `+` and observe that the UI has been updated as above. In general, test with iPhone, iPad, and iPhone that supports split views in landscape mode looking for edge cases.