### PR TITLE
[Hub Menu] Customers: Add Yosemite support for loading and searching WCAnalyticsCustomers

### DIFF
--- a/Networking/Networking/Remote/WCAnalyticsCustomerRemote.swift
+++ b/Networking/Networking/Remote/WCAnalyticsCustomerRemote.swift
@@ -22,7 +22,7 @@ public class WCAnalyticsCustomerRemote: Remote {
                                 order: Order,
                                 keyword: String,
                                 filter: String,
-                                filterEmpty: FilterEmpty?,
+                                filterEmpty: FilterEmpty? = nil,
                                 completion: @escaping (Result<[WCAnalyticsCustomer], Error>) -> Void) {
         let parameters: [String: Any] = [
             ParameterKey.page: String(pageNumber),
@@ -44,7 +44,7 @@ public class WCAnalyticsCustomerRemote: Remote {
                               pageSize: Int = 25,
                               orderby: OrderBy,
                               order: Order,
-                              filterEmpty: FilterEmpty?,
+                              filterEmpty: FilterEmpty? = nil,
                               completion: @escaping (Result<[WCAnalyticsCustomer], Error>) -> Void) {
         let parameters: [String: Any] = [
             ParameterKey.page: String(pageNumber),

--- a/Storage/Storage/Tools/StorageType+Deletions.swift
+++ b/Storage/Storage/Tools/StorageType+Deletions.swift
@@ -230,6 +230,12 @@ public extension StorageType {
         }
     }
 
+    func deleteWCAnalyticsCustomers(siteID: Int64) {
+        loadAllWCAnalyticsCustomers(siteID: siteID).forEach {
+            deleteObject($0)
+        }
+    }
+
     func deleteTaxRates(siteID: Int64) {
         loadTaxRates(siteID: siteID).forEach {
             deleteObject($0)

--- a/Storage/Storage/Tools/StorageType+Extensions.swift
+++ b/Storage/Storage/Tools/StorageType+Extensions.swift
@@ -681,6 +681,27 @@ public extension StorageType {
         return firstObject(ofType: CustomerSearchResult.self, matching: predicate)
     }
 
+    // MARK: - WCAnalytics Customers
+
+    /// Returns a single WCAnalyticsCustomer given a `siteID` and `customerID`
+    ///
+    func loadWCAnalyticsCustomer(siteID: Int64, customerID: Int64) -> WCAnalyticsCustomer? {
+        let predicate = \WCAnalyticsCustomer.siteID == siteID && \WCAnalyticsCustomer.customerID == customerID
+        return firstObject(ofType: WCAnalyticsCustomer.self, matching: predicate)
+    }
+
+    func loadAllWCAnalyticsCustomers(siteID: Int64) -> [WCAnalyticsCustomer] {
+        let predicate = \WCAnalyticsCustomer.siteID == siteID
+        return allObjects(ofType: WCAnalyticsCustomer.self, matching: predicate, sortedBy: [])
+    }
+
+    /// Returns a WCAnalyticsCustomerSearchResult given a `siteID` and a `keyword`
+    ///
+    func loadWCAnalyticsCustomerSearchResult(siteID: Int64, keyword: String) -> WCAnalyticsCustomerSearchResult? {
+        let predicate = \WCAnalyticsCustomerSearchResult.siteID == siteID && \WCAnalyticsCustomerSearchResult.keyword == keyword
+        return firstObject(ofType: WCAnalyticsCustomerSearchResult.self, matching: predicate)
+    }
+
     // MARK: - System plugins
 
     /// Returns all stored system plugins for a provided `siteID`.

--- a/Yosemite/Yosemite.xcodeproj/project.pbxproj
+++ b/Yosemite/Yosemite.xcodeproj/project.pbxproj
@@ -377,6 +377,7 @@
 		CE4FD4562350FD4800A16B31 /* Refund+ReadOnlyConvertible.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE4FD4552350FD4800A16B31 /* Refund+ReadOnlyConvertible.swift */; };
 		CE5F9A7A22B2D455001755E8 /* Array+Helpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE5F9A7922B2D455001755E8 /* Array+Helpers.swift */; };
 		CECC504023675DF4004540EA /* RefundStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CECC503F23675DF4004540EA /* RefundStoreTests.swift */; };
+		CECE6BBE2BA9DE3200A57C1F /* WCAnalyticsCustomer+ReadOnlyConvertible.swift in Sources */ = {isa = PBXBuildFile; fileRef = CECE6BBD2BA9DE3200A57C1F /* WCAnalyticsCustomer+ReadOnlyConvertible.swift */; };
 		CEE9188C29F7F68C004B23FF /* OrderGiftCard+ReadOnlyConvertible.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEE9188B29F7F68C004B23FF /* OrderGiftCard+ReadOnlyConvertible.swift */; };
 		CEF2DD992B56BEC500A3DD0B /* JetpackModule.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEF2DD982B56BEC500A3DD0B /* JetpackModule.swift */; };
 		CEF2DDA12B572D6F00A3DD0B /* JetpackSettingsStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEF2DDA02B572D6F00A3DD0B /* JetpackSettingsStore.swift */; };
