### PR TITLE
[Woo Express Sign Up] Remove subscriptions menu item

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Hub Menu/HubMenuViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Hub Menu/HubMenuViewModel.swift
@@ -112,10 +112,14 @@ final class HubMenuViewModel: ObservableObject {
     private func setupSettingsElements() {
         settingsElements = [Settings()]
 
-        // Only show the upgrades menu on WPCom sites
-        if stores.sessionManager.defaultSite?.isWordPressComStore == true {
-            settingsElements.append(Subscriptions())
+        guard let site = stores.sessionManager.defaultSite,
+              // Only show the upgrades menu on WPCom sites and non free trial sites
+              site.isWordPressComStore,
+              !site.isFreeTrialSite else {
+            return
         }
+
+        settingsElements.append(Subscriptions())
     }
 
     private func setupGeneralElements() {

--- a/WooCommerce/WooCommerceTests/ViewRelated/HubMenu/HubMenuViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/HubMenu/HubMenuViewModelTests.swift
@@ -325,7 +325,7 @@ final class HubMenuViewModelTests: XCTestCase {
         XCTAssertFalse(viewModel.shouldAuthenticateAdminPage)
     }
 
-    func test_menuElements_include_subscriptions_on_wp_com_sites() {
+    func test_menuElements_include_subscriptions_on_wp_com_sites_if_not_free_trial() {
         // Given
         let sessionManager = SessionManager.testingInstance
         sessionManager.defaultSite = Site.fake().copy(isWordPressComStore: true)
@@ -338,6 +338,24 @@ final class HubMenuViewModelTests: XCTestCase {
         viewModel.setupMenuElements()
 
         XCTAssertNotNil(viewModel.settingsElements.firstIndex(where: { item in
+            item.id == HubMenuViewModel.Subscriptions.id
+        }))
+    }
+
+    func test_menuElements_does_not_include_subscriptions_on_wp_com_free_trial_sites() {
+        // Given
+        let freeTrialPlanSlug = "ecommerce-trial-bundle-monthly"
+        let sessionManager = SessionManager.testingInstance
+        sessionManager.defaultSite = Site.fake().copy(plan: freeTrialPlanSlug, isWordPressComStore: true)
+        let stores = MockStoresManager(sessionManager: sessionManager)
+
+        // When
+        let viewModel = HubMenuViewModel(siteID: sampleSiteID,
+                                         tapToPayBadgePromotionChecker: TapToPayBadgePromotionChecker(),
+                                         stores: stores)
+        viewModel.setupMenuElements()
+
+        XCTAssertNil(viewModel.settingsElements.firstIndex(where: { item in
             item.id == HubMenuViewModel.Subscriptions.id
         }))
     }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #12390
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

Hide the "Subscriptions" menu item if the site is a free trial site. 

## Testing instructions
1. Sign in to a store hosted on WPCOM (not a free trial store).
1. Navigate to more menu.
1. Confirm that the "Subscriptions" menu item is visible.
1. Switch to a free trial website (create one from https://woo.com/express/ if needed)
1. Confirm that the "Subscriptions" entry in the more menu is not shown.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

Free trial store
| Before | After |
|--------|--------|
| ![Simulator Screenshot - iPhone 13 Pro - 2024-04-01 at 14 14 45](https://github.com/woocommerce/woocommerce-ios/assets/524475/49a891eb-1ff2-4754-bc1a-e4a4ad255890) | ![Simulator Screenshot - iPhone 13 Pro - 2024-04-01 at 14 06 56](https://github.com/woocommerce/woocommerce-ios/assets/524475/dd9de8f3-ef88-46ac-94c3-eeb6f96b9782) | 


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
