### PR TITLE
[Analytics Hub] Create view model for customizing analytics cards as needed

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/AnalyticsHubView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/AnalyticsHubView.swift
@@ -59,7 +59,6 @@ struct AnalyticsHubView: View {
     @StateObject var viewModel: AnalyticsHubViewModel
 
     @State private var isEnablingJetpackStats = false
-    @State private var isCustomizingAnalyticsCards = false
 
     var body: some View {
         RefreshablePlainList(action: {
@@ -106,16 +105,16 @@ struct AnalyticsHubView: View {
         .toolbar {
             ToolbarItem(placement: .topBarTrailing) {
                 Button {
-                    isCustomizingAnalyticsCards.toggle()
+                    viewModel.customizeAnalytics()
                 } label: {
                     Text(Localization.editButton)
                 }
                 .renderedIf(viewModel.canCustomizeAnalytics)
             }
         }
-        .sheet(isPresented: $isCustomizingAnalyticsCards) {
+        .sheet(item: $viewModel.customizeAnalyticsViewModel) { customizeViewModel in
             NavigationView {
-                AnalyticsHubCustomizeView(viewModel: viewModel.customizeAnalyticsViewModel)
+                AnalyticsHubCustomizeView(viewModel: customizeViewModel)
             }
         }
     }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/Customize/AnalyticsHubCustomizeViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/Customize/AnalyticsHubCustomizeViewModel.swift
@@ -2,7 +2,7 @@ import Foundation
 import Yosemite
 
 /// View model for `AnalyticsHubCustomizeView`.
-final class AnalyticsHubCustomizeViewModel: ObservableObject {
+final class AnalyticsHubCustomizeViewModel: ObservableObject, Identifiable {
 
     /// Ordered array of all available analytics cards.
     ///


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of: #11949
<!-- Id number of the GitHub issue this PR addresses. -->

## Why
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
A previous change introduced a bug where discarding changes didn't work as expected. The changes weren't saved (not stored or used in the Analytics Hub view) but they were visible if you opened the Customize Analytics screen again.

This PR fixes that bug so the Analytics Hub always opens the Customize Analytics view with the latest saved card settings.

## How

Previously we created a binding between `allCardsWithSettings` and `customizeAnalyticsViewModel`. Whenever the card property was updated, the view model would be recreated with the latest changes. However, that meant the view model wasn't being recreated when the changes were discarded, so if the view was reopened it retained those changes.

This fixes that issue by ensuring `customizeAnalyticsViewModel` is only created as needed, with the latest card data:

* In `AnalyticsHubView`:
   * Instead of showing `AnalyticsHubCustomizeView` by toggling a state variable, we now show it when `viewModel.customizeAnalyticsViewModel` is set.
   * When the "Edit" button is tapped, we call a method `viewModel.customizeAnalytics()` to set the required view model.
   * Because of how the modal sheet works, it sets `viewModel.customizeAnalyticsViewModel` to `nil` when the view is dismissed.
* In `AnalyticsHubViewModel`:
   * We start with `customizeAnalyticsViewModel` set to `nil`.
   * Instead of always retaining a view model and updating it with bindings, we have the method `customizeAnalytics()` that sets `customizeAnalyticsViewModel` on demand. This ensures it's always created with the latest card settings.
* `AnalyticsHubCustomizeView` now conforms to `Identifiable` so it can be used as the binding in the SwiftUI view modifier `sheet(item:content:)`.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

1. Build and run the app.
2. Tap "See more" to open the Analytics Hub.
3. Tap "Edit" to customize the analytics cards.
4. Change the card selections and/or order and tap "Save."
5. Tap "Edit" again and confirm you see your saved card settings.
6. Change the card selections and/or order again.
7. Tap the close button and discard your changes.
8. Tap "Edit" again and confirm you see your saved card settings (not the changes you made and discarded).

Bonus: When the "Customize Analytics" view is open, make changes to the settings and then rotate your device. Confirm the changes you're making are retained when the device is rotated.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

https://github.com/woocommerce/woocommerce-ios/assets/8658164/b7b0215a-cdd0-482a-aae7-d46d711689c5



---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
