### PR TITLE
[Analytics Hub] Show sessions card with error message when custom time range is selected

### DIFF
--- a/WooCommerce/Classes/Extensions/UIImage+Woo.swift
+++ b/WooCommerce/Classes/Extensions/UIImage+Woo.swift
@@ -1519,6 +1519,10 @@ extension UIImage {
         UIImage(systemName: "exclamationmark.circle.fill", withConfiguration: Configurations.barButtonItemSymbol)!.withRenderingMode(.alwaysTemplate)
     }
 
+    static var exclamationImage: UIImage {
+        UIImage(systemName: "exclamationmark.circle", withConfiguration: Configurations.barButtonItemSymbol)!.withRenderingMode(.alwaysTemplate)
+    }
+
 
 }
 

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/AnalyticsHubView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/AnalyticsHubView.swift
@@ -143,6 +143,8 @@ private extension AnalyticsHubView {
                     await viewModel.enableJetpackStats()
                     isEnablingJetpackStats = false
                 }
+            } else if case .custom = viewModel.timeRangeSelectionType {
+                AnalyticsSessionsUnavailableCard()
             } else {
                 AnalyticsReportCard(viewModel: viewModel.sessionsCard)
             }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/AnalyticsHubViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/AnalyticsHubViewModel.swift
@@ -152,24 +152,11 @@ final class AnalyticsHubViewModel: ObservableObject {
     private func canDisplayCard(ofType card: AnalyticsCard.CardType) -> Bool {
         switch card {
         case .sessions:
-            showSessionsCard
+            isEligibleForSessionsCard
         case .bundles:
             isExpandedAnalyticsHubEnabled && isPluginActive(SitePlugin.SupportedPlugin.WCProductBundles)
         default:
             true
-        }
-    }
-
-    /// Sessions Card display state
-    ///
-    private var showSessionsCard: Bool {
-        guard isEligibleForSessionsCard else {
-            return false
-        }
-        if case .custom = timeRangeSelectionType {
-            return false
-        } else {
-            return true
         }
     }
 
@@ -645,12 +632,9 @@ extension AnalyticsHubViewModel {
     /// Setting this view model opens the view.
     ///
     func customizeAnalytics() {
-        // Identify any cards the merchant/store is ineligible for.
-        // Inactive cards are displayed in the list with a promo link but can't be customized.
-        let inactiveCards: [AnalyticsCard] = [
-            isEligibleForSessionsCard ? nil : allCardsWithSettings.first(where: { $0.type == .sessions }),
-            canDisplayCard(ofType: .bundles) ? nil : allCardsWithSettings.first(where: { $0.type == .bundles })
-        ].compactMap({ $0 })
+        // Identify any inactive cards (that can't be displayed in the Analytics Hub).
+        // Inactive cards are displayed in the customize list with a promo link but can't be customized.
+        let inactiveCards: [AnalyticsCard] = allCardsWithSettings.filter { !canDisplayCard(ofType: $0.type) }
 
         analytics.track(event: .AnalyticsHub.customizeAnalyticsOpened())
         customizeAnalyticsViewModel = AnalyticsHubCustomizeViewModel(allCards: allCardsWithSettings,

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/Report Cards/AnalyticsSessionsUnavailableCard.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/Report Cards/AnalyticsSessionsUnavailableCard.swift
@@ -1,0 +1,52 @@
+import SwiftUI
+
+struct AnalyticsSessionsUnavailableCard: View {
+    var body: some View {
+        VStack(alignment: .leading, spacing: Layout.titleSpacing) {
+            Text(Localization.title)
+                .foregroundColor(Color(.text))
+                .footnoteStyle()
+
+            Grid(alignment: .leading) {
+                GridRow {
+                    Image(uiImage: .exclamationImage)
+                        .foregroundColor(Color(.error))
+                    Text(Localization.message)
+                        .headlineStyle()
+                }
+                GridRow {
+                    Spacer().fixedSize()
+                    Text(Localization.description)
+                        .bodyStyle()
+                }
+            }
+            .padding(Layout.cardPadding)
+            .overlay(RoundedRectangle(cornerRadius: Layout.cornerRadius)
+                .stroke(Color(.systemGray4)))
+        }
+        .padding(Layout.cardPadding)
+    }
+}
+
+// MARK: Constants
+private extension AnalyticsSessionsUnavailableCard {
+    enum Layout {
+        static let titleSpacing: CGFloat = 24
+        static let cardPadding: CGFloat = 16
+        static let cornerRadius: CGFloat = 8
+    }
+
+    enum Localization {
+        static let title = NSLocalizedString("analyticsHub.sessionsCard.Title", value: "SESSIONS", comment: "Title for sessions section in the Analytics Hub")
+        static let message = NSLocalizedString("analyticsHub.sessionsCard.dataUnavailable.Message",
+                                               value: "Session data unavailable",
+                                               comment: "Message when session data is unavailable in the Analytics Hub")
+        static let description = NSLocalizedString("analyticsHub.sessionsCard.dataUnavailable.Description",
+                                                   value: "Session analytics rely on unique visitor counts not available for custom date ranges.",
+                                                   comment: "Description when session data is unavailable in the Analytics Hub")
+    }
+}
+
+#Preview {
+    AnalyticsSessionsUnavailableCard()
+}

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -2065,6 +2065,7 @@
 		CEA16F3A20FD0C8C0061B4E1 /* WooAnalytics.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEA16F3920FD0C8C0061B4E1 /* WooAnalytics.swift */; };
 		CEA455C12BB3446D00D932CF /* BundlesReportCardViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEA455C02BB3446D00D932CF /* BundlesReportCardViewModel.swift */; };
 		CEA455C52BB44F9E00D932CF /* ProductsReportItem+Woo.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEA455C42BB44F9E00D932CF /* ProductsReportItem+Woo.swift */; };
