### PR TITLE
[Analytics Hub] Gift Cards: Show gift cards analytics in the analytics hub

### DIFF
--- a/Storage/Storage/Model/AnalyticsCard.swift
+++ b/Storage/Storage/Model/AnalyticsCard.swift
@@ -22,5 +22,6 @@ public struct AnalyticsCard: Codable, Hashable, Equatable, GeneratedCopiable {
         case products
         case sessions
         case bundles
+        case giftCards
     }
 }

--- a/WooCommerce/Classes/Extensions/SitePlugin+Woo.swift
+++ b/WooCommerce/Classes/Extensions/SitePlugin+Woo.swift
@@ -11,5 +11,6 @@ extension SitePlugin {
         public static let WCProductBundles = ["WooCommerce Product Bundles", "Woo Product Bundles"]
         public static let WCCompositeProducts = "WooCommerce Composite Products"
         public static let square = "WooCommerce Square"
+        public static let WCGiftCards = ["WooCommerce Gift Cards", "Woo Gift Cards"]
     }
 }

--- a/WooCommerce/Classes/System/WooConstants.swift
+++ b/WooCommerce/Classes/System/WooConstants.swift
@@ -328,6 +328,8 @@ extension WooConstants {
 
         case compositeProductsExtension = "https://woo.com/products/composite-products/"
 
+        case giftCardsExtension = "https://woo.com/products/gift-cards/"
+
         case wooPaymentsStartupGuide = "https://woo.com/document/woopayments/startup-guide/"
 
         // swiftlint:disable:next line_length

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/AnalyticsHubView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/AnalyticsHubView.swift
@@ -131,6 +131,8 @@ private extension AnalyticsHubView {
             AnalyticsSessionsReportCard(viewModel: viewModel.sessionsCard)
         case .bundles:
             AnalyticsItemsSoldCard(bundlesViewModel: viewModel.bundlesCard)
+        case .giftCards:
+            EmptyView() // TODO-12165: Show gift cards analytics report card
         }
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/AnalyticsHubView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/AnalyticsHubView.swift
@@ -132,7 +132,7 @@ private extension AnalyticsHubView {
         case .bundles:
             AnalyticsItemsSoldCard(bundlesViewModel: viewModel.bundlesCard)
         case .giftCards:
-            EmptyView() // TODO-12165: Show gift cards analytics report card
+            AnalyticsReportCard(viewModel: viewModel.giftCardsCard)
         }
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/AnalyticsHubViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/AnalyticsHubViewModel.swift
@@ -121,6 +121,16 @@ final class AnalyticsHubViewModel: ObservableObject {
                                             usageTracksEventEmitter: usageTracksEventEmitter)
     }
 
+    /// Gift Cards Card ViewModel
+    ///
+    var giftCardsCard: GiftCardsReportCardViewModel {
+        GiftCardsReportCardViewModel(currentPeriodStats: currentGiftCardStats,
+                                     previousPeriodStats: previousGiftCardStats,
+                                     timeRange: timeRangeSelectionType,
+                                     isRedacted: isLoadingGiftCardStats,
+                                     usageTracksEventEmitter: usageTracksEventEmitter)
+    }
+
     /// View model for `AnalyticsHubCustomizeView`, to customize the cards in the Analytics Hub.
     ///
     @Published var customizeAnalyticsViewModel: AnalyticsHubCustomizeViewModel?

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/AnalyticsHubViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/AnalyticsHubViewModel.swift
@@ -152,6 +152,8 @@ final class AnalyticsHubViewModel: ObservableObject {
             isEligibleForSessionsCard
         case .bundles:
             isExpandedAnalyticsHubEnabled && isPluginActive(SitePlugin.SupportedPlugin.WCProductBundles)
+        case .giftCards:
+            isExpandedAnalyticsHubEnabled && isPluginActive(SitePlugin.SupportedPlugin.WCGiftCards)
         default:
             true
         }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/Customize/AnalyticsCard+UI.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/Customize/AnalyticsCard+UI.swift
