### PR TITLE
My Store Analytics: Make time range bar visible to update custom range when data is not available

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Dashboard/DashboardUI.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/DashboardUI.swift
@@ -3,6 +3,9 @@ import UIKit
 /// Contains all UI content to show on Dashboard
 ///
 protocol DashboardUI: UIViewController {
+    /// Called when any stat data is reloaded.
+    var onDataReload: () -> Void { get set }
+
     /// Called when the Dashboard should display syncing error
     var displaySyncingError: (Error) -> Void { get set }
 

--- a/WooCommerce/Classes/ViewRelated/Dashboard/DashboardViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/DashboardViewController.swift
@@ -844,6 +844,10 @@ private extension DashboardViewController {
         // Sets `dashboardUI` after its view is added to the view hierarchy so that observers can update UI based on its view.
         dashboardUI = updatedDashboardUI
 
+        updatedDashboardUI.onDataReload = { [weak self] in
+            self?.hideTopBannerView()
+        }
+
         updatedDashboardUI.displaySyncingError = { [weak self] error in
             self?.showTopBannerView(for: error)
         }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Stats v3/DeprecatedStatsDashboardViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Stats v3/DeprecatedStatsDashboardViewController.swift
@@ -43,6 +43,13 @@ final class DeprecatedDashboardStatsViewController: UIViewController {
 // MARK: DashboardUI conformance
 // Everything is empty as this deprecated stats screen is static
 extension DeprecatedDashboardStatsViewController: DashboardUI {
+    var onDataReload: () -> Void {
+        get {
+            return {}
+        }
+        set {}
+    }
+    
     var displaySyncingError: (Error) -> Void {
         get {
             return { _ in }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Stats v3/DeprecatedStatsDashboardViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Stats v3/DeprecatedStatsDashboardViewController.swift
@@ -49,7 +49,7 @@ extension DeprecatedDashboardStatsViewController: DashboardUI {
         }
         set {}
     }
-    
+
     var displaySyncingError: (Error) -> Void {
         get {
             return { _ in }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Stats v4/StoreStatsAndTopPerformersViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Stats v4/StoreStatsAndTopPerformersViewController.swift
@@ -10,6 +10,8 @@ import class WidgetKit.WidgetCenter
 final class StoreStatsAndTopPerformersViewController: TabbedViewController {
     // MARK: - DashboardUI protocol
 
+    var onDataReload: () -> Void = {}
+
     var displaySyncingError: (Error) -> Void = { _ in }
 
     var onPullToRefresh: @MainActor () async -> Void = {}
@@ -174,6 +176,7 @@ private extension StoreStatsAndTopPerformersViewController {
 
         var syncError: Error? = nil
 
+        onDataReload()
         ensureGhostContentIsDisplayed(for: viewControllerToSync)
 
         defer {

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Stats v4/StoreStatsPeriodViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Stats v4/StoreStatsPeriodViewModel.swift
@@ -194,8 +194,16 @@ private extension StoreStatsPeriodViewModel {
         let orderStatsIntervals = orderStatsData.intervals
         guard let startDate = orderStatsIntervals.first?.dateStart(timeZone: self.siteTimezone),
               let endDate = orderStatsIntervals.last?.dateStart(timeZone: self.siteTimezone) else {
-                  return nil
-              }
+            if case let .custom(start, end) = timeRange {
+                // Ensure the bar is visible for updating the custom range even when no data is available.
+                return StatsTimeRangeBarViewModel(startDate: start,
+                                                  endDate: end,
+                                                  timeRange: timeRange,
+                                                  timezone: siteTimezone)
+            } else {
+                return nil
+            }
+        }
         guard let selectedIndex = selectedIntervalIndex else {
             return StatsTimeRangeBarViewModel(startDate: startDate,
                                               endDate: endDate,


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #12147 
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This PR fixes the issue when stats data cannot be loaded, the time range button is not visible on the custom range tab but is still tappable.

The cause of this issue is that the button to update the time range is enabled for the custom range tab, but the text is not updated since we're returning a nil view model for `StatsTimeRangeBarView`. So you can still tap on the time range bar view to open the date picker, even though it looks like nothing is there.

The solution is to return a non nil view model for the bar with the start and end date from the custom range.

Also: The error banner is now hidden when stats are reloaded.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
1. Testing time range bar for the custom range tab
- Update `maxNumberOfIntervals` for the custom time range in `StatsTimeRangeV4` to 1000 and build the app.
- Log in to a store and add a new custom range tab if none already exists.
- Select a large range, e.g. from 1999 to 2024.
- Notice that even though data cannot be loaded for this range, the button for editing the custom date range is still visible and enabled.

Note: this edge case is no longer exists now that we're setting a fixed 100 for the interval count. I figure it's still helpful if for some reason stats cannot be loaded for a specific range, and the user wants to switch to a different range.

2. Testing error banner when reloading stats
- Log in to the app.
- Disable your Internet connection.
- Create a custom range tab or edit the date range for an existing one.
- Notice that the error banner is displayed because stats cannot be loaded for the custom range.
- Enable your Internet connection and select a different date range.
- Confirm that the error banner is now dismissed.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

1. Time range bar for the custom range tab

<img src="https://github.com/woocommerce/woocommerce-ios/assets/5533851/7a6d3a7a-44e9-40fa-b4a2-ddea61096439" width=320 />

2. Hiding error banner when reloading stats


https://github.com/woocommerce/woocommerce-ios/assets/5533851/50543931-9cc3-49ee-be85-ed4f5d6ca4f3



---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
