### PR TITLE
[Blaze] Update campaign status options

### DIFF
--- a/Networking/Networking/Model/Blaze/BlazeCampaignListItem.swift
+++ b/Networking/Networking/Model/Blaze/BlazeCampaignListItem.swift
@@ -102,14 +102,12 @@ public struct BlazeCampaignListItem: Decodable, Equatable, GeneratedFakeable, Ge
 //
 public extension BlazeCampaignListItem {
     enum Status: String {
+        case pending
         case scheduled
-        case created
-        case rejected
-        case approved
         case active
+        case rejected
         case canceled
         case finished
-        case processing
         case unknown
     }
 

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -2,6 +2,7 @@
 
 17.7
 -----
+- [internal] Blaze: Update campaign status values to match v1.1 endpoint. [https://github.com/woocommerce/woocommerce-ios/pull/12207]
 
 
 17.6

--- a/WooCommerce/Classes/Extensions/BlazeCampaignListItem+Customizations.swift
+++ b/WooCommerce/Classes/Extensions/BlazeCampaignListItem+Customizations.swift
@@ -5,24 +5,18 @@ import struct Yosemite.BlazeCampaignListItem
 extension BlazeCampaignListItem.Status {
     var displayText: String {
         switch self {
-        case .active:
-            return Localization.active
-        case .approved:
-            return Localization.approved
-        case .created:
-            // There is no dedicated status for `In Moderation` on the backend.
-            // The app assumes that the campaign goes into moderation after creation.
-            return Localization.inModeration
+        case .pending:
+            return Localization.pending
         case .scheduled:
             return Localization.scheduled
-        case .finished:
-            return Localization.completed
-        case .canceled:
-            return Localization.canceled
+        case .active:
+            return Localization.active
         case .rejected:
             return Localization.rejected
-        case .processing:
-            return Localization.processing
+        case .canceled:
+            return Localization.canceled
+        case .finished:
+            return Localization.finished
         case .unknown:
             return Localization.unknown
         }
@@ -30,13 +24,13 @@ extension BlazeCampaignListItem.Status {
 
     var textColor: Color {
         switch self {
-        case .active, .approved:
+        case .active:
             return .withColorStudio(name: .green, shade: .shade60)
         case .scheduled, .finished:
             return .withColorStudio(name: .blue, shade: .shade80)
         case .canceled, .rejected:
             return .withColorStudio(name: .red, shade: .shade60)
-        case .created, .processing:
+        case .pending:
             return .withColorStudio(name: .yellow, shade: .shade70)
         case .unknown:
             return .withColorStudio(name: .gray, shade: .shade70)
@@ -45,13 +39,13 @@ extension BlazeCampaignListItem.Status {
 
     var backgroundColor: Color {
         switch self {
-        case .active, .approved:
+        case .active:
             return .withColorStudio(name: .green, shade: .shade5)
         case .scheduled, .finished:
             return .withColorStudio(name: .blue, shade: .shade5)
         case .canceled, .rejected:
             return .withColorStudio(name: .red, shade: .shade5)
-        case .created, .processing:
+        case .pending:
             return .withColorStudio(name: .yellow, shade: .shade5)
         case .unknown:
             return .withColorStudio(name: .gray, shade: .shade5)
@@ -59,14 +53,12 @@ extension BlazeCampaignListItem.Status {
     }
 
     private enum Localization {
-        static let active = NSLocalizedString("Active", comment: "Status name of an active Blaze campaign")
-        static let approved = NSLocalizedString("Approved", comment: "Status name of an approved Blaze campaign")
-        static let inModeration = NSLocalizedString("In Moderation", comment: "Status name of a Blaze campaign under moderation")
+        static let pending = NSLocalizedString("Pending", comment: "Status name of an active Blaze campaign")
         static let scheduled = NSLocalizedString("Scheduled", comment: "Status name of a scheduled Blaze campaign")
-        static let completed = NSLocalizedString("Completed", comment: "Status name of a completed Blaze campaign")
-        static let canceled = NSLocalizedString("Canceled", comment: "Status name of a canceled Blaze campaign")
+        static let active = NSLocalizedString("Active", comment: "Status name of an approved Blaze campaign")
         static let rejected = NSLocalizedString("Rejected", comment: "Status name of a rejected Blaze campaign")
-        static let processing = NSLocalizedString("Processing", comment: "Status name of a Blaze campaign under processing")
+        static let canceled = NSLocalizedString("Canceled", comment: "Status name of a canceled Blaze campaign")
+        static let finished = NSLocalizedString("Finished", comment: "Status name of a completed Blaze campaign")
         static let unknown = NSLocalizedString("Unknown", comment: "Status name of a Blaze campaign without specified state")
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewModel.swift
@@ -817,15 +817,14 @@ private extension ProductFormViewModel {
 //
 private extension ProductFormViewModel {
     /// Check whether there is already an existing campaign for the current Product, that also has one of these statuses:
-    /// - created (in moderation),
-    /// - approved,
+    /// - pending,
     /// - scheduled, or
     /// - active.
     func hasBlazeCampaign() -> Bool {
         let campaigns = blazeCampaignResultsController.fetchedObjects
         return campaigns.contains(where: {
             ($0.productID == product.productID) &&
-            ($0.status == .created || $0.status == .approved || $0.status == .scheduled || $0.status == .active)
+            ($0.status == .pending || $0.status == .scheduled || $0.status == .active)
         })
     }
 }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #12120 
<!-- Id number of the GitHub issue this PR addresses. -->

## Description

v1.1. GET campaigns endpoint sends different values for `status` field. 

From the API documentation, the following are the values for the `status` field.

> “pending” “scheduled” “active” “rejected” “canceled” “finished”

Internal - peeHDf-2fw-p2#comment-1896

This PR removes old status values and adds the new values to match the backend. 


Changes
- Update the values and removes unused cases from `Status` enum.
- Assign title and colors for new status values.
- Use new status values to determine whether a product has existing campaigns. 

## Testing instructions
- Login into a Woo store eligible for Blaze.
- Navigate to the Products tab and tap on a published product with no Blaze campaigns.
- You should see the "Promote with Blaze" button.
- Navigate back and open a product with an existing campaign. (Campaign can be newly submitted or currently running)
- You should not see the "Promote with Blaze" button in the product detail screen.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->
| With pending campaign | No campaign |
|--------|--------|
| ![Simulator Screenshot - iPhone 15 Pro Max - 2024-03-05 at 10 16 40](https://github.com/woocommerce/woocommerce-ios/assets/524475/f5f1b89c-6a48-4e56-bcc0-7838c40cce3a) | ![Simulator Screenshot - iPhone 15 Pro Max - 2024-03-05 at 10 16 44](https://github.com/woocommerce/woocommerce-ios/assets/524475/f8aff7bf-06f4-42d4-aac1-9553a63e498b) | 

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.