### PR TITLE
[Hub Menu] Release Customers in hub menu

### DIFF
--- a/Experiments/Experiments/DefaultFeatureFlagService.swift
+++ b/Experiments/Experiments/DefaultFeatureFlagService.swift
@@ -88,7 +88,7 @@ public struct DefaultFeatureFlagService: FeatureFlagService {
         case .splitViewInProductsTab:
             return true
         case .customersInHubMenu:
-            return buildConfig == .localDeveloper || buildConfig == .alpha
+            return true
         default:
             return true
         }

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -2,7 +2,7 @@
 
 18.0
 -----
-
+- [**] Hub Menu: A new Customers section shows a searchable list of customers with their details, including the option to contact a customer via email. [https://github.com/woocommerce/woocommerce-ios/pull/12349]
 
 17.9
 -----


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #12294
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This release the Customers section in the Hub Menu:

* Shows a list of the store's customers (equivalent to WooCommerce > Customers in wp-admin).
* The list shows each customer's name, username (if registered), and email address (if available).
* The list is searchable. On WooCommerce 8.0.0+, it searches the customer's name, username, and email. On previous version, a search filter appears so one of those fields can be selected for the search.
* Selecting a customer opens a detail view showing the same fields as Customers in wp-admin (contact details, analytics about their orders on the store, registration details).
* If the customer has an email address, the merchant can copy it or send them an email (if the device supports sending email).

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

1. Build and run the app.
2. Open the Hub menu.
3. Select Customers.
4. View the list of customers, scrolling to load more or pulling to refresh the list.
5. Perform a search to find a specific customer.
6. Select a customer to view their details.
7. When viewing the details of a customer with a provided email address, tap the email icon to copy it or send them an email.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->


https://github.com/woocommerce/woocommerce-ios/assets/8658164/69cc1eff-3631-4a20-b025-1aa34a62aa0e


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
