### PR TITLE
[Analytics Hub] Only fetch data for enabled analytics cards

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/AnalyticsHubViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/AnalyticsHubViewModel.swift
@@ -113,9 +113,10 @@ final class AnalyticsHubViewModel: ObservableObject {
     /// Sessions Card display state
     ///
     var showSessionsCard: Bool {
-        if !isCardEnabled(.sessions) {
+        guard enabledCards.contains(.sessions) else {
             return false
-        } else if stores.sessionManager.defaultSite?.isNonJetpackSite == true // Non-Jetpack stores don't have Jetpack stats
+        }
+        if stores.sessionManager.defaultSite?.isNonJetpackSite == true // Non-Jetpack stores don't have Jetpack stats
                     || stores.sessionManager.defaultSite?.isJetpackCPConnected == true // JCP stores don't have Jetpack stats
                     || (isJetpackStatsDisabled && !userIsAdmin) { // Non-admins can't enable sessions stats
             return false
@@ -591,12 +592,6 @@ private extension AnalyticsHubViewModel {
                                             webViewTitle: title,
                                             reportURL: url,
                                             usageTracksEventEmitter: usageTracksEventEmitter)
-    }
-
-    /// Whether the card should be displayed in the Analytics Hub.
-    ///
-    func isCardEnabled(_ type: AnalyticsCard.CardType) -> Bool {
-        return enabledCards.contains(where: { $0 == type })
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/AnalyticsHubViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/AnalyticsHubViewModel.swift
@@ -113,18 +113,22 @@ final class AnalyticsHubViewModel: ObservableObject {
     /// Sessions Card display state
     ///
     var showSessionsCard: Bool {
-        guard enabledCards.contains(.sessions) else {
+        guard enabledCards.contains(.sessions), isEligibleForSessionsCard else {
             return false
         }
-        if stores.sessionManager.defaultSite?.isNonJetpackSite == true // Non-Jetpack stores don't have Jetpack stats
-                    || stores.sessionManager.defaultSite?.isJetpackCPConnected == true // JCP stores don't have Jetpack stats
-                    || (isJetpackStatsDisabled && !userIsAdmin) { // Non-admins can't enable sessions stats
-            return false
-        } else if case .custom = timeRangeSelectionType {
+        if case .custom = timeRangeSelectionType {
             return false
         } else {
             return true
         }
+    }
+
+    /// Whether the user is eligible to view the Sessions cards
+    ///
+    private var isEligibleForSessionsCard: Bool {
+        stores.sessionManager.defaultSite?.isNonJetpackSite == false // Non-Jetpack stores don't have Jetpack stats
+        && stores.sessionManager.defaultSite?.isJetpackCPConnected == false // JCP stores don't have Jetpack stats
+        && (isJetpackStatsDisabled && !userIsAdmin) == false // Non-admins can't enable sessions stats
     }
 
     /// Whether Jetpack Stats are disabled on the store

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/AnalyticsHubViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/AnalyticsHubViewModel.swift
@@ -321,8 +321,12 @@ private extension AnalyticsHubViewModel {
     @MainActor
     /// Retrieves top ItemsSold stats using the `retrieveTopEarnerStats` action but without saving results into storage.
     ///
-    func retrieveTopItemsSoldStats(earliestDateToInclude: Date, latestDateToInclude: Date, forceRefresh: Bool) async throws -> TopEarnerStats {
-        try await withCheckedThrowingContinuation { continuation in
+    func retrieveTopItemsSoldStats(earliestDateToInclude: Date, latestDateToInclude: Date, forceRefresh: Bool) async throws -> TopEarnerStats? {
+        guard enabledCards.contains(.products) else {
+            return nil
+        }
+
+        return try await withCheckedThrowingContinuation { continuation in
             let action = StatsActionV4.retrieveTopEarnerStats(siteID: siteID,
                                                               timeRange: .thisYear, // Only needed for storing purposes, we can ignore it.
                                                               timeZone: timeZone,


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #11949
<!-- Id number of the GitHub issue this PR addresses. -->

## Why
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
We only want to fetch data being used in enabled analytics cards. This PR changes the behavior in two ways:

1. When data is fetched, we only fetch the data for enabled analytics cards.
2. When a card is enabled, we refresh the data to ensure we have all the required data for enabled cards.

Note: I looked into _only_ fetching the _new_ data that's needed for newly enabled cards, rather than refreshing all the data, but that would require a fairly significant refactor of the Analytics Hub data fetching. Right now, the Analytics Hub assumes that when we update data, we are loading data for all the cards. This affects both the remote requests for data and the visual loading status for each card. I'll look into making this change separately, since it requires more extensive changes to how we do that fetching.

## How

In `AnalyticsHubViewModel`:

* We always fetch order stats, since they are used in all the cards.
* We only fetch site summary stats when the sessions card is shown. (`showSessionsCard` is also updated to clarify why we're doing each check for its visibility.)
* We only fetch top earner stats when the products card is shown.
* There's a new binding so that when `allCardsWithSettings` is updated, we check to see if any new cards have been enabled (the new set of enabled cards has types that aren't included in the currently enabled cards). If new cards are enabled, we update the data.


## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

Loading data for enabled cards only:

1. Build and run the app.
2. Tap "See More" to open the Analytics Hub.
3. Tap "Edit" to customize the analytics cards.
4. Deselect the products and sessions cards and save the changes.
5. Go to Menu > Settings > Launch Wormholy Debug and clear the recorded requests.
6. Go back to the Analytics Hub and refresh the data.
7. Go back to Wormholy Debug and confirm the only requests are for stats data from `/wc-analytics/reports/revenue/stats`.

Disabling or reordering a card:

1. Build and run the app.
2. Tap "See More" to open the Analytics Hub.
3. Confirm all visible cards load with the expected data.
8. Tap "Edit" to customize the analytics cards.
9. Deselect a card or reorder the cards and save the changes.
10. Confirm the data isn't refreshed (no loading view) and all enabled cards are visible with the expected data.

Enabling a new card:

1. Build and run the app.
2. Tap "See More" to open the Analytics Hub.
3. Confirm all visible cards load with the expected data.
4. Tap "Edit" to customize the analytics cards.
5. Select a new card and save the changes.
6. Confirm the data is refreshed and all enabled cards load with the expected data.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->


https://github.com/woocommerce/woocommerce-ios/assets/8658164/a9a07059-cbaa-4f46-8327-763c0175cf92


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