@@ -16,6 +16,8 @@ extension AnalyticsCard {
             return Localization.sessions
         case .bundles:
             return Localization.bundles
+        case .giftCards:
+            return Localization.giftCards
         }
     }
 }
@@ -38,5 +40,8 @@ private extension AnalyticsCard {
         static let bundles = NSLocalizedString("analyticsHub.customize.bundles",
                                                 value: "Bundles",
                                                 comment: "Name for the Product Bundles analytics card in the Customize Analytics screen")
+        static let giftCards = NSLocalizedString("analyticsHub.customize.giftCards",
+                                                 value: "Gift Cards",
+                                                 comment: "Name for the Gift Cards analytics card in the Customize Analytics screen")
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/Customize/AnalyticsHubCustomizeViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/Customize/AnalyticsHubCustomizeViewModel.swift
@@ -81,7 +81,9 @@ final class AnalyticsHubCustomizeViewModel: ObservableObject, Identifiable {
             WooConstants.URLs.productBundlesExtension.asURL()
         case .sessions:
             WooConstants.URLs.jetpackStats.asURL()
-        default:
+        case .giftCards:
+            WooConstants.URLs.giftCardsExtension.asURL()
+        case .revenue, .orders, .products:
             nil
         }
     }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Analytics Hub/AnalyticsHubViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Analytics Hub/AnalyticsHubViewModelTests.swift
