### PR TITLE
[Product Creation AI] Use `response_format` to receive JSON

### DIFF
--- a/Networking/Networking/Remote/GenerativeContentRemote.swift
+++ b/Networking/Networking/Remote/GenerativeContentRemote.swift
@@ -9,6 +9,11 @@ public enum GenerativeContentRemoteFeature: String {
     case productCreation = "woo_ios_product_creation"
 }
 
+public enum GenerativeContentRemoteResponseFormat: String {
+    case json = "json_object"
+    case text = "text"
+}
+
 /// Protocol for `GenerativeContentRemote` mainly used for mocking.
 ///
 public protocol GenerativeContentRemoteProtocol {

--- a/Networking/Networking/Remote/GenerativeContentRemote.swift
+++ b/Networking/Networking/Remote/GenerativeContentRemote.swift
@@ -22,10 +22,12 @@ public protocol GenerativeContentRemoteProtocol {
     ///   - siteID: WPCOM ID of the site.
     ///   - base: Prompt for the AI-generated text.
     ///   - feature: Used by backend to track AI-generation usage and measure costs
+    ///   - responseFormat: enum parameter to specify response format.
     /// - Returns: AI-generated text based on the prompt if Jetpack AI is enabled.
     func generateText(siteID: Int64,
                       base: String,
-                      feature: GenerativeContentRemoteFeature) async throws -> String
+                      feature: GenerativeContentRemoteFeature,
+                      responseFormat: GenerativeContentRemoteResponseFormat) async throws -> String
 
     /// Identifies the language from the given string
     /// - Parameters:
@@ -73,17 +75,18 @@ public final class GenerativeContentRemote: Remote, GenerativeContentRemoteProto
 
     public func generateText(siteID: Int64,
                              base: String,
-                             feature: GenerativeContentRemoteFeature) async throws -> String {
+                             feature: GenerativeContentRemoteFeature,
+                             responseFormat: GenerativeContentRemoteResponseFormat) async throws -> String {
         do {
             guard let token, token.isTokenValid(for: siteID) else {
                 throw GenerativeContentRemoteError.tokenNotFound
             }
-            return try await generateText(siteID: siteID, base: base, feature: feature, token: token)
+            return try await generateText(siteID: siteID, base: base, feature: feature, responseFormat: responseFormat, token: token)
         } catch GenerativeContentRemoteError.tokenNotFound,
                 WordPressApiError.unknown(code: TokenExpiredError.code, message: TokenExpiredError.message) {
             let token = try await fetchToken(siteID: siteID)
             self.token = token
-            return try await generateText(siteID: siteID, base: base, feature: feature, token: token)
+            return try await generateText(siteID: siteID, base: base, feature: feature, responseFormat: responseFormat, token: token)
         }
     }
 
@@ -159,11 +162,13 @@ private extension GenerativeContentRemote {
     func generateText(siteID: Int64,
                       base: String,
                       feature: GenerativeContentRemoteFeature,
+                      responseFormat: GenerativeContentRemoteResponseFormat?,
                       token: JWToken) async throws -> String {
         let parameters = [ParameterKey.token: token.token,
                           ParameterKey.prompt: base,
                           ParameterKey.feature: feature.rawValue,
-                          ParameterKey.fields: ParameterValue.completion]
+                          ParameterKey.fields: ParameterValue.completion,
+                          ParameterKey.responseFormat: responseFormat?.rawValue].compactMapValues { $0 }
         let request = DotcomRequest(wordpressApiVersion: .wpcomMark2,
                                     method: .post,
                                     path: Path.textCompletion,
@@ -292,6 +297,7 @@ private extension GenerativeContentRemote {
         static let prompt = "prompt"
         static let feature = "feature"
         static let fields = "_fields"
+        static let responseFormat = "response_format"
     }
 
     enum ParameterValue {

--- a/Networking/NetworkingTests/Remote/GenerativeContentRemoteTests.swift
+++ b/Networking/NetworkingTests/Remote/GenerativeContentRemoteTests.swift
@@ -30,12 +30,31 @@ final class GenerativeContentRemoteTests: XCTestCase {
         // When
         _ = try await remote.generateText(siteID: sampleSiteID,
                                           base: "generate a product description for wapuu pencil",
-                                          feature: .productDescription)
+                                          feature: .productDescription,
+                                          responseFormat: .text)
 
         // Then
         let request = try XCTUnwrap(network.requestsForResponseData.last as? DotcomRequest)
         let fieldsValue = try XCTUnwrap(request.parameters?["_fields"] as? String)
         XCTAssertEqual("completion", fieldsValue)
+    }
+
+    func test_generateText_sends_correct_response_format_value() async throws {
+        // Given
+        let remote = GenerativeContentRemote(network: network)
+        network.simulateResponse(requestUrlSuffix: "sites/\(sampleSiteID)/jetpack-openai-query/jwt", filename: "jwt-token-success")
+        network.simulateResponse(requestUrlSuffix: "text-completion", filename: "generative-text-success")
+
+        // When
+        _ = try await remote.generateText(siteID: sampleSiteID,
+                                          base: "generate a product description for wapuu pencil",
+                                          feature: .productDescription,
+                                          responseFormat: .text)
+
+        // Then
+        let request = try XCTUnwrap(network.requestsForResponseData.last as? DotcomRequest)
+        let responseFormatValue = try XCTUnwrap(request.parameters?["response_format"] as? String)
+        XCTAssertEqual("text", responseFormatValue)
     }
 
     func test_generateText_with_success_returns_generated_text() async throws {
@@ -47,7 +66,8 @@ final class GenerativeContentRemoteTests: XCTestCase {
         // When
         let generatedText = try await remote.generateText(siteID: sampleSiteID,
                                                           base: "generate a product description for wapuu pencil",
-                                                          feature: .productDescription)
+                                                          feature: .productDescription,
+                                                          responseFormat: .text)
 
         // Then
         XCTAssertEqual(generatedText, "The Wapuu Pencil is a perfect writing tool for those who love cute things.")
@@ -63,7 +83,8 @@ final class GenerativeContentRemoteTests: XCTestCase {
         await assertThrowsError {
             _ = try await remote.generateText(siteID: sampleSiteID,
                                               base: "generate a product description for wapuu pencil",
-                                              feature: .productDescription)
+                                              feature: .productDescription,
+                                              responseFormat: .text)
         } errorAssert: { error in
             // Then
             error as? WordPressApiError == .unknown(code: "inactive", message: "OpenAI features have been disabled")
@@ -80,7 +101,8 @@ final class GenerativeContentRemoteTests: XCTestCase {
         await assertThrowsError {
             _ = try await remote.generateText(siteID: sampleSiteID,
                                               base: "generate a product description for wapuu pencil",
-                                              feature: .productDescription)
+                                              feature: .productDescription,
+                                              responseFormat: .text)
         } errorAssert: { error in
             // Then
             error as? WordPressApiError == .unknown(code: "oauth2_invalid_token", message: "The OAuth2 token is invalid.")
@@ -98,14 +120,16 @@ final class GenerativeContentRemoteTests: XCTestCase {
         // When
         _ = try await remote.generateText(siteID: sampleSiteID,
                                           base: "generate a product description for wapuu pencil",
-                                          feature: .productDescription)
+                                          feature: .productDescription,
+                                          responseFormat: .text)
         // Then
         XCTAssertEqual(numberOfJwtRequests(in: network.requestsForResponseData), 1)
 
         // When
         _ = try await remote.generateText(siteID: sampleSiteID,
                                           base: "generate a product description for wapuu pencil",
-                                          feature: .productDescription)
+                                          feature: .productDescription,
+                                          responseFormat: .text)
 
         // Then
         // Ensures that JWT is not requested again
@@ -116,7 +140,8 @@ final class GenerativeContentRemoteTests: XCTestCase {
         network.simulateResponse(requestUrlSuffix: textCompletionPath, filename: "generative-text-invalid-token")
         _ = try? await remote.generateText(siteID: sampleSiteID,
                                            base: "generate a product description for wapuu pencil",
-                                           feature: .productDescription)
+                                           feature: .productDescription,
+                                           responseFormat: .text)
 
         // Then
         XCTAssertEqual(numberOfJwtRequests(in: network.requestsForResponseData), 2)
@@ -134,14 +159,16 @@ final class GenerativeContentRemoteTests: XCTestCase {
         // When
         _ = try await remote.generateText(siteID: sampleSiteID,
                                           base: "generate a product description for wapuu pencil",
-                                          feature: .productDescription)
+                                          feature: .productDescription,
+                                          responseFormat: .text)
         // Then
         XCTAssertEqual(numberOfJwtRequests(in: network.requestsForResponseData), 1)
 
         // When
         _ = try await remote.generateText(siteID: sampleSiteID,
                                           base: "generate a product description for wapuu pencil",
-                                          feature: .productDescription)
+                                          feature: .productDescription,
+                                          responseFormat: .text)
 
         // Then
         // Ensures that token is requested again

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -11,6 +11,7 @@
 - [*] Login: Fix issues in Jetpack installation feature. [https://github.com/woocommerce/woocommerce-ios/pull/12426]
 - [Internal] WooExpress: Site creation with WooExpress is now disabled. [https://github.com/woocommerce/woocommerce-ios/issues/12323]
 - [*] Product Creation AI: Update prompt to fix error during product creation. [https://github.com/woocommerce/woocommerce-ios/pull/12457]
+- [internal] Fix product package flow error by specifying json as response format. [https://github.com/woocommerce/woocommerce-ios/pull/12466]
 
 
 18.0

--- a/Yosemite/Yosemite/Stores/ProductStore.swift
+++ b/Yosemite/Yosemite/Stores/ProductStore.swift
@@ -597,7 +597,7 @@ private extension ProductStore {
 
         Task { @MainActor in
             let result = await Result {
-                let description = try await generativeContentRemote.generateText(siteID: siteID, base: prompt, feature: .productDescription)
+                let description = try await generativeContentRemote.generateText(siteID: siteID, base: prompt, feature: .productDescription, responseFormat: .text)
                 return description
             }
             completion(result)
@@ -624,7 +624,7 @@ private extension ProductStore {
 
         Task { @MainActor in
             let result = await Result {
-                let message = try await generativeContentRemote.generateText(siteID: siteID, base: prompt, feature: .productSharing)
+                let message = try await generativeContentRemote.generateText(siteID: siteID, base: prompt, feature: .productSharing, responseFormat: .text)
                     .trimmingCharacters(in: CharacterSet(["\""]))  // Trims quotation mark
                 return message
             }
@@ -685,7 +685,7 @@ private extension ProductStore {
 
         Task { @MainActor in
             let result = await Result {
-                let description = try await generativeContentRemote.generateText(siteID: siteID, base: prompt, feature: .productName)
+                let description = try await generativeContentRemote.generateText(siteID: siteID, base: prompt, feature: .productName, responseFormat: .text)
                 return description
             }
             completion(result)

--- a/Yosemite/Yosemite/Stores/ProductStore.swift
+++ b/Yosemite/Yosemite/Stores/ProductStore.swift
@@ -656,7 +656,10 @@ private extension ProductStore {
         ].joined(separator: "\n")
         Task { @MainActor in
             do {
-                let jsonString = try await generativeContentRemote.generateText(siteID: siteID, base: prompt, feature: .productDetailsFromScannedTexts)
+                let jsonString = try await generativeContentRemote.generateText(siteID: siteID,
+                                                                                base: prompt,
+                                                                                feature: .productDetailsFromScannedTexts,
+                                                                                responseFormat: .json)
                 guard let jsonData = jsonString.data(using: .utf8) else {
                     return completion(.failure(DotcomError.resourceDoesNotExist))
                 }

--- a/Yosemite/YosemiteTests/Mocks/Networking/Remote/MockGenerativeContentRemote.swift
+++ b/Yosemite/YosemiteTests/Mocks/Networking/Remote/MockGenerativeContentRemote.swift
@@ -6,6 +6,7 @@ import XCTest
 final class MockGenerativeContentRemote {
     private(set) var generateTextBase: String?
     private(set) var generateTextFeature: GenerativeContentRemoteFeature?
+    private(set) var generateTextResponseFormat: GenerativeContentRemoteResponseFormat?
 
     /// The results to return in `generateText`.
     private var generateTextResult: Result<String, Error>?
@@ -38,9 +39,11 @@ final class MockGenerativeContentRemote {
 extension MockGenerativeContentRemote: GenerativeContentRemoteProtocol {
     func generateText(siteID: Int64,
                       base: String,
-                      feature: GenerativeContentRemoteFeature) async throws -> String {
+                      feature: GenerativeContentRemoteFeature,
+                      responseFormat: GenerativeContentRemoteResponseFormat) async throws -> String {
         generateTextBase = base
         generateTextFeature = feature
+        generateTextResponseFormat = responseFormat
         guard let result = generateTextResult else {
             XCTFail("Could not find result for generating text.")
             throw NetworkError.notFound()

--- a/Yosemite/YosemiteTests/Stores/ProductStoreTests.swift
+++ b/Yosemite/YosemiteTests/Stores/ProductStoreTests.swift
@@ -2536,6 +2536,31 @@ final class ProductStoreTests: XCTestCase {
         XCTAssertEqual(feature, GenerativeContentRemoteFeature.productDetailsFromScannedTexts)
     }
 
+    func test_generateProductDetails_uses_correct_response_format() throws {
+        // Given
+        let generativeContentRemote = MockGenerativeContentRemote()
+        generativeContentRemote.whenGeneratingText(thenReturn: .success(""))
+        let productStore = ProductStore(dispatcher: dispatcher,
+                                        storageManager: storageManager,
+                                        network: network,
+                                        remote: MockProductsRemote(),
+                                        generativeContentRemote: generativeContentRemote)
+
+        // When
+        waitFor { promise in
+            productStore.onAction(ProductAction.generateProductDetails(siteID: self.sampleSiteID,
+                                                                       productName: nil,
+                                                                       scannedTexts: [""],
+                                                                       language: "en") { _ in
+                promise(())
+            })
+        }
+
+        // Then
+        let format = try XCTUnwrap(generativeContentRemote.generateTextResponseFormat)
+        XCTAssertEqual(format, .json)
+    }
+
     // MARK: - `generateProductName`
 
     func test_generateProductName_returns_product_details_on_success() throws {

--- a/Yosemite/YosemiteTests/Stores/ProductStoreTests.swift
+++ b/Yosemite/YosemiteTests/Stores/ProductStoreTests.swift
@@ -1991,6 +1991,31 @@ final class ProductStoreTests: XCTestCase {
         XCTAssertEqual(feature, GenerativeContentRemoteFeature.productDescription)
     }
 
+    func test_generateProductDescription_uses_correct_response_format() throws {
+        // Given
+        let generativeContentRemote = MockGenerativeContentRemote()
+        generativeContentRemote.whenGeneratingText(thenReturn: .success(""))
+        let productStore = ProductStore(dispatcher: dispatcher,
+                                        storageManager: storageManager,
+                                        network: network,
+                                        remote: MockProductsRemote(),
+                                        generativeContentRemote: generativeContentRemote)
+
+        // When
+        waitFor { promise in
+            productStore.onAction(ProductAction.generateProductDescription(siteID: self.sampleSiteID,
+                                                                           name: "A product name",
+                                                                           features: "Trendy, cool, fun",
+                                                                           language: "en") { _ in
+                promise(())
+            })
+        }
+
+        // Then
+        let format = try XCTUnwrap(generativeContentRemote.generateTextResponseFormat)
+        XCTAssertEqual(format, .text)
+    }
+
     // MARK: - ProductAction.generateProductSharingMessage
 
     func test_generateProductSharingMessage_returns_text_on_success() throws {
@@ -2142,6 +2167,34 @@ final class ProductStoreTests: XCTestCase {
         // Then
         let feature = try XCTUnwrap(generativeContentRemote.generateTextFeature)
         XCTAssertEqual(feature, GenerativeContentRemoteFeature.productSharing)
+    }
+
+    func test_generateProductSharingMessage_uses_correct_response_format() throws {
+        // Given
+        let generativeContentRemote = MockGenerativeContentRemote()
+        generativeContentRemote.whenGeneratingText(thenReturn: .success(""))
+        let productStore = ProductStore(dispatcher: dispatcher,
+                                        storageManager: storageManager,
+                                        network: network,
+                                        remote: MockProductsRemote(),
+                                        generativeContentRemote: generativeContentRemote)
+
+        // When
+        waitFor { promise in
+            productStore.onAction(ProductAction.generateProductSharingMessage(
+                siteID: self.sampleSiteID,
+                url: "https://example.com",
+                name: "Sample product",
+                description: "Sample description",
+                language: "en"
+            ) { result in
+                promise(())
+            })
+        }
+
+        // Then
+        let format = try XCTUnwrap(generativeContentRemote.generateTextResponseFormat)
+        XCTAssertEqual(format, .text)
     }
 
     // MARK: - ProductAction.identifyLanguage
@@ -2651,6 +2704,28 @@ final class ProductStoreTests: XCTestCase {
         // Then
         let feature = try XCTUnwrap(generativeContentRemote.generateTextFeature)
         XCTAssertEqual(feature, GenerativeContentRemoteFeature.productName)
+    }
+
+    func test_generateProductName_uses_correct_response_format() throws {
+        // Given
+        let generativeContentRemote = MockGenerativeContentRemote()
+        generativeContentRemote.whenGeneratingText(thenReturn: .success(""))
+        let productStore = ProductStore(dispatcher: dispatcher,
+                                        storageManager: storageManager,
+                                        network: network,
+                                        remote: MockProductsRemote(),
+                                        generativeContentRemote: generativeContentRemote)
+
+        // When
+        waitFor { promise in
+            productStore.onAction(ProductAction.generateProductName(siteID: 123, keywords: "keyword", language: "en") { _ in
+                promise(())
+            })
+        }
+
+        // Then
+        let format = try XCTUnwrap(generativeContentRemote.generateTextResponseFormat)
+        XCTAssertEqual(format, .text)
     }
 
     // MARK: - `fetchNumberOfProducts`


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of: #12462 
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

While generating product details in the package flow we expect a JSON response but we receive a JSON with the keyword "JSON" prepended. 

In this PR, we start sending `json_object` as the value for `response_format` while generating the product name and description in the package flow to ensure we always receive a JSON value. 

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

- Create a JN store with the Jetpack AI plugin
- Login into the app
- Navigate to the Products tab
- Tap "+" -> "Create a product with AI"
- Tap the "Use package photo" button and select a package image
- Validate that the AI generates the product details as expected
- Follow the steps and ensure that you can successfully publish a product

More testing
- [x] @selanthiraiyan Test that product description or product name generation features work as before after sending `text` as a value for the `response_format` parameter.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

| Before | After |
|--------|--------|
| ![Simulator Screenshot - iPhone 13 Pro - 2024-04-10 at 16 07 56](https://github.com/woocommerce/woocommerce-ios/assets/524475/40b70376-3191-41e9-be93-97507aa6c34d) | ![Simulator Screenshot - iPhone 13 Pro - 2024-04-10 at 16 40 56](https://github.com/woocommerce/woocommerce-ios/assets/524475/6a7f3dd7-972e-493f-be76-15cd3f36139f) | 

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
