### PR TITLE
[Analytics Hub] Add generic methods for parsing different kinds of stats data

### DIFF
--- a/Networking/Networking.xcodeproj/project.pbxproj
+++ b/Networking/Networking.xcodeproj/project.pbxproj
@@ -666,6 +666,7 @@
 		CE070A382BBC543200017578 /* GiftCardStatsMapperTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE070A372BBC543200017578 /* GiftCardStatsMapperTests.swift */; };
 		CE070A3A2BBC56CC00017578 /* GiftCardStatsRemote.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE070A392BBC56CC00017578 /* GiftCardStatsRemote.swift */; };
 		CE070A3C2BBC577700017578 /* GiftCardStatsRemoteTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE070A3B2BBC577700017578 /* GiftCardStatsRemoteTests.swift */; };
+		CE070A402BBD6E8E00017578 /* WCAnalyticsStats.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE070A3F2BBD6E8E00017578 /* WCAnalyticsStats.swift */; };
 		CE0A0F13223942D90075ED8D /* ProductImage.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE0A0F12223942D90075ED8D /* ProductImage.swift */; };
 		CE0A0F1522396BF00075ED8D /* ProductAttribute.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE0A0F1422396BF00075ED8D /* ProductAttribute.swift */; };
 		CE0A0F17223970E80075ED8D /* ProductDefaultAttribute.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE0A0F16223970E80075ED8D /* ProductDefaultAttribute.swift */; };
@@ -1758,6 +1759,7 @@
 		CE070A372BBC543200017578 /* GiftCardStatsMapperTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GiftCardStatsMapperTests.swift; sourceTree = "<group>"; };
 		CE070A392BBC56CC00017578 /* GiftCardStatsRemote.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GiftCardStatsRemote.swift; sourceTree = "<group>"; };
 		CE070A3B2BBC577700017578 /* GiftCardStatsRemoteTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GiftCardStatsRemoteTests.swift; sourceTree = "<group>"; };
+		CE070A3F2BBD6E8E00017578 /* WCAnalyticsStats.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WCAnalyticsStats.swift; sourceTree = "<group>"; };
 		CE0A0F12223942D90075ED8D /* ProductImage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductImage.swift; sourceTree = "<group>"; };
 		CE0A0F1422396BF00075ED8D /* ProductAttribute.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductAttribute.swift; sourceTree = "<group>"; };
 		CE0A0F16223970E80075ED8D /* ProductDefaultAttribute.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ProductDefaultAttribute.swift; sourceTree = "<group>"; };
@@ -2332,6 +2334,7 @@
 				74ABA1CC213F1B6B00FFAD30 /* TopEarnerStats.swift */,
 				74ABA1CE213F1D1600FFAD30 /* TopEarnerStatsItem.swift */,
 				D8FBFF0C22D3AF4A006E3336 /* StatsGranularityV4.swift */,
+				CE070A3F2BBD6E8E00017578 /* WCAnalyticsStats.swift */,
 				D8FBFF1922D4DF7A006E3336 /* OrderStatsV4.swift */,
 				D8FBFF1F22D52553006E3336 /* OrderStatsV4Totals.swift */,
 				D8FBFF2122D5266E006E3336 /* OrderStatsV4Interval.swift */,
@@ -4469,6 +4472,7 @@
 				CE1BE7062A2A5E9A00C6B53B /* IdentifiableObject.swift in Sources */,
 				74A1D26F21189EA100931DFA /* SiteStatsRemote.swift in Sources */,
 				029BA4F4255D72EC006171FD /* ShippingLabelPrintData.swift in Sources */,
+				CE070A402BBD6E8E00017578 /* WCAnalyticsStats.swift in Sources */,
 				02AF07EA27492DBC00B2D81E /* WordPressMedia.swift in Sources */,
 				B557DA1D20979E7D005962F4 /* Order.swift in Sources */,
 				68F48B0928E3AF750045C15B /* WCAnalyticsCustomer.swift in Sources */,

--- a/Networking/Networking/Model/Stats/GiftCardStats.swift
+++ b/Networking/Networking/Model/Stats/GiftCardStats.swift
@@ -2,7 +2,7 @@ import Foundation
 import Codegen
 
 /// Represents gift card stats over a specific period.
