### PR TITLE
[Tablet Orders] Present notices across the AdaptiveModalContainer

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/EditableOrderViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/EditableOrderViewModel.swift
@@ -519,8 +519,6 @@ final class EditableOrderViewModel: ObservableObject {
         observeProductSelectorPresentationStateForViewModel()
         forwardSyncApproachToSynchronizer()
         observeChangesFromProductSelectorButtonTapSelectionSync()
-
-        forceSyncError()
     }
 
     /// Sets the notice property either with a fixedNotice or an autodismissable one
@@ -1330,33 +1328,6 @@ private extension EditableOrderViewModel {
                 }
             }
             .assign(to: &$doneButtonType)
-    }
-
-    /// For testing: remove before merging:
-    func forceSyncError() {
-        // 1. Test for fixed notice
-        //fixedNotice = NoticeFactory.createDummyFixedErrorNotice()
-
-        // 2. Test for auto-dismissable notice
-        autodismissableNotice = NoticeFactory.createDummyDissmissableErrorNotice()
-
-        // 3. Test for system error notices
-        /*
-        orderSynchronizer.statePublisher.map { [weak self] state -> Notice? in
-            guard let self = self else { return nil }
-            switch state {
-            default:
-                let error = NSError(domain: "some error", code: 0)
-                return NoticeFactory.syncOrderErrorNotice(error, flow: self.flow, with: self.orderSynchronizer)
-            }
-        }.sink { [weak self] notice in
-            guard let self = self else { return }
-            if let notice = notice {
-                self.fixedNotice = notice
-            }
-        }
-        .store(in: &cancellables)
-         */
     }
 
     /// Updates the notice based on the `orderSynchronizer` sync state.