@@ -865,6 +866,7 @@
 		CE4FD4552350FD4800A16B31 /* Refund+ReadOnlyConvertible.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Refund+ReadOnlyConvertible.swift"; sourceTree = "<group>"; };
 		CE5F9A7922B2D455001755E8 /* Array+Helpers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Array+Helpers.swift"; sourceTree = "<group>"; };
 		CECC503F23675DF4004540EA /* RefundStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RefundStoreTests.swift; sourceTree = "<group>"; };
+		CECE6BBD2BA9DE3200A57C1F /* WCAnalyticsCustomer+ReadOnlyConvertible.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "WCAnalyticsCustomer+ReadOnlyConvertible.swift"; sourceTree = "<group>"; };
 		CEE9188B29F7F68C004B23FF /* OrderGiftCard+ReadOnlyConvertible.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "OrderGiftCard+ReadOnlyConvertible.swift"; sourceTree = "<group>"; };
 		CEF2DD982B56BEC500A3DD0B /* JetpackModule.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JetpackModule.swift; sourceTree = "<group>"; };
 		CEF2DDA02B572D6F00A3DD0B /* JetpackSettingsStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JetpackSettingsStore.swift; sourceTree = "<group>"; };
@@ -1460,6 +1462,7 @@
 				DEFD6D962644423100E51E0D /* SitePlugin+ReadOnlyConvertible.swift */,
 				077F39E126A5AFCA00ABEADC /* SystemPlugin+ReadOnlyConvertible.swift */,
 				BAB3737827964A9500837B4A /* OrderTaxLine+ReadOnlyConvertible.swift */,
+				CECE6BBD2BA9DE3200A57C1F /* WCAnalyticsCustomer+ReadOnlyConvertible.swift */,
 				031C1EA927B1702800298699 /* WCPayCharge+ReadOnlyConvertible.swift */,
 				031C1EAB27B1873200298699 /* WCPayCardPresentReceiptDetails+ReadOnlyConvertible.swift */,
 				031C1EAF27B1879C00298699 /* WCPayCardPaymentDetails+ReadOnlyConvertible.swift */,
@@ -2124,6 +2127,7 @@
 				E138D4FA269EE5BD006EA5C6 /* CardPresentPaymentsOnboardingState.swift in Sources */,
 				02E3B625290267F2007E0F13 /* AccountCreationAction.swift in Sources */,
 				02C254FA2563B66600A04423 /* ShippingLabelRefund+ReadOnlyConvertible.swift in Sources */,
+				CECE6BBE2BA9DE3200A57C1F /* WCAnalyticsCustomer+ReadOnlyConvertible.swift in Sources */,
 				02FF054F23D983F30058E6E7 /* FileManager+URL.swift in Sources */,
 				03F3AFE728097D6400E328BE /* CardPresentPaymentsPlugin.swift in Sources */,
 				B52E0032211A440D00700FDE /* Order+ReadOnlyType.swift in Sources */,

--- a/Yosemite/Yosemite/Actions/CustomerAction.swift
+++ b/Yosemite/Yosemite/Actions/CustomerAction.swift
@@ -27,6 +27,20 @@ public enum CustomerAction: Action {
         filterEmpty: WCAnalyticsCustomerRemote.FilterEmpty? = nil,
         onCompletion: (Result<Bool, Error>) -> Void)
 
+    /// Synchronizes all customers (registered and unregistered) as `WCAnalyticsCustomer` objects.
+    /// When syncing the first page it resets (deletes) all the stored objects.
+    ///
+    /// - Parameters:
+    ///     - siteID: The site for which we will perform the search.
+    ///     - pageNumber: The number of the page you want to load.
+    ///     - pageSize: The size of the page you want to load.
+    ///     - onCompletion: Invoked when the operation finishes. Returns true if there are results synced.
+    ///
+    case synchronizeAllCustomers(siteID: Int64,
+                                 pageNumber: Int,
+                                 pageSize: Int,
+                                 onCompletion: (Result<Bool, Error>) -> Void)
+
     /// Searches for Customers by keyword. Currently, only searches by name.
     ///
     ///- `siteID`: The site for which we will perform the search.

