### PR TITLE
[Analytics Hub] Product Bundles: Add models for product bundle stats

### DIFF
--- a/Fakes/Fakes/Networking.generated.swift
+++ b/Fakes/Fakes/Networking.generated.swift
@@ -1244,6 +1244,43 @@ extension Networking.ProductBundleItemStockStatus {
         .inStock
     }
 }
+extension Networking.ProductBundleStats {
+    /// Returns a "ready to use" type filled with fake values.
+    ///
+    public static func fake() -> Networking.ProductBundleStats {
+        .init(
+            siteID: .fake(),
+            granularity: .fake(),
+            totals: .fake(),
+            intervals: .fake()
+        )
+    }
+}
+extension Networking.ProductBundleStatsInterval {
+    /// Returns a "ready to use" type filled with fake values.
+    ///
+    public static func fake() -> Networking.ProductBundleStatsInterval {
+        .init(
+            interval: .fake(),
+            dateStart: .fake(),
+            dateEnd: .fake(),
+            subtotals: .fake()
+        )
+    }
+}
+extension Networking.ProductBundleStatsTotals {
+    /// Returns a "ready to use" type filled with fake values.
+    ///
+    public static func fake() -> Networking.ProductBundleStatsTotals {
+        .init(
+            totalItemsSold: .fake(),
+            totalBundledItemsSold: .fake(),
+            netRevenue: .fake(),
+            totalOrders: .fake(),
+            totalProducts: .fake()
+        )
+    }
+}
 extension Networking.ProductCatalogVisibility {
     /// Returns a "ready to use" type filled with fake values.
     ///

--- a/Networking/Networking.xcodeproj/project.pbxproj
+++ b/Networking/Networking.xcodeproj/project.pbxproj
@@ -713,6 +713,9 @@
 		CE865AA52A4209A70049B03C /* EntityDateModifiedMapperTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE865AA42A4209A70049B03C /* EntityDateModifiedMapperTests.swift */; };
 		CEB9BF312BB190590007978A /* product-bundle-stats.json in Resources */ = {isa = PBXBuildFile; fileRef = CEB9BF302BB190590007978A /* product-bundle-stats.json */; };
 		CEB9BF352BB190960007978A /* product-bundle-stats-without-data.json in Resources */ = {isa = PBXBuildFile; fileRef = CEB9BF342BB190960007978A /* product-bundle-stats-without-data.json */; };
+		CEB9BF3D2BB1949F0007978A /* ProductBundleStatsInterval.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEB9BF3C2BB1949F0007978A /* ProductBundleStatsInterval.swift */; };
+		CEB9BF3F2BB196130007978A /* ProductBundleStats.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEB9BF3E2BB196130007978A /* ProductBundleStats.swift */; };
+		CEB9BF392BB193020007978A /* ProductBundleStatsTotals.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEB9BF382BB193020007978A /* ProductBundleStatsTotals.swift */; };
 		CEC4BF8F234E382F008D9195 /* RefundMapperTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEC4BF8E234E382F008D9195 /* RefundMapperTests.swift */; };
 		CEC4BF91234E40B5008D9195 /* refund-single.json in Resources */ = {isa = PBXBuildFile; fileRef = CEC4BF90234E40B5008D9195 /* refund-single.json */; };
 		CEC4BF93234E7EE0008D9195 /* refunds-all.json in Resources */ = {isa = PBXBuildFile; fileRef = CEC4BF92234E7EE0008D9195 /* refunds-all.json */; };
