### PR TITLE
Remove an out of place comment from `Fastfile`

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -678,7 +678,6 @@ platform :ios do
       distribute_external: true,
       # If there is a build waiting for beta review, we want to reject that so the new build can be submitted instead
       reject_build_waiting_for_review: true,
-      # These three groups are the same for iOS and Mac
       groups: ['Internal a8c beta testers', 'Public Beta Testers']
     )
     sh('cd .. && rm WooCommerce.ipa')


### PR DESCRIPTION
Notice this comment while comparing the Woo implementation with WP's https://github.com/wordpress-mobile/WordPress-iOS/commit/77c755fa828b0781f47e6b1405b9d39522c4fd8a

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary. — N.A.
