### PR TITLE
[Better Errors] Add M2 track events

### DIFF
--- a/WooCommerce/Classes/Analytics/WooAnalyticsEvent.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsEvent.swift
@@ -2821,14 +2821,6 @@ extension WooAnalyticsEvent {
             WooAnalyticsEvent(statName: .loginSiteCredentialsAppPasswordExplanationContinueButtonTapped, properties: [:])
         }
 
-        static func loginSuccess() -> WooAnalyticsEvent {
-            WooAnalyticsEvent(statName: .loginSiteCredentialsAppPasswordLoginSuccess, properties: [:])
-        }
-
-        static func loginFailed(error: Error) -> WooAnalyticsEvent {
-            WooAnalyticsEvent(statName: .loginSiteCredentialsAppPasswordLoginFailed, properties: [:], error: error)
-        }
-
         static func loginExitConfirmation() -> WooAnalyticsEvent {
             WooAnalyticsEvent(statName: .loginSiteCredentialsAppPasswordLoginExitConfirmation, properties: [:])
         }

--- a/WooCommerce/Classes/Analytics/WooAnalyticsEvent.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsEvent.swift
@@ -2804,6 +2804,39 @@ extension WooAnalyticsEvent {
             WooAnalyticsEvent(statName: .applicationPasswordAuthorizationWebViewShown,
                               properties: [Key.step.rawValue: step.rawValue])
         }
+
+        static func invalidLoginPageDetected() -> WooAnalyticsEvent {
+            WooAnalyticsEvent(statName: .loginSiteCredentialsInvalidLoginPageDetected, properties: [:])
+        }
+
+        static func explanationDismissed() -> WooAnalyticsEvent {
+            WooAnalyticsEvent(statName: .loginSiteCredentialsAppPasswordExplanationDismissed, properties: [:])
+        }
+
+        static func explanationContactSupportTapped() -> WooAnalyticsEvent {
+            WooAnalyticsEvent(statName: .loginSiteCredentialsAppPasswordExplanationContactSupportTapped, properties: [:])
+        }
+
+        static func explanationContinueButtonTapped() -> WooAnalyticsEvent {
+            WooAnalyticsEvent(statName: .loginSiteCredentialsAppPasswordExplanationContinueButtonTapped, properties: [:])
+        }
+
+        static func loginSuccess() -> WooAnalyticsEvent {
+            WooAnalyticsEvent(statName: .loginSiteCredentialsAppPasswordLoginSuccess, properties: [:])
+        }
+
+        static func loginFailed(error: Error) -> WooAnalyticsEvent {
+            WooAnalyticsEvent(statName: .loginSiteCredentialsAppPasswordLoginFailed, properties: [:], error: error)
+        }
+
+        static func loginExitConfirmation() -> WooAnalyticsEvent {
+            WooAnalyticsEvent(statName: .loginSiteCredentialsAppPasswordLoginExitConfirmation, properties: [:])
+        }
+
+        static func loginDismissed() -> WooAnalyticsEvent {
+            WooAnalyticsEvent(statName: .loginSiteCredentialsAppPasswordLoginDismissed, properties: [:])
+        }
+
     }
 }
 

