### PR TITLE
[Analytics Hub] Fix sessions card layout on large devices when data is unavailable

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/Report Cards/AnalyticsSessionsUnavailableCard.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/Report Cards/AnalyticsSessionsUnavailableCard.swift
@@ -20,6 +20,7 @@ struct AnalyticsSessionsUnavailableCard: View {
                         .bodyStyle()
                 }
             }
+            .frame(maxWidth: .infinity, alignment: .leading)
             .padding(Layout.cardPadding)
             .overlay(RoundedRectangle(cornerRadius: Layout.cornerRadius)
                 .stroke(Color(.systemGray4)))


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Related: #12295
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This fixes the Sessions card layout on larger devices, when the sessions data is unavailable.

It ensures the card takes up the entire device width when `AnalyticsSessionsUnavailableCard` is displayed.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

1. Build and run the app on a larger device (e.g. an iPad).
2. Open the analytics hub.
3. Select a custom date range.
4. Confirm the Sessions card is aligned to the leading edge of the screen and takes up the full screen width.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->
Before|After
-|-
![Simulator Screenshot - iPad Pro (12 9-inch) (6th generation) - 2024-04-03 at 16 16 59](https://github.com/woocommerce/woocommerce-ios/assets/8658164/475079f0-c689-494e-b17b-601db07d95ba)|![Simulator Screenshot - iPad Pro (12 9-inch) (6th generation) - 2024-04-03 at 16 16 16](https://github.com/woocommerce/woocommerce-ios/assets/8658164/d9b32e6a-2b37-451a-9620-2beefb7157f2)

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
