### PR TITLE
[Analytics Hub] Product Bundles: Add mapper and remote endpoint for product bundle stats

### DIFF
--- a/Networking/Networking.xcodeproj/project.pbxproj
+++ b/Networking/Networking.xcodeproj/project.pbxproj
@@ -713,9 +713,11 @@
 		CE865AA52A4209A70049B03C /* EntityDateModifiedMapperTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE865AA42A4209A70049B03C /* EntityDateModifiedMapperTests.swift */; };
 		CEB9BF312BB190590007978A /* product-bundle-stats.json in Resources */ = {isa = PBXBuildFile; fileRef = CEB9BF302BB190590007978A /* product-bundle-stats.json */; };
 		CEB9BF352BB190960007978A /* product-bundle-stats-without-data.json in Resources */ = {isa = PBXBuildFile; fileRef = CEB9BF342BB190960007978A /* product-bundle-stats-without-data.json */; };
+		CEB9BF392BB193020007978A /* ProductBundleStatsTotals.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEB9BF382BB193020007978A /* ProductBundleStatsTotals.swift */; };
 		CEB9BF3D2BB1949F0007978A /* ProductBundleStatsInterval.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEB9BF3C2BB1949F0007978A /* ProductBundleStatsInterval.swift */; };
 		CEB9BF3F2BB196130007978A /* ProductBundleStats.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEB9BF3E2BB196130007978A /* ProductBundleStats.swift */; };
-		CEB9BF392BB193020007978A /* ProductBundleStatsTotals.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEB9BF382BB193020007978A /* ProductBundleStatsTotals.swift */; };
+		CEB9BF432BB199600007978A /* ProductBundleStatsMapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEB9BF422BB199600007978A /* ProductBundleStatsMapper.swift */; };
+		CEB9BF452BB19EDE0007978A /* ProductBundleStatsMapperTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEB9BF442BB19EDE0007978A /* ProductBundleStatsMapperTests.swift */; };
 		CEC4BF8F234E382F008D9195 /* RefundMapperTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEC4BF8E234E382F008D9195 /* RefundMapperTests.swift */; };
 		CEC4BF91234E40B5008D9195 /* refund-single.json in Resources */ = {isa = PBXBuildFile; fileRef = CEC4BF90234E40B5008D9195 /* refund-single.json */; };
 		CEC4BF93234E7EE0008D9195 /* refunds-all.json in Resources */ = {isa = PBXBuildFile; fileRef = CEC4BF92234E7EE0008D9195 /* refunds-all.json */; };
@@ -1791,9 +1793,11 @@
 		CE865AA42A4209A70049B03C /* EntityDateModifiedMapperTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EntityDateModifiedMapperTests.swift; sourceTree = "<group>"; };
 		CEB9BF302BB190590007978A /* product-bundle-stats.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "product-bundle-stats.json"; sourceTree = "<group>"; };
 		CEB9BF342BB190960007978A /* product-bundle-stats-without-data.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "product-bundle-stats-without-data.json"; sourceTree = "<group>"; };
+		CEB9BF382BB193020007978A /* ProductBundleStatsTotals.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductBundleStatsTotals.swift; sourceTree = "<group>"; };
 		CEB9BF3C2BB1949F0007978A /* ProductBundleStatsInterval.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductBundleStatsInterval.swift; sourceTree = "<group>"; };
 		CEB9BF3E2BB196130007978A /* ProductBundleStats.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductBundleStats.swift; sourceTree = "<group>"; };
-		CEB9BF382BB193020007978A /* ProductBundleStatsTotals.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductBundleStatsTotals.swift; sourceTree = "<group>"; };
+		CEB9BF422BB199600007978A /* ProductBundleStatsMapper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductBundleStatsMapper.swift; sourceTree = "<group>"; };
+		CEB9BF442BB19EDE0007978A /* ProductBundleStatsMapperTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductBundleStatsMapperTests.swift; sourceTree = "<group>"; };
 		CEC4BF8E234E382F008D9195 /* RefundMapperTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RefundMapperTests.swift; sourceTree = "<group>"; };
 		CEC4BF90234E40B5008D9195 /* refund-single.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "refund-single.json"; sourceTree = "<group>"; };
 		CEC4BF92234E7EE0008D9195 /* refunds-all.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "refunds-all.json"; sourceTree = "<group>"; };
@@ -3178,6 +3182,7 @@
 				4515280C257A7EEC0076B03C /* ProductAttributeListMapper.swift */,
 				26B6453F259BCDFE00EF3FB3 /* ProductAttributeTermMapper.swift */,
 				26B64543259BCE0F00EF3FB3 /* ProductAttributeTermListMapper.swift */,
