### PR TITLE
[Analytics Hub] Release feature to customize analytics hub

### DIFF
--- a/Experiments/Experiments/DefaultFeatureFlagService.swift
+++ b/Experiments/Experiments/DefaultFeatureFlagService.swift
@@ -89,8 +89,6 @@ public struct DefaultFeatureFlagService: FeatureFlagService {
             return buildConfig == .localDeveloper || buildConfig == .alpha
         case .customRangeInMyStoreAnalytics:
             return buildConfig == .localDeveloper || buildConfig == .alpha
-        case .customizeAnalyticsHub:
-            return buildConfig == .localDeveloper || buildConfig == .alpha
         case .useURLSessionInWordPressKit:
             return buildConfig != .appStore
         case .connectivityTool:

--- a/Experiments/Experiments/FeatureFlag.swift
+++ b/Experiments/Experiments/FeatureFlag.swift
@@ -200,10 +200,6 @@ public enum FeatureFlag: Int {
     ///
     case customRangeInMyStoreAnalytics
 
-    /// Enables customizing the cards in the Analytics Hub
-    ///
-    case customizeAnalyticsHub
-
     /// Configures WordPressKit to send HTTP requests using URLSession instead of Alamofire.
     ///
     case useURLSessionInWordPressKit

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -5,6 +5,7 @@
 - Orders: Merchants can now contact their customers through WhatsApp and Telegram apps. [https://github.com/woocommerce/woocommerce-ios/pull/12099]
 - [internal] Blaze: Use v1.1 endpoint to load campaigns list. [https://github.com/woocommerce/woocommerce-ios/pull/12127]
 - Orders: Merchants can filter orders by selecting a product. [https://github.com/woocommerce/woocommerce-ios/pull/12129]
+- [***] Stats: Merchants can now customize their analytics by enabling/disabling and reordering the cards in the Analytics Hub. [https://github.com/woocommerce/woocommerce-ios/pull/12156]
 
 
 17.5

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/AnalyticsHubView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/AnalyticsHubView.swift
@@ -113,7 +113,6 @@ struct AnalyticsHubView: View {
                 } label: {
                     Text(Localization.editButton)
                 }
-                .renderedIf(viewModel.canCustomizeAnalytics)
             }
         }
         .sheet(item: $viewModel.customizeAnalyticsViewModel) { customizeViewModel in

--- a/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Analytics Hub/AnalyticsHubViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Analytics Hub/AnalyticsHubViewModelTests.swift
@@ -755,7 +755,6 @@ private extension AnalyticsHubViewModelTests {
                               stores: stores ?? self.stores,
                               analytics: analytics,
                               noticePresenter: noticePresenter,
-                              backendProcessingDelay: 0,
-                              canCustomizeAnalytics: true)
+                              backendProcessingDelay: 0)
     }
 }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #11951
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This removes the `customizeAnalyticsHub` feature flag to release the customization features.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

### Test steps

1. On the My store dashboard, tap "See More" to open the Analytics Hub.
2. Tap the Edit button to open a Customize Analytics view where the cards can be managed (added/removed/reordered).
3. Save the changes and confirm the Analytics Hub is updated to reflect the customizations.

### Expected behavior

On the Customize Analytics screen:

* When there are no changes to be saved, the Save button is disabled.
* When there are unsaved changes and the close button is tapped, you can discard the changes.
* Cards can be selected/deselected and reordered.
* At least one card must be selected (the last selected card can't be deselected).
* If the sessions card is not available (e.g. self-hosted or JCP-connected stores) there is no sessions card in the list.

In the Analytics Hub:

* When changes are saved, those changes are immediately reflected in the Analytics Hub.
* If no new cards are enabled, no data is fetched when the changes are saved.
* If new cards are enabled, their data is fetched and they load as expected.
* If the sessions card is the only one enabled, and a custom date range is selected, an empty view is shown with a relevant message.

### Environments to test
Device:

- [x] iPhone
- [x] iPad

Color scheme:

- [x] Dark mode
- [x] Light mode

Device orientation:

- [x] Portrait
- [x] Landscape

Store types:

- [x] Store using Jetpack plugin
- [x] Store using Jetpack connection package
- [x] Store without Jetpack

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

https://github.com/woocommerce/woocommerce-ios/assets/8658164/3e1d9558-c337-4baa-afed-97c0c629e7af



---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
