### PR TITLE
[Hub Menu] Customers: Add tracks events

### DIFF
--- a/WooCommerce/Classes/Analytics/WooAnalyticsEvent.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsEvent.swift
@@ -3074,3 +3074,43 @@ extension WooAnalyticsEvent {
         }
     }
 }
+
+// MARK: - Customers in Hub Menu
+
+extension WooAnalyticsEvent {
+    enum CustomersHub {
+        private enum Keys {
+            static let searchFilter = "filter"
+            static let registered = "registered"
+            static let hasEmail = "has_email_address"
+        }
+        static func customerListLoaded() -> WooAnalyticsEvent {
+            WooAnalyticsEvent(statName: .customerHubLoaded, properties: [:])
+        }
+
+        static func customerListLoadFailed(withError error: Error) -> WooAnalyticsEvent {
+            WooAnalyticsEvent(statName: .customerHubLoadFailed, properties: [:], error: error)
+        }
+
+        static func customerListSearched(withFilter filter: CustomerSearchFilter) -> WooAnalyticsEvent {
+            WooAnalyticsEvent(statName: .customersHubSearch, properties: [Keys.searchFilter: filter.rawValue])
+        }
+
+        static func customerDetailOpened(registered: Bool, hasEmail: Bool) -> WooAnalyticsEvent {
+            WooAnalyticsEvent(statName: .customersHubDetailOpen, properties: [Keys.registered: registered,
+                                                                              Keys.hasEmail: hasEmail])
+        }
+
+        static func customerDetailEmailMenuTapped() -> WooAnalyticsEvent {
+            WooAnalyticsEvent(statName: .customersHubDetailEmailMenuTapped, properties: [:])
+        }
+
+        static func customerDetailEmailOptionTapped() -> WooAnalyticsEvent {
+            WooAnalyticsEvent(statName: .customersHubDetailEmailOptionTapped, properties: [:])
+        }
+
+        static func customerDetailCopyEmailOptionTapped() -> WooAnalyticsEvent {
+            WooAnalyticsEvent(statName: .customersHubDetailCopyEmailOptionTapped, properties: [:])
+        }
+    }
+}

