### PR TITLE
[Product Creation AI] Update prompt to avoid receiving JSON word in response.

### DIFF
--- a/Networking/Networking/Remote/GenerativeContentRemote.swift
+++ b/Networking/Networking/Remote/GenerativeContentRemote.swift
@@ -201,8 +201,7 @@ private extension GenerativeContentRemote {
                            token: JWToken) async throws -> AIProduct {
         let input = [
             "You are a WooCommerce SEO and marketing expert, perform in-depth research about the product " +
-            "using the provided name, keywords and tone.",
-            "Your response should be in JSON format and don't send anything extra.",
+            "using the provided name, keywords and tone, and give your response in the below JSON format.",
             "name: ```\(productName)```",
             "keywords: ```\(keywords)```",
             "tone: ```\(tone)```",
@@ -254,7 +253,7 @@ private extension GenerativeContentRemote {
         }()
 
         let expectedJsonFormat =
-        "Expected json response format:" + "\n" + (jsonResponseFormatDict.toJSONEncoded() ?? "")
+        "Your response should be in JSON format and don't send anything extra. Don't include the word JSON in your response:" + "\n" + (jsonResponseFormatDict.toJSONEncoded() ?? "")
 
         let prompt = input + "\n" + expectedJsonFormat
 

--- a/Networking/Networking/Remote/GenerativeContentRemote.swift
+++ b/Networking/Networking/Remote/GenerativeContentRemote.swift
@@ -253,7 +253,10 @@ private extension GenerativeContentRemote {
         }()
 
         let expectedJsonFormat =
-        "Your response should be in JSON format and don't send anything extra. Don't include the word JSON in your response:" + "\n" + (jsonResponseFormatDict.toJSONEncoded() ?? "")
+        "Your response should be in JSON format and don't send anything extra. " +
+        "Don't include the word JSON in your response:" +
+        "\n" +
+        (jsonResponseFormatDict.toJSONEncoded() ?? "")
 
         let prompt = input + "\n" + expectedJsonFormat
 

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -10,6 +10,7 @@
 - [**] Stats: The Analytics Hub now includes analytics for Product Bundles and Gift Cards, when those extensions are active. [https://github.com/woocommerce/woocommerce-ios/pull/12425]
 - [*] Login: Fix issues in Jetpack installation feature. [https://github.com/woocommerce/woocommerce-ios/pull/12426]
 - [Internal] WooExpress: Site creation with WooExpress is now disabled. [https://github.com/woocommerce/woocommerce-ios/issues/12323]
+- [*] Product Creation AI: Update prompt to fix error during product creation. [https://github.com/woocommerce/woocommerce-ios/pull/12457]
 
 
 18.0


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #11188 
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

Updates the AI prompt for product creation AI feature to avoid receiving unexpected JSON response.

Changes
- We changed the AI generation prompt and asked to explicitly avoid the word "JSON" in response.
- Made slight updates to the prompt to match with Android prompt. 

## Testing instructions

- Create a JN store with the Jetpack AI plugin
- Login into the app
- Navigate to the Products tab
- Tap "+" -> "Create a product with AI"
- Follow the steps to enter the product name and features
- Validate that the AI generates the product details as expected
- Try the AI creation flow a few more times to generate diverse products and validate that you can generate product details successfully. 

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

https://github.com/woocommerce/woocommerce-ios/assets/524475/21373fa2-267e-460e-81bf-3386f7e10654


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
