### PR TITLE
Add Connectivity Tool troubleshoot tips and suggestions

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Connectivity Tool/ConnectivityTool.swift
+++ b/WooCommerce/Classes/ViewRelated/Connectivity Tool/ConnectivityTool.swift
@@ -29,10 +29,20 @@ final class ConnectivityToolViewController: UIHostingController<ConnectivityTool
             self?.rootView.cards = cards
         }
         .store(in: &subscriptions)
+
+        // Listen to the contact support button
+        rootView.onContactSupportTapped = { [weak self] in
+            self?.showContactSupportForm()
+        }
     }
 
     required dynamic init?(coder aDecoder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
+    }
+
+    private func showContactSupportForm() {
+        let supportController = SupportFormHostingController(viewModel: .init())
+        supportController.show(from: self)
     }
 }
 
@@ -52,6 +62,10 @@ struct ConnectivityTool: View {
     ///
     var cards: [Card]
 
+    /// Closure to be invoked when the "Contact Support" button is tapped.
+    ///
+    var onContactSupportTapped: (() -> ())?
+
     var body: some View {
         VStack(alignment: .center, spacing: .zero) {
 
@@ -62,7 +76,7 @@ struct ConnectivityTool: View {
             Spacer()
 
             Button(Localization.contactSupport) {
-                print()
+                onContactSupportTapped?()
             }
             .buttonStyle(PrimaryButtonStyle())
         }

--- a/WooCommerce/Classes/ViewRelated/Connectivity Tool/ConnectivityTool.swift
+++ b/WooCommerce/Classes/ViewRelated/Connectivity Tool/ConnectivityTool.swift
@@ -86,9 +86,17 @@ struct ConnectivityToolCard: View {
     /// Represents the state of the card.
     ///
     enum State {
+
+        /// Represents an action to could be performed when presenting an error.
+        ///
+        struct ErrorAction {
+            let title: String
+            let action: () -> ()
+        }
+
         case inProgress
         case success
-        case error(String)
+        case error(String, ErrorAction?)
 
         /// Builds the icon based on the state
         ///
@@ -162,11 +170,16 @@ struct ConnectivityToolCard: View {
                 state.buildIcon()
             }
 
-            if case let .error(message) = state {
+            if case let .error(message, buttonAction) = state {
                 Text(message)
                     .foregroundColor(Color(uiColor: .error))
                     .subheadlineStyle()
                     .padding(.horizontal, 6)
+
+                if let buttonAction {
+                    Button(buttonAction.title, action: buttonAction.action)
+                        .buttonStyle(SecondaryButtonStyle())
+                }
             }
         }
         .padding()
@@ -183,7 +196,7 @@ struct ConnectivityToolCard: View {
             .init(title: "WordPress.com servers", icon: .system("server.rack"), state: .success),
             .init(title: "Your Site",
                   icon: .system("storefront"),
-                  state: .error("Your site is not responding properly\nPlease reach out to your host for further assistance")),
+                  state: .error("Your site is not responding properly\nPlease reach out to your host for further assistance", nil)),
             .init(title: "Your site orders", icon: .system("list.clipboard"), state: .inProgress)
         ])
             .navigationTitle("Connectivity Test")

--- a/WooCommerce/Classes/ViewRelated/Connectivity Tool/ConnectivityTool.swift
+++ b/WooCommerce/Classes/ViewRelated/Connectivity Tool/ConnectivityTool.swift
@@ -140,9 +140,10 @@ struct ConnectivityToolCard: View {
     ///
     @ScaledMetric private var iconSize = 40.0
     private static let cornerRadius = 4.0
+    private static let verticalSpacing = 16.0
 
     var body: some View {
-        VStack {
+        VStack(spacing: Self.verticalSpacing) {
             HStack {
 
                 Circle()

--- a/WooCommerce/Classes/ViewRelated/Connectivity Tool/ConnectivityToolViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Connectivity Tool/ConnectivityToolViewModel.swift
@@ -100,7 +100,7 @@ final class ConnectivityToolViewModel {
                         .success :
                         .error(NSLocalizedString("It looks like you're not connected to the internet.\n\n" +
                                                  "Ensure your Wi-Fi is turned on. If you're using mobile data, make sure it's enabled in your device settings.",
-                                                 comment: "Message when there is no internet connection in the recovery tool"))
+                                                 comment: "Message when there is no internet connection in the recovery tool"), nil)
                     continuation.resume(returning: state)
                 }
                 .store(in: &subscriptions)
@@ -124,7 +124,7 @@ final class ConnectivityToolViewModel {
                     .success :
                     .error(NSLocalizedString("Oops! It seems we can't connect to WordPress.com at the moment.\n\n" +
                                              "But don't worry, our support team is here to help. Contact us and we will happily assist you.",
-                                             comment: "Message when we can't reach WPCom in the recovery tool"))
+                                             comment: "Message when we can't reach WPCom in the recovery tool"), nil)
                 continuation.resume(returning: state)
             }
         }
@@ -173,23 +173,45 @@ final class ConnectivityToolViewModel {
             return .success
         }
 
-        let errorMessage = {
-            switch error {
-            case is DecodingError:
-                return NSLocalizedString("Oops! It seems we can't work properly with your site's response.\n\n" +
-                                         "But don't worry, our support team is here to help. Contact us and we will happily assist you.",
-                                         comment: "Message when we there is a decoding error in the recovery tool")
-            case DotcomError.jetpackNotConnected:
-                return NSLocalizedString("Oops! It seems that your jetpack connection is broken.\n\n" +
-                                         "But don't worry, our support team is here to help. Contact us and we will happily assist you.",
-                                         comment: "Message when we there is a jetpack error in the recovery tool")
-            default:
-                return NSLocalizedString("Oops! There seems to be a problem with your site. Contact your hosting provider for further assistance",
-                                         comment: "Message when we there is a generic error in the recovery tool")
-            }
-        }()
+        let message: String
+        let errorAction: ConnectivityToolCard.State.ErrorAction?
+        let readMore = NSLocalizedString("Read More", comment: "Action button title for a generic error on the connectivity tool")
 
-        return .error(errorMessage)
+        // Handle timeout errors specially
+        if error.isTimeoutError {
+            message = NSLocalizedString("Oops! Your site seems to be taking too long to respond.\n\nContact your hosting provider for further assistance.",
+                                        comment: "Message when we there is a timeout error in the recovery tool")
+            errorAction = .init(title: readMore, action: {
+                UIApplication.shared.open(WooConstants.URLs.troubleshootErrorLoadingData.asURL())
+            })
+            return .error(message, errorAction)
+        }
+
+        // Handle all other types of errors.
+        switch error {
+        case is DecodingError:
+            message = NSLocalizedString("Oops! It seems we can't work properly with your site's response.\n\n" +
+                                        "But don't worry, our support team is here to help. Contact us and we will happily assist you.",
+                                        comment: "Message when we there is a decoding error in the recovery tool")
+            errorAction = .init(title: readMore, action: {
+                UIApplication.shared.open(WooConstants.URLs.troubleshootErrorLoadingData.asURL())
+            })
+        case DotcomError.jetpackNotConnected:
+            message = NSLocalizedString("Oops! There seems to be a problem with your jetpack connection.\n\n" +
+                                        "But don't worry, our support team is here to help. Contact us and we will happily assist you.",
+                                        comment: "Message when we there is a jetpack error in the recovery tool")
+            errorAction = .init(title: readMore, action: {
+                UIApplication.shared.open(WooConstants.URLs.troubleshootJetpackConnection.asURL())
+            })
+        default:
+            message = NSLocalizedString("Oops! There seems to be a problem with your site.\n\nContact your hosting provider for further assistance.",
+                                        comment: "Message when we there is a generic error in the recovery tool")
+            errorAction = .init(title: readMore, action: {
+                UIApplication.shared.open(WooConstants.URLs.troubleshootErrorLoadingData.asURL())
+            })
+        }
+
+        return .error(message, errorAction)
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Connectivity Tool/ConnectivityToolViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Connectivity Tool/ConnectivityToolViewModel.swift
@@ -123,8 +123,8 @@ final class ConnectivityToolViewModel {
                 let state: ConnectivityToolCard.State = result.isSuccess ?
                     .success :
                     .error(NSLocalizedString("Oops! It seems we can't connect to WordPress.com at the moment.\n\n" +
-                                             "But, our support team is here to help. Please contact us and we will happily assist you.",
-                                             comment: "Message when we can't reach WPCom recovery tool"))
+                                             "But don't worry, our support team is here to help. Contact us and we will happily assist you.",
+                                             comment: "Message when we can't reach WPCom in the recovery tool"))
                 continuation.resume(returning: state)
             }
         }
