### PR TITLE
[Analytics Hub] Refactor revenue card into separate view model

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/AnalyticsHubViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/AnalyticsHubViewModel.swift
@@ -481,10 +481,10 @@ private extension AnalyticsHubViewModel {
 
     func revenueCard(currentPeriodStats: OrderStatsV4?,
                      previousPeriodStats: OrderStatsV4?) -> AnalyticsReportCardProtocol {
-        RevenueReportCardViewModel(currentOrderStats: currentPeriodStats,
-                          previousOrderStats: previousPeriodStats,
-                          timeRange: timeRangeSelectionType,
-                          usageTracksEventEmitter: usageTracksEventEmitter)
+        RevenueReportCardViewModel(currentPeriodStats: currentPeriodStats,
+                                   previousPeriodStats: previousPeriodStats,
+                                   timeRange: timeRangeSelectionType,
+                                   usageTracksEventEmitter: usageTracksEventEmitter)
     }
 
     static func ordersCard(currentPeriodStats: OrderStatsV4?,

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/AnalyticsHubViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/AnalyticsHubViewModel.swift
@@ -82,7 +82,8 @@ final class AnalyticsHubViewModel: ObservableObject {
         RevenueReportCardViewModel(currentPeriodStats: currentOrderStats,
                                    previousPeriodStats: previousOrderStats,
                                    timeRange: timeRangeSelectionType,
-                                   usageTracksEventEmitter: usageTracksEventEmitter)
+                                   usageTracksEventEmitter: usageTracksEventEmitter,
+                                   storeAdminURL: stores.sessionManager.defaultSite?.adminURL)
     }()
 
     /// Orders Card ViewModel

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/AnalyticsHubViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/AnalyticsHubViewModel.swift
@@ -79,7 +79,10 @@ final class AnalyticsHubViewModel: ObservableObject {
     /// Revenue Card ViewModel
     ///
     lazy var revenueCard: RevenueReportCardViewModel = {
-        revenueCard(currentPeriodStats: currentOrderStats, previousPeriodStats: previousOrderStats)
+        RevenueReportCardViewModel(currentPeriodStats: currentOrderStats,
+                                   previousPeriodStats: previousOrderStats,
+                                   timeRange: timeRangeSelectionType,
+                                   usageTracksEventEmitter: usageTracksEventEmitter)
     }()
 
     /// Orders Card ViewModel
@@ -421,8 +424,7 @@ private extension AnalyticsHubViewModel {
             .sink { [weak self] currentOrderStats, previousOrderStats in
                 guard let self else { return }
 
-                self.revenueCard = revenueCard(currentPeriodStats: currentOrderStats,
-                                               previousPeriodStats: previousOrderStats)
+                self.revenueCard.update(currentPeriodStats: currentOrderStats, previousPeriodStats: previousOrderStats)
                 self.ordersCard = AnalyticsHubViewModel.ordersCard(currentPeriodStats: currentOrderStats,
                                                                    previousPeriodStats: previousOrderStats,
                                                                    webReportViewModel: webReportVM(for: .orders))
@@ -477,14 +479,6 @@ private extension AnalyticsHubViewModel {
                     }
                 }
             }.store(in: &subscriptions)
-    }
-
-    func revenueCard(currentPeriodStats: OrderStatsV4?,
-                     previousPeriodStats: OrderStatsV4?) -> RevenueReportCardViewModel {
-        RevenueReportCardViewModel(currentPeriodStats: currentPeriodStats,
-                                   previousPeriodStats: previousPeriodStats,
-                                   timeRange: timeRangeSelectionType,
-                                   usageTracksEventEmitter: usageTracksEventEmitter)
     }
 
     static func ordersCard(currentPeriodStats: OrderStatsV4?,

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/AnalyticsHubViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/AnalyticsHubViewModel.swift
@@ -78,7 +78,7 @@ final class AnalyticsHubViewModel: ObservableObject {
 
     /// Revenue Card ViewModel
     ///
-    lazy var revenueCard: AnalyticsReportCardProtocol = {
+    lazy var revenueCard: RevenueReportCardViewModel = {
         revenueCard(currentPeriodStats: currentOrderStats, previousPeriodStats: previousOrderStats)
     }()
 
@@ -480,7 +480,7 @@ private extension AnalyticsHubViewModel {
     }
 
     func revenueCard(currentPeriodStats: OrderStatsV4?,
-                     previousPeriodStats: OrderStatsV4?) -> AnalyticsReportCardProtocol {
+                     previousPeriodStats: OrderStatsV4?) -> RevenueReportCardViewModel {
         RevenueReportCardViewModel(currentPeriodStats: currentPeriodStats,
                                    previousPeriodStats: previousPeriodStats,
                                    timeRange: timeRangeSelectionType,

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/AnalyticsHubViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/AnalyticsHubViewModel.swift
@@ -458,6 +458,8 @@ private extension AnalyticsHubViewModel {
                                                                          usageTracksEventEmitter: self.usageTracksEventEmitter,
                                                                          analytics: self.analytics)
 
+                self.revenueCard.update(timeRange: newSelectionType)
+
                 // Update data on range selection change
                 Task.init {
                     await self.updateData()

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/AnalyticsReportCardProtocol.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/AnalyticsReportCardProtocol.swift
@@ -1,0 +1,135 @@
+import Foundation
+import class UIKit.UIColor
+
+/// Protocol for `AnalyticsReportCard` View Models
+/// Used to transmit analytics report data.
+///
+protocol AnalyticsReportCardProtocol {
+    /// Report Card Title.
+    ///
+    var title: String { get }
+
+    /// First Column Metric
+    ///
+    var leadingMetric: AnalyticsReportCardMetric { get set }
+
+    /// Second Column Metric
+    ///
+    var trailingMetric: AnalyticsReportCardMetric { get set }
+
+    /// Indicates if the values should be hidden (for loading state)
+    ///
+    var isRedacted: Bool { get set }
+
+    /// Indicates if there was an error loading the data for the card
+    ///
+    var showSyncError: Bool { get set }
+
+    /// Message to display if there was an error loading the data for the card
+    ///
+    var syncErrorMessage: String { get }
+
+    /// View model for the web analytics report link
+    ///
+    var reportViewModel: AnalyticsReportLinkViewModel? { get set }
+}
+
+extension AnalyticsReportCardProtocol {
+
+    /// Make redacted state of the card, replacing values with hardcoded placeholders
+    ///
+    mutating func redact() {
+        isRedacted = true
+        showSyncError = false
+    }
+
+    /// First Column Title
+    ///
+    var leadingTitle: String {
+        leadingMetric.title
+    }
+
+    /// First Column Value
+    ///
+    var leadingValue: String {
+        isRedacted ? "$1000" : leadingMetric.value
+    }
+
+    /// First Column Delta Percentage
+    ///
+    var leadingDelta: DeltaPercentage? {
+        isRedacted ? DeltaPercentage(string: "0%", direction: .zero) : leadingMetric.delta
+    }
+
+    /// First Column Chart Data
+    ///
+    var leadingChartData: [Double] {
+        isRedacted ? [] : leadingMetric.chartData
+    }
+
+    /// Second Column Title
+    ///
+    var trailingTitle: String {
+        trailingMetric.title
+    }
+
+    /// Second Column Value
+    ///
+    var trailingValue: String {
+        isRedacted ? "$1000" : trailingMetric.value
+    }
+
+    /// Second Column Delta Percentage
+    ///
+    var trailingDelta: DeltaPercentage? {
+        isRedacted ? DeltaPercentage(string: "0%", direction: .zero) : trailingMetric.delta
+    }
+
+    /// Second Column Chart Data
+    ///
+    var trailingChartData: [Double] {
+        isRedacted ? [] : trailingMetric.chartData
+    }
+}
+
+/// Represents a metric on an `AnalyticsReportCard`
+///
+struct AnalyticsReportCardMetric {
+    /// Metric title
+    let title: String
+
+    /// Metric value
+    let value: String
+
+    /// Metric delta percentage
+    let delta: DeltaPercentage?
+
+    /// Metric chart data
+    let chartData: [Double]
+}
+
+/// Convenience extension to create an `AnalyticsReportCard` from a view model.
+///
+extension AnalyticsReportCard {
+    init(viewModel: AnalyticsReportCardProtocol) {
+        self.title = viewModel.title
+        self.leadingTitle = viewModel.leadingTitle
+        self.leadingValue = viewModel.leadingValue
+        self.leadingDelta = viewModel.leadingDelta?.string
+        self.leadingDeltaColor = viewModel.leadingDelta?.direction.deltaBackgroundColor
+        self.leadingDeltaTextColor = viewModel.leadingDelta?.direction.deltaTextColor
+        self.leadingChartData = viewModel.leadingChartData
+        self.leadingChartColor = viewModel.leadingDelta?.direction.chartColor
+        self.trailingTitle = viewModel.trailingTitle
+        self.trailingValue = viewModel.trailingValue
+        self.trailingDelta = viewModel.trailingDelta?.string
+        self.trailingDeltaColor = viewModel.trailingDelta?.direction.deltaBackgroundColor
+        self.trailingDeltaTextColor = viewModel.trailingDelta?.direction.deltaTextColor
+        self.trailingChartData = viewModel.trailingChartData
+        self.trailingChartColor = viewModel.trailingDelta?.direction.chartColor
+        self.isRedacted = viewModel.isRedacted
+        self.showSyncError = viewModel.showSyncError
+        self.syncErrorMessage = viewModel.syncErrorMessage
+        self.reportViewModel = viewModel.reportViewModel
+    }
+}

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/AnalyticsReportCardProtocol.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/AnalyticsReportCardProtocol.swift
@@ -9,13 +9,37 @@ protocol AnalyticsReportCardProtocol {
     ///
     var title: String { get }
 
-    /// First Column Metric
+    /// First Column Title
     ///
-    var leadingMetric: AnalyticsReportCardMetric { get set }
+    var leadingTitle: String { get }
 
-    /// Second Column Metric
+    /// First Column Value
     ///
-    var trailingMetric: AnalyticsReportCardMetric { get set }
+    var leadingValue: String { get }
+
+    /// First Column Delta Percentage
+    ///
+    var leadingDelta: DeltaPercentage? { get }
+
+    /// First Column Chart Data
+    ///
+    var leadingChartData: [Double] { get }
+
+    /// Second Column Title
+    ///
+    var trailingTitle: String { get }
+
+    /// Second Column Value
+    ///
+    var trailingValue: String { get }
+
+    /// Second Column Delta Percentage
+    ///
+    var trailingDelta: DeltaPercentage? { get }
+
+    /// Second Column Chart Data
+    ///
+    var trailingChartData: [Double] { get }
 
     /// Indicates if the values should be hidden (for loading state)
     ///
@@ -23,7 +47,7 @@ protocol AnalyticsReportCardProtocol {
 
     /// Indicates if there was an error loading the data for the card
     ///
-    var showSyncError: Bool { get set }
+    var showSyncError: Bool { get }
 
     /// Message to display if there was an error loading the data for the card
     ///
@@ -31,81 +55,11 @@ protocol AnalyticsReportCardProtocol {
 
     /// View model for the web analytics report link
     ///
-    var reportViewModel: AnalyticsReportLinkViewModel? { get set }
-}
-
-extension AnalyticsReportCardProtocol {
+    var reportViewModel: AnalyticsReportLinkViewModel? { get }
 
     /// Make redacted state of the card, replacing values with hardcoded placeholders
     ///
-    mutating func redact() {
-        isRedacted = true
-        showSyncError = false
-    }
-
-    /// First Column Title
-    ///
-    var leadingTitle: String {
-        leadingMetric.title
-    }
-
-    /// First Column Value
-    ///
-    var leadingValue: String {
-        isRedacted ? "$1000" : leadingMetric.value
-    }
-
-    /// First Column Delta Percentage
-    ///
-    var leadingDelta: DeltaPercentage? {
-        isRedacted ? DeltaPercentage(string: "0%", direction: .zero) : leadingMetric.delta
-    }
-
-    /// First Column Chart Data
-    ///
-    var leadingChartData: [Double] {
-        isRedacted ? [] : leadingMetric.chartData
-    }
-
-    /// Second Column Title
-    ///
-    var trailingTitle: String {
-        trailingMetric.title
-    }
-
-    /// Second Column Value
-    ///
-    var trailingValue: String {
-        isRedacted ? "$1000" : trailingMetric.value
-    }
-
-    /// Second Column Delta Percentage
-    ///
-    var trailingDelta: DeltaPercentage? {
-        isRedacted ? DeltaPercentage(string: "0%", direction: .zero) : trailingMetric.delta
-    }
-
-    /// Second Column Chart Data
-    ///
-    var trailingChartData: [Double] {
-        isRedacted ? [] : trailingMetric.chartData
-    }
-}
-
-/// Represents a metric on an `AnalyticsReportCard`
-///
-struct AnalyticsReportCardMetric {
-    /// Metric title
-    let title: String
-
-    /// Metric value
-    let value: String
-
-    /// Metric delta percentage
-    let delta: DeltaPercentage?
-
-    /// Metric chart data
-    let chartData: [Double]
+    mutating func redact()
 }
 
 /// Convenience extension to create an `AnalyticsReportCard` from a view model.

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/AnalyticsReportCardProtocol.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/AnalyticsReportCardProtocol.swift
@@ -56,10 +56,6 @@ protocol AnalyticsReportCardProtocol {
     /// View model for the web analytics report link
     ///
     var reportViewModel: AnalyticsReportLinkViewModel? { get }
-
-    /// Make redacted state of the card, replacing values with hardcoded placeholders
-    ///
-    mutating func redact()
 }
 
 /// Convenience extension to create an `AnalyticsReportCard` from a view model.

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/DeltaPercentage.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/DeltaPercentage.swift
@@ -2,7 +2,7 @@ import Foundation
 import class UIKit.UIColor
 
 /// Represents a formatted delta percentage string and its direction of change
-struct DeltaPercentage {
+struct DeltaPercentage: Equatable {
     /// The delta percentage formatted as a localized string (e.g. `+100%`)
     let string: String
 

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/Report Cards/RevenueReportCardViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/Report Cards/RevenueReportCardViewModel.swift
@@ -36,14 +36,24 @@ final class RevenueReportCardViewModel: AnalyticsReportCardProtocol {
         self.storeAdminURL = storeAdminURL
     }
 
+    /// Redacts the card content for a card loading state.
+    ///
     func redact() {
         isRedacted = true
     }
 
+    /// Updates the stats used in the card metrics.
+    ///
     func update(currentPeriodStats: OrderStatsV4?, previousPeriodStats: OrderStatsV4?) {
         self.currentPeriodStats = currentPeriodStats
         self.previousPeriodStats = previousPeriodStats
         isRedacted = false
+    }
+
+    /// Updates the time range used in the card report link.
+    ///
+    func update(timeRange: AnalyticsHubTimeRangeSelection.SelectionType) {
+        self.timeRange = timeRange
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/Report Cards/RevenueReportCardViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/Report Cards/RevenueReportCardViewModel.swift
@@ -1,0 +1,75 @@
+import Foundation
+import Yosemite
+
+final class RevenueReportCardViewModel: AnalyticsReportCardProtocol {
+    let title: String = Localization.title
+
+    var leadingMetric: AnalyticsReportCardMetric
+
+    var trailingMetric: AnalyticsReportCardMetric
+
+    var isRedacted: Bool = false
+
+    var showSyncError: Bool
+
+    let syncErrorMessage: String = Localization.noRevenue
+
+    var reportViewModel: AnalyticsReportLinkViewModel?
+
+    init(currentOrderStats: OrderStatsV4?,
+         previousOrderStats: OrderStatsV4?,
+         timeRange: AnalyticsHubTimeRangeSelection.SelectionType,
+         usageTracksEventEmitter: StoreStatsUsageTracksEventEmitter,
+         storeAdminURL: String? = ServiceLocator.stores.sessionManager.defaultSite?.adminURL) {
+        leadingMetric = RevenueReportCardViewModel.createLeadingMetric(currentPeriodStats: currentOrderStats, previousPeriodStats: previousOrderStats)
+        trailingMetric = RevenueReportCardViewModel.createTrailingMetric(currentPeriodStats: currentOrderStats, previousPeriodStats: previousOrderStats)
+        showSyncError = currentOrderStats == nil || previousOrderStats == nil
+        reportViewModel = RevenueReportCardViewModel.createReportViewModel(timeRange: timeRange,
+                                                                  storeAdminURL: storeAdminURL,
+                                                                  usageTracksEventEmitter: usageTracksEventEmitter)
+    }
+}
+
+private extension RevenueReportCardViewModel {
+    static func createLeadingMetric(currentPeriodStats: OrderStatsV4?, previousPeriodStats: OrderStatsV4?) -> AnalyticsReportCardMetric {
+        AnalyticsReportCardMetric(title: Localization.leadingTitle,
+                                  value: StatsDataTextFormatter.createTotalRevenueText(orderStats: currentPeriodStats,
+                                                                                       selectedIntervalIndex: nil),
+                                  delta: StatsDataTextFormatter.createTotalRevenueDelta(from: previousPeriodStats, to: currentPeriodStats),
+                                  chartData: StatsIntervalDataParser.getChartData(for: .totalRevenue, from: currentPeriodStats))
+    }
+
+    static func createTrailingMetric(currentPeriodStats: OrderStatsV4?, previousPeriodStats: OrderStatsV4?) -> AnalyticsReportCardMetric {
+        AnalyticsReportCardMetric(title: Localization.trailingTitle,
+                                  value: StatsDataTextFormatter.createNetRevenueText(orderStats: currentPeriodStats),
+                                  delta: StatsDataTextFormatter.createNetRevenueDelta(from: previousPeriodStats, to: currentPeriodStats),
+                                  chartData: StatsIntervalDataParser.getChartData(for: .netRevenue, from: currentPeriodStats))
+    }
+
+    static func createReportViewModel(timeRange: AnalyticsHubTimeRangeSelection.SelectionType,
+                                      storeAdminURL: String?,
+                                      usageTracksEventEmitter: StoreStatsUsageTracksEventEmitter) -> AnalyticsReportLinkViewModel? {
+        guard let url = AnalyticsWebReport.getUrl(for: .revenue, timeRange: timeRange, storeAdminURL: storeAdminURL) else {
+            return nil
+        }
+        return AnalyticsReportLinkViewModel(reportType: .revenue,
+                                            period: timeRange,
+                                            webViewTitle: Localization.reportTitle,
+                                            reportURL: url,
+                                            usageTracksEventEmitter: usageTracksEventEmitter)
+    }
+}
+
+// MARK: Constants
+private extension RevenueReportCardViewModel {
+    enum Localization {
+        static let title = NSLocalizedString("REVENUE", comment: "Title for revenue analytics section in the Analytics Hub")
+        static let leadingTitle = NSLocalizedString("Total Sales", comment: "Label for total sales (gross revenue) in the Analytics Hub")
+        static let trailingTitle = NSLocalizedString("Net Sales", comment: "Label for net sales (net revenue) in the Analytics Hub")
+        static let noRevenue = NSLocalizedString("Unable to load revenue analytics",
+                                                 comment: "Text displayed when there is an error loading revenue stats data.")
+        static let reportTitle = NSLocalizedString("analyticsHub.revenueCard.reportTitle",
+                                                   value: "Revenue Report",
+                                                   comment: "Title for the revenue analytics report linked in the Analytics Hub")
+    }
+}

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/Report Cards/RevenueReportCardViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/Report Cards/RevenueReportCardViewModel.swift
@@ -39,6 +39,12 @@ final class RevenueReportCardViewModel: AnalyticsReportCardProtocol {
     func redact() {
         isRedacted = true
     }
+
+    func update(currentPeriodStats: OrderStatsV4?, previousPeriodStats: OrderStatsV4?) {
+        self.currentPeriodStats = currentPeriodStats
+        self.previousPeriodStats = previousPeriodStats
+        isRedacted = false
+    }
 }
 
 // MARK: AnalyticsReportCardProtocol conformance

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -2072,6 +2072,7 @@
 		CEEC9B6021E79CAA0055EEF0 /* FeatureFlagTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEEC9B5F21E79CAA0055EEF0 /* FeatureFlagTests.swift */; };
 		CEEC9B6421E7AB850055EEF0 /* AppRatingManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEEC9B6221E79EE00055EEF0 /* AppRatingManager.swift */; };
 		CEEC9B6621E7C5200055EEF0 /* AppRatingManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEEC9B6521E7C5200055EEF0 /* AppRatingManagerTests.swift */; };
+		CEEF74222B99EC5800B03948 /* AnalyticsReportCardProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEEF74212B99EC5800B03948 /* AnalyticsReportCardProtocol.swift */; };
 		CEF2DD862B558E3E00A3DD0B /* AnalyticsCTACard.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEF2DD852B558E3E00A3DD0B /* AnalyticsCTACard.swift */; };
 		CEF5A28F2A68466E0059CFD3 /* stats_summary_day.json in Resources */ = {isa = PBXBuildFile; fileRef = CEF5A28E2A68466E0059CFD3 /* stats_summary_day.json */; };
 		CEF5A2912A68467C0059CFD3 /* stats_summary_week.json in Resources */ = {isa = PBXBuildFile; fileRef = CEF5A2902A68467C0059CFD3 /* stats_summary_week.json */; };
@@ -4798,6 +4799,7 @@
 		CEEC9B5F21E79CAA0055EEF0 /* FeatureFlagTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeatureFlagTests.swift; sourceTree = "<group>"; };
 		CEEC9B6221E79EE00055EEF0 /* AppRatingManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppRatingManager.swift; sourceTree = "<group>"; };
 		CEEC9B6521E7C5200055EEF0 /* AppRatingManagerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppRatingManagerTests.swift; sourceTree = "<group>"; };
+		CEEF74212B99EC5800B03948 /* AnalyticsReportCardProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnalyticsReportCardProtocol.swift; sourceTree = "<group>"; };
 		CEF2DD852B558E3E00A3DD0B /* AnalyticsCTACard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnalyticsCTACard.swift; sourceTree = "<group>"; };
 		CEF5A28E2A68466E0059CFD3 /* stats_summary_day.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = stats_summary_day.json; sourceTree = "<group>"; };
 		CEF5A2902A68467C0059CFD3 /* stats_summary_week.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = stats_summary_week.json; sourceTree = "<group>"; };
@@ -7191,6 +7193,7 @@
 				2647F7B429280A7F00D59FDF /* AnalyticsHubView.swift */,
 				26E7EE69292D688900793045 /* AnalyticsHubViewModel.swift */,
 				2647F7B9292BE2F900D59FDF /* AnalyticsReportCard.swift */,
+				CEEF74212B99EC5800B03948 /* AnalyticsReportCardProtocol.swift */,
 				26E7EE6B292D894100793045 /* AnalyticsReportCardViewModel.swift */,
 				CCA1D6012943636100B40560 /* AnalyticsReportCardCurrentPeriodViewModel.swift */,
 				B60B5025292D308A00178C26 /* AnalyticsTimeRangeCard.swift */,
@@ -14069,6 +14072,7 @@
 				DEC51AFD276AEAE3009F3DF4 /* SystemStatusReportView.swift in Sources */,
 				CECC759C23D61C1400486676 /* AggregateDataHelper.swift in Sources */,
 				03E471D0293FA62B001A58AD /* CardReaderTransactionAlertsProviding.swift in Sources */,
+				CEEF74222B99EC5800B03948 /* AnalyticsReportCardProtocol.swift in Sources */,
 				02645D7D27BA027B0065DC68 /* Inbox.swift in Sources */,
 				D81D9228222E7F0800FFA585 /* OrderStatusListViewController.swift in Sources */,
 				CEE006082077D14C0079161F /* OrderDetailsViewController.swift in Sources */,

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -2073,6 +2073,8 @@
 		CEEC9B6421E7AB850055EEF0 /* AppRatingManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEEC9B6221E79EE00055EEF0 /* AppRatingManager.swift */; };
 		CEEC9B6621E7C5200055EEF0 /* AppRatingManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEEC9B6521E7C5200055EEF0 /* AppRatingManagerTests.swift */; };
 		CEEF74222B99EC5800B03948 /* AnalyticsReportCardProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEEF74212B99EC5800B03948 /* AnalyticsReportCardProtocol.swift */; };
+		CEEF74252B99EF1200B03948 /* RevenueReportCardViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEEF74242B99EF1200B03948 /* RevenueReportCardViewModel.swift */; };
+		CEEF74282B99F57A00B03948 /* RevenueReportCardViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEEF74272B99F57A00B03948 /* RevenueReportCardViewModelTests.swift */; };
 		CEF2DD862B558E3E00A3DD0B /* AnalyticsCTACard.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEF2DD852B558E3E00A3DD0B /* AnalyticsCTACard.swift */; };
 		CEF5A28F2A68466E0059CFD3 /* stats_summary_day.json in Resources */ = {isa = PBXBuildFile; fileRef = CEF5A28E2A68466E0059CFD3 /* stats_summary_day.json */; };
 		CEF5A2912A68467C0059CFD3 /* stats_summary_week.json in Resources */ = {isa = PBXBuildFile; fileRef = CEF5A2902A68467C0059CFD3 /* stats_summary_week.json */; };
@@ -4800,6 +4802,8 @@
 		CEEC9B6221E79EE00055EEF0 /* AppRatingManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppRatingManager.swift; sourceTree = "<group>"; };
 		CEEC9B6521E7C5200055EEF0 /* AppRatingManagerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppRatingManagerTests.swift; sourceTree = "<group>"; };
 		CEEF74212B99EC5800B03948 /* AnalyticsReportCardProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnalyticsReportCardProtocol.swift; sourceTree = "<group>"; };
+		CEEF74242B99EF1200B03948 /* RevenueReportCardViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RevenueReportCardViewModel.swift; sourceTree = "<group>"; };
+		CEEF74272B99F57A00B03948 /* RevenueReportCardViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RevenueReportCardViewModelTests.swift; sourceTree = "<group>"; };
 		CEF2DD852B558E3E00A3DD0B /* AnalyticsCTACard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnalyticsCTACard.swift; sourceTree = "<group>"; };
 		CEF5A28E2A68466E0059CFD3 /* stats_summary_day.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = stats_summary_day.json; sourceTree = "<group>"; };
 		CEF5A2902A68467C0059CFD3 /* stats_summary_week.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = stats_summary_week.json; sourceTree = "<group>"; };
@@ -7189,6 +7193,7 @@
 			isa = PBXGroup;
 			children = (
 				B6F379662937831D00718561 /* Time Range */,
+				CEEF74232B99EF0200B03948 /* Report Cards */,
 				CEFA16F22B75042300512782 /* Customize */,
 				2647F7B429280A7F00D59FDF /* AnalyticsHubView.swift */,
 				26E7EE69292D688900793045 /* AnalyticsHubViewModel.swift */,
@@ -9615,6 +9620,7 @@
 		B6440FB7292E73E50012D506 /* Analytics Hub */ = {
 			isa = PBXGroup;
 			children = (
+				CEEF74262B99F56C00B03948 /* Report Cards */,
 				AE4CCCEA29365CFD00B47EE8 /* AnalyticsHubViewModelTests.swift */,
 				B6440FB8292E74230012D506 /* AnalyticsHubTimeRangeSelectionTests.swift */,
 				CEA9C8DF2B6D323A000FE114 /* AnalyticsWebReportTests.swift */,
@@ -10974,6 +10980,22 @@
 				CEEC9B6221E79EE00055EEF0 /* AppRatingManager.swift */,
 			);
 			path = AppRatings;
+			sourceTree = "<group>";
+		};
+		CEEF74232B99EF0200B03948 /* Report Cards */ = {
+			isa = PBXGroup;
+			children = (
+				CEEF74242B99EF1200B03948 /* RevenueReportCardViewModel.swift */,
+			);
+			path = "Report Cards";
+			sourceTree = "<group>";
+		};
+		CEEF74262B99F56C00B03948 /* Report Cards */ = {
+			isa = PBXGroup;
+			children = (
+				CEEF74272B99F57A00B03948 /* RevenueReportCardViewModelTests.swift */,
+			);
+			path = "Report Cards";
 			sourceTree = "<group>";
 		};
 		CEFA16F22B75042300512782 /* Customize */ = {
@@ -13986,6 +14008,7 @@
 				EE3E9E8F2B05FDD500985B2C /* SubscriptionExpiryViewController.swift in Sources */,
 				68B6F22B2ADE7ED500D171FC /* TooltipView.swift in Sources */,
 				02EAF5BE29FA04750058071C /* ProductDescriptionGenerationView.swift in Sources */,
+				CEEF74252B99EF1200B03948 /* RevenueReportCardViewModel.swift in Sources */,
 				DE8BEB912ABAEBF800F5E56C /* AddProductFeaturesView.swift in Sources */,
 				CC857C7729B25FAF00E19D1E /* FooterNotice.swift in Sources */,
 				0202B68D23876BC100F3EBE0 /* ProductsTabProductViewModel+ProductVariation.swift in Sources */,
@@ -14868,6 +14891,7 @@
 				311F827626CD8AB100DF5BAD /* MockCardReaderSettingsAlerts.swift in Sources */,
 				26A280D62B45F00F00ACEE87 /* OrderNotificationViewModelTests.swift in Sources */,
 				EE45E2C22A42C9D80085F227 /* ProductDescriptionAITooltipUseCaseTests.swift in Sources */,
+				CEEF74282B99F57A00B03948 /* RevenueReportCardViewModelTests.swift in Sources */,
 				DEDAE30B2A0B523F00F9635F /* LocalNotificationTests.swift in Sources */,
 				B935D35F2A9F4EDA0067B927 /* WPAdminTaxSettingsURLProviderTests.swift in Sources */,
 				02ADC7CE23978EAA008D4BED /* PaginatedProductShippingClassListSelectorDataSourceTests.swift in Sources */,

--- a/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Analytics Hub/AnalyticsHubViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Analytics Hub/AnalyticsHubViewModelTests.swift
@@ -80,7 +80,6 @@ final class AnalyticsHubViewModelTests: XCTestCase {
         await vm.updateData()
 
         // Then
-        XCTAssertTrue(vm.revenueCard.showSyncError)
         XCTAssertTrue(vm.ordersCard.showSyncError)
         XCTAssertTrue(vm.productsStatsCard.showStatsError)
         XCTAssertTrue(vm.itemsSoldCard.showItemsSoldError)
@@ -107,7 +106,6 @@ final class AnalyticsHubViewModelTests: XCTestCase {
         await vm.updateData()
 
         // Then
-        XCTAssertTrue(vm.revenueCard.showSyncError)
         XCTAssertTrue(vm.ordersCard.showSyncError)
         XCTAssertTrue(vm.productsStatsCard.showStatsError)
 
@@ -119,7 +117,7 @@ final class AnalyticsHubViewModelTests: XCTestCase {
 
     func test_cards_viewmodels_redacted_while_updating_from_network() async {
         // Given
-        var loadingRevenueCard: AnalyticsReportCardViewModel?
+        var loadingRevenueCard: AnalyticsReportCardProtocol?
         var loadingOrdersCard: AnalyticsReportCardViewModel?
         var loadingProductsCard: AnalyticsProductsStatsCardViewModel?
         var loadingItemsSoldCard: AnalyticsItemsSoldViewModel?
@@ -416,28 +414,23 @@ final class AnalyticsHubViewModelTests: XCTestCase {
     @MainActor
     func test_cards_viewmodels_contain_expected_reportURL_elements() async throws {
         // When
-        let revenueCardReportURL = try XCTUnwrap(vm.revenueCard.reportViewModel?.initialURL)
         let ordersCardReportURL = try XCTUnwrap(vm.ordersCard.reportViewModel?.initialURL)
         let productsCardReportURL = try XCTUnwrap(vm.productsStatsCard.reportViewModel?.initialURL)
 
-        let revenueCardURLQueryItems = try XCTUnwrap(URLComponents(url: revenueCardReportURL, resolvingAgainstBaseURL: false)?.queryItems)
         let ordersCardURLQueryItems = try XCTUnwrap(URLComponents(url: ordersCardReportURL, resolvingAgainstBaseURL: false)?.queryItems)
         let productsCardURLQueryItems = try XCTUnwrap(URLComponents(url: productsCardReportURL, resolvingAgainstBaseURL: false)?.queryItems)
 
         // Then
         // Report URL contains expected admin URL
-        XCTAssertTrue(revenueCardReportURL.relativeString.contains(sampleAdminURL))
         XCTAssertTrue(ordersCardReportURL.relativeString.contains(sampleAdminURL))
         XCTAssertTrue(productsCardReportURL.relativeString.contains(sampleAdminURL))
 
         // Report URL contains expected report path
-        XCTAssertTrue(revenueCardURLQueryItems.contains(URLQueryItem(name: "path", value: "/analytics/revenue")))
         XCTAssertTrue(ordersCardURLQueryItems.contains(URLQueryItem(name: "path", value: "/analytics/orders")))
         XCTAssertTrue(productsCardURLQueryItems.contains(URLQueryItem(name: "path", value: "/analytics/products")))
 
         // Report URL contains expected time range period
         let expectedPeriodQueryItem = URLQueryItem(name: "period", value: "month")
-        XCTAssertTrue(revenueCardURLQueryItems.contains(expectedPeriodQueryItem))
         XCTAssertTrue(ordersCardURLQueryItems.contains(expectedPeriodQueryItem))
         XCTAssertTrue(productsCardURLQueryItems.contains(expectedPeriodQueryItem))
     }
@@ -465,16 +458,13 @@ final class AnalyticsHubViewModelTests: XCTestCase {
         await vm.updateData()
 
         // Then
-        let revenueCardReportURL = try XCTUnwrap(vm.revenueCard.reportViewModel?.initialURL)
         let ordersCardReportURL = try XCTUnwrap(vm.ordersCard.reportViewModel?.initialURL)
         let productsCardReportURL = try XCTUnwrap(vm.productsStatsCard.reportViewModel?.initialURL)
 
-        let revenueCardURLQueryItems = try XCTUnwrap(URLComponents(url: revenueCardReportURL, resolvingAgainstBaseURL: false)?.queryItems)
         let ordersCardURLQueryItems = try XCTUnwrap(URLComponents(url: ordersCardReportURL, resolvingAgainstBaseURL: false)?.queryItems)
         let productsCardURLQueryItems = try XCTUnwrap(URLComponents(url: productsCardReportURL, resolvingAgainstBaseURL: false)?.queryItems)
 
         // Report URL contains expected report path
-        XCTAssertTrue(revenueCardURLQueryItems.contains(URLQueryItem(name: "path", value: "/analytics/revenue")))
         XCTAssertTrue(ordersCardURLQueryItems.contains(URLQueryItem(name: "path", value: "/analytics/orders")))
         XCTAssertTrue(productsCardURLQueryItems.contains(URLQueryItem(name: "path", value: "/analytics/products")))
     }
@@ -482,13 +472,11 @@ final class AnalyticsHubViewModelTests: XCTestCase {
     @MainActor
     func test_cards_viewmodels_contain_non_nil_report_url_while_loading_and_after_error() async {
         // Given
-        var loadingRevenueCard: AnalyticsReportCardViewModel?
         var loadingOrdersCard: AnalyticsReportCardViewModel?
         var loadingProductsCard: AnalyticsProductsStatsCardViewModel?
         stores.whenReceivingAction(ofType: StatsActionV4.self) { action in
             switch action {
             case let .retrieveCustomStats(_, _, _, _, _, _, _, completion):
-                loadingRevenueCard = self.vm.revenueCard
                 loadingOrdersCard = self.vm.ordersCard
                 loadingProductsCard = self.vm.productsStatsCard
                 completion(.failure(NSError(domain: "Test", code: 1)))
@@ -505,11 +493,9 @@ final class AnalyticsHubViewModelTests: XCTestCase {
         await vm.updateData()
 
         // Then
-        XCTAssertNotNil(loadingRevenueCard?.reportViewModel?.initialURL)
         XCTAssertNotNil(loadingOrdersCard?.reportViewModel?.initialURL)
         XCTAssertNotNil(loadingProductsCard?.reportViewModel?.initialURL)
 
-        XCTAssertNotNil(vm.revenueCard.reportViewModel?.initialURL)
         XCTAssertNotNil(vm.ordersCard.reportViewModel?.initialURL)
         XCTAssertNotNil(vm.productsStatsCard.reportViewModel?.initialURL)
     }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Analytics Hub/AnalyticsHubViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Analytics Hub/AnalyticsHubViewModelTests.swift
@@ -117,7 +117,7 @@ final class AnalyticsHubViewModelTests: XCTestCase {
 
     func test_cards_viewmodels_redacted_while_updating_from_network() async {
         // Given
-        var loadingRevenueCard: AnalyticsReportCardProtocol?
+        var loadingRevenueCardRedacted: Bool = false
         var loadingOrdersCard: AnalyticsReportCardViewModel?
         var loadingProductsCard: AnalyticsProductsStatsCardViewModel?
         var loadingItemsSoldCard: AnalyticsItemsSoldViewModel?
@@ -126,7 +126,7 @@ final class AnalyticsHubViewModelTests: XCTestCase {
             switch action {
             case let .retrieveCustomStats(_, _, _, _, _, _, _, completion):
                 let stats = OrderStatsV4.fake().copy(totals: .fake().copy(totalOrders: 15, totalItemsSold: 5, grossRevenue: 62))
-                loadingRevenueCard = self.vm.revenueCard
+                loadingRevenueCardRedacted = self.vm.revenueCard.isRedacted
                 loadingOrdersCard = self.vm.ordersCard
                 loadingProductsCard = self.vm.productsStatsCard
                 loadingItemsSoldCard = self.vm.itemsSoldCard
@@ -147,7 +147,7 @@ final class AnalyticsHubViewModelTests: XCTestCase {
         await vm.updateData()
 
         // Then
-        XCTAssertEqual(loadingRevenueCard?.isRedacted, true)
+        XCTAssertTrue(loadingRevenueCardRedacted)
         XCTAssertEqual(loadingOrdersCard?.isRedacted, true)
         XCTAssertEqual(loadingProductsCard?.isRedacted, true)
         XCTAssertEqual(loadingItemsSoldCard?.isRedacted, true)

--- a/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Analytics Hub/AnalyticsHubViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Analytics Hub/AnalyticsHubViewModelTests.swift
@@ -500,6 +500,24 @@ final class AnalyticsHubViewModelTests: XCTestCase {
         XCTAssertNotNil(vm.productsStatsCard.reportViewModel?.initialURL)
     }
 
+    @MainActor
+    func test_card_report_URLs_contain_expected_period_after_new_timeRange_selection() async throws {
+        // Given
+        XCTAssertEqual(.monthToDate, vm.timeRangeSelectionType)
+
+        // When
+        vm.timeRangeSelectionType = .today
+
+        // Then
+        let revenueCardReportURL = try XCTUnwrap(vm.revenueCard.reportViewModel?.initialURL)
+
+        let revenueCardURLQueryItems = try XCTUnwrap(URLComponents(url: revenueCardReportURL, resolvingAgainstBaseURL: false)?.queryItems)
+
+        // Report URL contains expected time range period
+        let expectedPeriodQueryItem = URLQueryItem(name: "period", value: "today")
+        XCTAssertTrue(revenueCardURLQueryItems.contains(expectedPeriodQueryItem))
+    }
+
     // MARK: Customized Analytics
 
     func test_enabledCards_shows_correct_data_after_loading_from_storage() async {

--- a/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Analytics Hub/Report Cards/RevenueReportCardViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Analytics Hub/Report Cards/RevenueReportCardViewModelTests.swift
@@ -78,7 +78,7 @@ final class RevenueReportCardViewModelTests: XCTestCase {
 
     func test_redact_updates_properties_as_expected() {
         // Given
-        var vm = RevenueReportCardViewModel(currentPeriodStats: nil,
+        let vm = RevenueReportCardViewModel(currentPeriodStats: nil,
                                             previousPeriodStats: nil,
                                             timeRange: .monthToDate,
                                             usageTracksEventEmitter: eventEmitter,
@@ -98,6 +98,24 @@ final class RevenueReportCardViewModelTests: XCTestCase {
         XCTAssertTrue(vm.isRedacted)
         XCTAssertFalse(vm.showSyncError)
         XCTAssertNotNil(vm.reportViewModel)
+    }
+
+    func test_properties_updated_as_expected_after_update() {
+        // Given
+        let vm = RevenueReportCardViewModel(currentPeriodStats: nil,
+                                            previousPeriodStats: nil,
+                                            timeRange: .monthToDate,
+                                            usageTracksEventEmitter: eventEmitter,
+                                            storeAdminURL: sampleAdminURL)
+
+        // When
+        vm.update(currentPeriodStats: OrderStatsV4.fake().copy(totals: .fake().copy(grossRevenue: 60)),
+                  previousPeriodStats: OrderStatsV4.fake().copy(totals: .fake().copy(grossRevenue: 30)))
+
+        // Then
+        assertEqual("$60", vm.leadingValue)
+        assertEqual(DeltaPercentage(string: "+100%", direction: .positive), vm.leadingDelta)
+        XCTAssertFalse(vm.isRedacted)
     }
 
 }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Analytics Hub/Report Cards/RevenueReportCardViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Analytics Hub/Report Cards/RevenueReportCardViewModelTests.swift
@@ -21,12 +21,12 @@ final class RevenueReportCardViewModelTests: XCTestCase {
     func test_it_inits_with_expected_values() {
         // Given
         let vm = RevenueReportCardViewModel(
-            currentOrderStats: OrderStatsV4.fake().copy(totals: .fake().copy(grossRevenue: 60, netRevenue: 45),
+            currentPeriodStats: OrderStatsV4.fake().copy(totals: .fake().copy(grossRevenue: 60, netRevenue: 45),
                                                          intervals: [.fake().copy(dateStart: "2024-01-01 00:00:00",
                                                                                   subtotals: .fake().copy(grossRevenue: 45, netRevenue: 40)),
                                                                      .fake().copy(dateStart: "2024-01-02 00:00:00",
                                                                                   subtotals: .fake().copy(grossRevenue: 15, netRevenue: 5))]),
-            previousOrderStats: OrderStatsV4.fake().copy(totals: .fake().copy(grossRevenue: 30, netRevenue: 30)),
+            previousPeriodStats: OrderStatsV4.fake().copy(totals: .fake().copy(grossRevenue: 30, netRevenue: 30)),
             timeRange: .today,
             usageTracksEventEmitter: eventEmitter,
             storeAdminURL: sampleAdminURL
@@ -46,11 +46,11 @@ final class RevenueReportCardViewModelTests: XCTestCase {
 
     func test_it_contains_expected_reportURL_elements() throws {
         // When
-        let vm = RevenueReportCardViewModel(currentOrderStats: nil,
-                                   previousOrderStats: nil,
-                                      timeRange: .monthToDate,
-                                      usageTracksEventEmitter: eventEmitter,
-                                   storeAdminURL: sampleAdminURL)
+        let vm = RevenueReportCardViewModel(currentPeriodStats: nil,
+                                            previousPeriodStats: nil,
+                                            timeRange: .monthToDate,
+                                            usageTracksEventEmitter: eventEmitter,
+                                            storeAdminURL: sampleAdminURL)
         let revenueCardReportURL = try XCTUnwrap(vm.reportViewModel?.initialURL)
         let revenueCardURLQueryItems = try XCTUnwrap(URLComponents(url: revenueCardReportURL, resolvingAgainstBaseURL: false)?.queryItems)
 
@@ -62,7 +62,7 @@ final class RevenueReportCardViewModelTests: XCTestCase {
 
     func test_it_shows_sync_error_when_current_stats_are_nil() {
         // Given
-        let vm = RevenueReportCardViewModel(currentOrderStats: nil, previousOrderStats: .fake(), timeRange: .monthToDate, usageTracksEventEmitter: eventEmitter)
+        let vm = RevenueReportCardViewModel(currentPeriodStats: nil, previousPeriodStats: .fake(), timeRange: .monthToDate, usageTracksEventEmitter: eventEmitter)
 
         // Then
         XCTAssertTrue(vm.showSyncError)
@@ -70,7 +70,7 @@ final class RevenueReportCardViewModelTests: XCTestCase {
 
     func test_it_shows_sync_error_when_previous_stats_are_nil() {
         // Given
-        let vm = RevenueReportCardViewModel(currentOrderStats: .fake(), previousOrderStats: nil, timeRange: .monthToDate, usageTracksEventEmitter: eventEmitter)
+        let vm = RevenueReportCardViewModel(currentPeriodStats: .fake(), previousPeriodStats: nil, timeRange: .monthToDate, usageTracksEventEmitter: eventEmitter)
 
         // Then
         XCTAssertTrue(vm.showSyncError)
@@ -78,11 +78,11 @@ final class RevenueReportCardViewModelTests: XCTestCase {
 
     func test_redact_updates_properties_as_expected() {
         // Given
-        var vm = RevenueReportCardViewModel(currentOrderStats: nil,
-                                   previousOrderStats: nil,
-                                   timeRange: .monthToDate,
-                                   usageTracksEventEmitter: eventEmitter,
-                                   storeAdminURL: sampleAdminURL)
+        var vm = RevenueReportCardViewModel(currentPeriodStats: nil,
+                                            previousPeriodStats: nil,
+                                            timeRange: .monthToDate,
+                                            usageTracksEventEmitter: eventEmitter,
+                                            storeAdminURL: sampleAdminURL)
 
         // When
         vm.redact()

--- a/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Analytics Hub/Report Cards/RevenueReportCardViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Analytics Hub/Report Cards/RevenueReportCardViewModelTests.swift
@@ -1,0 +1,103 @@
+import XCTest
+import WooFoundation
+import Yosemite
+@testable import WooCommerce
+
+final class RevenueReportCardViewModelTests: XCTestCase {
+
+    private var eventEmitter: StoreStatsUsageTracksEventEmitter!
+    private var analyticsProvider: MockAnalyticsProvider!
+    private var analytics: Analytics!
+
+    private let sampleAdminURL = "https://example.com/wp-admin/"
+
+    override func setUp() {
+        analyticsProvider = MockAnalyticsProvider()
+        analytics = WooAnalytics(analyticsProvider: analyticsProvider)
+        eventEmitter = StoreStatsUsageTracksEventEmitter(analytics: analytics)
+        ServiceLocator.setCurrencySettings(CurrencySettings()) // Default is US
+    }
+
+    func test_it_inits_with_expected_values() {
+        // Given
+        let vm = RevenueReportCardViewModel(
+            currentOrderStats: OrderStatsV4.fake().copy(totals: .fake().copy(grossRevenue: 60, netRevenue: 45),
+                                                         intervals: [.fake().copy(dateStart: "2024-01-01 00:00:00",
+                                                                                  subtotals: .fake().copy(grossRevenue: 45, netRevenue: 40)),
+                                                                     .fake().copy(dateStart: "2024-01-02 00:00:00",
+                                                                                  subtotals: .fake().copy(grossRevenue: 15, netRevenue: 5))]),
+            previousOrderStats: OrderStatsV4.fake().copy(totals: .fake().copy(grossRevenue: 30, netRevenue: 30)),
+            timeRange: .today,
+            usageTracksEventEmitter: eventEmitter,
+            storeAdminURL: sampleAdminURL
+        )
+
+        // Then
+        assertEqual("$60", vm.leadingValue)
+        assertEqual(DeltaPercentage(string: "+100%", direction: .positive), vm.leadingDelta)
+        assertEqual([45, 15], vm.leadingChartData)
+        assertEqual("$45", vm.trailingValue)
+        assertEqual(DeltaPercentage(string: "+50%", direction: .positive), vm.trailingDelta)
+        assertEqual([40, 5], vm.trailingChartData)
+        XCTAssertFalse(vm.isRedacted)
+        XCTAssertFalse(vm.showSyncError)
+        XCTAssertNotNil(vm.reportViewModel)
+    }
+
+    func test_it_contains_expected_reportURL_elements() throws {
+        // When
+        let vm = RevenueReportCardViewModel(currentOrderStats: nil,
+                                   previousOrderStats: nil,
+                                      timeRange: .monthToDate,
+                                      usageTracksEventEmitter: eventEmitter,
+                                   storeAdminURL: sampleAdminURL)
+        let revenueCardReportURL = try XCTUnwrap(vm.reportViewModel?.initialURL)
+        let revenueCardURLQueryItems = try XCTUnwrap(URLComponents(url: revenueCardReportURL, resolvingAgainstBaseURL: false)?.queryItems)
+
+        // Then
+        XCTAssertTrue(revenueCardReportURL.relativeString.contains(sampleAdminURL))
+        XCTAssertTrue(revenueCardURLQueryItems.contains(URLQueryItem(name: "path", value: "/analytics/revenue")))
+        XCTAssertTrue(revenueCardURLQueryItems.contains(URLQueryItem(name: "period", value: "month")))
+    }
+
+    func test_it_shows_sync_error_when_current_stats_are_nil() {
+        // Given
+        let vm = RevenueReportCardViewModel(currentOrderStats: nil, previousOrderStats: .fake(), timeRange: .monthToDate, usageTracksEventEmitter: eventEmitter)
+
+        // Then
+        XCTAssertTrue(vm.showSyncError)
+    }
+
+    func test_it_shows_sync_error_when_previous_stats_are_nil() {
+        // Given
+        let vm = RevenueReportCardViewModel(currentOrderStats: .fake(), previousOrderStats: nil, timeRange: .monthToDate, usageTracksEventEmitter: eventEmitter)
+
+        // Then
+        XCTAssertTrue(vm.showSyncError)
+    }
+
+    func test_redact_updates_properties_as_expected() {
+        // Given
+        var vm = RevenueReportCardViewModel(currentOrderStats: nil,
+                                   previousOrderStats: nil,
+                                   timeRange: .monthToDate,
+                                   usageTracksEventEmitter: eventEmitter,
+                                   storeAdminURL: sampleAdminURL)
+
+        // When
+        vm.redact()
+
+        // Then
+
+        assertEqual("$1000", vm.leadingValue)
+        assertEqual(DeltaPercentage(string: "0%", direction: .zero), vm.leadingDelta)
+        assertEqual([], vm.leadingChartData)
+        assertEqual("$1000", vm.trailingValue)
+        assertEqual(DeltaPercentage(string: "0%", direction: .zero), vm.trailingDelta)
+        assertEqual([], vm.trailingChartData)
+        XCTAssertTrue(vm.isRedacted)
+        XCTAssertFalse(vm.showSyncError)
+        XCTAssertNotNil(vm.reportViewModel)
+    }
+
+}


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of: #12233
<!-- Id number of the GitHub issue this PR addresses. -->

## Why
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
We want to refactor the analytics hub to create separate view models for each card (with relevant unit tests), to separate their implementation details from the hub view model. This PR refactors the revenue card. Other cards will be refactored in following PRs.

## How

* Adds a new `AnalyticsReportCardProtocol`. This will take the place of the current `AnalyticsReportCardViewModel` for creating view models for the `AnalyticsReportCard` view.
* Adds a new `RevenueReportCardViewModel`. This is the view model with the data for the Revenue card, and it handles:
   * Parsing the required data from the given order stats and time range when initialized.
   * Redacting the card (for loading new data).
   * Updating the order stats and time range (when they change in the hub).
* Updates `AnalyticsHubViewModel` to use the new view model for `revenueCard`. This simplifies how the hub creates and updates that card.
* Adds unit tests for `RevenueReportCardViewModel` and removes extraneous tests for `revenueCard` from the `AnalyticsHubViewModel` unit tests.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

1. Build and run the app.
2. In the My Store tab, tap "See More" to open the analytics hub.
3. Confirm the Revenue card loads as expected, with the expected redacted loading view while data is being fetched.
4. Select a different time range and confirm the Revenue card loads as expected, with new stats data and an updated report link.
5. Customize the analytics hub cards and confirm the Revenue card is added/removed/updated as expected.


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