+		CEA455C72BB5CA5E00D932CF /* AnalyticsSessionsUnavailableCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEA455C62BB5CA5E00D932CF /* AnalyticsSessionsUnavailableCard.swift */; };
 		CEA9C8E02B6D323A000FE114 /* AnalyticsWebReportTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEA9C8DF2B6D323A000FE114 /* AnalyticsWebReportTests.swift */; };
 		CEC8188C2A3B7C8B00459843 /* AppStartupWaitingTimeTracker.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEC8188B2A3B7C8B00459843 /* AppStartupWaitingTimeTracker.swift */; };
 		CEC8188E2A3C75DD00459843 /* AppStartupWaitingTimeTrackerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEC8188D2A3C75DD00459843 /* AppStartupWaitingTimeTrackerTests.swift */; };
@@ -4807,6 +4808,7 @@
 		CEA16F3920FD0C8C0061B4E1 /* WooAnalytics.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WooAnalytics.swift; sourceTree = "<group>"; };
 		CEA455C02BB3446D00D932CF /* BundlesReportCardViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BundlesReportCardViewModel.swift; sourceTree = "<group>"; };
 		CEA455C42BB44F9E00D932CF /* ProductsReportItem+Woo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ProductsReportItem+Woo.swift"; sourceTree = "<group>"; };
+		CEA455C62BB5CA5E00D932CF /* AnalyticsSessionsUnavailableCard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnalyticsSessionsUnavailableCard.swift; sourceTree = "<group>"; };
 		CEA9C8DF2B6D323A000FE114 /* AnalyticsWebReportTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnalyticsWebReportTests.swift; sourceTree = "<group>"; };
 		CEC8188B2A3B7C8B00459843 /* AppStartupWaitingTimeTracker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppStartupWaitingTimeTracker.swift; sourceTree = "<group>"; };
 		CEC8188D2A3C75DD00459843 /* AppStartupWaitingTimeTrackerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppStartupWaitingTimeTrackerTests.swift; sourceTree = "<group>"; };
@@ -11043,6 +11045,7 @@
 				2647F7B9292BE2F900D59FDF /* AnalyticsReportCard.swift */,
 				26E7EE6D29300E8100793045 /* AnalyticsItemsSoldCard.swift */,
 				CEF2DD852B558E3E00A3DD0B /* AnalyticsCTACard.swift */,
