### PR TITLE
Blaze campaign edit view is shown in split view without any secondary view when split view is enabled

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Blaze/BlazeEditAd/BlazeEditAdView.swift
+++ b/WooCommerce/Classes/ViewRelated/Blaze/BlazeEditAd/BlazeEditAdView.swift
@@ -63,6 +63,7 @@ struct BlazeEditAdView: View {
             .wooNavigationBarStyle()
             .navigationBarTitleDisplayMode(.inline)
         }
+        .navigationViewStyle(StackNavigationViewStyle())
     }
 }
 


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #12104
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
Set **navigationViewStyle** to **StackNavigationViewStyle** for Blaze edit ad view

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

- Go to the products tab
- Tap Promote with Blaze
- Tap Edit ad
- Edit ad view should be presented normally/modally, and not with split view 

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

![Simulator Screen Recording - iPad Pro (11-inch) (4th generation) - 2024-02-26 at 10 44 29](https://github.com/woocommerce/woocommerce-ios/assets/6242034/9eb1426d-5d3a-470e-a123-07d4e61306f8)

---
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
