### PR TITLE
Compose a user agent instead of using WKWebView

### DIFF
--- a/Networking/Networking/Settings/UserAgent.swift
+++ b/Networking/Networking/Settings/UserAgent.swift
@@ -10,15 +10,45 @@ public class UserAgent {
         return webkitUserAgent + " " + Constants.woocommerceIdentifier + "/" + bundleShortVersion
     }()
 
-    /// Returns the WebKit User Agent
+    /// Returns a user agent string similar to (but may not exactly match) the one used in `WKWebView`.
     ///
-    static var webkitUserAgent: String {
-        guard let userAgent = WKWebView().value(forKey: Constants.userAgentKey) as? String,
-            !userAgent.isEmpty else {
-                return ""
+    static var webkitUserAgent: String = {
+        // Examples user agent strings from `WKWebView` in iOS simulators:
+        //
+        // ## iPhone 15 Pro (iOS 17.2)
+        // Mozilla/5.0 (iPhone; CPU iPhone OS 17_2 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Mobile/15E148
+        //
+        // ## iPad Pro (iOS 17.0.1)
+        // Mozilla/5.0 (iPad; CPU OS 17_0_1 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Mobile/15E148
+        //
+        // Based on the WebKit implementation[^1], most of the components are hardcoded, and there are only a couple of dynamic components:
+        // 1. Device model. i.e. iPhone/iPad
+        // 2. OS name and version. i.e. iPhone OS 17_2
+        //
+        // Please note the "Mobile/15E148" part is WKWebView's default and hardcoded "application name"[^2].
+        //
+        // [^1]: https://github.com/WebKit/WebKit/blob/5fbb03ee1c6210c79779d6fa1a9e7290daa746d1/Source/WebCore/platform/ios/UserAgentIOS.mm#L88-L113
+        // [^2]: https://github.com/WebKit/WebKit/blob/492140d27dbe/Source/WebKit/UIProcess/API/Cocoa/WKWebViewConfiguration.mm#L612
+
+        let device = UIDevice.current
+
+        let deviceModel = device.model // Example: "iPhone"
+        var osName = device.systemName // Example: "iPhone OS"
+        let osVersion = device.systemVersion.replacingOccurrences(of: ".", with: "_") // Example: "17_2"
+
+        // WKWebView on iPad uses a static user agent.
+        // https://github.com/WebKit/WebKit/blob/6a053cfb431bd70d5017ba881a39f004e52effc2/Source/WebCore/platform/ios/UserAgentIOS.mm#L97
+        if device.userInterfaceIdiom == .pad {
+            osName = "OS"
         }
-        return userAgent
-    }
+
+        // Use "iPhone OS" instead of "iOS", because that's what WKWebView uses.
+        if osName == "iOS" {
+            osName = "iPhone OS"
+        }
+
+        return "Mozilla/5.0 (\(deviceModel); CPU \(osName) \(osVersion) like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Mobile/15E148"
+    }()
 
     /// Returns the Bundle Version ID
     ///

--- a/Networking/NetworkingTests/Settings/UserAgentTests.swift
+++ b/Networking/NetworkingTests/Settings/UserAgentTests.swift
@@ -18,4 +18,12 @@ final class UserAgentTests: XCTestCase {
         let message = "This method for retrieveing the user agent seems to be no longer working. We need to figure out an alternative."
         XCTAssertFalse(UserAgent.webkitUserAgent.isEmpty, message)
     }
+
+    func testUserAgentFormat() throws {
+        let regex = #"^Mozilla/5\.0 \([a-zA-Z]+; CPU [\sa-zA-Z]+ [_0-9]+ like Mac OS X\) AppleWebKit/605\.1\.15 \(KHTML, like Gecko\) Mobile/15E148$"#
+        let regulardExpression = try NSRegularExpression(pattern: regex)
+        let userAgent = UserAgent.webkitUserAgent
+        XCTAssertEqual(regulardExpression.numberOfMatches(in: userAgent, range: NSMakeRange(0, userAgent.count)), 1)
+    }
+
 }

--- a/Networking/NetworkingTests/Settings/UserAgentTests.swift
+++ b/Networking/NetworkingTests/Settings/UserAgentTests.swift
@@ -1,9 +1,13 @@
 import XCTest
+import WebKit
+
 @testable import Networking
 
 /// UserAgent Unit Tests
 ///
 final class UserAgentTests: XCTestCase {
+
+    let webkitUserAgentRegex = #"^Mozilla/5\.0 \([a-zA-Z]+; CPU [\sa-zA-Z]+ [_0-9]+ like Mac OS X\) AppleWebKit/605\.1\.15 \(KHTML, like Gecko\) Mobile/15E148$"#
 
     func testDefaultUserAgent() {
         let appVersion = Bundle.main.object(forInfoDictionaryKey: "CFBundleShortVersionString") as? String ?? String()
@@ -20,9 +24,17 @@ final class UserAgentTests: XCTestCase {
     }
 
     func testUserAgentFormat() throws {
-        let regex = #"^Mozilla/5\.0 \([a-zA-Z]+; CPU [\sa-zA-Z]+ [_0-9]+ like Mac OS X\) AppleWebKit/605\.1\.15 \(KHTML, like Gecko\) Mobile/15E148$"#
-        let regulardExpression = try NSRegularExpression(pattern: regex)
+        let regulardExpression = try NSRegularExpression(pattern: webkitUserAgentRegex)
         let userAgent = UserAgent.webkitUserAgent
+        XCTAssertEqual(regulardExpression.numberOfMatches(in: userAgent, range: NSMakeRange(0, userAgent.count)), 1)
+    }
+
+    // If this test fails, it may mean `WKWebView` uses a user agent with an unexpected format (see `webkitUserAgentRegex`)
+    // and we may need to adjust `UserAgent.webkitUserAgent`'s implementation to match `WKWebView`'s user agent.
+    func testWKWebViewUserAgentFormat() throws {
+        let regulardExpression = try NSRegularExpression(pattern: webkitUserAgentRegex)
+        // Please note: WKWebView's user agent may be different on different test device types.
+        let userAgent = try XCTUnwrap(WKWebView().value(forKey: "_userAgent") as? String)
         XCTAssertEqual(regulardExpression.numberOfMatches(in: userAgent, range: NSMakeRange(0, userAgent.count)), 1)
     }
 


### PR DESCRIPTION
## Description

The `webkitUserAgent` is used to set UA for HTTP API requests and in-app web views. After migrating Alamofire to v5, this function may get called from a background queue, which is problematic because `WKWebView` should be created from the main thread.

I tried to retain the existing implementation which uses `WKWebView`, but makes it safe to be called from background threads (see https://github.com/woocommerce/woocommerce-ios/pull/12113). But that introduces deadlock. This PR removes `WKWebView` and creates a custom implementation that produces a user agent very similar to the one used by current `WKWebView`.

## Testing instructions

I have added an unit test. Not sure if there is any other test needed.

## Screenshots
N/A


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