+				CEB9BF422BB199600007978A /* ProductBundleStatsMapper.swift */,
 				CCF434632906BD7200B4475A /* ProductIDMapper.swift */,
 				CE0A0F18223987DF0075ED8D /* ProductListMapper.swift */,
 				45B204B72489095100FE6526 /* ProductCategoryMapper.swift */,
@@ -3421,6 +3426,7 @@
 				EE8C202C2B47886500FE967B /* CreateBlazeCampaignMapperTests.swift */,
 				EE1CB9172B4BD22800AD24D5 /* BlazeAISuggestionListMapperTests.swift */,
 				DE02ABB62B563F3A008E0AC4 /* BlazePaymentInfoMapperTests.swift */,
+				CEB9BF442BB19EDE0007978A /* ProductBundleStatsMapperTests.swift */,
 			);
 			path = Mapper;
 			sourceTree = "<group>";
@@ -4288,6 +4294,7 @@
 				CE227093228DD44C00C0626C /* ProductStatus.swift in Sources */,
 				451A97E9260B657D0059D135 /* ShippingLabelPredefinedOption.swift in Sources */,
 				263659DC2A264A3E00607A0D /* IPLocationRemote.swift in Sources */,
+				CEB9BF432BB199600007978A /* ProductBundleStatsMapper.swift in Sources */,
 				02C2548425635BD000A04423 /* ShippingLabelPaperSize.swift in Sources */,
 				B9DFE4BE2AA2057B00174004 /* TaxRateListMapper.swift in Sources */,
 				CE132BBC223859710029DB6C /* ProductTag.swift in Sources */,
@@ -4856,6 +4863,7 @@
 				B57B1E6A21C925280046E764 /* DotcomValidatorTests.swift in Sources */,
 				B567AF3020A0FB8F00AB6C62 /* DotcomRequestTests.swift in Sources */,
 				EE57C138297F9AC900BC31E7 /* ProductVariationsBulkUpdateMapperTests.swift in Sources */,
+				CEB9BF452BB19EDE0007978A /* ProductBundleStatsMapperTests.swift in Sources */,
 				E18152C428F85E5C0011A0EC /* InAppPurchasesProductsMapperTests.swift in Sources */,
 				68BFF9022B677F1D00B15FF2 /* ReceiptRemoteTests.swift in Sources */,
 				CCE5F39729F00B5200087332 /* SubscriptionsRemoteTests.swift in Sources */,

--- a/Networking/Networking.xcodeproj/project.pbxproj
+++ b/Networking/Networking.xcodeproj/project.pbxproj
@@ -711,6 +711,7 @@
 		CE865A9F2A41E42F0049B03C /* date-modified-gmt.json in Resources */ = {isa = PBXBuildFile; fileRef = CE865A9E2A41E42F0049B03C /* date-modified-gmt.json */; };
 		CE865AA32A4207A50049B03C /* date-modified-gmt-without-data.json in Resources */ = {isa = PBXBuildFile; fileRef = CE865AA22A4207A50049B03C /* date-modified-gmt-without-data.json */; };
 		CE865AA52A4209A70049B03C /* EntityDateModifiedMapperTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE865AA42A4209A70049B03C /* EntityDateModifiedMapperTests.swift */; };
