### PR TITLE
My Store Analytics: Add events for custom range

### DIFF
--- a/WooCommerce/Classes/Analytics/WooAnalyticsEvent+DashboardCustomRange.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsEvent+DashboardCustomRange.swift
@@ -1,0 +1,36 @@
+import Foundation
+
+extension WooAnalyticsEvent {
+    enum DashboardCustomRange {
+
+        private enum Keys {
+            static let isEditing = "is_editing"
+        }
+
+        /// When the user taps the button to add a custom range.
+        static func addButtonTapped() -> WooAnalyticsEvent {
+            WooAnalyticsEvent(statName: .dashboardStatsCustomRangeAddButtonTapped, properties: [:])
+        }
+
+        /// When the user confirms a date range for a custom range tab.
+        static func customRangeConfirmed(isEditing: Bool) -> WooAnalyticsEvent {
+            WooAnalyticsEvent(statName: .dashboardStatsCustomRangeConfirmed,
+                              properties: [Keys.isEditing: isEditing])
+        }
+
+        /// When the user selects the custom range tab of Dashboard stats.
+        static func tabSelected() -> WooAnalyticsEvent {
+            WooAnalyticsEvent(statName: .dashboardStatsCustomRangeTabSelected, properties: [:])
+        }
+
+        /// When the user taps the button to edit the date range on the custom range tab of Dashboard stats.
+        static func editButtonTapped() -> WooAnalyticsEvent {
+            WooAnalyticsEvent(statName: .dashboardStatsCustomRangeEditButtonTapped, properties: [:])
+        }
+
+        /// When the user taps on the chart on custom range to see metrics for specific periods.
+        static func interacted() -> WooAnalyticsEvent {
+            WooAnalyticsEvent(statName: .dashboardStatsCustomRangeInteracted, properties: [:])
+        }
+    }
+}

