### PR TITLE
[Tablet Orders] Enable side-by-side Order Creation feature flag

### DIFF
--- a/Experiments/Experiments/DefaultFeatureFlagService.swift
+++ b/Experiments/Experiments/DefaultFeatureFlagService.swift
@@ -14,7 +14,7 @@ public struct DefaultFeatureFlagService: FeatureFlagService {
         case .inbox:
             return buildConfig == .localDeveloper || buildConfig == .alpha
         case .sideBySideViewForOrderForm:
-            return buildConfig == .localDeveloper || buildConfig == .alpha
+            return true
         case .updateOrderOptimistically:
             return buildConfig == .localDeveloper || buildConfig == .alpha
         case .shippingLabelsOnboardingM1:

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -9,6 +9,7 @@
 - [**] Performance: Add a connectivity tool to diagnose possible network failures [https://github.com/woocommerce/woocommerce-ios/pull/12240]
 - [internal] Performance: Retries orders timeout errors [https://github.com/woocommerce/woocommerce-ios/pull/12240]
 - [**] My Store Analytics: Now a custom date range can be added for analyzing store performance in any arbitrary time ranges. [https://github.com/woocommerce/woocommerce-ios/pull/12243]
+- [***] Orders: Side-by-side view for Order Creation or Editing on iPad and larger iPhones [https://github.com/woocommerce/woocommerce-ios/pull/12246]
 
 
 


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

The tablet improvements to Order Creation and editing are ready for release. This PR enables them in release builds.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

1. In your Xcode scheme, change the build to use the `Release` profile
2. Launch the app on an iPad or large iPhone simulator (in landscape)
3. Open the Orders tab
4. Tap `+`
5. Observe that the side-by-side view is shown, with both the product selector and order summary in view.


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