+		CEB9BF2F2BB18F430007978A /* ProductBundleStatsRemoteTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEB9BF2E2BB18F430007978A /* ProductBundleStatsRemoteTests.swift */; };
 		CEB9BF312BB190590007978A /* product-bundle-stats.json in Resources */ = {isa = PBXBuildFile; fileRef = CEB9BF302BB190590007978A /* product-bundle-stats.json */; };
 		CEB9BF352BB190960007978A /* product-bundle-stats-without-data.json in Resources */ = {isa = PBXBuildFile; fileRef = CEB9BF342BB190960007978A /* product-bundle-stats-without-data.json */; };
 		CEB9BF392BB193020007978A /* ProductBundleStatsTotals.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEB9BF382BB193020007978A /* ProductBundleStatsTotals.swift */; };
@@ -718,6 +719,7 @@
 		CEB9BF3F2BB196130007978A /* ProductBundleStats.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEB9BF3E2BB196130007978A /* ProductBundleStats.swift */; };
 		CEB9BF432BB199600007978A /* ProductBundleStatsMapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEB9BF422BB199600007978A /* ProductBundleStatsMapper.swift */; };
 		CEB9BF452BB19EDE0007978A /* ProductBundleStatsMapperTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEB9BF442BB19EDE0007978A /* ProductBundleStatsMapperTests.swift */; };
+		CEB9BF412BB198860007978A /* ProductBundleStatsRemote.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEB9BF402BB198860007978A /* ProductBundleStatsRemote.swift */; };
 		CEC4BF8F234E382F008D9195 /* RefundMapperTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEC4BF8E234E382F008D9195 /* RefundMapperTests.swift */; };
 		CEC4BF91234E40B5008D9195 /* refund-single.json in Resources */ = {isa = PBXBuildFile; fileRef = CEC4BF90234E40B5008D9195 /* refund-single.json */; };
 		CEC4BF93234E7EE0008D9195 /* refunds-all.json in Resources */ = {isa = PBXBuildFile; fileRef = CEC4BF92234E7EE0008D9195 /* refunds-all.json */; };
@@ -1791,6 +1793,7 @@
 		CE865A9E2A41E42F0049B03C /* date-modified-gmt.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "date-modified-gmt.json"; sourceTree = "<group>"; };
 		CE865AA22A4207A50049B03C /* date-modified-gmt-without-data.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "date-modified-gmt-without-data.json"; sourceTree = "<group>"; };
 		CE865AA42A4209A70049B03C /* EntityDateModifiedMapperTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EntityDateModifiedMapperTests.swift; sourceTree = "<group>"; };
+		CEB9BF2E2BB18F430007978A /* ProductBundleStatsRemoteTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductBundleStatsRemoteTests.swift; sourceTree = "<group>"; };
 		CEB9BF302BB190590007978A /* product-bundle-stats.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "product-bundle-stats.json"; sourceTree = "<group>"; };
 		CEB9BF342BB190960007978A /* product-bundle-stats-without-data.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "product-bundle-stats-without-data.json"; sourceTree = "<group>"; };
 		CEB9BF382BB193020007978A /* ProductBundleStatsTotals.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductBundleStatsTotals.swift; sourceTree = "<group>"; };
@@ -1798,6 +1801,7 @@
 		CEB9BF3E2BB196130007978A /* ProductBundleStats.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductBundleStats.swift; sourceTree = "<group>"; };
 		CEB9BF422BB199600007978A /* ProductBundleStatsMapper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductBundleStatsMapper.swift; sourceTree = "<group>"; };
 		CEB9BF442BB19EDE0007978A /* ProductBundleStatsMapperTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductBundleStatsMapperTests.swift; sourceTree = "<group>"; };
+		CEB9BF402BB198860007978A /* ProductBundleStatsRemote.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductBundleStatsRemote.swift; sourceTree = "<group>"; };
 		CEC4BF8E234E382F008D9195 /* RefundMapperTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RefundMapperTests.swift; sourceTree = "<group>"; };
 		CEC4BF90234E40B5008D9195 /* refund-single.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "refund-single.json"; sourceTree = "<group>"; };
 		CEC4BF92234E7EE0008D9195 /* refunds-all.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "refunds-all.json"; sourceTree = "<group>"; };
@@ -2380,6 +2384,7 @@
 				74749B9422413119005C4CF2 /* ProductsRemoteTests.swift */,
 				D88D5A4C230BD010007B6E01 /* ProductReviewsRemoteTests.swift */,
 				45152814257A83DD0076B03C /* ProductAttributesRemoteTests.swift */,
