### PR TITLE
Scan to Pay window is very wide when presented on an iPad

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Orders/Payment Methods/PaymentMethodsView.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Payment Methods/PaymentMethodsView.swift
@@ -132,7 +132,7 @@ struct PaymentMethodsView: View {
                 }
             }
         }
-        .fullScreenCover(isPresented: $showingScanToPayView) {
+        .sheet(isPresented: $showingScanToPayView) {
             ScanToPayView(viewModel: ScanToPayViewModel(paymentURL: viewModel.paymentLink)) {
                 dismiss()
                 viewModel.performScanToPayFinishedTasks()

--- a/WooCommerce/Classes/ViewRelated/Orders/ScanToPay/ScanToPayView.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/ScanToPay/ScanToPayView.swift
@@ -11,7 +11,6 @@ struct ScanToPayView: View {
 
     var body: some View {
         ZStack {
-            Color.black.opacity(Layout.backgroundOpacity).edgesIgnoringSafeArea(.all)
             VStack {
                 VStack(alignment: .center, spacing: Layout.scanToPayBoxSpacing) {
                     if let qrCodeImage = viewModel.generateQRCodeImage() {


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #11778
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

- Show scan to pay view as a sheet and remove background opacity view

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

1. Launch the app on an iPad.
2. Tap `Orders`.
3. Select an unpaid order, or create a new order with a product.
4. Tap `Collect Payment`.
5. Tap `Scan to Pay`
6. Observe that in both landscape and portrait, the scan to pay modal looks ok and not too wide.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

| Before      | After |
| ----------- | ----------- |
| ![Simulator Screenshot - iPad Pro (11-inch) (4th generation) - 2024-03-28 at 15 04 04](https://github.com/woocommerce/woocommerce-ios/assets/6242034/aa9ad816-abc6-45d5-83de-b63d577336f1)      | ![Simulator Screenshot - iPad Pro (11-inch) (4th generation) - 2024-03-28 at 14 45 45](https://github.com/woocommerce/woocommerce-ios/assets/6242034/ab3a8eb5-b9ed-4e23-89a8-f272db0962c3)       |
| ![Simulator Screen Recording - iPad Pro (11-inch) (4th generation) - 2024-03-28 at 15 04 21](https://github.com/woocommerce/woocommerce-ios/assets/6242034/fc62824f-fcaf-4c23-875f-5409d59cb602) | ![Simulator Screen Recording - iPad Pro (11-inch) (4th generation) - 2024-03-28 at 14 45 28](https://github.com/woocommerce/woocommerce-ios/assets/6242034/9325b3b6-311d-4812-bdd9-60ddc177fd2a) |

---

- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
