### PR TITLE
Attempted fix for crash on view controller with nil view when removing offline banner 

### DIFF
--- a/WooCommerce/Classes/System/WooNavigationController.swift
+++ b/WooCommerce/Classes/System/WooNavigationController.swift
@@ -156,7 +156,7 @@ private extension WooNavigationControllerDelegate {
     /// Removes the offline banner from the view controller if it exists.
     ///
     func removeOfflineBanner(for viewController: UIViewController) {
-        guard let offlineBanner = viewController.view.subviews.first(where: { $0 is OfflineBannerView }) else {
+        guard let offlineBanner = viewController.view?.subviews.first(where: { $0 is OfflineBannerView }) else {
             return
         }
         offlineBanner.removeFromSuperview()


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Attempted for https://github.com/woocommerce/woocommerce-ios/issues/12222

<!-- Id number of the GitHub issue this PR addresses. -->

## Why

I encountered [a crash](https://a8c.sentry.io/issues/5040609777/events/e78981190be64ce7a2248ea950f698cf/) that started in release 17.6, where the view controller has 0x0 address in `navigationController(_:didShow:animated:)` and thus accessing its `view.subviews` crashes now that view is `nil`.

## How

The [pairing function](https://github.com/woocommerce/woocommerce-ios/blob/31304d9ce1e9cf8c13b8a3c0d9a966a17510dd5b/WooCommerce/Classes/System/WooNavigationController.swift#L113-L116) that shows the offline banner `setOfflineBannerWhenNoConnection` already guards on non-nil `view`:

https://github.com/woocommerce/woocommerce-ios/blob/31304d9ce1e9cf8c13b8a3c0d9a966a17510dd5b/WooCommerce/Classes/System/WooNavigationController.swift#L130

I think it makes sense to do the same optional check in `removeOfflineBanner` to catch this edge case.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

I haven't been able to reproduce this crash consistently, but a confidence check would be nice:

- Go to the products tab
- Tap in and out of many products --> the app shouldn't crash
- Tap on the search icon
- Tap in and out of many products, search for some products --> the app shouldn't crash


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
