### PR TITLE
[Analytics Hub] When a new card is enabled, fetch the data only for the newly enabled card

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/AnalyticsHubViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/AnalyticsHubViewModel.swift
@@ -232,7 +232,7 @@ final class AnalyticsHubViewModel: ObservableObject {
             try await remoteEnableJetpackStats()
             // Wait for backend to enable the module (it is not ready for stats to be requested immediately after a success response)
             try await Task.sleep(nanoseconds: backendProcessingDelay)
-            await updateData()
+            await updateData(for: [.sessions])
         } catch {
             noticePresenter.enqueue(notice: .init(title: Localization.statsCTAError))
             DDLogError("⚠️ Error enabling Jetpack Stats: \(error)")

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/AnalyticsHubViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/AnalyticsHubViewModel.swift
@@ -482,11 +482,11 @@ private extension AnalyticsHubViewModel {
             .removeDuplicates()
             .sink { [weak self] newCardSettings in
                 guard let self else { return }
-                // If there are newly enabled cards, refresh the stats data
-                let newEnabledCards = newCardSettings.filter({ $0.enabled }).map({ $0.type })
-                if !newEnabledCards.allSatisfy(self.enabledCards.contains) {
+                // If there are newly enabled cards, fetch their data
+                let newlyEnabledCards = newCardSettings.filter({ $0.enabled && !self.enabledCards.contains($0.type) }).map({ $0.type })
+                if newlyEnabledCards.isNotEmpty {
                     Task {
-                        await self.updateData()
+                        await self.updateData(for: newlyEnabledCards)
                     }
                 }
             }.store(in: &subscriptions)

--- a/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Analytics Hub/AnalyticsHubViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Analytics Hub/AnalyticsHubViewModelTests.swift
@@ -646,7 +646,15 @@ final class AnalyticsHubViewModelTests: XCTestCase {
     }
 
     func test_enabling_new_card_fetches_required_data() async throws {
-        // Given
+        // Given it fetches order stats (current and previous) for initial cards
+        stores.whenReceivingAction(ofType: StatsActionV4.self) { action in
+            switch action {
+            case let .retrieveCustomStats(_, _, _, _, _, _, _, completion):
+                completion(.success(.fake()))
+            default:
+                break
+            }
+        }
         stores.whenReceivingAction(ofType: AppSettingsAction.self) { action in
             switch action {
             case let .loadAnalyticsHubCards(_, completion):
@@ -659,9 +667,11 @@ final class AnalyticsHubViewModelTests: XCTestCase {
             }
         }
         await vm.loadAnalyticsCardSettings()
+        await vm.updateData()
+        assertEqual(2, stores.receivedActions.filter { $0 is StatsActionV4 }.count)
 
-        // When
-        let fetchedProductStats: Bool = try waitFor { promise in
+        // When the products card is enabled
+        let fetchedTopEarnerStats: Bool = try waitFor { promise in
             self.stores.whenReceivingAction(ofType: StatsActionV4.self) { action in
                 switch action {
                 case let .retrieveCustomStats(_, _, _, _, _, _, _, completion):
@@ -673,15 +683,15 @@ final class AnalyticsHubViewModelTests: XCTestCase {
                     break
                 }
             }
-            // Enable products card
             self.vm.customizeAnalytics()
             let customizeAnalytics = try XCTUnwrap(self.vm.customizeAnalyticsViewModel)
             customizeAnalytics.selectedCards.update(with: AnalyticsCard(type: .products, enabled: false))
             customizeAnalytics.saveChanges()
         }
 
-        // Then
-        XCTAssertTrue(fetchedProductStats)
+        // Then it fetches order stats and top earner stats for products card
+        XCTAssertTrue(fetchedTopEarnerStats)
+        assertEqual(5, stores.receivedActions.filter { $0 is StatsActionV4 }.count)
     }
 
     func test_changing_card_settings_without_enabling_new_cards_does_not_update_data() async throws {


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

<!-- Id number of the GitHub issue this PR addresses. -->

## Why
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
Previously, whenever a new analytics card was enabled we refreshed all the data in the Analytics Hub. This re-fetched data for cards that were already enabled. Now, when a new card is enabled we only fetch the stats needed for the new card.

## How

1. The data fetching can now be limited to fetch data for specific cards:
   - The method `updateData()` now has an optional parameter to limit the data fetching to specific cards.
   - The new behavior is handled in `retrieveData(for:)`. It sets the loading state only for cards that need data fetched, and determines which stats need to be fetched based on the given cards.
2. When Jetpack stats are enabled in `enableJetpackStats()`, we only fetch data for the Sessions card.
3. When a new card is enabled (in the Customize Analytics flow), we only fetch data for the newly enabled card (not all enabled cards).

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

1. Build and run the app.
2. Open the Analytics Hub ("See More" in the My store tab) and confirm everything loads as expected.
3. Tap "Edit" and deselect some of the analytics cards.
4. Save the changes and confirm no data is loaded.
5. Tap "Edit" and select some of the analytics cards.
6. Save the changes and confirm only the newly enabled cards have a loading state, and their data is loaded.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

https://github.com/woocommerce/woocommerce-ios/assets/8658164/3f644e7f-7c0a-4df7-94ac-45242bd28693



---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
