### PR TITLE
[Tablet Products] Show discard changes alert if the product form has unsaved changes and the user triggers product selection/creation

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormPresentationStyle.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormPresentationStyle.swift
@@ -13,16 +13,18 @@ enum ProductFormPresentationStyle {
 extension ProductFormPresentationStyle {
     /// Determines how a product form view controller exits.
     /// - Parameter viewController: the product form view controller that is about to exit.
+    /// - Parameter completion: called when the exit logic is complete.
     /// - Returns: a closure to be called that exits the product form.
-    func createExitForm(viewController: UIViewController) -> (() -> Void) {
+    func createExitForm(viewController: UIViewController, completion: @escaping () -> Void = {}) -> (() -> Void) {
         switch self {
         case .contained:
             return {
-                viewController.dismiss(animated: true, completion: nil)
+                viewController.dismiss(animated: true, completion: completion)
             }
         case .navigationStack:
             return {
                 viewController.navigationController?.popViewController(animated: true)
+                completion()
             }
         }
     }

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewController.swift
@@ -286,12 +286,21 @@ final class ProductFormViewController<ViewModel: ProductFormViewModelProtocol>: 
 
     // MARK: Navigation actions
 
-    @objc func closeNavigationBarButtonTapped() {
+    /// Closes the product form if the product has no unsaved changes or the user chooses to discard the changes.
+    /// - Parameters:
+    ///   - completion: Called when the product form is closed.
+    ///   - onCancel: Called when the user chooses not to close the form from the confirmation alert.
+    func close(completion: @escaping () -> Void = {}, onCancel: @escaping () -> Void = {}) {
         guard viewModel.hasUnsavedChanges() == false else {
-            presentBackNavigationActionSheet()
+            presentBackNavigationActionSheet(onDiscard: completion, onCancel: onCancel)
             return
         }
         exitForm()
+        completion()
+    }
+
+    @objc private func closeNavigationBarButtonTapped() {
+        close()
     }
 
     // MARK: Action Sheet
@@ -1259,18 +1268,26 @@ extension ProductFormViewController: KeyboardScrollable {
 // MARK: - Navigation actions handling
 //
 private extension ProductFormViewController {
-    func presentBackNavigationActionSheet() {
+    func presentBackNavigationActionSheet(onDiscard: @escaping () -> Void = {}, onCancel: @escaping () -> Void = {}) {
+        let exitForm: () -> Void = {
+            presentationStyle.createExitForm(viewController: self, completion: onDiscard)
+        }()
         switch viewModel.formType {
         case .add:
             UIAlertController.presentDiscardNewProductActionSheet(viewController: self,
                                                                   onSaveDraft: { [weak self] in
-                                                                    self?.saveProductAsDraft()
-                }, onDiscard: { [weak self] in
-                    self?.exitForm()
+                self?.saveProductAsDraft()
+            }, onDiscard: {
+                exitForm()
+            }, onCancel: {
+                onCancel()
             })
         case .edit:
-            UIAlertController.presentDiscardChangesActionSheet(viewController: self, onDiscard: { [weak self] in
-                self?.exitForm()
+            UIAlertController.presentDiscardChangesActionSheet(viewController: self,
+                                                               onDiscard: {
+                exitForm()
+            }, onCancel: {
+                onCancel()
             })
         case .readonly:
             break

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewController.swift
@@ -1272,9 +1272,10 @@ private extension ProductFormViewController {
         let exitForm: () -> Void = {
             presentationStyle.createExitForm(viewController: self, completion: onDiscard)
         }()
+        let viewControllerToPresentAlert = navigationController?.topViewController ?? self
         switch viewModel.formType {
         case .add:
-            UIAlertController.presentDiscardNewProductActionSheet(viewController: self,
+            UIAlertController.presentDiscardNewProductActionSheet(viewController: viewControllerToPresentAlert,
                                                                   onSaveDraft: { [weak self] in
                 self?.saveProductAsDraft()
             }, onDiscard: {
@@ -1283,7 +1284,7 @@ private extension ProductFormViewController {
                 onCancel()
             })
         case .edit:
-            UIAlertController.presentDiscardChangesActionSheet(viewController: self,
+            UIAlertController.presentDiscardChangesActionSheet(viewController: viewControllerToPresentAlert,
                                                                onDiscard: {
                 exitForm()
             }, onCancel: {

--- a/WooCommerce/Classes/ViewRelated/Products/ProductsSplitViewCoordinator.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductsSplitViewCoordinator.swift
@@ -67,9 +67,9 @@ private extension ProductsSplitViewCoordinator {
     func showFromProductList(content: ProductsViewController.NavigationContentType) {
         switch content {
             case let .productForm(product):
-                showProductForm(product: product)
+                showProductFormIfNoUnsavedChanges(product: product)
             case let .addProduct(sourceView, isFirstProduct):
-                startProductCreation(sourceView: sourceView, isFirstProduct: isFirstProduct)
+                startProductCreationIfNoUnsavedChanges(sourceView: sourceView, isFirstProduct: isFirstProduct)
         }
     }
 }
@@ -84,6 +84,12 @@ private extension ProductsSplitViewCoordinator {
         showSecondaryView(contentType: .empty, viewController: emptyStateViewController, replacesNavigationStack: true)
     }
 
+    func showProductFormIfNoUnsavedChanges(product: Product) {
+        whenSecondaryViewProductHasNoUnsavedChanges { [weak self] in
+            self?.showProductForm(product: product)
+        }
+    }
+
     func showProductForm(product: Product) {
         ProductDetailsFactory.productDetails(product: product,
                                              presentationStyle: .navigationStack,
@@ -95,15 +101,20 @@ private extension ProductsSplitViewCoordinator {
         }
     }
 
+    func startProductCreationIfNoUnsavedChanges(sourceView: AddProductCoordinator.SourceView, isFirstProduct: Bool) {
+        whenSecondaryViewProductHasNoUnsavedChanges { [weak self] in
+            self?.startProductCreation(sourceView: sourceView, isFirstProduct: isFirstProduct)
+        }
+    }
+
     func startProductCreation(sourceView: AddProductCoordinator.SourceView, isFirstProduct: Bool) {
-        let replacesNavigationStack = contentTypes.last == .empty
         let addProductCoordinator = AddProductCoordinator(siteID: siteID,
                                                           source: .productsTab,
                                                           sourceView: sourceView,
                                                           sourceNavigationController: primaryNavigationController,
                                                           isFirstProduct: isFirstProduct,
                                                           navigateToProductForm: { [weak self] viewController in
-            self?.showSecondaryView(contentType: .productForm(product: nil), viewController: viewController, replacesNavigationStack: replacesNavigationStack)
+            self?.showSecondaryView(contentType: .productForm(product: nil), viewController: viewController, replacesNavigationStack: true)
         }, onDeleteCompletion: { [weak self] in
             self?.onSecondaryProductFormDeletion()
         })
@@ -113,6 +124,24 @@ private extension ProductsSplitViewCoordinator {
         }
         addProductCoordinator.start()
         self.addProductCoordinator = addProductCoordinator
+    }
+
+    func whenSecondaryViewProductHasNoUnsavedChanges(then closure: @escaping () -> Void) {
+        // Closes the product form in the secondary view only if there are no unsaved changes or if the user chooses to discard the changes.
+        // This works based on the assumption that there is only one product form in the secondary navigation stack.
+        if let lastProductFormViewController = secondaryNavigationController.viewControllers
+            .compactMap({ $0 as? ProductFormViewController<ProductFormViewModel> }).last {
+            return lastProductFormViewController.close(completion: {
+                closure()
+            }, onCancel: { [weak self] in
+                guard let self else { return }
+                // Reassigns the secondary content types to trigger product list row selection to re-select the product in the secondary view.
+                // Otherwise, the most recently tapped row is selected in the table view.
+                contentTypes = contentTypes
+            })
+        } else {
+            closure()
+        }
     }
 
     func showSecondaryView(contentType: SecondaryViewContentType, viewController: UIViewController, replacesNavigationStack: Bool) {


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #12086 
Closes: #12114
<!-- Id number of the GitHub issue this PR addresses. -->

## Why

When the merchant has some unsaved changes in the product form in the secondary column, they can tap on a different product row or start product creation in the primary column when the split view is shown, intentionally or not. To prevent the frustrating scenario when the replacement by a different product isn't intentional, we'd like to show a confirmation alert for the merchant to confirm whether to discard the unsaved changes or not before replacing the secondary view with the new product form.

## How

The product form already has a similar UX to check for unsaved changes when navigating back by either tapping the navigation bar back button or swiping back (this doesn't seem to work from my testing but it's a pre-existing/separate issue that I'll log it later). This PR reuses the same UX by opening up `close` function to attempt to exit the product form in the secondary view, and show an alert when there are any unsaved changes. This is followed by 2 outcomes:

- When the user chooses to discard the unsaved changes by tapping `Discard changes` explicitly, it goes ahead and replaces the secondary view with the newly selected product or starts the product creation flow
- When the user taps outside of the alert, it cancels the selection/product creation

If there are no unsaved changes, the alert won't be shown.

I couldn't find a better way to know whether there are unsaved changes in a product form in the secondary view, please feel free to share any other suggestions.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

- [x] @jaclync tests on iPhone

Prerequisite: the device/simulator allows switching between expanded and collapsed states like a tablet

### Select product

- In code, enable `splitViewInProductsTab` feature flag in `DefaultFeatureFlagService`
- Launch the app
- Go to the products tab
- Tap on a product
- In the product form in the secondary view, make some changes to the product like the name --> `Save` CTA should be shown
- Tap on a different product in the product list --> an alert should be shown (🗒️ if you navigate to any details editing view like the description/price/inventory page, the alert can be shown at an odd place instead of on top of the product form. I'll look into this issue separately)
- Tap `Discard changes` --> the newly selected product should be shown
- Make some changes to the product like the name
- Tap on a different product in the product list --> an alert should be shown
- Tap anywhere outside of the alert --> it should stay on the product form and the the same product should be re-selected in the product list

### Create product

- Launch the app
- Go to the products tab
- Tap on a product
- In the product form in the secondary view, make some changes to the product like the name
- Tap on + to create a product --> an alert should be shown
- Tap `Discard changes` --> it should start the product creation flow that eventually replaces the product form
- Tap on a product in the product list
- Make some changes to the product like the name
- Tap on + to create a product --> an alert should be shown
- Tap anywhere outside of the alert --> it should stay on the product form and the the same product should be re-selected in the product list

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->


https://github.com/woocommerce/woocommerce-ios/assets/1945542/9bb1660f-ae88-4d46-8c87-a8e94bae6ae6

🗒️ Known issue:

If the alert is triggered when the product form is on a subpage (not the root view in the navigation stack), the alert is shown in an odd location

<img src="https://github.com/woocommerce/woocommerce-ios/assets/1945542/6b37b142-3d0d-4b99-a1fe-eff9b1313236" width="500" />

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
