### PR TITLE
My Store Analytics: Remove hour granularity for site visit stats and calculate quantity manually

### DIFF
--- a/Networking/Networking/Model/Stats/StatGranularity.swift
+++ b/Networking/Networking/Model/Stats/StatGranularity.swift
@@ -8,5 +8,4 @@ public enum StatGranularity: String, Decodable, GeneratedFakeable {
     case week
     case month
     case year
-    case hour
 }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Stats v4/StoreStatsPeriodViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Stats v4/StoreStatsPeriodViewModel.swift
@@ -319,6 +319,15 @@ private extension StoreStatsPeriodViewModel {
 //
 private extension StoreStatsPeriodViewModel {
     func updateSiteVisitDataIfNeeded() {
+        /// If granularity of site stats and order stats are not equivalent,
+        /// there can be discrepancy between site visit and order stats.
+        /// Hide all site stats in that case.
+        ///
+        guard timeRange.shouldSupportSelectingVisitStats else {
+            siteStats = nil
+            return
+        }
+
         let siteStats = siteStatsResultsController.fetchedObjects.first
         /// When the number of intervals for site visit stats is larger than order stats,
         /// the index of the stats will mismatch causing a discrepancy in data.

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Stats v4/StoreStatsPeriodViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Stats v4/StoreStatsPeriodViewModel.swift
@@ -285,9 +285,11 @@ private extension StoreStatsPeriodViewModel {
     func configureOrderStatsResultsController() {
         orderStatsResultsController.onDidChangeContent = { [weak self] in
             self?.updateOrderDataIfNeeded()
+            self?.updateSiteVisitDataIfNeeded()
         }
         orderStatsResultsController.onDidResetContent = { [weak self] in
             self?.updateOrderDataIfNeeded()
+            self?.updateSiteVisitDataIfNeeded()
         }
         try? orderStatsResultsController.performFetch()
     }
@@ -317,7 +319,24 @@ private extension StoreStatsPeriodViewModel {
 //
 private extension StoreStatsPeriodViewModel {
     func updateSiteVisitDataIfNeeded() {
-        siteStats = siteStatsResultsController.fetchedObjects.first
+        let siteStats = siteStatsResultsController.fetchedObjects.first
+        /// When the number of intervals for site visit stats is larger than order stats,
+        /// the index of the stats will mismatch causing a discrepancy in data.
+        /// Attempting to get only the last x items from site visit stats,
+        /// with x being the number of intervals available from order stats.
+        ///
+        if let orderStats = orderStatsResultsController.fetchedObjects.first,
+           orderStats.intervals.count > 0,
+           let items = siteStats?.items,
+           items.count > orderStats.intervals.count {
+            let sortedItems = items.sorted(by: { (lhs, rhs) -> Bool in
+                return lhs.period < rhs.period
+            })
+            let matchingItems = Array(sortedItems.suffix(orderStats.intervals.count))
+            self.siteStats = siteStats?.copy(items: matchingItems)
+        } else {
+            self.siteStats = siteStats
+        }
     }
 
     func updateSiteSummaryDataIfNeeded() {

--- a/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Stats V4/StoreStatsPeriodViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Stats V4/StoreStatsPeriodViewModelTests.swift
@@ -90,9 +90,35 @@ final class StoreStatsPeriodViewModelTests: XCTestCase {
         XCTAssertEqual(conversionStatsTextValues, ["-"])
     }
 
-    func test_visitorStatsText_is_emitted_after_visitor_stats_updated_and_selecting_interval() {
+    func test_visitorStatsText_is_not_emitted_for_time_range_with_inequivalent_granularities_of_order_and_visit_stats() {
         // Given
         let timeRange: StatsTimeRangeV4 = .today
+        let viewModel = createViewModel(timeRange: timeRange)
+        observeStatsEmittedValues(viewModel: viewModel)
+
+        XCTAssertEqual(orderStatsTextValues, ["-"])
+        XCTAssertEqual(revenueStatsTextValues, ["-"])
+        XCTAssertEqual(visitorStatsTextValues, ["-"])
+        XCTAssertEqual(conversionStatsTextValues, ["-"])
+
+        // When
+        let siteVisitStats = Yosemite.SiteVisitStats.fake().copy(siteID: siteID, items: [ .fake().copy(visitors: 17) ])
+        insertSiteVisitStats(siteVisitStats, timeRange: timeRange)
+
+        XCTAssertEqual(visitorStatsTextValues, ["-"])
+
+        viewModel.selectedIntervalIndex = 0
+
+        // Then
+        XCTAssertEqual(orderStatsTextValues, ["-"])
+        XCTAssertEqual(revenueStatsTextValues, ["-"])
+        XCTAssertEqual(visitorStatsTextValues, ["-"])
+        XCTAssertEqual(conversionStatsTextValues, ["-"])
+    }
+
+    func test_visitorStatsText_is_emitted_for_time_range_with_equivalent_granularities_of_order_and_visit_stats() {
+        // Given
+        let timeRange: StatsTimeRangeV4 = .thisMonth
         let viewModel = createViewModel(timeRange: timeRange)
         observeStatsEmittedValues(viewModel: viewModel)
 
@@ -139,9 +165,35 @@ final class StoreStatsPeriodViewModelTests: XCTestCase {
         XCTAssertEqual(conversionStatsTextValues, ["-", "20%"]) // order count: 3, visitor count: 15 => 0.2 (20%)
     }
 
-    func test_conversionStatsText_is_emitted_after_order_and_visitors_stats_updated_and_selecting_interval() {
+    func test_conversionStatsText_is_not_emitted_for_time_range_with_inequivalent_granularities_of_order_and_visit_stats() {
         // Given
         let timeRange: StatsTimeRangeV4 = .today
+        let viewModel = createViewModel(timeRange: timeRange)
+        observeStatsEmittedValues(viewModel: viewModel)
+
+        // When
+        let siteVisitStats = Yosemite.SiteVisitStats.fake().copy(siteID: siteID, items: [.fake().copy(visitors: 15)])
+        insertSiteVisitStats(siteVisitStats, timeRange: timeRange)
+
+        XCTAssertEqual(conversionStatsTextValues, ["-"])
+
+        let orderStats = OrderStatsV4(siteID: siteID,
+                                      granularity: timeRange.intervalGranularity,
+                                      totals: .fake(),
+                                      intervals: [ .fake().copy(subtotals: .fake().copy(totalOrders: 3, grossRevenue: 62.7)) ])
+        insertOrderStats(orderStats, timeRange: timeRange)
+
+        XCTAssertEqual(conversionStatsTextValues, ["-"])
+
+        viewModel.selectedIntervalIndex = 0
+
+        // Then
+        XCTAssertEqual(conversionStatsTextValues, ["-"])
+    }
+
+    func test_conversionStatsText_is_emitted_for_time_range_with_equivalent_granularities_of_order_and_visit_stats() {
+        // Given
+        let timeRange: StatsTimeRangeV4 = .thisMonth
         let viewModel = createViewModel(timeRange: timeRange)
         observeStatsEmittedValues(viewModel: viewModel)
 

--- a/Yosemite/Yosemite/Model/Enums/StatsTimeRangeV4.swift
+++ b/Yosemite/Yosemite/Model/Enums/StatsTimeRangeV4.swift
@@ -242,6 +242,19 @@ extension StatsTimeRangeV4 {
             }
         }
     }
+
+    /// If granularity of site stats and order stats are not equivalent,
+    /// there can be discrepancy between site visit and order stats.
+    /// Selecting visit stats is not supported in that case.
+    ///
+    public var shouldSupportSelectingVisitStats: Bool {
+        switch (intervalGranularity, siteVisitStatsGranularity) {
+        case (.daily, .day), (.weekly, .week), (.monthly, .month), (.yearly, .year):
+            return true
+        default:
+            return false
+        }
+    }
 }
 
 private extension StatsTimeRangeV4 {

--- a/Yosemite/Yosemite/Model/Mocks/MockObjectGraph.swift
+++ b/Yosemite/Yosemite/Model/Mocks/MockObjectGraph.swift
@@ -460,7 +460,6 @@ extension MockObjectGraph {
     static func createVisitStats(siteID: Int64, granularity: StatGranularity, items: [SiteVisitStatsItem]) -> SiteVisitStats {
 
         switch granularity {
-            case .hour: preconditionFailure("Not implemented")
             case .day: preconditionFailure("Not implemented")
             case .week: preconditionFailure("Not implemented")
             case .month:

--- a/Yosemite/Yosemite/Stores/StatsStoreV4.swift
+++ b/Yosemite/Yosemite/Stores/StatsStoreV4.swift
@@ -487,11 +487,6 @@ public extension StatsStoreV4 {
     ///
     static func buildDateString(from date: Date, with granularity: StatGranularity) -> String {
         switch granularity {
-        case .hour:
-            let dateFormatter = DateFormatter()
-            dateFormatter.dateStyle = .short
-            dateFormatter.timeStyle = .short
-            return dateFormatter.string(from: date)
         case .day:
             return DateFormatter.Stats.statsDayFormatter.string(from: date)
         case .week:

--- a/Yosemite/YosemiteTests/Model/Enums/StatsTimeRangeTests.swift
+++ b/Yosemite/YosemiteTests/Model/Enums/StatsTimeRangeTests.swift
@@ -143,7 +143,7 @@ final class StatsTimeRangeTests: XCTestCase {
         let range: StatsTimeRangeV4 = .custom(from: fromDate, to: toDate)
 
         // Then
-        XCTAssertEqual(range.siteVisitStatsGranularity, .hour)
+        XCTAssertEqual(range.siteVisitStatsGranularity, .day)
     }
 
     // MARK: `topEarnerStatsGranularity` for custom range
@@ -210,7 +210,7 @@ final class StatsTimeRangeTests: XCTestCase {
         let range: StatsTimeRangeV4 = .custom(from: fromDate, to: toDate)
 
         // Then
-        XCTAssertEqual(range.topEarnerStatsGranularity, .hour)
+        XCTAssertEqual(range.topEarnerStatsGranularity, .day)
     }
 
     // MARK: `summaryStatsGranularity` for custom range
@@ -277,7 +277,7 @@ final class StatsTimeRangeTests: XCTestCase {
         let range: StatsTimeRangeV4 = .custom(from: fromDate, to: toDate)
 
         // Then
-        XCTAssertEqual(range.summaryStatsGranularity, .hour)
+        XCTAssertEqual(range.summaryStatsGranularity, .day)
     }
     // MARK: Custom range
 


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #12228 
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
There are a few issues with site visit stats currently:
- the site visit stat endpoint doesn't support hour granularity.
- we are using a fixed 100 quantity for this endpoint, but it doesn't work similarly to the order endpoint so it would try to return all 100 items given the end date => causing the requests to be slow and discrepancies in site visit stats data [p1709778650288769-slack-C03L1NF1EA3].

This PR fixes the above issues by:
- Removing `hour` granularity from `StatsGranularity`. This granularity is only available for `StatsGranularityV4`.
- Setting `day` granularity for site visit stats of custom ranges with 1 day length.
- Calculating the quantity of items to be returned for site visit stats based on the length of the custom range. The length is calculated by adding 1 to the difference from the start date to the end date to include data for both dates.
- Attempting to fix the data discrepancy by removing extra items from site visit stats. This is to ensure the visit stats correctly match order stats.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
- Log in to a store with existing site visit and revenue stats.
- Create a custom range or edit an existing one with a range of 1 day length.
- Confirm with Proxyman that the `stats/visits` request is made with quantity = 2 and unit = `day`.
- Update the custom range to other length: 5 days, 1 month, 1 year, 4 years. Confirm that:
  - the `stats/visits` request is made with correct quantity and unit.
  - the visit stats are displayed correctly when selecting any specific date on the chart.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

https://github.com/woocommerce/woocommerce-ios/assets/5533851/0804ccc5-e0de-43a2-b1a9-f3e67e56b7eb



---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.