### PR TITLE
[Analytics Hub] Dynamically update stats and time range in analytics hub report cards

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/AnalyticsHubViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/AnalyticsHubViewModel.swift
@@ -64,8 +64,7 @@ final class AnalyticsHubViewModel: ObservableObject {
         RevenueReportCardViewModel(currentPeriodStats: currentOrderStats,
                                    previousPeriodStats: previousOrderStats,
                                    timeRange: timeRangeSelectionType,
-                                   usageTracksEventEmitter: usageTracksEventEmitter,
-                                   storeAdminURL: stores.sessionManager.defaultSite?.adminURL)
+                                   usageTracksEventEmitter: usageTracksEventEmitter)
     }()
 
     /// Orders Card ViewModel
@@ -74,8 +73,7 @@ final class AnalyticsHubViewModel: ObservableObject {
         OrdersReportCardViewModel(currentPeriodStats: currentOrderStats,
                                   previousPeriodStats: previousOrderStats,
                                   timeRange: timeRangeSelectionType,
-                                  usageTracksEventEmitter: usageTracksEventEmitter,
-                                  storeAdminURL: stores.sessionManager.defaultSite?.adminURL)
+                                  usageTracksEventEmitter: usageTracksEventEmitter)
     }()
 
     /// Products Stats Card ViewModel
@@ -84,8 +82,7 @@ final class AnalyticsHubViewModel: ObservableObject {
         AnalyticsProductsStatsCardViewModel(currentPeriodStats: currentOrderStats,
                                             previousPeriodStats: previousOrderStats,
                                             timeRange: timeRangeSelectionType,
-                                            usageTracksEventEmitter: usageTracksEventEmitter,
-                                            storeAdminURL: stores.sessionManager.defaultSite?.adminURL)
+                                            usageTracksEventEmitter: usageTracksEventEmitter)
     }()
 
     /// Items Sold Card ViewModel

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/AnalyticsHubViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/AnalyticsHubViewModel.swift
@@ -64,6 +64,7 @@ final class AnalyticsHubViewModel: ObservableObject {
         RevenueReportCardViewModel(currentPeriodStats: currentOrderStats,
                                    previousPeriodStats: previousOrderStats,
                                    timeRange: timeRangeSelectionType,
+                                   isRedacted: isLoadingOrderStats,
                                    usageTracksEventEmitter: usageTracksEventEmitter)
     }()
 
@@ -73,6 +74,7 @@ final class AnalyticsHubViewModel: ObservableObject {
         OrdersReportCardViewModel(currentPeriodStats: currentOrderStats,
                                   previousPeriodStats: previousOrderStats,
                                   timeRange: timeRangeSelectionType,
+                                  isRedacted: isLoadingOrderStats,
                                   usageTracksEventEmitter: usageTracksEventEmitter)
     }()
 
@@ -82,19 +84,23 @@ final class AnalyticsHubViewModel: ObservableObject {
         AnalyticsProductsStatsCardViewModel(currentPeriodStats: currentOrderStats,
                                             previousPeriodStats: previousOrderStats,
                                             timeRange: timeRangeSelectionType,
+                                            isRedacted: isLoadingOrderStats,
                                             usageTracksEventEmitter: usageTracksEventEmitter)
     }()
 
     /// Items Sold Card ViewModel
     ///
     lazy var itemsSoldCard = {
-        AnalyticsItemsSoldViewModel(itemsSoldStats: itemsSoldStats)
+        AnalyticsItemsSoldViewModel(itemsSoldStats: itemsSoldStats,
+                                    isRedacted: isLoadingItemsSoldStats)
     }()
 
     /// Sessions Card ViewModel
     ///
     lazy var sessionsCard: SessionsReportCardViewModel = {
-        SessionsReportCardViewModel(currentOrderStats: currentOrderStats, siteStats: siteStats)
+        SessionsReportCardViewModel(currentOrderStats: currentOrderStats,
+                                    siteStats: siteStats,
+                                    isRedacted: isLoadingOrderStats || isLoadingSiteStats)
     }()
 
     /// View model for `AnalyticsHubCustomizeView`, to customize the cards in the Analytics Hub.
