### PR TITLE
Add tracks to connectivity tool

### DIFF
--- a/Experiments/Experiments/DefaultFeatureFlagService.swift
+++ b/Experiments/Experiments/DefaultFeatureFlagService.swift
@@ -95,6 +95,8 @@ public struct DefaultFeatureFlagService: FeatureFlagService {
             return buildConfig == .localDeveloper || buildConfig == .alpha
         case .useURLSessionInWordPressKit:
             return buildConfig != .appStore
+        case .connectivityTool:
+            return buildConfig == .localDeveloper || buildConfig == .alpha
         default:
             return true
         }

--- a/Experiments/Experiments/FeatureFlag.swift
+++ b/Experiments/Experiments/FeatureFlag.swift
@@ -211,4 +211,8 @@ public enum FeatureFlag: Int {
     /// Configures WordPressKit to send HTTP requests using URLSession instead of Alamofire.
     ///
     case useURLSessionInWordPressKit
+
+    /// Enables the connectivity tool when an order list error happens.
+    ///
+    case connectivityTool
 }

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -7,6 +7,7 @@
 17.4
 -----
 - [***] Dropped iOS 15 support. From now we support iOS 16 and later. [https://github.com/woocommerce/woocommerce-ios/pull/11965]
+- [*] [internal] Added a connectivity tool to easily diagnose orders failed requests. [https://github.com/woocommerce/woocommerce-ios/pull/12084]
 
 17.3
 -----

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -7,7 +7,6 @@
 17.4
 -----
 - [***] Dropped iOS 15 support. From now we support iOS 16 and later. [https://github.com/woocommerce/woocommerce-ios/pull/11965]
-- [*] [internal] Added a connectivity tool to easily diagnose orders failed requests. [https://github.com/woocommerce/woocommerce-ios/pull/12084]
 
 17.3
 -----

--- a/WooCommerce/Classes/Analytics/WooAnalyticsEvent+ConnectivityTool.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsEvent+ConnectivityTool.swift
@@ -1,0 +1,41 @@
+import Foundation
+
+extension WooAnalyticsEvent {
+    enum ConnectivityTool {
+
+        /// Types of connectivity tests
+        ///
+        enum Test: String {
+            case internet
+            case wpCom
+            case site
+            case orders
+        }
+
+        static func automaticTimeoutRetry() -> WooAnalyticsEvent {
+            .init(statName: .ordersListAutomaticTimeoutRetry, properties: [:])
+        }
+
+        static func topBannerTroubleshootTapped() -> WooAnalyticsEvent {
+            .init(statName: .ordersListTopBannerTroubleshootTapped, properties: [:])
+        }
+
+        static func requestResponse(test: Test, success: Bool, timeTaken: Double, error: Error?) -> WooAnalyticsEvent {
+            .init(statName: .connectivityToolRequestResponse,
+                  properties: [
+                    "test": test.rawValue,
+                    "success": success,
+                    "time_taken": timeTaken
+                  ],
+                  error: error)
+        }
+
+        static func readMoreTapped() -> WooAnalyticsEvent {
+            .init(statName: .connectivityToolReadMoreTapped, properties: [:])
+        }
+
+        static func contactSupportTapped() -> WooAnalyticsEvent {
+            .init(statName: .connectivityToolContactSupportTapped, properties: [:])
+        }
+    }
+}

--- a/WooCommerce/Classes/Analytics/WooAnalyticsEvent+ConnectivityTool.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsEvent+ConnectivityTool.swift
@@ -20,14 +20,14 @@ extension WooAnalyticsEvent {
             .init(statName: .ordersListTopBannerTroubleshootTapped, properties: [:])
         }
 
-        static func requestResponse(test: Test, success: Bool, timeTaken: Double, error: Error?) -> WooAnalyticsEvent {
+        static func requestResponse(test: Test, success: Bool, timeTaken: Double) -> WooAnalyticsEvent {
             .init(statName: .connectivityToolRequestResponse,
                   properties: [
                     "test": test.rawValue,
                     "success": success,
                     "time_taken": timeTaken
-                  ],
-                  error: error)
+                  ]
+            )
         }
 
         static func readMoreTapped() -> WooAnalyticsEvent {

--- a/WooCommerce/Classes/Analytics/WooAnalyticsStat.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsStat.swift
@@ -442,6 +442,8 @@ public enum WooAnalyticsStat: String {
     case ordersListSearch = "orders_list_search"
     case ordersListLoaded = "orders_list_loaded"
     case ordersListLoadError = "orders_list_load_error"
+    case ordersListAutomaticTimeoutRetry = "orders_list_automatic_timeout_retry"
+    case ordersListTopBannerTroubleshootTapped = "orders_list_top_banner_troubleshoot_tapped"
     case orderProductAdd = "order_product_add"
     case orderProductQuantityChange = "order_product_quantity_change"
     case orderProductRemove = "order_product_remove"
@@ -1152,6 +1154,11 @@ public enum WooAnalyticsStat: String {
     case themePreviewStartWithThemeButtonTapped = "theme_preview_start_with_theme_button_tapped"
     case themeInstallationCompleted = "theme_installation_completed"
     case themeInstallationFailed = "theme_installation_failed"
+
+    // MARK: Connectivity Tool
+    case connectivityToolRequestResponse = "connectivity_tool_request_response"
+    case connectivityToolReadMoreTapped = "connectivity_tool_read_more_tapped"
+    case connectivityToolContactSupportTapped = "connectivity_tool_contact_support_tapped"
 }
 
 public extension WooAnalyticsStat {

--- a/WooCommerce/Classes/ViewRelated/Connectivity Tool/ConnectivityTool.swift
+++ b/WooCommerce/Classes/ViewRelated/Connectivity Tool/ConnectivityTool.swift
@@ -43,6 +43,8 @@ final class ConnectivityToolViewController: UIHostingController<ConnectivityTool
     private func showContactSupportForm() {
         let supportController = SupportFormHostingController(viewModel: .init())
         supportController.show(from: self)
+
+        ServiceLocator.analytics.track(event: .ConnectivityTool.contactSupportTapped())
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Connectivity Tool/ConnectivityTool.swift
+++ b/WooCommerce/Classes/ViewRelated/Connectivity Tool/ConnectivityTool.swift
@@ -128,6 +128,17 @@ struct ConnectivityToolCard: View {
                     .foregroundColor(Color.init(uiColor: .error))
             }
         }
+
+        /// Determines if the test was successful or not.
+        ///
+        var isSuccess: Bool {
+            switch self {
+            case .success:
+                return true
+            default:
+                return false
+            }
+        }
     }
 
     /// Represents the icon of the card

--- a/WooCommerce/Classes/ViewRelated/Connectivity Tool/ConnectivityToolViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Connectivity Tool/ConnectivityToolViewModel.swift
@@ -176,15 +176,20 @@ final class ConnectivityToolViewModel {
         let message: String
         let errorAction: ConnectivityToolCard.State.ErrorAction?
         let readMore = NSLocalizedString("Read More", comment: "Action button title for a generic error on the connectivity tool")
+        let generalTroubleshootAction = {
+            UIApplication.shared.open(WooConstants.URLs.troubleshootErrorLoadingData.asURL())
+            ServiceLocator.analytics.track(event: .ConnectivityTool.readMoreTapped())
+        }
+        let jetpackTroubleshootAction = {
+            UIApplication.shared.open(WooConstants.URLs.troubleshootJetpackConnection.asURL())
+            ServiceLocator.analytics.track(event: .ConnectivityTool.readMoreTapped())
+        }
 
         // Handle timeout errors specially
         if error.isTimeoutError {
             message = NSLocalizedString("Oops! Your site seems to be taking too long to respond.\n\nContact your hosting provider for further assistance.",
                                         comment: "Message when we there is a timeout error in the recovery tool")
-            errorAction = .init(title: readMore, action: {
-                UIApplication.shared.open(WooConstants.URLs.troubleshootErrorLoadingData.asURL())
-            })
-            return .error(message, errorAction)
+            return .error(message, .init(title: readMore, action: generalTroubleshootAction))
         }
 
         // Handle all other types of errors.
@@ -193,22 +198,16 @@ final class ConnectivityToolViewModel {
             message = NSLocalizedString("Oops! It seems we can't work properly with your site's response.\n\n" +
                                         "But don't worry, our support team is here to help. Contact us and we will happily assist you.",
                                         comment: "Message when we there is a decoding error in the recovery tool")
-            errorAction = .init(title: readMore, action: {
-                UIApplication.shared.open(WooConstants.URLs.troubleshootErrorLoadingData.asURL())
-            })
+            errorAction = .init(title: readMore, action: generalTroubleshootAction)
         case DotcomError.jetpackNotConnected:
             message = NSLocalizedString("Oops! There seems to be a problem with your jetpack connection.\n\n" +
                                         "But don't worry, our support team is here to help. Contact us and we will happily assist you.",
                                         comment: "Message when we there is a jetpack error in the recovery tool")
-            errorAction = .init(title: readMore, action: {
-                UIApplication.shared.open(WooConstants.URLs.troubleshootJetpackConnection.asURL())
-            })
+            errorAction = .init(title: readMore, action: jetpackTroubleshootAction)
         default:
             message = NSLocalizedString("Oops! There seems to be a problem with your site.\n\nContact your hosting provider for further assistance.",
                                         comment: "Message when we there is a generic error in the recovery tool")
-            errorAction = .init(title: readMore, action: {
-                UIApplication.shared.open(WooConstants.URLs.troubleshootErrorLoadingData.asURL())
-            })
+            errorAction = .init(title: readMore, action: generalTroubleshootAction)
         }
 
         return .error(message, errorAction)

--- a/WooCommerce/Classes/ViewRelated/Orders/OrderListViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrderListViewController.swift
@@ -920,9 +920,13 @@ private extension OrderListViewController {
         onTroubleshootButtonPressed: { [weak self] in
             guard let self = self else { return }
 
-            ServiceLocator.analytics.track(event: .ConnectivityTool.topBannerTroubleshootTapped())
-            let connectivityToolViewController = ConnectivityToolViewController()
-            self.show(connectivityToolViewController, sender: self)
+            if ServiceLocator.featureFlagService.isFeatureFlagEnabled(.connectivityTool) {
+                ServiceLocator.analytics.track(event: .ConnectivityTool.topBannerTroubleshootTapped())
+                let connectivityToolViewController = ConnectivityToolViewController()
+                self.show(connectivityToolViewController, sender: self)
+            } else {
+                WebviewHelper.launch(ErrorTopBannerFactory.troubleshootUrl(for: error), with: self)
+            }
         },
         onContactSupportButtonPressed: { [weak self] in
             guard let self = self else { return }

--- a/WooCommerce/Classes/ViewRelated/Orders/OrderListViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrderListViewController.swift
@@ -441,7 +441,10 @@ extension OrderListViewController: SyncingCoordinatorDelegate {
 
                     // Recursively retries timeout errors when required.
                     if error.isTimeoutError && retryTimeout {
+
                         self.sync(pageNumber: pageNumber, pageSize: pageSize, reason: reason, retryTimeout: false, onCompletion: onCompletion)
+                        ServiceLocator.analytics.track(event: .ConnectivityTool.automaticTimeoutRetry())
+
                     } else {
                         self.viewModel.dataLoadingError = error
                     }

--- a/WooCommerce/Classes/ViewRelated/Orders/OrderListViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrderListViewController.swift
@@ -917,7 +917,9 @@ private extension OrderListViewController {
         onTroubleshootButtonPressed: { [weak self] in
             guard let self = self else { return }
 
-            WebviewHelper.launch(ErrorTopBannerFactory.troubleshootUrl(for: error), with: self)
+            ServiceLocator.analytics.track(event: .ConnectivityTool.topBannerTroubleshootTapped())
+            let connectivityToolViewController = ConnectivityToolViewController()
+            self.show(connectivityToolViewController, sender: self)
         },
         onContactSupportButtonPressed: { [weak self] in
             guard let self = self else { return }

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -763,6 +763,7 @@
 		2602A64827BDBF8000B347F1 /* ProductInputTransformerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2602A64727BDBF8000B347F1 /* ProductInputTransformerTests.swift */; };
 		2602A64A27BDC80200B347F1 /* RemoteOrderSynchronizerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2602A64927BDC80200B347F1 /* RemoteOrderSynchronizerTests.swift */; };
 		260520F22B83B1B7005D5D59 /* ConnectivityToolViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 260520F12B83B1B7005D5D59 /* ConnectivityToolViewModel.swift */; };
+		260520F42B87BA23005D5D59 /* WooAnalyticsEvent+ConnectivityTool.swift in Sources */ = {isa = PBXBuildFile; fileRef = 260520F32B87BA23005D5D59 /* WooAnalyticsEvent+ConnectivityTool.swift */; };
 		260837092AA66E4B0004A12B /* UserNotifications.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 260837082AA66E4A0004A12B /* UserNotifications.framework */; };
 		2608370B2AA66E4B0004A12B /* UserNotificationsUI.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 2608370A2AA66E4B0004A12B /* UserNotificationsUI.framework */; };
 		2608370E2AA66E4B0004A12B /* OrderNotificationViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2608370D2AA66E4B0004A12B /* OrderNotificationViewController.swift */; };
@@ -3474,6 +3475,7 @@
 		2602A64727BDBF8000B347F1 /* ProductInputTransformerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductInputTransformerTests.swift; sourceTree = "<group>"; };
 		2602A64927BDC80200B347F1 /* RemoteOrderSynchronizerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteOrderSynchronizerTests.swift; sourceTree = "<group>"; };
 		260520F12B83B1B7005D5D59 /* ConnectivityToolViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConnectivityToolViewModel.swift; sourceTree = "<group>"; };
+		260520F32B87BA23005D5D59 /* WooAnalyticsEvent+ConnectivityTool.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "WooAnalyticsEvent+ConnectivityTool.swift"; sourceTree = "<group>"; };
 		260837072AA66E4A0004A12B /* NotificationExtension.appex */ = {isa = PBXFileReference; explicitFileType = "wrapper.app-extension"; includeInIndex = 0; path = NotificationExtension.appex; sourceTree = BUILT_PRODUCTS_DIR; };
 		260837082AA66E4A0004A12B /* UserNotifications.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = UserNotifications.framework; path = System/Library/Frameworks/UserNotifications.framework; sourceTree = SDKROOT; };
 		2608370A2AA66E4B0004A12B /* UserNotificationsUI.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = UserNotificationsUI.framework; path = System/Library/Frameworks/UserNotificationsUI.framework; sourceTree = SDKROOT; };
@@ -8597,6 +8599,7 @@
 				DE5C19C82AC42E7E0064600A /* WooAnalyticsEvent+ProductNameAI.swift */,
 				EEA1E20D2AC55F2200A37ADD /* WooAnalyticsEvent+ProductCreationAI.swift */,
 				DEFC9BE12B2FF62C00138B05 /* WooAnalyticsEvent+Themes.swift */,
+				260520F32B87BA23005D5D59 /* WooAnalyticsEvent+ConnectivityTool.swift */,
 			);
 			path = Analytics;
 			sourceTree = "<group>";
@@ -13966,6 +13969,7 @@
 				B626C71B287659D60083820C /* OrderCustomFieldsDetails.swift in Sources */,
 				025E32BC251D8FEF00685C4A /* ProductFormDataModel+ProductsTabProductViewModel.swift in Sources */,
 				02ECD1E624FFB4E900735BE5 /* ProductFactory.swift in Sources */,
+				260520F42B87BA23005D5D59 /* WooAnalyticsEvent+ConnectivityTool.swift in Sources */,
 				B946881229B8DD41000646B0 /* DashboardViewController+Activity.swift in Sources */,
 				579CDEFF274D7E7900E8903D /* StoreStatsUsageTracksEventEmitter.swift in Sources */,
 				74F9E9CE214C036400A3F2D2 /* NoPeriodDataTableViewCell.swift in Sources */,


### PR DESCRIPTION
Closes: #11988


# Why

This PR adds the following track events to the connectivity tool.

- https://github.com/Automattic/tracks-events-registration/pull/2254
- https://github.com/Automattic/tracks-events-registration/pull/2255
- https://github.com/Automattic/tracks-events-registration/pull/2256
- https://github.com/Automattic/tracks-events-registration/pull/2257
- https://github.com/Automattic/tracks-events-registration/pull/2258


# Demo

https://github.com/woocommerce/woocommerce-ios/assets/562080/8a9110ba-6c48-444c-8b95-03f22fd2570b

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
