### PR TITLE
[Tablet Products] Enable feature flag for dev & installable builds

### DIFF
--- a/Experiments/Experiments/DefaultFeatureFlagService.swift
+++ b/Experiments/Experiments/DefaultFeatureFlagService.swift
@@ -88,7 +88,7 @@ public struct DefaultFeatureFlagService: FeatureFlagService {
         case .backendReceipts:
             return true
         case .splitViewInProductsTab:
-            return false
+            return buildConfig == .localDeveloper || buildConfig == .alpha
         case .customRangeInMyStoreAnalytics:
             return buildConfig == .localDeveloper || buildConfig == .alpha
         case .customizeAnalyticsHub:

--- a/WooCommerce/Classes/ViewRelated/MainTabBarController.swift
+++ b/WooCommerce/Classes/ViewRelated/MainTabBarController.swift
@@ -747,7 +747,7 @@ private extension MainTabBarController {
                                                                 siteID: error.siteID,
                                                                 forceReadOnly: false)
         let productNavController = WooNavigationController(rootViewController: productViewController)
-        productsNavigationController.present(productNavController, animated: true)
+        rootTabViewController(tab: .products).present(productNavController, animated: true)
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewController.swift
@@ -564,6 +564,7 @@ private extension ProductFormViewController {
 
         tableView.dataSource = tableViewDataSource
         tableView.delegate = self
+        tableView.accessibilityIdentifier = "product-form"
 
         tableView.backgroundColor = .listForeground(modal: false)
         tableView.removeLastCellSeparator()

--- a/WooCommerce/UITestsFoundation/Screens/Products/ProductsScreen.swift
+++ b/WooCommerce/UITestsFoundation/Screens/Products/ProductsScreen.swift
@@ -100,7 +100,8 @@ public final class ProductsScreen: ScreenObject {
     public func verifyProductList(products: [ProductData]) throws -> Self {
         app.assertTextVisibilityCount(textToFind: products[0].name, expectedCount: 1)
         app.assertElement(matching: products[0].name, existsOnCellWithIdentifier: products[0].stock_status)
-        XCTAssertEqual(products.count, app.tables.cells.count, "Expected '\(products.count)' products but found '\(app.tables.cells.count)' instead!")
+        let productListTable = app.tables["products-table-view"]
+        XCTAssertEqual(products.count, productListTable.cells.count, "Expected '\(products.count)' products but found '\(productListTable.cells.count)' instead!")
 
         return self
     }

--- a/WooCommerce/UITestsFoundation/Screens/Products/SingleProductScreen.swift
+++ b/WooCommerce/UITestsFoundation/Screens/Products/SingleProductScreen.swift
@@ -9,6 +9,10 @@ public final class SingleProductScreen: ScreenObject {
         return screen.isLoaded && screen.expectedElement.isHittable
     }
 
+    private var productFormTable: XCUIElement {
+        app.tables["product-form"]
+    }
+
     init(app: XCUIApplication = XCUIApplication()) throws {
         try super.init(
             expectedElementGetters: [ {$0.buttons["edit-product-more-options-button"]} ],
@@ -18,14 +22,18 @@ public final class SingleProductScreen: ScreenObject {
 
     @discardableResult
     public func goBackToProductList() throws -> ProductsScreen {
-        navBackButton.tap()
+        let navBackButton = productFormTable.navigationBars.element(boundBy: 0).buttons.element(boundBy: 0)
+        // If split view is enabled, back button is not shown in the product form navigation bar.
+        if navBackButton.exists {
+            navBackButton.tap()
+        }
         return try ProductsScreen()
     }
 
     @discardableResult
     public func verifyProduct(product: ProductData) throws -> Self {
-        app.assertTextVisibilityCount(textToFind: product.stock_status, expectedCount: 1)
-        app.assertTextVisibilityCount(textToFind: product.regular_price, expectedCount: 1)
+        productFormTable.assertTextVisibilityCount(textToFind: product.stock_status, expectedCount: 1)
+        productFormTable.assertTextVisibilityCount(textToFind: product.regular_price, expectedCount: 1)
         XCTAssertTrue(app.textViews[product.name].isFullyVisibleOnScreen(), "Product name is not visible on screen!")
 
         return self

--- a/WooCommerce/UITestsFoundation/Screens/Products/SingleProductScreen.swift
+++ b/WooCommerce/UITestsFoundation/Screens/Products/SingleProductScreen.swift
@@ -22,7 +22,7 @@ public final class SingleProductScreen: ScreenObject {
 
     @discardableResult
     public func goBackToProductList() throws -> ProductsScreen {
-        let navBackButton = productFormTable.navigationBars.element(boundBy: 0).buttons.element(boundBy: 0)
+        let navBackButton = app.navigationBars.element(boundBy: 0).buttons["Products"]
         // If split view is enabled, back button is not shown in the product form navigation bar.
         if navBackButton.exists {
             navBackButton.tap()


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #12087 
<!-- Id number of the GitHub issue this PR addresses. -->

## Why

As the feature is close to completion, enabling the feature flag for dev & installable builds allows wider internal testing. While I turned on the feature flag, [2 unit tests and 1 UI test failed](https://buildkite.com/automattic/woocommerce-ios/builds/19786#_) and this PR fixes them.

## How

I was able to reproduce the test failures and confirm that these were caused by the split view support.

### Unit tests

- test_failureSavingProductAfterImageUploadNotice_events_are_tracked_when_showing_and_tapping_product_saving_error_notice() in MainTabBarControllerTests
- test_failureUploadingImageNotice_events_are_tracked_when_showing_and_tapping_product_image_upload_error_notice() in MainTabBarControllerTests

These two test cases failed because `MainTabBarController.showProductDetails` is referring to `productsNavigationController` that is used only when the feature flag is disabled (production). In https://github.com/woocommerce/woocommerce-ios/pull/12091/commits/86f757b149e42b5a97112e2a3ab95d1fc7630c36, this is now replaced by the root view controller for the products tab to work for both feature flag states.

### UI tests

The UI test failure debugging was more time-consuming because it took some time for the login flow to run every time. It turned out that the split view support in iPad caused a few assumptions in the pre-existing assertions to fail.

The test case that failed was `test_load_products_screen() in ProductsTests` and only on iPads. There were 3 places to fix:

- When verifying the number of rows in the product list in `ProductsScreen.verifyProductList`, if the split view is shown, the product form's table view rows are also counted. This causes the assertion on the number of rows to fail, and is fixed by only counting the number of rows for the product list table view
- When verifying the product form includes the expected stock status & regular price text in `SingleProductScreen.verifyProduct`, the assertion expects to have 1 UI element with the text. However, if the split view is shown where the product list is visible, the product rows in the product list also contain the stock status text and this causes the assertion on the 1 expected count to fail. To fix this, an accessibility identifier is set to the product form table view, and the assertions only find the text in the product form table view
- When navigating from the product form back to the product list in `SingleProductScreen.goBackToProductList`, it expects a back button in the navigation bar. However, if the split view is shown where the product list is visible, the back button isn't shown. As a fix, I changed how the back button is found to specify the `buttons["Products"]` to go back to the product list and check if it exists

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

The only app change is to enable the feature flag for internal builds, just a confidence check would be great.

Prerequisite: the device/simulator allows switching between expanded and collapsed states like a tablet

- Launch the app
- Go to the products tab --> the split view should be shown

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.