@@ -1788,6 +1791,9 @@
 		CE865AA42A4209A70049B03C /* EntityDateModifiedMapperTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EntityDateModifiedMapperTests.swift; sourceTree = "<group>"; };
 		CEB9BF302BB190590007978A /* product-bundle-stats.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "product-bundle-stats.json"; sourceTree = "<group>"; };
 		CEB9BF342BB190960007978A /* product-bundle-stats-without-data.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "product-bundle-stats-without-data.json"; sourceTree = "<group>"; };
+		CEB9BF3C2BB1949F0007978A /* ProductBundleStatsInterval.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductBundleStatsInterval.swift; sourceTree = "<group>"; };
+		CEB9BF3E2BB196130007978A /* ProductBundleStats.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductBundleStats.swift; sourceTree = "<group>"; };
+		CEB9BF382BB193020007978A /* ProductBundleStatsTotals.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductBundleStatsTotals.swift; sourceTree = "<group>"; };
 		CEC4BF8E234E382F008D9195 /* RefundMapperTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RefundMapperTests.swift; sourceTree = "<group>"; };
 		CEC4BF90234E40B5008D9195 /* refund-single.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "refund-single.json"; sourceTree = "<group>"; };
 		CEC4BF92234E7EE0008D9195 /* refunds-all.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "refunds-all.json"; sourceTree = "<group>"; };
@@ -2302,6 +2308,9 @@
 				D8FBFF1F22D52553006E3336 /* OrderStatsV4Totals.swift */,
 				D8FBFF2122D5266E006E3336 /* OrderStatsV4Interval.swift */,
 				CE71E22E2A4C38C900DB5376 /* ProductsReportItem.swift */,
+				CEB9BF3E2BB196130007978A /* ProductBundleStats.swift */,
+				CEB9BF3C2BB1949F0007978A /* ProductBundleStatsInterval.swift */,
+				CEB9BF382BB193020007978A /* ProductBundleStatsTotals.swift */,
 			);
 			path = Stats;
 			sourceTree = "<group>";
@@ -4385,6 +4394,7 @@
 				EE57C111297927C600BC31E7 /* ApplicationPasswordNameAndUUIDMapper.swift in Sources */,
 				D823D91222377DF300C90817 /* ShipmentTrackingProviderListMapper.swift in Sources */,
 				EE2C09BC29AF0AAD009396F9 /* StoreOnboardingTasksRemote.swift in Sources */,
+				CEB9BF3F2BB196130007978A /* ProductBundleStats.swift in Sources */,
 				B5C151BB217EC34100C7BDC1 /* KeyedDecodingContainer+Woo.swift in Sources */,
 				933A2732222234F800C2143A /* Logging.swift in Sources */,
 				CE50346021B5799F007573C6 /* SitePlan.swift in Sources */,
@@ -4400,6 +4410,7 @@
 				B556FD69211CE2EC00B5DAE7 /* NetworkError.swift in Sources */,
 				EE078D912AD2EFBA00C1199E /* JWTokenMapper.swift in Sources */,
 				024124862AC93E470035A247 /* OrderItemBundleItem.swift in Sources */,
+				CEB9BF392BB193020007978A /* ProductBundleStatsTotals.swift in Sources */,
 				CE71E22B2A4C363E00DB5376 /* ProductsReportsRemote.swift in Sources */,
 				45B204B82489095100FE6526 /* ProductCategoryMapper.swift in Sources */,
 				B557DA0D20975DB1005962F4 /* WordPressAPIVersion.swift in Sources */,
@@ -4546,6 +4557,7 @@
 				03EB99882906A78400F06A39 /* JustInTimeMessagesRemote.swift in Sources */,
 				74A1D26B21189B8100931DFA /* SiteVisitStatsItem.swift in Sources */,
 				DE34051728BDEB6D00CF0D97 /* JetpackConnectionRemote.swift in Sources */,
+				CEB9BF3D2BB1949F0007978A /* ProductBundleStatsInterval.swift in Sources */,
 				B505F6EC20BEFDC200BB1B69 /* Loader.swift in Sources */,
 				74D3BD142114FE6900A6E85E /* MIContainer.swift in Sources */,
 				E1BAB2C72913FB5800C3982B /* WordPressApiError.swift in Sources */,

--- a/Networking/Networking.xcodeproj/project.pbxproj
+++ b/Networking/Networking.xcodeproj/project.pbxproj
@@ -711,6 +711,8 @@
 		CE865A9F2A41E42F0049B03C /* date-modified-gmt.json in Resources */ = {isa = PBXBuildFile; fileRef = CE865A9E2A41E42F0049B03C /* date-modified-gmt.json */; };
 		CE865AA32A4207A50049B03C /* date-modified-gmt-without-data.json in Resources */ = {isa = PBXBuildFile; fileRef = CE865AA22A4207A50049B03C /* date-modified-gmt-without-data.json */; };
 		CE865AA52A4209A70049B03C /* EntityDateModifiedMapperTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE865AA42A4209A70049B03C /* EntityDateModifiedMapperTests.swift */; };
