### PR TITLE
Dynamic Dashboard: Update struct for dashboard cards and add button for layout editor

### DIFF
--- a/Storage/Storage.xcodeproj/project.pbxproj
+++ b/Storage/Storage.xcodeproj/project.pbxproj
@@ -248,6 +248,7 @@
 		DEA4938F2B3ACA3000EED015 /* BlazeTargetLanguage+CoreDataClass.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEA493892B3ACA3000EED015 /* BlazeTargetLanguage+CoreDataClass.swift */; };
 		DEA493902B3ACA3000EED015 /* BlazeTargetDevice+CoreDataClass.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEA4938A2B3ACA3000EED015 /* BlazeTargetDevice+CoreDataClass.swift */; };
 		DEC51AE0275B41BE009F3DF4 /* WooCommerce.xcdatamodeld in Sources */ = {isa = PBXBuildFile; fileRef = DEC51AA4275B41BE009F3DF4 /* WooCommerce.xcdatamodeld */; };
+		DEC75CBE2BC3D40E00763801 /* DashboardCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEC75CBD2BC3D40E00763801 /* DashboardCard.swift */; };
 		DEFD6D422641B70400E51E0D /* SitePlugin+CoreDataProperties.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEFD6D412641B70400E51E0D /* SitePlugin+CoreDataProperties.swift */; };
 		DEFD6D432641B70400E51E0D /* SitePlugin+CoreDataClass.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEFD6D402641B70400E51E0D /* SitePlugin+CoreDataClass.swift */; };
 		E16D3741284F1CDA005676BC /* GeneralAppSettingsStorageTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E16D3740284F1CDA005676BC /* GeneralAppSettingsStorageTests.swift */; };
@@ -621,6 +622,7 @@
 		DEC51ADD275B41BE009F3DF4 /* Model 37.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = "Model 37.xcdatamodel"; sourceTree = "<group>"; };
 		DEC51ADE275B41BE009F3DF4 /* Model 47.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = "Model 47.xcdatamodel"; sourceTree = "<group>"; };
 		DEC51ADF275B41BE009F3DF4 /* Model 19.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = "Model 19.xcdatamodel"; sourceTree = "<group>"; };
+		DEC75CBD2BC3D40E00763801 /* DashboardCard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DashboardCard.swift; sourceTree = "<group>"; };
 		DED91DE82AD66AA600CDCC53 /* Model 100.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = "Model 100.xcdatamodel"; sourceTree = "<group>"; };
 		DEFD6D402641B70400E51E0D /* SitePlugin+CoreDataClass.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "SitePlugin+CoreDataClass.swift"; sourceTree = "<group>"; };
 		DEFD6D412641B70400E51E0D /* SitePlugin+CoreDataProperties.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "SitePlugin+CoreDataProperties.swift"; sourceTree = "<group>"; };
@@ -777,6 +779,7 @@
 				02DA64182313C2AA00284168 /* StatsVersion.swift */,
 				02D45648231CFB27008CF0A9 /* StatsVersionBannerVisibility.swift */,
 				CEE482D22B83753100FAC8C5 /* AnalyticsCard.swift */,
+				DEC75CBD2BC3D40E00763801 /* DashboardCard.swift */,
 			);
 			name = Stats;
 			sourceTree = "<group>";
@@ -1424,6 +1427,7 @@
 				26EA01D124EC3AEA00176A57 /* FeedbackType.swift in Sources */,
 				452C23B427B4129300822986 /* InboxAction+CoreDataClass.swift in Sources */,
 				7426A05420F69DA4002A4E07 /* OrderItem+CoreDataClass.swift in Sources */,
+				DEC75CBE2BC3D40E00763801 /* DashboardCard.swift in Sources */,
 				028296F4237D404F00E84012 /* GenericAttribute+CoreDataClass.swift in Sources */,
 				262B270E2621412000A421CF /* ProductAddOn+CoreDataProperties.swift in Sources */,
 				7492FAD6217FA9C100ED2C69 /* SiteSetting+CoreDataClass.swift in Sources */,

