### PR TITLE
My Store Analytics: Display exact date of custom range and selected granularity

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Dashboard/Stats v4/StatsTimeRangeBarView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Stats v4/StatsTimeRangeBarView.swift
@@ -4,7 +4,9 @@ import Experiments
 /// Contains a label that displays the time range - a date, date range for a week, month, or year.
 final class StatsTimeRangeBarView: UIView {
     // MARK: Subviews
+    private let stackView = UIStackView(frame: .zero)
     private let button = UIButton(frame: .zero)
+    private let subtitleLabel = UILabel(frame: .zero)
 
     // To be updated externally to handle button tap
     var editCustomTimeRangeHandler: (() -> Void)?
@@ -12,12 +14,16 @@ final class StatsTimeRangeBarView: UIView {
     init() {
         super.init(frame: .zero)
         translatesAutoresizingMaskIntoConstraints = false
+        configureStackView()
         configureButton()
+        configureSubtitleLabel()
     }
 
     required init?(coder aDecoder: NSCoder) {
         super.init(coder: aDecoder)
+        configureStackView()
         configureButton()
+        configureSubtitleLabel()
     }
 
     /// Updates the label with start/end dates, time range type, and site time zone.
@@ -32,33 +38,51 @@ final class StatsTimeRangeBarView: UIView {
         configuration.imagePadding = Constants.imagePadding
 
         var container = AttributeContainer()
-        container.font = Constants.labelFont
+        container.font = Constants.labelFont.bold
         container.foregroundColor = viewModel.isTimeRangeEditable ? .accent : Constants.labelColor
         configuration.attributedTitle = AttributedString(viewModel.timeRangeText, attributes: container)
 
         button.configuration = configuration
+        subtitleLabel.text = viewModel.granularityText
     }
 }
 
 private extension StatsTimeRangeBarView {
+    func configureStackView() {
+        addSubview(stackView)
+        stackView.axis = .vertical
+        stackView.distribution = .fill
+        stackView.alignment = .center
+        stackView.spacing = Constants.stackViewSpacing
+        stackView.translatesAutoresizingMaskIntoConstraints = false
+        pinSubviewToAllEdges(stackView, insets: Constants.stackViewInset)
+    }
+
     func configureButton() {
-        addSubview(button)
         button.translatesAutoresizingMaskIntoConstraints = false
         button.setContentCompressionResistancePriority(.required, for: .vertical)
-        pinSubviewToAllEdges(button, insets: Constants.labelInsets)
-
         button.on(.touchUpInside) { [weak self] _ in
             self?.editCustomTimeRangeHandler?()
         }
+        stackView.addArrangedSubview(button)
+    }
+
+    func configureSubtitleLabel() {
+        subtitleLabel.font = Constants.labelFont
+        subtitleLabel.textColor = Constants.labelColor
+        subtitleLabel.setContentCompressionResistancePriority(.required, for: .vertical)
+        subtitleLabel.translatesAutoresizingMaskIntoConstraints = false
+        stackView.addArrangedSubview(subtitleLabel)
     }
 }
 
 private extension StatsTimeRangeBarView {
     enum Constants {
-        static let labelInsets = UIEdgeInsets(top: 15, left: 16, bottom: 10, right: 16)
+        static let stackViewInset = UIEdgeInsets(top: 15, left: 16, bottom: 10, right: 16)
         static let labelFont: UIFont = .footnote
         static let labelColor: UIColor = .secondaryLabel
         static let labelTextAlignment: NSTextAlignment = .center
         static let imagePadding: CGFloat = 8
+        static let stackViewSpacing: CGFloat = 0
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Stats v4/StatsTimeRangeBarViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Stats v4/StatsTimeRangeBarViewModel.swift
@@ -57,8 +57,10 @@ private extension StatsTimeRangeV4 {
             dateFormatter = DateFormatter.Charts.chartSelectedDateHourFormatter
         case .daily, .weekly:
             dateFormatter = DateFormatter.Charts.chartAxisDayFormatter
-        case .monthly, .quarterly, .yearly:
+        case .monthly, .quarterly:
             dateFormatter = DateFormatter.Charts.chartAxisFullMonthFormatter
+        case .yearly:
+            dateFormatter = DateFormatter.Charts.chartAxisYearFormatter
         }
         dateFormatter.timeZone = timezone
         return dateFormatter

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Stats v4/StatsTimeRangeBarViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Stats v4/StatsTimeRangeBarViewModel.swift
@@ -69,12 +69,14 @@ private extension StatsTimeRangeV4 {
 struct StatsTimeRangeBarViewModel: Equatable {
     let timeRangeText: String
     let isTimeRangeEditable: Bool
+    let granularityText: String?
 
     init(startDate: Date,
          endDate: Date,
          timeRange: StatsTimeRangeV4,
          timezone: TimeZone) {
         isTimeRangeEditable = timeRange.isCustomTimeRange
+        granularityText = timeRange.isCustomTimeRange ? timeRange.intervalGranularity.displayText : nil
         timeRangeText = timeRange.timeRangeText(startDate: startDate,
                                                 endDate: endDate,
                                                 timezone: timezone)
@@ -87,9 +89,53 @@ struct StatsTimeRangeBarViewModel: Equatable {
          timezone: TimeZone) {
         // Disable editing time range when selecting a specific date on the graph
         isTimeRangeEditable = false
+        granularityText = nil
         timeRangeText = timeRange.timeRangeText(startDate: startDate,
                                                 endDate: endDate,
                                                 selectedDate: selectedDate,
                                                 timezone: timezone)
+    }
+}
+
+extension StatsGranularityV4 {
+    var displayText: String {
+        switch self {
+        case .daily:
+            NSLocalizedString(
+                "statsGranularityV4.daily",
+                value: "By day",
+                comment: "Display text for the daily granularity of store stats on the My Store screen"
+            )
+        case .hourly:
+            NSLocalizedString(
+                "statsGranularityV4.hourly",
+                value: "By hour",
+                comment: "Display text for the hourly granularity of store stats on the My Store screen"
+            )
+        case .weekly:
+            NSLocalizedString(
+                "statsGranularityV4.weekly",
+                value: "By week",
+                comment: "Display text for the weekly granularity of store stats on the My Store screen"
+            )
+        case .monthly:
+            NSLocalizedString(
+                "statsGranularityV4.monthly",
+                value: "By month",
+                comment: "Display text for the monthly granularity of store stats on the My Store screen"
+            )
+        case .quarterly:
+            NSLocalizedString(
+                "statsGranularityV4.quarterly",
+                value: "By quarter",
+                comment: "Display text for the quarterly granularity of store stats on the My Store screen"
+            )
+        case .yearly:
+            NSLocalizedString(
+                "statsGranularityV4.yearly",
+                value: "By year",
+                comment: "Display text for the yearly granularity of store stats on the My Store screen"
+            )
+        }
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Stats v4/StatsTimeRangeBarViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Stats v4/StatsTimeRangeBarViewModel.swift
@@ -17,9 +17,10 @@ private extension StatsTimeRangeV4 {
             let endDateString = dateFormatter.string(from: endDate)
             let format = NSLocalizedString("%1$@ - %2$@", comment: "Displays a date range for a stats interval")
             return String.localizedStringWithFormat(format, startDateString, endDateString)
-        case .custom:
-            let startDateString = dateFormatter.string(from: startDate)
-            let endDateString = dateFormatter.string(from: endDate)
+        case let .custom(customStartDate, customEndDate):
+            // Always display the exact date for custom range.
+            let startDateString = dateFormatter.string(from: customStartDate)
+            let endDateString = dateFormatter.string(from: customEndDate)
             let format = NSLocalizedString("%1$@ - %2$@", comment: "Displays a date range for a custom stats interval")
             return String.localizedStringWithFormat(format, startDateString, endDateString)
         }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Stats v4/StatsTimeRangeBarViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Stats v4/StatsTimeRangeBarViewModel.swift
@@ -43,7 +43,7 @@ private extension StatsTimeRangeV4 {
             let formatter = DateFormatter()
             formatter.dateStyle = .medium
             formatter.timeStyle = .none
-            return formatter
+            dateFormatter = formatter
         }
         dateFormatter.timeZone = timezone
         return dateFormatter

--- a/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/StatsTimeRangeBarViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/StatsTimeRangeBarViewModelTests.swift
@@ -1,5 +1,6 @@
 import XCTest
 @testable import WooCommerce
+import enum Yosemite.StatsTimeRangeV4
 
 final class StatsTimeRangeBarViewModelTests: XCTestCase {
     func test_today_text() {
@@ -182,6 +183,36 @@ final class StatsTimeRangeBarViewModelTests: XCTestCase {
         formatter.setLocalizedDateFormatFromTemplate("MMMM yyyy")
         formatter.timeZone = timezone
         let expectedText = formatter.string(from: startDate) // "July 2019" in en-US locale.
+        XCTAssertEqual(viewModel.timeRangeText, expectedText)
+    }
+
+    func test_custom_range_text_displays_exact_date_from_custom_range() throws {
+        // Given
+        // GMT: Sunday, July 28, 2019 12:00:00 AM
+        let startDate = Date(timeIntervalSince1970: 1564272000)
+        // GMT: Saturday, August 3, 2019 11:59:59 PM
+        let endDate = Date(timeIntervalSince1970: 1564876799)
+        let timezone = TimeZone(identifier: "GMT") ?? .current
+
+        let actualStartDate = try XCTUnwrap(startDate.adding(days: -3))
+        let actualEndDate = try XCTUnwrap(endDate.adding(days: 3))
+        let timeRange = StatsTimeRangeV4.custom(from: actualStartDate, to: actualEndDate)
+
+        // When
+        let viewModel = StatsTimeRangeBarViewModel(startDate: startDate,
+                                                   endDate: endDate,
+                                                   timeRange: timeRange,
+                                                   timezone: timezone)
+
+        // Then
+        let formatter = DateFormatter()
+        formatter.dateStyle = .medium
+        formatter.timeStyle = .none
+        formatter.timeZone = timezone
+        // "July 25, 2019 - August 6, 2019" in en-US locale.
+        let expectedText = String(format: "%1$@ - %2$@",
+                                  formatter.string(from: actualStartDate),
+                                  formatter.string(from: actualEndDate))
         XCTAssertEqual(viewModel.timeRangeText, expectedText)
     }
 }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/StatsTimeRangeBarViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/StatsTimeRangeBarViewModelTests.swift
@@ -1,6 +1,7 @@
 import XCTest
 @testable import WooCommerce
 import enum Yosemite.StatsTimeRangeV4
+import enum Yosemite.StatsGranularityV4
 
 final class StatsTimeRangeBarViewModelTests: XCTestCase {
     func test_today_text() {
@@ -214,5 +215,162 @@ final class StatsTimeRangeBarViewModelTests: XCTestCase {
                                   formatter.string(from: actualStartDate),
                                   formatter.string(from: actualEndDate))
         XCTAssertEqual(viewModel.timeRangeText, expectedText)
+    }
+
+    func test_custom_range_with_selected_date_for_hourly_granularity() {
+        // Given
+        // GMT: March 4 2024 00:00:00 AM
+        let startDate = Date(timeIntervalSince1970: 1709510400)
+        // GMT: March 5 2024 00:00:00 AM
+        let endDate = Date(timeIntervalSince1970: 1709596800)
+        // GMT: March 4 2024 12:00:00 PM
+        let selectedDate = Date(timeIntervalSince1970: 1709553600)
+        let timezone = TimeZone(identifier: "GMT") ?? .current
+
+        // When
+        let viewModel = StatsTimeRangeBarViewModel(startDate: startDate,
+                                                   endDate: endDate,
+                                                   selectedDate: selectedDate,
+                                                   timeRange: .custom(from: startDate, to: endDate),
+                                                   timezone: timezone)
+
+        // Then
+        let formatter = DateFormatter.Charts.chartSelectedDateHourFormatter
+        formatter.timeZone = timezone
+        // "Monday, March 4 12:00 PM"
+        let expectedDate = formatter.string(from: selectedDate)
+        XCTAssertEqual(viewModel.timeRangeText, expectedDate)
+    }
+
+    func test_custom_range_with_selected_date_for_daily_granularity() {
+        // Given
+        // GMT: February 28 2024 00:00:00 AM
+        let startDate = Date(timeIntervalSince1970: 1709078400)
+        // GMT: March 5 2024 00:00:00 AM
+        let endDate = Date(timeIntervalSince1970: 1709596800)
+        // GMT: March 4 2024 12:00:00 PM
+        let selectedDate = Date(timeIntervalSince1970: 1709553600)
+        let timezone = TimeZone(identifier: "GMT") ?? .current
+
+        // When
+        let viewModel = StatsTimeRangeBarViewModel(startDate: startDate,
+                                                   endDate: endDate,
+                                                   selectedDate: selectedDate,
+                                                   timeRange: .custom(from: startDate, to: endDate),
+                                                   timezone: timezone)
+
+        // Then
+        let formatter = DateFormatter.Charts.chartAxisDayFormatter
+        formatter.timeZone = timezone
+        // "Mar 4"
+        let expectedDate = formatter.string(from: selectedDate)
+        XCTAssertEqual(viewModel.timeRangeText, expectedDate)
+    }
+
+    func test_custom_range_with_selected_date_for_weekly_granularity() {
+        // Given
+        // GMT: December 28 2023 00:00:00 AM
+        let startDate = Date(timeIntervalSince1970: 1703721600)
+        // GMT: March 5 2024 00:00:00 AM
+        let endDate = Date(timeIntervalSince1970: 1709596800)
+        // GMT: March 4 2024 12:00:00 PM
+        let selectedDate = Date(timeIntervalSince1970: 1709553600)
+        let timezone = TimeZone(identifier: "GMT") ?? .current
+
+        // When
+        let viewModel = StatsTimeRangeBarViewModel(startDate: startDate,
+                                                   endDate: endDate,
+                                                   selectedDate: selectedDate,
+                                                   timeRange: .custom(from: startDate, to: endDate),
+                                                   timezone: timezone)
+
+        // Then
+        let formatter = DateFormatter.Charts.chartAxisDayFormatter
+        formatter.timeZone = timezone
+        // "Mar 4"
+        let expectedDate = formatter.string(from: selectedDate)
+        XCTAssertEqual(viewModel.timeRangeText, expectedDate)
+    }
+
+    func test_custom_range_with_selected_date_for_monthly_granularity() {
+        // Given
+        // GMT: May 28 2023 00:00:00 AM
+        let startDate = Date(timeIntervalSince1970: 1685232000)
+        // GMT: March 5 2024 00:00:00 AM
+        let endDate = Date(timeIntervalSince1970: 1709596800)
+        // GMT: March 4 2024 12:00:00 PM
+        let selectedDate = Date(timeIntervalSince1970: 1709553600)
+        let timezone = TimeZone(identifier: "GMT") ?? .current
+
+        // When
+        let viewModel = StatsTimeRangeBarViewModel(startDate: startDate,
+                                                   endDate: endDate,
+                                                   selectedDate: selectedDate,
+                                                   timeRange: .custom(from: startDate, to: endDate),
+                                                   timezone: timezone)
+
+        // Then
+        let formatter = DateFormatter.Charts.chartAxisFullMonthFormatter
+        formatter.timeZone = timezone
+        // "March 2024"
+        let expectedDate = formatter.string(from: selectedDate)
+        XCTAssertEqual(viewModel.timeRangeText, expectedDate)
+    }
+
+    func test_granularityText_is_non_nil_for_custom_range_without_selected_date() {
+        // Given
+        // GMT: May 28 2023 00:00:00 AM
+        let startDate = Date(timeIntervalSince1970: 1685232000)
+        // GMT: March 5 2024 00:00:00 AM
+        let endDate = Date(timeIntervalSince1970: 1709596800)
+        let timezone = TimeZone(identifier: "GMT") ?? .current
+
+        // When
+        let viewModel = StatsTimeRangeBarViewModel(startDate: startDate,
+                                                   endDate: endDate,
+                                                   timeRange: .custom(from: startDate, to: endDate),
+                                                   timezone: timezone)
+
+        // Then
+        XCTAssertEqual(viewModel.granularityText, StatsGranularityV4.monthly.displayText)
+    }
+
+    func test_granularityText_is_nil_for_custom_range_with_selected_date() {
+        // Given
+        // GMT: May 28 2023 00:00:00 AM
+        let startDate = Date(timeIntervalSince1970: 1685232000)
+        // GMT: March 5 2024 00:00:00 AM
+        let endDate = Date(timeIntervalSince1970: 1709596800)
+        // GMT: March 4 2024 12:00:00 PM
+        let selectedDate = Date(timeIntervalSince1970: 1709553600)
+        let timezone = TimeZone(identifier: "GMT") ?? .current
+
+        // When
+        let viewModel = StatsTimeRangeBarViewModel(startDate: startDate,
+                                                   endDate: endDate,
+                                                   selectedDate: selectedDate,
+                                                   timeRange: .custom(from: startDate, to: endDate),
+                                                   timezone: timezone)
+
+        // Then
+        XCTAssertNil(viewModel.granularityText)
+    }
+
+    func test_granularityText_is_nil_for_today_range() {
+        // Given
+        // GMT: Thursday, August 15, 2019 6:14:35 PM
+        let startDate = Date(timeIntervalSince1970: 1565892875)
+        // GMT: Friday, August 16, 2019 2:14:35 AM
+        let endDate = Date(timeIntervalSince1970: 1565921675)
+        let timezone = TimeZone(identifier: "GMT") ?? .current
+
+        // When
+        let viewModel = StatsTimeRangeBarViewModel(startDate: startDate,
+                                                   endDate: endDate,
+                                                   timeRange: .today,
+                                                   timezone: timezone)
+
+        // Then
+        XCTAssertNil(viewModel.granularityText)
     }
 }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #12206 
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This PR updates the date range view on the custom range tab of the My Store stats screen. Changes include:
- The date range is updated to display the exact dates of the selected custom range rather than only dates included in the revenue stat response.
- Added a text for the selected granularity of the custom range below the date range. The placement is still under discussion [p1709651270092029-slack-C0354HSNUJH] - so if necessary it will be updated in a future PR.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
- Enable the feature flag `customRangeInMyStoreAnalytics` and build the app.
- Log in to a store and add a new custom range if none exists already. 
- Confirm that the date range reflects the exact selected date range, even though some dates at the end of the range might not be included on the chart.
- Confirm that the correct granularity is displayed below the date range.
- Select any date on the chart, confirm that the granularity text is not displayed.
- Confirm that the granularity text is not displayed on any other stats tabs.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->
No selected date | With selected date
--- | ---
<img src="https://github.com/woocommerce/woocommerce-ios/assets/5533851/eac499e2-f483-4f1e-ac47-b949186d1f5e" width=320 /> | <img src="https://github.com/woocommerce/woocommerce-ios/assets/5533851/247620fd-4ba6-40c1-a9a1-9177efb7ecdd" width=320 />



---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.