### PR TITLE
[Analytics Hub] Update Analytics Hub design with milestone 1 design feedback

### DIFF
--- a/WooCommerce/Classes/Extensions/Date+Woo.swift
+++ b/WooCommerce/Classes/Extensions/Date+Woo.swift
@@ -101,7 +101,7 @@ extension Date {
             formattedEnd = DateFormatter.Stats.createDayMonthYearFormatter(timezone: timezone).string(from: other)
         }
 
-        return "\(formattedStart) - \(formattedEnd)"
+        return "\(formattedStart) – \(formattedEnd)"
     }
 
     /// Returns the next midnight starting from `self`.

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/AnalyticsProductCard.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/AnalyticsProductCard.swift
@@ -89,11 +89,7 @@ struct AnalyticsProductCard: View {
             }
 
             if let reportViewModel {
-                VStack(spacing: Layout.cardPadding) {
-                    Divider()
-                        .padding(.horizontal, Layout.dividerPadding)
-                    AnalyticsReportLink(showingWebReport: $showingWebReport, reportViewModel: reportViewModel)
-                }
+                AnalyticsReportLink(showingWebReport: $showingWebReport, reportViewModel: reportViewModel)
             }
         }
         .padding(Layout.cardPadding)
@@ -115,7 +111,6 @@ private extension AnalyticsProductCard {
         static let titleSpacing: CGFloat = 24
         static let cardPadding: CGFloat = 16
         static let columnSpacing: CGFloat = 10
-        static let dividerPadding: CGFloat = -16
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/AnalyticsReportCard.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/AnalyticsReportCard.swift
@@ -107,11 +107,7 @@ struct AnalyticsReportCard: View {
             }
 
             if let reportViewModel {
-                VStack(spacing: Layout.cardPadding) {
-                    Divider()
-                        .padding(.horizontal, Layout.dividerPadding)
-                    AnalyticsReportLink(showingWebReport: $showingWebReport, reportViewModel: reportViewModel)
-                }
+                AnalyticsReportLink(showingWebReport: $showingWebReport, reportViewModel: reportViewModel)
             }
         }
         .padding(Layout.cardPadding)
