### PR TITLE
[Analytics Hub] Exclude Sessions card from Customize Analytics when ineligible

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/AnalyticsHubViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/AnalyticsHubViewModel.swift
@@ -650,7 +650,13 @@ extension AnalyticsHubViewModel {
             return
         }
 
-        customizeAnalyticsViewModel = AnalyticsHubCustomizeViewModel(allCards: allCardsWithSettings) { [weak self] updatedCards in
+        // Exclude any cards the merchant/store is ineligible for.
+        let cardsToExclude: [AnalyticsCard] = [
+            isEligibleForSessionsCard ? nil : allCardsWithSettings.first(where: { $0.type == .sessions })
+        ].compactMap({ $0 })
+
+        customizeAnalyticsViewModel = AnalyticsHubCustomizeViewModel(allCards: allCardsWithSettings,
+                                                                     cardsToExclude: cardsToExclude) { [weak self] updatedCards in
             guard let self else { return }
             self.allCardsWithSettings = updatedCards
             self.storeAnalyticsCardSettings(updatedCards)

--- a/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Analytics Hub/AnalyticsHubCustomizeViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Analytics Hub/AnalyticsHubCustomizeViewModelTests.swift
@@ -8,7 +8,8 @@ final class AnalyticsHubCustomizeViewModelTests: XCTestCase {
         // Given
         let revenueCard = AnalyticsCard(type: .revenue, enabled: true)
         let ordersCard = AnalyticsCard(type: .orders, enabled: false)
-        let vm = AnalyticsHubCustomizeViewModel(allCards: [revenueCard, ordersCard])
+        let sessionsCard = AnalyticsCard(type: .sessions, enabled: true)
+        let vm = AnalyticsHubCustomizeViewModel(allCards: [revenueCard, ordersCard, sessionsCard], cardsToExclude: [sessionsCard])
 
         // Then
         assertEqual([revenueCard, ordersCard], vm.allCards)
@@ -58,10 +59,11 @@ final class AnalyticsHubCustomizeViewModelTests: XCTestCase {
         let revenueCard = AnalyticsCard(type: .revenue, enabled: false)
         let ordersCard = AnalyticsCard(type: .orders, enabled: true)
         let productsCard = AnalyticsCard(type: .products, enabled: true)
+        let sessionsCard = AnalyticsCard(type: .sessions, enabled: true)
 
         // When
         let actualCards = waitFor { promise in
-            let vm = AnalyticsHubCustomizeViewModel(allCards: [revenueCard, ordersCard, productsCard]) { updatedCards in
+            let vm = AnalyticsHubCustomizeViewModel(allCards: [revenueCard, ordersCard, productsCard], cardsToExclude: [sessionsCard]) { updatedCards in
                 promise(updatedCards)
             }
 
@@ -71,7 +73,7 @@ final class AnalyticsHubCustomizeViewModelTests: XCTestCase {
         }
 
         // Then
-        let expectedCards = [ordersCard, revenueCard.copy(enabled: true), productsCard.copy(enabled: false)]
+        let expectedCards = [ordersCard, revenueCard.copy(enabled: true), productsCard.copy(enabled: false), sessionsCard]
         assertEqual(expectedCards, actualCards)
     }
 

--- a/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Analytics Hub/AnalyticsHubViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Analytics Hub/AnalyticsHubViewModelTests.swift
@@ -710,6 +710,23 @@ final class AnalyticsHubViewModelTests: XCTestCase {
         customizeAnalytics.selectedCards = [AnalyticsCard(type: .revenue, enabled: true)]
         customizeAnalytics.saveChanges()
     }
+
+    func test_customizeAnalytics_excludes_sessions_card_when_ineligible() throws {
+        // Given
+        let stores = MockStoresManager(sessionManager: .makeForTesting(authenticated: true, defaultSite: .fake().copy(siteID: -1)))
+        let vm = createViewModel(stores: stores)
+
+        // When
+        vm.customizeAnalytics()
+
+        // Then
+        let customizeAnalyticsVM = try XCTUnwrap(vm.customizeAnalyticsViewModel)
+        let expectedCards = [AnalyticsCard(type: .revenue, enabled: true),
+                             AnalyticsCard(type: .orders, enabled: true),
+                             AnalyticsCard(type: .products, enabled: true)]
+        XCTAssertFalse(vm.showSessionsCard)
+        assertEqual(expectedCards, customizeAnalyticsVM.allCards)
+    }
 }
 
 private extension AnalyticsHubViewModelTests {


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #12075
<!-- Id number of the GitHub issue this PR addresses. -->

## Why
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
We always hide the Sessions card in the Analytics Hub when the merchant/store is ineligible for it:

- Non-Jetpack stores (no Jetpack connection)
- Stores using the Jetpack Connection Package
- Stores where Jetpack stats are disabled and the user isn't an admin

In those cases, we shouldn't include Sessions in the list of cards that can be enabled/disabled in the Analytics Hub (since it won't ever be shown).

## How

* `AnalyticsHubCustomizeViewModel` now accepts a list of cards to exclude:
   * When the view model is initialized, we remove excluded cards from the list of all cards.
   * When the changes are saved, we add the excluded cards back to the list. (This ensures they are available if the merchant/store becomes eligible for them, and retains their existing `enabled` status.)
* In `AnalyticsHubViewModel`, when `AnalyticsHubCustomizeViewModel` is set, we check if the store is eligible for the sessions card. If not, we exclude it.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

These changes are also covered by unit tests.

Store eligible for the Sessions card:

1. Build and run the app.
2. Select a store eligible for the sessions card (using the full Jetpack plugin).
3. Go to the Analytics Hub and confirm you can view and customize the analytics cards as before.

Store ineligible for the Sessions card:

1. Select a store ineligible for the sessions card (not using Jetpack, only connected via JCP, or a shop manager on a store with Jetpack Stats disabled).
2. Go to the Analytics Hub and confirm the Sessions card is not shown.
3. Tap "Edit" and confirm the Sessions card is not visible.
4. Confirm you can't deselect the last selected card.

Bonus: On the ineligible store, install and connect Jetpack (or enable Jetpack Status if it was disabled) and confirm the Sessions card can now be customized.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

Ineligible store - no Sessions card:


https://github.com/woocommerce/woocommerce-ios/assets/8658164/c971065f-6fb1-44a5-9647-1eae0b8233e5



Eligible store (no change):


https://github.com/woocommerce/woocommerce-ios/assets/8658164/382ad7e2-9a70-4d14-ac0c-2c1afa1ca4ab

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
