### PR TITLE
[Site Credentials] Update login error regex checker

### DIFF
--- a/WooCommerce/Classes/Authentication/SiteCredentialLoginUseCase.swift
+++ b/WooCommerce/Classes/Authentication/SiteCredentialLoginUseCase.swift
@@ -263,7 +263,7 @@ private extension String {
     /// Gets contents between HTML tags with regex.
     ///
     func findLoginErrorMessage() -> String? {
-        let pattern = "<div[^>]*id=\"login_error\">([\\s\\S]+?)</div>"
+        let pattern = "<div[^>]*id=\"login_error\"[^>]*>([\\s\\S]+?)</div>"
         let urlPattern = "<a href=\".*\">[^~]*?</a>"
         let regexOptions = NSRegularExpression.Options.caseInsensitive
         let matchOptions = NSRegularExpression.MatchingOptions(rawValue: UInt(0))


### PR DESCRIPTION
closes #12445 

# Why

We noticed that the iOS app does not detect login errors like the Android app. This PR updates the login error regex checker to match the [Android one](https://github.com/wordpress-mobile/WordPress-FluxC-Android/blob/5ac70a3e8f6d41962de9ada5d61423d0877e26f3/fluxc/src/main/java/org/wordpress/android/fluxc/network/rest/wpapi/NonceRestClient.kt#L146).

# Screenshots

Before | After
---- | ----
<img width="441" alt="bad" src="https://github.com/woocommerce/woocommerce-ios/assets/562080/15df396e-e243-49b7-a2ca-6711b9c246b9"> | <img width="436" alt="good" src="https://github.com/woocommerce/woocommerce-ios/assets/562080/514f3717-07b5-4b78-a554-a1cc086cc96a">
