### PR TITLE
[Analytics Hub] Show cards in Analytics Hub in customized order

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/AnalyticsHubView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/AnalyticsHubView.swift
@@ -78,62 +78,9 @@ struct AnalyticsHubView: View {
                     Divider()
                 }
 
-                VStack(spacing: Layout.dividerSpacing) {
-                    Divider()
-
-                    AnalyticsReportCard(viewModel: viewModel.revenueCard)
-                        .padding(.horizontal, insets: safeAreaInsets)
-                        .background(Color(uiColor: .listForeground(modal: false)))
-
-                    Divider()
+                ForEach(viewModel.enabledCards, id: \.self) { card in
+                    analyticsCard(type: card)
                 }
-                .renderedIf(viewModel.isCardEnabled(.revenue))
-
-                VStack(spacing: Layout.dividerSpacing) {
-                    Divider()
-
-                    AnalyticsReportCard(viewModel: viewModel.ordersCard)
-                        .padding(.horizontal, insets: safeAreaInsets)
-                        .background(Color(uiColor: .listForeground(modal: false)))
-
-                    Divider()
-                }
-                .renderedIf(viewModel.isCardEnabled(.orders))
-
-                VStack(spacing: Layout.dividerSpacing) {
-                    Divider()
-
-                    AnalyticsProductCard(statsViewModel: viewModel.productsStatsCard, itemsViewModel: viewModel.itemsSoldCard)
-                        .padding(.horizontal, insets: safeAreaInsets)
-                        .background(Color(uiColor: .listForeground(modal: false)))
-
-                    Divider()
-                }
-                .renderedIf(viewModel.isCardEnabled(.products))
-
-                VStack(spacing: Layout.dividerSpacing) {
-                    Divider()
-
-                    Group {
-                        if viewModel.showJetpackStatsCTA {
-                            AnalyticsCTACard(title: Localization.sessionsCTATitle,
-                                             message: Localization.sessionsCTAMessage,
-                                             buttonLabel: Localization.sessionsCTAButton,
-                                             isLoading: $isEnablingJetpackStats) {
-                                isEnablingJetpackStats = true
-                                await viewModel.enableJetpackStats()
-                                isEnablingJetpackStats = false
-                            }
-                        } else {
-                            AnalyticsReportCard(viewModel: viewModel.sessionsCard)
-                        }
-                    }
-                    .padding(.horizontal, insets: safeAreaInsets)
-                    .background(Color(uiColor: .listForeground(modal: false)))
-
-                    Divider()
-                }
-                .renderedIf(viewModel.showSessionsCard)
 
                 Spacer()
             }
