### PR TITLE
Align "Delete" Button Wording Across iOS and Android Platforms for Products

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewController.swift
@@ -352,7 +352,7 @@ final class ProductFormViewController<ViewModel: ProductFormViewModelProtocol>: 
         }
 
         if viewModel.canDeleteProduct() {
-            actionSheet.addDestructiveActionWithTitle(ActionSheetStrings.delete) { [weak self] _ in
+            actionSheet.addDestructiveActionWithTitle(ActionSheetStrings.trashProduct) { [weak self] _ in
                 self?.displayDeleteProductAlert()
             }
         }
@@ -2027,7 +2027,9 @@ private enum ActionSheetStrings {
                                                comment: "Button title View product in store in Edit Product More Options Action Sheet")
     static let share = NSLocalizedString("Share", comment: "Button title Share in Edit Product More Options Action Sheet")
     static let promoteWithBlaze = NSLocalizedString("Promote with Blaze", comment: "Button title Promote with Blaze in Edit Product More Options Action Sheet")
-    static let delete = NSLocalizedString("Delete", comment: "Button title Delete in Edit Product More Options Action Sheet")
+    static let trashProduct = NSLocalizedString("productForm.bottomSheet.trashAction",
+                                                value: "Trash product",
+                                                comment: "Button title Trash product in Edit Product More Options Action Sheet")
     static let productSettings = NSLocalizedString("Product Settings", comment: "Button title Product Settings in Edit Product More Options Action Sheet")
     static let cancel = NSLocalizedString("Cancel", comment: "Button title Cancel in Edit Product More Options Action Sheet")
     static let duplicate = NSLocalizedString("Duplicate", comment: "Button title to duplicate a product in Product More Options Action Sheet")


### PR DESCRIPTION
Closes: #12271

## Description
This small PR addresses issue #12271, which highlights an inconsistency in the wording for the action related to deleting or trashing a product in the apps across different platforms. The goal is to unify the user experience and avoid confusion by aligning the terminology used for deletion actions.

## Testing instructions
- Verify that the button on iOS for putting in the trash a product now reads “Move to Trash”.

## Screenshot
<img src="https://github.com/woocommerce/woocommerce-ios/assets/495617/36ce4448-f0a0-4edb-8ce6-4d78ddb6e1b3" width=300 />


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
