### PR TITLE
My Store Analytics: Custom range redacted view information

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Dashboard/Stats v4/StoreStatsAndTopPerformersViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Stats v4/StoreStatsAndTopPerformersViewController.swift
@@ -532,9 +532,8 @@ private extension StoreStatsAndTopPerformersViewController {
 
         var siteVisitStatsMode: SiteVisitStatsMode
         if site.isJetpackConnected && site.isJetpackThePluginInstalled {
-            siteVisitStatsMode = StatsTimeRangeV4.differenceInDays(startDate: startDate, endDate: endDate) == .lessThan2
-                ? .default
-                : .redactedDueToCustomRange
+            let differenceInDay = StatsTimeRangeV4.differenceInDays(startDate: startDate, endDate: endDate)
+            siteVisitStatsMode = differenceInDay == .lessThan2 ? .default : .redactedDueToCustomRange
         } else if site.isJetpackCPConnected {
             siteVisitStatsMode = .redactedDueToJetpack
         } else {

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Stats v4/StoreStatsV4PeriodViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Stats v4/StoreStatsV4PeriodViewController.swift
@@ -552,7 +552,7 @@ private extension StoreStatsV4PeriodViewController {
             }
 
             if differenceInDays == .lessThan2 {
-                siteVisitStatsMode = selectedIndex != nil ? .redactedDueToCustomRange : .default
+                siteVisitStatsMode = selectedIndex != nil ? .hidden : .default
             } else {
                 siteVisitStatsMode = selectedIndex != nil ? .default : .redactedDueToCustomRange
             }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Stats v4/StoreStatsV4PeriodViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Stats v4/StoreStatsV4PeriodViewController.swift
@@ -544,9 +544,18 @@ private extension StoreStatsV4PeriodViewController {
     func updateUI(selectedBarIndex selectedIndex: Int?) {
 
         if unavailableVisitStatsDueToCustomRange {
-            // If selected, we should display the data, since it's accurate for individual values.
-            // If deselected, we should hide the data, as it's inaccurate for the entire range.
-            siteVisitStatsMode = selectedIndex != nil ? .default : .redactedDueToCustomRange
+            // If time range is less than 2 days, redact data when selected and show when deselected.
+            // Otherwise, show data when selected and redact when deselected.
+            guard case let .custom(from, to) = timeRange,
+                  let differenceInDays = StatsTimeRangeV4.differenceInDays(startDate: from, endDate: to) else {
+                return
+            }
+
+            if differenceInDays == .lessThan2 {
+                siteVisitStatsMode = selectedIndex != nil ? .redactedDueToCustomRange : .default
+            } else {
+                siteVisitStatsMode = selectedIndex != nil ? .default : .redactedDueToCustomRange
+            }
         }
 
         viewModel.selectedIntervalIndex = selectedIndex

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Stats v4/StoreStatsV4PeriodViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Stats v4/StoreStatsV4PeriodViewController.swift
@@ -86,6 +86,9 @@ final class StoreStatsV4PeriodViewController: UIViewController {
     ///
     private lazy var placeholderChartsView: ChartPlaceholderView = ChartPlaceholderView.instantiateFromNib()
 
+    /// Information alert for custom range tab redaction
+    ///
+    private lazy var fancyAlert = FancyAlertViewController.makeCustomRangeRedactionInformationAlert()
 
     // MARK: - Computed Properties
 
@@ -358,14 +361,19 @@ private extension StoreStatsV4PeriodViewController {
 
         // Taps
         if timeRange.isCustomTimeRange {
+            fancyAlert.modalPresentationStyle = .custom
+            fancyAlert.transitioningDelegate = AppDelegate.shared.tabBarController
+
             let visitorsTapRecognizer = UITapGestureRecognizer()
             visitorsTapRecognizer.on { [weak self] _ in
-                self?.showCustomRangeRedactionInformation()
+                guard let self else { return }
+                present(fancyAlert, animated: true)
             }
 
             let conversionTapRecognizer = UITapGestureRecognizer()
             conversionTapRecognizer.on { [weak self] _ in
-                self?.showCustomRangeRedactionInformation()
+                guard let self else { return }
+                present(fancyAlert, animated: true)
             }
 
             visitorsStackView.addGestureRecognizer(visitorsTapRecognizer)
@@ -740,13 +748,6 @@ private extension StoreStatsV4PeriodViewController {
         revenueData.textColor = Constants.statsTextColor
         revenueData.adjustsFontSizeToFitWidth = true
         revenueData.accessibilityIdentifier = "revenue-value"
-    }
-
-    @objc func showCustomRangeRedactionInformation() {
-        let fancyAlert = FancyAlertViewController.makeCustomRangeRedactionInformationAlert()
-        fancyAlert.modalPresentationStyle = .custom
-        fancyAlert.transitioningDelegate = AppDelegate.shared.tabBarController
-        present(fancyAlert, animated: true)
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Stats v4/StoreStatsV4PeriodViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Stats v4/StoreStatsV4PeriodViewController.swift
@@ -1,7 +1,7 @@
 import Charts
 import Combine
 import UIKit
-import struct WordPressUI.GhostStyle
+import WordPressUI
 import Yosemite
 import WooFoundation
 
@@ -62,6 +62,8 @@ final class StoreStatsV4PeriodViewController: UIViewController {
     @IBOutlet private weak var noRevenueView: UIView!
     @IBOutlet private weak var noRevenueLabel: UILabel!
     @IBOutlet private weak var timeRangeBarView: StatsTimeRangeBarView!
+    @IBOutlet private weak var visitorsStackView: UIStackView!
+    @IBOutlet private weak var conversionStackView: UIStackView!
 
     private var currencyCode: String {
         return ServiceLocator.currencySettings.symbol(from: ServiceLocator.currencySettings.currencyCode)
@@ -353,6 +355,25 @@ private extension StoreStatsV4PeriodViewController {
 
         // Data
         updateStatsDataToDefaultStyles()
+
+        // Taps
+        if timeRange.isCustomTimeRange {
+            let visitorsTapRecognizer = UITapGestureRecognizer()
+            visitorsTapRecognizer.on { [weak self] _ in
+                self?.showCustomRangeRedactionInformation()
+            }
+
+            let conversionTapRecognizer = UITapGestureRecognizer()
+            conversionTapRecognizer.on { [weak self] _ in
+                self?.showCustomRangeRedactionInformation()
+            }
+
+            visitorsStackView.addGestureRecognizer(visitorsTapRecognizer)
+            visitorsStackView.isUserInteractionEnabled = true
+
+            conversionStackView.addGestureRecognizer(conversionTapRecognizer)
+            conversionStackView.isUserInteractionEnabled = true
+        }
 
         // Accessibility elements
         xAxisAccessibilityView.isAccessibilityElement = true
@@ -719,6 +740,13 @@ private extension StoreStatsV4PeriodViewController {
         revenueData.textColor = Constants.statsTextColor
         revenueData.adjustsFontSizeToFitWidth = true
         revenueData.accessibilityIdentifier = "revenue-value"
+    }
+
+    @objc func showCustomRangeRedactionInformation() {
+        let fancyAlert = FancyAlertViewController.makeCustomRangeRedactionInformationAlert()
+        fancyAlert.modalPresentationStyle = .custom
+        fancyAlert.transitioningDelegate = AppDelegate.shared.tabBarController
+        present(fancyAlert, animated: true)
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Stats v4/StoreStatsV4PeriodViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Stats v4/StoreStatsV4PeriodViewController.swift
@@ -85,7 +85,7 @@ final class StoreStatsV4PeriodViewController: UIViewController {
     // To check whether the tab is showing the visitors and conversion views as redacted for custom range.
     // This redaction is only shown on Custom Range tab with WordPress.com or Jetpack connected sites,
     // while Jetpack CP sites has its own redacted for Jetpack state, and non-Jetpack sites simply has them empty.
-    private var isRedactedForCustomRangeShown: Bool {
+    private var unavailableVisitStatsDueToCustomRange: Bool {
         guard timeRange.isCustomTimeRange,
               let site = stores.sessionManager.defaultSite,
               site.isJetpackConnected,
@@ -373,7 +373,7 @@ private extension StoreStatsV4PeriodViewController {
         updateStatsDataToDefaultStyles()
 
         // Taps
-        if isRedactedForCustomRangeShown {
+        if unavailableVisitStatsDueToCustomRange {
             fancyAlert.modalPresentationStyle = .custom
             fancyAlert.transitioningDelegate = AppDelegate.shared.tabBarController
 
@@ -539,7 +539,7 @@ private extension StoreStatsV4PeriodViewController {
     /// - Parameter selectedIndex: the index of interval data for the bar chart. Nil if no bar is selected.
     func updateUI(selectedBarIndex selectedIndex: Int?) {
 
-        if isRedactedForCustomRangeShown {
+        if unavailableVisitStatsDueToCustomRange {
             // If selected, we should display the data, since it's accurate for individual values.
             // If deselected, we should hide the data, as it's inaccurate for the entire range.
             siteVisitStatsMode = selectedIndex != nil ? .default : .redactedDueToCustomRange

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Stats v4/StoreStatsV4PeriodViewController.xib
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Stats v4/StoreStatsV4PeriodViewController.xib
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="21507" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="22505" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina4_7" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="21505"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="22504"/>
         <capability name="Named colors" minToolsVersion="9.0"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
@@ -15,6 +15,7 @@
                 <outlet property="chartAccessibilityView" destination="NEo-bw-gS4" id="Ep1-tI-L3J"/>
                 <outlet property="containerStackView" destination="0he-5g-kXa" id="ni7-uB-XHh"/>
                 <outlet property="conversionDataOrRedactedView" destination="IWE-Kh-JF2" id="gdN-hN-du3"/>
+                <outlet property="conversionStackView" destination="EqQ-GQ-06J" id="FJE-gy-fzW"/>
                 <outlet property="conversionTitle" destination="Sam-pk-BxI" id="HI1-z6-dRL"/>
                 <outlet property="lineChartView" destination="zPE-Y0-ax8" id="3VU-s1-JmV"/>
                 <outlet property="noRevenueLabel" destination="5uh-zy-gDZ" id="ZRx-lP-Af2"/>
@@ -26,6 +27,7 @@
                 <outlet property="timeRangeBarView" destination="8nR-qE-vPw" id="vbk-sJ-3jq"/>
                 <outlet property="view" destination="Wvk-wb-yYI" id="EXC-1a-66J"/>
                 <outlet property="visitorsDataOrRedactedView" destination="Afo-HD-3TZ" id="7p2-EZ-KAi"/>
+                <outlet property="visitorsStackView" destination="e8D-G2-abm" id="T3r-Ny-JXA"/>
                 <outlet property="visitorsTitle" destination="rHw-ak-fRR" id="VJk-10-Z09"/>
                 <outlet property="xAxisAccessibilityView" destination="TTF-Fx-NHe" id="cdX-lJ-DWe"/>
                 <outlet property="yAxisAccessibilityView" destination="yvj-Kj-G3f" id="MRf-C4-jUk"/>
@@ -37,7 +39,7 @@
             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
             <subviews>
                 <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="0he-5g-kXa">
-                    <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
+                    <rect key="frame" x="0.0" y="20" width="375" height="647"/>
                     <subviews>
                         <view contentMode="scaleToFill" verticalCompressionResistancePriority="1000" ambiguous="YES" translatesAutoresizingMaskIntoConstraints="NO" id="8nR-qE-vPw" customClass="StatsTimeRangeBarView" customModule="WooCommerce" customModuleProvider="target">
                             <rect key="frame" x="0.0" y="0.0" width="375" height="50"/>
@@ -47,19 +49,19 @@
                             </constraints>
                         </view>
                         <stackView opaque="NO" contentMode="scaleToFill" ambiguous="YES" translatesAutoresizingMaskIntoConstraints="NO" id="15r-Bq-Hy6">
-                            <rect key="frame" x="0.0" y="50" width="375" height="302"/>
+                            <rect key="frame" x="0.0" y="50" width="375" height="282"/>
                             <subviews>
                                 <stackView opaque="NO" contentMode="scaleToFill" ambiguous="YES" axis="vertical" spacing="4" translatesAutoresizingMaskIntoConstraints="NO" id="VzI-74-cyb">
-                                    <rect key="frame" x="0.0" y="0.0" width="375" height="302"/>
+                                    <rect key="frame" x="0.0" y="0.0" width="375" height="282"/>
                                     <subviews>
                                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" verticalCompressionResistancePriority="1000" ambiguous="YES" text="-" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="5id-es-0m9" userLabel="-">
-                                            <rect key="frame" x="0.0" y="0.0" width="375" height="257"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="375" height="237"/>
                                             <fontDescription key="fontDescription" style="UICTFontTextStyleTitle0"/>
                                             <nil key="textColor"/>
                                             <nil key="highlightedColor"/>
                                         </label>
                                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" verticalCompressionResistancePriority="1000" ambiguous="YES" text="Revenue" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="L2i-fw-est" userLabel="Revenue">
-                                            <rect key="frame" x="0.0" y="261" width="375" height="41"/>
+                                            <rect key="frame" x="0.0" y="241" width="375" height="41"/>
                                             <fontDescription key="fontDescription" style="UICTFontTextStyleTitle0"/>
                                             <nil key="textColor"/>
                                             <nil key="highlightedColor"/>
@@ -69,7 +71,7 @@
                             </subviews>
                         </stackView>
                         <stackView opaque="NO" contentMode="scaleToFill" ambiguous="YES" distribution="fillEqually" spacing="-1" translatesAutoresizingMaskIntoConstraints="NO" id="PkT-rJ-Rn6">
-                            <rect key="frame" x="0.0" y="352" width="375" height="123"/>
+                            <rect key="frame" x="0.0" y="332" width="375" height="123"/>
                             <subviews>
                                 <stackView opaque="NO" contentMode="scaleToFill" ambiguous="YES" axis="vertical" alignment="center" spacing="7" translatesAutoresizingMaskIntoConstraints="NO" id="g0M-FH-Icp">
                                     <rect key="frame" x="0.0" y="0.0" width="125.5" height="123"/>
@@ -165,7 +167,7 @@
                             <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                         </stackView>
                         <stackView opaque="NO" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="3LG-lq-6W2">
-                            <rect key="frame" x="0.0" y="475" width="375" height="175"/>
+                            <rect key="frame" x="0.0" y="455" width="375" height="175"/>
                             <subviews>
                                 <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="bHo-ih-qrA">
                                     <rect key="frame" x="0.0" y="0.0" width="14" height="175"/>
@@ -241,7 +243,7 @@
                             </subviews>
                         </stackView>
                         <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="8Ra-EQ-KPf" userLabel="Spacer View">
-                            <rect key="frame" x="0.0" y="650" width="375" height="17"/>
+                            <rect key="frame" x="0.0" y="630" width="375" height="17"/>
                             <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                             <constraints>
                                 <constraint firstAttribute="height" constant="17" id="dH2-Fd-IgS"/>

--- a/WooCommerce/Classes/ViewRelated/Fancy Alerts/FancyAlertViewController+Stats.swift
+++ b/WooCommerce/Classes/ViewRelated/Fancy Alerts/FancyAlertViewController+Stats.swift
@@ -34,14 +34,14 @@ private extension FancyAlertViewController {
 
         static let redactionInfoTitle = NSLocalizedString(
             "fancyAlertViewControllerStats.redactionInfoTitle",
-            value: "Visitors and Conversion data not available",
+            value: "Visitors and conversion data not available",
             comment: "Title for redaction information alert in Custom Range stats tab"
         )
 
         static let redactionInfoDescription = NSLocalizedString(
             "fancyAlertViewControllerStats.redactionInfoDescription",
             value: "The stats feature does not support the display of visitors and conversions data for arbitrary date ranges. "
-            + "However, you can tap a value on the graph to see visitors and conversions for that specific range.",
+            + "\n\nHowever, you can tap a value on the graph to see visitors and conversions for that specific range.",
             comment: "Description for redaction information alert in Custom Range stats tab"
         )
     }

--- a/WooCommerce/Classes/ViewRelated/Fancy Alerts/FancyAlertViewController+Stats.swift
+++ b/WooCommerce/Classes/ViewRelated/Fancy Alerts/FancyAlertViewController+Stats.swift
@@ -1,0 +1,48 @@
+import WordPressUI
+
+extension FancyAlertViewController {
+    static func makeCustomRangeRedactionInformationAlert() -> FancyAlertViewController {
+        let dismissButton = makeDismissButtonConfig()
+        let config = FancyAlertViewController.Config(titleText: Localization.redactionInfoTitle,
+                                                     bodyText: Localization.redactionInfoDescription,
+                                                     headerImage: nil,
+                                                     dividerPosition: .top,
+                                                     defaultButton: dismissButton,
+                                                     cancelButton: nil,
+                                                     dismissAction: {})
+
+        let controller = FancyAlertViewController.controllerWithConfiguration(configuration: config)
+        return controller
+    }
+}
+
+private extension FancyAlertViewController {
+    static func makeDismissButtonConfig() -> FancyAlertViewController.Config.ButtonConfig {
+        return FancyAlertViewController.Config.ButtonConfig(Localization.dismissButton) { controller, _ in
+            controller.dismiss(animated: true)
+        }
+    }
+}
+
+private extension FancyAlertViewController {
+    enum Localization {
+        static let dismissButton = NSLocalizedString(
+            "fancyAlertViewControllerStats.dismissButton",
+            value: "OK",
+            comment: "Title of dismiss button for redaction information alert in Custom Range stats tab"
+        )
+
+        static let redactionInfoTitle = NSLocalizedString(
+            "fancyAlertViewControllerStats.redactionInfoTitle",
+            value: "Visitors and Conversion data not available",
+            comment: "Title for redaction information alert in Custom Range stats tab"
+        )
+
+        static let redactionInfoDescription = NSLocalizedString(
+            "fancyAlertViewControllerStats.redactionInfoDescription",
+            value: "The stats feature does not support the display of visitors and conversions data for arbitrary date ranges. "
+            + "However, you can tap a value on the graph to see visitors and conversions for that specific range.",
+            comment: "Description for redaction information alert in Custom Range stats tab"
+        )
+    }
+}

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -1495,6 +1495,7 @@
 		80ECB4E229D2A51A00C62EEC /* ProductFilterScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80ECB4E129D2A51A00C62EEC /* ProductFilterScreen.swift */; };
 		80F9176D2A28638C00890A83 /* products_add_new_grouped_2130.json in Resources */ = {isa = PBXBuildFile; fileRef = 80F9176C2A28638C00890A83 /* products_add_new_grouped_2130.json */; };
 		8194A48313C34FE1782D51BC /* Pods_StoreWidgetsExtension.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 2886DE5218EEA78ABAF0BE67 /* Pods_StoreWidgetsExtension.framework */; };
+		8601C29A2B9769C200C59D93 /* FancyAlertViewController+Stats.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8601C2992B9769C200C59D93 /* FancyAlertViewController+Stats.swift */; };
 		86023FAA2B15CAD800A28F07 /* ThemesEligibilityUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 86023FA92B15CAD800A28F07 /* ThemesEligibilityUseCase.swift */; };
 		86023FAD2B16D83000A28F07 /* ThemeEligibilityUseCaseTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 86023FAC2B16D83000A28F07 /* ThemeEligibilityUseCaseTests.swift */; };
 		86023FB12B199F6200A28F07 /* ThemesCarouselView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 86023FB02B199F6200A28F07 /* ThemesCarouselView.swift */; };
@@ -4187,6 +4188,7 @@
 		80E7E7F22AF4AD3E00AA52D3 /* AddCustomerDetailsScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddCustomerDetailsScreen.swift; sourceTree = "<group>"; };
 		80ECB4E129D2A51A00C62EEC /* ProductFilterScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductFilterScreen.swift; sourceTree = "<group>"; };
 		80F9176C2A28638C00890A83 /* products_add_new_grouped_2130.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = products_add_new_grouped_2130.json; sourceTree = "<group>"; };
+		8601C2992B9769C200C59D93 /* FancyAlertViewController+Stats.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "FancyAlertViewController+Stats.swift"; sourceTree = "<group>"; };
 		86023FA92B15CAD800A28F07 /* ThemesEligibilityUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ThemesEligibilityUseCase.swift; sourceTree = "<group>"; };
 		86023FAC2B16D83000A28F07 /* ThemeEligibilityUseCaseTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ThemeEligibilityUseCaseTests.swift; sourceTree = "<group>"; };
 		86023FB02B199F6200A28F07 /* ThemesCarouselView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ThemesCarouselView.swift; sourceTree = "<group>"; };
@@ -8489,6 +8491,7 @@
 				743E271F21AEF20100D6DC82 /* FancyAlertViewController+Upgrade.swift */,
 				CE0F17D122A8308900964A63 /* FancyAlertController+PurchaseNote.swift */,
 				D8610CE1257099E100A5DF27 /* FancyAlertViewController+UnifiedLogin.swift */,
+				8601C2992B9769C200C59D93 /* FancyAlertViewController+Stats.swift */,
 			);
 			path = "Fancy Alerts";
 			sourceTree = "<group>";
@@ -14283,6 +14286,7 @@
 				B9F3DAAF29BB73CD00DDD545 /* CreateOrderAppIntent.swift in Sources */,
 				AEDDDA0A25CA9C980077F9B2 /* AttributePickerViewController.swift in Sources */,
 				7E7C5F862719A93C00315B61 /* ProductCategoryViewModelBuilder.swift in Sources */,
+				8601C29A2B9769C200C59D93 /* FancyAlertViewController+Stats.swift in Sources */,
 				EE5A0A1C2A6908A800DA5926 /* WooAnalyticsEvent+LocalNotification.swift in Sources */,
 				02E3B63129066858007E0F13 /* StoreCreationCoordinator.swift in Sources */,
 				B554E1792152F20000F31188 /* UINavigationBar+Appearance.swift in Sources */,

--- a/Yosemite/Yosemite/Model/Enums/StatsTimeRangeV4.swift
+++ b/Yosemite/Yosemite/Model/Enums/StatsTimeRangeV4.swift
@@ -257,7 +257,7 @@ extension StatsTimeRangeV4 {
     }
 }
 
-private extension StatsTimeRangeV4 {
+public extension StatsTimeRangeV4 {
     enum DifferenceInDays {
         case greaterThan3Years
         case from91daysTo3Years


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #12162
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

This PR adds an informational alert to explain why visitors and conversion information are redacted from custom range tab.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

1. Start with a WordPress.com or Jetpack-connected site,
2. On the analytics area on My Store, go to the Custom Range tab. If you don't have a Custom Range tab, make one first using the calendar-plus icon,
3. When the Custom Range tab, confirm that the Visitors and Conversion area at the top (below revenue) is redacted,
4. Tap the redacted view for both Visitors and Conversion, and ensure the alert like on the screenshot below is shown.
5. Select a value in the graph, so that now Visitors and Conversion is showing some number. Tap them, ensure the alert is not shown.
6. Switch to a Jetpack CP site,
7. Tap the redacted view for both Visitors and Conversion, and ensure the alert is not shown.
8. Switch to a non-Jetpack site,
9. Tap the view for both Visitors and Conversion, and ensure the alert is not shown.

## screenshot & video
<!-- Include before and after images or gifs when appropriate. -->

<img src="https://github.com/woocommerce/woocommerce-ios/assets/266376/c714a314-5b8b-4f95-94e9-169aad88abe5" width="42%" /> 

https://github.com/woocommerce/woocommerce-ios/assets/266376/950ab306-bdbf-4d81-986a-cdb60946b297  


---

### Additional case: handling for less than 2 days custom range.

When custom date range is in less than 2 days, we want to add this behavior:
1. When custom range is first created (in deselected state), show visits data.
2. When a value is selected, then hide visits data.
3. When a value is deselected, again show the visits data.

To test this:
1. Create a custom date range that is only 1 day apart,
2. When created, ensure that Visitors and Conversion are showing value.
3. Select a value in the graph, ensure that Visitors and Conversion are now redacted (simple redaction state).
4. Deselect the value, ensure that Visitors and Conversion are now shown again.
5. Update custom range to be 2 days apart,
6. When created, ensure that Visitors and Conversion are redacted (redacted due to custom range state),
7. Select a value in the graph, ensure that Visitors and Conversion are now shown.
8. Deselect the value, ensure that Visitors and Conversion are now redacted again.

Check video below for example:


https://github.com/woocommerce/woocommerce-ios/assets/266376/f23ff7ba-d019-49f7-8263-f1cddbd1bdd8



 
