### PR TITLE
[Analytics Hub] Show empty state view when there are no cards to display

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/AnalyticsHubView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/AnalyticsHubView.swift
@@ -179,7 +179,6 @@ private extension AnalyticsHubView {
 
                 Divider()
             }
-            .renderedIf(viewModel.showSessionsCard)
         }
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/AnalyticsHubView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/AnalyticsHubView.swift
@@ -77,12 +77,12 @@ struct AnalyticsHubView: View {
                     Divider()
                 }
 
-                if viewModel.enabledCards.isEmpty {
-                    EmptyState(title: Localization.emptyStateTitle, description: Localization.emptyStateDescription, image: .enableAnalyticsImage)
-                } else {
+                if viewModel.enabledCards.isNotEmpty {
                     ForEach(viewModel.enabledCards, id: \.self) { card in
                         analyticsCard(type: card)
                     }
+                } else {
+                    EmptyState(title: Localization.emptyStateTitle, description: Localization.emptyStateDescription, image: .enableAnalyticsImage)
                 }
 
                 Spacer()

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/AnalyticsHubView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/AnalyticsHubView.swift
@@ -77,8 +77,12 @@ struct AnalyticsHubView: View {
                     Divider()
                 }
 
-                ForEach(viewModel.enabledCards, id: \.self) { card in
-                    analyticsCard(type: card)
+                if viewModel.enabledCards.isEmpty {
+                    EmptyState(title: Localization.emptyStateTitle, description: Localization.emptyStateDescription, image: .enableAnalyticsImage)
+                } else {
+                    ForEach(viewModel.enabledCards, id: \.self) { card in
+                        analyticsCard(type: card)
+                    }
                 }
 
                 Spacer()
@@ -202,6 +206,13 @@ private extension AnalyticsHubView {
         static let editButton = NSLocalizedString("analyticsHub.editButton.label",
                                                   value: "Edit",
                                                   comment: "Label for button that opens a screen to customize the Analytics Hub")
+
+        static let emptyStateTitle = NSLocalizedString("analyticsHub.emptyState.title",
+                                                       value: "No analytics available",
+                                                       comment: "Title when there are no analytics to display in the Analytics Hub.")
+        static let emptyStateDescription = NSLocalizedString("analyticsHub.emptyState.description",
+                                                             value: "Please select another date range or tap Edit to enable more analytics.",
+                                                             comment: "Description when there are no analytics to display in the Analytics Hub.")
     }
 
     struct Layout {

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/AnalyticsHubViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/AnalyticsHubViewModel.swift
@@ -127,13 +127,16 @@ final class AnalyticsHubViewModel: ObservableObject {
     ///
     var enabledCards: [AnalyticsCard.CardType] {
         let allCards = canCustomizeAnalytics ? allCardsWithSettings : AnalyticsHubViewModel.defaultCards
-        return allCards.filter { $0.enabled }.map { $0.type }
+        return allCards.filter { card in
+            let canBeDisplayed = card.type == .sessions ? showSessionsCard : true
+            return card.enabled && canBeDisplayed
+        }.map { $0.type }
     }
 
     /// Sessions Card display state
     ///
-    var showSessionsCard: Bool {
-        guard enabledCards.contains(.sessions), isEligibleForSessionsCard else {
+    private var showSessionsCard: Bool {
+        guard isEligibleForSessionsCard else {
             return false
         }
         if case .custom = timeRangeSelectionType {
@@ -351,7 +354,7 @@ private extension AnalyticsHubViewModel {
     /// Retrieves site summary stats using the `retrieveSiteSummaryStats` action.
     ///
     func retrieveSiteSummaryStats(latestDateToInclude: Date) async throws -> SiteSummaryStats? {
-        guard showSessionsCard, let period = timeRangeSelectionType.period else {
+        guard enabledCards.contains(.sessions), let period = timeRangeSelectionType.period else {
             return nil
         }
 

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/AnalyticsHubViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/AnalyticsHubViewModel.swift
@@ -87,6 +87,8 @@ final class AnalyticsHubViewModel: ObservableObject {
         bindCardSettingsWithData()
     }
 
+    // MARK: View Models
+
     /// Revenue Card ViewModel
     ///
     @Published var revenueCard: AnalyticsReportCardViewModel
@@ -110,6 +112,23 @@ final class AnalyticsHubViewModel: ObservableObject {
     /// View model for `AnalyticsHubCustomizeView`, to customize the cards in the Analytics Hub.
     ///
     @Published var customizeAnalyticsViewModel: AnalyticsHubCustomizeViewModel?
+
+    /// Time Range Selection Type
+    ///
+    @Published var timeRangeSelectionType: AnalyticsHubTimeRangeSelection.SelectionType
+
+    /// Time Range ViewModel
+    ///
+    @Published var timeRangeCard: AnalyticsTimeRangeCardViewModel
+
+    // MARK: Card Display States
+
+    /// All analytics cards to display in the Analytics Hub.
+    ///
+    var enabledCards: [AnalyticsCard.CardType] {
+        let allCards = canCustomizeAnalytics ? allCardsWithSettings : AnalyticsHubViewModel.defaultCards
+        return allCards.filter { $0.enabled }.map { $0.type }
+    }
 
     /// Sessions Card display state
     ///
@@ -142,25 +161,10 @@ final class AnalyticsHubViewModel: ObservableObject {
         isJetpackStatsDisabled && userIsAdmin
     }
 
-    /// Time Range Selection Type
-    ///
-    @Published var timeRangeSelectionType: AnalyticsHubTimeRangeSelection.SelectionType
-
-    /// Time Range ViewModel
-    ///
-    @Published var timeRangeCard: AnalyticsTimeRangeCardViewModel
-
     /// Defines a notice that, when set, dismisses the view and is then displayed.
     /// Defaults to `nil`.
     ///
     @Published var dismissNotice: Notice?
-
-    /// All analytics cards to display in the Analytics Hub.
-    ///
-    var enabledCards: [AnalyticsCard.CardType] {
-        let allCards = canCustomizeAnalytics ? allCardsWithSettings : AnalyticsHubViewModel.defaultCards
-        return allCards.filter { $0.enabled }.map { $0.type }
-    }
 
     // MARK: Private data
 

--- a/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Analytics Hub/AnalyticsHubViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Analytics Hub/AnalyticsHubViewModelTests.swift
@@ -158,19 +158,19 @@ final class AnalyticsHubViewModelTests: XCTestCase {
 
     func test_session_card_is_hidden_for_custom_range() async {
         // Given
-        XCTAssertTrue(vm.showSessionsCard)
+        XCTAssertTrue(vm.enabledCards.contains(.sessions))
 
         // When
         vm.timeRangeSelectionType = .custom(start: Date(), end: Date())
 
         // Then
-        XCTAssertFalse(vm.showSessionsCard)
+        XCTAssertFalse(vm.enabledCards.contains(.sessions))
 
         // When
         vm.timeRangeSelectionType = .lastMonth
 
         // Then
-        XCTAssertTrue(vm.showSessionsCard)
+        XCTAssertTrue(vm.enabledCards.contains(.sessions))
     }
 
     func test_session_card_is_hidden_for_sites_without_jetpack_plugin() {
@@ -184,8 +184,8 @@ final class AnalyticsHubViewModelTests: XCTestCase {
         let vmJCPSite = createViewModel(stores: storesForJCPSite)
 
         // Then
-        XCTAssertFalse(vmNonJetpackSite.showSessionsCard)
-        XCTAssertFalse(vmJCPSite.showSessionsCard)
+        XCTAssertFalse(vmNonJetpackSite.enabledCards.contains(.sessions))
+        XCTAssertFalse(vmJCPSite.enabledCards.contains(.sessions))
     }
 
     @MainActor
@@ -211,7 +211,7 @@ final class AnalyticsHubViewModelTests: XCTestCase {
 
         // Then
         XCTAssertFalse(vm.showJetpackStatsCTA)
-        XCTAssertFalse(vm.showSessionsCard)
+        XCTAssertFalse(vm.enabledCards.contains(.sessions))
     }
 
     func test_time_range_card_tracks_expected_events() throws {
@@ -589,7 +589,7 @@ final class AnalyticsHubViewModelTests: XCTestCase {
             case let .retrieveTopEarnerStats(_, _, _, _, _, _, _, _, completion):
                 completion(.success(.fake()))
             case let .retrieveSiteSummaryStats(_, _, _, _, _, _, completion):
-                XCTFail("Request to retrieve site summary stats should not be dispatched for sites without Jetpack")
+                XCTFail("Request to retrieve site summary stats should not be dispatched when sessions card is hidden")
                 completion(.failure(DotcomError.unknown(code: "unknown_blog", message: "Unknown blog")))
             default:
                 break
@@ -724,7 +724,7 @@ final class AnalyticsHubViewModelTests: XCTestCase {
         let expectedCards = [AnalyticsCard(type: .revenue, enabled: true),
                              AnalyticsCard(type: .orders, enabled: true),
                              AnalyticsCard(type: .products, enabled: true)]
-        XCTAssertFalse(vm.showSessionsCard)
+        XCTAssertFalse(vm.enabledCards.contains(.sessions))
         assertEqual(expectedCards, customizeAnalyticsVM.allCards)
     }
 }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #12131
<!-- Id number of the GitHub issue this PR addresses. -->

## Why
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
When a custom time range is selected, the Sessions card isn't shown (because we can't get those stats for custom time ranges).

If the Sessions card is the only selected/enabled card, then when the merchant chooses a custom date range they'll see an empty screen. This adds an empty state view in that scenario with a meaningful message.

## How

* Makes `enabledCards` the source of truth for which cards to display in the analytics hub. `showSessionsCard` is now a private var, used to filter out the Sessions card from `enabledCards` if it shouldn't be displayed.
* If `enabledCards` is empty, we show the empty state view.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

On a store using the full Jetpack plugin, with Jetpack Stats enabled:

1. Build and run the app.
2. Tap "See More" to open the analytics hub.
3. Tap "Edit" to open Customize Analytics.
4. Deselect everything except the Sessions card and save changes.
5. Select a preset date range (e.g. Today, Yesterday) and confirm the Sessions card loads as expected.
6. Select a custom date range and confirm you see the empty state view.

Bonus: Test that the sessions card visibility continues to work as expected in other scenarios, e.g. when the store isn't using the full Jetpack plugin or Jetpack Stats is not enabled.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

Preset date range|Custom date range
-|-
![Simulator Screenshot - iPhone 15 Pro - 2024-02-28 at 13 34 42](https://github.com/woocommerce/woocommerce-ios/assets/8658164/624e7d2d-b137-4437-8805-87e219e881c2)|![Simulator Screenshot - iPhone 15 Pro - 2024-02-28 at 13 35 02](https://github.com/woocommerce/woocommerce-ios/assets/8658164/0b9d7713-9e74-42d5-b13c-51a38214ace8)


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
