### PR TITLE
[Migrate simple payments] Show order creation in Payments > Collect Payment behind a feature flag

### DIFF
--- a/Experiments/Experiments/DefaultFeatureFlagService.swift
+++ b/Experiments/Experiments/DefaultFeatureFlagService.swift
@@ -94,7 +94,7 @@ public struct DefaultFeatureFlagService: FeatureFlagService {
         case .expandedAnalyticsHub:
             return buildConfig == .localDeveloper || buildConfig == .alpha
         case .migrateSimplePaymentsToOrderCreation:
-            return buildConfig == .localDeveloper || buildConfig == .alpha
+            return (buildConfig == .localDeveloper || buildConfig == .alpha) && !isUITesting
         default:
             return true
         }

--- a/Experiments/Experiments/DefaultFeatureFlagService.swift
+++ b/Experiments/Experiments/DefaultFeatureFlagService.swift
@@ -93,6 +93,8 @@ public struct DefaultFeatureFlagService: FeatureFlagService {
             return true
         case .expandedAnalyticsHub:
             return buildConfig == .localDeveloper || buildConfig == .alpha
+        case .migrateSimplePaymentsToOrderCreation:
+            return buildConfig == .localDeveloper || buildConfig == .alpha
         default:
             return true
         }

--- a/Experiments/Experiments/FeatureFlag.swift
+++ b/Experiments/Experiments/FeatureFlag.swift
@@ -207,4 +207,8 @@ public enum FeatureFlag: Int {
     /// Displays analytics cards for extensions in the Analytics Hub.
     ///
     case expandedAnalyticsHub
+
+    /// Enables migration from simple payments to order creation.
+    ///
+    case migrateSimplePaymentsToOrderCreation
 }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Payments Menu/InPersonPaymentsMenu.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Payments Menu/InPersonPaymentsMenu.swift
