### PR TITLE
[Tablet Products] Product form > shipping: apply cell margins to follow readable width similar to other settings screens

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Shipping Settings/ProductShippingSettingsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Shipping Settings/ProductShippingSettingsViewController.swift
@@ -64,6 +64,7 @@ private extension ProductShippingSettingsViewController {
     func configureTableView() {
         tableView.rowHeight = UITableView.automaticDimension
         tableView.backgroundColor = .listBackground
+        tableView.cellLayoutMarginsFollowReadableWidth = true
 
         registerTableViewCells()
 


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #12180

<!-- Id number of the GitHub issue this PR addresses. -->

## Why

When working on the margins in regular horizontal size class for the product form & subpages in https://github.com/woocommerce/woocommerce-ios/pull/12158, I was testing on a virtual product and forgot about the shipping settings screen. This PR simply applies the same table view setting to the product shipping settings table view.

## How

Apply the same `cellLayoutMarginsFollowReadableWidth` setting to the table view in `ProductShippingSettingsViewController`.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

Prerequisite: on a tablet in landscape mode

- Go to the products tab
- Tap on an editable physical product
- Tap on Shipping or `Add more details` > Shipping --> the rows should have readable width in tablet landscape mode where the product form has regular horizontal size class

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

before | after
-- | --
<img src="https://github.com/woocommerce/woocommerce-ios/assets/1945542/4a13b2ec-d408-41a5-9ecd-456dbe67ffba" width="500" /> | <img src="https://github.com/woocommerce/woocommerce-ios/assets/1945542/7b937cc7-f4f4-449e-99db-2a256949a68d" width="500" />

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
