### PR TITLE
Reviews: Fix unreliable logic for review age

### DIFF
--- a/WooCommerce/Classes/Model/ReviewAge.swift
+++ b/WooCommerce/Classes/Model/ReviewAge.swift
@@ -25,31 +25,15 @@ extension ReviewAge {
     /// Returns the Age entity that best describes a given timespan.
     ///
     static func from(startDate: Date, toDate: Date) -> ReviewAge {
-        let components = [.day, .weekOfYear, .month] as Set<Calendar.Component>
-        let dateComponents = Calendar.current.dateComponents(components, from: startDate, to: toDate)
+        let timeDifference = toDate.timeIntervalSince(startDate)
+        let oneDayInSeconds: TimeInterval = 86_400
 
-        // Months
-        if let month = dateComponents.month, month >= 1 {
-            return .theRest
-        }
-
-        // Weeks
-        if let week = dateComponents.weekOfYear, week >= 1 {
-            return .theRest
-        }
-
-        // Days
-        if let day = dateComponents.day,
-            let week = dateComponents.weekOfYear,
-            day > 1,
-            week <= 1 {
-            return .last7Days
-        }
-
-        if let day = dateComponents.day, day == 1 {
+        if timeDifference <= oneDayInSeconds { // 24hrs
             return .last24Hours
+        } else if timeDifference <= oneDayInSeconds * 7 { // 7 days
+            return .last7Days
+        } else {
+            return .theRest
         }
-
-        return .last24Hours
     }
 }

--- a/WooCommerce/WooCommerceTests/Tools/ReviewAgeTests.swift
+++ b/WooCommerce/WooCommerceTests/Tools/ReviewAgeTests.swift
@@ -2,6 +2,8 @@ import XCTest
 @testable import WooCommerce
 
 final class ReviewAgeTests: XCTestCase {
+    private let oneDayInSeconds: TimeInterval = 86_400
+
     func testDescriptionReturnsExpectationFor24Hours() {
         let age = ReviewAge(rawValue: "0")
 
@@ -26,7 +28,7 @@ final class ReviewAgeTests: XCTestCase {
     func testAgeCalculationsReturnLast24HoursAgeFor12Hours() {
         let initialDate = Date()
         // Let's move the clock 12 hours ahead
-        let finalDate = Date(timeInterval: 43200, since: initialDate)
+        let finalDate = Date(timeInterval: oneDayInSeconds/2, since: initialDate)
 
         let age = ReviewAge.from(startDate: initialDate, toDate: finalDate)
 
@@ -36,17 +38,7 @@ final class ReviewAgeTests: XCTestCase {
     func testAgeCalculationsReturnLast24HoursAgeFor23Hours() {
         let initialDate = Date()
         // Let's move the clock 23:59:59 hours ahead
-        let finalDate = Date(timeInterval: 84399, since: initialDate)
-
-        let age = ReviewAge.from(startDate: initialDate, toDate: finalDate)
-
-        XCTAssertEqual(age, .last24Hours)
-    }
-
-    func testAgeCalculationsReturnLast24HoursAgeFor24HoursAnd1Second() {
-        let initialDate = Date()
-        // Let's move the clock 24:00:01 hours ahead
-        let finalDate = Date(timeInterval: 84461, since: initialDate)
+        let finalDate = Date(timeInterval: oneDayInSeconds - 1, since: initialDate)
 
         let age = ReviewAge.from(startDate: initialDate, toDate: finalDate)
 
@@ -56,7 +48,7 @@ final class ReviewAgeTests: XCTestCase {
     func testAgeCalculationsReturnLast7DaysAgeForThreeDays() {
         let initialDate = Date()
         // Let's move the clock three days ahead
-        let finalDate = Date(timeInterval: 259200, since: initialDate)
+        let finalDate = Date(timeInterval: oneDayInSeconds * 3, since: initialDate)
 
         let age = ReviewAge.from(startDate: initialDate, toDate: finalDate)
 
@@ -66,7 +58,7 @@ final class ReviewAgeTests: XCTestCase {
     func testAgeCalculationsReturnLast7DaysAgeForAlmostSevenFullDays() {
         let initialDate = Date()
         // Let's move the clock almost seven full days ahead
-        let finalDate = Date(timeInterval: 604760, since: initialDate)
+        let finalDate = Date(timeInterval: oneDayInSeconds * 7 - 1, since: initialDate)
 
         let age = ReviewAge.from(startDate: initialDate, toDate: finalDate)
 
@@ -76,7 +68,7 @@ final class ReviewAgeTests: XCTestCase {
     func testAgeCalculationsReturnLastOlderForMoreThanSevenFullDays() {
         let initialDate = Date()
         // Let's move the clock a tad longer than seven full days ahead
-        let finalDate = Date(timeInterval: 691300, since: initialDate)
+        let finalDate = Date(timeInterval: oneDayInSeconds * 7 + 1, since: initialDate)
 
         let age = ReviewAge.from(startDate: initialDate, toDate: finalDate)
 


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #12194 
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This PR fixes the logic for calculating review age. The previous logic checks for calendar month/week/day difference, which is unreliable since we want to display only the difference in hours or days.

Consider the edge case: when the time difference is within 7 days but in calendar it's 1 month difference, the old logic will still return more than 7 days ago.

This PR fixes this by checking for difference in seconds rather than using calendar.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
- All unit tests should pass.
- It's tricky to test the edge case in action, but if you have a review created last Tuesday, the time on the review detail should says "Last 7 days" instead of "Older than 7 days"

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->
N/A

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
