### PR TITLE
[DO NOT MERGE] Demo of Lily pad order creation M3 with major update blocking only

### DIFF
--- a/Experiments/Experiments/DefaultFeatureFlagService.swift
+++ b/Experiments/Experiments/DefaultFeatureFlagService.swift
@@ -16,7 +16,7 @@ public struct DefaultFeatureFlagService: FeatureFlagService {
         case .splitViewInOrdersTab:
             return true
         case .sideBySideViewForOrderForm:
-            return false
+            return buildConfig == .localDeveloper || buildConfig == .alpha
         case .updateOrderOptimistically:
             return buildConfig == .localDeveloper || buildConfig == .alpha
         case .shippingLabelsOnboardingM1:


### PR DESCRIPTION
## Description
This is a demo branch to enable testing of order creation under Project Lily Pad M3, using a blocking sync behaviour for major updates to the order.

With this approach, it's possible for the product selector to get out of sync with the order, but it's quicker to make selections and you can see the effect of changes as you build the order.

Note that deselecting a product is not blocking here. Rapid changes of deselecting, then reselecting the same product will often lead to it being marked as selected on the left, but missing from the order on the right.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

https://github.com/woocommerce/woocommerce-ios/assets/2472348/d0601dc5-ef09-4d21-a638-0b1c449094c3