### PR TITLE
[Product images] Use `actor` based image storage 

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Products/Media/DefaultProductUIImageLoader.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Media/DefaultProductUIImageLoader.swift
@@ -14,7 +14,7 @@ final class DefaultProductUIImageLoader: ProductUIImageLoader {
         case unableToLoadImage
     }
 
-    private var imagesByProductImageID: [Int64: UIImage] = [:]
+    private var imageStorage: ImageStorage
     private let imageService: ImageService
 
     private let productImageActionHandler: ProductImageActionHandler?
@@ -44,6 +44,7 @@ final class DefaultProductUIImageLoader: ProductUIImageLoader {
         self.productImageActionHandler = productImageActionHandler
         self.imageService = imageService
         self.phAssetImageLoaderProvider = phAssetImageLoaderProvider
+        self.imageStorage = ImageStorage()
 
         assetUploadSubscription = productImageActionHandler?.addAssetUploadObserver(self) { [weak self] asset, result in
             guard let self = self else { return }
@@ -55,7 +56,7 @@ final class DefaultProductUIImageLoader: ProductUIImageLoader {
     }
 
     func requestImage(productImage: ProductImage) async throws -> UIImage {
-        if let image = imagesByProductImageID[productImage.imageID] {
+        if let image = await imageStorage.getImage(id: productImage.imageID) {
             return image
         }
 
@@ -111,18 +112,26 @@ final class DefaultProductUIImageLoader: ProductUIImageLoader {
 private extension DefaultProductUIImageLoader {
     func update(from asset: ProductImageAssetType, to productImage: ProductImage) {
         switch asset {
-            case .phAsset(let asset):
-                phAssetImageLoader.requestImage(for: asset,
-                                                targetSize: PHImageManagerMaximumSize,
-                                                contentMode: .aspectFit,
-                                                options: nil) { [weak self] (image, info) in
-                    guard let image else {
-                        return
-                    }
-                    self?.imagesByProductImageID[productImage.imageID] = image
+        case .phAsset(let asset):
+            phAssetImageLoader.requestImage(for: asset,
+                                            targetSize: PHImageManagerMaximumSize,
+                                            contentMode: .aspectFit,
+                                            options: nil) { (image, info) in
+                guard let image else {
+                    return
                 }
-            case .uiImage(let image, _, _):
-                imagesByProductImageID[productImage.imageID] = image
+                Task { [weak self] in
+                    guard let self else { return }
+
+                    await self.imageStorage.saveImage(image: image, id: productImage.imageID)
+                }
+            }
+        case .uiImage(let image, _, _):
+            Task { [weak self] in
+                guard let self else { return }
+
+                await self.imageStorage.saveImage(image: image, id: productImage.imageID)
+            }
         }
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Products/Media/DefaultProductUIImageLoader.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Media/DefaultProductUIImageLoader.swift
@@ -126,3 +126,17 @@ private extension DefaultProductUIImageLoader {
         }
     }
 }
+
+/// Stores images in a dictionary using given `id`
+///
+private actor ImageStorage {
+    private var images: [Int64: UIImage] = [:]
+
+    func saveImage(image: UIImage, id: Int64) {
+        images[id] = image
+    }
+
+    func getImage(id: Int64) -> UIImage? {
+        images[id]
+    }
+}

--- a/WooCommerce/Classes/ViewRelated/Products/Media/DefaultProductUIImageLoader.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Media/DefaultProductUIImageLoader.swift
@@ -116,21 +116,17 @@ private extension DefaultProductUIImageLoader {
             phAssetImageLoader.requestImage(for: asset,
                                             targetSize: PHImageManagerMaximumSize,
                                             contentMode: .aspectFit,
-                                            options: nil) { (image, info) in
-                guard let image else {
+                                            options: nil) { [weak self] (image, info) in
+                guard let image, let self else {
                     return
                 }
-                Task { [weak self] in
-                    guard let self else { return }
-
+                Task {
                     await self.imageStorage.saveImage(image: image, id: productImage.imageID)
                 }
             }
         case .uiImage(let image, _, _):
-            Task { [weak self] in
-                guard let self else { return }
-
-                await self.imageStorage.saveImage(image: image, id: productImage.imageID)
+            Task {
+                await imageStorage.saveImage(image: image, id: productImage.imageID)
             }
         }
     }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #12132 
<!-- Id number of the GitHub issue this PR addresses. -->

## Description

#### What? 

As part of the cache product images work (#11902 ), we refactored `DefaultProductUIImageLoader` to use Swift async await concurrency to request images. [code](https://github.com/woocommerce/woocommerce-ios/blob/trunk/WooCommerce/Classes/ViewRelated/Products/Media/DefaultProductUIImageLoader.swift#L57)

`DefaultProductUIImageLoader` uses a dictionary `private var imagesByProductImageID: [Int64: UIImage] = [:]` to hold images. Based on the sentry crash logs, this dictionary is being read and written into by two different threads. 

Looking into the code, `imagesByProductImageID` is ready when we call `requestImage`, which is an `async` method. `imagesByProductImageID` dictionary is written into from `func update(from asset: ProductImageAssetType, to productImage: ProductImage)`, which is fired asynchronously when an asset upload completes. 

I couldn't reproduce this crash, though. 

To prevent `imagesByProductImageID` being accessed by multiple threads simultaneously, I have introduced an `actor` to store the images. 

#### Why? 

Swift `actor` based `ImageStorage` prevents the image storage dictionary from being accessed by two threads at the same time. 

#### How?

- We have added a new actor, `ImageStorage`, which uses a dictionary to hold the images.
- We access the `ImageStorage` asynchronously using `Task` and `await`. 

## Testing instructions

Since I cannot reproduce the crash I don't have solid steps to test. We need to test that product image upload works as expected.

- Create a JN site
- Add a few products with many images
- Login into the app
- Open the products tab and open product and ensure that product images can be viewed as before.
- Try adding/removing product images and validate that it works as before.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

https://github.com/woocommerce/woocommerce-ios/assets/524475/703ab254-c616-4d8d-b717-2e23c8df7494


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.