### PR TITLE
Tooling: fix issue labels validation

### DIFF
--- a/.github/workflows/validate-issues.yml
+++ b/.github/workflows/validate-issues.yml
@@ -9,8 +9,8 @@ jobs:
     uses: Automattic/dangermattic/.github/workflows/reusable-check-labels-on-issues.yml@v1.0.0
     with:
       label-format-list: '[
-        "^type: *$",
-        "^feature: *$"
+        "^type: ",
+        "^feature: "
       ]'
       label-error-message: '🚫 Please add a type label (e.g. **type: enhancement**) and a feature label (e.g. **feature: stats**) to this issue.'
       label-success-message: 'Thanks for reporting! 👍'

--- a/.github/workflows/validate-issues.yml
+++ b/.github/workflows/validate-issues.yml
@@ -9,8 +9,8 @@ jobs:
     uses: Automattic/dangermattic/.github/workflows/reusable-check-labels-on-issues.yml@v1.0.0
     with:
       label-format-list: '[
-        "^type: ",
-        "^feature: "
+        "^type: .+",
+        "^feature: .+"
       ]'
       label-error-message: '🚫 Please add a type label (e.g. **type: enhancement**) and a feature label (e.g. **feature: stats**) to this issue.'
       label-success-message: 'Thanks for reporting! 👍'


### PR DESCRIPTION
This PR fixes the regex applied when we run labels validations on issues.
The ending part of the regex `*$` isn't really necessary and was breaking the regex match.