+				CEA455C62BB5CA5E00D932CF /* AnalyticsSessionsUnavailableCard.swift */,
 				CEEF74212B99EC5800B03948 /* AnalyticsReportCardProtocol.swift */,
 				CEEF74242B99EF1200B03948 /* RevenueReportCardViewModel.swift */,
 				CEEF74292B9A02EB00B03948 /* OrdersReportCardViewModel.swift */,
@@ -14033,6 +14036,7 @@
 				0204F0CA29C047A400CFC78F /* SelfSizingHostingController.swift in Sources */,
 				7441EBC9226A71AA008BF83D /* TitleBodyTableViewCell.swift in Sources */,
 				EECB6D1E2AFBFE0000040BC9 /* WooSubscriptionProductsEligibilityChecker.swift in Sources */,
+				CEA455C72BB5CA5E00D932CF /* AnalyticsSessionsUnavailableCard.swift in Sources */,
 				EE45E29D2A381A250085F227 /* ProductDescriptionGenerationCelebrationView.swift in Sources */,
 				0260B1B12805321B00FCFE8C /* OrderDetailsPaymentAlertsProtocol.swift in Sources */,
 				4556ED38270645A6005CBC0D /* ShippingLabelCarrierSectionHeader.swift in Sources */,

--- a/WooCommerce/WooCommerceTests/Extensions/IconsTests.swift
+++ b/WooCommerce/WooCommerceTests/Extensions/IconsTests.swift
@@ -932,4 +932,8 @@ final class IconsTests: XCTestCase {
     func test_exclamationFilledImage_is_not_nil() {
         XCTAssertNotNil(UIImage.exclamationFilledImage)
     }
+
+    func test_exclamationImage_is_not_nil() {
+        XCTAssertNotNil(UIImage.exclamationImage)
+    }
 }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Analytics Hub/AnalyticsHubViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Analytics Hub/AnalyticsHubViewModelTests.swift
@@ -135,23 +135,6 @@ final class AnalyticsHubViewModelTests: XCTestCase {
         // Given
     }
 
-    func test_session_card_is_hidden_for_custom_range() async {
-        // Given
-        XCTAssertTrue(vm.enabledCards.contains(.sessions))
-
-        // When
-        vm.timeRangeSelectionType = .custom(start: Date(), end: Date())
-
-        // Then
-        XCTAssertFalse(vm.enabledCards.contains(.sessions))
-
-        // When
-        vm.timeRangeSelectionType = .lastMonth
-
-        // Then
-        XCTAssertTrue(vm.enabledCards.contains(.sessions))
-    }
-
     func test_session_card_is_hidden_for_sites_without_jetpack_plugin() {
         // Given
         let storesForNonJetpackSite = MockStoresManager(sessionManager: .makeForTesting(authenticated: true, defaultSite: .fake().copy(siteID: -1)))


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #12295
<!-- Id number of the GitHub issue this PR addresses. -->

## Why
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
Previously we were hiding the Sessions card when a custom time range was selected. Now, we show the card with a "Session data unavailable" message explaining why we can't show the session data.

## How

* Adds a new card view `AnalyticsSessionsUnavailableCard` with the explanatory message.
* In `AnalyticsHubView`, adds a check for a custom time range and shows the new card.
* In `AnalyticsHubViewModel`:
   * Removes `showSessionsCard` (which was used to check the selected time range) and only checks `isEligibleForSessionsCard` to determine if the sessions card should be shown.
   * Simplifies `customizeAnalytics()`: now we can just check whether a card can be displayed in the Analytics Hub, and if it can't, it is added to the `inactiveCards` list.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

1. Build and run the app.
2. Select a store with Jetpack Stats active.
3. Open the analytics hub and confirm the sessions card show analytics when a non-custom time range is selected.
4. Select a custom time range and confirm the new message is shown.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->
<img src="https://github.com/woocommerce/woocommerce-ios/assets/8658164/e4adf1af-1063-499f-a825-6d8f803c4266" width="300px">


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
