### PR TITLE
Order Details: Support contacting customers through Whatsapp or Telegram

### DIFF
--- a/WooCommerce/Classes/Analytics/WooAnalyticsStat.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsStat.swift
@@ -384,6 +384,8 @@ public enum WooAnalyticsStat: String {
     case orderDetailCustomerPhoneOptionTapped = "order_detail_customer_info_phone_menu_phone_tapped"
     case orderDetailCustomerSMSOptionTapped = "order_detail_customer_info_phone_menu_sms_tapped"
     case orderDetailCustomerCopyNumberOptionTapped = "order_detail_customer_info_phone_menu_copy_tapped"
+    case orderDetailCustomerWhatsappOptionTapped = "order_detail_customer_info_phone_menu_whatsapp_tapped"
+    case orderDetailCustomerTelegramOptionTapped = "order_detail_customer_info_phone_menu_telegram_tapped"
     case orderDetailOrderStatusEditButtonTapped = "order_detail_order_status_edit_button_tapped"
     case orderDetailRefundDetailTapped = "order_detail_refund_detail_tapped"
     case orderDetailAddOnsViewed = "order_detail_addons_viewed"

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Customer Section/Billing Information/BillingInformationViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Customer Section/Billing Information/BillingInformationViewController.swift
@@ -301,6 +301,7 @@ private extension BillingInformationViewController {
             return
         }
         UIApplication.shared.open(whatsappDeeplink)
+        ServiceLocator.analytics.track(.orderDetailCustomerWhatsappOptionTapped)
     }
 
     private func sendTelegramMessage() {
@@ -308,6 +309,7 @@ private extension BillingInformationViewController {
             return
         }
         UIApplication.shared.open(telegramDeeplink)
+        ServiceLocator.analytics.track(.orderDetailCustomerTelegramOptionTapped)
     }
 }
 

--- a/WooCommerce/Resources/Info.plist
+++ b/WooCommerce/Resources/Info.plist
@@ -55,6 +55,7 @@
 		<string>readdle-spark</string>
 		<string>ymail</string>
 		<string>fastmail</string>
+		<string>whatsapp</string>
 	</array>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>

--- a/WooCommerce/Resources/Info.plist
+++ b/WooCommerce/Resources/Info.plist
@@ -56,6 +56,7 @@
 		<string>ymail</string>
 		<string>fastmail</string>
 		<string>whatsapp</string>
+		<string>tg</string>
 	</array>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #12088 
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This PR adds the option to contact customers through Whatsapp and Telegram using their phone numbers if the apps are available in the device.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
- Build the app to a physical device with Whatsapp and Telegram enabled.
- Place an order to your test site through the web or the app, with billing information containing a phone number that exists in those 2 apps.
- Log in to your store on the app and open the newly created order.
- Select Billing Information in the order details screen.
- Tap the phone number, notice that there are two new options for sending Whatsapp and Telegram message.
- Tap the Whatsapp option, notice that the event `order_detail_customer_info_phone_menu_whatsapp_tapped` is logged on the Xcode console. The Whatsapp app should be opened with the chat window with the billing info phone number.
- Repeat the test with the Telegram option, you should find the event `order_detail_customer_info_phone_menu_telegram_tapped` logged on the Xcode console. The Telegram app should be opened with a chat window with the phone number if the number exists on Telegram.

Test again on a simulator or a device without one or both of the apps. Confirm that the options are not available if the apps are not installed.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->
<img src="https://github.com/woocommerce/woocommerce-ios/assets/5533851/96af6027-940e-403f-ac59-04634b60da8b" width=320 />


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
