### PR TITLE
[Better Errors] M1 Design adjustments

### DIFF
--- a/Networking/Networking/Network/AlamofireNetwork.swift
+++ b/Networking/Networking/Network/AlamofireNetwork.swift
@@ -13,7 +13,6 @@ extension Alamofire.MultipartFormData: MultipartFormData {
 public class AlamofireNetwork: Network {
     private lazy var alamofireSession: Alamofire.Session = {
         let sessionConfiguration = URLSessionConfiguration.default
-        sessionConfiguration.timeoutIntervalForRequest = 1
         let sessionManager = makeSession(configuration: sessionConfiguration)
         return sessionManager
     }()

--- a/Networking/Networking/Network/AlamofireNetwork.swift
+++ b/Networking/Networking/Network/AlamofireNetwork.swift
@@ -13,6 +13,7 @@ extension Alamofire.MultipartFormData: MultipartFormData {
 public class AlamofireNetwork: Network {
     private lazy var alamofireSession: Alamofire.Session = {
         let sessionConfiguration = URLSessionConfiguration.default
+        sessionConfiguration.timeoutIntervalForRequest = 1
         let sessionManager = makeSession(configuration: sessionConfiguration)
         return sessionManager
     }()

--- a/WooCommerce/Classes/Extensions/Error+Timeout.swift
+++ b/WooCommerce/Classes/Extensions/Error+Timeout.swift
@@ -1,9 +1,15 @@
 import Foundation
+import enum Alamofire.AFError
 
 extension Error {
     /// Indicates if a given error is an URL timeout error.
     ///
     var isTimeoutError: Bool {
-        (self as NSError).code == NSURLErrorTimedOut
+        switch self {
+        case is AFError:
+            (self.asAFError?.underlyingError as? NSError)?.code == NSURLErrorTimedOut
+        default:
+            (self as NSError).code == NSURLErrorTimedOut
+        }
     }
 }

--- a/WooCommerce/Classes/Extensions/UIImage+Woo.swift
+++ b/WooCommerce/Classes/Extensions/UIImage+Woo.swift
@@ -1514,6 +1514,12 @@ extension UIImage {
     static var appPasswordTutorialImage: UIImage {
         UIImage(named: "app-password-tutorial-1")!
     }
+
+    static var exclamationFilledImage: UIImage {
+        UIImage(systemName: "exclamationmark.circle.fill", withConfiguration: Configurations.barButtonItemSymbol)!.withRenderingMode(.alwaysTemplate)
+    }
+
+
 }
 
 private extension UIImage {

--- a/WooCommerce/Classes/ViewRelated/Connectivity Tool/ConnectivityTool.swift
+++ b/WooCommerce/Classes/ViewRelated/Connectivity Tool/ConnectivityTool.swift
@@ -68,20 +68,31 @@ struct ConnectivityTool: View {
     ///
     var onContactSupportTapped: (() -> ())?
 
+    /// Internal layout values
+    ///
+    private static let dividerVerticalSpacing = 8.0
+
     var body: some View {
         VStack(alignment: .center, spacing: .zero) {
 
             Spacer()
 
-            Text(Localization.subtitle)
-                .secondaryBodyStyle()
-
             ScrollView {
+
+                Text(Localization.subtitle)
+                    .calloutStyle()
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .padding()
+
                 ForEach(cards, id: \.title) { card in
                     ConnectivityToolCard(icon: card.icon, title: card.title, state: card.state)
+                        .padding(.horizontal)
+
+                    Divider()
+                        .padding(.leading)
+                        .padding(.vertical, Self.dividerVerticalSpacing)
                 }
             }
-            .padding(.horizontal)
 
             Divider().ignoresSafeArea()
 
@@ -116,6 +127,7 @@ struct ConnectivityToolCard: View {
         ///
         struct ErrorAction {
             let title: String
+            let systemImage: String
             let action: () -> ()
         }
 
@@ -182,25 +194,18 @@ struct ConnectivityToolCard: View {
 
     /// Internal layout values
     ///
-    @ScaledMetric private var iconSize = 40.0
-    private static let cornerRadius = 4.0
     private static let verticalSpacing = 16.0
-    private static let cardSpacing = 8.0
 
     var body: some View {
         VStack(spacing: Self.verticalSpacing) {
             HStack {
 
-                Circle()
-                    .fill(Color(uiColor: .listBackground))
-                    .overlay {
-                        icon.buildAsset()
-                            .foregroundColor(Color(uiColor: .primary))
-                    }
-                    .frame(width: iconSize, height: iconSize)
+                icon.buildAsset()
+                    .foregroundColor(Color(uiColor: .text))
 
                 Text(title)
                     .bodyStyle()
+                    .bold()
 
                 Spacer()
 
@@ -209,23 +214,17 @@ struct ConnectivityToolCard: View {
 
             if case let .error(message, buttonAction) = state {
                 Text(message)
-                    .foregroundColor(Color(uiColor: .error))
+                    .foregroundColor(Color(uiColor: .text))
                     .subheadlineStyle()
-                    .padding(.horizontal, 6)
                     .frame(maxWidth: .infinity, alignment: .leading)
 
                 if let buttonAction {
-                    Button(buttonAction.title, action: buttonAction.action)
-                        .buttonStyle(SecondaryButtonStyle())
+                    Button(buttonAction.title, systemImage: buttonAction.systemImage, action: buttonAction.action)
+                        .foregroundColor(Color(uiColor: .accent))
+                        .frame(maxWidth: .infinity, alignment: .leading)
                 }
             }
         }
-        .padding()
-        .background(Color(uiColor: .listForeground(modal: false)))
-        .cornerRadius(Self.cornerRadius)
-        .padding(.horizontal)
-        .padding(.vertical, Self.cardSpacing)
-
     }
 }
 
@@ -233,12 +232,12 @@ struct ConnectivityToolCard: View {
     NavigationView {
         ConnectivityTool(cards: [
             .init(title: "Internet Connection", icon: .system("wifi"), state: .success),
-            .init(title: "WordPress.com servers", icon: .system("server.rack"), state: .success),
-            .init(title: "Your Site",
+            .init(title: "Connecting to WordPress.com servers", icon: .system("server.rack"), state: .success),
+            .init(title: "Connecting to your site",
                   icon: .system("storefront"),
-                  state: .error("Your site is not responding properly\nPlease reach out to your host for further assistance",
-                    .init(title: "Read More", action: {}))),
-            .init(title: "Your site orders", icon: .system("list.clipboard"), state: .inProgress)
+                  state: .error("Your site is taking too long to respond.\n\nPlease contact your hosting provider for further assistance.",
+                    .init(title: "Read More", systemImage: "arrow.up.forward.app", action: {}))),
+            .init(title: "Fetching your site orders", icon: .system("list.clipboard"), state: .inProgress)
         ])
             .navigationTitle("Connectivity Test")
             .navigationBarTitleDisplayMode(.inline)

--- a/WooCommerce/Classes/ViewRelated/Connectivity Tool/ConnectivityTool.swift
+++ b/WooCommerce/Classes/ViewRelated/Connectivity Tool/ConnectivityTool.swift
@@ -125,7 +125,7 @@ struct ConnectivityToolCard: View {
 
         /// Represents an action to could be performed when presenting an error.
         ///
-        struct ErrorAction {
+        struct Action {
             let title: String
             let systemImage: String
             let action: () -> ()
@@ -133,7 +133,7 @@ struct ConnectivityToolCard: View {
 
         case inProgress
         case success
-        case error(String, ErrorAction?)
+        case error(String, [Action])
 
         /// Builds the icon based on the state
         ///
@@ -212,14 +212,14 @@ struct ConnectivityToolCard: View {
                 state.buildIcon()
             }
 
-            if case let .error(message, buttonAction) = state {
+            if case let .error(message, actions) = state {
                 Text(message)
                     .foregroundColor(Color(uiColor: .text))
                     .subheadlineStyle()
                     .frame(maxWidth: .infinity, alignment: .leading)
 
-                if let buttonAction {
-                    Button(buttonAction.title, systemImage: buttonAction.systemImage, action: buttonAction.action)
+                ForEach(actions, id: \.title) { action in
+                    Button(action.title, systemImage: action.systemImage, action: action.action)
                         .foregroundColor(Color(uiColor: .accent))
                         .frame(maxWidth: .infinity, alignment: .leading)
                 }
@@ -236,7 +236,8 @@ struct ConnectivityToolCard: View {
             .init(title: "Connecting to your site",
                   icon: .system("storefront"),
                   state: .error("Your site is taking too long to respond.\n\nPlease contact your hosting provider for further assistance.",
-                    .init(title: "Read More", systemImage: "arrow.up.forward.app", action: {}))),
+                    [.init(title: "Retry connection", systemImage: "arrow.clockwise", action: {}),
+                     .init(title: "Read More", systemImage: "arrow.up.forward.app", action: {})])),
             .init(title: "Fetching your site orders", icon: .system("list.clipboard"), state: .inProgress)
         ])
             .navigationTitle("Connectivity Test")

--- a/WooCommerce/Classes/ViewRelated/Connectivity Tool/ConnectivityTool.swift
+++ b/WooCommerce/Classes/ViewRelated/Connectivity Tool/ConnectivityTool.swift
@@ -19,7 +19,7 @@ final class ConnectivityToolViewController: UIHostingController<ConnectivityTool
         let view = ConnectivityTool(cards: viewModel.cards)
         super.init(rootView: view)
         self.hidesBottomBarWhenPushed = true
-        self.title = NSLocalizedString("Connectivity Test", comment: "Screen title for the connectivity tool")
+        self.title = NSLocalizedString("Troubleshoot Connection", comment: "Screen title for the connectivity tool")
     }
 
     override func viewDidLoad() {
@@ -73,6 +73,9 @@ struct ConnectivityTool: View {
 
             Spacer()
 
+            Text(Localization.subtitle)
+                .secondaryBodyStyle()
+
             ScrollView {
                 ForEach(cards, id: \.title) { card in
                     ConnectivityToolCard(icon: card.icon, title: card.title, state: card.state)
@@ -85,7 +88,7 @@ struct ConnectivityTool: View {
             Button(Localization.contactSupport) {
                 onContactSupportTapped?()
             }
-            .buttonStyle(PrimaryButtonStyle())
+            .buttonStyle(SecondaryButtonStyle())
             .padding()
         }
         .background(Color(uiColor: .listBackground))
@@ -94,6 +97,8 @@ struct ConnectivityTool: View {
 
 private extension ConnectivityTool {
     enum Localization {
+        static let subtitle = NSLocalizedString("Please wait while we attempt to identify your connection issue.",
+                                                comment: "Subtitle on the connectivity tool screen")
         static let contactSupport = NSLocalizedString("Contact Support",
                                                       comment: "Contact support button in the connectivity tool screen")
     }

--- a/WooCommerce/Classes/ViewRelated/Connectivity Tool/ConnectivityTool.swift
+++ b/WooCommerce/Classes/ViewRelated/Connectivity Tool/ConnectivityTool.swift
@@ -145,7 +145,7 @@ struct ConnectivityToolCard: View {
                 Image(uiImage: .checkCircleImage)
                     .environment(\.colorScheme, .light)
             case .error:
-                Image(uiImage: .checkPartialCircleImage.withRenderingMode(.alwaysTemplate))
+                Image(uiImage: .exclamationFilledImage)
                     .foregroundColor(Color.init(uiColor: .error))
             }
         }

--- a/WooCommerce/Classes/ViewRelated/Connectivity Tool/ConnectivityToolViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Connectivity Tool/ConnectivityToolViewModel.swift
@@ -198,7 +198,7 @@ final class ConnectivityToolViewModel {
         if error.isTimeoutError {
             message = NSLocalizedString("Your site is taking too long to respond.\n\nPlease contact your hosting provider for further assistance.",
                                         comment: "Message when we there is a timeout error in the recovery tool")
-            return .error(message, .init(title: readMore, action: generalTroubleshootAction))
+            return .error(message, .init(title: readMore, systemImage: SystemImages.readMore.rawValue, action: generalTroubleshootAction))
         }
 
         // Handle all other types of errors.
@@ -207,16 +207,16 @@ final class ConnectivityToolViewModel {
             message = NSLocalizedString("We can't work properly with your site's response.\n\n" +
                                         "Read more about it or contact our support team and we will happily assist you.",
                                         comment: "Message when we there is a decoding error in the recovery tool")
-            errorAction = .init(title: readMore, action: generalTroubleshootAction)
+            errorAction = .init(title: readMore, systemImage: SystemImages.readMore.rawValue, action: generalTroubleshootAction)
         case DotcomError.jetpackNotConnected:
             message = NSLocalizedString("There is problem with your jetpack connection.\n\n" +
                                         "Read more about it or contact our support team and we will happily assist you.",
                                         comment: "Message when we there is a jetpack error in the recovery tool")
-            errorAction = .init(title: readMore, action: jetpackTroubleshootAction)
+            errorAction = .init(title: readMore, systemImage: SystemImages.readMore.rawValue, action: jetpackTroubleshootAction)
         default:
             message = NSLocalizedString("There seems to be a problem with your site.\n\nPlease contact your hosting provider for further assistance.",
                                         comment: "Message when we there is a generic error in the recovery tool")
-            errorAction = .init(title: readMore, action: generalTroubleshootAction)
+            errorAction = .init(title: readMore, systemImage: SystemImages.readMore.rawValue, action: generalTroubleshootAction)
         }
 
         return .error(message, errorAction)
@@ -238,6 +238,12 @@ final class ConnectivityToolViewModel {
 }
 
 private extension ConnectivityToolViewModel {
+
+    private enum SystemImages: String {
+        case retry = "arrow.clockwise"
+        case readMore = "arrow.up.forward.app"
+    }
+
     enum ConnectivityTest: CaseIterable {
         case internetConnection
         case wpComServers
@@ -277,6 +283,7 @@ private extension ConnectivityToolViewModel {
 }
 
 extension ConnectivityTool.Card {
+
     /// Updates a card state to a new given state.
     ///
     func updatingState(_ newState: ConnectivityToolCard.State) -> ConnectivityTool.Card {

--- a/WooCommerce/Classes/ViewRelated/Connectivity Tool/ConnectivityToolViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Connectivity Tool/ConnectivityToolViewModel.swift
@@ -25,10 +25,6 @@ final class ConnectivityToolViewModel {
     ///
     private let siteID: Int64
 
-    /// Combine subscriptions.
-    ///
-    private var subscriptions: Set<AnyCancellable> = []
-
     init(session: SessionManagerProtocol = ServiceLocator.stores.sessionManager) {
 
         let network = AlamofireNetwork(credentials: session.defaultCredentials)
@@ -43,10 +39,11 @@ final class ConnectivityToolViewModel {
     }
 
     /// Sequentially runs all connectivity tests defined in `ConnectivityTest`.
+    /// Provide a `sinceTest` parameter to omit test cases before it..
     ///
-    private func startConnectivityTest() async {
+    private func startConnectivityTest(sinceTest: ConnectivityTest = .internetConnection) async {
 
-        for (index, testCase) in ConnectivityTest.allCases.enumerated() {
+        for (index, testCase) in ConnectivityTest.allCases.enumerated().dropFirst(sinceTest.rawValue) {
 
             // Add an inProgress card for the current test.
             cards.append(testCase.inProgressCard)
@@ -89,31 +86,45 @@ final class ConnectivityToolViewModel {
         }
     }
 
+    /// Retries the last test case and the subsequent ones.
+    ///
+    private func retryLastTest() {
+        // Remove the last test
+        cards.removeLast()
+
+        // Make sure there is a test case to run.
+        guard let testCaseToRepeat = ConnectivityTest(rawValue: cards.count) else {
+            return
+        }
+
+        // Run tests again from the last one.
+        Task {
+            await startConnectivityTest(sinceTest: testCaseToRepeat)
+        }
+    }
+
     /// Perform internet connectivity case using the `connectivityObserver`.
     ///
     private func testInternetConnectivity() async -> ConnectivityToolCard.State {
-        await withCheckedContinuation { continuation in
-            ServiceLocator.connectivityObserver.statusPublisher.first()
-                .sink { status in
-                    let reachable = {
-                        if case .reachable = status {
-                            DDLogInfo("Connectivity Tool: ✅ Internet Connection")
-                            return true
-                        } else {
-                            DDLogError("Connectivity Tool: ❌ Internet Connection")
-                            return false
-                        }
-                    }()
 
-                    let state: ConnectivityToolCard.State = reachable ?
-                        .success :
-                        .error(NSLocalizedString("It looks like you're not connected to the internet.\n\n" +
-                                                 "Ensure your Wi-Fi is turned on. If you're using mobile data, make sure it's enabled in your device settings.",
-                                                 comment: "Message when there is no internet connection in the recovery tool"), nil)
-                    continuation.resume(returning: state)
-                }
-                .store(in: &subscriptions)
-        }
+        let status = ServiceLocator.connectivityObserver.currentStatus
+        let reachable = {
+            if case .reachable = status {
+                DDLogInfo("Connectivity Tool: ✅ Internet Connection")
+                return true
+            } else {
+                DDLogError("Connectivity Tool: ❌ Internet Connection")
+                return false
+            }
+        }()
+
+        let state: ConnectivityToolCard.State = reachable ?
+            .success :
+            .error(NSLocalizedString("It looks like you're not connected to the internet.\n\n" +
+                                     "Ensure your Wi-Fi is turned on. If you're using mobile data, make sure it's enabled in your device settings.",
+                                     comment: "Message when there is no internet connection in the recovery tool"), [self.retryAction()])
+
+        return state
     }
 
     /// Test WPCom connectivity by fetching the mobile announcements.
@@ -133,7 +144,7 @@ final class ConnectivityToolViewModel {
                     .success :
                     .error(NSLocalizedString("We can’t connect to WordPress.com right now.\n\n" +
                                              "Try again in a few minutes, or contact our support team and we will happily assist you.",
-                                             comment: "Message when we can't reach WPCom in the recovery tool"), nil)
+                                             comment: "Message when we can't reach WPCom in the recovery tool"), [self.retryAction()])
                 continuation.resume(returning: state)
             }
         }
@@ -143,7 +154,8 @@ final class ConnectivityToolViewModel {
     ///
     func testSiteConnectivity() async -> ConnectivityToolCard.State {
         await withCheckedContinuation { continuation in
-            systemStatusRemote.fetchSystemStatusReport(for: siteID) { result in
+            systemStatusRemote.fetchSystemStatusReport(for: siteID) { [weak self] result in
+                guard let self else { return }
 
                 switch result {
                 case .success:
@@ -152,7 +164,7 @@ final class ConnectivityToolViewModel {
                     DDLogError("Connectivity Tool: ❌ Site connection\n\(error)")
                 }
 
-                let state = Self.stateForSiteResult(result)
+                let state = self.stateForSiteResult(result)
                 continuation.resume(returning: state)
             }
         }
@@ -162,7 +174,8 @@ final class ConnectivityToolViewModel {
     ///
     func testFetchingOrders() async -> ConnectivityToolCard.State {
         await withCheckedContinuation { continuation in
-            orderRemote?.loadAllOrders(for: siteID) { result in
+            orderRemote?.loadAllOrders(for: siteID) { [weak self] result in
+                guard let self else { return }
 
                 switch result {
                 case .success:
@@ -171,20 +184,20 @@ final class ConnectivityToolViewModel {
                     DDLogError("Connectivity Tool: ❌ Site Orders\n\(error)")
                 }
 
-                let state = Self.stateForSiteResult(result)
+                let state = self.stateForSiteResult(result)
                 continuation.resume(returning: state)
             }
         }
     }
 
-    private static func stateForSiteResult<T>(_ result: Result<T, Error>) -> ConnectivityToolCard.State {
+    private func stateForSiteResult<T>(_ result: Result<T, Error>) -> ConnectivityToolCard.State {
         guard case let .failure(error) = result else {
             return .success
         }
 
         let message: String
-        let errorAction: ConnectivityToolCard.State.ErrorAction?
-        let readMore = NSLocalizedString("Read More", comment: "Action button title for a generic error on the connectivity tool")
+        let readMoreAction: ConnectivityToolCard.State.Action
+        let readMore = NSLocalizedString("Read more", comment: "Action button title for a generic error on the connectivity tool")
         let generalTroubleshootAction = {
             UIApplication.shared.open(WooConstants.URLs.troubleshootErrorLoadingData.asURL())
             ServiceLocator.analytics.track(event: .ConnectivityTool.readMoreTapped())
@@ -194,32 +207,36 @@ final class ConnectivityToolViewModel {
             ServiceLocator.analytics.track(event: .ConnectivityTool.readMoreTapped())
         }
 
-        // Handle timeout errors specially
-        if error.isTimeoutError {
+        // Handle all types of errors but timeouts are specific.
+        switch (error, error.isTimeoutError) {
+        case (_, true):
             message = NSLocalizedString("Your site is taking too long to respond.\n\nPlease contact your hosting provider for further assistance.",
                                         comment: "Message when we there is a timeout error in the recovery tool")
-            return .error(message, .init(title: readMore, systemImage: SystemImages.readMore.rawValue, action: generalTroubleshootAction))
-        }
-
-        // Handle all other types of errors.
-        switch error {
-        case is DecodingError:
+            readMoreAction = .init(title: readMore, systemImage: SystemImages.readMore.rawValue, action: generalTroubleshootAction)
+        case (is DecodingError, _):
             message = NSLocalizedString("We can't work properly with your site's response.\n\n" +
                                         "Read more about it or contact our support team and we will happily assist you.",
                                         comment: "Message when we there is a decoding error in the recovery tool")
-            errorAction = .init(title: readMore, systemImage: SystemImages.readMore.rawValue, action: generalTroubleshootAction)
-        case DotcomError.jetpackNotConnected:
+            readMoreAction = .init(title: readMore, systemImage: SystemImages.readMore.rawValue, action: generalTroubleshootAction)
+        case (DotcomError.jetpackNotConnected, _):
             message = NSLocalizedString("There is problem with your jetpack connection.\n\n" +
                                         "Read more about it or contact our support team and we will happily assist you.",
                                         comment: "Message when we there is a jetpack error in the recovery tool")
-            errorAction = .init(title: readMore, systemImage: SystemImages.readMore.rawValue, action: jetpackTroubleshootAction)
+            readMoreAction = .init(title: readMore, systemImage: SystemImages.readMore.rawValue, action: jetpackTroubleshootAction)
         default:
             message = NSLocalizedString("There seems to be a problem with your site.\n\nPlease contact your hosting provider for further assistance.",
                                         comment: "Message when we there is a generic error in the recovery tool")
-            errorAction = .init(title: readMore, systemImage: SystemImages.readMore.rawValue, action: generalTroubleshootAction)
+            readMoreAction = .init(title: readMore, systemImage: SystemImages.readMore.rawValue, action: generalTroubleshootAction)
         }
 
-        return .error(message, errorAction)
+        return .error(message, [readMoreAction, retryAction()])
+    }
+
+    private func retryAction() -> ConnectivityToolCard.State.Action {
+        let retryText = NSLocalizedString("Retry connection", comment: "Retry connection button in the connectivity tool screen")
+        return .init(title: retryText, systemImage: SystemImages.retry.rawValue, action: { [weak self] in
+            self?.retryLastTest()
+        })
     }
 
     /// Tracks the event with the respective test response.
@@ -244,7 +261,7 @@ private extension ConnectivityToolViewModel {
         case readMore = "arrow.up.forward.app"
     }
 
-    enum ConnectivityTest: CaseIterable {
+    enum ConnectivityTest: Int, CaseIterable {
         case internetConnection
         case wpComServers
         case site

--- a/WooCommerce/Classes/ViewRelated/Connectivity Tool/ConnectivityToolViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Connectivity Tool/ConnectivityToolViewModel.swift
@@ -68,6 +68,9 @@ final class ConnectivityToolViewModel {
                 return // Exit connectivity test.
             }
         }
+
+        // Add no connections issues card if all tests are successful.
+        cards.append(noConnectionsIssueState())
     }
 
     /// Perform the test for a provided test case.
@@ -251,6 +254,13 @@ final class ConnectivityToolViewModel {
             }
         }()
         ServiceLocator.analytics.track(event: .ConnectivityTool.requestResponse(test: eventTest, success: success, timeTaken: timeTaken))
+    }
+
+    private func noConnectionsIssueState() -> ConnectivityTool.Card {
+        .init(title: NSLocalizedString("No connection issues", comment: "Title for when there are no connection issues in the connectivity tool screen"),
+              icon: .empty,
+              state: .empty(NSLocalizedString("If your data still isn’t loading, contact our support team for assistance.",
+                                              comment: "Info message when there are no connection issues in the connectivity tool screen")))
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Connectivity Tool/ConnectivityToolViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Connectivity Tool/ConnectivityToolViewModel.swift
@@ -131,8 +131,8 @@ final class ConnectivityToolViewModel {
 
                 let state: ConnectivityToolCard.State = result.isSuccess ?
                     .success :
-                    .error(NSLocalizedString("Oops! It seems we can't connect to WordPress.com at the moment.\n\n" +
-                                             "But don't worry, our support team is here to help. Contact us and we will happily assist you.",
+                    .error(NSLocalizedString("We can’t connect to WordPress.com right now.\n\n" +
+                                             "Try again in a few minutes, or contact our support team and we will happily assist you.",
                                              comment: "Message when we can't reach WPCom in the recovery tool"), nil)
                 continuation.resume(returning: state)
             }
@@ -196,7 +196,7 @@ final class ConnectivityToolViewModel {
 
         // Handle timeout errors specially
         if error.isTimeoutError {
-            message = NSLocalizedString("Oops! Your site seems to be taking too long to respond.\n\nContact your hosting provider for further assistance.",
+            message = NSLocalizedString("Your site is taking too long to respond.\n\nPlease contact your hosting provider for further assistance.",
                                         comment: "Message when we there is a timeout error in the recovery tool")
             return .error(message, .init(title: readMore, action: generalTroubleshootAction))
         }
@@ -204,17 +204,17 @@ final class ConnectivityToolViewModel {
         // Handle all other types of errors.
         switch error {
         case is DecodingError:
-            message = NSLocalizedString("Oops! It seems we can't work properly with your site's response.\n\n" +
-                                        "But don't worry, our support team is here to help. Contact us and we will happily assist you.",
+            message = NSLocalizedString("We can't work properly with your site's response.\n\n" +
+                                        "Read more about it or contact our support team and we will happily assist you.",
                                         comment: "Message when we there is a decoding error in the recovery tool")
             errorAction = .init(title: readMore, action: generalTroubleshootAction)
         case DotcomError.jetpackNotConnected:
-            message = NSLocalizedString("Oops! There seems to be a problem with your jetpack connection.\n\n" +
-                                        "But don't worry, our support team is here to help. Contact us and we will happily assist you.",
+            message = NSLocalizedString("There is problem with your jetpack connection.\n\n" +
+                                        "Read more about it or contact our support team and we will happily assist you.",
                                         comment: "Message when we there is a jetpack error in the recovery tool")
             errorAction = .init(title: readMore, action: jetpackTroubleshootAction)
         default:
-            message = NSLocalizedString("Oops! There seems to be a problem with your site.\n\nContact your hosting provider for further assistance.",
+            message = NSLocalizedString("There seems to be a problem with your site.\n\nPlease contact your hosting provider for further assistance.",
                                         comment: "Message when we there is a generic error in the recovery tool")
             errorAction = .init(title: readMore, action: generalTroubleshootAction)
         }

--- a/WooCommerce/Classes/ViewRelated/Top Banner/ErrorTopBannerFactory.swift
+++ b/WooCommerce/Classes/ViewRelated/Top Banner/ErrorTopBannerFactory.swift
@@ -65,7 +65,9 @@ extension ErrorTopBannerFactory {
                 return Localization.decodingInfo
             case .jetpackConnectionError:
                 return Localization.jetpackConnectionInfo
-            case .timeoutError, .generalError:
+            case .timeoutError:
+                return Localization.timeoutInfo
+            case .generalError:
                 return Localization.generalInfo
             }
         }
@@ -102,6 +104,8 @@ extension ErrorTopBannerFactory {
                                                               comment: "The title of the Error Loading Data banner when there is a Jetpack connection error")
         static let timeoutTitle = NSLocalizedString("Your site is taking a long time to respond",
                                                     comment: "The title of the Error Loading Data banner when there is a Jetpack connection error")
+        static let timeoutInfo = NSLocalizedString("Refresh the screen to try again, or troubleshoot the connection. Contact support if your issue persists.",
+                                                    comment: "The info of the time out error banner")
         static let generalInfo = NSLocalizedString("Please try again later or reach out to us and we'll be happy to assist you!",
                                                    comment: "The info of the Error Loading Data banner")
         static let decodingInfo = NSLocalizedString("This could be related to a conflict with a plugin. " +

--- a/WooCommerce/WooCommerceTests/Extensions/IconsTests.swift
+++ b/WooCommerce/WooCommerceTests/Extensions/IconsTests.swift
@@ -928,4 +928,8 @@ final class IconsTests: XCTestCase {
     func test_cashRegisterImage_is_not_nil() {
         XCTAssertNotNil(UIImage.cashRegisterImage)
     }
+
+    func test_exclamationFilledImage_is_not_nil() {
+        XCTAssertNotNil(UIImage.exclamationFilledImage)
+    }
 }


### PR DESCRIPTION
Closes: #12298 

# Why

This PR adds the design adjustments for the Connectivity Tool.

Includes

- New UI
- Updated Strings
- Retry action
- Success messages

# Screenshots

Error | Success
--- | ---
<img width="434" alt="error" src="https://github.com/woocommerce/woocommerce-ios/assets/562080/04baa378-4453-4b51-b844-a1be238261ff"> | <img width="427" alt="success" src="https://github.com/woocommerce/woocommerce-ios/assets/562080/7cef00cc-c562-411a-a5ee-3e1c2eb68412">




---
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
