### PR TITLE
[Crash] Implicitly unwrapping an Optional value

### DIFF
--- a/WooCommerce/Classes/ViewRelated/ReusableViews/EmptyStateViewController/EmptyStateViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/EmptyStateViewController/EmptyStateViewController.swift
@@ -225,8 +225,8 @@ final class EmptyStateViewController: UIViewController, KeyboardFrameAdjustmentP
     ///
     private func updateImageVisibilityUsing(traits: UITraitCollection) {
         let shouldShowImageView = traits.verticalSizeClass != .compact &&
-            imageView.image != nil
-        imageView.isHidden = !shouldShowImageView
+            imageView?.image != nil
+        imageView?.isHidden = !shouldShowImageView
     }
 
     /// Update the `contentViewHeightConstraint` so that the StackView is kept vertically centered.


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #12221
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

- **imageView** is an IBOutlet so we need to be careful when using it since it can be nil
- simple **?** does the trick, with adding optionality

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

Tnx @rachelmcr for creating the reproduction steps:
- Open the App
- Navigate to the Menu screen
- Change the selected store
- Select a different time range in the My Store stats chart
- Minimize the app
- **App should not crash**! Previously app would crash when we minimized the app, backgrounded the app

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

<img width="2040" alt="Screenshot 2024-03-07 at 12 43 22" src="https://github.com/woocommerce/woocommerce-ios/assets/6242034/ba14b0cf-c5a9-4f74-a351-74497396134b">

---
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
