### PR TITLE
[Analytics Hub] Gift Cards: Add models for gift card stats

### DIFF
--- a/Fakes/Fakes/Networking.generated.swift
+++ b/Fakes/Fakes/Networking.generated.swift
@@ -535,6 +535,42 @@ extension Networking.FeatureIcon {
         )
     }
 }
+extension Networking.GiftCardStats {
+    /// Returns a "ready to use" type filled with fake values.
+    ///
+    public static func fake() -> Networking.GiftCardStats {
+        .init(
+            siteID: .fake(),
+            granularity: .fake(),
+            totals: .fake(),
+            intervals: .fake()
+        )
+    }
+}
+extension Networking.GiftCardStatsInterval {
+    /// Returns a "ready to use" type filled with fake values.
+    ///
+    public static func fake() -> Networking.GiftCardStatsInterval {
+        .init(
+            interval: .fake(),
+            dateStart: .fake(),
+            dateEnd: .fake(),
+            subtotals: .fake()
+        )
+    }
+}
+extension Networking.GiftCardStatsTotals {
+    /// Returns a "ready to use" type filled with fake values.
+    ///
+    public static func fake() -> Networking.GiftCardStatsTotals {
+        .init(
+            giftCardsCount: .fake(),
+            usedAmount: .fake(),
+            refundedAmount: .fake(),
+            netAmount: .fake()
+        )
+    }
+}
 extension Networking.InboxAction {
     /// Returns a "ready to use" type filled with fake values.
     ///

--- a/Networking/Networking.xcodeproj/project.pbxproj
+++ b/Networking/Networking.xcodeproj/project.pbxproj
@@ -660,6 +660,8 @@
 		CE070A2A2BBC3C0A00017578 /* GiftCardStats.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE070A292BBC3C0A00017578 /* GiftCardStats.swift */; };
 		CE070A2C2BBC3C2B00017578 /* GiftCardStatsInterval.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE070A2B2BBC3C2B00017578 /* GiftCardStatsInterval.swift */; };
 		CE070A2E2BBC3C3500017578 /* GiftCardStatsTotals.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE070A2D2BBC3C3500017578 /* GiftCardStatsTotals.swift */; };
+		CE070A302BBC527900017578 /* gift-card-stats.json in Resources */ = {isa = PBXBuildFile; fileRef = CE070A2F2BBC527900017578 /* gift-card-stats.json */; };
+		CE070A342BBC52B200017578 /* gift-card-stats-without-data.json in Resources */ = {isa = PBXBuildFile; fileRef = CE070A332BBC52B200017578 /* gift-card-stats-without-data.json */; };
 		CE0A0F13223942D90075ED8D /* ProductImage.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE0A0F12223942D90075ED8D /* ProductImage.swift */; };
 		CE0A0F1522396BF00075ED8D /* ProductAttribute.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE0A0F1422396BF00075ED8D /* ProductAttribute.swift */; };
 		CE0A0F17223970E80075ED8D /* ProductDefaultAttribute.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE0A0F16223970E80075ED8D /* ProductDefaultAttribute.swift */; };
@@ -1746,6 +1748,8 @@
 		CE070A292BBC3C0A00017578 /* GiftCardStats.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GiftCardStats.swift; sourceTree = "<group>"; };
 		CE070A2B2BBC3C2B00017578 /* GiftCardStatsInterval.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GiftCardStatsInterval.swift; sourceTree = "<group>"; };
 		CE070A2D2BBC3C3500017578 /* GiftCardStatsTotals.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GiftCardStatsTotals.swift; sourceTree = "<group>"; };
+		CE070A2F2BBC527900017578 /* gift-card-stats.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "gift-card-stats.json"; sourceTree = "<group>"; };
+		CE070A332BBC52B200017578 /* gift-card-stats-without-data.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "gift-card-stats-without-data.json"; sourceTree = "<group>"; };
 		CE0A0F12223942D90075ED8D /* ProductImage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductImage.swift; sourceTree = "<group>"; };
 		CE0A0F1422396BF00075ED8D /* ProductAttribute.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductAttribute.swift; sourceTree = "<group>"; };
 		CE0A0F16223970E80075ED8D /* ProductDefaultAttribute.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ProductDefaultAttribute.swift; sourceTree = "<group>"; };
@@ -3151,6 +3155,8 @@
 				CEB9BF302BB190590007978A /* product-bundle-stats.json */,
 				CEB9BF342BB190960007978A /* product-bundle-stats-without-data.json */,
 				CEA455B62BB2D64400D932CF /* product-bundle-top-bundles.json */,
