### PR TITLE
[Analytics Hub] Product Bundles: Fetch top product bundles

### DIFF
--- a/Networking/Networking.xcodeproj/project.pbxproj
+++ b/Networking/Networking.xcodeproj/project.pbxproj
@@ -711,15 +711,16 @@
 		CE865A9F2A41E42F0049B03C /* date-modified-gmt.json in Resources */ = {isa = PBXBuildFile; fileRef = CE865A9E2A41E42F0049B03C /* date-modified-gmt.json */; };
 		CE865AA32A4207A50049B03C /* date-modified-gmt-without-data.json in Resources */ = {isa = PBXBuildFile; fileRef = CE865AA22A4207A50049B03C /* date-modified-gmt-without-data.json */; };
 		CE865AA52A4209A70049B03C /* EntityDateModifiedMapperTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE865AA42A4209A70049B03C /* EntityDateModifiedMapperTests.swift */; };
+		CEA455B72BB2D64400D932CF /* product-bundle-top-bundles.json in Resources */ = {isa = PBXBuildFile; fileRef = CEA455B62BB2D64400D932CF /* product-bundle-top-bundles.json */; };
 		CEB9BF2F2BB18F430007978A /* ProductBundleStatsRemoteTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEB9BF2E2BB18F430007978A /* ProductBundleStatsRemoteTests.swift */; };
 		CEB9BF312BB190590007978A /* product-bundle-stats.json in Resources */ = {isa = PBXBuildFile; fileRef = CEB9BF302BB190590007978A /* product-bundle-stats.json */; };
 		CEB9BF352BB190960007978A /* product-bundle-stats-without-data.json in Resources */ = {isa = PBXBuildFile; fileRef = CEB9BF342BB190960007978A /* product-bundle-stats-without-data.json */; };
 		CEB9BF392BB193020007978A /* ProductBundleStatsTotals.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEB9BF382BB193020007978A /* ProductBundleStatsTotals.swift */; };
 		CEB9BF3D2BB1949F0007978A /* ProductBundleStatsInterval.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEB9BF3C2BB1949F0007978A /* ProductBundleStatsInterval.swift */; };
 		CEB9BF3F2BB196130007978A /* ProductBundleStats.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEB9BF3E2BB196130007978A /* ProductBundleStats.swift */; };
+		CEB9BF412BB198860007978A /* ProductBundleStatsRemote.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEB9BF402BB198860007978A /* ProductBundleStatsRemote.swift */; };
 		CEB9BF432BB199600007978A /* ProductBundleStatsMapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEB9BF422BB199600007978A /* ProductBundleStatsMapper.swift */; };
 		CEB9BF452BB19EDE0007978A /* ProductBundleStatsMapperTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEB9BF442BB19EDE0007978A /* ProductBundleStatsMapperTests.swift */; };
-		CEB9BF412BB198860007978A /* ProductBundleStatsRemote.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEB9BF402BB198860007978A /* ProductBundleStatsRemote.swift */; };
 		CEC4BF8F234E382F008D9195 /* RefundMapperTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEC4BF8E234E382F008D9195 /* RefundMapperTests.swift */; };
 		CEC4BF91234E40B5008D9195 /* refund-single.json in Resources */ = {isa = PBXBuildFile; fileRef = CEC4BF90234E40B5008D9195 /* refund-single.json */; };
 		CEC4BF93234E7EE0008D9195 /* refunds-all.json in Resources */ = {isa = PBXBuildFile; fileRef = CEC4BF92234E7EE0008D9195 /* refunds-all.json */; };
