### PR TITLE
Login: Detect invalid WP site address

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -85,9 +85,9 @@ target 'WooCommerce' do
   pod 'Gridicons', '~> 1.2.0'
 
   # To allow pod to pick up beta versions use -beta. E.g., 1.1.7-beta.1
-  pod 'WordPressAuthenticator', '~> 9.0'
+  # pod 'WordPressAuthenticator', '~> 9.0'
   # pod 'WordPressAuthenticator', git: 'https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git', branch: ''
-  # pod 'WordPressAuthenticator', git: 'https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git', commit: ''
+  pod 'WordPressAuthenticator', git: 'https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git', commit: '69277ab4179e784cf19759358c68bb20cbf007e7'
   # pod 'WordPressAuthenticator', path: '../WordPressAuthenticator-iOS'
 
   wordpress_shared

--- a/Podfile
+++ b/Podfile
@@ -87,7 +87,7 @@ target 'WooCommerce' do
   # To allow pod to pick up beta versions use -beta. E.g., 1.1.7-beta.1
   # pod 'WordPressAuthenticator', '~> 9.0'
   # pod 'WordPressAuthenticator', git: 'https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git', branch: ''
-  pod 'WordPressAuthenticator', git: 'https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git', commit: '69277ab4179e784cf19759358c68bb20cbf007e7'
+  pod 'WordPressAuthenticator', git: 'https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git', commit: '958e0c81a718fe35cc9d4f350c4a49cbf8e4458a'
   # pod 'WordPressAuthenticator', path: '../WordPressAuthenticator-iOS'
 
   wordpress_shared

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -72,7 +72,7 @@ DEPENDENCIES:
   - StripeTerminal (~> 3.1.0)
   - SwiftLint (= 0.54.0)
   - WordPress-Editor-iOS (~> 1.19)
-  - WordPressAuthenticator (from `https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git`, commit `69277ab4179e784cf19759358c68bb20cbf007e7`)
+  - WordPressAuthenticator (from `https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git`, commit `958e0c81a718fe35cc9d4f350c4a49cbf8e4458a`)
   - WordPressShared (~> 2.1)
   - WordPressUI (~> 1.15)
   - Wormholy (~> 1.6.6)
@@ -116,12 +116,12 @@ SPEC REPOS:
 
 EXTERNAL SOURCES:
   WordPressAuthenticator:
-    :commit: 69277ab4179e784cf19759358c68bb20cbf007e7
+    :commit: 958e0c81a718fe35cc9d4f350c4a49cbf8e4458a
     :git: https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git
 
 CHECKOUT OPTIONS:
   WordPressAuthenticator:
-    :commit: 69277ab4179e784cf19759358c68bb20cbf007e7
+    :commit: 958e0c81a718fe35cc9d4f350c4a49cbf8e4458a
     :git: https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git
 
 SPEC CHECKSUMS:
@@ -158,6 +158,6 @@ SPEC CHECKSUMS:
   ZendeskSupportProvidersSDK: 685b5d185af47ced0ec40564ec46355c838bbd06
   ZendeskSupportSDK: 92e6f9d334e81e9186f8a17583862350460a5393
 
-PODFILE CHECKSUM: 29db3eff91c824b6c857f56384df2bcc830f9f1d
+PODFILE CHECKSUM: b6992b3023929115c1aea0a419bb9d1ef24d585e
 
 COCOAPODS: 1.14.0

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -72,7 +72,7 @@ DEPENDENCIES:
   - StripeTerminal (~> 3.1.0)
   - SwiftLint (= 0.54.0)
   - WordPress-Editor-iOS (~> 1.19)
-  - WordPressAuthenticator (~> 9.0)
+  - WordPressAuthenticator (from `https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git`, commit `69277ab4179e784cf19759358c68bb20cbf007e7`)
   - WordPressShared (~> 2.1)
   - WordPressUI (~> 1.15)
   - Wormholy (~> 1.6.6)
