### PR TITLE
[Tablet Orders] Open order search results in split view

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Orders/OrderListViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrderListViewController.swift
@@ -612,7 +612,7 @@ extension OrderListViewController {
                     showOrderDetails(detailsViewModel.order)
                 }
                 else {
-                    onOrderSelected(id: orderID, shouldScrollIfNeeded: true)
+                    onOrderSelected(id: orderID)
                 }
                 return true
             }
@@ -620,12 +620,12 @@ extension OrderListViewController {
         return false
     }
 
-    func showOrderDetails(_ order: Order, onCompletion: ((Bool) -> Void)? = nil) {
+    func showOrderDetails(_ order: Order, shouldScrollIfNeeded: Bool = false, onCompletion: ((Bool) -> Void)? = nil) {
         let viewModel = OrderDetailsViewModel(order: order)
         switchDetailsHandler([viewModel], 0, true) { [weak self] hasBeenSelected in
             guard let self else { return }
             if hasBeenSelected {
-                onOrderSelected(id: order.orderID, shouldScrollIfNeeded: true)
+                onOrderSelected(id: order.orderID, shouldScrollIfNeeded: shouldScrollIfNeeded)
             }
             onCompletion?(hasBeenSelected)
         }

--- a/WooCommerce/Classes/ViewRelated/Orders/OrderListViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrderListViewController.swift
@@ -535,6 +535,7 @@ private extension OrderListViewController {
     ///
     func highlightSelectedRowIfNeeded(shouldScrollIfNeeded: Bool = false) {
         guard let selectedOrderID, let orderIndexPath = indexPath(for: selectedOrderID) else {
+            tableView.deselectSelectedRowWithAnimation(true)
             return
         }
         if splitViewController?.isCollapsed == true {

--- a/WooCommerce/Classes/ViewRelated/Orders/OrderListViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrderListViewController.swift
@@ -234,10 +234,11 @@ final class OrderListViewController: UIViewController, GhostableViewController {
 
     /// Called when an order is shown and the order should be selected in the order list.
     /// - Parameter orderID: ID of the order to be selected in the order list.
-    func onOrderSelected(id orderID: Int64) {
+    /// - Parameter shouldScrollIfNeeded: Boolean flag to turn on scrolling if the newly selected row is not visible
+    func onOrderSelected(id orderID: Int64, shouldScrollIfNeeded: Bool = false) {
         selectedOrderID = orderID
         selectedIndexPath = indexPath(for: orderID)
-        highlightSelectedRowIfNeeded()
+        highlightSelectedRowIfNeeded(shouldScrollIfNeeded: shouldScrollIfNeeded)
     }
 
     /// Returns a function that creates cells for `dataSource`.
@@ -532,7 +533,7 @@ private extension OrderListViewController {
     /// Highlights the selected row if any row has been selected and the split view is not collapsed.
     /// Removes the selected state otherwise.
     ///
-    func highlightSelectedRowIfNeeded() {
+    func highlightSelectedRowIfNeeded(shouldScrollIfNeeded: Bool = false) {
         guard let selectedOrderID, let orderIndexPath = indexPath(for: selectedOrderID) else {
             return
         }
@@ -540,6 +541,9 @@ private extension OrderListViewController {
             tableView.deselectRow(at: orderIndexPath, animated: false)
         } else {
             tableView.selectRow(at: orderIndexPath, animated: false, scrollPosition: .none)
+            if shouldScrollIfNeeded {
+                tableView.scrollToRow(at: orderIndexPath, at: .none, animated: true)
+            }
         }
     }
 
@@ -607,7 +611,7 @@ extension OrderListViewController {
                     showOrderDetails(detailsViewModel.order)
                 }
                 else {
-                    onOrderSelected(id: orderID)
+                    onOrderSelected(id: orderID, shouldScrollIfNeeded: true)
                 }
                 return true
             }
@@ -620,8 +624,9 @@ extension OrderListViewController {
         switchDetailsHandler([viewModel], 0, true) { [weak self] hasBeenSelected in
             guard let self else { return }
             if hasBeenSelected {
-                onOrderSelected(id: order.orderID)
+                onOrderSelected(id: order.orderID, shouldScrollIfNeeded: true)
             }
+            onCompletion?(hasBeenSelected)
         }
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Orders/OrdersRootViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrdersRootViewController.swift
@@ -514,7 +514,7 @@ private extension OrdersRootViewController {
             horizontalSizeClass: UITraitCollection.current.horizontalSizeClass
         ))
 
-        ordersViewController.showOrderDetails(order) { _ in
+        ordersViewController.showOrderDetails(order, shouldScrollIfNeeded: true) { _ in
             onCompletion?(true)
         }
     }

--- a/WooCommerce/Classes/ViewRelated/Orders/OrdersRootViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrdersRootViewController.swift
@@ -124,13 +124,32 @@ final class OrdersRootViewController: UIViewController {
     @objc private func displaySearchOrders() {
         analytics.track(.ordersListSearchTapped)
 
-        let searchViewController = SearchViewController<OrderTableViewCell, OrderSearchUICommand>(storeID: siteID,
-                                                                                                  command: OrderSearchUICommand(siteID: siteID),
-                                                                                                  cellType: OrderTableViewCell.self,
-                                                                                                  cellSeparator: .singleLine)
+        let searchViewController = SearchViewController<OrderTableViewCell, OrderSearchUICommand>(
+            storeID: siteID,
+            command: OrderSearchUICommand(siteID: siteID,
+                                          onSelectSearchResult: { [weak self] order, viewController in
+                                              guard let self else { return }
+                                              guard featureFlagService.isFeatureFlagEnabled(.sideBySideViewForOrderForm) else {
+                                                  return presentOrder(order, from: viewController)
+                                              }
+                                              navigateToOrderDetail(order)
+                                              viewController.dismiss(animated: true)
+                                          }),
+            cellType: OrderTableViewCell.self,
+            cellSeparator: .singleLine)
         let navigationController = WooNavigationController(rootViewController: searchViewController)
 
         present(navigationController, animated: true, completion: nil)
+    }
+
+    private func presentOrder(_ order: Order, from viewController: UIViewController) {
+        let viewModel = OrderDetailsViewModel(order: order)
+        let detailsViewController = OrderDetailsViewController(viewModel: viewModel)
+
+        viewController.navigationController?.pushViewController(detailsViewController, animated: true)
+        ServiceLocator.analytics.track(event: WooAnalyticsEvent.Orders.orderOpen(
+            order: order,
+            horizontalSizeClass: UITraitCollection.current.horizontalSizeClass))
     }
 
     /// Presents the Details for the Notification with the specified Identifier.
@@ -495,8 +514,9 @@ private extension OrdersRootViewController {
             horizontalSizeClass: UITraitCollection.current.horizontalSizeClass
         ))
 
-        ordersViewController.showOrderDetails(order)
-        onCompletion?(true)
+        ordersViewController.showOrderDetails(order) { _ in
+            onCompletion?(true)
+        }
     }
 
     var orderDetailsViewController: OrderDetailsViewController? {

--- a/WooCommerce/Classes/ViewRelated/Orders/OrdersRootViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrdersRootViewController.swift
@@ -147,7 +147,7 @@ final class OrdersRootViewController: UIViewController {
         let detailsViewController = OrderDetailsViewController(viewModel: viewModel)
 
         viewController.navigationController?.pushViewController(detailsViewController, animated: true)
-        ServiceLocator.analytics.track(event: WooAnalyticsEvent.Orders.orderOpen(
+        analytics.track(event: WooAnalyticsEvent.Orders.orderOpen(
             order: order,
             horizontalSizeClass: UITraitCollection.current.horizontalSizeClass))
     }

--- a/WooCommerce/Classes/ViewRelated/Search/Order/OrderSearchUICommand.swift
+++ b/WooCommerce/Classes/ViewRelated/Search/Order/OrderSearchUICommand.swift
@@ -26,8 +26,12 @@ final class OrderSearchUICommand: SearchUICommand {
 
     private let siteID: Int64
 
-    init(siteID: Int64) {
+    private let onSelectSearchResult: ((Order, UIViewController) -> Void)
+
+    init(siteID: Int64,
+         onSelectSearchResult: @escaping ((Order, UIViewController) -> Void)) {
         self.siteID = siteID
+        self.onSelectSearchResult = onSelectSearchResult
         configureResultsController()
     }
 
@@ -76,13 +80,7 @@ final class OrderSearchUICommand: SearchUICommand {
     }
 
     func didSelectSearchResult(model: Order, from viewController: UIViewController, reloadData: () -> Void, updateActionButton: () -> Void) {
-        let viewModel = OrderDetailsViewModel(order: model)
-        let detailsViewController = OrderDetailsViewController(viewModel: viewModel)
-
-        viewController.navigationController?.pushViewController(detailsViewController, animated: true)
-        ServiceLocator.analytics.track(event: WooAnalyticsEvent.Orders.orderOpen(
-            order: model,
-            horizontalSizeClass: UITraitCollection.current.horizontalSizeClass))
+        onSelectSearchResult(model, viewController)
     }
 
     /// Removes the `#` from the start of the search keyword, if present.


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #12170
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

Previously we opened order search results modally.

With the new side-by-side view for order editing, it looked strange to open a new full screen modal over the formSheet search modal when shown on an iPad, when the merchant tapped edit from a search result.

This commit changes the search results to open in the split view context, when the side-by-side view is enabled.

Since they’re opening in the split view context, opening the side-by-side order editing screen above makes sense.

Note that this change does mean that after selecting an order, the search context is lost. Previously it could be accessed by tapping back. Ideally, we'd show the whole search in the split view, but this is an initial fix to get us ready for release. Future changes covered in #12202

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

1. Enable the `sideBySideViewForOrderForm` feature flag
2. Launch the app on an iPad or large iPhone in landscape
3. Navigate to the `Orders` tab
4. Tap the magnifying glass
5. Search for an old order
6. Select it in the search result list
7. Observe that it's opened in the split view controller.

Repeat on a portrait or small iPhone

The selected order should be shown in both the list and the details view, but sometimes the list data source is not updated in time. In that case, 7050aa3 ensures that we don't leave a confusing selection state in the list.

Note that some of the updated functions are used for deeplinks, so some deeplink testing would also be worthwhile, however the row selection approach was already not great.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->


https://github.com/woocommerce/woocommerce-ios/assets/2472348/b508c27c-a04a-4f0e-a820-3243aa0c6fdc


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
