### PR TITLE
[Analytics Hub] Ensure new analytics cards are shown when storage contains previous customizations

### DIFF
--- a/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Analytics Hub/AnalyticsHubViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Analytics Hub/AnalyticsHubViewModelTests.swift
@@ -236,6 +236,30 @@ final class AnalyticsHubViewModelTests: XCTestCase {
         assertEqual([.revenue], vm.enabledCards)
     }
 
+    func test_enabledCards_contains_new_cards_not_in_stored_customizations_when_extensions_are_active() async {
+        // Given
+        let storage = MockStorageManager()
+        insertActivePlugins([SitePlugin.SupportedPlugin.WCProductBundles.first, SitePlugin.SupportedPlugin.WCGiftCards.first], to: storage)
+        let vm = createViewModel(storage: storage)
+        stores.whenReceivingAction(ofType: AppSettingsAction.self) { action in
+            switch action {
+            case let .loadAnalyticsHubCards(_, completion):
+                completion([AnalyticsCard(type: .orders, enabled: true),
+                            AnalyticsCard(type: .revenue, enabled: true),
+                            AnalyticsCard(type: .products, enabled: false),
+                            AnalyticsCard(type: .sessions, enabled: false)])
+            default:
+                break
+            }
+        }
+
+        // When
+        await vm.loadAnalyticsCardSettings()
+
+        // Then
+        assertEqual([.orders, .revenue, .bundles, .giftCards], vm.enabledCards)
+    }
+
     func test_it_updates_enabledCards_when_saved() async throws {
         // Given
         assertEqual([.revenue, .orders, .products, .sessions], vm.enabledCards)
@@ -362,7 +386,9 @@ final class AnalyticsHubViewModelTests: XCTestCase {
                 completion([AnalyticsCard(type: .revenue, enabled: true),
                             AnalyticsCard(type: .orders, enabled: true),
                             AnalyticsCard(type: .products, enabled: false),
-                            AnalyticsCard(type: .sessions, enabled: false)])
+                            AnalyticsCard(type: .sessions, enabled: false),
+                            AnalyticsCard(type: .bundles, enabled: false),
+                            AnalyticsCard(type: .giftCards, enabled: false)])
             default:
                 break
             }
@@ -403,7 +429,9 @@ final class AnalyticsHubViewModelTests: XCTestCase {
                 completion([AnalyticsCard(type: .revenue, enabled: true),
                             AnalyticsCard(type: .orders, enabled: true),
                             AnalyticsCard(type: .products, enabled: false),
-                            AnalyticsCard(type: .sessions, enabled: false)])
+                            AnalyticsCard(type: .sessions, enabled: false),
+                            AnalyticsCard(type: .bundles, enabled: false),
+                            AnalyticsCard(type: .giftCards, enabled: false)])
             default:
                 break
             }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #12166
<!-- Id number of the GitHub issue this PR addresses. -->

## Why
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
If a merchant has customized the analytics cards in the analytics hub, we load those settings from storage to determine what cards to show. This PR ensures that any new cards (that didn't exist when the previous customizations were saved) are also shown in the analytics hub.

## How

After we load the card with their settings from storage, if there are any cards in `defaultCards` that aren't in the stored cards, we add them to the stored cards in `allCardsWithSettings`. (We add them to the end to retain the customized order of the stored cards.)

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

On a store with the Gift Cards extension installed:

1. Build and run the app from the last release build (or another branch without Gift Cards analytics).
2. Open the analytics hub.
3. Tap "Edit" to customize the analytics hub.
4. Change the settings and save them.
5. Build and run the app from this branch.
6. Open the analytics hub and confirm the Gift Cards card is shown.
7. Tap "Edit" and confirm Gift Cards is in the list of cards to customize.

## Screenshots

Before|After
-|-
![Simulator Screenshot - iPhone 15 Pro - 2024-04-03 at 18 42 36](https://github.com/woocommerce/woocommerce-ios/assets/8658164/45bef870-ca30-4caf-90c3-1bf560a3a171)|![Simulator Screenshot - iPhone 15 Pro - 2024-04-03 at 18 40 13](https://github.com/woocommerce/woocommerce-ios/assets/8658164/679577fe-9fb8-474f-8f64-3556bd9f67a3)
![Simulator Screenshot - iPhone 15 Pro - 2024-04-03 at 18 39 10](https://github.com/woocommerce/woocommerce-ios/assets/8658164/741b4110-c619-4809-a358-edc63f3f5302)|![Simulator Screenshot - iPhone 15 Pro - 2024-04-03 at 18 40 16](https://github.com/woocommerce/woocommerce-ios/assets/8658164/9404fde2-1516-49d0-9ca4-bdd3157faffb)

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
