### PR TITLE
My Store Analytics: Update rules for fixed granularities in custom range tab

### DIFF
--- a/Networking/Networking/Model/Stats/StatGranularity.swift
+++ b/Networking/Networking/Model/Stats/StatGranularity.swift
@@ -7,7 +7,6 @@ public enum StatGranularity: String, Decodable, GeneratedFakeable {
     case day
     case week
     case month
-    case quarter
     case year
     case hour
 }

--- a/Networking/Networking/Model/Stats/StatsGranularityV4.swift
+++ b/Networking/Networking/Model/Stats/StatsGranularityV4.swift
@@ -8,6 +8,5 @@ public enum StatsGranularityV4: String, Decodable, GeneratedFakeable {
     case daily = "day"
     case weekly = "week"
     case monthly = "month"
-    case quarterly = "quarter"
     case yearly = "year"
 }

--- a/WooCommerce/Classes/Analytics/WooAnalyticsEvent+Dashboard.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsEvent+Dashboard.swift
@@ -59,7 +59,6 @@ private extension StatsTimeRangeV4 {
         case .thisYear:
             return "years"
         case .custom:
-            // TODO: 11935 Update analytics value
             return "custom"
         }
     }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Stats v4/StatsTimeRangeBarViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Stats v4/StatsTimeRangeBarViewModel.swift
@@ -57,7 +57,7 @@ private extension StatsTimeRangeV4 {
             dateFormatter = DateFormatter.Charts.chartSelectedDateHourFormatter
         case .daily, .weekly:
             dateFormatter = DateFormatter.Charts.chartAxisDayFormatter
-        case .monthly, .quarterly:
+        case .monthly:
             dateFormatter = DateFormatter.Charts.chartAxisFullMonthFormatter
         case .yearly:
             dateFormatter = DateFormatter.Charts.chartAxisYearFormatter
@@ -125,12 +125,6 @@ extension StatsGranularityV4 {
                 "statsGranularityV4.monthly",
                 value: "By month",
                 comment: "Display text for the monthly granularity of store stats on the My Store screen"
-            )
-        case .quarterly:
-            NSLocalizedString(
-                "statsGranularityV4.quarterly",
-                value: "By quarter",
-                comment: "Display text for the quarterly granularity of store stats on the My Store screen"
             )
         case .yearly:
             NSLocalizedString(

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Stats v4/StatsTimeRangeV4+UI.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Stats v4/StatsTimeRangeV4+UI.swift
@@ -92,7 +92,7 @@ extension StatsTimeRangeV4 {
             dateFormatter = DateFormatter.Charts.chartAxisDayFormatter
         case .weekly:
             dateFormatter = DateFormatter.Charts.chartAxisDayFormatter
-        case .monthly, .quarterly:
+        case .monthly:
             dateFormatter = DateFormatter.Charts.chartAxisMonthFormatter
         case .yearly:
             fatalError("This case is not supported: \(intervalGranularity.rawValue)")

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Stats v4/StatsTimeRangeV4+UI.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Stats v4/StatsTimeRangeV4+UI.swift
@@ -95,7 +95,7 @@ extension StatsTimeRangeV4 {
         case .monthly:
             dateFormatter = DateFormatter.Charts.chartAxisMonthFormatter
         case .yearly:
-            fatalError("This case is not supported: \(intervalGranularity.rawValue)")
+            dateFormatter = DateFormatter.Charts.chartAxisYearFormatter
         }
         dateFormatter.timeZone = siteTimezone
         return dateFormatter

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Stats v4/StoreStatsAndTopPerformersPeriodViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Stats v4/StoreStatsAndTopPerformersPeriodViewController.swift
@@ -46,7 +46,7 @@ final class StoreStatsAndTopPerformersPeriodViewController: UIViewController {
             return 60
         case .daily, .weekly:
             return 60*60
-        case .monthly, .quarterly:
+        case .monthly:
             return 60*60*12
         case .yearly:
             return 60*60*24

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Stats v4/StoreStatsV4ChartAxisHelper.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Stats v4/StoreStatsV4ChartAxisHelper.swift
@@ -14,7 +14,6 @@ final class StoreStatsV4ChartAxisHelper {
         case .thisWeek:
             labelCount = 7
         case .custom:
-            // TODO: 11935 Update label count
             labelCount = 5
         }
         return labelCount

--- a/Yosemite/Yosemite/Model/Enums/StatsTimeRangeV4.swift
+++ b/Yosemite/Yosemite/Model/Enums/StatsTimeRangeV4.swift
@@ -120,10 +120,10 @@ extension StatsTimeRangeV4 {
                 return .daily
             case .from29To90:
                 return .weekly
-            case .from91to365:
+            case .from91daysTo3Years:
                 return .monthly
-            case .greaterThan365:
-                return .quarterly
+            case .greaterThan3Years:
+                return .yearly
             }
         }
     }
@@ -146,10 +146,10 @@ extension StatsTimeRangeV4 {
                 return .day
             case .from29To90:
                 return .week
-            case .from91to365:
+            case .from91daysTo3Years:
                 return .month
-            case .greaterThan365:
-                return .quarter
+            case .greaterThan3Years:
+                return .year
             }
         }
     }
