### PR TITLE
[Analytics Hub] Product Bundles: Show bundles card in Analytics Hub

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/AnalyticsHubView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/AnalyticsHubView.swift
@@ -147,7 +147,7 @@ private extension AnalyticsHubView {
                 AnalyticsReportCard(viewModel: viewModel.sessionsCard)
             }
         case .bundles:
-            EmptyView() // TODO-12160: Add bundles card UI
+            AnalyticsItemsSoldCard(bundlesViewModel: viewModel.bundlesCard)
         }
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/AnalyticsHubViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/AnalyticsHubViewModel.swift
@@ -113,6 +113,17 @@ final class AnalyticsHubViewModel: ObservableObject {
                                     isRedacted: isLoadingOrderStats || isLoadingSiteStats)
     }
 
+    /// Product Bundles Card ViewModel
+    ///
+    var bundlesCard: AnalyticsBundlesReportCardViewModel {
+        AnalyticsBundlesReportCardViewModel(currentPeriodStats: currentBundleStats,
+                                            previousPeriodStats: previousBundleStats,
+                                            bundlesSoldReport: bundlesSoldStats,
+                                            timeRange: timeRangeSelectionType,
+                                            isRedacted: isLoadingBundleStats,
+                                            usageTracksEventEmitter: usageTracksEventEmitter)
+    }
+
     /// View model for `AnalyticsHubCustomizeView`, to customize the cards in the Analytics Hub.
     ///
     @Published var customizeAnalyticsViewModel: AnalyticsHubCustomizeViewModel?
@@ -208,6 +219,18 @@ final class AnalyticsHubViewModel: ObservableObject {
     ///
     @Published private var siteStats: SiteSummaryStats? = nil
 
+    /// Product bundle stats for the current selected time period. Used in the bundles card.
+    ///
+    @Published private var currentBundleStats: ProductBundleStats? = nil
+
+    /// Product bundle stats for the previous selected time period. Used in the bundles card.
+    ///
+    @Published private var previousBundleStats: ProductBundleStats? = nil
+
+    /// Stats fo the current top bundles sold. Used in the bundles card.
+    ///
+    @Published private var bundlesSoldStats: [ProductsReportItem]? = nil
+
     /// Loading state for order stats.
     ///
     @Published private var isLoadingOrderStats = false
@@ -219,6 +242,10 @@ final class AnalyticsHubViewModel: ObservableObject {
     /// Loading state for site stats.
     ///
     @Published private var isLoadingSiteStats = false
+
+    /// Loading state for bundle stats.
+    ///
+    @Published private var isLoadingBundleStats = false
 
     /// Time Range selection data defining the current and previous time period
     ///


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #12160
⚠️ Depends on #12366 ⚠️ 
<!-- Id number of the GitHub issue this PR addresses. -->

## Why
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This PR adds the new product bundles card to the Analytics Hub. It is visible when the product bundles extension is active on the store.

## How

* Adds the view model `AnalyticsBundlesReportCardViewModel` and its data (current and previous bundle stats and the current top bundles sold) to `AnalyticsHubViewModel`.
* Retrieves the required data from remote when the bundles card is enabled in the hub.
* Adds the `AnalyticsItemsSoldCard` view with the bundles card view model in `AnalyticsHubView`.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

On a store with the Product Bundles extension:

1. Build and run the app.
2. Open the Analytics Hub.
3. Confirm the Bundles card appears and loads its data (bundles sold analytics and list of top bundles).
4. Edit the hub and confirm you can enable/disable/reorder the bundles card.

On a store without the Product Bundles extension:

1. Build and run the app.
2. Open the Analytics Hub.
3. Confirm no Bundles card appears and no API request is made for bundles analytics.
4. Edit the hub and confirm the bundles card does not appear in the list. (Additional support will be added for this in #12161.)


## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

Analytics Hub|Customize
-|-
![Simulator Screenshot - iPhone 15 Pro - 2024-03-27 at 13 11 10](https://github.com/woocommerce/woocommerce-ios/assets/8658164/48cc9cf1-81a9-4c4b-aa02-694fffb2d6db)|![Simulator Screenshot - iPhone 15 Pro - 2024-03-27 at 12 52 28](https://github.com/woocommerce/woocommerce-ios/assets/8658164/cadb924e-80a8-47ac-9751-6fe744771196)

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
