### PR TITLE
Blaze: Update campaign creation request with the `budget` field

### DIFF
--- a/Fakes/Fakes/Networking.generated.swift
+++ b/Fakes/Fakes/Networking.generated.swift
@@ -422,7 +422,7 @@ extension Networking.CreateBlazeCampaign {
             startDate: .fake(),
             endDate: .fake(),
             timeZone: .fake(),
-            totalBudget: .fake(),
+            budget: .fake(),
             siteName: .fake(),
             textSnippet: .fake(),
             targetUrl: .fake(),

--- a/Fakes/Fakes/Networking.generated.swift
+++ b/Fakes/Fakes/Networking.generated.swift
@@ -166,17 +166,6 @@ extension Networking.BlazeAISuggestion {
         )
     }
 }
-extension Networking.BlazeAddPaymentInfo {
-    /// Returns a "ready to use" type filled with fake values.
-    ///
-    public static func fake() -> Networking.BlazeAddPaymentInfo {
-        .init(
-            formUrl: .fake(),
-            successUrl: .fake(),
-            idUrlParameter: .fake()
-        )
-    }
-}
 extension Networking.BlazeCampaignBudget {
     /// Returns a "ready to use" type filled with fake values.
     ///
@@ -246,8 +235,7 @@ extension Networking.BlazePaymentInfo {
     ///
     public static func fake() -> Networking.BlazePaymentInfo {
         .init(
-            savedPaymentMethods: .fake(),
-            addPaymentMethod: .fake()
+            paymentMethods: .fake()
         )
     }
 }

--- a/Fakes/Fakes/Networking.generated.swift
+++ b/Fakes/Fakes/Networking.generated.swift
@@ -166,6 +166,28 @@ extension Networking.BlazeAISuggestion {
         )
     }
 }
+extension Networking.BlazeAddPaymentInfo {
+    /// Returns a "ready to use" type filled with fake values.
+    ///
+    public static func fake() -> Networking.BlazeAddPaymentInfo {
+        .init(
+            formUrl: .fake(),
+            successUrl: .fake(),
+            idUrlParameter: .fake()
+        )
+    }
+}
+extension Networking.BlazeCampaignBudget {
+    /// Returns a "ready to use" type filled with fake values.
+    ///
+    public static func fake() -> Networking.BlazeCampaignBudget {
+        .init(
+            mode: .fake(),
+            amount: .fake(),
+            currency: .fake()
+        )
+    }
+}
 extension Networking.BlazeCampaignListItem {
     /// Returns a "ready to use" type filled with fake values.
     ///
@@ -224,7 +246,8 @@ extension Networking.BlazePaymentInfo {
     ///
     public static func fake() -> Networking.BlazePaymentInfo {
         .init(
-            paymentMethods: .fake()
+            savedPaymentMethods: .fake(),
+            addPaymentMethod: .fake()
         )
     }
 }

--- a/Fakes/Fakes/Networking.generated.swift
+++ b/Fakes/Fakes/Networking.generated.swift
@@ -188,6 +188,13 @@ extension Networking.BlazeCampaignBudget {
         )
     }
 }