@@ -176,10 +176,10 @@ extension StatsTimeRangeV4 {
                 return .day
             case .from29To90:
                 return .week
-            case .from91to365:
+            case .from91daysTo3Years:
                 return .month
-            case .greaterThan365:
-                return .quarter
+            case .greaterThan3Years:
+                return .year
             }
         }
     }
@@ -206,10 +206,10 @@ extension StatsTimeRangeV4 {
                 return .day
             case .from29To90:
                 return .week
-            case .from91to365:
+            case .from91daysTo3Years:
                 return .month
-            case .greaterThan365:
-                return .quarter
+            case .greaterThan3Years:
+                return .year
             }
         }
     }
@@ -240,8 +240,8 @@ extension StatsTimeRangeV4 {
 
 private extension StatsTimeRangeV4 {
     enum DifferenceInDays {
-        case greaterThan365
-        case from91to365
+        case greaterThan3Years
+        case from91daysTo3Years
         case from29To90
         case from2To28
         case lessThan2
@@ -261,10 +261,10 @@ private extension StatsTimeRangeV4 {
         }
 
         switch day {
-        case 366...Int.max:
-            return .greaterThan365
-        case 91...365:
-            return .from91to365
+        case 365*3+1...Int.max:
+            return .greaterThan3Years
+        case 91...365*3:
+            return .from91daysTo3Years
         case 29...90:
             return .from29To90
         case 2...28:

--- a/Yosemite/Yosemite/Model/Mocks/MockObjectGraph.swift
+++ b/Yosemite/Yosemite/Model/Mocks/MockObjectGraph.swift
@@ -470,7 +470,6 @@ extension MockObjectGraph {
                 granularity: .day,
                 items: items
             )
-            case .quarter: preconditionFailure("Not implemented")
             case .year: preconditionFailure("Not implemented")
         }
     }

--- a/Yosemite/Yosemite/Stores/StatsStoreV4.swift
+++ b/Yosemite/Yosemite/Stores/StatsStoreV4.swift
@@ -496,7 +496,7 @@ public extension StatsStoreV4 {
             return DateFormatter.Stats.statsDayFormatter.string(from: date)
         case .week:
             return DateFormatter.Stats.statsWeekFormatter.string(from: date)
-        case .month, .quarter:
+        case .month:
             return DateFormatter.Stats.statsMonthFormatter.string(from: date)
         case .year:
             return DateFormatter.Stats.statsYearFormatter.string(from: date)

--- a/Yosemite/YosemiteTests/Model/Enums/StatsTimeRangeTests.swift
+++ b/Yosemite/YosemiteTests/Model/Enums/StatsTimeRangeTests.swift
@@ -14,24 +14,24 @@ final class StatsTimeRangeTests: XCTestCase {
 
     // MARK: `intervalGranularity` for custom range
 
-    func test_intervalGranularity_for_dates_with_days_difference_greater_than_365() {
+    func test_intervalGranularity_for_dates_with_days_difference_greater_than_3_years() {
         // Given
         // GMT: Saturday, February 1, 2020 12:29:29 AM
         let fromDate = Date(timeIntervalSince1970: 1580516969)
-        let toDate = fromDate.addingDays(366)
+        let toDate = fromDate.addingDays(365*3+1)
 
         // When
         let range: StatsTimeRangeV4 = .custom(from: fromDate, to: toDate)
 
         // Then
-        XCTAssertEqual(range.intervalGranularity, .quarterly)
+        XCTAssertEqual(range.intervalGranularity, .yearly)
     }
 
-    func test_intervalGranularity_for_dates_with_days_difference_from_91_to_365() {
+    func test_intervalGranularity_for_dates_with_days_difference_from_91_to_3_years() {
         // Given
         // GMT: Saturday, February 1, 2020 12:29:29 AM
         let fromDate = Date(timeIntervalSince1970: 1580516969)
-        let toDate = fromDate.addingDays(Int.random(in: 91...365))
+        let toDate = fromDate.addingDays(Int.random(in: 91...365*3))
 
         // When
         let range: StatsTimeRangeV4 = .custom(from: fromDate, to: toDate)
@@ -81,24 +81,24 @@ final class StatsTimeRangeTests: XCTestCase {
 
     // MARK: `siteVisitStatsGranularity` for custom range
 
-    func test_siteVisitStatsGranularity_for_dates_with_days_difference_greater_than_365() {
+    func test_siteVisitStatsGranularity_for_dates_with_days_difference_greater_than_3_years() {
         // Given
         // GMT: Saturday, February 1, 2020 12:29:29 AM
         let fromDate = Date(timeIntervalSince1970: 1580516969)
-        let toDate = fromDate.addingDays(366)
+        let toDate = fromDate.addingDays(365*3+1)
 
         // When
         let range: StatsTimeRangeV4 = .custom(from: fromDate, to: toDate)
 
         // Then
-        XCTAssertEqual(range.siteVisitStatsGranularity, .quarter)
+        XCTAssertEqual(range.siteVisitStatsGranularity, .year)
     }
 
-    func test_siteVisitStatsGranularity_for_dates_with_days_difference_from_91_to_365() {
+    func test_siteVisitStatsGranularity_for_dates_with_days_difference_from_91_to_3_years() {
         // Given
         // GMT: Saturday, February 1, 2020 12:29:29 AM
         let fromDate = Date(timeIntervalSince1970: 1580516969)
-        let toDate = fromDate.addingDays(Int.random(in: 91...365))
+        let toDate = fromDate.addingDays(Int.random(in: 91...365*3))
 
         // When
         let range: StatsTimeRangeV4 = .custom(from: fromDate, to: toDate)
@@ -148,24 +148,24 @@ final class StatsTimeRangeTests: XCTestCase {
 
     // MARK: `topEarnerStatsGranularity` for custom range
 
-    func test_topEarnerStatsGranularity_for_dates_with_days_difference_greater_than_365() {
+    func test_topEarnerStatsGranularity_for_dates_with_days_difference_greater_than_3_years() {
         // Given
         // GMT: Saturday, February 1, 2020 12:29:29 AM
         let fromDate = Date(timeIntervalSince1970: 1580516969)
-        let toDate = fromDate.addingDays(366)
+        let toDate = fromDate.addingDays(365*3+1)
 
         // When
         let range: StatsTimeRangeV4 = .custom(from: fromDate, to: toDate)
 
         // Then
-        XCTAssertEqual(range.topEarnerStatsGranularity, .quarter)
+        XCTAssertEqual(range.topEarnerStatsGranularity, .year)
     }
 
-    func test_topEarnerStatsGranularity_for_dates_with_days_difference_from_91_to_365() {
+    func test_topEarnerStatsGranularity_for_dates_with_days_difference_from_91_to_3_years() {
         // Given
         // GMT: Saturday, February 1, 2020 12:29:29 AM
         let fromDate = Date(timeIntervalSince1970: 1580516969)
-        let toDate = fromDate.addingDays(Int.random(in: 91...365))
+        let toDate = fromDate.addingDays(Int.random(in: 91...365*3))
 
         // When
         let range: StatsTimeRangeV4 = .custom(from: fromDate, to: toDate)
@@ -215,24 +215,24 @@ final class StatsTimeRangeTests: XCTestCase {
 
     // MARK: `summaryStatsGranularity` for custom range
 
-    func test_summaryStatsGranularity_for_dates_with_days_difference_greater_than_365() {
+    func test_summaryStatsGranularity_for_dates_with_days_difference_greater_than_3_years() {
         // Given
         // GMT: Saturday, February 1, 2020 12:29:29 AM
         let fromDate = Date(timeIntervalSince1970: 1580516969)
-        let toDate = fromDate.addingDays(366)
+        let toDate = fromDate.addingDays(365*3+1)
 
         // When
         let range: StatsTimeRangeV4 = .custom(from: fromDate, to: toDate)
 
         // Then
-        XCTAssertEqual(range.summaryStatsGranularity, .quarter)
+        XCTAssertEqual(range.summaryStatsGranularity, .year)
     }
 
-    func test_summaryStatsGranularity_for_dates_with_days_difference_from_91_to_365() {
+    func test_summaryStatsGranularity_for_dates_with_days_difference_from_91_to_3_years() {
         // Given
         // GMT: Saturday, February 1, 2020 12:29:29 AM
         let fromDate = Date(timeIntervalSince1970: 1580516969)
-        let toDate = fromDate.addingDays(Int.random(in: 91...365))
+        let toDate = fromDate.addingDays(Int.random(in: 91...365*3))
 
         // When
         let range: StatsTimeRangeV4 = .custom(from: fromDate, to: toDate)


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #12205 
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This PR follows the latest decision [pe5sF9-2ri-p2#comment-3443] to remove the quarter granularity since it's not supported for visit stats. Now, if the custom date range length spans from 91 days to 3 years, we keep the monthly granularity, otherwise, the yearly granularity is used for date ranges longer than 3 years.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
- Enable the feature flag `customRangeInMyStoreAnalytics` and build the app.
- Log in to a store and add a new custom range or edit an existing one to be almost 3 years (e.g: March 1 2021 to Feb 6 2024). Confirm that the monthly granularity is used.
- Update the custom range to 3 years (e.g Feb 1 2021 to Feb 6 2024). Confirm that the yearly granularity is used.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->
Monthly granularity | Yearly granularity
--- | ---
<img src="https://github.com/woocommerce/woocommerce-ios/assets/5533851/fc81d59d-0021-4a3d-9a83-294b513e3a56" width=320 /> | <img src="https://github.com/woocommerce/woocommerce-ios/assets/5533851/a6e882ba-cb53-491d-a54a-fa479bed0eea" width=320 />


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.