+				CEB9BF2E2BB18F430007978A /* ProductBundleStatsRemoteTests.swift */,
 				2661547A242DAC1C00A31661 /* ProductCategoriesRemoteTests.swift */,
 				26E5A08B25A66FD3000DF8F6 /* ProductAttributeTermRemoteTests.swift */,
 				4599FC6524A633A10056157A /* ProductTagsRemoteTests.swift */,
@@ -2535,6 +2540,7 @@
 				D8FBFF0A22D3ADB1006E3336 /* OrderStatsRemoteV4.swift */,
 				261CF1B7255AE62D0090D8D3 /* PaymentGatewayRemote.swift */,
 				45152808257A7C6E0076B03C /* ProductAttributesRemote.swift */,
+				CEB9BF402BB198860007978A /* ProductBundleStatsRemote.swift */,
 				26615472242D596B00A31661 /* ProductCategoriesRemote.swift */,
 				026CF61F237D69D6009563D4 /* ProductVariationsRemote.swift */,
 				26E5A08725A66AFC000DF8F6 /* ProductAttributeTermRemote.swift */,
@@ -4325,6 +4331,7 @@
 				453305E92459DF2100264E50 /* PostMapper.swift in Sources */,
 				E12552C526385B05001CEE70 /* ShippingLabelAddressValidationSuccess.swift in Sources */,
 				456F71D424CB1E2400472EC1 /* ProductTagFromBatchCreation.swift in Sources */,
+				CEB9BF412BB198860007978A /* ProductBundleStatsRemote.swift in Sources */,
 				2685C0FA263B5D5300D9EE97 /* AddOnGroupMapper.swift in Sources */,
 				CCE5F38D29EFFBC400087332 /* SubscriptionListMapper.swift in Sources */,
 				DEC51AF527699F3A009F3DF4 /* SystemStatus+Theme.swift in Sources */,
@@ -4783,6 +4790,7 @@
 				2670C3FC270F4E06002FE931 /* SiteListMapperTests.swift in Sources */,
 				EE065AD02B8E56C2009848CB /* BlazeCampaignListItemsMapperTests.swift in Sources */,
 				02E2AF2F2AFD1C3A00EE6FE8 /* AlamofireNetworkTests.swift in Sources */,
+				CEB9BF2F2BB18F430007978A /* ProductBundleStatsRemoteTests.swift in Sources */,
 				025CA2C6238F4F3500B05C81 /* ProductShippingClassRemoteTests.swift in Sources */,
 				EE078D932AD2F1E500C1199E /* JWTokenMapperTests.swift in Sources */,
 				D800DA0A25EFEB9C001E13CE /* WCPayRemoteTests.swift in Sources */,

