### PR TITLE
[Orders] Filter by product - Remove feature flag

### DIFF
--- a/Experiments/Experiments/DefaultFeatureFlagService.swift
+++ b/Experiments/Experiments/DefaultFeatureFlagService.swift
@@ -95,8 +95,6 @@ public struct DefaultFeatureFlagService: FeatureFlagService {
             return buildConfig != .appStore
         case .connectivityTool:
             return buildConfig == .localDeveloper || buildConfig == .alpha
-        case .filterOrdersByProduct:
-            return buildConfig == .localDeveloper || buildConfig == .alpha
         default:
             return true
         }

--- a/Experiments/Experiments/FeatureFlag.swift
+++ b/Experiments/Experiments/FeatureFlag.swift
@@ -211,8 +211,4 @@ public enum FeatureFlag: Int {
     /// Enables the connectivity tool when an order list error happens.
     ///
     case connectivityTool
-
-    /// Enables filtering orders by product
-    ///
-    case filterOrdersByProduct
 }

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -3,6 +3,7 @@
 17.6
 -----
 - Orders: Merchants can now contact their customers through WhatsApp and Telegram apps. [https://github.com/woocommerce/woocommerce-ios/pull/12099]
+- Orders: Merchants can filter orders by selecting a product. [https://github.com/woocommerce/woocommerce-ios/pull/12129]
 
 
 17.5

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Filters/FilterOrderListViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Filters/FilterOrderListViewModel.swift
@@ -68,11 +68,7 @@ final class FilterOrderListViewModel: FilterListViewModel {
         dateRangeFilterViewModel = OrderListFilter.dateRange.createViewModel(filters: filters, allowedStatuses: allowedStatuses)
         productFilterViewModel = OrderListFilter.product(siteID: siteID).createViewModel(filters: filters, allowedStatuses: allowedStatuses)
         self.featureFlagService = featureFlagService
-        if featureFlagService.isFeatureFlagEnabled(.filterOrdersByProduct) {
-            filterTypeViewModels = [orderStatusFilterViewModel, dateRangeFilterViewModel, productFilterViewModel]
-        } else {
-            filterTypeViewModels = [orderStatusFilterViewModel, dateRangeFilterViewModel]
-        }
+        filterTypeViewModels = [orderStatusFilterViewModel, dateRangeFilterViewModel, productFilterViewModel]
     }
 
     var criteria: Filters {

--- a/WooCommerce/WooCommerceTests/Mocks/MockFeatureFlagService.swift
+++ b/WooCommerce/WooCommerceTests/Mocks/MockFeatureFlagService.swift
@@ -22,7 +22,6 @@ struct MockFeatureFlagService: FeatureFlagService {
     private let isScanToUpdateInventoryEnabled: Bool
     private let blazei3NativeCampaignCreation: Bool
     private let isBackendReceiptsEnabled: Bool
-    private let filterOrdersByProduct: Bool
 
     init(isInboxOn: Bool = false,
          isUpdateOrderOptimisticallyOn: Bool = false,
@@ -43,8 +42,7 @@ struct MockFeatureFlagService: FeatureFlagService {
          productBundlesInOrderForm: Bool = false,
          isScanToUpdateInventoryEnabled: Bool = false,
          blazei3NativeCampaignCreation: Bool = false,
-         isBackendReceiptsEnabled: Bool = false,
-         filterOrdersByProduct: Bool = false) {
+         isBackendReceiptsEnabled: Bool = false) {
         self.isInboxOn = isInboxOn
         self.isUpdateOrderOptimisticallyOn = isUpdateOrderOptimisticallyOn
         self.shippingLabelsOnboardingM1 = shippingLabelsOnboardingM1
@@ -65,7 +63,6 @@ struct MockFeatureFlagService: FeatureFlagService {
         self.isScanToUpdateInventoryEnabled = isScanToUpdateInventoryEnabled
         self.blazei3NativeCampaignCreation = blazei3NativeCampaignCreation
         self.isBackendReceiptsEnabled = isBackendReceiptsEnabled
-        self.filterOrdersByProduct = filterOrdersByProduct
     }
 
     func isFeatureFlagEnabled(_ featureFlag: FeatureFlag) -> Bool {
@@ -108,8 +105,6 @@ struct MockFeatureFlagService: FeatureFlagService {
             return blazei3NativeCampaignCreation
         case .backendReceipts:
             return isBackendReceiptsEnabled
-        case .filterOrdersByProduct:
-            return filterOrdersByProduct
         default:
             return false
         }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Filters/FilterOrderListViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Filters/FilterOrderListViewModelTests.swift
@@ -54,7 +54,7 @@ final class FilterOrderListViewModelTests: XCTestCase {
 
     // MARK: Filter based on product
 
-    func test_product_filter_is_not_added_to_filterTypeViewModels_when_feature_flag_off() {
+    func test_product_filter_is_added_to_filterTypeViewModels() {
         // Given
         let filters = FilterOrderListViewModel.Filters(orderStatus: [.processing],
                                                        dateRange: OrderDateRangeFilter(filter: .today),
@@ -64,30 +64,7 @@ final class FilterOrderListViewModelTests: XCTestCase {
         // When
         let viewModel = FilterOrderListViewModel(filters: filters,
                                                  allowedStatuses: [],
-                                                 siteID: 1,
-                                                 featureFlagService: MockFeatureFlagService(filterOrdersByProduct: false))
-
-        // Then
-        XCTAssertFalse(viewModel.filterTypeViewModels.contains(where: {
-            if case .products = $0.listSelectorConfig {
-                return true
-            } else {
-                return false
-            }}))
-    }
-
-    func test_product_filter_is_added_to_filterTypeViewModels_when_feature_flag_on() {
-        // Given
-        let filters = FilterOrderListViewModel.Filters(orderStatus: [.processing],
-                                                       dateRange: OrderDateRangeFilter(filter: .today),
-                                                       product: FilterOrdersByProduct(id: 1, name: "Sample product"),
-                                                       numberOfActiveFilters: 3)
-
-        // When
-        let viewModel = FilterOrderListViewModel(filters: filters,
-                                                 allowedStatuses: [],
-                                                 siteID: 1,
-                                                 featureFlagService: MockFeatureFlagService(filterOrdersByProduct: true))
+                                                 siteID: 1)
 
         // Then
         XCTAssertTrue(viewModel.filterTypeViewModels.contains(where: {


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of: #12059 
<!-- Id number of the GitHub issue this PR addresses. -->

## Description

Remove the feature flag and release the feature that allows merchants to view orders by filtering them using a product. 

## Testing instructions

- Create a store
- Create a few products and orders
- Login into the app
- Navigate to the Orders tab
- Tap "Filter" -> "Product" 
- From the list of products select one
- Tap "Show Orders"
- The order list screen should show only the orders related to the selected order now.
- Tap "Filter" again and validate that the previously selected product name is visible in the filter.
- Tap "Clear all" to clear the filters. 
- Applying the filter should start showing all the orders in the order list screen.

## Screenshots

https://github.com/woocommerce/woocommerce-ios/assets/524475/1f87f218-58fe-4fae-920b-7fb5d47def1f



---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
