### PR TITLE
[Tablet Orders] Restore offline banner

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/OrderDetailsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/OrderDetailsViewController.swift
@@ -113,6 +113,10 @@ final class OrderDetailsViewController: UIViewController {
         super.viewDidLayoutSubviews()
         tableView.updateHeaderHeight()
     }
+
+    override var shouldShowOfflineBanner: Bool {
+        true
+    }
 }
 
 // MARK: - TableView Configuration

--- a/WooCommerce/Classes/ViewRelated/Orders/OrdersRootViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrdersRootViewController.swift
@@ -112,6 +112,16 @@ final class OrdersRootViewController: UIViewController {
         }
     }
 
+    override var shouldShowOfflineBanner: Bool {
+        // Should show the offline banner only when there's no orderDetailsViewController in memory
+        // otherwise, it will be shown within the order details view, so there's no need to duplicate it
+        if let orderDetailsViewController {
+            return false
+        } else {
+            return true
+        }
+    }
+
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
 

--- a/WooCommerce/Classes/ViewRelated/Orders/OrdersSplitViewWrapperController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrdersSplitViewWrapperController.swift
@@ -25,10 +25,6 @@ final class OrdersSplitViewWrapperController: UIViewController {
         configureChildViewController()
     }
 
-    override var shouldShowOfflineBanner: Bool {
-        return true
-    }
-
     /// Presents the Details for the Notification with the specified Identifier.
     ///
     func presentDetails(for note: Note) {


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes #12112 

## Description
This PR restores the offline banner for the Order details view, as well as the Order list view. These were removed when we removed the `splitViewInOrdersTab` https://github.com/woocommerce/woocommerce-ios/pull/12107

Following the conversation on p1709261954192889-slack-C06C3CZFHGD ,we also address rendering the banner only on the left side of the view (Order Details) when using a split view in large iPhones or tablets.

## Testing instructions:
I found this banner quite buggy, the easiest way to test it is : 
* Is not used in through order creation, so we can have `sideBySideViewForOrderForm` flag on, or off.
* In the `WooNavigationController` class, [comment out the lines from 124 to 126](https://github.com/woocommerce/woocommerce-ios/blob/trunk/WooCommerce/Classes/System/WooNavigationController.swift#L124-L126).
* Turn off your internet connection
  * On an iPhone, in portrait or landscape: Go to Orders, observe that the banner appears correctly across the bottom.
  * On a large iPhone, in portrait: Go to Orders, observe that the banner appears correctly across the bottom.
<img width=600 src="https://github.com/woocommerce/woocommerce-ios/assets/3812076/3cca0982-4be8-4333-b81b-b18bb27a38c6"/>


  * On a large iPhone in landscape (please note the caveat below), or tablet: Go to Orders, observe that the banner appears only across the right side of the screen. It does not appear in the order list.

| iPhone landscape | Tablet |
|--------|--------|
| <img width=600 src="https://github.com/woocommerce/woocommerce-ios/assets/3812076/42f0809d-5607-4e08-8b26-32754fcdcf6f"/> | <img width=600 src="https://github.com/woocommerce/woocommerce-ios/assets/3812076/209f9425-a5db-45f5-8626-338b95411295"/> | 

### Caveats
There's one edge case on large iPhones, if we switch from portrait to landscape without the connection state being changed, the banner will also appear across the order list. I was unable to change this due to the way it's implemented via the class override.

<img width=600 src="https://github.com/woocommerce/woocommerce-ios/assets/3812076/6a8bef0b-727f-4e20-85f6-7561100b4530"/>