--- a/WooCommerce/Classes/Analytics/WooAnalyticsStat.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsStat.swift
@@ -100,9 +100,9 @@ public enum WooAnalyticsStat: String {
     case loginMalformedAppLoginLink = "login_malformed_app_login_link"
 
     case loginSiteCredentialsInvalidLoginPageDetected = "login_site_credentials_invalid_login_page_detected"
-    case loginSiteCredentialsAppPasswordExplanationDismissed = "_login_site_credentials_app_password_explanation_dismissed"
-    case loginSiteCredentialsAppPasswordExplanationContactSupportTapped = "_login_site_credentials_app_password_explanation_contact_support_tapped"
-    case loginSiteCredentialsAppPasswordExplanationContinueButtonTapped = "_login_site_credentials_app_password_explanation_continue_button_tapped"
+    case loginSiteCredentialsAppPasswordExplanationDismissed = "login_site_credentials_app_password_explanation_dismissed"
+    case loginSiteCredentialsAppPasswordExplanationContactSupportTapped = "login_site_credentials_app_password_explanation_contact_support_tapped"
+    case loginSiteCredentialsAppPasswordExplanationContinueButtonTapped = "login_site_credentials_app_password_explanation_continue_button_tapped"
     case loginSiteCredentialsAppPasswordLoginSuccess = "login_site_credentials_app_password_login_success"
     case loginSiteCredentialsAppPasswordLoginFailed = "login_site_credentials_app_password_login_failed"
     case loginSiteCredentialsAppPasswordLoginExitConfirmation = "login_site_credentials_app_password_login_exit_confirmation"

--- a/WooCommerce/Classes/Analytics/WooAnalyticsStat.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsStat.swift
@@ -99,6 +99,16 @@ public enum WooAnalyticsStat: String {
     case loginAppLoginLinkSuccess = "login_app_login_link_success"
     case loginMalformedAppLoginLink = "login_malformed_app_login_link"
 
+    case loginSiteCredentialsInvalidLoginPageDetected = "login_site_credentials_invalid_login_page_detected"
+    case loginSiteCredentialsAppPasswordExplanationDismissed = "_login_site_credentials_app_password_explanation_dismissed"
+    case loginSiteCredentialsAppPasswordExplanationContactSupportTapped = "_login_site_credentials_app_password_explanation_contact_support_tapped"
+    case loginSiteCredentialsAppPasswordExplanationContinueButtonTapped = "_login_site_credentials_app_password_explanation_continue_button_tapped"
+    case loginSiteCredentialsAppPasswordLoginSuccess = "login_site_credentials_app_password_login_success"
+    case loginSiteCredentialsAppPasswordLoginFailed = "login_site_credentials_app_password_login_failed"
+    case loginSiteCredentialsAppPasswordLoginExitConfirmation = "login_site_credentials_app_password_login_exit_confirmation"
+    case loginSiteCredentialsAppPasswordLoginDismissed = "login_site_credentials_app_password_login_dismissed"
+
+
     // MARK: Install/Setup Jetpack (`LoginJetpackSetupView`)
     //
     case loginJetpackSetupScreenViewed = "login_jetpack_setup_screen_viewed"

--- a/WooCommerce/Classes/Analytics/WooAnalyticsStat.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsStat.swift
@@ -103,8 +103,6 @@ public enum WooAnalyticsStat: String {
     case loginSiteCredentialsAppPasswordExplanationDismissed = "login_site_credentials_app_password_explanation_dismissed"
     case loginSiteCredentialsAppPasswordExplanationContactSupportTapped = "login_site_credentials_app_password_explanation_contact_support_tapped"
     case loginSiteCredentialsAppPasswordExplanationContinueButtonTapped = "login_site_credentials_app_password_explanation_continue_button_tapped"
-    case loginSiteCredentialsAppPasswordLoginSuccess = "login_site_credentials_app_password_login_success"
-    case loginSiteCredentialsAppPasswordLoginFailed = "login_site_credentials_app_password_login_failed"
     case loginSiteCredentialsAppPasswordLoginExitConfirmation = "login_site_credentials_app_password_login_exit_confirmation"
     case loginSiteCredentialsAppPasswordLoginDismissed = "login_site_credentials_app_password_login_dismissed"
 

--- a/WooCommerce/Classes/Authentication/Application Password/ApplicationPasswordAuthorizationWebViewController.swift
+++ b/WooCommerce/Classes/Authentication/Application Password/ApplicationPasswordAuthorizationWebViewController.swift
@@ -88,7 +88,10 @@ extension ApplicationPasswordAuthorizationWebViewController {
     private func presentBackNavigationAlert() {
         UIAlertController.presentUnfinishedApplicationPasswordAlert(from: self) { [weak self] in
             self?.navigationController?.popViewController(animated: true)
+            self?.analytics.track(event: .ApplicationPasswordAuthorization.loginDismissed())
         }
+
+        analytics.track(event: .ApplicationPasswordAuthorization.loginExitConfirmation())
     }
 }
 

--- a/WooCommerce/Classes/Authentication/Application Password/ApplicationPasswordTutorial.swift
+++ b/WooCommerce/Classes/Authentication/Application Password/ApplicationPasswordTutorial.swift
@@ -27,6 +27,14 @@ final class ApplicationPasswordTutorialViewController: UIHostingController<Appli
         }
     }
 
+    override func viewDidDisappear(_ animated: Bool) {
+        super.viewDidDisappear(animated)
+
+        if isMovingFromParent {
+            ServiceLocator.analytics.track(event: .ApplicationPasswordAuthorization.explanationDismissed())
+        }
+    }
+
     init(error: Error) {
         let view = ApplicationPasswordTutorial(errorDescription: ApplicationPasswordTutorialViewModel.friendlyErrorMessage(for: error))
         super.init(rootView: view)

--- a/WooCommerce/Classes/Authentication/AuthenticationManager.swift
+++ b/WooCommerce/Classes/Authentication/AuthenticationManager.swift
@@ -813,12 +813,16 @@ private extension AuthenticationManager {
         let tutorialVC = ApplicationPasswordTutorialViewController(error: error)
         tutorialVC.continueButtonTapped = { [weak self] in
             self?.presentApplicationPasswordWebView(for: siteURL, in: viewController)
+            self?.analytics.track(event: .ApplicationPasswordAuthorization.explanationContinueButtonTapped())
         }
-        tutorialVC.contactSupportButtonTapped = {
+        tutorialVC.contactSupportButtonTapped = { [weak self] in
             let supportController = SupportFormHostingController(viewModel: .init(sourceTag: WordPressSupportSourceTag.loginUsernamePassword.origin))
             supportController.show(from: viewController)
+            self?.analytics.track(event: .ApplicationPasswordAuthorization.explanationContactSupportTapped())
         }
         viewController.show(tutorialVC, sender: viewController)
+
+        analytics.track(event: .ApplicationPasswordAuthorization.invalidLoginPageDetected())
     }
 
     /// Presents login error alert before redirecting user to the site login using a web view.


### PR DESCRIPTION
closes #11989

# Why

This PR adds the events defined for the M2

# Events

-  https://github.com/Automattic/tracks-events-registration/pull/2279
- https://github.com/Automattic/tracks-events-registration/pull/2280
- https://github.com/Automattic/tracks-events-registration/pull/2281
- https://github.com/Automattic/tracks-events-registration/pull/2282
- https://github.com/Automattic/tracks-events-registration/pull/2283
- https://github.com/Automattic/tracks-events-registration/pull/2284

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
