### PR TITLE
[AnalyticsHub] Simplify AnalyticsCard data model and storage methods

### DIFF
--- a/Storage/Storage/Model/AnalyticsCard.swift
+++ b/Storage/Storage/Model/AnalyticsCard.swift
@@ -1,20 +1,16 @@
 import Foundation
 
 /// Represents an analytics report card in the Analytics Hub
-public struct AnalyticsCard: Codable, Hashable, Equatable, Comparable {
+public struct AnalyticsCard: Codable, Hashable, Equatable {
     /// The type of analytics report card.
     public let type: CardType
 
     /// Whether the card is enabled in the Analytics Hub.
-    public let enabled: Bool
+    public var enabled: Bool
 
-    /// The card's order in a sorted list of cards in the Analytics Hub.
-    public let sortOrder: Int
-
-    public init(type: CardType, enabled: Bool, sortOrder: Int) {
+    public init(type: CardType, enabled: Bool) {
         self.type = type
         self.enabled = enabled
-        self.sortOrder = sortOrder
     }
 
     /// Types of report cards to display in the Analytics Hub.
@@ -24,21 +20,5 @@ public struct AnalyticsCard: Codable, Hashable, Equatable, Comparable {
         case orders
         case products
         case sessions
-    }
-
-    /// The default set of cards for the Analytics Hub.
-    /// Provides all card types enabled in their default order.
-    public static let defaultCards: Set<AnalyticsCard> = {
-        let allCards = CardType.allCases.map { type in
-            AnalyticsCard(type: type, enabled: true, sortOrder: CardType.allCases.firstIndex(of: type) ?? 0)
-        }
-        return Set(allCards)
-    }()
-}
-
-// MARK: - Comparable conformance
-extension AnalyticsCard {
-    public static func < (lhs: AnalyticsCard, rhs: AnalyticsCard) -> Bool {
-        lhs.sortOrder < rhs.sortOrder
     }
 }

--- a/Storage/Storage/Model/Copiable/Models+Copiable.generated.swift
+++ b/Storage/Storage/Model/Copiable/Models+Copiable.generated.swift
@@ -72,7 +72,7 @@ extension Storage.GeneralStoreSettings {
         lastSelectedStatsTimeRange: CopiableProp<String> = .copy,
         firstInPersonPaymentsTransactionsByReaderType: CopiableProp<[CardReaderType: Date]> = .copy,
         selectedTaxRateID: NullableCopiableProp<Int64> = .copy,
-        analyticsHubCards: NullableCopiableProp<Set<AnalyticsCard>> = .copy
+        analyticsHubCards: NullableCopiableProp<[AnalyticsCard]> = .copy
     ) -> Storage.GeneralStoreSettings {
         let storeID = storeID ?? self.storeID
         let isTelemetryAvailable = isTelemetryAvailable ?? self.isTelemetryAvailable

--- a/Storage/Storage/Model/GeneralStoreSettings.swift
+++ b/Storage/Storage/Model/GeneralStoreSettings.swift
@@ -51,7 +51,7 @@ public struct GeneralStoreSettings: Codable, Equatable, GeneratedCopiable {
     public let selectedTaxRateID: Int64?
 
     /// The set of cards for the Analytics Hub, with their enabled status and sort order.
-    public let analyticsHubCards: Set<AnalyticsCard>?
+    public let analyticsHubCards: [AnalyticsCard]?
 
     public init(storeID: String? = nil,
                 isTelemetryAvailable: Bool = false,
@@ -62,7 +62,7 @@ public struct GeneralStoreSettings: Codable, Equatable, GeneratedCopiable {
                 lastSelectedStatsTimeRange: String = "",
                 firstInPersonPaymentsTransactionsByReaderType: [CardReaderType: Date] = [:],
                 selectedTaxRateID: Int64? = nil,
-                analyticsHubCards: Set<AnalyticsCard>? = nil) {
+                analyticsHubCards: [AnalyticsCard]? = nil) {
         self.storeID = storeID
         self.isTelemetryAvailable = isTelemetryAvailable
         self.telemetryLastReportedTime = telemetryLastReportedTime
@@ -106,7 +106,7 @@ extension GeneralStoreSettings {
         self.firstInPersonPaymentsTransactionsByReaderType = try container.decodeIfPresent([CardReaderType: Date].self,
                                                                                            forKey: .firstInPersonPaymentsTransactionsByReaderType) ?? [:]
         self.selectedTaxRateID = try container.decodeIfPresent(Int64.self, forKey: .selectedTaxRateID)
-        self.analyticsHubCards = try container.decodeIfPresent(Set<AnalyticsCard>.self, forKey: .analyticsHubCards)
+        self.analyticsHubCards = try container.decodeIfPresent([AnalyticsCard].self, forKey: .analyticsHubCards)
 
         // Decode new properties with `decodeIfPresent` and provide a default value if necessary.
     }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/AnalyticsHubViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/AnalyticsHubViewModel.swift
@@ -137,7 +137,7 @@ final class AnalyticsHubViewModel: ObservableObject {
     @Published var dismissNotice: Notice?
 
     var customizeAnalyticsViewModel: AnalyticsHubCustomizeViewModel {
-        AnalyticsHubCustomizeViewModel(allCards: AnalyticsCard.defaultCards) // TODO: Use real data from storage
+        AnalyticsHubCustomizeViewModel(allCards: AnalyticsHubViewModel.defaultCards) // TODO: Use real data from storage
     }
 
     // MARK: Private data
@@ -625,5 +625,10 @@ private extension AnalyticsHubViewModel {
         static let statsCTAError = NSLocalizedString("analyticsHub.jetpackStatsCTA.errorNotice",
                                                      value: "We couldn't enable Jetpack Stats on your store",
                                                      comment: "Error shown when Jetpack Stats can't be enabled in the Analytics Hub.")
+    }
+
+    /// Set of enabled analytics cards in default order.
+    static let defaultCards: [AnalyticsCard] = AnalyticsCard.CardType.allCases.map { type in
+        AnalyticsCard(type: type, enabled: true)
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/Customize/AnalyticsHubCustomizeViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/Customize/AnalyticsHubCustomizeViewModel.swift
@@ -26,12 +26,12 @@ final class AnalyticsHubCustomizeViewModel: ObservableObject {
         allCards != originalCards || selectedCards != originalSelection
     }
 
-    init(allCards: Set<AnalyticsCard>) {
+    init(allCards: [AnalyticsCard]) {
         let groupedCards = AnalyticsHubCustomizeViewModel.groupSelectedCards(in: allCards)
         self.allCards = groupedCards
         self.originalCards = groupedCards
 
-        let selectedCards = allCards.filter { $0.enabled }
+        let selectedCards = Set(allCards.filter { $0.enabled })
         self.selectedCards = selectedCards
         self.originalSelection = selectedCards
     }
@@ -41,9 +41,9 @@ private extension AnalyticsHubCustomizeViewModel {
     /// Groups the selected cards at the start of the list of all cards.
     /// This preserves the relative order of selected and unselected cards.
     ///
-    static func groupSelectedCards(in allCards: Set<AnalyticsCard>) -> [AnalyticsCard] {
-        var groupedCards = Array(allCards).sorted() // Sort cards by sort order
-        _ = groupedCards.stablePartition(by: { !$0.enabled }) // Group cards by enabled status
+    static func groupSelectedCards(in allCards: [AnalyticsCard]) -> [AnalyticsCard] {
+        var groupedCards = allCards
+        _ = groupedCards.stablePartition(by: { !$0.enabled })
         return groupedCards
     }
 }
@@ -52,10 +52,10 @@ private extension AnalyticsHubCustomizeViewModel {
 extension AnalyticsHubCustomizeViewModel {
     /// Sample cards to display in the SwiftUI preview
     ///
-    static let sampleCards: Set<AnalyticsCard> = [
-        AnalyticsCard(type: .revenue, enabled: true, sortOrder: 0),
-        AnalyticsCard(type: .orders, enabled: false, sortOrder: 1),
-        AnalyticsCard(type: .products, enabled: true, sortOrder: 2),
-        AnalyticsCard(type: .sessions, enabled: false, sortOrder: 3)
+    static let sampleCards = [
+        AnalyticsCard(type: .revenue, enabled: true),
+        AnalyticsCard(type: .orders, enabled: false),
+        AnalyticsCard(type: .products, enabled: true),
+        AnalyticsCard(type: .sessions, enabled: false)
     ]
 }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Analytics Hub/AnalyticsHubCustomizeViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Analytics Hub/AnalyticsHubCustomizeViewModelTests.swift
@@ -6,8 +6,8 @@ final class AnalyticsHubCustomizeViewModelTests: XCTestCase {
 
     func test_it_inits_with_expected_properties() {
         // Given
-        let revenueCard = AnalyticsCard(type: .revenue, enabled: true, sortOrder: 0)
-        let ordersCard = AnalyticsCard(type: .orders, enabled: false, sortOrder: 1)
+        let revenueCard = AnalyticsCard(type: .revenue, enabled: true)
+        let ordersCard = AnalyticsCard(type: .orders, enabled: false)
         let vm = AnalyticsHubCustomizeViewModel(allCards: [revenueCard, ordersCard])
 
         // Then
@@ -18,9 +18,9 @@ final class AnalyticsHubCustomizeViewModelTests: XCTestCase {
 
     func test_it_groups_all_selected_cards_at_top_of_allCards_list_in_original_order() {
         // Given
-        let revenueCard = AnalyticsCard(type: .revenue, enabled: false, sortOrder: 0)
-        let ordersCard = AnalyticsCard(type: .orders, enabled: true, sortOrder: 1)
-        let productsCard = AnalyticsCard(type: .products, enabled: true, sortOrder: 2)
+        let revenueCard = AnalyticsCard(type: .revenue, enabled: false)
+        let ordersCard = AnalyticsCard(type: .orders, enabled: true)
+        let productsCard = AnalyticsCard(type: .products, enabled: true)
         let vm = AnalyticsHubCustomizeViewModel(allCards: [revenueCard, ordersCard, productsCard])
 
         // Then
@@ -29,8 +29,8 @@ final class AnalyticsHubCustomizeViewModelTests: XCTestCase {
 
     func test_hasChanges_is_true_when_card_order_changes() {
         // Given
-        let revenueCard = AnalyticsCard(type: .revenue, enabled: false, sortOrder: 0)
-        let ordersCard = AnalyticsCard(type: .orders, enabled: false, sortOrder: 1)
+        let revenueCard = AnalyticsCard(type: .revenue, enabled: false)
+        let ordersCard = AnalyticsCard(type: .orders, enabled: false)
         let vm = AnalyticsHubCustomizeViewModel(allCards: [revenueCard, ordersCard])
 
         // When
@@ -42,8 +42,8 @@ final class AnalyticsHubCustomizeViewModelTests: XCTestCase {
 
     func test_hasChanges_is_true_when_selection_changes() {
         // Given
-        let revenueCard = AnalyticsCard(type: .revenue, enabled: false, sortOrder: 0)
-        let ordersCard = AnalyticsCard(type: .orders, enabled: true, sortOrder: 1)
+        let revenueCard = AnalyticsCard(type: .revenue, enabled: false)
+        let ordersCard = AnalyticsCard(type: .orders, enabled: true)
         let vm = AnalyticsHubCustomizeViewModel(allCards: [revenueCard, ordersCard])
 
         // When

--- a/Yosemite/Yosemite/Actions/AppSettingsAction.swift
+++ b/Yosemite/Yosemite/Actions/AppSettingsAction.swift
@@ -243,12 +243,11 @@ public enum AppSettingsAction: Action {
 
     // MARK: - Analytics Hub Cards
 
-    /// Stores the set of cards for the Analytics Hub with their updated enabled status and sort order.
+    /// Stores an ordered array of cards for the Analytics Hub.
     ///
-    case setAnalyticsHubCards(siteID: Int64, cards: Set<AnalyticsCard>)
+    case setAnalyticsHubCards(siteID: Int64, cards: [AnalyticsCard])
 
-    /// Loads the set of cards for the Analytics Hub with their enabled status and sort order.
-    /// Defaults to all cards enabled in a default order if no customized settings have been saved.
+    /// Loads the stored, ordered array of cards for the Analytics Hub.
     ///
-    case loadAnalyticsHubCards(siteID: Int64, onCompletion: (Set<AnalyticsCard>) -> Void)
+    case loadAnalyticsHubCards(siteID: Int64, onCompletion: ([AnalyticsCard]?) -> Void)
 }

--- a/Yosemite/Yosemite/Stores/AppSettingsStore.swift
+++ b/Yosemite/Yosemite/Stores/AppSettingsStore.swift
@@ -911,17 +911,14 @@ private extension AppSettingsStore {
 // MARK: - Analytics Hub Cards
 
 private extension AppSettingsStore {
-    func setAnalyticsHubCards(siteID: Int64, cards: Set<AnalyticsCard>) {
+    func setAnalyticsHubCards(siteID: Int64, cards: [AnalyticsCard]) {
         let storeSettings = getStoreSettings(for: siteID)
         let updatedSettings = storeSettings.copy(analyticsHubCards: cards)
         setStoreSettings(settings: updatedSettings, for: siteID)
     }
 
-    func loadAnalyticsHubCards(siteID: Int64, onCompletion: (Set<AnalyticsCard>) -> Void) {
-        guard let storedCards = getStoreSettings(for: siteID).analyticsHubCards else {
-            return onCompletion(AnalyticsCard.defaultCards)
-        }
-        onCompletion(storedCards)
+    func loadAnalyticsHubCards(siteID: Int64, onCompletion: ([AnalyticsCard]?) -> Void) {
+        onCompletion(getStoreSettings(for: siteID).analyticsHubCards)
     }
 }
 

--- a/Yosemite/YosemiteTests/Stores/AppSettingsStoreTests.swift
+++ b/Yosemite/YosemiteTests/Stores/AppSettingsStoreTests.swift
@@ -1242,11 +1242,11 @@ extension AppSettingsStoreTests {
 
     func test_setAnalyticsHubCards_works_correctly() throws {
         // Given
-        let analyticsCards: Set<AnalyticsCard> = [
-            AnalyticsCard(type: .revenue, enabled: true, sortOrder: 1),
-            AnalyticsCard(type: .orders, enabled: false, sortOrder: 3),
-            AnalyticsCard(type: .products, enabled: true, sortOrder: 0),
-            AnalyticsCard(type: .sessions, enabled: false, sortOrder: 2)
+        let analyticsCards = [
+            AnalyticsCard(type: .revenue, enabled: true),
+            AnalyticsCard(type: .orders, enabled: false),
+            AnalyticsCard(type: .products, enabled: true),
+            AnalyticsCard(type: .sessions, enabled: false)
         ]
         let existingSettings = GeneralStoreSettingsBySite(storeSettingsBySite: [TestConstants.siteID: GeneralStoreSettings()])
         try fileStorage?.write(existingSettings, to: expectedGeneralStoreSettingsFileURL)
@@ -1264,18 +1264,18 @@ extension AppSettingsStoreTests {
 
     func test_loadAnalyticsHubCards_works_correctly() throws {
         // Given
-        let storedAnalyticsCards: Set<AnalyticsCard> = [
-            AnalyticsCard(type: .revenue, enabled: true, sortOrder: 1),
-            AnalyticsCard(type: .orders, enabled: false, sortOrder: 3),
-            AnalyticsCard(type: .products, enabled: true, sortOrder: 0),
-            AnalyticsCard(type: .sessions, enabled: false, sortOrder: 2)
+        let storedAnalyticsCards = [
+            AnalyticsCard(type: .revenue, enabled: true),
+            AnalyticsCard(type: .orders, enabled: false),
+            AnalyticsCard(type: .products, enabled: true),
+            AnalyticsCard(type: .sessions, enabled: false)
         ]
         let storeSettings = GeneralStoreSettings(analyticsHubCards: storedAnalyticsCards)
         let existingSettings = GeneralStoreSettingsBySite(storeSettingsBySite: [TestConstants.siteID: storeSettings])
         try fileStorage?.write(existingSettings, to: expectedGeneralStoreSettingsFileURL)
 
         // When
-        var loadedAnalyticsCards: Set<AnalyticsCard> = []
+        var loadedAnalyticsCards: [AnalyticsCard]?
         let action = AppSettingsAction.loadAnalyticsHubCards(siteID: TestConstants.siteID) { cards in
             loadedAnalyticsCards = cards
         }
@@ -1285,21 +1285,20 @@ extension AppSettingsStoreTests {
         assertEqual(storedAnalyticsCards, loadedAnalyticsCards)
     }
 
-    func test_loadAnalyticsHubCards_loads_default_cards_when_no_cards_are_saved() throws {
+    func test_loadAnalyticsHubCards_returns_nil_when_no_cards_are_saved() throws {
         // Given
         let existingSettings = GeneralStoreSettingsBySite(storeSettingsBySite: [TestConstants.siteID: GeneralStoreSettings()])
         try fileStorage?.write(existingSettings, to: expectedGeneralStoreSettingsFileURL)
 
         // When
-        var loadedAnalyticsCards: Set<AnalyticsCard> = []
+        var loadedAnalyticsCards: [AnalyticsCard]?
         let action = AppSettingsAction.loadAnalyticsHubCards(siteID: TestConstants.siteID) { cards in
             loadedAnalyticsCards = cards
         }
         subject?.onAction(action)
 
         // Then
-        let defaultAnalyticsCards = AnalyticsCard.defaultCards
-        assertEqual(defaultAnalyticsCards, loadedAnalyticsCards)
+        XCTAssertNil(loadedAnalyticsCards)
     }
 }
 


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of: #11948
<!-- Id number of the GitHub issue this PR addresses. -->

## Why
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This is a followup to #12048 and #12054, to simplify the `AnalyticsCard` data model and how we're storing the customized settings for analytics cards in the Analytics Hub. Storing the cards as a `Set` with a defined `sortOrder` property added unnecessary complexity when handling the data. This PR simplifies things by storing the cards as an ordered `Array`, instead.

## How
* Removes the `sortOrder` property from `AnalyticsCard`.
* Moves the `defaultCards` property from `AnalyticsCard` to `AnalyticsHubViewModel` (where we want to use/define what the default set of cards should be).
* Updates `GeneralStoreSettings`, `AppSettingsAction`, and `AppSettingsStore` to store the cards as an `Array` instead of a `Set`.
* Updates `AnalyticsHubCustomizeViewModel` to be initialized with an ordered array of cards instead of a set.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

1. Build and run the app.
2. On the My Store dashboard, tap "See More" to open the Analytics Hub.
3. Tap the "Edit" button in the navigation bar.
4. Confirm the "Customize Analytics" screen opens with all cards preselected and in the default order (same as the cards visible in the Analytics Hub).

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
