### PR TITLE
What's New Announcement: Fix crash and layout issue

### DIFF
--- a/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/IconListItem.swift
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/IconListItem.swift
@@ -57,20 +57,15 @@ struct IconListItem: View {
     let icon: Icon?
 
     var body: some View {
-        HStack(alignment: .center, spacing: Layout.contentSpacing) {
-            VStack {
-                icon?.getImage()
-                    .frame(width: Layout.iconSize.width, height: Layout.iconSize.height)
-                    .accessibility(hidden: true)
-                Spacer()
-            }
+        HStack(alignment: .top, spacing: Layout.contentSpacing) {
+            icon?.getImage()
+                .frame(width: Layout.iconSize.width, height: Layout.iconSize.height)
+                .accessibility(hidden: true)
             VStack(alignment: .leading, spacing: Layout.innerSpacing) {
                 Text(title)
                     .headlineStyle()
-                    .fixedSize(horizontal: false, vertical: true)
                 Text(subtitle)
                     .secondaryBodyStyle()
-                    .fixedSize(horizontal: false, vertical: true)
             }
             Spacer()
         }

--- a/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/ReportList.swift
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/ReportList.swift
@@ -23,9 +23,10 @@ struct ReportList: View {
     @Environment(\.horizontalSizeClass) var sizeClass: UserInterfaceSizeClass?
 
     var body: some View {
-        VStack {
+        ScrollView {
             LargeTitle(text: viewModel.title)
                 .padding(.bottom, Layout.titleBottomPadding(sizeClass))
+                .padding(.top, Layout.topPadding(sizeClass))
             VStack(spacing: Layout.listSpacing(sizeClass)) {
                 ForEach(viewModel.items, id: \.id) {
                     IconListItem(title: $0.title,
@@ -33,15 +34,16 @@ struct ReportList: View {
                                  icon: $0.icon)
                 }
             }
-            .scrollVerticallyIfNeeded()
-            Spacer()
-            Button(viewModel.ctaTitle, action: viewModel.onDismiss)
-                .buttonStyle(PrimaryButtonStyle())
-                .padding(.horizontal, Layout.buttonHorizontalPadding(sizeClass))
         }
         .onAppear(perform: viewModel.onAppear)
-        .padding(.top, Layout.topPadding(sizeClass))
-        .padding(.bottom, Layout.bottomPadding(sizeClass))
+        .safeAreaInset(edge: .bottom) {
+            VStack {
+                Button(viewModel.ctaTitle, action: viewModel.onDismiss)
+                    .buttonStyle(PrimaryButtonStyle())
+                    .padding()
+            }
+            .background(Color(.systemBackground))
+        }
     }
 }
 
@@ -52,16 +54,8 @@ private extension ReportList {
             sizeClass == .regular ? 40 : 75
         }
 
-        static func bottomPadding(_ sizeClass: UserInterfaceSizeClass?) -> CGFloat {
-            sizeClass == .regular ? 40 : 60
-        }
-
         static func titleBottomPadding(_ sizeClass: UserInterfaceSizeClass?) -> CGFloat {
             sizeClass == .regular ? 32 : 40
-        }
-
-        static func buttonHorizontalPadding(_ sizeClass: UserInterfaceSizeClass?) -> CGFloat {
-            sizeClass == .regular ? 40 : 24
         }
 
         static func listSpacing(_ sizeClass: UserInterfaceSizeClass?) -> CGFloat {

--- a/WooCommerce/Classes/ViewRelated/WhatsNew/WhatsNewHostingController.swift
+++ b/WooCommerce/Classes/ViewRelated/WhatsNew/WhatsNewHostingController.swift
@@ -7,11 +7,6 @@ final class WhatsNewHostingController: UIHostingController<ReportList> {
         modalPresentationStyle = .formSheet
     }
 
-    /// Since preferredContentSize may be custom (in case of iPad) we must override traitCollection in order to obtain the "real" trait collection
-    override var traitCollection: UITraitCollection {
-        self.presentingViewController?.traitCollection ?? .current
-    }
-
     required dynamic init?(coder aDecoder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #12234 
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This PR fixes layout issue and removes the trait collection overwriting that causes a crash when opening the What's new announcement from Settings.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
- In the project info.plist file, update the `MARKETING_VERSION` field to a version with a feature announcement. E.g: 17.7.
- Build the app and log in to a store.
- Confirm that you can see the What's New announcement modal, and the layout looks correct.
- Switch to Menu tab > Settings > What's New in WooCommerce.
- Confirm that the What's New modal is presented and the app doesn't crash.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->
Before | After
--- | ---
<img src="https://github.com/woocommerce/woocommerce-ios/assets/5533851/bace24a6-2593-41b9-9df0-2fe796524350" width=320 /> | <img src="https://github.com/woocommerce/woocommerce-ios/assets/5533851/19d7490d-fc06-4a56-9889-eb86f54c6a7c" width=320 />


On iPad:

<img src="https://github.com/woocommerce/woocommerce-ios/assets/5533851/b37580ad-a718-48e7-b415-285c1e6ed7ef" width=320 />

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