@@ -178,6 +184,18 @@ final class AnalyticsHubViewModel: ObservableObject {
     /// Site summary stats for visitors and views. Used in the sessions card.
     ///
     @Published private var siteStats: SiteSummaryStats? = nil
+
+    /// Loading state for order stats.
+    ///
+    private var isLoadingOrderStats = false
+
+    /// Loading state for items sold stats.
+    ///
+    private var isLoadingItemsSoldStats = false
+
+    /// Loading state for site stats.
+    ///
+    private var isLoadingSiteStats = false
 
     /// Time Range selection data defining the current and previous time period
     ///

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/Report Cards/OrdersReportCardViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/Report Cards/OrdersReportCardViewModel.swift
@@ -22,16 +22,20 @@ final class OrdersReportCardViewModel: AnalyticsReportCardProtocol {
     ///
     private let storeAdminURL: String?
 
-    var isRedacted: Bool = false
+    /// Indicates if the values should be hidden (for loading state)
+    ///
+    var isRedacted: Bool
 
     init(currentPeriodStats: OrderStatsV4?,
          previousPeriodStats: OrderStatsV4?,
          timeRange: AnalyticsHubTimeRangeSelection.SelectionType,
+         isRedacted: Bool = false,
          usageTracksEventEmitter: StoreStatsUsageTracksEventEmitter,
          storeAdminURL: String? = ServiceLocator.stores.sessionManager.defaultSite?.adminURL) {
         self.currentPeriodStats = currentPeriodStats
         self.previousPeriodStats = previousPeriodStats
         self.timeRange = timeRange
+        self.isRedacted = isRedacted
         self.usageTracksEventEmitter = usageTracksEventEmitter
         self.storeAdminURL = storeAdminURL
     }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/Report Cards/OrdersReportCardViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/Report Cards/OrdersReportCardViewModel.swift
@@ -39,26 +39,6 @@ final class OrdersReportCardViewModel: AnalyticsReportCardProtocol {
         self.usageTracksEventEmitter = usageTracksEventEmitter
         self.storeAdminURL = storeAdminURL
     }
-
-    /// Redacts the card content for a card loading state.
-    ///
-    func redact() {
-        isRedacted = true
-    }
-
-    /// Updates the stats used in the card metrics.
-    ///
-    func update(currentPeriodStats: OrderStatsV4?, previousPeriodStats: OrderStatsV4?) {
-        self.currentPeriodStats = currentPeriodStats
-        self.previousPeriodStats = previousPeriodStats
-        isRedacted = false
-    }
-
-    /// Updates the time range used in the card report link.
-    ///
-    func update(timeRange: AnalyticsHubTimeRangeSelection.SelectionType) {
-        self.timeRange = timeRange
-    }
 }
 
 // MARK: AnalyticsReportCardProtocol conformance

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/Report Cards/ProductsReportCardViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/Report Cards/ProductsReportCardViewModel.swift
@@ -43,26 +43,6 @@ final class AnalyticsProductsStatsCardViewModel {
         self.usageTracksEventEmitter = usageTracksEventEmitter
         self.storeAdminURL = storeAdminURL
     }
-
-    /// Redacts the card content for a card loading state.
-    ///
-    func redact() {
-        isRedacted = true
-    }
-
-    /// Updates the stats used in the card metrics.
-    ///
-    func update(currentPeriodStats: OrderStatsV4?, previousPeriodStats: OrderStatsV4?) {
-        self.currentPeriodStats = currentPeriodStats
-        self.previousPeriodStats = previousPeriodStats
-        isRedacted = false
-    }
-
-    /// Updates the time range used in the card report link.
-    ///
-    func update(timeRange: AnalyticsHubTimeRangeSelection.SelectionType) {
-        self.timeRange = timeRange
-    }
 }
 
 /// Analytics Hub Items Sold ViewModel.