+				CE070A2F2BBC527900017578 /* gift-card-stats.json */,
+				CE070A332BBC52B200017578 /* gift-card-stats-without-data.json */,
 			);
 			path = Responses;
 			sourceTree = "<group>";
@@ -3840,6 +3846,7 @@
 				26BD9FCD2965EC3C004E0D15 /* product-variations-bulk-create.json in Resources */,
 				02C43260298A55D100F14AEE /* validate-domain-contact-info-failure.json in Resources */,
 				B9DFE4C22AA22B6F00174004 /* taxes.json in Resources */,
+				CE070A302BBC527900017578 /* gift-card-stats.json in Resources */,
 				EE57C13C297FBECB00BC31E7 /* product-tags-all-without-data.json in Resources */,
 				028CB718290223CB00331C09 /* account-username-suggestions.json in Resources */,
 				0282DD91233A120A006A5FDB /* products-search-photo.json in Resources */,
@@ -3927,6 +3934,7 @@
 				DEA493722B3997ED00EED015 /* blaze-target-languages.json in Resources */,
 				02698CF624C17FC1005337C4 /* product-alternative-types.json in Resources */,
 				03EB99962907F03000F06A39 /* empty-data-array.json in Resources */,
+				CE070A342BBC52B200017578 /* gift-card-stats-without-data.json in Resources */,
 				57BE08D82409B63800F6DCED /* reviews-missing-avatar-urls.json in Resources */,
 				EEFC4C962A5E996C004C5A83 /* jwt-token-failure.json in Resources */,
 				3158FE8026129EC300E566B9 /* wcpay-account-restricted-overdue.json in Resources */,

--- a/Networking/Networking.xcodeproj/project.pbxproj
+++ b/Networking/Networking.xcodeproj/project.pbxproj
@@ -657,6 +657,9 @@
 		CCF48B802628BBC10034EA83 /* ShippingLabelAccountSettingsMapperTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CCF48B7F2628BBC10034EA83 /* ShippingLabelAccountSettingsMapperTests.swift */; };
 		CCFEB8F429E8504300537456 /* product-subscription.json in Resources */ = {isa = PBXBuildFile; fileRef = CCFEB8F329E8504300537456 /* product-subscription.json */; };
 		CCFEB8F629E8648C00537456 /* ProductMetadataExtractor.swift in Sources */ = {isa = PBXBuildFile; fileRef = CCFEB8F529E8648C00537456 /* ProductMetadataExtractor.swift */; };
+		CE070A2A2BBC3C0A00017578 /* GiftCardStats.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE070A292BBC3C0A00017578 /* GiftCardStats.swift */; };
+		CE070A2C2BBC3C2B00017578 /* GiftCardStatsInterval.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE070A2B2BBC3C2B00017578 /* GiftCardStatsInterval.swift */; };
+		CE070A2E2BBC3C3500017578 /* GiftCardStatsTotals.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE070A2D2BBC3C3500017578 /* GiftCardStatsTotals.swift */; };
 		CE0A0F13223942D90075ED8D /* ProductImage.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE0A0F12223942D90075ED8D /* ProductImage.swift */; };
 		CE0A0F1522396BF00075ED8D /* ProductAttribute.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE0A0F1422396BF00075ED8D /* ProductAttribute.swift */; };
 		CE0A0F17223970E80075ED8D /* ProductDefaultAttribute.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE0A0F16223970E80075ED8D /* ProductDefaultAttribute.swift */; };
@@ -1740,6 +1743,9 @@
 		CCF48B7F2628BBC10034EA83 /* ShippingLabelAccountSettingsMapperTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShippingLabelAccountSettingsMapperTests.swift; sourceTree = "<group>"; };
 		CCFEB8F329E8504300537456 /* product-subscription.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "product-subscription.json"; sourceTree = "<group>"; };
 		CCFEB8F529E8648C00537456 /* ProductMetadataExtractor.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ProductMetadataExtractor.swift; sourceTree = "<group>"; };
+		CE070A292BBC3C0A00017578 /* GiftCardStats.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GiftCardStats.swift; sourceTree = "<group>"; };
+		CE070A2B2BBC3C2B00017578 /* GiftCardStatsInterval.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GiftCardStatsInterval.swift; sourceTree = "<group>"; };
+		CE070A2D2BBC3C3500017578 /* GiftCardStatsTotals.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GiftCardStatsTotals.swift; sourceTree = "<group>"; };
 		CE0A0F12223942D90075ED8D /* ProductImage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductImage.swift; sourceTree = "<group>"; };
 		CE0A0F1422396BF00075ED8D /* ProductAttribute.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductAttribute.swift; sourceTree = "<group>"; };
 		CE0A0F16223970E80075ED8D /* ProductDefaultAttribute.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ProductDefaultAttribute.swift; sourceTree = "<group>"; };
@@ -2321,6 +2327,9 @@
 				CEB9BF3E2BB196130007978A /* ProductBundleStats.swift */,
 				CEB9BF3C2BB1949F0007978A /* ProductBundleStatsInterval.swift */,
 				CEB9BF382BB193020007978A /* ProductBundleStatsTotals.swift */,
