### PR TITLE
[Analytics Hub] Product Bundles: Add Yosemite support for fetching product bundle analytics

### DIFF
--- a/Fakes/Fakes/Networking.generated.swift
+++ b/Fakes/Fakes/Networking.generated.swift
@@ -1530,6 +1530,19 @@ extension Networking.ProductVariationAttribute {
         )
     }
 }
+extension Networking.ProductsReportItem {
+    /// Returns a "ready to use" type filled with fake values.
+    ///
+    public static func fake() -> Networking.ProductsReportItem {
+        .init(
+            productID: .fake(),
+            productName: .fake(),
+            quantity: .fake(),
+            total: .fake(),
+            imageUrl: .fake()
+        )
+    }
+}
 extension Networking.Receipt {
     /// Returns a "ready to use" type filled with fake values.
     ///

--- a/Networking/Networking/Model/Stats/ProductsReportItem.swift
+++ b/Networking/Networking/Model/Stats/ProductsReportItem.swift
@@ -4,7 +4,7 @@ import class Aztec.HTMLParser
 
 /// Represents a single product in a products analytics report over a specific period.
 ///
-public struct ProductsReportItem: Decodable, Equatable {
+public struct ProductsReportItem: Decodable, Equatable, GeneratedFakeable {
 
     /// Product ID
     ///

--- a/Yosemite/Yosemite/Actions/StatsActionV4.swift
+++ b/Yosemite/Yosemite/Actions/StatsActionV4.swift
@@ -73,4 +73,13 @@ public enum StatsActionV4: Action {
                                     quantity: Int,
                                     forceRefresh: Bool,
                                     onCompletion: (Result<ProductBundleStats, Error>) -> Void)
+
+    /// Retrieves the top product bundles for the provided site ID and time range, without saving them to the Storage layer.
+    ///
+    case retrieveTopProductBundles(siteID: Int64,
+                                   timeZone: TimeZone,
+                                   earliestDateToInclude: Date,
+                                   latestDateToInclude: Date,
+                                   quantity: Int,
+                                   onCompletion: (Result<[ProductsReportItem], Error>) -> Void)
 }

--- a/Yosemite/Yosemite/Actions/StatsActionV4.swift
+++ b/Yosemite/Yosemite/Actions/StatsActionV4.swift
@@ -62,4 +62,15 @@ public enum StatsActionV4: Action {
                                   latestDateToInclude: Date,
                                   saveInStorage: Bool,
                                   onCompletion: (Result<SiteSummaryStats, Error>) -> Void)
+
+    /// Retrieves the product bundle stats for the provided site ID and time range, without saving them to the Storage layer.
+    ///
+    case retrieveProductBundleStats(siteID: Int64,
+                                    unit: StatsGranularityV4,
+                                    timeZone: TimeZone,
+                                    earliestDateToInclude: Date,
+                                    latestDateToInclude: Date,
+                                    quantity: Int,
+                                    forceRefresh: Bool,
+                                    onCompletion: (Result<ProductBundleStats, Error>) -> Void)
 }

--- a/Yosemite/Yosemite/Model/Model.swift
+++ b/Yosemite/Yosemite/Model/Model.swift
@@ -89,6 +89,7 @@ public typealias ProductCompositeComponent = Networking.ProductCompositeComponen
 public typealias ProductReview = Networking.ProductReview
 public typealias ProductReviewStatus = Networking.ProductReviewStatus
 public typealias ProductShippingClass = Networking.ProductShippingClass
+public typealias ProductsReportItem = Networking.ProductsReportItem
 public typealias ProductStatus = Networking.ProductStatus
 public typealias ProductCatalogVisibility = Networking.ProductCatalogVisibility
 public typealias ProductStockStatus = Networking.ProductStockStatus

--- a/Yosemite/Yosemite/Stores/StatsStoreV4.swift
+++ b/Yosemite/Yosemite/Stores/StatsStoreV4.swift
@@ -121,6 +121,13 @@ public final class StatsStoreV4: Store {
                                        quantity: quantity,
                                        forceRefresh: forceRefresh,
                                        onCompletion: onCompletion)
+        case let .retrieveTopProductBundles(siteID, timeZone, earliestDateToInclude, latestDateToInclude, quantity, onCompletion):
+            retrieveTopProductBundles(siteID: siteID,
+                                      timeZone: timeZone,
+                                      earliestDateToInclude: earliestDateToInclude,
+                                      latestDateToInclude: latestDateToInclude,
+                                      quantity: quantity,
+                                      onCompletion: onCompletion)
         }
     }
 }
@@ -337,6 +344,28 @@ private extension StatsStoreV4 {
                                                                                             quantity: quantity,
                                                                                             forceRefresh: forceRefresh)
                 onCompletion(.success(bundleStats))
+            } catch {
+                onCompletion(.failure(error))
+            }
+        }
+    }
+
+    /// Retrieves the top product bundles for the provided siteID, and time range, without saving them to the Storage layer.
+    ///
+    func retrieveTopProductBundles(siteID: Int64,
+                                   timeZone: TimeZone,
+                                   earliestDateToInclude: Date,
+                                   latestDateToInclude: Date,
+                                   quantity: Int,
+                                   onCompletion: @escaping (Result<[ProductsReportItem], Error>) -> Void) {
+        Task { @MainActor in
+            do {
+                let topBundles = try await productBundleStatsRemote.loadTopProductBundlesReport(for: siteID,
+                                                                                                timeZone: timeZone,
+                                                                                                earliestDateToInclude: earliestDateToInclude,
+                                                                                                latestDateToInclude: latestDateToInclude,
+                                                                                                quantity: quantity)
+                onCompletion(.success(topBundles))
             } catch {
                 onCompletion(.failure(error))
             }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #12356
<!-- Id number of the GitHub issue this PR addresses. -->

## Why
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This adds Yosemite support for fetching product bundle analytics (stats and top bundles) for display in the Analytics Hub. Like other actions for the Analytics Hub, it returns the results directly without storing them.

## How

1. Adds two new actions to `StatsActionV4` and `StatsStoreV4` (added to this store because they are stats and are similar both in how they are used and how the requests/responses are formatted, even though they use different remote endpoints).
2. Adds a `fake()` method for `ProductsReportItem`, for unit testing.
3. Adds unit tests.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
These actions aren't used in the app yet, so confirm tests pass in CI.


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
