### PR TITLE
My Store Analytics: Update contents for custom time range tab

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Dashboard/MyStore/TopPerformerDataViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/MyStore/TopPerformerDataViewController.swift
@@ -49,22 +49,6 @@ final class TopPerformerDataViewController: UIViewController {
         resultsController?.fetchedObjects.first
     }
 
-    private var tabDescription: String {
-        switch granularity {
-        case .day:
-            return NSLocalizedString("Today", comment: "Top Performers section title - today")
-        case .week:
-            return NSLocalizedString("This Week", comment: "Top Performers section title - this week")
-        case .month:
-            return NSLocalizedString("This Month", comment: "Top Performers section title - this month")
-        case .year:
-            return NSLocalizedString("This Year", comment: "Top Performers section title - this year")
-        case .hour, .quarter:
-            // TODO: 11935 I think we should calculate this based on `timeRange: StatsTimeRangeV4`?
-            return NSLocalizedString("Custom", comment: "Top Performers section title - Custom")
-        }
-    }
-
     // MARK: - Initialization
 
     /// Designated Initializer

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Stats v4/CustomRangeTabCreationCoordinator.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Stats v4/CustomRangeTabCreationCoordinator.swift
@@ -35,24 +35,11 @@ private extension CustomRangeTabCreationCoordinator {
             datesFormatter: DatesFormatter(),
             customApplyButtonTitle: buttonTitle,
             datesSelected: { [weak self] start, end in
-                guard let self else { return }
-                guard start < end else {
-                    self.presentInvalidTimeRangeAlert()
-                    return
-                }
-                self.onDateRangeSelected(start, end)
+                self?.onDateRangeSelected(start, end)
             }
         )
 
         navigationController.present(controller, animated: true)
-    }
-
-    func presentInvalidTimeRangeAlert() {
-        let alert = UIAlertController(title: Localization.InvalidTimeRangeAlert.title,
-                                      message: Localization.InvalidTimeRangeAlert.message,
-                                      preferredStyle: .alert)
-        alert.addAction(UIAlertAction(title: Localization.InvalidTimeRangeAlert.action, style: .cancel))
-        navigationController.present(alert, animated: true)
     }
 
     /// Specific `DatesFormatter` for the `RangedDatePicker` when presented in the analytics hub module.
@@ -76,22 +63,5 @@ private extension CustomRangeTabCreationCoordinator {
             value: "Add",
             comment: "Button in date range picker to add a Custom Range tab"
         )
