### PR TITLE
[Shipping Labels] Avoid crash when accessing NSManagedObject from a background thread

### DIFF
--- a/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsViewModel.swift
+++ b/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsViewModel.swift
@@ -704,6 +704,7 @@ extension OrderDetailsViewModel {
         }
     }
 
+    @MainActor
     func localRequirementsForShippingLabelsAreFulfilled() async -> Bool {
         guard !orderContainsOnlyVirtualProducts else {
             return false


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
With this PR we fix a crash we have when accessing `NSManagedObject` from a background thread. This was added on https://github.com/woocommerce/woocommerce-ios/pull/12345, where we extracted some functionality to its own method without adding the `@MainActor` attribute. That's added with the current PR.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

- Log in if needed
- Go to the orders tab
- Filter the order list so that some orders (e.g. refunded) with at least one product with a category show up (I’m not sure if the filtering is required but from my time-boxed testing it was)
- Tap on order with at least one product with a category -> **Before** app crashes (if it doesn’t, try relaunching the app and repeat. Sometimes it takes a few tries but I was able to get the crash on every simulator and device eventually) **Now** It doesn't crash

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

https://github.com/woocommerce/woocommerce-ios/assets/1864060/ac9844f3-af2d-40b3-a7ed-f3620b3bd4b5





---
- [X] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
