### PR TITLE
My Store Analytics: Persist custom range locally to load again upon relaunching

### DIFF
--- a/Networking/Networking/Model/Copiable/Models+Copiable.generated.swift
+++ b/Networking/Networking/Model/Copiable/Models+Copiable.generated.swift
@@ -3,6 +3,7 @@
 import Codegen
 import Foundation
 
+
 extension Networking.AIProduct {
     public func copy(
         name: CopiableProp<String> = .copy,

--- a/Storage/Storage/Model/Copiable/Models+Copiable.generated.swift
+++ b/Storage/Storage/Model/Copiable/Models+Copiable.generated.swift
@@ -85,6 +85,7 @@ extension Storage.GeneralStoreSettings {
         preferredInPersonPaymentGateway: NullableCopiableProp<String> = .copy,
         skippedCashOnDeliveryOnboardingStep: CopiableProp<Bool> = .copy,
         lastSelectedStatsTimeRange: CopiableProp<String> = .copy,
+        customStatsTimeRange: CopiableProp<String> = .copy,
         firstInPersonPaymentsTransactionsByReaderType: CopiableProp<[CardReaderType: Date]> = .copy,
         selectedTaxRateID: NullableCopiableProp<Int64> = .copy,
         analyticsHubCards: NullableCopiableProp<[AnalyticsCard]> = .copy
@@ -96,6 +97,7 @@ extension Storage.GeneralStoreSettings {
         let preferredInPersonPaymentGateway = preferredInPersonPaymentGateway ?? self.preferredInPersonPaymentGateway
         let skippedCashOnDeliveryOnboardingStep = skippedCashOnDeliveryOnboardingStep ?? self.skippedCashOnDeliveryOnboardingStep
         let lastSelectedStatsTimeRange = lastSelectedStatsTimeRange ?? self.lastSelectedStatsTimeRange
+        let customStatsTimeRange = customStatsTimeRange ?? self.customStatsTimeRange
         let firstInPersonPaymentsTransactionsByReaderType = firstInPersonPaymentsTransactionsByReaderType ?? self.firstInPersonPaymentsTransactionsByReaderType
         let selectedTaxRateID = selectedTaxRateID ?? self.selectedTaxRateID
         let analyticsHubCards = analyticsHubCards ?? self.analyticsHubCards
@@ -108,6 +110,7 @@ extension Storage.GeneralStoreSettings {
             preferredInPersonPaymentGateway: preferredInPersonPaymentGateway,
             skippedCashOnDeliveryOnboardingStep: skippedCashOnDeliveryOnboardingStep,
             lastSelectedStatsTimeRange: lastSelectedStatsTimeRange,
+            customStatsTimeRange: customStatsTimeRange,
             firstInPersonPaymentsTransactionsByReaderType: firstInPersonPaymentsTransactionsByReaderType,
             selectedTaxRateID: selectedTaxRateID,
             analyticsHubCards: analyticsHubCards

--- a/Storage/Storage/Model/GeneralStoreSettings.swift
+++ b/Storage/Storage/Model/GeneralStoreSettings.swift
@@ -44,6 +44,9 @@ public struct GeneralStoreSettings: Codable, Equatable, GeneratedCopiable {
     /// The raw value string of `StatsTimeRangeV4` that indicates the last selected time range tab in store stats.
     public var lastSelectedStatsTimeRange: String
 
+    /// The raw value string of `StatsTimeRangeV4` that indicates the custom time range tab in store stats.
+    public var customStatsTimeRange: String
+
     /// We keep the dates of the first In Person Payments transactions using this phone/store/reader combination for
     public let firstInPersonPaymentsTransactionsByReaderType: [CardReaderType: Date]
 
@@ -60,6 +63,7 @@ public struct GeneralStoreSettings: Codable, Equatable, GeneratedCopiable {
                 preferredInPersonPaymentGateway: String? = nil,
                 skippedCashOnDeliveryOnboardingStep: Bool = false,
                 lastSelectedStatsTimeRange: String = "",
+                customStatsTimeRange: String = "",
                 firstInPersonPaymentsTransactionsByReaderType: [CardReaderType: Date] = [:],
                 selectedTaxRateID: Int64? = nil,
                 analyticsHubCards: [AnalyticsCard]? = nil) {
@@ -70,6 +74,7 @@ public struct GeneralStoreSettings: Codable, Equatable, GeneratedCopiable {
         self.preferredInPersonPaymentGateway = preferredInPersonPaymentGateway
         self.skippedCashOnDeliveryOnboardingStep = skippedCashOnDeliveryOnboardingStep
         self.lastSelectedStatsTimeRange = lastSelectedStatsTimeRange
+        self.customStatsTimeRange = customStatsTimeRange
         self.firstInPersonPaymentsTransactionsByReaderType = firstInPersonPaymentsTransactionsByReaderType
         self.selectedTaxRateID = selectedTaxRateID
         self.analyticsHubCards = analyticsHubCards
@@ -83,6 +88,7 @@ public struct GeneralStoreSettings: Codable, Equatable, GeneratedCopiable {
                              preferredInPersonPaymentGateway: preferredInPersonPaymentGateway,
                              skippedCashOnDeliveryOnboardingStep: skippedCashOnDeliveryOnboardingStep,
                              lastSelectedStatsTimeRange: lastSelectedStatsTimeRange,
+                             customStatsTimeRange: customStatsTimeRange,
                              firstInPersonPaymentsTransactionsByReaderType: firstInPersonPaymentsTransactionsByReaderType,
                              selectedTaxRateID: nil,
                              analyticsHubCards: analyticsHubCards)
@@ -103,6 +109,7 @@ extension GeneralStoreSettings {
         self.preferredInPersonPaymentGateway = try container.decodeIfPresent(String.self, forKey: .preferredInPersonPaymentGateway)
         self.skippedCashOnDeliveryOnboardingStep = try container.decodeIfPresent(Bool.self, forKey: .skippedCashOnDeliveryOnboardingStep) ?? false
         self.lastSelectedStatsTimeRange = try container.decodeIfPresent(String.self, forKey: .lastSelectedStatsTimeRange) ?? ""
+        self.customStatsTimeRange = try container.decodeIfPresent(String.self, forKey: .customStatsTimeRange) ?? ""
         self.firstInPersonPaymentsTransactionsByReaderType = try container.decodeIfPresent([CardReaderType: Date].self,
                                                                                            forKey: .firstInPersonPaymentsTransactionsByReaderType) ?? [:]
         self.selectedTaxRateID = try container.decodeIfPresent(Int64.self, forKey: .selectedTaxRateID)

--- a/Yosemite/Yosemite/Actions/AppSettingsAction.swift
+++ b/Yosemite/Yosemite/Actions/AppSettingsAction.swift
@@ -184,6 +184,12 @@ public enum AppSettingsAction: Action {
 
     case loadLastSelectedStatsTimeRange(siteID: Int64, onCompletion: (StatsTimeRangeV4?) -> Void)
 
+    // MARK: - Stats custom time range tab
+
+    case setCustomStatsTimeRange(siteID: Int64, timeRange: StatsTimeRangeV4)
+
+    case loadCustomStatsTimeRange(siteID: Int64, onCompletion: (StatsTimeRangeV4?) -> Void)
+
     /// Loads whether the user finished an IPP transaction for the given siteID
     ///
     case loadSiteHasAtLeastOneIPPTransactionFinished(siteID: Int64, onCompletion: (Bool) -> Void)

--- a/Yosemite/Yosemite/Stores/AppSettingsStore.swift
+++ b/Yosemite/Yosemite/Stores/AppSettingsStore.swift
@@ -210,6 +210,10 @@ public class AppSettingsStore: Store {
             setAnalyticsHubCards(siteID: siteID, cards: cards)
         case .loadAnalyticsHubCards(let siteID, let onCompletion):
             loadAnalyticsHubCards(siteID: siteID, onCompletion: onCompletion)
+        case let .loadCustomStatsTimeRange(siteID, onCompletion):
+            loadCustomStatsTimeRange(siteID: siteID, onCompletion: onCompletion)
+        case let .setCustomStatsTimeRange(siteID, timeRange):
+            setCustomStatsTimeRange(siteID: siteID, timeRange: timeRange)
         }
     }
 }
@@ -886,6 +890,21 @@ private extension AppSettingsStore {
     func loadLastSelectedStatsTimeRange(siteID: Int64, onCompletion: (StatsTimeRangeV4?) -> Void) {
         let storeSettings = getStoreSettings(for: siteID)
         let timeRangeRawValue = storeSettings.lastSelectedStatsTimeRange
+        let timeRange = StatsTimeRangeV4(rawValue: timeRangeRawValue)
+        onCompletion(timeRange)
+    }
+}
+
+private extension AppSettingsStore {
+    func setCustomStatsTimeRange(siteID: Int64, timeRange: StatsTimeRangeV4) {
+        let storeSettings = getStoreSettings(for: siteID)
+        let updatedSettings = storeSettings.copy(customStatsTimeRange: timeRange.rawValue)
+        setStoreSettings(settings: updatedSettings, for: siteID)
+    }
+
+    func loadCustomStatsTimeRange(siteID: Int64, onCompletion: @escaping (StatsTimeRangeV4?) -> Void) {
+        let storeSettings = getStoreSettings(for: siteID)
+        let timeRangeRawValue = storeSettings.customStatsTimeRange
         let timeRange = StatsTimeRangeV4(rawValue: timeRangeRawValue)
         onCompletion(timeRange)
     }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #12115
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This PR updates updates `AppStoreSettings` store and action to support persisting custom time ranges on My Store stats. The UI layer has also been updated to load and save any custom range if the feature flag is enabled.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
- Enable the feature flag `customRangeInMyStoreAnalytics` and build the app.
- Log in to your test store.
- Select the Calendar icon on the stats section on the My Store screen and pick a custom date range.
- Save the custom range and confirm that a new tab for the custom range is added to the stats section.
- Force close the app and relaunch it. Confirm that the custom range that you just created is displayed. 
- Switch to any other stats tab and relaunch the app again.
- Confirm that the custom range tab you created was still there, although the initially selected tab is the last one that you saw before relaunching.
- Disable the feature flag `customRangeInMyStoreAnalytics` and rebuild the app.
- Confirm that the selected tab is the Today tab, and data are loaded properly on all the stat tabs.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->
<img src="https://github.com/woocommerce/woocommerce-ios/assets/5533851/727e8c2f-190a-4245-937f-25c707918447" width=320 />


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
