### PR TITLE
[Hub Menu] Customers: Add search to customers list

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Customers/CustomersListView.swift
+++ b/WooCommerce/Classes/ViewRelated/Customers/CustomersListView.swift
@@ -10,6 +10,7 @@ struct CustomersListView: View {
             SearchHeader(text: $viewModel.searchTerm, placeholder: Localization.searchPlaceholder) { isEditing in
                 isEditingSearchTerm = isEditing
             }
+            .renderedIf(viewModel.showSearchHeader)
             Picker(selection: $viewModel.searchFilter, label: EmptyView()) {
                 ForEach(viewModel.searchFilters, id: \.self) { option in Text(option.title) }
             }
@@ -54,10 +55,16 @@ struct CustomersListView: View {
                     }
                 }
             case .empty:
-                EmptyState(title: Localization.emptyStateTitle,
-                           description: Localization.emptyStateMessage,
-                           image: .cashRegisterImage)
+                if viewModel.searchTerm.isEmpty {
+                    EmptyState(title: Localization.emptyStateTitle,
+                               description: Localization.emptyStateMessage,
+                               image: .cashRegisterImage)
                     .frame(maxHeight: .infinity)
+                } else {
+                    EmptyState(title: Localization.emptySearchTitle,
+                               image: .searchNoResultImage)
+                    .frame(maxHeight: .infinity)
+                }
             }
         }
         .listStyle(.plain)