--- a/WooCommerce/Classes/Analytics/WooAnalyticsStat.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsStat.swift
@@ -157,6 +157,13 @@ public enum WooAnalyticsStat: String {
     case dashboardTopPerformersWaitingTimeLoaded = "dashboard_top_performers_waiting_time_loaded"
     case dashboardStoreTimezoneDifferFromDevice = "dashboard_store_timezone_differ_from_device"
 
+    // MARK: Dashboard stats custom range
+    case dashboardStatsCustomRangeAddButtonTapped = "dashboard_stats_custom_range_add_button_tapped"
+    case dashboardStatsCustomRangeConfirmed = "dashboard_stats_custom_range_confirmed"
+    case dashboardStatsCustomRangeTabSelected = "dashboard_stats_custom_range_tab_selected"
+    case dashboardStatsCustomRangeEditButtonTapped = "dashboard_stats_custom_range_edit_button_tapped"
+    case dashboardStatsCustomRangeInteracted = "dashboard_stats_custom_range_interacted"
+
     // MARK: Dashboard Stats v3/v4 Events
     //
     case dashboardNewStatsAvailabilityBannerCancelTapped = "dashboard_new_stats_availability_banner_cancel_tapped"

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Stats v4/StoreStatsAndTopPerformersViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Stats v4/StoreStatsAndTopPerformersViewController.swift
@@ -425,7 +425,7 @@ private extension StoreStatsAndTopPerformersViewController {
                 guard let self, let range = timeRanges[safe: index] else {
                     return
                 }
-                
+
                 if range.isCustomTimeRange {
                     ServiceLocator.analytics.track(event: .DashboardCustomRange.tabSelected())
                 }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Stats v4/StoreStatsV4PeriodViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Stats v4/StoreStatsV4PeriodViewController.swift
@@ -475,7 +475,11 @@ extension StoreStatsV4PeriodViewController: ChartViewDelegate {
         chartValueSelectedEventsSubject
             .debounce(for: .seconds(Constants.chartValueSelectedEventsDebounce), scheduler: DispatchQueue.main)
             .sink { [weak self] _ in
-                self?.usageTracksEventEmitter.interacted()
+                guard let self else { return }
+                if self.timeRange.isCustomTimeRange {
+                    ServiceLocator.analytics.track(event: .DashboardCustomRange.interacted())
+                }
+                self.usageTracksEventEmitter.interacted()
             }.store(in: &cancellables)
     }
 }

--- a/WooCommerce/Classes/ViewRelated/FilterTabBar/FilterTabBar.swift
+++ b/WooCommerce/Classes/ViewRelated/FilterTabBar/FilterTabBar.swift
@@ -373,7 +373,7 @@ final class FilterTabBar: UIControl {
 
     /// The index of the currently selected tab.
     ///
-    private(set) var selectedIndex: Int = 0 {
+    @Published private(set) var selectedIndex: Int = 0 {
         didSet {
             if selectedIndex != oldValue && oldValue < tabs.count {
                 let oldTab = tabs[oldValue]

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -2222,6 +2222,7 @@
 		DE126D0B26CA2331007F901D /* ValidationErrorRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE126D0A26CA2331007F901D /* ValidationErrorRow.swift */; };
 		DE126D0D26CA4A0C007F901D /* ShippingLabelCustomsFormItemDetailsViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE126D0C26CA4A0C007F901D /* ShippingLabelCustomsFormItemDetailsViewModelTests.swift */; };
 		DE126D0F26CA71E8007F901D /* ShippingLabelCustomsFormInputViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE126D0E26CA71E8007F901D /* ShippingLabelCustomsFormInputViewModelTests.swift */; };
+		DE12BED92B95C30800B19C01 /* WooAnalyticsEvent+DashboardCustomRange.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE12BED82B95C30800B19C01 /* WooAnalyticsEvent+DashboardCustomRange.swift */; };
 		DE157E152B01F26500542A9B /* ProductFormDataModel+SubscriptionDescription.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE157E142B01F26500542A9B /* ProductFormDataModel+SubscriptionDescription.swift */; };
 		DE157E1A2B02406400542A9B /* ProductSubscriptionPeriodPickerUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE157E192B02406400542A9B /* ProductSubscriptionPeriodPickerUseCase.swift */; };
 		DE19BB0C26C2688B00AB70D9 /* SingleSelectionList.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE19BB0B26C2688B00AB70D9 /* SingleSelectionList.swift */; };
@@ -4951,6 +4952,7 @@
 		DE126D0A26CA2331007F901D /* ValidationErrorRow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ValidationErrorRow.swift; sourceTree = "<group>"; };
 		DE126D0C26CA4A0C007F901D /* ShippingLabelCustomsFormItemDetailsViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShippingLabelCustomsFormItemDetailsViewModelTests.swift; sourceTree = "<group>"; };
 		DE126D0E26CA71E8007F901D /* ShippingLabelCustomsFormInputViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShippingLabelCustomsFormInputViewModelTests.swift; sourceTree = "<group>"; };
+		DE12BED82B95C30800B19C01 /* WooAnalyticsEvent+DashboardCustomRange.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "WooAnalyticsEvent+DashboardCustomRange.swift"; sourceTree = "<group>"; };
 		DE157E142B01F26500542A9B /* ProductFormDataModel+SubscriptionDescription.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ProductFormDataModel+SubscriptionDescription.swift"; sourceTree = "<group>"; };
 		DE157E192B02406400542A9B /* ProductSubscriptionPeriodPickerUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductSubscriptionPeriodPickerUseCase.swift; sourceTree = "<group>"; };
 		DE19BB0B26C2688B00AB70D9 /* SingleSelectionList.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SingleSelectionList.swift; sourceTree = "<group>"; };
@@ -8619,6 +8621,7 @@
 				260520F32B87BA23005D5D59 /* WooAnalyticsEvent+ConnectivityTool.swift */,
 				EE9D03112B89DF760077CED1 /* WooAnalyticsEvent+OrdersListFilter.swift */,
 				0204E3612B8CD40B00F1B5FD /* WooAnalyticsEvent+Products.swift */,
