### PR TITLE
[Migrate simple payments] Fix UI test

### DIFF
--- a/Experiments/Experiments/DefaultFeatureFlagService.swift
+++ b/Experiments/Experiments/DefaultFeatureFlagService.swift
@@ -91,7 +91,7 @@ public struct DefaultFeatureFlagService: FeatureFlagService {
         case .customersInHubMenu:
             return true
         case .migrateSimplePaymentsToOrderCreation:
-            return (buildConfig == .localDeveloper || buildConfig == .alpha) && !isUITesting
+            return buildConfig == .localDeveloper || buildConfig == .alpha
         case .dynamicDashboard:
             return buildConfig == .localDeveloper || buildConfig == .alpha
         default:

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Payments Menu/SimplePaymentsMigrationView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Payments Menu/SimplePaymentsMigrationView.swift
@@ -25,6 +25,7 @@ struct SimplePaymentsMigrationView: View {
             }
             .buttonStyle(PrimaryButtonStyle())
             .padding(.top, Layout.extraButtonTopPadding)
+            .accessibilityIdentifier("simple-payments-migration-add-custom-amount")
         }
         .multilineTextAlignment(.center)
         .padding(Layout.padding)

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/OrderForm.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/OrderForm.swift
@@ -517,6 +517,7 @@ struct OrderForm: View {
             }
             .buttonStyle(PrimaryLoadingButtonStyle(isLoading: loading))
             .disabled(viewModel.collectPaymentDisabled)
