### PR TITLE
[Analytics Hub] Product Bundles: Add logic for displaying a product bundles card

### DIFF
--- a/Experiments/Experiments/DefaultFeatureFlagService.swift
+++ b/Experiments/Experiments/DefaultFeatureFlagService.swift
@@ -89,6 +89,8 @@ public struct DefaultFeatureFlagService: FeatureFlagService {
             return true
         case .customersInHubMenu:
             return true
+        case .expandedAnalyticsHub:
+            return buildConfig == .localDeveloper || buildConfig == .alpha
         default:
             return true
         }

--- a/Experiments/Experiments/FeatureFlag.swift
+++ b/Experiments/Experiments/FeatureFlag.swift
@@ -199,4 +199,8 @@ public enum FeatureFlag: Int {
     /// Displays a Customers section in the Hub menu.
     ///
     case customersInHubMenu
+
+    /// Displays analytics cards for extensions in the Analytics Hub.
+    ///
+    case expandedAnalyticsHub
 }

--- a/Storage/Storage/Model/AnalyticsCard.swift
+++ b/Storage/Storage/Model/AnalyticsCard.swift
@@ -21,5 +21,6 @@ public struct AnalyticsCard: Codable, Hashable, Equatable, GeneratedCopiable {
         case orders
         case products
         case sessions
+        case bundles
     }
 }

--- a/WooCommerce/Classes/Extensions/SitePlugin+Woo.swift
+++ b/WooCommerce/Classes/Extensions/SitePlugin+Woo.swift
@@ -7,7 +7,7 @@ extension SitePlugin {
         public static let WCShip = "WooCommerce Shipping &amp; Tax"
         public static let WCTracking = "WooCommerce Shipment Tracking"
         public static let WCSubscriptions = ["WooCommerce Subscriptions", "Woo Subscriptions"]
-        public static let WCProductBundles = "WooCommerce Product Bundles"
+        public static let WCProductBundles = ["WooCommerce Product Bundles", "Woo Product Bundles"]
         public static let WCCompositeProducts = "WooCommerce Composite Products"
         public static let square = "WooCommerce Square"
     }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/AnalyticsHubView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/AnalyticsHubView.swift
@@ -146,6 +146,8 @@ private extension AnalyticsHubView {
             } else {
                 AnalyticsReportCard(viewModel: viewModel.sessionsCard)
             }
