### PR TITLE
[Hub Menu] Customers: Unit tests for customer list view model

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Customers/CustomersListViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Customers/CustomersListViewModel.swift
@@ -131,6 +131,7 @@ private extension CustomersListViewModel {
 
         do {
             try resultsController.performFetch()
+            updateResults()
         } catch {
             ServiceLocator.crashLogging.logError(error)
         }

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -2045,6 +2045,7 @@
 		CE63023D2BAAEF2C00E3325C /* CustomersListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE63023C2BAAEF2C00E3325C /* CustomersListView.swift */; };
 		CE63023F2BAAF04600E3325C /* TitleAndSubtitleAndDetailRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE63023E2BAAF04600E3325C /* TitleAndSubtitleAndDetailRow.swift */; };
 		CE6302412BAAFB5E00E3325C /* CustomersListViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE6302402BAAFB5E00E3325C /* CustomersListViewModel.swift */; };
+		CE6302462BAB528900E3325C /* CustomerListViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE6302452BAB528900E3325C /* CustomerListViewModelTests.swift */; };
 		CE6A8FB42B724D7C0063564D /* AnalyticsReportLink.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE6A8FB32B724D7C0063564D /* AnalyticsReportLink.swift */; };
 		CE6A8FB62B725A690063564D /* AnalyticsReportLinkViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE6A8FB52B725A690063564D /* AnalyticsReportLinkViewModel.swift */; };
 		CE6A8FB82B7291760063564D /* AnalyticsReportLinkViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE6A8FB72B7291760063564D /* AnalyticsReportLinkViewModelTests.swift */; };