--- a/Yosemite/Yosemite/Actions/CustomerAction.swift
+++ b/Yosemite/Yosemite/Actions/CustomerAction.swift
@@ -65,6 +65,23 @@ public enum CustomerAction: Action {
         filterEmpty: WCAnalyticsCustomerRemote.FilterEmpty? = nil,
         onCompletion: (Result<(), Error>) -> Void)
 
+    /// Searches for WCAnalyticsCustomers by keyword and stores the results.
+    ///
+    /// - Parameters:
+    ///     - siteID: The site for which we will perform the search.
+    ///     - pageNumber: The number of the page you want to load.
+    ///     - pageSize: The size of the page you want to load.
+    ///     - keyword: Keyword to perform the search.
+    ///     - filter: Filter to perform the search.
+    ///     - onCompletion: Invoked when the operation finishes.
+    ///
+    case searchWCAnalyticsCustomers(siteID: Int64,
+                                    pageNumber: Int,
+                                    pageSize: Int,
+                                    keyword: String,
+                                    filter: CustomerSearchFilter,
+                                    onCompletion: (Result<(), Error>) -> Void)
+
     /// Retrieves a single Customer from a site
     ///
     ///- `siteID`: The site for which customers should be fetched.

--- a/Yosemite/Yosemite/Model/Storage/WCAnalyticsCustomer+ReadOnlyConvertible.swift
+++ b/Yosemite/Yosemite/Model/Storage/WCAnalyticsCustomer+ReadOnlyConvertible.swift
@@ -1,0 +1,49 @@
+import Foundation
+import Storage
+
+// MARK: - Storage.WCAnalyticsCustomer: ReadOnlyConvertible
+//
+extension Storage.WCAnalyticsCustomer: ReadOnlyConvertible {
+
+    /// Updates the `Storage.WCAnalyticsCustomer` using the ReadOnly representation (`Networking.WCAnalyticsCustomer`)
+    ///
+    /// - Parameter customer: ReadOnly representation of WCAnalyticsCustomer
+    ///
+    public func update(with customer: Yosemite.WCAnalyticsCustomer) {
+        siteID = customer.siteID
+        customerID = customer.customerID
+        userID = customer.userID
+        name = customer.name
+        email = customer.email
+        username = customer.username
+        dateRegistered = customer.dateRegistered
+        dateLastActive = customer.dateLastActive
+        ordersCount = Int64(customer.ordersCount)
+        totalSpend = NSDecimalNumber(decimal: customer.totalSpend)
+        averageOrderValue = NSDecimalNumber(decimal: customer.averageOrderValue)
+        country = customer.country
+        region = customer.region
+        city = customer.city
+        postcode = customer.postcode
+    }
+
+    /// Returns a ReadOnly (`Networking.WCAnalyticsCustomer`) version of the `Storage.WCAnalyticsCustomer`
+    ///
+    public func toReadOnly() -> Yosemite.WCAnalyticsCustomer {
+        return WCAnalyticsCustomer(siteID: siteID,
+                                   customerID: customerID,
+                                   userID: userID,
+                                   name: name,
+                                   email: email,
+                                   username: username,
+                                   dateRegistered: dateRegistered,
+                                   dateLastActive: dateLastActive ?? Date(),
+                                   ordersCount: Int(ordersCount),
+                                   totalSpend: totalSpend?.decimalValue ?? 0,
+                                   averageOrderValue: averageOrderValue?.decimalValue ?? 0,
+                                   country: country ?? String(),
+                                   region: region ?? String(),
+                                   city: city ?? String(),
+                                   postcode: postcode ?? String())
+    }
+}


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #12314
<!-- Id number of the GitHub issue this PR addresses. -->

## Why
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
We want to be able to load and search customers and have the fetched customers stored as `WCAnalyticsCustomer` objects, rather than `Customer` objects. This PR adds two new actions in `CustomerAction` to do that.

## How
* Adds two new actions to `CustomerAction` and `CustomerStore`:
   * `searchWCAnalyticsCustomers` searches customers via `WCAnalyticsCustomerRemote` and stores the results as `WCAnalyticsCustomer` and `WCAnalyticsCustomerSearchResult` objects. This is distinct from the existing `searchCustomers` action, which uses the same endpoint but parses the results as `Customer` objects.
   * `synchronizeAllCustomers` fetches customers (registered and unregistered) via `WCAnalyticsCustomerRemote` and stores the results as `WCAnalyticsCustomer` objects.
* Adds supporting extensions for `ReadOnlyConvertible` (to convert `WCAnalyticsCustomer` objects to/from storage) and `StorageType` (to load/delete objects from storage).
* Adds related unit tests.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
We aren't using these new action yet, so it's sufficient to confirm that all tests pass in CI.

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
