### PR TITLE
[Order List] Scan barcode button is only announced as "Button" in voiceover

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Orders/OrdersRootViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrdersRootViewController.swift
@@ -505,7 +505,10 @@ private extension OrdersRootViewController {
                                      target: self,
                                      action: #selector(presentOrderCreationFlowByProductScanning))
         button.accessibilityTraits = .button
-        button.accessibilityLabel = NSLocalizedString("Scan product barcode", comment: "Opens barcode scanning screen")
+        button.accessibilityLabel = NSLocalizedString(
+            "orderForm.products.add.scan.button.accessibilityLabel",
+            value: "Scan barcode",
+            comment: "Accessibility label for the barcode scanning button to add product")
         button.accessibilityIdentifier = "create-new-order-by-product-scanning"
         return button
     }

--- a/WooCommerce/Classes/ViewRelated/Orders/OrdersRootViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrdersRootViewController.swift
@@ -505,6 +505,7 @@ private extension OrdersRootViewController {
                                      target: self,
                                      action: #selector(presentOrderCreationFlowByProductScanning))
         button.accessibilityTraits = .button
+        button.accessibilityLabel = NSLocalizedString("Scan product barcode", comment: "Opens barcode scanning screen")
         button.accessibilityIdentifier = "create-new-order-by-product-scanning"
         return button
     }

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Inventory Settings/ProductInventorySettingsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Inventory Settings/ProductInventorySettingsViewController.swift
@@ -295,6 +295,11 @@ private extension ProductInventorySettingsViewController {
         button.addAction(UIAction(handler: { [weak self] _ in
             self?.scanSKUButtonTapped()
         }), for: .touchUpInside)
+        button.accessibilityLabel = NSLocalizedString("Scan products", comment: "Scan Products")
+        button.accessibilityHint = NSLocalizedString(
+            "Scans barcodes that are associated with a product SKU for stock management.",
+            comment: "VoiceOver accessibility hint, informing the user the button can be used to scan products."
+        )
         cell.accessoryView = button
     }
 


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #11792
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

- Added missing accessibility label for scan barcode button

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

- For easier testing, without turning on accessibility voice over on your device you can open "Accessibility Inspector" app on your mack and select Woo app from list of proccesses
- Open orders tab
- Check that for the scan button in navigation bar the voice over says "Scan barcode"
- I also added the accessibility label in product details, so open a product that has inventory management, tap "Inventory", check that for scan button voice over says "Scan products" and "Scans barcodes that are associated with a product SKU for stock management."

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

<img width="975" alt="Screenshot 2024-03-06 at 10 25 53" src="https://github.com/woocommerce/woocommerce-ios/assets/6242034/a211d5ed-0be6-42c4-8960-2000ef23ba4f">

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
