### PR TITLE
[Subscriptions in Order Creation 3] Add feature flag

### DIFF
--- a/Experiments/Experiments/DefaultFeatureFlagService.swift
+++ b/Experiments/Experiments/DefaultFeatureFlagService.swift
@@ -92,6 +92,8 @@ public struct DefaultFeatureFlagService: FeatureFlagService {
             return true
         case .migrateSimplePaymentsToOrderCreation:
             return (buildConfig == .localDeveloper || buildConfig == .alpha) && !isUITesting
+        case .subscriptionsInOrderCreationUI:
+            return buildConfig == .localDeveloper || buildConfig == .alpha
         default:
             return true
         }

--- a/Experiments/Experiments/FeatureFlag.swift
+++ b/Experiments/Experiments/FeatureFlag.swift
@@ -203,4 +203,8 @@ public enum FeatureFlag: Int {
     /// Enables migration from simple payments to order creation.
     ///
     case migrateSimplePaymentsToOrderCreation
+
+    /// Enables visibility of Subscription product details when creating an order, within product selection, and order details.
+    ///
+    case subscriptionsInOrderCreationUI
 }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #12434

## Description
This PR adds a feature flag for the Subscriptions in Order Creation subproject 3, that is, updating UI components across product selection, product cards, and order details within the order creation flow to support subscriptions.

## Testing instructions
There are no changes except the feature flag addition. Project should compile and CI pass.
