### PR TITLE
[Analytics Hub] Show promo link in customize view for inactive extensions

### DIFF
--- a/WooCommerce/Classes/System/WooConstants.swift
+++ b/WooCommerce/Classes/System/WooConstants.swift
@@ -339,6 +339,10 @@ extension WooConstants {
 
         case wooPaymentsDepositSchedule = "https://woo.com/document/woopayments/deposits/deposit-schedule/"
 
+        /// URL to learn more about Jetpack Stats
+        ///
+        case jetpackStats = "https://jetpack.com/stats/"
+
         /// Returns the URL version of the receiver
         ///
         func asURL() -> URL {

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/AnalyticsHubViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/AnalyticsHubViewModel.swift
@@ -646,9 +646,10 @@ extension AnalyticsHubViewModel {
     ///
     func customizeAnalytics() {
         // Exclude any cards the merchant/store is ineligible for.
+        // Excluded cards are displayed but can't be customized.
         let cardsToExclude: [AnalyticsCard] = [
             isEligibleForSessionsCard ? nil : allCardsWithSettings.first(where: { $0.type == .sessions }),
-            canDisplayCard(ofType: .bundles) ? nil : allCardsWithSettings.first(where: { $0.type == .bundles }) // TODO-12161: Support when extension is inactive
+            canDisplayCard(ofType: .bundles) ? nil : allCardsWithSettings.first(where: { $0.type == .bundles })
         ].compactMap({ $0 })
 
         analytics.track(event: .AnalyticsHub.customizeAnalyticsOpened())

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/AnalyticsHubViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/AnalyticsHubViewModel.swift
@@ -645,16 +645,16 @@ extension AnalyticsHubViewModel {
     /// Setting this view model opens the view.
     ///
     func customizeAnalytics() {
-        // Exclude any cards the merchant/store is ineligible for.
-        // Excluded cards are displayed but can't be customized.
-        let cardsToExclude: [AnalyticsCard] = [
+        // Identify any cards the merchant/store is ineligible for.
+        // Inactive cards are displayed in the list with a promo link but can't be customized.
+        let inactiveCards: [AnalyticsCard] = [
             isEligibleForSessionsCard ? nil : allCardsWithSettings.first(where: { $0.type == .sessions }),
             canDisplayCard(ofType: .bundles) ? nil : allCardsWithSettings.first(where: { $0.type == .bundles })
         ].compactMap({ $0 })
 
         analytics.track(event: .AnalyticsHub.customizeAnalyticsOpened())
         customizeAnalyticsViewModel = AnalyticsHubCustomizeViewModel(allCards: allCardsWithSettings,
-                                                                     cardsToExclude: cardsToExclude) { [weak self] updatedCards in
+                                                                     inactiveCards: inactiveCards) { [weak self] updatedCards in
             guard let self else { return }
             self.allCardsWithSettings = updatedCards
             self.storeAnalyticsCardSettings(updatedCards)

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/Customize/AnalyticsHubCustomizeView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/Customize/AnalyticsHubCustomizeView.swift
@@ -16,11 +16,7 @@ struct AnalyticsHubCustomizeView: View {
                                           selectedItems: $viewModel.selectedCards,
                                           disabledItems: viewModel.excludedCards,
                                           disabledAccessoryView: { card in
-                Button {
-                    selectedPromoURL = viewModel.promoURL(for: card)
-                } label: {
-                    Text("Explore") // TODO-12161: Show localized label with background
-                }
+                exploreButton(with: viewModel.promoURL(for: card))
             })
                 .toolbar(content: {
                     ToolbarItem(placement: .confirmationAction) {
@@ -47,6 +43,26 @@ struct AnalyticsHubCustomizeView: View {
     }
 }
 
+private extension AnalyticsHubCustomizeView {
+    /// Creates a button with a link to the provided promo URL, to explore inactive extensions.
+    ///
+    @ViewBuilder func exploreButton(with promoURL: URL?) -> some View {
+        if let promoURL {
+            Button {
+                selectedPromoURL = promoURL
+            } label: {
+                Text(Localization.explore)
+                    .foregroundColor(Color(.primary))
+            }
+            .buttonStyle(.bordered)
+            .buttonBorderShape(.roundedRectangle)
+            .controlSize(.mini)
+        } else {
+            EmptyView()
+        }
+    }
+}
+
 // MARK: - Constants
 private extension AnalyticsHubCustomizeView {
     enum Localization {
@@ -56,11 +72,20 @@ private extension AnalyticsHubCustomizeView {
         static let saveButton = NSLocalizedString("analyticsHub.customizeAnalytics.saveButton",
                                                   value: "Save",
                                                   comment: "Button to save changes on the Customize Analytics screen")
+        static let explore = NSLocalizedString("analyticsHub.customizeAnalytics.exploreButton",
+                                               value: "Explore",
+                                               comment: "Button title to explore an extension that isn't installed")
     }
 }
 
 #Preview {
     NavigationView {
         AnalyticsHubCustomizeView(viewModel: AnalyticsHubCustomizeViewModel(allCards: AnalyticsHubCustomizeViewModel.sampleCards))
+    }
+}
+
+#Preview("Inactive cards") {
+    NavigationView {
+        AnalyticsHubCustomizeView(viewModel: AnalyticsHubCustomizeViewModel(allCards: [], cardsToExclude: AnalyticsHubCustomizeViewModel.sampleCards))
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/Customize/AnalyticsHubCustomizeView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/Customize/AnalyticsHubCustomizeView.swift
@@ -10,26 +10,24 @@ struct AnalyticsHubCustomizeView: View {
     @Environment(\.dismiss) private var dismiss
 
     var body: some View {
-        VStack {
-            MultiSelectionReorderableList(contents: $viewModel.allCards,
-                                          contentKeyPath: \.name,
-                                          selectedItems: $viewModel.selectedCards,
-                                          inactiveItems: viewModel.inactiveCards,
-                                          inactiveAccessoryView: { card in
-                exploreButton(with: viewModel.promoURL(for: card))
-            })
-                .toolbar(content: {
-                    ToolbarItem(placement: .confirmationAction) {
-                        Button {
-                            viewModel.saveChanges()
-                            dismiss()
-                        } label: {
-                            Text(Localization.saveButton)
-                        }
-                        .disabled(!viewModel.hasChanges)
-                    }
-                })
-        }
+        MultiSelectionReorderableList(contents: $viewModel.allCards,
+                                      contentKeyPath: \.name,
+                                      selectedItems: $viewModel.selectedCards,
+                                      inactiveItems: viewModel.inactiveCards,
+                                      inactiveAccessoryView: { card in
+            exploreButton(with: viewModel.promoURL(for: card))
+        })
+        .toolbar(content: {
+            ToolbarItem(placement: .confirmationAction) {
+                Button {
+                    viewModel.saveChanges()
+                    dismiss()
+                } label: {
+                    Text(Localization.saveButton)
+                }
+                .disabled(!viewModel.hasChanges)
+            }
+        })
         .navigationTitle(Localization.title)
         .navigationBarTitleDisplayMode(.inline)
         .background(Color(uiColor: .listBackground))

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/Customize/AnalyticsHubCustomizeView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/Customize/AnalyticsHubCustomizeView.swift
@@ -14,7 +14,7 @@ struct AnalyticsHubCustomizeView: View {
             MultiSelectionReorderableList(contents: $viewModel.allCards,
                                           contentKeyPath: \.name,
                                           selectedItems: $viewModel.selectedCards,
-                                          inactiveItems: viewModel.excludedCards,
+                                          inactiveItems: viewModel.inactiveCards,
                                           inactiveAccessoryView: { card in
                 exploreButton(with: viewModel.promoURL(for: card))
             })
@@ -86,6 +86,6 @@ private extension AnalyticsHubCustomizeView {
 
 #Preview("Inactive cards") {
     NavigationView {
-        AnalyticsHubCustomizeView(viewModel: AnalyticsHubCustomizeViewModel(allCards: [], cardsToExclude: AnalyticsHubCustomizeViewModel.sampleCards))
+        AnalyticsHubCustomizeView(viewModel: AnalyticsHubCustomizeViewModel(allCards: [], inactiveCards: AnalyticsHubCustomizeViewModel.sampleCards))
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/Customize/AnalyticsHubCustomizeView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/Customize/AnalyticsHubCustomizeView.swift
@@ -14,8 +14,8 @@ struct AnalyticsHubCustomizeView: View {
             MultiSelectionReorderableList(contents: $viewModel.allCards,
                                           contentKeyPath: \.name,
                                           selectedItems: $viewModel.selectedCards,
-                                          disabledItems: viewModel.excludedCards,
-                                          disabledAccessoryView: { card in
+                                          inactiveItems: viewModel.excludedCards,
+                                          inactiveAccessoryView: { card in
                 exploreButton(with: viewModel.promoURL(for: card))
             })
                 .toolbar(content: {

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/Customize/AnalyticsHubCustomizeViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/Customize/AnalyticsHubCustomizeViewModel.swift
@@ -32,21 +32,21 @@ final class AnalyticsHubCustomizeViewModel: ObservableObject, Identifiable {
     ///
     private let onSave: (([AnalyticsCard]) -> Void)?
 
-    /// Any cards that are excluded from being selected or reordered.
+    /// Inactive analytics cards. These cards are excluded from being selected or reordered.
     ///
-    let excludedCards: [AnalyticsCard]
+    let inactiveCards: [AnalyticsCard]
 
     /// - Parameters:
     ///   - allCards: An ordered list of all possible analytics cards, with their settings.
-    ///   - cardsToExclude: Optional list of analytics cards to exclude from selecting/reordering, because their analytics are not available for the store.
+    ///   - inactiveCards: Optional list of inactive (unavailable) analytics cards, to exclude them from selecting/reordering.
     ///   - onSave: Optional closure to perform when the changes are saved.
     init(allCards: [AnalyticsCard],
-         cardsToExclude: [AnalyticsCard] = [],
+         inactiveCards: [AnalyticsCard] = [],
          analytics: Analytics = ServiceLocator.analytics,
          onSave: (([AnalyticsCard]) -> Void)? = nil) {
-        self.excludedCards = cardsToExclude
-        let availableCards = AnalyticsHubCustomizeViewModel.availableCards(from: allCards, excluding: cardsToExclude)
+        self.inactiveCards = inactiveCards
 
+        let availableCards = AnalyticsHubCustomizeViewModel.availableCards(from: allCards, excluding: inactiveCards)
         let groupedCards = AnalyticsHubCustomizeViewModel.groupSelectedCards(in: availableCards)
         self.allCards = groupedCards
         self.originalCards = groupedCards
@@ -69,8 +69,8 @@ final class AnalyticsHubCustomizeViewModel: ObservableObject, Identifiable {
 
         analytics.track(event: .AnalyticsHub.customizeAnalyticsSaved(cards: updatedCards))
 
-        // Add back any cards that were excluded
-        updatedCards.append(contentsOf: excludedCards)
+        // Add back any inactive cards
+        updatedCards.append(contentsOf: inactiveCards)
 
         onSave?(updatedCards)
     }
@@ -88,11 +88,11 @@ final class AnalyticsHubCustomizeViewModel: ObservableObject, Identifiable {
 }
 
 private extension AnalyticsHubCustomizeViewModel {
-    /// Removes excluded cards from the list of all cards to display in the view.
+    /// Removes inactive cards from the list of all cards to display in the view.
     ///
-    static func availableCards(from allCards: [AnalyticsCard], excluding cardsToExclude: [AnalyticsCard]) -> [AnalyticsCard] {
+    static func availableCards(from allCards: [AnalyticsCard], excluding inactiveCards: [AnalyticsCard]) -> [AnalyticsCard] {
         var allCardsToDisplay = allCards
-        allCardsToDisplay.removeAll(where: cardsToExclude.contains)
+        allCardsToDisplay.removeAll(where: inactiveCards.contains)
         return allCardsToDisplay
     }
 

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/Customize/AnalyticsHubCustomizeViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/Customize/AnalyticsHubCustomizeViewModel.swift
@@ -80,7 +80,7 @@ final class AnalyticsHubCustomizeViewModel: ObservableObject, Identifiable {
         case .bundles:
             WooConstants.URLs.productBundlesExtension.asURL()
         case .sessions:
-            nil // TODO-12161: Link to Jetpack or stop excluding this card
+            WooConstants.URLs.jetpackStats.asURL()
         default:
             nil
         }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/Customize/AnalyticsHubCustomizeViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/Customize/AnalyticsHubCustomizeViewModel.swift
@@ -32,9 +32,9 @@ final class AnalyticsHubCustomizeViewModel: ObservableObject, Identifiable {
     ///
     private let onSave: (([AnalyticsCard]) -> Void)?
 
-    /// Any cards that are excluded from display.
+    /// Any cards that are excluded from being selected or reordered.
     ///
-    private let excludedCards: [AnalyticsCard]
+    let excludedCards: [AnalyticsCard]
 
     /// - Parameters:
     ///   - allCards: An ordered list of all possible analytics cards, with their settings.
@@ -73,6 +73,17 @@ final class AnalyticsHubCustomizeViewModel: ObservableObject, Identifiable {
         updatedCards.append(contentsOf: excludedCards)
 
         onSave?(updatedCards)
+    }
+
+    func promoURL(for card: AnalyticsCard) -> URL? {
+        switch card.type {
+        case .bundles:
+            WooConstants.URLs.productBundlesExtension.asURL()
+        case .sessions:
+            nil // TODO-12161: Link to Jetpack or stop excluding this card
+        default:
+            nil
+        }
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/Customize/AnalyticsHubCustomizeViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/Customize/AnalyticsHubCustomizeViewModel.swift
@@ -38,7 +38,7 @@ final class AnalyticsHubCustomizeViewModel: ObservableObject, Identifiable {
 
     /// - Parameters:
     ///   - allCards: An ordered list of all possible analytics cards, with their settings.
-    ///   - cardsToExclude: Optional list of analytics cards to exclude from display, e.g. because the user or store is not eligible to view them.
+    ///   - cardsToExclude: Optional list of analytics cards to exclude from selecting/reordering, because their analytics are not available for the store.
     ///   - onSave: Optional closure to perform when the changes are saved.
     init(allCards: [AnalyticsCard],
          cardsToExclude: [AnalyticsCard] = [],

--- a/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/MultiSelectionReorderableList.swift
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/MultiSelectionReorderableList.swift
@@ -12,32 +12,32 @@ struct MultiSelectionReorderableList<T: Hashable, Content: View>: View {
     @Binding private var selectedItems: Set<T>
 
     /// Items in addition to the list of `contents` that can't be moved or selected.
-    private let disabledItems: [T]
+    private let inactiveItems: [T]
 
-    /// Accessory view to display next to disabled contents
-    @ViewBuilder private let disabledAccessoryView: (T) -> Content
+    /// Accessory view to display next to inactive items.
+    @ViewBuilder private let inactiveAccessoryView: (T) -> Content
 
     init(contents: Binding<[T]>,
          contentKeyPath: KeyPath<T, String>,
          selectedItems: Binding<Set<T>>,
-         disabledItems: [T] = [],
-         disabledAccessoryView: @escaping (T) -> Content) {
+         inactiveItems: [T] = [],
+         inactiveAccessoryView: @escaping (T) -> Content) {
         self._contents = contents
         self.contentKeyPath = contentKeyPath
         self._selectedItems = selectedItems
-        self.disabledItems = disabledItems
-        self.disabledAccessoryView = disabledAccessoryView
+        self.inactiveItems = inactiveItems
+        self.inactiveAccessoryView = inactiveAccessoryView
     }
 
     init(contents: Binding<[T]>,
          contentKeyPath: KeyPath<T, String>,
          selectedItems: Binding<Set<T>>,
-         disabledItems: [T] = []) where Content == EmptyView {
+         inactiveItems: [T] = []) where Content == EmptyView {
         self.init(contents: contents,
                   contentKeyPath: contentKeyPath,
                   selectedItems: selectedItems,
-                  disabledItems: disabledItems,
-                  disabledAccessoryView: { _ in EmptyView() })
+                  inactiveItems: inactiveItems,
+                  inactiveAccessoryView: { _ in EmptyView() })
     }
 
     var body: some View {
@@ -57,15 +57,15 @@ struct MultiSelectionReorderableList<T: Hashable, Content: View>: View {
                 .onMove(perform: moveItem)
             }
             Section {
-                ForEach(disabledItems, id: contentKeyPath) { item in
+                ForEach(inactiveItems, id: contentKeyPath) { item in
                     HStack(spacing: 0) {
                         Text(item[keyPath: contentKeyPath])
                         Spacer()
-                        disabledAccessoryView(item)
+                        inactiveAccessoryView(item)
                     }
                 }
-                .frame(height: Layout.disabledRowHeight)
-                .listRowInsets(.init(top: 0, leading: Layout.disabledRowLeadingInset, bottom: 0, trailing: Layout.disabledRowTrailingInset))
+                .frame(height: Layout.inactiveRowHeight)
+                .listRowInsets(.init(top: 0, leading: Layout.inactiveRowLeadingInset, bottom: 0, trailing: Layout.inactiveRowTrailingInset))
             }
         }
         .listStyle(.plain)
@@ -103,18 +103,18 @@ private extension MultiSelectionReorderableList {
 
 // MARK: - Constants
 private enum Layout {
-    static let disabledRowPadding: CGFloat = 10
-    static let disabledRowHeight: CGFloat = 52
-    static let disabledRowLeadingInset: CGFloat = 48
-    static let disabledRowTrailingInset: CGFloat = 20
+    static let inactiveRowPadding: CGFloat = 10
+    static let inactiveRowHeight: CGFloat = 52
+    static let inactiveRowLeadingInset: CGFloat = 48
+    static let inactiveRowTrailingInset: CGFloat = 20
 }
 
 #Preview("List") {
     MultiSelectionReorderableList(contents: .constant(["🥪", "🥓", "🥗"]),
                                   contentKeyPath: \.self,
                                   selectedItems: .constant(["🥗", "🥓"]),
-                                  disabledItems: ["🥫"],
-                                  disabledAccessoryView: { item in
+                                  inactiveItems: ["🥫"],
+                                  inactiveAccessoryView: { item in
         Text("Learn more about \(item)")
     })
 }

--- a/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/MultiSelectionReorderableList.swift
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/MultiSelectionReorderableList.swift
@@ -106,7 +106,7 @@ private enum Layout {
     static let disabledRowPadding: CGFloat = 10
     static let disabledRowHeight: CGFloat = 52
     static let disabledRowLeadingInset: CGFloat = 48
-    static let disabledRowTrailingInset: CGFloat = 24
+    static let disabledRowTrailingInset: CGFloat = 20
 }
 
 #Preview("List") {

--- a/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/MultiSelectionReorderableList.swift
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/MultiSelectionReorderableList.swift
@@ -1,7 +1,7 @@
 import SwiftUI
 
 /// View to select multiple items from a list and drag-and-drop to reorder them.
-struct MultiSelectionReorderableList<T: Hashable>: View {
+struct MultiSelectionReorderableList<T: Hashable, Content: View>: View {
     /// Ordered array of contents to be displayed in the list.
     @Binding private var contents: [T]
 
@@ -11,28 +11,62 @@ struct MultiSelectionReorderableList<T: Hashable>: View {
     /// Items selected from the list of `contents`.
     @Binding private var selectedItems: Set<T>
 
+    /// Items in addition to the list of `contents` that can't be moved or selected.
+    private let disabledItems: [T]
+
+    /// Accessory view to display next to disabled contents
+    @ViewBuilder private let disabledAccessoryView: (T) -> Content
+
     init(contents: Binding<[T]>,
          contentKeyPath: KeyPath<T, String>,
-         selectedItems: Binding<Set<T>>) {
+         selectedItems: Binding<Set<T>>,
+         disabledItems: [T] = [],
+         disabledAccessoryView: @escaping (T) -> Content) {
         self._contents = contents
         self.contentKeyPath = contentKeyPath
         self._selectedItems = selectedItems
+        self.disabledItems = disabledItems
+        self.disabledAccessoryView = disabledAccessoryView
+    }
+
+    init(contents: Binding<[T]>,
+         contentKeyPath: KeyPath<T, String>,
+         selectedItems: Binding<Set<T>>,
+         disabledItems: [T] = []) where Content == EmptyView {
+        self.init(contents: contents,
+                  contentKeyPath: contentKeyPath,
+                  selectedItems: selectedItems,
+                  disabledItems: disabledItems,
+                  disabledAccessoryView: { _ in EmptyView() })
     }
 
     var body: some View {
         List {
-            ForEach(contents, id: contentKeyPath) { item in
-                SelectableItemRow(title: item[keyPath: contentKeyPath],
-                                  selected: isSelected(item),
-                                  displayMode: .compact,
-                                  selectionStyle: .checkcircle)
+            Section {
+                ForEach(contents, id: contentKeyPath) { item in
+                    SelectableItemRow(title: item[keyPath: contentKeyPath],
+                                      selected: isSelected(item),
+                                      displayMode: .compact,
+                                      selectionStyle: .checkcircle)
                     .listRowInsets(.zero)
                     .onTapGesture {
                         toggleItem(item)
                     }
                     .disabled(isLastSelected(item))
+                }
+                .onMove(perform: moveItem)
             }
-            .onMove(perform: moveItem)
+            Section {
+                ForEach(disabledItems, id: contentKeyPath) { item in
+                    HStack(spacing: 0) {
+                        Text(item[keyPath: contentKeyPath])
+                        Spacer()
+                        disabledAccessoryView(item)
+                    }
+                }
+                .frame(height: Layout.disabledRowHeight)
+                .listRowInsets(.init(top: 0, leading: Layout.disabledRowLeadingInset, bottom: 0, trailing: Layout.disabledRowTrailingInset))
+            }
         }
         .listStyle(.plain)
         .environment(\.editMode, .constant(.active)) // Always allow reordering
@@ -67,10 +101,22 @@ private extension MultiSelectionReorderableList {
     }
 }
 
+// MARK: - Constants
+private enum Layout {
+    static let disabledRowPadding: CGFloat = 10
+    static let disabledRowHeight: CGFloat = 52
+    static let disabledRowLeadingInset: CGFloat = 48
+    static let disabledRowTrailingInset: CGFloat = 24
+}
+
 #Preview("List") {
     MultiSelectionReorderableList(contents: .constant(["🥪", "🥓", "🥗"]),
                                   contentKeyPath: \.self,
-                                  selectedItems: .constant(["🥗", "🥓"]))
+                                  selectedItems: .constant(["🥗", "🥓"]),
+                                  disabledItems: ["🥫"],
+                                  disabledAccessoryView: { item in
+        Text("Learn more about \(item)")
+    })
 }
 
 #Preview("Last selected item") {

--- a/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Analytics Hub/AnalyticsHubCustomizeViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Analytics Hub/AnalyticsHubCustomizeViewModelTests.swift
@@ -17,7 +17,7 @@ final class AnalyticsHubCustomizeViewModelTests: XCTestCase {
         let revenueCard = AnalyticsCard(type: .revenue, enabled: true)
         let ordersCard = AnalyticsCard(type: .orders, enabled: false)
         let sessionsCard = AnalyticsCard(type: .sessions, enabled: true)
-        let vm = AnalyticsHubCustomizeViewModel(allCards: [revenueCard, ordersCard, sessionsCard], cardsToExclude: [sessionsCard])
+        let vm = AnalyticsHubCustomizeViewModel(allCards: [revenueCard, ordersCard, sessionsCard], inactiveCards: [sessionsCard])
 
         // Then
         assertEqual([revenueCard, ordersCard], vm.allCards)
@@ -72,7 +72,7 @@ final class AnalyticsHubCustomizeViewModelTests: XCTestCase {
         // When
         let actualCards = waitFor { promise in
             let vm = AnalyticsHubCustomizeViewModel(allCards: [revenueCard, ordersCard, productsCard],
-                                                    cardsToExclude: [sessionsCard],
+                                                    inactiveCards: [sessionsCard],
                                                     analytics: self.analytics) { updatedCards in
                 promise(updatedCards)
             }
@@ -94,7 +94,7 @@ final class AnalyticsHubCustomizeViewModelTests: XCTestCase {
         let productsCard = AnalyticsCard(type: .products, enabled: false)
         let sessionsCard = AnalyticsCard(type: .sessions, enabled: true)
         let vm = AnalyticsHubCustomizeViewModel(allCards: [revenueCard, ordersCard, productsCard, sessionsCard],
-                                                cardsToExclude: [sessionsCard],
+                                                inactiveCards: [sessionsCard],
                                                 analytics: analytics)
 
         // When

--- a/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Analytics Hub/AnalyticsHubViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Analytics Hub/AnalyticsHubViewModelTests.swift
@@ -600,7 +600,7 @@ final class AnalyticsHubViewModelTests: XCTestCase {
         customizeAnalytics.saveChanges()
     }
 
-    func test_customizeAnalytics_excludes_sessions_card_when_ineligible() throws {
+    func test_sessions_card_is_inactive_in_customizeAnalytics_when_ineligible() throws {
         // Given
         let stores = MockStoresManager(sessionManager: .makeForTesting(authenticated: true, defaultSite: .fake().copy(siteID: -1)))
         let vm = createViewModel(stores: stores)
@@ -611,10 +611,10 @@ final class AnalyticsHubViewModelTests: XCTestCase {
         // Then
         let customizeAnalyticsVM = try XCTUnwrap(vm.customizeAnalyticsViewModel)
         XCTAssertFalse(vm.enabledCards.contains(.sessions))
-        XCTAssertTrue(customizeAnalyticsVM.excludedCards.contains(where: { $0.type == .sessions }))
+        XCTAssertTrue(customizeAnalyticsVM.inactiveCards.contains(where: { $0.type == .sessions }))
     }
 
-    func test_customizeAnalytics_excludes_bundles_card_when_extension_is_inactive() throws {
+    func test_bundles_card_is_inactive_in_customizeAnalytics_when_extension_is_inactive() throws {
         // Given
         let storage = MockStorageManager()
         storage.insertSampleSystemPlugin(readOnlySystemPlugin: .fake().copy(siteID: sampleSiteID,
@@ -628,7 +628,7 @@ final class AnalyticsHubViewModelTests: XCTestCase {
         // Then
         let customizeAnalyticsVM = try XCTUnwrap(vm.customizeAnalyticsViewModel)
         XCTAssertFalse(vm.enabledCards.contains(.bundles))
-        XCTAssertTrue(customizeAnalyticsVM.excludedCards.contains(where: { $0.type == .bundles }))
+        XCTAssertTrue(customizeAnalyticsVM.inactiveCards.contains(where: { $0.type == .bundles }))
     }
 
     func test_customizeAnalytics_tracks_expected_event() {

--- a/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Analytics Hub/AnalyticsHubViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Analytics Hub/AnalyticsHubViewModelTests.swift
@@ -611,7 +611,24 @@ final class AnalyticsHubViewModelTests: XCTestCase {
         // Then
         let customizeAnalyticsVM = try XCTUnwrap(vm.customizeAnalyticsViewModel)
         XCTAssertFalse(vm.enabledCards.contains(.sessions))
-        XCTAssertFalse(customizeAnalyticsVM.allCards.contains(where: { $0.type == .sessions }))
+        XCTAssertTrue(customizeAnalyticsVM.excludedCards.contains(where: { $0.type == .sessions }))
+    }
+
+    func test_customizeAnalytics_excludes_bundles_card_when_extension_is_inactive() throws {
+        // Given
+        let storage = MockStorageManager()
+        storage.insertSampleSystemPlugin(readOnlySystemPlugin: .fake().copy(siteID: sampleSiteID,
+                                                                            name: SitePlugin.SupportedPlugin.WCProductBundles.first,
+                                                                            active: false))
+        let vm = createViewModel(storage: storage)
+
+        // When
+        vm.customizeAnalytics()
+
+        // Then
+        let customizeAnalyticsVM = try XCTUnwrap(vm.customizeAnalyticsViewModel)
+        XCTAssertFalse(vm.enabledCards.contains(.bundles))
+        XCTAssertTrue(customizeAnalyticsVM.excludedCards.contains(where: { $0.type == .bundles }))
     }
 
     func test_customizeAnalytics_tracks_expected_event() {


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #12161
<!-- Id number of the GitHub issue this PR addresses. -->

## Why
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
When a supported extension is not active, the Analytics Hub customize view now includes its analytics card in the list. It can't be selected or reordered, and it shows an "Explore" button with a link to the extension details. For the Sessions card, it shows a link to the Jetpack Stats info page.

## How

1. `MultiSelectionReorderableList` now supports an optional list of inactive items and an optional accessory view for those item rows. Those items are displayed in a separate section in the list that doesn't support selection or reordering.
2. The naming for cards that the user/merchant isn't eligible for is now "inactive cards" instead of "excluded cards", to clarify that they are not excluded entirely but are just inactive (can't be selected/reordered).
3. In `AnalyticsHubCustomizeViewModel `:
   * `inactiveCards` are no longer private (so they can be displayed in the list)
   * The helper `promoURL(for:)` gets the promo URL for any cards that require an extension.
5. In `AnalyticsHubCustomizeView`, we pass the `inactiveCards` to the reorderable list component along with an accessory view for the "Explore" button.


## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

1. Build and run the app.
2. Select a store that doesn't not have the Product Bundles extension installed, and/or a store that is not using Jetpack.
3. Open the analytics hub.
4. Tap "Edit" to customize the analytics.
6. Confirm you can select and reorder the cards you are eligible for, as expected.
7. Confirm the cards you are not eligible for (bundles and/or sessions) are visible at the bottom of the list and can't be selected or reordered.
8. Tap the "Explore" button and confirm it takes you to more information about the required extension.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->
/|Light|Dark
-|-|-
No Jetpack or Product Bundles extension|![Simulator Screenshot - iPhone 15 Pro - 2024-03-28 at 12 57 47](https://github.com/woocommerce/woocommerce-ios/assets/8658164/56ba15e5-cd1b-4252-9c4b-e9bdd430a065)|![Simulator Screenshot - iPhone 15 Pro - 2024-03-28 at 12 58 05](https://github.com/woocommerce/woocommerce-ios/assets/8658164/2490d3d1-5b74-4a3e-99a3-0d51b78f008d)
No Product Bundles extension|![Simulator Screenshot - iPhone 15 Pro - 2024-03-28 at 11 48 07](https://github.com/woocommerce/woocommerce-ios/assets/8658164/a972ff84-1b16-4c53-9196-81542233811f)|![Simulator Screenshot - iPhone 15 Pro - 2024-03-28 at 11 48 10](https://github.com/woocommerce/woocommerce-ios/assets/8658164/398539e4-c6b4-43a9-a135-66fe56d80316)
All supported extensions active|![Simulator Screenshot - iPhone 15 Pro - 2024-03-28 at 11 49 06](https://github.com/woocommerce/woocommerce-ios/assets/8658164/ea6f4f95-a9a8-4959-a936-2ad450bd53bc)|![Simulator Screenshot - iPhone 15 Pro - 2024-03-28 at 11 49 15](https://github.com/woocommerce/woocommerce-ios/assets/8658164/db9f1b7f-3412-444a-b2d7-85c59a3228e0)

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
