### PR TITLE
Remove the explicit dependency on WordPressKit

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -85,9 +85,9 @@ target 'WooCommerce' do
   pod 'Gridicons', '~> 1.2.0'
 
   # To allow pod to pick up beta versions use -beta. E.g., 1.1.7-beta.1
-  pod 'WordPressAuthenticator', '~> 9.0'
+  # pod 'WordPressAuthenticator', '~> 9.0'
   # pod 'WordPressAuthenticator', git: 'https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git', branch: ''
-  # pod 'WordPressAuthenticator', git: 'https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git', commit: ''
+  pod 'WordPressAuthenticator', git: 'https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git', commit: 'b516ec85375fe4e3fa0d4f5a2358697cf43cc6a8'
   # pod 'WordPressAuthenticator', path: '../WordPressAuthenticator-iOS'
 
   pod 'WordPressKit', '~> 13.1'

--- a/Podfile
+++ b/Podfile
@@ -90,9 +90,6 @@ target 'WooCommerce' do
   pod 'WordPressAuthenticator', git: 'https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git', commit: 'b516ec85375fe4e3fa0d4f5a2358697cf43cc6a8'
   # pod 'WordPressAuthenticator', path: '../WordPressAuthenticator-iOS'
 
-  pod 'WordPressKit', '~> 13.1'
-  # pod 'WordPressKit', git: 'https://github.com/wordpress-mobile/WordPressKit-iOS.git', commit: ''
-
   wordpress_shared
 
   pod 'WordPressUI', '~> 1.15'

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -75,7 +75,6 @@ DEPENDENCIES:
   - WordPress-Aztec-iOS (from `https://github.com/wordpress-mobile/AztecEditor-iOS.git`, commit `950c7bc1bf98326986f10cccb2715ad86976f0fd`)
   - WordPress-Editor-iOS (from `https://github.com/wordpress-mobile/AztecEditor-iOS.git`, commit `950c7bc1bf98326986f10cccb2715ad86976f0fd`)
   - WordPressAuthenticator (from `https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git`, commit `b516ec85375fe4e3fa0d4f5a2358697cf43cc6a8`)
-  - WordPressKit (~> 13.1)
   - WordPressShared (~> 2.1)
   - WordPressUI (~> 1.15)
   - Wormholy (~> 1.6.6)
@@ -171,6 +170,6 @@ SPEC CHECKSUMS:
   ZendeskSupportProvidersSDK: 685b5d185af47ced0ec40564ec46355c838bbd06
   ZendeskSupportSDK: 92e6f9d334e81e9186f8a17583862350460a5393
 
-PODFILE CHECKSUM: da09a93ffffcdbe2305f5c3e0f0390052772f3c6
+PODFILE CHECKSUM: f9cfeec9fa67afdd05758ab2a2e55553154d2f1c
 
 COCOAPODS: 1.14.0

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -33,7 +33,7 @@ PODS:
     - Gridicons (~> 1.0)
     - "NSURL+IDN (= 0.4)"
     - SVProgressHUD (~> 2.2.5)
-    - WordPressKit (~> 13.0)
+    - WordPressKit (~> 13.1)
     - WordPressShared (~> 2.1-beta)
     - WordPressUI (~> 1.7-beta)
   - WordPressKit (13.1.0):
@@ -74,7 +74,7 @@ DEPENDENCIES:
   - SwiftLint (~> 0.54)
   - WordPress-Aztec-iOS (from `https://github.com/wordpress-mobile/AztecEditor-iOS.git`, commit `950c7bc1bf98326986f10cccb2715ad86976f0fd`)
   - WordPress-Editor-iOS (from `https://github.com/wordpress-mobile/AztecEditor-iOS.git`, commit `950c7bc1bf98326986f10cccb2715ad86976f0fd`)
-  - WordPressAuthenticator (~> 9.0)
+  - WordPressAuthenticator (from `https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git`, commit `b516ec85375fe4e3fa0d4f5a2358697cf43cc6a8`)
   - WordPressKit (~> 13.1)
   - WordPressShared (~> 2.1)
   - WordPressUI (~> 1.15)
@@ -84,7 +84,6 @@ DEPENDENCIES:
 
 SPEC REPOS:
   https://github.com/wordpress-mobile/cocoapods-specs.git:
-    - WordPressAuthenticator
     - WordPressKit
   trunk:
     - Alamofire
@@ -123,6 +122,9 @@ EXTERNAL SOURCES:
   WordPress-Editor-iOS:
     :commit: 950c7bc1bf98326986f10cccb2715ad86976f0fd
     :git: https://github.com/wordpress-mobile/AztecEditor-iOS.git
+  WordPressAuthenticator:
+    :commit: b516ec85375fe4e3fa0d4f5a2358697cf43cc6a8
+    :git: https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git
 
 CHECKOUT OPTIONS:
   WordPress-Aztec-iOS:
@@ -131,6 +133,9 @@ CHECKOUT OPTIONS:
   WordPress-Editor-iOS:
     :commit: 950c7bc1bf98326986f10cccb2715ad86976f0fd
     :git: https://github.com/wordpress-mobile/AztecEditor-iOS.git
