### PR TITLE
[Woo Express Cleanup] Remove "Upgrade now" text and functionality on free trial banner.

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Dashboard/Free Trial/StorePlanBanner.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Free Trial/StorePlanBanner.swift
@@ -5,10 +5,8 @@ import SwiftUI
 final class StorePlanBannerHostingViewController: UIHostingController<StorePlanBanner> {
     /// Designated initializer.
     ///
-    init(actionText: String, mainText: String, onLearnMoreTapped: @escaping () -> Void) {
-        super.init(rootView: StorePlanBanner(actionText: actionText,
-                                             mainText: mainText,
-                                             onLearnMoreTapped: onLearnMoreTapped))
+    init(mainText: String) {
+        super.init(rootView: StorePlanBanner(mainText: mainText))
     }
 
     /// Needed for protocol conformance.
@@ -21,18 +19,9 @@ final class StorePlanBannerHostingViewController: UIHostingController<StorePlanB
 /// Store Plan Banner. To be used inside the Dashboard.
 ///
 struct StorePlanBanner: View {
-
-    /// Text to be rendered as the banner action button
-    ///
-    let actionText: String
-
     /// Text to be rendered next to the info image.
     ///
     let mainText: String
-
-    /// Closure invoked when the merchants taps on the `Learn More` button.
-    ///
-    let onLearnMoreTapped: () -> Void
 
     var body: some View {
         VStack(spacing: .zero) {
@@ -45,12 +34,6 @@ struct StorePlanBanner: View {
                 AdaptiveStack(verticalAlignment: .center, spacing: Layout.spacing) {
                     Text(mainText)
                         .bodyStyle()
-
-                    Text(actionText)
-                        .underline(true)
-                        .linkStyle()
-                        .onTapGesture(perform: onLearnMoreTapped)
-                        .accessibilityAddTraits(.isButton)
                 }
             }
             .padding()
@@ -75,7 +58,7 @@ extension StorePlanBanner {
 
 struct StorePlanBanner_Preview: PreviewProvider {
     static var previews: some View {
-        StorePlanBanner(actionText: "Upgrade now", mainText: "Your Free trial has ended", onLearnMoreTapped: { })
+        StorePlanBanner(mainText: "Your Free trial has ended")
             .previewLayout(.sizeThatFits)
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Free Trial/StorePlanBanner.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Free Trial/StorePlanBanner.swift
@@ -5,8 +5,8 @@ import SwiftUI
 final class StorePlanBannerHostingViewController: UIHostingController<StorePlanBanner> {
     /// Designated initializer.
     ///
-    init(mainText: String) {
-        super.init(rootView: StorePlanBanner(mainText: mainText))
+    init(text: String) {
+        super.init(rootView: StorePlanBanner(text: text))
     }
 
     /// Needed for protocol conformance.
@@ -21,7 +21,7 @@ final class StorePlanBannerHostingViewController: UIHostingController<StorePlanB
 struct StorePlanBanner: View {
     /// Text to be rendered next to the info image.
     ///
-    let mainText: String
+    let text: String
 
     var body: some View {
         VStack(spacing: .zero) {
@@ -32,7 +32,7 @@ struct StorePlanBanner: View {
                     .accessibilityHidden(true)
 
                 AdaptiveStack(verticalAlignment: .center, spacing: Layout.spacing) {
-                    Text(mainText)
+                    Text(text)
                         .bodyStyle()
                 }
             }
@@ -58,7 +58,7 @@ extension StorePlanBanner {
 
 struct StorePlanBanner_Preview: PreviewProvider {
     static var previews: some View {
-        StorePlanBanner(mainText: "Your Free trial has ended")
+        StorePlanBanner(text: "Your Free trial has ended")
             .previewLayout(.sizeThatFits)
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Free Trial/StorePlanBannerPresenter.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Free Trial/StorePlanBannerPresenter.swift
@@ -123,17 +123,6 @@ private extension StorePlanBannerPresenter {
         .store(in: &subscriptions)
     }
 
-    /// String for the banner action button text
-    /// Will display different CTA text depending if IAP is supported and is enabled
-    ///
-    private func setupBannerText() async -> String {
-        if await inAppPurchasesManager.inAppPurchasesAreSupported() {
-            return Localization.upgradeNow
-        } else {
-            return Localization.learnMore
-        }
-    }
-
     /// Adds a Free Trial bar at the bottom of the container view.
     ///
     @MainActor
@@ -143,11 +132,7 @@ private extension StorePlanBannerPresenter {
         // Remove any previous banner.
         storePlanBanner?.removeFromSuperview()
 
-        let bannerActionText = await setupBannerText()
-
-        let storePlanViewController = StorePlanBannerHostingViewController(actionText: bannerActionText, mainText: contentText) { [weak self] in
-            self?.showUpgradesView()
-        }
+        let storePlanViewController = StorePlanBannerHostingViewController(mainText: contentText)
         storePlanViewController.view.translatesAutoresizingMaskIntoConstraints = false
 
         containerView.addSubview(storePlanViewController.view)
@@ -174,20 +159,10 @@ private extension StorePlanBannerPresenter {
         onLayoutUpdated(.zero)
         self.storePlanBanner = nil
     }
-
-    /// Shows a view for the merchant to upgrade their site's plan.
-    ///
-    func showUpgradesView() {
-        guard let viewController else { return }
-
-        UpgradesViewPresentationCoordinator().presentUpgrades(for: siteID, from: viewController)
-    }
 }
 
 private extension StorePlanBannerPresenter {
     enum Localization {
-        static let learnMore = NSLocalizedString("Learn more", comment: "Title on the button to learn more about the free trial plan.")
-        static let upgradeNow = NSLocalizedString("Upgrade Now", comment: "Title on the button to upgrade a free trial plan.")
         static let expiredPlan = NSLocalizedString("Your site plan has ended.", comment: "Title on the banner when the site's WooExpress plan has expired")
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Free Trial/StorePlanBannerPresenter.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Free Trial/StorePlanBannerPresenter.swift
@@ -132,7 +132,7 @@ private extension StorePlanBannerPresenter {
         // Remove any previous banner.
         storePlanBanner?.removeFromSuperview()
 
-        let storePlanViewController = StorePlanBannerHostingViewController(mainText: contentText)
+        let storePlanViewController = StorePlanBannerHostingViewController(text: contentText)
         storePlanViewController.view.translatesAutoresizingMaskIntoConstraints = false
 
         containerView.addSubview(storePlanViewController.view)


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #12377 
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

Removes the ability to upgrade free trial WooExpress site directly from the app, by removing the "Upgrade now" button on the free trial banner on the bottom of My Store page.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
1. From the app, create a new free trial site,
2. Once the site is created and you are brought to My Store, ensure the bottom banner only says "15 days left in your trial" without "Upgrade now" button next to it.


## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

<img src="https://github.com/woocommerce/woocommerce-ios/assets/266376/24454513-b9b7-46e9-9e66-21a977174a3f" width="42%">

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
