### PR TITLE
[Tablet Orders] Enable side by side orders in dev builds

### DIFF
--- a/Experiments/Experiments/DefaultFeatureFlagService.swift
+++ b/Experiments/Experiments/DefaultFeatureFlagService.swift
@@ -14,7 +14,7 @@ public struct DefaultFeatureFlagService: FeatureFlagService {
         case .inbox:
             return buildConfig == .localDeveloper || buildConfig == .alpha
         case .sideBySideViewForOrderForm:
-            return false
+            return buildConfig == .localDeveloper || buildConfig == .alpha
         case .updateOrderOptimistically:
             return buildConfig == .localDeveloper || buildConfig == .alpha
         case .shippingLabelsOnboardingM1:

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/OrderForm.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/OrderForm.swift
@@ -125,14 +125,17 @@ struct OrderFormPresentationWrapper: View {
                         }
                     }
                 },
-                isShowingSecondaryView: $viewModel.isProductSelectorPresented,
-                onViewContainerDismiss: {
-                    // By only calling the dismissHandler here, we wouldn't sync the selected items on dismissal
-                    // this is normally done via a callback through the ProductSelector's onCloseButtonTapped(),
-                    // but on split views we move this responsibility to the AdaptiveModalContainer
-                    viewModel.syncOrderItemSelectionStateOnDismiss()
-                    dismissHandler()
-                })
+                dismissBarButton: {
+                    Button(OrderForm.Localization.cancelButton) {
+                        // By only calling the dismissHandler here, we wouldn't sync the selected items on dismissal
+                        // this is normally done via a callback through the ProductSelector's onCloseButtonTapped(),
+                        // but on split views we move this responsibility to the AdaptiveModalContainer
+                        viewModel.syncOrderItemSelectionStateOnDismiss()
+                        dismissHandler()
+                    }
+                    .accessibilityIdentifier(OrderForm.Accessibility.cancelButtonIdentifier)
+                },
+                isShowingSecondaryView: $viewModel.isProductSelectorPresented)
         } else {
             OrderForm(dismissHandler: dismissHandler, flow: flow, viewModel: viewModel, presentProductSelector: nil)
         }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/OrderForm.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/OrderForm.swift
@@ -386,6 +386,7 @@ struct OrderForm: View {
                     Button(Localization.recalculateButton) {
                         viewModel.onRecalculateTapped()
                     }
+                    .accessibilityIdentifier(Accessibility.recalculateButtonIdentifier)
                 case .none:
                     EmptyView()
                 }
@@ -863,6 +864,7 @@ private extension OrderForm {
     enum Accessibility {
         static let createButtonIdentifier = "new-order-create-button"
         static let cancelButtonIdentifier = "new-order-cancel-button"
+        static let recalculateButtonIdentifier = "new-order-recalculate-button"
         static let doneButtonIdentifier = "edit-order-done-button"
         static let addProductButtonIdentifier = "new-order-add-product-button"
         static let addProductViaSKUScannerButtonIdentifier = "new-order-add-product-via-sku-scanner-button"

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/OrderForm.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/OrderForm.swift
@@ -331,6 +331,7 @@ struct OrderForm: View {
                     }
                     .disabled(viewModel.disabled)
                 }
+                .accessibilityIdentifier(Accessibility.orderFormScrollViewIdentifier)
                 .background(Color(.listBackground).ignoresSafeArea())
                 .ignoresSafeArea(.container, edges: [.horizontal])
             }
