### PR TITLE
Blaze: Remove the stubbed response for campaign creation request and enabled the feature flag

### DIFF
--- a/Experiments/Experiments/DefaultFeatureFlagService.swift
+++ b/Experiments/Experiments/DefaultFeatureFlagService.swift
@@ -82,7 +82,7 @@ public struct DefaultFeatureFlagService: FeatureFlagService {
         case .scanToUpdateInventory:
             return true
         case .blazei3NativeCampaignCreation:
-            return buildConfig == .localDeveloper || buildConfig == .alpha
+            return true
         case .backendReceipts:
             return true
         case .splitViewInProductsTab:

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -2,7 +2,7 @@
 
 18.0
 -----
-- [***] Blaze: revamped the Blaze advertising flow with a native implementation to enhance user experience. This allows merchants to seamlessly create and manage their campaigns directly within the Woo mobile apps, without opening the flow in a webview.
+- [***] Blaze: revamped the Blaze advertising flow with a native implementation to enhance user experience. This allows merchants to seamlessly create and manage their campaigns directly within the Woo mobile apps, without opening the flow in a webview. [https://github.com/woocommerce/woocommerce-ios/pull/12360]
 - [**] Hub Menu: A new Customers section shows a searchable list of customers with their details, including the option to contact a customer via email. [https://github.com/woocommerce/woocommerce-ios/pull/12349]
 - [Internal] Update Woo Purple color palette [https://github.com/woocommerce/woocommerce-ios/pull/12330]
 - [internal] The dependency setup in `AppDelegate`'s `application(_:willFinishLaunchingWithOptions:)` was updated as an attempted fix for one of the top crashes. [https://github.com/woocommerce/woocommerce-ios/pull/12268]

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -2,6 +2,7 @@
 
 18.0
 -----
+- [***] Blaze: revamped the Blaze advertising flow with a native implementation to enhance user experience. This allows merchants to seamlessly create and manage their campaigns directly within the Woo mobile apps, without opening the flow in a webview.
 - [**] Hub Menu: A new Customers section shows a searchable list of customers with their details, including the option to contact a customer via email. [https://github.com/woocommerce/woocommerce-ios/pull/12349]
 - [Internal] Update Woo Purple color palette [https://github.com/woocommerce/woocommerce-ios/pull/12330]
 - [internal] The dependency setup in `AppDelegate`'s `application(_:willFinishLaunchingWithOptions:)` was updated as an attempted fix for one of the top crashes. [https://github.com/woocommerce/woocommerce-ios/pull/12268]

--- a/Yosemite/Yosemite/Stores/BlazeStore.swift
+++ b/Yosemite/Yosemite/Stores/BlazeStore.swift
@@ -87,10 +87,7 @@ private extension BlazeStore {
                         onCompletion: @escaping (Result<Void, Error>) -> Void) {
         Task { @MainActor in
             do {
-                // TODO-11540: remove stubbed result when the API is ready.
-                try await mockResponse(stubbedResult: (), onExecution: {
-                    try await remote.createCampaign(campaign, siteID: siteID)
-                })
+                try await remote.createCampaign(campaign, siteID: siteID)
                 onCompletion(.success(()))
             } catch {
                 onCompletion(.failure(error))


### PR DESCRIPTION
Closes: #11894
Closes: #11803

## Description
This PR updates the campaign creation endpoint handling since the endpoint has been deployed, removing the stubbed response. Additionally, I have activated the feature flag to make the feature accessible in the production environment.


## Testing instructions
1. Test that you can create a new Blaze campaign in production.
2. Based on [this issue](https://github.com/woocommerce/woocommerce-ios/issues/11803), follow the testing instructions of [this PR](https://github.com/woocommerce/woocommerce-ios/pull/11840) for Campaign Creation, checking that the tracking is working as expected.

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