@@ -82,19 +62,6 @@ final class AnalyticsItemsSoldViewModel {
          isRedacted: Bool = false) {
         self.itemsSoldStats = itemsSoldStats
         self.isRedacted = isRedacted
-    }
-
-    /// Redacts the card content for a card loading state.
-    ///
-    func redact() {
-        isRedacted = true
-    }
-
-    /// Updates the stats used in the card metrics.
-    ///
-    func update(itemsSoldStats: TopEarnerStats?) {
-        self.itemsSoldStats = itemsSoldStats
-        isRedacted = false
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/Report Cards/ProductsReportCardViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/Report Cards/ProductsReportCardViewModel.swift
@@ -28,16 +28,18 @@ final class AnalyticsProductsStatsCardViewModel {
 
     /// Indicates if the values should be hidden (for loading state)
     ///
-    var isRedacted: Bool = false
+    var isRedacted: Bool
 
     init(currentPeriodStats: OrderStatsV4?,
          previousPeriodStats: OrderStatsV4?,
          timeRange: AnalyticsHubTimeRangeSelection.SelectionType,
+         isRedacted: Bool = false,
          usageTracksEventEmitter: StoreStatsUsageTracksEventEmitter,
          storeAdminURL: String? = ServiceLocator.stores.sessionManager.defaultSite?.adminURL) {
         self.currentPeriodStats = currentPeriodStats
         self.previousPeriodStats = previousPeriodStats
         self.timeRange = timeRange
+        self.isRedacted = isRedacted
         self.usageTracksEventEmitter = usageTracksEventEmitter
         self.storeAdminURL = storeAdminURL
     }
@@ -74,10 +76,12 @@ final class AnalyticsItemsSoldViewModel {
 
     /// Indicates if the values should be hidden (for loading state)
     ///
-    var isRedacted: Bool = false
+    var isRedacted: Bool
 
-    init(itemsSoldStats: TopEarnerStats?) {
+    init(itemsSoldStats: TopEarnerStats?,
+         isRedacted: Bool = false) {
         self.itemsSoldStats = itemsSoldStats
+        self.isRedacted = isRedacted
     }
 
     /// Redacts the card content for a card loading state.

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/Report Cards/RevenueReportCardViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/Report Cards/RevenueReportCardViewModel.swift
@@ -39,26 +39,6 @@ final class RevenueReportCardViewModel: AnalyticsReportCardProtocol {
         self.usageTracksEventEmitter = usageTracksEventEmitter
         self.storeAdminURL = storeAdminURL
     }
-
-    /// Redacts the card content for a card loading state.
-    ///
-    func redact() {
-        isRedacted = true
-    }
-
-    /// Updates the stats used in the card metrics.
-    ///
-    func update(currentPeriodStats: OrderStatsV4?, previousPeriodStats: OrderStatsV4?) {
-        self.currentPeriodStats = currentPeriodStats
-        self.previousPeriodStats = previousPeriodStats
-        isRedacted = false
-    }
-
-    /// Updates the time range used in the card report link.
-    ///
-    func update(timeRange: AnalyticsHubTimeRangeSelection.SelectionType) {
-        self.timeRange = timeRange
-    }
 }
 
 // MARK: AnalyticsReportCardProtocol conformance

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/Report Cards/RevenueReportCardViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/Report Cards/RevenueReportCardViewModel.swift
@@ -22,16 +22,20 @@ final class RevenueReportCardViewModel: AnalyticsReportCardProtocol {
     ///
     private let storeAdminURL: String?
 
-    var isRedacted: Bool = false
+    /// Indicates if the values should be hidden (for loading state)
+    ///
+    var isRedacted: Bool
 
     init(currentPeriodStats: OrderStatsV4?,
          previousPeriodStats: OrderStatsV4?,
          timeRange: AnalyticsHubTimeRangeSelection.SelectionType,
+         isRedacted: Bool = false,
          usageTracksEventEmitter: StoreStatsUsageTracksEventEmitter,
          storeAdminURL: String? = ServiceLocator.stores.sessionManager.defaultSite?.adminURL) {
         self.currentPeriodStats = currentPeriodStats
         self.previousPeriodStats = previousPeriodStats
         self.timeRange = timeRange
+        self.isRedacted = isRedacted
         self.usageTracksEventEmitter = usageTracksEventEmitter
         self.storeAdminURL = storeAdminURL
     }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/Report Cards/SessionsReportCardViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/Report Cards/SessionsReportCardViewModel.swift
@@ -11,12 +11,16 @@ final class SessionsReportCardViewModel: AnalyticsReportCardProtocol {
     ///
     private var siteStats: SiteSummaryStats?
 
-    var isRedacted: Bool = false
+    /// Indicates if the values should be hidden (for loading state)
+    ///
+    var isRedacted: Bool
 
     init(currentOrderStats: OrderStatsV4?,
-         siteStats: SiteSummaryStats?) {
+         siteStats: SiteSummaryStats?,
+         isRedacted: Bool = false) {
         self.currentOrderStats = currentOrderStats
         self.siteStats = siteStats
+        self.isRedacted = isRedacted
     }
 
     func redact() {

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/Report Cards/SessionsReportCardViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/Report Cards/SessionsReportCardViewModel.swift
@@ -22,18 +22,6 @@ final class SessionsReportCardViewModel: AnalyticsReportCardProtocol {
         self.siteStats = siteStats
         self.isRedacted = isRedacted
     }
-
-    func redact() {
-        isRedacted = true
-    }
-
-    /// Updates the stats used in the card metrics.
-    ///
-    func update(currentOrderStats: OrderStatsV4?, siteStats: SiteSummaryStats?) {
-        self.currentOrderStats = currentOrderStats
-        self.siteStats = siteStats
-        isRedacted = false
-    }
 }
 
 // MARK: AnalyticsReportCardProtocol conformance

--- a/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Analytics Hub/AnalyticsHubViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Analytics Hub/AnalyticsHubViewModelTests.swift
@@ -356,30 +356,6 @@ final class AnalyticsHubViewModelTests: XCTestCase {
         }
     }
 
-    @MainActor
-    func test_card_report_URLs_contain_expected_period_after_new_timeRange_selection() async throws {
-        // Given
-        XCTAssertEqual(.monthToDate, vm.timeRangeSelectionType)
-
-        // When
-        vm.timeRangeSelectionType = .today
-
-        // Then
-        let revenueCardReportURL = try XCTUnwrap(vm.revenueCard.reportViewModel?.initialURL)
-        let ordersCardReportURL = try XCTUnwrap(vm.ordersCard.reportViewModel?.initialURL)
-        let productsStatsCardReportURL = try XCTUnwrap(vm.productsStatsCard.reportViewModel?.initialURL)
-
-        let revenueCardURLQueryItems = try XCTUnwrap(URLComponents(url: revenueCardReportURL, resolvingAgainstBaseURL: false)?.queryItems)
-        let ordersCardURLQueryItems = try XCTUnwrap(URLComponents(url: ordersCardReportURL, resolvingAgainstBaseURL: false)?.queryItems)
-        let productsStatsCardURLQueryItems = try XCTUnwrap(URLComponents(url: productsStatsCardReportURL, resolvingAgainstBaseURL: false)?.queryItems)
-
-        // Report URL contains expected time range period
-        let expectedPeriodQueryItem = URLQueryItem(name: "period", value: "today")
-        XCTAssertTrue(revenueCardURLQueryItems.contains(expectedPeriodQueryItem))
-        XCTAssertTrue(ordersCardURLQueryItems.contains(expectedPeriodQueryItem))
-        XCTAssertTrue(productsStatsCardURLQueryItems.contains(expectedPeriodQueryItem))
-    }
-
     // MARK: Customized Analytics
 
     func test_enabledCards_shows_correct_data_after_loading_from_storage() async {

--- a/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Analytics Hub/Report Cards/OrdersReportCardViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Analytics Hub/Report Cards/OrdersReportCardViewModelTests.swift
@@ -77,19 +77,16 @@ final class OrdersReportCardViewModelTests: XCTestCase {
         XCTAssertTrue(vm.showSyncError)
     }
 
-    func test_redact_updates_properties_as_expected() {
+    func test_it_provides_expected_values_when_redacted() {
         // Given
         let vm = OrdersReportCardViewModel(currentPeriodStats: nil,
                                            previousPeriodStats: nil,
                                            timeRange: .monthToDate,
+                                           isRedacted: true,
                                            usageTracksEventEmitter: eventEmitter,
                                            storeAdminURL: sampleAdminURL)
 
-        // When
-        vm.redact()
-
         // Then
-
         assertEqual("$1000", vm.leadingValue)
         assertEqual(DeltaPercentage(string: "0%", direction: .zero), vm.leadingDelta)
         assertEqual([], vm.leadingChartData)
@@ -99,41 +96,6 @@ final class OrdersReportCardViewModelTests: XCTestCase {
         XCTAssertTrue(vm.isRedacted)
         XCTAssertFalse(vm.showSyncError)
         XCTAssertNotNil(vm.reportViewModel)
-    }
-
-    func test_properties_updated_as_expected_after_stats_update() {
-        // Given
-        let vm = OrdersReportCardViewModel(currentPeriodStats: nil,
-                                           previousPeriodStats: nil,
-                                           timeRange: .monthToDate,
-                                           usageTracksEventEmitter: eventEmitter,
-                                           storeAdminURL: sampleAdminURL)
-
-        // When
-        vm.update(currentPeriodStats: OrderStatsV4.fake().copy(totals: .fake().copy(totalOrders: 60)),
-                  previousPeriodStats: OrderStatsV4.fake().copy(totals: .fake().copy(totalOrders: 30)))
-
-        // Then
-        assertEqual("60", vm.leadingValue)
-        assertEqual(DeltaPercentage(string: "+100%", direction: .positive), vm.leadingDelta)
-        XCTAssertFalse(vm.isRedacted)
-    }
-
-    func test_properties_updated_as_expected_after_timeRange_update() throws {
-        // Given
-        let vm = OrdersReportCardViewModel(currentPeriodStats: nil,
-                                           previousPeriodStats: nil,
-                                           timeRange: .monthToDate,
-                                           usageTracksEventEmitter: eventEmitter,
-                                           storeAdminURL: sampleAdminURL)
-
-        // When
-        vm.update(timeRange: .today)
-
-        // Then
-        let reportURL = try XCTUnwrap(vm.reportViewModel?.initialURL)
-        let queryItems = try XCTUnwrap(URLComponents(url: reportURL, resolvingAgainstBaseURL: false)?.queryItems)
-        XCTAssertTrue(queryItems.contains(URLQueryItem(name: "period", value: "today")))
     }
 
 }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Analytics Hub/Report Cards/OrdersReportCardViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Analytics Hub/Report Cards/OrdersReportCardViewModelTests.swift
@@ -28,6 +28,7 @@ final class OrdersReportCardViewModelTests: XCTestCase {
                                                                                  subtotals: .fake().copy(totalOrders: 15, averageOrderValue: 5))]),
             previousPeriodStats: OrderStatsV4.fake().copy(totals: .fake().copy(totalOrders: 30, averageOrderValue: 30)),
             timeRange: .today,
+            isRedacted: false,
             usageTracksEventEmitter: eventEmitter,
             storeAdminURL: sampleAdminURL
         )

--- a/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Analytics Hub/Report Cards/ProductsReportCardViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Analytics Hub/Report Cards/ProductsReportCardViewModelTests.swift
@@ -30,6 +30,7 @@ final class ProductsReportCardViewModelTests: XCTestCase {
                                                                                   subtotals: .fake().copy(totalItemsSold: 15))]),
             previousPeriodStats: OrderStatsV4.fake().copy(totals: .fake().copy(totalItemsSold: 30)),
             timeRange: .today,
+            isRedacted: false,
             usageTracksEventEmitter: eventEmitter,
             storeAdminURL: sampleAdminURL
         )