@@ -868,6 +869,7 @@ private extension OrderForm {
         static let doneButtonIdentifier = "edit-order-done-button"
         static let addProductButtonIdentifier = "new-order-add-product-button"
         static let addProductViaSKUScannerButtonIdentifier = "new-order-add-product-via-sku-scanner-button"
+        static let orderFormScrollViewIdentifier = "order-form-scroll-view"
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/AdaptiveModalContainer.swift
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/AdaptiveModalContainer.swift
@@ -9,29 +9,29 @@ import SwiftUI
 ///
 /// Each view is wrapped in its own Navigation Stack
 ///
-/// Intended to be presented modally – a close button will be added to the leftmost navigation bar.
+/// Intended to be presented modally – the `dismissBarButton` will be added to the leftmost navigation bar.
 ///
 /// This was initially developed for the Order Form and Product Selector to be presented together on iPad.
-struct AdaptiveModalContainer<PrimaryView: View, SecondaryView: View>: View {
+struct AdaptiveModalContainer<PrimaryView: View, SecondaryView: View, DismissButton: View>: View {
     @Environment(\.horizontalSizeClass) var horizontalSizeClass
 
     @ViewBuilder let primaryView: (_ presentSecondaryView: (() -> Void)?) -> PrimaryView
     @ViewBuilder let secondaryView: (_ isPresented: Binding<Bool>) -> SecondaryView
+    @ViewBuilder let dismissBarButton: () -> DismissButton
     @Binding var isShowingSecondaryView: Bool
-    var onViewContainerDismiss: (() -> Void)?
 
     var body: some View {
         if horizontalSizeClass == .compact {
             ModalOnModalView(primaryView: primaryView,
                              secondaryView: secondaryView,
-                             isShowingSecondaryView: $isShowingSecondaryView,
-                             onDimissButtonTapped: onViewContainerDismiss)
+                             dismissBarButton: dismissBarButton,
+                             isShowingSecondaryView: $isShowingSecondaryView)
                 .environment(\.adaptiveModalContainerPresentationStyle, .modalOnModal)
         } else {
             SideBySideView(primaryView: primaryView,
                            secondaryView: secondaryView,
-                           isShowingSecondaryView: $isShowingSecondaryView,
-                           onDimissButtonTapped: onViewContainerDismiss)
+                           dismissBarButton: dismissBarButton,
+                           isShowingSecondaryView: $isShowingSecondaryView)
                 .environment(\.adaptiveModalContainerPresentationStyle, .sideBySide)
         }
     }
@@ -39,8 +39,8 @@ struct AdaptiveModalContainer<PrimaryView: View, SecondaryView: View>: View {
     private struct ModalOnModalView: View {
         @ViewBuilder let primaryView: (_ presentSecondaryView: @escaping () -> Void) -> PrimaryView
         @ViewBuilder let secondaryView: (_ isPresented: Binding<Bool>) -> SecondaryView
+        @ViewBuilder let dismissBarButton: () -> DismissButton
         @Binding var isShowingSecondaryView: Bool
-        var onDimissButtonTapped: (() -> Void)?
 
         var body: some View {
             NavigationView {
@@ -49,11 +49,7 @@ struct AdaptiveModalContainer<PrimaryView: View, SecondaryView: View>: View {
                 })
                 .toolbar {
                     ToolbarItem(placement: .navigationBarLeading) {
-                        Button(action: {
-                            onDimissButtonTapped?()
-                        }, label: {
-                            Text(Localization.cancelButtonText)
-                        })
+                        dismissBarButton()
                     }
                 }
                 .sheet(isPresented: $isShowingSecondaryView) {
@@ -72,8 +68,8 @@ struct AdaptiveModalContainer<PrimaryView: View, SecondaryView: View>: View {
     private struct SideBySideView: View {
         @ViewBuilder let primaryView: (_ presentSecondaryView: (() -> Void)?) -> PrimaryView
         @ViewBuilder let secondaryView: (_ isPresented: Binding<Bool>) -> SecondaryView
+        @ViewBuilder let dismissBarButton: () -> DismissButton
         @Binding var isShowingSecondaryView: Bool
-        var onDimissButtonTapped: (() -> Void)?
 
         var body: some View {
             HStack(spacing: 0) {
@@ -81,11 +77,7 @@ struct AdaptiveModalContainer<PrimaryView: View, SecondaryView: View>: View {
                     secondaryView($isShowingSecondaryView)
                         .toolbar {
                             ToolbarItem(placement: .navigationBarLeading) {
-                                Button(action: {
-                                    onDimissButtonTapped?()
-                                }, label: {
-                                    Text(Localization.cancelButtonText)
-                                })
+                                dismissBarButton()
                             }
                         }
                 }

--- a/WooCommerce/UITestsFoundation/Screens/Orders/AddProductScreen.swift
+++ b/WooCommerce/UITestsFoundation/Screens/Orders/AddProductScreen.swift
@@ -23,10 +23,9 @@ public final class AddProductScreen: ScreenObject {
     /// Taps a product from the list.
     /// - Returns: Unified Order screen object.
     @discardableResult
-    public func tapProduct(byName name: String) throws -> UnifiedOrderScreen {
+    public func tapProduct(byName name: String) {
         app.buttons.staticTexts[name].firstMatch.tap()
         tapDoneButton()
-        return try UnifiedOrderScreen()
     }
 
     /// Taps multiple products from the list.

--- a/WooCommerce/UITestsFoundation/Screens/Orders/UnifiedOrderScreen.swift
+++ b/WooCommerce/UITestsFoundation/Screens/Orders/UnifiedOrderScreen.swift
@@ -172,7 +172,11 @@ public final class UnifiedOrderScreen: ScreenObject {
     /// Opens the Customer Note screen.
     /// - Returns: Customer Note screen object.
     public func openCustomerNoteScreen() throws -> CustomerNoteScreen {
+        /// The `scrollintoView` function doesn’t perform any scrolling on the iPad, because `isFullyVisibleOnScreen`
+        /// is returning true, even when the note button is hidden (just) below the expandable totals drawer.
+        /// Unfortunately, the button can't be tapped in this instance.
         app.scrollViews["order-form-scroll-view"].swipeUp()
+        
         addNoteButton.scrollIntoView()
         addNoteButton.tap()
         return try CustomerNoteScreen()

--- a/WooCommerce/UITestsFoundation/Screens/Orders/UnifiedOrderScreen.swift
+++ b/WooCommerce/UITestsFoundation/Screens/Orders/UnifiedOrderScreen.swift
@@ -176,7 +176,7 @@ public final class UnifiedOrderScreen: ScreenObject {
         /// is returning true, even when the note button is hidden (just) below the expandable totals drawer.
         /// Unfortunately, the button can't be tapped in this instance.
         app.scrollViews["order-form-scroll-view"].swipeUp()
-        
+
         addNoteButton.scrollIntoView()
         addNoteButton.tap()
         return try CustomerNoteScreen()

--- a/WooCommerce/UITestsFoundation/Screens/Orders/UnifiedOrderScreen.swift
+++ b/WooCommerce/UITestsFoundation/Screens/Orders/UnifiedOrderScreen.swift
@@ -172,6 +172,7 @@ public final class UnifiedOrderScreen: ScreenObject {
     /// Opens the Customer Note screen.
     /// - Returns: Customer Note screen object.
     public func openCustomerNoteScreen() throws -> CustomerNoteScreen {
+        app.scrollViews["order-form-scroll-view"].swipeUp()
         addNoteButton.scrollIntoView()
         addNoteButton.tap()
         return try CustomerNoteScreen()

--- a/WooCommerce/UITestsFoundation/Screens/Orders/UnifiedOrderScreen.swift
+++ b/WooCommerce/UITestsFoundation/Screens/Orders/UnifiedOrderScreen.swift
@@ -9,6 +9,10 @@ public final class UnifiedOrderScreen: ScreenObject {
         $0.buttons["new-order-create-button"]
     }
 
+    private let recalculateButtonGetter: (XCUIApplication) -> XCUIElement = {
+        $0.buttons["new-order-recalculate-button"]
+    }
+
     private let cancelButtonGetter: (XCUIApplication) -> XCUIElement = {
         $0.buttons["new-order-cancel-button"]
     }
@@ -50,6 +54,8 @@ public final class UnifiedOrderScreen: ScreenObject {
     }
 
     private var createButton: XCUIElement { createButtonGetter(app) }
+
+    private var recalculateButton: XCUIElement { recalculateButtonGetter(app) }
 
     /// Cancel button in the Navigation bar.
     ///
@@ -126,7 +132,10 @@ public final class UnifiedOrderScreen: ScreenObject {
     /// Opens the Add Product screen (to add a new product).
     /// - Returns: Add Product screen object.
     private func openAddProductScreen() throws -> AddProductScreen {
-        addProductButton.tap()
+        // on iPad, it will already be showing on the left of the side-by side view, and there's no addProductButton
+        if UIDevice.current.userInterfaceIdiom == .phone {
+            addProductButton.tap()
+        }
         return try AddProductScreen()
     }
 
@@ -177,6 +186,12 @@ public final class UnifiedOrderScreen: ScreenObject {
         return try SingleOrderScreen()
     }
 
+    public func recalculateTotalIfRequired() {
+        if recalculateButton.exists {
+            recalculateButton.tap()
+        }
+    }
+
     /// Changes the new order status to the second status in the Order Status list.
     /// - Returns: Unified Order screen object.
     public func editOrderStatus() throws -> UnifiedOrderScreen {
@@ -187,8 +202,10 @@ public final class UnifiedOrderScreen: ScreenObject {
     /// Tap the first product from the addProductScreen
     /// - Returns: Unified Order screen object.
     public func addProduct(byName name: String) throws -> UnifiedOrderScreen {
-        return try openAddProductScreen()
+        try openAddProductScreen()
             .tapProduct(byName: name)
+        recalculateTotalIfRequired()
+        return try UnifiedOrderScreen()
     }
 
     /// Tap the first product from the addProductScreen


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

Mostly tweaks were required to UI tests to have them continue working with the side-by-side view.

I wasn't hugely pleased with the `swipeUp` call I had to add to fix one of the tests, as it seems a bit hacked in. If anyone on @woocommerce/mobile-ui-testing-squad has any thoughts on how to better get `isFullyVisibleOnScreen()` to return false for the Add Note button when it's hidden below the summary totals drawer, that would be appreciated. See f9fd029

The `Cancel` button on the order form has been refactored a little to make it easier to set an accessibility identifier, so checking that it shows and works in both types of view may be helpful.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

Check UI tests pass.


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
