### PR TITLE
[Tablet Orders] Make `x` button `cancel`

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/OrderForm.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/OrderForm.swift
@@ -901,7 +901,7 @@ private extension ProductSelectorView.Configuration {
             doneButtonTitleSingularFormat: "",
             doneButtonTitlePluralFormat: "",
             title: Localization.title,
-            cancelButtonTitle: nil,
+            cancelButtonTitle: Localization.close,
             productRowAccessibilityHint: Localization.productRowAccessibilityHint,
             variableProductRowAccessibilityHint: Localization.variableProductRowAccessibilityHint)
     }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/OrderForm.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/OrderForm.swift
@@ -122,6 +122,12 @@ struct OrderFormPresentationWrapper: View {
                         ConfigurableBundleProductView(viewModel: viewModel)
                     }
                 }
+            }, onViewContainerDismiss: {
+                // By only calling the dismissHandler here, we wouldn't sync the selected items on dismissal
+                // this is normally done via a callback through the ProductSelector's onCloseButtonTapped(),
+                // but on split views we move this responsibility to the AdaptiveModalContainer
+                viewModel.syncOrderItemSelectionStateOnDismiss()
+                dismissHandler()
             })
         } else {
             OrderForm(dismissHandler: dismissHandler, flow: flow, viewModel: viewModel, presentProductSelector: nil)
@@ -901,7 +907,7 @@ private extension ProductSelectorView.Configuration {
             doneButtonTitleSingularFormat: "",
             doneButtonTitlePluralFormat: "",
             title: Localization.title,
-            cancelButtonTitle: Localization.close,
+            cancelButtonTitle: nil,
             productRowAccessibilityHint: Localization.productRowAccessibilityHint,
             variableProductRowAccessibilityHint: Localization.variableProductRowAccessibilityHint)
     }

--- a/WooCommerce/Classes/ViewRelated/Products/ProductSelector/ProductSelectorView.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductSelector/ProductSelectorView.swift
@@ -59,6 +59,7 @@ struct ProductSelectorView: View {
     @State private var hasTrackedBundleProductConfigureCTAShownEvent: Bool = false
 
     @Environment(\.horizontalSizeClass) var horizontalSizeClass
+    @Environment(\.dismiss) var dismiss
 
     @ScaledMetric private var scale: CGFloat = 1.0
 
@@ -175,6 +176,7 @@ struct ProductSelectorView: View {
                     Button(cancelButtonTitle) {
                         isPresented = false
                         viewModel.closeButtonTapped()
+                        dismiss()
                     }
                 }
             }

--- a/WooCommerce/Classes/ViewRelated/Products/ProductSelector/ProductSelectorView.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductSelector/ProductSelectorView.swift
@@ -176,7 +176,6 @@ struct ProductSelectorView: View {
                     Button(cancelButtonTitle) {
                         isPresented = false
                         viewModel.closeButtonTapped()
-                        dismiss()
                     }
                 }
             }

