### PR TITLE
[Analytics Hub] Show and hide analytics cards in Analytics Hub

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/AnalyticsHubView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/AnalyticsHubView.swift
@@ -87,6 +87,7 @@ struct AnalyticsHubView: View {
 
                     Divider()
                 }
+                .renderedIf(viewModel.isCardEnabled(.revenue))
 
                 VStack(spacing: Layout.dividerSpacing) {
                     Divider()
@@ -97,6 +98,7 @@ struct AnalyticsHubView: View {
 
                     Divider()
                 }
+                .renderedIf(viewModel.isCardEnabled(.orders))
 
                 VStack(spacing: Layout.dividerSpacing) {
                     Divider()
@@ -107,6 +109,7 @@ struct AnalyticsHubView: View {
 
                     Divider()
                 }
+                .renderedIf(viewModel.isCardEnabled(.products))
 
                 VStack(spacing: Layout.dividerSpacing) {
                     Divider()

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/AnalyticsHubView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/AnalyticsHubView.swift
@@ -163,7 +163,7 @@ struct AnalyticsHubView: View {
                 } label: {
                     Text(Localization.editButton)
                 }
-                .renderedIf(ServiceLocator.featureFlagService.isFeatureFlagEnabled(.customizeAnalyticsHub))
+                .renderedIf(viewModel.canCustomizeAnalytics)
             }
         }
         .sheet(isPresented: $isCustomizingAnalyticsCards) {

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/AnalyticsHubViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/AnalyticsHubViewModel.swift
@@ -109,7 +109,9 @@ final class AnalyticsHubViewModel: ObservableObject {
     /// Sessions Card display state
     ///
     var showSessionsCard: Bool {
-        if stores.isAuthenticatedWithoutWPCom // Non-Jetpack stores don't have sessions stats
+        if !isCardEnabled(.sessions) {
+            return false
+        } else if stores.isAuthenticatedWithoutWPCom // Non-Jetpack stores don't have sessions stats
             || (isJetpackStatsDisabled && !userIsAdmin) { // Non-admins can't enable sessions stats
             return false
         } else if case .custom = timeRangeSelectionType {
@@ -141,6 +143,18 @@ final class AnalyticsHubViewModel: ObservableObject {
     /// Defaults to `nil`.
     ///
     @Published var dismissNotice: Notice?
+
+    /// All analytics cards to display in the Analytics Hub.
+    ///
+    var enabledCards: [AnalyticsCard.CardType] {
+        allCardsWithSettings.filter { $0.enabled }.map { $0.type }
+    }
+
+    /// Whether the card should be displayed in the Analytics Hub.
+    ///
+    func isCardEnabled(_ type: AnalyticsCard.CardType) -> Bool {
+        return enabledCards.contains(where: { $0 == type })
+    }
 
     // MARK: Private data
 

--- a/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Analytics Hub/AnalyticsHubViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Analytics Hub/AnalyticsHubViewModelTests.swift
@@ -574,17 +574,16 @@ final class AnalyticsHubViewModelTests: XCTestCase {
         XCTAssertNotNil(vm.productsStatsCard.reportViewModel?.initialURL)
     }
 
-    func test_allCardsWithSettings_shows_correct_data_after_loading_from_storage() async {
+    func test_enabledCards_shows_correct_data_after_loading_from_storage() async {
         // Given
         let vm = AnalyticsHubViewModel(siteID: 123, statsTimeRange: .thisMonth, usageTracksEventEmitter: eventEmitter, stores: stores)
-        let expectedCards = [AnalyticsCard(type: .revenue, enabled: true),
-                             AnalyticsCard(type: .orders, enabled: false),
-                             AnalyticsCard(type: .products, enabled: false),
-                             AnalyticsCard(type: .sessions, enabled: false)]
         stores.whenReceivingAction(ofType: AppSettingsAction.self) { action in
             switch action {
             case let .loadAnalyticsHubCards(_, completion):
-                completion(expectedCards)
+                completion([AnalyticsCard(type: .revenue, enabled: true),
+                            AnalyticsCard(type: .orders, enabled: false),
+                            AnalyticsCard(type: .products, enabled: false),
+                            AnalyticsCard(type: .sessions, enabled: false)])
             default:
                 break
             }
@@ -594,10 +593,10 @@ final class AnalyticsHubViewModelTests: XCTestCase {
         await vm.loadAnalyticsCardSettings()
 
         // Then
-        assertEqual(expectedCards, vm.allCardsWithSettings)
+        assertEqual([.revenue], vm.enabledCards)
     }
 
-    func test_it_updates_allCardsWithSettings_when_saved() async {
+    func test_it_updates_enabledCards_when_saved() async {
         // Given
         let vm = AnalyticsHubViewModel(siteID: 123, statsTimeRange: .thisMonth, usageTracksEventEmitter: eventEmitter, stores: stores)
 
@@ -606,11 +605,7 @@ final class AnalyticsHubViewModelTests: XCTestCase {
         vm.customizeAnalyticsViewModel.saveChanges()
 
         // Then
-        let expectedCards = [AnalyticsCard(type: .revenue, enabled: true),
-                             AnalyticsCard(type: .orders, enabled: false),
-                             AnalyticsCard(type: .products, enabled: false),
-                             AnalyticsCard(type: .sessions, enabled: false)]
-        assertEqual(expectedCards, vm.allCardsWithSettings)
+        assertEqual([.revenue], vm.enabledCards)
     }
 
     func test_it_stores_updated_analytics_cards_when_saved() async {
@@ -669,5 +664,30 @@ final class AnalyticsHubViewModelTests: XCTestCase {
                              AnalyticsCard(type: .products, enabled: false),
                              AnalyticsCard(type: .sessions, enabled: false)]
         assertEqual(expectedCards, vm.customizeAnalyticsViewModel.allCards)
+    }
+
+    func test_isCardEnabled_returns_expected_card_visibility() async {
+        // Given
+        let vm = AnalyticsHubViewModel(siteID: 123, statsTimeRange: .thisMonth, usageTracksEventEmitter: eventEmitter, stores: stores)
+        stores.whenReceivingAction(ofType: AppSettingsAction.self) { action in
+            switch action {
+            case let .loadAnalyticsHubCards(_, completion):
+                completion([AnalyticsCard(type: .revenue, enabled: true),
+                            AnalyticsCard(type: .orders, enabled: false),
+                            AnalyticsCard(type: .products, enabled: false),
+                            AnalyticsCard(type: .sessions, enabled: false)])
+            default:
+                break
+            }
+        }
+
+        // When
+        await vm.loadAnalyticsCardSettings()
+
+        // Then
+        XCTAssertTrue(vm.isCardEnabled(.revenue))
+        [.orders, .products, .sessions].forEach { card in
+            XCTAssertFalse(vm.isCardEnabled(card))
+        }
     }
 }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Analytics Hub/AnalyticsHubViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Analytics Hub/AnalyticsHubViewModelTests.swift
@@ -576,7 +576,7 @@ final class AnalyticsHubViewModelTests: XCTestCase {
 
     func test_enabledCards_shows_correct_data_after_loading_from_storage() async {
         // Given
-        let vm = AnalyticsHubViewModel(siteID: 123, statsTimeRange: .thisMonth, usageTracksEventEmitter: eventEmitter, stores: stores)
+        let vm = AnalyticsHubViewModel(siteID: 123, statsTimeRange: .thisMonth, usageTracksEventEmitter: eventEmitter, stores: stores, canCustomizeAnalytics: true)
         stores.whenReceivingAction(ofType: AppSettingsAction.self) { action in
             switch action {
             case let .loadAnalyticsHubCards(_, completion):
@@ -598,7 +598,7 @@ final class AnalyticsHubViewModelTests: XCTestCase {
 
     func test_it_updates_enabledCards_when_saved() async {
         // Given
-        let vm = AnalyticsHubViewModel(siteID: 123, statsTimeRange: .thisMonth, usageTracksEventEmitter: eventEmitter, stores: stores)
+        let vm = AnalyticsHubViewModel(siteID: 123, statsTimeRange: .thisMonth, usageTracksEventEmitter: eventEmitter, stores: stores, canCustomizeAnalytics: true)
 
         // When
         vm.customizeAnalyticsViewModel.selectedCards = [AnalyticsCard(type: .revenue, enabled: true)]
@@ -610,7 +610,7 @@ final class AnalyticsHubViewModelTests: XCTestCase {
 
     func test_it_stores_updated_analytics_cards_when_saved() async {
         // Given
-        let vm = AnalyticsHubViewModel(siteID: 123, statsTimeRange: .thisMonth, usageTracksEventEmitter: eventEmitter, stores: stores)
+        let vm = AnalyticsHubViewModel(siteID: 123, statsTimeRange: .thisMonth, usageTracksEventEmitter: eventEmitter, stores: stores, canCustomizeAnalytics: true)
 
         // When
         let storedAnalyticsCards = waitFor { promise in
@@ -639,7 +639,7 @@ final class AnalyticsHubViewModelTests: XCTestCase {
 
     func test_it_updates_customizeAnalyticsVM_when_analytics_cards_saved() async {
         // Given
-        let vm = AnalyticsHubViewModel(siteID: 123, statsTimeRange: .thisMonth, usageTracksEventEmitter: eventEmitter, stores: stores)
+        let vm = AnalyticsHubViewModel(siteID: 123, statsTimeRange: .thisMonth, usageTracksEventEmitter: eventEmitter, stores: stores, canCustomizeAnalytics: true)
 
         // When
         let storedAnalyticsCards = waitFor { promise in
@@ -668,7 +668,7 @@ final class AnalyticsHubViewModelTests: XCTestCase {
 
     func test_isCardEnabled_returns_expected_card_visibility() async {
         // Given
-        let vm = AnalyticsHubViewModel(siteID: 123, statsTimeRange: .thisMonth, usageTracksEventEmitter: eventEmitter, stores: stores)
+        let vm = AnalyticsHubViewModel(siteID: 123, statsTimeRange: .thisMonth, usageTracksEventEmitter: eventEmitter, stores: stores, canCustomizeAnalytics: true)
         stores.whenReceivingAction(ofType: AppSettingsAction.self) { action in
             switch action {
             case let .loadAnalyticsHubCards(_, completion):


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of: #11949
<!-- Id number of the GitHub issue this PR addresses. -->

## Why
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
We want to show or hide cards in the Analytics Hub depending on whether the merchant has enabled them (whether they were selected and saved in the Customized Analytics screen).

## How
* In `AnalyticsHubViewModel`:
   * A new property `enabledCards` contains an array of the enabled card types.
   * A new function `isCardEnabled(type:)` checks if a given type is in `enabledCards`.
   * The `showSessionsCard` property checks first if the card is enabled, and returns false right away if it isn't.
   * Adds a `canCustomizeAnalytics` constant to hide Analytics Hub customizations if the feature flag is disabled.
* In `AnalyticsHubView`:
   * Each of the other cards (revenue, orders, products) is now rendered if the card is enabled.

Note: We could do this without the `enabledCards` property, but this is just an intermediate step toward allowing the cards to be reordered as well as hidden in the Analytics Hub. At that point we should be able to create the view using just `enabledCards`.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

1. Build and run the app.
2. Tap "See more" to open the Analytics Hub.
3. Tap "Edit" to customize the analytics cards.
4. Change the card selections, so some cards are disabled.
5. Tap "Save" and confirm the Analytics Hub only shows the cards you selected.

Additional testing: Disable the feature flag and confirm the "Edit" button does not appear and all cards are visible in the Analytics Hub.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

https://github.com/woocommerce/woocommerce-ios/assets/8658164/963c701f-2aeb-4d50-b785-b1354c2bb2d4



---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