+            .accessibilityIdentifier("order-form-collect-payment")
         case .done(let loading):
             Button {
                 viewModel.finishEditing()

--- a/WooCommerce/UITestsFoundation/Screens/Payments/PaymentsScreen.swift
+++ b/WooCommerce/UITestsFoundation/Screens/Payments/PaymentsScreen.swift
@@ -14,10 +14,6 @@ public final class PaymentsScreen: ScreenObject {
         $0.buttons["next-button"]
     }
 
-    private let takePaymentButtonGetter: (XCUIApplication) -> XCUIElement = {
-        $0.buttons["take-payment-button"]
-    }
-
     private let cashPaymentButtonGetter: (XCUIApplication) -> XCUIElement = {
         $0.buttons["payment-methods-view-cash-row"]
     }
@@ -38,15 +34,29 @@ public final class PaymentsScreen: ScreenObject {
         $0.navigationBars["Payments"]
     }
 
+    private let addCustomAmountGetter: (XCUIApplication) -> XCUIElement = {
+        $0.buttons["simple-payments-migration-add-custom-amount"]
+    }
+
+    private let confirmCustomAmountGetter: (XCUIApplication) -> XCUIElement = {
+        $0.buttons["order-add-custom-amount-view-add-custom-amount-button"]
+    }
+
+    private let orderFormCollectPaymentButtonGetter: (XCUIApplication) -> XCUIElement = {
+        $0.buttons["order-form-collect-payment"]
+    }
+
     private var collectPaymentButton: XCUIElement { collectPaymentButtonGetter(app) }
     private var cardReaderManualsButton: XCUIElement { cardReaderManualsButtonGetter(app) }
     private var learnMoreButton: XCUIElement { learnMoreButtonGetter(app) }
     private var nextButton: XCUIElement { nextButtonGetter(app) }
     private var paymentsNavigationBar: XCUIElement { paymentsNavigationBarGetter(app) }
-    private var takePaymentButton: XCUIElement { takePaymentButtonGetter(app) }
     private var cashPaymentButton: XCUIElement { cashPaymentButtonGetter(app) }
     private var markAsPaidButton: XCUIElement { markAsPaidButtonGetter(app) }
     private var IPPDocumentationHeaderText: XCUIElement { IPPDocumentationHeaderTextGetter(app) }
+    private var addCustomAmountButton: XCUIElement { addCustomAmountGetter(app) }
+    private var confirmCustomAmountButton: XCUIElement { confirmCustomAmountGetter(app) }
+    private var orderFormCollectPaymentButton: XCUIElement { orderFormCollectPaymentButtonGetter(app) }
 
     public init(app: XCUIApplication = XCUIApplication()) throws {
         try super.init(
@@ -75,14 +85,18 @@ public final class PaymentsScreen: ScreenObject {
         return self
     }
 
+    /// Enters a custom amount by tapping a button on the numeric keypad.
+    /// This is done instead of entering text because the text field for custom amount
+    /// is custom with opacity 0, and gets no keyboard focus when tapped.
     public func enterPaymentAmount(_ amount: String) throws -> Self {
-        app.enterText(text: amount)
-        nextButton.tap()
+        addCustomAmountButton.waitAndTap()
+        app.keyboards.keys[amount].firstMatch.tap()
+        confirmCustomAmountButton.waitAndTap()
         return self
     }
 
     public func takeCashPayment() throws -> Self {
-        takePaymentButton.waitAndTap()
+        orderFormCollectPaymentButton.waitAndTap()
         cashPaymentButton.waitAndTap()
 
         markAsPaidButton.tap()

--- a/WooCommerce/UITestsFoundation/Screens/Payments/PaymentsScreen.swift
+++ b/WooCommerce/UITestsFoundation/Screens/Payments/PaymentsScreen.swift
@@ -98,8 +98,7 @@ public final class PaymentsScreen: ScreenObject {
     public func takeCashPayment() throws -> Self {
         orderFormCollectPaymentButton.waitAndTap()
         cashPaymentButton.waitAndTap()
-
-        markAsPaidButton.tap()
+        markAsPaidButton.waitAndTap()
         return self
     }
 

--- a/WooCommerce/WooCommerceUITests/Mocks/mappings/jetpack-blogs/wc/orders/orders_complete_custom_amount.json
+++ b/WooCommerce/WooCommerceUITests/Mocks/mappings/jetpack-blogs/wc/orders/orders_complete_custom_amount.json
@@ -3,7 +3,8 @@
         "method": "POST",
         "urlPath": "/rest/v1.1/jetpack-blogs/161477129/rest-api/",
         "bodyPatterns": [
-            { "matches": ".*path=/wc/v3/orders.*" }
+            { "matches": ".*path=/wc/v3/orders.*" },
+            { "contains": "%22Custom%20amount%22" }
         ]
     },
     "response": {

--- a/WooCommerce/WooCommerceUITests/Mocks/mappings/jetpack-blogs/wc/orders/orders_complete_custom_amount.json
+++ b/WooCommerce/WooCommerceUITests/Mocks/mappings/jetpack-blogs/wc/orders/orders_complete_custom_amount.json
@@ -1,0 +1,110 @@
+{
+    "request": {
+        "method": "POST",
+        "urlPath": "/rest/v1.1/jetpack-blogs/161477129/rest-api/",
+        "bodyPatterns": [
+            { "matches": ".*path=/wc/v3/orders.*" }
+        ]
+    },
+    "response": {
+        "status": 200,
+        "jsonBody": {
+            "data": {
+                "id": 630,
+                "parent_id": 0,
+                "status": "auto-draft",
+                "currency": "USD",
+                "version": "7.6.1",
+                "prices_include_tax": false,
+                "date_created": "{{#assign 'customformat'}}yyyy-MM-dd'T'HH:mm:ss{{/assign}}{{now format=customformat}}",
+                "date_modified": "{{now format=customformat}}",
+                "discount_total": "0.00",
+                "discount_tax": "0.00",
+                "shipping_total": "0.00",
+                "shipping_tax": "0.00",
+                "cart_tax": "0.00",
+                "total": "5.00",
+                "total_tax": "0.00",
+                "customer_id": 0,
+                "order_key": "wc_order_xxx",
+                "billing": {
+                    "first_name": "",
+                    "last_name": "",
+                    "company": "",
+                    "address_1": "",
+                    "address_2": "",
+                    "city": "",
+                    "state": "",
+                    "postcode": "",
+                    "country": "",
+                    "email": "",
+                    "phone": ""
+                },
+                "shipping": {
+                    "first_name": "",
+                    "last_name": "",
+                    "company": "",
+                    "address_1": "",
+                    "address_2": "",
+                    "city": "",
+                    "state": "",
+                    "postcode": "",
+                    "country": "",
+                    "phone": ""
+                },
+                "payment_method": "",
+                "payment_method_title": "",
+                "transaction_id": "",
+                "customer_ip_address": "",
+                "customer_user_agent": "",
+                "created_via": "rest-api",
+                "customer_note": "",
+                "date_completed": null,
+                "date_paid": null,
+                "cart_hash": "",
+                "number": "630",
+                "meta_data": [],
+                "line_items": [],
+                "tax_lines": [],
+                "shipping_lines": [],
+                "fee_lines": [
+                    {
+                        "id": 475,
+                        "name": "Custom amount",
+                        "tax_class": "",
+                        "tax_status": "taxable",
+                        "amount": "",
+                        "total": "5.00",
+                        "total_tax": "0.00",
+                        "taxes": [],
+                        "meta_data": []
+                    }
+                ],
+                "coupon_lines": [],
+                "refunds": [],
+                "payment_url": "https://automatticwidgets.wpcomstaging.com/checkout/order-pay/630/?pay_for_order=true&key=wc_order_xxx",
+                "is_editable": true,
+                "needs_payment": false,
+                "needs_processing": false,
+                "date_created_gmt": "{{now format=customformat}}",
+                "date_modified_gmt": "{{now format=customformat}}",
+                "date_completed_gmt": null,
+                "date_paid_gmt": null,
+                "gift_cards": [],
+                "currency_symbol": "$",
+                "_links": {
+                    "self": [
+                        {
+                            "href": "https://automatticwidgets.wpcomstaging.com/wp-json/wc/v3/orders/630"
+                        }
+                    ],
+                    "collection": [
+                        {
+                            "href": "https://automatticwidgets.wpcomstaging.com/wp-json/wc/v3/orders"
+                        }
+                    ]
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #12387 
⚠️ Currently based on https://github.com/woocommerce/woocommerce-ios/pull/12400

<!-- Id number of the GitHub issue this PR addresses. -->

## Why

From the UX changes to migrate from simple payments to order form https://github.com/woocommerce/woocommerce-ios/issues/12387, `test_complete_cash_simple_payment` starts failing because it's based on the simple payments flow that we're sunsetting. This PR updates the related test components with new accessibility identifiers for the UI elements that the test depends on.

## How

I encountered two challenges:

1. Entering the custom amount while the text field has an opacity of 0

Because the custom amount screen uses a custom text field component `FormattableAmountTextField`, it uses `BindableTextfield` with the actual text field `UITextField` but it has opacity 0 to display the "formatted amount" label to the user. This results in the Xcode UI testing framework not being able to find the element where it can type in a text using `typeText`. After a bunch of trials and errors, I landed on the same workaround as another existing UI test `OrdersTests.test_create_new_order`'s call to `AddCustomAmountScreen.enterCustomAmount` that I discovered too late. The workaround is to tap on the numeric key (e.g. "5") on the keyboard. The tests that rely on this keyboard workaround would still fail if the keyboard is not visible in the simulator, but this isn't an issue in CI probably with some configuration to enable the keyboard.

2. Adding a network response mock for the order creation API request

It took me quite some time to figure out how to add a network mock using Wiremock. Both paaHJt-yC-p2 and the UI test documentation point to the Wiremock documentation without concrete steps. The only way I found was to manually create a JSON file based on a similar response mock and modify it for the new request(s), and it wasn't very straightforward to debug even with the use of Charles proxy tool. For the new mock creating/updating an order with a custom amount, I created `orders_complete_custom_amount.json` based on [`orders_complete_simple_payment.json`](https://github.com/woocommerce/woocommerce-ios/blob/a487d144ebbd248b41ad1b03a908e9f0a719644a/WooCommerce/WooCommerceUITests/Mocks/mappings/jetpack-blogs/wc/orders/orders_complete_simple_payment.json).

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

Just CI is sufficient, as the changes are only on the UI tests.

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.