### PR TITLE
Add `Close` button to Plugins view

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/PluginDetailsRowView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/PluginDetailsRowView.swift
@@ -4,23 +4,43 @@ import Yosemite
 struct PluginListView: View {
     private let siteID: Int64
     private let viewModel: PluginListViewModel
+    var onClose: (() -> Void)?
 
-    init(siteID: Int64, viewModel: PluginListViewModel) {
+    init(siteID: Int64, viewModel: PluginListViewModel, onClose: (() -> Void)? = nil) {
         self.siteID = siteID
         self.viewModel = viewModel
+        self.onClose = onClose
     }
 
     var body: some View {
-        ScrollView {
-            VStack {
-                Divider()
-                ForEach(viewModel.pluginNameList, id: \.self) { pluginName in
-                    PluginDetailsRowView(viewModel: PluginDetailsViewModel(siteID: siteID,
-                                                                           pluginName: pluginName))
+            ScrollView {
+                VStack {
                     Divider()
+                    ForEach(viewModel.pluginNameList, id: \.self) { pluginName in
+                        PluginDetailsRowView(viewModel: PluginDetailsViewModel(siteID: siteID,
+                                                                               pluginName: pluginName))
+                        Divider()
+                    }
                 }
             }
-        }
+            .navigationBarTitle(Localization.pluginsTitle, displayMode: .inline)
+            .navigationBarItems(trailing: Button(Localization.closeButton) {
+                onClose?()
+            })
+    }
+}
+
+private extension PluginListView {
+    enum Localization {
+        static let pluginsTitle = NSLocalizedString(
+            "pluginListView.title.plugins",
+            value: "Plugins",
+            comment: "Title for the Plugin List view.")
+
+        static let closeButton = NSLocalizedString(
+            "pluginListView.button.close",
+            value: "Close",
+            comment: "Title for the Close button within the Plugin List view.")
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Settings/SettingsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Settings/SettingsViewController.swift
@@ -371,7 +371,9 @@ private extension SettingsViewController {
             return DDLogError("⛔️ Cannot find ID for current site to load plugins for!")
         }
         let pluginListViewModel = PluginListViewModel(siteID: siteID)
-        let pluginListHostingController = UIHostingController(rootView: PluginListView(siteID: siteID, viewModel: pluginListViewModel))
+        let pluginListHostingController = UIHostingController(rootView: PluginListView(siteID: siteID, viewModel: pluginListViewModel, onClose: { [weak self] in
+            self?.dismiss(animated: true)
+        }))
 
         // Since UIHostingController does not have a navigation bar by itself, we need
         // to wrap it into a navigation controller if we want to set a title in the resulting view


### PR DESCRIPTION


## Description
When creating the new Plugin List view, I didn't realized that is not dismissible on compact vertical size class (eg: iPhone 15 on landscape mode) since we cannot drag down to dismiss in this mode, so the UI is blocked if a merchant navigates to this screen on this mode.

This PR addresses this problem by adding a Close button to the view, so it can either be dismissed by dragging down when available, or by tapping on `Close` when not available.

![Simulator Screen Recording - iPhone 15 - 2024-03-19 at 20 07 06](https://github.com/woocommerce/woocommerce-ios/assets/3812076/8bc7b020-cc7b-44d1-91e2-0d25a026f2b9)


## Changes
Since the view is wrapped into a UIHostingController, we cannot call the SwiftUI’s environment dismissal directly, but need to setup a callback to dismiss the view from the SettingsViewController

## Testing instructions
1. On an iPhone 15, on landscape mode
2. Go to Menu > Settings > Plugins
3. Observe that you can dismiss the view by tapping on `Close`
