### PR TITLE
[Backend Receipts] Remove share receipt URL button

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Receipts/ReceiptViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Receipts/ReceiptViewController.swift
@@ -60,39 +60,11 @@ final class ReceiptViewController: UIViewController, WKNavigationDelegate {
     }
 
     private func configureNavigation() {
-        let shareButton = UIBarButtonItem(image: UIImage(systemName: "square.and.arrow.up"),
-                                          style: .plain,
-                                          target: self,
-                                          action: #selector(shareReceipt))
         let printButton = UIBarButtonItem(image: UIImage(systemName: "printer"),
                                           style: .plain,
                                           target: self,
                                           action: #selector(printReceipt))
-        navigationItem.rightBarButtonItems = [shareButton, printButton]
-    }
-
-    @objc private func shareReceipt() {
-        ServiceLocator.analytics.track(event: .InPersonPayments.receiptEmailTapped(countryCode: nil,
-                                                                                   cardReaderModel: nil,
-                                                                                   source: .backend))
-        guard let url = URL(string: viewModel.receiptURLString) else {
-            return
-        }
-        let activityViewController = UIActivityViewController(activityItems: [url],
-                                                applicationActivities: nil)
-        activityViewController.completionWithItemsHandler = { [weak self] _, success, _, error in
-            if let error = error {
-                ServiceLocator.analytics.track(event: .InPersonPayments.receiptEmailFailed(error: error, source: .backend))
-                DDLogError("Failed to share receipt for orderID \(String(describing: self?.viewModel.orderID)). Error: \(error)")
-            }
-            switch success {
-            case true:
-                ServiceLocator.analytics.track(event: .InPersonPayments.receiptEmailSuccess(countryCode: nil, cardReaderModel: nil, source: .backend))
-            case false:
-                ServiceLocator.analytics.track(event: .InPersonPayments.receiptEmailCanceled(countryCode: nil, cardReaderModel: nil, source: .backend))
-            }
-        }
-        present(activityViewController, animated: true)
+        navigationItem.rightBarButtonItems = [printButton]
     }
 
     @objc private func printReceipt() {


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Partially addresses https://github.com/woocommerce/woocommerce-ios/issues/11961

## Description
Previously we had 2 buttons to share the receipt: 
- Button 1: Shares receipt URL
- Button 2: Offers the option to both share the receipt file, and print the receipt file

After some discussion, we don't really want to share the URL. One option was to recreate the built-in "share file functionality" on the second button, but this was a bit too much since we already have a built-in system in iOS. In order to avoid confusion for the merchant, we'll remove the "share receipt URL" and leave only the button to either share the file, or print the file.

Caveats:
By removing this button, we also remove the tracking for "share receipt", since the delegate does not notify us when a merchant taps on "share", only when the printing completes or errors out. We can restore this event in future iterations.

## Testing instructions
1. On an eligible store ( you can use https://receipts-api.mystagingwebsite.com/ or https://indiemelon.mystagingwebsite.com/ )
2. Create an order, collect payment (eg via cash), and tap on "See receipt". You may need to pull-to-refresh in order to see the button.
3. Observe that only a "print" button appears now. Upon tapping, you can share or print (if a printer, or a simulated printer is plugged, otherwise will appear greyed-out).

<img width="472" alt="Screenshot 2024-02-23 at 14 40 17" src="https://github.com/woocommerce/woocommerce-ios/assets/3812076/514b76a4-a702-43c3-a77b-d76264407eda">