+  WordPressAuthenticator:
+    :commit: b516ec85375fe4e3fa0d4f5a2358697cf43cc6a8
+    :git: https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git
 
 SPEC CHECKSUMS:
   Alamofire: 3ec537f71edc9804815215393ae2b1a8ea33a844
@@ -151,7 +156,7 @@ SPEC CHECKSUMS:
   UIDeviceIdentifier: 442b65b4ff1832d4ca9c2a157815cb29ad981b17
   WordPress-Aztec-iOS: fbebd569c61baa252b3f5058c0a2a9a6ada686bb
   WordPress-Editor-iOS: bda9f7f942212589b890329a0cb22547311749ef
-  WordPressAuthenticator: 0891ba77c788044d32fe67a4d0435fdd598cecbd
+  WordPressAuthenticator: 415b7a0957826ebde01f944f540fd502913b8a35
   WordPressKit: 7189845e0325fc6022a02638b572e1de8c1d7cc6
   WordPressShared: 0aa459e5257a77184db87805a998f447443c9706
   WordPressUI: 700e3ec5a9f77b6920c8104c338c85788036ab3c
@@ -166,6 +171,6 @@ SPEC CHECKSUMS:
   ZendeskSupportProvidersSDK: 685b5d185af47ced0ec40564ec46355c838bbd06
   ZendeskSupportSDK: 92e6f9d334e81e9186f8a17583862350460a5393
 
-PODFILE CHECKSUM: 296197a9c546e1c3e40c103704720a4b850f7ab1
+PODFILE CHECKSUM: da09a93ffffcdbe2305f5c3e0f0390052772f3c6
 
 COCOAPODS: 1.14.0

--- a/WooCommerce/Classes/AppDelegate.swift
+++ b/WooCommerce/Classes/AppDelegate.swift
@@ -10,7 +10,6 @@ import KeychainAccess
 import WordPressUI
 import WordPressAuthenticator
 import AutomatticTracks
-import WordPressKit
 
 import class Yosemite.ScreenshotStoresManager
 
@@ -102,8 +101,6 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         setupNoticePresenter()
         setupUniversalLinkRouter()
         disableAnimationsIfNeeded()
-
-        configureWordPressKit()
 
         // Don't track startup waiting time if user starts logged out
         if !ServiceLocator.stores.isAuthenticated {
@@ -460,13 +457,6 @@ private extension AppDelegate {
             ServiceLocator.analytics.track(event: .Widgets.widgetTapped(name: .appLink))
         default:
             break
-        }
-    }
-
-    func configureWordPressKit() {
-        if ServiceLocator.featureFlagService.isFeatureFlagEnabled(.useURLSessionInWordPressKit) {
-            WordPressOrgXMLRPCApi.useURLSession = true
-            WordPressComRestApi.useURLSession = true
         }
     }
 }

--- a/WooCommerce/Classes/Extensions/WordPressAuthenticator+Woo.swift
+++ b/WooCommerce/Classes/Extensions/WordPressAuthenticator+Woo.swift
@@ -8,6 +8,8 @@ extension WordPressAuthenticator {
                                             featureFlagService: FeatureFlagService = ServiceLocator.featureFlagService) {
         let isWPComMagicLinkShownAsSecondaryActionOnPasswordScreen = true
         let isManualErrorHandlingEnabled = featureFlagService.isFeatureFlagEnabled(.manualErrorHandlingForSiteCredentialLogin)
+        let useURLSession = ServiceLocator.featureFlagService.isFeatureFlagEnabled(.useURLSessionInWordPressKit)
+
         let configuration = WordPressAuthenticatorConfiguration(wpcomClientId: ApiCredentials.dotcomAppId,
                                                                 wpcomSecret: ApiCredentials.dotcomSecret,
                                                                 wpcomScheme: dotcomAuthScheme,
@@ -39,7 +41,8 @@ extension WordPressAuthenticator {
                                                                 enableManualSiteCredentialLogin: true,
                                                                 enableManualErrorHandlingForSiteCredentialLogin: isManualErrorHandlingEnabled,
                                                                 useEnterEmailAddressAsStepValueForGetStartedVC: true,
-                                                                enableSiteAddressLoginOnlyInPrologue: true)
+                                                                enableSiteAddressLoginOnlyInPrologue: true,
+                                                                useURLSession: useURLSession)
 
         let systemGray3LightModeColor = UIColor(red: 199/255.0, green: 199/255.0, blue: 204/255.0, alpha: 1)
         let systemLabelLightModeColor = UIColor(red: 0, green: 0, blue: 0, alpha: 1)


### PR DESCRIPTION
## Description

Building on top of https://github.com/wordpress-mobile/WordPressAuthenticator-iOS/pull/836, this removes the implicit dependency on WordPressKit. That is, it removes the one `import` it had and removes it from `Podfile`.

This is not a game changer, we still depend on the library implicitly via WordPressAuthenticator. But I think it's a little win. One less library to look at in the `Podfile` and to be aware of.

## Testing instructions
I run the app with breakpoints to verify the `useURLSession` value is passed along from Woo to Authenticator. The only flows that trigger WordPressKit usages are authentication ones (which is obvious given Authenticator is the the one depending on it.

---

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary. — N.A.
