### PR TITLE
[Analytics Hub] Gift Cards: Add mapper and remote endpoint for gift card stats

### DIFF
--- a/Networking/Networking.xcodeproj/project.pbxproj
+++ b/Networking/Networking.xcodeproj/project.pbxproj
@@ -662,6 +662,8 @@
 		CE070A2E2BBC3C3500017578 /* GiftCardStatsTotals.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE070A2D2BBC3C3500017578 /* GiftCardStatsTotals.swift */; };
 		CE070A302BBC527900017578 /* gift-card-stats.json in Resources */ = {isa = PBXBuildFile; fileRef = CE070A2F2BBC527900017578 /* gift-card-stats.json */; };
 		CE070A342BBC52B200017578 /* gift-card-stats-without-data.json in Resources */ = {isa = PBXBuildFile; fileRef = CE070A332BBC52B200017578 /* gift-card-stats-without-data.json */; };
+		CE070A362BBC53D100017578 /* GiftCardStatsMapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE070A352BBC53D100017578 /* GiftCardStatsMapper.swift */; };
+		CE070A382BBC543200017578 /* GiftCardStatsMapperTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE070A372BBC543200017578 /* GiftCardStatsMapperTests.swift */; };
 		CE0A0F13223942D90075ED8D /* ProductImage.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE0A0F12223942D90075ED8D /* ProductImage.swift */; };
 		CE0A0F1522396BF00075ED8D /* ProductAttribute.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE0A0F1422396BF00075ED8D /* ProductAttribute.swift */; };
 		CE0A0F17223970E80075ED8D /* ProductDefaultAttribute.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE0A0F16223970E80075ED8D /* ProductDefaultAttribute.swift */; };
@@ -1750,6 +1752,8 @@
 		CE070A2D2BBC3C3500017578 /* GiftCardStatsTotals.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GiftCardStatsTotals.swift; sourceTree = "<group>"; };
 		CE070A2F2BBC527900017578 /* gift-card-stats.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "gift-card-stats.json"; sourceTree = "<group>"; };
 		CE070A332BBC52B200017578 /* gift-card-stats-without-data.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "gift-card-stats-without-data.json"; sourceTree = "<group>"; };
+		CE070A352BBC53D100017578 /* GiftCardStatsMapper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GiftCardStatsMapper.swift; sourceTree = "<group>"; };
+		CE070A372BBC543200017578 /* GiftCardStatsMapperTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GiftCardStatsMapperTests.swift; sourceTree = "<group>"; };
 		CE0A0F12223942D90075ED8D /* ProductImage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductImage.swift; sourceTree = "<group>"; };
 		CE0A0F1422396BF00075ED8D /* ProductAttribute.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductAttribute.swift; sourceTree = "<group>"; };
 		CE0A0F16223970E80075ED8D /* ProductDefaultAttribute.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ProductDefaultAttribute.swift; sourceTree = "<group>"; };
@@ -3180,6 +3184,7 @@
 				B524193E21AC5FE400D6FC0A /* DotcomDeviceMapper.swift */,
 				CE865A9C2A41E1480049B03C /* EntityDateModifiedMapper.swift */,
 				2676F4CD290AE6BB00C7A15B /* EntityIDMapper.swift */,
+				CE070A352BBC53D100017578 /* GiftCardStatsMapper.swift */,
 				DE50295C28C6068B00551736 /* JetpackUserMapper.swift */,
 				AEF9458A27297FF6001DCCFB /* IgnoringResponseMapper.swift */,
 				E18152BF28F85D4A0011A0EC /* InAppPurchasesProductMapper.swift */,
@@ -3369,6 +3374,7 @@
 				45150A9F26837357006922EA /* CountryListMapperTests.swift */,
 				B524194221AC622500D6FC0A /* DotcomDeviceMapperTests.swift */,
 				CE865AA42A4209A70049B03C /* EntityDateModifiedMapperTests.swift */,