@@ -2427,17 +2398,7 @@ extension EditableOrderViewModel {
 // MARK: Constants
 
 extension EditableOrderViewModel {
-
     enum NoticeFactory {
-        static func createDummyFixedErrorNotice() -> Notice {
-            return Notice(title: "Error!", subtitle: "Some subtitle", message: "some error message")
-        }
-
-        static func createDummyDissmissableErrorNotice() -> Notice {
-            return Notice(title: "Error!", subtitle: "Some subtitle", message: "some error message", feedbackType: .error, actionTitle: "Retry?", actionHandler: {
-                debugPrint("Action tapped!")
-            })
-        }
         /// Returns a default order creation error notice.
         ///
         static func createOrderErrorNotice(_ error: Error, order: Order) -> Notice {

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/EditableOrderViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/EditableOrderViewModel.swift
@@ -138,25 +138,12 @@ final class EditableOrderViewModel: ObservableObject {
     /// Defines the current notice that should be shown. It doesn't dismiss automatically
     /// Defaults to `nil`.
     ///
-    @Published var fixedNotice: Notice? {
-        didSet {
-            updateUnifiedNotice()
-        }
-    }
+    @Published var fixedNotice: Notice?
 
     /// Defines the current notice that should be shown. Autodismissable
     /// Defaults to `nil`.
     ///
-    @Published var autodismissableNotice: Notice? {
-        didSet {
-            updateUnifiedNotice()
-        }
-    }
-
-    /// Defines the current notice that should be shown. Unifies both autodismissable and non-autodismissable notices
-    /// Defaults to `nil`
-    ///
-    @Published var notice: Notice?
+    @Published var autodismissableNotice: Notice?
 
     /// Optional view model for configurable a bundle product from the product selector.
     /// When the value is non-nil, the bundle product configuration screen is shown.
@@ -519,12 +506,6 @@ final class EditableOrderViewModel: ObservableObject {
         observeProductSelectorPresentationStateForViewModel()
         forwardSyncApproachToSynchronizer()
         observeChangesFromProductSelectorButtonTapSelectionSync()
-    }
-
-    /// Sets the notice property either with a fixedNotice or an autodismissable one
-    ///
-    private func updateUnifiedNotice() {
-        notice = fixedNotice ?? autodismissableNotice
     }
 
     /// Checks the latest Order sync, and returns the current items that are in the Order

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/EditableOrderViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/EditableOrderViewModel.swift
@@ -1825,6 +1825,7 @@ private extension EditableOrderViewModel {
                     syncApproach: selectionSyncApproach.productSelectorSyncApproach,
                     orderSyncState: orderSynchronizer.statePublisher,
                     shouldShowNonEditableIndicators: shouldShowNonEditableIndicators,
+                    externalNoticePublisher: $autodismissableNotice,
                     onProductSelectionStateChanged: { [weak self] product, isSelected in
                         guard let self else { return }
                         changeSelectionStateForProduct(product, to: isSelected)

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/OrderForm.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/OrderForm.swift
@@ -399,9 +399,13 @@ struct OrderForm: View {
         .onTapGesture {
             shouldShowInformationalCouponTooltip = false
         }
-        // TODO: These notices need to be hidden when the split view is used, otherwise we'll see a duplicated notice in the order summary
-        //.notice($viewModel.autodismissableNotice)
-        //.notice($viewModel.fixedNotice, autoDismiss: false)
+        // Avoids Notice duplication when the feature flag is enabled. These can be removed when the flag is removed.
+        .if(!ServiceLocator.featureFlagService.isFeatureFlagEnabled(.sideBySideViewForOrderForm), transform: {
+            $0.notice($viewModel.autodismissableNotice)
+        })
+        .if(!ServiceLocator.featureFlagService.isFeatureFlagEnabled(.sideBySideViewForOrderForm), transform: {
+            $0.notice($viewModel.fixedNotice, autoDismiss: false)
+        })
     }
 
     @ViewBuilder private var storedTaxRateBottomSheetContent: some View {

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/OrderForm.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/OrderForm.swift
@@ -136,7 +136,8 @@ struct OrderFormPresentationWrapper: View {
                     .accessibilityIdentifier(OrderForm.Accessibility.cancelButtonIdentifier)
                 },
                 isShowingSecondaryView: $viewModel.isProductSelectorPresented)
-            .notice($viewModel.notice)
+            .notice($viewModel.autodismissableNotice)
+            .notice($viewModel.fixedNotice, autoDismiss: false)
         } else {
             OrderForm(dismissHandler: dismissHandler, flow: flow, viewModel: viewModel, presentProductSelector: nil)
         }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/OrderForm.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/OrderForm.swift
@@ -135,8 +135,8 @@ struct OrderFormPresentationWrapper: View {
                     }
                     .accessibilityIdentifier(OrderForm.Accessibility.cancelButtonIdentifier)
                 },
-                isShowingSecondaryView: $viewModel.isProductSelectorPresented,
-                notice: $viewModel.notice)
+                isShowingSecondaryView: $viewModel.isProductSelectorPresented)
+            .notice($viewModel.notice)
         } else {
             OrderForm(dismissHandler: dismissHandler, flow: flow, viewModel: viewModel, presentProductSelector: nil)
         }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/OrderForm.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/OrderForm.swift
@@ -135,7 +135,8 @@ struct OrderFormPresentationWrapper: View {
                     }
                     .accessibilityIdentifier(OrderForm.Accessibility.cancelButtonIdentifier)
                 },
-                isShowingSecondaryView: $viewModel.isProductSelectorPresented)
+                isShowingSecondaryView: $viewModel.isProductSelectorPresented,
+                notice: $viewModel.notice)
         } else {
             OrderForm(dismissHandler: dismissHandler, flow: flow, viewModel: viewModel, presentProductSelector: nil)
         }