@@ -143,7 +143,7 @@ final class ConnectivityToolViewModel {
                     DDLogError("Connectivity Tool: ❌ Site connection\n\(error)")
                 }
 
-                let state: ConnectivityToolCard.State = result.isSuccess ? .success : .error("Can't reach your site servers")
+                let state = Self.stateForSiteResult(result)
                 continuation.resume(returning: state)
             }
         }
@@ -162,10 +162,34 @@ final class ConnectivityToolViewModel {
                     DDLogError("Connectivity Tool: ❌ Site Orders\n\(error)")
                 }
 
-                let state: ConnectivityToolCard.State = result.isSuccess ? .success : .error("Can't reach your site servers")
+                let state = Self.stateForSiteResult(result)
                 continuation.resume(returning: state)
             }
         }
+    }
+
+    static func stateForSiteResult<T>(_ result: Result<T, Error>) -> ConnectivityToolCard.State {
+        guard case let .failure(error) = result else {
+            return .success
+        }
+
+        let errorMessage = {
+            switch error {
+            case is DecodingError:
+                return NSLocalizedString("Oops! It seems we can't work properly with your site's response.\n\n" +
+                                         "But don't worry, our support team is here to help. Contact us and we will happily assist you.",
+                                         comment: "Message when we there is a decoding error in the recovery tool")
+            case DotcomError.jetpackNotConnected:
+                return NSLocalizedString("Oops! It seems that your jetpack connection is broken.\n\n" +
+                                         "But don't worry, our support team is here to help. Contact us and we will happily assist you.",
+                                         comment: "Message when we there is a jetpack error in the recovery tool")
+            default:
+                return NSLocalizedString("Oops! There seems to be a problem with your site. Contact your hosting provider for further assistance",
+                                         comment: "Message when we there is a generic error in the recovery tool")
+            }
+        }()
+
+        return .error(errorMessage)
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Connectivity Tool/ConnectivityToolViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Connectivity Tool/ConnectivityToolViewModel.swift
@@ -120,7 +120,11 @@ final class ConnectivityToolViewModel {
                     DDLogError("Connectivity Tool: ❌ WPCom connection\n\(error)")
                 }
 
-                let state: ConnectivityToolCard.State = result.isSuccess ? .success : .error("Can't reach WordPress.com servers")
+                let state: ConnectivityToolCard.State = result.isSuccess ?
+                    .success :
+                    .error(NSLocalizedString("Oops! It seems we can't connect to WordPress.com at the moment.\n\n" +
+                                             "But, our support team is here to help. Please contact us and we will happily assist you.",
+                                             comment: "Message when we can't reach WPCom recovery tool"))
                 continuation.resume(returning: state)
             }
         }