+				CE070A372BBC543200017578 /* GiftCardStatsMapperTests.swift */,
 				AED8AEBB272A997500663FCC /* IgnoringResponseMapperTests.swift */,
 				E18152C328F85E5C0011A0EC /* InAppPurchasesProductsMapperTests.swift */,
 				E1A5C27128F93ED900081046 /* InAppPurchaseOrderResultMapperTests.swift */,
@@ -4360,6 +4366,7 @@
 				457453E725A72C9700276508 /* CreateProductVariation.swift in Sources */,
 				45E461BC26837CC500011BF2 /* DataRemote.swift in Sources */,
 				B505F6EA20BEFC3700BB1B69 /* MockNetwork.swift in Sources */,
+				CE070A362BBC53D100017578 /* GiftCardStatsMapper.swift in Sources */,
 				CC9A24A32641BCF2005DE56E /* ShippingLabelCreationEligibilityResponse.swift in Sources */,
 				CE0A0F17223970E80075ED8D /* ProductDefaultAttribute.swift in Sources */,
 				EE1CB90E2B4BC99E00AD24D5 /* BlazeAISuggestion.swift in Sources */,
@@ -4721,6 +4728,7 @@
 				02BDB83723EA9C4D00BCC63E /* String+HTMLTests.swift in Sources */,
 				74CF5E8421402C04000CED0A /* TopEarnerStatsRemoteTests.swift in Sources */,
 				45B204BA24890A8C00FE6526 /* ProductCategoryMapperTests.swift in Sources */,
+				CE070A382BBC543200017578 /* GiftCardStatsMapperTests.swift in Sources */,
 				EE8DE432294B17CD005054E7 /* DefaultApplicationPasswordUseCaseTests.swift in Sources */,
 				74749B9522413119005C4CF2 /* ProductsRemoteTests.swift in Sources */,
 				B524194321AC622500D6FC0A /* DotcomDeviceMapperTests.swift in Sources */,

--- a/Networking/Networking.xcodeproj/project.pbxproj
+++ b/Networking/Networking.xcodeproj/project.pbxproj
@@ -664,6 +664,8 @@
 		CE070A342BBC52B200017578 /* gift-card-stats-without-data.json in Resources */ = {isa = PBXBuildFile; fileRef = CE070A332BBC52B200017578 /* gift-card-stats-without-data.json */; };
 		CE070A362BBC53D100017578 /* GiftCardStatsMapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE070A352BBC53D100017578 /* GiftCardStatsMapper.swift */; };
 		CE070A382BBC543200017578 /* GiftCardStatsMapperTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE070A372BBC543200017578 /* GiftCardStatsMapperTests.swift */; };
+		CE070A3A2BBC56CC00017578 /* GiftCardStatsRemote.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE070A392BBC56CC00017578 /* GiftCardStatsRemote.swift */; };
+		CE070A3C2BBC577700017578 /* GiftCardStatsRemoteTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE070A3B2BBC577700017578 /* GiftCardStatsRemoteTests.swift */; };
 		CE0A0F13223942D90075ED8D /* ProductImage.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE0A0F12223942D90075ED8D /* ProductImage.swift */; };
 		CE0A0F1522396BF00075ED8D /* ProductAttribute.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE0A0F1422396BF00075ED8D /* ProductAttribute.swift */; };
 		CE0A0F17223970E80075ED8D /* ProductDefaultAttribute.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE0A0F16223970E80075ED8D /* ProductDefaultAttribute.swift */; };