@@ -143,7 +144,8 @@ final class ProductsReportCardViewModelTests: XCTestCase {
         let imageUrl = "https://woo.com/woo.png"
         let vm = AnalyticsItemsSoldViewModel(itemsSoldStats: .fake().copy(items: [
             .fake().copy(productName: productName, quantity: 5, total: 100, currency: "USD", imageUrl: imageUrl)
-        ]))
+        ]),
+                                             isRedacted: false)
 
         // Then
         assertEqual(URL(string: imageUrl), vm.itemsSoldData.first?.imageURL)

--- a/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Analytics Hub/Report Cards/ProductsReportCardViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Analytics Hub/Report Cards/ProductsReportCardViewModelTests.swift
@@ -81,16 +81,14 @@ final class ProductsReportCardViewModelTests: XCTestCase {
         XCTAssertTrue(vm.showStatsError)
     }
 
-    func test_AnalyticsProductsStatsCardViewModel_redact_updates_properties_as_expected() {
+    func test_AnalyticsProductsStatsCardViewModel_provides_expected_values_when_redacted() {
         // Given
         let vm = AnalyticsProductsStatsCardViewModel(currentPeriodStats: nil,
                                                      previousPeriodStats: nil,
                                                      timeRange: .monthToDate,
+                                                     isRedacted: true,
                                                      usageTracksEventEmitter: eventEmitter,
                                                      storeAdminURL: sampleAdminURL)
-
-        // When
-        vm.redact()
 
         // Then
 
@@ -99,41 +97,6 @@ final class ProductsReportCardViewModelTests: XCTestCase {
         XCTAssertTrue(vm.isRedacted)
         XCTAssertFalse(vm.showStatsError)
         XCTAssertNotNil(vm.reportViewModel)
-    }
-
-    func test_AnalyticsProductsStatsCardViewModel_properties_updated_as_expected_after_update() {
-        // Given
-        let vm = AnalyticsProductsStatsCardViewModel(currentPeriodStats: nil,
-                                            previousPeriodStats: nil,
-                                            timeRange: .monthToDate,
-                                            usageTracksEventEmitter: eventEmitter,
-                                            storeAdminURL: sampleAdminURL)
-
-        // When
-        vm.update(currentPeriodStats: OrderStatsV4.fake().copy(totals: .fake().copy(totalItemsSold: 60)),
-                  previousPeriodStats: OrderStatsV4.fake().copy(totals: .fake().copy(totalItemsSold: 30)))
-
-        // Then
-        assertEqual("60", vm.itemsSold)
-        assertEqual(DeltaPercentage(string: "+100%", direction: .positive), vm.delta)
-        XCTAssertFalse(vm.isRedacted)
-    }
-
-    func test_AnalyticsProductsStatsCardViewModel_properties_updated_as_expected_after_timeRange_update() throws {
-        // Given
-        let vm = AnalyticsProductsStatsCardViewModel(currentPeriodStats: nil,
-                                                     previousPeriodStats: nil,
-                                                     timeRange: .monthToDate,
-                                                     usageTracksEventEmitter: eventEmitter,
-                                                     storeAdminURL: sampleAdminURL)
-
-        // When
-        vm.update(timeRange: .today)
-
-        // Then
-        let reportURL = try XCTUnwrap(vm.reportViewModel?.initialURL)
-        let queryItems = try XCTUnwrap(URLComponents(url: reportURL, resolvingAgainstBaseURL: false)?.queryItems)
-        XCTAssertTrue(queryItems.contains(URLQueryItem(name: "period", value: "today")))
     }
 
     // MARK: - AnalyticsItemsSoldViewModel
@@ -164,12 +127,9 @@ final class ProductsReportCardViewModelTests: XCTestCase {
         XCTAssertTrue(vm.showItemsSoldError)
     }
 
-    func test_AnalyticsItemsSoldViewModel_redact_updates_properties_as_expected() {
+    func test_AnalyticsItemsSoldViewModel_provides_expected_values_when_redacted() {
         // Given
-        let vm = AnalyticsItemsSoldViewModel(itemsSoldStats: nil)
-
-        // When
-        vm.redact()
+        let vm = AnalyticsItemsSoldViewModel(itemsSoldStats: nil, isRedacted: true)
 
         // Then
         let expectedPlaceholder = TopPerformersRow.Data(imageURL: nil, name: "Product Name", details: "Net Sales", value: "$5678")
@@ -179,21 +139,6 @@ final class ProductsReportCardViewModelTests: XCTestCase {
         assertEqual(expectedPlaceholder.value, vm.itemsSoldData.first?.value)
         XCTAssertTrue(vm.isRedacted)
         XCTAssertFalse(vm.showItemsSoldError)
-    }
-
-    func test_AnalyticsItemsSoldViewModel_properties_updated_as_expected_after_stats_update() {
-        // Given
-        let vm = AnalyticsItemsSoldViewModel(itemsSoldStats: nil)
-
-        // When
-        let productName = "Woo!"
-        vm.update(itemsSoldStats: .fake().copy(items: [
-            .fake().copy(productName: productName, quantity: 5, total: 100, currency: "USD", imageUrl: "https://woo.com/woo.png")
-        ]))
-
-        // Then
-        assertEqual(productName, vm.itemsSoldData.first?.name)
-        XCTAssertFalse(vm.isRedacted)
     }
 
 }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Analytics Hub/Report Cards/RevenueReportCardViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Analytics Hub/Report Cards/RevenueReportCardViewModelTests.swift
@@ -28,6 +28,7 @@ final class RevenueReportCardViewModelTests: XCTestCase {
                                                                                   subtotals: .fake().copy(grossRevenue: 15, netRevenue: 5))]),
             previousPeriodStats: OrderStatsV4.fake().copy(totals: .fake().copy(grossRevenue: 30, netRevenue: 30)),
             timeRange: .today,
+            isRedacted: false,
             usageTracksEventEmitter: eventEmitter,
             storeAdminURL: sampleAdminURL
         )

