### PR TITLE
[Hub Menu] Customers: Fill in customer details screen with real details

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Customers/CustomerDetailView.swift
+++ b/WooCommerce/Classes/ViewRelated/Customers/CustomerDetailView.swift
@@ -1,77 +1,43 @@
 import SwiftUI
 
 struct CustomerDetailView: View {
-    /// Customer name
-    let name: String
-
-    /// Date the customer was last active
-    let dateLastActive: String
-
-    /// Customer email
-    let email: String?
-
-    /// Number of orders from the customer
-    let ordersCount: String
-
-    /// Customer's total spend
-    let totalSpend: String
-
-    /// Customer's average order value
-    let avgOrderValue: String
-
-    /// Customer username
-    let username: String?
-
-    /// Date the customer was registered on the store
-    let dateRegistered: String?
-
-    /// Customer country
-    let country: String?
-
-    /// Customer region
-    let region: String?
-
-    /// Customer city
-    let city: String?
-
-    /// Customer postal code
-    let postcode: String?
+    let viewModel: CustomerDetailViewModel
 
     var body: some View {
         List {
             Section(header: Text(Localization.customerSection)) {
-                Text(name)
+                Text(viewModel.name)
                 HStack {
-                    Text(email ?? Localization.emailPlaceholder)
-                        .style(for: email)
+                    Text(viewModel.email ?? Localization.emailPlaceholder)
+                        .style(for: viewModel.email)
                     Spacer()
                     Image(uiImage: .mailImage)
-                        .renderedIf(email != nil)
+                        .renderedIf(viewModel.canEmailCustomer)
                 }
-                customerDetailRow(label: Localization.dateLastActiveLabel, value: dateLastActive)
+                customerDetailRow(label: Localization.dateLastActiveLabel, value: viewModel.dateLastActive)
             }
 
             Section(header: Text(Localization.ordersSection)) {
-                customerDetailRow(label: Localization.ordersCountLabel, value: ordersCount)
-                customerDetailRow(label: Localization.totalSpendLabel, value: totalSpend)
-                customerDetailRow(label: Localization.avgOrderValueLabel, value: avgOrderValue)
+                customerDetailRow(label: Localization.ordersCountLabel, value: viewModel.ordersCount)
+                customerDetailRow(label: Localization.totalSpendLabel, value: viewModel.totalSpend)
+                customerDetailRow(label: Localization.avgOrderValueLabel, value: viewModel.avgOrderValue)
             }
 
             Section(header: Text(Localization.registrationSection)) {
-                customerDetailRow(label: Localization.usernameLabel, value: username)
-                customerDetailRow(label: Localization.dateRegisteredLabel, value: dateRegistered)
+                customerDetailRow(label: Localization.usernameLabel, value: viewModel.username)
+                customerDetailRow(label: Localization.dateRegisteredLabel, value: viewModel.dateRegistered)
             }
 
             Section(header: Text(Localization.locationSection)) {
-                customerDetailRow(label: Localization.countryLabel, value: country)
-                customerDetailRow(label: Localization.regionLabel, value: region)
-                customerDetailRow(label: Localization.cityLabel, value: city)
-                customerDetailRow(label: Localization.postcodeLabel, value: postcode)
+                customerDetailRow(label: Localization.countryLabel, value: viewModel.country)
+                customerDetailRow(label: Localization.regionLabel, value: viewModel.region)
+                customerDetailRow(label: Localization.cityLabel, value: viewModel.city)
+                customerDetailRow(label: Localization.postcodeLabel, value: viewModel.postcode)
             }
         }
         .listStyle(.plain)
         .background(Color(uiColor: .listBackground))
-        .navigationTitle(name)
+        .navigationTitle(viewModel.name)
         .navigationBarTitleDisplayMode(.inline)
         .wooNavigationBarStyle()
     }
@@ -158,31 +124,31 @@ private extension CustomerDetailView {
 }
 
 #Preview("Customer") {
-    CustomerDetailView(name: "Pat Smith",
-                       dateLastActive: "Jan 1, 2024",
-                       email: "patsmith@example.com",
-                       ordersCount: "3",
-                       totalSpend: "$81.75",
-                       avgOrderValue: "$27.25",
-                       username: "patsmith",
-                       dateRegistered: "Jan 1, 2023",
-                       country: "United States",
-                       region: "Oregon",
-                       city: "Portland",
-                       postcode: "12345")
+    CustomerDetailView(viewModel: CustomerDetailViewModel(name: "Pat Smith",
+                                                          dateLastActive: "Jan 1, 2024",
+                                                          email: "patsmith@example.com",
+                                                          ordersCount: "3",
+                                                          totalSpend: "$81.75",
+                                                          avgOrderValue: "$27.25",
+                                                          username: "patsmith",
+                                                          dateRegistered: "Jan 1, 2023",
+                                                          country: "United States",
+                                                          region: "Oregon",
+                                                          city: "Portland",
+                                                          postcode: "12345"))
 }
 
 #Preview("Customer with Placeholders") {