-        enum InvalidTimeRangeAlert {
-            static let title = NSLocalizedString(
-                "customRangeTabCreationCoordinator.invalidTimeRangeAlert.title",
-                value: "Invalid time range",
-                comment: "Title of the alert displayed when selecting an invalid time range for My Store Analytics"
-            )
-            static let message = NSLocalizedString(
-                "customRangeTabCreationCoordinator.invalidTimeRangeAlert.message",
-                value: "The start date should be earlier than the end date. Please select a different time range.",
-                comment: "Message of the alert displayed when selecting an invalid time range for My Store Analytics"
-            )
-            static let action = NSLocalizedString(
-                "customRangeTabCreationCoordinator.invalidTimeRangeAlert.action",
-                value: "Got It",
-                comment: "Button to dismiss the alert displayed when selecting an invalid time range for My Store Analytics"
-            )
-        }
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Stats v4/CustomRangeTabCreationCoordinator.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Stats v4/CustomRangeTabCreationCoordinator.swift
@@ -28,7 +28,7 @@ private extension CustomRangeTabCreationCoordinator {
     func presentDateRangePicker() {
         let buttonTitle = (startDate == nil && endDate == nil) ? Localization.add : nil
         let endDate = self.endDate ?? Date()
-        let startDate = self.startDate ?? Date(timeInterval: -Constants.thirtyDaysInSeconds, since: endDate) // 30 day before end date
+        let startDate = self.startDate ?? Date(timeInterval: -Constants.thirtyDaysInSeconds, since: endDate) // 30 days before end date
         let controller = RangedDatePickerHostingController(
             startDate: startDate,
             endDate: endDate,
@@ -36,11 +36,23 @@ private extension CustomRangeTabCreationCoordinator {
             customApplyButtonTitle: buttonTitle,
             datesSelected: { [weak self] start, end in
                 guard let self else { return }
+                guard start < end else {
+                    self.presentInvalidTimeRangeAlert()
+                    return
+                }
                 self.onDateRangeSelected(start, end)
             }
         )
 
         navigationController.present(controller, animated: true)
+    }
+
+    func presentInvalidTimeRangeAlert() {
+        let alert = UIAlertController(title: Localization.InvalidTimeRangeAlert.title,
+                                      message: Localization.InvalidTimeRangeAlert.message,
+                                      preferredStyle: .alert)
+        alert.addAction(UIAlertAction(title: Localization.InvalidTimeRangeAlert.action, style: .cancel))
+        navigationController.present(alert, animated: true)
     }
 
     /// Specific `DatesFormatter` for the `RangedDatePicker` when presented in the analytics hub module.
@@ -64,5 +76,22 @@ private extension CustomRangeTabCreationCoordinator {
             value: "Add",
             comment: "Button in date range picker to add a Custom Range tab"
         )
+        enum InvalidTimeRangeAlert {
+            static let title = NSLocalizedString(
+                "customRangeTabCreationCoordinator.invalidTimeRangeAlert.title",
+                value: "Invalid time range",
+                comment: "Title of the alert displayed when selecting an invalid time range for My Store Analytics"
+            )
+            static let message = NSLocalizedString(
+                "customRangeTabCreationCoordinator.invalidTimeRangeAlert.message",
+                value: "The start date should be earlier than the end date. Please select a different time range.",
+                comment: "Message of the alert displayed when selecting an invalid time range for My Store Analytics"
+            )
+            static let action = NSLocalizedString(
+                "customRangeTabCreationCoordinator.invalidTimeRangeAlert.action",
+                value: "Got It",
+                comment: "Button to dismiss the alert displayed when selecting an invalid time range for My Store Analytics"
+            )
+        }
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Stats v4/CustomRangeTabCreationCoordinator.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Stats v4/CustomRangeTabCreationCoordinator.swift
@@ -4,9 +4,17 @@ import UIKit
 /// Coordinates navigation into Custom Range tab creation from the Stats dashboard.
 final class CustomRangeTabCreationCoordinator: Coordinator {
     let navigationController: UINavigationController
+
+    private let startDate: Date?
+    private let endDate: Date?
     private let onDateRangeSelected: (_ start: Date, _ end: Date) -> Void
 
-    init(navigationController: UINavigationController, onDateRangeSelected: @escaping (_ start: Date, _ end: Date) -> Void) {
+    init(startDate: Date?,
+         endDate: Date?,
+         navigationController: UINavigationController,
+         onDateRangeSelected: @escaping (_ start: Date, _ end: Date) -> Void) {
+        self.startDate = startDate
+        self.endDate = endDate
         self.navigationController = navigationController
         self.onDateRangeSelected = onDateRangeSelected
     }
@@ -18,9 +26,14 @@ final class CustomRangeTabCreationCoordinator: Coordinator {
 
 private extension CustomRangeTabCreationCoordinator {
     func presentDateRangePicker() {
+        let buttonTitle = (startDate == nil && endDate == nil) ? Localization.add : nil
+        let endDate = self.endDate ?? Date()
+        let startDate = self.startDate ?? Date(timeInterval: -Constants.thirtyDays, since: endDate) // 30 day before end date
         let controller = RangedDatePickerHostingController(
+            startDate: startDate,
+            endDate: endDate,
             datesFormatter: DatesFormatter(),
-            customApplyButtonTitle: Localization.add,
+            customApplyButtonTitle: buttonTitle,
             datesSelected: { [weak self] start, end in
                 guard let self else { return }
                 self.onDateRangeSelected(start, end)
@@ -42,6 +55,9 @@ private extension CustomRangeTabCreationCoordinator {
 // MARK: Constant
 
 private extension CustomRangeTabCreationCoordinator {
+    enum Constants {
+        static let thirtyDays: TimeInterval = 86400*30
+    }
     enum Localization {
         static let add = NSLocalizedString(
             "customRangeTabCreationCoordinator.add",

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Stats v4/CustomRangeTabCreationCoordinator.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Stats v4/CustomRangeTabCreationCoordinator.swift
@@ -28,7 +28,7 @@ private extension CustomRangeTabCreationCoordinator {
     func presentDateRangePicker() {
         let buttonTitle = (startDate == nil && endDate == nil) ? Localization.add : nil
         let endDate = self.endDate ?? Date()
-        let startDate = self.startDate ?? Date(timeInterval: -Constants.thirtyDays, since: endDate) // 30 day before end date
+        let startDate = self.startDate ?? Date(timeInterval: -Constants.thirtyDaysInSeconds, since: endDate) // 30 day before end date
         let controller = RangedDatePickerHostingController(
             startDate: startDate,
             endDate: endDate,
@@ -56,7 +56,7 @@ private extension CustomRangeTabCreationCoordinator {
 
 private extension CustomRangeTabCreationCoordinator {
     enum Constants {
-        static let thirtyDays: TimeInterval = 86400*30
+        static let thirtyDaysInSeconds: TimeInterval = 86400*30
     }
     enum Localization {
         static let add = NSLocalizedString(

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Stats v4/StatsTimeRangeBarView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Stats v4/StatsTimeRangeBarView.swift
@@ -4,36 +4,52 @@ import Experiments
 /// Contains a label that displays the time range - a date, date range for a week, month, or year.
 final class StatsTimeRangeBarView: UIView {
     // MARK: Subviews
-    private let label = UILabel(frame: .zero)
+    private let button = UIButton(frame: .zero)
+
+    // To be updated externally to handle button tap
+    var editCustomTimeRangeHandler: (() -> Void)?
 
     init() {
         super.init(frame: .zero)
         translatesAutoresizingMaskIntoConstraints = false
-        configureLabel()
+        configureButton()
     }
 
     required init?(coder aDecoder: NSCoder) {
         super.init(coder: aDecoder)
-        configureLabel()
+        configureButton()
     }
 
     /// Updates the label with start/end dates, time range type, and site time zone.
     func updateUI(viewModel: StatsTimeRangeBarViewModel) {
-        label.text = viewModel.timeRangeText
+        button.isEnabled = viewModel.isTimeRangeEditable
+
+        var configuration = UIButton.Configuration.plain()
+        configuration.titleAlignment = .center
+        configuration.image = viewModel.isTimeRangeEditable ? UIImage(systemName: "calendar") : nil
+        configuration.imagePlacement = .leading
+        configuration.preferredSymbolConfigurationForImage = UIImage.SymbolConfiguration(font: Constants.labelFont)
+        configuration.imagePadding = Constants.imagePadding
+
+        var container = AttributeContainer()
+        container.font = Constants.labelFont
+        container.foregroundColor = viewModel.isTimeRangeEditable ? .accent : Constants.labelColor
+        configuration.attributedTitle = AttributedString(viewModel.timeRangeText, attributes: container)
+
+        button.configuration = configuration
     }
 }
 
 private extension StatsTimeRangeBarView {
-    func configureLabel() {
-        addSubview(label)
-        label.translatesAutoresizingMaskIntoConstraints = false
-        label.setContentCompressionResistancePriority(.required, for: .vertical)
-        pinSubviewToAllEdges(label, insets: Constants.labelInsets)
+    func configureButton() {
+        addSubview(button)
+        button.translatesAutoresizingMaskIntoConstraints = false
+        button.setContentCompressionResistancePriority(.required, for: .vertical)
+        pinSubviewToAllEdges(button, insets: Constants.labelInsets)
 
-        label.font = Constants.labelFont
-        label.textColor = Constants.labelColor
-        label.textAlignment = Constants.labelTextAlignment
-        label.adjustsFontSizeToFitWidth = true
+        button.on(.touchUpInside) { [weak self] _ in
+            self?.editCustomTimeRangeHandler?()
+        }
     }
 }
 
@@ -43,5 +59,6 @@ private extension StatsTimeRangeBarView {
         static let labelFont: UIFont = .footnote
         static let labelColor: UIColor = .secondaryLabel
         static let labelTextAlignment: NSTextAlignment = .center
+        static let imagePadding: CGFloat = 8
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Stats v4/StatsTimeRangeBarViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Stats v4/StatsTimeRangeBarViewModel.swift
@@ -72,11 +72,13 @@ private extension StatsTimeRangeV4 {
 /// View model for `StatsTimeRangeBarView`.
 struct StatsTimeRangeBarViewModel: Equatable {
     let timeRangeText: String
+    let isTimeRangeEditable: Bool
 
     init(startDate: Date,
          endDate: Date,
          timeRange: StatsTimeRangeV4,
          timezone: TimeZone) {
+        isTimeRangeEditable = timeRange.isCustomTimeRange
         timeRangeText = timeRange.timeRangeText(startDate: startDate,
                                                 endDate: endDate,
                                                 timezone: timezone)
@@ -87,6 +89,8 @@ struct StatsTimeRangeBarViewModel: Equatable {
          selectedDate: Date,
          timeRange: StatsTimeRangeV4,
          timezone: TimeZone) {
+        // Disable editing time range when selecting a specific date on the graph
+        isTimeRangeEditable = false
         timeRangeText = timeRange.timeRangeText(startDate: startDate,
                                                 endDate: endDate,
                                                 selectedDate: selectedDate,

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Stats v4/StatsTimeRangeBarViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Stats v4/StatsTimeRangeBarViewModel.swift
@@ -18,10 +18,9 @@ private extension StatsTimeRangeV4 {
             let format = NSLocalizedString("%1$@ - %2$@", comment: "Displays a date range for a stats interval")
             return String.localizedStringWithFormat(format, startDateString, endDateString)
         case .custom:
-            // TODO: 11935 Update label count
             let startDateString = dateFormatter.string(from: startDate)
             let endDateString = dateFormatter.string(from: endDate)
-            let format = NSLocalizedString("%1$@ - %2$@", comment: "Displays a date range for a stats interval")
+            let format = NSLocalizedString("%1$@ - %2$@", comment: "Displays a date range for a custom stats interval")
             return String.localizedStringWithFormat(format, startDateString, endDateString)
         }
     }
@@ -40,8 +39,10 @@ private extension StatsTimeRangeV4 {
         case .thisYear:
             dateFormatter = DateFormatter.Charts.chartAxisYearFormatter
         case .custom:
-            // TODO: 11935 Set chart axis formatter based on interval
-            dateFormatter = DateFormatter.Charts.chartAxisYearFormatter
+            let formatter = DateFormatter()
+            formatter.dateStyle = .medium
+            formatter.timeStyle = .none
+            return formatter
         }
         dateFormatter.timeZone = timezone
         return dateFormatter
@@ -58,8 +59,10 @@ private extension StatsTimeRangeV4 {
         case .thisYear:
             dateFormatter = DateFormatter.Charts.chartAxisFullMonthFormatter
         case .custom:
-            // TODO: 11935 Set chart axis formatter based on interval
-            dateFormatter = DateFormatter.Charts.chartAxisYearFormatter
+            let formatter = DateFormatter()
+            formatter.dateStyle = .medium
+            formatter.timeStyle = .none
+            return formatter
         }
         dateFormatter.timeZone = timezone
         return dateFormatter

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Stats v4/StatsTimeRangeV4+UI.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Stats v4/StatsTimeRangeV4+UI.swift
@@ -20,10 +20,8 @@ extension StatsTimeRangeV4 {
                     calendar.dateComponents([.hour], from: startDate, to: endDate).hour
                 case .daily, .weekly:
                     calendar.dateComponents([.day], from: startDate, to: endDate).day
-                case .monthly:
+                case .monthly, .quarterly:
                     calendar.dateComponents([.month], from: startDate, to: endDate).month
-                case .quarterly:
-                    calendar.dateComponents([.quarter], from: startDate, to: endDate).quarter
                 case .yearly:
                     calendar.dateComponents([.year], from: startDate, to: endDate).year
                 }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Stats v4/StatsTimeRangeV4+UI.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Stats v4/StatsTimeRangeV4+UI.swift
@@ -12,9 +12,23 @@ extension StatsTimeRangeV4 {
             return 31
         case .thisYear:
             return 12
-        case .custom:
-            // TODO: 11935 Calculate number of intervals
-            return 7
+        case let .custom(startDate, endDate):
+            let calendar = Calendar.current
+            let quantity: Int? = {
+                switch intervalGranularity {
+                case .hourly:
+                    calendar.dateComponents([.hour], from: startDate, to: endDate).hour
+                case .daily, .weekly:
+                    calendar.dateComponents([.day], from: startDate, to: endDate).day
+                case .monthly:
+                    calendar.dateComponents([.month], from: startDate, to: endDate).month
+                case .quarterly:
+                    calendar.dateComponents([.quarter], from: startDate, to: endDate).quarter
+                case .yearly:
+                    calendar.dateComponents([.year], from: startDate, to: endDate).year
+                }
+            }()
+            return quantity ?? 7
         }
     }
 

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Stats v4/StoreStatsAndTopPerformersPeriodViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Stats v4/StoreStatsAndTopPerformersPeriodViewController.swift
@@ -41,16 +41,15 @@ final class StoreStatsAndTopPerformersPeriodViewController: UIViewController {
 
     /// Minimal time interval for data refresh
     var minimalIntervalBetweenSync: TimeInterval {
-        switch timeRange {
-        case .today:
+        switch timeRange.intervalGranularity {
+        case .hourly:
             return 60
-        case .thisWeek, .thisMonth:
+        case .daily, .weekly:
             return 60*60
-        case .thisYear:
+        case .monthly, .quarterly:
             return 60*60*12
-        case .custom:
-            // TODO: 11935 Specify refresh interval
-            return 60
+        case .yearly:
+            return 60*60*24*15
         }
     }
 

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Stats v4/StoreStatsAndTopPerformersPeriodViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Stats v4/StoreStatsAndTopPerformersPeriodViewController.swift
@@ -49,7 +49,7 @@ final class StoreStatsAndTopPerformersPeriodViewController: UIViewController {
         case .monthly, .quarterly:
             return 60*60*12
         case .yearly:
-            return 60*60*24*15
+            return 60*60*24
         }
     }
 

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Stats v4/StoreStatsAndTopPerformersPeriodViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Stats v4/StoreStatsAndTopPerformersPeriodViewController.swift
@@ -71,7 +71,11 @@ final class StoreStatsAndTopPerformersPeriodViewController: UIViewController {
         StoreStatsV4PeriodViewController(siteID: siteID,
                                          timeRange: timeRange,
                                          currentDate: currentDate,
-                                         usageTracksEventEmitter: usageTracksEventEmitter)
+                                         usageTracksEventEmitter: usageTracksEventEmitter,
+                                         onEditCustomTimeRange: { [weak self] in
+            guard let self else { return }
+            editCustomTimeRangeHandler?(timeRange)
+        })
     }()
 
     private lazy var inAppFeedbackCardViewController = InAppFeedbackCardViewController()
@@ -104,6 +108,8 @@ final class StoreStatsAndTopPerformersPeriodViewController: UIViewController {
 
     private var subscriptions = Set<AnyCancellable>()
 
+    private let editCustomTimeRangeHandler: ((StatsTimeRangeV4) -> Void)?
+
     /// Create an instance of `self`.
     ///
     /// - Parameter canDisplayInAppFeedbackCard: If applicable, present the in-app feedback card.
@@ -114,12 +120,14 @@ final class StoreStatsAndTopPerformersPeriodViewController: UIViewController {
          timeRange: StatsTimeRangeV4,
          currentDate: Date,
          canDisplayInAppFeedbackCard: Bool,
-         usageTracksEventEmitter: StoreStatsUsageTracksEventEmitter) {
+         usageTracksEventEmitter: StoreStatsUsageTracksEventEmitter,
+         onEditCustomTimeRange: ((StatsTimeRangeV4) -> Void)?) {
         self.siteID = siteID
         self.timeRange = timeRange
         self.currentDate = currentDate
         self.viewModel = StoreStatsAndTopPerformersPeriodViewModel(canDisplayInAppFeedbackCard: canDisplayInAppFeedbackCard)
         self.usageTracksEventEmitter = usageTracksEventEmitter
+        self.editCustomTimeRangeHandler = onEditCustomTimeRange
 
         super.init(nibName: nil, bundle: nil)
 

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Stats v4/StoreStatsAndTopPerformersViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Stats v4/StoreStatsAndTopPerformersViewController.swift
@@ -409,8 +409,6 @@ private extension StoreStatsAndTopPerformersViewController {
         tabBar.equalWidthFill = .equalSpacing
         tabBar.equalWidthSpacing = TabBar.tabSpacing
 
-        /// TODO-11935: Check if a custom range has been added and hide this button.
-        ///
         if featureFlagService.isFeatureFlagEnabled(.customRangeInMyStoreAnalytics) {
             addCustomViewToTabBar(customRangeButtonView)
         }
@@ -451,7 +449,6 @@ private extension StoreStatsAndTopPerformersViewController {
         stackView.translatesAutoresizingMaskIntoConstraints = false
         stackView.axis = .vertical
 
-        // TODO-11935: handle button action
         let button = UIButton(configuration: .plain())
         button.setImage(UIImage(systemName: "calendar.badge.plus"), for: .normal)
         button.tintColor = .accent
@@ -487,7 +484,6 @@ private extension StoreStatsAndTopPerformersViewController {
     func createCustomRangeTab(range: StatsTimeRangeV4) {
         let currentDate = Date()
 
-        // TODO: 11935 Add the correct data fetching and displaying based on custom range.
         let customRangeVC = StoreStatsAndTopPerformersPeriodViewController(siteID: siteID,
                                                                            timeRange: range,
                                                                            currentDate: currentDate,

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Stats v4/StoreStatsAndTopPerformersViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Stats v4/StoreStatsAndTopPerformersViewController.swift
@@ -421,7 +421,7 @@ private extension StoreStatsAndTopPerformersViewController {
             return
         }
 
-        guard let customRange = await loadCustomRangeTab() else {
+        guard let customRange = await loadTimeRangeForCustomRangeTab() else {
             return
         }
 
@@ -429,7 +429,7 @@ private extension StoreStatsAndTopPerformersViewController {
     }
 
     @MainActor
-    func loadCustomRangeTab() async -> StatsTimeRangeV4? {
+    func loadTimeRangeForCustomRangeTab() async -> StatsTimeRangeV4? {
         guard featureFlagService.isFeatureFlagEnabled(.customRangeInMyStoreAnalytics) else {
             return nil
         }
@@ -441,7 +441,7 @@ private extension StoreStatsAndTopPerformersViewController {
         }
     }
 
-    func saveCustomRangeTab(timeRange: StatsTimeRangeV4) {
+    func saveTimeRangeForCustomRangeTab(timeRange: StatsTimeRangeV4) {
         stores.dispatch(AppSettingsAction.setCustomStatsTimeRange(siteID: siteID, timeRange: timeRange))
     }
 
@@ -477,7 +477,7 @@ private extension StoreStatsAndTopPerformersViewController {
             navigationController: navigationController,
             onDateRangeSelected: { [weak self] start, end in
                 let range = StatsTimeRangeV4.custom(from: start, to: end)
-                self?.saveCustomRangeTab(timeRange: range)
+                self?.saveTimeRangeForCustomRangeTab(timeRange: range)
                 self?.createCustomRangeTab(range: range)
             }
         )

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Stats v4/StoreStatsAndTopPerformersViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Stats v4/StoreStatsAndTopPerformersViewController.swift
@@ -457,7 +457,7 @@ private extension StoreStatsAndTopPerformersViewController {
         button.backgroundColor = .listForeground(modal: false)
 
         button.on(.touchUpInside) { [weak self] _ in
-            self?.startCustomRangeTabCreation(startDate: nil, endDate: nil)
+            self?.startCustomRangeTabCreation()
         }
 
         let separator = UIView()
@@ -469,7 +469,7 @@ private extension StoreStatsAndTopPerformersViewController {
         return stackView
     }
 
-    func startCustomRangeTabCreation(startDate: Date?, endDate: Date?) {
+    func startCustomRangeTabCreation(startDate: Date? = nil, endDate: Date? = nil) {
         guard let navigationController else { return }
         customRangeCoordinator = CustomRangeTabCreationCoordinator(
             startDate: startDate,

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Stats v4/StoreStatsV4PeriodViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Stats v4/StoreStatsV4PeriodViewController.swift
@@ -503,7 +503,7 @@ extension StoreStatsV4PeriodViewController: AxisValueFormatter {
             if index >= intervalLabels.count {
                 DDLogInfo("🔴 orderStatsIntervals count: \(orderStatsIntervals.count); value: \(value); index: \(index); interval labels: \(intervalLabels)")
             }
-            return intervalLabels[index]
+            return intervalLabels[safe: index] ?? ""
         } else {
             if value == 0.0 {
                 // Do not show the "0" label on the Y axis

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Stats v4/StoreStatsV4PeriodViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Stats v4/StoreStatsV4PeriodViewController.swift
@@ -121,6 +121,7 @@ final class StoreStatsV4PeriodViewController: UIViewController {
 
     private var cancellables: Set<AnyCancellable> = []
     private let chartValueSelectedEventsSubject = PassthroughSubject<Void, Never>()
+    private let editCustomTimeRangeHandler: (() -> Void)?
 
     // MARK: - Initialization
 
@@ -131,7 +132,8 @@ final class StoreStatsV4PeriodViewController: UIViewController {
          currentDate: Date,
          currencyFormatter: CurrencyFormatter = CurrencyFormatter(currencySettings: ServiceLocator.currencySettings),
          currencySettings: CurrencySettings = ServiceLocator.currencySettings,
-         usageTracksEventEmitter: StoreStatsUsageTracksEventEmitter) {
+         usageTracksEventEmitter: StoreStatsUsageTracksEventEmitter,
+         onEditCustomTimeRange: (() -> Void)?) {
         self.timeRange = timeRange
         self.granularity = timeRange.intervalGranularity
         self.viewModel = StoreStatsPeriodViewModel(siteID: siteID,
@@ -141,6 +143,7 @@ final class StoreStatsV4PeriodViewController: UIViewController {
                                                    currencyFormatter: currencyFormatter,
                                                    currencySettings: currencySettings)
         self.usageTracksEventEmitter = usageTracksEventEmitter
+        self.editCustomTimeRangeHandler = onEditCustomTimeRange
         super.init(nibName: type(of: self).nibName, bundle: nil)
     }
 
@@ -330,6 +333,7 @@ private extension StoreStatsV4PeriodViewController {
         view.backgroundColor = Constants.containerBackgroundColor
         containerStackView.backgroundColor = Constants.containerBackgroundColor
         timeRangeBarView.backgroundColor = Constants.headerComponentBackgroundColor
+        timeRangeBarView.editCustomTimeRangeHandler = editCustomTimeRangeHandler
 
         // Titles
         visitorsTitle.text = NSLocalizedString("Visitors", comment: "Visitors stat label on dashboard - should be plural.")

--- a/WooCommerce/Classes/ViewRelated/FilterTabBar/TabbedViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/FilterTabBar/TabbedViewController.swift
@@ -120,6 +120,16 @@ class TabbedViewController: UIViewController {
         selection = tabPosition
         updateVisibleChildViewController(at: tabPosition)
     }
+
+    func replaceTab(at index: Int, with newTab: TabbedItem) {
+        let oldTab = items[index]
+        stackView.removeArrangedSubview(oldTab.viewController.view)
+        oldTab.viewController.removeFromParent()
+        oldTab.viewController.view.removeFromSuperview()
+        items.remove(at: index)
+
+        appendToTabBar(newTab)
+    }
 }
 
 private extension TabbedViewController {

--- a/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/RangedDatePicker.swift
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/RangedDatePicker.swift
@@ -47,6 +47,10 @@ struct RangedDatePicker: View {
     ///
     @State private var endDate: Date
 
+    /// Whether to display the alert for invalid date range
+    ///
+    @State private var shouldShowInvalidDateRangeAlert = false
+
     /// Type to format the subtitle range.
     ///
     private let datesFormatter: RangedDateTextFormatter
@@ -114,6 +118,10 @@ struct RangedDatePicker: View {
                 }
                 ToolbarItem(placement: .confirmationAction) {
                     Button(action: {
+                        guard startDate < endDate else {
+                            shouldShowInvalidDateRangeAlert = true
+                            return
+                        }
                         presentation.wrappedValue.dismiss()
                         datesSelected?(startDate, endDate)
                     }, label: {
@@ -131,6 +139,14 @@ struct RangedDatePicker: View {
         }
         .navigationViewStyle(.stack)
         .wooNavigationBarStyle()
+        .alert(Localization.InvalidTimeRangeAlert.title, isPresented: $shouldShowInvalidDateRangeAlert) {
+            Button(Localization.InvalidTimeRangeAlert.action) {
+                shouldShowInvalidDateRangeAlert = false
+            }
+        } message: {
+            Text(Localization.InvalidTimeRangeAlert.message)
+        }
+
     }
 }
 
@@ -142,6 +158,24 @@ private extension RangedDatePicker {
         static let apply = NSLocalizedString("Apply", comment: "Apply navigation button in custom range date picker")
         static let startDate = NSLocalizedString("Start Date", comment: "Start Date label in custom range date picker")
         static let endDate = NSLocalizedString("End Date", comment: "End Date label in custom range date picker")
+
+        enum InvalidTimeRangeAlert {
+            static let title = NSLocalizedString(
+                "rangedDatePicker.invalidTimeRangeAlert.title",
+                value: "Invalid time range",
+                comment: "Title of the alert displayed when selecting an invalid time range for analytics"
+            )
+            static let message = NSLocalizedString(
+                "rangedDatePicker.invalidTimeRangeAlert.message",
+                value: "The start date should be earlier than the end date. Please select a different time range.",
+                comment: "Message of the alert displayed when selecting an invalid time range for analytics"
+            )
+            static let action = NSLocalizedString(
+                "rangedDatePicker.invalidTimeRangeAlert.action",
+                value: "Got It",
+                comment: "Button to dismiss the alert displayed when selecting an invalid time range for analytics"
+            )
+        }
     }
     enum Layout {
         static let titleSpacing: CGFloat = 4.0

--- a/Yosemite/Yosemite/Model/Enums/StatsTimeRangeV4.swift
+++ b/Yosemite/Yosemite/Model/Enums/StatsTimeRangeV4.swift
@@ -114,9 +114,9 @@ extension StatsTimeRangeV4 {
                 return .hourly
             }
             switch differenceInDays {
-            case .lessThan1:
+            case .lessThan2:
                 return .hourly
-            case .from1To28:
+            case .from2To28:
                 return .daily
             case .from29To90:
                 return .weekly
@@ -140,9 +140,9 @@ extension StatsTimeRangeV4 {
                 return .hour
             }
             switch differenceInDays {
-            case .lessThan1:
+            case .lessThan2:
                 return .hour
-            case .from1To28:
+            case .from2To28:
                 return .day
             case .from29To90:
                 return .week
@@ -170,9 +170,9 @@ extension StatsTimeRangeV4 {
                 return .hour
             }
             switch differenceInDays {
-            case .lessThan1:
+            case .lessThan2:
                 return .hour
-            case .from1To28:
+            case .from2To28:
                 return .day
             case .from29To90:
                 return .week
@@ -200,9 +200,9 @@ extension StatsTimeRangeV4 {
                 return .hour
             }
             switch differenceInDays {
-            case .lessThan1:
+            case .lessThan2:
                 return .hour
-            case .from1To28:
+            case .from2To28:
                 return .day
             case .from29To90:
                 return .week
@@ -253,8 +253,8 @@ private extension StatsTimeRangeV4 {
         case greaterThan365
         case from91to365
         case from29To90
-        case from1To28
-        case lessThan1
+        case from2To28
+        case lessThan2
     }
 
     /// Based on WooCommerce Core
@@ -277,10 +277,10 @@ private extension StatsTimeRangeV4 {
             return .from91to365
         case 29...90:
             return .from29To90
-        case 1...28:
-            return .from1To28
-        case 0:
-            return .lessThan1
+        case 2...28:
+            return .from2To28
+        case 0..<2:
+            return .lessThan2
         default:
             return nil
         }

--- a/Yosemite/Yosemite/Model/Enums/StatsTimeRangeV4.swift
+++ b/Yosemite/Yosemite/Model/Enums/StatsTimeRangeV4.swift
@@ -48,6 +48,15 @@ extension StatsTimeRangeV4: RawRepresentable, Hashable {
         }
     }
 
+    public var isCustomTimeRange: Bool {
+        switch self {
+        case .today, .thisWeek, .thisMonth, .thisYear:
+            false
+        case .custom:
+            true
+        }
+    }
+
     private enum CustomRangeFormatter {
         static private let dateFormatter = DateFormatter.Defaults.yearMonthDayDateFormatter
         static private let separator = "_"
@@ -220,9 +229,23 @@ extension StatsTimeRangeV4 {
             return daysThisMonth?.count ?? 0
         case .thisYear:
             return 12
-        case .custom:
-            // TODO: 11935 Calculate interval units
-            return 1
+        case let .custom(startDate, endDate):
+            let calendar = Calendar.current
+            let quantity: Int? = {
+                switch siteVisitStatsGranularity {
+                case .hour:
+                    calendar.dateComponents([.hour], from: startDate, to: endDate).hour
+                case .day, .week:
+                    calendar.dateComponents([.day], from: startDate, to: endDate).day
+                case .month:
+                    calendar.dateComponents([.month], from: startDate, to: endDate).month
+                case .quarter:
+                    calendar.dateComponents([.quarter], from: startDate, to: endDate).quarter
+                case .year:
+                    calendar.dateComponents([.year], from: startDate, to: endDate).year
+                }
+            }()
+            return quantity ?? 1
         }
     }
 }

--- a/Yosemite/Yosemite/Model/Enums/StatsTimeRangeV4.swift
+++ b/Yosemite/Yosemite/Model/Enums/StatsTimeRangeV4.swift
@@ -237,15 +237,13 @@ extension StatsTimeRangeV4 {
                     calendar.dateComponents([.hour], from: startDate, to: endDate).hour
                 case .day, .week:
                     calendar.dateComponents([.day], from: startDate, to: endDate).day
-                case .month:
+                case .month, .quarter:
                     calendar.dateComponents([.month], from: startDate, to: endDate).month
-                case .quarter:
-                    calendar.dateComponents([.quarter], from: startDate, to: endDate).quarter
                 case .year:
                     calendar.dateComponents([.year], from: startDate, to: endDate).year
                 }
             }()
-            return quantity ?? 1
+            return quantity ?? 7
         }
     }
 }

--- a/Yosemite/Yosemite/Stores/StatsStoreV4.swift
+++ b/Yosemite/Yosemite/Stores/StatsStoreV4.swift
@@ -496,9 +496,7 @@ public extension StatsStoreV4 {
             return DateFormatter.Stats.statsDayFormatter.string(from: date)
         case .week:
             return DateFormatter.Stats.statsWeekFormatter.string(from: date)
-        case .month:
-            return DateFormatter.Stats.statsMonthFormatter.string(from: date)
-        case .quarter:
+        case .month, .quarter:
             return DateFormatter.Stats.statsMonthFormatter.string(from: date)
         case .year:
             return DateFormatter.Stats.statsYearFormatter.string(from: date)

--- a/Yosemite/Yosemite/Stores/StatsStoreV4.swift
+++ b/Yosemite/Yosemite/Stores/StatsStoreV4.swift
@@ -488,8 +488,10 @@ public extension StatsStoreV4 {
     static func buildDateString(from date: Date, with granularity: StatGranularity) -> String {
         switch granularity {
         case .hour:
-            // TODO: 11935 Check and update date formatter
-            return DateFormatter.Defaults.dateTimeFormatter.string(from: date)
+            let dateFormatter = DateFormatter()
+            dateFormatter.dateStyle = .short
+            dateFormatter.timeStyle = .short
+            return dateFormatter.string(from: date)
         case .day:
             return DateFormatter.Stats.statsDayFormatter.string(from: date)
         case .week:
@@ -497,7 +499,6 @@ public extension StatsStoreV4 {
         case .month:
             return DateFormatter.Stats.statsMonthFormatter.string(from: date)
         case .quarter:
-            // TODO: 11935 Check and update date formatter
             return DateFormatter.Stats.statsMonthFormatter.string(from: date)
         case .year:
             return DateFormatter.Stats.statsYearFormatter.string(from: date)


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #11985 
Also closes: #11980
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This PR updates the content for the custom range tab on My Store analytics. Changes include:
- Updated `CustomRangeTabCreationCoordinator` logic:
  - Accept an optional start date and end date in the initializer to support updating an existing time range.
  - If start date and end date are nil, default to the last 30 days for the time range picker.
  - Check to ensure the selected time range is valid, and display an alert if the range is invalid.
- `StatsTimeRangeBarView`: Update style and enable tapping to update the custom time range. I'm using the calendar icon for the button as it's more straightforward than adding an "Edit" text like in the original design proposal.
- Updated the date formatter for the custom time range.
- Calculated the number of intervals for revenue and visit stats based on granularity for custom time range.
- Calculated refresh interval for custom time range based on interval granularity rather than time range.
- Handled updating existing custom time range.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
- Enable the feature flag `customRangeInMyStoreAnalytics` and build the app.
- Log in to a test store.
- Tap the calendar icon to add a new custom range if you haven't already done that.
- Select an invalid time range (with start date >= end date) and tap Add => an alert should be displayed asking you to select again.
- Select a valid time range, a new tab for custom time range should be added.
- Confirm that the time range is a purple button with a calendar icon. Select any interval in the graph, the time should be display in gray text without the icon.
- Select the time range button to change to a different time range and select Apply. The custom range tab should be updated accordingly.
- Test with different range length to see if there's any issue with the intervals.

Please feel free to test again with the feature flag `customRangeInMyStoreAnalytics` off to confirm that everything works as previously.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->
Invalid time range | Valid time range
--- | ---
<img src="https://github.com/woocommerce/woocommerce-ios/assets/5533851/a0a17fdc-d580-46a6-8721-ae644a62ab94" width=320 /> | <img src="https://github.com/woocommerce/woocommerce-ios/assets/5533851/f7aec315-ed58-4e16-b089-5ccbfb6a0ff2" width=320 />


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
