### PR TITLE
[DO NOT MERGE] Demo of Lily pad order creation M3 with blocking for all updates

### DIFF
--- a/Experiments/Experiments/DefaultFeatureFlagService.swift
+++ b/Experiments/Experiments/DefaultFeatureFlagService.swift
@@ -16,7 +16,7 @@ public struct DefaultFeatureFlagService: FeatureFlagService {
         case .splitViewInOrdersTab:
             return true
         case .sideBySideViewForOrderForm:
-            return false
+            return buildConfig == .localDeveloper || buildConfig == .alpha
         case .updateOrderOptimistically:
             return buildConfig == .localDeveloper || buildConfig == .alpha
         case .shippingLabelsOnboardingM1:

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/EditableOrderViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/EditableOrderViewModel.swift
@@ -492,6 +492,7 @@ final class EditableOrderViewModel: ObservableObject {
         configureGiftCardSupport()
         observeGiftCardStatesForAnalytics()
         observeProductSelectorPresentationStateForViewModel()
+        forwardSyncApproachToSynchronizer()
     }
 
     /// Checks the latest Order sync, and returns the current items that are in the Order
@@ -1795,6 +1796,15 @@ private extension EditableOrderViewModel {
             DDLogWarn("Unknown horizontalSizeClass used to determine initialProductSelectionSyncApproach.")
             return .onButtonTap
         }
+    }
+
+    func forwardSyncApproachToSynchronizer() {
+        $syncChangesImmediately
+            .share()
+            .sink { [weak self] syncImmediately in
+                self?.orderSynchronizer.updateBlockingBehavior(syncImmediately ? .allUpdates : .majorUpdates)
+            }
+            .store(in: &cancellables)
     }
 
     /// Tracks when customer details have been added

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/Synchronizer/OrderSynchronizer.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/Synchronizer/OrderSynchronizer.swift
@@ -10,6 +10,11 @@ enum OrderSyncState {
     case error(Error, usesGiftCard: Bool)
 }
 
+enum OrderSyncBlockBehavior {
+    case allUpdates
+    case majorUpdates
+}
+
 /// Product input for an `OrderSynchronizer` type.
 ///
 struct OrderSyncProductInput {
@@ -150,4 +155,8 @@ protocol OrderSynchronizer {
     /// Commits all order changes to the remote source. State needs to be in `.synced` to initiate work.
     ///
     func commitAllChanges(onCompletion: @escaping (Result<Order, Error>, _ usesGiftCard: Bool) -> Void)
+
+    /// Sets the block behavior for sync requests
+    ///
+    func updateBlockingBehavior(_ behavior: OrderSyncBlockBehavior)
 }


### PR DESCRIPTION
## Description
This is a demo branch to enable testing of order creation under Project Lily Pad M3, using a blocking sync behaviour for all updates to the order.

This approach avoids the product selector from getting out of sync with the order, but makes it slower to build an order.

Note that the quantity changes are blocking here, and so is deselecting a product.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

https://github.com/woocommerce/woocommerce-ios/assets/2472348/fa3f23e2-3efb-42ca-8ef8-d6063c4a64c5