--- a/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Analytics Hub/Report Cards/RevenueReportCardViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Analytics Hub/Report Cards/RevenueReportCardViewModelTests.swift
@@ -77,16 +77,14 @@ final class RevenueReportCardViewModelTests: XCTestCase {
         XCTAssertTrue(vm.showSyncError)
     }
 
-    func test_redact_updates_properties_as_expected() {
+    func test_it_provides_expected_values_when_redacted() {
         // Given
         let vm = RevenueReportCardViewModel(currentPeriodStats: nil,
                                             previousPeriodStats: nil,
                                             timeRange: .monthToDate,
+                                            isRedacted: true,
                                             usageTracksEventEmitter: eventEmitter,
                                             storeAdminURL: sampleAdminURL)
-
-        // When
-        vm.redact()
 
         // Then
 
@@ -99,41 +97,6 @@ final class RevenueReportCardViewModelTests: XCTestCase {
         XCTAssertTrue(vm.isRedacted)
         XCTAssertFalse(vm.showSyncError)
         XCTAssertNotNil(vm.reportViewModel)
-    }
-
-    func test_properties_updated_as_expected_after_update() {
-        // Given
-        let vm = RevenueReportCardViewModel(currentPeriodStats: nil,
-                                            previousPeriodStats: nil,
-                                            timeRange: .monthToDate,
-                                            usageTracksEventEmitter: eventEmitter,
-                                            storeAdminURL: sampleAdminURL)
-
-        // When
-        vm.update(currentPeriodStats: OrderStatsV4.fake().copy(totals: .fake().copy(grossRevenue: 60)),
-                  previousPeriodStats: OrderStatsV4.fake().copy(totals: .fake().copy(grossRevenue: 30)))
-
-        // Then
-        assertEqual("$60", vm.leadingValue)
-        assertEqual(DeltaPercentage(string: "+100%", direction: .positive), vm.leadingDelta)
-        XCTAssertFalse(vm.isRedacted)
-    }
-
-    func test_properties_updated_as_expected_after_timeRange_update() throws {
-        // Given
-        let vm = RevenueReportCardViewModel(currentPeriodStats: nil,
-                                            previousPeriodStats: nil,
-                                            timeRange: .monthToDate,
-                                            usageTracksEventEmitter: eventEmitter,
-                                            storeAdminURL: sampleAdminURL)
-
-        // When
-        vm.update(timeRange: .today)
-
-        // Then
-        let reportURL = try XCTUnwrap(vm.reportViewModel?.initialURL)
-        let queryItems = try XCTUnwrap(URLComponents(url: reportURL, resolvingAgainstBaseURL: false)?.queryItems)
-        XCTAssertTrue(queryItems.contains(URLQueryItem(name: "period", value: "today")))
     }
 
 }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Analytics Hub/Report Cards/SessionsReportCardViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Analytics Hub/Report Cards/SessionsReportCardViewModelTests.swift
@@ -41,12 +41,9 @@ final class SessionsReportCardViewModelTests: XCTestCase {
         XCTAssertTrue(vm.showSyncError)
     }
 
-    func test_redact_updates_properties_as_expected() {
+    func test_it_provides_expected_values_when_redacted() {
         // Given
-        var vm = SessionsReportCardViewModel(currentOrderStats: nil, siteStats: nil)
-
-        // When
-        vm.redact()
+        var vm = SessionsReportCardViewModel(currentOrderStats: nil, siteStats: nil, isRedacted: true)
 
         // Then
 
@@ -59,20 +56,6 @@ final class SessionsReportCardViewModelTests: XCTestCase {
         XCTAssertTrue(vm.isRedacted)
         XCTAssertFalse(vm.showSyncError)
         XCTAssertNil(vm.reportViewModel)
-    }
-
-    func test_properties_updated_as_expected_after_stats_update() {
-        // Given
-        let vm = SessionsReportCardViewModel(currentOrderStats: nil, siteStats: nil)
-
-        // When
-        vm.update(currentOrderStats: OrderStatsV4.fake().copy(totals: .fake().copy(totalOrders: 5)),
-                  siteStats: SiteSummaryStats.fake().copy(visitors: 10, views: 60))
-
-        // Then
-        assertEqual("60", vm.leadingValue)
-        assertEqual("50%", vm.trailingValue)
-        XCTAssertFalse(vm.isRedacted)
     }
 
 }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Analytics Hub/Report Cards/SessionsReportCardViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Analytics Hub/Report Cards/SessionsReportCardViewModelTests.swift
@@ -9,7 +9,8 @@ final class SessionsReportCardViewModelTests: XCTestCase {
         // Given
         let vm = SessionsReportCardViewModel(
             currentOrderStats: OrderStatsV4.fake().copy(totals: .fake().copy(totalOrders: 5)),
-            siteStats: SiteSummaryStats.fake().copy(visitors: 10, views: 60)
+            siteStats: SiteSummaryStats.fake().copy(visitors: 10, views: 60),
+            isRedacted: false
         )
 
         // Then


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

## Why
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
As a followup to #12233, this simplifies the way the analytics hub updates the stats data and state for individual analytics report cards.

It replaces the previous Combine approach (binding the stats and time range properties to the card view models) with computed variables for each card that update when:

* We start loading the data for a card (setting a redacted card state)
* We stop loading the data for a card (setting a non-redacted card state and showing the relevant metrics)
* We update the selected time range/stats data

This way, we don't have to keep track of every card in the hub and update its data and state individually (an approach that becomes more complex as we add more stats data and cards). Instead, we only keep track of the stats data and its loading state within the hub, and that is passed to each card's view model so it can update accordingly.

## How

In `AnalyticsHubViewModel`:
* Adds properties to track if we are loading stats data (one property for each type of stats data we may fetch).
* Makes each card view model a computed variable, and adds a parameter to each view model that links the stats loading state with the card's redacted state.
* Removes the method `switchToLoadingState(_:)` and instead sets each stats data loading state when it is fetched.
* Removes the Combine binding between stats data/time range and card view models from `bindViewModelsWithData()`, since the card view models are now updated dynamically as those properties change.

In each card view model:
* Sets the `isRedacted` state in the card's `init` method.
* Removes the methods to redact and update the card, since these are no longer needed.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

1. Build and run the app.
2. Open the Analytics Hub.
3. Confirm the cards display a loading state as soon as they start loading data (when the hub is opened or when pulling to refresh data).
4. Select a new time range and confirm the cards update their metrics and report link.
5. Customize the cards and confirm any newly enabled cards load new data as expected.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

https://github.com/woocommerce/woocommerce-ios/assets/8658164/fddc6e1f-0741-43a4-8e45-0f6068f6c9f6



---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
