### PR TITLE
Dynamic Dashboard: Update Storage and Yosemite to persist dashboard cards

### DIFF
--- a/Storage/Storage/Model/Copiable/Models+Copiable.generated.swift
+++ b/Storage/Storage/Model/Copiable/Models+Copiable.generated.swift
@@ -103,7 +103,8 @@ extension Storage.GeneralStoreSettings {
         customStatsTimeRange: CopiableProp<String> = .copy,
         firstInPersonPaymentsTransactionsByReaderType: CopiableProp<[CardReaderType: Date]> = .copy,
         selectedTaxRateID: NullableCopiableProp<Int64> = .copy,
-        analyticsHubCards: NullableCopiableProp<[AnalyticsCard]> = .copy
+        analyticsHubCards: NullableCopiableProp<[AnalyticsCard]> = .copy,
+        dashboardCards: NullableCopiableProp<[DashboardCard]> = .copy
     ) -> Storage.GeneralStoreSettings {
         let storeID = storeID ?? self.storeID
         let isTelemetryAvailable = isTelemetryAvailable ?? self.isTelemetryAvailable
@@ -116,6 +117,7 @@ extension Storage.GeneralStoreSettings {
         let firstInPersonPaymentsTransactionsByReaderType = firstInPersonPaymentsTransactionsByReaderType ?? self.firstInPersonPaymentsTransactionsByReaderType
         let selectedTaxRateID = selectedTaxRateID ?? self.selectedTaxRateID
         let analyticsHubCards = analyticsHubCards ?? self.analyticsHubCards
+        let dashboardCards = dashboardCards ?? self.dashboardCards
 
         return Storage.GeneralStoreSettings(
             storeID: storeID,
@@ -128,7 +130,8 @@ extension Storage.GeneralStoreSettings {
             customStatsTimeRange: customStatsTimeRange,
             firstInPersonPaymentsTransactionsByReaderType: firstInPersonPaymentsTransactionsByReaderType,
             selectedTaxRateID: selectedTaxRateID,
-            analyticsHubCards: analyticsHubCards
+            analyticsHubCards: analyticsHubCards,
+            dashboardCards: dashboardCards
         )
     }
 }

--- a/Storage/Storage/Model/GeneralStoreSettings.swift
+++ b/Storage/Storage/Model/GeneralStoreSettings.swift
@@ -56,6 +56,9 @@ public struct GeneralStoreSettings: Codable, Equatable, GeneratedCopiable {
     /// The set of cards for the Analytics Hub, with their enabled status and sort order.
     public let analyticsHubCards: [AnalyticsCard]?
 
+    /// The set of cards for the Dashboard screen, with their enabled status and sort order.
+    public let dashboardCards: [DashboardCard]?
+
     public init(storeID: String? = nil,
                 isTelemetryAvailable: Bool = false,
                 telemetryLastReportedTime: Date? = nil,
@@ -66,7 +69,8 @@ public struct GeneralStoreSettings: Codable, Equatable, GeneratedCopiable {
                 customStatsTimeRange: String = "",
                 firstInPersonPaymentsTransactionsByReaderType: [CardReaderType: Date] = [:],
                 selectedTaxRateID: Int64? = nil,
-                analyticsHubCards: [AnalyticsCard]? = nil) {
+                analyticsHubCards: [AnalyticsCard]? = nil,
+                dashboardCards: [DashboardCard]? = nil) {
         self.storeID = storeID
         self.isTelemetryAvailable = isTelemetryAvailable
         self.telemetryLastReportedTime = telemetryLastReportedTime
@@ -78,6 +82,7 @@ public struct GeneralStoreSettings: Codable, Equatable, GeneratedCopiable {
         self.firstInPersonPaymentsTransactionsByReaderType = firstInPersonPaymentsTransactionsByReaderType
         self.selectedTaxRateID = selectedTaxRateID
         self.analyticsHubCards = analyticsHubCards
+        self.dashboardCards = dashboardCards
     }
 
     public func erasingSelectedTaxRateID() -> GeneralStoreSettings {
@@ -91,7 +96,8 @@ public struct GeneralStoreSettings: Codable, Equatable, GeneratedCopiable {
                              customStatsTimeRange: customStatsTimeRange,
                              firstInPersonPaymentsTransactionsByReaderType: firstInPersonPaymentsTransactionsByReaderType,
                              selectedTaxRateID: nil,
-                             analyticsHubCards: analyticsHubCards)
+                             analyticsHubCards: analyticsHubCards,
+                             dashboardCards: dashboardCards)
     }
 }
 
@@ -114,6 +120,7 @@ extension GeneralStoreSettings {
                                                                                            forKey: .firstInPersonPaymentsTransactionsByReaderType) ?? [:]
         self.selectedTaxRateID = try container.decodeIfPresent(Int64.self, forKey: .selectedTaxRateID)
         self.analyticsHubCards = try container.decodeIfPresent([AnalyticsCard].self, forKey: .analyticsHubCards)
+        self.dashboardCards = try container.decodeIfPresent([DashboardCard].self, forKey: .dashboardCards)
 
         // Decode new properties with `decodeIfPresent` and provide a default value if necessary.
     }

--- a/Yosemite/Yosemite/Actions/AppSettingsAction.swift
+++ b/Yosemite/Yosemite/Actions/AppSettingsAction.swift
@@ -258,4 +258,14 @@ public enum AppSettingsAction: Action {
     /// Loads the stored, ordered array of cards for the Analytics Hub.
     ///
     case loadAnalyticsHubCards(siteID: Int64, onCompletion: ([AnalyticsCard]?) -> Void)
+
+    // MARK: - Dashboard Cards
+
+    /// Stores an ordered array of cards for the Dashboard screen.
+    ///
+    case setDashboardCards(siteID: Int64, cards: [DashboardCard])
+
+    /// Loads the stored, ordered array of cards for the Dashboard screen.
+    ///
+    case loadDashboardCards(siteID: Int64, onCompletion: ([DashboardCard]?) -> Void)
 }

--- a/Yosemite/Yosemite/Stores/AppSettingsStore.swift
+++ b/Yosemite/Yosemite/Stores/AppSettingsStore.swift
@@ -216,6 +216,10 @@ public class AppSettingsStore: Store {
             loadCustomStatsTimeRange(siteID: siteID, onCompletion: onCompletion)
         case let .setCustomStatsTimeRange(siteID, timeRange):
             setCustomStatsTimeRange(siteID: siteID, timeRange: timeRange)
+        case let .loadDashboardCards(siteID, onCompletion):
+            loadDashboardCards(siteID: siteID, onCompletion: onCompletion)
+        case let .setDashboardCards(siteID, cards):
+            setDashboardCards(siteID: siteID, cards: cards)
         }
     }
 }
