### PR TITLE
[Product images] Use `weak self` to access `productUIImageLoader`

### DIFF
--- a/WooCommerce/Classes/Model/ReviewAge.swift
+++ b/WooCommerce/Classes/Model/ReviewAge.swift
@@ -25,31 +25,15 @@ extension ReviewAge {
     /// Returns the Age entity that best describes a given timespan.
     ///
     static func from(startDate: Date, toDate: Date) -> ReviewAge {
-        let components = [.day, .weekOfYear, .month] as Set<Calendar.Component>
-        let dateComponents = Calendar.current.dateComponents(components, from: startDate, to: toDate)
+        let timeDifference = toDate.timeIntervalSince(startDate)
+        let oneDayInSeconds: TimeInterval = 86_400
 
-        // Months
-        if let month = dateComponents.month, month >= 1 {
-            return .theRest
-        }
-
-        // Weeks
-        if let week = dateComponents.weekOfYear, week >= 1 {
-            return .theRest
-        }
-
-        // Days
-        if let day = dateComponents.day,
-            let week = dateComponents.weekOfYear,
-            day > 1,
-            week <= 1 {
-            return .last7Days
-        }
-
-        if let day = dateComponents.day, day == 1 {
+        if timeDifference <= oneDayInSeconds { // 24hrs
             return .last24Hours
+        } else if timeDifference <= oneDayInSeconds * 7 { // 7 days
+            return .last7Days
+        } else {
+            return .theRest
         }
-
-        return .last24Hours
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Products/Cells/Product Images/ProductImagesCollectionViewDataSource.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Cells/Product Images/ProductImagesCollectionViewDataSource.swift
@@ -69,8 +69,8 @@ private extension ProductImagesCollectionViewDataSource {
 
         cell.imageView.contentMode = .center
         cell.imageView.image = .productsTabProductCellPlaceholderImage
-        cell.cancellableTask = Task { @MainActor [weak cell] in
-            guard let image = try? await productUIImageLoader.requestImage(productImage: productImage) else {
+        cell.cancellableTask = Task { @MainActor [weak self, weak cell] in
+            guard let image = try? await self?.productUIImageLoader.requestImage(productImage: productImage) else {
                 return
             }
 

--- a/WooCommerce/WooCommerceTests/Tools/ReviewAgeTests.swift
+++ b/WooCommerce/WooCommerceTests/Tools/ReviewAgeTests.swift
@@ -2,6 +2,8 @@ import XCTest
 @testable import WooCommerce
 
 final class ReviewAgeTests: XCTestCase {
+    private let oneDayInSeconds: TimeInterval = 86_400
+
     func testDescriptionReturnsExpectationFor24Hours() {
         let age = ReviewAge(rawValue: "0")
 
@@ -26,7 +28,7 @@ final class ReviewAgeTests: XCTestCase {
     func testAgeCalculationsReturnLast24HoursAgeFor12Hours() {
         let initialDate = Date()
         // Let's move the clock 12 hours ahead
-        let finalDate = Date(timeInterval: 43200, since: initialDate)
+        let finalDate = Date(timeInterval: oneDayInSeconds/2, since: initialDate)
 
         let age = ReviewAge.from(startDate: initialDate, toDate: finalDate)
 
@@ -36,17 +38,7 @@ final class ReviewAgeTests: XCTestCase {
     func testAgeCalculationsReturnLast24HoursAgeFor23Hours() {
         let initialDate = Date()
         // Let's move the clock 23:59:59 hours ahead
-        let finalDate = Date(timeInterval: 84399, since: initialDate)
-
-        let age = ReviewAge.from(startDate: initialDate, toDate: finalDate)
-
-        XCTAssertEqual(age, .last24Hours)
-    }
-
-    func testAgeCalculationsReturnLast24HoursAgeFor24HoursAnd1Second() {
-        let initialDate = Date()
-        // Let's move the clock 24:00:01 hours ahead
-        let finalDate = Date(timeInterval: 84461, since: initialDate)
+        let finalDate = Date(timeInterval: oneDayInSeconds - 1, since: initialDate)
 
         let age = ReviewAge.from(startDate: initialDate, toDate: finalDate)
 
@@ -56,7 +48,7 @@ final class ReviewAgeTests: XCTestCase {
     func testAgeCalculationsReturnLast7DaysAgeForThreeDays() {
         let initialDate = Date()
         // Let's move the clock three days ahead
-        let finalDate = Date(timeInterval: 259200, since: initialDate)
+        let finalDate = Date(timeInterval: oneDayInSeconds * 3, since: initialDate)
 
         let age = ReviewAge.from(startDate: initialDate, toDate: finalDate)
 
@@ -66,7 +58,7 @@ final class ReviewAgeTests: XCTestCase {
     func testAgeCalculationsReturnLast7DaysAgeForAlmostSevenFullDays() {
         let initialDate = Date()
         // Let's move the clock almost seven full days ahead
-        let finalDate = Date(timeInterval: 604760, since: initialDate)
+        let finalDate = Date(timeInterval: oneDayInSeconds * 7 - 1, since: initialDate)
 
         let age = ReviewAge.from(startDate: initialDate, toDate: finalDate)
 
@@ -76,7 +68,7 @@ final class ReviewAgeTests: XCTestCase {
     func testAgeCalculationsReturnLastOlderForMoreThanSevenFullDays() {
         let initialDate = Date()
         // Let's move the clock a tad longer than seven full days ahead
-        let finalDate = Date(timeInterval: 691300, since: initialDate)
+        let finalDate = Date(timeInterval: oneDayInSeconds * 7 + 1, since: initialDate)
 
         let age = ReviewAge.from(startDate: initialDate, toDate: finalDate)
 


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #12220 
<!-- Id number of the GitHub issue this PR addresses. -->

## Description

#### What? 

As part of the cache product images work (#11902 ), we added a`Task` to the `ProductImagesCollectionViewDataSource.configureRemoteImageCell` method. From inside the `Task` we access `productUIImageLoader` to request product image for the cell asynchronously. 

Sentry reports an `EXC_BAD_ACCESS` crash in line `ProductImagesCollectionViewDataSource.configureRemoteImageCell`. 
Internal - peaMlT-t4-p2

Upon inspecting the code, I guess `EXC_BAD_ACCESS` error is happens because of accessing `productUIImageLoader` after self deallocation. 

I tried reproducing this crash by navigating back from the product form while uploading images. I also tried turning on the `Thread Sanitizer` and tested product image uploads. I couldn't reproduce the crash. 

To prevent a strong reference to `productUIImageLoader`, I have used a `weak self` reference to access `productUIImageLoader`. 

#### Why? 

Using `weak self` will prevent the Task from accessing `productUIImageLoader` after `ProductImagesCollectionViewDataSource` is deallocated. 

#### How?

Add `weak self` to the capture list of `cell.cancellableTask = Task { @MainActor` and use weakly captured self to access `productUIImageLoader` from inside the `Task`.

## Testing instructions

Since I cannot reproduce the crash I don't have solid steps to test. We need to test that product image upload works as expected.

- Create a JN site
- Add a few products with many images
- Login into the app
- Open the products tab and open product and ensure that product images can be viewed as before.
- Try adding/removing product images and validate that it works as before.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

https://github.com/woocommerce/woocommerce-ios/assets/524475/703ab254-c616-4d8d-b717-2e23c8df7494


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.