### PR TITLE
[Hub Menu] Update remote endpoint behavior for fetching wc-analytics customer data

### DIFF
--- a/Networking/Networking/Remote/WCAnalyticsCustomerRemote.swift
+++ b/Networking/Networking/Remote/WCAnalyticsCustomerRemote.swift
@@ -18,11 +18,11 @@ public class WCAnalyticsCustomerRemote: Remote {
     public func searchCustomers(for siteID: Int64,
                                 pageNumber: Int = 1,
                                 pageSize: Int = 25,
-                                orderby: OrderBy = .name,
-                                order: Order = .asc,
+                                orderby: OrderBy,
+                                order: Order,
                                 keyword: String,
                                 filter: String,
-                                filterEmpty: FilterEmpty? = .email,
+                                filterEmpty: FilterEmpty?,
                                 completion: @escaping (Result<[WCAnalyticsCustomer], Error>) -> Void) {
         let parameters: [String: Any] = [
             ParameterKey.page: String(pageNumber),
@@ -42,9 +42,9 @@ public class WCAnalyticsCustomerRemote: Remote {
     public func loadCustomers(for siteID: Int64,
                               pageNumber: Int = 1,
                               pageSize: Int = 25,
-                              orderby: OrderBy = .name,
-                              order: Order = .asc,
-                              filterEmpty: FilterEmpty? = .email,
+                              orderby: OrderBy,
+                              order: Order,
+                              filterEmpty: FilterEmpty?,
                               completion: @escaping (Result<[WCAnalyticsCustomer], Error>) -> Void) {
         let parameters: [String: Any] = [
             ParameterKey.page: String(pageNumber),

--- a/Networking/Networking/Remote/WCAnalyticsCustomerRemote.swift
+++ b/Networking/Networking/Remote/WCAnalyticsCustomerRemote.swift
@@ -6,21 +6,33 @@ public class WCAnalyticsCustomerRemote: Remote {
     ///
     /// - Parameters:
     ///     - siteID: Site for which we'll fetch the customer.
-    ///     - name: Name of the customer that will be retrieved
-    ///     - filter: Filter by which the search will be performed. Possible values: all (in WC 8.0.0+), name, username, email
     ///     - pageNumber: Number of page that should be retrieved.
     ///     - pageSize: Number of customers to be retrieved per page.
+    ///     - orderby: Field to use for sorting the customers to be retrieved.
+    ///     - order: Sort order for customers to be retrieved (ascending or descending).
+    ///     - keyword: Name of the customer that will be retrieved
+    ///     - filter: Filter by which the search will be performed. Possible values: all (in WC 8.0.0+), name, username, email
+    ///     - filterEmptyEmails: Filter customers to retrieve only those with email addresses.
     ///     - completion: Closure to be executed upon completion.
     ///
     public func searchCustomers(for siteID: Int64,
                                 pageNumber: Int = 1,
                                 pageSize: Int = 25,
+                                orderby: OrderBy = .name,
+                                order: Order = .asc,
                                 keyword: String,
                                 filter: String,
+                                filterEmpty: FilterEmpty? = .email,
                                 completion: @escaping (Result<[WCAnalyticsCustomer], Error>) -> Void) {
-        var parameters = coreRequestParameters(from: pageNumber, pageSize: pageSize)
-        parameters[ParameterKey.search] = keyword
-        parameters[ParameterKey.searchBy] = filter
+        let parameters: [String: Any] = [
+            ParameterKey.page: String(pageNumber),
+            ParameterKey.perPage: String(pageSize),
+            ParameterKey.orderBy: orderby.rawValue,
+            ParameterKey.order: order.rawValue,
+            ParameterKey.filterEmpty: filterEmpty?.rawValue,
+            ParameterKey.search: keyword,
+            ParameterKey.searchBy: filter
+        ].compactMapValues { $0 }
 
         enqueueRequest(with: parameters, siteID: siteID, completion: completion)
     }
@@ -28,21 +40,24 @@ public class WCAnalyticsCustomerRemote: Remote {
     /// Loads a paginated list of customers
     ///
     public func loadCustomers(for siteID: Int64,
-                                pageNumber: Int = 1,
-                                pageSize: Int = 25,
-                                completion: @escaping (Result<[WCAnalyticsCustomer], Error>) -> Void) {
-        enqueueRequest(with: coreRequestParameters(from: pageNumber, pageSize: pageSize), siteID: siteID, completion: completion)
+                              pageNumber: Int = 1,
+                              pageSize: Int = 25,
+                              orderby: OrderBy = .name,
+                              order: Order = .asc,
+                              filterEmpty: FilterEmpty? = .email,
+                              completion: @escaping (Result<[WCAnalyticsCustomer], Error>) -> Void) {
+        let parameters: [String: Any] = [
+            ParameterKey.page: String(pageNumber),
+            ParameterKey.perPage: String(pageSize),
+            ParameterKey.orderBy: orderby.rawValue,
+            ParameterKey.order: order.rawValue,
+            ParameterKey.filterEmpty: filterEmpty?.rawValue
+        ].compactMapValues { $0 }
+        enqueueRequest(with: parameters, siteID: siteID, completion: completion)
     }
 }
 
 private extension WCAnalyticsCustomerRemote {
-    func coreRequestParameters(from pageNumber: Int = 1, pageSize: Int = 25) -> [String: Any] {
-        [ParameterKey.page: String(pageNumber),
-            ParameterKey.perPage: String(pageSize),
-            ParameterKey.orderBy: "name",
-            ParameterKey.order: "asc",
-            ParameterKey.filterEmpty: "email"]
-    }
     func enqueueRequest(with parameters: [String: Any], siteID: Int64, completion: @escaping (Result<[WCAnalyticsCustomer], Error>) -> Void) {
         let path = "customers"
         let request = JetpackRequest(
@@ -63,6 +78,25 @@ private extension WCAnalyticsCustomerRemote {
                 completion(.failure(error))
             }
         })
+    }
+}
+
+public extension WCAnalyticsCustomerRemote {
+    /// `orderby` parameter values
+    enum OrderBy: String {
+        case name
+        case dateLastActive = "date_last_active"
+    }
+
+    /// `order` parameter values
+    enum Order: String {
+        case asc
+        case desc
+    }
+
+    /// `filter_empty` parameter values
+    enum FilterEmpty: String {
+        case email
     }
 }
 

--- a/Networking/NetworkingTests/Remote/WCAnalyticsCustomerRemoteTests.swift
+++ b/Networking/NetworkingTests/Remote/WCAnalyticsCustomerRemoteTests.swift
@@ -42,8 +42,11 @@ class WCAnalyticsCustomerRemoteTests: XCTestCase {
             self.remote.searchCustomers(for: self.sampleSiteID,
                                         pageNumber: pageNumber,
                                         pageSize: pageSize,
+                                        orderby: .name,
+                                        order: .asc,
                                         keyword: self.sampleCustomerName,
-                                        filter: filter) { result in
+                                        filter: filter,
+                                        filterEmpty: .email) { result in
                 promise(result)
             }
         }
@@ -56,6 +59,7 @@ class WCAnalyticsCustomerRemoteTests: XCTestCase {
         let hasPageSizeParameter = network.queryParameters?.contains(where: { $0 == "per_page=\(pageSize)" }) ?? false
         let hasOrderByParameter = network.queryParameters?.contains(where: { $0 == "orderby=name" }) ?? false
         let hasOrderParameter = network.queryParameters?.contains(where: { $0 == "order=asc" }) ?? false
+        let hasFilterEmptyParameter = network.queryParameters?.contains(where: { $0 == "filter_empty=email" }) ?? false
 
         XCTAssertTrue(hasSearchParameter)
         XCTAssertTrue(hasSearchByParameter)
@@ -63,6 +67,7 @@ class WCAnalyticsCustomerRemoteTests: XCTestCase {
         XCTAssertTrue(hasPageSizeParameter)
         XCTAssertTrue(hasOrderByParameter)
         XCTAssertTrue(hasOrderParameter)
+        XCTAssertTrue(hasFilterEmptyParameter)
 
         assertParsedResultsAreCorrect(with: customers)
     }
@@ -75,7 +80,12 @@ class WCAnalyticsCustomerRemoteTests: XCTestCase {
 
         // When
         let result = waitFor { promise in
-            self.remote.loadCustomers(for: self.sampleSiteID, pageNumber: 2, pageSize: pageSize) { result in
+            self.remote.loadCustomers(for: self.sampleSiteID,
+                                      pageNumber: 2,
+                                      pageSize: pageSize,
+                                      orderby: .name,
+                                      order: .asc,
+                                      filterEmpty: .email) { result in
                 promise(result)
             }
         }
@@ -104,7 +114,14 @@ class WCAnalyticsCustomerRemoteTests: XCTestCase {
 
         // When
         let result = waitFor { promise in
-            self.remote.searchCustomers(for: self.sampleSiteID, pageNumber: 1, pageSize: 25, keyword: self.sampleCustomerName, filter: "all") { result in
+            self.remote.searchCustomers(for: self.sampleSiteID,
+                                        pageNumber: 1,
+                                        pageSize: 25,
+                                        orderby: .name,
+                                        order: .asc,
+                                        keyword: self.sampleCustomerName,
+                                        filter: "all",
+                                        filterEmpty: nil) { result in
                 promise(result)
             }
         }
@@ -120,7 +137,14 @@ class WCAnalyticsCustomerRemoteTests: XCTestCase {
 
         // When
         let result = waitFor { promise in
-            self.remote.searchCustomers(for: self.sampleSiteID, pageNumber: 1, pageSize: 25, keyword: self.sampleCustomerName, filter: "all") { result in
+            self.remote.searchCustomers(for: self.sampleSiteID,
+                                        pageNumber: 1,
+                                        pageSize: 25,
+                                        orderby: .name,
+                                        order: .asc,
+                                        keyword: self.sampleCustomerName,
+                                        filter: "all",
+                                        filterEmpty: nil) { result in
                 promise(result)
             }
         }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/CustomerSection/CustomerSearchUICommand.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/CustomerSection/CustomerSearchUICommand.swift
@@ -250,7 +250,12 @@ private extension CustomerSearchUICommand {
     }
 
     func synchronizeAllLightCustomersDataAction(siteID: Int64, pageNumber: Int, pageSize: Int, onCompletion: ((Bool) -> Void)?) -> CustomerAction {
-        CustomerAction.synchronizeLightCustomersData(siteID: siteID, pageNumber: pageNumber, pageSize: pageSize) { [weak self] result in
+        CustomerAction.synchronizeLightCustomersData(siteID: siteID,
+                                                     pageNumber: pageNumber,
+                                                     pageSize: pageSize,
+                                                     orderby: .name,
+                                                     order: .asc,
+                                                     filterEmpty: .email) { [weak self] result in
             switch result {
             case .success:
                 onCompletion?(result.isSuccess)
@@ -280,9 +285,12 @@ private extension CustomerSearchUICommand {
         return CustomerAction.searchCustomers(siteID: siteID,
                                               pageNumber: pageNumber,
                                               pageSize: pageSize,
+                                              orderby: .name,
+                                              order: .asc,
                                               keyword: keyword,
                                               retrieveFullCustomersData: !featureFlagService.isFeatureFlagEnabled(.betterCustomerSelectionInOrder),
-                                              filter: searchFilter) { result in
+                                              filter: searchFilter,
+                                              filterEmpty: .email) { result in
             switch result {
             case .success:
                 onCompletion?(result.isSuccess)

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/CustomerSection/CustomerSelectorViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/CustomerSection/CustomerSelectorViewModel.swift
@@ -33,8 +33,12 @@ final class CustomerSelectorViewModel {
     ///
     func loadCustomersListData(onCompletion: @escaping (Result<Bool, Error>) -> Void) {
         stores.dispatch(CustomerAction.synchronizeLightCustomersData(siteID: siteID,
-                                                                                    pageNumber: Constants.firstPageNumber,
-                                                                                    pageSize: Constants.pageSize, onCompletion: onCompletion))
+                                                                     pageNumber: Constants.firstPageNumber,
+                                                                     pageSize: Constants.pageSize,
+                                                                     orderby: .name,
+                                                                     order: .asc,
+                                                                     filterEmpty: .email,
+                                                                     onCompletion: onCompletion))
     }
 
     /// Loads the whole customer information and calls the completion closures

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/CustomerSection/CustomerSelectorViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/CustomerSection/CustomerSelectorViewModelTests.swift
@@ -2,6 +2,7 @@ import Foundation
 import XCTest
 @testable import WooCommerce
 import Yosemite
+import Networking
 
 final class CustomerSelectorViewModelTests: XCTestCase {
     var viewModel: CustomerSelectorViewModel!
@@ -142,13 +143,19 @@ final class CustomerSelectorViewModelTests: XCTestCase {
         var passedSiteID: Int64?
         var passedPageNumber: Int?
         var passedPageSize: Int?
+        var passedOrderBy: WCAnalyticsCustomerRemote.OrderBy?
+        var passedOrder: WCAnalyticsCustomerRemote.Order?
+        var passedFilterEmpty: WCAnalyticsCustomerRemote.FilterEmpty?
 
         stores.whenReceivingAction(ofType: CustomerAction.self) { action in
             switch action {
-            case let .synchronizeLightCustomersData(siteID, pageNumber, pageSize, onCompletion):
+            case let .synchronizeLightCustomersData(siteID, pageNumber, pageSize, orderby, order, filterEmpty, onCompletion):
                 passedSiteID = siteID
                 passedPageNumber = pageNumber
                 passedPageSize = pageSize
+                passedOrderBy = orderby
+                passedOrder = order
+                passedFilterEmpty = filterEmpty
                 onCompletion(.success(true))
             default:
                 XCTFail("Received unsupported action: \(action)")
@@ -166,6 +173,9 @@ final class CustomerSelectorViewModelTests: XCTestCase {
         XCTAssertEqual(passedSiteID, sampleSiteID)
         XCTAssertEqual(passedPageNumber, 1)
         XCTAssertEqual(passedPageSize, 25)
+        XCTAssertEqual(passedOrderBy, .name)
+        XCTAssertEqual(passedOrder, .asc)
+        XCTAssertEqual(passedFilterEmpty, .email)
     }
 
     func test_loadCustomersListData_calls_to_synchronizeLightCustomersData_and_passes_error() {
@@ -175,7 +185,7 @@ final class CustomerSelectorViewModelTests: XCTestCase {
 
         stores.whenReceivingAction(ofType: CustomerAction.self) { action in
             switch action {
-            case let .synchronizeLightCustomersData(_, _, _, onCompletion):
+            case let .synchronizeLightCustomersData(_, _, _, _, _, _, onCompletion):
                 onCompletion(.failure(error))
             default:
                 XCTFail("Received unsupported action: \(action)")

--- a/WooCommerce/WooCommerceTests/ViewRelated/Search/Customer/CustomerSearchUICommandTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Search/Customer/CustomerSearchUICommandTests.swift
@@ -98,7 +98,7 @@ final class CustomerSearchUICommandTests: XCTestCase {
 
         var invocationCount = 0
         stores.whenReceivingAction(ofType: CustomerAction.self) { action in
-            guard case let .synchronizeLightCustomersData(_, _, _, onCompletion) = action else {
+            guard case let .synchronizeLightCustomersData(_, _, _, _, _, _, onCompletion) = action else {
                 return XCTFail("Unexpected action: \(action)")
             }
             invocationCount += 1

--- a/Yosemite/Yosemite/Actions/CustomerAction.swift
+++ b/Yosemite/Yosemite/Actions/CustomerAction.swift
@@ -1,4 +1,5 @@
 import Foundation
+import Networking
 
 /// The type of filter when searching for customers.
 public enum CustomerSearchFilter: String, Equatable, CaseIterable {
@@ -21,6 +22,9 @@ public enum CustomerAction: Action {
         siteID: Int64,
         pageNumber: Int,
         pageSize: Int,
+        orderby: WCAnalyticsCustomerRemote.OrderBy = .name,
+        order: WCAnalyticsCustomerRemote.Order = .asc,
+        filterEmpty: WCAnalyticsCustomerRemote.FilterEmpty? = .email,
         onCompletion: (Result<Bool, Error>) -> Void)
 
     /// Searches for Customers by keyword. Currently, only searches by name.
@@ -39,9 +43,12 @@ public enum CustomerAction: Action {
         siteID: Int64,
         pageNumber: Int,
         pageSize: Int,
+        orderby: WCAnalyticsCustomerRemote.OrderBy = .name,
+        order: WCAnalyticsCustomerRemote.Order = .asc,
         keyword: String,
         retrieveFullCustomersData: Bool,
         filter: CustomerSearchFilter,
+        filterEmpty: WCAnalyticsCustomerRemote.FilterEmpty? = .email,
         onCompletion: (Result<(), Error>) -> Void)
 
     /// Retrieves a single Customer from a site

--- a/Yosemite/Yosemite/Actions/CustomerAction.swift
+++ b/Yosemite/Yosemite/Actions/CustomerAction.swift
@@ -22,9 +22,9 @@ public enum CustomerAction: Action {
         siteID: Int64,
         pageNumber: Int,
         pageSize: Int,
-        orderby: WCAnalyticsCustomerRemote.OrderBy = .name,
-        order: WCAnalyticsCustomerRemote.Order = .asc,
-        filterEmpty: WCAnalyticsCustomerRemote.FilterEmpty? = .email,
+        orderby: WCAnalyticsCustomerRemote.OrderBy,
+        order: WCAnalyticsCustomerRemote.Order,
+        filterEmpty: WCAnalyticsCustomerRemote.FilterEmpty? = nil,
         onCompletion: (Result<Bool, Error>) -> Void)
 
     /// Searches for Customers by keyword. Currently, only searches by name.
@@ -43,12 +43,12 @@ public enum CustomerAction: Action {
         siteID: Int64,
         pageNumber: Int,
         pageSize: Int,
-        orderby: WCAnalyticsCustomerRemote.OrderBy = .name,
-        order: WCAnalyticsCustomerRemote.Order = .asc,
+        orderby: WCAnalyticsCustomerRemote.OrderBy,
+        order: WCAnalyticsCustomerRemote.Order,
         keyword: String,
         retrieveFullCustomersData: Bool,
         filter: CustomerSearchFilter,
-        filterEmpty: WCAnalyticsCustomerRemote.FilterEmpty? = .email,
+        filterEmpty: WCAnalyticsCustomerRemote.FilterEmpty? = nil,
         onCompletion: (Result<(), Error>) -> Void)
 
     /// Retrieves a single Customer from a site

--- a/Yosemite/Yosemite/Stores/CustomerStore.swift
+++ b/Yosemite/Yosemite/Stores/CustomerStore.swift
@@ -47,24 +47,36 @@ public final class CustomerStore: Store {
             return
         }
         switch action {
-        case .searchCustomers(siteID: let siteID,
-                              pageNumber: let pageNumber,
-                              pageSize: let pageSize,
-                              keyword: let keyword,
-                              retrieveFullCustomersData: let retrieveFullCustomersData,
-                              filter: let filter,
-                              onCompletion: let onCompletion):
+        case let .searchCustomers(siteID: siteID,
+                                  pageNumber: pageNumber,
+                                  pageSize: pageSize,
+                                  orderby: orderby,
+                                  order: order,
+                                  keyword: keyword,
+                                  retrieveFullCustomersData: retrieveFullCustomersData,
+                                  filter: filter,
+                                  filterEmpty: filterEmpty,
+                                  onCompletion: onCompletion):
             searchCustomers(for: siteID,
                             pageNumber: pageNumber,
                             pageSize: pageSize,
+                            orderby: orderby,
+                            order: order,
                             keyword: keyword,
                             retrieveFullCustomersData: retrieveFullCustomersData,
                             filter: filter,
+                            filterEmpty: filterEmpty,
                             onCompletion: onCompletion)
         case .retrieveCustomer(siteID: let siteID, customerID: let customerID, onCompletion: let onCompletion):
             retrieveCustomer(for: siteID, with: customerID, onCompletion: onCompletion)
-        case .synchronizeLightCustomersData(siteID: let siteID, pageNumber: let pageNumber, pageSize: let pageSize, onCompletion: let onCompletion):
-            synchronizeLightCustomersData(siteID: siteID, pageNumber: pageNumber, pageSize: pageSize, onCompletion: onCompletion)
+        case let .synchronizeLightCustomersData(siteID, pageNumber, pageSize, orderby, order, filterEmpty, onCompletion):
+            synchronizeLightCustomersData(siteID: siteID,
+                                          pageNumber: pageNumber,
+                                          pageSize: pageSize,
+                                          orderby: orderby,
+                                          order: order,
+                                          filterEmpty: filterEmpty,
+                                          onCompletion: onCompletion)
         case .deleteAllCustomers(siteID: let siteID, onCompletion: let onCompletion):
             deleteAllCustomers(from: siteID, onCompletion: onCompletion)
         }
@@ -83,15 +95,21 @@ public final class CustomerStore: Store {
         for siteID: Int64,
         pageNumber: Int,
         pageSize: Int,
+        orderby: WCAnalyticsCustomerRemote.OrderBy,
+        order: WCAnalyticsCustomerRemote.Order,
         keyword: String,
         retrieveFullCustomersData: Bool,
         filter: CustomerSearchFilter,
+        filterEmpty: WCAnalyticsCustomerRemote.FilterEmpty?,
         onCompletion: @escaping (Result<(), Error>) -> Void) {
             wcAnalyticsCustomerRemote.searchCustomers(for: siteID,
                                                       pageNumber: pageNumber,
                                                       pageSize: pageSize,
+                                                      orderby: orderby,
+                                                      order: order,
                                                       keyword: keyword,
-                                                      filter: filter.rawValue) { [weak self] result in
+                                                      filter: filter.rawValue,
+                                                      filterEmpty: filterEmpty) { [weak self] result in
                 guard let self else { return }
                 switch result {
                 case .success(let customers):
@@ -138,8 +156,19 @@ public final class CustomerStore: Store {
             }
     }
 
-    func synchronizeLightCustomersData(siteID: Int64, pageNumber: Int, pageSize: Int, onCompletion: @escaping (Result<Bool, Error>) -> Void) {
-        wcAnalyticsCustomerRemote.loadCustomers(for: siteID, pageNumber: pageNumber, pageSize: pageSize) { result in
+    func synchronizeLightCustomersData(siteID: Int64,
+                                       pageNumber: Int,
+                                       pageSize: Int,
+                                       orderby: WCAnalyticsCustomerRemote.OrderBy,
+                                       order: WCAnalyticsCustomerRemote.Order,
+                                       filterEmpty: WCAnalyticsCustomerRemote.FilterEmpty?,
+                                       onCompletion: @escaping (Result<Bool, Error>) -> Void) {
+        wcAnalyticsCustomerRemote.loadCustomers(for: siteID,
+                                                pageNumber: pageNumber,
+                                                pageSize: pageSize,
+                                                orderby: orderby,
+                                                order: order,
+                                                filterEmpty: filterEmpty) { result in
             switch result {
             case .success(let customers):
                 self.upsertCustomersAndSave(siteID: siteID,

--- a/Yosemite/YosemiteTests/Stores/CustomerStoreTests.swift
+++ b/Yosemite/YosemiteTests/Stores/CustomerStoreTests.swift
@@ -96,7 +96,11 @@ final class CustomerStoreTests: XCTestCase {
 
         // When
         let result = waitFor { promise in
-            let action = CustomerAction.synchronizeLightCustomersData(siteID: self.dummySiteID, pageNumber: 1, pageSize: 2) { result in
+            let action = CustomerAction.synchronizeLightCustomersData(siteID: self.dummySiteID,
+                                                                      pageNumber: 1,
+                                                                      pageSize: 2,
+                                                                      orderby: .name,
+                                                                      order: .asc) { result in
                 promise(result)
             }
             self.dispatcher.dispatch(action)
@@ -139,6 +143,8 @@ final class CustomerStoreTests: XCTestCase {
                 siteID: self.dummySiteID,
                 pageNumber: 1,
                 pageSize: 25,
+                orderby: .name,
+                order: .asc,
                 keyword: self.dummyKeyword,
                 retrieveFullCustomersData: true,
                 filter: .name) { result in
@@ -165,6 +171,8 @@ final class CustomerStoreTests: XCTestCase {
             let action = CustomerAction.searchCustomers(siteID: self.dummySiteID,
                                                         pageNumber: 1,
                                                         pageSize: 25,
+                                                        orderby: .name,
+                                                        order: .asc,
                                                         keyword: self.dummyKeyword,
                                                         retrieveFullCustomersData: true,
                                                         filter: .name) { result in
@@ -220,6 +228,8 @@ final class CustomerStoreTests: XCTestCase {
             let action = CustomerAction.searchCustomers(siteID: self.dummySiteID,
                                                         pageNumber: 1,
                                                         pageSize: 25,
+                                                        orderby: .name,
+                                                        order: .asc,
                                                         keyword: self.dummyKeyword,
                                                         retrieveFullCustomersData: true,
                                                         filter: .name) { result in


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #12296
<!-- Id number of the GitHub issue this PR addresses. -->

## Why
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
We want to stop hardcoding the `orderby`, `order`, and `filter_empty` parameters when loading and searching customers in `WCAnalyticsCustomerRemote`.

We want to retain the current behavior for the customer list in order creation, but allow different ordering and remove the email address filtering for the new Customers section in the hub menu.

## How
This adds explicit parameters to the requests in `WCAnalyticsCustomerRemote` (Networking layer) and `CustomerStore` (Yosemite layer). We now set those parameters when the actions are called in the UI layer during order creation.

There are no changes yet to the behavior in the app, but this sets us up to use those endpoints differently when we add the new Customers section to the hub menu.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

1. Build and run the app.
2. Go to the Orders tab.
3. Create a new order.
4. Add customer details to the order.
5. Confirm the customer list loads in alphabetical order by name, and only customers with email addresses appear.
6. Search for customers and confirm the results load in alphabetical order by name, and only customers with email addresses appear.


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
