### PR TITLE
[DO NOT MERGE] Demo of Lily pad order creation existing experience

### DIFF
--- a/Experiments/Experiments/DefaultFeatureFlagService.swift
+++ b/Experiments/Experiments/DefaultFeatureFlagService.swift
@@ -16,7 +16,7 @@ public struct DefaultFeatureFlagService: FeatureFlagService {
         case .splitViewInOrdersTab:
             return true
         case .sideBySideViewForOrderForm:
-            return false
+            return false // leave order creation at M2 for demo
         case .updateOrderOptimistically:
             return buildConfig == .localDeveloper || buildConfig == .alpha
         case .shippingLabelsOnboardingM1:


### PR DESCRIPTION
## Description
This is a demo branch to enable testing of order creation under Project Lily Pad M3, but it only shows the status quo – i.e. what if we don't ship M3 yet.

This approach avoids the product selector from getting out of sync with the order, as you need to open the selector, make selections, then confirm them. The network request that updates the order is only made after you complete that process. 

However, this doesn't allow good use of the screen space, nor can we see the context of the order as we build it.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

https://github.com/woocommerce/woocommerce-ios/assets/2472348/7d396f88-5bcc-445b-a6d6-b7db06d882c2


