### PR TITLE
Blaze: Add new budget fields for campaign list item

### DIFF
--- a/Fakes/Fakes/Networking.generated.swift
+++ b/Fakes/Fakes/Networking.generated.swift
@@ -193,7 +193,10 @@ extension Networking.BlazeCampaignListItem {
             impressions: .fake(),
             clicks: .fake(),
             totalBudget: .fake(),
-            spentBudget: .fake()
+            spentBudget: .fake(),
+            budgetMode: .fake(),
+            budgetAmount: .fake(),
+            budgetCurrency: .fake()
         )
     }
 }

--- a/Fakes/Fakes/Networking.generated.swift
+++ b/Fakes/Fakes/Networking.generated.swift
@@ -200,6 +200,13 @@ extension Networking.BlazeCampaignListItem {
         )
     }
 }
+extension Networking.BlazeCampaignListItem.BudgetMode {
+    /// Returns a "ready to use" type filled with fake values.
+    ///
+    public static func fake() -> Networking.BlazeCampaignListItem.BudgetMode {
+        .total
+    }
+}
 extension Networking.BlazeForecastedImpressionsInput {
     /// Returns a "ready to use" type filled with fake values.
     ///

--- a/Networking/Networking/Model/Blaze/BlazeCampaignListItem.swift
+++ b/Networking/Networking/Model/Blaze/BlazeCampaignListItem.swift
@@ -48,7 +48,7 @@ public struct BlazeCampaignListItem: Decodable, Equatable, GeneratedFakeable, Ge
     /// Can be total or daily amount, so check `budgetMode` to identify this.
     public let budgetAmount: Double
 
-    /// Currency used in `budgetAmount`.
+    /// Currency used in `budgetAmount`. Default to be USD.
     public let budgetCurrency: String
 
     public init(siteID: Int64,
@@ -141,7 +141,7 @@ public extension BlazeCampaignListItem {
         Status(rawValue: uiStatus) ?? .unknown
     }
 
-    enum BudgetMode: String {
+    enum BudgetMode: String, GeneratedFakeable {
         case total
         case daily
     }

--- a/Networking/Networking/Model/Blaze/BlazeCampaignListItem.swift
+++ b/Networking/Networking/Model/Blaze/BlazeCampaignListItem.swift
@@ -120,7 +120,6 @@ public struct BlazeCampaignListItem: Decodable, Equatable, GeneratedFakeable, Ge
         }()
         budgetAmount = budget?.amount ?? totalBudget
         budgetCurrency = budget?.currency ?? "USD"
-        
     }
 }
 

--- a/Networking/Networking/Model/Copiable/Models+Copiable.generated.swift
+++ b/Networking/Networking/Model/Copiable/Models+Copiable.generated.swift
@@ -3,7 +3,6 @@
 import Codegen
 import Foundation
 
-
 extension Networking.AIProduct {
     public func copy(
         name: CopiableProp<String> = .copy,
@@ -206,7 +205,10 @@ extension Networking.BlazeCampaignListItem {
         impressions: CopiableProp<Int64> = .copy,
         clicks: CopiableProp<Int64> = .copy,
         totalBudget: CopiableProp<Double> = .copy,
-        spentBudget: CopiableProp<Double> = .copy
+        spentBudget: CopiableProp<Double> = .copy,
+        budgetMode: CopiableProp<BlazeCampaignListItem.BudgetMode> = .copy,
+        budgetAmount: CopiableProp<Double> = .copy,
+        budgetCurrency: CopiableProp<String> = .copy
     ) -> Networking.BlazeCampaignListItem {
         let siteID = siteID ?? self.siteID
         let campaignID = campaignID ?? self.campaignID
@@ -220,6 +222,9 @@ extension Networking.BlazeCampaignListItem {
         let clicks = clicks ?? self.clicks
         let totalBudget = totalBudget ?? self.totalBudget
         let spentBudget = spentBudget ?? self.spentBudget
+        let budgetMode = budgetMode ?? self.budgetMode
+        let budgetAmount = budgetAmount ?? self.budgetAmount
+        let budgetCurrency = budgetCurrency ?? self.budgetCurrency
 
         return Networking.BlazeCampaignListItem(
             siteID: siteID,
@@ -233,7 +238,10 @@ extension Networking.BlazeCampaignListItem {
             impressions: impressions,
             clicks: clicks,
             totalBudget: totalBudget,
-            spentBudget: spentBudget
+            spentBudget: spentBudget,
+            budgetMode: budgetMode,
+            budgetAmount: budgetAmount,
+            budgetCurrency: budgetCurrency
         )
     }
 }

--- a/Networking/NetworkingTests/Mapper/BlazeCampaignListItemsMapperTests.swift
+++ b/Networking/NetworkingTests/Mapper/BlazeCampaignListItemsMapperTests.swift
@@ -25,6 +25,9 @@ final class BlazeCampaignListItemsMapperTests: XCTestCase {
         XCTAssertEqual(item.spentBudget, 5)
         XCTAssertEqual(item.clicks, 12)
         XCTAssertEqual(item.impressions, 34)
+        XCTAssertEqual(item.budgetMode, .total)
+        XCTAssertEqual(item.budgetAmount, 230)
+        XCTAssertEqual(item.budgetCurrency, "USD")
     }
 }
 

--- a/Networking/NetworkingTests/Responses/blaze-campaigns-list-success.json
+++ b/Networking/NetworkingTests/Responses/blaze-campaigns-list-success.json
@@ -18,6 +18,11 @@
         "mime_type": "image/jpeg",
         "width": 500,
         "height": 500
+      },
+      "budget": {
+          "mode": "total",
+          "amount": 230.00,
+          "currency": "USD"
       }
     }
   ],

