### PR TITLE
Remove background URLSession instances

### DIFF
--- a/Networking/Networking/Network/AlamofireNetwork.swift
+++ b/Networking/Networking/Network/AlamofireNetwork.swift
@@ -7,15 +7,6 @@ extension Alamofire.MultipartFormData: MultipartFormData {}
 /// AlamofireWrapper: Encapsulates all of the Alamofire OP's
 ///
 public class AlamofireNetwork: Network {
-    private lazy var backgroundSessionManager: Alamofire.SessionManager = {
-        // A unique ID is included in the background session identifier so that the session does not get invalidated when the initializer is called multiple
-        // times (e.g. when logging in).
-        let uniqueID = UUID().uuidString
-        let sessionConfiguration = URLSessionConfiguration.background(withIdentifier: "com.automattic.woocommerce.backgroundsession.\(uniqueID)")
-        let sessionManager = makeSessionManager(configuration: sessionConfiguration)
-        return sessionManager
-    }()
-
     private lazy var sessionManager: Alamofire.SessionManager = {
         let sessionConfiguration = URLSessionConfiguration.default
         let sessionManager = makeSessionManager(configuration: sessionConfiguration)
@@ -116,7 +107,7 @@ public class AlamofireNetwork: Network {
                                         to request: URLRequestConvertible,
                                         completion: @escaping (Data?, Error?) -> Void) {
         let request = requestConverter.convert(request)
-        backgroundSessionManager.upload(multipartFormData: multipartFormData, with: request) { (encodingResult) in
+        sessionManager.upload(multipartFormData: multipartFormData, with: request) { (encodingResult) in
             switch encodingResult {
             case .success(let upload, _, _):
                 upload.responseData { response in

--- a/Networking/Networking/Network/WordPressOrgNetwork.swift
+++ b/Networking/Networking/Network/WordPressOrgNetwork.swift
@@ -31,15 +31,6 @@ public final class WordPressOrgNetwork: Network {
         return sessionManager
     }()
 
-    private lazy var backgroundSessionManager: Alamofire.SessionManager = {
-        // A unique ID is included in the background session identifier so that the session does not get invalidated when the initializer is called multiple
-        // times (e.g. when logging in).
-        let uniqueID = UUID().uuidString
-        let sessionConfiguration = URLSessionConfiguration.background(withIdentifier: "com.automattic.woocommerce.backgroundsession.\(uniqueID)")
-        let sessionManager = makeSessionManager(configuration: sessionConfiguration)
-        return sessionManager
-    }()
-
     public var session: URLSession { sessionManager.session }
 
     public init(configuration: CookieNonceAuthenticatorConfiguration, userAgent: String = UserAgent.defaultUserAgent) {
@@ -141,7 +132,7 @@ public final class WordPressOrgNetwork: Network {
     public func uploadMultipartFormData(multipartFormData: @escaping (MultipartFormData) -> Void,
                                         to request: URLRequestConvertible,
                                         completion: @escaping (Data?, Error?) -> Void) {
-        backgroundSessionManager.upload(multipartFormData: multipartFormData, with: request) { (encodingResult) in
+        sessionManager.upload(multipartFormData: multipartFormData, with: request) { (encodingResult) in
             switch encodingResult {
             case .success(let upload, _, _):
                 upload.responseData { response in


### PR DESCRIPTION
## Description

This PR replaces background `URLSession` instances, which are used to upload files, with regular `URLSession` instances.

### Why?

I don't think these background URLSession instances are used according to [Apple's design](https://developer.apple.com/documentation/foundation/url_loading_system/downloading_files_in_the_background#2920773). One example is these URLSession's identifiers are unique strings that no one uses. I believe we are suppose to use these identifiers to [handle background session events](https://developer.apple.com/documentation/foundation/url_loading_system/downloading_files_in_the_background#2928518).
> Because most apps need only a few background sessions (usually one), you can use a fixed string for the identifier, rather than a dynamically generated identifier. The identifier doesn’t need to be unique globally. 

That means the current usages of background `URLSession`s has no difference compared to using regular `URLSession`s.

Also, one of the major changes in Alamofire 5 is it intentionally crashes when used with a background URLSession. Using background `URLSession` with Alamofire becomes a blocker to upgrading to Alamofire 5.

> Background `URLSessionConfiguration`s are no longer supported and attempting to use one will result in a fatal runtime error. Alamofire was never designed to work in the background and its closure-based APIs cannot survive a background transition, leading to ongoing issues around background behavior. Explicit background support will be added through dedicated APIs at some point in the future.

## Testing instructions

Verify file uploads still works. For example, adding images to products.

## Screenshots
N/A

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
