### PR TITLE
[Tablet Orders] Remove the splitViewInOrdersTab feature flag

### DIFF
--- a/Experiments/Experiments/DefaultFeatureFlagService.swift
+++ b/Experiments/Experiments/DefaultFeatureFlagService.swift
@@ -13,8 +13,6 @@ public struct DefaultFeatureFlagService: FeatureFlagService {
         switch featureFlag {
         case .inbox:
             return buildConfig == .localDeveloper || buildConfig == .alpha
-        case .splitViewInOrdersTab:
-            return true
         case .sideBySideViewForOrderForm:
             return false
         case .updateOrderOptimistically:

--- a/Experiments/Experiments/FeatureFlag.swift
+++ b/Experiments/Experiments/FeatureFlag.swift
@@ -18,10 +18,6 @@ public enum FeatureFlag: Int {
     ///
     case inbox
 
-    /// Displays the Orders tab in a split view
-    ///
-    case splitViewInOrdersTab
-
     /// Displays the OrderForm side by side with the Product Selector
     ///
     case sideBySideViewForOrderForm

--- a/WooCommerce/Classes/Extensions/UITabBar+Appearance.swift
+++ b/WooCommerce/Classes/Extensions/UITabBar+Appearance.swift
@@ -10,11 +10,10 @@ extension UITabBar {
         let appearance = Self.appearance()
         appearance.barTintColor = .appTabBar
         appearance.tintColor = .accent
-        if ServiceLocator.featureFlagService.isFeatureFlagEnabled(.splitViewInOrdersTab) {
-            // tab bar needs to be translucent to get rid of the extra space at the bottom of
-            // the view controllers embedded in split view.
-            appearance.isTranslucent = true
-        }
+
+        // tab bar needs to be translucent to get rid of the extra space at the bottom of
+        // the view controllers embedded in split view.
+        appearance.isTranslucent = true
 
         /// iOS 13.0 and 13.1 doesn't render the tabbar shadow color correctly while in dark mode.
         /// To fix it, we have to specifically set it in the `standardAppearance` object.

--- a/WooCommerce/Classes/System/WooNavigationController.swift
+++ b/WooCommerce/Classes/System/WooNavigationController.swift
@@ -138,15 +138,11 @@ private extension WooNavigationControllerDelegate {
         view.addSubview(offlineBannerView)
 
         let extraBottomSpace: CGFloat
-        if ServiceLocator.featureFlagService.isFeatureFlagEnabled(.splitViewInOrdersTab) {
-            // When split view is enabled, we're using a translucent tab bar.
-            // So when tab bar is visible, the bottom safe area is non-zero and we need to display content based on that.
-            extraBottomSpace = navigationController.view.safeAreaInsets.bottom
-        } else {
-            // With an opaque tab bar, all contents are displayed above it,
-            // so we don't need to care about the bottom safe area, only when the tab bar is hidden.
-            extraBottomSpace = viewController.hidesBottomBarWhenPushed ? navigationController.view.safeAreaInsets.bottom : 0
-        }
+
+        // When split view is enabled, we're using a translucent tab bar.
+        // So when tab bar is visible, the bottom safe area is non-zero and we need to display content based on that.
+        extraBottomSpace = navigationController.view.safeAreaInsets.bottom
+
         NSLayoutConstraint.activate([
             offlineBannerView.heightAnchor.constraint(equalToConstant: OfflineBannerView.height),
             offlineBannerView.leadingAnchor.constraint(equalTo: view.leadingAnchor),

--- a/WooCommerce/Classes/ViewRelated/MainTabBarController.swift
+++ b/WooCommerce/Classes/ViewRelated/MainTabBarController.swift
@@ -87,13 +87,6 @@ final class MainTabBarController: UITabBarController {
     private let dashboardNavigationController = WooTabNavigationController()
     private let ordersContainerController = TabContainerController()
 
-    /// Unfortunately, we can't use the above container to directly hold a WooTabNavigationController, due to
-    /// a longstanding bug where a black bar equal to the tab bar height is shown when a nav controller
-    /// is shown as an embedded vc in a tab. See link for details, but the solutions don't work here.
-    /// https://stackoverflow.com/questions/28608817/uinavigationcontroller-embedded-in-a-container-view-displays-a-table-view-contr
-    // remove when .splitViewInOrdersTab is removed.
-    private let ordersNavigationController = WooTabNavigationController()
-
     private let productsContainerController = TabContainerController()
 
     /// Unfortunately, we can't use the above container to directly hold a WooTabNavigationController, due to
@@ -116,7 +109,6 @@ final class MainTabBarController: UITabBarController {
 
     private var productImageUploadErrorsSubscription: AnyCancellable?
 
-    private lazy var isOrdersSplitViewFeatureFlagOn = featureFlagService.isFeatureFlagEnabled(.splitViewInOrdersTab)
     private lazy var isProductsSplitViewFeatureFlagOn = featureFlagService.isFeatureFlagEnabled(.splitViewInProductsTab)
 
     init?(coder: NSCoder,
@@ -382,11 +374,7 @@ extension MainTabBarController {
         switch note.kind {
         case .storeOrder:
             switchToOrdersTab {
-                if ServiceLocator.featureFlagService.isFeatureFlagEnabled(.splitViewInOrdersTab) {
-                    ordersTabSplitViewWrapper()?.presentDetails(for: note)
-                } else {
-                    (childViewController() as? OrdersRootViewController)?.presentDetails(for: note)
-                }
+                ordersTabSplitViewWrapper()?.presentDetails(for: note)
             }
         default:
             break
@@ -446,11 +434,7 @@ extension MainTabBarController {
     }
 
     private static func presentDetails(for orderID: Int64, siteID: Int64) {
-        if ServiceLocator.featureFlagService.isFeatureFlagEnabled(.splitViewInOrdersTab) {
-            ordersTabSplitViewWrapper()?.presentDetails(for: orderID, siteID: siteID)
-        } else {
-            (childViewController() as? OrdersRootViewController)?.presentDetails(for: orderID, siteID: siteID)
-        }
+        ordersTabSplitViewWrapper()?.presentDetails(for: orderID, siteID: siteID)
     }
 
     private static func ordersTabSplitViewWrapper() -> OrdersSplitViewWrapperController? {
@@ -525,7 +509,7 @@ private extension MainTabBarController {
             case .myStore:
                 return dashboardNavigationController
             case .orders:
-                return isOrdersSplitViewFeatureFlagOn ? ordersContainerController: ordersNavigationController
+                return ordersContainerController
             case .products:
                 return isProductsSplitViewFeatureFlagOn ? productsContainerController: productsNavigationController
             case .hubMenu:
@@ -554,12 +538,7 @@ private extension MainTabBarController {
         let dashboardViewController = createDashboardViewController(siteID: siteID)
         dashboardNavigationController.viewControllers = [dashboardViewController]
 
-        let ordersViewController = createOrdersViewController(siteID: siteID)
-        if isOrdersSplitViewFeatureFlagOn {
-            ordersContainerController.wrappedController = ordersViewController
-        } else {
-            ordersNavigationController.viewControllers = [ordersViewController]
-        }
+        ordersContainerController.wrappedController = createOrdersViewController(siteID: siteID)
 
         if isProductsSplitViewFeatureFlagOn {
             productsContainerController.wrappedController = ProductsSplitViewWrapperController(siteID: siteID)
@@ -588,11 +567,7 @@ private extension MainTabBarController {
     }
 
     func createOrdersViewController(siteID: Int64) -> UIViewController {
-        if isOrdersSplitViewFeatureFlagOn {
-            return OrdersSplitViewWrapperController(siteID: siteID)
-        } else {
-            return OrdersRootViewController(siteID: siteID, switchDetailsHandler: { _, _, _, _ in })
-        }
+        OrdersSplitViewWrapperController(siteID: siteID)
     }
 
     func createHubMenuTabCoordinator() -> HubMenuCoordinator {

--- a/WooCommerce/Classes/ViewRelated/Orders/Cells/OrderTableViewCell.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Cells/OrderTableViewCell.swift
@@ -97,9 +97,6 @@ final class OrderTableViewCell: UITableViewCell & SearchResultCell {
 
     override func updateConfiguration(using state: UICellConfigurationState) {
         super.updateConfiguration(using: state)
-        guard ServiceLocator.featureFlagService.isFeatureFlagEnabled(.splitViewInOrdersTab) else {
-            return
-        }
         updateDefaultBackgroundConfiguration(using: state)
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/EditableOrderViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/EditableOrderViewModel.swift
@@ -83,9 +83,6 @@ final class EditableOrderViewModel: ObservableObject {
     /// Indicates whether the cancel button is visible.
     ///
     var shouldShowCancelButton: Bool {
-        guard featureFlagService.isFeatureFlagEnabled(.splitViewInOrdersTab) else {
-            return false
-        }
         // The cancel button is handled by the AdaptiveModalContainer with the side-by-side view enabled, so this one should not be shown.
         guard !featureFlagService.isFeatureFlagEnabled(.sideBySideViewForOrderForm) else {
             return false

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/OrderForm.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/OrderForm.swift
@@ -35,15 +35,11 @@ final class OrderFormHostingController: UIHostingController<OrderFormPresentatio
     override func viewDidLoad() {
         super.viewDidLoad()
 
-        if ServiceLocator.featureFlagService.isFeatureFlagEnabled(.splitViewInOrdersTab) {
-            // Set presentation delegate to track the user dismiss flow event
-            if let navigationController = navigationController {
-                navigationController.presentationController?.delegate = self
-            } else {
-                presentationController?.delegate = self
-            }
+        // Set presentation delegate to track the user dismiss flow event
+        if let navigationController = navigationController {
+            navigationController.presentationController?.delegate = self
         } else {
-            handleSwipeBackGesture()
+            presentationController?.delegate = self
         }
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Customer Section/Billing Information/BillingInformationViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Customer Section/Billing Information/BillingInformationViewController.swift
@@ -93,9 +93,6 @@ final class BillingInformationViewController: UIViewController {
     private let emailComposer = OrderEmailComposer()
 
     private let messageComposerPresenter: MessageComposerPresenter = ServiceLocator.messageComposerPresenter
-
-    private let isSplitViewInOrdersTabEnabled: Bool = ServiceLocator.featureFlagService.isFeatureFlagEnabled(.splitViewInOrdersTab)
-
 }
 
 // MARK: - Interface Initialization
@@ -119,10 +116,6 @@ private extension BillingInformationViewController {
     }
 
     func constrainToMaxWidth() {
-        guard isSplitViewInOrdersTabEnabled else {
-            return
-        }
-
         let maxWidthConstraint = tableView.widthAnchor.constraint(lessThanOrEqualToConstant: Constants.maxWidth)
         maxWidthConstraint.priority = .required
         NSLayoutConstraint.activate([maxWidthConstraint])
@@ -500,9 +493,6 @@ private extension BillingInformationViewController {
             telegramAction
         ].compactMap { $0 }
 
-        guard isSplitViewInOrdersTabEnabled else {
-            return
-        }
         cell.showSideBorders(fromWidth: Constants.maxWidth)
     }
 
@@ -537,9 +527,6 @@ private extension BillingInformationViewController {
 
         cell.accessibilityCustomActions = [emailAccessibilityAction, copyEmailAccessibilityAction]
 
-        guard isSplitViewInOrdersTabEnabled else {
-            return
-        }
         cell.showSideBorders(fromWidth: Constants.maxWidth)
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/OrderDetailsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/OrderDetailsViewController.swift
@@ -60,8 +60,6 @@ final class OrderDetailsViewController: UIViewController {
 
     private let currentIndex: Int
 
-    private let isSplitViewInOrdersTabEnabled: Bool = ServiceLocator.featureFlagService.isFeatureFlagEnabled(.splitViewInOrdersTab)
-
     /// Callback closure when a different order is selected like from the quick navigation arrows.
     private let switchDetailsHandler: OrderListViewController.SelectOrderDetails
 
@@ -115,10 +113,6 @@ final class OrderDetailsViewController: UIViewController {
         super.viewDidLayoutSubviews()
         tableView.updateHeaderHeight()
     }
-
-    override var shouldShowOfflineBanner: Bool {
-        !isSplitViewInOrdersTabEnabled
-    }
 }
 
 // MARK: - TableView Configuration
@@ -144,9 +138,6 @@ private extension OrderDetailsViewController {
     }
 
     func configureStackView() {
-        guard isSplitViewInOrdersTabEnabled else {
-            return
-        }
         stackView.layer.borderWidth = Constants.borderWidth
         stackView.layer.borderColor = UIColor.border.cgColor
 
@@ -208,11 +199,6 @@ private extension OrderDetailsViewController {
     }
 
     func loadOrder(with index: Int) {
-        guard isSplitViewInOrdersTabEnabled else {
-            let viewController = OrderDetailsViewController(viewModels: viewModels, currentIndex: index, switchDetailsHandler: switchDetailsHandler)
-            navigationController?.replaceTopViewController(with: viewController, animated: false)
-            return
-        }
         switchDetailsHandler(viewModels, index, true, nil)
     }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Review Order/ReviewOrderViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Review Order/ReviewOrderViewController.swift
@@ -64,13 +64,6 @@ final class ReviewOrderViewController: UIViewController {
         super.viewDidLayoutSubviews()
         tableView.updateFooterHeight()
     }
-
-    override var shouldShowOfflineBanner: Bool {
-        if ServiceLocator.featureFlagService.isFeatureFlagEnabled(.splitViewInOrdersTab) {
-            return false
-        }
-        return true
-    }
 }
 
 // MARK: - UI Configuration

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/ShippingLabelFormViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/ShippingLabelFormViewController.swift
@@ -82,9 +82,6 @@ final class ShippingLabelFormViewController: UIViewController {
     }
 
     override var shouldShowOfflineBanner: Bool {
-        if ServiceLocator.featureFlagService.isFeatureFlagEnabled(.splitViewInOrdersTab) {
-            return false
-        }
         return true
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Orders/OrderListViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrderListViewController.swift
@@ -136,8 +136,6 @@ final class OrderListViewController: UIViewController, GhostableViewController {
     ///
     private var selectedOrderID: Int64?
 
-    private lazy var isSplitViewInOrdersTabEnabled: Bool = ServiceLocator.featureFlagService.isFeatureFlagEnabled(.splitViewInOrdersTab)
-
     /// Tracks if the swipe actions have been glanced to the user.
     ///
     private var swipeActionsGlanced = false
@@ -228,7 +226,7 @@ final class OrderListViewController: UIViewController, GhostableViewController {
 
     override func willTransition(to newCollection: UITraitCollection, with coordinator: UIViewControllerTransitionCoordinator) {
         super.willTransition(to: newCollection, with: coordinator)
-        if isSplitViewInOrdersTabEnabled, selectedIndexPath != nil {
+        if selectedIndexPath != nil {
             // Reload table view to update selected state on the list when changing rotation
             tableView.reloadData()
         }
@@ -290,7 +288,7 @@ private extension OrderListViewController {
 
             transitionToResultsUpdatedState()
 
-            if self.isSplitViewInOrdersTabEnabled, self.splitViewController?.isCollapsed == false {
+            if self.splitViewController?.isCollapsed == false {
                 self.checkSelectedItem()
             }
 
@@ -771,7 +769,7 @@ private extension OrderListViewController {
 extension OrderListViewController: UITableViewDelegate {
 
     func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
-        if splitViewController?.isCollapsed == true || !isSplitViewInOrdersTabEnabled {
+        if splitViewController?.isCollapsed == true {
             tableView.deselectRow(at: indexPath, animated: true)
         }
 
@@ -794,19 +792,12 @@ extension OrderListViewController: UITableViewDelegate {
 
         guard let currentIndex = currentIndex else { return }
 
-        if isSplitViewInOrdersTabEnabled {
-            let allowOrderNavigation = splitViewController?.isCollapsed ?? true
-            // There is no point of having order navigation in the order details view when we have a split screen,
-            // because orders can be easily selected in the left view (orders list).
-            // Passing just one order (the selected one) disables navigation
-            allowOrderNavigation ? switchDetailsHandler(allViewModels, currentIndex, true, nil) :
-            switchDetailsHandler([orderDetailsViewModel], 0, true, nil)
-        } else {
-            let viewController = OrderDetailsViewController(viewModels: allViewModels,
-                                                            currentIndex: currentIndex,
-                                                            switchDetailsHandler: { _, _, _, _ in })
-            navigationController?.pushViewController(viewController, animated: true)
-        }
+        let allowOrderNavigation = splitViewController?.isCollapsed ?? true
+        // There is no point of having order navigation in the order details view when we have a split screen,
+        // because orders can be easily selected in the left view (orders list).
+        // Passing just one order (the selected one) disables navigation
+        allowOrderNavigation ? switchDetailsHandler(allViewModels, currentIndex, true, nil) :
+        switchDetailsHandler([orderDetailsViewModel], 0, true, nil)
     }
 
     func tableView(_ tableView: UITableView, willDisplay cell: UITableViewCell, forRowAt indexPath: IndexPath) {
@@ -815,7 +806,7 @@ extension OrderListViewController: UITableViewDelegate {
         }
 
         syncingCoordinator.ensureNextPageIsSynchronized(lastVisibleIndex: itemIndex)
-        if isSplitViewInOrdersTabEnabled, indexPath == selectedIndexPath {
+        if indexPath == selectedIndexPath {
             highlightSelectedRowIfNeeded()
         }
     }

--- a/WooCommerce/Classes/ViewRelated/Orders/OrdersRootViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrdersRootViewController.swift
@@ -89,10 +89,6 @@ final class OrdersRootViewController: UIViewController {
         super.init(nibName: Self.nibName, bundle: nil)
 
         configureTitle()
-
-        if !featureFlagService.isFeatureFlagEnabled(.splitViewInOrdersTab) {
-            configureTabBarItem()
-        }
     }
 
     required init?(coder: NSCoder) {
@@ -121,13 +117,6 @@ final class OrdersRootViewController: UIViewController {
 
         // Clears application icon badge
         ServiceLocator.pushNotesManager.resetBadgeCount(type: .storeOrder)
-    }
-
-    override var shouldShowOfflineBanner: Bool {
-        if featureFlagService.isFeatureFlagEnabled(.splitViewInOrdersTab) {
-            return false
-        }
-        return true
     }
 
     /// Shows `SearchViewController`.
@@ -223,17 +212,12 @@ final class OrdersRootViewController: UIViewController {
             }
         }
 
-        if featureFlagService.isFeatureFlagEnabled(.splitViewInOrdersTab) {
-            if featureFlagService.isFeatureFlagEnabled(.sideBySideViewForOrderForm) {
-                viewController.modalPresentationStyle = .overFullScreen
-                navigationController.present(viewController, animated: true)
-            } else {
-                let newOrderNavigationController = WooNavigationController(rootViewController: viewController)
-                navigationController.present(newOrderNavigationController, animated: true)
-            }
+        if featureFlagService.isFeatureFlagEnabled(.sideBySideViewForOrderForm) {
+            viewController.modalPresentationStyle = .overFullScreen
+            navigationController.present(viewController, animated: true)
         } else {
-            viewController.hidesBottomBarWhenPushed = true
-            navigationController.pushViewController(viewController, animated: true)
+            let newOrderNavigationController = WooNavigationController(rootViewController: viewController)
+            navigationController.present(newOrderNavigationController, animated: true)
         }
 
         analytics.track(event: WooAnalyticsEvent.Orders.orderAddNew())
@@ -510,30 +494,12 @@ private extension OrdersRootViewController {
             order: order,
             horizontalSizeClass: UITraitCollection.current.horizontalSizeClass
         ))
-        let viewModel = OrderDetailsViewModel(order: order)
-        guard !featureFlagService.isFeatureFlagEnabled(.splitViewInOrdersTab) else {
-            ordersViewController.showOrderDetails(order)
-            onCompletion?(true)
-            return
-        }
 
-        let orderViewController = OrderDetailsViewController(viewModel: viewModel)
-
-        // Cleanup navigation (remove new order flow views) before navigating to order details
-        if let navigationController = navigationController, let indexOfSelf = navigationController.viewControllers.firstIndex(of: self) {
-            let viewControllersIncludingSelf = navigationController.viewControllers[0...indexOfSelf]
-            navigationController.setViewControllers(viewControllersIncludingSelf + [orderViewController], animated: true)
-        } else {
-            show(orderViewController, sender: self)
-        }
+        ordersViewController.showOrderDetails(order)
         onCompletion?(true)
     }
 
     var orderDetailsViewController: OrderDetailsViewController? {
-        guard featureFlagService.isFeatureFlagEnabled(.splitViewInOrdersTab) else {
-            return navigationController?.topViewController as? OrderDetailsViewController
-        }
-
         guard let secondaryViewNavigationController = splitViewController?.viewController(for: .secondary) as? UINavigationController else {
             return nil
         }

--- a/WooCommerce/Classes/ViewRelated/Orders/Payment Methods/PaymentMethodsHostingController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Payment Methods/PaymentMethodsHostingController.swift
@@ -91,18 +91,10 @@ extension PaymentMethodsHostingController: UIAdaptivePresentationControllerDeleg
     }
 
     func presentationControllerShouldDismiss(_ presentationController: UIPresentationController) -> Bool {
-        guard ServiceLocator.featureFlagService.isFeatureFlagEnabled(.splitViewInOrdersTab) else {
-            return !rootView.viewModel.disableViewActions
-        }
-
-        return rootView.viewModel.shouldEnableSwipeToDismiss
+        rootView.viewModel.shouldEnableSwipeToDismiss
     }
 
     func presentationControllerDidAttemptToDismiss(_ presentationController: UIPresentationController) {
-        guard ServiceLocator.featureFlagService.isFeatureFlagEnabled(.splitViewInOrdersTab) else {
-            return
-        }
-
         presentCancelOrderActionSheet(viewController: self) { [weak self] _ in
             self?.dismiss(animated: true, completion: nil)
             self?.rootView.viewModel.userDidCancelFlow()

--- a/WooCommerce/Classes/ViewRelated/Orders/Simple Payments/Amount/SimplePaymentsAmount.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Simple Payments/Amount/SimplePaymentsAmount.swift
@@ -77,18 +77,10 @@ extension SimplePaymentsAmountHostingController: UIAdaptivePresentationControlle
     }
 
     func presentationControllerShouldDismiss(_ presentationController: UIPresentationController) -> Bool {
-        guard ServiceLocator.featureFlagService.isFeatureFlagEnabled(.splitViewInOrdersTab) else {
-            return !rootView.viewModel.disableViewActions
-        }
-
         return rootView.viewModel.shouldEnableSwipeToDismiss
     }
 
     func presentationControllerDidAttemptToDismiss(_ presentationController: UIPresentationController) {
-        guard ServiceLocator.featureFlagService.isFeatureFlagEnabled(.splitViewInOrdersTab) else {
-            return
-        }
-
         presentCancelOrderActionSheet(viewController: self) { [weak self] _ in
             self?.dismiss(animated: true, completion: nil)
             self?.rootView.viewModel.userDidCancelFlow()

--- a/WooCommerce/UITestsFoundation/Screens/Orders/UnifiedOrderScreen.swift
+++ b/WooCommerce/UITestsFoundation/Screens/Orders/UnifiedOrderScreen.swift
@@ -243,13 +243,7 @@ public final class UnifiedOrderScreen: ScreenObject {
     /// Cancels Order Creation process
     /// - Returns: Orders Screen object.
     public func cancelOrderCreation() throws -> OrdersScreen {
-        // This cancel button exists only if the feature flag `.splitViewInOrdersTab` is on.
-        // For taking app store screenshot, the beta feature is turned off so we should pop to get out of this screen.
-        if cancelButton.exists {
-            cancelButton.tap()
-        } else {
-            pop()
-        }
+        cancelButton.tap()
         return try OrdersScreen()
     }
 

--- a/WooCommerce/WooCommerceTests/Mocks/MockFeatureFlagService.swift
+++ b/WooCommerce/WooCommerceTests/Mocks/MockFeatureFlagService.swift
@@ -3,7 +3,6 @@ import Experiments
 
 struct MockFeatureFlagService: FeatureFlagService {
     private let isInboxOn: Bool
-    private let isSplitViewInOrdersTabOn: Bool
     private let isUpdateOrderOptimisticallyOn: Bool
     private let shippingLabelsOnboardingM1: Bool
     private let isDomainSettingsEnabled: Bool
@@ -26,7 +25,6 @@ struct MockFeatureFlagService: FeatureFlagService {
     private let filterOrdersByProduct: Bool
 
     init(isInboxOn: Bool = false,
-         isSplitViewInOrdersTabOn: Bool = false,
          isUpdateOrderOptimisticallyOn: Bool = false,
          shippingLabelsOnboardingM1: Bool = false,
          isDomainSettingsEnabled: Bool = false,
@@ -48,7 +46,6 @@ struct MockFeatureFlagService: FeatureFlagService {
          isBackendReceiptsEnabled: Bool = false,
          filterOrdersByProduct: Bool = false) {
         self.isInboxOn = isInboxOn
-        self.isSplitViewInOrdersTabOn = isSplitViewInOrdersTabOn
         self.isUpdateOrderOptimisticallyOn = isUpdateOrderOptimisticallyOn
         self.shippingLabelsOnboardingM1 = shippingLabelsOnboardingM1
         self.isDomainSettingsEnabled = isDomainSettingsEnabled
@@ -75,8 +72,6 @@ struct MockFeatureFlagService: FeatureFlagService {
         switch featureFlag {
         case .inbox:
             return isInboxOn
-        case .splitViewInOrdersTab:
-            return isSplitViewInOrdersTabOn
         case .updateOrderOptimistically:
             return isUpdateOrderOptimisticallyOn
         case .shippingLabelsOnboardingM1:

--- a/WooCommerce/WooCommerceTests/ViewRelated/MainTabBarControllerTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/MainTabBarControllerTests.swift
@@ -61,7 +61,7 @@ final class MainTabBarControllerTests: XCTestCase {
         assertThat(tabBarController.tabRootViewController(tab: .myStore),
                    isAnInstanceOf: DashboardViewController.self)
         assertThat(tabBarController.tabRootViewController(tab: .orders),
-                   isAnInstanceOf: OrdersRootViewController.self)
+                   isAnInstanceOf: OrdersSplitViewWrapperController.self)
         assertThat(tabBarController.tabRootViewController(tab: .products),
                    isAnInstanceOf: ProductsViewController.self)
         assertThat(tabBarController.tabRootViewController(tab: .hubMenu),
@@ -70,38 +70,7 @@ final class MainTabBarControllerTests: XCTestCase {
 
     func test_tab_view_controllers_returns_expected_values() {
         // Arrange
-        // Sets mock `FeatureFlagService` before `MainTabBarController` is initialized so that the feature flags are set correctly.
         let featureFlagService = MockFeatureFlagService()
-        guard let tabBarController = UIStoryboard(name: "Main", bundle: nil).instantiateInitialViewController(creator: { coder in
-            return MainTabBarController(coder: coder, featureFlagService: featureFlagService)
-        }) else {
-            return
-        }
-
-        // Trigger `viewDidLoad`
-        XCTAssertNotNil(tabBarController.view)
-
-        // Action
-        let siteID: Int64 = 134
-        stores.updateDefaultStore(storeID: siteID)
-
-        // Assert
-        XCTAssertEqual(tabBarController.viewControllers?.count, 4)
-        assertThat(tabBarController.tabRootViewController(tab: .myStore),
-                   isAnInstanceOf: DashboardViewController.self)
-        assertThat(tabBarController.tabRootViewController(tab: .orders),
-                   isAnInstanceOf: OrdersRootViewController.self)
-        assertThat(tabBarController.tabRootViewController(tab: .products),
-                   isAnInstanceOf: ProductsViewController.self)
-        assertThat(tabBarController.tabRootViewController(tab: .hubMenu),
-                   isAnInstanceOf: HubMenuViewController.self)
-    }
-
-    func test_tab_view_controllers_returns_expected_values_with_hub_menu_and_split_view_in_orders_tab_enabled() {
-        // Arrange
-        // Sets mock `FeatureFlagService` before `MainTabBarController` is initialized so that the feature flags are set correctly.
-        let isSplitViewInOrdersTabOn = true
-        let featureFlagService = MockFeatureFlagService(isSplitViewInOrdersTabOn: isSplitViewInOrdersTabOn)
 
         guard let tabBarController = UIStoryboard(name: "Main", bundle: nil).instantiateInitialViewController(creator: { coder in
             return MainTabBarController(coder: coder, featureFlagService: featureFlagService)
@@ -501,7 +470,7 @@ final class MainTabBarControllerTests: XCTestCase {
         let siteID: Int64 = 256
         stores.updateDefaultStore(storeID: siteID)
 
-        let mockFeatureFlagService = MockFeatureFlagService(isSplitViewInOrdersTabOn: true)
+        let mockFeatureFlagService = MockFeatureFlagService()
         ServiceLocator.setFeatureFlagService(mockFeatureFlagService)
 
         let tabBarController = try XCTUnwrap(UIStoryboard(name: "Main", bundle: nil).instantiateInitialViewController() as? MainTabBarController)
@@ -544,7 +513,7 @@ final class MainTabBarControllerTests: XCTestCase {
             completion(note, nil)
         }
 
-        let mockFeatureFlagService = MockFeatureFlagService(isSplitViewInOrdersTabOn: true)
+        let mockFeatureFlagService = MockFeatureFlagService()
         ServiceLocator.setFeatureFlagService(mockFeatureFlagService)
 
         let tabBarController = try XCTUnwrap(UIStoryboard(name: "Main", bundle: nil).instantiateInitialViewController() as? MainTabBarController)


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

Now that we've released M2 of Project Lily Pad, we can remove the feature flag.

I noticed while testing this that our offline banners aren't working, but that's not to do with this change so we'll handle it separately

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

Launch the app on an iPad
Check that the Orders tab works as you expect
Repeat on a phone.

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