-public struct GiftCardStats: Decodable, Equatable, GeneratedCopiable, GeneratedFakeable {
+public struct GiftCardStats: Decodable, Equatable, GeneratedCopiable, GeneratedFakeable, WCAnalyticsStats {
     public let siteID: Int64
     public let granularity: StatsGranularityV4
     public let totals: GiftCardStatsTotals

--- a/Networking/Networking/Model/Stats/GiftCardStatsInterval.swift
+++ b/Networking/Networking/Model/Stats/GiftCardStatsInterval.swift
@@ -1,7 +1,7 @@
 import Codegen
 
 /// Represents gift card stats for a specific period.
-public struct GiftCardStatsInterval: Decodable, Equatable, GeneratedCopiable, GeneratedFakeable {
+public struct GiftCardStatsInterval: Decodable, Equatable, GeneratedCopiable, GeneratedFakeable, WCAnalyticsStatsInterval {
     public let interval: String
     /// Interval start date string in the site time zone.
     public let dateStart: String

--- a/Networking/Networking/Model/Stats/GiftCardStatsTotals.swift
+++ b/Networking/Networking/Model/Stats/GiftCardStatsTotals.swift
@@ -1,7 +1,7 @@
 import Codegen
 
 /// Represents the data associated with gift card stats over a specific period.
-public struct GiftCardStatsTotals: Decodable, Equatable, GeneratedCopiable, GeneratedFakeable {
+public struct GiftCardStatsTotals: Decodable, Equatable, GeneratedCopiable, GeneratedFakeable, WCAnalyticsStatsTotals {
     /// Number of Gift Cards
     public let giftCardsCount: Int
 

--- a/Networking/Networking/Model/Stats/GiftCardStatsTotals.swift
+++ b/Networking/Networking/Model/Stats/GiftCardStatsTotals.swift
@@ -1,7 +1,7 @@
 import Codegen
 
 /// Represents the data associated with gift card stats over a specific period.
-public struct GiftCardStatsTotals: Decodable, Equatable, GeneratedCopiable, GeneratedFakeable, WCAnalyticsStatsTotals {
+public struct GiftCardStatsTotals: Decodable, Equatable, GeneratedCopiable, GeneratedFakeable {
     /// Number of Gift Cards
     public let giftCardsCount: Int
 
@@ -35,6 +35,29 @@ public struct GiftCardStatsTotals: Decodable, Equatable, GeneratedCopiable, Gene
                   usedAmount: usedAmount,
                   refundedAmount: refundedAmount,
                   netAmount: netAmount)
+    }
+}
+
+extension GiftCardStatsTotals: WCAnalyticsStatsTotals {
+    /// Represents a type of gift cards total data
+    public enum TotalData: Double {
+        case giftCardsCount
+        case usedAmount
+        case refundedAmount
+        case netAmount
+    }
+
+    public func getDoubleValue(for data: TotalData) -> Double {
+        switch data {
+        case .giftCardsCount:
+            return Double(giftCardsCount)
+        case .usedAmount:
+            return (usedAmount as NSNumber).doubleValue
+        case .refundedAmount:
+            return (refundedAmount as NSNumber).doubleValue
+        case .netAmount:
+            return (netAmount as NSNumber).doubleValue
+        }
     }
 }
 

--- a/Networking/Networking/Model/Stats/OrderStatsV4.swift
+++ b/Networking/Networking/Model/Stats/OrderStatsV4.swift
@@ -3,7 +3,7 @@ import Codegen
 
 /// Represents order stats over a specific period.
 /// v4 API
-public struct OrderStatsV4: Decodable, Equatable, GeneratedCopiable, GeneratedFakeable {
+public struct OrderStatsV4: Decodable, Equatable, GeneratedCopiable, GeneratedFakeable, WCAnalyticsStats {
     public let siteID: Int64
     public let granularity: StatsGranularityV4
     public let totals: OrderStatsV4Totals

--- a/Networking/Networking/Model/Stats/OrderStatsV4Interval.swift
+++ b/Networking/Networking/Model/Stats/OrderStatsV4Interval.swift
@@ -2,7 +2,7 @@ import Codegen
 
 /// Represents a single order stat for a specific period.
 /// v4 API
-public struct OrderStatsV4Interval: Decodable, Equatable, GeneratedCopiable, GeneratedFakeable {
+public struct OrderStatsV4Interval: Decodable, Equatable, GeneratedCopiable, GeneratedFakeable, WCAnalyticsStatsInterval {
     public let interval: String
     /// Interval start date string in the site time zone.
     public let dateStart: String

--- a/Networking/Networking/Model/Stats/OrderStatsV4Totals.swift
+++ b/Networking/Networking/Model/Stats/OrderStatsV4Totals.swift
@@ -2,7 +2,7 @@ import Codegen
 
 /// Represents the data associated with order stats over a specific period.
 /// v4
-public struct OrderStatsV4Totals: Decodable, Equatable, GeneratedCopiable, GeneratedFakeable, WCAnalyticsStatsTotals {
+public struct OrderStatsV4Totals: Decodable, Equatable, GeneratedCopiable, GeneratedFakeable {
     public let totalOrders: Int
     public let totalItemsSold: Int
     public let grossRevenue: Decimal
@@ -34,6 +34,32 @@ public struct OrderStatsV4Totals: Decodable, Equatable, GeneratedCopiable, Gener
                   grossRevenue: grossRevenue,
                   netRevenue: netRevenue,
                   averageOrderValue: averageOrderValue)
+    }
+}
+
+extension OrderStatsV4Totals: WCAnalyticsStatsTotals {
+    /// Represents a type of orders total data
+    public enum TotalData: String {
+        case totalOrders
+        case totalItemsSold
+        case grossRevenue
+        case netRevenue
+        case averageOrderValue
+    }
+
+    public func getDoubleValue(for data: TotalData) -> Double {
+        switch data {
+        case .totalOrders:
+            return Double(totalOrders)
+        case .totalItemsSold:
+            return Double(totalItemsSold)
+        case .grossRevenue:
+            return (grossRevenue as NSNumber).doubleValue
+        case .netRevenue:
+            return (netRevenue as NSNumber).doubleValue
+        case .averageOrderValue:
+            return (averageOrderValue as NSNumber).doubleValue
+        }
     }
 }
 

--- a/Networking/Networking/Model/Stats/OrderStatsV4Totals.swift
+++ b/Networking/Networking/Model/Stats/OrderStatsV4Totals.swift
@@ -2,7 +2,7 @@ import Codegen
 
 /// Represents the data associated with order stats over a specific period.
 /// v4
-public struct OrderStatsV4Totals: Decodable, Equatable, GeneratedCopiable, GeneratedFakeable {
+public struct OrderStatsV4Totals: Decodable, Equatable, GeneratedCopiable, GeneratedFakeable, WCAnalyticsStatsTotals {
     public let totalOrders: Int
     public let totalItemsSold: Int
     public let grossRevenue: Decimal

--- a/Networking/Networking/Model/Stats/ProductBundleStats.swift
+++ b/Networking/Networking/Model/Stats/ProductBundleStats.swift
@@ -2,7 +2,7 @@ import Foundation
 import Codegen
 
 /// Represents product bundle stats over a specific period.
-public struct ProductBundleStats: Decodable, Equatable, GeneratedCopiable, GeneratedFakeable {
+public struct ProductBundleStats: Decodable, Equatable, GeneratedCopiable, GeneratedFakeable, WCAnalyticsStats {
     public let siteID: Int64
     public let granularity: StatsGranularityV4
     public let totals: ProductBundleStatsTotals

--- a/Networking/Networking/Model/Stats/ProductBundleStatsInterval.swift
+++ b/Networking/Networking/Model/Stats/ProductBundleStatsInterval.swift
@@ -1,7 +1,7 @@
 import Codegen
 
 /// Represents product bundle stats for a specific period.
-public struct ProductBundleStatsInterval: Decodable, Equatable, GeneratedCopiable, GeneratedFakeable {
+public struct ProductBundleStatsInterval: Decodable, Equatable, GeneratedCopiable, GeneratedFakeable, WCAnalyticsStatsInterval {
     public let interval: String
     /// Interval start date string in the site time zone.
     public let dateStart: String

--- a/Networking/Networking/Model/Stats/ProductBundleStatsTotals.swift
+++ b/Networking/Networking/Model/Stats/ProductBundleStatsTotals.swift
@@ -1,7 +1,7 @@
 import Codegen
 
 /// Represents the data associated with product bundle stats over a specific period.
-public struct ProductBundleStatsTotals: Decodable, Equatable, GeneratedCopiable, GeneratedFakeable {
+public struct ProductBundleStatsTotals: Decodable, Equatable, GeneratedCopiable, GeneratedFakeable, WCAnalyticsStatsTotals {
     public let totalItemsSold: Int
     public let totalBundledItemsSold: Int
     public let netRevenue: Decimal

--- a/Networking/Networking/Model/Stats/ProductBundleStatsTotals.swift
+++ b/Networking/Networking/Model/Stats/ProductBundleStatsTotals.swift
@@ -1,7 +1,7 @@
 import Codegen
 
 /// Represents the data associated with product bundle stats over a specific period.
-public struct ProductBundleStatsTotals: Decodable, Equatable, GeneratedCopiable, GeneratedFakeable, WCAnalyticsStatsTotals {
+public struct ProductBundleStatsTotals: Decodable, Equatable, GeneratedCopiable, GeneratedFakeable {
     public let totalItemsSold: Int
     public let totalBundledItemsSold: Int
     public let netRevenue: Decimal
@@ -33,6 +33,32 @@ public struct ProductBundleStatsTotals: Decodable, Equatable, GeneratedCopiable,
                   netRevenue: netRevenue,
                   totalOrders: totalOrders,
                   totalProducts: productsCount)
+    }
+}
+
+extension ProductBundleStatsTotals: WCAnalyticsStatsTotals {
+    /// Represents a type of product bundles total data
+    public enum TotalData: String {
+        case totalItemsSold
+        case totalBundledItemsSold
+        case netRevenue
+        case totalOrders
+        case totalProducts
+    }
+
+    public func getDoubleValue(for data: TotalData) -> Double {
+        switch data {
+        case .totalItemsSold:
+            return Double(totalItemsSold)
+        case .totalBundledItemsSold:
+            return Double(totalBundledItemsSold)
+        case .netRevenue:
+            return (netRevenue as NSNumber).doubleValue
+        case .totalOrders:
+            return Double(totalOrders)
+        case .totalProducts:
+            return Double(totalProducts)
+        }
     }
 }
 

--- a/Networking/Networking/Model/Stats/WCAnalyticsStats.swift
+++ b/Networking/Networking/Model/Stats/WCAnalyticsStats.swift
@@ -1,0 +1,45 @@
+import Foundation
+
+/// Protocol for stats over a specific period, returned from a `wc-analytics` endpoint.
+///
+public protocol WCAnalyticsStats {
+    associatedtype Totals: WCAnalyticsStatsTotals
+    associatedtype Interval: WCAnalyticsStatsInterval
+
+    /// ID for the site.
+    var siteID: Int64 { get }
+
+    /// Granularity of the stats.
+    var granularity: StatsGranularityV4 { get }
+
+    /// Totals over the entire period.
+    var totals: Totals { get }
+
+    /// Each interval within the entire period.
+    var intervals: [Interval] { get }
+}
+
+/// Protocol for stats totals (the data associated with stats over a specific period) returned from a `wc-analytics` endpoint.
+///
+public protocol WCAnalyticsStatsTotals {
+    // The stats totals will vary depending on the specific stats type.
+    // These may be counts, currency amounts, etc.
+}
+
+/// Protocol for stats intervals (represents a single order stat within a larger period) returned from a `wc-analytics` endpoint.
+///
+public protocol WCAnalyticsStatsInterval {
+    associatedtype Totals: WCAnalyticsStatsTotals
+
+    /// Identifies which interval is represented.
+    var interval: String { get }
+
+    /// Interval start date string in the site time zone.
+    var dateStart: String { get }
+
+    /// Interval end date string in the site time zone.
+    var dateEnd: String { get }
+
+    /// Totals over the interval period.
+    var subtotals: Totals { get }
+}

--- a/Networking/Networking/Model/Stats/WCAnalyticsStats.swift
+++ b/Networking/Networking/Model/Stats/WCAnalyticsStats.swift
@@ -24,6 +24,11 @@ public protocol WCAnalyticsStats {
 public protocol WCAnalyticsStatsTotals {
     // The stats totals will vary depending on the specific stats type.
     // These may be counts, currency amounts, etc.
+
+    /// Represents the types of stats total data
+    associatedtype TotalData: RawRepresentable
+
+    func getDoubleValue(for data: TotalData) -> Double
 }
 
 /// Protocol for stats intervals (represents a single order stat within a larger period) returned from a `wc-analytics` endpoint.

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/Report Cards/BundlesReportCardViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/Report Cards/BundlesReportCardViewModel.swift
@@ -77,7 +77,7 @@ extension AnalyticsBundlesReportCardViewModel {
     ///
     var delta: DeltaPercentage {
         isRedacted ? DeltaPercentage(string: "0%", direction: .zero)
-        : StatsDataTextFormatter.createBundlesSoldDelta(from: previousPeriodStats, to: currentPeriodStats)
+        : StatsDataTextFormatter.createDelta(for: .totalItemsSold, from: previousPeriodStats, to: currentPeriodStats)
     }
 
     /// Indicates if there was an error loading stats part of the card.

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/Report Cards/OrdersReportCardViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/Report Cards/OrdersReportCardViewModel.swift
@@ -61,7 +61,7 @@ extension OrdersReportCardViewModel {
 
     var leadingDelta: DeltaPercentage? {
         isRedacted ? DeltaPercentage(string: "0%", direction: .zero)
-        : StatsDataTextFormatter.createOrderCountDelta(from: previousPeriodStats, to: currentPeriodStats)
+        : StatsDataTextFormatter.createDelta(for: .totalOrders, from: previousPeriodStats, to: currentPeriodStats)
     }
 
     var leadingChartData: [Double] {
@@ -80,7 +80,7 @@ extension OrdersReportCardViewModel {
 
     var trailingDelta: DeltaPercentage? {
         isRedacted ? DeltaPercentage(string: "0%", direction: .zero)
-        : StatsDataTextFormatter.createAverageOrderValueDelta(from: previousPeriodStats, to: currentPeriodStats)
+        : StatsDataTextFormatter.createDelta(for: .averageOrderValue, from: previousPeriodStats, to: currentPeriodStats)
     }
 
     var trailingChartData: [Double] {

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/Report Cards/OrdersReportCardViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/Report Cards/OrdersReportCardViewModel.swift
@@ -65,7 +65,7 @@ extension OrdersReportCardViewModel {
     }
 
     var leadingChartData: [Double] {
-        isRedacted ? [] : StatsIntervalDataParser.getChartData(for: .orderCount, from: currentPeriodStats)
+        isRedacted ? [] : StatsIntervalDataParser.getChartData(for: .totalOrders, from: currentPeriodStats)
     }
 
     // MARK: Average Order Value metric

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/Report Cards/ProductsReportCardViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/Report Cards/ProductsReportCardViewModel.swift
@@ -89,7 +89,7 @@ extension AnalyticsProductsStatsCardViewModel {
     ///
     var delta: DeltaPercentage {
         isRedacted ? DeltaPercentage(string: "0%", direction: .zero)
-        : StatsDataTextFormatter.createOrderItemsSoldDelta(from: previousPeriodStats, to: currentPeriodStats)
+        : StatsDataTextFormatter.createDelta(for: .totalItemsSold, from: previousPeriodStats, to: currentPeriodStats)
     }
 
     /// Indicates if there was an error loading stats part of the card.

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/Report Cards/RevenueReportCardViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/Report Cards/RevenueReportCardViewModel.swift
@@ -65,7 +65,7 @@ extension RevenueReportCardViewModel {
     }
 
     var leadingChartData: [Double] {
-        isRedacted ? [] : StatsIntervalDataParser.getChartData(for: .totalRevenue, from: currentPeriodStats)
+        isRedacted ? [] : StatsIntervalDataParser.getChartData(for: OrderStatsV4Totals.TotalData.grossRevenue, from: currentPeriodStats)
     }
 
     // MARK: Net Revenue metric

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/Report Cards/RevenueReportCardViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/Report Cards/RevenueReportCardViewModel.swift
@@ -61,7 +61,7 @@ extension RevenueReportCardViewModel {
 
     var leadingDelta: DeltaPercentage? {
         isRedacted ? DeltaPercentage(string: "0%", direction: .zero)
-        : StatsDataTextFormatter.createTotalRevenueDelta(from: previousPeriodStats, to: currentPeriodStats)
+        : StatsDataTextFormatter.createDelta(for: .grossRevenue, from: previousPeriodStats, to: currentPeriodStats)
     }
 
     var leadingChartData: [Double] {
@@ -80,7 +80,7 @@ extension RevenueReportCardViewModel {
 
     var trailingDelta: DeltaPercentage? {
         isRedacted ? DeltaPercentage(string: "0%", direction: .zero)
-        : StatsDataTextFormatter.createNetRevenueDelta(from: previousPeriodStats, to: currentPeriodStats)
+        : StatsDataTextFormatter.createDelta(for: .netRevenue, from: previousPeriodStats, to: currentPeriodStats)
     }
 
     var trailingChartData: [Double] {

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Factories/StatsDataTextFormatter.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Factories/StatsDataTextFormatter.swift
@@ -258,7 +258,7 @@ private extension StatsDataTextFormatter {
     /// Retrieves the order count for the provided order stats and, optionally, a specific interval.
     ///
     static func orderCount(at selectedIndex: Int?, orderStats: OrderStatsV4?) -> Double? {
-        let orderStatsIntervals = StatsIntervalDataParser.sortOrderStatsIntervals(from: orderStats)
+        let orderStatsIntervals = StatsIntervalDataParser.sortStatsIntervals(from: orderStats)
         if let selectedIndex, selectedIndex < orderStatsIntervals.count {
             let orderStats = orderStatsIntervals[selectedIndex]
             return Double(orderStats.subtotals.totalOrders)
@@ -282,7 +282,7 @@ private extension StatsDataTextFormatter {
     /// Retrieves the total revenue from the provided order stats and, optionally, a specific interval.
     ///
     static func totalRevenue(at selectedIndex: Int?, orderStats: OrderStatsV4?) -> Decimal? {
-        let orderStatsIntervals = StatsIntervalDataParser.sortOrderStatsIntervals(from: orderStats)
+        let orderStatsIntervals = StatsIntervalDataParser.sortStatsIntervals(from: orderStats)
         if let selectedIndex, selectedIndex < orderStatsIntervals.count {
             let orderStats = orderStatsIntervals[selectedIndex]
             return orderStats.subtotals.grossRevenue

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Factories/StatsDataTextFormatter.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Factories/StatsDataTextFormatter.swift
@@ -24,14 +24,6 @@ struct StatsDataTextFormatter {
         }
     }
 
-    /// Creates the text to display for the total revenue delta.
-    ///
-    static func createTotalRevenueDelta(from previousPeriod: OrderStatsV4?, to currentPeriod: OrderStatsV4?) -> DeltaPercentage {
-        let previousRevenue = totalRevenue(at: nil, orderStats: previousPeriod)
-        let currentRevenue = totalRevenue(at: nil, orderStats: currentPeriod)
-        return createDeltaPercentage(from: previousRevenue, to: currentRevenue)
-    }
-
     /// Creates the text to display for the net revenue.
     ///
     static func createNetRevenueText(orderStats: OrderStatsV4?,
@@ -47,14 +39,6 @@ struct StatsDataTextFormatter {
         return currencyFormatter.formatAmount(revenue, with: currencyCode, numberOfDecimals: numberOfDecimals) ?? String()
     }
 
-    /// Creates the text to display for the net revenue delta.
-    ///
-    static func createNetRevenueDelta(from previousPeriod: OrderStatsV4?, to currentPeriod: OrderStatsV4?) -> DeltaPercentage {
-        let previousRevenue = previousPeriod?.totals.netRevenue
-        let currentRevenue = currentPeriod?.totals.netRevenue
-        return createDeltaPercentage(from: previousRevenue, to: currentRevenue)
-    }
-
     // MARK: Orders Stats
 
     /// Creates the text to display for the order count.
@@ -65,14 +49,6 @@ struct StatsDataTextFormatter {
         } else {
             return Constants.placeholderText
         }
-    }
-
-    /// Creates the text to display for the order count delta.
-    ///
-    static func createOrderCountDelta(from previousPeriod: OrderStatsV4?, to currentPeriod: OrderStatsV4?) -> DeltaPercentage {
-        let previousCount = orderCount(at: nil, orderStats: previousPeriod)
-        let currentCount = orderCount(at: nil, orderStats: currentPeriod)
-        return createDeltaPercentage(from: previousCount, to: currentCount)
     }
 
     /// Creates the text to display for the average order value.
@@ -88,14 +64,6 @@ struct StatsDataTextFormatter {
         } else {
             return Constants.placeholderText
         }
-    }
-
-    /// Creates the text to display for the average order value delta.
-    ///
-    static func createAverageOrderValueDelta(from previousPeriod: OrderStatsV4?, to currentPeriod: OrderStatsV4?) -> DeltaPercentage {
-        let previousAverage = averageOrderValue(orderStats: previousPeriod)
-        let currentAverage = averageOrderValue(orderStats: currentPeriod)
-        return createDeltaPercentage(from: previousAverage, to: currentAverage)
     }
 
     // MARK: Views and Visitors Stats
@@ -164,17 +132,6 @@ struct StatsDataTextFormatter {
         return Double(orderStats.totals.totalItemsSold).humanReadableString()
     }
 
-    /// Creates the text to display for the orders item sold delta.
-    ///
-    static func createOrderItemsSoldDelta(from previousPeriod: OrderStatsV4?, to currentPeriod: OrderStatsV4?) -> DeltaPercentage {
-        guard let previousPeriod, let currentPeriod else {
-            return DeltaPercentage(value: 0, formatter: deltaNumberFormatter) // Missing data: 0% change
-        }
-        let previousItemsSold = Double(previousPeriod.totals.totalItemsSold)
-        let currentItemsSold = Double(currentPeriod.totals.totalItemsSold)
-        return createDeltaPercentage(from: previousItemsSold, to: currentItemsSold)
-    }
-
     // MARK: Bundles Stats
 
     /// Creates the text to display for bundles sold value.
@@ -185,22 +142,22 @@ struct StatsDataTextFormatter {
         }
         return Double(bundleStats.totals.totalItemsSold).humanReadableString()
     }
-
-    /// Creates the text to display for the bundles sold delta.
-    ///
-    static func createBundlesSoldDelta(from previousPeriod: ProductBundleStats?, to currentPeriod: ProductBundleStats?) -> DeltaPercentage {
-        guard let previousPeriod, let currentPeriod else {
-            return DeltaPercentage(value: 0, formatter: deltaNumberFormatter) // Missing data: 0% change
-        }
-        let previousItemsSold = Double(previousPeriod.totals.totalItemsSold)
-        let currentItemsSold = Double(currentPeriod.totals.totalItemsSold)
-        return createDeltaPercentage(from: previousItemsSold, to: currentItemsSold)
-    }
 }
 
 extension StatsDataTextFormatter {
 
     // MARK: Delta Calculations
+
+    static func createDelta<Stats: WCAnalyticsStats>(for totalData: Stats.Totals.TotalData,
+                                                     from previousPeriod: Stats?,
+                                                     to currentPeriod: Stats?) -> DeltaPercentage {
+        guard let previousPeriod, let currentPeriod else {
+            return DeltaPercentage(value: 0, formatter: deltaNumberFormatter) // Missing data: 0% change
+        }
+        let previousTotal = previousPeriod.totals.getDoubleValue(for: totalData)
+        let currentTotal = currentPeriod.totals.getDoubleValue(for: totalData)
+        return createDeltaPercentage(from: previousTotal, to: currentTotal)
+    }
 
     /// Creates the `DeltaPercentage` for the percent change from the previous `Decimal` value to the current `Decimal` value
     ///

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Factories/StatsIntervalDataParser.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Factories/StatsIntervalDataParser.swift
@@ -12,31 +12,14 @@ struct StatsIntervalDataParser {
         }) ?? []
     }
 
-    /// Returns the requested stats total data values for every interval in the provided order stats.
+    /// Returns the requested stats total data values for every interval in the provided stats.
     ///
     /// Used to create a line chart with the returned values.
     ///
-    static func getChartData(for statsTotal: OrderStatsTotalData, from orderStats: OrderStatsV4?) -> [Double] {
-        let intervals = sortStatsIntervals(from: orderStats)
+    static func getChartData<Stats: WCAnalyticsStats>(for statsTotal: Stats.Interval.Totals.TotalData, from stats: Stats?) -> [Double] {
+        let intervals = sortStatsIntervals(from: stats)
         return intervals.map { interval in
-            switch statsTotal {
-            case .totalRevenue:
-                return (interval.subtotals.grossRevenue as NSNumber).doubleValue
-            case .netRevenue:
-                return (interval.subtotals.netRevenue as NSNumber).doubleValue
-            case .orderCount:
-                return Double(interval.subtotals.totalOrders)
-            case .averageOrderValue:
-                return (interval.subtotals.averageOrderValue as NSNumber).doubleValue
-            }
+            interval.subtotals.getDoubleValue(for: statsTotal)
         }
-    }
-
-    /// Represents a type of stats total data
-    enum OrderStatsTotalData {
-        case totalRevenue
-        case netRevenue
-        case orderCount
-        case averageOrderValue
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Factories/StatsIntervalDataParser.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Factories/StatsIntervalDataParser.swift
@@ -1,13 +1,12 @@
 import Foundation
-import struct Yosemite.OrderStatsV4
-import struct Yosemite.OrderStatsV4Interval
+import Yosemite
 
 struct StatsIntervalDataParser {
 
-    /// Returns the order stats intervals, ordered by date.
+    /// Returns the stats intervals, ordered by date.
     ///
-    static func sortOrderStatsIntervals(from orderStats: OrderStatsV4?) -> [OrderStatsV4Interval] {
-        return orderStats?.intervals.sorted(by: { (lhs, rhs) -> Bool in
+    static func sortStatsIntervals<Stats: WCAnalyticsStats>(from stats: Stats?) -> [Stats.Interval] {
+        return stats?.intervals.sorted(by: { (lhs, rhs) -> Bool in
             let siteTimezone = TimeZone.siteTimezone
             return lhs.dateStart(timeZone: siteTimezone) < rhs.dateStart(timeZone: siteTimezone)
         }) ?? []
@@ -17,8 +16,8 @@ struct StatsIntervalDataParser {
     ///
     /// Used to create a line chart with the returned values.
     ///
-    static func getChartData(for statsTotal: StatsTotalData, from orderStats: OrderStatsV4?) -> [Double] {
-        let intervals = sortOrderStatsIntervals(from: orderStats)
+    static func getChartData(for statsTotal: OrderStatsTotalData, from orderStats: OrderStatsV4?) -> [Double] {
+        let intervals = sortStatsIntervals(from: orderStats)
         return intervals.map { interval in
             switch statsTotal {
             case .totalRevenue:
@@ -34,7 +33,7 @@ struct StatsIntervalDataParser {
     }
 
     /// Represents a type of stats total data
-    enum StatsTotalData {
+    enum OrderStatsTotalData {
         case totalRevenue
         case netRevenue
         case orderCount

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Stats v4/StoreStatsPeriodViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Stats v4/StoreStatsPeriodViewModel.swift
@@ -354,7 +354,7 @@ private extension StoreStatsPeriodViewModel {
 
     func updateOrderDataIfNeeded() {
         let orderStats = orderStatsResultsController.fetchedObjects.first
-        let intervals = StatsIntervalDataParser.sortOrderStatsIntervals(from: orderStats)
+        let intervals = StatsIntervalDataParser.sortStatsIntervals(from: orderStats)
         orderStatsData = (stats: orderStats, intervals: intervals)
     }
 }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Factories/StatsDataTextFormatterTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Factories/StatsDataTextFormatterTests.swift
@@ -94,13 +94,13 @@ final class StatsDataTextFormatterTests: XCTestCase {
         XCTAssertEqual(totalRevenue, "$25")
     }
 
-    func test_createTotalRevenueDelta_returns_expected_delta() {
+    func test_createDelta_for_grossRevenue_returns_expected_delta() {
         // Given
         let previousOrderStats = OrderStatsV4.fake().copy(totals: .fake().copy(grossRevenue: 10))
         let currentOrderStats = OrderStatsV4.fake().copy(totals: .fake().copy(grossRevenue: 15))
 
         // When
-        let totalRevenueDelta = StatsDataTextFormatter.createTotalRevenueDelta(from: previousOrderStats, to: currentOrderStats)
+        let totalRevenueDelta = StatsDataTextFormatter.createDelta(for: .grossRevenue, from: previousOrderStats, to: currentOrderStats)
 
         // Then
         XCTAssertEqual(totalRevenueDelta.string, "+50%")
@@ -163,13 +163,13 @@ final class StatsDataTextFormatterTests: XCTestCase {
         XCTAssertEqual(netRevenue, "$62.86")
     }
 
-    func test_createNetRevenueDelta_returns_expected_delta() {
+    func test_createDelta_for_netRevenue_returns_expected_delta() {
         // Given
         let previousOrderStats = OrderStatsV4.fake().copy(totals: .fake().copy(netRevenue: 10))
         let currentOrderStats = OrderStatsV4.fake().copy(totals: .fake().copy(netRevenue: 15))
 
         // When
-        let netRevenueDelta = StatsDataTextFormatter.createNetRevenueDelta(from: previousOrderStats, to: currentOrderStats)
+        let netRevenueDelta = StatsDataTextFormatter.createDelta(for: .netRevenue, from: previousOrderStats, to: currentOrderStats)
 
         // Then
         XCTAssertEqual(netRevenueDelta.string, "+50%")
@@ -208,13 +208,13 @@ final class StatsDataTextFormatterTests: XCTestCase {
         XCTAssertEqual(orderCount, "1")
     }
 
-    func test_createOrderCountDelta_returns_expected_delta() {
+    func test_createDelta_for_totalOrders_returns_expected_delta() {
         // Given
         let previousOrderStats = OrderStatsV4.fake().copy(totals: .fake().copy(totalOrders: 10))
         let currentOrderStats = OrderStatsV4.fake().copy(totals: .fake().copy(totalOrders: 15))
 
         // When
-        let orderCountDelta = StatsDataTextFormatter.createOrderCountDelta(from: previousOrderStats, to: currentOrderStats)
+        let orderCountDelta = StatsDataTextFormatter.createDelta(for: .totalOrders, from: previousOrderStats, to: currentOrderStats)
 
         // Then
         XCTAssertEqual(orderCountDelta.string, "+50%")
@@ -277,13 +277,13 @@ final class StatsDataTextFormatterTests: XCTestCase {
         XCTAssertEqual(averageOrderValue, "$62.86")
     }
 
-    func test_createAverageOrderValueDelta_returns_expected_delta() {
+    func test_createDelta_for_averageOrderValue_returns_expected_delta() {
         // Given
         let previousOrderStats = OrderStatsV4.fake().copy(totals: .fake().copy(averageOrderValue: 10.00))
         let currentOrderStats = OrderStatsV4.fake().copy(totals: .fake().copy(averageOrderValue: 15.00))
 
         // When
-        let averageOrderValueDelta = StatsDataTextFormatter.createAverageOrderValueDelta(from: previousOrderStats, to: currentOrderStats)
+        let averageOrderValueDelta = StatsDataTextFormatter.createDelta(for: .averageOrderValue, from: previousOrderStats, to: currentOrderStats)
 
         // Then
         XCTAssertEqual(averageOrderValueDelta.string, "+50%")
@@ -511,32 +511,33 @@ final class StatsDataTextFormatterTests: XCTestCase {
         XCTAssertEqual(text, "67.9k")
     }
 
-    func test_createOrderItemsSoldDelta_returns_zero_on_nil_stats() {
-        let delta = StatsDataTextFormatter.createOrderItemsSoldDelta(from: nil, to: nil)
+    func test_createDelta_for_totalItemsSold_returns_zero_on_nil_stats() {
+        let stats: OrderStatsV4? = nil
+        let delta = StatsDataTextFormatter.createDelta(for: .totalItemsSold, from: stats, to: stats)
         XCTAssertEqual(delta.string, "+0%")
         XCTAssertEqual(delta.direction, .zero)
     }
 
-    func test_createOrderItemsSoldDelta_returns_correct_positive_value() {
+    func test_createDelta_for_totalItemsSold_returns_correct_positive_value() {
         // Given
         let previousStats = OrderStatsV4.fake().copy(totals: .fake().copy(totalItemsSold: 100))
         let currentStats = OrderStatsV4.fake().copy(totals: .fake().copy(totalItemsSold: 133))
 
         // When
-        let delta = StatsDataTextFormatter.createOrderItemsSoldDelta(from: previousStats, to: currentStats)
+        let delta = StatsDataTextFormatter.createDelta(for: .totalItemsSold, from: previousStats, to: currentStats)
 
         // Then
         XCTAssertEqual(delta.string, "+33%")
         XCTAssertEqual(delta.direction, .positive)
     }
 
-    func test_createOrderItemsSoldDelta_returns_correct_negative_value() {
+    func test_createDelta_for_totalItemsSold_returns_correct_negative_value() {
         // Given
         let previousStats = OrderStatsV4.fake().copy(totals: .fake().copy(totalItemsSold: 100))
         let currentStats = OrderStatsV4.fake().copy(totals: .fake().copy(totalItemsSold: 77))
 
         // When
-        let delta = StatsDataTextFormatter.createOrderItemsSoldDelta(from: previousStats, to: currentStats)
+        let delta = StatsDataTextFormatter.createDelta(for: .totalItemsSold, from: previousStats, to: currentStats)
 
         // Then
         XCTAssertEqual(delta.string, "-23%")
@@ -561,32 +562,33 @@ final class StatsDataTextFormatterTests: XCTestCase {
         XCTAssertEqual(text, "67.9k")
     }
 
-    func test_createBundlesSoldDelta_returns_zero_on_nil_stats() {
-        let delta = StatsDataTextFormatter.createBundlesSoldDelta(from: nil, to: nil)
+    func test_createDelta_for_bundlesSold_returns_zero_on_nil_stats() {
+        let stats: ProductBundleStats? = nil
+        let delta = StatsDataTextFormatter.createDelta(for: .totalItemsSold, from: stats, to: stats)
         XCTAssertEqual(delta.string, "+0%")
         XCTAssertEqual(delta.direction, .zero)
     }
 
-    func test_createBundlesSoldDelta_returns_correct_positive_value() {
+    func test_createDelta_for_bundlesSold_returns_correct_positive_value() {
         // Given
         let previousStats = ProductBundleStats.fake().copy(totals: .fake().copy(totalItemsSold: 100))
         let currentStats = ProductBundleStats.fake().copy(totals: .fake().copy(totalItemsSold: 133))
 
         // When
-        let delta = StatsDataTextFormatter.createBundlesSoldDelta(from: previousStats, to: currentStats)
+        let delta = StatsDataTextFormatter.createDelta(for: .totalItemsSold, from: previousStats, to: currentStats)
 
         // Then
         XCTAssertEqual(delta.string, "+33%")
         XCTAssertEqual(delta.direction, .positive)
     }
 
-    func test_createBundlesSoldDelta_returns_correct_negative_value() {
+    func test_createDelta_for_bundlesSold_returns_correct_negative_value() {
         // Given
         let previousStats = ProductBundleStats.fake().copy(totals: .fake().copy(totalItemsSold: 100))
         let currentStats = ProductBundleStats.fake().copy(totals: .fake().copy(totalItemsSold: 77))
 
         // When
-        let delta = StatsDataTextFormatter.createBundlesSoldDelta(from: previousStats, to: currentStats)
+        let delta = StatsDataTextFormatter.createDelta(for: .totalItemsSold, from: previousStats, to: currentStats)
 
         // Then
         XCTAssertEqual(delta.string, "-23%")

--- a/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Factories/StatsIntervalDataParserTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Factories/StatsIntervalDataParserTests.swift
@@ -16,7 +16,7 @@ final class StatsIntervalDataParserTests: XCTestCase {
                                                   ])
 
         // When
-        let totalRevenueData = StatsIntervalDataParser.getChartData(for: .totalRevenue, from: orderStats)
+        let totalRevenueData = StatsIntervalDataParser.getChartData(for: .grossRevenue, from: orderStats)
 
         // Then
         XCTAssertEqual(totalRevenueData, [31, 25])
@@ -52,7 +52,7 @@ final class StatsIntervalDataParserTests: XCTestCase {
                                                   ])
 
         // When
-        let orderCountData = StatsIntervalDataParser.getChartData(for: .orderCount, from: orderStats)
+        let orderCountData = StatsIntervalDataParser.getChartData(for: .totalOrders, from: orderStats)
 
         // Then
         XCTAssertEqual(orderCountData, [2, 1])

--- a/Yosemite/Yosemite.xcodeproj/project.pbxproj
+++ b/Yosemite/Yosemite.xcodeproj/project.pbxproj
@@ -30,7 +30,7 @@
 		021940E4291E8A660090354E /* SiteAction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 021940E3291E8A660090354E /* SiteAction.swift */; };
 		021940E6291E8AD80090354E /* SiteStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 021940E5291E8AD80090354E /* SiteStore.swift */; };
 		021EAA5C25493E9300AA8CCD /* OrderItemAttribute+ReadOnlyConvertible.swift in Sources */ = {isa = PBXBuildFile; fileRef = 021EAA5B25493E9300AA8CCD /* OrderItemAttribute+ReadOnlyConvertible.swift */; };
-		0225512122FC2F3000D98613 /* OrderStatsV4Interval+Date.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0225512022FC2F3000D98613 /* OrderStatsV4Interval+Date.swift */; };
+		0225512122FC2F3000D98613 /* WCAnalyticsStatsInterval+Date.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0225512022FC2F3000D98613 /* WCAnalyticsStatsInterval+Date.swift */; };
 		0225512522FC312400D98613 /* OrderStatsV4Interval+DateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0225512422FC312400D98613 /* OrderStatsV4Interval+DateTests.swift */; };
 		02291735270BE18C00449FA0 /* ProductReviewFromNoteParcel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02291734270BE18C00449FA0 /* ProductReviewFromNoteParcel.swift */; };
 		022F00BE24725BAF008CD97F /* NotificationCountStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 022F00BD24725BAF008CD97F /* NotificationCountStore.swift */; };
@@ -514,7 +514,7 @@
 		021940E3291E8A660090354E /* SiteAction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SiteAction.swift; sourceTree = "<group>"; };
 		021940E5291E8AD80090354E /* SiteStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SiteStore.swift; sourceTree = "<group>"; };
 		021EAA5B25493E9300AA8CCD /* OrderItemAttribute+ReadOnlyConvertible.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "OrderItemAttribute+ReadOnlyConvertible.swift"; sourceTree = "<group>"; };
-		0225512022FC2F3000D98613 /* OrderStatsV4Interval+Date.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "OrderStatsV4Interval+Date.swift"; sourceTree = "<group>"; };
+		0225512022FC2F3000D98613 /* WCAnalyticsStatsInterval+Date.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "WCAnalyticsStatsInterval+Date.swift"; sourceTree = "<group>"; };
 		0225512422FC312400D98613 /* OrderStatsV4Interval+DateTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "OrderStatsV4Interval+DateTests.swift"; sourceTree = "<group>"; };
 		02291734270BE18C00449FA0 /* ProductReviewFromNoteParcel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductReviewFromNoteParcel.swift; sourceTree = "<group>"; };
 		022F00BD24725BAF008CD97F /* NotificationCountStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationCountStore.swift; sourceTree = "<group>"; };
@@ -1032,7 +1032,7 @@
 		0225511F22FC2ED000D98613 /* Extensions */ = {
 			isa = PBXGroup;
 			children = (
-				0225512022FC2F3000D98613 /* OrderStatsV4Interval+Date.swift */,
+				0225512022FC2F3000D98613 /* WCAnalyticsStatsInterval+Date.swift */,
 				FEEB2F5C268A15730075A6E0 /* User+Roles.swift */,
 			);
 			path = Extensions;
@@ -2340,7 +2340,7 @@
 				CE0DB6C0233EB3F300A27E7A /* OrderRefundCondensed+ReadOnlyConvertible.swift in Sources */,
 				247CE87225832E7000F9D9D1 /* MockProductReviewAction.swift in Sources */,
 				DEA493942B3D588500EED015 /* BlazeTargetLanguage+ReadonlyConvertible.swift in Sources */,
-				0225512122FC2F3000D98613 /* OrderStatsV4Interval+Date.swift in Sources */,
+				0225512122FC2F3000D98613 /* WCAnalyticsStatsInterval+Date.swift in Sources */,
 				0202B690238790E200F3EBE0 /* ProductsFeatureSwitchPListWrapper.swift in Sources */,
 				077F39DE26A5A1CB00ABEADC /* SystemStatusAction.swift in Sources */,
 				74D7F29B20F6A7FB0058B2F0 /* Order+ReadOnlyConvertible.swift in Sources */,

--- a/Yosemite/Yosemite/Model/Extensions/WCAnalyticsStatsInterval+Date.swift
+++ b/Yosemite/Yosemite/Model/Extensions/WCAnalyticsStatsInterval+Date.swift
@@ -1,7 +1,7 @@
 import Foundation
 import WooFoundation
 
-extension OrderStatsV4Interval {
+extension WCAnalyticsStatsInterval {
     /// Returns the interval start date by parsing the `dateStart` string.
     public func dateStart(timeZone: TimeZone) -> Date {
         guard let date = createDateFormatter(timeZone: timeZone).date(from: dateStart) else {
@@ -19,7 +19,7 @@ extension OrderStatsV4Interval {
     }
 }
 
-private extension OrderStatsV4Interval {
+private extension WCAnalyticsStatsInterval {
     func createDateFormatter(timeZone: TimeZone) -> DateFormatter {
         let dateFormatter = DateFormatter.Stats.dateTimeFormatter
         dateFormatter.calendar = Calendar(identifier: .iso8601)

--- a/Yosemite/Yosemite/Model/Model.swift
+++ b/Yosemite/Yosemite/Model/Model.swift
@@ -204,6 +204,7 @@ public typealias WooPaymentsDepositInterval = Networking.WooPaymentsDepositInter
 public typealias WooPaymentsDepositStatus = Networking.WooPaymentsDepositStatus
 public typealias StoreOnboardingTask = Networking.StoreOnboardingTask
 public typealias WCAnalyticsCustomer = Networking.WCAnalyticsCustomer
+public typealias WCAnalyticsStatsInterval = Networking.WCAnalyticsStatsInterval
 public typealias WordPressPage = Networking.WordPressPage
 public typealias WordPressTheme = Networking.WordPressTheme
 

--- a/Yosemite/Yosemite/Model/Model.swift
+++ b/Yosemite/Yosemite/Model/Model.swift
@@ -204,6 +204,7 @@ public typealias WooPaymentsDepositInterval = Networking.WooPaymentsDepositInter
 public typealias WooPaymentsDepositStatus = Networking.WooPaymentsDepositStatus
 public typealias StoreOnboardingTask = Networking.StoreOnboardingTask
 public typealias WCAnalyticsCustomer = Networking.WCAnalyticsCustomer
+public typealias WCAnalyticsStats = Networking.WCAnalyticsStats
 public typealias WCAnalyticsStatsInterval = Networking.WCAnalyticsStatsInterval
 public typealias WordPressPage = Networking.WordPressPage
 public typealias WordPressTheme = Networking.WordPressTheme


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of: #12165
<!-- Id number of the GitHub issue this PR addresses. -->

## Why
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
We now have different kinds of stats data (order stats, product bundle stats, gift card stats) that can all be parsed in similar ways. This updates our stats data parsing so we can handle different kinds of stats data with the same methods, to generate the deltas and charts we use in the Analytics Hub.

## How

* Adds protocols for `WCAnalyticsStats`, `WCAnalyticsStatsInterval`, and `WCAnalyticsStatsTotals` so any stats data conforming to these protocols can be handled with generic methods.
* Adds conformance to these protocols to the existing stats data types (`OrderStatsV4`, `ProductBundleStats`, `GiftCardStats`).
* In `StatsDataTextFormatter`, replaces the individual methods for generating `DeltaPercentage` for different stats totals with a generic method `createDelta(for: from: to:)`. This method can be used for different stats types and their totals to get their delta for the delta tag on the analytics card.
* In `StatsIntervalDataParser`, it replaces the methods for parsing `OrderStatsV4` with generic methods `sortStatsIntervals(from:)` (to sort the intervals in the given stats) and `getChartData(for: from:)` (to get the chart data for a stats total from the given stats). This allows us to create the sparkline chart in an analytics card for any stats type, not just order stats.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

This should not change the existing data shown in the dashboard and analytics hub:

1. Build and run the app.
2. In the dashboard, confirm the stats chart and metrics show the expected values.
3. Open the analytics hub and confirm the analytics cards show the expected values.


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
