### PR TITLE
My Store Analytics: Fix missing stats for custom range

### DIFF
--- a/Networking/Networking/Remote/OrderStatsRemoteV4.swift
+++ b/Networking/Networking/Remote/OrderStatsRemoteV4.swift
@@ -28,12 +28,11 @@ public final class OrderStatsRemoteV4: Remote {
         let dateFormatter = DateFormatter.Defaults.iso8601WithoutTimeZone
         dateFormatter.timeZone = timeZone
 
-        let parameters: [String: Any] = [
+        var parameters: [String: Any] = [
             ParameterKeys.interval: unit.rawValue,
             ParameterKeys.after: dateFormatter.string(from: earliestDateToInclude),
             ParameterKeys.before: dateFormatter.string(from: latestDateToInclude),
             ParameterKeys.quantity: String(quantity),
-            ParameterKeys.forceRefresh: forceRefresh,
             // Product stats in `ProductsReportsRemote.loadTopProductsReport` are based on the order creation date, while the order/revenue
             // stats are based on a store option in the analytics settings with the order paid date as the default.
             // In WC version 8.6+, a new parameter `date_type` is available to override the date type so that we can
@@ -41,6 +40,11 @@ public final class OrderStatsRemoteV4: Remote {
             ParameterKeys.dateType: ParameterValues.dateType,
             ParameterKeys.fields: ParameterValues.fieldValues
         ]
+
+        if forceRefresh {
+            // includes this parameter only if it's true, otherwise the request fails
+            parameters[ParameterKeys.forceRefresh] = forceRefresh
+        }
 
         let request = JetpackRequest(wooApiVersion: .wcAnalytics,
                                      method: .get,

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Stats v4/StatsTimeRangeBarViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Stats v4/StatsTimeRangeBarViewModel.swift
@@ -51,18 +51,13 @@ private extension StatsTimeRangeV4 {
     /// Date formatter for a selected date for a time range.
     func timeRangeSelectedDateFormatter(timezone: TimeZone) -> DateFormatter {
         let dateFormatter: DateFormatter
-        switch self {
-        case .today:
+        switch intervalGranularity {
+        case .hourly:
             dateFormatter = DateFormatter.Charts.chartSelectedDateHourFormatter
-        case .thisWeek, .thisMonth:
+        case .daily, .weekly:
             dateFormatter = DateFormatter.Charts.chartAxisDayFormatter
-        case .thisYear:
+        case .monthly, .quarterly, .yearly:
             dateFormatter = DateFormatter.Charts.chartAxisFullMonthFormatter
-        case .custom:
-            let formatter = DateFormatter()
-            formatter.dateStyle = .medium
-            formatter.timeStyle = .none
-            return formatter
         }
         dateFormatter.timeZone = timezone
         return dateFormatter

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Stats v4/StatsTimeRangeV4+UI.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Stats v4/StatsTimeRangeV4+UI.swift
@@ -12,21 +12,11 @@ extension StatsTimeRangeV4 {
             return 31
         case .thisYear:
             return 12
-        case let .custom(startDate, endDate):
-            let calendar = Calendar.current
-            let quantity: Int? = {
-                switch intervalGranularity {
-                case .hourly:
-                    calendar.dateComponents([.hour], from: startDate, to: endDate).hour
-                case .daily, .weekly:
-                    calendar.dateComponents([.day], from: startDate, to: endDate).day
-                case .monthly, .quarterly:
-                    calendar.dateComponents([.month], from: startDate, to: endDate).month
-                case .yearly:
-                    calendar.dateComponents([.year], from: startDate, to: endDate).year
-                }
-            }()
-            return quantity ?? 7
+        case .custom:
+            // Returns maximum value allowed for pagination,
+            // the plugin would return the maximum values available for the required granularity.
+            // https://developer.wordpress.org/rest-api/using-the-rest-api/pagination/
+            return 100
         }
     }
 

--- a/Yosemite/Yosemite/Model/Enums/StatsTimeRangeV4.swift
+++ b/Yosemite/Yosemite/Model/Enums/StatsTimeRangeV4.swift
@@ -229,21 +229,11 @@ extension StatsTimeRangeV4 {
             return daysThisMonth?.count ?? 0
         case .thisYear:
             return 12
-        case let .custom(startDate, endDate):
-            let calendar = Calendar.current
-            let quantity: Int? = {
-                switch siteVisitStatsGranularity {
-                case .hour:
-                    calendar.dateComponents([.hour], from: startDate, to: endDate).hour
-                case .day, .week:
-                    calendar.dateComponents([.day], from: startDate, to: endDate).day
-                case .month, .quarter:
-                    calendar.dateComponents([.month], from: startDate, to: endDate).month
-                case .year:
-                    calendar.dateComponents([.year], from: startDate, to: endDate).year
-                }
-            }()
-            return quantity ?? 7
+        case .custom:
+            // Returns maximum value allowed for pagination,
+            // the plugin would return the maximum values available for the required granularity.
+            // https://developer.wordpress.org/rest-api/using-the-rest-api/pagination/
+            return 100
         }
     }
 }

--- a/Yosemite/YosemiteTests/Model/Enums/StatsTimeRangeTests.swift
+++ b/Yosemite/YosemiteTests/Model/Enums/StatsTimeRangeTests.swift
@@ -53,11 +53,11 @@ final class StatsTimeRangeTests: XCTestCase {
         XCTAssertEqual(range.intervalGranularity, .weekly)
     }
 
-    func test_intervalGranularity_for_dates_with_days_difference_from_1_to_28() {
+    func test_intervalGranularity_for_dates_with_days_difference_from_2_to_28() {
         // Given
         // GMT: Saturday, February 1, 2020 12:29:29 AM
         let fromDate = Date(timeIntervalSince1970: 1580516969)
-        let toDate = fromDate.addingDays(Int.random(in: 1...28))
+        let toDate = fromDate.addingDays(Int.random(in: 2...28))
 
         // When
         let range: StatsTimeRangeV4 = .custom(from: fromDate, to: toDate)
@@ -66,11 +66,11 @@ final class StatsTimeRangeTests: XCTestCase {
         XCTAssertEqual(range.intervalGranularity, .daily)
     }
 
-    func test_intervalGranularity_for_dates_with_days_difference_less_than_1() {
+    func test_intervalGranularity_for_dates_with_days_difference_less_than_2() {
         // Given
         // GMT: Saturday, February 1, 2020 12:29:29 AM
         let fromDate = Date(timeIntervalSince1970: 1580516969)
-        let toDate = fromDate.addingDays(0)
+        let toDate = fromDate.addingDays(1)
 
         // When
         let range: StatsTimeRangeV4 = .custom(from: fromDate, to: toDate)
@@ -120,11 +120,11 @@ final class StatsTimeRangeTests: XCTestCase {
         XCTAssertEqual(range.siteVisitStatsGranularity, .week)
     }
 
-    func test_siteVisitStatsGranularity_for_dates_with_days_difference_from_1_to_28() {
+    func test_siteVisitStatsGranularity_for_dates_with_days_difference_from_2_to_28() {
         // Given
         // GMT: Saturday, February 1, 2020 12:29:29 AM
         let fromDate = Date(timeIntervalSince1970: 1580516969)
-        let toDate = fromDate.addingDays(Int.random(in: 1...28))
+        let toDate = fromDate.addingDays(Int.random(in: 2...28))
 
         // When
         let range: StatsTimeRangeV4 = .custom(from: fromDate, to: toDate)
@@ -133,11 +133,11 @@ final class StatsTimeRangeTests: XCTestCase {
         XCTAssertEqual(range.siteVisitStatsGranularity, .day)
     }
 
-    func test_siteVisitStatsGranularity_for_dates_with_days_difference_less_than_1() {
+    func test_siteVisitStatsGranularity_for_dates_with_days_difference_less_than_2() {
         // Given
         // GMT: Saturday, February 1, 2020 12:29:29 AM
         let fromDate = Date(timeIntervalSince1970: 1580516969)
-        let toDate = fromDate.addingDays(0)
+        let toDate = fromDate.addingDays(1)
 
         // When
         let range: StatsTimeRangeV4 = .custom(from: fromDate, to: toDate)
@@ -200,11 +200,11 @@ final class StatsTimeRangeTests: XCTestCase {
         XCTAssertEqual(range.topEarnerStatsGranularity, .day)
     }
 
-    func test_topEarnerStatsGranularity_for_dates_with_days_difference_less_than_1() {
+    func test_topEarnerStatsGranularity_for_dates_with_days_difference_less_than_2() {
         // Given
         // GMT: Saturday, February 1, 2020 12:29:29 AM
         let fromDate = Date(timeIntervalSince1970: 1580516969)
-        let toDate = fromDate.addingDays(0)
+        let toDate = fromDate.addingDays(1)
 
         // When
         let range: StatsTimeRangeV4 = .custom(from: fromDate, to: toDate)
@@ -254,11 +254,11 @@ final class StatsTimeRangeTests: XCTestCase {
         XCTAssertEqual(range.summaryStatsGranularity, .week)
     }
 
-    func test_summaryStatsGranularity_for_dates_with_days_difference_from_1_to_28() {
+    func test_summaryStatsGranularity_for_dates_with_days_difference_from_2_to_28() {
         // Given
         // GMT: Saturday, February 1, 2020 12:29:29 AM
         let fromDate = Date(timeIntervalSince1970: 1580516969)
-        let toDate = fromDate.addingDays(Int.random(in: 1...28))
+        let toDate = fromDate.addingDays(Int.random(in: 2...28))
 
         // When
         let range: StatsTimeRangeV4 = .custom(from: fromDate, to: toDate)
@@ -267,11 +267,11 @@ final class StatsTimeRangeTests: XCTestCase {
         XCTAssertEqual(range.summaryStatsGranularity, .day)
     }
 
-    func test_summaryStatsGranularity_for_dates_with_days_difference_less_than_1() {
+    func test_summaryStatsGranularity_for_dates_with_days_difference_less_than_2() {
         // Given
         // GMT: Saturday, February 1, 2020 12:29:29 AM
         let fromDate = Date(timeIntervalSince1970: 1580516969)
-        let toDate = fromDate.addingDays(0)
+        let toDate = fromDate.addingDays(1)
 
         // When
         let range: StatsTimeRangeV4 = .custom(from: fromDate, to: toDate)

--- a/Yosemite/YosemiteTests/Stores/StatsStoreV4Tests.swift
+++ b/Yosemite/YosemiteTests/Stores/StatsStoreV4Tests.swift
@@ -318,7 +318,7 @@ final class StatsStoreV4Tests: XCTestCase {
 
     /// Verifies that `StatsActionV4.retrieveStats` makes a network request with the given `force_cache_refresh` parameter if `forceRefresh` is true.
     ///
-    func test_retrieveStats_makes_network_request_with_given_force_cache_rerefresh_parameter_if_forceRefresh_is_true() {
+    func test_retrieveStats_makes_network_request_with_given_force_cache_rerefresh_parameter_if_forceRefresh_is_true() throws {
         // Given
         let store = StatsStoreV4(dispatcher: dispatcher, storageManager: storageManager, network: network)
 
@@ -337,7 +337,8 @@ final class StatsStoreV4Tests: XCTestCase {
         }
 
         // Then
-        XCTAssertEqual(network.queryParametersDictionary?["force_cache_refresh"] as? Bool, true)
+        let forceCacheRefreshValue = try XCTUnwrap(network.queryParametersDictionary?["force_cache_refresh"] as? Bool)
+        XCTAssertTrue(forceCacheRefreshValue)
     }
 
     /// Verifies that `StatsActionV4.retrieveStats` makes a network request without the `force_cache_refresh` parameter if `forceRefresh` is false.
@@ -361,7 +362,8 @@ final class StatsStoreV4Tests: XCTestCase {
         }
 
         // Then
-        XCTAssertNil(network.queryParametersDictionary?["force_cache_refresh"])
+        let forceCacheRefreshValue = network.queryParametersDictionary?["force_cache_refresh"]
+        XCTAssertNil(forceCacheRefreshValue)
     }
 
     /// Verifies that `StatsActionV4.retrieveTopEarnerStats` effectively persists any updated TopEarnerStatsItems.

--- a/Yosemite/YosemiteTests/Stores/StatsStoreV4Tests.swift
+++ b/Yosemite/YosemiteTests/Stores/StatsStoreV4Tests.swift
@@ -316,9 +316,33 @@ final class StatsStoreV4Tests: XCTestCase {
         XCTAssertEqual(network.queryParameters?.contains(expectedQuantityParam), true)
     }
 
-    /// Verifies that `StatsActionV4.retrieveStats` makes a network request with the given `force_cache_refresh` parameter.
+    /// Verifies that `StatsActionV4.retrieveStats` makes a network request with the given `force_cache_refresh` parameter if `forceRefresh` is true.
     ///
-    func test_retrieveStats_makes_network_request_with_given_force_cache_rerefresh_parameter() {
+    func test_retrieveStats_makes_network_request_with_given_force_cache_rerefresh_parameter_if_forceRefresh_is_true() {
+        // Given
+        let store = StatsStoreV4(dispatcher: dispatcher, storageManager: storageManager, network: network)
+
+        // When
+        let _: Void = waitFor { promise in
+            let action = StatsActionV4.retrieveStats(siteID: self.sampleSiteID,
+                                                     timeRange: .thisMonth,
+                                                     timeZone: .current,
+                                                     earliestDateToInclude: .init(),
+                                                     latestDateToInclude: .init(),
+                                                     quantity: 1,
+                                                     forceRefresh: true) { _ in
+                promise(())
+            }
+            store.onAction(action)
+        }
+
+        // Then
+        XCTAssertEqual(network.queryParametersDictionary?["force_cache_refresh"] as? Bool, true)
+    }
+
+    /// Verifies that `StatsActionV4.retrieveStats` makes a network request without the `force_cache_refresh` parameter if `forceRefresh` is false.
+    ///
+    func test_retrieveStats_makes_network_request_without_force_cache_rerefresh_parameter_if_forceRefresh_is_false() {
         // Given
         let store = StatsStoreV4(dispatcher: dispatcher, storageManager: storageManager, network: network)
 
@@ -337,7 +361,7 @@ final class StatsStoreV4Tests: XCTestCase {
         }
 
         // Then
-        XCTAssertEqual(network.queryParametersDictionary?["force_cache_refresh"] as? Bool, false)
+        XCTAssertNil(network.queryParametersDictionary?["force_cache_refresh"])
     }
 
     /// Verifies that `StatsActionV4.retrieveTopEarnerStats` effectively persists any updated TopEarnerStatsItems.


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #12142 
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
Previously we were calculating manually the difference in hours/days/months/years to determine the `per_page` param to be sent to the endpoint `GET wc-analytics/reports/revenue/stats`.

This calculation is error-prone and can cause missing stats. This PR fixes this by simply returning the maximum number of items allowed for pagination (defined [here](https://developer.wordpress.org/rest-api/using-the-rest-api/pagination/)), and the backend will [determine](https://github.com/woocommerce/woocommerce/blob/b471e51734a09eadd5ff80d6eda268a5627b5f3d/plugins/woocommerce/src/Admin/API/Reports/Orders/Stats/DataStore.php#L384) the maximum values it can return based on the provided granularity.

Internal discussion: p1709207657326339-slack-C03L1NF1EA3.

Also: 
- Updated the displayed selected date to consider granularity rather than specific range.
- Fixed failed requests to refresh stats with `force_cache_refresh` being false (400 error code).
- Fixed failed unit tests for stats granularity.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
- Log in to a test store with revenue history.
- Add a custom range or edit an existing one.
- Try a range of 2-7 days. Confirm that the stats include both start and end dates.
- Try a range of 1 day. Confirm that the stats include the time from start date 12 AM to end date 12 am.
- Try a large range in months or years. The stats will only include the possible range for the respective granularity. E.g. if the selected range is from Oct 1 2023 to Feb 7 2024, we can only see stats from Oct 2023 to Feb 7.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

https://github.com/woocommerce/woocommerce-ios/assets/5533851/44b5def1-ad86-4fee-abcf-545761efba9e



---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.