### PR TITLE
Allow manual dismissal after firmware update. Add mandatory update cancel option.

### DIFF
--- a/WooCommerce/Classes/ViewModels/CardPresentPayments/CardPresentModalUpdateProgress.swift
+++ b/WooCommerce/Classes/ViewModels/CardPresentPayments/CardPresentModalUpdateProgress.swift
@@ -15,7 +15,7 @@ final class CardPresentModalUpdateProgress: CardPresentPaymentsModalViewModel, C
 
     let primaryButtonTitle: String? = nil
 
-    let secondaryButtonTitle: String? = Localization.cancel
+    var secondaryButtonTitle: String? = nil
 
     let auxiliaryButtonTitle: String? = nil
 
@@ -34,19 +34,28 @@ final class CardPresentModalUpdateProgress: CardPresentPaymentsModalViewModel, C
     init(requiredUpdate: Bool, progress: Float, cancel: (() -> Void)?) {
         self.progress = progress
         self.cancelAction = cancel
-        actionsMode = cancel != nil ? .secondaryOnlyAction : .none
+
+        actionsMode = .secondaryOnlyAction
         titleComplete = Localization.titleComplete
         titleInProgress = Localization.title
+        secondaryButtonTitle = Localization.dismissButtonText
 
         if !isComplete {
             messageInProgress = requiredUpdate ? Localization.messageRequired : Localization.messageOptional
+            secondaryButtonTitle = requiredUpdate ? Localization.cancelRequiredButtonText : Localization.cancelOptionalButtonText
         }
     }
 
     func didTapPrimaryButton(in viewController: UIViewController?) {}
 
     func didTapSecondaryButton(in viewController: UIViewController?) {
-        cancelAction?()
+        if !isComplete {
+            cancelAction?()
+        } else {
+            // The cancel action closure is triggered when we tap the button on a firmware complete scenario
+            // but since we cannot cancel an update that has already been completed, at some point it does not dismiss the view
+            debugPrint("Secondary button tapped, but firmware update completed.")
+        }
     }
 
     func didTapAuxiliaryButton(in viewController: UIViewController?) {}
@@ -74,9 +83,22 @@ private extension CardPresentModalUpdateProgress {
             comment: "Label that displays when an optional software update is happening"
         )
 
-        static let cancel = NSLocalizedString(
-            "Cancel",
-            comment: "Label for a cancel button"
+        static let cancelOptionalButtonText = NSLocalizedString(
+            "CardPresentModalUpdateProgress.button.cancelOptionalButtonText",
+            value: "Cancel",
+            comment: "Label for a cancel button when an optional software update is happening"
+        )
+
+        static let cancelRequiredButtonText = NSLocalizedString(
+            "CardPresentModalUpdateProgress.button.cancelRequiredButtonText",
+            value: "Cancel anyway",
+            comment: "Label for a cancel button when a mandatory software update is happening"
+        )
+
+        static let dismissButtonText = NSLocalizedString(
+            "CardPresentModalUpdateProgress.button.dismissButtonText",
+            value: "Dismiss",
+            comment: "Label for a dismiss button when a software update has finished"
         )
     }
 }

--- a/WooCommerce/Classes/ViewModels/CardPresentPayments/CardPresentModalUpdateProgress.swift
+++ b/WooCommerce/Classes/ViewModels/CardPresentPayments/CardPresentModalUpdateProgress.swift
@@ -52,9 +52,7 @@ final class CardPresentModalUpdateProgress: CardPresentPaymentsModalViewModel, C
         if !isComplete {
             cancelAction?()
         } else {
-            // The cancel action closure is triggered when we tap the button on a firmware complete scenario
-            // but since we cannot cancel an update that has already been completed, at some point it does not dismiss the view
-            debugPrint("Secondary button tapped, but firmware update completed.")
+            viewController?.dismiss(animated: true)
         }
     }
 


### PR DESCRIPTION
👋 This can wait after HACK week.

Closes #11974 
Closes #11210
CUW: peaMlT-qp-p2

