### PR TITLE
CI: Re-add configure_apply to Code Freeze pipeline

### DIFF
--- a/.buildkite/release-pipelines/start-code-freeze.yml
+++ b/.buildkite/release-pipelines/start-code-freeze.yml
@@ -8,6 +8,9 @@ steps:
     command: |
       .buildkite/commands/configure-environment.sh
 
+      echo '--- :closed_lock_with_key: Access Secrets'
+      bundle exec fastlane run configure_apply
+
       echo '--- :snowflake: Start Code Freeze'
       bundle exec fastlane start_code_freeze skip_confirm:true
 


### PR DESCRIPTION
In a recent PR, https://github.com/woocommerce/woocommerce-ios/pull/11733, I accidentally removed the `configure_apply` step from the `start-code-freeze.yml` pipeline. This PR adds it back. 