### PR TITLE
[Analytics Hub] Refactor sessions card view

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/AnalyticsHubView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/AnalyticsHubView.swift
@@ -128,8 +128,7 @@ private extension AnalyticsHubView {
         case .products:
             AnalyticsItemsSoldCard(statsViewModel: viewModel.productsStatsCard, itemsViewModel: viewModel.itemsSoldCard)
         case .sessions:
-            AnalyticsSessionsReportCard(isSessionsDataAvailable: viewModel.isSessionsDataAvailable,
-                                        viewModel: viewModel.sessionsCard)
+            AnalyticsSessionsReportCard(viewModel: viewModel.sessionsCard)
         case .bundles:
             AnalyticsItemsSoldCard(bundlesViewModel: viewModel.bundlesCard)
         }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/AnalyticsHubView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/AnalyticsHubView.swift
@@ -58,8 +58,6 @@ struct AnalyticsHubView: View {
 
     @StateObject var viewModel: AnalyticsHubViewModel
 
-    @State private var isEnablingJetpackStats = false
-
     var body: some View {
         RefreshablePlainList(action: {
             viewModel.trackAnalyticsInteraction()
@@ -72,15 +70,11 @@ struct AnalyticsHubView: View {
                 .background(Color(uiColor: .listForeground(modal: false)))
                 .addingTopAndBottomDividers()
 
-                if viewModel.enabledCards.isNotEmpty {
-                    ForEach(viewModel.enabledCards, id: \.self) { card in
-                        analyticsCard(type: card)
-                            .padding(.horizontal, insets: safeAreaInsets)
-                            .background(Color(uiColor: .listForeground(modal: false)))
-                            .addingTopAndBottomDividers()
-                    }
-                } else {
-                    EmptyState(title: Localization.emptyStateTitle, description: Localization.emptyStateDescription, image: .enableAnalyticsImage)
+                ForEach(viewModel.enabledCards, id: \.self) { card in
+                    analyticsCard(type: card)
+                        .padding(.horizontal, insets: safeAreaInsets)
+                        .background(Color(uiColor: .listForeground(modal: false)))
+                        .addingTopAndBottomDividers()
                 }
 
                 Spacer()
@@ -134,20 +128,11 @@ private extension AnalyticsHubView {
         case .products:
             AnalyticsItemsSoldCard(statsViewModel: viewModel.productsStatsCard, itemsViewModel: viewModel.itemsSoldCard)
         case .sessions:
-            if viewModel.showJetpackStatsCTA {
-                AnalyticsCTACard(title: Localization.sessionsCTATitle,
-                                 message: Localization.sessionsCTAMessage,
-                                 buttonLabel: Localization.sessionsCTAButton,
-                                 isLoading: $isEnablingJetpackStats) {
-                    isEnablingJetpackStats = true
-                    await viewModel.enableJetpackStats()
-                    isEnablingJetpackStats = false
-                }
-            } else if case .custom = viewModel.timeRangeSelectionType {
-                AnalyticsSessionsUnavailableCard()
-            } else {
-                AnalyticsReportCard(viewModel: viewModel.sessionsCard)
-            }
+            AnalyticsSessionsReportCard(showJetpackStatsCTA: viewModel.showJetpackStatsCTA,
+                                        enableJetpackStats: viewModel.enableJetpackStats,
+                                        trackJetpackStatsCTAShown: viewModel.trackJetpackStatsCTAShown,
+                                        isSessionsDataAvailable: viewModel.isSessionsDataAvailable,
+                                        viewModel: viewModel.sessionsCard)
         case .bundles:
             AnalyticsItemsSoldCard(bundlesViewModel: viewModel.bundlesCard)
         }
@@ -159,27 +144,9 @@ private extension AnalyticsHubView {
 private extension AnalyticsHubView {
     struct Localization {
         static let title = NSLocalizedString("Analytics", comment: "Title for the Analytics Hub screen.")
-
-
-        static let sessionsCTATitle = NSLocalizedString("analyticsHub.jetpackStatsCTA.title",
-                                                        value: "SESSIONS",
-                                                        comment: "Title for sessions section in the Analytics Hub")
-        static let sessionsCTAMessage = NSLocalizedString("analyticsHub.jetpackStatsCTA.message",
-                                                          value: "Enable Jetpack Stats to see your store's session analytics.",
-                                                          comment: "Text displayed in the Analytics Hub when the Jetpack Stats module is disabled")
-        static let sessionsCTAButton = NSLocalizedString("analyticsHub.jetpackStatsCTA.buttonLabel",
-                                                         value: "Enable Jetpack Stats",
-                                                         comment: "Label for button to enable Jetpack Stats")
         static let editButton = NSLocalizedString("analyticsHub.editButton.label",
                                                   value: "Edit",
                                                   comment: "Label for button that opens a screen to customize the Analytics Hub")
-
-        static let emptyStateTitle = NSLocalizedString("analyticsHub.emptyState.title",
-                                                       value: "No analytics available",
-                                                       comment: "Title when there are no analytics to display in the Analytics Hub.")
-        static let emptyStateDescription = NSLocalizedString("analyticsHub.emptyState.description",
-                                                             value: "Please select another date range or tap Edit to enable more analytics.",
-                                                             comment: "Description when there are no analytics to display in the Analytics Hub.")
     }
 
     struct Layout {

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/AnalyticsHubView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/AnalyticsHubView.swift
@@ -128,10 +128,7 @@ private extension AnalyticsHubView {
         case .products:
             AnalyticsItemsSoldCard(statsViewModel: viewModel.productsStatsCard, itemsViewModel: viewModel.itemsSoldCard)
         case .sessions:
-            AnalyticsSessionsReportCard(showJetpackStatsCTA: viewModel.showJetpackStatsCTA,
-                                        enableJetpackStats: viewModel.enableJetpackStats,
-                                        trackJetpackStatsCTAShown: viewModel.trackJetpackStatsCTAShown,
-                                        isSessionsDataAvailable: viewModel.isSessionsDataAvailable,
+            AnalyticsSessionsReportCard(isSessionsDataAvailable: viewModel.isSessionsDataAvailable,
                                         viewModel: viewModel.sessionsCard)
         case .bundles:
             AnalyticsItemsSoldCard(bundlesViewModel: viewModel.bundlesCard)

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/AnalyticsHubViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/AnalyticsHubViewModel.swift
@@ -178,6 +178,16 @@ final class AnalyticsHubViewModel: ObservableObject {
         isJetpackStatsDisabled && userIsAdmin
     }
 
+    /// Whether sessions data is available to display; `false` if a custom time range is selected.
+    ///
+    var isSessionsDataAvailable: Bool {
+        if case .custom = timeRangeSelectionType {
+            return false
+        } else {
+            return true
+        }
+    }
+
     /// Defines a notice that, when set, dismisses the view and is then displayed.
     /// Defaults to `nil`.
     ///
@@ -280,7 +290,7 @@ final class AnalyticsHubViewModel: ObservableObject {
     /// Enables the Jetpack Status module on the store and requests new stats data
     ///
     @MainActor
-    func enableJetpackStats() async {
+    func enableJetpackStats() async -> Void {
         analytics.track(event: .AnalyticsHub.jetpackStatsCTATapped())
 
         do {
@@ -292,6 +302,12 @@ final class AnalyticsHubViewModel: ObservableObject {
             noticePresenter.enqueue(notice: .init(title: Localization.statsCTAError))
             DDLogError("⚠️ Error enabling Jetpack Stats: \(error)")
         }
+    }
+
+    /// Tracks when the call to action to enable Jetpack Stats is shown.
+    ///
+    func trackJetpackStatsCTAShown() {
+        analytics.track(event: .AnalyticsHub.jetpackStatsCTAShown())
     }
 }
 
@@ -382,9 +398,6 @@ private extension AnalyticsHubViewModel {
         } catch SiteStatsStoreError.statsModuleDisabled {
             self.isJetpackStatsDisabled = true
             self.siteStats = nil
-            if showJetpackStatsCTA {
-                analytics.track(event: .AnalyticsHub.jetpackStatsCTAShown())
-            }
             DDLogError("⚠️ Analytics Hub Sessions card can't be loaded: Jetpack stats are disabled")
         } catch {
             self.siteStats = nil

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/AnalyticsHubViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/AnalyticsHubViewModel.swift
@@ -102,6 +102,7 @@ final class AnalyticsHubViewModel: ObservableObject {
         SessionsReportCardViewModel(siteID: siteID,
                                     currentOrderStats: currentOrderStats,
                                     siteStats: siteStats,
+                                    timeRange: timeRangeSelectionType,
                                     isJetpackStatsDisabled: isJetpackStatsDisabled,
                                     isRedacted: isLoadingOrderStats || isLoadingSiteStats,
                                     updateSiteStatsData: { [weak self] in
@@ -167,16 +168,6 @@ final class AnalyticsHubViewModel: ObservableObject {
     /// Whether Jetpack Stats are disabled on the store
     ///
     private var isJetpackStatsDisabled = false
-
-    /// Whether sessions data is available to display; `false` if a custom time range is selected.
-    ///
-    var isSessionsDataAvailable: Bool {
-        if case .custom = timeRangeSelectionType {
-            return false
-        } else {
-            return true
-        }
-    }
 
     /// Defines a notice that, when set, dismisses the view and is then displayed.
     /// Defaults to `nil`.

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/Report Cards/AnalyticsSessionsReportCard.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/Report Cards/AnalyticsSessionsReportCard.swift
@@ -1,10 +1,6 @@
 import SwiftUI
 
 struct AnalyticsSessionsReportCard: View {
-    /// Whether sessions data is available.
-    ///
-    let isSessionsDataAvailable: Bool
-
     /// View model for the Sessions report card, when data is available.
     ///
     let viewModel: SessionsReportCardViewModel
@@ -23,7 +19,7 @@ struct AnalyticsSessionsReportCard: View {
             }.onAppear {
                 viewModel.trackJetpackStatsCTAShown()
             }
-        } else if !isSessionsDataAvailable {
+        } else if !viewModel.isSessionsDataAvailable {
             AnalyticsSessionsUnavailableCard()
         } else {
             AnalyticsReportCard(viewModel: viewModel)
@@ -44,10 +40,10 @@ private extension AnalyticsSessionsReportCard {
 }
 
 #Preview("Sessions report card") {
-    AnalyticsSessionsReportCard(isSessionsDataAvailable: true,
-                                viewModel: .init(siteID: 123,
+    AnalyticsSessionsReportCard(viewModel: .init(siteID: 123,
                                                  currentOrderStats: SessionsReportCardViewModel.sampleOrderStats(),
                                                  siteStats: SessionsReportCardViewModel.sampleSiteStats(),
+                                                 timeRange: .today,
                                                  isJetpackStatsDisabled: false,
                                                  updateSiteStatsData: {}))
 }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/Report Cards/AnalyticsSessionsReportCard.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/Report Cards/AnalyticsSessionsReportCard.swift
@@ -1,18 +1,6 @@
 import SwiftUI
 
 struct AnalyticsSessionsReportCard: View {
-    /// Whether to show the call to action to enable Jetpack Stats.
-    ///
-    let showJetpackStatsCTA: Bool
-
-    /// Enables Jetpack Stats remotely.
-    ///
-    let enableJetpackStats: () async -> Void
-
-    /// Tracks when the Jetpack Stats CTA is shown.
-    ///
-    let trackJetpackStatsCTAShown: () -> Void
-
     /// Whether sessions data is available.
     ///
     let isSessionsDataAvailable: Bool
@@ -24,16 +12,16 @@ struct AnalyticsSessionsReportCard: View {
     @State private var isEnablingJetpackStats = false
 
     var body: some View {
-        if showJetpackStatsCTA {
+        if viewModel.showJetpackStatsCTA {
             AnalyticsCTACard(title: Localization.title,
                              message: Localization.sessionsCTAMessage,
                              buttonLabel: Localization.sessionsCTAButton,
                              isLoading: $isEnablingJetpackStats) {
                 isEnablingJetpackStats = true
-                await enableJetpackStats()
+                await viewModel.enableJetpackStats()
                 isEnablingJetpackStats = false
             }.onAppear {
-                trackJetpackStatsCTAShown()
+                viewModel.trackJetpackStatsCTAShown()
             }
         } else if !isSessionsDataAvailable {
             AnalyticsSessionsUnavailableCard()
@@ -56,10 +44,10 @@ private extension AnalyticsSessionsReportCard {
 }
 
 #Preview("Sessions report card") {
-    AnalyticsSessionsReportCard(showJetpackStatsCTA: false,
-                                enableJetpackStats: {},
-                                trackJetpackStatsCTAShown: {},
-                                isSessionsDataAvailable: true,
-                                viewModel: .init(currentOrderStats: nil,
-                                                 siteStats: nil))
+    AnalyticsSessionsReportCard(isSessionsDataAvailable: true,
+                                viewModel: .init(siteID: 123,
+                                                 currentOrderStats: SessionsReportCardViewModel.sampleOrderStats(),
+                                                 siteStats: SessionsReportCardViewModel.sampleSiteStats(),
+                                                 isJetpackStatsDisabled: false,
+                                                 updateSiteStatsData: {}))
 }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/Report Cards/AnalyticsSessionsReportCard.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/Report Cards/AnalyticsSessionsReportCard.swift
@@ -1,0 +1,65 @@
+import SwiftUI
+
+struct AnalyticsSessionsReportCard: View {
+    /// Whether to show the call to action to enable Jetpack Stats.
+    ///
+    let showJetpackStatsCTA: Bool
+
+    /// Enables Jetpack Stats remotely.
+    ///
+    let enableJetpackStats: () async -> Void
+
+    /// Tracks when the Jetpack Stats CTA is shown.
+    ///
+    let trackJetpackStatsCTAShown: () -> Void
+
+    /// Whether sessions data is available.
+    ///
+    let isSessionsDataAvailable: Bool
+
+    /// View model for the Sessions report card, when data is available.
+    ///
+    let viewModel: SessionsReportCardViewModel
+
+    @State private var isEnablingJetpackStats = false
+
+    var body: some View {
+        if showJetpackStatsCTA {
+            AnalyticsCTACard(title: Localization.title,
+                             message: Localization.sessionsCTAMessage,
+                             buttonLabel: Localization.sessionsCTAButton,
+                             isLoading: $isEnablingJetpackStats) {
+                isEnablingJetpackStats = true
+                await enableJetpackStats()
+                isEnablingJetpackStats = false
+            }.onAppear {
+                trackJetpackStatsCTAShown()
+            }
+        } else if !isSessionsDataAvailable {
+            AnalyticsSessionsUnavailableCard()
+        } else {
+            AnalyticsReportCard(viewModel: viewModel)
+        }
+    }
+}
+
+private extension AnalyticsSessionsReportCard {
+    enum Localization {
+        static let title = NSLocalizedString("SESSIONS", comment: "Title for sessions section in the Analytics Hub")
+        static let sessionsCTAMessage = NSLocalizedString("analyticsHub.jetpackStatsCTA.message",
+                                                          value: "Enable Jetpack Stats to see your store's session analytics.",
+                                                          comment: "Text displayed in the Analytics Hub when the Jetpack Stats module is disabled")
+        static let sessionsCTAButton = NSLocalizedString("analyticsHub.jetpackStatsCTA.buttonLabel",
+                                                         value: "Enable Jetpack Stats",
+                                                         comment: "Label for button to enable Jetpack Stats")
+    }
+}
+
+#Preview("Sessions report card") {
+    AnalyticsSessionsReportCard(showJetpackStatsCTA: false,
+                                enableJetpackStats: {},
+                                trackJetpackStatsCTAShown: {},
+                                isSessionsDataAvailable: true,
+                                viewModel: .init(currentOrderStats: nil,
+                                                 siteStats: nil))
+}

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/Report Cards/SessionsReportCardViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/Report Cards/SessionsReportCardViewModel.swift
@@ -19,6 +19,10 @@ final class SessionsReportCardViewModel: AnalyticsReportCardProtocol {
     ///
     private var siteStats: SiteSummaryStats?
 
+    /// Selected time range
+    ///
+    private var timeRange: AnalyticsHubTimeRangeSelection.SelectionType
+
     /// Whether the Jetpack Stats module is disabled
     ///
     private var isJetpackStatsDisabled: Bool
@@ -33,6 +37,16 @@ final class SessionsReportCardViewModel: AnalyticsReportCardProtocol {
         isJetpackStatsDisabled && userIsAdmin
     }
 
+    /// Whether sessions data is available to display; `false` if the time range is custom.
+    ///
+    var isSessionsDataAvailable: Bool {
+        if case .custom = timeRange {
+            return false
+        } else {
+            return true
+        }
+    }
+
     /// Indicates if the values should be hidden (for loading state)
     ///
     var isRedacted: Bool
@@ -44,6 +58,7 @@ final class SessionsReportCardViewModel: AnalyticsReportCardProtocol {
     init(siteID: Int64,
          currentOrderStats: OrderStatsV4?,
          siteStats: SiteSummaryStats?,
+         timeRange: AnalyticsHubTimeRangeSelection.SelectionType,
          isJetpackStatsDisabled: Bool,
          isRedacted: Bool = false,
          stores: StoresManager = ServiceLocator.stores,
@@ -54,6 +69,7 @@ final class SessionsReportCardViewModel: AnalyticsReportCardProtocol {
         self.siteID = siteID
         self.currentOrderStats = currentOrderStats
         self.siteStats = siteStats
+        self.timeRange = timeRange
         self.isJetpackStatsDisabled = isJetpackStatsDisabled
         self.userIsAdmin = stores.sessionManager.defaultRoles.contains(.administrator)
         self.isRedacted = isRedacted

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/Report Cards/SessionsReportCardViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/Report Cards/SessionsReportCardViewModel.swift
@@ -2,6 +2,14 @@ import Foundation
 import Yosemite
 
 final class SessionsReportCardViewModel: AnalyticsReportCardProtocol {
+    private let siteID: Int64
+    private let stores: StoresManager
+    private let analytics: Analytics
+    private let noticePresenter: NoticePresenter
+
+    /// Delay to allow the backend to process enabling the Jetpack Stats module.
+    /// Defaults to 0.5 seconds.
+    private let backendProcessingDelay: UInt64
 
     /// Order stats for the current period
     ///
@@ -11,16 +19,96 @@ final class SessionsReportCardViewModel: AnalyticsReportCardProtocol {
     ///
     private var siteStats: SiteSummaryStats?
 
+    /// Whether the Jetpack Stats module is disabled
+    ///
+    private var isJetpackStatsDisabled: Bool
+
+    /// User is an administrator on the store
+    ///
+    private let userIsAdmin: Bool
+
+    /// Whether to show the call to action to enable Jetpack Stats.
+    ///
+    var showJetpackStatsCTA: Bool {
+        isJetpackStatsDisabled && userIsAdmin
+    }
+
     /// Indicates if the values should be hidden (for loading state)
     ///
     var isRedacted: Bool
 
-    init(currentOrderStats: OrderStatsV4?,
+    /// Callback if site stats data needs to be updated
+    ///
+    var updateSiteStatsData: (() async -> Void)
+
+    init(siteID: Int64,
+         currentOrderStats: OrderStatsV4?,
          siteStats: SiteSummaryStats?,
-         isRedacted: Bool = false) {
+         isJetpackStatsDisabled: Bool,
+         isRedacted: Bool = false,
+         stores: StoresManager = ServiceLocator.stores,
+         analytics: Analytics = ServiceLocator.analytics,
+         noticePresenter: NoticePresenter = ServiceLocator.noticePresenter,
+         backendProcessingDelay: UInt64 = 500_000_000,
+         updateSiteStatsData: @escaping () async -> Void) {
+        self.siteID = siteID
         self.currentOrderStats = currentOrderStats
         self.siteStats = siteStats
+        self.isJetpackStatsDisabled = isJetpackStatsDisabled
+        self.userIsAdmin = stores.sessionManager.defaultRoles.contains(.administrator)
         self.isRedacted = isRedacted
+        self.stores = stores
+        self.analytics = analytics
+        self.noticePresenter = noticePresenter
+        self.backendProcessingDelay = backendProcessingDelay
+        self.updateSiteStatsData = updateSiteStatsData
+    }
+}
+
+// MARK: Jetpack Stats
+extension SessionsReportCardViewModel {
+    /// Tracks when the call to action to enable Jetpack Stats is shown.
+    ///
+    func trackJetpackStatsCTAShown() {
+        analytics.track(event: .AnalyticsHub.jetpackStatsCTAShown())
+    }
+
+    /// Enables the Jetpack Stats module on the store and requests new stats data
+    ///
+    @MainActor
+    func enableJetpackStats() async {
+        analytics.track(event: .AnalyticsHub.jetpackStatsCTATapped())
+
+        do {
+            try await remoteEnableJetpackStats()
+            // Wait for backend to enable the module (it is not ready for stats to be requested immediately after a success response)
+            try await Task.sleep(nanoseconds: backendProcessingDelay)
+            await updateSiteStatsData()
+        } catch {
+            noticePresenter.enqueue(notice: .init(title: Localization.statsCTAError))
+            DDLogError("⚠️ Error enabling Jetpack Stats: \(error)")
+        }
+    }
+
+    @MainActor
+    /// Makes the remote request to enable the Jetpack Stats module on the site.
+    ///
+    private func remoteEnableJetpackStats() async throws {
+        try await withCheckedThrowingContinuation { continuation in
+            let action = JetpackSettingsAction.enableJetpackModule(.stats, siteID: siteID) { [weak self] result in
+                switch result {
+                case .success:
+                    self?.isJetpackStatsDisabled = false
+                    self?.analytics.track(event: .AnalyticsHub.enableJetpackStatsSuccess())
+                    continuation.resume()
+                case let .failure(error):
+                    self?.isJetpackStatsDisabled = true
+                    self?.analytics.track(event: .AnalyticsHub.enableJetpackStatsFailed(error: error))
+                    continuation.resume(throwing: error)
+                }
+            }
+            stores.dispatch(action)
+        }
     }
 }
 
@@ -89,5 +177,35 @@ private extension SessionsReportCardViewModel {
         static let trailingTitle = NSLocalizedString("Conversion Rate", comment: "Label for the conversion rate (orders per visitor) in the Analytics Hub")
         static let noSessions = NSLocalizedString("Unable to load session analytics",
                                                   comment: "Text displayed when there is an error loading session stats data.")
+        static let statsCTAError = NSLocalizedString("analyticsHub.jetpackStatsCTA.errorNotice",
+                                                     value: "We couldn't enable Jetpack Stats on your store",
+                                                     comment: "Error shown when Jetpack Stats can't be enabled in the Analytics Hub.")
+    }
+}
+
+// MARK: - Methods for rendering a SwiftUI Preview
+//
+extension SessionsReportCardViewModel {
+    static func sampleOrderStats() -> OrderStatsV4 {
+        let sampleTotals = OrderStatsV4Totals(totalOrders: 5,
+                                              totalItemsSold: 5,
+                                              grossRevenue: 500,
+                                              netRevenue: 500,
+                                              averageOrderValue: 100)
+        return OrderStatsV4(siteID: 123,
+                            granularity: .daily,
+                            totals: sampleTotals,
+                            intervals: [OrderStatsV4Interval(interval: "Hour",
+                                                             dateStart: "Day",
+                                                             dateEnd: "Day",
+                                                             subtotals: sampleTotals)])
+    }
+
+    static func sampleSiteStats() -> SiteSummaryStats {
+        SiteSummaryStats(siteID: 123,
+                         date: "Day",
+                         period: .day,
+                         visitors: 8,
+                         views: 40)
     }
 }

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -2066,6 +2066,7 @@
 		CEA455C12BB3446D00D932CF /* BundlesReportCardViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEA455C02BB3446D00D932CF /* BundlesReportCardViewModel.swift */; };
 		CEA455C52BB44F9E00D932CF /* ProductsReportItem+Woo.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEA455C42BB44F9E00D932CF /* ProductsReportItem+Woo.swift */; };
 		CEA455C72BB5CA5E00D932CF /* AnalyticsSessionsUnavailableCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEA455C62BB5CA5E00D932CF /* AnalyticsSessionsUnavailableCard.swift */; };
+		CEA455C92BB5DA4C00D932CF /* AnalyticsSessionsReportCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEA455C82BB5DA4C00D932CF /* AnalyticsSessionsReportCard.swift */; };
 		CEA9C8E02B6D323A000FE114 /* AnalyticsWebReportTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEA9C8DF2B6D323A000FE114 /* AnalyticsWebReportTests.swift */; };
 		CEC8188C2A3B7C8B00459843 /* AppStartupWaitingTimeTracker.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEC8188B2A3B7C8B00459843 /* AppStartupWaitingTimeTracker.swift */; };
 		CEC8188E2A3C75DD00459843 /* AppStartupWaitingTimeTrackerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEC8188D2A3C75DD00459843 /* AppStartupWaitingTimeTrackerTests.swift */; };
@@ -4809,6 +4810,7 @@
 		CEA455C02BB3446D00D932CF /* BundlesReportCardViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BundlesReportCardViewModel.swift; sourceTree = "<group>"; };
 		CEA455C42BB44F9E00D932CF /* ProductsReportItem+Woo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ProductsReportItem+Woo.swift"; sourceTree = "<group>"; };
 		CEA455C62BB5CA5E00D932CF /* AnalyticsSessionsUnavailableCard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnalyticsSessionsUnavailableCard.swift; sourceTree = "<group>"; };
+		CEA455C82BB5DA4C00D932CF /* AnalyticsSessionsReportCard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnalyticsSessionsReportCard.swift; sourceTree = "<group>"; };
 		CEA9C8DF2B6D323A000FE114 /* AnalyticsWebReportTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnalyticsWebReportTests.swift; sourceTree = "<group>"; };
 		CEC8188B2A3B7C8B00459843 /* AppStartupWaitingTimeTracker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppStartupWaitingTimeTracker.swift; sourceTree = "<group>"; };
 		CEC8188D2A3C75DD00459843 /* AppStartupWaitingTimeTrackerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppStartupWaitingTimeTrackerTests.swift; sourceTree = "<group>"; };
@@ -11046,6 +11048,7 @@
 				26E7EE6D29300E8100793045 /* AnalyticsItemsSoldCard.swift */,
 				CEF2DD852B558E3E00A3DD0B /* AnalyticsCTACard.swift */,
 				CEA455C62BB5CA5E00D932CF /* AnalyticsSessionsUnavailableCard.swift */,
+				CEA455C82BB5DA4C00D932CF /* AnalyticsSessionsReportCard.swift */,
 				CEEF74212B99EC5800B03948 /* AnalyticsReportCardProtocol.swift */,
 				CEEF74242B99EF1200B03948 /* RevenueReportCardViewModel.swift */,
 				CEEF74292B9A02EB00B03948 /* OrdersReportCardViewModel.swift */,
@@ -14372,6 +14375,7 @@
 				029F29FE24DA5B2D004751CA /* ProductInventorySettingsViewModel.swift in Sources */,
 				57CFCD28248845B4003F51EC /* PrimarySectionHeaderView.swift in Sources */,
 				023A059A24135F2600E3FC99 /* ReviewsViewController.swift in Sources */,
+				CEA455C92BB5DA4C00D932CF /* AnalyticsSessionsReportCard.swift in Sources */,
 				B5C3876421C41B9F006CE970 /* UIApplication+Woo.swift in Sources */,
 				09E41E1D27B90B3C00BFCB7C /* BulkUpdateViewModel.swift in Sources */,
 				032E481D2982996E00469D92 /* CardPresentModalBuiltInConnectingFailedNonRetryable.swift in Sources */,

--- a/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Analytics Hub/AnalyticsHubViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Analytics Hub/AnalyticsHubViewModelTests.swift
@@ -10,7 +10,6 @@ final class AnalyticsHubViewModelTests: XCTestCase {
     private var eventEmitter: StoreStatsUsageTracksEventEmitter!
     private var analyticsProvider: MockAnalyticsProvider!
     private var analytics: Analytics!
-    private var noticePresenter: MockNoticePresenter!
     private var vm: AnalyticsHubViewModel!
 
     private let sampleSiteID: Int64 = 123
@@ -21,7 +20,6 @@ final class AnalyticsHubViewModelTests: XCTestCase {
         analyticsProvider = MockAnalyticsProvider()
         analytics = WooAnalytics(analyticsProvider: analyticsProvider)
         eventEmitter = StoreStatsUsageTracksEventEmitter(analytics: analytics)
-        noticePresenter = MockNoticePresenter()
         ServiceLocator.setCurrencySettings(CurrencySettings()) // Default is US
         vm = createViewModel()
     }
@@ -151,7 +149,7 @@ final class AnalyticsHubViewModelTests: XCTestCase {
     }
 
     @MainActor
-    func test_session_card_and_stats_CTA_are_hidden_for_shop_manager_when_stats_module_disabled() async {
+    func test_session_card_is_hidden_for_shop_manager_when_stats_module_disabled() async {
         // Given
         let stores = MockStoresManager(sessionManager: .makeForTesting(defaultRoles: [.shopManager]))
         let vm = createViewModel(stores: stores)
@@ -172,7 +170,6 @@ final class AnalyticsHubViewModelTests: XCTestCase {
         await vm.updateData()
 
         // Then
-        XCTAssertFalse(vm.showJetpackStatsCTA)
         XCTAssertFalse(vm.enabledCards.contains(.sessions))
     }
 
@@ -207,174 +204,6 @@ final class AnalyticsHubViewModelTests: XCTestCase {
 
         // Then
         XCTAssert(analyticsProvider.receivedEvents.contains(WooAnalyticsStat.analyticsHubWaitingTimeLoaded.rawValue))
-    }
-
-    @MainActor
-    func test_showJetpackStatsCTA_true_for_admin_when_stats_module_disabled() async {
-        // Given
-        stores.whenReceivingAction(ofType: StatsActionV4.self) { action in
-            switch action {
-            case let .retrieveCustomStats(_, _, _, _, _, _, _, completion):
-                completion(.success(.fake()))
-            case let .retrieveTopEarnerStats(_, _, _, _, _, _, _, _, completion):
-                completion(.success(.fake()))
-            case let .retrieveSiteSummaryStats(_, _, _, _, _, _, completion):
-                completion(.failure(SiteStatsStoreError.statsModuleDisabled))
-            default:
-                break
-            }
-        }
-        XCTAssertFalse(vm.showJetpackStatsCTA)
-
-        // When
-        await vm.updateData()
-
-        // Then
-        XCTAssertTrue(vm.showJetpackStatsCTA)
-    }
-
-    @MainActor
-    func test_showJetpackStatsCTA_false_for_admin_when_stats_request_fails_and_stats_module_enabled() async {
-        // Given
-        stores.whenReceivingAction(ofType: StatsActionV4.self) { action in
-            switch action {
-            case let .retrieveCustomStats(_, _, _, _, _, _, _, completion):
-                completion(.success(.fake()))
-            case let .retrieveTopEarnerStats(_, _, _, _, _, _, _, _, completion):
-                completion(.success(.fake()))
-            case let .retrieveSiteSummaryStats(_, _, _, _, _, _, completion):
-                completion(.failure(NSError(domain: "Test", code: 1)))
-            default:
-                break
-            }
-        }
-
-        // When
-        await vm.updateData()
-
-        // Then
-        XCTAssertFalse(vm.showJetpackStatsCTA)
-    }
-
-    @MainActor
-    func test_enableJetpackStats_hides_call_to_action_after_successfully_enabling_stats() async {
-        // Given
-        stores.whenReceivingAction(ofType: JetpackSettingsAction.self) { action in
-            switch action {
-            case let .enableJetpackModule(_, _, completion):
-                completion(.success(()))
-            }
-        }
-        stores.whenReceivingAction(ofType: StatsActionV4.self) { action in
-            switch action {
-            case let .retrieveCustomStats(_, _, _, _, _, _, _, completion):
-                completion(.success(.fake()))
-            case let .retrieveTopEarnerStats(_, _, _, _, _, _, _, _, completion):
-                completion(.success(.fake()))
-            case let .retrieveSiteSummaryStats(_, _, _, _, _, _, completion):
-                completion(.success(.fake()))
-            default:
-                break
-            }
-        }
-
-        // When
-        await vm.enableJetpackStats()
-
-        // Then
-        XCTAssertFalse(vm.showJetpackStatsCTA)
-    }
-
-    @MainActor
-    func test_enableJetpackStats_shows_error_and_call_to_action_after_failing_to_enable_stats() async {
-        // Given
-        stores.whenReceivingAction(ofType: JetpackSettingsAction.self) { action in
-            switch action {
-            case let .enableJetpackModule(_, _, completion):
-                completion(.failure(NSError(domain: "Test", code: 1)))
-            }
-        }
-
-        // When
-        await vm.enableJetpackStats()
-
-        // Then
-        XCTAssertEqual(noticePresenter.queuedNotices.count, 1)
-        XCTAssertTrue(vm.showJetpackStatsCTA)
-    }
-
-    func test_it_tracks_expected_jetpack_stats_CTA_success_events() async {
-        // Given
-        stores.whenReceivingAction(ofType: StatsActionV4.self) { action in
-            switch action {
-            case let .retrieveCustomStats(_, _, _, _, _, _, _, completion):
-                completion(.success(.fake()))
-            case let .retrieveTopEarnerStats(_, _, _, _, _, _, _, _, completion):
-                completion(.success(.fake()))
-            case let .retrieveSiteSummaryStats(_, _, _, _, _, _, completion):
-                completion(.failure(SiteStatsStoreError.statsModuleDisabled))
-            default:
-                break
-            }
-        }
-        stores.whenReceivingAction(ofType: JetpackSettingsAction.self) { action in
-            switch action {
-            case let .enableJetpackModule(_, _, completion):
-                completion(.success(()))
-            }
-        }
-
-        // When
-        await vm.updateData()
-        vm.trackJetpackStatsCTAShown()
-        await vm.enableJetpackStats()
-
-        // Then
-        let expectedEvents: [WooAnalyticsStat] = [
-            .analyticsHubEnableJetpackStatsShown,
-            .analyticsHubEnableJetpackStatsTapped,
-            .analyticsHubEnableJetpackStatsSuccess
-        ]
-        for event in expectedEvents {
-            XCTAssert(analyticsProvider.receivedEvents.contains(event.rawValue), "Did not receive expected event: \(event.rawValue)")
-        }
-    }
-
-    func test_it_tracks_expected_jetpack_stats_CTA_failure_events() async {
-        // Given
-        stores.whenReceivingAction(ofType: StatsActionV4.self) { action in
-            switch action {
-            case let .retrieveCustomStats(_, _, _, _, _, _, _, completion):
-                completion(.success(.fake()))
-            case let .retrieveTopEarnerStats(_, _, _, _, _, _, _, _, completion):
-                completion(.success(.fake()))
-            case let .retrieveSiteSummaryStats(_, _, _, _, _, _, completion):
-                completion(.failure(SiteStatsStoreError.statsModuleDisabled))
-            default:
-                break
-            }
-        }
-        stores.whenReceivingAction(ofType: JetpackSettingsAction.self) { action in
-            switch action {
-            case let .enableJetpackModule(_, _, completion):
-                completion(.failure(NSError(domain: "Test", code: 1)))
-            }
-        }
-
-        // When
-        await vm.updateData()
-        vm.trackJetpackStatsCTAShown()
-        await vm.enableJetpackStats()
-
-        // Then
-        let expectedEvents: [WooAnalyticsStat] = [
-            .analyticsHubEnableJetpackStatsShown,
-            .analyticsHubEnableJetpackStatsTapped,
-            .analyticsHubEnableJetpackStatsFailed
-        ]
-        for event in expectedEvents {
-            XCTAssert(analyticsProvider.receivedEvents.contains(event.rawValue), "Did not receive expected event: \(event.rawValue)")
-        }
     }
 
     // MARK: Customized Analytics
@@ -657,8 +486,6 @@ private extension AnalyticsHubViewModelTests {
                               stores: stores ?? self.stores,
                               storage: storage ?? MockStorageManager(),
                               analytics: analytics,
-                              noticePresenter: noticePresenter,
-                              backendProcessingDelay: 0,
                               isExpandedAnalyticsHubEnabled: true)
     }
 }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Analytics Hub/AnalyticsHubViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Analytics Hub/AnalyticsHubViewModelTests.swift
@@ -326,6 +326,7 @@ final class AnalyticsHubViewModelTests: XCTestCase {
 
         // When
         await vm.updateData()
+        vm.trackJetpackStatsCTAShown()
         await vm.enableJetpackStats()
 
         // Then
@@ -362,6 +363,7 @@ final class AnalyticsHubViewModelTests: XCTestCase {
 
         // When
         await vm.updateData()
+        vm.trackJetpackStatsCTAShown()
         await vm.enableJetpackStats()
 
         // Then

--- a/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Analytics Hub/Report Cards/SessionsReportCardViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Analytics Hub/Report Cards/SessionsReportCardViewModelTests.swift
@@ -24,6 +24,7 @@ final class SessionsReportCardViewModelTests: XCTestCase {
             siteID: sampleSiteID,
             currentOrderStats: OrderStatsV4.fake().copy(totals: .fake().copy(totalOrders: 5)),
             siteStats: SiteSummaryStats.fake().copy(visitors: 10, views: 60),
+            timeRange: .today,
             isJetpackStatsDisabled: false,
             isRedacted: false,
             updateSiteStatsData: {}
@@ -46,6 +47,7 @@ final class SessionsReportCardViewModelTests: XCTestCase {
         let vm = SessionsReportCardViewModel(siteID: sampleSiteID,
                                              currentOrderStats: nil,
                                              siteStats: .fake(),
+                                             timeRange: .today,
                                              isJetpackStatsDisabled: false,
                                              updateSiteStatsData: {})
 
@@ -58,6 +60,7 @@ final class SessionsReportCardViewModelTests: XCTestCase {
         let vm = SessionsReportCardViewModel(siteID: sampleSiteID,
                                              currentOrderStats: .fake(),
                                              siteStats: nil,
+                                             timeRange: .today,
                                              isJetpackStatsDisabled: false,
                                              updateSiteStatsData: {})
 
@@ -70,6 +73,7 @@ final class SessionsReportCardViewModelTests: XCTestCase {
         let vm = SessionsReportCardViewModel(siteID: sampleSiteID,
                                              currentOrderStats: nil,
                                              siteStats: nil,
+                                             timeRange: .today,
                                              isJetpackStatsDisabled: false,
                                              isRedacted: true,
                                              updateSiteStatsData: {})
@@ -87,6 +91,34 @@ final class SessionsReportCardViewModelTests: XCTestCase {
         XCTAssertNil(vm.reportViewModel)
     }
 
+    // MARK: Sessions Data Availability
+
+    func test_sessions_data_available_when_custom_time_range_not_selected() {
+        // Given
+        let vm = SessionsReportCardViewModel(siteID: sampleSiteID,
+                                             currentOrderStats: nil,
+                                             siteStats: nil,
+                                             timeRange: .today,
+                                             isJetpackStatsDisabled: false,
+                                             updateSiteStatsData: {})
+
+        // Then
+        XCTAssertTrue(vm.isSessionsDataAvailable)
+    }
+
+    func test_sessions_data_not_available_when_custom_time_range_selected() {
+        // Given
+        let vm = SessionsReportCardViewModel(siteID: sampleSiteID,
+                                             currentOrderStats: nil,
+                                             siteStats: nil,
+                                             timeRange: .custom(start: Date(), end: Date()),
+                                             isJetpackStatsDisabled: false,
+                                             updateSiteStatsData: {})
+
+        // Then
+        XCTAssertFalse(vm.isSessionsDataAvailable)
+    }
+
     // MARK: Jetpack Stats CTA
 
     @MainActor
@@ -95,6 +127,7 @@ final class SessionsReportCardViewModelTests: XCTestCase {
         let vm = SessionsReportCardViewModel(siteID: sampleSiteID,
                                              currentOrderStats: nil,
                                              siteStats: .fake(),
+                                             timeRange: .today,
                                              isJetpackStatsDisabled: true,
                                              stores: stores,
                                              updateSiteStatsData: {})
@@ -109,6 +142,7 @@ final class SessionsReportCardViewModelTests: XCTestCase {
         let vm = SessionsReportCardViewModel(siteID: sampleSiteID,
                                              currentOrderStats: nil,
                                              siteStats: .fake(),
+                                             timeRange: .today,
                                              isJetpackStatsDisabled: true,
                                              stores: stores,
                                              updateSiteStatsData: {})
@@ -132,6 +166,7 @@ final class SessionsReportCardViewModelTests: XCTestCase {
         let vm = SessionsReportCardViewModel(siteID: sampleSiteID,
                                              currentOrderStats: nil,
                                              siteStats: .fake(),
+                                             timeRange: .today,
                                              isJetpackStatsDisabled: true,
                                              stores: stores,
                                              noticePresenter: noticePresenter,
@@ -156,6 +191,7 @@ final class SessionsReportCardViewModelTests: XCTestCase {
         let vm = SessionsReportCardViewModel(siteID: sampleSiteID,
                                              currentOrderStats: nil,
                                              siteStats: .fake(),
+                                             timeRange: .today,
                                              isJetpackStatsDisabled: true,
                                              stores: stores,
                                              analytics: analytics,
@@ -187,6 +223,7 @@ final class SessionsReportCardViewModelTests: XCTestCase {
         let vm = SessionsReportCardViewModel(siteID: sampleSiteID,
                                              currentOrderStats: nil,
                                              siteStats: .fake(),
+                                             timeRange: .today,
                                              isJetpackStatsDisabled: true,
                                              stores: stores,
                                              analytics: analytics,

--- a/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Analytics Hub/Report Cards/SessionsReportCardViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Analytics Hub/Report Cards/SessionsReportCardViewModelTests.swift
@@ -5,12 +5,28 @@ import Yosemite
 
 final class SessionsReportCardViewModelTests: XCTestCase {
 
+    private let sampleSiteID: Int64 = 123
+    private var stores: MockStoresManager!
+    private var analyticsProvider: MockAnalyticsProvider!
+    private var analytics: Analytics!
+    private var noticePresenter: MockNoticePresenter!
+
+    override func setUp() {
+        stores = MockStoresManager(sessionManager: .makeForTesting(authenticated: true))
+        analyticsProvider = MockAnalyticsProvider()
+        analytics = WooAnalytics(analyticsProvider: analyticsProvider)
+        noticePresenter = MockNoticePresenter()
+    }
+
     func test_it_inits_with_expected_values() {
         // Given
         let vm = SessionsReportCardViewModel(
+            siteID: sampleSiteID,
             currentOrderStats: OrderStatsV4.fake().copy(totals: .fake().copy(totalOrders: 5)),
             siteStats: SiteSummaryStats.fake().copy(visitors: 10, views: 60),
-            isRedacted: false
+            isJetpackStatsDisabled: false,
+            isRedacted: false,
+            updateSiteStatsData: {}
         )
 
         // Then
@@ -27,7 +43,11 @@ final class SessionsReportCardViewModelTests: XCTestCase {
 
     func test_it_shows_sync_error_when_current_stats_are_nil() {
         // Given
-        let vm = SessionsReportCardViewModel(currentOrderStats: nil, siteStats: .fake())
+        let vm = SessionsReportCardViewModel(siteID: sampleSiteID,
+                                             currentOrderStats: nil,
+                                             siteStats: .fake(),
+                                             isJetpackStatsDisabled: false,
+                                             updateSiteStatsData: {})
 
         // Then
         XCTAssertTrue(vm.showSyncError)
@@ -35,7 +55,11 @@ final class SessionsReportCardViewModelTests: XCTestCase {
 
     func test_it_shows_sync_error_when_previous_stats_are_nil() {
         // Given
-        let vm = SessionsReportCardViewModel(currentOrderStats: .fake(), siteStats: nil)
+        let vm = SessionsReportCardViewModel(siteID: sampleSiteID,
+                                             currentOrderStats: .fake(),
+                                             siteStats: nil,
+                                             isJetpackStatsDisabled: false,
+                                             updateSiteStatsData: {})
 
         // Then
         XCTAssertTrue(vm.showSyncError)
@@ -43,7 +67,12 @@ final class SessionsReportCardViewModelTests: XCTestCase {
 
     func test_it_provides_expected_values_when_redacted() {
         // Given
-        var vm = SessionsReportCardViewModel(currentOrderStats: nil, siteStats: nil, isRedacted: true)
+        let vm = SessionsReportCardViewModel(siteID: sampleSiteID,
+                                             currentOrderStats: nil,
+                                             siteStats: nil,
+                                             isJetpackStatsDisabled: false,
+                                             isRedacted: true,
+                                             updateSiteStatsData: {})
 
         // Then
 
@@ -56,6 +85,132 @@ final class SessionsReportCardViewModelTests: XCTestCase {
         XCTAssertTrue(vm.isRedacted)
         XCTAssertFalse(vm.showSyncError)
         XCTAssertNil(vm.reportViewModel)
+    }
+
+    // MARK: Jetpack Stats CTA
+
+    @MainActor
+    func test_showJetpackStatsCTA_true_for_admin_when_stats_module_disabled() async {
+        // Given
+        let vm = SessionsReportCardViewModel(siteID: sampleSiteID,
+                                             currentOrderStats: nil,
+                                             siteStats: .fake(),
+                                             isJetpackStatsDisabled: true,
+                                             stores: stores,
+                                             updateSiteStatsData: {})
+
+        // Then
+        XCTAssertTrue(vm.showJetpackStatsCTA)
+    }
+
+    @MainActor
+    func test_enableJetpackStats_hides_call_to_action_after_successfully_enabling_stats() async {
+        // Given
+        let vm = SessionsReportCardViewModel(siteID: sampleSiteID,
+                                             currentOrderStats: nil,
+                                             siteStats: .fake(),
+                                             isJetpackStatsDisabled: true,
+                                             stores: stores,
+                                             updateSiteStatsData: {})
+        stores.whenReceivingAction(ofType: JetpackSettingsAction.self) { action in
+            switch action {
+            case let .enableJetpackModule(_, _, completion):
+                completion(.success(()))
+            }
+        }
+
+        // When
+        await vm.enableJetpackStats()
+
+        // Then
+        XCTAssertFalse(vm.showJetpackStatsCTA)
+    }
+
+    @MainActor
+    func test_enableJetpackStats_shows_error_and_call_to_action_after_failing_to_enable_stats() async {
+        // Given
+        let vm = SessionsReportCardViewModel(siteID: sampleSiteID,
+                                             currentOrderStats: nil,
+                                             siteStats: .fake(),
+                                             isJetpackStatsDisabled: true,
+                                             stores: stores,
+                                             noticePresenter: noticePresenter,
+                                             updateSiteStatsData: {})
+        stores.whenReceivingAction(ofType: JetpackSettingsAction.self) { action in
+            switch action {
+            case let .enableJetpackModule(_, _, completion):
+                completion(.failure(NSError(domain: "Test", code: 1)))
+            }
+        }
+
+        // When
+        await vm.enableJetpackStats()
+
+        // Then
+        XCTAssertEqual(noticePresenter.queuedNotices.count, 1)
+        XCTAssertTrue(vm.showJetpackStatsCTA)
+    }
+
+    func test_it_tracks_expected_jetpack_stats_CTA_success_events() async {
+        // Given
+        let vm = SessionsReportCardViewModel(siteID: sampleSiteID,
+                                             currentOrderStats: nil,
+                                             siteStats: .fake(),
+                                             isJetpackStatsDisabled: true,
+                                             stores: stores,
+                                             analytics: analytics,
+                                             updateSiteStatsData: {})
+        stores.whenReceivingAction(ofType: JetpackSettingsAction.self) { action in
+            switch action {
+            case let .enableJetpackModule(_, _, completion):
+                completion(.success(()))
+            }
+        }
+
+        // When
+        vm.trackJetpackStatsCTAShown()
+        await vm.enableJetpackStats()
+
+        // Then
+        let expectedEvents: [WooAnalyticsStat] = [
+            .analyticsHubEnableJetpackStatsShown,
+            .analyticsHubEnableJetpackStatsTapped,
+            .analyticsHubEnableJetpackStatsSuccess
+        ]
+        for event in expectedEvents {
+            XCTAssert(analyticsProvider.receivedEvents.contains(event.rawValue), "Did not receive expected event: \(event.rawValue)")
+        }
+    }
+
+    func test_it_tracks_expected_jetpack_stats_CTA_failure_events() async {
+        // Given
+        let vm = SessionsReportCardViewModel(siteID: sampleSiteID,
+                                             currentOrderStats: nil,
+                                             siteStats: .fake(),
+                                             isJetpackStatsDisabled: true,
+                                             stores: stores,
+                                             analytics: analytics,
+                                             updateSiteStatsData: {})
+        stores.whenReceivingAction(ofType: JetpackSettingsAction.self) { action in
+            switch action {
+            case let .enableJetpackModule(_, _, completion):
+                completion(.failure(NSError(domain: "Test", code: 1)))
+            }
+        }
+
+        // When
+        vm.trackJetpackStatsCTAShown()
+        await vm.enableJetpackStats()
+
+        // Then
+        let expectedEvents: [WooAnalyticsStat] = [
+            .analyticsHubEnableJetpackStatsShown,
+            .analyticsHubEnableJetpackStatsTapped,
+            .analyticsHubEnableJetpackStatsFailed
+        ]
+        for event in expectedEvents {
+            XCTAssert(analyticsProvider.receivedEvents.contains(event.rawValue), "Did not receive expected event: \(event.rawValue)")
+        }
     }
 
 }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

<!-- Id number of the GitHub issue this PR addresses. -->

## Why
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This refactors the analytics hub to encapsulate the logic about which subview to show for the sessions card. Subviews include:

* `AnalyticsReportCard` when there is sessions data to show.
* `AnalyticsSessionsUnavailableCard` if a custom time range is selected (because we don't have sessions data for arbitrary time ranges).
* `AnalyticsCTACard` to enable Jetpack Stats (if the stats module is disabled and the user is an admin).

This should hopefully make it easier to reuse this view in other places (e.g. the dynamic dashboard), since its view model now contains the logic it needs to decide what to display on the card.

## How

* Adds a new view `AnalyticsSessionsReportCard` containing the three subviews that might be displayed on the Sessions card.
* Moves the properties and methods required for the Jetpack Stats CTA to `SessionsReportCardViewModel`.
* Moves the property required for the Sessions Data Unavailable card to `SessionsReportCardViewModel`.
* Updates unit tests.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
On a store with Jetpack Stats enabled:

1. Build and run the app.
2. Open the analytics hub.
3. Confirm the Sessions card loads its metrics as expected.
4. Select a custom time range and confirm the Sessions card shows a "data unavailable" message.

On a store with Jetpack Stats enabled:

1. Build and run the app.
2. Open the analytics hub.
3. Confirm the Sessions card shows a call to action to enable Jetpack Stats.
4. Tap the CTA button and confirm the stats reload and the Sessions card now shows the expected metrics.

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
