### PR TITLE
[Analytics Hub] Hide sessions card for JCP sites

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/AnalyticsHubViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/AnalyticsHubViewModel.swift
@@ -115,7 +115,8 @@ final class AnalyticsHubViewModel: ObservableObject {
     var showSessionsCard: Bool {
         if !isCardEnabled(.sessions) {
             return false
-        } else if stores.sessionManager.defaultSite?.isJetpackThePluginInstalled == false // Non-Jetpack stores don't have sessions stats
+        } else if stores.sessionManager.defaultSite?.isNonJetpackSite == true // Non-Jetpack stores don't have Jetpack stats
+                    || stores.sessionManager.defaultSite?.isJetpackCPConnected == true // JCP stores don't have Jetpack stats
                     || (isJetpackStatsDisabled && !userIsAdmin) { // Non-admins can't enable sessions stats
             return false
         } else if case .custom = timeRangeSelectionType {

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/AnalyticsHubViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/AnalyticsHubViewModel.swift
@@ -115,8 +115,8 @@ final class AnalyticsHubViewModel: ObservableObject {
     var showSessionsCard: Bool {
         if !isCardEnabled(.sessions) {
             return false
-        } else if stores.isAuthenticatedWithoutWPCom // Non-Jetpack stores don't have sessions stats
-            || (isJetpackStatsDisabled && !userIsAdmin) { // Non-admins can't enable sessions stats
+        } else if stores.sessionManager.defaultSite?.isJetpackThePluginInstalled == false // Non-Jetpack stores don't have sessions stats
+                    || (isJetpackStatsDisabled && !userIsAdmin) { // Non-admins can't enable sessions stats
             return false
         } else if case .custom = timeRangeSelectionType {
             return false
@@ -336,7 +336,7 @@ private extension AnalyticsHubViewModel {
     /// Retrieves site summary stats using the `retrieveSiteSummaryStats` action.
     ///
     func retrieveSiteSummaryStats(latestDateToInclude: Date) async throws -> SiteSummaryStats? {
-        guard !stores.isAuthenticatedWithoutWPCom, let period = timeRangeSelectionType.period else {
+        guard showSessionsCard, let period = timeRangeSelectionType.period else {
             return nil
         }
 

--- a/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Analytics Hub/AnalyticsHubViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Analytics Hub/AnalyticsHubViewModelTests.swift
@@ -173,9 +173,9 @@ final class AnalyticsHubViewModelTests: XCTestCase {
         XCTAssertTrue(vm.showSessionsCard)
     }
 
-    func test_session_card_is_hidden_for_sites_without_jetpack() {
+    func test_session_card_is_hidden_for_sites_without_jetpack_plugin() {
         // Given
-        let stores = MockStoresManager(sessionManager: .makeForTesting(authenticated: true, isWPCom: false))
+        let stores = MockStoresManager(sessionManager: .makeForTesting(authenticated: true, defaultSite: .fake().copy(isJetpackThePluginInstalled: false)))
         let vm = AnalyticsHubViewModel(siteID: 123, statsTimeRange: .today, usageTracksEventEmitter: eventEmitter, stores: stores)
 
         // Then
@@ -246,9 +246,9 @@ final class AnalyticsHubViewModelTests: XCTestCase {
     }
 
     @MainActor
-    func test_retrieving_stats_skips_summary_stats_request_for_sites_without_jetpack() async {
+    func test_retrieving_stats_skips_summary_stats_request_for_sites_without_jetpack_plugin() async {
         // Given
-        let stores = MockStoresManager(sessionManager: .makeForTesting(authenticated: true, isWPCom: false))
+        let stores = MockStoresManager(sessionManager: .makeForTesting(authenticated: true, defaultSite: .fake().copy(isJetpackThePluginInstalled: false)))
         let vm = AnalyticsHubViewModel(siteID: 123, statsTimeRange: .today, usageTracksEventEmitter: eventEmitter, stores: stores)
         stores.whenReceivingAction(ofType: StatsActionV4.self) { action in
             switch action {

--- a/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Analytics Hub/AnalyticsHubViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Analytics Hub/AnalyticsHubViewModelTests.swift
@@ -271,7 +271,7 @@ final class AnalyticsHubViewModelTests: XCTestCase {
     @MainActor
     func test_showJetpackStatsCTA_true_for_admin_when_stats_module_disabled() async {
         // Given
-        let vm = AnalyticsHubViewModel(siteID: 123, statsTimeRange: .today, usageTracksEventEmitter: eventEmitter, stores: stores)
+        let vm = AnalyticsHubViewModel(siteID: 123, statsTimeRange: .today, usageTracksEventEmitter: eventEmitter, stores: stores, analytics: analytics)
         stores.whenReceivingAction(ofType: StatsActionV4.self) { action in
             switch action {
             case let .retrieveCustomStats(_, _, _, _, _, _, _, completion):
@@ -324,6 +324,7 @@ final class AnalyticsHubViewModelTests: XCTestCase {
                                        statsTimeRange: .today,
                                        usageTracksEventEmitter: eventEmitter,
                                        stores: stores,
+                                       analytics: analytics,
                                        backendProcessingDelay: 0)
         stores.whenReceivingAction(ofType: JetpackSettingsAction.self) { action in
             switch action {
@@ -359,6 +360,7 @@ final class AnalyticsHubViewModelTests: XCTestCase {
                                        statsTimeRange: .today,
                                        usageTracksEventEmitter: eventEmitter,
                                        stores: stores,
+                                       analytics: analytics,
                                        noticePresenter: noticePresenter,
                                        backendProcessingDelay: 0)
         stores.whenReceivingAction(ofType: JetpackSettingsAction.self) { action in

--- a/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Analytics Hub/AnalyticsHubViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Analytics Hub/AnalyticsHubViewModelTests.swift
@@ -175,11 +175,17 @@ final class AnalyticsHubViewModelTests: XCTestCase {
 
     func test_session_card_is_hidden_for_sites_without_jetpack_plugin() {
         // Given
-        let stores = MockStoresManager(sessionManager: .makeForTesting(authenticated: true, defaultSite: .fake().copy(isJetpackThePluginInstalled: false)))
-        let vm = AnalyticsHubViewModel(siteID: 123, statsTimeRange: .today, usageTracksEventEmitter: eventEmitter, stores: stores)
+        let storesForNonJetpackSite = MockStoresManager(sessionManager: .makeForTesting(authenticated: true, defaultSite: .fake().copy(siteID: -1)))
+        let vmNonJetpackSite = AnalyticsHubViewModel(siteID: 123, statsTimeRange: .today, usageTracksEventEmitter: eventEmitter, stores: storesForNonJetpackSite)
+
+        let storesForJCPSite = MockStoresManager(sessionManager: .makeForTesting(authenticated: true,
+                                                                              defaultSite: .fake().copy(isJetpackThePluginInstalled: false,
+                                                                                                        isJetpackConnected: true)))
+        let vmJCPSite = AnalyticsHubViewModel(siteID: 123, statsTimeRange: .today, usageTracksEventEmitter: eventEmitter, stores: storesForJCPSite)
 
         // Then
-        XCTAssertFalse(vm.showSessionsCard)
+        XCTAssertFalse(vmNonJetpackSite.showSessionsCard)
+        XCTAssertFalse(vmJCPSite.showSessionsCard)
     }
 
     @MainActor
@@ -248,7 +254,7 @@ final class AnalyticsHubViewModelTests: XCTestCase {
     @MainActor
     func test_retrieving_stats_skips_summary_stats_request_for_sites_without_jetpack_plugin() async {
         // Given
-        let stores = MockStoresManager(sessionManager: .makeForTesting(authenticated: true, defaultSite: .fake().copy(isJetpackThePluginInstalled: false)))
+        let stores = MockStoresManager(sessionManager: .makeForTesting(authenticated: true, defaultSite: .fake().copy(siteID: -1)))
         let vm = AnalyticsHubViewModel(siteID: 123, statsTimeRange: .today, usageTracksEventEmitter: eventEmitter, stores: stores)
         stores.whenReceivingAction(ofType: StatsActionV4.self) { action in
             switch action {


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

<!-- Id number of the GitHub issue this PR addresses. -->

## Why
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
While looking into the current Sessions card behavior I noticed that it appears for sites connected only via JCP. It should be hidden for all sites that aren't connected with the full Jetpack plugin, because it relies on Jetpack Stats data that is only available with Jetpack.

## How
This replaces the check for whether a store is authenticated via WPCom with two checks:

* Whether the store is a non-Jetpack site (no Jetpack connection at all)
* Whether the store is connected with the Jetpack Connection Package

In those cases, the sessions cards is hidden.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

Scenarios to test:

- [x] Site connected with Jetpack plugin
- [x] Site with Jetpack Connection Package
- [x] Self-hosted site (no connection to WPCom)

1. Build and run the app.
2. Log in to the site in the scenario under test.
3. Tap "See more" in the dashboard to open the Analytics Hub.
4. Confirm the Sessions card is only visible in the first scenario (site connected with Jetpack plugin).


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
