### PR TITLE
HACK Week: Update navigation in Hub Menu to replace deprecated APIs

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Payments Menu/InPersonPaymentsMenu.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Payments Menu/InPersonPaymentsMenu.swift
@@ -213,6 +213,7 @@ struct InPersonPaymentsMenu: View {
                                   style: .medium)
             }
         }
+        .navigationTitle(InPersonPaymentsView.Localization.title)
     }
 
     @ViewBuilder

--- a/WooCommerce/Classes/ViewRelated/Hub Menu/HubMenu.swift
+++ b/WooCommerce/Classes/ViewRelated/Hub Menu/HubMenu.swift
@@ -19,12 +19,20 @@ struct HubMenu: View {
 
     var body: some View {
         NavigationStack {
+            /// TODO: switch to `navigationDestination(item:destination)`
+            /// when we drop support for iOS 16.
             menuList
                 .navigationDestination(for: String.self) { id in
                     detailView(menuID: id)
                 }
                 .navigationDestination(isPresented: $viewModel.showingReviewDetail) {
                     reviewDetailView
+                }
+                .navigationDestination(isPresented: $viewModel.showingPayments) {
+                    paymentsView
+                }
+                .navigationDestination(isPresented: $viewModel.showingCoupons) {
+                    couponListView
                 }
         }
         .onAppear {
@@ -135,7 +143,7 @@ private extension HubMenu {
             case HubMenuViewModel.Settings.id:
                 SettingsView()
             case HubMenuViewModel.Payments.id:
-                InPersonPaymentsMenu(viewModel: viewModel.inPersonPaymentsMenuViewModel)
+                paymentsView
             case HubMenuViewModel.Blaze.id:
                 BlazeCampaignListView(viewModel: .init(siteID: viewModel.siteID))
             case HubMenuViewModel.WoocommerceAdmin.id:
@@ -151,7 +159,7 @@ private extension HubMenu {
             case HubMenuViewModel.Reviews.id:
                 ReviewsView(siteID: viewModel.siteID)
             case HubMenuViewModel.Coupons.id:
-                EnhancedCouponListView(siteID: viewModel.siteID)
+                couponListView
             case HubMenuViewModel.InAppPurchases.id:
                 InAppPurchasesDebugView()
             case HubMenuViewModel.Subscriptions.id:
@@ -184,6 +192,16 @@ private extension HubMenu {
                 .navigationBarTitleDisplayMode(.inline)
                 .navigationTitle(Localization.productReview)
         }
+    }
+
+    var paymentsView: some View {
+        InPersonPaymentsMenu(viewModel: viewModel.inPersonPaymentsMenuViewModel)
+            .navigationBarTitleDisplayMode(.inline)
+    }
+
+    var couponListView: some View {
+        EnhancedCouponListView(siteID: viewModel.siteID)
+            .navigationBarTitleDisplayMode(.inline)
     }
 
     /// Reusable List row for the hub menu

--- a/WooCommerce/Classes/ViewRelated/Hub Menu/HubMenu.swift
+++ b/WooCommerce/Classes/ViewRelated/Hub Menu/HubMenu.swift
@@ -24,7 +24,6 @@ struct HubMenu: View {
 
     var body: some View {
         List {
-
             // Store Section
             Section {
                 Button {
@@ -249,6 +248,7 @@ private extension HubMenu {
                                     .overlay {
                                         Image(uiImage: asset)
                                             .resizable()
+                                            .aspectRatio(contentMode: .fit)
                                             .frame(width: HubMenu.Constants.iconSize, height: HubMenu.Constants.iconSize)
                                     }
 
@@ -256,6 +256,7 @@ private extension HubMenu {
                                 KFImage(url)
                                     .placeholder { Image(uiImage: .gravatarPlaceholderImage).resizable() }
                                     .resizable()
+                                    .aspectRatio(contentMode: .fit)
                                     .frame(width: HubMenu.Constants.avatarSize, height: HubMenu.Constants.avatarSize)
                                     .clipShape(Circle())
                             }

--- a/WooCommerce/Classes/ViewRelated/Hub Menu/HubMenu.swift
+++ b/WooCommerce/Classes/ViewRelated/Hub Menu/HubMenu.swift
@@ -161,7 +161,6 @@ private extension HubMenu {
             }
         }
         .navigationBarTitleDisplayMode(.inline)
-        .toolbarRole(.editor)
     }
 
     @ViewBuilder
@@ -184,7 +183,6 @@ private extension HubMenu {
             ReviewDetailView(productReview: parcel.review, product: parcel.product, notification: parcel.note)
                 .navigationBarTitleDisplayMode(.inline)
                 .navigationTitle(Localization.productReview)
-                .toolbarRole(.editor)
         }
     }
 

--- a/WooCommerce/Classes/ViewRelated/Hub Menu/HubMenu.swift
+++ b/WooCommerce/Classes/ViewRelated/Hub Menu/HubMenu.swift
@@ -142,6 +142,7 @@ private extension HubMenu {
             switch menuID {
             case HubMenuViewModel.Settings.id:
                 SettingsView()
+                    .navigationTitle(HubMenuViewModel.Localization.settings)
             case HubMenuViewModel.Payments.id:
                 paymentsView
             case HubMenuViewModel.Blaze.id:

--- a/WooCommerce/Classes/ViewRelated/Hub Menu/HubMenu.swift
+++ b/WooCommerce/Classes/ViewRelated/Hub Menu/HubMenu.swift
@@ -6,6 +6,9 @@ import Yosemite
 /// and will be the entry point of the `Menu` Tab.
 ///
 struct HubMenu: View {
+    /// Set from the hosting controller to handle switching store.
+    var switchStoreHandler: () -> Void = {}
+
     @ObservedObject private var iO = Inject.observer
 
     @ObservedObject private var viewModel: HubMenuViewModel
@@ -54,7 +57,8 @@ private extension HubMenu {
             // Store Section
             Section {
                 Button {
-                    viewModel.presentSwitchStore()
+                    ServiceLocator.analytics.track(.hubMenuSwitchStoreTapped)
+                    switchStoreHandler()
                 } label: {
                     Row(title: viewModel.storeTitle,
                         titleBadge: viewModel.planName,

--- a/WooCommerce/Classes/ViewRelated/Hub Menu/HubMenuViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Hub Menu/HubMenuViewController.swift
@@ -35,12 +35,11 @@ final class HubMenuViewController: UIHostingController<HubMenu> {
     }
 
     func showPaymentsMenu() {
-        viewModel.showingPayments = true
+        viewModel.selectedMenuID = HubMenuViewModel.Payments.id
     }
 
     func showCoupons() {
-        let enhancedCouponListViewController = EnhancedCouponListViewController(siteID: viewModel.siteID)
-        show(enhancedCouponListViewController, sender: self)
+        viewModel.selectedMenuID = HubMenuViewModel.Coupons.id
     }
 
     /// Pushes the Settings & Privacy screen onto the navigation stack.

--- a/WooCommerce/Classes/ViewRelated/Hub Menu/HubMenuViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Hub Menu/HubMenuViewController.swift
@@ -7,6 +7,8 @@ final class HubMenuViewController: UIHostingController<HubMenu> {
     private let viewModel: HubMenuViewModel
     private let tapToPayBadgePromotionChecker: TapToPayBadgePromotionChecker
 
+    private var storePickerCoordinator: StorePickerCoordinator?
+
     init(siteID: Int64,
          navigationController: UINavigationController?,
          tapToPayBadgePromotionChecker: TapToPayBadgePromotionChecker) {
@@ -16,6 +18,9 @@ final class HubMenuViewController: UIHostingController<HubMenu> {
         self.tapToPayBadgePromotionChecker = tapToPayBadgePromotionChecker
         super.init(rootView: HubMenu(viewModel: viewModel))
         configureTabBarItem()
+        rootView.switchStoreHandler = { [weak self] in
+            self?.presentSwitchStore()
+        }
     }
 
     required dynamic init?(coder aDecoder: NSCoder) {
@@ -72,6 +77,17 @@ final class HubMenuViewController: UIHostingController<HubMenu> {
 
         if #available(iOS 16.0, *) {
             self.navigationController?.setNavigationBarHidden(false, animated: animated)
+        }
+    }
+}
+
+private extension HubMenuViewController {
+    /// Present the `StorePickerViewController` using the `StorePickerCoordinator`, passing the navigation controller from the entry point.
+    ///
+    func presentSwitchStore() {
+        if let navigationController = navigationController {
+            storePickerCoordinator = StorePickerCoordinator(navigationController, config: .switchingStores)
+            storePickerCoordinator?.start()
         }
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Hub Menu/HubMenuViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Hub Menu/HubMenuViewController.swift
@@ -13,7 +13,6 @@ final class HubMenuViewController: UIHostingController<HubMenu> {
          navigationController: UINavigationController?,
          tapToPayBadgePromotionChecker: TapToPayBadgePromotionChecker) {
         self.viewModel = HubMenuViewModel(siteID: siteID,
-                                          navigationController: navigationController,
                                           tapToPayBadgePromotionChecker: tapToPayBadgePromotionChecker)
         self.tapToPayBadgePromotionChecker = tapToPayBadgePromotionChecker
         super.init(rootView: HubMenu(viewModel: viewModel))

--- a/WooCommerce/Classes/ViewRelated/Hub Menu/HubMenuViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Hub Menu/HubMenuViewController.swift
@@ -39,11 +39,11 @@ final class HubMenuViewController: UIHostingController<HubMenu> {
     }
 
     func showPaymentsMenu() {
-        viewModel.selectedMenuID = HubMenuViewModel.Payments.id
+        viewModel.showingPayments = true
     }
 
     func showCoupons() {
-        viewModel.selectedMenuID = HubMenuViewModel.Coupons.id
+        viewModel.showingCoupons = true
     }
 
     /// Pushes the Settings & Privacy screen onto the navigation stack.

--- a/WooCommerce/Classes/ViewRelated/Hub Menu/HubMenuViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Hub Menu/HubMenuViewModel.swift
@@ -49,9 +49,9 @@ final class HubMenuViewModel: ObservableObject {
     ///
     @Published private(set) var switchStoreEnabled = false
 
-    @Published var showingReviewDetail = false
+    @Published var selectedMenuID: String?
 
-    @Published var showingPayments = false
+    @Published var showingReviewDetail = false
 
     @Published var shouldAuthenticateAdminPage = false
 
@@ -59,7 +59,7 @@ final class HubMenuViewModel: ObservableObject {
     private let featureFlagService: FeatureFlagService
     private let generalAppSettings: GeneralAppSettingsStorage
 
-    private var productReviewFromNoteParcel: ProductReviewFromNoteParcel?
+    private(set) var productReviewFromNoteParcel: ProductReviewFromNoteParcel?
 
     private var storePickerCoordinator: StorePickerCoordinator?
 
@@ -174,37 +174,9 @@ final class HubMenuViewModel: ObservableObject {
         }
     }
 
-    /// Presents the `Subscriptions` view from the view model's navigation controller property.
-    ///
-    func presentSubscriptions() {
-        let subscriptionController = SubscriptionsHostingController(siteID: siteID)
-        navigationController?.show(subscriptionController, sender: self)
-    }
-
     func showReviewDetails(using parcel: ProductReviewFromNoteParcel) {
         productReviewFromNoteParcel = parcel
         showingReviewDetail = true
-    }
-
-    func getReviewDetailDestination() -> ReviewDetailView? {
-        guard let parcel = productReviewFromNoteParcel else {
-            return nil
-        }
-
-        return ReviewDetailView(productReview: parcel.review, product: parcel.product, notification: parcel.note)
-    }
-
-    /// Navigates to show the Blaze view from the view model's navigation controller property.
-    ///
-    func showBlaze() {
-        guard let site = stores.sessionManager.defaultSite else {
-            return
-        }
-
-        // shows campaign list for the new Blaze experience.
-        let controller = BlazeCampaignListHostingController(viewModel: .init(siteID: site.siteID))
-        navigationController?.show(controller, sender: self)
-        ServiceLocator.analytics.track(event: .Blaze.blazeCampaignListEntryPointSelected(source: .menu))
     }
 
     private func observeSiteForUIUpdates() {

--- a/WooCommerce/Classes/ViewRelated/Hub Menu/HubMenuViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Hub Menu/HubMenuViewModel.swift
@@ -18,10 +18,6 @@ final class HubMenuViewModel: ObservableObject {
 
     let siteID: Int64
 
-    /// The view controller that will be used for presenting the `StorePickerViewController` via `StorePickerCoordinator`
-    ///
-    private(set) unowned var navigationController: UINavigationController?
-
     var avatarURL: URL? {
         guard let urlString = stores.sessionManager.defaultAccount?.gravatarUrl, let url = URL(string: urlString) else {
             return nil
@@ -83,14 +79,12 @@ final class HubMenuViewModel: ObservableObject {
     }()
 
     init(siteID: Int64,
-         navigationController: UINavigationController? = nil,
          tapToPayBadgePromotionChecker: TapToPayBadgePromotionChecker,
          featureFlagService: FeatureFlagService = ServiceLocator.featureFlagService,
          stores: StoresManager = ServiceLocator.stores,
          generalAppSettings: GeneralAppSettingsStorage = ServiceLocator.generalAppSettings,
          blazeEligibilityChecker: BlazeEligibilityCheckerProtocol = BlazeEligibilityChecker()) {
         self.siteID = siteID
-        self.navigationController = navigationController
         self.tapToPayBadgePromotionChecker = tapToPayBadgePromotionChecker
         self.stores = stores
         self.featureFlagService = featureFlagService

--- a/WooCommerce/Classes/ViewRelated/Hub Menu/HubMenuViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Hub Menu/HubMenuViewModel.swift
@@ -61,8 +61,6 @@ final class HubMenuViewModel: ObservableObject {
 
     private(set) var productReviewFromNoteParcel: ProductReviewFromNoteParcel?
 
-    private var storePickerCoordinator: StorePickerCoordinator?
-
     @Published private(set) var shouldShowNewFeatureBadgeOnPayments: Bool = false
 
     @Published private var isSiteEligibleForBlaze: Bool = false
@@ -161,16 +159,6 @@ final class HubMenuViewModel: ObservableObject {
             }
         } else {
             generalElements.removeAll(where: { $0.id == Blaze.id })
-        }
-    }
-
-    /// Present the `StorePickerViewController` using the `StorePickerCoordinator`, passing the navigation controller from the entry point.
-    ///
-    func presentSwitchStore() {
-        ServiceLocator.analytics.track(.hubMenuSwitchStoreTapped)
-        if let navigationController = navigationController {
-            storePickerCoordinator = StorePickerCoordinator(navigationController, config: .switchingStores)
-            storePickerCoordinator?.start()
         }
     }
 

--- a/WooCommerce/Classes/ViewRelated/Hub Menu/HubMenuViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Hub Menu/HubMenuViewModel.swift
@@ -48,6 +48,8 @@ final class HubMenuViewModel: ObservableObject {
     @Published var selectedMenuID: String?
 
     @Published var showingReviewDetail = false
+    @Published var showingPayments = false
+    @Published var showingCoupons = false
 
     @Published var shouldAuthenticateAdminPage = false
 


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #12282 
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This PR added a refactoring to the Hub menu to replace the outdated `NavigationLink` API. Changes include:
- Replaced the bool checks for displaying views with an ID for the selected menu.
- Replaced the use of `NavigationLink(destination:isActive:)` with an explicit `NavigationStack` and `navigationDestination` modifiers.
- Moved store switch handling to the `HubMenuViewController` and removed `navigationController` from `HubMenuViewModel`.
- Also: fixed the stretching icons on the menu.

🗒️ With the use of SwiftUI `NavigationStack`, we now have text on the back buttons. We can set `toolbarRole(.editor)` to the views to hide the back button title, but this pushes the title to the left on iPad. IMO it's fine to keep the back button title so I'm not using this workaround.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
1. Confirm UI
- Log in to the app.
- Confirm that the hub menu still works properly on both iPhone and iPad.
- Confirm that icons on the menu are not stretched anymore.

<img src="https://github.com/woocommerce/woocommerce-ios/assets/5533851/f8ec27e5-a9ac-4b6f-9929-012efce11724" width=320 />

2. Payment handling
- Open Shortcuts app and add a new shorcut.
- Enter Payments, you should see a suggestion for collecting payments.
- Tap the triangle button to start the shortcut.
- Confirm that the app can open the Payments tab with the collect payment modal opened.

https://github.com/woocommerce/woocommerce-ios/assets/5533851/6c10c640-5c43-4e56-8ae1-09f0323ca798



3. Opening coupon from order creation.
- Log in to a store with no existing coupons.
- Switch to Orders tab and select "+" to add a new order.
- Select a product then select Add coupon.
- Notice that an empty coupon screen is displayed. Tap Add coupon.
- Tap add coupon on the displayed alert.
- Confirm that the coupon screen is displayed from the Hub menu.


https://github.com/woocommerce/woocommerce-ios/assets/5533851/42bbf8f6-9a73-4789-991b-7c9263fd2059



4. Product review notification
- Enable notification for Woo on your simulator.
- Create a new product review on your test store.
- Create an `apns` file similar to [this](https://github.com/woocommerce/woocommerce-ios/blob/4857351967722cd18909c7318174587f8e370dee/review.apns) with your store ID and notification ID of the new review. You can get this ID by using proxyman and check for the latest item returned in the GET /rest/v1.1/notifications request.
- Drag the apns file to the simulator - a notification should appear.
- Select the notification, and confirm that the review detail screen is displayed properly. 


https://github.com/woocommerce/woocommerce-ios/assets/5533851/472d6ea0-d711-4d62-a92b-8b83eba1c565



---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
