### PR TITLE
[Tablet Products] Fix product form showing large title when the product list shows large title in collapsed mode

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Products/ProductsSplitViewCoordinator.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductsSplitViewCoordinator.swift
@@ -205,6 +205,10 @@ extension ProductsSplitViewCoordinator: UINavigationControllerDelegate {
             return
         }
 
+        if let tabNavigationController = navigationController as? WooTabNavigationController {
+            tabNavigationController.navigationController(navigationController, willShow: viewController, animated: animated)
+        }
+
         // The goal here is to detect when the user pops a view controller in the secondary navigation stack like from tapping the back button,
         // so that the secondary content types state can be updated accordingly.
         // There is no proper way that I can find to detect this, as a workaround it checks whether the secondary navigation stack has fewer


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #12176
<!-- Id number of the GitHub issue this PR addresses. -->

## Why

While testing in iPhone where the split view is collapsed, if the product list is showing large title then tapping on a product, the product form also unexpectedly shows the large title height in the navigation bar. After some debugging, it's because the large title logic in `WooTabNavigationController.navigationController(_:willShow:)` (the primary navigation controller) where only the root view controller (product list) prefers large title and subsequent view controllers should not. However, because this `navigationController(_:willShow:)` call is a `UINavigationControllerDelegate` delegate call while the delegate is overridden in `ProductsSplitViewCoordinator`, the delegate call in `WooTabNavigationController` is never called to update the large title preference. There can only be one delegate (the drawback of using the delegate pattern).

## How

This PR fixes it by also calling `WooTabNavigationController.navigationController(_:willShow:)` when the navigation controller is `WooTabNavigationController` in `ProductsSplitViewCoordinator.navigationController(_:willShow:)`.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

- [x] @jaclync tests in split view expanded mode

Prerequisite: using a phone or tablet where the app width is in collapsed mode

- Go to the products tab --> large title should be shown
- Tap on a product --> the product form shouldn't show a tall navigation bar from the large title preference in the product list
- Tap on any row in the product form --> the navigation bar shouldn't show large title

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->


https://github.com/woocommerce/woocommerce-ios/assets/1945542/56be78d1-8293-4264-b8cc-b55a650fa03c



---
- [X] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
