### PR TITLE
[Better Error] Properly identify invalid credential errors

### DIFF
--- a/WooCommerce/Classes/Authentication/Application Password/ApplicationPasswordTutorialViewModel.swift
+++ b/WooCommerce/Classes/Authentication/Application Password/ApplicationPasswordTutorialViewModel.swift
@@ -21,6 +21,8 @@ struct ApplicationPasswordTutorialViewModel {
         case .inaccessibleLoginPage, .inaccessibleAdminPage, .unacceptableStatusCode:
             return NSLocalizedString("This is likely because your store has some extra security steps in place.",
                                      comment: "Reason for why the user could not login tin the application password tutorial screen")
+        case .invalidCredentials:
+            return error.localizedDescription
         }
     }
 }

--- a/WooCommerce/Classes/Authentication/AuthenticationManager.swift
+++ b/WooCommerce/Classes/Authentication/AuthenticationManager.swift
@@ -359,9 +359,9 @@ extension AuthenticationManager: WordPressAuthenticatorDelegate {
             return
         }
 
-        let isSiteCredentialError = {
+        let isAppPasswordAuthError = {
             switch error {
-            case SiteCredentialLoginError.genericFailure:
+            case SiteCredentialLoginError.genericFailure, SiteCredentialLoginError.invalidCredentials:
                 return false
             case is SiteCredentialLoginError:
                 return true
@@ -370,8 +370,8 @@ extension AuthenticationManager: WordPressAuthenticatorDelegate {
             }
         }()
 
-        // Only show the tutorial if the error is a real site credential error
-        if featureFlagService.isFeatureFlagEnabled(.appPasswordTutorial) && isSiteCredentialError {
+        // Only show the tutorial if the error can be solved by the app password flow.
+        if featureFlagService.isFeatureFlagEnabled(.appPasswordTutorial) && isAppPasswordAuthError {
             presentAppPasswordTutorial(error: error, for: siteURL, in: viewController)
         } else {
             presentAppPasswordAlert(error: error, for: siteURL, in: viewController)

--- a/WooCommerce/Classes/Authentication/SiteCredentialLoginUseCase.swift
+++ b/WooCommerce/Classes/Authentication/SiteCredentialLoginUseCase.swift
@@ -302,9 +302,9 @@ private extension String {
         }
     }
 
-    /// When logging with with site credentials there is not way to properly tell if an error message is an invalid credentials error.
-    /// However, the server injects this `shake` patten when an invalid credential error is found.
-    /// For the time being we will use that pattern as a guess for an invalid credential error message.
+    /// When logging in with site credentials there is no way to properly tell if an error message is an invalid credentials error.
+    /// However, the server injects this `shake` pattern when an invalid credential error is found.
+    /// For the time being, we will use that pattern as a guess for an invalid credential error message.
     /// ref: https://github.com/WordPress/WordPress/blob/master/wp-login.php#L65-L67
     ///
     func hasInvalidCredentialsPattern() -> Bool {

--- a/WooCommerce/Classes/Authentication/SiteCredentialLoginUseCase.swift
+++ b/WooCommerce/Classes/Authentication/SiteCredentialLoginUseCase.swift
@@ -59,7 +59,7 @@ enum SiteCredentialLoginError: LocalizedError {
         case .invalidLoginResponse:
             return Localization.invalidLoginResponse
         case .invalidCredentials:
-            return Localization.invalidLoginResponse
+            return Localization.invalidCredentials
         case .loginFailed(let message):
             return message
         case .unacceptableStatusCode(let code):

--- a/WooCommerce/Classes/Authentication/SiteCredentialLoginUseCase.swift
+++ b/WooCommerce/Classes/Authentication/SiteCredentialLoginUseCase.swift
@@ -9,6 +9,7 @@ protocol SiteCredentialLoginProtocol {
 
 enum SiteCredentialLoginError: LocalizedError {
     static let errorDomain = "SiteCredentialLogin"
+    case invalidCredentials
     case loginFailed(message: String)
     case invalidLoginResponse
     case inaccessibleLoginPage
@@ -23,6 +24,7 @@ enum SiteCredentialLoginError: LocalizedError {
         case .inaccessibleLoginPage,
              .inaccessibleAdminPage,
              .invalidLoginResponse,
+             .invalidCredentials,
              .loginFailed,
              .unacceptableStatusCode:
             return NSError(domain: Self.errorDomain, code: errorCode, userInfo: [NSLocalizedDescriptionKey: errorMessage])
@@ -38,6 +40,8 @@ enum SiteCredentialLoginError: LocalizedError {
         case .invalidLoginResponse:
             return -1
         case .loginFailed:
+            return 403
+        case .invalidCredentials:
             return 401
         case .unacceptableStatusCode(let code):
             return code
@@ -53,6 +57,8 @@ enum SiteCredentialLoginError: LocalizedError {
         case .inaccessibleAdminPage:
             return Localization.inaccessibleAdminPage
         case .invalidLoginResponse:
+            return Localization.invalidLoginResponse
+        case .invalidCredentials:
             return Localization.invalidLoginResponse
         case .loginFailed(let message):
             return message
@@ -83,6 +89,10 @@ enum SiteCredentialLoginError: LocalizedError {
         static let unacceptableStatusCode = NSLocalizedString(
             "Unable to login with response status code %1$d.",
             comment: "Error message explaining login failure due to unacceptable status code."
+        )
+        static let invalidCredentials = NSLocalizedString(
+            "It seems the username or password you entered doesn't quite match. Double-check your credentials and try again.",
+            comment: "Error message explaining login failure due to invalid credentials."
         )
     }
 }
@@ -156,6 +166,9 @@ private extension SiteCredentialLoginUseCase {
         case 200:
             guard let html = String(data: data, encoding: .utf8) else {
                 throw SiteCredentialLoginError.invalidLoginResponse
+            }
+            if html.hasInvalidCredentialsPattern() {
+                throw SiteCredentialLoginError.invalidCredentials
             }
             if let errorMessage = html.findLoginErrorMessage() {
                 throw SiteCredentialLoginError.loginFailed(message: errorMessage)
@@ -287,5 +300,14 @@ private extension String {
             DDLogError("⚠️" + pattern + "<-- not found in string -->" + self )
             return nil
         }
+    }
+
+    /// When logging with with site credentials there is not way to properly tell if an error message is an invalid credentials error.
+    /// However, the server injects this `shake` patten when an invalid credential error is found.
+    /// For the time being we will use that pattern as a guess for an invalid credential error message.
+    /// ref: https://github.com/WordPress/WordPress/blob/master/wp-login.php#L65-L67
+    ///
+    func hasInvalidCredentialsPattern() -> Bool {
+        contains("document.querySelector('form').classList.add('shake')")
     }
 }


### PR DESCRIPTION
Closes: #12172 

# Why

This PR tries to identify invalid credential errors when logging in with site credentials, in order to not navigate the user to the app password tutorial when is not really needed.

# How

When logging in with site credentials there is no way to properly tell if an error message is an invalid credentials error.
However, the server injects a `shake` pattern when an invalid credential error is found.

For the time being, we will use that pattern as a guess for an invalid credential error message.

https://github.com/WordPress/WordPress/blob/master/wp-login.php#L65-L67

# Demo

https://github.com/woocommerce/woocommerce-ios/assets/562080/e61b12b9-dd92-414c-96fd-caa9a83450a6

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
