### PR TITLE
[Tablet Orders] Variation removal from Order Summary sync to open Variation List.

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/EditableOrderViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/EditableOrderViewModel.swift
@@ -577,16 +577,13 @@ final class EditableOrderViewModel: ObservableObject {
             selectedProducts.removeAll(where: { $0.productID == item.productID })
         }
 
-        if syncChangesImmediately {
-            productSelectorViewModel?.removeSelection(id: item.productOrVariationID)
+        productSelectorViewModel?.removeSelection(id: item.productOrVariationID)
 
-            // When synching changes inmediately, we need to update variations as well.
-            // If the variation list isn't showing, this will do nothing, but the model will still be accurate
-            // the next time the variation list is opened.
-            if let productVariationSelectorViewModel = productSelectorViewModel?.productVariationListViewModel {
-                productVariationSelectorViewModel.removeSelection(item.productOrVariationID)
-            }
-
+        // When synching changes immediately, we need to update variations as well.
+        // If the variation list isn't showing, this will do nothing, but the model will still be accurate
+        // the next time the variation list is opened.
+        if let productVariationSelectorViewModel = productSelectorViewModel?.productVariationListViewModel {
+            productVariationSelectorViewModel.removeSelection(item.productOrVariationID)
         }
 
         analytics.track(event: WooAnalyticsEvent.Orders.orderProductRemove(flow: flow.analyticsFlow))

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/EditableOrderViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/EditableOrderViewModel.swift
@@ -579,6 +579,14 @@ final class EditableOrderViewModel: ObservableObject {
 
         if syncChangesImmediately {
             productSelectorViewModel?.removeSelection(id: item.productOrVariationID)
+
+            // When synching changes inmediately, we need to update variations as well.
+            // If the variation list isn't showing, this will do nothing, but the model will still be accurate
+            // the next time the variation list is opened.
+            if let productVariationSelectorViewModel = productSelectorViewModel?.productVariationListViewModel {
+                productVariationSelectorViewModel.removeSelection(item.productOrVariationID)
+            }
+
         }
 
         analytics.track(event: WooAnalyticsEvent.Orders.orderProductRemove(flow: flow.analyticsFlow))

--- a/WooCommerce/Classes/ViewRelated/Products/ProductSelector/ProductSelectorView.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductSelector/ProductSelectorView.swift
@@ -221,7 +221,7 @@ struct ProductSelectorView: View {
                 })
                 .frame(maxWidth: .infinity, alignment: .leading)
                 .onTapGesture {
-                    viewModel.variationRowTapped(for: rowViewModel.productOrVariationID)	
+                    viewModel.variationRowTapped(for: rowViewModel.productOrVariationID)
                 }
                 .redacted(reason: viewModel.selectionDisabled ? .placeholder : [])
                 .disabled(viewModel.selectionDisabled)

--- a/WooCommerce/Classes/ViewRelated/Products/ProductSelector/ProductSelectorViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductSelector/ProductSelectorViewModel.swift
@@ -332,20 +332,20 @@ final class ProductSelectorViewModel: ObservableObject {
     }
 
     func variationCheckboxTapped(for productOrVariationID: Int64) {
-        guard let variationListViewModel = getVariationsViewModel(for: productOrVariationID) else {
-            return
-        }
-        toggleSelectionForAllVariations(of: productOrVariationID)
-        // Display the variations list if toggleSelectionForAllVariations is not allowed
-        if !toggleAllVariationsOnSelection {
-            isShowingProductVariationList.toggle()
-            productVariationListViewModel = variationListViewModel
+        if toggleAllVariationsOnSelection {
+            toggleSelectionForAllVariations(of: productOrVariationID)
+        } else {
+            showVariationList(for: productOrVariationID)
         }
     }
 
     func variationRowTapped(for productOrVariationID: Int64) {
-        isShowingProductVariationList.toggle()
+        showVariationList(for: productOrVariationID)
+    }
+
+    private func showVariationList(for productOrVariationID: Int64) {
         productVariationListViewModel = getVariationsViewModel(for: productOrVariationID)
+        isShowingProductVariationList = productVariationListViewModel != nil
     }
 
     private func variableProduct(for productID: Int64) -> Product? {

--- a/WooCommerce/Classes/ViewRelated/Products/ProductSelector/ProductSelectorViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductSelector/ProductSelectorViewModel.swift
@@ -214,6 +214,10 @@ final class ProductSelectorViewModel: ObservableObject {
 
     private var orderSyncState: Published<OrderSyncState>.Publisher?
 
+    @Published var isShowingProductVariationList: Bool = false
+
+    @Published var productVariationListViewModel: ProductVariationSelectorViewModel? = nil
+
     init(siteID: Int64,
          selectedItemIDs: [Int64] = [],
          purchasableItemsOnly: Bool = false,
@@ -323,12 +327,42 @@ final class ProductSelectorViewModel: ObservableObject {
         }
     }
 
-    /// Get the view model for a list of product variations to add to the order
-    ///
-    func getVariationsViewModel(for productID: Int64) -> ProductVariationSelectorViewModel? {
-        guard let variableProduct = products.first(where: { $0.productID == productID }), variableProduct.variations.isNotEmpty else {
+    func isVariableProduct(productOrVariationID: Int64) -> Bool {
+        return variableProduct(for: productOrVariationID) != nil
+    }
+
+    func variationCheckboxTapped(for productOrVariationID: Int64) {
+        guard let variationListViewModel = getVariationsViewModel(for: productOrVariationID) else {
+            return
+        }
+        toggleSelectionForAllVariations(of: productOrVariationID)
+        // Display the variations list if toggleSelectionForAllVariations is not allowed
+        if !toggleAllVariationsOnSelection {
+            isShowingProductVariationList.toggle()
+            productVariationListViewModel = variationListViewModel
+        }
+    }
+
+    func variationRowTapped(for productOrVariationID: Int64) {
+        isShowingProductVariationList.toggle()
+        productVariationListViewModel = getVariationsViewModel(for: productOrVariationID)
+    }
+
+    private func variableProduct(for productID: Int64) -> Product? {
+        guard let variableProduct = products.first(where: { $0.productID == productID }), 
+                variableProduct.variations.isNotEmpty else {
             return nil
         }
+        return variableProduct
+    }
+
+    /// Get the view model for a list of product variations to add to the order
+    ///
+    private func getVariationsViewModel(for productID: Int64) -> ProductVariationSelectorViewModel? {
+        guard let variableProduct = variableProduct(for: productID) else {
+            return nil
+        }
+
         let selectedItems = selectedItemsIDs.filter { variableProduct.variations.contains($0) }
         return ProductVariationSelectorViewModel(siteID: siteID,
                                                  product: variableProduct,

--- a/WooCommerce/Classes/ViewRelated/Products/ProductSelector/ProductSelectorViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductSelector/ProductSelectorViewModel.swift
@@ -349,7 +349,7 @@ final class ProductSelectorViewModel: ObservableObject {
     }
 
     private func variableProduct(for productID: Int64) -> Product? {
-        guard let variableProduct = products.first(where: { $0.productID == productID }), 
+        guard let variableProduct = products.first(where: { $0.productID == productID }),
                 variableProduct.variations.isNotEmpty else {
             return nil
         }

--- a/WooCommerce/Classes/ViewRelated/Products/ProductSelector/ProductVariationSelectorView.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductSelector/ProductVariationSelectorView.swift
@@ -92,6 +92,7 @@ struct ProductVariationSelectorView: View {
             // Minimal back button
             ToolbarItem(placement: .navigationBarLeading) {
                 Button {
+                    onMultipleSelections?(viewModel.selectedProductVariationIDs)
                     presentation.wrappedValue.dismiss()
                 } label: {
                     Image(uiImage: .chevronLeftImage).flipsForRightToLeftLayoutDirection(true)
@@ -101,9 +102,6 @@ struct ProductVariationSelectorView: View {
         }
         .onAppear {
             viewModel.onLoadTrigger.send()
-        }
-        .onDisappear {
-            onMultipleSelections?(viewModel.selectedProductVariationIDs)
         }
         .notice($viewModel.notice, autoDismiss: false)
         .interactiveDismissDisabled()

--- a/WooCommerce/Classes/ViewRelated/Products/ProductSelector/ProductVariationSelectorViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductSelector/ProductVariationSelectorViewModel.swift
@@ -216,6 +216,10 @@ final class ProductVariationSelectorViewModel: ObservableObject {
         selectedProductVariationIDs = []
         onSelectionsCleared?()
     }
+
+    func removeSelection(_ productVariationID: Int64) {
+        selectedProductVariationIDs = selectedProductVariationIDs.filter { $0 != productVariationID}
+    }
 }
 
 // MARK: - SyncingCoordinatorDelegate & Sync Methods

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/ProductSelectorViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/ProductSelectorViewModelTests.swift
@@ -538,33 +538,72 @@ final class ProductSelectorViewModelTests: XCTestCase {
         XCTAssertEqual(selectedProducts, [product.productID])
     }
 
-    func test_getVariationsViewModel_returns_expected_view_model_for_variable_product() throws {
+    func test_variationRowTapped_sets_expected_view_model_for_variable_product() throws {
         // Given
         let product = Product.fake().copy(siteID: sampleSiteID, productID: 1, name: "Test Product", purchasable: true, variations: [1, 2])
         insert(product)
         let viewModel = ProductSelectorViewModel(siteID: sampleSiteID,
-                                                   storageManager: storageManager)
+                                                 storageManager: storageManager)
 
         // When
-        let variationsViewModel = viewModel.getVariationsViewModel(for: product.productID)
+        viewModel.variationRowTapped(for: product.productID)
 
         // Then
+        let variationsViewModel = viewModel.productVariationListViewModel
         let actualViewModel = try XCTUnwrap(variationsViewModel)
         XCTAssertEqual(actualViewModel.productName, product.name)
+        XCTAssertTrue(viewModel.isShowingProductVariationList)
     }
 
-    func test_getVariationsViewModel_returns_nil_for_simple_product() {
+    func test_variationRowTapped_sets_nil_for_simple_product() {
         // Given
         let product = Product.fake().copy(siteID: sampleSiteID, productID: 1, name: "Test Product", purchasable: true)
         insert(product)
         let viewModel = ProductSelectorViewModel(siteID: sampleSiteID,
-                                                   storageManager: storageManager)
+                                                 storageManager: storageManager)
 
         // When
-        let variationsViewModel = viewModel.getVariationsViewModel(for: product.productID)
+        viewModel.variationRowTapped(for: product.productID)
 
         // Then
+        let variationsViewModel = viewModel.productVariationListViewModel
         XCTAssertNil(variationsViewModel)
+        XCTAssertFalse(viewModel.isShowingProductVariationList)
+    }
+
+    func test_variationCheckboxTapped_sets_expected_view_model_for_variable_product() throws {
+        // Given
+        let product = Product.fake().copy(siteID: sampleSiteID, productID: 1, name: "Test Product", purchasable: true, variations: [1, 2])
+        insert(product)
+        let viewModel = ProductSelectorViewModel(siteID: sampleSiteID,
+                                                 storageManager: storageManager,
+                                                 toggleAllVariationsOnSelection: false)
+
+        // When
+        viewModel.variationCheckboxTapped(for: product.productID)
+
+        // Then
+        let variationsViewModel = viewModel.productVariationListViewModel
+        let actualViewModel = try XCTUnwrap(variationsViewModel)
+        XCTAssertEqual(actualViewModel.productName, product.name)
+        XCTAssertTrue(viewModel.isShowingProductVariationList)
+    }
+
+    func test_variationCheckboxTapped_sets_nil_for_simple_product() {
+        // Given
+        let product = Product.fake().copy(siteID: sampleSiteID, productID: 1, name: "Test Product", purchasable: true)
+        insert(product)
+        let viewModel = ProductSelectorViewModel(siteID: sampleSiteID,
+                                                 storageManager: storageManager,
+                                                 toggleAllVariationsOnSelection: false)
+
+        // When
+        viewModel.variationCheckboxTapped(for: product.productID)
+
+        // Then
+        let variationsViewModel = viewModel.productVariationListViewModel
+        XCTAssertNil(variationsViewModel)
+        XCTAssertFalse(viewModel.isShowingProductVariationList)
     }
 
     func test_selecting_a_product_if_supportsMultipleSelection_is_true_and_selectProduct_is_invoked_sets_its_row_to_selected_state() {

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/ProductSelectorViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/ProductSelectorViewModelTests.swift
@@ -584,8 +584,7 @@ final class ProductSelectorViewModelTests: XCTestCase {
 
         // Then
         let variationsViewModel = viewModel.productVariationListViewModel
-        let actualViewModel = try XCTUnwrap(variationsViewModel)
-        XCTAssertEqual(actualViewModel.productName, product.name)
+        XCTAssertEqual(variationsViewModel?.productName, product.name)
         XCTAssertTrue(viewModel.isShowingProductVariationList)
     }
 


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #11932
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

When a variable product is removed from the order using the button in the order summary, we need to show that accurately in the variation list as well, to avoid confusing the merchant.

When the variation list was open, previously we did not update the selection effectively – it would only be updated if the list was closed and reopened.

This PR ensures the selections are kept in sync even when the list is open, by accessing the active variation list view model and removing the selection there.

In this PR, we:
1. Move the storage of the state for whether/which variation list is open from the ProductSelectorView, to its view model.
2. Call `removeSelection` with the appropriate variation ID when a user taps `Remove product from order` in the order summary.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

1. Enable the `sideBySideViewForOrderForm` feature flag
2. Launch the app on an iPad or large iPhone in landscape
3. Navigate to `Orders`, and tap `+`
4. Tap on a variable product
5. Add a variation to your order – observe that it shows as selected in the list
6. Expand the variation in the OrderSummary
7. Tap `Remove product from order`
8. Observe that the variation is no longer selected in the list

### Test coupons:
1. Enable the `sideBySideViewForOrderForm` feature flag
2. Launch the app and navigate to `Menu > Coupons`
3. Add a coupon
4. Select Product coupon
5. Tap `All Products`
6. Tap a checkbox for a variable product
7. Observe that all the variations are selected
8. Tap the row for the variable product
9. Change how many are selected
10. Tap back
11. Observe that the variation selection state is `-`, and the correct number of products is mentioned in the button.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

https://github.com/woocommerce/woocommerce-ios/assets/2472348/b23da6bf-466f-4846-ad5d-529c98b07545



---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