+				CE070A292BBC3C0A00017578 /* GiftCardStats.swift */,
+				CE070A2B2BBC3C2B00017578 /* GiftCardStatsInterval.swift */,
+				CE070A2D2BBC3C3500017578 /* GiftCardStatsTotals.swift */,
 			);
 			path = Stats;
 			sourceTree = "<group>";
@@ -4348,6 +4357,7 @@
 				EE1CB90E2B4BC99E00AD24D5 /* BlazeAISuggestion.swift in Sources */,
 				03DCB772262591D900C8953D /* CouponsRemote.swift in Sources */,
 				CE6BFEE52236BF05005C79FB /* Product.swift in Sources */,
+				CE070A2A2BBC3C0A00017578 /* GiftCardStats.swift in Sources */,
 				077F39C8269F2C7E00ABEADC /* SystemPlugin.swift in Sources */,
 				5726F159248E9D88005AE9B4 /* Models+Copiable.generated.swift in Sources */,
 				456930A7264EA7CE009ED69D /* ShippingLabelCarrierRate.swift in Sources */,
@@ -4478,6 +4488,7 @@
 				03DCB72626244B9B00C8953D /* Coupon.swift in Sources */,
 				EE4D51B22ACC6F1E00783D77 /* ProductCategoryFromBatchCreation.swift in Sources */,
 				31054706262E278100C5C02B /* RemotePaymentIntent.swift in Sources */,
+				CE070A2C2BBC3C2B00017578 /* GiftCardStatsInterval.swift in Sources */,
 				026CF61E237D6985009563D4 /* ProductVariationListMapper.swift in Sources */,
 				CE43066E2347CBA70073CBFF /* OrderItemTaxRefund.swift in Sources */,
 				26455E2125F66951008A1D32 /* ProductAttributeTerm.swift in Sources */,
@@ -4547,6 +4558,7 @@
 				74046E1B217A684D007DD7BF /* SiteSettingsRemote.swift in Sources */,
 				0359EA1D27AADE000048DE2D /* WCPayChargeMapper.swift in Sources */,
 				B5C6FCCF20A3592900A4F8E4 /* OrderItem.swift in Sources */,
+				CE070A2E2BBC3C3500017578 /* GiftCardStatsTotals.swift in Sources */,
 				CEE9187D29F7D636004B23FF /* OrderGiftCard.swift in Sources */,
 				020EF5E92A8BC957009D2169 /* ProductsTotalMapper.swift in Sources */,
 				02C254A025636F6900A04423 /* ShippingLabelRefund.swift in Sources */,

--- a/Networking/Networking/Model/Copiable/Models+Copiable.generated.swift
+++ b/Networking/Networking/Model/Copiable/Models+Copiable.generated.swift
@@ -738,6 +738,69 @@ extension Networking.FeatureIcon {
     }
 }
 