@@ -81,7 +81,6 @@ DEPENDENCIES:
 
 SPEC REPOS:
   https://github.com/wordpress-mobile/cocoapods-specs.git:
-    - WordPressAuthenticator
     - WordPressKit
   trunk:
     - Alamofire
@@ -115,6 +114,16 @@ SPEC REPOS:
     - ZendeskSupportProvidersSDK
     - ZendeskSupportSDK
 
+EXTERNAL SOURCES:
+  WordPressAuthenticator:
+    :commit: 69277ab4179e784cf19759358c68bb20cbf007e7
+    :git: https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git
+
+CHECKOUT OPTIONS:
+  WordPressAuthenticator:
+    :commit: 69277ab4179e784cf19759358c68bb20cbf007e7
+    :git: https://github.com/wordpress-mobile/WordPressAuthenticator-iOS.git
+
 SPEC CHECKSUMS:
   Alamofire: 3ca42e259043ee0dc5c0cdd76c4bc568b8e42af7
   Automattic-Tracks-iOS: f30bf3362a77010ccb9fe9aded453645089f6ccb
@@ -134,7 +143,7 @@ SPEC CHECKSUMS:
   UIDeviceIdentifier: 442b65b4ff1832d4ca9c2a157815cb29ad981b17
   WordPress-Aztec-iOS: 8eaa928fb3a5694924ed3befac64beaae5656e12
   WordPress-Editor-iOS: 98ce1fc542c3a09e48ddc9423405b1d1e48240f1
-  WordPressAuthenticator: d906a1005febb28de9f5c3a802736ca0850307f6
+  WordPressAuthenticator: c86057e67ca76074f54c87213086b202210c82c6
   WordPressKit: 6fbe0528c43df471a73de17909413a1e42f862b1
   WordPressShared: 0aa459e5257a77184db87805a998f447443c9706
   WordPressUI: 700e3ec5a9f77b6920c8104c338c85788036ab3c
@@ -149,6 +158,6 @@ SPEC CHECKSUMS:
   ZendeskSupportProvidersSDK: 685b5d185af47ced0ec40564ec46355c838bbd06
   ZendeskSupportSDK: 92e6f9d334e81e9186f8a17583862350460a5393
 
-PODFILE CHECKSUM: 023a42d75e7703ceb23107fcaeb7ab7d7eb9b824
+PODFILE CHECKSUM: 29db3eff91c824b6c857f56384df2bcc830f9f1d
 
 COCOAPODS: 1.14.0

--- a/WooCommerce/WooCommerceUITests/Mocks/mappings/sites/site_info_wordpress_com.json
+++ b/WooCommerce/WooCommerceUITests/Mocks/mappings/sites/site_info_wordpress_com.json
@@ -1,7 +1,7 @@
 {
     "request": {
         "method": "GET",
-        "urlPath": "/rest/v1.1/connect/site-info/"
+        "urlPathPattern": "/rest/v1.1/connect/site-info?(.*)"
     },
     "response": {
         "status": 200,
@@ -12,7 +12,7 @@
             "isJetpackActive": true,
             "isJetpackConnected": true,
             "isWordPressDotCom": true,
-            "urlAfterRedirects": "https:\/\/automatticwidgets.wpcomstaging.com",
+            "urlAfterRedirects": "http:\/\/yourwoosite.com",
             "jetpackVersion": false
         },
         "headers": {


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #12244 
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This PR adds the fix from WPAuthenticator https://github.com/wordpress-mobile/WordPressAuthenticator-iOS/pull/841 to fix the issue when invalid WP site addresses are bypassed to the WPCom login flow.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

- Log out of the app if needed.
- Select Log In on the Prologue screen.
- Enter an invalid WP site that ends with "wpcomstaging.com" or "wordpress.com".
- Confirm that an alert is displayed and you cannot reach the WPCom login flow.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

https://github.com/woocommerce/woocommerce-ios/assets/5533851/c6245c00-4c25-43bf-8d05-816be7cbcff3



---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