@@ -88,6 +95,9 @@ private extension CustomersListView {
         static let searchPlaceholder = NSLocalizedString("customersList.searchPlaceholder",
                                                          value: "Search for customers",
                                                          comment: "Placeholder in the search bar in the Customers list screen.")
+        static let emptySearchTitle = NSLocalizedString("customerList.emptySearchTitle",
+                                                        value: "No customers found",
+                                                        comment: "Title when there are no customers in the search results in the Customers list screen.")
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Customers/CustomersListView.swift
+++ b/WooCommerce/Classes/ViewRelated/Customers/CustomersListView.swift
@@ -3,9 +3,20 @@ import SwiftUI
 struct CustomersListView: View {
     @StateObject var viewModel: CustomersListViewModel
 
+    @State private var isEditingSearchTerm: Bool = false
+
     var body: some View {
-        Group {
-            SearchHeader(text: $viewModel.searchTerm, placeholder: Localization.searchPlaceholder)
+        VStack(spacing: 0) {
+            SearchHeader(text: $viewModel.searchTerm, placeholder: Localization.searchPlaceholder) { isEditing in
+                isEditingSearchTerm = isEditing
+            }
+            Picker(selection: $viewModel.searchFilter, label: EmptyView()) {
+                ForEach(viewModel.searchFilters, id: \.self) { option in Text(option.title) }
+            }
+            .pickerStyle(.segmented)
+            .padding([.horizontal, .bottom])
+            .renderedIf(isEditingSearchTerm && !viewModel.showAdvancedSearch)
+
             switch viewModel.syncState {
             case .results:
                 RefreshableInfiniteScrollList(isLoading: viewModel.shouldShowBottomActivityIndicator,

--- a/WooCommerce/Classes/ViewRelated/Customers/CustomersListView.swift
+++ b/WooCommerce/Classes/ViewRelated/Customers/CustomersListView.swift
@@ -7,16 +7,18 @@ struct CustomersListView: View {
 
     var body: some View {
         VStack(spacing: 0) {
-            SearchHeader(text: $viewModel.searchTerm, placeholder: Localization.searchPlaceholder) { isEditing in
-                isEditingSearchTerm = isEditing
+            Group {
+                SearchHeader(text: $viewModel.searchTerm, placeholder: Localization.searchPlaceholder) { isEditing in
+                    isEditingSearchTerm = isEditing
+                }
+                Picker(selection: $viewModel.searchFilter, label: EmptyView()) {
+                    ForEach(viewModel.searchFilters, id: \.self) { option in Text(option.title) }
+                }
+                .pickerStyle(.segmented)
+                .padding([.horizontal, .bottom])
+                .renderedIf(isEditingSearchTerm && !viewModel.showAdvancedSearch)
             }
             .renderedIf(viewModel.showSearchHeader)
-            Picker(selection: $viewModel.searchFilter, label: EmptyView()) {
-                ForEach(viewModel.searchFilters, id: \.self) { option in Text(option.title) }
-            }
-            .pickerStyle(.segmented)
-            .padding([.horizontal, .bottom])
-            .renderedIf(isEditingSearchTerm && !viewModel.showAdvancedSearch)
 
             switch viewModel.syncState {
             case .results:

--- a/WooCommerce/Classes/ViewRelated/Customers/CustomersListView.swift
+++ b/WooCommerce/Classes/ViewRelated/Customers/CustomersListView.swift
@@ -5,6 +5,7 @@ struct CustomersListView: View {
 
     var body: some View {
         Group {
+            SearchHeader(text: $viewModel.searchTerm, placeholder: Localization.searchPlaceholder)
             switch viewModel.syncState {
             case .results:
                 RefreshableInfiniteScrollList(isLoading: viewModel.shouldShowBottomActivityIndicator,
@@ -73,6 +74,9 @@ private extension CustomersListView {
         static let emptyStateMessage = NSLocalizedString("customerList.emptyStateMessage",
                                                          value: "Create an order to start gathering customer insights",
                                                          comment: "Message when there are no customers to show in the Customers list screen.")
+        static let searchPlaceholder = NSLocalizedString("customersList.searchPlaceholder",
+                                                         value: "Search for customers",
+                                                         comment: "Placeholder in the search bar in the Customers list screen.")
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Customers/CustomersListViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Customers/CustomersListViewModel.swift
@@ -132,11 +132,15 @@ extension CustomersListViewModel: PaginationTrackerDelegate {
     func observeSearch() {
         let searchTermPublisher = $searchTerm
             .removeDuplicates()
+            .dropFirst()
             .debounce(for: .milliseconds(500), scheduler: DispatchQueue.main)
 
-        let searchFilterPublisher = $searchFilter.removeDuplicates()
+        let searchFilterPublisher = $searchFilter
+            .removeDuplicates()
+            .dropFirst()
 
-        searchTermPublisher.combineLatest(searchFilterPublisher)
+        searchTermPublisher
+            .combineLatest(searchFilterPublisher.prepend(searchFilter)) // Use configured filter as initial value
             .sink { [weak self] (searchTerm, searchFilter) in
                 guard let self else { return }
                 self.updatePredicate(searchTerm: searchTerm)

--- a/WooCommerce/Classes/ViewRelated/Customers/CustomersListViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Customers/CustomersListViewModel.swift
@@ -141,6 +141,7 @@ extension CustomersListViewModel: PaginationTrackerDelegate {
                 guard let self else { return }
                 self.updatePredicate(searchTerm: searchTerm)
                 self.updateResults()
+                self.searchFilter = searchFilter // Ensure latest filter is used in remote search
                 self.paginationTracker.resync()
             }.store(in: &subscriptions)
     }

--- a/WooCommerce/Classes/ViewRelated/Customers/CustomersListViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Customers/CustomersListViewModel.swift
@@ -23,6 +23,11 @@ final class CustomersListViewModel: ObservableObject {
     /// Available filters for the customer search.
     let searchFilters: [CustomerSearchFilter] = [.name, .username, .email]
 
+    /// Whether the search header should be displayed.
+    var showSearchHeader: Bool {
+        customers.isNotEmpty || searchTerm.isNotEmpty
+    }
+
     // MARK: Sync
 
     /// Current sync status; used to determine the view state.

--- a/Yosemite/Yosemite/Actions/CustomerAction.swift
+++ b/Yosemite/Yosemite/Actions/CustomerAction.swift
@@ -73,14 +73,14 @@ public enum CustomerAction: Action {
     ///     - pageSize: The size of the page you want to load.
     ///     - keyword: Keyword to perform the search.
     ///     - filter: Filter to perform the search.
-    ///     - onCompletion: Invoked when the operation finishes.
+    ///     - onCompletion: Invoked when the operation finishes. Returns true if there are more customers to be synced in the search results.
     ///
     case searchWCAnalyticsCustomers(siteID: Int64,
                                     pageNumber: Int,
                                     pageSize: Int,
                                     keyword: String,
                                     filter: CustomerSearchFilter,
-                                    onCompletion: (Result<(), Error>) -> Void)
+                                    onCompletion: (Result<Bool, Error>) -> Void)
 
     /// Retrieves a single Customer from a site
     ///

--- a/Yosemite/Yosemite/Stores/CustomerStore.swift
+++ b/Yosemite/Yosemite/Stores/CustomerStore.swift
@@ -149,7 +149,7 @@ public final class CustomerStore: Store {
                                     pageSize: Int,
                                     keyword: String,
                                     filter: CustomerSearchFilter,
-                                    onCompletion: @escaping (Result<(), Error>) -> Void) {
+                                    onCompletion: @escaping (Result<Bool, Error>) -> Void) {
         wcAnalyticsCustomerRemote.searchCustomers(for: siteID,
                                                   pageNumber: pageNumber,
                                                   pageSize: pageSize,
@@ -162,10 +162,10 @@ public final class CustomerStore: Store {
             case let .success(customers):
                 self.upsertWCAnalyticsCustomersAndSave(siteID: siteID,
                                                        readOnlyCustomers: customers,
-                                                       shouldDeleteExistingCustomers: pageNumber == 1,
                                                        keyword: keyword,
                                                        in: self.sharedDerivedStorage) {
-                    onCompletion(.success(()))
+                    let hasNextPage = customers.count == pageSize
+                    onCompletion(.success(hasNextPage))
                 }
             case .failure(let error):
                 onCompletion(.failure(error))

--- a/Yosemite/Yosemite/Stores/CustomerStore.swift
+++ b/Yosemite/Yosemite/Stores/CustomerStore.swift
@@ -162,6 +162,7 @@ public final class CustomerStore: Store {
             case let .success(customers):
                 self.upsertWCAnalyticsCustomersAndSave(siteID: siteID,
                                                        readOnlyCustomers: customers,
+                                                       shouldDeleteExistingCustomers: filter != .all,
                                                        keyword: keyword,
                                                        in: self.sharedDerivedStorage) {
                     let hasNextPage = customers.count == pageSize

--- a/Yosemite/YosemiteTests/Stores/CustomerStoreTests.swift
+++ b/Yosemite/YosemiteTests/Stores/CustomerStoreTests.swift
@@ -320,14 +320,14 @@ final class CustomerStoreTests: XCTestCase {
         XCTAssertEqual(result.failure as? NetworkError, expectedError)
     }
 
-    func test_searchWCAnalyticsCustomers_upserts_the_returned_WCAnalyticsCustomerSearchResult() {
+    func test_searchWCAnalyticsCustomers_upserts_the_returned_WCAnalyticsCustomerSearchResult() throws {
         // Given
         network.simulateResponse(requestUrlSuffix: "customers", filename: "wc-analytics-customers")
 
         XCTAssertEqual(viewStorage.countObjects(ofType: Storage.WCAnalyticsCustomerSearchResult.self), 0)
 
         // When
-        let result: Result<(), Error> = waitFor { promise in
+        let result: Result<Bool, Error> = waitFor { promise in
             let action = CustomerAction.searchWCAnalyticsCustomers(siteID: self.dummySiteID,
                                                                    pageNumber: 1,
                                                                    pageSize: 25,
@@ -339,7 +339,9 @@ final class CustomerStoreTests: XCTestCase {
         }
 
         // Then
+        let hasMoreCustomers = try XCTUnwrap(result.get())
         XCTAssertTrue(result.isSuccess)
+        XCTAssertFalse(hasMoreCustomers)
         XCTAssertEqual(viewStorage.countObjects(ofType: Storage.WCAnalyticsCustomer.self), 4)
         XCTAssertEqual(viewStorage.countObjects(ofType: Storage.WCAnalyticsCustomerSearchResult.self), 1)
 
@@ -357,7 +359,7 @@ final class CustomerStoreTests: XCTestCase {
         network.simulateError(requestUrlSuffix: "", error: expectedError)
 
         // When
-        let result: Result<(), Error> = waitFor { promise in
+        let result: Result<Bool, Error> = waitFor { promise in
             let action = CustomerAction.searchWCAnalyticsCustomers(siteID: self.dummySiteID,
                                                                    pageNumber: 1,
                                                                    pageSize: 25,


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #12342
<!-- Id number of the GitHub issue this PR addresses. -->

## Why
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This adds a search header to the Customers list in the hub menu. It also adds a new empty state view when there are no search results (different from the empty state when there are no customers on the store).

If the store's version of WooCommerce supports it, the search will search all available fields. Otherwise, the search shows a picker to select which field to search (name, username, or email).

## How

* `CustomersListView`:
   * A `SearchHeader` is added to the view. It is rendered except when the store has no customers.
   * A `Picker` is added to the view below the search header. It is rendered when the store is not eligible for advanced search (<WC 8.0.0-beta.1) and a search is being performed.
   * The `.empty` sync state is updated to show different empty states depending on whether a search is being performed.
* `CustomersListViewModel`:
   * The view model now has published properties for the entered search term, selected search filter, and whether advanced search should be shown. It defaults to an empty search term, not showing advanced search, and the "name" search filter.
   * When the view model is initialized, the search header is configured. This makes a remote request to check if the store is eligible for advanced search; if it is, the relevant properties are updated.
   * When a search term is set or the search filter is changed, the results controller predicate is updated (so the list only shows matching search results) and a new search is performed remotely.
* Yosemite: `CustomerAction`/`CustomerStore`:
   * The `Result` from the search action is updated to return whether there are more customers to be synced in the search results. That way the infinite scroll will work as expected for searches with many results.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

On a store with WooCommerce 8.0.0 or greater:

1. Build and run the app.
2. Go to the hub menu.
3. Select the Customers item.
4. Confirm a search header appears above the customer list.
5. Enter a search term and confirm you get the expected results. (Searching should return any customers with the search term in their name, email, or username.)
6. Clear the search field and confirm the full customer list appears.

On a store with WooCommerce <8.0.0:

1. Build and run the app.
2. Go to the hub menu.
3. Select the Customers item.
4. Confirm a search header appears above the customer list.
5. Tap into the search header and confirm a search filter appears, with the options "Name," "Email," and "Username."
6. Enter a search term and confirm you get the expected results (Searching should return any customers with the search term in the selected filter field.)
7. Change the search filter and confirm the results update as expected.
8. Clear the search field and confirm the full customer list appears.

Additional tests:

1. On a store with no customers, confirm an empty state appears with the message "No customers yet" and the search header is not shown.
2. Perform a search with no results and confirm an empty state appears with the message "No customers found" and the search header is still shown with the entered search term.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

### Advanced search


https://github.com/woocommerce/woocommerce-ios/assets/8658164/7d18654e-c58e-4397-a41a-559277de23c0



### Search with filters

https://github.com/woocommerce/woocommerce-ios/assets/8658164/56eac2b3-bcab-440e-ac03-f55296bb8467



### Empty states

No customers|No search results
-|-
![Simulator Screenshot - iPhone 15 Pro - 2024-03-21 at 18 06 16](https://github.com/woocommerce/woocommerce-ios/assets/8658164/36393f4b-db89-41d2-b672-6c02e60ab042)|![Simulator Screenshot - iPhone 15 Pro - 2024-03-21 at 18 06 55](https://github.com/woocommerce/woocommerce-ios/assets/8658164/34b6e70e-bdeb-4abc-ae93-0e4ee434b93e)

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
