### PR TITLE
[Hub Menu] Customers: Fixes for customer sync action

### DIFF
--- a/Yosemite/Yosemite/Actions/CustomerAction.swift
+++ b/Yosemite/Yosemite/Actions/CustomerAction.swift
@@ -34,7 +34,7 @@ public enum CustomerAction: Action {
     ///     - siteID: The site for which we will perform the search.
     ///     - pageNumber: The number of the page you want to load.
     ///     - pageSize: The size of the page you want to load.
-    ///     - onCompletion: Invoked when the operation finishes. Returns true if there are results synced.
+    ///     - onCompletion: Invoked when the operation finishes. Returns true if there are more customers to be synced.
     ///
     case synchronizeAllCustomers(siteID: Int64,
                                  pageNumber: Int,

--- a/Yosemite/Yosemite/Model/Model.swift
+++ b/Yosemite/Yosemite/Model/Model.swift
@@ -282,6 +282,7 @@ public typealias StorageTopEarnerStats = Storage.TopEarnerStats
 public typealias StorageTopEarnerStatsItem = Storage.TopEarnerStatsItem
 public typealias StorageTaxClass = Storage.TaxClass
 public typealias StorageTaxRate = Storage.TaxRate
+public typealias StorageWCAnalyticsCustomer = Storage.WCAnalyticsCustomer
 public typealias StorageWCPayCharge = Storage.WCPayCharge
 public typealias FeatureAnnouncementCampaign = Storage.FeatureAnnouncementCampaign
 public typealias FeatureAnnouncementCampaignSettings = Storage.FeatureAnnouncementCampaignSettings

--- a/Yosemite/Yosemite/Stores/CustomerStore.swift
+++ b/Yosemite/Yosemite/Stores/CustomerStore.swift
@@ -230,7 +230,11 @@ public final class CustomerStore: Store {
                                  pageNumber: Int,
                                  pageSize: Int,
                                  onCompletion: @escaping (Result<Bool, Error>) -> Void) {
-        wcAnalyticsCustomerRemote.loadCustomers(for: siteID, orderby: .dateLastActive, order: .desc) { [weak self] result in
+        wcAnalyticsCustomerRemote.loadCustomers(for: siteID,
+                                                pageNumber: pageNumber,
+                                                pageSize: pageSize,
+                                                orderby: .dateLastActive,
+                                                order: .desc) { [weak self] result in
             guard let self else { return }
             switch result {
             case let .success(customers):
@@ -238,7 +242,8 @@ public final class CustomerStore: Store {
                                                        readOnlyCustomers: customers,
                                                        shouldDeleteExistingCustomers: pageNumber == 1,
                                                        in: self.sharedDerivedStorage) {
-                    onCompletion(.success(!customers.isEmpty))
+                    let hasNextPage = customers.count == pageSize
+                    onCompletion(.success(hasNextPage))
                 }
             case let .failure(error):
                 onCompletion(.failure(error))

--- a/Yosemite/YosemiteTests/Stores/CustomerStoreTests.swift
+++ b/Yosemite/YosemiteTests/Stores/CustomerStoreTests.swift
@@ -273,7 +273,7 @@ final class CustomerStoreTests: XCTestCase {
         let result = waitFor { promise in
             let action = CustomerAction.synchronizeAllCustomers(siteID: self.dummySiteID,
                                                                 pageNumber: 1,
-                                                                pageSize: 2) { result in
+                                                                pageSize: 4) { result in
                 promise(result)
             }
             self.dispatcher.dispatch(action)
@@ -284,13 +284,13 @@ final class CustomerStoreTests: XCTestCase {
             .map { $0.toReadOnly() }
             .sorted(by: { $0.customerID < $1.customerID })
 
-        guard case .success(let thereAreCustomers) = result else {
+        guard case .success(let hasNextPage) = result else {
             XCTFail()
 
             return
         }
 
-        XCTAssertTrue(thereAreCustomers)
+        XCTAssertTrue(hasNextPage)
         assertEqual(4, customers.count)
         assertEqual(0, customers[0].customerID)
         assertEqual(1, customers[1].customerID)


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of: #12316
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
These are some small fixes in the Yosemite layer for syncing customers:

* Adds `StorageWCAnalyticsCustomer` to the Yosemite model so we can work with those storage entities in the UI layer.
* Passes the page number and page size to the remote request so we fetch the correct page of customers.
* Updates the result so it returns not just whether there were customers in the remote response but whether there are more to be fetched (so we can continue syncing if needed).

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

This action isn't used yet, so confirm tests pass in CI.


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
