### PR TITLE
[Tablet Products] Add margin or max width to product form and the main subpages

### DIFF
--- a/Experiments/Experiments/DefaultFeatureFlagService.swift
+++ b/Experiments/Experiments/DefaultFeatureFlagService.swift
@@ -86,7 +86,7 @@ public struct DefaultFeatureFlagService: FeatureFlagService {
         case .backendReceipts:
             return true
         case .splitViewInProductsTab:
-            return buildConfig == .localDeveloper || buildConfig == .alpha
+            return true
         case .customRangeInMyStoreAnalytics:
             return buildConfig == .localDeveloper || buildConfig == .alpha
         case .customizeAnalyticsHub:

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -5,7 +5,7 @@
 - Orders: Merchants can now contact their customers through WhatsApp and Telegram apps. [https://github.com/woocommerce/woocommerce-ios/pull/12099]
 - [internal] Blaze: Use v1.1 endpoint to load campaigns list. [https://github.com/woocommerce/woocommerce-ios/pull/12127]
 - Orders: Merchants can filter orders by selecting a product. [https://github.com/woocommerce/woocommerce-ios/pull/12129]
-
+- [**] Products tab: split view is now supported in the products tab. [https://github.com/woocommerce/woocommerce-ios/pull/12158]
 
 17.5
 -----

--- a/WooCommerce/Classes/ViewRelated/Products/Categories/ProductCategoryListViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Categories/ProductCategoryListViewController.swift
@@ -92,6 +92,7 @@ private extension ProductCategoryListViewController {
         tableView.delegate = self
         tableView.removeLastCellSeparator()
         tableView.keyboardDismissMode = .onDrag
+        tableView.cellLayoutMarginsFollowReadableWidth = true
     }
 
     func configureSearchBar() {

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Cells/ImageAndTitleAndTextTableViewCell.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Cells/ImageAndTitleAndTextTableViewCell.swift
@@ -120,6 +120,8 @@ final class ImageAndTitleAndTextTableViewCell: UITableViewCell {
     @IBOutlet private weak var titleLabel: UILabel!
     @IBOutlet private weak var descriptionLabel: UILabel!
 
+    @IBOutlet private weak var separatorView: UIView!
+
     /// Disabled by default. When active, image is constrained to 24pt
     @IBOutlet private var contentImageViewWidthConstraint: NSLayoutConstraint!
 
@@ -131,6 +133,7 @@ final class ImageAndTitleAndTextTableViewCell: UITableViewCell {
         configureImageView()
         configureContentStackView()
         configureTitleAndTextStackView()
+        configureSeparatorView()
         configureDefaultBackgroundConfiguration()
         configureSelectedBackground()
     }
@@ -188,11 +191,7 @@ extension ImageAndTitleAndTextTableViewCell {
 
         contentImageViewWidthConstraint.isActive = false
 
-        if viewModel.showsSeparator {
-            showSeparator()
-        } else {
-            hideSeparator()
-        }
+        separatorView.isHidden = !viewModel.showsSeparator
     }
 
     func updateUI(switchableViewModel: SwitchableViewModel) {
@@ -304,6 +303,13 @@ private extension ImageAndTitleAndTextTableViewCell {
 
     func configureTitleAndTextStackView() {
         titleAndTextStackView.spacing = 2
+    }
+
+    func configureSeparatorView() {
+        // Hides the `UITableViewCell` separator and uses a custom separator view because the cell's separator inset cannot be
+        // easily adjusted based on layout margins for better tablet support.
+        hideSeparator()
+        separatorView.backgroundColor = .divider
     }
 
     func configureSelectedBackground() {

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Cells/ImageAndTitleAndTextTableViewCell.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Cells/ImageAndTitleAndTextTableViewCell.swift
@@ -123,6 +123,8 @@ final class ImageAndTitleAndTextTableViewCell: UITableViewCell {
     /// Disabled by default. When active, image is constrained to 24pt
     @IBOutlet private var contentImageViewWidthConstraint: NSLayoutConstraint!
 
+    private var showsSeparator: Bool = true
+
     private var cancellable: AnyCancellable?
 
     override func awakeFromNib() {
@@ -143,6 +145,11 @@ final class ImageAndTitleAndTextTableViewCell: UITableViewCell {
     override func updateConfiguration(using state: UICellConfigurationState) {
         super.updateConfiguration(using: state)
         updateDefaultBackgroundConfiguration(using: state)
+    }
+
+    override func layoutMarginsDidChange() {
+        super.layoutMarginsDidChange()
+        updateSeparatorInset(layoutMargins: layoutMargins)
     }
 }
 
@@ -189,10 +196,11 @@ extension ImageAndTitleAndTextTableViewCell {
         contentImageViewWidthConstraint.isActive = false
 
         if viewModel.showsSeparator {
-            showSeparator()
+            updateSeparatorInset(layoutMargins: layoutMargins)
         } else {
             hideSeparator()
         }
+        showsSeparator = viewModel.showsSeparator
     }
 
     func updateUI(switchableViewModel: SwitchableViewModel) {
@@ -279,6 +287,18 @@ private extension ImageAndTitleAndTextTableViewCell {
                                   showsSeparator: data.showsSeparator)
         updateUI(viewModel: viewModel)
     }
+    
+    /// In `UITableViewCell`, the trait collection horizontal size class stays the same for the device regardless of the parent view size.
+    /// As a workaround, it responds to `layoutMargins` changes and shows different separator inset based on the left margin.
+    func updateSeparatorInset(layoutMargins: UIEdgeInsets) {
+        guard showsSeparator else {
+            return
+        }
+        let inset: UIEdgeInsets = layoutMargins.left > Layout.compactHorizontalSizeClassLayoutMargin ?
+            .init(top: 0, left: layoutMargins.left, bottom: 0, right: layoutMargins.right) :
+            .init(top: 0, left: 16, bottom: 0, right: 0)
+        showSeparator(inset: inset)
+    }
 }
 
 // MARK: Configurations
@@ -336,5 +356,11 @@ private extension ImageAndTitleAndTextTableViewCell.Style {
         default:
             return .firstBaseline
         }
+    }
+}
+
+private extension ImageAndTitleAndTextTableViewCell {
+    enum Layout {
+        static let compactHorizontalSizeClassLayoutMargin: CGFloat = 16
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Cells/ImageAndTitleAndTextTableViewCell.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Cells/ImageAndTitleAndTextTableViewCell.swift
@@ -120,8 +120,6 @@ final class ImageAndTitleAndTextTableViewCell: UITableViewCell {
     @IBOutlet private weak var titleLabel: UILabel!
     @IBOutlet private weak var descriptionLabel: UILabel!
 
-    @IBOutlet private weak var separatorView: UIView!
-
     /// Disabled by default. When active, image is constrained to 24pt
     @IBOutlet private var contentImageViewWidthConstraint: NSLayoutConstraint!
 
@@ -133,7 +131,6 @@ final class ImageAndTitleAndTextTableViewCell: UITableViewCell {
         configureImageView()
         configureContentStackView()
         configureTitleAndTextStackView()
-        configureSeparatorView()
         configureDefaultBackgroundConfiguration()
         configureSelectedBackground()
     }
@@ -191,7 +188,11 @@ extension ImageAndTitleAndTextTableViewCell {
 
         contentImageViewWidthConstraint.isActive = false
 
-        separatorView.isHidden = !viewModel.showsSeparator
+        if viewModel.showsSeparator {
+            showSeparator()
+        } else {
+            hideSeparator()
+        }
     }
 
     func updateUI(switchableViewModel: SwitchableViewModel) {
@@ -303,13 +304,6 @@ private extension ImageAndTitleAndTextTableViewCell {
 
     func configureTitleAndTextStackView() {
         titleAndTextStackView.spacing = 2
-    }
-
-    func configureSeparatorView() {
-        // Hides the `UITableViewCell` separator and uses a custom separator view because the cell's separator inset cannot be
-        // easily adjusted based on layout margins for better tablet support.
-        hideSeparator()
-        separatorView.backgroundColor = .divider
     }
 
     func configureSelectedBackground() {

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Cells/ImageAndTitleAndTextTableViewCell.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Cells/ImageAndTitleAndTextTableViewCell.swift
@@ -287,7 +287,7 @@ private extension ImageAndTitleAndTextTableViewCell {
                                   showsSeparator: data.showsSeparator)
         updateUI(viewModel: viewModel)
     }
-    
+
     /// In `UITableViewCell`, the trait collection horizontal size class stays the same for the device regardless of the parent view size.
     /// As a workaround, it responds to `layoutMargins` changes and shows different separator inset based on the left margin.
     func updateSeparatorInset(layoutMargins: UIEdgeInsets) {

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Cells/ImageAndTitleAndTextTableViewCell.xib
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Cells/ImageAndTitleAndTextTableViewCell.xib
@@ -1,11 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="22505" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="17156" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="22504"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="17126"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
-        <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
@@ -62,19 +61,9 @@
                             </stackView>
                         </subviews>
                     </stackView>
-                    <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="vVA-DE-nz2" userLabel="Separator View">
-                        <rect key="frame" x="16" y="89.5" width="288" height="0.5"/>
-                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
-                        <constraints>
-                            <constraint firstAttribute="height" constant="0.5" id="eh2-QG-y5g"/>
-                        </constraints>
-                    </view>
                 </subviews>
                 <constraints>
-                    <constraint firstAttribute="trailingMargin" secondItem="vVA-DE-nz2" secondAttribute="trailing" id="2h8-IB-b2e"/>
-                    <constraint firstItem="vVA-DE-nz2" firstAttribute="leading" secondItem="H2p-sc-9uM" secondAttribute="leadingMargin" id="53e-uk-EbS"/>
                     <constraint firstItem="I1O-4G-30m" firstAttribute="top" secondItem="H2p-sc-9uM" secondAttribute="top" constant="10" id="8IX-hW-PFy"/>
-                    <constraint firstAttribute="bottom" secondItem="vVA-DE-nz2" secondAttribute="bottom" id="IRr-9H-LBc"/>
                     <constraint firstAttribute="bottom" secondItem="I1O-4G-30m" secondAttribute="bottom" priority="998" constant="10" id="KGS-SG-1Y9"/>
                     <constraint firstItem="I1O-4G-30m" firstAttribute="leading" secondItem="H2p-sc-9uM" secondAttribute="leadingMargin" id="rNN-Ra-lRW"/>
                     <constraint firstAttribute="trailingMargin" secondItem="I1O-4G-30m" secondAttribute="trailing" priority="999" id="uPB-pm-qaR"/>
@@ -87,16 +76,10 @@
                 <outlet property="contentImageViewWidthConstraint" destination="hrc-Xu-yMN" id="eCJ-2n-6N2"/>
                 <outlet property="contentStackView" destination="I1O-4G-30m" id="ehz-kd-Cf7"/>
                 <outlet property="descriptionLabel" destination="afj-1k-DXC" id="elJ-NR-F1b"/>
-                <outlet property="separatorView" destination="vVA-DE-nz2" id="Dqf-4K-SLA"/>
                 <outlet property="titleAndTextStackView" destination="HHf-VV-Yya" id="PtG-04-hY3"/>
                 <outlet property="titleLabel" destination="6WI-8Q-5Qr" id="hfT-X6-mFX"/>
             </connections>
             <point key="canvasLocation" x="131.8840579710145" y="121.20535714285714"/>
         </tableViewCell>
     </objects>
-    <resources>
-        <systemColor name="systemBackgroundColor">
-            <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-        </systemColor>
-    </resources>
 </document>

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Cells/ImageAndTitleAndTextTableViewCell.xib
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Cells/ImageAndTitleAndTextTableViewCell.xib
@@ -1,10 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="17156" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="22505" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="17126"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="22504"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
@@ -61,9 +62,19 @@
                             </stackView>
                         </subviews>
                     </stackView>
+                    <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="vVA-DE-nz2" userLabel="Separator View">
+                        <rect key="frame" x="16" y="89.5" width="288" height="0.5"/>
+                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                        <constraints>
+                            <constraint firstAttribute="height" constant="0.5" id="eh2-QG-y5g"/>
+                        </constraints>
+                    </view>
                 </subviews>
                 <constraints>
+                    <constraint firstAttribute="trailingMargin" secondItem="vVA-DE-nz2" secondAttribute="trailing" id="2h8-IB-b2e"/>
+                    <constraint firstItem="vVA-DE-nz2" firstAttribute="leading" secondItem="H2p-sc-9uM" secondAttribute="leadingMargin" id="53e-uk-EbS"/>
                     <constraint firstItem="I1O-4G-30m" firstAttribute="top" secondItem="H2p-sc-9uM" secondAttribute="top" constant="10" id="8IX-hW-PFy"/>
+                    <constraint firstAttribute="bottom" secondItem="vVA-DE-nz2" secondAttribute="bottom" id="IRr-9H-LBc"/>
                     <constraint firstAttribute="bottom" secondItem="I1O-4G-30m" secondAttribute="bottom" priority="998" constant="10" id="KGS-SG-1Y9"/>
                     <constraint firstItem="I1O-4G-30m" firstAttribute="leading" secondItem="H2p-sc-9uM" secondAttribute="leadingMargin" id="rNN-Ra-lRW"/>
                     <constraint firstAttribute="trailingMargin" secondItem="I1O-4G-30m" secondAttribute="trailing" priority="999" id="uPB-pm-qaR"/>
@@ -76,10 +87,16 @@
                 <outlet property="contentImageViewWidthConstraint" destination="hrc-Xu-yMN" id="eCJ-2n-6N2"/>
                 <outlet property="contentStackView" destination="I1O-4G-30m" id="ehz-kd-Cf7"/>
                 <outlet property="descriptionLabel" destination="afj-1k-DXC" id="elJ-NR-F1b"/>
+                <outlet property="separatorView" destination="vVA-DE-nz2" id="Dqf-4K-SLA"/>
                 <outlet property="titleAndTextStackView" destination="HHf-VV-Yya" id="PtG-04-hY3"/>
                 <outlet property="titleLabel" destination="6WI-8Q-5Qr" id="hfT-X6-mFX"/>
             </connections>
             <point key="canvasLocation" x="131.8840579710145" y="121.20535714285714"/>
         </tableViewCell>
     </objects>
+    <resources>
+        <systemColor name="systemBackgroundColor">
+            <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+        </systemColor>
+    </resources>
 </document>

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Downloadable Files/File List/ProductDownloadListViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Downloadable Files/File List/ProductDownloadListViewController.swift
@@ -135,6 +135,7 @@ private extension ProductDownloadListViewController {
         tableView.delegate = self
         tableView.removeLastCellSeparator()
         tableView.dragInteractionEnabled = true
+        tableView.cellLayoutMarginsFollowReadableWidth = true
         tableView.dragDelegate = self
         tableView.dropDelegate = self
         tableView.reloadData()

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Edit Price/ProductPriceSettingsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Edit Price/ProductPriceSettingsViewController.swift
@@ -123,6 +123,7 @@ private extension ProductPriceSettingsViewController {
         tableView.rowHeight = UITableView.automaticDimension
         tableView.backgroundColor = .listBackground
         tableView.keyboardDismissMode = .onDragWithAccessory
+        tableView.cellLayoutMarginsFollowReadableWidth = true
 
         registerTableViewHeaderSections()
         registerTableViewCells()

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Inventory Settings/ProductInventorySettingsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Inventory Settings/ProductInventorySettingsViewController.swift
@@ -99,6 +99,7 @@ private extension ProductInventorySettingsViewController {
     func configureTableView() {
         tableView.rowHeight = UITableView.automaticDimension
         tableView.backgroundColor = .listBackground
+        tableView.cellLayoutMarginsFollowReadableWidth = true
 
         registerTableViewCells()
         registerTableViewHeaderFooters()

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Product Settings/ProductSettingsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Product Settings/ProductSettingsViewController.swift
@@ -77,6 +77,7 @@ private extension ProductSettingsViewController {
 
         tableView.backgroundColor = .listBackground
         tableView.removeLastCellSeparator()
+        tableView.cellLayoutMarginsFollowReadableWidth = true
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewController.swift
@@ -574,6 +574,7 @@ private extension ProductFormViewController {
         tableView.dataSource = tableViewDataSource
         tableView.delegate = self
         tableView.accessibilityIdentifier = "product-form"
+        tableView.cellLayoutMarginsFollowReadableWidth = true
 
         tableView.backgroundColor = .listForeground(modal: false)
         tableView.removeLastCellSeparator()

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Reviews/ProductReviewsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Reviews/ProductReviewsViewController.swift
@@ -115,6 +115,7 @@ private extension ProductReviewsViewController {
         tableView.delegate = self
         tableView.tableFooterView = footerSpinnerView
         tableView.sectionFooterHeight = .leastNonzeroMagnitude
+        tableView.cellLayoutMarginsFollowReadableWidth = true
     }
 
     /// Setup: ResultsController

--- a/WooCommerce/Classes/ViewRelated/ReusableViews/LabeledTextViewTableViewCell.xib
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/LabeledTextViewTableViewCell.xib
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="20037" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="22505" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="20020"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="22504"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
@@ -22,20 +22,20 @@
                         <rect key="frame" x="16" y="8" width="288" height="28"/>
                         <subviews>
                             <textView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" textAlignment="natural" translatesAutoresizingMaskIntoConstraints="NO" id="gvh-NZ-8It" customClass="EnhancedTextView" customModule="WooCommerce" customModuleProvider="target">
-                                <rect key="frame" x="0.0" y="0.0" width="231.5" height="28"/>
+                                <rect key="frame" x="0.0" y="0.0" width="217.5" height="28"/>
                                 <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                                 <color key="textColor" systemColor="labelColor"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                 <textInputTraits key="textInputTraits" autocapitalizationType="sentences"/>
                             </textView>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="n4n-89-c1P">
-                                <rect key="frame" x="236.5" y="0.0" width="51.5" height="28"/>
+                                <rect key="frame" x="222.5" y="0.0" width="65.5" height="28"/>
                                 <subviews>
                                     <view clipsSubviews="YES" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="A6r-Hf-px7" userLabel="Product Status Label Holder">
-                                        <rect key="frame" x="0.0" y="8" width="51.5" height="20"/>
+                                        <rect key="frame" x="0.0" y="8" width="65.5" height="20"/>
                                         <subviews>
                                             <label opaque="NO" clipsSubviews="YES" userInteractionEnabled="NO" contentMode="center" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="9Ls-Wz-Lz4">
-                                                <rect key="frame" x="12" y="4" width="27.5" height="12"/>
+                                                <rect key="frame" x="12" y="4" width="41.5" height="12"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
@@ -63,8 +63,8 @@
                 </subviews>
                 <constraints>
                     <constraint firstItem="UC5-pp-RCE" firstAttribute="top" secondItem="0sv-hP-tpf" secondAttribute="top" constant="8" id="8Wf-g3-eXM"/>
-                    <constraint firstItem="UC5-pp-RCE" firstAttribute="leading" secondItem="0sv-hP-tpf" secondAttribute="leading" constant="16" id="GgM-C5-CHt"/>
-                    <constraint firstAttribute="trailing" secondItem="UC5-pp-RCE" secondAttribute="trailing" constant="16" id="Sjf-TQ-4xv"/>
+                    <constraint firstItem="UC5-pp-RCE" firstAttribute="leading" secondItem="0sv-hP-tpf" secondAttribute="leadingMargin" id="GgM-C5-CHt"/>
+                    <constraint firstAttribute="trailingMargin" secondItem="UC5-pp-RCE" secondAttribute="trailing" id="Sjf-TQ-4xv"/>
                     <constraint firstAttribute="bottom" secondItem="UC5-pp-RCE" secondAttribute="bottom" constant="8" id="ZhY-zm-fhU"/>
                 </constraints>
             </tableViewCellContentView>


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #12144 
<!-- Id number of the GitHub issue this PR addresses. -->

## Why

From Joe's design feedback pfoUAQ-iv-p2#comment-227:

> On Orders, I advised that we should add margins to the order details area, to reduce the amount of space between label and data in the table views. I think we should apply this consistently on products, too.

As the last blocker of the products tab split view support, this PR also turns on the feature flag for release 17.6.

## How

To add margins to the product form in a more native way, the table view of the product form and its subpages (screens that can be navigated to) now has `cellLayoutMarginsFollowReadableWidth = true` to enable a bigger horizontal layout largin when the view has regular horizontal size class.

There were two tricky issues to fix in the product form:

- The product name cell's stack view edges used to be pinned to the cell's edges, which results in misalignment with other cell types in the product form. In this PR, the stack view's edges are now pinned to the content's leading/trailing **margins** to adapt to readable width as set in `tableView.cellLayoutMarginsFollowReadableWidth`
- [The trickiest] The product form has a few cell types, and all of them except for `ImageAndTitleAndTextTableViewCell` never override its `separatorInset`. Once `separatorInset` is overridden to a value, it can not follow the readable width automatically anymore. It's needed because `ImageAndTitleAndTextTableViewCell`'s separator can be hidden, and it's implemented by updating the separator inset. As a workaround after quite some attempts, it overrides `layoutMarginsDidChange` and updates its separator inset in the same way as in the native way in other cell types. Other things I tried:
  - Hiding the native separator, and implementing a custom separator as a subview. However, the separator view can't be easily extended to the accessory view like in other cell types
  - Overriding `traitCollectionDidChange(_:)` in addition to `layoutMarginsDidChange` to update the separator inset based on the horizontal size class. But this function is never triggered in UITableViewCell's from my testing. From reading other posts online, it's recommended to get the size class from the table view / view controller
  - Trying out the iOS 17+ trait observation API `registerForTraitChanges([UITraitHorizontalSizeClass.self])`, but similar to the previous attempt, it's never triggered in the table view cell

Please feel free to suggest a better workaround for the separator issue!

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

- [x] @jaclync tests any other views that reuse one of the updated view controllers

---

Prerequisite: a tablet device/simulator

- Launch the app
- Go to the products tab when the tablet is in landscape mode where the product form has a regular horizontal size class  --> the cells should have greater margins so that they are more readable
- Rotate the device so that the product form has a compact horizontal size class --> the cells should have 16px horizontal leading margin, and 0 trailing margin
- Tap on the price row (or `Add more details` > Price) --> the cells should follow the same readable width after rotating the device
- Go back to the product form, tap on the reviews row --> if there are non-zero reviews, the cells should follow the same readable width after rotating the device
- Go back to the product form, tap on the inventory row (or `Add more details` > Inventory) --> the cells should follow the same readable width after rotating the device
- Go back to the product form, tap on the categories row (or `Add more details` > Categories) --> the cells should follow the same readable width after rotating the device
- Go back to the product form, tap on the ellipsis menu > Product Settings --> the cells should follow the same readable width after rotating the device

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->


https://github.com/woocommerce/woocommerce-ios/assets/1945542/e8832e85-779e-48d8-88b7-6267b29a9080



---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