--- a/Storage/Storage/Model/DashboardCard.swift
+++ b/Storage/Storage/Model/DashboardCard.swift
@@ -1,0 +1,23 @@
+import Foundation
+
+/// Represents a card on the Dashboard screen.
+public struct DashboardCard: Codable, Hashable, Equatable {
+    /// The type of dashboard card.
+    public let type: CardType
+
+    /// Whether the card is enabled in the Analytics Hub.
+    public var enabled: Bool
+
+    public init(type: CardType, enabled: Bool) {
+        self.type = type
+        self.enabled = enabled
+    }
+
+    /// Types of cards to display on the Dashboard screen.
+    /// The order of the cases in this enum defines the default order.
+    public enum CardType: String, Codable, CaseIterable {
+        case onboarding
+        case statsAndTopPerformers // TODO-12403: separate stats and top performers if needed
+        case blaze
+    }
+}

--- a/WooCommerce/Classes/ViewRelated/Dashboard/DashboardView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/DashboardView.swift
@@ -137,7 +137,7 @@ struct DashboardView: View {
 private extension DashboardView {
     var dashboardCards: some View {
         ForEach(viewModel.dashboardCards, id: \.self) { card in
-            switch card {
+            switch card.type {
             case .onboarding:
                 StoreOnboardingView(viewModel: viewModel.storeOnboardingViewModel, onTaskTapped: { task in
                     guard let currentSite else { return }
@@ -211,7 +211,7 @@ private extension DashboardView {
     @ViewBuilder
     var featureAnnouncementCard: some View {
         if let announcementViewModel = viewModel.announcementViewModel,
-            viewModel.dashboardCards.contains(.onboarding) == false {
+           viewModel.dashboardCards.contains(where: { $0.type == .onboarding }) == false {
             FeatureAnnouncementCardView(viewModel: announcementViewModel, dismiss: {
                 viewModel.announcementViewModel = nil
             })

--- a/WooCommerce/Classes/ViewRelated/Dashboard/DashboardView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/DashboardView.swift
@@ -152,14 +152,12 @@ private extension DashboardView {
                 BlazeCampaignDashboardView(viewModel: viewModel.blazeCampaignDashboardViewModel,
                                            showAllCampaignsTapped: showAllBlazeCampaignsTapped,
                                            createCampaignTapped: createBlazeCampaignTapped)
-            case .stats:
+            case .statsAndTopPerformers:
                 if viewModel.statsVersion == .v4 {
                     ViewControllerContainer(storeStatsAndTopPerformersViewController)
                 } else {
                     ViewControllerContainer(DeprecatedDashboardStatsViewController())
                 }
-            case .topPerformers:
-                EmptyView() // TODO-12403: handle this after separating stats and top performers
             }
         }
     }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/DashboardView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/DashboardView.swift
@@ -88,6 +88,13 @@ struct DashboardView: View {
                     }
                 }
             }
+            ToolbarItem(placement: .topBarTrailing) {
+                Button {
+                    // TODO
+                } label: {
+                    Image(systemName: "gearshape")
+                }
+            }
         }
         .onReceive(ServiceLocator.stores.site) { currentSite in
             self.currentSite = currentSite

--- a/WooCommerce/Classes/ViewRelated/Dashboard/DashboardViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/DashboardViewModel.swift
@@ -4,14 +4,6 @@ import enum Networking.DotcomError
 import enum Storage.StatsVersion
 import protocol Experiments.FeatureFlagService
 
-/// Contents to be displayed on the dashboard.
-///
-enum DashboardCard: Int, CaseIterable {
-    case onboarding
-    case statsAndTopPerformers // TODO-12403: separate stats and top performers if needed
-    case blaze
-}
-
 /// Syncs data for dashboard stats UI and determines the state of the dashboard UI based on stats version.
 final class DashboardViewModel: ObservableObject {
     /// Stats v4 is shown by default, then falls back to v3 if store stats are unavailable.
@@ -31,7 +23,8 @@ final class DashboardViewModel: ObservableObject {
 
     @Published private(set) var showOnboarding: Bool = false
     @Published private(set) var showBlazeCampaignView: Bool = false
-    @Published private(set) var dashboardCards: [DashboardCard] = [.statsAndTopPerformers]
+
+    @Published private(set) var dashboardCards: [DashboardCard] = [DashboardCard(type: .statsAndTopPerformers, enabled: true)]
 
     @Published private(set) var jetpackBannerVisibleFromAppSettings = false
     @Published var statSyncingError: Error?
@@ -328,9 +321,9 @@ private extension DashboardViewModel {
         $showOnboarding.combineLatest($showBlazeCampaignView)
             .map { showOnboarding, showBlazeCampaignView -> [DashboardCard] in
                 [
-                    showOnboarding ? .onboarding : nil,
-                    .statsAndTopPerformers,
-                    showBlazeCampaignView ? .blaze : nil
+                    showOnboarding ? DashboardCard(type: .onboarding, enabled: true) : nil,
+                    DashboardCard(type: .statsAndTopPerformers, enabled: true),
+                    showBlazeCampaignView ? DashboardCard(type: .blaze, enabled: true) : nil
                 ].compactMap { $0 }
             }
             .receive(on: RunLoop.main)

--- a/WooCommerce/Classes/ViewRelated/Dashboard/DashboardViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/DashboardViewModel.swift
@@ -8,8 +8,7 @@ import protocol Experiments.FeatureFlagService
 ///
 enum DashboardCard: Int, CaseIterable {
     case onboarding
-    case stats
-    case topPerformers
+    case statsAndTopPerformers // TODO-12403: separate stats and top performers if needed
     case blaze
 }
 
@@ -32,7 +31,7 @@ final class DashboardViewModel: ObservableObject {
 
     @Published private(set) var showOnboarding: Bool = false
     @Published private(set) var showBlazeCampaignView: Bool = false
-    @Published private(set) var dashboardCards: [DashboardCard] = [.stats, .topPerformers]
+    @Published private(set) var dashboardCards: [DashboardCard] = [.statsAndTopPerformers]
 
     @Published private(set) var jetpackBannerVisibleFromAppSettings = false
     @Published var statSyncingError: Error?
@@ -330,8 +329,7 @@ private extension DashboardViewModel {
             .map { showOnboarding, showBlazeCampaignView -> [DashboardCard] in
                 [
                     showOnboarding ? .onboarding : nil,
-                    .stats,
-                    .topPerformers,
+                    .statsAndTopPerformers,
                     showBlazeCampaignView ? .blaze : nil
                 ].compactMap { $0 }
             }

--- a/Yosemite/Yosemite/Model/Model.swift
+++ b/Yosemite/Yosemite/Model/Model.swift
@@ -294,6 +294,7 @@ public typealias FeatureAnnouncementCampaign = Storage.FeatureAnnouncementCampai
 public typealias FeatureAnnouncementCampaignSettings = Storage.FeatureAnnouncementCampaignSettings
 public typealias LocalAnnouncement = Storage.LocalAnnouncement
 public typealias AnalyticsCard = Storage.AnalyticsCard
+public typealias DashboardCard = Storage.DashboardCard
 
 // MARK: - Internal ReadOnly Models
 


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #12448
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
Previously, I wanted to create a new view for layout editor as part of this PR. Then I realized that I need to update the struct for dashboard cards, so this is a separate PR to handle that to unblock any other tasks in the project.

Also, I'm grouping store stats and top performers in the same card type for now, as we will have another task for separating these sections later on.  

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
- Enable the `dynamicDashboard` feature flag and build the app.
- Log in to a store.
- Confirm that the dashboard screen works similarly as before, and there's a new button on the top right for layout editing. The functionality for the button will be handled in a separate PR.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->
<img src="https://github.com/woocommerce/woocommerce-ios/assets/5533851/bf5110ca-d177-44d0-a5f9-729c50ec8e89" width=320 />


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