--- a/Networking/Networking/Mapper/ProductBundleStatsMapper.swift
+++ b/Networking/Networking/Mapper/ProductBundleStatsMapper.swift
@@ -1,0 +1,47 @@
+import Foundation
+
+
+/// Mapper: ProductBundleStats
+///
+struct ProductBundleStatsMapper: Mapper {
+    /// Site Identifier associated to the stats that will be parsed.
+    /// We're injecting this field via `JSONDecoder.userInfo` because the remote endpoints don't
+    /// really return the siteID for the stats v4 endpoint
+    ///
+    let siteID: Int64
+
+    /// Granularity associated to the stats that will be parsed.
+    /// We're injecting this field via `JSONDecoder.userInfo` because the remote endpoints don't
+    /// really return the granularity for the stats v4 endpoint
+    ///
+    let granularity: StatsGranularityV4
+
+    /// (Attempts) to convert a dictionary into a StatsReport entity.
+    ///
+    func map(response: Data) throws -> ProductBundleStats {
+        let decoder = JSONDecoder()
+        decoder.userInfo = [
+            .siteID: siteID,
+            .granularity: granularity
+        ]
+        if hasDataEnvelope(in: response) {
+            return try decoder.decode(ProductBundleStatsEnvelope.self, from: response).bundleStats
+        } else {
+            return try decoder.decode(ProductBundleStats.self, from: response)
+        }
+    }
+}
+
+
+/// StatsReportEnvelope Disposable Entity
+///
+/// Stats endpoint returns the requested stats in the `data` key. This entity
+/// allows us to parse all the things with JSONDecoder.
+///
+private struct ProductBundleStatsEnvelope: Decodable {
+    let bundleStats: ProductBundleStats
+
+    private enum CodingKeys: String, CodingKey {
+        case bundleStats = "data"
+    }
+}

--- a/Networking/Networking/Remote/ProductBundleStatsRemote.swift
+++ b/Networking/Networking/Remote/ProductBundleStatsRemote.swift
@@ -1,0 +1,68 @@
+import Foundation
+
+/// Product Bundle Stats: Remote Endpoints for fetching product bundle stats.
+///
+public final class ProductBundleStatsRemote: Remote {
+
+    /// Fetch the product bundle stats for a given site, depending on the given granularity of the `unit` parameter.
+    ///
+    /// - Parameters:
+    ///   - siteID: The site ID.
+    ///   - unit: Defines the granularity of the stats we are fetching (one of 'hourly', 'daily', 'weekly', 'monthly', or 'yearly').
+    ///   - timeZone: The time zone to set the earliest/latest date strings in the API request.
+    ///   - earliestDateToInclude: The earliest date to include in the results.
+    ///   - latestDateToInclude: The latest date to include in the results.
+    ///   - quantity: The number of intervals to fetch.
+    ///   - forceRefresh: Whether to enforce the data being refreshed.
+    ///   - completion: Closure to be executed upon completion.
+    ///
+    public func loadProductBundleStats(for siteID: Int64,
+                                       unit: StatsGranularityV4,
+                                       timeZone: TimeZone,
+                                       earliestDateToInclude: Date,
+                                       latestDateToInclude: Date,
+                                       quantity: Int,
+                                       forceRefresh: Bool,
+                                       completion: @escaping (Result<ProductBundleStats, Error>) -> Void) {
+        let dateFormatter = DateFormatter.Defaults.iso8601WithoutTimeZone
+        dateFormatter.timeZone = timeZone
+
+        var parameters: [String: Any] = [
+            ParameterKeys.interval: unit.rawValue,
+            ParameterKeys.after: dateFormatter.string(from: earliestDateToInclude),
+            ParameterKeys.before: dateFormatter.string(from: latestDateToInclude),
+            ParameterKeys.quantity: String(quantity)
+        ]
+
+        if forceRefresh {
+            // includes this parameter only if it's true, otherwise the request fails
+            parameters[ParameterKeys.forceRefresh] = forceRefresh
+        }
+
+        let request = JetpackRequest(wooApiVersion: .wcAnalytics,
+                                     method: .get,
+                                     siteID: siteID,
+                                     path: Constants.bundleStatsPath,
+                                     parameters: parameters,
+                                     availableAsRESTRequest: true)
+        let mapper = ProductBundleStatsMapper(siteID: siteID, granularity: unit)
+        enqueue(request, mapper: mapper, completion: completion)
+    }
+}
+
+
+// MARK: - Constants!
+//
+private extension ProductBundleStatsRemote {
+    enum Constants {
+        static let bundleStatsPath: String = "reports/bundles/stats"
+    }
+
+    enum ParameterKeys {
+        static let interval = "interval"
+        static let after = "after"
+        static let before = "before"
+        static let quantity = "per_page"
+        static let forceRefresh = "force_cache_refresh"
+    }
+}

