### PR TITLE
[Hub Menu] Customers: Add customers menu item behind a feature flag

### DIFF
--- a/Experiments/Experiments/DefaultFeatureFlagService.swift
+++ b/Experiments/Experiments/DefaultFeatureFlagService.swift
@@ -87,6 +87,8 @@ public struct DefaultFeatureFlagService: FeatureFlagService {
             return true
         case .splitViewInProductsTab:
             return true
+        case .customersInHubMenu:
+            return buildConfig == .localDeveloper || buildConfig == .alpha
         default:
             return true
         }

--- a/Experiments/Experiments/FeatureFlag.swift
+++ b/Experiments/Experiments/FeatureFlag.swift
@@ -195,4 +195,8 @@ public enum FeatureFlag: Int {
     /// Displays the Products tab in a split view
     ///
     case splitViewInProductsTab
+
+    /// Displays a Customers section in the Hub menu.
+    ///
+    case customersInHubMenu
 }

--- a/WooCommerce/Classes/ViewRelated/Hub Menu/HubMenu.swift
+++ b/WooCommerce/Classes/ViewRelated/Hub Menu/HubMenu.swift
@@ -165,6 +165,8 @@ private extension HubMenu {
                 InAppPurchasesDebugView()
             case HubMenuViewModel.Subscriptions.id:
                 SubscriptionsView(viewModel: .init())
+            case HubMenuViewModel.Customers.id:
+                EmptyView() // TODO-12294: Navigate to customer list
             default:
                 fatalError("🚨 Unsupported menu item")
             }

--- a/WooCommerce/Classes/ViewRelated/Hub Menu/HubMenuViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Hub Menu/HubMenuViewModel.swift
@@ -156,6 +156,10 @@ final class HubMenuViewModel: ObservableObject {
         } else {
             generalElements.removeAll(where: { $0.id == Blaze.id })
         }
+
+        if featureFlagService.isFeatureFlagEnabled(.customersInHubMenu) {
+            generalElements.append(Customers())
+        }
     }
 
     func showReviewDetails(using parcel: ProductReviewFromNoteParcel) {
@@ -382,6 +386,18 @@ extension HubMenuViewModel {
         let iconBadge: HubMenuBadgeType? = nil
     }
 
+    struct Customers: HubMenuItem {
+        static var id = "customers"
+
+        let title: String = Localization.customers
+        let description: String = Localization.customersDescription
+        let icon: UIImage = .multipleUsersImage.withRenderingMode(.alwaysTemplate)
+        let iconColor: UIColor = .primary
+        let accessibilityIdentifier: String = "menu-customers"
+        let trackingOption: String = "customers"
+        let iconBadge: HubMenuBadgeType? = nil
+    }
+
     enum Localization {
         static let settings = NSLocalizedString(
             "Settings",
@@ -457,6 +473,16 @@ extension HubMenuViewModel {
 
         static let subscriptionsDescription = NSLocalizedString(
             "Manage your subscription",
+            comment: "Description of one of the hub menu options")
+
+        static let customers = NSLocalizedString(
+            "hubMenu.customers",
+            value: "Customers",
+            comment: "Title of one of the hub menu options")
+
+        static let customersDescription = NSLocalizedString(
+            "hubMenu.customersDescription",
+            value: "Get customer insights",
             comment: "Description of one of the hub menu options")
     }
 }

--- a/WooCommerce/WooCommerceTests/Mocks/MockFeatureFlagService.swift
+++ b/WooCommerce/WooCommerceTests/Mocks/MockFeatureFlagService.swift
@@ -23,6 +23,7 @@ struct MockFeatureFlagService: FeatureFlagService {
     private let blazei3NativeCampaignCreation: Bool
     private let isBackendReceiptsEnabled: Bool
     private let sideBySideViewForOrderForm: Bool
+    private let isCustomersInHubMenuEnabled: Bool
 
     init(isInboxOn: Bool = false,
          isUpdateOrderOptimisticallyOn: Bool = false,
@@ -44,7 +45,8 @@ struct MockFeatureFlagService: FeatureFlagService {
          isScanToUpdateInventoryEnabled: Bool = false,
          blazei3NativeCampaignCreation: Bool = false,
          isBackendReceiptsEnabled: Bool = false,
-         sideBySideViewForOrderForm: Bool = false) {
+         sideBySideViewForOrderForm: Bool = false,
+         isCustomersInHubMenuEnabled: Bool = false) {
         self.isInboxOn = isInboxOn
         self.isUpdateOrderOptimisticallyOn = isUpdateOrderOptimisticallyOn
         self.shippingLabelsOnboardingM1 = shippingLabelsOnboardingM1
@@ -66,6 +68,7 @@ struct MockFeatureFlagService: FeatureFlagService {
         self.blazei3NativeCampaignCreation = blazei3NativeCampaignCreation
         self.isBackendReceiptsEnabled = isBackendReceiptsEnabled
         self.sideBySideViewForOrderForm = sideBySideViewForOrderForm
+        self.isCustomersInHubMenuEnabled = isCustomersInHubMenuEnabled
     }
 
     func isFeatureFlagEnabled(_ featureFlag: FeatureFlag) -> Bool {
@@ -110,6 +113,8 @@ struct MockFeatureFlagService: FeatureFlagService {
             return isBackendReceiptsEnabled
         case .sideBySideViewForOrderForm:
             return sideBySideViewForOrderForm
+        case .customersInHubMenu:
+            return isCustomersInHubMenuEnabled
         default:
             return false
         }

--- a/WooCommerce/WooCommerceTests/ViewRelated/HubMenu/HubMenuViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/HubMenu/HubMenuViewModelTests.swift
@@ -358,6 +358,21 @@ final class HubMenuViewModelTests: XCTestCase {
             item.id == HubMenuViewModel.Subscriptions.id
         }))
     }
+
+    func test_menuElements_do_not_include_customers_when_feature_flag_is_off() {
+        // Given
+        let featureFlagService = MockFeatureFlagService(isCustomersInHubMenuEnabled: false)
+
+        // When
+        let viewModel = HubMenuViewModel(siteID: sampleSiteID,
+                                         tapToPayBadgePromotionChecker: TapToPayBadgePromotionChecker(),
+                                         featureFlagService: featureFlagService)
+
+        // Then
+        XCTAssertNil(viewModel.generalElements.firstIndex(where: { item in
+            item.id == HubMenuViewModel.Customers.id
+        }))
+    }
 }
 
 private extension HubMenuViewModelTests {


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of: #12316
<!-- Id number of the GitHub issue this PR addresses. -->

## Why
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This adds a Customers menu item to the General section in the hub menu, behind a feature flag.

## How

* Adds a new feature flag `customersInHubMenu`, enabled in development and alpha builds.
* Defines a Customers menu item and appends it to the General section in the hub menu.
* When the Customers item is tapped, for now opens an empty view (this will be replaced with a customer list).
* Adds a unit test to confirm the Customers menu item doesn't appear when the feature flag is disabled.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

1. Build and run the app.
2. Open the hub menu.
3. Scroll down and confirm the Customers menu item appears.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

<img src="https://github.com/woocommerce/woocommerce-ios/assets/8658164/a8daa81b-bb2c-44cf-ae17-4f949d5f7697" width="300px">


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
