### PR TITLE
[Crash] Implicitly unwrapping an Optional value – beta fix

### DIFF
--- a/WooCommerce/Classes/ViewRelated/ReusableViews/EmptyStateViewController/EmptyStateViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/EmptyStateViewController/EmptyStateViewController.swift
@@ -225,8 +225,8 @@ final class EmptyStateViewController: UIViewController, KeyboardFrameAdjustmentP
     ///
     private func updateImageVisibilityUsing(traits: UITraitCollection) {
         let shouldShowImageView = traits.verticalSizeClass != .compact &&
-            imageView.image != nil
-        imageView.isHidden = !shouldShowImageView
+            imageView?.image != nil
+        imageView?.isHidden = !shouldShowImageView
     }
 
     /// Update the `contentViewHeightConstraint` so that the StackView is kept vertically centered.


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

This PR cherry-picks the changes from #12239 to fix the crash in the 17.6 beta branch.

The conflicts when we merge back to trunk should be trivial to resolve.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->


1. Open the App
2. Navigate to the Menu screen
3. Change the selected store
4. Select a different time range in the My Store stats chart
5. Minimize the app
6. App should not crash! Previously app would crash when we minimized the app, backgrounded the app



---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
