### PR TITLE
[Hub Menu] Customers: Add fields for Customers section to `WCAnalyticsCustomer` model

### DIFF
--- a/Fakes/Fakes/Networking.generated.swift
+++ b/Fakes/Fakes/Networking.generated.swift
@@ -2254,10 +2254,20 @@ extension Networking.WCAnalyticsCustomer {
     public static func fake() -> Networking.WCAnalyticsCustomer {
         .init(
             siteID: .fake(),
+            customerID: .fake(),
             userID: .fake(),
             name: .fake(),
             email: .fake(),
-            username: .fake()
+            username: .fake(),
+            dateRegistered: .fake(),
+            dateLastActive: .fake(),
+            ordersCount: .fake(),
+            totalSpend: .fake(),
+            averageOrderValue: .fake(),
+            country: .fake(),
+            region: .fake(),
+            city: .fake(),
+            postcode: .fake()
         )
     }
 }

--- a/Networking/Networking/Model/Copiable/Models+Copiable.generated.swift
+++ b/Networking/Networking/Model/Copiable/Models+Copiable.generated.swift
@@ -3244,23 +3244,53 @@ extension Networking.User {
 extension Networking.WCAnalyticsCustomer {
     public func copy(
         siteID: CopiableProp<Int64> = .copy,
+        customerID: CopiableProp<Int64> = .copy,
         userID: CopiableProp<Int64> = .copy,
         name: NullableCopiableProp<String> = .copy,
         email: NullableCopiableProp<String> = .copy,
-        username: NullableCopiableProp<String> = .copy
+        username: NullableCopiableProp<String> = .copy,
+        dateRegistered: NullableCopiableProp<Date> = .copy,
+        dateLastActive: CopiableProp<Date> = .copy,
+        ordersCount: CopiableProp<Int> = .copy,
+        totalSpend: CopiableProp<Decimal> = .copy,
+        averageOrderValue: CopiableProp<Decimal> = .copy,
+        country: CopiableProp<String> = .copy,
+        region: CopiableProp<String> = .copy,
+        city: CopiableProp<String> = .copy,
+        postcode: CopiableProp<String> = .copy
     ) -> Networking.WCAnalyticsCustomer {
         let siteID = siteID ?? self.siteID
+        let customerID = customerID ?? self.customerID
         let userID = userID ?? self.userID
         let name = name ?? self.name
         let email = email ?? self.email
         let username = username ?? self.username
+        let dateRegistered = dateRegistered ?? self.dateRegistered
+        let dateLastActive = dateLastActive ?? self.dateLastActive
+        let ordersCount = ordersCount ?? self.ordersCount
+        let totalSpend = totalSpend ?? self.totalSpend
+        let averageOrderValue = averageOrderValue ?? self.averageOrderValue
+        let country = country ?? self.country
+        let region = region ?? self.region
+        let city = city ?? self.city
+        let postcode = postcode ?? self.postcode
 
         return Networking.WCAnalyticsCustomer(
             siteID: siteID,
+            customerID: customerID,
             userID: userID,
             name: name,
             email: email,
-            username: username
+            username: username,
+            dateRegistered: dateRegistered,
+            dateLastActive: dateLastActive,
+            ordersCount: ordersCount,
+            totalSpend: totalSpend,
+            averageOrderValue: averageOrderValue,
+            country: country,
+            region: region,
+            city: city,
+            postcode: postcode
         )
     }
 }

--- a/Networking/Networking/Model/WCAnalyticsCustomer.swift
+++ b/Networking/Networking/Model/WCAnalyticsCustomer.swift
@@ -1,9 +1,12 @@
 import Foundation
 import Codegen
 
-public struct WCAnalyticsCustomer: Codable, GeneratedCopiable, GeneratedFakeable {
+public struct WCAnalyticsCustomer: Decodable, GeneratedCopiable, GeneratedFakeable {
     /// The siteID for the WCAnalyticsCustomer
     public let siteID: Int64
+
+    /// Unique identifier for the customer, including non-registered customers
+    public let customerID: Int64
 
     /// Unique identifier for the user, only non-zero when the user is registered
     public let userID: Int64
@@ -17,14 +20,65 @@ public struct WCAnalyticsCustomer: Codable, GeneratedCopiable, GeneratedFakeable
     /// Customer username
     public let username: String?
 
+    /// Date customer registered, in GMT
+    public let dateRegistered: Date?
+
+    /// Date customer was last active, in GMT
+    public let dateLastActive: Date
+
+    /// Number of orders for the customer
+    public let ordersCount: Int
+
+    /// Total amount spent by the customer
+    public let totalSpend: Decimal
+
+    /// Average order value for the customer's orders
+    public let averageOrderValue: Decimal
+
+    /// Customer country
+    public let country: String
+
+    /// Customer region or state
+    public let region: String
+
+    /// Customer city
+    public let city: String
+
+    /// Customer postcode
+    public let postcode: String
+
     /// WCAnalyticsCustomer struct Initializer
     ///
-    public init(siteID: Int64, userID: Int64, name: String?, email: String?, username: String?) {
+    public init(siteID: Int64,
+                customerID: Int64,
+                userID: Int64,
+                name: String?,
+                email: String?,
+                username: String?,
+                dateRegistered: Date?,
+                dateLastActive: Date,
+                ordersCount: Int,
+                totalSpend: Decimal,
+                averageOrderValue: Decimal,
+                country: String,
+                region: String,
+                city: String,
+                postcode: String) {
         self.siteID = siteID
+        self.customerID = customerID
         self.userID = userID
         self.name = name
         self.email = email
         self.username = username
+        self.dateRegistered = dateRegistered
+        self.dateLastActive = dateLastActive
+        self.ordersCount = ordersCount
+        self.totalSpend = totalSpend
+        self.averageOrderValue = averageOrderValue
+        self.country = country
+        self.region = region
+        self.city = city
+        self.postcode = postcode
     }
 
     /// Public initializer for WCAnalyticsCustomer
@@ -36,21 +90,55 @@ public struct WCAnalyticsCustomer: Codable, GeneratedCopiable, GeneratedFakeable
 
         let container = try decoder.container(keyedBy: CodingKeys.self)
 
+        let customerID = try container.decode(Int64.self, forKey: .customerID)
         let userID = try container.decode(Int64.self, forKey: .userID)
         let name = try container.decode(String.self, forKey: .name)
         let email = try container.decode(String.self, forKey: .email)
         let username = try container.decode(String.self, forKey: .username)
+        let dateRegistered = try? container.decode(Date.self, forKey: .dateRegisteredGMT)
+        let dateLastActive = try container.decode(Date.self, forKey: .dateLastActiveGMT)
+        let ordersCount = try container.decode(Int.self, forKey: .ordersCount)
+        let totalSpend = try container.decode(Decimal.self, forKey: .totalSpend)
+        let averageOrderValue = try container.decode(Decimal.self, forKey: .avgOrderValue)
+        let country = try container.decode(String.self, forKey: .country)
+        let region = try container.decode(String.self, forKey: .region)
+        let city = try container.decode(String.self, forKey: .city)
+        let postcode = try container.decode(String.self, forKey: .postcode)
 
-        self.init(siteID: siteID, userID: userID, name: name, email: email, username: username)
+        self.init(siteID: siteID,
+                  customerID: customerID,
+                  userID: userID,
+                  name: name,
+                  email: email,
+                  username: username,
+                  dateRegistered: dateRegistered,
+                  dateLastActive: dateLastActive,
+                  ordersCount: ordersCount,
+                  totalSpend: totalSpend,
+                  averageOrderValue: averageOrderValue,
+                  country: country,
+                  region: region,
+                  city: city,
+                  postcode: postcode)
     }
 }
 
 extension WCAnalyticsCustomer {
     enum CodingKeys: String, CodingKey {
-        case userID =   "user_id"
-        case name   =   "name"
-        case email  =   "email"
-        case username = "username"
+        case customerID         = "id"
+        case userID             = "user_id"
+        case name               = "name"
+        case email              = "email"
+        case username           = "username"
+        case dateRegisteredGMT  = "date_registered_gmt"
+        case dateLastActiveGMT  = "date_last_active_gmt"
+        case ordersCount        = "orders_count"
+        case totalSpend         = "total_spend"
+        case avgOrderValue      = "avg_order_value"
+        case country            = "country"
+        case city               = "city"
+        case region             = "state"
+        case postcode           = "postcode"
     }
 
     enum DecodingError: Error {


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #12297
<!-- Id number of the GitHub issue this PR addresses. -->

## Why
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
We want to add a new Customers section reflecting all the customer data fetched for `WCAnalyticsCustomer` from the `WCAnalyticsCustomerRemote` endpoints. Previously we were ignoring most of that data and only decoding the name, email, and username. Now, we support all the fields for display in customer details.

## How
* Adds fields to `WCAnalyticsCustomer`.
* Updates the model's `fake()` and `copy()` methods.

This doesn't change how `WCAnalyticsCustomer` is currently used, as the new fields will be ignored when the customer is stored. A future PR will update the storage and yosemite layers so we can use this new data.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

1. Build and run the app.
2. Go to the Orders tab.
3. Create a new order.
4. Add customer details to the order.
5. Confirm the customer list loads as expected.
6. Search for customers and confirm the results load as expected.


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