+				DE12BED82B95C30800B19C01 /* WooAnalyticsEvent+DashboardCustomRange.swift */,
 			);
 			path = Analytics;
 			sourceTree = "<group>";
@@ -13309,6 +13312,7 @@
 				039D948F276113490044EF38 /* UIView+SuperviewConstraints.swift in Sources */,
 				D8736B5322EF4F5900A14A29 /* NotificationsBadgeController.swift in Sources */,
 				03E471CC293E0FB8001A58AD /* CardPresentModalProgressDisplaying.swift in Sources */,
+				DE12BED92B95C30800B19C01 /* WooAnalyticsEvent+DashboardCustomRange.swift in Sources */,
 				B541B220218A007C008FE7C1 /* NSMutableParagraphStyle+Helpers.swift in Sources */,
 				45AE582C230D9D35001901E3 /* OrderNoteHeaderTableViewCell.swift in Sources */,
 				6832C7CA26DA5C4500BA4088 /* LabeledTextViewTableViewCell.swift in Sources */,

--- a/Yosemite/YosemiteTests/Model/Enums/StatsTimeRangeTests.swift
+++ b/Yosemite/YosemiteTests/Model/Enums/StatsTimeRangeTests.swift
@@ -187,11 +187,11 @@ final class StatsTimeRangeTests: XCTestCase {
         XCTAssertEqual(range.topEarnerStatsGranularity, .week)
     }
 
-    func test_topEarnerStatsGranularity_for_dates_with_days_difference_from_1_to_28() {
+    func test_topEarnerStatsGranularity_for_dates_with_days_difference_from_2_to_28() {
         // Given
         // GMT: Saturday, February 1, 2020 12:29:29 AM
         let fromDate = Date(timeIntervalSince1970: 1580516969)
-        let toDate = fromDate.addingDays(Int.random(in: 1...28))
+        let toDate = fromDate.addingDays(Int.random(in: 2...28))
 
         // When
         let range: StatsTimeRangeV4 = .custom(from: fromDate, to: toDate)


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #12178 
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This PR adds the following tracking events for the custom range tab on the My Store screen:

Event name | Properties | Triggers
-- | -- | --
*_dashboard_stats_custom_range_add_button_tapped |   | When the user taps the button to add a custom range
*_dashboard_stats_custom_range_confirmed | is_editing: true / false | When the user confirms a date range for a custom range tab
*_dashboard_stats_custom_range_tab_selected |   | When the user selects the custom range tab of Dashboard stats.
*_dashboard_stats_custom_range_edit_button_tapped |   | When the user taps the button to edit the date range on the custom range tab of Dashboard stats.
*_dashboard_stats_custom_range_interacted |   | When the user taps on the chart on custom range to see metrics for specific periods.




## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
- Enable the feature flag `customRangeInMyStoreAnalytics` and build the app.
- Log in to a store.
- On My Store, tap the calendar button on the stats tab bar to add a new custom range. Confirm that  `dashboard_stats_custom_range_add_button_tapped` is logged in Xcode console.
- Select a valid date range then select Add. Confirm that `dashboard_stats_custom_range_confirmed` is tracked with `is_editing` being false.
- When a new tab for the new custom range is added, select the date range button and confirm that `dashboard_stats_custom_range_edit_button_tapped` is tracked.
- Select a different date range and tap Apply. Confirm that `dashboard_stats_custom_range_confirmed` is tracked with `is_editing` being true.
- Switch to a different tab then back to the custom range tab. Confirm that `dashboard_stats_custom_range_tab_selected` is tracked.
- Select any date on the stat graph of the custom range tab. Confirm that `dashboard_stats_custom_range_interacted` is tracked.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->
N/A

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
