### PR TITLE
[Woo Express Cleanup] Add store button on site picker

### DIFF
--- a/WooCommerce/Classes/Analytics/WooAnalyticsEvent+StoreCreation.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsEvent+StoreCreation.swift
@@ -20,12 +20,6 @@ extension WooAnalyticsEvent {
             static let initialDomain = "initial_domain"
         }
 
-        /// Tracked when the user taps on the CTA in store picker (logged in to WPCOM) to create a store.
-        static func sitePickerCreateSiteTapped(source: StorePickerSource) -> WooAnalyticsEvent {
-            WooAnalyticsEvent(statName: .sitePickerCreateSiteTapped,
-                              properties: [Key.source: source.rawValue])
-        }
-
         static func siteCreationFlowStarted(source: Source) -> WooAnalyticsEvent {
             WooAnalyticsEvent(statName: .siteCreationFlowStarted,
                               properties: [Key.source: source.rawValue])

--- a/WooCommerce/Classes/Analytics/WooAnalyticsStat.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsStat.swift
@@ -249,7 +249,6 @@ public enum WooAnalyticsStat: String {
 
     // MARK: Site creation
     //
-    case sitePickerCreateSiteTapped = "site_picker_create_site_tapped"
     case siteCreated = "login_woocommerce_site_created"
     case siteCreationFailed = "site_creation_failed"
     case siteCreationDismissed = "site_creation_dismissed"

--- a/WooCommerce/Classes/Authentication/Epilogue/AddStoreFooterView.swift
+++ b/WooCommerce/Classes/Authentication/Epilogue/AddStoreFooterView.swift
@@ -34,6 +34,13 @@ final class AddStoreFooterView: UIView {
                                             trailing: Constants.horizontalPadding)
         addStoreButton.configuration = configuration
 
+        NSLayoutConstraint.activate([
+            addStoreButton.leadingAnchor.constraint(equalTo: leadingAnchor),
+            trailingAnchor.constraint(equalTo: addStoreButton.trailingAnchor),
+            addStoreButton.topAnchor.constraint(equalTo: topAnchor),
+            bottomAnchor.constraint(equalTo: addStoreButton.bottomAnchor),
+        ])
+
         addStoreButton.addAction(UIAction { [weak self] _ in
             self?.addStoreHandler()
         }, for: .touchUpInside)

--- a/WooCommerce/Classes/Authentication/Epilogue/AddStoreFooterView.swift
+++ b/WooCommerce/Classes/Authentication/Epilogue/AddStoreFooterView.swift
@@ -7,16 +7,10 @@ final class AddStoreFooterView: UIView {
     private let addStoreHandler: () -> Void
 
     private lazy var addStoreButton = UIButton(type: .custom)
-    private lazy var divider: UIView = {
-        let view = UIView(frame: .zero)
-        view.backgroundColor = .border
-        return view
-    }()
 
     init(addStoreHandler: @escaping () -> Void) {
         self.addStoreHandler = addStoreHandler
         super.init(frame: .zero)
-        configureSubviews()
         configureAddStoreButton()
     }
 
@@ -24,27 +18,10 @@ final class AddStoreFooterView: UIView {
         fatalError("init(coder:) has not been implemented")
     }
 
-    private func configureSubviews() {
+    private func configureAddStoreButton() {
         addStoreButton.translatesAutoresizingMaskIntoConstraints = false
         addSubview(addStoreButton)
-
-        divider.translatesAutoresizingMaskIntoConstraints = false
-        addSubview(divider)
-
-        NSLayoutConstraint.activate([
-            addStoreButton.leadingAnchor.constraint(equalTo: leadingAnchor),
-            trailingAnchor.constraint(equalTo: addStoreButton.trailingAnchor),
-            addStoreButton.topAnchor.constraint(equalTo: topAnchor),
-            bottomAnchor.constraint(equalTo: addStoreButton.bottomAnchor),
-            divider.leadingAnchor.constraint(equalTo: leadingAnchor),
-            divider.trailingAnchor.constraint(equalTo: trailingAnchor),
-            divider.bottomAnchor.constraint(equalTo: bottomAnchor),
-            divider.heightAnchor.constraint(equalToConstant: 1.0 / UIScreen.main.scale)
-        ])
-    }
-
-    private func configureAddStoreButton() {
-        addStoreButton.setTitle(Localization.addStoreButton, for: .normal)
+        addStoreButton.setTitle(Localization.connectExistingStoreButton, for: .normal)
         addStoreButton.applyLinkButtonStyle()
         addStoreButton.contentHorizontalAlignment = .leading
 
@@ -65,7 +42,10 @@ final class AddStoreFooterView: UIView {
 
 private extension AddStoreFooterView {
     enum Localization {
-        static let addStoreButton = NSLocalizedString("Add a Store", comment: "Button title on the store picker for store creation")
+        static let connectExistingStoreButton = NSLocalizedString(
+            "addStoreFooterView.connectExistingStoreButton",
+            value: "Connect existing store",
+            comment: "Button title on the store picker for store connection")
     }
 
     enum Constants {

--- a/WooCommerce/Classes/Authentication/Epilogue/StorePickerCoordinator.swift
+++ b/WooCommerce/Classes/Authentication/Epilogue/StorePickerCoordinator.swift
@@ -87,35 +87,6 @@ extension StorePickerCoordinator: StorePickerViewControllerDelegate {
             self?.onDismiss?()
         }
     }
-
-    func createStore() {
-        let source: StoreCreationCoordinator.Source
-        switch selectedConfiguration {
-        case .storeCreationFromLogin(let loggedOutSource):
-            source = .loggedOut(source: loggedOutSource)
-        default:
-            source = .storePicker
-        }
-
-        switch selectedConfiguration.presentationStyle {
-        case .fullscreen:
-            // The store picker was presented modally in fullscreen, and thus we need to present the
-            // store creation flow on top of the store picker instead of the store picker's navigation controller
-            // (invisible behind the store picker).
-            guard let presentedNavigationController = navigationController.topmostPresentedViewController as? UINavigationController else {
-                return
-            }
-            let coordinator = StoreCreationCoordinator(source: source,
-                                                       navigationController: presentedNavigationController)
-            self.storeCreationCoordinator = coordinator
-            coordinator.start()
-        case .modally, .navigationStack:
-            let coordinator = StoreCreationCoordinator(source: source,
-                                                       navigationController: navigationController)
-            self.storeCreationCoordinator = coordinator
-            coordinator.start()
-        }
-    }
 }
 
 // MARK: - Private Helpers

--- a/WooCommerce/Classes/Authentication/Epilogue/StorePickerViewController.swift
+++ b/WooCommerce/Classes/Authentication/Epilogue/StorePickerViewController.swift
@@ -27,9 +27,6 @@ protocol StorePickerViewControllerDelegate: AnyObject {
 
     /// Notifies the delegate to dismiss the store picker and restart authentication.
     func restartAuthentication()
-
-    /// Notifies the delegate to create a store.
-    func createStore()
 }
 
 
@@ -665,29 +662,6 @@ private extension StorePickerViewController {
     ///
     @IBAction func secondaryActionWasPressed() {
         restartAuthentication()
-    }
-
-    func createStoreButtonPressed() {
-        let source: WooAnalyticsEvent.StoreCreation.StorePickerSource = {
-            switch configuration {
-            case .switchingStores:
-                return .switchStores
-            case .login, .standard:
-                return .login
-            case .storeCreationFromLogin(let loggedOutSource):
-                switch loggedOutSource {
-                case .prologue:
-                    return .loginPrologue
-                case .loginEmailError:
-                    return .other
-                }
-            default:
-                return .other
-            }
-        }()
-        ServiceLocator.analytics.track(event: .StoreCreation.sitePickerCreateSiteTapped(source: source))
-
-        delegate?.createStore()
     }
 }
 

--- a/WooCommerce/Classes/Authentication/Epilogue/StorePickerViewController.swift
+++ b/WooCommerce/Classes/Authentication/Epilogue/StorePickerViewController.swift
@@ -853,10 +853,6 @@ private extension StorePickerViewController {
         static let continueButton = NSLocalizedString("Continue", comment: "Button on the Store Picker screen to select a store")
         static let tryAnotherAccount = NSLocalizedString("Log In With Another Account",
                                                          comment: "Button to trigger connection to another account in store picker")
-        static let createStore = NSLocalizedString("Create a new store",
-                                                   comment: "Button to create a new store from the store picker")
-        static let connectExistingStore = NSLocalizedString("Connect an existing store",
-                                                            comment: "Button to connect to an existing store from the store picker")
         static let cancel = NSLocalizedString("Cancel",
                                               comment: "Button to dismiss the action sheet on the store picker")
         static let addStoreButton = NSLocalizedString("storePickerViewController.addStoreButton",

--- a/WooCommerce/Classes/Authentication/Epilogue/StorePickerViewController.swift
+++ b/WooCommerce/Classes/Authentication/Epilogue/StorePickerViewController.swift
@@ -125,8 +125,7 @@ final class StorePickerViewController: UIViewController {
     private lazy var addStoreFooterView: AddStoreFooterView = {
        AddStoreFooterView(addStoreHandler: { [weak self] in
            guard let self else { return }
-           ServiceLocator.analytics.track(.sitePickerConnectExistingStoreTapped)
-           self.presentSiteDiscovery()
+           addStoreWasPressed()
        })
     }()
 

--- a/WooCommerce/Classes/Authentication/Epilogue/StorePickerViewController.swift
+++ b/WooCommerce/Classes/Authentication/Epilogue/StorePickerViewController.swift
@@ -128,8 +128,8 @@ final class StorePickerViewController: UIViewController {
     private lazy var addStoreFooterView: AddStoreFooterView = {
        AddStoreFooterView(addStoreHandler: { [weak self] in
            guard let self else { return }
-           ServiceLocator.analytics.track(.sitePickerAddStoreTapped)
-           self.presentAddStoreActionSheet(from: self.addStoreFooterView)
+           ServiceLocator.analytics.track(.sitePickerConnectExistingStoreTapped)
+           self.presentSiteDiscovery()
        })
     }()
 

--- a/WooCommerce/Classes/Authentication/Epilogue/StorePickerViewController.swift
+++ b/WooCommerce/Classes/Authentication/Epilogue/StorePickerViewController.swift
@@ -364,31 +364,6 @@ private extension StorePickerViewController {
         ServiceLocator.authenticationManager.presentSupport(from: self, screen: .storePicker)
     }
 
-    func presentAddStoreActionSheet(from view: UIView) {
-        let actionSheet = UIAlertController(title: nil, message: nil, preferredStyle: .actionSheet)
-        actionSheet.view.tintColor = .text
-        let createStoreAction = UIAlertAction(title: Localization.createStore, style: .default) { [weak self] _ in
-            // TODO: add tracks for site creation
-            self?.createStoreButtonPressed()
-        }
-        let addExistingStoreAction = UIAlertAction(title: Localization.connectExistingStore, style: .default) { [weak self] _ in
-            ServiceLocator.analytics.track(.sitePickerConnectExistingStoreTapped)
-            self?.presentSiteDiscovery()
-        }
-        let cancelAction = UIAlertAction(title: Localization.cancel, style: .cancel)
-
-        actionSheet.addAction(createStoreAction)
-        actionSheet.addAction(addExistingStoreAction)
-        actionSheet.addAction(cancelAction)
-
-        if let popoverController = actionSheet.popoverPresentationController {
-            popoverController.sourceView = view
-            popoverController.sourceRect = view.bounds
-        }
-
-        present(actionSheet, animated: true)
-    }
-
     func presentSiteDiscovery() {
         guard let viewController = WordPressAuthenticator.siteDiscoveryUI() else {
             return
@@ -679,12 +654,11 @@ private extension StorePickerViewController {
         }
     }
 
-    /// Presents a screen to enter a store address to connect,
-    /// or the add store action sheet for simplified login.
+    /// Button to allow connecting to an existing store.
     ///
     @IBAction private func addStoreWasPressed() {
-        ServiceLocator.analytics.track(.sitePickerAddStoreTapped)
-        presentAddStoreActionSheet(from: addStoreButton)
+        ServiceLocator.analytics.track(.sitePickerConnectExistingStoreTapped)
+        self.presentSiteDiscovery()
     }
 
     /// Proceeds with the Logout Flow.
@@ -885,8 +859,9 @@ private extension StorePickerViewController {
                                                             comment: "Button to connect to an existing store from the store picker")
         static let cancel = NSLocalizedString("Cancel",
                                               comment: "Button to dismiss the action sheet on the store picker")
-        static let addStoreButton = NSLocalizedString("Add a Store",
-                                                      comment: "Button title on the store picker for store creation")
+        static let addStoreButton = NSLocalizedString("storePickerViewController.addStoreButton",
+                                                      value: "Connect existing store",
+                                                      comment: "Button title on the store picker for store connection")
         enum ActionMenu {
             static let logOut = NSLocalizedString("Log out",
                                                   comment: "Button to log out from the current account from the store picker")


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #12367
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

In the Site Picker, updates these:
- small "+ Add A Store" button that's shown when there are existing stores,
- big "Add A Store" button when there are no existing stores

They both become "Connect existing store", that immediately opens the "Enter store address to connect" screen, removing the site creation process.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

1. Go to Site Picker,
2. Under the list of stores, ensure the button says "+ Connect existing store"
3. Tap the button, ensure this opens the "Enter store address to connect" screen.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

<img src="https://github.com/woocommerce/woocommerce-ios/assets/266376/a3f23762-003e-4d88-b5aa-c1f49bb68dc0" width="42%">