@@ -1793,15 +1794,16 @@
 		CE865A9E2A41E42F0049B03C /* date-modified-gmt.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "date-modified-gmt.json"; sourceTree = "<group>"; };
 		CE865AA22A4207A50049B03C /* date-modified-gmt-without-data.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "date-modified-gmt-without-data.json"; sourceTree = "<group>"; };
 		CE865AA42A4209A70049B03C /* EntityDateModifiedMapperTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EntityDateModifiedMapperTests.swift; sourceTree = "<group>"; };
+		CEA455B62BB2D64400D932CF /* product-bundle-top-bundles.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "product-bundle-top-bundles.json"; sourceTree = "<group>"; };
 		CEB9BF2E2BB18F430007978A /* ProductBundleStatsRemoteTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductBundleStatsRemoteTests.swift; sourceTree = "<group>"; };
 		CEB9BF302BB190590007978A /* product-bundle-stats.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "product-bundle-stats.json"; sourceTree = "<group>"; };
 		CEB9BF342BB190960007978A /* product-bundle-stats-without-data.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "product-bundle-stats-without-data.json"; sourceTree = "<group>"; };
 		CEB9BF382BB193020007978A /* ProductBundleStatsTotals.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductBundleStatsTotals.swift; sourceTree = "<group>"; };
 		CEB9BF3C2BB1949F0007978A /* ProductBundleStatsInterval.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductBundleStatsInterval.swift; sourceTree = "<group>"; };
 		CEB9BF3E2BB196130007978A /* ProductBundleStats.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductBundleStats.swift; sourceTree = "<group>"; };
+		CEB9BF402BB198860007978A /* ProductBundleStatsRemote.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductBundleStatsRemote.swift; sourceTree = "<group>"; };
 		CEB9BF422BB199600007978A /* ProductBundleStatsMapper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductBundleStatsMapper.swift; sourceTree = "<group>"; };
 		CEB9BF442BB19EDE0007978A /* ProductBundleStatsMapperTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductBundleStatsMapperTests.swift; sourceTree = "<group>"; };
-		CEB9BF402BB198860007978A /* ProductBundleStatsRemote.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductBundleStatsRemote.swift; sourceTree = "<group>"; };
 		CEC4BF8E234E382F008D9195 /* RefundMapperTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RefundMapperTests.swift; sourceTree = "<group>"; };
 		CEC4BF90234E40B5008D9195 /* refund-single.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "refund-single.json"; sourceTree = "<group>"; };
 		CEC4BF92234E7EE0008D9195 /* refunds-all.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "refunds-all.json"; sourceTree = "<group>"; };
@@ -3139,6 +3141,7 @@
 				68BFF9052B6785C700B15FF2 /* receipt-without-data-envelope.json */,
 				CEB9BF302BB190590007978A /* product-bundle-stats.json */,
 				CEB9BF342BB190960007978A /* product-bundle-stats-without-data.json */,
+				CEA455B62BB2D64400D932CF /* product-bundle-top-bundles.json */,
 			);
 			path = Responses;
 			sourceTree = "<group>";
@@ -3808,6 +3811,7 @@
 				688908AE28FF920C0081A07E /* customer-2.json in Resources */,
 				034480C327A42F9100DFACD2 /* order-with-charge.json in Resources */,
 				74A7B4BE217A841400E85A8B /* broken-settings-general.json in Resources */,
+				CEA455B72BB2D64400D932CF /* product-bundle-top-bundles.json in Resources */,
 				026CF624237D839B009563D4 /* product-variations-load-all.json in Resources */,
 				02AF07EC27492FDD00B2D81E /* media-library-from-wordpress-site.json in Resources */,
 				CC9A253C26442C71005DE56E /* shipping-label-eligibility-success.json in Resources */,

--- a/Networking/Networking/Remote/ProductBundleStatsRemote.swift
+++ b/Networking/Networking/Remote/ProductBundleStatsRemote.swift
@@ -48,6 +48,44 @@ public final class ProductBundleStatsRemote: Remote {
         let mapper = ProductBundleStatsMapper(siteID: siteID, granularity: unit)
         enqueue(request, mapper: mapper, completion: completion)
     }