+extension Networking.BlazeCampaignBudget.Mode {
+    /// Returns a "ready to use" type filled with fake values.
+    ///
+    public static func fake() -> Networking.BlazeCampaignBudget.Mode {
+        .total
+    }
+}
 extension Networking.BlazeCampaignListItem {
     /// Returns a "ready to use" type filled with fake values.
     ///
@@ -209,13 +216,6 @@ extension Networking.BlazeCampaignListItem {
             budgetAmount: .fake(),
             budgetCurrency: .fake()
         )
-    }
-}
-extension Networking.BlazeCampaignListItem.BudgetMode {
-    /// Returns a "ready to use" type filled with fake values.
-    ///
-    public static func fake() -> Networking.BlazeCampaignListItem.BudgetMode {
-        .total
     }
 }
 extension Networking.BlazeForecastedImpressionsInput {

--- a/Networking/Networking/Model/Blaze/BlazeCampaignListItem.swift
+++ b/Networking/Networking/Model/Blaze/BlazeCampaignListItem.swift
@@ -111,7 +111,7 @@ public struct BlazeCampaignListItem: Decodable, Equatable, GeneratedFakeable, Ge
         totalBudget = try container.decode(Double.self, forKey: .totalBudget)
         spentBudget = try container.decodeIfPresent(Double.self, forKey: .spentBudget) ?? 0
 
-        let budget = try container.decodeIfPresent(Budget.self, forKey: .budget)
+        let budget = try container.decodeIfPresent(BlazeCampaignBudget.self, forKey: .budget)
         budgetMode = {
             guard let budget else {
                 return .total
@@ -165,12 +165,6 @@ private extension BlazeCampaignListItem {
         case budget
     }
 
-    struct Budget: Decodable {
-        public let mode: String
-        public let amount: Double
-        public let currency: String
-    }
-
     /// Private subtype for parsing image details.
     struct Image: Decodable {
         public let url: String?
@@ -179,5 +173,17 @@ private extension BlazeCampaignListItem {
     /// Decoding Errors
     enum DecodingError: Error {
         case missingSiteID
+    }
+}
+
+public struct BlazeCampaignBudget: Codable, GeneratedFakeable, GeneratedCopiable {
+    public let mode: String
+    public let amount: Double
+    public let currency: String
+
+    public init(mode: String, amount: Double, currency: String) {
+        self.mode = mode
+        self.amount = amount
+        self.currency = currency
     }
 }

--- a/Networking/Networking/Model/Blaze/BlazeCampaignListItem.swift
+++ b/Networking/Networking/Model/Blaze/BlazeCampaignListItem.swift
@@ -116,7 +116,7 @@ public struct BlazeCampaignListItem: Decodable, Equatable, GeneratedFakeable, Ge
             guard let budget else {
                 return .total
             }
-            return BlazeCampaignBudget.Mode(rawValue: budget.mode) ?? .total
+            return budget.mode
         }()
         budgetAmount = budget?.amount ?? totalBudget
         budgetCurrency = budget?.currency ?? "USD"
@@ -172,17 +172,17 @@ private extension BlazeCampaignListItem {
 }
 
 public struct BlazeCampaignBudget: Codable, GeneratedFakeable, GeneratedCopiable {
-    public let mode: String
+    public let mode: Mode
     public let amount: Double
     public let currency: String
 
-    public init(mode: String, amount: Double, currency: String) {
+    public init(mode: Mode, amount: Double, currency: String) {
         self.mode = mode
         self.amount = amount
         self.currency = currency
     }
 
-    public enum Mode: String, GeneratedFakeable {
+    public enum Mode: String, Codable, GeneratedFakeable {
         case total
         case daily
     }

--- a/Networking/Networking/Model/Blaze/BlazeCampaignListItem.swift
+++ b/Networking/Networking/Model/Blaze/BlazeCampaignListItem.swift
@@ -112,12 +112,7 @@ public struct BlazeCampaignListItem: Decodable, Equatable, GeneratedFakeable, Ge
         spentBudget = try container.decodeIfPresent(Double.self, forKey: .spentBudget) ?? 0
 
         let budget = try container.decodeIfPresent(BlazeCampaignBudget.self, forKey: .budget)
-        budgetMode = {
-            guard let budget else {
-                return .total
-            }
-            return budget.mode
-        }()
+        budgetMode = budget?.mode ?? .total
         budgetAmount = budget?.amount ?? totalBudget
         budgetCurrency = budget?.currency ?? "USD"
     }

--- a/Networking/Networking/Model/Blaze/BlazeCampaignListItem.swift
+++ b/Networking/Networking/Model/Blaze/BlazeCampaignListItem.swift
@@ -43,7 +43,7 @@ public struct BlazeCampaignListItem: Decodable, Equatable, GeneratedFakeable, Ge
     public let spentBudget: Double
 
     /// Indicates whether the `budgetAmount` field is total or daily amount.
-    public let budgetMode: BudgetMode
+    public let budgetMode: BlazeCampaignBudget.Mode
 
     /// Can be total or daily amount, so check `budgetMode` to identify this.
     public let budgetAmount: Double
@@ -63,7 +63,7 @@ public struct BlazeCampaignListItem: Decodable, Equatable, GeneratedFakeable, Ge
                 clicks: Int64,
                 totalBudget: Double,
                 spentBudget: Double,
-                budgetMode: BudgetMode,
+                budgetMode: BlazeCampaignBudget.Mode,
                 budgetAmount: Double,
                 budgetCurrency: String) {
         self.siteID = siteID
@@ -116,7 +116,7 @@ public struct BlazeCampaignListItem: Decodable, Equatable, GeneratedFakeable, Ge
             guard let budget else {
                 return .total
             }
-            return BudgetMode(rawValue: budget.mode) ?? .total
+            return BlazeCampaignBudget.Mode(rawValue: budget.mode) ?? .total
         }()
         budgetAmount = budget?.amount ?? totalBudget
         budgetCurrency = budget?.currency ?? "USD"
@@ -139,11 +139,6 @@ public extension BlazeCampaignListItem {
     /// Status of the current campaign.
     var status: Status {
         Status(rawValue: uiStatus) ?? .unknown
-    }
-
-    enum BudgetMode: String, GeneratedFakeable {
-        case total
-        case daily
     }
 }
 
@@ -185,5 +180,10 @@ public struct BlazeCampaignBudget: Codable, GeneratedFakeable, GeneratedCopiable
         self.mode = mode
         self.amount = amount
         self.currency = currency
+    }
+
+    public enum Mode: String, GeneratedFakeable {
+        case total
+        case daily
     }
 }

--- a/Networking/Networking/Model/Blaze/CreateBlazeCampaign.swift
+++ b/Networking/Networking/Model/Blaze/CreateBlazeCampaign.swift
@@ -48,9 +48,9 @@ public struct CreateBlazeCampaign: Encodable, GeneratedFakeable, GeneratedCopiab
     ///
     public let timeZone: String
 
-    /// Total campaign budget in USD
+    /// Campaign budget with specified amount, currency, and mode.
     ///
-    public let totalBudget: Double
+    public let budget: BlazeCampaignBudget
 
     /// Tagline of the campaign
     ///
@@ -93,7 +93,7 @@ public struct CreateBlazeCampaign: Encodable, GeneratedFakeable, GeneratedCopiab
                 startDate: Date,
                 endDate: Date,
                 timeZone: String,
-                totalBudget: Double,
+                budget: BlazeCampaignBudget,
                 siteName: String,
                 textSnippet: String,
                 targetUrl: String,
@@ -108,7 +108,7 @@ public struct CreateBlazeCampaign: Encodable, GeneratedFakeable, GeneratedCopiab
         self.startDate = startDate
         self.endDate = endDate
         self.timeZone = timeZone
-        self.totalBudget = totalBudget
+        self.budget = budget
         self.siteName = siteName
         self.textSnippet = textSnippet
         self.targetUrl = targetUrl

--- a/Networking/Networking/Model/Copiable/Models+Copiable.generated.swift
+++ b/Networking/Networking/Model/Copiable/Models+Copiable.generated.swift
@@ -194,7 +194,7 @@ extension Networking.BlazeAddPaymentInfo {
 
 extension Networking.BlazeCampaignBudget {
     public func copy(
-        mode: CopiableProp<String> = .copy,
+        mode: CopiableProp<BlazeCampaignBudget.Mode> = .copy,
         amount: CopiableProp<Double> = .copy,
         currency: CopiableProp<String> = .copy
     ) -> Networking.BlazeCampaignBudget {
@@ -557,7 +557,7 @@ extension Networking.CreateBlazeCampaign {
         startDate: CopiableProp<Date> = .copy,
         endDate: CopiableProp<Date> = .copy,
         timeZone: CopiableProp<String> = .copy,
-        totalBudget: CopiableProp<Double> = .copy,
+        budget: CopiableProp<BlazeCampaignBudget> = .copy,
         siteName: CopiableProp<String> = .copy,
         textSnippet: CopiableProp<String> = .copy,
         targetUrl: CopiableProp<String> = .copy,
@@ -573,7 +573,7 @@ extension Networking.CreateBlazeCampaign {
         let startDate = startDate ?? self.startDate
         let endDate = endDate ?? self.endDate
         let timeZone = timeZone ?? self.timeZone
-        let totalBudget = totalBudget ?? self.totalBudget
+        let budget = budget ?? self.budget
         let siteName = siteName ?? self.siteName
         let textSnippet = textSnippet ?? self.textSnippet
         let targetUrl = targetUrl ?? self.targetUrl
@@ -590,7 +590,7 @@ extension Networking.CreateBlazeCampaign {
             startDate: startDate,
             endDate: endDate,
             timeZone: timeZone,
-            totalBudget: totalBudget,
+            budget: budget,
             siteName: siteName,
             textSnippet: textSnippet,
             targetUrl: targetUrl,

--- a/Networking/Networking/Model/Copiable/Models+Copiable.generated.swift
+++ b/Networking/Networking/Model/Copiable/Models+Copiable.generated.swift
@@ -174,6 +174,42 @@ extension Networking.BlazeAISuggestion {
     }
 }
 
+extension Networking.BlazeAddPaymentInfo {
+    public func copy(
+        formUrl: CopiableProp<String> = .copy,
+        successUrl: CopiableProp<String> = .copy,
+        idUrlParameter: CopiableProp<String> = .copy
+    ) -> Networking.BlazeAddPaymentInfo {
+        let formUrl = formUrl ?? self.formUrl
+        let successUrl = successUrl ?? self.successUrl
+        let idUrlParameter = idUrlParameter ?? self.idUrlParameter
+
+        return Networking.BlazeAddPaymentInfo(
+            formUrl: formUrl,
+            successUrl: successUrl,
+            idUrlParameter: idUrlParameter
+        )
+    }
+}
+
+extension Networking.BlazeCampaignBudget {
+    public func copy(
+        mode: CopiableProp<String> = .copy,
+        amount: CopiableProp<Double> = .copy,
+        currency: CopiableProp<String> = .copy
+    ) -> Networking.BlazeCampaignBudget {
+        let mode = mode ?? self.mode
+        let amount = amount ?? self.amount
+        let currency = currency ?? self.currency
+
+        return Networking.BlazeCampaignBudget(
+            mode: mode,
+            amount: amount,
+            currency: currency
+        )
+    }
+}
+
 extension Networking.BlazeCampaignListItem {
     public func copy(
         siteID: CopiableProp<Int64> = .copy,
@@ -245,12 +281,15 @@ extension Networking.BlazeImpressions {
 
 extension Networking.BlazePaymentInfo {
     public func copy(
-        paymentMethods: CopiableProp<[BlazePaymentMethod]> = .copy
+        savedPaymentMethods: CopiableProp<[BlazePaymentMethod]> = .copy,
+        addPaymentMethod: CopiableProp<BlazeAddPaymentInfo> = .copy
     ) -> Networking.BlazePaymentInfo {
-        let paymentMethods = paymentMethods ?? self.paymentMethods
+        let savedPaymentMethods = savedPaymentMethods ?? self.savedPaymentMethods
+        let addPaymentMethod = addPaymentMethod ?? self.addPaymentMethod
 
         return Networking.BlazePaymentInfo(
-            paymentMethods: paymentMethods
+            savedPaymentMethods: savedPaymentMethods,
+            addPaymentMethod: addPaymentMethod
         )
     }
 }

--- a/Networking/Networking/Model/Copiable/Models+Copiable.generated.swift
+++ b/Networking/Networking/Model/Copiable/Models+Copiable.generated.swift
@@ -224,7 +224,7 @@ extension Networking.BlazeCampaignListItem {
         clicks: CopiableProp<Int64> = .copy,
         totalBudget: CopiableProp<Double> = .copy,
         spentBudget: CopiableProp<Double> = .copy,
-        budgetMode: CopiableProp<BlazeCampaignListItem.BudgetMode> = .copy,
+        budgetMode: CopiableProp<BlazeCampaignBudget.Mode> = .copy,
         budgetAmount: CopiableProp<Double> = .copy,
         budgetCurrency: CopiableProp<String> = .copy
     ) -> Networking.BlazeCampaignListItem {

--- a/Networking/Networking/Model/Copiable/Models+Copiable.generated.swift
+++ b/Networking/Networking/Model/Copiable/Models+Copiable.generated.swift
@@ -174,24 +174,6 @@ extension Networking.BlazeAISuggestion {
     }
 }
 
-extension Networking.BlazeAddPaymentInfo {
-    public func copy(
-        formUrl: CopiableProp<String> = .copy,
-        successUrl: CopiableProp<String> = .copy,
-        idUrlParameter: CopiableProp<String> = .copy
-    ) -> Networking.BlazeAddPaymentInfo {
-        let formUrl = formUrl ?? self.formUrl
-        let successUrl = successUrl ?? self.successUrl
-        let idUrlParameter = idUrlParameter ?? self.idUrlParameter
-
-        return Networking.BlazeAddPaymentInfo(
-            formUrl: formUrl,
-            successUrl: successUrl,
-            idUrlParameter: idUrlParameter
-        )
-    }
-}
-
 extension Networking.BlazeCampaignBudget {
     public func copy(
         mode: CopiableProp<BlazeCampaignBudget.Mode> = .copy,
@@ -281,15 +263,12 @@ extension Networking.BlazeImpressions {
 
 extension Networking.BlazePaymentInfo {
     public func copy(
-        savedPaymentMethods: CopiableProp<[BlazePaymentMethod]> = .copy,
-        addPaymentMethod: CopiableProp<BlazeAddPaymentInfo> = .copy
+        paymentMethods: CopiableProp<[BlazePaymentMethod]> = .copy
     ) -> Networking.BlazePaymentInfo {
-        let savedPaymentMethods = savedPaymentMethods ?? self.savedPaymentMethods
-        let addPaymentMethod = addPaymentMethod ?? self.addPaymentMethod
+        let paymentMethods = paymentMethods ?? self.paymentMethods
 
         return Networking.BlazePaymentInfo(
-            savedPaymentMethods: savedPaymentMethods,
-            addPaymentMethod: addPaymentMethod
+            paymentMethods: paymentMethods
         )
     }
 }

--- a/Networking/NetworkingTests/Remote/BlazeRemoteTests.swift
+++ b/Networking/NetworkingTests/Remote/BlazeRemoteTests.swift
@@ -59,13 +59,14 @@ final class BlazeRemoteTests: XCTestCase {
                                            languages: ["en", "de"],
                                            devices: nil,
                                            pageTopics: ["IAB3", "IAB4"])
+        let budget = BlazeCampaignBudget(mode: .total, amount: 35, currency: "USD")
         let campaign = CreateBlazeCampaign.fake().copy(origin: "WooMobile",
                                                        originVersion: "1.0.1",
                                                        paymentMethodID: "payment-method-id-123",
                                                        startDate: startDate,
                                                        endDate: endDate,
                                                        timeZone: "America/New_York",
-                                                       totalBudget: 35.00,
+                                                       budget: budget,
                                                        siteName: "Unleash Your Brain's Potential",
                                                        textSnippet: "Discover the power of computer neural networks in unlocking your brain's full potential.",
                                                        targetUrl: "https://example.com/2023/06/25/unlocking-the-secrets-of-computer-neural-networks/",
@@ -86,7 +87,12 @@ final class BlazeRemoteTests: XCTestCase {
         XCTAssertEqual(request.parameters?["start_date"] as? String, startDateString)
         XCTAssertEqual(request.parameters?["end_date"] as? String, endDateString)
         XCTAssertEqual(request.parameters?["time_zone"] as? String, campaign.timeZone)
-        XCTAssertEqual(request.parameters?["total_budget"] as? Double, campaign.totalBudget)
+
+        let requestedBudget = try XCTUnwrap(request.parameters?["budget"] as? [String: Any])
+        XCTAssertEqual(requestedBudget["amount"] as? Double, budget.amount)
+        XCTAssertEqual(requestedBudget["currency"] as? String, budget.currency)
+        XCTAssertEqual(requestedBudget["mode"] as? String, budget.mode.rawValue)
+
         XCTAssertEqual(request.parameters?["site_name"] as? String, campaign.siteName)
         XCTAssertEqual(request.parameters?["text_snippet"] as? String, campaign.textSnippet)
         XCTAssertEqual(request.parameters?["target_url"] as? String, campaign.targetUrl)

--- a/WooCommerce/Classes/ViewRelated/Blaze/CampaignCreation/BlazeCampaignCreationFormViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Blaze/CampaignCreation/BlazeCampaignCreationFormViewModel.swift
@@ -206,7 +206,9 @@ final class BlazeCampaignCreationFormViewModel: ObservableObject {
                             startDate: startDate,
                             endDate: startDate.addingTimeInterval(Constants.oneDayInSeconds * Double(duration)),
                             timeZone: TimeZone.current.identifier,
-                            totalBudget: dailyBudget * Double(duration),
+                            budget: BlazeCampaignBudget(mode: .total,
+                                                        amount: dailyBudget * Double(duration),
+                                                        currency: Constants.defaultCurrency),
                             siteName: tagline,
                             textSnippet: description,
                             targetUrl: targetUrl,
@@ -436,6 +438,7 @@ private extension BlazeCampaignCreationFormViewModel {
         static let campaignType = "product"
         static let oneDayInSeconds: Double = 86400
         static let targetUrnFormat = "urn:wpcom:post:%d:%d"
+        static let defaultCurrency = "USD"
     }
     enum Localization {
         static let budgetSingleDay = NSLocalizedString(

--- a/WooCommerce/Classes/ViewRelated/Blaze/ConfirmPayment/BlazeConfirmPaymentView.swift
+++ b/WooCommerce/Classes/ViewRelated/Blaze/ConfirmPayment/BlazeConfirmPaymentView.swift
@@ -361,7 +361,7 @@ private extension BlazeConfirmPaymentView {
                             startDate: Date(),
                             endDate: Date(),
                             timeZone: "US-NY",
-                            totalBudget: 35,
+                            budget: .init(mode: .total, amount: 35.0, currency: "USD"),
                             siteName: "iPhone 15",
                             textSnippet: "Fancy new phone",
                             targetUrl: "https://example.com",

--- a/WooCommerce/Classes/ViewRelated/Blaze/ConfirmPayment/BlazeConfirmPaymentViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Blaze/ConfirmPayment/BlazeConfirmPaymentViewModel.swift
@@ -81,7 +81,7 @@ final class BlazeConfirmPaymentViewModel: ObservableObject {
         self.stores = stores
         self.analytics = analytics
         self.completionHandler = onCompletion
-        self.totalAmount = String(format: "$%.0f", campaignInfo.totalBudget)
+        self.totalAmount = String(format: "$%.0f", campaignInfo.budget.amount)
     }
 
     @MainActor

--- a/Yosemite/Yosemite/Model/Model.swift
+++ b/Yosemite/Yosemite/Model/Model.swift
@@ -14,6 +14,7 @@ public typealias AIProduct = Networking.AIProduct
 public typealias Announcement = Networking.Announcement
 public typealias APNSDevice = Networking.APNSDevice
 public typealias BlazeCampaignListItem = Networking.BlazeCampaignListItem
+public typealias BlazeCampaignBudget = Networking.BlazeCampaignBudget
 public typealias BlazeForecastedImpressionsInput = Networking.BlazeForecastedImpressionsInput
 public typealias BlazeImpressions = Networking.BlazeImpressions
 public typealias BlazePaymentInfo = Networking.BlazePaymentInfo

--- a/Yosemite/Yosemite/Model/Storage/BlazeCampaignListItem+ReadOnlyConvertible.swift
+++ b/Yosemite/Yosemite/Model/Storage/BlazeCampaignListItem+ReadOnlyConvertible.swift
@@ -44,7 +44,7 @@ extension Storage.BlazeCampaignListItem: ReadOnlyConvertible {
                               clicks: clicks,
                               totalBudget: totalBudget,
                               spentBudget: spentBudget,
-                              budgetMode: BlazeCampaignListItem.BudgetMode(rawValue: budgetMode) ?? .total,
+                              budgetMode: BlazeCampaignBudget.Mode(rawValue: budgetMode) ?? .total,
                               budgetAmount: budgetAmount,
                               budgetCurrency: budgetCurrency)
     }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #12320 
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This PR follows the planned API update [peeHDf-2fw-p2#comment-1934] to replace the `total_budget` field in the campaign creation request with `budget` dictionary. Changes include:
- Extracted `CampaignBudget` and `BudgetMode` from `BlazeCampaignListItem` to reuse in `CreateBlazeCampaign` request.
- Replaced `totalBudget` with `budget` in `CreateBlazeCampaign`.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
The update has not been deployed for the campaign creation endpoint yet, so I'm keeping the stub for the request in place. Just CI passing is sufficient for now.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->
N/A

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.