### PR TITLE
Product Form: Extra title on the product form causes the navigation bar to be cluttering in small screens

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewController.swift
@@ -195,6 +195,12 @@ final class ProductFormViewController<ViewModel: ProductFormViewModelProtocol>: 
     override var shouldShowOfflineBanner: Bool {
         return true
     }
+    
+    override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
+        super.traitCollectionDidChange(previousTraitCollection)
+        
+        updateNavigationBarTitle()
+    }
 
     // MARK: - Navigation actions handling
 
@@ -1183,6 +1189,10 @@ private extension ProductFormViewController {
     }
 
     func updateNavigationBarTitle() {
+        guard traitCollection.horizontalSizeClass != .compact else {
+            title = nil
+            return
+        }
         // Update navigation bar title with variation ID for variation page
         guard let variationID = viewModel.productionVariationID else {
             title = Localization.defaultTitle

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewController.swift
@@ -195,10 +195,10 @@ final class ProductFormViewController<ViewModel: ProductFormViewModelProtocol>: 
     override var shouldShowOfflineBanner: Bool {
         return true
     }
-    
+
     override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
         super.traitCollectionDidChange(previousTraitCollection)
-        
+
         updateNavigationBarTitle()
     }
 


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #12289
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

- Set navigation title for non compact horizontal size class

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

- Test on both iPhone and iPad with different layouts (compact, regular)
- Navigation title on product screen should be shown only if the horizontal size class is not compact

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

![Simulator Screenshot - iPad Pro (11-inch) (4th generation) - 2024-03-27 at 09 51 10](https://github.com/woocommerce/woocommerce-ios/assets/6242034/fb264cde-4d56-4b0b-8642-ba3d776e614b)
![Simulator Screenshot - iPad Pro (11-inch) (4th generation) - 2024-03-27 at 09 51 08](https://github.com/woocommerce/woocommerce-ios/assets/6242034/31f8921b-aa5b-47c2-a951-e986e4f78a4f)
![Simulator Screenshot - iPad Pro (11-inch) (4th generation) - 2024-03-27 at 09 51 05](https://github.com/woocommerce/woocommerce-ios/assets/6242034/73b0dafa-3559-4872-bb7d-40c9e2c7e0e9)
![Simulator Screenshot - iPad Pro (11-inch) (4th generation) - 2024-03-27 at 09 51 03](https://github.com/woocommerce/woocommerce-ios/assets/6242034/c6b4e026-f12f-4fb6-8fed-8175b53e98d5)

---
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
