### PR TITLE
Better Errors: Application Tutorial Logic

### DIFF
--- a/WooCommerce/Classes/Authentication/Application Password/ApplicationPasswordTutorial.swift
+++ b/WooCommerce/Classes/Authentication/Application Password/ApplicationPasswordTutorial.swift
@@ -27,8 +27,8 @@ final class ApplicationPasswordTutorialViewController: UIHostingController<Appli
         }
     }
 
-    init() {
-        let view = ApplicationPasswordTutorial()
+    init(error: Error) {
+        let view = ApplicationPasswordTutorial(errorDescription: ApplicationPasswordTutorialViewModel.friendlyErrorMessage(for: error))
         super.init(rootView: view)
     }
 
@@ -49,10 +49,14 @@ struct ApplicationPasswordTutorial: View {
     ///
     var contactSupportButtonTapped: (() -> ())?
 
+    /// Friendly error description.
+    ///
+    let errorDescription: String
+
     var body: some View {
         VStack(spacing: .zero) {
             ScrollView {
-                Text(Localization.reason)
+                Text(errorDescription)
                     .subheadlineStyle()
                     .multilineTextAlignment(.center)
                     .padding([.bottom, .top])
@@ -107,7 +111,7 @@ private extension ApplicationPasswordTutorial {
         static let tutorial = NSLocalizedString("""
                                                 ⁃ Tap the continue button at the bottom to login directly into your site.
 
-                                                ⁃ Once logged in, approve the connection to give access to the woo app   like the in the image below.
+                                                ⁃ Once logged in, approve the connection to give access to the woo app like the in the image below.
                                                 """, comment: "Tutorial steps on the application password tutorial screen")
         static let contactSupport = NSLocalizedString("If you encounter any problem, contact us and we will happily assist you!",
                                                       comment: "Text to contact support in the application password tutorial screen")
@@ -122,6 +126,6 @@ private extension ApplicationPasswordTutorial {
 
 #Preview {
     NavigationStack {
-        ApplicationPasswordTutorial()
+        ApplicationPasswordTutorial(errorDescription: ApplicationPasswordTutorial.Localization.title)
     }
 }

--- a/WooCommerce/Classes/Authentication/Application Password/ApplicationPasswordTutorial.swift
+++ b/WooCommerce/Classes/Authentication/Application Password/ApplicationPasswordTutorial.swift
@@ -5,6 +5,28 @@ import SwiftUI
 ///
 final class ApplicationPasswordTutorialViewController: UIHostingController<ApplicationPasswordTutorial> {
 
+    /// Assign it to react when the continue button is tapped.
+    ///
+    var continueButtonTapped: (() -> ())? {
+        get {
+            rootView.continueButtonTapped
+        }
+        set {
+            rootView.continueButtonTapped = newValue
+        }
+    }
+
+    /// Assign it to react when the contact support button is tapped.
+    ///
+    var contactSupportButtonTapped: (() -> ())? {
+        get {
+            rootView.contactSupportButtonTapped
+        }
+        set {
+            rootView.contactSupportButtonTapped = newValue
+        }
+    }
+
     init() {
         let view = ApplicationPasswordTutorial()
         super.init(rootView: view)

--- a/WooCommerce/Classes/Authentication/Application Password/ApplicationPasswordTutorial.swift
+++ b/WooCommerce/Classes/Authentication/Application Password/ApplicationPasswordTutorial.swift
@@ -82,12 +82,12 @@ struct ApplicationPasswordTutorial: View {
             VStack {
 
                 Button(Localization.continueTitle) {
-                    print("Continue tapped")
+                    continueButtonTapped?()
                 }
                 .buttonStyle(PrimaryButtonStyle())
 
                 Button(Localization.contactSupportTitle) {
-                    print("Contact support tapped")
+                    contactSupportButtonTapped?()
                 }
                 .buttonStyle(SecondaryButtonStyle())
             }

--- a/WooCommerce/Classes/Authentication/Application Password/ApplicationPasswordTutorialViewModel.swift
+++ b/WooCommerce/Classes/Authentication/Application Password/ApplicationPasswordTutorialViewModel.swift
@@ -1,0 +1,26 @@
+import Foundation
+
+/// View Model for the Application Password Tutorial.
+///
+struct ApplicationPasswordTutorialViewModel {
+
+    static func friendlyErrorMessage(for error: Error) -> String {
+
+        let genericMessage = NSLocalizedString("This is because we got an unexpected response from your site.",
+                                               comment: "Generic reason for why the user could not login tin the application password tutorial screen")
+
+        guard let loginError = error as? SiteCredentialLoginError else {
+            return genericMessage
+        }
+
+        switch loginError {
+        case .loginFailed(message: let message):
+            return message
+        case .invalidLoginResponse, .genericFailure:
+            return genericMessage
+        case .inaccessibleLoginPage, .inaccessibleAdminPage, .unacceptableStatusCode:
+            return NSLocalizedString("This is likely because your store has some extra security steps in place.",
+                                     comment: "Reason for why the user could not login tin the application password tutorial screen")
+        }
+    }
+}

--- a/WooCommerce/Classes/Authentication/AuthenticationManager.swift
+++ b/WooCommerce/Classes/Authentication/AuthenticationManager.swift
@@ -360,7 +360,7 @@ extension AuthenticationManager: WordPressAuthenticatorDelegate {
         }
 
         if featureFlagService.isFeatureFlagEnabled(.appPasswordTutorial) {
-            presentAppPasswordTutorial(for: siteURL, in: viewController)
+            presentAppPasswordTutorial(error: error, for: siteURL, in: viewController)
         } else {
             presentAppPasswordAlert(error: error, for: siteURL, in: viewController)
         }
@@ -797,8 +797,8 @@ private extension AuthenticationManager {
 
     /// Presents Application Passwords tutorial before redirecting user to the site login using a web view.
     ///
-    private func presentAppPasswordTutorial(for siteURL: String, in viewController: UIViewController) {
-        let tutorialVC = ApplicationPasswordTutorialViewController()
+    private func presentAppPasswordTutorial(error: Error, for siteURL: String, in viewController: UIViewController) {
+        let tutorialVC = ApplicationPasswordTutorialViewController(error: error)
         tutorialVC.continueButtonTapped = { [weak self] in
             self?.presentApplicationPasswordWebView(for: siteURL, in: viewController)
         }

--- a/WooCommerce/Classes/Authentication/AuthenticationManager.swift
+++ b/WooCommerce/Classes/Authentication/AuthenticationManager.swift
@@ -359,7 +359,8 @@ extension AuthenticationManager: WordPressAuthenticatorDelegate {
             return
         }
 
-        if featureFlagService.isFeatureFlagEnabled(.appPasswordTutorial) && error is SiteCredentialLoginError {
+        let isSiteCredentialError = (error as NSError).domain == SiteCredentialLoginError.errorDomain
+        if featureFlagService.isFeatureFlagEnabled(.appPasswordTutorial) && isSiteCredentialError {
             presentAppPasswordTutorial(error: error, for: siteURL, in: viewController)
         } else {
             presentAppPasswordAlert(error: error, for: siteURL, in: viewController)

--- a/WooCommerce/Classes/Authentication/AuthenticationManager.swift
+++ b/WooCommerce/Classes/Authentication/AuthenticationManager.swift
@@ -795,14 +795,21 @@ private extension AuthenticationManager {
         self.postSiteCredentialLoginChecker = checker
     }
 
-    /// Presents Application Passwords tutorial before redirecting user to the site login.
+    /// Presents Application Passwords tutorial before redirecting user to the site login using a web view.
     ///
     private func presentAppPasswordTutorial(for siteURL: String, in viewController: UIViewController) {
         let tutorialVC = ApplicationPasswordTutorialViewController()
+        tutorialVC.continueButtonTapped = { [weak self] in
+            self?.presentApplicationPasswordWebView(for: siteURL, in: viewController)
+        }
+        tutorialVC.contactSupportButtonTapped = {
+            let supportController = SupportFormHostingController(viewModel: .init(sourceTag: WordPressSupportSourceTag.loginUsernamePassword.origin))
+            supportController.show(from: viewController)
+        }
         viewController.show(tutorialVC, sender: viewController)
     }
 
-    /// Presents login alert before redirecting user to the site login.
+    /// Presents login alert before redirecting user to the site login using a web view.
     ///
     private func presentAppPasswordAlert(error: Error, for siteURL: String, in viewController: UIViewController) {
         let alertController = FancyAlertViewController.makeSiteCredentialLoginErrorAlert(
@@ -811,10 +818,18 @@ private extension AuthenticationManager {
                 guard let self else { return }
                 let webViewController = self.applicationPasswordWebView(for: siteURL)
                 viewController.navigationController?.pushViewController(webViewController, animated: true)
+                self.presentApplicationPasswordWebView(for: siteURL, in: viewController)
                 self.analytics.track(.applicationPasswordAuthorizationButtonTapped)
             }
         )
         viewController.present(alertController, animated: true)
+    }
+
+    /// Presents app password site login using a web view.
+    ///
+    private func presentApplicationPasswordWebView(for siteURL: String, in viewController: UIViewController) {
+        let webViewController = applicationPasswordWebView(for: siteURL)
+        viewController.navigationController?.pushViewController(webViewController, animated: true)
     }
 }
 

--- a/WooCommerce/Classes/Authentication/SiteCredentialLoginUseCase.swift
+++ b/WooCommerce/Classes/Authentication/SiteCredentialLoginUseCase.swift
@@ -7,7 +7,7 @@ protocol SiteCredentialLoginProtocol {
     func handleLogin(username: String, password: String)
 }
 
-enum SiteCredentialLoginError: Error {
+enum SiteCredentialLoginError: LocalizedError {
     static let errorDomain = "SiteCredentialLogin"
     case loginFailed(message: String)
     case invalidLoginResponse
@@ -61,6 +61,10 @@ enum SiteCredentialLoginError: Error {
         case .genericFailure:
             return ""
         }
+    }
+
+    var errorDescription: String? {
+        underlyingError.localizedDescription
     }
 
     private enum Localization {

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -792,6 +792,7 @@
 		261F1A7929C2AB2E001D9861 /* FreeTrialBannerViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 261F1A7829C2AB2E001D9861 /* FreeTrialBannerViewModel.swift */; };
 		261F1A7C29C2B09D001D9861 /* FreeTrialBannerViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 261F1A7B29C2B09D001D9861 /* FreeTrialBannerViewModelTests.swift */; };
 		262418332B8D3630009A3834 /* ApplicationPasswordTutorial.swift in Sources */ = {isa = PBXBuildFile; fileRef = 262418322B8D3630009A3834 /* ApplicationPasswordTutorial.swift */; };
+		262418372B9044FF009A3834 /* ApplicationPasswordTutorialViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 262418362B9044FF009A3834 /* ApplicationPasswordTutorialViewModel.swift */; };
 		26281776278F0B0100C836D3 /* View+NoticesModifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26281775278F0B0100C836D3 /* View+NoticesModifier.swift */; };
 		262A098B2628C51D0033AD20 /* OrderAddOnListViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 262A098A2628C51D0033AD20 /* OrderAddOnListViewModel.swift */; };
 		262A0999262908A60033AD20 /* OrderAddOnListI1Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 262A0998262908A60033AD20 /* OrderAddOnListI1Tests.swift */; };
@@ -3508,6 +3509,7 @@
 		261F1A7829C2AB2E001D9861 /* FreeTrialBannerViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FreeTrialBannerViewModel.swift; sourceTree = "<group>"; };
 		261F1A7B29C2B09D001D9861 /* FreeTrialBannerViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FreeTrialBannerViewModelTests.swift; sourceTree = "<group>"; };
 		262418322B8D3630009A3834 /* ApplicationPasswordTutorial.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ApplicationPasswordTutorial.swift; sourceTree = "<group>"; };
+		262418362B9044FF009A3834 /* ApplicationPasswordTutorialViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ApplicationPasswordTutorialViewModel.swift; sourceTree = "<group>"; };
 		26281775278F0B0100C836D3 /* View+NoticesModifier.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "View+NoticesModifier.swift"; sourceTree = "<group>"; };
 		262A098A2628C51D0033AD20 /* OrderAddOnListViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OrderAddOnListViewModel.swift; sourceTree = "<group>"; };
 		262A0998262908A60033AD20 /* OrderAddOnListI1Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OrderAddOnListI1Tests.swift; sourceTree = "<group>"; };
@@ -11576,6 +11578,7 @@
 				DEC0293629C418FF00FD0E2F /* ApplicationPasswordAuthorizationWebViewController.swift */,
 				DEC0293929C41BC500FD0E2F /* ApplicationPasswordAuthorizationViewModel.swift */,
 				262418322B8D3630009A3834 /* ApplicationPasswordTutorial.swift */,
+				262418362B9044FF009A3834 /* ApplicationPasswordTutorialViewModel.swift */,
 			);
 			path = "Application Password";
 			sourceTree = "<group>";
@@ -13662,6 +13665,7 @@
 				DE653EAF2A72577500937C78 /* WooAnalyticsEvent+TestOrder.swift in Sources */,
 				CE4DDB7B20DD312400D32EC8 /* DateFormatter+Helpers.swift in Sources */,
 				45968545254069AE00D17B90 /* DownloadableFileBottomSheetListSelectorCommand.swift in Sources */,
+				262418372B9044FF009A3834 /* ApplicationPasswordTutorialViewModel.swift in Sources */,
 				7E7C5F7A2719A8F900315B61 /* EditProductCategoryListViewController.swift in Sources */,
 				77E53EC82510FE07003D385F /* ProductDownloadsEditableData.swift in Sources */,
 				0235595B24496E88004BE2B8 /* BottomSheetListSelectorViewController+DrawerPresentable.swift in Sources */,


### PR DESCRIPTION
Closes: #11998 

# Why

This PR adds the logic to the Application Tutorial Logic.

In particular:

- Connects the continue button with the app password web view
- Connects the support form
- Shows a friendly error message on the tutorial.
- Only show the tutorial when a real site credential error happens.

# Demo

https://github.com/woocommerce/woocommerce-ios/assets/562080/95435963-abfc-455c-b396-3559e2134bc4

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
