### PR TITLE
Connectivity Tool: Improve accessibility

### DIFF
--- a/Networking/Networking/Network/AlamofireNetwork.swift
+++ b/Networking/Networking/Network/AlamofireNetwork.swift
@@ -18,6 +18,7 @@ public class AlamofireNetwork: Network {
 
     private lazy var sessionManager: Alamofire.SessionManager = {
         let sessionConfiguration = URLSessionConfiguration.default
+        sessionConfiguration.timeoutIntervalForRequest = 1
         let sessionManager = makeSessionManager(configuration: sessionConfiguration)
         return sessionManager
     }()

--- a/Networking/Networking/Network/AlamofireNetwork.swift
+++ b/Networking/Networking/Network/AlamofireNetwork.swift
@@ -18,7 +18,6 @@ public class AlamofireNetwork: Network {
 
     private lazy var sessionManager: Alamofire.SessionManager = {
         let sessionConfiguration = URLSessionConfiguration.default
-        sessionConfiguration.timeoutIntervalForRequest = 1
         let sessionManager = makeSessionManager(configuration: sessionConfiguration)
         return sessionManager
     }()

--- a/WooCommerce/Classes/ViewRelated/Connectivity Tool/ConnectivityTool.swift
+++ b/WooCommerce/Classes/ViewRelated/Connectivity Tool/ConnectivityTool.swift
@@ -71,19 +71,23 @@ struct ConnectivityTool: View {
     var body: some View {
         VStack(alignment: .center, spacing: .zero) {
 
-            ForEach(cards, id: \.title) { card in
-                ConnectivityToolCard(icon: card.icon, title: card.title, state: card.state)
-            }
-
             Spacer()
+
+            ScrollView {
+                ForEach(cards, id: \.title) { card in
+                    ConnectivityToolCard(icon: card.icon, title: card.title, state: card.state)
+                }
+            }
+            .padding(.horizontal)
+
+            Divider()
 
             Button(Localization.contactSupport) {
                 onContactSupportTapped?()
             }
             .buttonStyle(PrimaryButtonStyle())
+            .padding()
         }
-        .frame(maxWidth: .greatestFiniteMagnitude, maxHeight: .greatestFiniteMagnitude, alignment: .topLeading)
-        .padding()
         .background(Color(uiColor: .listBackground))
     }
 }
@@ -176,6 +180,7 @@ struct ConnectivityToolCard: View {
     @ScaledMetric private var iconSize = 40.0
     private static let cornerRadius = 4.0
     private static let verticalSpacing = 16.0
+    private static let cardSpacing = 8.0
 
     var body: some View {
         VStack(spacing: Self.verticalSpacing) {
@@ -212,7 +217,9 @@ struct ConnectivityToolCard: View {
         .padding()
         .background(Color(uiColor: .listForeground(modal: false)))
         .cornerRadius(Self.cornerRadius)
-        .padding()
+        .padding(.horizontal)
+        .padding(.vertical, Self.cardSpacing)
+
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Connectivity Tool/ConnectivityTool.swift
+++ b/WooCommerce/Classes/ViewRelated/Connectivity Tool/ConnectivityTool.swift
@@ -80,7 +80,7 @@ struct ConnectivityTool: View {
             }
             .padding(.horizontal)
 
-            Divider()
+            Divider().ignoresSafeArea()
 
             Button(Localization.contactSupport) {
                 onContactSupportTapped?()
@@ -207,6 +207,7 @@ struct ConnectivityToolCard: View {
                     .foregroundColor(Color(uiColor: .error))
                     .subheadlineStyle()
                     .padding(.horizontal, 6)
+                    .frame(maxWidth: .infinity, alignment: .leading)
 
                 if let buttonAction {
                     Button(buttonAction.title, action: buttonAction.action)
@@ -230,7 +231,8 @@ struct ConnectivityToolCard: View {
             .init(title: "WordPress.com servers", icon: .system("server.rack"), state: .success),
             .init(title: "Your Site",
                   icon: .system("storefront"),
-                  state: .error("Your site is not responding properly\nPlease reach out to your host for further assistance", nil)),
+                  state: .error("Your site is not responding properly\nPlease reach out to your host for further assistance",
+                    .init(title: "Read More", action: {}))),
             .init(title: "Your site orders", icon: .system("list.clipboard"), state: .inProgress)
         ])
             .navigationTitle("Connectivity Test")


### PR DESCRIPTION
Closes: #12082 

# Why

This PR improves the accessibility of the Connectivity Tool.

# Screenshot

Light | Dark
--- | ---
![ligh](https://github.com/woocommerce/woocommerce-ios/assets/562080/d27437e1-3fe2-455f-a426-817d9630a079) | ![dark](https://github.com/woocommerce/woocommerce-ios/assets/562080/686c537e-04eb-4816-949d-60d7402aaf29)

Landscape | Big Fonts
--- | ---
![big-font](https://github.com/woocommerce/woocommerce-ios/assets/562080/ffb71407-2dd4-45ca-abc5-ff16fedc4936) | ![landscape](https://github.com/woocommerce/woocommerce-ios/assets/562080/d9a0b03c-d1ea-4989-9b4c-77ee1311ed28)


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