--- a/Networking/NetworkingTests/Mapper/ProductBundleStatsMapperTests.swift
+++ b/Networking/NetworkingTests/Mapper/ProductBundleStatsMapperTests.swift
@@ -1,0 +1,90 @@
+import XCTest
+@testable import Networking
+
+
+/// ProductBundleStatsMapper Unit Tests
+///
+final class ProductBundleStatsMapperTests: XCTestCase {
+    private struct Constants {
+        static let siteID: Int64 = 1234
+    }
+
+    /// Verifies that all of the ProductBundleStatsTotals fields are parsed correctly.
+    ///
+    func test_product_bundle_stat_fields_are_properly_parsed() throws {
+        // Given
+        let granularity = StatsGranularityV4.daily
+
+        // When
+        guard let bundleStats = mapStatItems(from: "product-bundle-stats", granularity: granularity) else {
+            XCTFail()
+            return
+        }
+
+        // Then
+        XCTAssertEqual(bundleStats.siteID, Constants.siteID)
+        XCTAssertEqual(bundleStats.granularity, .daily)
+
+        // Stats report totals are parsed
+        XCTAssertEqual(bundleStats.totals.totalItemsSold, 5)
+        XCTAssertEqual(bundleStats.totals.totalBundledItemsSold, 3)
+        XCTAssertEqual(bundleStats.totals.netRevenue, 50)
+        XCTAssertEqual(bundleStats.totals.totalOrders, 2)
+        XCTAssertEqual(bundleStats.totals.totalProducts, 4)
+
+        // Starts report intervals are parsed
+        XCTAssertEqual(bundleStats.intervals.count, 2)
+        let firstInterval = try XCTUnwrap(bundleStats.intervals.first)
+        XCTAssertEqual(firstInterval.subtotals.totalItemsSold, 3)
+        XCTAssertEqual(firstInterval.subtotals.totalBundledItemsSold, 2)
+        XCTAssertEqual(firstInterval.subtotals.netRevenue, 35)
+        XCTAssertEqual(firstInterval.subtotals.totalOrders, 1)
+        XCTAssertEqual(firstInterval.subtotals.totalProducts, 2)
+    }
+
+    /// Verifies that all of the ProductBundleStatsTotals fields are parsed correctly.
+    ///
+    func test_product_bundle_stat_fields_are_properly_parsed_without_data_envelope() throws {
+        // Given
+        let granularity = StatsGranularityV4.daily
+
+        // When
+        guard let bundleStats = mapStatItems(from: "product-bundle-stats-without-data", granularity: granularity) else {
+            XCTFail()
+            return
+        }
+
+        // Then
+        XCTAssertEqual(bundleStats.siteID, Constants.siteID)
+        XCTAssertEqual(bundleStats.granularity, .daily)
+
+        // Stats report totals are parsed
+        XCTAssertEqual(bundleStats.totals.totalItemsSold, 5)
+        XCTAssertEqual(bundleStats.totals.totalBundledItemsSold, 3)
+        XCTAssertEqual(bundleStats.totals.netRevenue, 50)
+        XCTAssertEqual(bundleStats.totals.totalOrders, 2)
+        XCTAssertEqual(bundleStats.totals.totalProducts, 4)
+
+        // Starts report intervals are parsed
+        XCTAssertEqual(bundleStats.intervals.count, 2)
+        let firstInterval = try XCTUnwrap(bundleStats.intervals.first)
+        XCTAssertEqual(firstInterval.subtotals.totalItemsSold, 3)
+        XCTAssertEqual(firstInterval.subtotals.totalBundledItemsSold, 2)
+        XCTAssertEqual(firstInterval.subtotals.netRevenue, 35)
+        XCTAssertEqual(firstInterval.subtotals.totalOrders, 1)
+        XCTAssertEqual(firstInterval.subtotals.totalProducts, 2)
+    }
+}
+
+private extension ProductBundleStatsMapperTests {
+    /// Returns the ProductBundleStatsMapper output upon receiving `filename` (Data Encoded)
+    ///
+    func mapStatItems(from filename: String, granularity: StatsGranularityV4) -> ProductBundleStats? {
+        guard let response = Loader.contentsOf(filename) else {
+            return nil
+        }
+
+        return try! ProductBundleStatsMapper(siteID: Constants.siteID,
+                                             granularity: granularity).map(response: response)
+    }
+}