@@ -398,8 +399,9 @@ struct OrderForm: View {
         .onTapGesture {
             shouldShowInformationalCouponTooltip = false
         }
-        .notice($viewModel.autodismissableNotice)
-        .notice($viewModel.fixedNotice, autoDismiss: false)
+        // TODO: These notices need to be hidden when the split view is used, otherwise we'll see a duplicated notice in the order summary
+        //.notice($viewModel.autodismissableNotice)
+        //.notice($viewModel.fixedNotice, autoDismiss: false)
     }
 
     @ViewBuilder private var storedTaxRateBottomSheetContent: some View {

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/OrderForm.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/OrderForm.swift
@@ -113,6 +113,12 @@ struct OrderFormPresentationWrapper: View {
                               flow: flow,
                               viewModel: viewModel,
                               presentProductSelector: presentProductSelector)
+                    // When we're modal-on-modal, show the notices on both screens so they're definitely visible
+                    .if(horizontalSizeClass == .compact, transform: {
+                        $0
+                            .notice($viewModel.autodismissableNotice)
+                            .notice($viewModel.fixedNotice, autoDismiss: false)
+                    })
                 },
                 secondaryView: { isShowingProductSelector in
                     if let productSelectorViewModel = viewModel.productSelectorViewModel {
@@ -123,6 +129,12 @@ struct OrderFormPresentationWrapper: View {
                         .sheet(item: $viewModel.productToConfigureViewModel) { viewModel in
                             ConfigurableBundleProductView(viewModel: viewModel)
                         }
+                        // When we're modal-on-modal, show the notices on both screens so they're definitely visible
+                        .if(horizontalSizeClass == .compact, transform: {
+                            $0
+                                .notice($viewModel.autodismissableNotice)
+                                .notice($viewModel.fixedNotice, autoDismiss: false)
+                        })
                     }
                 },
                 dismissBarButton: {
@@ -136,8 +148,12 @@ struct OrderFormPresentationWrapper: View {
                     .accessibilityIdentifier(OrderForm.Accessibility.cancelButtonIdentifier)
                 },
                 isShowingSecondaryView: $viewModel.isProductSelectorPresented)
-            .notice($viewModel.autodismissableNotice)
-            .notice($viewModel.fixedNotice, autoDismiss: false)
+            // When we're side-by-side, show the notices over the combined screen
+            .if(horizontalSizeClass == .regular, transform: {
+                $0
+                    .notice($viewModel.autodismissableNotice)
+                    .notice($viewModel.fixedNotice, autoDismiss: false)
+            })
         } else {
             OrderForm(dismissHandler: dismissHandler, flow: flow, viewModel: viewModel, presentProductSelector: nil)
         }