@@ -27,9 +27,7 @@ final class AnalyticsHubViewModelTests: XCTestCase {
     func test_cards_viewmodels_show_correct_data_after_updating_from_network() async {
         // Given
         let storage = MockStorageManager()
-        storage.insertSampleSystemPlugin(readOnlySystemPlugin: .fake().copy(siteID: sampleSiteID,
-                                                                            name: SitePlugin.SupportedPlugin.WCProductBundles.first,
-                                                                            active: true))
+        insertActivePlugins([SitePlugin.SupportedPlugin.WCProductBundles.first, SitePlugin.SupportedPlugin.WCGiftCards.first], to: storage)
         let vm = createViewModel(storage: storage)
         stores.whenReceivingAction(ofType: StatsActionV4.self) { action in
             switch action {
@@ -48,6 +46,9 @@ final class AnalyticsHubViewModelTests: XCTestCase {
             case let .retrieveTopProductBundles(_, _, _, _, _, completion):
                 let topBundle = ProductsReportItem.fake()
                 completion(.success([topBundle]))
+            case let .retrieveUsedGiftCardStats(_, _, _, _, _, _, _, completion):
+                let giftCardStats = GiftCardStats.fake().copy(totals: .fake().copy(giftCardsCount: 20))
+                completion(.success(giftCardStats))
             default:
                 break
             }
@@ -63,6 +64,7 @@ final class AnalyticsHubViewModelTests: XCTestCase {
         XCTAssertFalse(vm.itemsSoldCard.isRedacted)
         XCTAssertFalse(vm.sessionsCard.isRedacted)
         XCTAssertFalse(vm.bundlesCard.isRedacted)
+        XCTAssertFalse(vm.giftCardsCard.isRedacted)
 
         XCTAssertEqual(vm.revenueCard.leadingValue, "$62")
         XCTAssertEqual(vm.ordersCard.leadingValue, "15")
@@ -71,6 +73,7 @@ final class AnalyticsHubViewModelTests: XCTestCase {
         XCTAssertEqual(vm.sessionsCard.leadingValue, "53")
         XCTAssertEqual(vm.bundlesCard.bundlesSold, "3")
         XCTAssertEqual(vm.bundlesCard.bundlesSoldData.count, 1)
+        XCTAssertEqual(vm.giftCardsCard.leadingValue, "20")
     }
 
     func test_cards_viewmodels_redacted_while_updating_from_network() async {
@@ -82,10 +85,9 @@ final class AnalyticsHubViewModelTests: XCTestCase {
         var loadingSessionsCardRedacted: Bool = false
         var loadingBundlesStatsCardRedacted: Bool = false
         var loadingBundlesSoldCardRedacted: Bool = false
+        var loadingGiftCardsCardRedacted: Bool = false
         let storage = MockStorageManager()
-        storage.insertSampleSystemPlugin(readOnlySystemPlugin: .fake().copy(siteID: sampleSiteID,
-                                                                            name: SitePlugin.SupportedPlugin.WCProductBundles.first,
-                                                                            active: true))
+        insertActivePlugins([SitePlugin.SupportedPlugin.WCProductBundles.first, SitePlugin.SupportedPlugin.WCGiftCards.first], to: storage)
         let vm = createViewModel(storage: storage)
         stores.whenReceivingAction(ofType: StatsActionV4.self) { action in
             switch action {
@@ -111,6 +113,10 @@ final class AnalyticsHubViewModelTests: XCTestCase {
                 let topBundle = ProductsReportItem.fake()
                 loadingBundlesSoldCardRedacted = vm.bundlesCard.isRedacted
                 completion(.success([topBundle]))
+            case let .retrieveUsedGiftCardStats(_, _, _, _, _, _, _, completion):
+                let giftCardStats = GiftCardStats.fake()
+                loadingGiftCardsCardRedacted = vm.giftCardsCard.isRedacted
+                completion(.success(giftCardStats))
             default:
                 break
             }
@@ -127,6 +133,7 @@ final class AnalyticsHubViewModelTests: XCTestCase {
         XCTAssertTrue(loadingSessionsCardRedacted)
         XCTAssertTrue(loadingBundlesStatsCardRedacted)
         XCTAssertTrue(loadingBundlesSoldCardRedacted)
+        XCTAssertTrue(loadingGiftCardsCardRedacted)
     }
 
     func test_bundles_card_shows_correct_loading_state_and_data_with_network_update() {
@@ -529,5 +536,11 @@ private extension AnalyticsHubViewModelTests {
                               storage: storage ?? MockStorageManager(),
                               analytics: analytics,
                               isExpandedAnalyticsHubEnabled: true)
+    }
+
+    func insertActivePlugins(_ pluginNames: [String?], to storage: MockStorageManager) {
+        pluginNames.forEach { pluginName in
+            storage.insertSampleSystemPlugin(readOnlySystemPlugin: .fake().copy(siteID: sampleSiteID, name: pluginName, active: true))
+        }
     }
 }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Analytics Hub/AnalyticsHubViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Analytics Hub/AnalyticsHubViewModelTests.swift
@@ -268,7 +268,8 @@ final class AnalyticsHubViewModelTests: XCTestCase {
                              AnalyticsCard(type: .orders, enabled: false),
                              AnalyticsCard(type: .products, enabled: false),
                              AnalyticsCard(type: .sessions, enabled: false),
-                             AnalyticsCard(type: .bundles, enabled: true)]
+                             AnalyticsCard(type: .bundles, enabled: true),
+                             AnalyticsCard(type: .giftCards, enabled: true)]
         assertEqual(expectedCards, storedAnalyticsCards)
     }
 
@@ -445,6 +446,23 @@ final class AnalyticsHubViewModelTests: XCTestCase {
         XCTAssertTrue(customizeAnalyticsVM.inactiveCards.contains(where: { $0.type == .bundles }))
     }
 
+    func test_gift_cards_card_is_inactive_in_customizeAnalytics_when_extension_is_inactive() throws {
+        // Given
+        let storage = MockStorageManager()
+        storage.insertSampleSystemPlugin(readOnlySystemPlugin: .fake().copy(siteID: sampleSiteID,
+                                                                            name: SitePlugin.SupportedPlugin.WCGiftCards.first,
+                                                                            active: false))
+        let vm = createViewModel(storage: storage)
+
+        // When
+        vm.customizeAnalytics()
+
+        // Then
+        let customizeAnalyticsVM = try XCTUnwrap(vm.customizeAnalyticsViewModel)
+        XCTAssertFalse(vm.enabledCards.contains(.giftCards))
+        XCTAssertTrue(customizeAnalyticsVM.inactiveCards.contains(where: { $0.type == .giftCards }))
+    }
+
     func test_customizeAnalytics_tracks_expected_event() {
         // When
         vm.customizeAnalytics()
@@ -475,6 +493,30 @@ final class AnalyticsHubViewModelTests: XCTestCase {
 
         // Then
         XCTAssertFalse(vm.enabledCards.contains(.bundles))
+    }
+
+    func test_gift_cards_card_displayed_when_plugin_active() {
+        // Given
+        let storage = MockStorageManager()
+        storage.insertSampleSystemPlugin(readOnlySystemPlugin: .fake().copy(siteID: sampleSiteID,
+                                                                            name: SitePlugin.SupportedPlugin.WCGiftCards.first,
+                                                                            active: true))
+        let vm = createViewModel(storage: storage)
+
+        // Then
+        XCTAssertTrue(vm.enabledCards.contains(.giftCards))
+    }
+
+    func test_gift_cards_card_not_displayed_when_plugin_inactive() {
+        // Given
+        let storage = MockStorageManager()
+        storage.insertSampleSystemPlugin(readOnlySystemPlugin: .fake().copy(siteID: sampleSiteID,
+                                                                            name: SitePlugin.SupportedPlugin.WCGiftCards.first,
+                                                                            active: false))
+        let vm = createViewModel(storage: storage)
+
+        // Then
+        XCTAssertFalse(vm.enabledCards.contains(.giftCards))
     }
 }
 


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #12165
<!-- Id number of the GitHub issue this PR addresses. -->

## Why
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This PR adds the new gift cards analytics card to the Analytics Hub. It is visible when the gift cards extension is active on the store.

## How

- Adds the gift cards type to `AnalyticsCard`.
- Adds the gift cards extension to `SitePlugin.SupportedPlugin`.
- Adds a promo URL for gift cards, to display in the Customize screen when the gift cards extension is not active.
- Adds the view model `GiftCardsReportCardViewModel` and its data (current and previous gift card stats) to `AnalyticsHubViewModel`.
- Retrieves the required data from remote when the gift cards card is enabled in the hub.
- Adds the `AnalyticsReportCard` view with the gift cards card view model in `AnalyticsHubView`.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

On a store with the Gift Cards extension:

1. Build and run the app.
2. Open the Analytics Hub.
3. Confirm the Gift Cards card appears and loads its data (used gift cards count and net amount used).
4. Edit the hub and confirm you can enable/disable/reorder the Gift Cards card.

On a store without the Gift Cards extension:

1. Build and run the app.
2. Open the Analytics Hub.
3. Confirm no Gift Cards card appears and no API request is made for Gift Cards analytics.
4. Edit the hub and confirm the Gift Cards card does not appear in the list.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->
Analytics Hub|Customize|Customize - Inactive extension
-|-|-
![Simulator Screenshot - iPhone 15 Pro - 2024-04-03 at 17 36 40](https://github.com/woocommerce/woocommerce-ios/assets/8658164/a8684e16-dafa-4e60-ac27-2abc5140c826)|![Simulator Screenshot - iPhone 15 Pro - 2024-04-03 at 17 36 42](https://github.com/woocommerce/woocommerce-ios/assets/8658164/4608977f-e5d4-46d4-9a22-544c1cbabb53)|![Simulator Screenshot - iPhone 15 Pro - 2024-04-03 at 17 36 56](https://github.com/woocommerce/woocommerce-ios/assets/8658164/4a6510be-2f0e-4201-9059-9b4a44a781db)

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
