### PR TITLE
Add event tracking to Plugin List and out of date plugins

### DIFF
--- a/WooCommerce/Classes/Analytics/WooAnalyticsEvent.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsEvent.swift
@@ -3118,8 +3118,9 @@ extension WooAnalyticsEvent {
 // MARK: - Plugin events
 //
 extension WooAnalyticsEvent {
-    static func logOutOfDatePlugins(_ pluginList: [String]) -> WooAnalyticsEvent {
+    static func logOutOfDatePlugins(_ outOfDatePluginCount: Int, _ pluginList: String) -> WooAnalyticsEvent {
         WooAnalyticsEvent(statName: .outOfDatePluginList, properties: [
+            "out_of_date_plugin_count": outOfDatePluginCount,
             "plugins": "\(pluginList)"
         ])
     }

--- a/WooCommerce/Classes/Analytics/WooAnalyticsEvent.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsEvent.swift
@@ -3114,3 +3114,13 @@ extension WooAnalyticsEvent {
         }
     }
 }
+
+// MARK: - Plugin events
+//
+extension WooAnalyticsEvent {
+    static func logOutOfDatePlugins(_ pluginList: [String]) -> WooAnalyticsEvent {
+        WooAnalyticsEvent(statName: .outOfDatePluginList, properties: [
+            "plugins": "\(pluginList)"
+        ])
+    }
+}

--- a/WooCommerce/Classes/Analytics/WooAnalyticsStat.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsStat.swift
@@ -296,6 +296,8 @@ public enum WooAnalyticsStat: String {
     // MARK: Settings Plugin List Events
     //
     case settingsPluginListTapped = "settings_plugin_list_tapped"
+    case outOfDatePluginList = "out_of_date_plugin_list"
+
     // MARK: Settings View Events
     //
     case settingsTapped = "main_menu_settings_tapped"

--- a/WooCommerce/Classes/Analytics/WooAnalyticsStat.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsStat.swift
@@ -293,6 +293,9 @@ public enum WooAnalyticsStat: String {
     case supportSSROpened = "support_ssr_opened"
     case supportSSRCopyButtonTapped = "support_ssr_copy_button_tapped"
 
+    // MARK: Settings Plugin List Events
+    //
+    case settingsPluginListTapped = "settings_plugin_list_tapped"
     // MARK: Settings View Events
     //
     case settingsTapped = "main_menu_settings_tapped"

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Plugins/PluginListViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Plugins/PluginListViewModel.swift
@@ -46,6 +46,8 @@ final class PluginListViewModel {
         self.siteID = siteID
         self.storesManager = storesManager
         self.storageManager = storageManager
+
+        trackOutOfDatePluginsIfAny()
     }
 
     /// Start fetching and observing plugin data from local storage.
@@ -59,5 +61,18 @@ final class PluginListViewModel {
     func syncPlugins(onCompletion: @escaping (Result<Void, Error>) -> Void) {
         let action = SitePluginAction.synchronizeSitePlugins(siteID: siteID, onCompletion: onCompletion)
         storesManager.dispatch(action)
+    }
+}
+
+private extension PluginListViewModel {
+    /// Tracks outdated plugins and their versions, if any
+    ///
+    func trackOutOfDatePluginsIfAny() {
+        let outOfDatePlugins = resultsController.fetchedObjects.filter { $0.version != $0.versionLatest }
+        guard outOfDatePlugins.isNotEmpty else {
+            return
+        }
+        let pluginNamesAndVersions = outOfDatePlugins.map { "\($0.name) - \($0.version)" }
+        ServiceLocator.analytics.track(event: .logOutOfDatePlugins(pluginNamesAndVersions))
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Plugins/PluginListViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Plugins/PluginListViewModel.swift
@@ -72,7 +72,7 @@ private extension PluginListViewModel {
         guard outOfDatePlugins.isNotEmpty else {
             return
         }
-        let pluginNamesAndVersions = outOfDatePlugins.map { "\($0.name) - \($0.version)" }
-        ServiceLocator.analytics.track(event: .logOutOfDatePlugins(pluginNamesAndVersions))
+        let pluginNamesAndVersions = outOfDatePlugins.map { "\($0.name) - \($0.version)" }.joined(separator: ", ")
+        ServiceLocator.analytics.track(event: .logOutOfDatePlugins(outOfDatePlugins.count, pluginNamesAndVersions))
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Settings/SettingsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Settings/SettingsViewController.swift
@@ -367,6 +367,7 @@ private extension SettingsViewController {
     }
 
     func sitePluginsWasPressed() {
+        ServiceLocator.analytics.track(.settingsPluginListTapped)
         guard let siteID = ServiceLocator.stores.sessionManager.defaultStoreID else {
             return DDLogError("⛔️ Cannot find ID for current site to load plugins for!")
         }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #12327

## Description
This PR adds tracking for plugins that are out of date by adding a new event to the `PluginListViewModel`, so is tracked when the Plugin List view is loaded:

<img width=450 src="https://github.com/woocommerce/woocommerce-ios/assets/3812076/22449e68-ee24-461b-b1b4-6cd062411179)" />


## Testing instructions
1. On a site with out of date plugins (https://indiemelon.mystagingwebsite.com/ has outdated plugins if needed)
2. Go to `Menu` > `Settings` > Tap on `Plugins`
3. Observe that the following two events are tracked in the console:
```
🔵 Tracked settings_plugin_list_tapped
🔵 Tracked out_of_date_plugin_list
```
The `out_of_date_plugin_list` event will also contain a list of out of date plugins and their versions:
```
AnyHashable("plugins"): "[\"Code Snippets - 3.6.2\", \"Woo Gift Cards - 1.16.8\", \"Woo Product Bundles - 6.22.7\", \"WooCommerce - 8.7.0-dev\", \"WooCommerce Payments - 5.5.4\", \"WooCommerce Shipping &amp; Tax - 2.3.1\"]",
```