### PR TITLE
[Tablet support] Set max height to the Blaze image view so that the image doesn't look overly large on tablets

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Blaze/BlazeEditAd/BlazeEditAdView.swift
+++ b/WooCommerce/Classes/ViewRelated/Blaze/BlazeEditAd/BlazeEditAdView.swift
@@ -26,6 +26,7 @@ struct BlazeEditAdView: View {
                 VStack(spacing: Layout.parentVerticalSpacing) {
                     imageBlock
                         .padding(insets: Layout.imageBlockInsets)
+                        .frame(maxWidth: Layout.imageBlockMaxWidth)
 
                     Divider()
                         .frame(height: Layout.strokeWidth)
@@ -286,6 +287,7 @@ private extension BlazeEditAdView {
 
 private enum Layout {
     static let imageBlockInsets: EdgeInsets = .init(top: 24, leading: 16, bottom: 0, trailing: 16)
+    static let imageBlockMaxWidth: CGFloat = 430
     static let textBlockInsets: EdgeInsets = .init(top: 0, leading: 16, bottom: 16, trailing: 16)
 
     static let parentVerticalSpacing: CGFloat = 24


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #12141
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
- Set image block max width

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
- Go to the products tab
- Tap Promote with Blaze
- Tap Edit ad
- Check that image width is a bit smaller then before (max width 430)

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

![Simulator Screen Recording - iPad Pro (11-inch) (4th generation) - 2024-02-29 at 09 06 15](https://github.com/woocommerce/woocommerce-ios/assets/6242034/943b6f08-5e00-4de1-b599-6d2f219d92a8)

---
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