@@ -23,7 +23,7 @@ struct InPersonPaymentsMenu: View {
                         .onTapGesture {
                             viewModel.collectPaymentTapped()
                         }
-                        .sheet(isPresented: $viewModel.presentCollectPayment,
+                        .sheet(isPresented: $viewModel.presentCollectPaymentWithSimplePayments,
                                onDismiss: {
                             Task { @MainActor in
                                 await viewModel.onAppear()

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Payments Menu/InPersonPaymentsMenu.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Payments Menu/InPersonPaymentsMenu.swift
@@ -183,12 +183,20 @@ struct InPersonPaymentsMenu: View {
             }
             .scrollViewSectionStyle(.insetGrouped)
             .safariSheet(url: $viewModel.safariSheetURL)
-
-            NavigationLink(isActive: $viewModel.shouldShowOnboarding) {
+            .navigationDestination(isPresented: $viewModel.shouldShowOnboarding) {
                 InPersonPaymentsView(viewModel: viewModel.onboardingViewModel)
-            } label: {
-                EmptyView()
-            }.hidden()
+            }
+            .navigationDestination(isPresented: $viewModel.presentCollectPayment) {
+                OrderFormPresentationWrapper(dismissHandler: {
+                    viewModel.presentCollectPayment = false
+                    Task { @MainActor in
+                        await viewModel.onAppear()
+                    }
+                },
+                                             flow: .creation,
+                                             viewModel: EditableOrderViewModel(siteID: viewModel.siteID))
+                .navigationBarHidden(true)
+            }
 
             if let onboardingNotice = viewModel.cardPresentPaymentsOnboardingNotice {
                 PermanentNoticeView(notice: onboardingNotice)

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Payments Menu/InPersonPaymentsMenu.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Payments Menu/InPersonPaymentsMenu.swift
@@ -194,6 +194,7 @@ struct InPersonPaymentsMenu: View {
                     }
                 },
                                              flow: .creation,
+                                             dismissLabel: .backButton,
                                              viewModel: EditableOrderViewModel(siteID: viewModel.siteID))
                 .navigationBarHidden(true)
             }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Payments Menu/InPersonPaymentsMenuViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Payments Menu/InPersonPaymentsMenuViewModel.swift
@@ -1,3 +1,4 @@
+import Experiments
 import Foundation
 import SwiftUI
 import Yosemite
@@ -49,6 +50,7 @@ class InPersonPaymentsMenuViewModel: ObservableObject {
         let wooPaymentsDepositService: WooPaymentsDepositServiceProtocol
         let analytics: Analytics
         let systemStatusService: SystemStatusServiceProtocol
+        let featureFlagService: FeatureFlagService
 
         init(cardPresentPaymentsConfiguration: CardPresentPaymentsConfiguration,
              onboardingUseCase: CardPresentPaymentsOnboardingUseCaseProtocol,
@@ -56,7 +58,8 @@ class InPersonPaymentsMenuViewModel: ObservableObject {
              tapToPayBadgePromotionChecker: TapToPayBadgePromotionChecker = TapToPayBadgePromotionChecker(),
              wooPaymentsDepositService: WooPaymentsDepositServiceProtocol,
              systemStatusService: SystemStatusServiceProtocol = SystemStatusService(stores: ServiceLocator.stores),
-             analytics: Analytics = ServiceLocator.analytics) {
+             analytics: Analytics = ServiceLocator.analytics,
+             featureFlagService: FeatureFlagService = ServiceLocator.featureFlagService) {
             self.cardPresentPaymentsConfiguration = cardPresentPaymentsConfiguration
             self.onboardingUseCase = onboardingUseCase
             self.cardReaderSupportDeterminer = cardReaderSupportDeterminer
@@ -64,6 +67,7 @@ class InPersonPaymentsMenuViewModel: ObservableObject {
             self.wooPaymentsDepositService = wooPaymentsDepositService
             self.systemStatusService = systemStatusService
             self.analytics = analytics
+            self.featureFlagService = featureFlagService
         }
     }
 
@@ -146,7 +150,7 @@ class InPersonPaymentsMenuViewModel: ObservableObject {
     }
 
     func collectPaymentTapped() {
-        guard ServiceLocator.featureFlagService.isFeatureFlagEnabled(.migrateSimplePaymentsToOrderCreation) else {
+        guard dependencies.featureFlagService.isFeatureFlagEnabled(.migrateSimplePaymentsToOrderCreation) else {
             presentCollectPaymentWithSimplePayments = true
             analytics.track(event: WooAnalyticsEvent.SimplePayments.simplePaymentsFlowStarted())
             analytics.track(.paymentsMenuCollectPaymentTapped)
@@ -382,7 +386,7 @@ extension InPersonPaymentsMenuViewModel: DeepLinkNavigator {
         }
         switch paymentsDestination {
         case .collectPayment:
-            guard ServiceLocator.featureFlagService.isFeatureFlagEnabled(.migrateSimplePaymentsToOrderCreation) else {
+            guard dependencies.featureFlagService.isFeatureFlagEnabled(.migrateSimplePaymentsToOrderCreation) else {
                 return presentCollectPaymentWithSimplePayments = true
             }
             presentCollectPayment = true

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Payments Menu/InPersonPaymentsMenuViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Payments Menu/InPersonPaymentsMenuViewModel.swift
@@ -20,6 +20,7 @@ class InPersonPaymentsMenuViewModel: ObservableObject {
     @Published var presentManagePaymentGateways: Bool = false
     @Published private(set) var selectedPaymentGatewayName: String?
     @Published private(set) var selectedPaymentGatewayPlugin: CardPresentPaymentsPlugin?
+    @Published var presentCollectPaymentWithSimplePayments: Bool = false
     @Published var presentCollectPayment: Bool = false
     @Published var presentSetUpTryOutTapToPay: Bool = false
     @Published var presentAboutTapToPay: Bool = false
@@ -145,9 +146,13 @@ class InPersonPaymentsMenuViewModel: ObservableObject {
     }
 
     func collectPaymentTapped() {
+        guard ServiceLocator.featureFlagService.isFeatureFlagEnabled(.migrateSimplePaymentsToOrderCreation) else {
+            presentCollectPaymentWithSimplePayments = true
+            analytics.track(event: WooAnalyticsEvent.SimplePayments.simplePaymentsFlowStarted())
+            analytics.track(.paymentsMenuCollectPaymentTapped)
+            return
+        }
         presentCollectPayment = true
-
-        analytics.track(event: WooAnalyticsEvent.SimplePayments.simplePaymentsFlowStarted())
         analytics.track(.paymentsMenuCollectPaymentTapped)
     }
 

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Payments Menu/InPersonPaymentsMenuViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Payments Menu/InPersonPaymentsMenuViewModel.swift
@@ -382,6 +382,9 @@ extension InPersonPaymentsMenuViewModel: DeepLinkNavigator {
         }
         switch paymentsDestination {
         case .collectPayment:
+            guard ServiceLocator.featureFlagService.isFeatureFlagEnabled(.migrateSimplePaymentsToOrderCreation) else {
+                return presentCollectPaymentWithSimplePayments = true
+            }
             presentCollectPayment = true
         case .tapToPay:
             presentSetUpTryOutTapToPay = true

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/OrderForm.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/OrderForm.swift
@@ -20,7 +20,7 @@ final class OrderFormHostingController: UIHostingController<OrderFormPresentatio
                     return .editing
             }
         }()
-        super.init(rootView: OrderFormPresentationWrapper(flow: flow, viewModel: viewModel))
+        super.init(rootView: OrderFormPresentationWrapper(flow: flow, dismissLabel: .cancelButton, viewModel: viewModel))
 
         // Needed because a `SwiftUI` cannot be dismissed when being presented by a UIHostingController
         rootView.dismissHandler = { [weak self] in
@@ -95,11 +95,21 @@ private extension OrderFormHostingController {
 }
 
 struct OrderFormPresentationWrapper: View {
+    /// Style of the dismiss button label.
+    enum DismissLabel {
+        /// Text label with Cancel copy.
+        case cancelButton
+        /// Backward chevron image.
+        case backButton
+    }
+
     /// Set this closure with UIKit dismiss code. Needed because we need access to the UIHostingController `dismiss` method.
     ///
     var dismissHandler: (() -> Void) = {}
 
     let flow: WooAnalyticsEvent.Orders.Flow
+
+    let dismissLabel: DismissLabel
 
     @ObservedObject var viewModel: EditableOrderViewModel
 
@@ -138,12 +148,20 @@ struct OrderFormPresentationWrapper: View {
                     }
                 },
                 dismissBarButton: {
-                    Button(OrderForm.Localization.cancelButton) {
+                    Button {
                         // By only calling the dismissHandler here, we wouldn't sync the selected items on dismissal
                         // this is normally done via a callback through the ProductSelector's onCloseButtonTapped(),
                         // but on split views we move this responsibility to the AdaptiveModalContainer
                         viewModel.syncOrderItemSelectionStateOnDismiss()
                         dismissHandler()
+                    } label: {
+                        switch dismissLabel {
+                            case .cancelButton:
+                                Text(OrderForm.Localization.cancelButton)
+                            case .backButton:
+                                Image(systemName: "chevron.backward")
+                                    .headlineLinkStyle()
+                        }
                     }
                     .accessibilityIdentifier(OrderForm.Accessibility.cancelButtonIdentifier)
                 },

--- a/WooCommerce/WooCommerceTests/Mocks/MockFeatureFlagService.swift
+++ b/WooCommerce/WooCommerceTests/Mocks/MockFeatureFlagService.swift
@@ -24,6 +24,7 @@ struct MockFeatureFlagService: FeatureFlagService {
     private let isBackendReceiptsEnabled: Bool
     private let sideBySideViewForOrderForm: Bool
     private let isCustomersInHubMenuEnabled: Bool
+    private let isMigrateSimplePaymentsToOrderCreationEnabled: Bool
 
     init(isInboxOn: Bool = false,
          isUpdateOrderOptimisticallyOn: Bool = false,
@@ -46,7 +47,8 @@ struct MockFeatureFlagService: FeatureFlagService {
          blazei3NativeCampaignCreation: Bool = false,
          isBackendReceiptsEnabled: Bool = false,
          sideBySideViewForOrderForm: Bool = false,
-         isCustomersInHubMenuEnabled: Bool = false) {
+         isCustomersInHubMenuEnabled: Bool = false,
+         isMigrateSimplePaymentsToOrderCreationEnabled: Bool = false) {
         self.isInboxOn = isInboxOn
         self.isUpdateOrderOptimisticallyOn = isUpdateOrderOptimisticallyOn
         self.shippingLabelsOnboardingM1 = shippingLabelsOnboardingM1
@@ -69,6 +71,7 @@ struct MockFeatureFlagService: FeatureFlagService {
         self.isBackendReceiptsEnabled = isBackendReceiptsEnabled
         self.sideBySideViewForOrderForm = sideBySideViewForOrderForm
         self.isCustomersInHubMenuEnabled = isCustomersInHubMenuEnabled
+        self.isMigrateSimplePaymentsToOrderCreationEnabled = isMigrateSimplePaymentsToOrderCreationEnabled
     }
 
     func isFeatureFlagEnabled(_ featureFlag: FeatureFlag) -> Bool {
@@ -115,6 +118,8 @@ struct MockFeatureFlagService: FeatureFlagService {
             return sideBySideViewForOrderForm
         case .customersInHubMenu:
             return isCustomersInHubMenuEnabled
+        case .migrateSimplePaymentsToOrderCreation:
+            return isMigrateSimplePaymentsToOrderCreationEnabled
         default:
             return false
         }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Settings/In-Person Payments/InPersonPaymentsMenuViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Settings/In-Person Payments/InPersonPaymentsMenuViewModelTests.swift
@@ -243,4 +243,78 @@ class InPersonPaymentsMenuViewModelTests: XCTestCase {
         // Then
         XCTAssertFalse(sut.shouldShowTapToPaySection)
     }
+
+    // MARK: - Collect Payment tests
+
+    func test_collectPaymentTapped_sets_presentCollectPaymentWithSimplePayments_to_true_when_feature_is_disabled() {
+        // Given
+        let featureFlagService = MockFeatureFlagService(isMigrateSimplePaymentsToOrderCreationEnabled: false)
+        let dependencies = InPersonPaymentsMenuViewModel.Dependencies(cardPresentPaymentsConfiguration: .init(country: .US),
+                                                                      onboardingUseCase: mockOnboardingUseCase,
+                                                                      cardReaderSupportDeterminer: MockCardReaderSupportDeterminer(),
+                                                                      wooPaymentsDepositService: mockDepositService,
+                                                                      featureFlagService: featureFlagService)
+        sut = InPersonPaymentsMenuViewModel(siteID: sampleStoreID,
+                                            dependencies: dependencies)
+
+        // When
+        sut.collectPaymentTapped()
+
+        // Then
+        XCTAssertTrue(sut.presentCollectPaymentWithSimplePayments)
+    }
+
+    func test_collectPaymentTapped_sets_presentCollectPayment_to_true() {
+        // Given
+        let featureFlagService = MockFeatureFlagService(isMigrateSimplePaymentsToOrderCreationEnabled: true)
+        let dependencies = InPersonPaymentsMenuViewModel.Dependencies(cardPresentPaymentsConfiguration: .init(country: .US),
+                                                                      onboardingUseCase: mockOnboardingUseCase,
+                                                                      cardReaderSupportDeterminer: MockCardReaderSupportDeterminer(),
+                                                                      wooPaymentsDepositService: mockDepositService,
+                                                                      featureFlagService: featureFlagService)
+        sut = InPersonPaymentsMenuViewModel(siteID: sampleStoreID,
+                                            dependencies: dependencies)
+
+        // When
+        sut.collectPaymentTapped()
+
+        // Then
+        XCTAssertTrue(sut.presentCollectPayment)
+    }
+
+    func test_navigate_to_collectPayment_sets_presentCollectPaymentWithSimplePayments_to_true_when_feature_is_disabled() {
+        // Given
+        let featureFlagService = MockFeatureFlagService(isMigrateSimplePaymentsToOrderCreationEnabled: false)
+        let dependencies = InPersonPaymentsMenuViewModel.Dependencies(cardPresentPaymentsConfiguration: .init(country: .US),
+                                                                      onboardingUseCase: mockOnboardingUseCase,
+                                                                      cardReaderSupportDeterminer: MockCardReaderSupportDeterminer(),
+                                                                      wooPaymentsDepositService: mockDepositService,
+                                                                      featureFlagService: featureFlagService)
+        sut = InPersonPaymentsMenuViewModel(siteID: sampleStoreID,
+                                            dependencies: dependencies)
+
+        // When
+        sut.navigate(to: PaymentsMenuDestination.collectPayment)
+
+        // Then
+        XCTAssertTrue(sut.presentCollectPaymentWithSimplePayments)
+    }
+
+    func test_navigate_to_collectPayment_sets_presentCollectPayment_to_true() {
+        // Given
+        let featureFlagService = MockFeatureFlagService(isMigrateSimplePaymentsToOrderCreationEnabled: true)
+        let dependencies = InPersonPaymentsMenuViewModel.Dependencies(cardPresentPaymentsConfiguration: .init(country: .US),
+                                                                      onboardingUseCase: mockOnboardingUseCase,
+                                                                      cardReaderSupportDeterminer: MockCardReaderSupportDeterminer(),
+                                                                      wooPaymentsDepositService: mockDepositService,
+                                                                      featureFlagService: featureFlagService)
+        sut = InPersonPaymentsMenuViewModel(siteID: sampleStoreID,
+                                            dependencies: dependencies)
+
+        // When
+        sut.navigate(to: PaymentsMenuDestination.collectPayment)
+
+        // Then
+        XCTAssertTrue(sut.presentCollectPayment)
+    }
 }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of #12387 
<!-- Id number of the GitHub issue this PR addresses. -->

## Why

As we're migrating from simple payments to order creation, we want to show the order form with a bottom sheet instead of the simple payments when the user taps on Payments > Collect Payment. This PR is the first part of the feature, adding a feature flag and showing the order form without a bottom sheet to keep the changes small for easier review.

## How

- Added a new feature flag `migrateSimplePaymentsToOrderCreation`, it's disabled for UI tests for now. Otherwise, the simple payments UI tests would fail
- In `InPersonPaymentsMenuViewModel`, added a new `presentCollectPaymentWithSimplePayments` state for the simple payments flow while using `presentCollectPayment` for the new order creation flow. In the future, we can just delete this when we remove the feature flag. In cases where `presentCollectPayment` is set to `true`, the feature flag is checked to set `presentCollectPaymentWithSimplePayments`/`presentCollectPayment` when the feature flag is off/on
- In the SwiftUI view `InPersonPaymentsMenu`: when `viewModel.presentCollectPayment` is `true`, `OrderFormPresentationWrapper` is shown in push navigation. As [`NavigationLink(_:destination:isActive:)` is deprecated](https://developer.apple.com/documentation/swiftui/navigationlink/init(_:destination:isactive:)-3v44) in iOS 17.0, it uses the iOS 16+ `navigationDestination` modifier to navigate to the order form. I also updated the deprecated usage for the onboarding case since it was a build warning

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

- [x] @jaclync tests when the feature flag is off
- [x] @jaclync tests the deep link case

---

- Go to the Menu tab
- Go to Payments > Collect Payment --> the order form should be shown instead of simple payments 

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->



https://github.com/woocommerce/woocommerce-ios/assets/1945542/bc973b52-2d61-4cb3-8c43-bd65b38c9396




\ | dark | light
-- | -- | --
Menu > Payments > Collect Payment | <img src="https://github.com/woocommerce/woocommerce-ios/assets/1945542/e7f5b432-8866-4291-b638-12ac359dfdc3" width="300" /> | <img src="https://github.com/woocommerce/woocommerce-ios/assets/1945542/93b6a6a0-b2f0-485c-a0e2-ba9ab1d19bfa" width="300" />
Orders > create order | <img src="https://github.com/woocommerce/woocommerce-ios/assets/1945542/e8ac2963-8894-4eeb-9144-3eb2150b9d9f" width="300" /> | <img src="https://github.com/woocommerce/woocommerce-ios/assets/1945542/89aab168-2f87-411d-b357-c89daa808370" width="300" />


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
