### PR TITLE
[Woo Express Sign up] Remove “Name your store” task & Stop adding “Launch your store” task locally

### DIFF
--- a/Networking/Networking/Model/StoreOnboardingTask.swift
+++ b/Networking/Networking/Model/StoreOnboardingTask.swift
@@ -54,17 +54,17 @@ private extension StoreOnboardingTask.TaskType {
         case .addFirstProduct:
             return 0
         case .storeDetails:
-            return 2
+            return 1
         case .woocommercePayments:
-            return 3
+            return 2
         case .launchStore:
-            return 4
+            return 3
         case .customizeDomains:
-            return 5
+            return 4
         case .payments:
-            return 6
+            return 5
         case .unsupported:
-            return 7
+            return 6
         }
     }
 }

--- a/Networking/Networking/Model/StoreOnboardingTask.swift
+++ b/Networking/Networking/Model/StoreOnboardingTask.swift
@@ -23,7 +23,6 @@ public extension StoreOnboardingTask {
         case customizeDomains
         case payments
         case woocommercePayments
-        case storeName
         case unsupported(String)
 
         public init(from decoder: Decoder) throws {
@@ -42,8 +41,6 @@ public extension StoreOnboardingTask {
                 self = .payments
             case "woocommerce-payments":
                 self = .woocommercePayments
-            case "store_name":
-                self = .storeName
             default:
                 self = .unsupported(id)
             }
@@ -56,8 +53,6 @@ private extension StoreOnboardingTask.TaskType {
         switch self {
         case .addFirstProduct:
             return 0
-        case .storeName:
-            return 1
         case .storeDetails:
             return 2
         case .woocommercePayments:

--- a/WooCommerce/Classes/Analytics/WooAnalyticsEvent+StoreOnboarding.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsEvent+StoreOnboarding.swift
@@ -59,8 +59,6 @@ private extension StoreOnboardingTask.TaskType {
             return "payments"
         case .woocommercePayments:
             return "woocommerce-payments"
-        case .storeName:
-            return "store_name"
         case .unsupported(let task):
             return task
         }

--- a/WooCommerce/Classes/Extensions/UIImage+Woo.swift
+++ b/WooCommerce/Classes/Extensions/UIImage+Woo.swift
@@ -595,12 +595,6 @@ extension UIImage {
         UIImage(named: "icon-get-paid")!
     }
 
-    /// Set store name image
-    ///
-    static var setStoreNameImage: UIImage {
-        UIImage(systemName: "pencil.circle")!
-    }
-
     /// Store summary image used in the store creation flow.
     ///
     static var storeSummaryImage: UIImage {

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Onboarding/StoreOnboardingCoordinator.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Onboarding/StoreOnboardingCoordinator.swift
@@ -22,12 +22,6 @@ final class StoreOnboardingCoordinator: Coordinator {
     private let reloadTasks: () -> Void
     private let onUpgradePlan: (() -> Void)?
 
-    private lazy var noticePresenter: DefaultNoticePresenter = {
-        let noticePresenter = DefaultNoticePresenter()
-        noticePresenter.presentingViewController = navigationController
-        return noticePresenter
-    }()
-
     init(navigationController: UINavigationController,
          site: Site,
          onTaskCompleted: @escaping (_ task: TaskType) -> Void,
@@ -68,8 +62,6 @@ final class StoreOnboardingCoordinator: Coordinator {
             showWCPaySetup()
         case .payments:
             showPaymentsSetup()
-        case .storeName:
-            showStoreNameSetup()
         case .unsupported:
             assertionFailure("Unexpected onboarding task: \(task)")
         }
@@ -153,23 +145,6 @@ private extension StoreOnboardingCoordinator {
         coordinator.start()
     }
 
-    func showStoreNameSetup() {
-        let viewModel = StoreNameSetupViewModel(siteID: site.siteID, name: site.name, onNameSaved: { [weak self] in
-            self?.onTaskCompleted(.storeName)
-            self?.navigationController.presentedViewController?.dismiss(animated: true) { [weak self] in
-                self?.showStoreNameNotice()
-            }
-        })
-        let controller = StoreNameSetupHostingController(viewModel: viewModel)
-        navigationController.present(controller, animated: true)
-    }
-
-    func showStoreNameNotice() {
-        let notice = Notice(title: Localization.StoreNameNotice.title,
-                            subtitle: Localization.StoreNameNotice.subtitle)
-        noticePresenter.enqueue(notice: notice)
-    }
-
     func showWooPaySetupCelebrationView() {
         wooPaySetupCelebrationViewBottomSheetPresenter = buildBottomSheetPresenter()
         let controller = CelebrationHostingController(
@@ -209,17 +184,6 @@ private extension StoreOnboardingCoordinator {
 
 private extension StoreOnboardingCoordinator {
     enum Localization {
-        enum StoreNameNotice {
-            static let title = NSLocalizedString(
-                "Store Name Set!",
-                comment: "Title on the notice presented when the store name is updated"
-            )
-            static let subtitle = NSLocalizedString(
-                "To change again, visit Store Settings.",
-                comment: "Subtitle on the notice presented when the store name is updated"
-            )
-        }
-
         enum Celebration {
             static let title = NSLocalizedString(
                 "You did it!",

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Onboarding/StoreOnboardingTaskViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Onboarding/StoreOnboardingTaskViewModel.swift
@@ -41,10 +41,6 @@ struct StoreOnboardingTaskViewModel: Identifiable, Equatable {
             icon = .getPaidImage
             title = Localization.Payments.title
             subtitle = Localization.Payments.subtitle
-        case .storeName:
-            icon = .setStoreNameImage
-            title = Localization.StoreTitle.title
-            subtitle = Localization.StoreTitle.subtitle
         case .unsupported:
             icon = .checkCircleImage
             title = ""
@@ -119,14 +115,6 @@ extension StoreOnboardingTaskViewModel {
             static let subtitle = NSLocalizedString(
                 "Give your customers an easy and convenient way to pay!",
                 comment: "Subtitle of the store onboarding task to get paid."
-            )
-        }
-
-        enum StoreTitle {
-            static let title = NSLocalizedString("Name your store", comment: "Title of the store onboarding task to update store title")
-            static let subtitle = NSLocalizedString(
-                "Customizing your store name can also help your store search engine optimization.",
-                comment: "Subtitle of the store onboarding task to update store title"
             )
         }
     }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Onboarding/StoreOnboardingViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Onboarding/StoreOnboardingViewModel.swift
@@ -68,17 +68,6 @@ class StoreOnboardingViewModel: ObservableObject {
 
     private let waitingTimeTracker: AppStartupWaitingTimeTracker
 
-    private var isFreeTrialStore: Bool {
-        guard let site = stores.sessionManager.defaultSite else {
-            return false
-        }
-        return site.isFreeTrialSite
-    }
-
-    private var siteHasDefaultTitle: Bool {
-        stores.sessionManager.defaultSite?.name == WooConstants.defaultStoreName
-    }
-
     /// Emits when there are no tasks available for display after reload.
     /// i.e. When (request failed && No previously loaded local data available)
     ///

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Onboarding/StoreOnboardingViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Onboarding/StoreOnboardingViewModel.swift
@@ -145,19 +145,7 @@ class StoreOnboardingViewModel: ObservableObject {
 private extension StoreOnboardingViewModel {
     @MainActor
     func loadTasks() async throws -> [StoreOnboardingTaskViewModel] {
-
-        let localTasks: [StoreOnboardingTask] = {
-            var tasks: [StoreOnboardingTask] = []
-            if isFreeTrialStore {
-                tasks.append(.init(isComplete: false, type: .launchStore))
-                tasks.append(.init(isComplete: !siteHasDefaultTitle, type: .storeName))
-            }
-            return tasks
-        }()
-
-        let tasksFromServer: [StoreOnboardingTask] = try await fetchTasks()
-
-        return (tasksFromServer + localTasks)
+        try await fetchTasks()
             .sorted()
             .map { .init(task: $0, badgeText: nil) }
     }

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -2602,7 +2602,6 @@
 		EEB44A1A2A8A254700FE089E /* MockStoreCreationProfilerUploadAnswersUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = EEB44A192A8A254700FE089E /* MockStoreCreationProfilerUploadAnswersUseCase.swift */; };
 		EEB4E2D329B2047700371C3C /* StoreOnboardingViewHostingControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EEB4E2D229B2047700371C3C /* StoreOnboardingViewHostingControllerTests.swift */; };
 		EEB4E2D629B2063800371C3C /* StoreOnboardingTaskViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = EEB4E2D429B205F400371C3C /* StoreOnboardingTaskViewModel.swift */; };
-		EEB4E2D829B20F0F00371C3C /* StoreOnboardingTaskViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = EEB4E2D729B20F0F00371C3C /* StoreOnboardingTaskViewModel.swift */; };
 		EEB4E2DA29B5F8FC00371C3C /* CouponLineDetailsViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = EEB4E2D929B5F8FC00371C3C /* CouponLineDetailsViewModel.swift */; };
 		EEB4E2DC29B600B800371C3C /* CouponLineDetails.swift in Sources */ = {isa = PBXBuildFile; fileRef = EEB4E2DB29B600B800371C3C /* CouponLineDetails.swift */; };
 		EEB4E2DE29B61AAD00371C3C /* CouponInputTransformer.swift in Sources */ = {isa = PBXBuildFile; fileRef = EEB4E2DD29B61AAD00371C3C /* CouponInputTransformer.swift */; };
@@ -2629,6 +2628,7 @@
 		EECB7EE62864647F0028C888 /* ProductImagesProductIDUpdater.swift in Sources */ = {isa = PBXBuildFile; fileRef = EECB7EE52864647F0028C888 /* ProductImagesProductIDUpdater.swift */; };
 		EEEA41F22869A5F400AEFC4B /* MockProductImagesProductIDUpdater.swift in Sources */ = {isa = PBXBuildFile; fileRef = EEEA41F12869A5F400AEFC4B /* MockProductImagesProductIDUpdater.swift */; };
 		EEEDA916290A799E004B001D /* WordPressAuthenticator+Internal.swift in Sources */ = {isa = PBXBuildFile; fileRef = EEEDA915290A799E004B001D /* WordPressAuthenticator+Internal.swift */; };
+		EEF5C1502BBAFA5900535C86 /* StoreOnboardingTaskViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EEF5C14F2BBAFA5900535C86 /* StoreOnboardingTaskViewModelTests.swift */; };
 		EEFF472A2B2AB24D009BF302 /* StoreCreationStoreSwitchScheduler.swift in Sources */ = {isa = PBXBuildFile; fileRef = EEFF47292B2AB24D009BF302 /* StoreCreationStoreSwitchScheduler.swift */; };
 		EEFF472C2B2B2B06009BF302 /* DefaultStoreCreationStoreSwitchSchedulerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EEFF472B2B2B2B06009BF302 /* DefaultStoreCreationStoreSwitchSchedulerTests.swift */; };
 		EEFF47322B309221009BF302 /* MockStoreCreationStoreSwitchScheduler.swift in Sources */ = {isa = PBXBuildFile; fileRef = EEFF47312B309221009BF302 /* MockStoreCreationStoreSwitchScheduler.swift */; };
@@ -5351,7 +5351,6 @@
 		EEB44A192A8A254700FE089E /* MockStoreCreationProfilerUploadAnswersUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockStoreCreationProfilerUploadAnswersUseCase.swift; sourceTree = "<group>"; };
 		EEB4E2D229B2047700371C3C /* StoreOnboardingViewHostingControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StoreOnboardingViewHostingControllerTests.swift; sourceTree = "<group>"; };
 		EEB4E2D429B205F400371C3C /* StoreOnboardingTaskViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StoreOnboardingTaskViewModel.swift; sourceTree = "<group>"; };
-		EEB4E2D729B20F0F00371C3C /* StoreOnboardingTaskViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StoreOnboardingTaskViewModel.swift; sourceTree = "<group>"; };
 		EEB4E2D929B5F8FC00371C3C /* CouponLineDetailsViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CouponLineDetailsViewModel.swift; sourceTree = "<group>"; };
 		EEB4E2DB29B600B800371C3C /* CouponLineDetails.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CouponLineDetails.swift; sourceTree = "<group>"; };
 		EEB4E2DD29B61AAD00371C3C /* CouponInputTransformer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CouponInputTransformer.swift; sourceTree = "<group>"; };
@@ -5378,6 +5377,7 @@
 		EECB7EE52864647F0028C888 /* ProductImagesProductIDUpdater.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductImagesProductIDUpdater.swift; sourceTree = "<group>"; };
 		EEEA41F12869A5F400AEFC4B /* MockProductImagesProductIDUpdater.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockProductImagesProductIDUpdater.swift; sourceTree = "<group>"; };
 		EEEDA915290A799E004B001D /* WordPressAuthenticator+Internal.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "WordPressAuthenticator+Internal.swift"; sourceTree = "<group>"; };
+		EEF5C14F2BBAFA5900535C86 /* StoreOnboardingTaskViewModelTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = StoreOnboardingTaskViewModelTests.swift; sourceTree = "<group>"; };
 		EEFF47292B2AB24D009BF302 /* StoreCreationStoreSwitchScheduler.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = StoreCreationStoreSwitchScheduler.swift; sourceTree = "<group>"; };
 		EEFF472B2B2B2B06009BF302 /* DefaultStoreCreationStoreSwitchSchedulerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefaultStoreCreationStoreSwitchSchedulerTests.swift; sourceTree = "<group>"; };
 		EEFF47312B309221009BF302 /* MockStoreCreationStoreSwitchScheduler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockStoreCreationStoreSwitchScheduler.swift; sourceTree = "<group>"; };
@@ -11933,8 +11933,8 @@
 		EE3272A229A88F670015F8D0 /* Onboarding */ = {
 			isa = PBXGroup;
 			children = (
+				EEF5C14F2BBAFA5900535C86 /* StoreOnboardingTaskViewModelTests.swift */,
 				EE3272A329A88F750015F8D0 /* StoreOnboardingViewModelTests.swift */,
-				EEB4E2D729B20F0F00371C3C /* StoreOnboardingTaskViewModel.swift */,
 				027EB57729C18AAC003CE551 /* StoreOnboardingLaunchStoreViewModelTests.swift */,
 				DE36E09B2A89EEA400B98496 /* StoreNameSetupViewModelTests.swift */,
 				DE5FBB922A9EFBCC0072FB35 /* WooPaymentSetupWebViewModelTests.swift */,
@@ -15135,6 +15135,7 @@
 				02EAF5C329FA30FF0058071C /* ProductDescriptionGenerationViewModelTests.swift in Sources */,
 				B57C5C9A21B80E7100FF82B2 /* DataWooTests.swift in Sources */,
 				B53A56A42112483E000776C9 /* Constants.swift in Sources */,
+				EEF5C1502BBAFA5900535C86 /* StoreOnboardingTaskViewModelTests.swift in Sources */,
 				2667BFE72530E78F008099D4 /* RefundItemsValuesCalculationUseCaseTests.swift in Sources */,
 				02AA586628531D0E0068B6F0 /* CloseAccountCoordinatorTests.swift in Sources */,
 				E12AF69B26BA8B2000C371C1 /* CardPresentPaymentsOnboardingUseCaseTests.swift in Sources */,
@@ -15169,7 +15170,6 @@
 				AEFF77AA29786DAA00667F7A /* PriceInputViewModelTests.swift in Sources */,
 				EEC2D27F292CF60E0072132E /* JetpackSetupHostingControllerTests.swift in Sources */,
 				4535EE82281BE726004212B4 /* CouponCodeInputFormatterTests.swift in Sources */,
-				EEB4E2D829B20F0F00371C3C /* StoreOnboardingTaskViewModel.swift in Sources */,
 				EE8A302B2B70B63E001D7C66 /* MockImageService.swift in Sources */,
 				DEF36DEC2898D64600178AC2 /* JetpackSetupWebViewModelTests.swift in Sources */,
 				023EC2E424DA95DB0021DA91 /* ProductInventorySettingsViewModel+VariationTests.swift in Sources */,

--- a/WooCommerce/WooCommerceTests/Extensions/IconsTests.swift
+++ b/WooCommerce/WooCommerceTests/Extensions/IconsTests.swift
@@ -324,10 +324,6 @@ final class IconsTests: XCTestCase {
         XCTAssertNotNil(UIImage.getPaidImage)
     }
 
-    func test_setStoreNameImage_is_not_nil() {
-        XCTAssertNotNil(UIImage.setStoreNameImage)
-    }
-
     func test_storeSummaryImage_is_not_nil() {
         XCTAssertNotNil(UIImage.storeSummaryImage)
     }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Onboarding/StoreOnboardingTaskViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Onboarding/StoreOnboardingTaskViewModelTests.swift
@@ -46,8 +46,6 @@ final class StoreOnboardingTaskViewModelTests: XCTestCase {
                 XCTAssertEqual(sut.icon, .customizeDomainsImage)
             case .payments, .woocommercePayments:
                 XCTAssertEqual(sut.icon, .getPaidImage)
-            case .storeName:
-                XCTAssertEqual(sut.icon, .setStoreNameImage)
             case .unsupported:
                 XCTAssertEqual(sut.icon, .checkCircleImage)
             }
@@ -68,8 +66,6 @@ final class StoreOnboardingTaskViewModelTests: XCTestCase {
                 XCTAssertEqual(sut.title, StoreOnboardingTaskViewModel.Localization.CustomizeDomains.title)
             case .payments, .woocommercePayments:
                 XCTAssertEqual(sut.title, StoreOnboardingTaskViewModel.Localization.Payments.title)
-            case .storeName:
-                XCTAssertEqual(sut.title, StoreOnboardingTaskViewModel.Localization.StoreTitle.title)
             case .unsupported:
                 XCTAssertEqual(sut.title, "")
             }
@@ -90,8 +86,6 @@ final class StoreOnboardingTaskViewModelTests: XCTestCase {
                 XCTAssertEqual(sut.subtitle, StoreOnboardingTaskViewModel.Localization.CustomizeDomains.subtitle)
             case .payments, .woocommercePayments:
                 XCTAssertEqual(sut.subtitle, StoreOnboardingTaskViewModel.Localization.Payments.subtitle)
-            case .storeName:
-                XCTAssertEqual(sut.subtitle, StoreOnboardingTaskViewModel.Localization.StoreTitle.subtitle)
             case .unsupported:
                 XCTAssertEqual(sut.subtitle, "")
             }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Onboarding/StoreOnboardingViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Onboarding/StoreOnboardingViewModelTests.swift
@@ -164,91 +164,6 @@ final class StoreOnboardingViewModelTests: XCTestCase {
         XCTAssertEqual(sut.tasksForDisplay[1].task.type, .launchStore)
     }
 
-    func test_tasksForDisplay_contains_launch_store_and_store_name_task_for_WPCOM_site_under_free_trial() async {
-        // Given
-        sessionManager.defaultSite = .fake().copy(plan: freeTrialPlanSlug, isWordPressComStore: true)
-        sessionManager.defaultRoles = [.administrator]
-        mockLoadOnboardingTasks(result: .success([
-            .init(isComplete: false, type: .addFirstProduct),
-        ]))
-
-        let sut = StoreOnboardingViewModel(siteID: 0,
-                                           isExpanded: true,
-                                           stores: stores,
-                                           defaults: defaults)
-        // When
-        await sut.reloadTasks()
-
-        // Then
-        XCTAssertTrue(sut.tasksForDisplay.filter({ $0.task.type == .launchStore}).isNotEmpty)
-        XCTAssertNotNil(sut.tasksForDisplay.first(where: { $0.task.type == .storeName }))
-    }
-
-    func test_tasksForDisplay_does_not_contain_launch_store_and_store_name_task_for_non_WPCOM_site() async {
-        // Given
-        sessionManager.defaultSite = .fake().copy(isWordPressComStore: false)
-        sessionManager.defaultRoles = [.administrator]
-        mockLoadOnboardingTasks(result: .success([
-            .init(isComplete: false, type: .addFirstProduct),
-        ]))
-
-        let sut = StoreOnboardingViewModel(siteID: 0,
-                                           isExpanded: true,
-                                           stores: stores,
-                                           defaults: defaults)
-        // When
-        await sut.reloadTasks()
-
-        // Then
-        XCTAssertTrue(sut.tasksForDisplay.filter({ $0.task.type == .launchStore}).isEmpty)
-        XCTAssertNil(sut.tasksForDisplay.first(where: { $0.task.type == .storeName }))
-    }
-
-    func test_tasksForDisplay_does_not_contain_launch_store_task_and_store_name_for_WPCOM_site_not_under_free_trial() async {
-        // Given
-        sessionManager.defaultSite = .fake().copy(plan: "ecommerce-plan", isWordPressComStore: true)
-        sessionManager.defaultRoles = [.administrator]
-        mockLoadOnboardingTasks(result: .success([
-            .init(isComplete: false, type: .addFirstProduct),
-        ]))
-
-        let sut = StoreOnboardingViewModel(siteID: 0,
-                                           isExpanded: true,
-                                           stores: stores,
-                                           defaults: defaults)
-        // When
-        await sut.reloadTasks()
-
-        // Then
-        XCTAssertTrue(sut.tasksForDisplay.filter({ $0.task.type == .launchStore}).isEmpty)
-        XCTAssertNil(sut.tasksForDisplay.first(where: { $0.task.type == .storeName }))
-    }
-
-    func test_tasksForDisplay_is_sorted_when_launch_store_and_store_name_tasks_get_manually_added_for_WPCOM_site_under_free_trial() async {
-        // Given
-        sessionManager.defaultSite = .fake().copy(name: WooConstants.defaultStoreName, plan: freeTrialPlanSlug, isWordPressComStore: true)
-        sessionManager.defaultRoles = [.administrator]
-        mockLoadOnboardingTasks(result: .success([
-            .init(isComplete: false, type: .addFirstProduct),
-            .init(isComplete: false, type: .customizeDomains),
-        ]))
-
-        let sut = StoreOnboardingViewModel(siteID: 0,
-                                           isExpanded: true,
-                                           stores: stores,
-                                           defaults: defaults)
-        // When
-        await sut.reloadTasks()
-
-        // Then
-        XCTAssertEqual(sut.tasksForDisplay.map({ $0.task }), [
-            .init(isComplete: false, type: .addFirstProduct),
-            .init(isComplete: false, type: .storeName),
-            .init(isComplete: false, type: .launchStore),
-            .init(isComplete: false, type: .customizeDomains)
-        ])
-    }
-
     func test_launch_store_task_is_marked_as_complete_for_already_public_store() async throws {
         // Given
         sessionManager.defaultSite = .fake().copy(plan: freeTrialPlanSlug, isWordPressComStore: true, isPublic: true)
@@ -309,26 +224,6 @@ final class StoreOnboardingViewModelTests: XCTestCase {
 
         // Then
         XCTAssertTrue(sut.tasksForDisplay.filter({ $0.task.isComplete}).isEmpty)
-    }
-
-    func test_store_name_task_is_marked_as_complete_for_free_trial_site_with_custom_name() async throws {
-        // Given
-        sessionManager.defaultSite = .fake().copy(name: "Test", plan: freeTrialPlanSlug, isWordPressComStore: true)
-        mockLoadOnboardingTasks(result: .success([
-            .init(isComplete: false, type: .addFirstProduct),
-            .init(isComplete: false, type: .launchStore)
-        ]))
-
-        let sut = StoreOnboardingViewModel(siteID: 0,
-                                           isExpanded: true,
-                                           stores: stores,
-                                           defaults: defaults)
-        // When
-        await sut.reloadTasks()
-
-        // Then
-        let storeNameTask = try XCTUnwrap(sut.tasksForDisplay.first(where: { $0.task.type == .storeName }))
-        XCTAssertTrue(storeNameTask.isComplete)
     }
 
     // MARK: - shouldShowViewAllButton


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #12394
Closes: #12395
<!-- Id number of the GitHub issue this PR addresses. -->

## Description

This PR makes the following changes to the Free trial related onboarding tasks. 

“Name your store” task
- Remove the “Name your store” task and related code completely.

“Launch your store” task
- Stop adding the “Launch your store” task locally for free trial stores.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->
| Before | After |
|--------|--------|
| ![Simulator Screenshot - iPhone 13 Pro - 2024-04-01 at 20 44 56](https://github.com/woocommerce/woocommerce-ios/assets/524475/3a625cc5-402c-49ee-8207-6c19e4f0fbe6) | ![Simulator Screenshot - iPhone 13 Pro - 2024-04-01 at 20 46 52](https://github.com/woocommerce/woocommerce-ios/assets/524475/7b70ae8c-9a32-4492-b999-53499dda4d02) | 


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