@@ -1754,6 +1756,8 @@
 		CE070A332BBC52B200017578 /* gift-card-stats-without-data.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "gift-card-stats-without-data.json"; sourceTree = "<group>"; };
 		CE070A352BBC53D100017578 /* GiftCardStatsMapper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GiftCardStatsMapper.swift; sourceTree = "<group>"; };
 		CE070A372BBC543200017578 /* GiftCardStatsMapperTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GiftCardStatsMapperTests.swift; sourceTree = "<group>"; };
+		CE070A392BBC56CC00017578 /* GiftCardStatsRemote.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GiftCardStatsRemote.swift; sourceTree = "<group>"; };
+		CE070A3B2BBC577700017578 /* GiftCardStatsRemoteTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GiftCardStatsRemoteTests.swift; sourceTree = "<group>"; };
 		CE0A0F12223942D90075ED8D /* ProductImage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductImage.swift; sourceTree = "<group>"; };
 		CE0A0F1422396BF00075ED8D /* ProductAttribute.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductAttribute.swift; sourceTree = "<group>"; };
 		CE0A0F16223970E80075ED8D /* ProductDefaultAttribute.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ProductDefaultAttribute.swift; sourceTree = "<group>"; };
@@ -2390,6 +2394,7 @@
 				45E461BD26837DB900011BF2 /* DataRemoteTests.swift */,
 				B524194821AC659500D6FC0A /* DevicesRemoteTests.swift */,
 				24F98C5F2502EF8200F49B68 /* FeatureFlagRemoteTests.swift */,
+				CE070A3B2BBC577700017578 /* GiftCardStatsRemoteTests.swift */,
 				4513382127A8409000AE5E78 /* InboxNotesRemoteTests.swift */,
 				E13BAD5228F8625600217769 /* InAppPurchasesRemoteTests.swift */,
 				263659DD2A2694A000607A0D /* IPLocationRemoteTests.swift */,
@@ -2549,6 +2554,7 @@
 				45E461BB26837CC500011BF2 /* DataRemote.swift */,
 				B572F69921AC475C003EEFF0 /* DevicesRemote.swift */,
 				24F98C512502E79800F49B68 /* FeatureFlagRemote.swift */,
+				CE070A392BBC56CC00017578 /* GiftCardStatsRemote.swift */,
 				E18152BD28F85B5B0011A0EC /* InAppPurchasesRemote.swift */,
 				4513381F27A8227F00AE5E78 /* InboxNotesRemote.swift */,
 				263659DB2A264A3E00607A0D /* IPLocationRemote.swift */,
@@ -4557,6 +4563,7 @@
 				45CCFCE227A2C9BF0012E8CB /* InboxNote.swift in Sources */,
 				311D412C2783BF7400052F64 /* StripeAccount.swift in Sources */,
 				B518662420A099BF00037A38 /* AlamofireNetwork.swift in Sources */,
+				CE070A3A2BBC56CC00017578 /* GiftCardStatsRemote.swift in Sources */,
 				311D412E2783C07D00052F64 /* StripeAccountMapper.swift in Sources */,
 				DE78DE482B2AEBEC002E58DE /* WordPressPageMapper.swift in Sources */,
 				CE430676234BA7920073CBFF /* RefundListMapper.swift in Sources */,
@@ -4741,6 +4748,7 @@
 				EE8C202D2B47886500FE967B /* CreateBlazeCampaignMapperTests.swift in Sources */,
 				CE6D666F2379E82A007835A1 /* ArrayWooTests.swift in Sources */,
 				DE2E8EAD295418D8002E4B14 /* WordPressSiteRemoteTests.swift in Sources */,
+				CE070A3C2BBC577700017578 /* GiftCardStatsRemoteTests.swift in Sources */,
 				45D685FC23D0C739005F87D0 /* ProductSkuMapperTests.swift in Sources */,
 				CEC4BF95234E7F34008D9195 /* RefundListMapperTests.swift in Sources */,
 				74A7B4BC217A807400E85A8B /* SiteSettingsMapperTests.swift in Sources */,

