### PR TITLE
[Analytics Hub] Release expanded analytics hub with extension analytics

### DIFF
--- a/Experiments/Experiments/DefaultFeatureFlagService.swift
+++ b/Experiments/Experiments/DefaultFeatureFlagService.swift
@@ -92,8 +92,6 @@ public struct DefaultFeatureFlagService: FeatureFlagService {
             return buildConfig == .localDeveloper || buildConfig == .alpha
         case .customersInHubMenu:
             return true
-        case .expandedAnalyticsHub:
-            return buildConfig == .localDeveloper || buildConfig == .alpha
         case .migrateSimplePaymentsToOrderCreation:
             return (buildConfig == .localDeveloper || buildConfig == .alpha) && !isUITesting
         default:

--- a/Experiments/Experiments/FeatureFlag.swift
+++ b/Experiments/Experiments/FeatureFlag.swift
@@ -204,10 +204,6 @@ public enum FeatureFlag: Int {
     ///
     case customersInHubMenu
 
-    /// Displays analytics cards for extensions in the Analytics Hub.
-    ///
-    case expandedAnalyticsHub
-
     /// Enables migration from simple payments to order creation.
     ///
     case migrateSimplePaymentsToOrderCreation

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -3,6 +3,7 @@
 18.1
 -----
 - [**] Orders: now it's possible to swiftly delete orders right from the Order Detail page.
+- [**] Stats: The Analytics Hub now includes analytics for Product Bundles and Gift Cards, when those extensions are active. [https://github.com/woocommerce/woocommerce-ios/pull/12425]
 
 
 18.0

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/AnalyticsHubViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/AnalyticsHubViewModel.swift
@@ -24,18 +24,13 @@ final class AnalyticsHubViewModel: ObservableObject {
     ///
     private let userIsAdmin: Bool
 
-    /// Feature flag for Expanded Analytics Hub (extension analytics)
-    ///
-    private let isExpandedAnalyticsHubEnabled: Bool
-
     init(siteID: Int64,
          timeZone: TimeZone = .siteTimezone,
          statsTimeRange: StatsTimeRangeV4,
          usageTracksEventEmitter: StoreStatsUsageTracksEventEmitter,
          stores: StoresManager = ServiceLocator.stores,
          storage: StorageManagerType = ServiceLocator.storageManager,
-         analytics: Analytics = ServiceLocator.analytics,
-         isExpandedAnalyticsHubEnabled: Bool = ServiceLocator.featureFlagService.isFeatureFlagEnabled(.expandedAnalyticsHub)) {
+         analytics: Analytics = ServiceLocator.analytics) {
         let selectedType = AnalyticsHubTimeRangeSelection.SelectionType(statsTimeRange)
         let timeRangeSelection = AnalyticsHubTimeRangeSelection(selectionType: selectedType, timezone: timeZone)
 
@@ -45,7 +40,6 @@ final class AnalyticsHubViewModel: ObservableObject {
         self.storage = storage
         self.userIsAdmin = stores.sessionManager.defaultRoles.contains(.administrator)
         self.analytics = analytics
-        self.isExpandedAnalyticsHubEnabled = isExpandedAnalyticsHubEnabled
         self.timeRangeSelectionType = selectedType
         self.timeRangeSelection = timeRangeSelection
         self.timeRangeCard = AnalyticsHubViewModel.timeRangeCard(timeRangeSelection: timeRangeSelection,
@@ -161,9 +155,9 @@ final class AnalyticsHubViewModel: ObservableObject {
         case .sessions:
             isEligibleForSessionsCard
         case .bundles:
-            isExpandedAnalyticsHubEnabled && isPluginActive(SitePlugin.SupportedPlugin.WCProductBundles)
+            isPluginActive(SitePlugin.SupportedPlugin.WCProductBundles)
         case .giftCards:
-            isExpandedAnalyticsHubEnabled && isPluginActive(SitePlugin.SupportedPlugin.WCGiftCards)
+            isPluginActive(SitePlugin.SupportedPlugin.WCGiftCards)
         default:
             true
         }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Analytics Hub/AnalyticsHubViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Analytics Hub/AnalyticsHubViewModelTests.swift
@@ -562,8 +562,7 @@ private extension AnalyticsHubViewModelTests {
                               usageTracksEventEmitter: eventEmitter,
                               stores: stores ?? self.stores,
                               storage: storage ?? MockStorageManager(),
-                              analytics: analytics,
-                              isExpandedAnalyticsHubEnabled: true)
+                              analytics: analytics)
     }
 
     func insertActivePlugins(_ pluginNames: [String?], to storage: MockStorageManager) {


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This releases the full support for Product Bundles and Gift Cards extension analytics in the analytics hub.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

On a store with the Product Bundles and Gift Cards extensions active:

* Confirm the product bundles and gift cards analytics cards are shown by default in the Analytics Hub.
* Confirm they can be managed (added/removed/reordered) when customizing the Analytics Hub cards.

On a store without the Product Bundles and Gift Cards extensions active:

* Confirm both cards are hidden by default in the Analytics Hub.
* Confirm both cards are included in the list when customizing the Analytics Hub cards. The cards can't be customized (added/reordered); instead, they have an “Explore” button that opens the corresponding woo.com extension page, so the merchant can learn more about the extension.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

Bundles|Gift Cards|Customize|Customize - extensions not installed
-|-|-|-
![Simulator Screenshot - iPhone 15 Pro - 2024-04-03 at 18 51 24](https://github.com/woocommerce/woocommerce-ios/assets/8658164/5970ed55-da6c-41b5-8224-f32bef6a8b22)|![Simulator Screenshot - iPhone 15 Pro - 2024-04-03 at 18 51 30](https://github.com/woocommerce/woocommerce-ios/assets/8658164/858bc3ec-1965-4778-92cf-7f3cac3203eb)|![Simulator Screenshot - iPhone 15 Pro - 2024-04-03 at 18 52 19](https://github.com/woocommerce/woocommerce-ios/assets/8658164/9f67ce9d-ba31-403e-ad93-f3475f787cad)|![Simulator Screenshot - iPhone 15 Pro - 2024-04-03 at 18 52 43](https://github.com/woocommerce/woocommerce-ios/assets/8658164/8b86c61c-57fd-4623-935a-1a3ae4bf4551)

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