-    CustomerDetailView(name: "Guest",
-                       dateLastActive: "Jan 1, 2024",
-                       email: nil,
-                       ordersCount: "0",
-                       totalSpend: "$0.00",
-                       avgOrderValue: "$0.00",
-                       username: nil,
-                       dateRegistered: nil,
-                       country: nil,
-                       region: nil,
-                       city: nil,
-                       postcode: nil)
+    CustomerDetailView(viewModel: CustomerDetailViewModel(name: "Guest",
+                                                          dateLastActive: "Jan 1, 2024",
+                                                          email: nil,
+                                                          ordersCount: "0",
+                                                          totalSpend: "$0.00",
+                                                          avgOrderValue: "$0.00",
+                                                          username: nil,
+                                                          dateRegistered: nil,
+                                                          country: nil,
+                                                          region: nil,
+                                                          city: nil,
+                                                          postcode: nil))
 }

--- a/WooCommerce/Classes/ViewRelated/Customers/CustomerDetailView.swift
+++ b/WooCommerce/Classes/ViewRelated/Customers/CustomerDetailView.swift
@@ -8,7 +8,7 @@ struct CustomerDetailView: View {
     let dateLastActive: String
 
     /// Customer email
-    let email: String
+    let email: String?
 
     /// Number of orders from the customer
     let ordersCount: String
@@ -20,28 +20,34 @@ struct CustomerDetailView: View {
     let avgOrderValue: String
 
     /// Customer username
-    let username: String
+    let username: String?
 
     /// Date the customer was registered on the store
-    let dateRegistered: String
+    let dateRegistered: String?
 
     /// Customer country
-    let country: String
+    let country: String?
 
     /// Customer region
-    let region: String
+    let region: String?
 
     /// Customer city
-    let city: String
+    let city: String?
 
     /// Customer postal code
-    let postcode: String
+    let postcode: String?
 
     var body: some View {
         List {
             Section(header: Text(Localization.customerSection)) {
                 Text(name)
-                Text(email)
+                HStack {
+                    Text(email ?? Localization.emailPlaceholder)
+                        .style(for: email)
+                    Spacer()
+                    Image(uiImage: .mailImage)
+                        .renderedIf(email != nil)
+                }
                 customerDetailRow(label: Localization.dateLastActiveLabel, value: dateLastActive)
             }
 
@@ -72,12 +78,24 @@ struct CustomerDetailView: View {
 }
 
 private extension CustomerDetailView {
-    @ViewBuilder
-    func customerDetailRow(label: String, value: String) -> some View {
+    @ViewBuilder func customerDetailRow(label: String, value: String?) -> some View {
         HStack {
             Text(label)
             Spacer()
-            Text(value)
+            Text(value ?? Localization.defaultPlaceholder)
+                .style(for: value)
+        }
+    }
+}
+
+private extension Text {
+    /// Styles the text based on whether there is a provided value.
+    ///
+    @ViewBuilder func style(for value: String?) -> some View {
+        if value != nil {
+            self.bodyStyle()
+        } else {
+            self.secondaryBodyStyle()
         }
     }
 }
@@ -129,10 +147,17 @@ private extension CustomerDetailView {
         static let postcodeLabel = NSLocalizedString("customerDetailView.postcodeLabel",
                                                           value: "Postal code",
                                                           comment: "Label for the customer's postal code in the Customer Details screen.")
+
+        static let defaultPlaceholder = NSLocalizedString("customerDetailView.defaultPlaceholder",
+                                                          value: "None",
+                                                          comment: "Default placeholder if a customer's details are not available in the Customer Details screen.")
+        static let emailPlaceholder = NSLocalizedString("customerDetailView.emailPlaceholder",
+                                                          value: "No email address",
+                                                          comment: "Placeholder if a customer's email address is not available in the Customer Details screen.")
     }
 }
 
-#Preview {
+#Preview("Customer") {
     CustomerDetailView(name: "Pat Smith",
                        dateLastActive: "Jan 1, 2024",
                        email: "patsmith@example.com",
@@ -145,4 +170,19 @@ private extension CustomerDetailView {
                        region: "Oregon",
                        city: "Portland",
                        postcode: "12345")
+}
+
+#Preview("Customer with Placeholders") {
+    CustomerDetailView(name: "Guest",
+                       dateLastActive: "Jan 1, 2024",
+                       email: nil,
+                       ordersCount: "0",
+                       totalSpend: "$0.00",
+                       avgOrderValue: "$0.00",
+                       username: nil,
+                       dateRegistered: nil,
+                       country: nil,
+                       region: nil,
+                       city: nil,
+                       postcode: nil)
 }

--- a/WooCommerce/Classes/ViewRelated/Customers/CustomerDetailView.swift
+++ b/WooCommerce/Classes/ViewRelated/Customers/CustomerDetailView.swift
@@ -5,7 +5,7 @@ struct CustomerDetailView: View {
     let name: String
 
     /// Date the customer was last active
-    let lastActiveDate: String
+    let dateLastActive: String
 
     /// Customer email
     let email: String
@@ -42,7 +42,7 @@ struct CustomerDetailView: View {
             Section(header: Text(Localization.customerSection)) {
                 Text(name)
                 Text(email)
-                customerDetailRow(label: Localization.lastActiveDateLabel, value: lastActiveDate)
+                customerDetailRow(label: Localization.dateLastActiveLabel, value: dateLastActive)
             }
 
             Section(header: Text(Localization.ordersSection)) {
@@ -87,7 +87,7 @@ private extension CustomerDetailView {
         static let customerSection = NSLocalizedString("customerDetailView.customerSection",
                                                        value: "CUSTOMER",
                                                        comment: "Heading for the section with general customer details in the Customer Details screen.")
-        static let lastActiveDateLabel = NSLocalizedString("customerDetailView.lastActiveDateLabel",
+        static let dateLastActiveLabel = NSLocalizedString("customerDetailView.dateLastActiveLabel",
                                                       value: "Last active",
                                                       comment: "Label for the date the customer was last active in the Customer Details screen.")
 
@@ -134,13 +134,13 @@ private extension CustomerDetailView {
 
 #Preview {
     CustomerDetailView(name: "Pat Smith",
-                       lastActiveDate: "1/1/24",
+                       dateLastActive: "Jan 1, 2024",
                        email: "patsmith@example.com",
                        ordersCount: "3",
-                       totalSpend: "$81",
-                       avgOrderValue: "$27",
+                       totalSpend: "$81.75",
+                       avgOrderValue: "$27.25",
                        username: "patsmith",
-                       dateRegistered: "1/1/23",
+                       dateRegistered: "Jan 1, 2023",
                        country: "United States",
                        region: "Oregon",
                        city: "Portland",

--- a/WooCommerce/Classes/ViewRelated/Customers/CustomerDetailViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Customers/CustomerDetailViewModel.swift
@@ -2,7 +2,7 @@ import Foundation
 import struct Yosemite.WCAnalyticsCustomer
 import WooFoundation
 
-struct CustomerDetailViewModel {
+final class CustomerDetailViewModel {
     /// Customer name
     let name: String
 
@@ -11,6 +11,11 @@ struct CustomerDetailViewModel {
 
     /// Customer email
     let email: String?
+
+    /// Whether the customer can be contacted via email
+    lazy var canEmailCustomer: Bool = {
+        email != nil
+    }()
 
     // MARK: Orders
 
@@ -45,22 +50,47 @@ struct CustomerDetailViewModel {
     /// Customer postal code
     let postcode: String?
 
-    init(customer: WCAnalyticsCustomer,
-         currencySettings: CurrencySettings = ServiceLocator.currencySettings) {
-        let currencyFormatter = CurrencyFormatter(currencySettings: currencySettings)
+    init(name: String?,
+         dateLastActive: String,
+         email: String?,
+         ordersCount: String,
+         totalSpend: String,
+         avgOrderValue: String,
+         username: String?,
+         dateRegistered: String?,
+         country: String?,
+         region: String?,
+         city: String?,
+         postcode: String?) {
+        self.name = name ?? Localization.guestName
+        self.dateLastActive = dateLastActive
+        self.email = email
+        self.ordersCount = ordersCount
+        self.totalSpend = totalSpend
+        self.avgOrderValue = avgOrderValue
+        self.username = username
+        self.dateRegistered = dateRegistered
+        self.country = country
+        self.region = region
+        self.city = city
+        self.postcode = postcode
+    }
 
-        name = customer.name?.nullifyIfEmptyOrWhitespace() ?? Localization.guestName
-        dateLastActive = DateFormatter.mediumLengthLocalizedDateFormatter.string(from: customer.dateLastActive)
-        email = customer.email?.nullifyIfEmptyOrWhitespace()
-        ordersCount = customer.ordersCount.description
-        totalSpend = currencyFormatter.formatAmount(customer.totalSpend) ?? customer.totalSpend.description
-        avgOrderValue = currencyFormatter.formatAmount(customer.averageOrderValue) ?? customer.averageOrderValue.description
-        username = customer.username?.nullifyIfEmptyOrWhitespace()
-        dateRegistered = customer.dateRegistered.map { DateFormatter.mediumLengthLocalizedDateFormatter.string(from: $0) }
-        country = customer.country.nullifyIfEmptyOrWhitespace()
-        region = customer.region.nullifyIfEmptyOrWhitespace()
-        city = customer.city.nullifyIfEmptyOrWhitespace()
-        postcode = customer.postcode.nullifyIfEmptyOrWhitespace()
+    convenience init(customer: WCAnalyticsCustomer,
+                     currencySettings: CurrencySettings = ServiceLocator.currencySettings) {
+        let currencyFormatter = CurrencyFormatter(currencySettings: currencySettings)
+        self.init(name: customer.name?.nullifyIfEmptyOrWhitespace(),
+                  dateLastActive: DateFormatter.mediumLengthLocalizedDateFormatter.string(from: customer.dateLastActive),
+                  email: customer.email?.nullifyIfEmptyOrWhitespace(),
+                  ordersCount: customer.ordersCount.description,
+                  totalSpend: currencyFormatter.formatAmount(customer.totalSpend) ?? customer.totalSpend.description,
+                  avgOrderValue: currencyFormatter.formatAmount(customer.averageOrderValue) ?? customer.averageOrderValue.description,
+                  username: customer.username?.nullifyIfEmptyOrWhitespace(),
+                  dateRegistered: customer.dateRegistered.map { DateFormatter.mediumLengthLocalizedDateFormatter.string(from: $0) },
+                  country: customer.country.nullifyIfEmptyOrWhitespace(),
+                  region: customer.region.nullifyIfEmptyOrWhitespace(),
+                  city: customer.city.nullifyIfEmptyOrWhitespace(),
+                  postcode: customer.postcode.nullifyIfEmptyOrWhitespace())
     }
 }
 
@@ -68,23 +98,6 @@ private extension String {
     /// Returns nil if the string is empty or only contains whitespace
     func nullifyIfEmptyOrWhitespace() -> Self? {
         self.trimmingCharacters(in: .whitespaces).isNotEmpty ? self : nil
-    }
-}
-
-extension CustomerDetailView {
-    init(viewModel: CustomerDetailViewModel) {
-        self.name = viewModel.name
-        self.email = viewModel.email
-        self.dateLastActive = viewModel.dateLastActive
-        self.ordersCount = viewModel.ordersCount
-        self.totalSpend = viewModel.totalSpend
-        self.avgOrderValue = viewModel.avgOrderValue
-        self.username = viewModel.username
-        self.dateRegistered = viewModel.dateRegistered
-        self.country = viewModel.country
-        self.region = viewModel.region
-        self.city = viewModel.city
-        self.postcode = viewModel.postcode
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Customers/CustomerDetailViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Customers/CustomerDetailViewModel.swift
@@ -18,10 +18,10 @@ struct CustomerDetailViewModel {
     let ordersCount: String
 
     /// Customer's total spend
-    let totalSpend: String?
+    let totalSpend: String
 
     /// Customer's average order value
-    let avgOrderValue: String?
+    let avgOrderValue: String
 
     // MARK: Registration
 
@@ -74,17 +74,17 @@ private extension String {
 extension CustomerDetailView {
     init(viewModel: CustomerDetailViewModel) {
         self.name = viewModel.name
-        self.email = viewModel.email ?? ""
+        self.email = viewModel.email
         self.dateLastActive = viewModel.dateLastActive
         self.ordersCount = viewModel.ordersCount
-        self.totalSpend = viewModel.totalSpend ?? ""
-        self.avgOrderValue = viewModel.avgOrderValue ?? ""
-        self.username = viewModel.username ?? ""
-        self.dateRegistered = viewModel.dateRegistered ?? ""
-        self.country = viewModel.country ?? ""
-        self.region = viewModel.region ?? ""
-        self.city = viewModel.city ?? ""
-        self.postcode = viewModel.postcode ?? ""
+        self.totalSpend = viewModel.totalSpend
+        self.avgOrderValue = viewModel.avgOrderValue
+        self.username = viewModel.username
+        self.dateRegistered = viewModel.dateRegistered
+        self.country = viewModel.country
+        self.region = viewModel.region
+        self.city = viewModel.city
+        self.postcode = viewModel.postcode
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Customers/CustomerDetailViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Customers/CustomerDetailViewModel.swift
@@ -1,0 +1,97 @@
+import Foundation
+import struct Yosemite.WCAnalyticsCustomer
+import WooFoundation
+
+struct CustomerDetailViewModel {
+    /// Customer name
+    let name: String
+
+    /// Date the customer was last active
+    let dateLastActive: String
+
+    /// Customer email
+    let email: String?
+
+    // MARK: Orders
+
+    /// Number of orders from the customer
+    let ordersCount: String
+
+    /// Customer's total spend
+    let totalSpend: String?
+
+    /// Customer's average order value
+    let avgOrderValue: String?
+
+    // MARK: Registration
+
+    /// Customer username
+    let username: String?
+
+    /// Date the customer was registered on the store
+    let dateRegistered: String?
+
+    // MARK: Location
+
+    /// Customer country
+    let country: String?
+
+    /// Customer region
+    let region: String?
+
+    /// Customer city
+    let city: String?
+
+    /// Customer postal code
+    let postcode: String?
+
+    init(customer: WCAnalyticsCustomer,
+         currencySettings: CurrencySettings = ServiceLocator.currencySettings) {
+        let currencyFormatter = CurrencyFormatter(currencySettings: currencySettings)
+
+        name = customer.name?.nullifyIfEmptyOrWhitespace() ?? Localization.guestName
+        dateLastActive = DateFormatter.mediumLengthLocalizedDateFormatter.string(from: customer.dateLastActive)
+        email = customer.email?.nullifyIfEmptyOrWhitespace()
+        ordersCount = customer.ordersCount.description
+        totalSpend = currencyFormatter.formatAmount(customer.totalSpend) ?? customer.totalSpend.description
+        avgOrderValue = currencyFormatter.formatAmount(customer.averageOrderValue) ?? customer.averageOrderValue.description
+        username = customer.username?.nullifyIfEmptyOrWhitespace()
+        dateRegistered = customer.dateRegistered.map { DateFormatter.mediumLengthLocalizedDateFormatter.string(from: $0) }
+        country = customer.country.nullifyIfEmptyOrWhitespace()
+        region = customer.region.nullifyIfEmptyOrWhitespace()
+        city = customer.city.nullifyIfEmptyOrWhitespace()
+        postcode = customer.postcode.nullifyIfEmptyOrWhitespace()
+    }
+}
+
+private extension String {
+    /// Returns nil if the string is empty or only contains whitespace
+    func nullifyIfEmptyOrWhitespace() -> Self? {
+        self.trimmingCharacters(in: .whitespaces).isNotEmpty ? self : nil
+    }
+}
+
+extension CustomerDetailView {
+    init(viewModel: CustomerDetailViewModel) {
+        self.name = viewModel.name
+        self.email = viewModel.email ?? ""
+        self.dateLastActive = viewModel.dateLastActive
+        self.ordersCount = viewModel.ordersCount
+        self.totalSpend = viewModel.totalSpend ?? ""
+        self.avgOrderValue = viewModel.avgOrderValue ?? ""
+        self.username = viewModel.username ?? ""
+        self.dateRegistered = viewModel.dateRegistered ?? ""
+        self.country = viewModel.country ?? ""
+        self.region = viewModel.region ?? ""
+        self.city = viewModel.city ?? ""
+        self.postcode = viewModel.postcode ?? ""
+    }
+}
+
+private extension CustomerDetailViewModel {
+    enum Localization {
+        static let guestName = NSLocalizedString("customerDetail.guestName",
+                                                 value: "Guest",
+                                                 comment: "Label for a customer with no name in the Customer detail screen.")
+    }
+}

--- a/WooCommerce/Classes/ViewRelated/Customers/CustomersListView.swift
+++ b/WooCommerce/Classes/ViewRelated/Customers/CustomersListView.swift
@@ -14,7 +14,7 @@ struct CustomersListView: View {
                 }) {
                     ForEach(viewModel.customers, id: \.customerID) { customer in
                         VStack(spacing: 0) {
-                            LazyNavigationLink(destination: EmptyView(), label: {
+                            LazyNavigationLink(destination: CustomerDetailView(viewModel: .init(customer: customer)), label: {
                                 HStack {
                                     TitleAndSubtitleAndDetailRow(title: viewModel.displayName(for: customer),
                                                                  detail: viewModel.displayUsername(for: customer),

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -2047,6 +2047,8 @@
 		CE6302412BAAFB5E00E3325C /* CustomersListViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE6302402BAAFB5E00E3325C /* CustomersListViewModel.swift */; };
 		CE6302432BAB431D00E3325C /* CustomerDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE6302422BAB431D00E3325C /* CustomerDetailView.swift */; };
 		CE6302462BAB528900E3325C /* CustomerListViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE6302452BAB528900E3325C /* CustomerListViewModelTests.swift */; };
+		CE6302482BAB60AE00E3325C /* CustomerDetailViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE6302472BAB60AE00E3325C /* CustomerDetailViewModel.swift */; };
+		CE63024A2BAC46A200E3325C /* CustomerDetailViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE6302492BAC46A200E3325C /* CustomerDetailViewModelTests.swift */; };
 		CE6A8FB42B724D7C0063564D /* AnalyticsReportLink.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE6A8FB32B724D7C0063564D /* AnalyticsReportLink.swift */; };
 		CE6A8FB62B725A690063564D /* AnalyticsReportLinkViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE6A8FB52B725A690063564D /* AnalyticsReportLinkViewModel.swift */; };
 		CE6A8FB82B7291760063564D /* AnalyticsReportLinkViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE6A8FB72B7291760063564D /* AnalyticsReportLinkViewModelTests.swift */; };
@@ -4784,6 +4786,8 @@
 		CE6302402BAAFB5E00E3325C /* CustomersListViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomersListViewModel.swift; sourceTree = "<group>"; };
 		CE6302422BAB431D00E3325C /* CustomerDetailView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomerDetailView.swift; sourceTree = "<group>"; };
 		CE6302452BAB528900E3325C /* CustomerListViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomerListViewModelTests.swift; sourceTree = "<group>"; };
+		CE6302472BAB60AE00E3325C /* CustomerDetailViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomerDetailViewModel.swift; sourceTree = "<group>"; };
+		CE6302492BAC46A200E3325C /* CustomerDetailViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomerDetailViewModelTests.swift; sourceTree = "<group>"; };
 		CE6A8FB32B724D7C0063564D /* AnalyticsReportLink.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnalyticsReportLink.swift; sourceTree = "<group>"; };
 		CE6A8FB52B725A690063564D /* AnalyticsReportLinkViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnalyticsReportLinkViewModel.swift; sourceTree = "<group>"; };
 		CE6A8FB72B7291760063564D /* AnalyticsReportLinkViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnalyticsReportLinkViewModelTests.swift; sourceTree = "<group>"; };
@@ -10767,6 +10771,7 @@
 				CE63023C2BAAEF2C00E3325C /* CustomersListView.swift */,
 				CE6302402BAAFB5E00E3325C /* CustomersListViewModel.swift */,
 				CE6302422BAB431D00E3325C /* CustomerDetailView.swift */,
+				CE6302472BAB60AE00E3325C /* CustomerDetailViewModel.swift */,
 			);
 			path = Customers;
 			sourceTree = "<group>";
@@ -10775,6 +10780,7 @@
 			isa = PBXGroup;
 			children = (
 				CE6302452BAB528900E3325C /* CustomerListViewModelTests.swift */,
+				CE6302492BAC46A200E3325C /* CustomerDetailViewModelTests.swift */,
 			);
 			path = Customers;
 			sourceTree = "<group>";
@@ -14693,6 +14699,7 @@
 				B541B21A2189F3A2008FE7C1 /* StringFormatter.swift in Sources */,
 				0279F0DF252DC12D0098D7DE /* ProductLoaderViewControllerModel+Init.swift in Sources */,
 				26B9875D273C6A830090E8CA /* SimplePaymentsNoteViewModel.swift in Sources */,
+				CE6302482BAB60AE00E3325C /* CustomerDetailViewModel.swift in Sources */,
 				DEF36DEA2898D3CF00178AC2 /* AuthenticatedWebViewModel.swift in Sources */,
 				45A0E4CB2566B56000D4E8C3 /* NumberOfLinkedProductsTableViewCell.swift in Sources */,
 				DEDA8D9D2B1609DE0076BF0F /* UserDefaults+Blaze.swift in Sources */,
@@ -14977,6 +14984,7 @@
 				0298431225936DFC00979CAE /* ShippingLabelsTopBannerFactoryTests.swift in Sources */,
 				CE6A8FB82B7291760063564D /* AnalyticsReportLinkViewModelTests.swift in Sources */,
 				B98968572A98F227007A2FBE /* TaxEducationalDialogViewModelTests.swift in Sources */,
+				CE63024A2BAC46A200E3325C /* CustomerDetailViewModelTests.swift in Sources */,
 				57B374B6245B331100D58BE0 /* EmptyStateViewControllerTests.swift in Sources */,
 				EE6F08662A718DFB00AA9B88 /* FreeTrialSurveyViewModelTests.swift in Sources */,
 				EE572A212B4684FF00B74B2E /* BlazeEditAdViewModelTests.swift in Sources */,

--- a/WooCommerce/WooCommerceTests/ViewRelated/Customers/CustomerDetailViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Customers/CustomerDetailViewModelTests.swift
@@ -1,0 +1,74 @@
+import XCTest
+import Yosemite
+@testable import WooCommerce
+import WooFoundation
+
+final class CustomerDetailViewModelTests: XCTestCase {
+
+    private let dateFormatter = DateFormatter.mediumLengthLocalizedDateFormatter
+
+    func test_it_inits_with_expected_values_from_customer() throws {
+        // Given
+        let customer = WCAnalyticsCustomer.fake().copy(name: "Pat Smith",
+                                                       email: "pat.smith@example.com",
+                                                       username: "psmith",
+                                                       dateRegistered: Date(),
+                                                       dateLastActive: Date(),
+                                                       ordersCount: 2,
+                                                       totalSpend: 10,
+                                                       averageOrderValue: 5,
+                                                       country: "US",
+                                                       region: "CA",
+                                                       city: "San Francisco",
+                                                       postcode: "94103")
+
+        // When
+        let vm = CustomerDetailViewModel(customer: customer, currencySettings: CurrencySettings())
+
+        // Then
+        assertEqual(customer.name, vm.name)
+        assertEqual(customer.email, vm.email)
+        assertEqual(dateFormatter.string(from: try XCTUnwrap(customer.dateRegistered)), vm.dateRegistered)
+        assertEqual(dateFormatter.string(from: customer.dateLastActive), vm.dateLastActive)
+        assertEqual(customer.ordersCount.description, vm.ordersCount)
+        assertEqual("$10.00", vm.totalSpend)
+        assertEqual("$5.00", vm.avgOrderValue)
+        assertEqual(customer.country, vm.country)
+        assertEqual(customer.region, vm.region)
+        assertEqual(customer.city, vm.city)
+        assertEqual(customer.postcode, vm.postcode)
+    }
+
+    func test_it_inits_with_expected_values_from_empty_customer() {
+        // Given
+        let customer = WCAnalyticsCustomer.fake().copy(name: " ",
+                                                       email: "",
+                                                       username: "",
+                                                       dateRegistered: .some(nil),
+                                                       dateLastActive: Date(),
+                                                       ordersCount: 0,
+                                                       totalSpend: 0,
+                                                       averageOrderValue: 0,
+                                                       country: "",
+                                                       region: "",
+                                                       city: "",
+                                                       postcode: "")
+
+        // When
+        let vm = CustomerDetailViewModel(customer: customer, currencySettings: CurrencySettings())
+
+        // Then
+        assertEqual("Guest", vm.name)
+        assertEqual(dateFormatter.string(from: customer.dateLastActive), vm.dateLastActive)
+        assertEqual(customer.ordersCount.description, vm.ordersCount)
+        assertEqual("$0.00", vm.totalSpend)
+        assertEqual("$0.00", vm.avgOrderValue)
+        XCTAssertNil(vm.email)
+        XCTAssertNil(vm.dateRegistered)
+        XCTAssertNil(vm.country)
+        XCTAssertNil(vm.region)
+        XCTAssertNil(vm.city)
+        XCTAssertNil(vm.postcode)
+    }
+
+}


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of: #12334
<!-- Id number of the GitHub issue this PR addresses. -->

## Why
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This adds navigation from the Customers list to the customer details view, and fills in the actual customer details.

Note: An email icon will appear when the customer has an email address, but the icon doesn't perform any action yet.

## How
* `CustomerDetailView` now uses a view model for its data. It shows placeholders whether the customer data is not provided.
* `CustomerDetailViewModel` parses the data from a `WCAnalyticsCustomer` object for display in the view. In cases where the `WCAnalyticsCustomer` contains empty or whitespace strings, it nullifies those strings so placeholders can be used in the view.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

1. Build and run the app.
2. Open the hub menu.
3. Select the Customers item.
4. Select a registered customer and confirm all their expected details are loaded.
5. Select an unregistered (guest) customer and confirm placeholders appear where their details are not available.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->
Registered customer|Guest customer with details|Guest customer no details
-|-|-
![Simulator Screenshot - iPhone 15 Pro - 2024-03-21 at 11 43 46](https://github.com/woocommerce/woocommerce-ios/assets/8658164/9c3fe8e8-0128-416d-bfe3-2d54708dc394)|![Simulator Screenshot - iPhone 15 Pro - 2024-03-21 at 11 43 41](https://github.com/woocommerce/woocommerce-ios/assets/8658164/fa0226ad-a549-4435-8ef9-a975d3ff8f94)|![Simulator Screenshot - iPhone 15 Pro - 2024-03-21 at 11 44 01](https://github.com/woocommerce/woocommerce-ios/assets/8658164/c31a2a1e-5105-45e2-a02a-918acf0f740b)

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
