### PR TITLE
[Tablet Orders] Prevent edit non-editable orders

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/EditableOrderViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/EditableOrderViewModel.swift
@@ -1824,6 +1824,7 @@ private extension EditableOrderViewModel {
                     topProductsProvider: TopProductsFromCachedOrdersProvider(),
                     syncApproach: selectionSyncApproach.productSelectorSyncApproach,
                     orderSyncState: orderSynchronizer.statePublisher,
+                    shouldShowNonEditableIndicators: shouldShowNonEditableIndicators,
                     onProductSelectionStateChanged: { [weak self] product, isSelected in
                         guard let self else { return }
                         changeSelectionStateForProduct(product, to: isSelected)

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/OrderForm.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/OrderForm.swift
@@ -387,6 +387,7 @@ struct OrderForm: View {
                     Button(Localization.recalculateButton) {
                         viewModel.onRecalculateTapped()
                     }
+                    .disabled(viewModel.shouldShowNonEditableIndicators)
                     .accessibilityIdentifier(Accessibility.recalculateButtonIdentifier)
                 case .none:
                     EmptyView()
@@ -465,6 +466,7 @@ struct OrderForm: View {
             } label: {
                 Text(Localization.recalculateButton)
             }
+            .disabled(viewModel.shouldShowNonEditableIndicators)
             .buttonStyle(PrimaryLoadingButtonStyle(isLoading: loading))
         case .create(let loading):
             Button {

--- a/WooCommerce/Classes/ViewRelated/Products/ProductSelector/ProductRow.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductSelector/ProductRow.swift
@@ -17,6 +17,8 @@ struct ProductRow: View {
     // Tracks the scale of the view due to accessibility changes
     @ScaledMetric private var scale: CGFloat = 1
 
+    @Environment(\.isEnabled) private var isEnabled
+
     /// Accessibility hint describing the product row tap gesture.
     /// Avoids overwriting the product stepper accessibility hint, when the stepper is rendered.
     ///
@@ -75,7 +77,7 @@ struct ProductRow: View {
     private var checkbox: some View {
         Image(uiImage: viewModel.selectedState.image)
             .frame(width: Layout.checkImageSize * scale, height: Layout.checkImageSize * scale)
-            .foregroundColor(.init(UIColor.brand))
+            .foregroundColor(isEnabled ? .init(UIColor.brand) : .gray)
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Products/ProductSelector/ProductSelectorView.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductSelector/ProductSelectorView.swift
@@ -237,7 +237,7 @@ struct ProductSelectorView: View {
                 .onTapGesture {
                     viewModel.variationRowTapped(for: rowViewModel.productOrVariationID)
                 }
-                .redacted(reason: viewModel.selectionDisabled ? .placeholder : [])
+                .redacted(reason: viewModel.showPlaceholders ? .placeholder : [])
                 .disabled(viewModel.selectionDisabled)
 
                 DisclosureIndicator()
@@ -279,7 +279,7 @@ struct ProductSelectorView: View {
                                                              selected: rowViewModel.selectedState != .selected)
                 }
             }
-            .redacted(reason: viewModel.selectionDisabled ? .placeholder : [])
+            .redacted(reason: viewModel.showPlaceholders ? .placeholder : [])
             .disabled(viewModel.selectionDisabled)
         }
     }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes #12200 
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
This PR disables the `recalculate` button when an order is non-editable, preventing changes in side-by-side views that were not possible in modal views due to the product selector being visible at all times.

With the recalculate button disabled, no changes from the product selector can be made and saved non-editable orders (note that other allowed changes, like adding customer details, are still possible) unless the order status is switched to be editable again (eg: pending payment).

| Non-editable order | Editable order |
|--------|--------|
| ![20240306 non editable disabled button](https://github.com/woocommerce/woocommerce-ios/assets/3812076/a90a188a-4f54-4327-9210-f2e7db6a88fb) | ![20240306 editable enabled button](https://github.com/woocommerce/woocommerce-ios/assets/3812076/79c272da-613d-448b-ad3c-6352220c171f) | 

## Changes
We update the buttons with a `.disabled()` property modifier, that relies on the state of `shouldShowNonEditableIndicators` This value is computed in the viewModel, and published, based on the latest order status and flow, so only orders in creation flow and _"editable orders in edit flow"_ will allow editing.

## Testing instructions
- On an iPad or large iPhone, go to Orders
- Create a new order, observe the recalculate button works as expected
- Using the previous order, or a different order with the `Completed` status, tap on `Edit`
- Observe the `Done` button is active upon editing the order, but as soon as we select/unselect a product, a disabled `Recalculate` button overrides it.
- Tap the order status pencil icon to switch a `Completed` order to `Pending Payment`. Observe that upon selecting/unselecting products, the recalculate button is enabled again and changes can be saved.