--- a/Networking/NetworkingTests/Remote/ProductBundleStatsRemoteTests.swift
+++ b/Networking/NetworkingTests/Remote/ProductBundleStatsRemoteTests.swift
@@ -1,0 +1,72 @@
+import XCTest
+@testable import Networking
+
+
+/// ProductBundleStatsRemote Unit Tests
+///
+class ProductBundleStatsRemoteTests: XCTestCase {
+
+    /// Dummy Network Wrapper
+    ///
+    let network = MockNetwork()
+
+    /// Dummy Site ID
+    ///
+    let sampleSiteID: Int64 = 1234
+
+    /// Repeat always!
+    ///
+    override func setUp() {
+        network.removeAllSimulatedResponses()
+    }
+
+
+    /// Verifies that loadProductBundleStats properly parses the `ProductBundleStats` sample response.
+    ///
+    func test_loadProductBundleStats_properly_returns_parsed_stats() throws {
+        // Given
+        let remote = ProductBundleStatsRemote(network: network)
+        network.simulateResponse(requestUrlSuffix: "reports/bundles/stats", filename: "product-bundle-stats")
+
+        // When
+        let result: Result<ProductBundleStats, Error> = waitFor { promise in
+            remote.loadProductBundleStats(for: self.sampleSiteID,
+                                          unit: .daily,
+                                          timeZone: .gmt,
+                                          earliestDateToInclude: Date(),
+                                          latestDateToInclude: Date(),
+                                          quantity: 2,
+                                          forceRefresh: false) { result in
+                promise(result)
+            }
+        }
+
+        // Then
+        XCTAssertTrue(result.isSuccess)
+        let productBundleStats = try result.get()
+        XCTAssertEqual(productBundleStats.intervals.count, 2)
+    }
+
+    /// Verifies that loadProductBundleStats properly relays Networking Layer errors.
+    ///
+    func test_loadSiteVisitorStats_properly_relays_networking_errors() {
+        // Given
+        let remote = ProductBundleStatsRemote(network: network)
+
+        // When
+        let result: Result<ProductBundleStats, Error> = waitFor { promise in
+            remote.loadProductBundleStats(for: self.sampleSiteID,
+                                          unit: .daily,
+                                          timeZone: .gmt,
+                                          earliestDateToInclude: Date(),
+                                          latestDateToInclude: Date(),
+                                          quantity: 2,
+                                          forceRefresh: false) { result in
+                promise(result)
+            }
+        }
+
+        // Then
+        XCTAssertTrue(result.isFailure)
+    }
+}


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of #12159 
⚠️ Depends on #12353 ⚠️ 
<!-- Id number of the GitHub issue this PR addresses. -->

## Why
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This adds support for fetching product bundle stats from remote.

## How

* Adds a mapper for `ProductBundleStats`.
* Adds `ProductBundleStatsRemote` with a method to fetch and parse `ProductBundleStats`.
* Adds unit tests for the mapper and remote method.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
This endpoint isn't used in the app yet, so confirm tests pass in CI.


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