+        case .bundles:
+            EmptyView() // TODO-12160: Add bundles card UI
         }
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/AnalyticsHubViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/AnalyticsHubViewModel.swift
@@ -27,6 +27,10 @@ final class AnalyticsHubViewModel: ObservableObject {
     ///
     private let userIsAdmin: Bool
 
+    /// Feature flag for Expanded Analytics Hub (extension analytics)
+    ///
+    private let isExpandedAnalyticsHubEnabled: Bool
+
     init(siteID: Int64,
          timeZone: TimeZone = .siteTimezone,
          statsTimeRange: StatsTimeRangeV4,
@@ -34,7 +38,8 @@ final class AnalyticsHubViewModel: ObservableObject {
          stores: StoresManager = ServiceLocator.stores,
          analytics: Analytics = ServiceLocator.analytics,
          noticePresenter: NoticePresenter = ServiceLocator.noticePresenter,
-         backendProcessingDelay: UInt64 = 500_000_000) {
+         backendProcessingDelay: UInt64 = 500_000_000,
+         isExpandedAnalyticsHubEnabled: Bool = ServiceLocator.featureFlagService.isFeatureFlagEnabled(.expandedAnalyticsHub)) {
         let selectedType = AnalyticsHubTimeRangeSelection.SelectionType(statsTimeRange)
         let timeRangeSelection = AnalyticsHubTimeRangeSelection(selectionType: selectedType, timezone: timeZone)
 
@@ -45,6 +50,7 @@ final class AnalyticsHubViewModel: ObservableObject {
         self.analytics = analytics
         self.noticePresenter = noticePresenter
         self.backendProcessingDelay = backendProcessingDelay
+        self.isExpandedAnalyticsHubEnabled = isExpandedAnalyticsHubEnabled
         self.timeRangeSelectionType = selectedType
         self.timeRangeSelection = timeRangeSelection
         self.timeRangeCard = AnalyticsHubViewModel.timeRangeCard(timeRangeSelection: timeRangeSelection,

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/Customize/AnalyticsCard+UI.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/Customize/AnalyticsCard+UI.swift
@@ -14,6 +14,8 @@ extension AnalyticsCard {
             return Localization.products
         case .sessions:
             return Localization.sessions
+        case .bundles:
+            return Localization.bundles
         }
     }
 }
@@ -33,5 +35,8 @@ private extension AnalyticsCard {
         static let sessions = NSLocalizedString("analyticsHub.customize.sessions",
                                                 value: "Sessions",
                                                 comment: "Name for the Sessions analytics card in the Customize Analytics screen")
+        static let bundles = NSLocalizedString("analyticsHub.customize.bundles",
+                                                value: "Bundles",
+                                                comment: "Name for the Product Bundles analytics card in the Customize Analytics screen")
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Products/Filters/FilterProductListViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Filters/FilterProductListViewModel.swift
@@ -157,7 +157,7 @@ extension FilterProductListViewModel.ProductListFilter {
         let activePluginNames = fetchActivePluginNames(siteID: siteID, storageManager: storageManager)
         let isSubscriptionsAvailable = Set(activePluginNames).intersection(SitePlugin.SupportedPlugin.WCSubscriptions).count > 0
         let isCompositeProductsAvailable = activePluginNames.contains(SitePlugin.SupportedPlugin.WCCompositeProducts)
-        let isProductBundlesAvailable = activePluginNames.contains(SitePlugin.SupportedPlugin.WCProductBundles)
+        let isProductBundlesAvailable = activePluginNames.contains(where: SitePlugin.SupportedPlugin.WCProductBundles.contains)
 
         return [nil,
                 .init(productType: .simple, isAvailable: true, promoteUrl: nil),

--- a/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Analytics Hub/AnalyticsHubViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Analytics Hub/AnalyticsHubViewModelTests.swift
@@ -590,7 +590,9 @@ final class AnalyticsHubViewModelTests: XCTestCase {
     func test_product_bundles_card_displayed_when_plugin_active() {
         // Given
         let storage = MockStorageManager()
-        storage.insertSampleSystemPlugin(readOnlySystemPlugin: .fake().copy(siteID: sampleSiteID, name: SitePlugin.SupportedPlugin.WCProductBundles.first, active: true))
+        storage.insertSampleSystemPlugin(readOnlySystemPlugin: .fake().copy(siteID: sampleSiteID,
+                                                                            name: SitePlugin.SupportedPlugin.WCProductBundles.first,
+                                                                            active: true))
         let vm = createViewModel(storage: storage)
 
         // Then

--- a/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Analytics Hub/AnalyticsHubViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Analytics Hub/AnalyticsHubViewModelTests.swift
@@ -13,6 +13,7 @@ final class AnalyticsHubViewModelTests: XCTestCase {
     private var noticePresenter: MockNoticePresenter!
     private var vm: AnalyticsHubViewModel!
 
+    private let sampleSiteID: Int64 = 123
     private let sampleAdminURL = "https://example.com/wp-admin/"
 
     override func setUp() {
@@ -417,7 +418,8 @@ final class AnalyticsHubViewModelTests: XCTestCase {
         let expectedCards = [AnalyticsCard(type: .revenue, enabled: true),
                              AnalyticsCard(type: .orders, enabled: false),
                              AnalyticsCard(type: .products, enabled: false),
-                             AnalyticsCard(type: .sessions, enabled: false)]
+                             AnalyticsCard(type: .sessions, enabled: false),
+                             AnalyticsCard(type: .bundles, enabled: true)]
         assertEqual(expectedCards, storedAnalyticsCards)
     }
 
@@ -573,11 +575,8 @@ final class AnalyticsHubViewModelTests: XCTestCase {
 
         // Then
         let customizeAnalyticsVM = try XCTUnwrap(vm.customizeAnalyticsViewModel)
-        let expectedCards = [AnalyticsCard(type: .revenue, enabled: true),
-                             AnalyticsCard(type: .orders, enabled: true),
-                             AnalyticsCard(type: .products, enabled: true)]
         XCTAssertFalse(vm.enabledCards.contains(.sessions))
-        assertEqual(expectedCards, customizeAnalyticsVM.allCards)
+        XCTAssertFalse(customizeAnalyticsVM.allCards.contains(where: { $0.type == .sessions }))
     }
 
     func test_customizeAnalytics_tracks_expected_event() {
@@ -587,16 +586,40 @@ final class AnalyticsHubViewModelTests: XCTestCase {
         // Then
         XCTAssert(analyticsProvider.receivedEvents.contains(WooAnalyticsStat.analyticsHubSettingsOpened.rawValue))
     }
+
+    func test_product_bundles_card_displayed_when_plugin_active() {
+        // Given
+        let storage = MockStorageManager()
+        storage.insertSampleSystemPlugin(readOnlySystemPlugin: .fake().copy(siteID: sampleSiteID, name: SitePlugin.SupportedPlugin.WCProductBundles.first, active: true))
+        let vm = createViewModel(storage: storage)
+
+        // Then
+        XCTAssertTrue(vm.enabledCards.contains(.bundles))
+    }
+
+    func test_product_bundles_card_not_displayed_when_plugin_inactive() {
+        // Given
+        let storage = MockStorageManager()
+        storage.insertSampleSystemPlugin(readOnlySystemPlugin: .fake().copy(siteID: sampleSiteID,
+                                                                            name: SitePlugin.SupportedPlugin.WCProductBundles.first,
+                                                                            active: false))
+        let vm = createViewModel(storage: storage)
+
+        // Then
+        XCTAssertFalse(vm.enabledCards.contains(.bundles))
+    }
 }
 
 private extension AnalyticsHubViewModelTests {
-    func createViewModel(stores: MockStoresManager? = nil) -> AnalyticsHubViewModel {
-        AnalyticsHubViewModel(siteID: 123,
+    func createViewModel(stores: MockStoresManager? = nil, storage: MockStorageManager? = nil) -> AnalyticsHubViewModel {
+        AnalyticsHubViewModel(siteID: sampleSiteID,
                               statsTimeRange: .thisMonth,
                               usageTracksEventEmitter: eventEmitter,
                               stores: stores ?? self.stores,
+                              storage: storage ?? MockStorageManager(),
                               analytics: analytics,
                               noticePresenter: noticePresenter,
-                              backendProcessingDelay: 0)
+                              backendProcessingDelay: 0,
+                              isExpandedAnalyticsHubEnabled: true)
     }
 }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/Filters/FilterProductListViewModelProductListFilterTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/Filters/FilterProductListViewModelProductListFilterTests.swift
@@ -108,7 +108,7 @@ final class FilterProductListViewModelProductListFilterTests: XCTestCase {
                                                                                 name: SitePlugin.SupportedPlugin.WCSubscriptions[0],
                                                                                 active: true))
         mockStorage.insertSampleSystemPlugin(readOnlySystemPlugin: .fake().copy(siteID: sampleSiteID,
-                                                                                name: SitePlugin.SupportedPlugin.WCProductBundles,
+                                                                                name: SitePlugin.SupportedPlugin.WCProductBundles[0],
                                                                                 active: true))
 
         // When


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of: #12160
<!-- Id number of the GitHub issue this PR addresses. -->

## Why
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This adds the logic for displaying a product bundles card in the Analytics Hub:

* Only displays the card if the feature flag is active (for development).
* Only displays the card if the Product Bundles plugin is active on the store.

It also shows a Bundles row when customizing cards in the Analytics Hub, with the same conditions.

## How

* Adds a feature flag `expandedAnalyticsHub` to hide the bundles card during development.
* Adds a `bundles` card type to `AnalyticsCard`.
* Updates `WCProductBundles` in the `SitePlugin.SupportedPlugins` extension to include the newer plugin name, so we can check if it's active on the store.
   * Note: This also fixes an issue where the bundle product filter wasn't available on stores with the new plugin name.
* In the Analytics Hub view model:
   * Adds an `activePlugins` property that fetches the names of the active plugins from storage. These plugins are synced when the app is opened, so this data should always be available.
   * Adds a helper to check if a given plugin is in `activePlugins`.
   * Checks if the bundles card can be included in `enabledCards` (if the feature flag is enabled and the plugin is active).
   * In `customizeAnalytics()`, excludes the bundles card if the plugin isn't active.
* In the Analytics Hub view, adds an empty view for the bundles card. This will be updated with the real UI in another PR.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

1. Build and run the app.
2. Open the Analytics Hub.
3. Select "Edit" to customize the cards.
4. On a store with Product Bundles extension active, confirm you see the option to enable/disable the bundles card.
5. On a store without that extension, confirm you don't see the option to enable/disable the bundles card.

Testing for the bundles card appearing in the Analytics Hub will be done in the PR where the card UI is added.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->
With plugin|Without plugin
-|-
![Simulator Screenshot - iPhone 15 Pro - 2024-03-26 at 16 55 15](https://github.com/woocommerce/woocommerce-ios/assets/8658164/0a085708-d51d-45c3-b4a2-37c103486a9f)|![Simulator Screenshot - iPhone 15 Pro - 2024-03-26 at 16 56 09](https://github.com/woocommerce/woocommerce-ios/assets/8658164/13864430-6a38-4ff1-8487-c9b6d06c7b11)

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
