### PR TITLE
Refund details display excessively wide on iPad in some orientations

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Payment Section/Refunds/RefundDetailsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Payment Section/Refunds/RefundDetailsViewController.swift
@@ -64,7 +64,7 @@ private extension RefundDetailsViewController {
         tableView.rowHeight = UITableView.automaticDimension
 
         tableView.dataSource = viewModel.dataSource
-        
+
         let maxWidthConstraint = tableView.widthAnchor.constraint(lessThanOrEqualToConstant: Constants.maxWidth)
         maxWidthConstraint.priority = .required
         NSLayoutConstraint.activate([maxWidthConstraint])

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Payment Section/Refunds/RefundDetailsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Payment Section/Refunds/RefundDetailsViewController.swift
@@ -64,6 +64,10 @@ private extension RefundDetailsViewController {
         tableView.rowHeight = UITableView.automaticDimension
 
         tableView.dataSource = viewModel.dataSource
+        
+        let maxWidthConstraint = tableView.widthAnchor.constraint(lessThanOrEqualToConstant: Constants.maxWidth)
+        maxWidthConstraint.priority = .required
+        NSLayoutConstraint.activate([maxWidthConstraint])
     }
 
     /// Setup: Configure viewModel
@@ -171,5 +175,6 @@ extension RefundDetailsViewController {
     enum Constants {
         static let rowHeight = CGFloat(38)
         static let sectionHeight = CGFloat(44)
+        static let maxWidth = CGFloat(525)
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Payment Section/Refunds/RefundDetailsViewController.xib
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Payment Section/Refunds/RefundDetailsViewController.xib
@@ -1,10 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="15702" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="22505" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="15704"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="22504"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
@@ -20,22 +21,28 @@
             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
             <subviews>
                 <tableView clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" style="grouped" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="18" sectionFooterHeight="18" translatesAutoresizingMaskIntoConstraints="NO" id="sS9-NB-PXk">
-                    <rect key="frame" x="0.0" y="44" width="414" height="818"/>
-                    <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+                    <rect key="frame" x="0.0" y="48" width="414" height="814"/>
+                    <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                     <connections>
                         <outlet property="delegate" destination="-1" id="4pF-XC-J8U"/>
                     </connections>
                 </tableView>
             </subviews>
+            <viewLayoutGuide key="safeArea" id="fnl-2z-Ty3"/>
             <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
             <constraints>
-                <constraint firstItem="fnl-2z-Ty3" firstAttribute="trailing" secondItem="sS9-NB-PXk" secondAttribute="trailing" id="DQQ-YV-0Qh"/>
+                <constraint firstItem="fnl-2z-Ty3" firstAttribute="trailing" secondItem="sS9-NB-PXk" secondAttribute="trailing" priority="750" id="DQQ-YV-0Qh"/>
                 <constraint firstItem="fnl-2z-Ty3" firstAttribute="bottom" secondItem="sS9-NB-PXk" secondAttribute="bottom" id="JkO-0b-Jzs"/>
                 <constraint firstItem="sS9-NB-PXk" firstAttribute="top" secondItem="fnl-2z-Ty3" secondAttribute="top" id="fXW-b1-HLm"/>
-                <constraint firstItem="sS9-NB-PXk" firstAttribute="leading" secondItem="fnl-2z-Ty3" secondAttribute="leading" id="nga-3k-xEb"/>
+                <constraint firstItem="sS9-NB-PXk" firstAttribute="leading" secondItem="fnl-2z-Ty3" secondAttribute="leading" priority="750" id="nga-3k-xEb"/>
+                <constraint firstItem="sS9-NB-PXk" firstAttribute="centerX" secondItem="i5M-Pr-FkT" secondAttribute="centerX" id="vF6-rm-FG5"/>
             </constraints>
-            <viewLayoutGuide key="safeArea" id="fnl-2z-Ty3"/>
             <point key="canvasLocation" x="137.68115942028987" y="84.375"/>
         </view>
     </objects>
+    <resources>
+        <systemColor name="systemBackgroundColor">
+            <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+        </systemColor>
+    </resources>
 </document>


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #11776
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
- Setting max width for refund details screen, same as on order details screen

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

- Be sure to test on both iPad and iPhone
- Tap Orders
- Select a refunded order
- Tap the refund row
- Observe that the refund details are shown as below, with the same width as order details

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

| Before      | After |
| ----------- | ----------- |
| ![Simulator Screenshot - iPad Pro (11-inch) (4th generation) - 2024-04-02 at 12 59 24](https://github.com/woocommerce/woocommerce-ios/assets/6242034/5bbb5a9f-6834-4d8d-9eef-7dfdd9a151c0)      | ![Simulator Screenshot - iPad Pro (11-inch) (4th generation) - 2024-04-02 at 12 53 52](https://github.com/woocommerce/woocommerce-ios/assets/6242034/c51b0962-4ca4-4dad-8220-226780f1bfde)       |
| ![Simulator Screen Recording - iPad Pro (11-inch) (4th generation) - 2024-04-02 at 12 59 32](https://github.com/woocommerce/woocommerce-ios/assets/6242034/836757cd-a4e0-4298-9fec-a3eade825667)     | ![Simulator Screen Recording - iPad Pro (11-inch) (4th generation) - 2024-04-02 at 12 54 01](https://github.com/woocommerce/woocommerce-ios/assets/6242034/a41ad7d5-de7d-43e3-a540-e1bb3d0eff62)       |

---
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