+
+    /// Fetch the top product bundles for a given site within the dates provided.
+    ///
+    /// - Parameters:
+    ///   - siteID: The site ID.
+    ///   - timeZone: The time zone to set the earliest/latest date strings in the API request.
+    ///   - earliestDateToInclude: The earliest date to include in the results.
+    ///   - latestDateToInclude: The latest date to include in the results.
+    ///   - quantity: The number of bundles to fetch.
+    ///   - completion: Closure to be executed upon completion.
+    ///
+    public func loadTopProductBundlesReport(for siteID: Int64,
+                                            timeZone: TimeZone,
+                                            earliestDateToInclude: Date,
+                                            latestDateToInclude: Date,
+                                            quantity: Int) async throws -> [ProductsReportItem] {
+        let dateFormatter = DateFormatter.Defaults.iso8601WithoutTimeZone
+        dateFormatter.timeZone = timeZone
+
+        let parameters: [String: Any] = [
+            ParameterKeys.after: dateFormatter.string(from: earliestDateToInclude),
+            ParameterKeys.before: dateFormatter.string(from: latestDateToInclude),
+            ParameterKeys.quantity: String(quantity),
+            ParameterKeys.orderBy: ParameterValues.orderBy,
+            ParameterKeys.order: ParameterValues.order,
+            ParameterKeys.extendedInfo: ParameterValues.extendedInfo
+        ]
+
+        let request = JetpackRequest(wooApiVersion: .wcAnalytics,
+                                     method: .get,
+                                     siteID: siteID,
+                                     path: Constants.bundleReportsPath,
+                                     parameters: parameters,
+                                     availableAsRESTRequest: true)
+        let mapper = ProductsReportMapper()
+
+        return try await enqueue(request, mapper: mapper)
+    }
 }
 
 