@@ -170,6 +117,70 @@ struct AnalyticsHubView: View {
             NavigationView {
                 AnalyticsHubCustomizeView(viewModel: viewModel.customizeAnalyticsViewModel)
             }
+        }
+    }
+}
+
+private extension AnalyticsHubView {
+    /// Creates an analytics card for the given type.
+    /// - Parameter type: Type of analytics card, e.g. revenue or orders.
+    @ViewBuilder
+    func analyticsCard(type: AnalyticsCard.CardType) -> some View {
+        switch type {
+        case .revenue:
+            VStack(spacing: Layout.dividerSpacing) {
+                Divider()
+
+                AnalyticsReportCard(viewModel: viewModel.revenueCard)
+                    .padding(.horizontal, insets: safeAreaInsets)
+                    .background(Color(uiColor: .listForeground(modal: false)))
+
+                Divider()
+            }
+        case .orders:
+            VStack(spacing: Layout.dividerSpacing) {
+                Divider()
+
+                AnalyticsReportCard(viewModel: viewModel.ordersCard)
+                    .padding(.horizontal, insets: safeAreaInsets)
+                    .background(Color(uiColor: .listForeground(modal: false)))
+
+                Divider()
+            }
+        case .products:
+            VStack(spacing: Layout.dividerSpacing) {
+                Divider()
+
+                AnalyticsProductCard(statsViewModel: viewModel.productsStatsCard, itemsViewModel: viewModel.itemsSoldCard)
+                    .padding(.horizontal, insets: safeAreaInsets)
+                    .background(Color(uiColor: .listForeground(modal: false)))
+
+                Divider()
+            }
+        case .sessions:
+            VStack(spacing: Layout.dividerSpacing) {
+                Divider()
+
+                Group {
+                    if viewModel.showJetpackStatsCTA {
+                        AnalyticsCTACard(title: Localization.sessionsCTATitle,
+                                         message: Localization.sessionsCTAMessage,
+                                         buttonLabel: Localization.sessionsCTAButton,
+                                         isLoading: $isEnablingJetpackStats) {
+                            isEnablingJetpackStats = true
+                            await viewModel.enableJetpackStats()
+                            isEnablingJetpackStats = false
+                        }
+                    } else {
+                        AnalyticsReportCard(viewModel: viewModel.sessionsCard)
+                    }
+                }
+                .padding(.horizontal, insets: safeAreaInsets)
+                .background(Color(uiColor: .listForeground(modal: false)))
+
+                Divider()
+            }
+            .renderedIf(viewModel.showSessionsCard)
         }
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/AnalyticsHubViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/AnalyticsHubViewModel.swift
@@ -157,12 +157,6 @@ final class AnalyticsHubViewModel: ObservableObject {
         return allCards.filter { $0.enabled }.map { $0.type }
     }
 
-    /// Whether the card should be displayed in the Analytics Hub.
-    ///
-    func isCardEnabled(_ type: AnalyticsCard.CardType) -> Bool {
-        return enabledCards.contains(where: { $0 == type })
-    }
-
     // MARK: Private data
 
     /// All analytics cards with their enabled/disabled settings.
@@ -612,6 +606,12 @@ private extension AnalyticsHubViewModel {
     func onCustomizeCards(_ updatedCards: [AnalyticsCard]) {
         allCardsWithSettings = updatedCards
         storeAnalyticsCardSettings(updatedCards)
+    }
+
+    /// Whether the card should be displayed in the Analytics Hub.
+    ///
+    func isCardEnabled(_ type: AnalyticsCard.CardType) -> Bool {
+        return enabledCards.contains(where: { $0 == type })
     }
 }
 

--- a/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Analytics Hub/AnalyticsHubViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Analytics Hub/AnalyticsHubViewModelTests.swift
@@ -665,29 +665,4 @@ final class AnalyticsHubViewModelTests: XCTestCase {
                              AnalyticsCard(type: .sessions, enabled: false)]
         assertEqual(expectedCards, vm.customizeAnalyticsViewModel.allCards)
     }
-
-    func test_isCardEnabled_returns_expected_card_visibility() async {
-        // Given
-        let vm = AnalyticsHubViewModel(siteID: 123, statsTimeRange: .thisMonth, usageTracksEventEmitter: eventEmitter, stores: stores, canCustomizeAnalytics: true)
-        stores.whenReceivingAction(ofType: AppSettingsAction.self) { action in
-            switch action {
-            case let .loadAnalyticsHubCards(_, completion):
-                completion([AnalyticsCard(type: .revenue, enabled: true),
-                            AnalyticsCard(type: .orders, enabled: false),
-                            AnalyticsCard(type: .products, enabled: false),
-                            AnalyticsCard(type: .sessions, enabled: false)])
-            default:
-                break
-            }
-        }
-
-        // When
-        await vm.loadAnalyticsCardSettings()
-
-        // Then
-        XCTAssertTrue(vm.isCardEnabled(.revenue))
-        [.orders, .products, .sessions].forEach { card in
-            XCTAssertFalse(vm.isCardEnabled(card))
-        }
-    }
 }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of: #11949
⚠️ Depends on https://github.com/woocommerce/woocommerce-ios/pull/12076 ⚠️ 
<!-- Id number of the GitHub issue this PR addresses. -->

## Why
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
We want to show cards in the Analytics Hub in the order the merchant customized them (in the Customize Analytics screen).

## How

* Adds a view builder `analyticsCard(type:)` to `AnalyticsHubView`. This returns the card corresponding to the given type (e.g. the Revenue card for the `.revenue` type).
* Uses the list of `enabledCards` in the view model with the new view builder to lay out the analytics cards in the correct order.
* Make `isCardEnabled(type:)` a private function (used only in the view model now).

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

1. Build and run the app.
2. Tap "See more" to open the Analytics Hub.
3. Tap "Edit" to customize the analytics cards.
4. Change the card selections and order.
5. Tap "Save" and confirm the Analytics Hub shows the selected cards in the order you placed them.

Additional testing: Disable the feature flag and confirm the "Edit" button does not appear and all cards are visible in the default order in the Analytics Hub.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

https://github.com/woocommerce/woocommerce-ios/assets/8658164/f3b99f57-3ad1-4c05-9d71-3e49f3047d6b



---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
