### PR TITLE
[Woo Express Cleanup] Remove feature flag

### DIFF
--- a/Experiments/Experiments/DefaultFeatureFlagService.swift
+++ b/Experiments/Experiments/DefaultFeatureFlagService.swift
@@ -88,8 +88,6 @@ public struct DefaultFeatureFlagService: FeatureFlagService {
             return true
         case .splitViewInProductsTab:
             return true
-        case .noMoreWooExpressSignup:
-            return buildConfig == .localDeveloper || buildConfig == .alpha
         case .customersInHubMenu:
             return true
         case .expandedAnalyticsHub:

--- a/Experiments/Experiments/FeatureFlag.swift
+++ b/Experiments/Experiments/FeatureFlag.swift
@@ -196,10 +196,6 @@ public enum FeatureFlag: Int {
     ///
     case splitViewInProductsTab
 
-    /// Removes the entry points to account and site creation.
-    ///
-    case noMoreWooExpressSignup
-
     /// Displays a Customers section in the Hub menu.
     ///
     case customersInHubMenu

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -3,6 +3,7 @@
 18.1
 -----
 - [**] Orders: now it's possible to swiftly delete orders right from the Order Detail page.
+- [Internal] WooExpress: Site creation with WooExpress is now disabled. [https://github.com/woocommerce/woocommerce-ios/issues/12323]
 
 
 18.0

--- a/WooCommerce/Classes/Analytics/WooAnalyticsEvent+StoreCreation.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsEvent+StoreCreation.swift
@@ -118,7 +118,7 @@ extension WooAnalyticsEvent {
                               properties: [Key.isFreeTrial: isFreeTrial])
         }
 
-        /// Tracked when the user taps on the "Staring a new store?" button in login prologue (logged out).
+        /// Tracked when the user taps on the "Starting a new store?" button in login prologue (logged out).
         static func loginPrologueStartingANewStoreTapped() -> WooAnalyticsEvent {
             WooAnalyticsEvent(statName: .loginPrologueStartingANewStoreTapped,
                               properties: [:])

--- a/WooCommerce/Classes/Extensions/WordPressAuthenticator+Woo.swift
+++ b/WooCommerce/Classes/Extensions/WordPressAuthenticator+Woo.swift
@@ -8,7 +8,6 @@ extension WordPressAuthenticator {
                                             featureFlagService: FeatureFlagService = ServiceLocator.featureFlagService) {
         let isWPComMagicLinkShownAsSecondaryActionOnPasswordScreen = true
         let isManualErrorHandlingEnabled = featureFlagService.isFeatureFlagEnabled(.manualErrorHandlingForSiteCredentialLogin)
-        let noMoreWooExpressSignup = true
         let configuration = WordPressAuthenticatorConfiguration(wpcomClientId: ApiCredentials.dotcomAppId,
                                                                 wpcomSecret: ApiCredentials.dotcomSecret,
                                                                 wpcomScheme: dotcomAuthScheme,
@@ -30,7 +29,7 @@ extension WordPressAuthenticator {
                                                                 isWPComMagicLinkShownAsSecondaryActionOnPasswordScreen:
                                                                     isWPComMagicLinkShownAsSecondaryActionOnPasswordScreen,
                                                                 enableWPComLoginOnlyInPrologue: false,
-                                                                enableSiteCreation: !noMoreWooExpressSignup,
+                                                                enableSiteCreation: false,
                                                                 enableSocialLogin: true,
                                                                 emphasizeEmailForWPComPassword: true,
                                                                 wpcomPasswordInstructions:
@@ -41,7 +40,7 @@ extension WordPressAuthenticator {
                                                                 enableManualErrorHandlingForSiteCredentialLogin: isManualErrorHandlingEnabled,
                                                                 useEnterEmailAddressAsStepValueForGetStartedVC: true,
                                                                 enableSiteAddressLoginOnlyInPrologue: true,
-                                                                enableSiteCreationGuide: noMoreWooExpressSignup)
+                                                                enableSiteCreationGuide: true)
 
         let systemGray3LightModeColor = UIColor(red: 199/255.0, green: 199/255.0, blue: 204/255.0, alpha: 1)
         let systemLabelLightModeColor = UIColor(red: 0, green: 0, blue: 0, alpha: 1)

--- a/WooCommerce/Classes/Extensions/WordPressAuthenticator+Woo.swift
+++ b/WooCommerce/Classes/Extensions/WordPressAuthenticator+Woo.swift
@@ -8,7 +8,7 @@ extension WordPressAuthenticator {
                                             featureFlagService: FeatureFlagService = ServiceLocator.featureFlagService) {
         let isWPComMagicLinkShownAsSecondaryActionOnPasswordScreen = true
         let isManualErrorHandlingEnabled = featureFlagService.isFeatureFlagEnabled(.manualErrorHandlingForSiteCredentialLogin)
-        let noMoreWooExpressSignup = featureFlagService.isFeatureFlagEnabled(.noMoreWooExpressSignup)
+        let noMoreWooExpressSignup = true
         let configuration = WordPressAuthenticatorConfiguration(wpcomClientId: ApiCredentials.dotcomAppId,
                                                                 wpcomSecret: ApiCredentials.dotcomSecret,
                                                                 wpcomScheme: dotcomAuthScheme,


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #12412 
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

This PR removes the `.noMoreWooExpressSignup` feature flag that was initially added on https://github.com/woocommerce/woocommerce-ios/pull/12328

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

Just ensure the app builds correctly, and that prologue no longer offers store creation.