--- a/Networking/Networking/Mapper/GiftCardStatsMapper.swift
+++ b/Networking/Networking/Mapper/GiftCardStatsMapper.swift
@@ -1,0 +1,47 @@
+import Foundation
+
+
+/// Mapper: GiftCardStats
+///
+struct GiftCardStatsMapper: Mapper {
+    /// Site Identifier associated to the stats that will be parsed.
+    /// We're injecting this field via `JSONDecoder.userInfo` because the remote endpoints don't
+    /// really return the siteID for the stats v4 endpoint
+    ///
+    let siteID: Int64
+
+    /// Granularity associated to the stats that will be parsed.
+    /// We're injecting this field via `JSONDecoder.userInfo` because the remote endpoints don't
+    /// really return the granularity for the stats v4 endpoint
+    ///
+    let granularity: StatsGranularityV4
+
+    /// (Attempts) to convert a dictionary into a StatsReport entity.
+    ///
+    func map(response: Data) throws -> GiftCardStats {
+        let decoder = JSONDecoder()
+        decoder.userInfo = [
+            .siteID: siteID,
+            .granularity: granularity
+        ]
+        if hasDataEnvelope(in: response) {
+            return try decoder.decode(GiftCardStatsEnvelope.self, from: response).giftCardStats
+        } else {
+            return try decoder.decode(GiftCardStats.self, from: response)
+        }
+    }
+}
+
+
+/// GiftCardStatsEnvelope Disposable Entity
+///
+/// Stats endpoint returns the requested stats in the `data` key. This entity
+/// allows us to parse all the things with JSONDecoder.
+///
+private struct GiftCardStatsEnvelope: Decodable {
+    let giftCardStats: GiftCardStats
+
+    private enum CodingKeys: String, CodingKey {
+        case giftCardStats = "data"
+    }
+}

--- a/Networking/Networking/Remote/GiftCardStatsRemote.swift
+++ b/Networking/Networking/Remote/GiftCardStatsRemote.swift
@@ -1,0 +1,68 @@
+import Foundation
+
+/// Gift Card Stats: Remote Endpoints for fetching gift card stats.
+///
+public final class GiftCardStatsRemote: Remote {
+
+    /// Fetch the used gift card stats for a given site, depending on the given granularity of the `unit` parameter.
+    ///
+    /// - Parameters:
+    ///   - siteID: The site ID.
+    ///   - unit: Defines the granularity of the stats we are fetching (one of 'hourly', 'daily', 'weekly', 'monthly', or 'yearly').
+    ///   - timeZone: The time zone to set the earliest/latest date strings in the API request.
+    ///   - earliestDateToInclude: The earliest date to include in the results.
+    ///   - latestDateToInclude: The latest date to include in the results.
+    ///   - quantity: The number of intervals to fetch.
+    ///   - forceRefresh: Whether to enforce the data being refreshed.
+    ///   - completion: Closure to be executed upon completion.
+    ///
+    public func loadUsedGiftCardStats(for siteID: Int64,
+                                      unit: StatsGranularityV4,
+                                      timeZone: TimeZone,
+                                      earliestDateToInclude: Date,
+                                      latestDateToInclude: Date,
+                                      quantity: Int,
+                                      forceRefresh: Bool) async throws -> GiftCardStats {
+        let dateFormatter = DateFormatter.Defaults.iso8601WithoutTimeZone
+        dateFormatter.timeZone = timeZone
+
+        var parameters: [String: Any] = [
+            ParameterKeys.interval: unit.rawValue,
+            ParameterKeys.after: dateFormatter.string(from: earliestDateToInclude),
+            ParameterKeys.before: dateFormatter.string(from: latestDateToInclude),
+            ParameterKeys.quantity: String(quantity)
+        ]
+
+        if forceRefresh {
+            // includes this parameter only if it's true, otherwise the request fails
+            parameters[ParameterKeys.forceRefresh] = forceRefresh
+        }
+
+        let request = JetpackRequest(wooApiVersion: .wcAnalytics,
+                                     method: .get,
+                                     siteID: siteID,
+                                     path: Constants.giftCardsStatsPath,
+                                     parameters: parameters,
+                                     availableAsRESTRequest: true)
+        let mapper = GiftCardStatsMapper(siteID: siteID, granularity: unit)
+
+        return try await enqueue(request, mapper: mapper)
+    }
+}
+
+
+// MARK: - Constants!
+//
+private extension GiftCardStatsRemote {
+    enum Constants {
+        static let giftCardsStatsPath: String = "reports/giftcards/used/stats"
+    }
+
+    enum ParameterKeys {
+        static let interval     = "interval"
+        static let after        = "after"
+        static let before       = "before"
+        static let quantity     = "per_page"
+        static let forceRefresh = "force_cache_refresh"
+    }
+}

