### PR TITLE
Show alert when trying to exit the application password flow

### DIFF
--- a/WooCommerce/Classes/Authentication/Application Password/ApplicationPasswordAuthorizationWebViewController.swift
+++ b/WooCommerce/Classes/Authentication/Application Password/ApplicationPasswordAuthorizationWebViewController.swift
@@ -68,7 +68,10 @@ final class ApplicationPasswordAuthorizationWebViewController: UIViewController 
         configureProgressBar()
         configureActivityIndicator()
         fetchAuthorizationURL()
-        handleSwipeBackGesture()
+
+        if ServiceLocator.featureFlagService.isFeatureFlagEnabled(.appPasswordTutorial) {
+            handleSwipeBackGesture()
+        }
     }
 }
 

--- a/WooCommerce/Classes/Authentication/Application Password/ApplicationPasswordAuthorizationWebViewController.swift
+++ b/WooCommerce/Classes/Authentication/Application Password/ApplicationPasswordAuthorizationWebViewController.swift
@@ -68,6 +68,24 @@ final class ApplicationPasswordAuthorizationWebViewController: UIViewController 
         configureProgressBar()
         configureActivityIndicator()
         fetchAuthorizationURL()
+        handleSwipeBackGesture()
+    }
+}
+
+extension ApplicationPasswordAuthorizationWebViewController {
+    override func shouldPopOnBackButton() -> Bool {
+        presentBackNavigationAlert()
+        return false
+    }
+
+    override func shouldPopOnSwipeBack() -> Bool {
+        return shouldPopOnBackButton()
+    }
+
+    private func presentBackNavigationAlert() {
+        UIAlertController.presentUnfinishedApplicationPasswordAlert(from: self) { [weak self] in
+            self?.navigationController?.popViewController(animated: true)
+        }
     }
 }
 

--- a/WooCommerce/Classes/Extensions/UIAlertController+Helpers.swift
+++ b/WooCommerce/Classes/Extensions/UIAlertController+Helpers.swift
@@ -107,6 +107,18 @@ extension UIAlertController {
         alertController.addAction(action)
         viewController.present(alertController, animated: true)
     }
+
+    /// Unfinished App Password alert.
+    ///
+    static func presentUnfinishedApplicationPasswordAlert(from viewController: UIViewController, onExit: @escaping () -> Void) {
+        let alertController = UIAlertController(title: UnfinishedApplicationPasswordAlert.title, message: nil, preferredStyle: .alert)
+        let action = UIAlertAction(title: UnfinishedApplicationPasswordAlert.exit, style: .destructive) { _ in
+            onExit()
+        }
+        alertController.addAction(action)
+        alertController.addCancelActionWithTitle(ActionSheetStrings.cancel)
+        viewController.present(alertController, animated: true)
+    }
 }
 
 private enum ActionSheetStrings {
@@ -155,4 +167,10 @@ private enum ExpiredWPComPlanAlert {
         comment: "Message on the expired WPCom plan alert"
     )
     static let upgrade = NSLocalizedString("Upgrade", comment: "Button to upgrade a WPCom plan on the expired WPCom plan alert")
+}
+
+private enum UnfinishedApplicationPasswordAlert {
+    static let title = NSLocalizedString("It seems that you have not approved the app connection yet. Are you sure you want to exit?",
+                                         comment: "Title for the unfinished application password alert")
+    static let exit = NSLocalizedString("Exit Anyway", comment: "Button to exit the application password flow.")
 }


### PR DESCRIPTION
Closes: #12000 

# Why

To prevent users from leaving the flow without approving the app password first, this PR shows an alert when the user tries to leave the flow.

# Screenshot

![alert](https://github.com/woocommerce/woocommerce-ios/assets/562080/cc98e4fc-4a3c-44a2-964c-a025c0e4936f)


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