--- a/WooCommerce/Classes/ViewRelated/Products/ProductSelector/ProductSelectorView.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductSelector/ProductSelectorView.swift
@@ -188,6 +188,7 @@ struct ProductSelectorView: View {
         .onChange(of: horizontalSizeClass, perform: { newSizeClass in
             updateSyncApproach(for: newSizeClass)
         })
+        // On the order form, this is not connected; the OrderForm displays the notices.
         .notice($viewModel.notice, autoDismiss: false)
         .sheet(isPresented: $showingFilters) {
             FilterListView(viewModel: viewModel.filterListViewModel) { filters in

--- a/WooCommerce/Classes/ViewRelated/Products/ProductSelector/ProductSelectorViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductSelector/ProductSelectorViewModel.swift
@@ -274,7 +274,7 @@ final class ProductSelectorViewModel: ObservableObject {
         synchronizeProductFilterSearch()
         bindShowPlaceholdersState()
         bindSelectionDisabledState()
-        
+
         if var externalNoticePublisher {
             self.$productNotice.assign(to: &externalNoticePublisher)
         } else {

--- a/WooCommerce/Classes/ViewRelated/Products/ProductSelector/ProductSelectorViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductSelector/ProductSelectorViewModel.swift
@@ -93,9 +93,11 @@ final class ProductSelectorViewModel: ObservableObject {
         }
     }
 
-    /// Defines the current notice that should be shown.
+    /// Defines the current notice that should be shown. Only for internal use as it may be routed different ways.
     /// Defaults to `nil`.
     ///
+    @Published private var productNotice: Notice?
+
     @Published var notice: Notice?
 
     /// All products that can be added to an order.
@@ -233,6 +235,7 @@ final class ProductSelectorViewModel: ObservableObject {
          syncApproach: SyncApproach = .onButtonTap,
          orderSyncState: Published<OrderSyncState>.Publisher? = nil,
          shouldShowNonEditableIndicators: Bool = false,
+         externalNoticePublisher: Published<Notice?>.Publisher? = nil,
          onProductSelectionStateChanged: ((Product, Bool) -> Void)? = nil,
          onVariationSelectionStateChanged: ((ProductVariation, Product, Bool) -> Void)? = nil,
          onMultipleSelectionCompleted: (([Int64]) -> Void)? = nil,
@@ -271,6 +274,12 @@ final class ProductSelectorViewModel: ObservableObject {
         synchronizeProductFilterSearch()
         bindShowPlaceholdersState()
         bindSelectionDisabledState()
+        
+        if var externalNoticePublisher {
+            self.$productNotice.assign(to: &externalNoticePublisher)
+        } else {
+            self.$productNotice.assign(to: &$notice)
+        }
     }
 
     private let nonEditable: Bool
@@ -495,7 +504,7 @@ extension ProductSelectorViewModel: PaginationTrackerDelegate {
             case .success:
                 self.reloadData()
             case .failure(let error):
-                self.notice = NoticeFactory.productSyncNotice() { [weak self] in
+                self.productNotice = NoticeFactory.productSyncNotice() { [weak self] in
                     self?.sync(pageNumber: pageNumber, pageSize: pageSize, onCompletion: nil)
                 }
                 DDLogError("⛔️ Error synchronizing products during order creation: \(error)")
@@ -532,7 +541,7 @@ extension ProductSelectorViewModel: PaginationTrackerDelegate {
                 self.reloadData()
             case .failure(let error):
                 self.tracker.trackSearchFailureIfNecessary(with: error)
-                self.notice = NoticeFactory.productSearchNotice() { [weak self] in
+                self.productNotice = NoticeFactory.productSearchNotice() { [weak self] in
                     self?.searchProducts(siteID: siteID, keyword: keyword, pageNumber: pageNumber, pageSize: pageSize, onCompletion: nil)
                 }
                 DDLogError("⛔️ Error searching products during order creation: \(error)")
@@ -593,7 +602,7 @@ private extension ProductSelectorViewModel {
     ///
     func transitionToSyncingState(pageNumber: Int) {
         shouldShowScrollIndicator = true
-        notice = nil
+        productNotice = nil
 
         if shouldShowLoadingScreen(pageNumber: pageNumber) {
             syncStatus = .loading

--- a/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/AdaptiveModalContainer.swift
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/AdaptiveModalContainer.swift
@@ -19,22 +19,19 @@ struct AdaptiveModalContainer<PrimaryView: View, SecondaryView: View, DismissBut
     @ViewBuilder let secondaryView: (_ isPresented: Binding<Bool>) -> SecondaryView
     @ViewBuilder let dismissBarButton: () -> DismissButton
     @Binding var isShowingSecondaryView: Bool
-    @Binding var notice: Notice?
 
     var body: some View {
         if horizontalSizeClass == .compact {
             ModalOnModalView(primaryView: primaryView,
                              secondaryView: secondaryView,
                              dismissBarButton: dismissBarButton,
-                             isShowingSecondaryView: $isShowingSecondaryView,
-                             notice: $notice)
+                             isShowingSecondaryView: $isShowingSecondaryView)
                 .environment(\.adaptiveModalContainerPresentationStyle, .modalOnModal)
         } else {
             SideBySideView(primaryView: primaryView,
                            secondaryView: secondaryView,
                            dismissBarButton: dismissBarButton,
-                           isShowingSecondaryView: $isShowingSecondaryView,
-                           notice: $notice)
+                           isShowingSecondaryView: $isShowingSecondaryView)
                 .environment(\.adaptiveModalContainerPresentationStyle, .sideBySide)
         }
     }
@@ -44,7 +41,6 @@ struct AdaptiveModalContainer<PrimaryView: View, SecondaryView: View, DismissBut
         @ViewBuilder let secondaryView: (_ isPresented: Binding<Bool>) -> SecondaryView
         @ViewBuilder let dismissBarButton: () -> DismissButton
         @Binding var isShowingSecondaryView: Bool
-        @Binding var notice: Notice?
 
         var body: some View {
             NavigationView {
@@ -66,7 +62,6 @@ struct AdaptiveModalContainer<PrimaryView: View, SecondaryView: View, DismissBut
             .onAppear {
                 isShowingSecondaryView = false
             }
-            .notice($notice)
         }
     }
 
@@ -75,7 +70,6 @@ struct AdaptiveModalContainer<PrimaryView: View, SecondaryView: View, DismissBut
         @ViewBuilder let secondaryView: (_ isPresented: Binding<Bool>) -> SecondaryView
         @ViewBuilder let dismissBarButton: () -> DismissButton
         @Binding var isShowingSecondaryView: Bool
-        @Binding var notice: Notice?
 
         var body: some View {
             HStack(spacing: 0) {
@@ -101,7 +95,6 @@ struct AdaptiveModalContainer<PrimaryView: View, SecondaryView: View, DismissBut
             .onAppear {
                 isShowingSecondaryView = true
             }
-            .notice($notice)
         }
     }
 }

--- a/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/AdaptiveModalContainer.swift
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/AdaptiveModalContainer.swift
@@ -19,19 +19,22 @@ struct AdaptiveModalContainer<PrimaryView: View, SecondaryView: View, DismissBut
     @ViewBuilder let secondaryView: (_ isPresented: Binding<Bool>) -> SecondaryView
     @ViewBuilder let dismissBarButton: () -> DismissButton
     @Binding var isShowingSecondaryView: Bool
+    @Binding var notice: Notice?
 
     var body: some View {
         if horizontalSizeClass == .compact {
             ModalOnModalView(primaryView: primaryView,
                              secondaryView: secondaryView,
                              dismissBarButton: dismissBarButton,
-                             isShowingSecondaryView: $isShowingSecondaryView)
+                             isShowingSecondaryView: $isShowingSecondaryView,
+                             notice: $notice)
                 .environment(\.adaptiveModalContainerPresentationStyle, .modalOnModal)
         } else {
             SideBySideView(primaryView: primaryView,
                            secondaryView: secondaryView,
                            dismissBarButton: dismissBarButton,
-                           isShowingSecondaryView: $isShowingSecondaryView)
+                           isShowingSecondaryView: $isShowingSecondaryView,
+                           notice: $notice)
                 .environment(\.adaptiveModalContainerPresentationStyle, .sideBySide)
         }
     }
@@ -41,6 +44,7 @@ struct AdaptiveModalContainer<PrimaryView: View, SecondaryView: View, DismissBut
         @ViewBuilder let secondaryView: (_ isPresented: Binding<Bool>) -> SecondaryView
         @ViewBuilder let dismissBarButton: () -> DismissButton
         @Binding var isShowingSecondaryView: Bool
+        @Binding var notice: Notice?
 
         var body: some View {
             NavigationView {
@@ -62,6 +66,7 @@ struct AdaptiveModalContainer<PrimaryView: View, SecondaryView: View, DismissBut
             .onAppear {
                 isShowingSecondaryView = false
             }
+            .notice($notice)
         }
     }
 
@@ -70,6 +75,7 @@ struct AdaptiveModalContainer<PrimaryView: View, SecondaryView: View, DismissBut
         @ViewBuilder let secondaryView: (_ isPresented: Binding<Bool>) -> SecondaryView
         @ViewBuilder let dismissBarButton: () -> DismissButton
         @Binding var isShowingSecondaryView: Bool
+        @Binding var notice: Notice?
 
         var body: some View {
             HStack(spacing: 0) {
@@ -95,6 +101,7 @@ struct AdaptiveModalContainer<PrimaryView: View, SecondaryView: View, DismissBut
             .onAppear {
                 isShowingSecondaryView = true
             }
+            .notice($notice)
         }
     }
 }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/EditableOrderViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/EditableOrderViewModelTests.swift
@@ -245,54 +245,6 @@ final class EditableOrderViewModelTests: XCTestCase {
         XCTAssertNil(notice)
     }
 
-    func test_viewModel_when_fixedNotice_is_set_then_emitted_notice_value_matches() {
-        // Given
-        let viewModel = EditableOrderViewModel(siteID: sampleSiteID, stores: stores)
-        let error = NSError(domain: "Error", code: 0)
-        let expectedNotice = EditableOrderViewModel.NoticeFactory.createOrderErrorNotice(error, order: .fake())
-        var cancellables: Set<AnyCancellable> = []
-        var emittedValues: [Notice?] = []
-        let expectation = XCTestExpectation(description: "Notice should be updated")
-
-        // When
-        viewModel.$notice.sink { notice in
-            emittedValues.append(notice)
-            expectation.fulfill()
-        }
-        .store(in: &cancellables)
-        viewModel.fixedNotice = expectedNotice
-
-        // Then
-        XCTAssertEqual(emittedValues.last, viewModel.notice, "The emitted value should match the expected notice")
-
-        // Tear down Cancellables, since we only use these in this test:
-        cancellables = []
-    }
-
-    func test_viewModel_when_autoDismissableNotice_is_set_then_emitted_notice_value_matches() {
-        // Given
-        let viewModel = EditableOrderViewModel(siteID: sampleSiteID, stores: stores)
-        let error = NSError(domain: "Error", code: 0)
-        let expectedNotice = EditableOrderViewModel.NoticeFactory.createOrderErrorNotice(error, order: .fake())
-        var cancellables: Set<AnyCancellable> = []
-        var emittedValues: [Notice?] = []
-        let expectation = XCTestExpectation(description: "Notice should be updated")
-
-        // When
-        viewModel.$notice.sink { notice in
-            emittedValues.append(notice)
-            expectation.fulfill()
-        }
-        .store(in: &cancellables)
-        viewModel.autodismissableNotice = expectedNotice
-
-        // Then
-        XCTAssertEqual(emittedValues.last, viewModel.notice, "The emitted value should match the expected notice")
-
-        // Tear down Cancellables, since we only use these in this test:
-        cancellables = []
-    }
-
     func test_view_model_loads_synced_pending_order_status() {
         // Given
         storageManager.insertOrderStatus(.init(name: "Pending payment", siteID: sampleSiteID, slug: "pending", total: 0))
@@ -2331,7 +2283,6 @@ final class EditableOrderViewModelTests: XCTestCase {
         // Then
         XCTAssertEqual(expectedError, .productNotFound)
         XCTAssertEqual(viewModel.autodismissableNotice, expectedNotice)
-        XCTAssertEqual(viewModel.notice, expectedNotice)
         XCTAssertEqual(analytics.receivedEvents.first, WooAnalyticsStat.barcodeScanningSuccess.rawValue)
         XCTAssertEqual(analytics.receivedProperties.first?["source"] as? String, "order_creation")
 

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/EditableOrderViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/EditableOrderViewModelTests.swift
@@ -3,6 +3,7 @@ import XCTest
 import Yosemite
 import WooFoundation
 import Networking
+import Combine
 
 final class EditableOrderViewModelTests: XCTestCase {
     var viewModel: EditableOrderViewModel!
@@ -242,6 +243,54 @@ final class EditableOrderViewModelTests: XCTestCase {
 
         // Then
         XCTAssertNil(notice)
+    }
+
+    func test_viewModel_when_fixedNotice_is_set_then_emitted_notice_value_matches() {
+        // Given
+        let viewModel = EditableOrderViewModel(siteID: sampleSiteID, stores: stores)
+        let error = NSError(domain: "Error", code: 0)
+        let expectedNotice = EditableOrderViewModel.NoticeFactory.createOrderErrorNotice(error, order: .fake())
+        var cancellables: Set<AnyCancellable> = []
+        var emittedValues: [Notice?] = []
+        let expectation = XCTestExpectation(description: "Notice should be updated")
+
+        // When
+        viewModel.$notice.sink { notice in
+            emittedValues.append(notice)
+            expectation.fulfill()
+        }
+        .store(in: &cancellables)
+        viewModel.fixedNotice = expectedNotice
+
+        // Then
+        XCTAssertEqual(emittedValues.last, viewModel.notice, "The emitted value should match the expected notice")
+
+        // Tear down Cancellables, since we only use these in this test:
+        cancellables = []
+    }
+
+    func test_viewModel_when_autoDismissableNotice_is_set_then_emitted_notice_value_matches() {
+        // Given
+        let viewModel = EditableOrderViewModel(siteID: sampleSiteID, stores: stores)
+        let error = NSError(domain: "Error", code: 0)
+        let expectedNotice = EditableOrderViewModel.NoticeFactory.createOrderErrorNotice(error, order: .fake())
+        var cancellables: Set<AnyCancellable> = []
+        var emittedValues: [Notice?] = []
+        let expectation = XCTestExpectation(description: "Notice should be updated")
+
+        // When
+        viewModel.$notice.sink { notice in
+            emittedValues.append(notice)
+            expectation.fulfill()
+        }
+        .store(in: &cancellables)
+        viewModel.autodismissableNotice = expectedNotice
+
+        // Then
+        XCTAssertEqual(emittedValues.last, viewModel.notice, "The emitted value should match the expected notice")
+
+        // Tear down Cancellables, since we only use these in this test:
+        cancellables = []
     }
 
     func test_view_model_loads_synced_pending_order_status() {
@@ -2282,6 +2331,7 @@ final class EditableOrderViewModelTests: XCTestCase {
         // Then
         XCTAssertEqual(expectedError, .productNotFound)
         XCTAssertEqual(viewModel.autodismissableNotice, expectedNotice)
+        XCTAssertEqual(viewModel.notice, expectedNotice)
         XCTAssertEqual(analytics.receivedEvents.first, WooAnalyticsStat.barcodeScanningSuccess.rawValue)
         XCTAssertEqual(analytics.receivedProperties.first?["source"] as? String, "order_creation")
 

--- a/Yosemite/Yosemite/Stores/ProductVariationStore.swift
+++ b/Yosemite/Yosemite/Stores/ProductVariationStore.swift
@@ -110,7 +110,7 @@ private extension ProductVariationStore {
                                         pageNumber: pageNumber,
                                         pageSize: pageSize) { [weak self] (productVariations, error) in
             guard let productVariations = productVariations else {
-                onCompletion(.failure(error ?? NSError()))
+                onCompletion(.failure(error ?? ProductVariationLoadError.unexpected))
                 return
             }
 


### PR DESCRIPTION
Work in progress. Closes #12250 

## Description
This PR addresses the problem with `Notices` when using split view, as these appear in one panel only (rather than across the whole `AdaptiveModalContainer`) as well as might display truncated:

<img width="692" alt="Screenshot 2024-03-20 at 14 09 12" src="https://github.com/woocommerce/woocommerce-ios/assets/3812076/3795bc5c-c355-48bf-be47-5e17d01c330b">

## Changes
We created a new `Notice` publisher that unifies emissions either from `fixedNotice` or `autodismissableNotice`. When the view model emits a new value for this unified `Notice`, our `AdaptiveModalContainer` will propagate the changes internally and populate it via the `.notice()` view modifier.

## Testing instructions
1. In `EditableOrderViewModel`, add the following code to force Notices:
```
    func forceSyncError() {
        // 1. Test for fixed notice
        fixedNotice = NoticeFactory.createDummyFixedErrorNotice()

        // 2. Test for auto-dismissable notice
        //autodismissableNotice = NoticeFactory.createDummyDissmissableErrorNotice()

        // 3. Test for system error notices
        /*
        orderSynchronizer.statePublisher.map { [weak self] state -> Notice? in
            guard let self = self else { return nil }
            switch state {
            default:
                let error = NSError(domain: "some error", code: 0)
                return NoticeFactory.syncOrderErrorNotice(error, flow: self.flow, with: self.orderSynchronizer)
            }
        }.sink { [weak self] notice in
            guard let self = self else { return }
            if let notice = notice {
                self.fixedNotice = notice
            }
        }
        .store(in: &cancellables)
         */
    }
```
As well as the following dummy Notices in the same file, within `EditableOrderViewModel.NoticeFactory` extension:

```
        static func createDummyFixedErrorNotice() -> Notice {
            return Notice(title: "Error!", subtitle: "Some subtitle", message: "some error message")
        }

        static func createDummyDissmissableErrorNotice() -> Notice {
            return Notice(title: "Error!", subtitle: "Some subtitle", message: "some error message", feedbackType: .error, actionTitle: "Retry?", actionHandler: {
                debugPrint("Action tapped!")
            })
        }
```
Finally, invoke `forceSyncError()` on `EditableOrderViewModel.init()` method.

2. One at a time, comment out the different notice types in `forceSyncError()`, and run the app on an iPad:
```
// 1. Test for fixed notice
// 2. Test for auto-dismissable notice
// 3. Test for system error notices
```
3. Go to `Orders` > `+` > Observe that the notice appears in the bottom of the screen, across the `AdaptiveModalContainer`
4. Observe that Notices work as always on iPhone as well.

## Screenshots
![Simulator Screenshot - iPad Pro (12 9-inch) (6th generation) - 2024-03-20 at 14 04 03](https://github.com/woocommerce/woocommerce-ios/assets/3812076/7a6860c3-568f-4a9a-98a1-bf4fdc87bedb)

<img width="1073" alt="Screenshot 2024-03-20 at 14 45 25" src="https://github.com/woocommerce/woocommerce-ios/assets/3812076/b3359865-1581-4abe-9501-bb3618b91d37">