--- a/Networking/NetworkingTests/Mapper/GiftCardStatsMapperTests.swift
+++ b/Networking/NetworkingTests/Mapper/GiftCardStatsMapperTests.swift
@@ -1,0 +1,86 @@
+import XCTest
+@testable import Networking
+
+
+/// GiftCardStatsMapper Unit Tests
+///
+final class GiftCardStatsMapperTests: XCTestCase {
+    private struct Constants {
+        static let siteID: Int64 = 1234
+    }
+
+    /// Verifies that all of the GiftCardStatsTotals fields are parsed correctly.
+    ///
+    func test_gift_card_stat_fields_are_properly_parsed() throws {
+        // Given
+        let granularity = StatsGranularityV4.daily
+
+        // When
+        guard let giftCardStats = mapStatItems(from: "gift-card-stats", granularity: granularity) else {
+            XCTFail()
+            return
+        }
+
+        // Then
+        XCTAssertEqual(giftCardStats.siteID, Constants.siteID)
+        XCTAssertEqual(giftCardStats.granularity, granularity)
+
+        // Stats report totals are parsed
+        XCTAssertEqual(giftCardStats.totals.giftCardsCount, 1)
+        XCTAssertEqual(giftCardStats.totals.usedAmount, 20)
+        XCTAssertEqual(giftCardStats.totals.refundedAmount, 0)
+        XCTAssertEqual(giftCardStats.totals.netAmount, 20)
+
+        // Starts report intervals are parsed
+        XCTAssertEqual(giftCardStats.intervals.count, 1)
+        let firstInterval = try XCTUnwrap(giftCardStats.intervals.first)
+        XCTAssertEqual(firstInterval.subtotals.giftCardsCount, 1)
+        XCTAssertEqual(firstInterval.subtotals.usedAmount, 20)
+        XCTAssertEqual(firstInterval.subtotals.refundedAmount, 0)
+        XCTAssertEqual(firstInterval.subtotals.netAmount, 20)
+    }
+
+    /// Verifies that all of the GiftCardStatsTotals fields are parsed correctly.
+    ///
+    func test_gift_card_stat_fields_are_properly_parsed_without_data_envelope() throws {
+        // Given
+        let granularity = StatsGranularityV4.daily
+
+        // When
+        guard let giftCardStats = mapStatItems(from: "gift-card-stats-without-data", granularity: granularity) else {
+            XCTFail()
+            return
+        }
+
+        // Then
+        XCTAssertEqual(giftCardStats.siteID, Constants.siteID)
+        XCTAssertEqual(giftCardStats.granularity, granularity)
+
+        // Stats report totals are parsed
+        XCTAssertEqual(giftCardStats.totals.giftCardsCount, 1)
+        XCTAssertEqual(giftCardStats.totals.usedAmount, 20)
+        XCTAssertEqual(giftCardStats.totals.refundedAmount, 0)
+        XCTAssertEqual(giftCardStats.totals.netAmount, 20)
+
+        // Starts report intervals are parsed
+        XCTAssertEqual(giftCardStats.intervals.count, 1)
+        let firstInterval = try XCTUnwrap(giftCardStats.intervals.first)
+        XCTAssertEqual(firstInterval.subtotals.giftCardsCount, 1)
+        XCTAssertEqual(firstInterval.subtotals.usedAmount, 20)
+        XCTAssertEqual(firstInterval.subtotals.refundedAmount, 0)
+        XCTAssertEqual(firstInterval.subtotals.netAmount, 20)
+    }
+}
+
+private extension GiftCardStatsMapperTests {
+    /// Returns the GiftCardStatsMapper output upon receiving `filename` (Data Encoded)
+    ///
+    func mapStatItems(from filename: String, granularity: StatsGranularityV4) -> GiftCardStats? {
+        guard let response = Loader.contentsOf(filename) else {
+            return nil
+        }
+
+        return try! GiftCardStatsMapper(siteID: Constants.siteID,
+                                        granularity: granularity).map(response: response)
+    }
+}

