### PR TITLE
[Order List] Speculative fix for crash on use of datasource

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -5,6 +5,7 @@
 - [**] Hub Menu: A new Customers section shows a searchable list of customers with their details, including the option to contact a customer via email. [https://github.com/woocommerce/woocommerce-ios/pull/12349]
 - [Internal] Update Woo Purple color palette [https://github.com/woocommerce/woocommerce-ios/pull/12330]
 - [internal] The dependency setup in `AppDelegate`'s `application(_:willFinishLaunchingWithOptions:)` was updated as an attempted fix for one of the top crashes. [https://github.com/woocommerce/woocommerce-ios/pull/12268]
+- [*] Order List: Speculative fix for a crash on the iPad when viewing orders [https://github.com/woocommerce/woocommerce-ios/pull/12369]
 
 17.9
 -----

--- a/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsViewModel.swift
+++ b/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsViewModel.swift
@@ -34,6 +34,9 @@ final class OrderDetailsViewModel {
         self.stores = stores
         self.storageManager = storageManager
         self.currencyFormatter = currencyFormatter
+        self.configurationLoader = CardPresentConfigurationLoader(stores: stores)
+        self.dataSource = OrderDetailsDataSource(order: order,
+                                                 cardPresentPaymentsConfiguration: configurationLoader.configuration)
     }
 
     func update(order newOrder: Order) {
@@ -99,14 +102,11 @@ final class OrderDetailsViewModel {
     }
 
     /// IPP Configuration loader
-    private lazy var configurationLoader = CardPresentConfigurationLoader(stores: stores)
+    private let configurationLoader: CardPresentConfigurationLoader
 
     /// The datasource that will be used to render the Order Details screen
     ///
-    private(set) lazy var dataSource: OrderDetailsDataSource = {
-        return OrderDetailsDataSource(order: order,
-                                      cardPresentPaymentsConfiguration: configurationLoader.configuration)
-    }()
+    let dataSource: OrderDetailsDataSource
 
     private(set) lazy var editNoteViewModel: EditCustomerNoteViewModel = {
         return EditCustomerNoteViewModel(order: order)

--- a/WooCommerce/Classes/ViewRelated/Orders/OrderListViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrderListViewModel.swift
@@ -110,7 +110,7 @@ final class OrderListViewModel {
         return statusResultsController.fetchedObjects
     }
 
-    private lazy var snapshotsProvider: FetchResultSnapshotsProvider<StorageOrder> = .init(storageManager: self.storageManager, query: createQuery())
+    private let snapshotsProvider: FetchResultSnapshotsProvider<StorageOrder>
 
     /// Emits snapshots of orders that should be displayed in the table view.
     var snapshot: AnyPublisher<FetchResultSnapshot, Never> {
@@ -143,6 +143,9 @@ final class OrderListViewModel {
         self.notificationCenter = notificationCenter
         self.filters = filters
         self.featureFlagService = featureFlagService
+        self.snapshotsProvider = FetchResultSnapshotsProvider<StorageOrder>(storageManager: storageManager,
+                                                                            query: Self.createQuery(siteID: siteID,
+                                                                                                    filters: filters))
     }
 
     deinit {
@@ -227,7 +230,7 @@ final class OrderListViewModel {
         })
     }
 
-    private func createQuery() -> FetchResultSnapshotsProvider<StorageOrder>.Query {
+    private static func createQuery(siteID: Int64, filters: FilterOrderListViewModel.Filters?) -> FetchResultSnapshotsProvider<StorageOrder>.Query {
         let predicateStatus: NSPredicate = {
             let excludeSearchCache = NSPredicate(format: "exclusiveForSearch = false")
             let excludeNonMatchingStatus = filters?.orderStatus.map { NSPredicate(format: "statusKey IN %@", $0.map { $0.rawValue }) }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #12257
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

We've been unable to reproduce this crash, however it happens on access of the `snapshotProvider` and `dataSource`, seemingly early in the lifecycle of the OrderList.

Both these are created lazily, which is convenient because the `dataSource` requires the `tableView`, which is not set at init time... however, lazily-initialisation of properties is not thread safe, so if the `dataSource` or `snapshotProvider` is accessed concurrently the first time it's created, the app will crash.

We don't have full control of when these are accessed, so they're a poor fit for lazy initialisation. Additionally, we know that if we make an OrderListViewController (or at least, if we load its view), we'll definitely need both these objects, so we might as well create them when we need them. We don't get any benefit from using lazy, other than avoiding some optional checks.

I also took the precaution of removing lazy instantiation on the OrderDetailsViewModel's data source, for the same reasons

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

1. Launch the app
2. Open the orders tab
3. Observe that the app works normally
4. Test that searching and filtering works as you expect.


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