@@ -56,13 +94,23 @@ public final class ProductBundleStatsRemote: Remote {
 private extension ProductBundleStatsRemote {
     enum Constants {
         static let bundleStatsPath: String = "reports/bundles/stats"
+        static let bundleReportsPath: String = "reports/bundles"
     }
 
     enum ParameterKeys {
-        static let interval = "interval"
-        static let after = "after"
-        static let before = "before"
-        static let quantity = "per_page"
+        static let interval     = "interval"
+        static let after        = "after"
+        static let before       = "before"
+        static let quantity     = "per_page"
         static let forceRefresh = "force_cache_refresh"
+        static let orderBy      = "orderby"
+        static let order        = "order"
+        static let extendedInfo = "extended_info"
+    }
+
+    enum ParameterValues {
+        static let orderBy      = "items_sold"
+        static let order        = "desc"
+        static let extendedInfo = "true"
     }
 }

--- a/Networking/Networking/Remote/ProductBundleStatsRemote.swift
+++ b/Networking/Networking/Remote/ProductBundleStatsRemote.swift
@@ -22,8 +22,7 @@ public final class ProductBundleStatsRemote: Remote {
                                        earliestDateToInclude: Date,
                                        latestDateToInclude: Date,
                                        quantity: Int,
-                                       forceRefresh: Bool,
-                                       completion: @escaping (Result<ProductBundleStats, Error>) -> Void) {
+                                       forceRefresh: Bool) async throws -> ProductBundleStats {
         let dateFormatter = DateFormatter.Defaults.iso8601WithoutTimeZone
         dateFormatter.timeZone = timeZone
 
@@ -46,7 +45,8 @@ public final class ProductBundleStatsRemote: Remote {
                                      parameters: parameters,
                                      availableAsRESTRequest: true)
         let mapper = ProductBundleStatsMapper(siteID: siteID, granularity: unit)
-        enqueue(request, mapper: mapper, completion: completion)
+
+        return try await enqueue(request, mapper: mapper)
     }
 
     /// Fetch the top product bundles for a given site within the dates provided.

--- a/Networking/NetworkingTests/Responses/product-bundle-top-bundles.json
+++ b/Networking/NetworkingTests/Responses/product-bundle-top-bundles.json
@@ -1,0 +1,109 @@
+{
+    "data": [
+        {
+            "product_id": 507,
+            "items_sold": 6,
+            "bundled_items_sold": 12,
+            "net_revenue": 361,
+            "orders_count": 4,
+            "extended_info": {
+                "name": "Awesome bundle",
+                "price": 48,
+                "image": "<img width=\"450\" height=\"450\" src=\"https://example.com/wp-content/uploads/2023/01/logo-1-600x599.jpg\" class=\"attachment-woocommerce_thumbnail size-woocommerce_thumbnail\" alt=\"\" decoding=\"async\" loading=\"lazy\" srcset=\"https://example.com/wp-content/uploads/2023/01/logo-1-600x599.jpg 600w, https://example.com/wp-content/uploads/2023/01/logo-1-300x300.jpg 300w, https://example.com/wp-content/uploads/2023/01/logo-1-100x100.jpg?crop=1 100w, https://example.com/wp-content/uploads/2023/01/logo-1-150x150.jpg?crop=1 150w, https://example.com/wp-content/uploads/2023/01/logo-1-768x767.jpg 768w, https://example.com/wp-content/uploads/2023/01/logo-1-400x400.jpg?crop=1 400w, https://example.com/wp-content/uploads/2023/01/logo-1-200x200.jpg?crop=1 200w, https://example.com/wp-content/uploads/2023/01/logo-1.jpg 800w\" sizes=\"(max-width: 450px) 100vw, 450px\" data-attachment-id=\"60\" data-permalink=\"https://example.com/?attachment_id=60\" data-orig-file=\"https://example.com/wp-content/uploads/2023/01/logo-1.jpg\" data-orig-size=\"800,799\" data-comments-opened=\"1\" data-image-meta=\"{&quot;aperture&quot;:&quot;0&quot;,&quot;credit&quot;:&quot;&quot;,&quot;camera&quot;:&quot;&quot;,&quot;caption&quot;:&quot;&quot;,&quot;created_timestamp&quot;:&quot;0&quot;,&quot;copyright&quot;:&quot;&quot;,&quot;focal_length&quot;:&quot;0&quot;,&quot;iso&quot;:&quot;0&quot;,&quot;shutter_speed&quot;:&quot;0&quot;,&quot;title&quot;:&quot;&quot;,&quot;orientation&quot;:&quot;0&quot;}\" data-image-title=\"logo-1.jpg\" data-image-description=\"\" data-image-caption=\"\" data-medium-file=\"https://example.com/wp-content/uploads/2023/01/logo-1-300x300.jpg\" data-large-file=\"https://example.com/wp-content/uploads/2023/01/logo-1.jpg\" />",
+                "permalink": "https://example.com/product/awesome-bundle/",
+                "stock_status": "instock",
+                "sku": ""
+            },
+            "_links": {
+                "product": [
+                    {
+                        "href": "https://example.com/wp-json/wc-analytics/products/507"
+                    }
+                ]
+            }
+        },
+        {
+            "product_id": 129,
+            "items_sold": 4,
+            "bundled_items_sold": 7,
+            "net_revenue": 477.11,
+            "orders_count": 1,
+            "extended_info": {
+                "name": "Subscription Bundle",
+                "price": 0,
+                "image": "<img width=\"450\" height=\"450\" src=\"https://example.com/wp-content/uploads/2023/01/gift-box-present-gift-card-800x800.jpeg?crop=1\" class=\"attachment-woocommerce_thumbnail size-woocommerce_thumbnail\" alt=\"\" decoding=\"async\" loading=\"lazy\" srcset=\"https://example.com/wp-content/uploads/2023/01/gift-box-present-gift-card-800x800.jpeg?crop=1 800w, https://example.com/wp-content/uploads/2023/01/gift-box-present-gift-card-150x150.jpeg?crop=1 150w, https://example.com/wp-content/uploads/2023/01/gift-box-present-gift-card-1200x1200.jpeg?crop=1 1200w, https://example.com/wp-content/uploads/2023/01/gift-box-present-gift-card-400x400.jpeg?crop=1 400w, https://example.com/wp-content/uploads/2023/01/gift-box-present-gift-card-200x200.jpeg?crop=1 200w, https://example.com/wp-content/uploads/2023/01/gift-box-present-gift-card-300x300.jpeg 300w, https://example.com/wp-content/uploads/2023/01/gift-box-present-gift-card-100x100.jpeg?crop=1 100w\" sizes=\"(max-width: 450px) 100vw, 450px\" data-attachment-id=\"69\" data-permalink=\"https://example.com/?attachment_id=69\" data-orig-file=\"https://example.com/wp-content/uploads/2023/01/gift-box-present-gift-card.jpeg\" data-orig-size=\"1920,1280\" data-comments-opened=\"1\" data-image-meta=\"{&quot;aperture&quot;:&quot;0&quot;,&quot;credit&quot;:&quot;&quot;,&quot;camera&quot;:&quot;&quot;,&quot;caption&quot;:&quot;&quot;,&quot;created_timestamp&quot;:&quot;0&quot;,&quot;copyright&quot;:&quot;&quot;,&quot;focal_length&quot;:&quot;0&quot;,&quot;iso&quot;:&quot;0&quot;,&quot;shutter_speed&quot;:&quot;0&quot;,&quot;title&quot;:&quot;&quot;,&quot;orientation&quot;:&quot;0&quot;}\" data-image-title=\"gift-box-present-gift-card\" data-image-description=\"\" data-image-caption=\"\" data-medium-file=\"https://example.com/wp-content/uploads/2023/01/gift-box-present-gift-card-300x200.jpeg\" data-large-file=\"https://example.com/wp-content/uploads/2023/01/gift-box-present-gift-card-1024x683.jpeg\" />",
+                "permalink": "https://example.com/product/my-test-product-bundle/",
+                "stock_status": "insufficientstock",
+                "sku": ""
+            },
+            "_links": {
+                "product": [
+                    {
+                        "href": "https://example.com/wp-json/wc-analytics/products/129"
+                    }
+                ]
+            }
+        },
+        {
+            "product_id": 190,
+            "items_sold": 4,
+            "bundled_items_sold": 10,
+            "net_revenue": 261.5,
+            "orders_count": 4,
+            "extended_info": {
+                "name": "Super Awesome Bundle (Deleted)"
+            },
+            "_links": {
+                "product": [
+                    {
+                        "href": "https://example.com/wp-json/wc-analytics/products/190"
+                    }
+                ]
+            }
+        },
+        {
+            "product_id": 404,
+            "items_sold": 3,
+            "bundled_items_sold": 25,
+            "net_revenue": 405,
+            "orders_count": 3,
+            "extended_info": {
+                "name": "A bundle ⚡️",
+                "price": 15,
+                "image": "<img width=\"450\" height=\"450\" src=\"https://example.com/wp-content/uploads/2023/01/logo-1-600x599.jpg\" class=\"attachment-woocommerce_thumbnail size-woocommerce_thumbnail\" alt=\"\" decoding=\"async\" loading=\"lazy\" srcset=\"https://example.com/wp-content/uploads/2023/01/logo-1-600x599.jpg 600w, https://example.com/wp-content/uploads/2023/01/logo-1-300x300.jpg 300w, https://example.com/wp-content/uploads/2023/01/logo-1-100x100.jpg?crop=1 100w, https://example.com/wp-content/uploads/2023/01/logo-1-150x150.jpg?crop=1 150w, https://example.com/wp-content/uploads/2023/01/logo-1-768x767.jpg 768w, https://example.com/wp-content/uploads/2023/01/logo-1-400x400.jpg?crop=1 400w, https://example.com/wp-content/uploads/2023/01/logo-1-200x200.jpg?crop=1 200w, https://example.com/wp-content/uploads/2023/01/logo-1.jpg 800w\" sizes=\"(max-width: 450px) 100vw, 450px\" data-attachment-id=\"60\" data-permalink=\"https://example.com/?attachment_id=60\" data-orig-file=\"https://example.com/wp-content/uploads/2023/01/logo-1.jpg\" data-orig-size=\"800,799\" data-comments-opened=\"1\" data-image-meta=\"{&quot;aperture&quot;:&quot;0&quot;,&quot;credit&quot;:&quot;&quot;,&quot;camera&quot;:&quot;&quot;,&quot;caption&quot;:&quot;&quot;,&quot;created_timestamp&quot;:&quot;0&quot;,&quot;copyright&quot;:&quot;&quot;,&quot;focal_length&quot;:&quot;0&quot;,&quot;iso&quot;:&quot;0&quot;,&quot;shutter_speed&quot;:&quot;0&quot;,&quot;title&quot;:&quot;&quot;,&quot;orientation&quot;:&quot;0&quot;}\" data-image-title=\"logo-1.jpg\" data-image-description=\"\" data-image-caption=\"\" data-medium-file=\"https://example.com/wp-content/uploads/2023/01/logo-1-300x300.jpg\" data-large-file=\"https://example.com/wp-content/uploads/2023/01/logo-1.jpg\" />",
+                "permalink": "https://example.com/product/a-bundle/",
+                "stock_status": "instock",
+                "sku": "bundle-lightning"
+            },
+            "_links": {
+                "product": [
+                    {
+                        "href": "https://example.com/wp-json/wc-analytics/products/404"
+                    }
+                ]
+            }
+        },
+        {
+            "product_id": 100,
+            "items_sold": 1,
+            "bundled_items_sold": 1,
+            "net_revenue": 12,
+            "orders_count": 1,
+            "extended_info": {
+                "name": "Small Bundle",
+                "price": 12,
+                "image": "<img width=\"450\" height=\"450\" src=\"https://example.com/wp-content/uploads/2023/01/logo-1-600x599.jpg\" class=\"attachment-woocommerce_thumbnail size-woocommerce_thumbnail\" alt=\"\" decoding=\"async\" loading=\"lazy\" srcset=\"https://example.com/wp-content/uploads/2023/01/logo-1-600x599.jpg 600w, https://example.com/wp-content/uploads/2023/01/logo-1-300x300.jpg 300w, https://example.com/wp-content/uploads/2023/01/logo-1-100x100.jpg?crop=1 100w, https://example.com/wp-content/uploads/2023/01/logo-1-150x150.jpg?crop=1 150w, https://example.com/wp-content/uploads/2023/01/logo-1-768x767.jpg 768w, https://example.com/wp-content/uploads/2023/01/logo-1-400x400.jpg?crop=1 400w, https://example.com/wp-content/uploads/2023/01/logo-1-200x200.jpg?crop=1 200w, https://example.com/wp-content/uploads/2023/01/logo-1.jpg 800w\" sizes=\"(max-width: 450px) 100vw, 450px\" data-attachment-id=\"60\" data-permalink=\"https://example.com/?attachment_id=60\" data-orig-file=\"https://example.com/wp-content/uploads/2023/01/logo-1.jpg\" data-orig-size=\"800,799\" data-comments-opened=\"1\" data-image-meta=\"{&quot;aperture&quot;:&quot;0&quot;,&quot;credit&quot;:&quot;&quot;,&quot;camera&quot;:&quot;&quot;,&quot;caption&quot;:&quot;&quot;,&quot;created_timestamp&quot;:&quot;0&quot;,&quot;copyright&quot;:&quot;&quot;,&quot;focal_length&quot;:&quot;0&quot;,&quot;iso&quot;:&quot;0&quot;,&quot;shutter_speed&quot;:&quot;0&quot;,&quot;title&quot;:&quot;&quot;,&quot;orientation&quot;:&quot;0&quot;}\" data-image-title=\"logo-1.jpg\" data-image-description=\"\" data-image-caption=\"\" data-medium-file=\"https://example.com/wp-content/uploads/2023/01/logo-1-300x300.jpg\" data-large-file=\"https://example.com/wp-content/uploads/2023/01/logo-1.jpg\" />",
+                "permalink": "https://example.com/product/small-bundle/",
+                "stock_status": "instock",
+                "sku": "small-bundle"
+            },
+            "_links": {
+                "product": [
+                    {
+                        "href": "https://example.com/wp-json/wc-analytics/products/100"
+                    }
+                ]
+            }
+        }
+    ]
+}


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #12159
<!-- Id number of the GitHub issue this PR addresses. -->

## Why
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This adds support for fetching a list of top product bundles for a given period, so we can display them in the Analytics Hub.

## How

* Adds support for the top bundles endpoint in `ProductBundleStatsRemote`.
   * Note that the response is formatted the same as the top products response, so we can use the same model and mapper (`ProductsReportItem` and `ProductsReportMapper`) to decode the response.
* Also updates the existing method in `ProductBundleStatsRemote` (for fetching product bundle stats) to be async.
* Adds mock response and unit tests.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
This endpoint isn't used in the app yet, so confirm tests pass in CI.


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