## Description
This PR addresses several issues reported around the card present firmware update modal view, which was blocking the UI and not allowing merchants to continue using the app unless this was restarted. eg:

> Connecting to a Chipper reader which needed an updated never showed the update, completed, nor timed out: app ended up in a locked-up state and had to be force-quit.

> After doing a mandatory update of a WisePad 3, the reader connected with up to date software, but the software update screen never showed its dismiss button

> When a card reader is not charged above 50, and an update is needed, then we show an explanation pop-up that says to charge a reader. But for some reason, when a user clicks on “ok” we don’t finish the flow but continue “scanning” for a reader.

We address this by adding two changes:
1. We now allow cancelling mandatory updates (as Android does)
2. We show a dismiss button when a software update is completed. If the automatic modal view dismissal fails, the merchant can always tap on that button for manual dismissal.

Caveat: At some point, if we cancel some update mid-way, and then we attempt to reconnect the reader again, the flow seems to be stuck in "searching for reader", which is not resolved until we restart the process or re-run the app. This issue is out of scope (and unrelated) to the changes of this PR.

## Testing instructions
* In the WooCommerce target > Edit scheme > Enable `-simulated-stripe-card-reader`
* In `StripeCardReaderService`, find `Terminal.shared.simulatorConfiguration.availableReaderUpdate = .none`

### Case: Low Battery
1. Set `Terminal.shared.simulatorConfiguration.availableReaderUpdate` to `.lowBattery`, and run the app
2. Go to Menu > Payments > Manage Card Readers > Tap "Update Reader Software"
3. This is a mandatory update, so you will see a "Cancel anyway" before the "Low battery" error is shown. 
4. Cancel the update mid-way and see how the update stops and the modal is dismissed
5. Re-run the app, allow the update to run until the "Low battery" error is shown. Tap on cancel and see that is also dismissed.

| While updating | End of flow |
|--------|--------|
| ![mandatory updating](https://github.com/woocommerce/woocommerce-ios/assets/3812076/71d226c0-b885-4ef9-896f-bdf02fed7e19) | ![low on battery while updating](https://github.com/woocommerce/woocommerce-ios/assets/3812076/6f2bf31e-2c27-4257-a478-a5f9790f765f)| 

### Case: Optional updates
1. Set `Terminal.shared.simulatorConfiguration.availableReaderUpdate` to `.available`, and run the app
2. Go to Menu > Payments > Manage Card Readers > Tap "Update Reader Software"
3. This is an optional update, so you will see a "Cancel" button
4. Cancel the update mid-way and see how the update stops and the modal is dismissed
5. Re-run the app, allow the update to run until completes. Observe that the modal is dismissed automatically. If doesn't, you'll see a "Dismiss" button that can be tapped as a fallback.

| While updating | End of flow |
|--------|--------|
| ![optional updating](https://github.com/woocommerce/woocommerce-ios/assets/3812076/75bda488-769d-4886-9742-adc63b35c2c1) | ![Simulator Screenshot - iPhone 15 - 2024-03-14 at 12 28 15](https://github.com/woocommerce/woocommerce-ios/assets/3812076/03eacf6b-dee3-4529-be43-02d5fe2e546d) |


### Case: Mandatory updates
1. Set `Terminal.shared.simulatorConfiguration.availableReaderUpdate` to `.required`, and run the app
2. Go to Menu > Payments > Manage Card Readers > Tap "Update Reader Software"
3. This is a required update, so you will see a "Cancel anyway" button
4. Cancel the update mid-way and see how the update stops and the modal is dismissed
5. Re-run the app, allow the update to run until completes. Observe that the modal is dismissed automatically. If doesn't, you'll see a "Dismiss" button that can be tapped as a fallback.

| While updating | End of flow |
|--------|--------|
|![mandatory updating](https://github.com/woocommerce/woocommerce-ios/assets/3812076/71d226c0-b885-4ef9-896f-bdf02fed7e19) | ![Simulator Screenshot - iPhone 15 - 2024-03-14 at 12 28 15](https://github.com/woocommerce/woocommerce-ios/assets/3812076/03eacf6b-dee3-4529-be43-02d5fe2e546d) |