+extension Networking.GiftCardStats {
+    public func copy(
+        siteID: CopiableProp<Int64> = .copy,
+        granularity: CopiableProp<StatsGranularityV4> = .copy,
+        totals: CopiableProp<GiftCardStatsTotals> = .copy,
+        intervals: CopiableProp<[GiftCardStatsInterval]> = .copy
+    ) -> Networking.GiftCardStats {
+        let siteID = siteID ?? self.siteID
+        let granularity = granularity ?? self.granularity
+        let totals = totals ?? self.totals
+        let intervals = intervals ?? self.intervals
+
+        return Networking.GiftCardStats(
+            siteID: siteID,
+            granularity: granularity,
+            totals: totals,
+            intervals: intervals
+        )
+    }
+}
+
+extension Networking.GiftCardStatsInterval {
+    public func copy(
+        interval: CopiableProp<String> = .copy,
+        dateStart: CopiableProp<String> = .copy,
+        dateEnd: CopiableProp<String> = .copy,
+        subtotals: CopiableProp<GiftCardStatsTotals> = .copy
+    ) -> Networking.GiftCardStatsInterval {
+        let interval = interval ?? self.interval
+        let dateStart = dateStart ?? self.dateStart
+        let dateEnd = dateEnd ?? self.dateEnd
+        let subtotals = subtotals ?? self.subtotals
+
+        return Networking.GiftCardStatsInterval(
+            interval: interval,
+            dateStart: dateStart,
+            dateEnd: dateEnd,
+            subtotals: subtotals
+        )
+    }
+}
+
+extension Networking.GiftCardStatsTotals {
+    public func copy(
+        giftCardsCount: CopiableProp<Int> = .copy,
+        usedAmount: CopiableProp<Decimal> = .copy,
+        refundedAmount: CopiableProp<Decimal> = .copy,
+        netAmount: CopiableProp<Decimal> = .copy
+    ) -> Networking.GiftCardStatsTotals {
+        let giftCardsCount = giftCardsCount ?? self.giftCardsCount
+        let usedAmount = usedAmount ?? self.usedAmount
+        let refundedAmount = refundedAmount ?? self.refundedAmount
+        let netAmount = netAmount ?? self.netAmount
+
+        return Networking.GiftCardStatsTotals(
+            giftCardsCount: giftCardsCount,
+            usedAmount: usedAmount,
+            refundedAmount: refundedAmount,
+            netAmount: netAmount
+        )
+    }
+}
+
 extension Networking.InboxAction {
     public func copy(
         id: CopiableProp<Int64> = .copy,

--- a/Networking/Networking/Model/Stats/GiftCardStats.swift
+++ b/Networking/Networking/Model/Stats/GiftCardStats.swift
@@ -1,0 +1,57 @@
+import Foundation
+import Codegen
+
+/// Represents gift card stats over a specific period.
+public struct GiftCardStats: Decodable, Equatable, GeneratedCopiable, GeneratedFakeable {
+    public let siteID: Int64
+    public let granularity: StatsGranularityV4
+    public let totals: GiftCardStatsTotals
+    public let intervals: [GiftCardStatsInterval]
+
+    public init(siteID: Int64,
+                granularity: StatsGranularityV4,
+                totals: GiftCardStatsTotals,
+                intervals: [GiftCardStatsInterval]) {
+        self.siteID = siteID
+        self.granularity = granularity
+        self.totals = totals
+        self.intervals = intervals
+    }
+
+    public init(from decoder: Decoder) throws {
+        guard let siteID = decoder.userInfo[.siteID] as? Int64 else {
+            throw GiftCardStatsAPIError.missingSiteID
+        }
+
+        guard let granularity = decoder.userInfo[.granularity] as? StatsGranularityV4 else {
+            throw GiftCardStatsAPIError.missingGranularity
+        }
+
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        let totals = try container.decode(GiftCardStatsTotals.self, forKey: .totals)
+        let intervals = try container.decode([GiftCardStatsInterval].self, forKey: .intervals)
+
+        self.init(siteID: siteID,
+                  granularity: granularity,
+                  totals: totals,
+                  intervals: intervals)
+    }
+}
+
+
+// MARK: - Constants!
+//
+private extension GiftCardStats {
+
+    enum CodingKeys: String, CodingKey {
+        case totals = "totals"
+        case intervals = "intervals"
+    }
+}
+
+// MARK: - Decoding Errors
+//
+enum GiftCardStatsAPIError: Error {
+    case missingSiteID
+    case missingGranularity
+}

--- a/Networking/Networking/Model/Stats/GiftCardStatsInterval.swift
+++ b/Networking/Networking/Model/Stats/GiftCardStatsInterval.swift
@@ -1,0 +1,46 @@
+import Codegen
+
+/// Represents gift card stats for a specific period.
+public struct GiftCardStatsInterval: Decodable, Equatable, GeneratedCopiable, GeneratedFakeable {
+    public let interval: String
+    /// Interval start date string in the site time zone.
+    public let dateStart: String
+    /// Interval end date string in the site time zone.
+    public let dateEnd: String
+    public let subtotals: GiftCardStatsTotals
+
+    public init(interval: String,
+                dateStart: String,
+                dateEnd: String,
+                subtotals: GiftCardStatsTotals) {
+        self.interval = interval
+        self.dateStart = dateStart
+        self.dateEnd = dateEnd
+        self.subtotals = subtotals
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        let interval = try container.decode(String.self, forKey: .interval)
+        let dateStart = try container.decode(String.self, forKey: .dateStart)
+        let dateEnd = try container.decode(String.self, forKey: .dateEnd)
+        let subtotals = try container.decode(GiftCardStatsTotals.self, forKey: .subtotals)
+
+        self.init(interval: interval,
+                  dateStart: dateStart,
+                  dateEnd: dateEnd,
+                  subtotals: subtotals)
+    }
+}
+
+
+// MARK: - Constants!
+//
+private extension GiftCardStatsInterval {
+    enum CodingKeys: String, CodingKey {
+        case interval = "interval"
+        case dateStart = "date_start"
+        case dateEnd = "date_end"
+        case subtotals = "subtotals"
+    }
+}

--- a/Networking/Networking/Model/Stats/GiftCardStatsTotals.swift
+++ b/Networking/Networking/Model/Stats/GiftCardStatsTotals.swift
@@ -1,0 +1,51 @@
+import Codegen
+
+/// Represents the data associated with gift card stats over a specific period.
+public struct GiftCardStatsTotals: Decodable, Equatable, GeneratedCopiable, GeneratedFakeable {
+    /// Number of Gift Cards
+    public let giftCardsCount: Int
+
+    /// Used Amount
+    public let usedAmount: Decimal
+
+    /// Refunded Amount
+    public let refundedAmount: Decimal
+
+    /// Net Amount
+    public let netAmount: Decimal
+
+    public init(giftCardsCount: Int,
+                usedAmount: Decimal,
+                refundedAmount: Decimal,
+                netAmount: Decimal) {
+        self.giftCardsCount = giftCardsCount
+        self.usedAmount = usedAmount
+        self.refundedAmount = refundedAmount
+        self.netAmount = netAmount
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        let giftCardsCount = try container.decode(Int.self, forKey: .giftCardsCount)
+        let usedAmount = try container.decode(Decimal.self, forKey: .usedAmount)
+        let refundedAmount = try container.decode(Decimal.self, forKey: .refundedAmount)
+        let netAmount = try container.decode(Decimal.self, forKey: .netAmount)
+
+        self.init(giftCardsCount: giftCardsCount,
+                  usedAmount: usedAmount,
+                  refundedAmount: refundedAmount,
+                  netAmount: netAmount)
+    }
+}
+
+
+// MARK: - Constants!
+//
+private extension GiftCardStatsTotals {
+    enum CodingKeys: String, CodingKey {
+        case giftCardsCount = "giftcards_count"
+        case usedAmount = "used_amount"
+        case refundedAmount = "refunded_amount"
+        case netAmount = "net_amount"
+    }
+}

--- a/Networking/NetworkingTests/Responses/gift-card-stats-without-data.json
+++ b/Networking/NetworkingTests/Responses/gift-card-stats-without-data.json
@@ -1,0 +1,23 @@
+{
+    "totals": {
+        "giftcards_count": 1,
+        "used_amount": 20,
+        "refunded_amount": 0,
+        "net_amount": 20
+    },
+    "intervals": [
+        {
+            "interval": "2024-02",
+            "date_start": "2024-01-08 00:00:00",
+            "date_start_gmt": "2024-01-08 00:00:00",
+            "date_end": "2024-01-14 23:59:59",
+            "date_end_gmt": "2024-01-14 23:59:59",
+            "subtotals": {
+                "giftcards_count": 1,
+                "used_amount": 20,
+                "refunded_amount": 0,
+                "net_amount": 20
+            }
+        }
+    ]
+}

--- a/Networking/NetworkingTests/Responses/gift-card-stats.json
+++ b/Networking/NetworkingTests/Responses/gift-card-stats.json
@@ -1,0 +1,25 @@
+{
+    "data": {
+        "totals": {
+            "giftcards_count": 1,
+            "used_amount": 20,
+            "refunded_amount": 0,
+            "net_amount": 20
+        },
+        "intervals": [
+            {
+                "interval": "2024-02",
+                "date_start": "2024-01-08 00:00:00",
+                "date_start_gmt": "2024-01-08 00:00:00",
+                "date_end": "2024-01-14 23:59:59",
+                "date_end_gmt": "2024-01-14 23:59:59",
+                "subtotals": {
+                    "giftcards_count": 1,
+                    "used_amount": 20,
+                    "refunded_amount": 0,
+                    "net_amount": 20
+                }
+            }
+        ]
+    }
+}


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of #12163
<!-- Id number of the GitHub issue this PR addresses. -->

## Why
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

This adds mock responses and models to represent the gift card stats fetched from `GET /wc-analytics/reports/giftcards/used/stats`. It's the first step in adding networking support for a Gift Cards analytics card in the Analytics Hub.

## How

- Adds mock responses for gift card stats with and without a data envelope.
- Adds models for git card stats, intervals, and totals.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

These models aren't yet used, so it's sufficient to confirm that the app builds and tests pass in CI.


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
