### PR TITLE
[Analytics Hub] Gift Cards: Add Yosemite support for fetching gift card stats

### DIFF
--- a/Yosemite/Yosemite/Actions/StatsActionV4.swift
+++ b/Yosemite/Yosemite/Actions/StatsActionV4.swift
@@ -82,4 +82,15 @@ public enum StatsActionV4: Action {
                                    latestDateToInclude: Date,
                                    quantity: Int,
                                    onCompletion: (Result<[ProductsReportItem], Error>) -> Void)
+
+    /// Retrieves the used gift card stats for the provided site ID and time range, without saving them to the Storage layer.
+    ///
+    case retrieveUsedGiftCardStats(siteID: Int64,
+                                   unit: StatsGranularityV4,
+                                   timeZone: TimeZone,
+                                   earliestDateToInclude: Date,
+                                   latestDateToInclude: Date,
+                                   quantity: Int,
+                                   forceRefresh: Bool,
+                                   onCompletion: (Result<GiftCardStats, Error>) -> Void)
 }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #12408
<!-- Id number of the GitHub issue this PR addresses. -->

## Why
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This adds Yosemite support for fetching gift card stats for display in the Analytics Hub. Like other actions for the Analytics Hub, it returns the results directly without storing them.

## How

1. Adds a new action to `StatsActionV4` and `StatsStoreV4` (added to this store because they are stats and are similar both in how they are used and how the requests/responses are formatted, even though they use different remote endpoints).
2. Adds unit tests.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
These actions aren't used in the app yet, so confirm tests pass in CI.


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
