### PR TITLE
My Store Analytics: Support same day custom range

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Dashboard/Stats v4/StatsTimeRangeBarViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Stats v4/StatsTimeRangeBarViewModel.swift
@@ -18,7 +18,12 @@ private extension StatsTimeRangeV4 {
             let format = NSLocalizedString("%1$@ – %2$@", comment: "Displays a date range for a stats interval")
             return String.localizedStringWithFormat(format, startDateString, endDateString)
         case let .custom(customStartDate, customEndDate):
-            // Always display the exact date for custom range.
+            let differenceInDay = StatsTimeRangeV4.differenceInDays(startDate: customStartDate, endDate: customEndDate)
+            if differenceInDay == .sameDay {
+                // Return only the day if it's the same day.
+                return dateFormatter.string(from: startDate)
+            }
+            // Always display the exact dates for custom range otherwise.
             let startDateString = dateFormatter.string(from: customStartDate)
             let endDateString = dateFormatter.string(from: customEndDate)
             let format = NSLocalizedString("%1$@ – %2$@", comment: "Displays a date range for a custom stats interval")

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Stats v4/StoreStatsAndTopPerformersViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Stats v4/StoreStatsAndTopPerformersViewController.swift
@@ -523,7 +523,7 @@ private extension StoreStatsAndTopPerformersViewController {
         var siteVisitStatsMode: SiteVisitStatsMode
         if site.isJetpackConnected && site.isJetpackThePluginInstalled {
             let differenceInDay = StatsTimeRangeV4.differenceInDays(startDate: startDate, endDate: endDate)
-            siteVisitStatsMode = differenceInDay == .lessThan2 ? .default : .redactedDueToCustomRange
+            siteVisitStatsMode = differenceInDay == .sameDay ? .default : .redactedDueToCustomRange
         } else if site.isJetpackCPConnected {
             siteVisitStatsMode = .redactedDueToJetpack
         } else {

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Stats v4/StoreStatsV4PeriodViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Stats v4/StoreStatsV4PeriodViewController.swift
@@ -557,7 +557,7 @@ private extension StoreStatsV4PeriodViewController {
                 return
             }
 
-            if differenceInDays == .lessThan2 {
+            if differenceInDays == .sameDay {
                 siteVisitStatsMode = selectedIndex != nil ? .hidden : .default
             } else {
                 siteVisitStatsMode = selectedIndex != nil ? .default : .redactedDueToCustomRange

--- a/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/RangedDatePicker.swift
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/RangedDatePicker.swift
@@ -118,7 +118,7 @@ struct RangedDatePicker: View {
                 }
                 ToolbarItem(placement: .confirmationAction) {
                     Button(action: {
-                        guard startDate < endDate else {
+                        guard startDate <= endDate else {
                             shouldShowInvalidDateRangeAlert = true
                             return
                         }
@@ -167,7 +167,7 @@ private extension RangedDatePicker {
             )
             static let message = NSLocalizedString(
                 "rangedDatePicker.invalidTimeRangeAlert.message",
-                value: "The start date should be earlier than the end date. Please select a different time range.",
+                value: "The start date should not be later than the end date. Please select a different time range.",
                 comment: "Message of the alert displayed when selecting an invalid time range for analytics"
             )
             static let action = NSLocalizedString(

--- a/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/StatsTimeRangeBarViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/StatsTimeRangeBarViewModelTests.swift
@@ -219,11 +219,11 @@ final class StatsTimeRangeBarViewModelTests: XCTestCase {
 
     func test_custom_range_with_selected_date_for_hourly_granularity() {
         // Given
-        // GMT: March 4 2024 00:00:00 AM
+        // GMT: March 4 2024 00:00:00
         let startDate = Date(timeIntervalSince1970: 1709510400)
-        // GMT: March 5 2024 00:00:00 AM
-        let endDate = Date(timeIntervalSince1970: 1709596800)
-        // GMT: March 4 2024 12:00:00 PM
+        // GMT: March 4 2024 23:59:59
+        let endDate = Date(timeIntervalSince1970: 1709596799)
+        // GMT: March 4 2024 12:00:00
         let selectedDate = Date(timeIntervalSince1970: 1709553600)
         let timezone = TimeZone(identifier: "GMT") ?? .current
 

--- a/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/StatsTimeRangeBarViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/StatsTimeRangeBarViewModelTests.swift
@@ -187,7 +187,33 @@ final class StatsTimeRangeBarViewModelTests: XCTestCase {
         XCTAssertEqual(viewModel.timeRangeText, expectedText)
     }
 
-    func test_custom_range_text_displays_exact_date_from_custom_range() throws {
+    func test_custom_range_text_displays_only_start_date_for_1_day_range() throws {
+        // Given
+        // GMT: March 4 2024 00:00:00
+        let startDate = Date(timeIntervalSince1970: 1709510400)
+        // GMT: March 4 2024 23:59:59
+        let endDate = Date(timeIntervalSince1970: 1709596799)
+        let timezone = TimeZone(identifier: "GMT") ?? .current
+
+        let timeRange = StatsTimeRangeV4.custom(from: startDate, to: endDate)
+
+        // When
+        let viewModel = StatsTimeRangeBarViewModel(startDate: startDate,
+                                                   endDate: endDate,
+                                                   timeRange: timeRange,
+                                                   timezone: timezone)
+
+        // Then
+        let formatter = DateFormatter()
+        formatter.dateStyle = .medium
+        formatter.timeStyle = .none
+        formatter.timeZone = timezone
+        // "March 4 2024" in en-US locale.
+        let expectedText = formatter.string(from: startDate)
+        XCTAssertEqual(viewModel.timeRangeText, expectedText)
+    }
+
+    func test_custom_range_text_displays_exact_date_from_custom_range_for_range_longer_than_1_day() throws {
         // Given
         // GMT: Sunday, July 28, 2019 12:00:00 AM
         let startDate = Date(timeIntervalSince1970: 1564272000)

--- a/Yosemite/Yosemite/Model/Enums/StatsTimeRangeV4.swift
+++ b/Yosemite/Yosemite/Model/Enums/StatsTimeRangeV4.swift
@@ -114,9 +114,9 @@ extension StatsTimeRangeV4 {
                 return .hourly
             }
             switch differenceInDays {
-            case .lessThan2:
+            case .sameDay:
                 return .hourly
-            case .from2To28:
+            case .from1To28:
                 return .daily
             case .from29To90:
                 return .weekly
@@ -140,7 +140,7 @@ extension StatsTimeRangeV4 {
                 return .day
             }
             switch differenceInDays {
-            case .lessThan2, .from2To28:
+            case .sameDay, .from1To28:
                 return .day
             case .from29To90:
                 return .week
@@ -168,7 +168,7 @@ extension StatsTimeRangeV4 {
                 return .day
             }
             switch differenceInDays {
-            case .lessThan2, .from2To28:
+            case .sameDay, .from1To28:
                 return .day
             case .from29To90:
                 return .week
@@ -196,7 +196,7 @@ extension StatsTimeRangeV4 {
                 return .day
             }
             switch differenceInDays {
-            case .lessThan2, .from2To28:
+            case .sameDay, .from1To28:
                 return .day
             case .from29To90:
                 return .week
@@ -262,8 +262,8 @@ public extension StatsTimeRangeV4 {
         case greaterThan3Years
         case from91daysTo3Years
         case from29To90
-        case from2To28
-        case lessThan2
+        case from1To28
+        case sameDay
     }
 
     /// Based on WooCommerce Core
@@ -286,10 +286,10 @@ public extension StatsTimeRangeV4 {
             return .from91daysTo3Years
         case 29...90:
             return .from29To90
-        case 2...28:
-            return .from2To28
-        case 0..<2:
-            return .lessThan2
+        case 1...28:
+            return .from1To28
+        case 0:
+            return .sameDay
         default:
             return nil
         }

--- a/Yosemite/YosemiteTests/Model/Enums/StatsTimeRangeTests.swift
+++ b/Yosemite/YosemiteTests/Model/Enums/StatsTimeRangeTests.swift
@@ -53,11 +53,11 @@ final class StatsTimeRangeTests: XCTestCase {
         XCTAssertEqual(range.intervalGranularity, .weekly)
     }
 
-    func test_intervalGranularity_for_dates_with_days_difference_from_2_to_28() {
+    func test_intervalGranularity_for_dates_with_days_difference_from_1_to_28() {
         // Given
         // GMT: Saturday, February 1, 2020 12:29:29 AM
         let fromDate = Date(timeIntervalSince1970: 1580516969)
-        let toDate = fromDate.addingDays(Int.random(in: 2...28))
+        let toDate = fromDate.addingDays(Int.random(in: 1...28))
 
         // When
         let range: StatsTimeRangeV4 = .custom(from: fromDate, to: toDate)
@@ -66,14 +66,15 @@ final class StatsTimeRangeTests: XCTestCase {
         XCTAssertEqual(range.intervalGranularity, .daily)
     }
 
-    func test_intervalGranularity_for_dates_with_days_difference_less_than_2() {
+    func test_intervalGranularity_for_a_same_day_range() {
         // Given
-        // GMT: Saturday, February 1, 2020 12:29:29 AM
-        let fromDate = Date(timeIntervalSince1970: 1580516969)
-        let toDate = fromDate.addingDays(1)
+        // GMT: March 4 2024 00:00:00
+        let startDate = Date(timeIntervalSince1970: 1709510400)
+        // GMT: March 4 2024 23:59:59
+        let endDate = Date(timeIntervalSince1970: 1709596799)
 
         // When
-        let range: StatsTimeRangeV4 = .custom(from: fromDate, to: toDate)
+        let range: StatsTimeRangeV4 = .custom(from: startDate, to: endDate)
 
         // Then
         XCTAssertEqual(range.intervalGranularity, .hourly)
@@ -120,11 +121,11 @@ final class StatsTimeRangeTests: XCTestCase {
         XCTAssertEqual(range.siteVisitStatsGranularity, .week)
     }
 
-    func test_siteVisitStatsGranularity_for_dates_with_days_difference_from_2_to_28() {
+    func test_siteVisitStatsGranularity_for_dates_with_days_difference_from_1_to_28() {
         // Given
         // GMT: Saturday, February 1, 2020 12:29:29 AM
         let fromDate = Date(timeIntervalSince1970: 1580516969)
-        let toDate = fromDate.addingDays(Int.random(in: 2...28))
+        let toDate = fromDate.addingDays(Int.random(in: 1...28))
 
         // When
         let range: StatsTimeRangeV4 = .custom(from: fromDate, to: toDate)
@@ -133,14 +134,15 @@ final class StatsTimeRangeTests: XCTestCase {
         XCTAssertEqual(range.siteVisitStatsGranularity, .day)
     }
 
-    func test_siteVisitStatsGranularity_for_dates_with_days_difference_less_than_2() {
+    func test_siteVisitStatsGranularity_for_a_same_day_range() {
         // Given
-        // GMT: Saturday, February 1, 2020 12:29:29 AM
-        let fromDate = Date(timeIntervalSince1970: 1580516969)
-        let toDate = fromDate.addingDays(1)
+        // GMT: March 4 2024 00:00:00
+        let startDate = Date(timeIntervalSince1970: 1709510400)
+        // GMT: March 4 2024 23:59:59
+        let endDate = Date(timeIntervalSince1970: 1709596799)
 
         // When
-        let range: StatsTimeRangeV4 = .custom(from: fromDate, to: toDate)
+        let range: StatsTimeRangeV4 = .custom(from: startDate, to: endDate)
 
         // Then
         XCTAssertEqual(range.siteVisitStatsGranularity, .day)


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #12397 
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This PR fixes the incorrect visitor stats for the 2-day date range as reported in p1711724047631339-slack-C03L1NF1EA3. We now let users select the same day for the custom date range, which lets them see the hourly metrics for that day. Please note that this works for analytics hub too.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
- Log in to a store with existing orders and revenues.
- Create a custom range with the start date and end date being the same with existing orders and revenues.
- Confirm that you can create the range with that setting and that the visitor stat is correct.
- Update the start date to be one day earlier for the custom range.
- Confirm that the visitor stat is hidden for this new custom range.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->
1-day range | 2-day range
--- | ---
<img src="https://github.com/woocommerce/woocommerce-ios/assets/5533851/7bb39576-85f7-4140-a53e-ac220392308d" width=320 /> | <img src="https://github.com/woocommerce/woocommerce-ios/assets/5533851/c049c3d1-470c-49ec-8909-579556e15f0b" width=320 />

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.