### PR TITLE
[Hub Menu] Customers: Add options to copy and send email in customer details

### DIFF
--- a/WooCommerce/Classes/Extensions/String+Helpers.swift
+++ b/WooCommerce/Classes/Extensions/String+Helpers.swift
@@ -1,4 +1,5 @@
 import Foundation
+import UIKit
 
 
 /// String: Helper Methods
@@ -99,5 +100,26 @@ extension String {
         }
 
         return Set(arrayOfTags)
+    }
+}
+
+extension String {
+    /// Sends the string to the general pasteboard and triggers a success haptic.
+    /// If the string is nil, nothing is sent to the pasteboard.
+    ///
+    /// - Parameter includeTrailingNewline: If true, inserts a trailing newline; defaults to true
+    ///
+    func sendToPasteboard(includeTrailingNewline: Bool = true) {
+        guard self.isEmpty == false else {
+            return
+        }
+
+        var text: String = self
+        if includeTrailingNewline {
+            text += "\n"
+        }
+
+        UIPasteboard.general.string = text
+        UINotificationFeedbackGenerator().notificationOccurred(.success)
     }
 }

--- a/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsDataSource.swift
+++ b/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsDataSource.swift
@@ -16,10 +16,6 @@ final class OrderDetailsDataSource: NSObject {
     private(set) var order: Order
     private let couponLines: [OrderCouponLine]?
 
-    /// Haptic Feedback!
-    ///
-    private let hapticGenerator = UINotificationFeedbackGenerator()
-
     /// Sections to be rendered
     ///
     private(set) var sections = [Section]()
@@ -1540,32 +1536,12 @@ extension OrderDetailsDataSource {
 
         switch row {
         case .shippingAddress:
-            sendToPasteboard(order.shippingAddress?.fullNameWithCompanyAndAddress)
+            order.shippingAddress?.fullNameWithCompanyAndAddress.sendToPasteboard()
         case .tracking:
-            sendToPasteboard(orderTracking(at: indexPath)?.trackingNumber, includeTrailingNewline: false)
+            orderTracking(at: indexPath)?.trackingNumber.sendToPasteboard(includeTrailingNewline: false)
         default:
             break // We only send text to the pasteboard from the address rows right meow
         }
-    }
-
-    /// Sends the provided text to the general pasteboard and triggers a success haptic. If the text param
-    /// is nil, nothing is sent to the pasteboard.
-    ///
-    /// - Parameter
-    ///   - text: string value to send to the pasteboard
-    ///   - includeTrailingNewline: If true, insert a trailing newline; defaults to true
-    ///
-    func sendToPasteboard(_ text: String?, includeTrailingNewline: Bool = true) {
-        guard var text = text, text.isEmpty == false else {
-            return
-        }
-
-        if includeTrailingNewline {
-            text += "\n"
-        }
-
-        UIPasteboard.general.string = text
-        hapticGenerator.notificationOccurred(.success)
     }
 
     /// Checks if copying the row data at the provided indexPath is allowed

--- a/WooCommerce/Classes/ViewRelated/Customers/CustomerDetailView.swift
+++ b/WooCommerce/Classes/ViewRelated/Customers/CustomerDetailView.swift
@@ -3,6 +3,9 @@ import SwiftUI
 struct CustomerDetailView: View {
     let viewModel: CustomerDetailViewModel
 
+    @State private var isPresentingEmailDialog: Bool = false
+    @State private var isShowingEmailView: Bool = false
+
     var body: some View {
         List {
             Section(header: Text(Localization.customerSection)) {
@@ -11,8 +14,14 @@ struct CustomerDetailView: View {
                     Text(viewModel.email ?? Localization.emailPlaceholder)
                         .style(for: viewModel.email)
                     Spacer()
-                    Image(uiImage: .mailImage)
-                        .renderedIf(viewModel.canEmailCustomer)
+                    Button {
+                        isPresentingEmailDialog.toggle()
+                    } label: {
+                        Image(uiImage: .mailImage)
+                            .foregroundColor(Color(.primary))
+                    }
+                    .accessibilityLabel(Localization.emailAction)
+                    .renderedIf(viewModel.email != nil)
                 }
                 customerDetailRow(label: Localization.dateLastActiveLabel, value: viewModel.dateLastActive)
             }
@@ -40,6 +49,20 @@ struct CustomerDetailView: View {
         .navigationTitle(viewModel.name)
         .navigationBarTitleDisplayMode(.inline)
         .wooNavigationBarStyle()
+        .sheet(isPresented: $isShowingEmailView) {
+            EmailView(emailAddress: viewModel.email)
+                .ignoresSafeArea(edges: .bottom)
+        }
+        .confirmationDialog(Localization.emailAction, isPresented: $isPresentingEmailDialog) {
+            Button(Localization.sendEmail) {
+                isShowingEmailView.toggle()
+            }
+            .renderedIf(EmailView.canSendEmail())
+
+            Button(Localization.copyEmail) {
+                viewModel.copyEmail()
+            }
+        }
     }
 }
 
@@ -120,6 +143,16 @@ private extension CustomerDetailView {
         static let emailPlaceholder = NSLocalizedString("customerDetailView.emailPlaceholder",
                                                           value: "No email address",
                                                           comment: "Placeholder if a customer's email address is not available in the Customer Details screen.")
+
+        static let emailAction = NSLocalizedString("customerDetailView.emailActionLabel",
+                                                   value: "Contact customer via email",
+                                                   comment: "Title for action to contact a customer via email.")
+        static let sendEmail = NSLocalizedString("customerDetailView.sendEmail",
+                                                 value: "Email",
+                                                 comment: "Button to email a customer in the Customer Details screen.")
+        static let copyEmail = NSLocalizedString("customerDetailView.copyEmail",
+                                                 value: "Copy email address",
+                                                 comment: "Button to copy a customer's email address in the Customer Details screen.")
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Customers/CustomerDetailView.swift
+++ b/WooCommerce/Classes/ViewRelated/Customers/CustomerDetailView.swift
@@ -22,6 +22,16 @@ struct CustomerDetailView: View {
                     }
                     .accessibilityLabel(Localization.emailAction)
                     .renderedIf(viewModel.email != nil)
+                    .confirmationDialog(Localization.emailAction, isPresented: $isPresentingEmailDialog) {
+                        Button(Localization.sendEmail) {
+                            isShowingEmailView.toggle()
+                        }
+                        .renderedIf(EmailView.canSendEmail())
+
+                        Button(Localization.copyEmail) {
+                            viewModel.copyEmail()
+                        }
+                    }
                 }
                 customerDetailRow(label: Localization.dateLastActiveLabel, value: viewModel.dateLastActive)
             }
@@ -52,16 +62,6 @@ struct CustomerDetailView: View {
         .sheet(isPresented: $isShowingEmailView) {
             EmailView(emailAddress: viewModel.email)
                 .ignoresSafeArea(edges: .bottom)
-        }
-        .confirmationDialog(Localization.emailAction, isPresented: $isPresentingEmailDialog) {
-            Button(Localization.sendEmail) {
-                isShowingEmailView.toggle()
-            }
-            .renderedIf(EmailView.canSendEmail())
-
-            Button(Localization.copyEmail) {
-                viewModel.copyEmail()
-            }
         }
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Customers/CustomerDetailViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Customers/CustomerDetailViewModel.swift
@@ -12,11 +12,6 @@ final class CustomerDetailViewModel {
     /// Customer email
     let email: String?
 
-    /// Whether the customer can be contacted via email
-    lazy var canEmailCustomer: Bool = {
-        email != nil
-    }()
-
     // MARK: Orders
 
     /// Number of orders from the customer
@@ -91,6 +86,11 @@ final class CustomerDetailViewModel {
                   region: customer.region.nullifyIfEmptyOrWhitespace(),
                   city: customer.city.nullifyIfEmptyOrWhitespace(),
                   postcode: customer.postcode.nullifyIfEmptyOrWhitespace())
+    }
+
+    /// Copies the customer email to the pasteboard.
+    func copyEmail() {
+        email?.sendToPasteboard(includeTrailingNewline: false)
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/OrderDetailsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/OrderDetailsViewController.swift
@@ -595,9 +595,9 @@ private extension OrderDetailsViewController {
 
         actionSheet.addCancelActionWithTitle(Localization.ShippingLabelTrackingMoreMenu.cancelAction)
 
-        actionSheet.addDefaultActionWithTitle(Localization.ShippingLabelTrackingMoreMenu.copyTrackingNumberAction) { [weak self] _ in
+        actionSheet.addDefaultActionWithTitle(Localization.ShippingLabelTrackingMoreMenu.copyTrackingNumberAction) { _ in
             ServiceLocator.analytics.track(event: .shipmentTrackingMenu(action: .copy))
-            self?.viewModel.dataSource.sendToPasteboard(shippingLabel.trackingNumber, includeTrailingNewline: false)
+            shippingLabel.trackingNumber.sendToPasteboard(includeTrailingNewline: false)
         }
 
         // Only shows the tracking action when there is a tracking URL.

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Review Order/ReviewOrderViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Review Order/ReviewOrderViewController.swift
@@ -422,8 +422,8 @@ private extension ReviewOrderViewController {
 
         actionSheet.addCancelActionWithTitle(TrackingAction.dismiss)
 
-        actionSheet.addDefaultActionWithTitle(TrackingAction.copyTrackingNumber) { [weak self] _ in
-            self?.sendToPasteboard(tracking.trackingNumber, includeTrailingNewline: false)
+        actionSheet.addDefaultActionWithTitle(TrackingAction.copyTrackingNumber) { _ in
+            tracking.trackingNumber.sendToPasteboard(includeTrailingNewline: false)
         }
 
         if tracking.trackingURL?.isEmpty == false {
@@ -442,21 +442,6 @@ private extension ReviewOrderViewController {
         popoverController?.sourceRect = cell.bounds
 
         present(actionSheet, animated: true)
-    }
-
-    /// Sends the provided text to the general pasteboard and triggers a success haptic.
-    ///
-    func sendToPasteboard(_ text: String?, includeTrailingNewline: Bool = true) {
-        guard var text = text, text.isEmpty == false else {
-            return
-        }
-
-        if includeTrailingNewline {
-            text += "\n"
-        }
-
-        UIPasteboard.general.string = text
-        hapticGenerator.notificationOccurred(.success)
     }
 
     /// Opens details of the shipment tracking in a web view

--- a/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/EmailView.swift
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/EmailView.swift
@@ -2,6 +2,8 @@ import SwiftUI
 import UIKit
 import MessageUI
 
+/// SwiftUI wrapper of `MFMailComposeViewController`.
+/// Its interface lets the user manage, edit, and send email messages.
 struct EmailView: UIViewControllerRepresentable {
 
     /// Email address to set as recipient
@@ -36,6 +38,11 @@ struct EmailView: UIViewControllerRepresentable {
 
     }
 
+    /// Returns a Boolean that indicates whether the current device is able to send email.
+    ///
+    /// You should call this method before attempting to display the mail composition interface.
+    /// If it returns false, you must not display the mail composition interface.
+    ///
     static func canSendEmail() -> Bool {
         MFMailComposeViewController.canSendMail()
     }

--- a/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/EmailView.swift
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/EmailView.swift
@@ -1,0 +1,42 @@
+import SwiftUI
+import UIKit
+import MessageUI
+
+struct EmailView: UIViewControllerRepresentable {
+
+    /// Email address to set as recipient
+    let emailAddress: String?
+
+    class Coordinator: NSObject, MFMailComposeViewControllerDelegate {
+
+        func mailComposeController(_ controller: MFMailComposeViewController,
+                                   didFinishWith result: MFMailComposeResult,
+                                   error: Error?) {
+            controller.dismiss(animated: true, completion: nil)
+        }
+    }
+
+    func makeCoordinator() -> Coordinator {
+        return Coordinator()
+    }
+
+    func makeUIViewController(context: UIViewControllerRepresentableContext<EmailView>) -> MFMailComposeViewController {
+        let mail = MFMailComposeViewController()
+        mail.mailComposeDelegate = context.coordinator
+
+        if let emailAddress {
+            mail.setToRecipients([emailAddress])
+        }
+
+        return mail
+    }
+
+    func updateUIViewController(_ uiViewController: MFMailComposeViewController,
+                                context: UIViewControllerRepresentableContext<EmailView>) {
+
+    }
+
+    static func canSendEmail() -> Bool {
+        MFMailComposeViewController.canSendMail()
+    }
+}

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -2049,6 +2049,7 @@
 		CE6302462BAB528900E3325C /* CustomerListViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE6302452BAB528900E3325C /* CustomerListViewModelTests.swift */; };
 		CE6302482BAB60AE00E3325C /* CustomerDetailViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE6302472BAB60AE00E3325C /* CustomerDetailViewModel.swift */; };
 		CE63024A2BAC46A200E3325C /* CustomerDetailViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE6302492BAC46A200E3325C /* CustomerDetailViewModelTests.swift */; };
+		CE63024E2BAC664900E3325C /* EmailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE63024D2BAC664900E3325C /* EmailView.swift */; };
 		CE6A8FB42B724D7C0063564D /* AnalyticsReportLink.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE6A8FB32B724D7C0063564D /* AnalyticsReportLink.swift */; };
 		CE6A8FB62B725A690063564D /* AnalyticsReportLinkViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE6A8FB52B725A690063564D /* AnalyticsReportLinkViewModel.swift */; };
 		CE6A8FB82B7291760063564D /* AnalyticsReportLinkViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE6A8FB72B7291760063564D /* AnalyticsReportLinkViewModelTests.swift */; };
@@ -4788,6 +4789,7 @@
 		CE6302452BAB528900E3325C /* CustomerListViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomerListViewModelTests.swift; sourceTree = "<group>"; };
 		CE6302472BAB60AE00E3325C /* CustomerDetailViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomerDetailViewModel.swift; sourceTree = "<group>"; };
 		CE6302492BAC46A200E3325C /* CustomerDetailViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomerDetailViewModelTests.swift; sourceTree = "<group>"; };
+		CE63024D2BAC664900E3325C /* EmailView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EmailView.swift; sourceTree = "<group>"; };
 		CE6A8FB32B724D7C0063564D /* AnalyticsReportLink.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnalyticsReportLink.swift; sourceTree = "<group>"; };
 		CE6A8FB52B725A690063564D /* AnalyticsReportLinkViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnalyticsReportLinkViewModel.swift; sourceTree = "<group>"; };
 		CE6A8FB72B7291760063564D /* AnalyticsReportLinkViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnalyticsReportLinkViewModelTests.swift; sourceTree = "<group>"; };
@@ -8179,6 +8181,7 @@
 				B9B7E37D2AF105EF00A959CA /* PencilEditButton.swift */,
 				20203AB12B31EEF1009D0C11 /* ExpandableBottomSheet.swift */,
 				20DA6DDA2B681175002AA0FB /* AdaptiveModalContainer.swift */,
+				CE63024D2BAC664900E3325C /* EmailView.swift */,
 			);
 			path = "SwiftUI Components";
 			sourceTree = "<group>";
@@ -14178,6 +14181,7 @@
 				02FADA9D2A5F20B000FE8683 /* AddProductFromImageScannedTextView.swift in Sources */,
 				022F2FA6295E77F4003A0A46 /* StoreCreationCountrySectionView.swift in Sources */,
 				CEE006052077D1280079161F /* SummaryTableViewCell.swift in Sources */,
+				CE63024E2BAC664900E3325C /* EmailView.swift in Sources */,
 				DE4B3B5826A7041800EEF2D8 /* EdgeInsets+Woo.swift in Sources */,
 				02CE4304276993DA0006EAEF /* CaptureDevicePermissionChecker.swift in Sources */,
 				DEF8CF1F29AC870A00800A60 /* WPComEmailLoginViewModel.swift in Sources */,


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #12334
<!-- Id number of the GitHub issue this PR addresses. -->

## Why
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This adds the ability to contact customers via email (copy the email address or send an email directly) in customer details.

## How
* Adds a `String.sendToPasteboard()` helper to copy a string, with haptic feedback. This reuses an existing method we've used elsewhere in the app.
* Adds a reusable SwiftUI `EmailView` component, which wraps `MFMailComposeViewController` to display the email composer.
* In `CustomerDetailView`, replaces the static email icon with a button. Tapping the button presents a confirmation dialog with options to email the customer (if the device can send email) or copy their email address.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

1. Build and run the app.
2. Open the hub menu.
3. Select the Customers item.
4. Select a customer with an email address.
5. Tap the email icon and confirm a confirmation dialog is displayed with your options.
6. Tap "Copy email address" and confirm the email address is copied to your pasteboard and you get haptic feedback.
7. Tap "Copy" and confirm the email composer is displayed in a sheet. Confirm you can send or cancel the email.

Also confirm the copy action continues to work where it did before:

* Copy the tracking number from an order.
* Copy the shipping address from an order.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

https://github.com/woocommerce/woocommerce-ios/assets/8658164/a60a7f03-8537-4ad3-9d25-86728eaafc5e



---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