--- a/WooCommerce/Classes/Analytics/WooAnalyticsStat.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsStat.swift
@@ -1056,6 +1056,15 @@ public enum WooAnalyticsStat: String {
     case inboxNotesLoadedFailed = "inbox_notes_load_failed"
     case inboxNoteAction = "inbox_note_action"
 
+    // MARK: Customers
+    case customerHubLoaded = "customers_hub_loaded"
+    case customerHubLoadFailed = "customers_hub_load_failed"
+    case customersHubSearch = "customers_hub_customer_search"
+    case customersHubDetailOpen = "customers_hub_customer_detail_open"
+    case customersHubDetailEmailMenuTapped = "customers_hub_customer_detail_email_menu_tapped"
+    case customersHubDetailEmailOptionTapped = "customers_hub_customer_detail_email_option_tapped"
+    case customersHubDetailCopyEmailOptionTapped = "customers_hub_customer_detail_email_copy_option_tapped"
+
     // MARK: Close Account
     case closeAccountTapped = "close_account_tapped"
     case closeAccountSuccess = "close_account_success"

--- a/WooCommerce/Classes/ViewRelated/Customers/CustomerDetailView.swift
+++ b/WooCommerce/Classes/ViewRelated/Customers/CustomerDetailView.swift
@@ -16,6 +16,7 @@ struct CustomerDetailView: View {
                     Spacer()
                     Button {
                         isPresentingEmailDialog.toggle()
+                        viewModel.trackEmailMenuTapped()
                     } label: {
                         Image(uiImage: .mailImage)
                             .foregroundColor(Color(.primary))
@@ -25,6 +26,7 @@ struct CustomerDetailView: View {
                     .confirmationDialog(Localization.emailAction, isPresented: $isPresentingEmailDialog) {
                         Button(Localization.sendEmail) {
                             isShowingEmailView.toggle()
+                            viewModel.trackEmailOptionTapped()
                         }
                         .renderedIf(EmailView.canSendEmail())
 

--- a/WooCommerce/Classes/ViewRelated/Customers/CustomerDetailViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Customers/CustomerDetailViewModel.swift
@@ -91,6 +91,17 @@ final class CustomerDetailViewModel {
     /// Copies the customer email to the pasteboard.
     func copyEmail() {
         email?.sendToPasteboard(includeTrailingNewline: false)
+        ServiceLocator.analytics.track(event: .CustomersHub.customerDetailCopyEmailOptionTapped())
+    }
+
+    /// Tracks when the email menu is opened.
+    func trackEmailMenuTapped() {
+        ServiceLocator.analytics.track(event: .CustomersHub.customerDetailEmailMenuTapped())
+    }
+
+    /// Tracks when the option to send an email is tapped.
+    func trackEmailOptionTapped() {
+        ServiceLocator.analytics.track(event: .CustomersHub.customerDetailEmailOptionTapped())
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Customers/CustomersListView.swift
+++ b/WooCommerce/Classes/ViewRelated/Customers/CustomersListView.swift
@@ -43,6 +43,9 @@ struct CustomersListView: View {
 
                             Divider().padding(.leading)
                         }
+                        .simultaneousGesture(TapGesture().onEnded { _ in
+                            viewModel.trackCustomerSelected(customer)
+                        })
                     }
                 }
             case .syncingFirstPage:

--- a/WooCommerce/Classes/ViewRelated/Customers/CustomersListViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Customers/CustomersListViewModel.swift
@@ -117,6 +117,12 @@ final class CustomersListViewModel: ObservableObject {
             completion()
         }
     }
+
+    /// Called when a customer is selected.
+    func trackCustomerSelected(_ customer: WCAnalyticsCustomer) {
+        ServiceLocator.analytics.track(event: .CustomersHub.customerDetailOpened(registered: customer.userID != 0,
+                                                                                 hasEmail: customer.email?.isNotEmpty == true))
+    }
 }
 
 // MARK: - Remote Sync
@@ -166,9 +172,11 @@ extension CustomersListViewModel: PaginationTrackerDelegate {
             guard let self else { return }
             switch result {
             case let .success(hasNextPage):
+                ServiceLocator.analytics.track(event: .CustomersHub.customerListLoaded())
                 onCompletion?(.success(hasNextPage))
             case let .failure(error):
                 DDLogError("⛔️ Error synchronizing customers: \(error)")
+                ServiceLocator.analytics.track(event: .CustomersHub.customerListLoadFailed(withError: error))
                 onCompletion?(.failure(error))
             }
             self.updateResults()
@@ -178,6 +186,7 @@ extension CustomersListViewModel: PaginationTrackerDelegate {
 
     /// Searches all customers from remote.
     private func searchCustomers(keyword: String, pageNumber: Int, pageSize: Int, onCompletion: SyncCompletion?) {
+        ServiceLocator.analytics.track(event: .CustomersHub.customerListSearched(withFilter: searchFilter))
         let action = CustomerAction.searchWCAnalyticsCustomers(siteID: siteID,
                                                                pageNumber: pageNumber,
                                                                pageSize: pageSize,


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #12346
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

This adds tracks events for the new Customers section in the hub menu:

* When the customer list is loaded: `customers_hub_loaded` (https://github.com/Automattic/tracks-events-registration/pull/2321)
* If the customer list fails to load: `customers_hub_load_failed` (https://github.com/Automattic/tracks-events-registration/pull/2327)
* When the customer list is searched: `customers_hub_customer_search` (https://github.com/Automattic/tracks-events-registration/pull/2323)
   * Custom prop: `filter` with the selected search filter
* When a customer is tapped to open customer details: `customers_hub_customer_detail_open` (https://github.com/Automattic/tracks-events-registration/pull/2322)
   * Custom prop: `registered` with whether the selected customer is registered (bool)
   * Custom prop: `has_email` with whether the selected customer has an email address (bool)
* When a customer is contacted via customer details:
   * Email menu opened: `customers_hub_customer_detail_email_menu_tapped` (https://github.com/Automattic/tracks-events-registration/pull/2324)
   * Send email tapped: `customers_hub_customer_detail_email_option_tapped` (https://github.com/Automattic/tracks-events-registration/pull/2326)
   * Copy email tapped: `customers_hub_customer_detail_email_copy_option_tapped` (https://github.com/Automattic/tracks-events-registration/pull/2325)


## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

1. Build and run the app.
2. Open the hub menu.
3. Select Customers and confirm the event `hub_menu_option_tapped` is tracked with the prop `option` set to `customers`.
4. When the customer list loads, confirm `customers_hub_loaded` is tracked.
5. Disable your network connection, pull to refresh the list, and confirm `customers_hub_load_failed` is tracked with the error.
6. Search the customer list and confirm `customers_hub_customer_search` is tracked with the prop `filter` set to the selected filter (`all` if there are no filter options in the UI).
7. Select a customer in the list and confirm `customers_hub_customer_detail_open` with the props `registered` and `has_email` reflecting the customer's info.
8. Select a customer with an email address and tap the email icon. Confirm `customers_hub_customer_detail_email_menu_tapped` is tracked.
9. Select the "Email" option and confirm `customers_hub_customer_detail_email_option_tapped` is tracked.
10. Select the copy option and confirm `customers_hub_customer_detail_email_copy_option_tapped` is tracked.


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