@@ -946,6 +950,20 @@ private extension AppSettingsStore {
 
     func loadAnalyticsHubCards(siteID: Int64, onCompletion: ([AnalyticsCard]?) -> Void) {
         onCompletion(getStoreSettings(for: siteID).analyticsHubCards)
+    }
+}
+
+// MARK: - Dashboard Cards
+
+private extension AppSettingsStore {
+    func setDashboardCards(siteID: Int64, cards: [DashboardCard]) {
+        let storeSettings = getStoreSettings(for: siteID)
+        let updatedSettings = storeSettings.copy(dashboardCards: cards)
+        setStoreSettings(settings: updatedSettings, for: siteID)
+    }
+
+    func loadDashboardCards(siteID: Int64, onCompletion: ([DashboardCard]?) -> Void) {
+        onCompletion(getStoreSettings(for: siteID).dashboardCards)
     }
 }
 

--- a/Yosemite/YosemiteTests/Stores/AppSettingsStoreTests.swift
+++ b/Yosemite/YosemiteTests/Stores/AppSettingsStoreTests.swift
@@ -1364,6 +1364,66 @@ extension AppSettingsStoreTests {
         // Then
         XCTAssertNil(customTimeRange)
     }
+
+    // MARK: - dashboard cards
+    func test_setDashboardCards_works_correctly() throws {
+        // Given
+        let dashboardCards = [
+            DashboardCard(type: .onboarding, enabled: false),
+            DashboardCard(type: .statsAndTopPerformers, enabled: true),
+            DashboardCard(type: .blaze, enabled: true)
+        ]
+        let existingSettings = GeneralStoreSettingsBySite(storeSettingsBySite: [TestConstants.siteID: GeneralStoreSettings()])
+        try fileStorage?.write(existingSettings, to: expectedGeneralStoreSettingsFileURL)
+
+        // When
+        let action = AppSettingsAction.setDashboardCards(siteID: TestConstants.siteID, cards: dashboardCards)
+        subject?.onAction(action)
+
+        // Then
+        let savedSettings: GeneralStoreSettingsBySite = try XCTUnwrap(fileStorage?.data(for: expectedGeneralStoreSettingsFileURL))
+        let settingsForSite = savedSettings.storeSettingsBySite[TestConstants.siteID]
+
+        assertEqual(dashboardCards, settingsForSite?.dashboardCards)
+    }
+
+    func test_loadDashboardCards_works_correctly() throws {
+        // Given
+        let storedDashboardCards = [
+            DashboardCard(type: .onboarding, enabled: false),
+            DashboardCard(type: .statsAndTopPerformers, enabled: true),
+            DashboardCard(type: .blaze, enabled: true)
+        ]
+        let storeSettings = GeneralStoreSettings(dashboardCards: storedDashboardCards)
+        let existingSettings = GeneralStoreSettingsBySite(storeSettingsBySite: [TestConstants.siteID: storeSettings])
+        try fileStorage?.write(existingSettings, to: expectedGeneralStoreSettingsFileURL)
+
+        // When
+        var loadedDashboardCards: [DashboardCard]?
+        let action = AppSettingsAction.loadDashboardCards(siteID: TestConstants.siteID) { cards in
+            loadedDashboardCards = cards
+        }
+        subject?.onAction(action)
+
+        // Then
+        assertEqual(storedDashboardCards, loadedDashboardCards)
+    }
+
+    func test_loadDashboardCards_returns_nil_when_no_cards_are_saved() throws {
+        // Given
+        let existingSettings = GeneralStoreSettingsBySite(storeSettingsBySite: [TestConstants.siteID: GeneralStoreSettings()])
+        try fileStorage?.write(existingSettings, to: expectedGeneralStoreSettingsFileURL)
+
+        // When
+        var loadedDashboardCards: [DashboardCard]?
+        let action = AppSettingsAction.loadDashboardCards(siteID: TestConstants.siteID) { cards in
+            loadedDashboardCards = cards
+        }
+        subject?.onAction(action)
+
+        // Then
+        XCTAssertNil(loadedDashboardCards)
+    }
 }
 
 // MARK: - Utils


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #12459 
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This PR updates `GeneralAppSettings` and `AppSettingStore` and action to support persisting dashboard cards' orders and states.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
The new action hasn't been integrated, so just CI passing is sufficient

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->
N/A

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