+		CEB9BF312BB190590007978A /* product-bundle-stats.json in Resources */ = {isa = PBXBuildFile; fileRef = CEB9BF302BB190590007978A /* product-bundle-stats.json */; };
+		CEB9BF352BB190960007978A /* product-bundle-stats-without-data.json in Resources */ = {isa = PBXBuildFile; fileRef = CEB9BF342BB190960007978A /* product-bundle-stats-without-data.json */; };
 		CEC4BF8F234E382F008D9195 /* RefundMapperTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEC4BF8E234E382F008D9195 /* RefundMapperTests.swift */; };
 		CEC4BF91234E40B5008D9195 /* refund-single.json in Resources */ = {isa = PBXBuildFile; fileRef = CEC4BF90234E40B5008D9195 /* refund-single.json */; };
 		CEC4BF93234E7EE0008D9195 /* refunds-all.json in Resources */ = {isa = PBXBuildFile; fileRef = CEC4BF92234E7EE0008D9195 /* refunds-all.json */; };
@@ -1784,6 +1786,8 @@
 		CE865A9E2A41E42F0049B03C /* date-modified-gmt.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "date-modified-gmt.json"; sourceTree = "<group>"; };
 		CE865AA22A4207A50049B03C /* date-modified-gmt-without-data.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "date-modified-gmt-without-data.json"; sourceTree = "<group>"; };
 		CE865AA42A4209A70049B03C /* EntityDateModifiedMapperTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EntityDateModifiedMapperTests.swift; sourceTree = "<group>"; };
+		CEB9BF302BB190590007978A /* product-bundle-stats.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "product-bundle-stats.json"; sourceTree = "<group>"; };
+		CEB9BF342BB190960007978A /* product-bundle-stats-without-data.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "product-bundle-stats-without-data.json"; sourceTree = "<group>"; };
 		CEC4BF8E234E382F008D9195 /* RefundMapperTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RefundMapperTests.swift; sourceTree = "<group>"; };
 		CEC4BF90234E40B5008D9195 /* refund-single.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "refund-single.json"; sourceTree = "<group>"; };
 		CEC4BF92234E7EE0008D9195 /* refunds-all.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "refunds-all.json"; sourceTree = "<group>"; };
@@ -3114,6 +3118,8 @@
 				20D210C22B1780CE0099E517 /* deposits-overview-all.json */,
 				20D210C42B1788E60099E517 /* deposits-overview-all-no-default-currency.json */,
 				68BFF9052B6785C700B15FF2 /* receipt-without-data-envelope.json */,
+				CEB9BF302BB190590007978A /* product-bundle-stats.json */,
+				CEB9BF342BB190960007978A /* product-bundle-stats-without-data.json */,
 			);
 			path = Responses;
 			sourceTree = "<group>";
@@ -4044,6 +4050,7 @@
 				DEC2B08D297AA048003923FB /* reviews-all-without-data.json in Resources */,
 				74A1D266211898F000931DFA /* site-visits-year.json in Resources */,
 				743BF8BE21191B63008A9D87 /* site-visits.json in Resources */,
+				CEB9BF352BB190960007978A /* product-bundle-stats-without-data.json in Resources */,
 				CE0A0F1F223998A10075ED8D /* products-load-all.json in Resources */,
 				EE57C1502980F0B700BC31E7 /* shipment_tracking_new-without-data.json in Resources */,
 				02935AEE29DFFA74001B793E /* site-enable-trial-success.json in Resources */,
@@ -4109,6 +4116,7 @@
 				261CF1B4255AD6B30090D8D3 /* payment-gateway-list.json in Resources */,
 				0359EA2527AAF7D60048DE2D /* wcpay-charge-card.json in Resources */,
 				028FA473257E110700F88A48 /* shipping-label-refund-error.json in Resources */,
+				CEB9BF312BB190590007978A /* product-bundle-stats.json in Resources */,
 				74ABA1C9213F19FE00FFAD30 /* top-performers-month.json in Resources */,
 				3158FE7026129D7500E566B9 /* wcpay-account-rejected-listed.json in Resources */,
 				743E84F622172D3E00FAC9D7 /* shipment_tracking_single.json in Resources */,