@@ -4780,6 +4781,7 @@
 		CE63023C2BAAEF2C00E3325C /* CustomersListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomersListView.swift; sourceTree = "<group>"; };
 		CE63023E2BAAF04600E3325C /* TitleAndSubtitleAndDetailRow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TitleAndSubtitleAndDetailRow.swift; sourceTree = "<group>"; };
 		CE6302402BAAFB5E00E3325C /* CustomersListViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomersListViewModel.swift; sourceTree = "<group>"; };
+		CE6302452BAB528900E3325C /* CustomerListViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomerListViewModelTests.swift; sourceTree = "<group>"; };
 		CE6A8FB32B724D7C0063564D /* AnalyticsReportLink.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnalyticsReportLink.swift; sourceTree = "<group>"; };
 		CE6A8FB52B725A690063564D /* AnalyticsReportLinkViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnalyticsReportLinkViewModel.swift; sourceTree = "<group>"; };
 		CE6A8FB72B7291760063564D /* AnalyticsReportLinkViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnalyticsReportLinkViewModelTests.swift; sourceTree = "<group>"; };
@@ -10766,6 +10768,14 @@
 			path = Customers;
 			sourceTree = "<group>";
 		};
+		CE6302442BAB527600E3325C /* Customers */ = {
+			isa = PBXGroup;
+			children = (
+				CE6302452BAB528900E3325C /* CustomerListViewModelTests.swift */,
+			);
+			path = Customers;
+			sourceTree = "<group>";
+		};
 		CE85535B209B5B6A00938BDC /* ViewModels */ = {
 			isa = PBXGroup;
 			children = (
@@ -11153,6 +11163,7 @@
 				2619FA2A25C897720006DAFF /* Add Attributes */,
 				454453C62755170100464AC5 /* HubMenu */,
 				261E91A129C9880C00A5C118 /* Upgrades */,
+				CE6302442BAB527600E3325C /* Customers */,
 				D85B8335222FCDA1002168F3 /* StatusListTableViewCellTests.swift */,
 				D816DDBB22265DA300903E59 /* OrderTrackingTableViewCellTests.swift */,
 				45C8B25A231521510002FA77 /* CustomerNoteTableViewCellTests.swift */,
@@ -14906,6 +14917,7 @@
 				3190D61D26D6E97B00EF364D /* CardPresentModalRetryableErrorTests.swift in Sources */,
 				027EB57829C18AAC003CE551 /* StoreOnboardingLaunchStoreViewModelTests.swift in Sources */,
 				DEBAB70B2A7A3FE000743185 /* StorePlanBannerPresenterTests.swift in Sources */,
+				CE6302462BAB528900E3325C /* CustomerListViewModelTests.swift in Sources */,
 				456417F6247D5643001203F6 /* UITableView+HelpersTests.swift in Sources */,
 				EEA693602B23303A00BAECA6 /* ProductCreationAISurveyUseCaseTests.swift in Sources */,
 				DE4B3B2C2692DC2200EEF2D8 /* ReviewOrderViewModelTests.swift in Sources */,

--- a/WooCommerce/WooCommerceTests/ViewRelated/Customers/CustomerListViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Customers/CustomerListViewModelTests.swift
@@ -242,6 +242,32 @@ final class CustomerListViewModelTests: XCTestCase {
         assertEqual(viewModel.customers[1].name, olderCustomer.name)
     }
 
+    // MARK: - `onRefreshAction`
+
+    func test_onRefreshAction_resyncs_the_first_page() {
+        // Given
+        let stores = MockStoresManager(sessionManager: .testingInstance)
+        var invocationCountOfSyncCustomers = 0
+        stores.whenReceivingAction(ofType: CustomerAction.self) { action in
+            guard case let .synchronizeAllCustomers(_, _, _, onCompletion) = action else {
+                return
+            }
+            invocationCountOfSyncCustomers += 1
+            onCompletion(.success(false))
+        }
+        let viewModel = CustomersListViewModel(siteID: sampleSiteID, stores: stores)
+
+        // When
+        waitFor { promise in
+            viewModel.onRefreshAction {
+                promise(())
+            }
+        }
+
+        // Then
+        XCTAssertEqual(invocationCountOfSyncCustomers, 1)
+    }
+
 }
 
 private extension CustomerListViewModelTests {

--- a/WooCommerce/WooCommerceTests/ViewRelated/Customers/CustomerListViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Customers/CustomerListViewModelTests.swift
@@ -1,0 +1,191 @@
+import XCTest
+import Yosemite
+import protocol Storage.StorageManagerType
+import protocol Storage.StorageType
+@testable import WooCommerce
+import Combine
+
+final class CustomerListViewModelTests: XCTestCase {
+    private let sampleSiteID: Int64 = 322
+
+    private var subscriptions: [AnyCancellable] = []
+
+    /// Mock Storage: InMemory
+    private var storageManager: StorageManagerType!
+
+    /// View storage for tests
+    private var storage: StorageType {
+        storageManager.viewStorage
+    }
+
+    override func setUp() {
+        super.setUp()
+        subscriptions = []
+        storageManager = MockStorageManager()
+    }
+
+    // MARK: - State transitions
+
+    func test_state_is_empty_without_any_actions() {
+        // Given
+        let stores = MockStoresManager(sessionManager: .testingInstance)
+        var invocationCountOfSyncCustomers = 0
+        stores.whenReceivingAction(ofType: CustomerAction.self) { action in
+            guard case .synchronizeAllCustomers = action else {
+                return
+            }
+            invocationCountOfSyncCustomers += 1
+        }
+        let viewModel = CustomersListViewModel(siteID: sampleSiteID, stores: stores)
+
+        // Then
+        XCTAssertEqual(viewModel.syncState, .empty)
+        XCTAssertEqual(invocationCountOfSyncCustomers, 0)
+    }
+
+    func test_state_is_syncingFirstPage_and_synchronizeAllCustomers_is_dispatched_upon_loadCustomers() {
+        // Given
+        let stores = MockStoresManager(sessionManager: .testingInstance)
+        var invocationCountOfSyncCustomers = 0
+        stores.whenReceivingAction(ofType: CustomerAction.self) { action in
+            guard case .synchronizeAllCustomers = action else {
+                return
+            }
+            invocationCountOfSyncCustomers += 1
+        }
+        let viewModel = CustomersListViewModel(siteID: sampleSiteID, stores: stores)
+
+        // When
+        viewModel.loadCustomers()
+
+        // Then
+        XCTAssertEqual(viewModel.syncState, .syncingFirstPage)
+        XCTAssertEqual(invocationCountOfSyncCustomers, 1)
+    }
+
+    func test_state_is_syncingFirstPage_upon_loadCustomers_if_there_is_no_existing_customer_in_storage() {
+        let viewModel = CustomersListViewModel(siteID: sampleSiteID)
+
+        // When
+        viewModel.loadCustomers()
+
+        // Then
+        XCTAssertEqual(viewModel.syncState, .syncingFirstPage)
+    }
+
+    func test_state_is_results_upon_loadCustomers_if_there_are_existing_customers_in_storage() {
+        let existingCustomer = WCAnalyticsCustomer.fake().copy(siteID: sampleSiteID, customerID: 123)
+        insertCustomers([existingCustomer])
+        let viewModel = CustomersListViewModel(siteID: sampleSiteID, storageManager: storageManager)
+
+        // When
+        viewModel.loadCustomers()
+
+        // Then
+        XCTAssertEqual(viewModel.syncState, .results)
+    }
+
+    func test_state_is_results_after_loadCustomers_with_nonempty_results() {
+        // Given
+        let stores = MockStoresManager(sessionManager: .testingInstance)
+        let customer = WCAnalyticsCustomer.fake().copy(siteID: sampleSiteID)
+        stores.whenReceivingAction(ofType: CustomerAction.self) { action in
+            guard case let .synchronizeAllCustomers(_, _, _, completion) = action else {
+                return
+            }
+            self.insertCustomers([customer])
+            completion(.success(true))
+        }
+        let viewModel = CustomersListViewModel(siteID: sampleSiteID, stores: stores, storageManager: storageManager)
+
+        var states = [CustomersListViewModel.SyncState]()
+        viewModel.$syncState
+            .removeDuplicates()
+            .sink { state in
+                states.append(state)
+            }
+            .store(in: &subscriptions)
+
+        // When
+        viewModel.loadCustomers()
+
+        // Then
+        XCTAssertEqual(states, [.empty, .syncingFirstPage, .results])
+    }
+
+    func test_state_is_back_to_empty_after_loadCustomers_with_empty_results() {
+        // Given
+        let stores = MockStoresManager(sessionManager: .testingInstance)
+        var invocationCountOfSyncCustomers = 0
+        var syncPageNumber: Int?
+        stores.whenReceivingAction(ofType: CustomerAction.self) { action in
+            guard case let .synchronizeAllCustomers(_, pageNumber, _, completion) = action else {
+                return
+            }
+            invocationCountOfSyncCustomers += 1
+            syncPageNumber = pageNumber
+            completion(.success(false))
+        }
+        let viewModel = CustomersListViewModel(siteID: sampleSiteID, stores: stores)
+
+        var states = [CustomersListViewModel.SyncState]()
+        viewModel.$syncState.sink { state in
+            states.append(state)
+        }.store(in: &subscriptions)
+
+        // When
+        viewModel.loadCustomers()
+
+        // Then
+        XCTAssertEqual(invocationCountOfSyncCustomers, 1)
+        XCTAssertEqual(syncPageNumber, 1)
+        XCTAssertEqual(states, [.empty, .syncingFirstPage, .empty])
+    }
+
+    func test_it_loads_next_page_after_loadCustomers_and_onLoadNextPageAction_until_hasNextPage_is_false() {
+        // Given
+        let stores = MockStoresManager(sessionManager: .testingInstance)
+        var invocationCountOfSyncCustomers = 0
+        let firstPageItems = [WCAnalyticsCustomer](repeating: .fake().copy(siteID: sampleSiteID), count: 2)
+        let secondPageItems = [WCAnalyticsCustomer](repeating: .fake().copy(siteID: sampleSiteID), count: 1)
+        stores.whenReceivingAction(ofType: CustomerAction.self) { action in
+            guard case let .synchronizeAllCustomers(_, pageNumber, _, completion) = action else {
+                return
+            }
+            invocationCountOfSyncCustomers += 1
+            let customers = pageNumber == 1 ? firstPageItems: secondPageItems
+            self.insertCustomers(customers)
+            completion(.success(pageNumber == 1 ? true : false))
+        }
+
+        let viewModel = CustomersListViewModel(siteID: sampleSiteID, stores: stores, storageManager: storageManager)
+
+        var states = [CustomersListViewModel.SyncState]()
+        viewModel.$syncState
+            .removeDuplicates()
+            .sink { state in
+                states.append(state)
+            }
+            .store(in: &subscriptions)
+
+        // When
+        viewModel.loadCustomers()// Syncs first page of customers.
+        viewModel.onLoadNextPageAction() // Syncs next page of customers.
+        viewModel.onLoadNextPageAction() // No more data to be synced.
+
+        // Then
+        XCTAssertEqual(states, [.empty, .syncingFirstPage, .results])
+        XCTAssertEqual(invocationCountOfSyncCustomers, 2)
+    }
+
+}
+
+private extension CustomerListViewModelTests {
+    func insertCustomers(_ readOnlyCustomers: [WCAnalyticsCustomer]) {
+        readOnlyCustomers.forEach { customer in
+            let newCustomer = storage.insertNewObject(ofType: StorageWCAnalyticsCustomer.self)
+            newCustomer.update(with: customer)
+        }
+        storage.saveIfNeeded()
+    }
+}


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This is a followup to #12333 adding unit tests for the view model. It includes tests for syncing, loading customers from storage, the loaded customers, and pull to refresh.

It also includes a small update to the view model to make sure the customer list shows any locally stored customers while it's syncing remotely. This improves the perceived performance since there's no wait if the customers have been synced before.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
Confirm tests pass in CI.


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
