### PR TITLE
[Jetpack install] Handle error in Jetpack install response

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -3,7 +3,7 @@
 18.1
 -----
 - [**] Orders: now it's possible to swiftly delete orders right from the Order Detail page.
-
+- [*] Login: Fix issues in Jetpack installation feature. [https://github.com/woocommerce/woocommerce-ios/pull/12426]
 
 18.0
 -----

--- a/WooCommerce/Classes/Authentication/Jetpack Setup/Native Jetpack Setup/JetpackSetupViewModel.swift
+++ b/WooCommerce/Classes/Authentication/Jetpack Setup/Native Jetpack Setup/JetpackSetupViewModel.swift
@@ -74,10 +74,7 @@ final class JetpackSetupViewModel: ObservableObject {
     }
 
     var hasEncounteredPermissionError: Bool {
-        if case let .unacceptableStatusCode(statusCode, _) = setupError as? NetworkError, statusCode == 403 {
-            return true
-        }
-        return false
+        setupErrorCode == 403
     }
 
     /// Attributed string for the description text
@@ -220,7 +217,7 @@ private extension JetpackSetupViewModel {
             case .failure(let error):
                 DDLogError("⛔️ Error retrieving Jetpack: \(error)")
                 self.setupError = error
-                if case .notFound = error as? NetworkError {
+                if self.setupErrorCode == 404 {
                     if self.connectionOnly {
                         /// If site has WCPay installed and activated but not connected,
                         /// plugins need to be installed even though we detected a connection before
@@ -351,25 +348,26 @@ private extension JetpackSetupViewModel {
     }
 
     func updateErrorMessage() {
-        switch setupError {
-        case let .some(NetworkError.unacceptableStatusCode(statusCode, _)) where statusCode == 403:
-            setupErrorDetail = .init(setupErrorMessage: Localization.permissionErrorMessage,
-                                     setupErrorSuggestion: Localization.permissionErrorSuggestion,
-                                     errorCode: 403)
-        case let .some(NetworkError.unacceptableStatusCode(statusCode, _)) where 500...599 ~= statusCode:
-            setupErrorDetail = .init(setupErrorMessage: Localization.communicationErrorMessage,
-                                     setupErrorSuggestion: Localization.communicationErrorSuggestion,
-                                     errorCode: statusCode)
-        default:
-            let code: Int? = {
-                if let networkError = setupError as? NetworkError, let code = networkError.responseCode {
-                    return code
-                }
-                return (setupError as? NSError)?.code
-            }()
+        guard let setupErrorCode else {
             setupErrorDetail = .init(setupErrorMessage: Localization.genericErrorMessage,
                                      setupErrorSuggestion: Localization.communicationErrorSuggestion,
-                                     errorCode: code)
+                                     errorCode: nil)
+            return
+        }
+
+        switch setupErrorCode {
+        case 403:
+            setupErrorDetail = .init(setupErrorMessage: Localization.permissionErrorMessage,
+                                     setupErrorSuggestion: Localization.permissionErrorSuggestion,
+                                     errorCode: setupErrorCode)
+        case 500...599:
+            setupErrorDetail = .init(setupErrorMessage: Localization.communicationErrorMessage,
+                                     setupErrorSuggestion: Localization.communicationErrorSuggestion,
+                                     errorCode: setupErrorCode)
+        default:
+            setupErrorDetail = .init(setupErrorMessage: Localization.genericErrorMessage,
+                                     setupErrorSuggestion: Localization.communicationErrorSuggestion,
+                                     errorCode: setupErrorCode)
         }
     }
 }

--- a/WooCommerce/Classes/Authentication/Jetpack Setup/Native Jetpack Setup/JetpackSetupViewModel.swift
+++ b/WooCommerce/Classes/Authentication/Jetpack Setup/Native Jetpack Setup/JetpackSetupViewModel.swift
@@ -1,5 +1,6 @@
 import Foundation
 import Yosemite
+import enum Alamofire.AFError
 import enum Networking.NetworkError
 
 /// View model for `JetpackSetupView`.
@@ -59,6 +60,16 @@ final class JetpackSetupViewModel: ObservableObject {
     private var setupError: Error? {
         didSet {
             updateErrorMessage()
+        }
+    }
+
+    private var setupErrorCode: Int? {
+        if let error = setupError as? NetworkError, let code = error.responseCode {
+            return code
+        } else if let error = setupError as? AFError, let code = error.responseCode {
+            return code
+        } else {
+            return (setupError as? NSError)?.code
         }
     }
 


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #12402 
<!-- Id number of the GitHub issue this PR addresses. -->

## Description

After this #11110 Networking layer change, `JetpackSetupViewModel` stopped receiving `NetworkError` and started receiving `AFError` instead.  This is because the Networking layer change was done only on `AlamofireNetwork` while Jetpack connection process uses `WordPressOrgNetwork`. More info at https://github.com/woocommerce/woocommerce-ios/pull/7600.

We already have a technical debt issue to throw `NetworkError` from `WordPressOrgNetwork` logged here. #11577 I attempted making changes to `WordPressOrgNetwork`, but the `NetworkError` related changes ended up affecting the site credential login flow. 

I decided to look for a simpler solution to avoid spending too much time making changes to `WordPressOrgNetwork` without introducing unnecessary side effects. 

In this PR, I made changes to `JetpackSetupViewModel` to start extracting the error code from AFError/NetworkError/Error and using the error code to perform the Jetpack installation-related logic. 


## Testing instructions

1. Spin up a Jurassic NInja site.
2. Open the mobile app.
3. Connect a new site.
4. Connect a new store.
5. Connect an existing store.
6. Add the JN site URL and auto-generated credentials.
7. Try to install Jetpack.
8. You should be able to install Jetpack and login into the app to manage the store. 

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->


https://github.com/woocommerce/woocommerce-ios/assets/524475/8d2a5b7e-f9e6-4f6a-b7a4-258e91348820


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