--- a/Networking/Networking/Model/Copiable/Models+Copiable.generated.swift
+++ b/Networking/Networking/Model/Copiable/Models+Copiable.generated.swift
@@ -2070,6 +2070,72 @@ extension Networking.ProductBundleItem {
     }
 }
 
+extension Networking.ProductBundleStats {
+    public func copy(
+        siteID: CopiableProp<Int64> = .copy,
+        granularity: CopiableProp<StatsGranularityV4> = .copy,
+        totals: CopiableProp<ProductBundleStatsTotals> = .copy,
+        intervals: CopiableProp<[ProductBundleStatsInterval]> = .copy
+    ) -> Networking.ProductBundleStats {
+        let siteID = siteID ?? self.siteID
+        let granularity = granularity ?? self.granularity
+        let totals = totals ?? self.totals
+        let intervals = intervals ?? self.intervals
+
+        return Networking.ProductBundleStats(
+            siteID: siteID,
+            granularity: granularity,
+            totals: totals,
+            intervals: intervals
+        )
+    }
+}
+
+extension Networking.ProductBundleStatsInterval {
+    public func copy(
+        interval: CopiableProp<String> = .copy,
+        dateStart: CopiableProp<String> = .copy,
+        dateEnd: CopiableProp<String> = .copy,
+        subtotals: CopiableProp<ProductBundleStatsTotals> = .copy
+    ) -> Networking.ProductBundleStatsInterval {
+        let interval = interval ?? self.interval
+        let dateStart = dateStart ?? self.dateStart
+        let dateEnd = dateEnd ?? self.dateEnd
+        let subtotals = subtotals ?? self.subtotals
+
+        return Networking.ProductBundleStatsInterval(
+            interval: interval,
+            dateStart: dateStart,
+            dateEnd: dateEnd,
+            subtotals: subtotals
+        )
+    }
+}
+
+extension Networking.ProductBundleStatsTotals {
+    public func copy(
+        totalItemsSold: CopiableProp<Int> = .copy,
+        totalBundledItemsSold: CopiableProp<Int> = .copy,
+        netRevenue: CopiableProp<Decimal> = .copy,
+        totalOrders: CopiableProp<Int> = .copy,
+        totalProducts: CopiableProp<Int> = .copy
+    ) -> Networking.ProductBundleStatsTotals {
+        let totalItemsSold = totalItemsSold ?? self.totalItemsSold
+        let totalBundledItemsSold = totalBundledItemsSold ?? self.totalBundledItemsSold
+        let netRevenue = netRevenue ?? self.netRevenue
+        let totalOrders = totalOrders ?? self.totalOrders
+        let totalProducts = totalProducts ?? self.totalProducts
+
+        return Networking.ProductBundleStatsTotals(
+            totalItemsSold: totalItemsSold,
+            totalBundledItemsSold: totalBundledItemsSold,
+            netRevenue: netRevenue,
+            totalOrders: totalOrders,
+            totalProducts: totalProducts
+        )
+    }
+}
+
 extension Networking.ProductCategory {
     public func copy(
         categoryID: CopiableProp<Int64> = .copy,

--- a/Networking/Networking/Model/Stats/ProductBundleStats.swift
+++ b/Networking/Networking/Model/Stats/ProductBundleStats.swift
@@ -1,0 +1,57 @@
+import Foundation
+import Codegen
+
+/// Represents product bundle stats over a specific period.
+public struct ProductBundleStats: Decodable, Equatable, GeneratedCopiable, GeneratedFakeable {
+    public let siteID: Int64
+    public let granularity: StatsGranularityV4
+    public let totals: ProductBundleStatsTotals
+    public let intervals: [ProductBundleStatsInterval]
+
+    public init(siteID: Int64,
+                granularity: StatsGranularityV4,
+                totals: ProductBundleStatsTotals,
+                intervals: [ProductBundleStatsInterval]) {
+        self.siteID = siteID
+        self.granularity = granularity
+        self.totals = totals
+        self.intervals = intervals
+    }
+
+    public init(from decoder: Decoder) throws {
+        guard let siteID = decoder.userInfo[.siteID] as? Int64 else {
+            throw ProductBundleStatsAPIError.missingSiteID
+        }
+
+        guard let granularity = decoder.userInfo[.granularity] as? StatsGranularityV4 else {
+            throw ProductBundleStatsAPIError.missingGranularity
+        }
+
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        let totals = try container.decode(ProductBundleStatsTotals.self, forKey: .totals)
+        let intervals = try container.decode([ProductBundleStatsInterval].self, forKey: .intervals)
+
+        self.init(siteID: siteID,
+                  granularity: granularity,
+                  totals: totals,
+                  intervals: intervals)
+    }
+}
+
+
+// MARK: - Constants!
+//
+private extension ProductBundleStats {
+
+    enum CodingKeys: String, CodingKey {
+        case totals = "totals"
+        case intervals = "intervals"
+    }
+}
+
+// MARK: - Decoding Errors
+//
+enum ProductBundleStatsAPIError: Error {
+    case missingSiteID
+    case missingGranularity
+}

--- a/Networking/Networking/Model/Stats/ProductBundleStatsInterval.swift
+++ b/Networking/Networking/Model/Stats/ProductBundleStatsInterval.swift
@@ -1,0 +1,46 @@
+import Codegen
+
+/// Represents product bundle stats for a specific period.
+public struct ProductBundleStatsInterval: Decodable, Equatable, GeneratedCopiable, GeneratedFakeable {
+    public let interval: String
+    /// Interval start date string in the site time zone.
+    public let dateStart: String
+    /// Interval end date string in the site time zone.
+    public let dateEnd: String
+    public let subtotals: ProductBundleStatsTotals
+
+    public init(interval: String,
+                dateStart: String,
+                dateEnd: String,
+                subtotals: ProductBundleStatsTotals) {
+        self.interval = interval
+        self.dateStart = dateStart
+        self.dateEnd = dateEnd
+        self.subtotals = subtotals
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        let interval = try container.decode(String.self, forKey: .interval)
+        let dateStart = try container.decode(String.self, forKey: .dateStart)
+        let dateEnd = try container.decode(String.self, forKey: .dateEnd)
+        let subtotals = try container.decode(ProductBundleStatsTotals.self, forKey: .subtotals)
+
+        self.init(interval: interval,
+                  dateStart: dateStart,
+                  dateEnd: dateEnd,
+                  subtotals: subtotals)
+    }
+}
+
+
+// MARK: - Constants!
+//
+private extension ProductBundleStatsInterval {
+    enum CodingKeys: String, CodingKey {
+        case interval = "interval"
+        case dateStart = "date_start"
+        case dateEnd = "date_end"
+        case subtotals = "subtotals"
+    }
+}

--- a/Networking/Networking/Model/Stats/ProductBundleStatsTotals.swift
+++ b/Networking/Networking/Model/Stats/ProductBundleStatsTotals.swift
@@ -1,0 +1,50 @@
+import Codegen
+
+/// Represents the data associated with product bundle stats over a specific period.
+public struct ProductBundleStatsTotals: Decodable, Equatable, GeneratedCopiable, GeneratedFakeable {
+    public let totalItemsSold: Int
+    public let totalBundledItemsSold: Int
+    public let netRevenue: Decimal
+    public let totalOrders: Int
+    public let totalProducts: Int
+
+    public init(totalItemsSold: Int,
+                totalBundledItemsSold: Int,
+                netRevenue: Decimal,
+                totalOrders: Int,
+                totalProducts: Int) {
+        self.totalItemsSold = totalItemsSold
+        self.totalBundledItemsSold = totalBundledItemsSold
+        self.netRevenue = netRevenue
+        self.totalOrders = totalOrders
+        self.totalProducts = totalProducts
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        let totalItemsSold = try container.decode(Int.self, forKey: .itemsSold)
+        let bundledItemsSold = try container.decode(Int.self, forKey: .bundledItemsSold)
+        let netRevenue = try container.decode(Decimal.self, forKey: .netRevenue)
+        let totalOrders = try container.decode(Int.self, forKey: .ordersCount)
+        let productsCount = try container.decode(Int.self, forKey: .productsCount)
+
+        self.init(totalItemsSold: totalItemsSold,
+                  totalBundledItemsSold: bundledItemsSold,
+                  netRevenue: netRevenue,
+                  totalOrders: totalOrders,
+                  totalProducts: productsCount)
+    }
+}
+
+
+// MARK: - Constants!
+//
+private extension ProductBundleStatsTotals {
+    enum CodingKeys: String, CodingKey {
+        case itemsSold = "items_sold"
+        case bundledItemsSold = "bundled_items_sold"
+        case netRevenue = "net_revenue"
+        case ordersCount = "orders_count"
+        case productsCount = "products_count"
+    }
+}

--- a/Networking/NetworkingTests/Responses/product-bundle-stats-without-data.json
+++ b/Networking/NetworkingTests/Responses/product-bundle-stats-without-data.json
@@ -1,0 +1,39 @@
+{
+    "totals": {
+        "items_sold": 5,
+        "bundled_items_sold": 3,
+        "net_revenue": 50,
+        "orders_count": 2,
+        "products_count": 4
+    },
+    "intervals": [
+        {
+            "interval": "2024-01-21",
+            "date_start": "2024-01-21 00:00:00",
+            "date_start_gmt": "2024-01-21 00:00:00",
+            "date_end": "2024-01-21 23:59:59",
+            "date_end_gmt": "2024-01-21 23:59:59",
+            "subtotals": {
+                "items_sold": 3,
+                "bundled_items_sold": 2,
+                "net_revenue": 35,
+                "orders_count": 1,
+                "products_count": 2
+            }
+        },
+        {
+            "interval": "2024-01-20",
+            "date_start": "2024-01-20 00:00:00",
+            "date_start_gmt": "2024-01-20 00:00:00",
+            "date_end": "2024-01-20 23:59:59",
+            "date_end_gmt": "2024-01-20 23:59:59",
+            "subtotals": {
+                "items_sold": 2,
+                "bundled_items_sold": 1,
+                "net_revenue": 15,
+                "orders_count": 1,
+                "products_count": 2
+            }
+        }
+    ]
+}

--- a/Networking/NetworkingTests/Responses/product-bundle-stats.json
+++ b/Networking/NetworkingTests/Responses/product-bundle-stats.json
@@ -1,0 +1,41 @@
+{
+    "data": {
+        "totals": {
+            "items_sold": 5,
+            "bundled_items_sold": 3,
+            "net_revenue": 50,
+            "orders_count": 2,
+            "products_count": 4
+        },
+        "intervals": [
+            {
+                "interval": "2024-01-21",
+                "date_start": "2024-01-21 00:00:00",
+                "date_start_gmt": "2024-01-21 00:00:00",
+                "date_end": "2024-01-21 23:59:59",
+                "date_end_gmt": "2024-01-21 23:59:59",
+                "subtotals": {
+                    "items_sold": 3,
+                    "bundled_items_sold": 2,
+                    "net_revenue": 35,
+                    "orders_count": 1,
+                    "products_count": 2
+                }
+            },
+            {
+                "interval": "2024-01-20",
+                "date_start": "2024-01-20 00:00:00",
+                "date_start_gmt": "2024-01-20 00:00:00",
+                "date_end": "2024-01-20 23:59:59",
+                "date_end_gmt": "2024-01-20 23:59:59",
+                "subtotals": {
+                    "items_sold": 2,
+                    "bundled_items_sold": 1,
+                    "net_revenue": 15,
+                    "orders_count": 1,
+                    "products_count": 2
+                }
+            }
+        ]
+    }
+}


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of: #12159
<!-- Id number of the GitHub issue this PR addresses. -->

## Why
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This adds mock responses and models to represent the product bundle stats fetched from `/wc-analytics/reports/bundles/stats`. It's the first step in adding networking support for a Product Bundles analytics card in the Analytics Hub.

## How

* Adds mock responses for product bundles stats with and without a data envelope.
* Adds models for product bundles stats, intervals, and totals.

Note: I explored creating generic types to model these stats, since all of these stats responses are formatted the same way (just with different fields for the stats totals) — see `OrderStatsV4` for comparison. However, I couldn't find a straightforward way to do this without losing the `Codegen` support. (We'd need to update our `Sourcery` pod for full support for generic types, and in my time-boxed exploration I couldn't get the `GeneratedCopiable` template to work correctly for a generic type.) This could be worth returning to later, to reduce the number of models we need to create to represent stats like these.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
These models aren't yet used, so it's sufficient to confirm that the app builds and tests pass in CI.


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
