### PR TITLE
Blaze: Remove the stubbed response for campaign creation request and enabled the feature flag

### DIFF
--- a/Experiments/Experiments/DefaultFeatureFlagService.swift
+++ b/Experiments/Experiments/DefaultFeatureFlagService.swift
@@ -82,7 +82,7 @@ public struct DefaultFeatureFlagService: FeatureFlagService {
         case .scanToUpdateInventory:
             return true
         case .blazei3NativeCampaignCreation:
-            return buildConfig == .localDeveloper || buildConfig == .alpha
+            return true
         case .backendReceipts:
             return true
         case .splitViewInProductsTab:

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -6,6 +6,7 @@
 
 17.9
 -----
+- [***] Blaze: revamped the Blaze advertising flow with a native implementation to enhance user experience. This allows merchants to seamlessly create and manage their campaigns directly within the Woo mobile apps, without opening the flow in a webview.
 - [**] Added 4 home screen quick actions: "New Order", "Orders", "Add a product", "Collect Payment" [https://github.com/woocommerce/woocommerce-ios/pull/12264/]
 - [Internal] Payments: Updated StripeTerminal pod to 3.3.1 [https://github.com/woocommerce/woocommerce-ios/pull/12078]
 

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -6,7 +6,7 @@
 
 17.9
 -----
-- [***] Blaze: revamped the Blaze advertising flow with a native implementation to enhance user experience. This allows merchants to seamlessly create and manage their campaigns directly within the Woo mobile apps, without opening the flow in a webview.
+- [***] Blaze: revamped the Blaze advertising flow with a native implementation to enhance user experience. This allows merchants to seamlessly create and manage their campaigns directly within the Woo mobile apps, without opening the flow in a webview. [https://github.com/woocommerce/woocommerce-ios/pull/12361]
 - [**] Added 4 home screen quick actions: "New Order", "Orders", "Add a product", "Collect Payment" [https://github.com/woocommerce/woocommerce-ios/pull/12264/]
 - [Internal] Payments: Updated StripeTerminal pod to 3.3.1 [https://github.com/woocommerce/woocommerce-ios/pull/12078]
 

--- a/WooCommerce/Classes/ViewRelated/Blaze/BlazeCampaignList/BlazeCampaignListView.swift
+++ b/WooCommerce/Classes/ViewRelated/Blaze/BlazeCampaignList/BlazeCampaignListView.swift
@@ -60,6 +60,20 @@ private extension BlazeCampaignListHostingController {
     }
 }
 
+/// To be used in case we want to present BlazeCampaignListView from a SwiftUI view.
+///
+struct BlazeCampaignListHostingControllerRepresentable: UIViewControllerRepresentable {
+    let siteID: Int64
+
+    func makeUIViewController(context: Context) -> BlazeCampaignListHostingController {
+        let viewModel = BlazeCampaignListViewModel(siteID: siteID)
+        return BlazeCampaignListHostingController(viewModel: viewModel)
+    }
+
+    func updateUIViewController(_ uiViewController: BlazeCampaignListHostingController, context: Context) {
+    }
+}
+
 /// View for showing a list of campaigns.
 ///
 struct BlazeCampaignListView: View {

--- a/WooCommerce/Classes/ViewRelated/Blaze/BudgetSetting/BlazeBudgetSettingView.swift
+++ b/WooCommerce/Classes/ViewRelated/Blaze/BudgetSetting/BlazeBudgetSettingView.swift
@@ -9,7 +9,6 @@ struct BlazeBudgetSettingView: View {
     @State private var showingDurationSetting = false
     @State private var duration: Double = 0
     @State private var startDate = Date()
-    private var minDayAllowedInPickerSelection = Date.now + 60 * 60 * 24 // Current date + 1 day
 
     @ObservedObject private var viewModel: BlazeBudgetSettingViewModel
 
@@ -208,7 +207,7 @@ private extension BlazeBudgetSettingView {
 
                         Spacer()
 
-                        DatePicker(selection: $startDate, in: minDayAllowedInPickerSelection..., displayedComponents: [.date]) {
+                        DatePicker(selection: $startDate, in: viewModel.minDayAllowedInPickerSelection..., displayedComponents: [.date]) {
                             EmptyView()
                         }
                         .datePickerStyle(.compact)

--- a/WooCommerce/Classes/ViewRelated/Blaze/BudgetSetting/BlazeBudgetSettingView.swift
+++ b/WooCommerce/Classes/ViewRelated/Blaze/BudgetSetting/BlazeBudgetSettingView.swift
@@ -9,6 +9,7 @@ struct BlazeBudgetSettingView: View {
     @State private var showingDurationSetting = false
     @State private var duration: Double = 0
     @State private var startDate = Date()
+    private var minDayAllowedInPickerSelection = Date.now + 60 * 60 * 24 // Current date + 1 day
 
     @ObservedObject private var viewModel: BlazeBudgetSettingViewModel
 
@@ -207,7 +208,7 @@ private extension BlazeBudgetSettingView {
 
                         Spacer()
 
-                        DatePicker(selection: $startDate, in: Date()..., displayedComponents: [.date]) {
+                        DatePicker(selection: $startDate, in: minDayAllowedInPickerSelection..., displayedComponents: [.date]) {
                             EmptyView()
                         }
                         .datePickerStyle(.compact)
@@ -331,6 +332,7 @@ private extension BlazeBudgetSettingView {
 
 struct BlazeBudgetSettingView_Previews: PreviewProvider {
     static var previews: some View {
-        BlazeBudgetSettingView(viewModel: BlazeBudgetSettingViewModel(siteID: 123, dailyBudget: 5, duration: 7, startDate: .now) { _, _, _ in })
+        let tomorrow = Date.now + 60 * 60 * 24 // Current date + 1 day
+        BlazeBudgetSettingView(viewModel: BlazeBudgetSettingViewModel(siteID: 123, dailyBudget: 5, duration: 7, startDate: tomorrow) { _, _, _ in })
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Blaze/BudgetSetting/BlazeBudgetSettingViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Blaze/BudgetSetting/BlazeBudgetSettingViewModel.swift
@@ -19,6 +19,8 @@ final class BlazeBudgetSettingViewModel: ObservableObject {
     /// Using Double because Slider doesn't work with Int
     let dayCountSliderRange = Double(Constants.minimumDayCount)...Double(Constants.maximumDayCount)
 
+    let minDayAllowedInPickerSelection = Date.now + 60 * 60 * 24 // Current date + 1 day
+    
     var dailyAmountText: String {
         let formattedAmount = String(format: "$%.0f", dailyAmount)
         return String.localizedStringWithFormat(Localization.dailyAmount, formattedAmount)

--- a/WooCommerce/Classes/ViewRelated/Blaze/BudgetSetting/BlazeBudgetSettingViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Blaze/BudgetSetting/BlazeBudgetSettingViewModel.swift
@@ -20,7 +20,7 @@ final class BlazeBudgetSettingViewModel: ObservableObject {
     let dayCountSliderRange = Double(Constants.minimumDayCount)...Double(Constants.maximumDayCount)
 
     let minDayAllowedInPickerSelection = Date.now + 60 * 60 * 24 // Current date + 1 day
-    
+
     var dailyAmountText: String {
         let formattedAmount = String(format: "$%.0f", dailyAmount)
         return String.localizedStringWithFormat(Localization.dailyAmount, formattedAmount)

--- a/WooCommerce/Classes/ViewRelated/Blaze/CampaignCreation/BlazeCampaignCreationFormViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Blaze/CampaignCreation/BlazeCampaignCreationFormViewModel.swift
@@ -29,7 +29,7 @@ final class BlazeCampaignCreationFormViewModel: ObservableObject {
     @Published private(set) var description: String = ""
 
     // Budget details
-    private var startDate = Date.now
+    private var startDate = Date.now + 60 * 60 * 24 // Current date + 1 day
     private var dailyBudget = BlazeBudgetSettingViewModel.Constants.minimumDailyAmount
     private var duration = BlazeBudgetSettingViewModel.Constants.defaultDayCount
 

--- a/WooCommerce/Classes/ViewRelated/Hub Menu/HubMenu.swift
+++ b/WooCommerce/Classes/ViewRelated/Hub Menu/HubMenu.swift
@@ -146,7 +146,7 @@ private extension HubMenu {
             case HubMenuViewModel.Payments.id:
                 paymentsView
             case HubMenuViewModel.Blaze.id:
-                BlazeCampaignListView(viewModel: .init(siteID: viewModel.siteID))
+                BlazeCampaignListHostingControllerRepresentable(siteID: viewModel.siteID)
             case HubMenuViewModel.WoocommerceAdmin.id:
                 webView(url: viewModel.woocommerceAdminURL,
                         title: HubMenuViewModel.Localization.woocommerceAdmin,

--- a/Yosemite/Yosemite/Stores/BlazeStore.swift
+++ b/Yosemite/Yosemite/Stores/BlazeStore.swift
@@ -87,10 +87,7 @@ private extension BlazeStore {
                         onCompletion: @escaping (Result<Void, Error>) -> Void) {
         Task { @MainActor in
             do {
-                // TODO-11540: remove stubbed result when the API is ready.
-                try await mockResponse(stubbedResult: (), onExecution: {
-                    try await remote.createCampaign(campaign, siteID: siteID)
-                })
+                try await remote.createCampaign(campaign, siteID: siteID)
                 onCompletion(.success(()))
             } catch {
                 onCompletion(.failure(error))


### PR DESCRIPTION
Closes: #11894
Closes: #11803

## Description
This PR updates the campaign creation endpoint handling since the endpoint has been deployed, removing the stubbed response. Additionally, I have activated the feature flag to make the feature accessible in the production environment.


## Testing instructions
1. Test that you can create a new Blaze campaign in production.
2. Based on [this issue](https://github.com/woocommerce/woocommerce-ios/issues/11803), follow the testing instructions of [this PR](https://github.com/woocommerce/woocommerce-ios/pull/11840) for Campaign Creation, checking that the tracking is working as expected.
3. Make sure you are able to create a new Blaze campaign starting from Menu -> Blaze.

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.