--- a/WooCommerce/Classes/ViewRelated/Connectivity Tool/ConnectivityToolViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Connectivity Tool/ConnectivityToolViewModel.swift
@@ -96,7 +96,11 @@ final class ConnectivityToolViewModel {
                         }
                     }()
 
-                    let state: ConnectivityToolCard.State = reachable ? .success : .error("No internet connection")
+                    let state: ConnectivityToolCard.State = reachable ? 
+                        .success : 
+                        .error(NSLocalizedString("It looks like you're not connected to the internet.\n" +
+                                                 "Ensure your Wi-Fi is turned on. If you're using mobile data, make sure it's enabled in your device settings.",
+                                                 comment: "Message when there is no internet connection in the recovery tool"))
                     continuation.resume(returning: state)
                 }
                 .store(in: &subscriptions)

--- a/WooCommerce/Classes/ViewRelated/Connectivity Tool/ConnectivityToolViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Connectivity Tool/ConnectivityToolViewModel.swift
@@ -96,9 +96,9 @@ final class ConnectivityToolViewModel {
                         }
                     }()
 
-                    let state: ConnectivityToolCard.State = reachable ? 
-                        .success : 
-                        .error(NSLocalizedString("It looks like you're not connected to the internet.\n" +
+                    let state: ConnectivityToolCard.State = reachable ?
+                        .success :
+                        .error(NSLocalizedString("It looks like you're not connected to the internet.\n\n" +
                                                  "Ensure your Wi-Fi is turned on. If you're using mobile data, make sure it's enabled in your device settings.",
                                                  comment: "Message when there is no internet connection in the recovery tool"))
                     continuation.resume(returning: state)

--- a/WooCommerce/Classes/ViewRelated/Dashboard/DashboardViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/DashboardViewController.swift
@@ -174,7 +174,7 @@ final class DashboardViewController: UIViewController {
 
         DispatchQueue.main.asyncAfter(deadline: .now() + 2) {
             let vc = ConnectivityToolViewController()
-            self.show(self, sender: nil)
+            self.show(vc, sender: nil)
         }
     }
 

--- a/WooCommerce/Classes/ViewRelated/Dashboard/DashboardViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/DashboardViewController.swift
@@ -171,6 +171,11 @@ final class DashboardViewController: UIViewController {
         Task { @MainActor in
             await viewModel.syncAnnouncements(for: siteID)
         }
+
+        DispatchQueue.main.asyncAfter(deadline: .now() + 2) {
+            let vc = ConnectivityToolViewController()
+            self.show(self, sender: nil)
+        }
     }
 
     override func viewWillAppear(_ animated: Bool) {

--- a/WooCommerce/Classes/ViewRelated/Dashboard/DashboardViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/DashboardViewController.swift
@@ -171,11 +171,6 @@ final class DashboardViewController: UIViewController {
         Task { @MainActor in
             await viewModel.syncAnnouncements(for: siteID)
         }
-
-        DispatchQueue.main.asyncAfter(deadline: .now() + 2) {
-            let vc = ConnectivityToolViewController()
-            self.show(vc, sender: nil)
-        }
     }
 
     override func viewWillAppear(_ animated: Bool) {


### PR DESCRIPTION
Closes: #11995 

# Why

This PR adds the connectivity tool suggestions and troubleshoot tips according to this comment pe5pgL-4yi-p2#comment-3750

# Screenshots

Internet Connection | WPCom Servers | Connecting to the site
---- | ---- | ----
![internet connection](https://github.com/woocommerce/woocommerce-ios/assets/562080/f0cd1378-e2b2-4527-bcbc-85372bc6a12f) | ![WPCOM](https://github.com/woocommerce/woocommerce-ios/assets/562080/fdf3be1b-cb34-48e2-a8d1-cba0960e9d11) | ![ConnectingToSite](https://github.com/woocommerce/woocommerce-ios/assets/562080/c18ec531-c1b2-4567-89bb-37e8e24cd6df)


---
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