--- a/WooCommerce/Classes/ViewRelated/Blaze/BlazeCampaignList/BlazeCampaignItemView.swift
+++ b/WooCommerce/Classes/ViewRelated/Blaze/BlazeCampaignList/BlazeCampaignItemView.swift
@@ -138,17 +138,20 @@ private extension BlazeCampaignItemView {
 
 struct BlazeCampaignItemView_Previews: PreviewProvider {
     static let campaign: BlazeCampaignListItem = .init(siteID: 123,
-                                                        campaignID: "11",
-                                                        productID: 33,
-                                                        name: "Fluffy bunny pouch",
-                                                        textSnippet: "Buy now!",
-                                                        uiStatus: BlazeCampaignListItem.Status.finished.rawValue,
-                                                        imageURL: nil,
-                                                        targetUrl: nil,
-                                                        impressions: 112,
-                                                        clicks: 22,
-                                                        totalBudget: 35,
-                                                        spentBudget: 4)
+                                                       campaignID: "11",
+                                                       productID: 33,
+                                                       name: "Fluffy bunny pouch",
+                                                       textSnippet: "Buy now!",
+                                                       uiStatus: BlazeCampaignListItem.Status.finished.rawValue,
+                                                       imageURL: nil,
+                                                       targetUrl: nil,
+                                                       impressions: 112,
+                                                       clicks: 22,
+                                                       totalBudget: 35,
+                                                       spentBudget: 4,
+                                                       budgetMode: .total,
+                                                       budgetAmount: 0,
+                                                       budgetCurrency: "USD")
     static var previews: some View {
         BlazeCampaignItemView(campaign: campaign)
     }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Blaze/BlazeCampaignListViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Blaze/BlazeCampaignListViewModelTests.swift
@@ -194,7 +194,7 @@ final class BlazeCampaignListViewModelTests: XCTestCase {
     func test_campaignModels_match_loaded_campaigns() {
         // Given
         let stores = MockStoresManager(sessionManager: .testingInstance)
-        let campaign = BlazeCampaignListItem.fake().copy(siteID: sampleSiteID)
+        let campaign = BlazeCampaignListItem.fake().copy(siteID: sampleSiteID, budgetCurrency: "USD")
         stores.whenReceivingAction(ofType: BlazeAction.self) { action in
             guard case let .synchronizeCampaignsList(_, _, _, onCompletion) = action else {
                 return
@@ -232,8 +232,8 @@ final class BlazeCampaignListViewModelTests: XCTestCase {
     func test_campaignModels_are_sorted_by_id() {
         // Given
         let stores = MockStoresManager(sessionManager: .testingInstance)
-        let campaignWithSmallerID = BlazeCampaignListItem.fake().copy(siteID: sampleSiteID, campaignID: "1")
-        let campaignWithLargerID = BlazeCampaignListItem.fake().copy(siteID: sampleSiteID, campaignID: "3")
+        let campaignWithSmallerID = BlazeCampaignListItem.fake().copy(siteID: sampleSiteID, campaignID: "1", budgetCurrency: "USD")
+        let campaignWithLargerID = BlazeCampaignListItem.fake().copy(siteID: sampleSiteID, campaignID: "3", budgetCurrency: "USD")
         stores.whenReceivingAction(ofType: BlazeAction.self) { action in
             guard case let .synchronizeCampaignsList(_, _, _, onCompletion) = action else {
                 return

--- a/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Blaze/BlazeCampaignDashboardViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Blaze/BlazeCampaignDashboardViewModelTests.swift
@@ -292,7 +292,7 @@ final class BlazeCampaignDashboardViewModelTests: XCTestCase {
     func test_state_is_showCampaign_if_blaze_campaign_available() async {
         // Given
         let checker = MockBlazeEligibilityChecker(isSiteEligible: true)
-        let fakeBlazeCampaign = BlazeCampaignListItem.fake().copy(siteID: sampleSiteID)
+        let fakeBlazeCampaign = BlazeCampaignListItem.fake().copy(siteID: sampleSiteID, budgetCurrency: "USD")
         let sut = BlazeCampaignDashboardViewModel(siteID: sampleSiteID,
                                                   stores: stores,
                                                   storageManager: storageManager,
@@ -578,7 +578,7 @@ final class BlazeCampaignDashboardViewModelTests: XCTestCase {
     func test_state_is_showCampaign_if_blaze_campaign_is_added_to_storage() async {
         // Given
         let checker = MockBlazeEligibilityChecker(isSiteEligible: true)
-        let fakeBlazeCampaign = BlazeCampaignListItem.fake().copy(siteID: sampleSiteID)
+        let fakeBlazeCampaign = BlazeCampaignListItem.fake().copy(siteID: sampleSiteID, budgetCurrency: "USD")
         let sut = BlazeCampaignDashboardViewModel(siteID: sampleSiteID,
                                                   stores: stores,
                                                   storageManager: storageManager,
@@ -909,7 +909,7 @@ final class BlazeCampaignDashboardViewModelTests: XCTestCase {
                                                         blazeEligibilityChecker: checker,
                                                         userDefaults: userDefaults)
 
-        let fakeBlazeCampaign = BlazeCampaignListItem.fake().copy(siteID: sampleSiteID)
+        let fakeBlazeCampaign = BlazeCampaignListItem.fake().copy(siteID: sampleSiteID, budgetCurrency: "USD")
         mockSynchronizeCampaignsList(insertCampaignToStorage: fakeBlazeCampaign)
         mockSynchronizeProducts()
 

--- a/Yosemite/Yosemite/Model/Storage/BlazeCampaignListItem+ReadOnlyConvertible.swift
+++ b/Yosemite/Yosemite/Model/Storage/BlazeCampaignListItem+ReadOnlyConvertible.swift
@@ -24,22 +24,27 @@ extension Storage.BlazeCampaignListItem: ReadOnlyConvertible {
         clicks = campaign.clicks
         totalBudget = campaign.totalBudget
         spentBudget = campaign.spentBudget
+        // TODO-12301: map values between storage and networking models for budget fields
     }
 
     /// Returns a ReadOnly (`Networking.BlazeCampaignListItem`) version of the `Storage.BlazeCampaignListItem`
     ///
     public func toReadOnly() -> BlazeCampaignListItem {
+        // TODO-12301: map values between storage and networking models for budget fields
         BlazeCampaignListItem(siteID: siteID,
-                               campaignID: campaignID,
-                               productID: productID?.int64Value,
-                               name: name,
-                               textSnippet: textSnippet,
-                               uiStatus: rawStatus,
-                               imageURL: imageURL,
-                               targetUrl: targetUrl,
-                               impressions: impressions,
-                               clicks: clicks,
-                               totalBudget: totalBudget,
-                               spentBudget: spentBudget)
+                              campaignID: campaignID,
+                              productID: productID?.int64Value,
+                              name: name,
+                              textSnippet: textSnippet,
+                              uiStatus: rawStatus,
+                              imageURL: imageURL,
+                              targetUrl: targetUrl,
+                              impressions: impressions,
+                              clicks: clicks,
+                              totalBudget: totalBudget,
+                              spentBudget: spentBudget,
+                              budgetMode: .total,
+                              budgetAmount: 0,
+                              budgetCurrency: "USD")
     }
 }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of #12301 
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This PR updates the `BlazeCampaignListItem` model in the Networking layer to include the new budget fields following a new API update [peeHDf-2fw-p2#comment-1934].

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
Just CI passing is sufficient.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->
N/A

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.