--- a/Networking/NetworkingTests/Remote/GiftCardStatsRemoteTests.swift
+++ b/Networking/NetworkingTests/Remote/GiftCardStatsRemoteTests.swift
@@ -1,0 +1,64 @@
+import XCTest
+import TestKit
+@testable import Networking
+
+
+/// GiftCardStatsRemote Unit Tests
+///
+class GiftCardStatsRemoteTests: XCTestCase {
+
+    /// Dummy Network Wrapper
+    ///
+    let network = MockNetwork()
+
+    /// Dummy Site ID
+    ///
+    let sampleSiteID: Int64 = 1234
+
+    /// Repeat always!
+    ///
+    override func setUp() {
+        network.removeAllSimulatedResponses()
+    }
+
+
+    /// Verifies that loadUsedGiftCardStats properly parses the `GiftCardStats` sample response.
+    ///
+    func test_loadUsedGiftCardStats_properly_returns_parsed_stats() async throws {
+        // Given
+        let remote = GiftCardStatsRemote(network: network)
+        network.simulateResponse(requestUrlSuffix: "reports/giftcards/used/stats", filename: "gift-card-stats")
+
+        // When
+        let giftCardStats = try await remote.loadUsedGiftCardStats(for: self.sampleSiteID,
+                                                                   unit: .daily,
+                                                                   timeZone: .gmt,
+                                                                   earliestDateToInclude: Date(),
+                                                                   latestDateToInclude: Date(),
+                                                                   quantity: 2,
+                                                                   forceRefresh: false)
+
+        // Then
+        XCTAssertEqual(giftCardStats.intervals.count, 1)
+    }
+
+    /// Verifies that loadUsedGiftCardStats properly relays Networking Layer errors.
+    ///
+    func test_loadUsedGiftCardStats_properly_relays_networking_errors() async {
+        // Given
+        let remote = GiftCardStatsRemote(network: network)
+        let expectedError = NetworkError.unacceptableStatusCode(statusCode: 403)
+        network.simulateError(requestUrlSuffix: "reports/giftcards/used/stats", error: expectedError)
+
+        // When & Then
+        await assertThrowsError({
+            _ = try await remote.loadUsedGiftCardStats(for: self.sampleSiteID,
+                                                       unit: .daily,
+                                                       timeZone: .gmt,
+                                                       earliestDateToInclude: Date(),
+                                                       latestDateToInclude: Date(),
+                                                       quantity: 2,
+                                                       forceRefresh: false)
+        }, errorAssert: { ($0 as? NetworkError) == expectedError })
+    }
+}


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #12163
<!-- Id number of the GitHub issue this PR addresses. -->

## Why
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This adds support for fetching gift card stats from remote.

## How

* Adds a mapper for `GiftCardStats`.
* Adds `GiftCardStatsRemote` with a method to fetch and parse `GiftCardStats`.
* Adds unit tests for the mapper and remote method.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
This endpoint isn't used in the app yet, so confirm tests pass in CI.


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
