### PR TITLE
[Tablet Products] Handle product deletion

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductCoordinator.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductCoordinator.swift
@@ -40,6 +40,7 @@ final class AddProductCoordinator: Coordinator {
     private let isFirstProduct: Bool
     private let analytics: Analytics
     private let navigateToProductForm: ((UIViewController) -> Void)?
+    private let onDeleteCompletion: () -> Void
 
     /// ResultController to to track the current product count.
     ///
@@ -84,7 +85,8 @@ final class AddProductCoordinator: Coordinator {
          productImageUploader: ProductImageUploaderProtocol = ServiceLocator.productImageUploader,
          analytics: Analytics = ServiceLocator.analytics,
          isFirstProduct: Bool,
-         navigateToProductForm: ((UIViewController) -> Void)? = nil) {
+         navigateToProductForm: ((UIViewController) -> Void)? = nil,
+         onDeleteCompletion: @escaping () -> Void = {}) {
         self.siteID = siteID
         self.source = source
         switch sourceView {
@@ -106,6 +108,7 @@ final class AddProductCoordinator: Coordinator {
         self.analytics = analytics
         self.isFirstProduct = isFirstProduct
         self.navigateToProductForm = navigateToProductForm
+        self.onDeleteCompletion = onDeleteCompletion
     }
 
     func start() {
@@ -366,7 +369,8 @@ private extension AddProductCoordinator {
                                                        eventLogger: ProductFormEventLogger(),
                                                        productImageActionHandler: productImageActionHandler,
                                                        currency: currency,
-                                                       presentationStyle: .navigationStack)
+                                                       presentationStyle: .navigationStack,
+                                                       onDeleteCompletion: onDeleteCompletion)
         // Since the Add Product UI could hold local changes, disables the bottom bar (tab bar) to simplify app states.
         viewController.hidesBottomBarWhenPushed = true
         if let navigateToProductForm {

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewController.swift
@@ -94,13 +94,16 @@ final class ProductFormViewController<ViewModel: ProductFormViewModelProtocol>: 
     ///
     private var blazeCampaignCreationCoordinator: BlazeCampaignCreationCoordinator?
 
+    private let onDeleteCompletion: () -> Void
+
     init(viewModel: ViewModel,
          isAIContent: Bool = false,
          eventLogger: ProductFormEventLoggerProtocol,
          productImageActionHandler: ProductImageActionHandler,
          currency: String = ServiceLocator.currencySettings.symbol(from: ServiceLocator.currencySettings.currencyCode),
          presentationStyle: ProductFormPresentationStyle,
-         productImageUploader: ProductImageUploaderProtocol = ServiceLocator.productImageUploader) {
+         productImageUploader: ProductImageUploaderProtocol = ServiceLocator.productImageUploader,
+         onDeleteCompletion: @escaping () -> Void = {}) {
         self.viewModel = viewModel
         self.isAIContent = isAIContent
         self.eventLogger = eventLogger
@@ -110,6 +113,7 @@ final class ProductFormViewController<ViewModel: ProductFormViewModelProtocol>: 
         self.productUIImageLoader = DefaultProductUIImageLoader(productImageActionHandler: productImageActionHandler,
                                                                 phAssetImageLoaderProvider: { PHImageManager.default() })
         self.productImageUploader = productImageUploader
+        self.onDeleteCompletion = onDeleteCompletion
         self.aiEligibilityChecker = .init(site: ServiceLocator.stores.sessionManager.defaultSite)
         self.tableViewModel = DefaultProductFormTableViewModel(product: viewModel.productModel,
                                                                actionsFactory: viewModel.actionsFactory,
@@ -1080,6 +1084,7 @@ private extension ProductFormViewController {
                 self.navigationController?.dismiss(animated: true, completion: nil)
                 // Dismiss or Pop the Product Form
                 self.dismissOrPopViewController()
+                self.onDeleteCompletion()
             case .failure(let error):
                 DDLogError("⛔️ Error deleting Product: \(error)")
 

--- a/WooCommerce/Classes/ViewRelated/Products/ProductDetailsFactory.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductDetailsFactory.swift
@@ -9,18 +9,21 @@ struct ProductDetailsFactory {
     ///   - presentationStyle: how the product details are presented.
     ///   - currencySettings: site currency settings.
     ///   - forceReadOnly: force the product detail to be presented in read only mode
+    ///   - onDeleteCompletion: called when the product deletion completes in the product form.
     ///   - onCompletion: called when the view controller is created and ready for display.
     static func productDetails(product: Product,
                                presentationStyle: ProductFormPresentationStyle,
                                currencySettings: CurrencySettings = ServiceLocator.currencySettings,
                                forceReadOnly: Bool,
                                productImageUploader: ProductImageUploaderProtocol = ServiceLocator.productImageUploader,
+                               onDeleteCompletion: @escaping () -> Void = {},
                                onCompletion: @escaping (UIViewController) -> Void) {
         let vc = productDetails(product: product,
                                 presentationStyle: presentationStyle,
                                 currencySettings: currencySettings,
                                 isEditProductsEnabled: forceReadOnly ? false: true,
-                                productImageUploader: productImageUploader)
+                                productImageUploader: productImageUploader,
+                                onDeleteCompletion: onDeleteCompletion)
         onCompletion(vc)
     }
 }
@@ -30,7 +33,8 @@ private extension ProductDetailsFactory {
                                presentationStyle: ProductFormPresentationStyle,
                                currencySettings: CurrencySettings,
                                isEditProductsEnabled: Bool,
-                               productImageUploader: ProductImageUploaderProtocol) -> UIViewController {
+                               productImageUploader: ProductImageUploaderProtocol,
+                               onDeleteCompletion: @escaping () -> Void) -> UIViewController {
         let vc: UIViewController
         let productModel = EditableProductModel(product: product)
         let productImageActionHandler = productImageUploader
@@ -45,7 +49,8 @@ private extension ProductDetailsFactory {
         vc = ProductFormViewController(viewModel: viewModel,
                                        eventLogger: ProductFormEventLogger(),
                                        productImageActionHandler: productImageActionHandler,
-                                       presentationStyle: presentationStyle)
+                                       presentationStyle: presentationStyle,
+                                       onDeleteCompletion: onDeleteCompletion)
         // Since the edit Product UI could hold local changes, disables the bottom bar (tab bar) to simplify app states.
         vc.hidesBottomBarWhenPushed = true
         return vc

--- a/WooCommerce/Classes/ViewRelated/Products/ProductsSplitViewCoordinator.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductsSplitViewCoordinator.swift
@@ -88,7 +88,10 @@ private extension ProductsSplitViewCoordinator {
     func showProductForm(product: Product) {
         ProductDetailsFactory.productDetails(product: product,
                                              presentationStyle: .navigationStack,
-                                             forceReadOnly: false) { [weak self] viewController in
+                                             forceReadOnly: false,
+                                             onDeleteCompletion: { [weak self] in
+            self?.productsViewController.selectFirstProductIfAvailable()
+        }) { [weak self] viewController in
             self?.showSecondaryView(contentType: .productForm(product: product), viewController: viewController, replacesNavigationStack: true)
         }
     }

--- a/WooCommerce/Classes/ViewRelated/Products/ProductsSplitViewCoordinator.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductsSplitViewCoordinator.swift
@@ -58,8 +58,7 @@ final class ProductsSplitViewCoordinator: NSObject {
     func didExpand() {
         // Auto-selects the first product if there is no content to be shown.
         if contentTypes.isEmpty {
-            showEmptyView()
-            productsViewController.selectFirstProductIfAvailable()
+            showEmptyViewOrFirstProduct()
         }
     }
 }
@@ -90,11 +89,7 @@ private extension ProductsSplitViewCoordinator {
                                              presentationStyle: .navigationStack,
                                              forceReadOnly: false,
                                              onDeleteCompletion: { [weak self] in
-            guard let self else { return }
-            splitViewController.show(.primary)
-            if !splitViewController.isCollapsed {
-                productsViewController.selectFirstProductIfAvailable()
-            }
+            self?.onSecondaryProductFormDeletion()
         }) { [weak self] viewController in
             self?.showSecondaryView(contentType: .productForm(product: product), viewController: viewController, replacesNavigationStack: true)
         }
@@ -128,6 +123,18 @@ private extension ProductsSplitViewCoordinator {
         }
 
         splitViewController.show(.secondary)
+    }
+
+    func onSecondaryProductFormDeletion() {
+        splitViewController.show(.primary)
+        if !splitViewController.isCollapsed {
+            showEmptyViewOrFirstProduct()
+        }
+    }
+
+    func showEmptyViewOrFirstProduct() {
+        showEmptyView()
+        productsViewController.selectFirstProductIfAvailable()
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Products/ProductsSplitViewCoordinator.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductsSplitViewCoordinator.swift
@@ -90,7 +90,11 @@ private extension ProductsSplitViewCoordinator {
                                              presentationStyle: .navigationStack,
                                              forceReadOnly: false,
                                              onDeleteCompletion: { [weak self] in
-            self?.productsViewController.selectFirstProductIfAvailable()
+            guard let self else { return }
+            splitViewController.show(.primary)
+            if !splitViewController.isCollapsed {
+                productsViewController.selectFirstProductIfAvailable()
+            }
         }) { [weak self] viewController in
             self?.showSecondaryView(contentType: .productForm(product: product), viewController: viewController, replacesNavigationStack: true)
         }

--- a/WooCommerce/Classes/ViewRelated/Products/ProductsSplitViewCoordinator.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductsSplitViewCoordinator.swift
@@ -98,12 +98,14 @@ private extension ProductsSplitViewCoordinator {
     func startProductCreation(sourceView: AddProductCoordinator.SourceView, isFirstProduct: Bool) {
         let replacesNavigationStack = contentTypes.last == .empty
         let addProductCoordinator = AddProductCoordinator(siteID: siteID,
-                                                           source: .productsTab,
-                                                           sourceView: sourceView,
-                                                           sourceNavigationController: primaryNavigationController,
-                                                           isFirstProduct: isFirstProduct,
-                                                           navigateToProductForm: { [weak self] viewController in
+                                                          source: .productsTab,
+                                                          sourceView: sourceView,
+                                                          sourceNavigationController: primaryNavigationController,
+                                                          isFirstProduct: isFirstProduct,
+                                                          navigateToProductForm: { [weak self] viewController in
             self?.showSecondaryView(contentType: .productForm(product: nil), viewController: viewController, replacesNavigationStack: replacesNavigationStack)
+        }, onDeleteCompletion: { [weak self] in
+            self?.onSecondaryProductFormDeletion()
         })
         addProductCoordinator.onProductCreated = { [weak self] product in
             guard let self, let lastContentType = contentTypes.last, lastContentType == .productForm(product: nil) else { return }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #12067 
<!-- Id number of the GitHub issue this PR addresses. -->

## Why

When a product is deleted from the product form (ellipsis menu > Delete), the product form is currently [dismissed or popped to root](https://github.com/woocommerce/woocommerce-ios/blob/15ace487568010ba9623871c7e45bda82f18ac28/WooCommerce/Classes/ViewRelated/Products/Edit%20Product/ProductFormViewController.swift#L1082) when after it's deleted remotely. However, when the product form is in a split view's secondary view, the secondary navigation stack remains visible and thus the deleted product form stays in view.

## How

This PR handles the deletion scenario so that:

- The primary view is shown after product deletion, so that the primary view (product list) is shown when the split view is collapsed
- When the split view is not collapsed, the empty view is shown (in case the list becomes empty after the deletion) first then the first product is selected

In order to handle product deletion completion, `onDeleteCompletion` closure is added to `ProductFormViewController`/`ProductDetailsFactory`.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

Prerequisite: the device/simulator allows switching between expanded and collapsed states like a tablet

- [x] @jaclync tests when the feature flag is off
- [x] @jaclync tests iPhone
- [x] @jaclync tests when there's no product left after deleting the last product

### Collapsed state

- In code, enable `splitViewInProductsTab` feature flag in `DefaultFeatureFlagService`
- Launch the app in **compact** horizontal size class
- Go to the products tab
- Tap on a product
- Ellipsis menu > Delete --> after the in-progress modal is dismissed, it should navigate back to the product list
- (If on iPad) Expand the app so that the split view is shown --> the first product should be selected and shown in the secondary view

### Expanded state

- Launch the app in **regular** horizontal size class
- Go to the products tab
- Tap on a product
- Ellipsis menu > Delete --> after the in-progress modal is dismissed, the first product should be selected and shown in the secondary view

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

Collapsed state -> expanded state:

https://github.com/woocommerce/woocommerce-ios/assets/1945542/2d73dd65-89a8-4988-9931-b44e0a54e964

Expanded state:

https://github.com/woocommerce/woocommerce-ios/assets/1945542/cdd7727f-0457-478c-a6ef-1bb55e83f6f3

Last product deleted from the list:


https://github.com/woocommerce/woocommerce-ios/assets/1945542/deb55b3b-3a70-4b2d-bd5c-e5b5a3313c95



---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
