### PR TITLE
My Store Analytics: Remove feature flag customRangeInMyStoreAnalytics

### DIFF
--- a/Experiments/Experiments/DefaultFeatureFlagService.swift
+++ b/Experiments/Experiments/DefaultFeatureFlagService.swift
@@ -87,8 +87,6 @@ public struct DefaultFeatureFlagService: FeatureFlagService {
             return true
         case .splitViewInProductsTab:
             return true
-        case .customRangeInMyStoreAnalytics:
-            return buildConfig == .localDeveloper || buildConfig == .alpha
         default:
             return true
         }

--- a/Experiments/Experiments/FeatureFlag.swift
+++ b/Experiments/Experiments/FeatureFlag.swift
@@ -195,8 +195,4 @@ public enum FeatureFlag: Int {
     /// Displays the Products tab in a split view
     ///
     case splitViewInProductsTab
-
-    /// Displays the option to add a custom date range in My Store Analytics
-    ///
-    case customRangeInMyStoreAnalytics
 }

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -4,10 +4,11 @@
 -----
 - [***] [internal] Alamofire, which is the HTTP client library used in the app, has been updated to v5. [https://github.com/woocommerce/woocommerce-ios/pull/12125]
 - [internal] Blaze: Update campaign status values to match v1.1 endpoint. [https://github.com/woocommerce/woocommerce-ios/pull/12207]
-- Orders: Merchants can filter orders by selecting a customer [https://github.com/woocommerce/woocommerce-ios/pull/12100]
-- Login: Adds a small tutorial before presenting the web view application password authentication screen. [https://github.com/woocommerce/woocommerce-ios/pull/12240]
-- Performance: Add a connectivity tool to diagnose possible network failures [https://github.com/woocommerce/woocommerce-ios/pull/12240]
+- [**] Orders: Merchants can filter orders by selecting a customer [https://github.com/woocommerce/woocommerce-ios/pull/12100]
+- [**] Login: Adds a small tutorial before presenting the web view application password authentication screen. [https://github.com/woocommerce/woocommerce-ios/pull/12240]
+- [**] Performance: Add a connectivity tool to diagnose possible network failures [https://github.com/woocommerce/woocommerce-ios/pull/12240]
 - [internal] Performance: Retries orders timeout errors [https://github.com/woocommerce/woocommerce-ios/pull/12240]
+- [**] My Store Analytics: Now a custom date range can be added for analyzing store performance in any arbitrary time ranges. [https://github.com/woocommerce/woocommerce-ios/pull/12243]
 
 
 

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Stats v4/StoreStatsAndTopPerformersViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Stats v4/StoreStatsAndTopPerformersViewController.swift
@@ -415,9 +415,7 @@ private extension StoreStatsAndTopPerformersViewController {
         tabBar.equalWidthFill = .equalSpacing
         tabBar.equalWidthSpacing = TabBar.tabSpacing
 
-        if featureFlagService.isFeatureFlagEnabled(.customRangeInMyStoreAnalytics) {
-            addCustomViewToTabBar(customRangeButtonView)
-        }
+        addCustomViewToTabBar(customRangeButtonView)
 
         selectedTabSubscription = tabBar.$selectedIndex
             .print("🍎 tab switched")
@@ -435,10 +433,6 @@ private extension StoreStatsAndTopPerformersViewController {
 
     @MainActor
     func configureCustomRangeTab() async {
-        guard featureFlagService.isFeatureFlagEnabled(.customRangeInMyStoreAnalytics) else {
-            return
-        }
-
         guard let customRange = await loadTimeRangeForCustomRangeTab() else {
             return
         }
@@ -448,10 +442,6 @@ private extension StoreStatsAndTopPerformersViewController {
 
     @MainActor
     func loadTimeRangeForCustomRangeTab() async -> StatsTimeRangeV4? {
-        guard featureFlagService.isFeatureFlagEnabled(.customRangeInMyStoreAnalytics) else {
-            return nil
-        }
-
         return await withCheckedContinuation { continuation in
             stores.dispatch(AppSettingsAction.loadCustomStatsTimeRange(siteID: siteID) { timeRange in
                 continuation.resume(returning: timeRange)


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #11935 
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This PR removes the feature flag `customRangeInMyStoreAnalytics` to enable the feature in production builds.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
- Log in to a store with existing stats.
- Create a new custom range by tapping the calendar icon on the My Store stats tab bar.
- Confirm the start and end dates, a new tab should be added with stats for the selected dates.
- Tap the date range button and switch to a different range, the custom tab should be updated accordingly.
- Confirm that the visit and conversion stats are redacted for ranges longer than 1 day and not for 1-day range. Tapping the redacted view should present a modal explaining the unavailability of the stats.
- Select any specific date, the visit and conversion stats should not be redacted for ranges longer than 1 day. Confirm that the data is correct.
- Relaunch the app, you should land on the custom range tab again if it was the last tab you saw before.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

https://github.com/woocommerce/woocommerce-ios/assets/5533851/eb9a1bc4-275d-4dc0-af1b-616be3886e71



---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
