### PR TITLE
HACK Week: Fix tablet UI issues

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Blaze/AdDestination/BlazeAddParameterView.swift
+++ b/WooCommerce/Classes/ViewRelated/Blaze/AdDestination/BlazeAddParameterView.swift
@@ -12,7 +12,7 @@ struct BlazeAddParameterView: View {
     }
 
     var body: some View {
-        NavigationView {
+        NavigationStack {
             List {
                 Section {
                     AdaptiveStack(horizontalAlignment: .leading) {

--- a/WooCommerce/Classes/ViewRelated/Coupons/Add and Edit Coupons/AddEditCoupon.swift
+++ b/WooCommerce/Classes/ViewRelated/Coupons/Add and Edit Coupons/AddEditCoupon.swift
@@ -1,4 +1,5 @@
 import SwiftUI
+import WordPressUI
 import Yosemite
 
 final class AddEditCouponHostingController: UIHostingController<AddEditCoupon> {
@@ -21,8 +22,9 @@ final class AddEditCouponHostingController: UIHostingController<AddEditCoupon> {
                 viewModel.discountType = selectedType
                 self.presentedViewController?.dismiss(animated: true, completion: nil)
             }
-            let presenter = BottomSheetListSelectorPresenter(viewProperties: viewProperties, command: command)
-            presenter.show(from: self, sourceView: self.view, sourceBarButtonItem: nil, arrowDirections: .any)
+            let bottomSheet = BottomSheetListSelectorViewController(viewProperties: viewProperties, command: command, onDismiss: nil)
+            let bottomSheetViewController = BottomSheetViewController(childViewController: bottomSheet)
+            bottomSheetViewController.show(from: self)
         }
     }
 
@@ -64,16 +66,14 @@ struct AddEditCoupon: View {
     ///
     var discountTypeHandler: (BottomSheetListSelectorViewProperties) -> Void = { _ in }
 
+    private let viewProperties = BottomSheetListSelectorViewProperties(subtitle: Localization.discountTypeSheetTitle)
+
     @ObservedObject private var viewModel: AddEditCouponViewModel
     @State private var showingEditDescription: Bool = false
     @State private var showingCouponExpiryDate: Bool = false
     @State private var showingCouponRestrictions: Bool = false
     @State private var showingSelectProducts: Bool = false
     @State private var showingSelectCategories: Bool = false
-    @State private var showingDiscountType: Bool = false
-
-    private var idiom: UIUserInterfaceIdiom { UIDevice.current.userInterfaceIdiom }
-    private let viewProperties = BottomSheetListSelectorViewProperties(subtitle: Localization.discountTypeSheetTitle)
 
     private let categorySelectorConfig = ProductCategorySelector.Configuration.categoriesForCoupons
     private let categoryListConfig = ProductCategoryListViewController.Configuration(searchEnabled: true, clearSelectionEnabled: true)
@@ -94,19 +94,8 @@ struct AddEditCoupon: View {
                                 TitleAndValueRow(title: Localization.discountType,
                                                  value: viewModel.discountTypeValue,
                                                  selectionStyle: .disclosure, action: {
-                                    // TODO: remove this workaround with `adaptiveSheetPresentationController` when we drop support for iOS 14
-                                    if idiom == .pad {
-                                        showingDiscountType.toggle()
-                                    } else {
-                                        discountTypeHandler(viewProperties)
-                                    }
-                                }).popover(isPresented: $showingDiscountType) {
-                                    let command = DiscountTypeBottomSheetListSelectorCommand(selected: viewModel.discountType) { selectedType in
-                                        viewModel.discountType = selectedType
-                                        showingDiscountType.toggle()
-                                    }
-                                    BottomSheetListSelector(viewProperties: viewProperties, command: command, onDismiss: nil)
-                                }
+                                    discountTypeHandler(viewProperties)
+                                })
 
                                 Divider()
                                     .padding(.leading, Constants.margin)

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Onboarding/StoreName/StoreNameSetupView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Onboarding/StoreName/StoreNameSetupView.swift
@@ -30,7 +30,7 @@ struct StoreNameSetupView: View {
     }
 
     var body: some View {
-        NavigationView {
+        NavigationStack {
             VStack {
                 HStack {
                     TextField(Localization.placeholder, text: $viewModel.name)


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #12280 
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This PR adds fixes for UI glitches in some screens when displayed on tablets:
- Replaced `NavigationView` with `NavigationStack` to fix layout issues on the store name and Blaze add parameter screens.
- Replaced `actionSheet` with `confirmationDialog` to display a popover from a button on the coupon detail screen.
- Fix layout issue for the discount type sheet on the add coupon screen.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
1. Store name
- Log in to a store.
- Switch to Menu tab and select Settings > Store Name.
- Confirm that the store name screen is correct on both iPhone and iPad.

2. Blaze add parameter
- Log in to a store eligible for Blaze.
- On the Dashboard screen select Promote in the Blaze section.
- Select a product if prompted.
- On the campaign creation form, select Ad Destination > Add new parameter.
- Confirm that the Add parameter screen is correct on both iPhone and iPad.

3. Coupon creation
- Log in to a store with Coupon enabled.
- Switch to the Menu tab and select Coupons.
- Select an existing coupon or create a new one.
- On the coupon detail screen, tap the "..." button on the top right. Confirm that a popover is displayed from that button on iPad, and an action sheet is displayed on iPhone.
- Select Edit coupon and tap the discount type row. Confirm that the discount type sheet is displayed properly on both iPhone and iPad.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->
Before | After
--- | ---
<img src="https://github.com/woocommerce/woocommerce-ios/assets/5533851/25b4c1dd-2e5d-49ae-a236-4aa1f11a3b38" width=320 /> | <img src="https://github.com/woocommerce/woocommerce-ios/assets/5533851/6de8b147-2a2d-4518-8e5e-9f5ee318f9ee" width=320 />
<img src="https://github.com/woocommerce/woocommerce-ios/assets/5533851/b411d879-40d3-4339-b1f5-f049da90ef49" width=320 /> | <img src="https://github.com/woocommerce/woocommerce-ios/assets/5533851/3e2c8eed-d9f6-479a-842a-c7bb02d138d9" width=320 />
<img src="https://github.com/woocommerce/woocommerce-ios/assets/5533851/d3dbac35-0cf8-49d9-b4a0-fe0f97eb66a0" width=320 /> | <img src="https://github.com/woocommerce/woocommerce-ios/assets/5533851/5e7692f2-25a9-475f-9201-588256ccc288" width=320 />
<img src="https://github.com/woocommerce/woocommerce-ios/assets/5533851/4f4852bc-682f-45fa-8743-de768b9cedca" width=320 /> | <img src="https://github.com/woocommerce/woocommerce-ios/assets/5533851/0a0121a9-e568-45e3-b3d2-659ff571b518" width=320 />

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