@@ -128,7 +124,6 @@ private extension AnalyticsReportCard {
         static let chartHeight: CGFloat = 32
         static let chartWidth: CGFloat = 72
         static let chartAspectRatio: CGFloat = 2.25
-        static let dividerPadding: CGFloat = -16
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/AnalyticsReportLink.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/AnalyticsReportLink.swift
@@ -30,7 +30,7 @@ struct AnalyticsReportLink: View {
 private extension AnalyticsReportLink {
     enum Localization {
         static let seeReport = NSLocalizedString("analyticsHub.reportCard.webReport",
-                                                 value: "See Report",
+                                                 value: "See report",
                                                  comment: "Button label to show an analytics report in the Analytics Hub")
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/AnalyticsReportLink.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/AnalyticsReportLink.swift
@@ -7,20 +7,23 @@ struct AnalyticsReportLink: View {
     let reportViewModel: AnalyticsReportLinkViewModel
 
     var body: some View {
-        Button {
-            reportViewModel.onWebViewOpen()
-            showingWebReport = true
-        } label: {
-            Text(Localization.seeReport)
-                .bodyStyle()
-                .frame(maxWidth: .infinity, alignment: .leading)
-            DisclosureIndicator()
-        }
-        .sheet(isPresented: $showingWebReport) {
-            WooNavigationSheet(viewModel: .init(navigationTitle: reportViewModel.title, done: {
-                showingWebReport = false
-            })) {
-                AuthenticatedWebView(isPresented: $showingWebReport, viewModel: reportViewModel)
+        VStack(spacing: Layout.spacing) {
+            Divider().padding(.trailing, Layout.dividerPadding)
+            Button {
+                reportViewModel.onWebViewOpen()
+                showingWebReport = true
+            } label: {
+                Text(Localization.seeReport)
+                    .bodyStyle()
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                DisclosureIndicator()
+            }
+            .sheet(isPresented: $showingWebReport) {
+                WooNavigationSheet(viewModel: .init(navigationTitle: reportViewModel.title, done: {
+                    showingWebReport = false
+                })) {
+                    AuthenticatedWebView(isPresented: $showingWebReport, viewModel: reportViewModel)
+                }
             }
         }
     }
@@ -28,6 +31,11 @@ struct AnalyticsReportLink: View {
 
 // MARK: Constants
 private extension AnalyticsReportLink {
+    enum Layout {
+        static let spacing: CGFloat = 16
+        static let dividerPadding: CGFloat = -16
+    }
+
     enum Localization {
         static let seeReport = NSLocalizedString("analyticsHub.reportCard.webReport",
                                                  value: "See report",

--- a/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Analytics Hub/AnalyticsHubTimeRangeSelectionTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Analytics Hub/AnalyticsHubTimeRangeSelectionTests.swift
@@ -226,8 +226,8 @@ final class AnalyticsHubTimeRangeSelectionTests: XCTestCase {
         let previousRangeDescription = timeRange.previousRangeDescription
 
         // Then
-        XCTAssertEqual(currentRangeDescription, "Jan 1 - Jul 1, 2022")
-        XCTAssertEqual(previousRangeDescription, "Jan 1 - Jul 1, 2021")
+        XCTAssertEqual(currentRangeDescription, "Jan 1 – Jul 1, 2022")
+        XCTAssertEqual(previousRangeDescription, "Jan 1 – Jul 1, 2021")
     }
 
     func test_when_time_range_inits_with_lastYear_then_generate_expected_descriptions() throws {
@@ -243,8 +243,8 @@ final class AnalyticsHubTimeRangeSelectionTests: XCTestCase {
         let previousRangeDescription = timeRange.previousRangeDescription
 
         // Then
-        XCTAssertEqual(currentRangeDescription, "Jan 1 - Dec 31, 2021")
-        XCTAssertEqual(previousRangeDescription, "Jan 1 - Dec 31, 2020")
+        XCTAssertEqual(currentRangeDescription, "Jan 1 – Dec 31, 2021")
+        XCTAssertEqual(previousRangeDescription, "Jan 1 – Dec 31, 2020")
     }
 
     func test_when_time_range_inits_with_quarterToDate_then_generate_expected_descriptions() throws {
@@ -260,8 +260,8 @@ final class AnalyticsHubTimeRangeSelectionTests: XCTestCase {
         let previousRangeDescription = timeRange.previousRangeDescription
 
         // Then
-        XCTAssertEqual(currentRangeDescription, "Jan 1 - Feb 15, 2022")
-        XCTAssertEqual(previousRangeDescription, "Oct 1 - Nov 15, 2021")
+        XCTAssertEqual(currentRangeDescription, "Jan 1 – Feb 15, 2022")
+        XCTAssertEqual(previousRangeDescription, "Oct 1 – Nov 15, 2021")
     }
 
     func test_when_time_range_inits_with_lastQuarter_then_generate_expected_descriptions() throws {
@@ -277,8 +277,8 @@ final class AnalyticsHubTimeRangeSelectionTests: XCTestCase {
         let previousRangeDescription = timeRange.previousRangeDescription
 
         // Then
-        XCTAssertEqual(currentRangeDescription, "Jan 1 - Mar 31, 2022")
-        XCTAssertEqual(previousRangeDescription, "Oct 1 - Dec 31, 2021")
+        XCTAssertEqual(currentRangeDescription, "Jan 1 – Mar 31, 2022")
+        XCTAssertEqual(previousRangeDescription, "Oct 1 – Dec 31, 2021")
     }
 
     func test_when_time_range_inits_with_monthToDate_in_month_last_day_then_generate_expected_descriptions() throws {
@@ -294,8 +294,8 @@ final class AnalyticsHubTimeRangeSelectionTests: XCTestCase {
         let previousRangeDescription = timeRange.previousRangeDescription
 
         // Then
-        XCTAssertEqual(currentRangeDescription, "Jul 1 - 31, 2022")
-        XCTAssertEqual(previousRangeDescription, "Jun 1 - 30, 2022")
+        XCTAssertEqual(currentRangeDescription, "Jul 1 – 31, 2022")
+        XCTAssertEqual(previousRangeDescription, "Jun 1 – 30, 2022")
     }
 
     func test_when_time_range_inits_with_monthToDate_then_generate_expected_descriptions() throws {
@@ -311,8 +311,8 @@ final class AnalyticsHubTimeRangeSelectionTests: XCTestCase {
         let previousRangeDescription = timeRange.previousRangeDescription
 
         // Then
-        XCTAssertEqual(currentRangeDescription, "Jul 1 - 20, 2022")
-        XCTAssertEqual(previousRangeDescription, "Jun 1 - 20, 2022")
+        XCTAssertEqual(currentRangeDescription, "Jul 1 – 20, 2022")
+        XCTAssertEqual(previousRangeDescription, "Jun 1 – 20, 2022")
     }
 
     func test_when_time_range_inits_with_lastMonth_then_generate_expected_descriptions() throws {
@@ -328,8 +328,8 @@ final class AnalyticsHubTimeRangeSelectionTests: XCTestCase {
         let previousRangeDescription = timeRange.previousRangeDescription
 
         // Then
-        XCTAssertEqual(currentRangeDescription, "Jun 1 - 30, 2022")
-        XCTAssertEqual(previousRangeDescription, "May 1 - 31, 2022")
+        XCTAssertEqual(currentRangeDescription, "Jun 1 – 30, 2022")
+        XCTAssertEqual(previousRangeDescription, "May 1 – 31, 2022")
     }
 
     func test_when_time_range_inits_with_weekToDate_then_generate_expected_descriptions() throws {
@@ -345,8 +345,8 @@ final class AnalyticsHubTimeRangeSelectionTests: XCTestCase {
         let previousRangeDescription = timeRange.previousRangeDescription
 
         // Then
-        XCTAssertEqual(currentRangeDescription, "Jul 25 - 29, 2022")
-        XCTAssertEqual(previousRangeDescription, "Jul 18 - 22, 2022")
+        XCTAssertEqual(currentRangeDescription, "Jul 25 – 29, 2022")
+        XCTAssertEqual(previousRangeDescription, "Jul 18 – 22, 2022")
     }
 
     func test_when_time_range_inits_with_weekToDate_with_different_months_then_generate_expected_descriptions() throws {
@@ -362,8 +362,8 @@ final class AnalyticsHubTimeRangeSelectionTests: XCTestCase {
         let previousRangeDescription = timeRange.previousRangeDescription
 
         // Then
-        XCTAssertEqual(currentRangeDescription, "Jun 27 - Jul 2, 2022")
-        XCTAssertEqual(previousRangeDescription, "Jun 20 - 25, 2022")
+        XCTAssertEqual(currentRangeDescription, "Jun 27 – Jul 2, 2022")
+        XCTAssertEqual(previousRangeDescription, "Jun 20 – 25, 2022")
     }
 
     func test_when_time_range_inits_with_lastWeek_then_generate_expected_descriptions() throws {
@@ -379,8 +379,8 @@ final class AnalyticsHubTimeRangeSelectionTests: XCTestCase {
         let previousRangeDescription = timeRange.previousRangeDescription
 
         // Then
-        XCTAssertEqual(currentRangeDescription, "Jul 18 - 24, 2022")
-        XCTAssertEqual(previousRangeDescription, "Jul 11 - 17, 2022")
+        XCTAssertEqual(currentRangeDescription, "Jul 18 – 24, 2022")
+        XCTAssertEqual(previousRangeDescription, "Jul 11 – 17, 2022")
     }
 
     func test_when_time_range_inits_with_lastWeek_with_different_months_then_generate_expected_descriptions() throws {
@@ -396,8 +396,8 @@ final class AnalyticsHubTimeRangeSelectionTests: XCTestCase {
         let previousRangeDescription = timeRange.previousRangeDescription
 
         // Then
-        XCTAssertEqual(currentRangeDescription, "Jun 27 - Jul 3, 2022")
-        XCTAssertEqual(previousRangeDescription, "Jun 20 - 26, 2022")
+        XCTAssertEqual(currentRangeDescription, "Jun 27 – Jul 3, 2022")
+        XCTAssertEqual(previousRangeDescription, "Jun 20 – 26, 2022")
     }
 
     func test_when_time_range_inits_with_today_then_generate_expected_descriptions() throws {
@@ -447,8 +447,8 @@ final class AnalyticsHubTimeRangeSelectionTests: XCTestCase {
         let previousRangeDescription = timeRange.previousRangeDescription
 
         // Then
-        XCTAssertEqual(currentRangeDescription, "Dec 5 - 7, 2022")
-        XCTAssertEqual(previousRangeDescription, "Dec 2 - 4, 2022")
+        XCTAssertEqual(currentRangeDescription, "Dec 5 – 7, 2022")
+        XCTAssertEqual(previousRangeDescription, "Dec 2 – 4, 2022")
     }
 
     private func currentDate(from date: String) -> Date {


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #12035
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

This fixes three issues in the Analytics Hub based on design feedback:

1. Updates the Analytics Hub time range to use an en dash between dates.
2. Updates the analytics report link to use sentence case ("See report" instead of "See Report").
3. Updates the divider between the analytics card metrics and report link to have leading padding. The divider and padding are now part of the `AnalyticsReportLink` view, to ensure consistency in all the cards where it's used.

Note: The report link text will continue to use title case ("See Report") until the app's `Localizable.strings` file is updated during release.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

1. Build and run the app.
2. Open the Analytics Hub.
3. Select a time range described with a range of dates, and confirm it uses an en dash instead of a hyphen.
4. Confirm the report links are displayed as expected on the cards, with leading padding on the divider.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->
Before|After
-|-
![Simulator Screenshot - iPhone 15 Pro - 2024-03-26 at 17 16 40](https://github.com/woocommerce/woocommerce-ios/assets/8658164/4d360167-d10c-44cd-9ed1-875138923dbd)|![Simulator Screenshot - iPhone 15 Pro - 2024-03-26 at 17 17 43](https://github.com/woocommerce/woocommerce-ios/assets/8658164/77ef93eb-4b2c-4286-9473-b8fd6504b8cf)

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
