### PR TITLE
Update the search keyboard to use a "Done" button

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Coupons/CouponSearchUICommand.swift
+++ b/WooCommerce/Classes/ViewRelated/Coupons/CouponSearchUICommand.swift
@@ -11,6 +11,8 @@ final class CouponSearchUICommand: SearchUICommand {
 
     let searchBarPlaceholder = Localization.searchBarPlaceholder
 
+    let returnKeyType = UIReturnKeyType.done
+
     let searchBarAccessibilityIdentifier = "coupon-search-screen-search-field"
 
     let cancelButtonAccessibilityIdentifier = "coupon-search-screen-cancel-button"

--- a/WooCommerce/Classes/ViewRelated/Customers/CustomersListView.swift
+++ b/WooCommerce/Classes/ViewRelated/Customers/CustomersListView.swift
@@ -11,6 +11,7 @@ struct CustomersListView: View {
                 SearchHeader(text: $viewModel.searchTerm, placeholder: Localization.searchPlaceholder) { isEditing in
                     isEditingSearchTerm = isEditing
                 }
+                .submitLabel(.done)
                 Picker(selection: $viewModel.searchFilter, label: EmptyView()) {
                     ForEach(viewModel.searchFilters, id: \.self) { option in Text(option.title) }
                 }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/CustomerSection/CustomerSearchUICommand.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/CustomerSection/CustomerSearchUICommand.swift
@@ -18,6 +18,8 @@ final class CustomerSearchUICommand: SearchUICommand {
         return showSearchFilters ? Localization.customerFiltersSearchBarPlaceHolder : Localization.customerSelectorSearchBarPlaceHolder
     }
 
+    let returnKeyType = UIReturnKeyType.done
+
     var searchBarAccessibilityIdentifier: String = "customer-search-screen-search-field"
 
     var cancelButtonAccessibilityIdentifier: String = "customer-search-screen-cancel-button"

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Linked Products List Selector/ProductListSelector/ProductListMultiSelectorSearchUICommand.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Linked Products List Selector/ProductListSelector/ProductListMultiSelectorSearchUICommand.swift
@@ -8,6 +8,8 @@ final class ProductListMultiSelectorSearchUICommand: NSObject, SearchUICommand {
 
     let searchBarPlaceholder = NSLocalizedString("Search all products", comment: "Products Search Placeholder")
 
+    let returnKeyType = UIReturnKeyType.done
+
     let searchBarAccessibilityIdentifier = "product-search-screen-search-field"
 
     let cancelButtonAccessibilityIdentifier = "product-search-screen-cancel-button"

--- a/WooCommerce/Classes/ViewRelated/Products/ProductSelector/ProductSelectorView.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductSelector/ProductSelectorView.swift
@@ -377,6 +377,7 @@ private extension ProductSelectorView {
                 SearchHeader(text: $viewModel.searchTerm, placeholder: Localization.searchPlaceholder, onEditingChanged: { isEditing in
                     searchHeaderisBeingEdited = isEditing
                 })
+                .submitLabel(.done)
                 .accessibilityIdentifier("product-selector-search-bar")
                 Picker(selection: $viewModel.productSearchFilter, label: EmptyView()) {
                     ForEach(ProductSearchFilter.allCases, id: \.self) { option in Text(option.title) }

--- a/WooCommerce/Classes/ViewRelated/Search/Order/OrderSearchUICommand.swift
+++ b/WooCommerce/Classes/ViewRelated/Search/Order/OrderSearchUICommand.swift
@@ -10,6 +10,8 @@ final class OrderSearchUICommand: SearchUICommand {
 
     let searchBarPlaceholder = NSLocalizedString("Search all orders", comment: "Orders Search Placeholder")
 
+    let returnKeyType = UIReturnKeyType.done
+
     let searchBarAccessibilityIdentifier = "order-search-screen-search-field"
 
     let cancelButtonAccessibilityIdentifier = "order-search-screen-cancel-button"

--- a/WooCommerce/Classes/ViewRelated/Search/Product/ProductSearchUICommand.swift
+++ b/WooCommerce/Classes/ViewRelated/Search/Product/ProductSearchUICommand.swift
@@ -8,6 +8,8 @@ final class ProductSearchUICommand: SearchUICommand {
 
     let searchBarPlaceholder = NSLocalizedString("Search products", comment: "Products Search Placeholder")
 
+    let returnKeyType = UIReturnKeyType.done
+
     let searchBarAccessibilityIdentifier = "product-search-screen-search-field"
 
     let cancelButtonAccessibilityIdentifier = "product-search-screen-cancel-button"

--- a/WooCommerce/Classes/ViewRelated/Search/SearchUICommand.swift
+++ b/WooCommerce/Classes/ViewRelated/Search/SearchUICommand.swift
@@ -10,6 +10,9 @@ protocol SearchUICommand {
     /// The placeholder of the search bar.
     var searchBarPlaceholder: String { get }
 
+    /// The visible title of the Return key.
+    var returnKeyType: UIReturnKeyType { get }
+
     /// Hides the cancel button on the search bar right. If it's hidden the search bar fills the hidden button space.
     ///
     var hideCancelButton: Bool { get }

--- a/WooCommerce/Classes/ViewRelated/Search/SearchViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Search/SearchViewController.swift
@@ -314,6 +314,7 @@ private extension SearchViewController {
         searchBar.placeholder = searchUICommand.searchBarPlaceholder
         searchBar.accessibilityIdentifier = searchUICommand.searchBarAccessibilityIdentifier
         searchBar.searchTextField.textColor = .text
+        searchBar.returnKeyType = searchUICommand.returnKeyType
     }
 
     /// Setup: Search Bar Borders


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #12326
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

- Using `.submitLabel(.done)` for products selection search and customers list
- Added `returnKeyType` parameter to `SearchUICommand` protocol

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

- Run app on iPhone or iPhone simulator
- Open "Orders" tab
- Tap "+" to start creating new order
- Tap "Add Products"
- Tap on the search bar
- Keyboard return key should say "Done" (in your language)

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

| Before      | After |
| ----------- | ----------- |
| ![Simulator Screenshot - iPhone 15 Pro - 2024-03-25 at 12 51 07](https://github.com/woocommerce/woocommerce-ios/assets/6242034/0b028f02-c362-4a27-b91b-45de316676a5)      | ![Simulator Screenshot - iPhone 15 Pro - 2024-03-25 at 12 54 00](https://github.com/woocommerce/woocommerce-ios/assets/6242034/c4f95ee1-3ddf-4f33-a31b-f21a12857dfe)       |

---
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
