### PR TITLE
[Analytics Hub] Simplify analytics card view layout in analytics hub

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/AnalyticsHubView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/AnalyticsHubView.swift
@@ -66,20 +66,18 @@ struct AnalyticsHubView: View {
             await viewModel.updateData()
         }) {
             VStack(alignment: .leading, spacing: Layout.verticalSpacing) {
-                VStack(spacing: Layout.dividerSpacing) {
-                    Divider()
-
-                    AnalyticsTimeRangeCard(viewModel: viewModel.timeRangeCard,
-                                           selectionType: $viewModel.timeRangeSelectionType)
-                        .padding(.horizontal, insets: safeAreaInsets)
-                        .background(Color(uiColor: .listForeground(modal: false)))
-
-                    Divider()
-                }
+                AnalyticsTimeRangeCard(viewModel: viewModel.timeRangeCard,
+                                       selectionType: $viewModel.timeRangeSelectionType)
+                .padding(.horizontal, insets: safeAreaInsets)
+                .background(Color(uiColor: .listForeground(modal: false)))
+                .addingTopAndBottomDividers()
 
                 if viewModel.enabledCards.isNotEmpty {
                     ForEach(viewModel.enabledCards, id: \.self) { card in
                         analyticsCard(type: card)
+                            .padding(.horizontal, insets: safeAreaInsets)
+                            .background(Color(uiColor: .listForeground(modal: false)))
+                            .addingTopAndBottomDividers()
                     }
                 } else {
                     EmptyState(title: Localization.emptyStateTitle, description: Localization.emptyStateDescription, image: .enableAnalyticsImage)
@@ -130,57 +128,23 @@ private extension AnalyticsHubView {
     func analyticsCard(type: AnalyticsCard.CardType) -> some View {
         switch type {
         case .revenue:
-            VStack(spacing: Layout.dividerSpacing) {
-                Divider()
-
-                AnalyticsReportCard(viewModel: viewModel.revenueCard)
-                    .padding(.horizontal, insets: safeAreaInsets)
-                    .background(Color(uiColor: .listForeground(modal: false)))
-
-                Divider()
-            }
+            AnalyticsReportCard(viewModel: viewModel.revenueCard)
         case .orders:
-            VStack(spacing: Layout.dividerSpacing) {
-                Divider()
-
-                AnalyticsReportCard(viewModel: viewModel.ordersCard)
-                    .padding(.horizontal, insets: safeAreaInsets)
-                    .background(Color(uiColor: .listForeground(modal: false)))
-
-                Divider()
-            }
+            AnalyticsReportCard(viewModel: viewModel.ordersCard)
         case .products:
-            VStack(spacing: Layout.dividerSpacing) {
-                Divider()
-
-                AnalyticsProductCard(statsViewModel: viewModel.productsStatsCard, itemsViewModel: viewModel.itemsSoldCard)
-                    .padding(.horizontal, insets: safeAreaInsets)
-                    .background(Color(uiColor: .listForeground(modal: false)))
-
-                Divider()
-            }
+            AnalyticsProductCard(statsViewModel: viewModel.productsStatsCard, itemsViewModel: viewModel.itemsSoldCard)
         case .sessions:
-            VStack(spacing: Layout.dividerSpacing) {
-                Divider()
-
-                Group {
-                    if viewModel.showJetpackStatsCTA {
-                        AnalyticsCTACard(title: Localization.sessionsCTATitle,
-                                         message: Localization.sessionsCTAMessage,
-                                         buttonLabel: Localization.sessionsCTAButton,
-                                         isLoading: $isEnablingJetpackStats) {
-                            isEnablingJetpackStats = true
-                            await viewModel.enableJetpackStats()
-                            isEnablingJetpackStats = false
-                        }
-                    } else {
-                        AnalyticsReportCard(viewModel: viewModel.sessionsCard)
-                    }
+            if viewModel.showJetpackStatsCTA {
+                AnalyticsCTACard(title: Localization.sessionsCTATitle,
+                                 message: Localization.sessionsCTAMessage,
+                                 buttonLabel: Localization.sessionsCTAButton,
+                                 isLoading: $isEnablingJetpackStats) {
+                    isEnablingJetpackStats = true
+                    await viewModel.enableJetpackStats()
+                    isEnablingJetpackStats = false
                 }
-                .padding(.horizontal, insets: safeAreaInsets)
-                .background(Color(uiColor: .listForeground(modal: false)))
-
-                Divider()
+            } else {
+                AnalyticsReportCard(viewModel: viewModel.sessionsCard)
             }
         }
     }
@@ -216,7 +180,6 @@ private extension AnalyticsHubView {
 
     struct Layout {
         static let verticalSpacing: CGFloat = 24.0
-        static let dividerSpacing: CGFloat = .zero
     }
 }
 


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

<!-- Id number of the GitHub issue this PR addresses. -->

## Why
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This is just a small enhancement to remove some repeated code in the `AnalyticsHubView` layout, with no visible changes.

## How

* Moves the analytics card view modifiers to the main body of the view, instead of adding them to each card in the `analyticsCard(type:)` view builder.
* Uses the `addingTopAndBottomDividers()` modifier to add dividers to each card.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

1. Build and run the app.
2. Tap "See More" to open the analytics hub.
3. Confirm each card appears with the expected background color, padding, and dividers.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->
Before|After
-|-
![Before](https://github.com/woocommerce/woocommerce-ios/assets/8658164/f4eac93c-7987-4e21-8ede-5daca4a89b51)|![After](https://github.com/woocommerce/woocommerce-ios/assets/8658164/7e825e10-6ca0-43b8-b4d8-1e6042f5b36f)

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