--- a/WooCommerce/Classes/ViewRelated/Products/ProductSelector/ProductSelectorView.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductSelector/ProductSelectorView.swift
@@ -59,7 +59,6 @@ struct ProductSelectorView: View {
     @State private var hasTrackedBundleProductConfigureCTAShownEvent: Bool = false
 
     @Environment(\.horizontalSizeClass) var horizontalSizeClass
-    @Environment(\.dismiss) var dismiss
 
     @ScaledMetric private var scale: CGFloat = 1.0
 

--- a/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/AdaptiveModalContainer.swift
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/AdaptiveModalContainer.swift
@@ -22,13 +22,13 @@ struct AdaptiveModalContainer<PrimaryView: View, SecondaryView: View>: View {
 
     var body: some View {
         if horizontalSizeClass == .compact {
-            ModalOnModalView(primaryView: primaryView, 
+            ModalOnModalView(primaryView: primaryView,
                              secondaryView: secondaryView,
                              isShowingSecondaryView: $isShowingSecondaryView,
                              onDimissButtonTapped: onViewContainerDismiss)
                 .environment(\.adaptiveModalContainerPresentationStyle, .modalOnModal)
         } else {
-            SideBySideView(primaryView: primaryView, 
+            SideBySideView(primaryView: primaryView,
                            secondaryView: secondaryView,
                            isShowingSecondaryView: $isShowingSecondaryView,
                            onDimissButtonTapped: onViewContainerDismiss)

--- a/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/AdaptiveModalContainer.swift
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/AdaptiveModalContainer.swift
@@ -22,10 +22,16 @@ struct AdaptiveModalContainer<PrimaryView: View, SecondaryView: View>: View {
 
     var body: some View {
         if horizontalSizeClass == .compact {
-            ModalOnModalView(primaryView: primaryView, secondaryView: secondaryView, isShowingSecondaryView: $isShowingSecondaryView, onDimissButtonTapped: onViewContainerDismiss)
+            ModalOnModalView(primaryView: primaryView, 
+                             secondaryView: secondaryView,
+                             isShowingSecondaryView: $isShowingSecondaryView,
+                             onDimissButtonTapped: onViewContainerDismiss)
                 .environment(\.adaptiveModalContainerPresentationStyle, .modalOnModal)
         } else {
-            SideBySideView(primaryView: primaryView, secondaryView: secondaryView, isShowingSecondaryView: $isShowingSecondaryView, onDimissButtonTapped: onViewContainerDismiss)
+            SideBySideView(primaryView: primaryView, 
+                           secondaryView: secondaryView,
+                           isShowingSecondaryView: $isShowingSecondaryView,
+                           onDimissButtonTapped: onViewContainerDismiss)
                 .environment(\.adaptiveModalContainerPresentationStyle, .sideBySide)
         }
     }

--- a/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/AdaptiveModalContainer.swift
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/AdaptiveModalContainer.swift
@@ -17,13 +17,14 @@ struct AdaptiveModalContainer<PrimaryView: View, SecondaryView: View>: View {
 
     @ViewBuilder let primaryView: (_ presentSecondaryView: (() -> Void)?) -> PrimaryView
     @ViewBuilder let secondaryView: (_ isPresented: Binding<Bool>) -> SecondaryView
+    var onViewContainerDismiss: (() -> Void)?
 
     var body: some View {
         if horizontalSizeClass == .compact {
-            ModalOnModalView(primaryView: primaryView, secondaryView: secondaryView)
+            ModalOnModalView(primaryView: primaryView, secondaryView: secondaryView, onDimissButtonTapped: onViewContainerDismiss)
                 .environment(\.adaptiveModalContainerPresentationStyle, .modalOnModal)
         } else {
-            SideBySideView(primaryView: primaryView, secondaryView: secondaryView)
+            SideBySideView(primaryView: primaryView, secondaryView: secondaryView, onDimissButtonTapped: onViewContainerDismiss)
                 .environment(\.adaptiveModalContainerPresentationStyle, .sideBySide)
         }
     }
@@ -32,12 +33,22 @@ struct AdaptiveModalContainer<PrimaryView: View, SecondaryView: View>: View {
         @ViewBuilder let primaryView: (_ presentSecondaryView: @escaping () -> Void) -> PrimaryView
         @ViewBuilder let secondaryView: (_ isPresented: Binding<Bool>) -> SecondaryView
         @State var isShowingSecondaryView = false
+        var onDimissButtonTapped: (() -> Void)?
 
         var body: some View {
             NavigationView {
                 primaryView({
                     isShowingSecondaryView = true
                 })
+                .toolbar {
+                    ToolbarItem(placement: .navigationBarLeading) {
+                        Button(action: {
+                            onDimissButtonTapped?()
+                        }) {
+                            Image(systemName: "xmark")
+                        }
+                    }
+                }
                 .sheet(isPresented: $isShowingSecondaryView) {
                     NavigationView {
                         secondaryView($isShowingSecondaryView)
@@ -51,12 +62,22 @@ struct AdaptiveModalContainer<PrimaryView: View, SecondaryView: View>: View {
     private struct SideBySideView: View {
         @ViewBuilder let primaryView: (_ presentSecondaryView: (() -> Void)?) -> PrimaryView
         @ViewBuilder let secondaryView: (_ isPresented: Binding<Bool>) -> SecondaryView
+        var onDimissButtonTapped: (() -> Void)?
         @State var isShowingSecondaryView = true
 
         var body: some View {
             HStack(spacing: 0) {
                 NavigationView {
                     secondaryView($isShowingSecondaryView)
+                        .toolbar {
+                            ToolbarItem(placement: .navigationBarLeading) {
+                                Button(action: {
+                                    onDimissButtonTapped?()
+                                }) {
+                                    Image(systemName: "xmark")
+                                }
+                            }
+                        }
                 }
                 .navigationViewStyle(.stack)
                 .layoutPriority(1)

--- a/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/AdaptiveModalContainer.swift
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/AdaptiveModalContainer.swift
@@ -1,4 +1,3 @@
-import Foundation
 import SwiftUI
 
 /// `AdaptiveModalContainer` shows two views, primary and secondary

--- a/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/AdaptiveModalContainer.swift
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/AdaptiveModalContainer.swift
@@ -32,22 +32,12 @@ struct AdaptiveModalContainer<PrimaryView: View, SecondaryView: View>: View {
         @ViewBuilder let primaryView: (_ presentSecondaryView: @escaping () -> Void) -> PrimaryView
         @ViewBuilder let secondaryView: (_ isPresented: Binding<Bool>) -> SecondaryView
         @State var isShowingSecondaryView = false
-        @Environment(\.dismiss) var dismiss
 
         var body: some View {
             NavigationView {
                 primaryView({
                     isShowingSecondaryView = true
                 })
-                .toolbar {
-                    ToolbarItem(placement: .navigationBarLeading) {
-                        Button(action: {
-                            dismiss()
-                        }) {
-                            Image(systemName: "xmark")
-                        }
-                    }
-                }
                 .sheet(isPresented: $isShowingSecondaryView) {
                     NavigationView {
                         secondaryView($isShowingSecondaryView)
@@ -61,22 +51,12 @@ struct AdaptiveModalContainer<PrimaryView: View, SecondaryView: View>: View {
     private struct SideBySideView: View {
         @ViewBuilder let primaryView: (_ presentSecondaryView: (() -> Void)?) -> PrimaryView
         @ViewBuilder let secondaryView: (_ isPresented: Binding<Bool>) -> SecondaryView
-        @Environment(\.dismiss) var dismiss
         @State var isShowingSecondaryView = true
 
         var body: some View {
             HStack(spacing: 0) {
                 NavigationView {
                     secondaryView($isShowingSecondaryView)
-                        .toolbar {
-                            ToolbarItem(placement: .navigationBarLeading) {
-                                Button(action: {
-                                    dismiss()
-                                }) {
-                                    Image(systemName: "xmark")
-                                }
-                            }
-                        }
                 }
                 .navigationViewStyle(.stack)
                 .layoutPriority(1)

--- a/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/AdaptiveModalContainer.swift
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/AdaptiveModalContainer.swift
@@ -1,3 +1,4 @@
+import Foundation
 import SwiftUI
 
 /// `AdaptiveModalContainer` shows two views, primary and secondary
@@ -44,9 +45,9 @@ struct AdaptiveModalContainer<PrimaryView: View, SecondaryView: View>: View {
                     ToolbarItem(placement: .navigationBarLeading) {
                         Button(action: {
                             onDimissButtonTapped?()
-                        }) {
-                            Image(systemName: "xmark")
-                        }
+                        }, label: {
+                            Text(Localization.cancelButtonText)
+                        })
                     }
                 }
                 .sheet(isPresented: $isShowingSecondaryView) {
@@ -73,9 +74,9 @@ struct AdaptiveModalContainer<PrimaryView: View, SecondaryView: View>: View {
                             ToolbarItem(placement: .navigationBarLeading) {
                                 Button(action: {
                                     onDimissButtonTapped?()
-                                }) {
-                                    Image(systemName: "xmark")
-                                }
+                                }, label: {
+                                    Text(Localization.cancelButtonText)
+                                })
                             }
                         }
                 }
@@ -90,6 +91,16 @@ struct AdaptiveModalContainer<PrimaryView: View, SecondaryView: View>: View {
                 .navigationViewStyle(.stack)
                 .frame(minWidth: 400)
             }
+        }
+    }
+}
+
+private extension AdaptiveModalContainer {
+    enum Localization {
+        static var cancelButtonText: String {
+            NSLocalizedString("adaptiveModalContainer.views.cancelButtonText",
+                              value: "Cancel",
+                              comment: "Text for the 'Cancel' button that appears in the navigation bar, and closes the view")
         }
     }
 }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes #12168
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
This PR addresses updating the `x` button for a `cancel` button on iPads or large iPhones. The `x` button in this case is not generated by the `Configuration` injected into the `ProductSelectorView`, but by the `AdaptiveModalContainer` since must handle more than one view.

![20240304-cancel-button](https://github.com/woocommerce/woocommerce-ios/assets/3812076/76da7824-14df-43f9-b561-e88474493377)

## Changes
- Update the `AdaptiveModalContainer` with a `onViewContainerDismiss` callback that is triggered when the cancel button is pressed on its subviews.
- Updated the `x` icon for `Cancel` text
- On callback invocation, we'll sync the selected items if needed, then dismiss the view. This copies the behaviour on iPhone, when only one view is rendered.

## Testing instructions
- Enable `sideBySideViewForOrderForm `, run the app on iPad or large iPhone on landscape mode
- Observe that going to `Orders` > `+` will show a `Cancel` button in the top left corner, where an `x` icon was previously shown.
- Tapping the `Cancel` button dismisses the view as before.