### PR TITLE
[Analytics Hub] Add tracks events for customizing analytics hub

### DIFF
--- a/Storage/Storage/Model/AnalyticsCard.swift
+++ b/Storage/Storage/Model/AnalyticsCard.swift
@@ -16,7 +16,7 @@ public struct AnalyticsCard: Codable, Hashable, Equatable, GeneratedCopiable {
 
     /// Types of report cards to display in the Analytics Hub.
     /// The order of the cases in this enum defines the default order of cards in the Analytics Hub.
-    public enum CardType: Codable, CaseIterable {
+    public enum CardType: String, Codable, CaseIterable {
         case revenue
         case orders
         case products

--- a/WooCommerce/Classes/Analytics/WooAnalyticsEvent.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsEvent.swift
@@ -2639,6 +2639,8 @@ extension WooAnalyticsEvent {
             case report
             case period
             case compare
+            case enabledCards = "enabled_cards"
+            case disabledCards = "disabled_cards"
         }
 
         /// Tracks when the "See more" button is tapped in My Store, to open the Analytics Hub.
@@ -2700,6 +2702,21 @@ extension WooAnalyticsEvent {
                 Keys.report.rawValue: report.rawValue,
                 Keys.period.rawValue: period.tracksIdentifier,
                 Keys.compare.rawValue: "previous_period" // For now this is the only compare option in the app
+            ])
+        }
+
+        /// Tracks when the Analytics Hub settings ("Customize Analytics") are opened.
+        ///
+        static func customizeAnalyticsOpened() -> WooAnalyticsEvent {
+            WooAnalyticsEvent(statName: .analyticsHubSettingsOpened, properties: [:])
+        }
+
+        /// Tracks when the Analytics Hub settings ("Customize Analytics) are saved.
+        ///
+        static func customizeAnalyticsSaved(cards: [AnalyticsCard]) -> WooAnalyticsEvent {
+            WooAnalyticsEvent(statName: .analyticsHubSettingsSaved, properties: [
+                Keys.enabledCards.rawValue: cards.filter { $0.enabled }.map { $0.type.rawValue }.joined(separator: ","),
+                Keys.disabledCards.rawValue: cards.filter { !$0.enabled }.map { $0.type.rawValue }.joined(separator: ",")
             ])
         }
     }

--- a/WooCommerce/Classes/Analytics/WooAnalyticsStat.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsStat.swift
@@ -176,6 +176,8 @@ public enum WooAnalyticsStat: String {
     case analyticsHubEnableJetpackStatsSuccess = "analytics_hub_enable_jetpack_stats_success"
     case analyticsHubEnableJetpackStatsFailed = "analytics_hub_enable_jetpack_stats_failed"
     case analyticsHubViewFullReportTapped = "analytics_hub_view_full_report_tapped"
+    case analyticsHubSettingsOpened = "analytics_hub_settings_opened"
+    case analyticsHubSettingsSaved = "analytics_hub_settings_saved"
 
     // MARK: Blaze Events
     //

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/AnalyticsHubViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/AnalyticsHubViewModel.swift
@@ -650,7 +650,7 @@ extension AnalyticsHubViewModel {
     }
 
     /// Sets a view model for `customizeAnalyticsViewModel` when the feature is enabled.
-    /// This allows the view to open
+    /// Setting this view model opens the view.
     ///
     func customizeAnalytics() {
         guard canCustomizeAnalytics else {
@@ -662,6 +662,7 @@ extension AnalyticsHubViewModel {
             isEligibleForSessionsCard ? nil : allCardsWithSettings.first(where: { $0.type == .sessions })
         ].compactMap({ $0 })
 
+        analytics.track(event: .AnalyticsHub.customizeAnalyticsOpened())
         customizeAnalyticsViewModel = AnalyticsHubCustomizeViewModel(allCards: allCardsWithSettings,
                                                                      cardsToExclude: cardsToExclude) { [weak self] updatedCards in
             guard let self else { return }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/Customize/AnalyticsHubCustomizeViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/Customize/AnalyticsHubCustomizeViewModel.swift
@@ -4,6 +4,8 @@ import Yosemite
 /// View model for `AnalyticsHubCustomizeView`.
 final class AnalyticsHubCustomizeViewModel: ObservableObject, Identifiable {
 
+    private let analytics: Analytics
+
     /// Ordered array of all available analytics cards.
     ///
     @Published var allCards: [AnalyticsCard]
@@ -40,6 +42,7 @@ final class AnalyticsHubCustomizeViewModel: ObservableObject, Identifiable {
     ///   - onSave: Optional closure to perform when the changes are saved.
     init(allCards: [AnalyticsCard],
          cardsToExclude: [AnalyticsCard] = [],
+         analytics: Analytics = ServiceLocator.analytics,
          onSave: (([AnalyticsCard]) -> Void)? = nil) {
         self.excludedCards = cardsToExclude
         let availableCards = AnalyticsHubCustomizeViewModel.availableCards(from: allCards, excluding: cardsToExclude)
@@ -53,6 +56,7 @@ final class AnalyticsHubCustomizeViewModel: ObservableObject, Identifiable {
         self.originalSelection = selectedCards
 
         self.onSave = onSave
+        self.analytics = analytics
     }
 
     /// Assembles the new selections and order into an updated set of cards.
@@ -62,6 +66,8 @@ final class AnalyticsHubCustomizeViewModel: ObservableObject, Identifiable {
         var updatedCards = allCards.map { card in
             card.copy(enabled: selectedCards.contains(card))
         }
+
+        analytics.track(event: .AnalyticsHub.customizeAnalyticsSaved(cards: updatedCards))
 
         // Add back any cards that were excluded
         updatedCards.append(contentsOf: excludedCards)

--- a/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Analytics Hub/AnalyticsHubViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Analytics Hub/AnalyticsHubViewModelTests.swift
@@ -727,6 +727,14 @@ final class AnalyticsHubViewModelTests: XCTestCase {
         XCTAssertFalse(vm.enabledCards.contains(.sessions))
         assertEqual(expectedCards, customizeAnalyticsVM.allCards)
     }
+
+    func test_customizeAnalytics_tracks_expected_event() {
+        // When
+        vm.customizeAnalytics()
+
+        // Then
+        XCTAssert(analyticsProvider.receivedEvents.contains(WooAnalyticsStat.analyticsHubSettingsOpened.rawValue))
+    }
 }
 
 private extension AnalyticsHubViewModelTests {


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #11950
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This adds two new events for customizing the Analytics Hub:

- `analytics_hub_settings_opened` (Registration: https://github.com/Automattic/tracks-events-registration/pull/2269)
   - Triggered when the user taps on the settings icon in the Analytics Hub, to open the settings screen.
- `analytics_hub_settings_saved` (Registration: https://github.com/Automattic/tracks-events-registration/pull/2270)
   - Custom prop `enabled_cards` with value set to a comma-separated list of all the currently enabled cards (e.g. `revenue,orders,products`)
   - Custom prop `disabled_cards` with value set to a comma-separated list of all the currently disabled cards

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

1. Build and run the app.
2. Tap "See More" to open the Analytics Hub.
3. Tap "Edit" and confirm the `analytics_hub_settings_opened` event is tracked.
4. Make some changes to the card settings.
5. Tap "Save" and confirm the `analytics_hub_settings_saved` event is tracked with the expected properties matching your saved card settings.

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
