### PR TITLE
Update blaze campaign creation form width

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Blaze/CampaignCreation/BlazeCampaignCreationForm.swift
+++ b/WooCommerce/Classes/ViewRelated/Blaze/CampaignCreation/BlazeCampaignCreationForm.swift
@@ -6,7 +6,7 @@ final class BlazeCampaignCreationFormHostingController: UIHostingController<Blaz
 
     init(viewModel: BlazeCampaignCreationFormViewModel) {
         self.viewModel = viewModel
-        super.init(rootView: BlazeCampaignCreationForm.init(viewModel: viewModel))
+        super.init(rootView: BlazeCampaignCreationForm(viewModel: viewModel))
         self.viewModel.onEditAd = { [weak self] in
             self?.navigateToEditAd()
         }

--- a/WooCommerce/Classes/ViewRelated/Blaze/CampaignCreation/BlazeCampaignCreationForm.swift
+++ b/WooCommerce/Classes/ViewRelated/Blaze/CampaignCreation/BlazeCampaignCreationForm.swift
@@ -6,7 +6,7 @@ final class BlazeCampaignCreationFormHostingController: UIHostingController<Blaz
 
     init(viewModel: BlazeCampaignCreationFormViewModel) {
         self.viewModel = viewModel
-        super.init(rootView: .init(viewModel: viewModel))
+        super.init(rootView: BlazeCampaignCreationForm.init(viewModel: viewModel))
         self.viewModel.onEditAd = { [weak self] in
             self?.navigateToEditAd()
         }
@@ -20,6 +20,7 @@ final class BlazeCampaignCreationFormHostingController: UIHostingController<Blaz
     override func viewDidLoad() {
         super.viewDidLoad()
         configureNavigation()
+        view.backgroundColor = .listBackground
     }
 }
 
@@ -202,6 +203,7 @@ struct BlazeCampaignCreationForm: View {
         .onAppear() {
             viewModel.onAppear()
         }
+        .frame(maxWidth: Layout.maxWidth)
         .task {
             await viewModel.onLoad()
         }
@@ -340,6 +342,7 @@ private extension BlazeCampaignCreationForm {
         static let detailContentSpacing: CGFloat = 4
         static let shadowRadius: CGFloat = 2
         static let shadowYOffset: CGFloat = 2
+        static let maxWidth: CGFloat = 525
     }
 
     enum Constants {


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #11983
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
Same as we do for the order details now we do for blaze campaign creation form. We use max width of 525 and update the background color to have the same look as order details.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
- make sure `splitViewInProductsTab` is turned ON
- open app on the iPad (device or simulator)
- open Products tab
- select one product
- tap on "Promote with Blaze"
- check that the form width looks properly (as in the gif posted below)

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

![Simulator Screen Recording - iPad Pro (11-inch) (4th generation) - 2024-02-23 at 11 21 19](https://github.com/woocommerce/woocommerce-ios/assets/6242034/db19ea0e-13f0-4cd6-974e-226cf086da9f)

---
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
