### PR TITLE
Dynamic Dashboard: New store stats chart in SwiftUI

### DIFF
--- a/WooCommerce.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/WooCommerce.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -11,12 +11,12 @@
         }
       },
       {
-        "package": "Charts",
+        "package": "DGCharts",
         "repositoryURL": "https://github.com/danielgindi/Charts",
         "state": {
           "branch": null,
-          "revision": "07b23476ad52b926be772f317d8f1d4511ee8d02",
-          "version": "4.1.0"
+          "revision": "dd9c72e3d7e751e769971092a6bd72d39198ae63",
+          "version": "5.1.0"
         }
       },
       {
@@ -75,11 +75,11 @@
       },
       {
         "package": "swift-algorithms",
-        "repositoryURL": "https://github.com/apple/swift-algorithms",
+        "repositoryURL": "https://github.com/apple/swift-algorithms.git",
         "state": {
           "branch": null,
-          "revision": "b14b7f4c528c942f121c8b860b9410b2bf57825e",
-          "version": "1.0.0"
+          "revision": "f6919dfc309e7f1b56224378b11e28bab5bccc42",
+          "version": "1.2.0"
         }
       },
       {

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/Customize/AnalyticsHubCustomizeViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/Customize/AnalyticsHubCustomizeViewModel.swift
@@ -1,3 +1,4 @@
+import Algorithms
 import Foundation
 import Yosemite
 

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/Report Cards/Components/AnalyticsLineChart.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/Report Cards/Components/AnalyticsLineChart.swift
@@ -1,5 +1,5 @@
 import SwiftUI
-import Charts
+import DGCharts
 
 /// `SwiftUI` representable type for `LineChartView` to use in the Analytics Hub
 struct AnalyticsLineChart: UIViewRepresentable {

--- a/WooCommerce/Classes/ViewRelated/Dashboard/MyStore/ChartMarker.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/MyStore/ChartMarker.swift
@@ -1,5 +1,5 @@
 import Foundation
-import Charts
+import DGCharts
 import UIKit
 
 /// This class is a custom view which is displayed over a chart element (e.g. a Bar) when it is highlighted.

--- a/WooCommerce/Classes/ViewRelated/Dashboard/MyStore/TopPerformerDataViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/MyStore/TopPerformerDataViewController.swift
@@ -1,6 +1,6 @@
 import UIKit
 import Yosemite
-import Charts
+import DGCharts
 import Experiments
 import SwiftUI
 import WordPressUI

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Stats v4/StoreStatsChartCircleMarker.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Stats v4/StoreStatsChartCircleMarker.swift
@@ -1,4 +1,4 @@
-import Charts
+import DGCharts
 import UIKit
 
 /// Circle marker which is shown on the highlighted point in the line chart.

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Stats v4/StoreStatsV4PeriodViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Stats v4/StoreStatsV4PeriodViewController.swift
@@ -1,4 +1,4 @@
-import Charts
+import DGCharts
 import Combine
 import UIKit
 import WordPressUI

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Stats v4/StoreStatsV4PeriodViewController.xib
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Stats v4/StoreStatsV4PeriodViewController.xib
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="22505" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="32700.99.1234" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina4_7" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="22504"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="22684"/>
         <capability name="Named colors" minToolsVersion="9.0"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
@@ -177,7 +177,7 @@
                                         <constraint firstAttribute="width" constant="14" id="a3T-HU-g4E"/>
                                     </constraints>
                                 </view>
-                                <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="zPE-Y0-ax8" customClass="LineChartView" customModule="Charts">
+                                <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="zPE-Y0-ax8" customClass="LineChartView" customModule="DGCharts">
                                     <rect key="frame" x="14" y="0.0" width="347" height="175"/>
                                     <subviews>
                                         <view opaque="NO" clearsContextBeforeDrawing="NO" contentMode="scaleToFill" verticalCompressionResistancePriority="250" translatesAutoresizingMaskIntoConstraints="NO" id="yvj-Kj-G3f">

--- a/WooCommerce/Classes/ViewRelated/Dashboard/StoreStats/StoreStatsChart.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/StoreStats/StoreStatsChart.swift
@@ -2,6 +2,7 @@ import Charts
 import SwiftUI
 
 /// Chart for store performance built with Swift Charts.
+/// Technical notes: paNNhX-tA-p2
 ///
 struct StoreStatsChart: View {
     @ObservedObject private var viewModel: StoreStatsChartViewModel
@@ -18,12 +19,12 @@ struct StoreStatsChart: View {
 
     var body: some View {
         Chart(viewModel.intervals) { item in
-            LineMark(x: .value("Date", item.date),
-                     y: .value("Revenue", item.revenue))
+            LineMark(x: .value(Localization.xValue, item.date),
+                     y: .value(Localization.yValue, item.revenue))
             .foregroundStyle(Color(Constants.chartLineColor))
 
             if !viewModel.hasRevenue {
-                RuleMark(y: .value("Zero revenue", 0))
+                RuleMark(y: .value(Localization.zeroRevenue, 0))
                     .annotation(position: .overlay, alignment: .center) {
                         Text("No revenue this period")
                             .font(.footnote)
@@ -32,19 +33,19 @@ struct StoreStatsChart: View {
                     }
             }
 
-            AreaMark(x: .value("Date", item.date),
-                     y: .value("Revenue", item.revenue))
+            AreaMark(x: .value(Localization.xValue, item.date),
+                     y: .value(Localization.yValue, item.revenue))
             .foregroundStyle(.linearGradient(colors: [Color(Constants.chartGradientTopColor), Color(Constants.chartGradientBottomColor)],
                                              startPoint: .top,
                                              endPoint: .bottom))
 
             if let selectedDate = selectedDate, viewModel.hasRevenue {
-                RuleMark(x: .value("Selected date", selectedDate))
+                RuleMark(x: .value(Localization.xSelectedValue, selectedDate))
                     .foregroundStyle(Color(Constants.chartHighlightLineColor))
 
                 if let selectedRevenue = selectedRevenue {
-                    PointMark(x: .value("Selected date", selectedDate),
-                              y: .value("Selected revenue", selectedRevenue))
+                    PointMark(x: .value(Localization.xSelectedValue, selectedDate),
+                              y: .value(Localization.ySelectedValue, selectedRevenue))
                     .foregroundStyle(Color(Constants.chartHighlightLineColor))
                 }
             }
@@ -100,6 +101,39 @@ struct StoreStatsChart: View {
 }
 
 private extension StoreStatsChart {
+    enum Localization {
+        static let xValue = NSLocalizedString(
+            "storeStatsChart.xValue",
+            value: "Date",
+            comment: "Value for the x-Axis of the store stats chart on the Dashboard screen"
+        )
+        static let yValue = NSLocalizedString(
+            "storeStatsChart.yValue",
+            value: "Revenue",
+            comment: "Value for the y-Axis of the store stats chart on the Dashboard screen"
+        )
+        static let zeroRevenue = NSLocalizedString(
+            "storeStatsChart.zeroRevenue",
+            value: "Zero revenue",
+            comment: "Value for the y-Axis of the store stats chart on the Dashboard screen when there is no revenue"
+        )
+        static let noRevenueText = NSLocalizedString(
+            "storeStatsChart.noRevenueText",
+            value: "No revenue this period",
+            comment: "Text on the store stats chart on the Dashboard screen when there is no revenue"
+        )
+        static let xSelectedValue = NSLocalizedString(
+            "storeStatsChart.xSelectedValue",
+            value: "Selected date",
+            comment: "Value for the x-Axis of any selected point on the store stats chart on the Dashboard screen"
+        )
+        static let ySelectedValue = NSLocalizedString(
+            "storeStatsChart.ySelectedValue",
+            value: "Selected revenue",
+            comment: "Value for the y-Axis of any selected point on the store stats chart on the Dashboard screen"
+        )
+    }
+
     enum Constants {
         static var chartLineColor: UIColor {
             UIColor(light: .withColorStudio(.wooCommercePurple, shade: .shade50),

--- a/WooCommerce/Classes/ViewRelated/Dashboard/StoreStats/StoreStatsChart.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/StoreStats/StoreStatsChart.swift
@@ -156,9 +156,24 @@ private extension StoreStatsChart {
     }
 }
 
-#Preview {
-    StoreStatsChart(viewModel: .init(intervals: [
-        .init(date: Date(), revenue: 1299),
-        .init(date: Date().addingTimeInterval(3000), revenue: 3245),
-    ], timeRange: .thisWeek)) { _ in }
+#if DEBUG
+
+private extension StoreStatsChartViewModel {
+    static let sampleDataForThisWeek: [StoreStatsChartData] = {
+        let startOfWeek = Date().startOfWeek(timezone: .current)!
+        var data = [StoreStatsChartData]()
+        var day = 0
+        while day < 7 {
+            data.append(StoreStatsChartData(date: startOfWeek.adding(days: day)!, revenue: Double.random(in: 0...1000)))
+            day += 1
+        }
+        return data
+    }()
 }
+
+#Preview {
+    StoreStatsChart(viewModel: .init(intervals: StoreStatsChartViewModel.sampleDataForThisWeek,
+                                     timeRange: .thisWeek)) { _ in }
+}
+
+#endif

--- a/WooCommerce/Classes/ViewRelated/Dashboard/StoreStats/StoreStatsChart.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/StoreStats/StoreStatsChart.swift
@@ -21,7 +21,7 @@ struct StoreStatsChart: View {
         Chart(viewModel.intervals) { item in
             LineMark(x: .value(Localization.xValue, item.date),
                      y: .value(Localization.yValue, item.revenue))
-            .foregroundStyle(Color(Constants.chartLineColor))
+            .foregroundStyle(Constants.chartLineColor)
 
             if !viewModel.hasRevenue {
                 RuleMark(y: .value(Localization.zeroRevenue, 0))
@@ -35,18 +35,19 @@ struct StoreStatsChart: View {
 
             AreaMark(x: .value(Localization.xValue, item.date),
                      y: .value(Localization.yValue, item.revenue))
-            .foregroundStyle(.linearGradient(colors: [Color(Constants.chartGradientTopColor), Color(Constants.chartGradientBottomColor)],
+            .foregroundStyle(.linearGradient(colors: [Constants.chartGradientTopColor,
+                                                      Constants.chartGradientBottomColor],
                                              startPoint: .top,
                                              endPoint: .bottom))
 
             if let selectedDate = selectedDate, viewModel.hasRevenue {
                 RuleMark(x: .value(Localization.xSelectedValue, selectedDate))
-                    .foregroundStyle(Color(Constants.chartHighlightLineColor))
+                    .foregroundStyle(Constants.chartHighlightLineColor)
 
                 if let selectedRevenue = selectedRevenue {
                     PointMark(x: .value(Localization.xSelectedValue, selectedDate),
                               y: .value(Localization.ySelectedValue, selectedRevenue))
-                    .foregroundStyle(Color(Constants.chartHighlightLineColor))
+                    .foregroundStyle(Constants.chartHighlightLineColor)
                 }
             }
         }
@@ -135,14 +136,16 @@ private extension StoreStatsChart {
     }
 
     enum Constants {
-        static var chartLineColor: UIColor {
-            UIColor(light: .withColorStudio(.wooCommercePurple, shade: .shade50),
-                    dark: .withColorStudio(.wooCommercePurple, shade: .shade30))
-        }
-        static let chartHighlightLineColor: UIColor = .withColorStudio(.pink)
-        static let chartGradientTopColor: UIColor = UIColor(light: .withColorStudio(.wooCommercePurple, shade: .shade50).withAlphaComponent(0.1),
-                                                            dark: UIColor(red: 204.0/256, green: 204.0/256, blue: 204.0/256, alpha: 0.3))
-        static let chartGradientBottomColor: UIColor = .clear.withAlphaComponent(0)
+        static var chartLineColor = Color(
+            light: .withColorStudio(name: .wooCommercePurple, shade: .shade50),
+            dark: .withColorStudio(name: .wooCommercePurple, shade: .shade30)
+        )
+        static let chartHighlightLineColor = Color.withColorStudio(name: .pink, shade: .shade50)
+        static let chartGradientTopColor = Color(
+            light: .withColorStudio(name: .wooCommercePurple, shade: .shade50).opacity(0.1),
+            dark: Color(UIColor(red: 204.0/256, green: 204.0/256, blue: 204.0/256, alpha: 0.3))
+        )
+        static let chartGradientBottomColor = Color.clear
         static let chartPadding: CGFloat = 8
         static let annotationPadding: CGFloat = 4
     }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/StoreStats/StoreStatsChart.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/StoreStats/StoreStatsChart.swift
@@ -19,10 +19,12 @@ struct StoreStatsChart: View {
 
     var body: some View {
         Chart(viewModel.intervals) { item in
+            // Line for the chart
             LineMark(x: .value(Localization.xValue, item.date),
                      y: .value(Localization.yValue, item.revenue))
             .foregroundStyle(Constants.chartLineColor)
 
+            // No revenue text and horizontal line
             if !viewModel.hasRevenue {
                 RuleMark(y: .value(Localization.zeroRevenue, 0))
                     .annotation(position: .overlay, alignment: .center) {
@@ -33,6 +35,7 @@ struct StoreStatsChart: View {
                     }
             }
 
+            // Gradient area
             AreaMark(x: .value(Localization.xValue, item.date),
                      y: .value(Localization.yValue, item.revenue))
             .foregroundStyle(.linearGradient(colors: [Constants.chartGradientTopColor,
@@ -40,6 +43,7 @@ struct StoreStatsChart: View {
                                              startPoint: .top,
                                              endPoint: .bottom))
 
+            // Vertical line for a selected point
             if let selectedDate = selectedDate, viewModel.hasRevenue {
                 RuleMark(x: .value(Localization.xSelectedValue, selectedDate))
                     .foregroundStyle(Constants.chartHighlightLineColor)
@@ -65,6 +69,7 @@ struct StoreStatsChart: View {
         }
         .chartYAxis(viewModel.hasRevenue ? .visible : .hidden)
         .chartOverlay { proxy in
+            // Overlay to handle tap and drag gestures
             GeometryReader { geometry in
                 Rectangle().fill(.clear).contentShape(Rectangle())
                     .gesture(DragGesture()

--- a/WooCommerce/Classes/ViewRelated/Dashboard/StoreStats/StoreStatsChart.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/StoreStats/StoreStatsChart.swift
@@ -1,0 +1,122 @@
+import Charts
+import SwiftUI
+
+/// Chart for store performance built with Swift Charts.
+///
+struct StoreStatsChart: View {
+    @ObservedObject private var viewModel: StoreStatsChartViewModel
+    let onIntervalSelected: (Int) -> Void
+
+    @State private var selectedDate: Date?
+    @State private var selectedRevenue: Double?
+
+    init(viewModel: StoreStatsChartViewModel,
+         onIntervalSelected: @escaping (Int) -> Void) {
+        self.viewModel = viewModel
+        self.onIntervalSelected = onIntervalSelected
+    }
+
+    var body: some View {
+        Chart(viewModel.intervals) { item in
+            LineMark(x: .value("Date", item.date),
+                     y: .value("Revenue", item.revenue))
+            .foregroundStyle(Color(Constants.chartLineColor))
+
+            if !viewModel.hasRevenue {
+                RuleMark(y: .value("Zero revenue", 0))
+                    .annotation(position: .overlay, alignment: .center) {
+                        Text("No revenue this period")
+                            .font(.footnote)
+                            .padding(Constants.annotationPadding)
+                            .background(Color(UIColor.systemBackground))
+                    }
+            }
+
+            AreaMark(x: .value("Date", item.date),
+                     y: .value("Revenue", item.revenue))
+            .foregroundStyle(.linearGradient(colors: [Color(Constants.chartGradientTopColor), Color(Constants.chartGradientBottomColor)],
+                                             startPoint: .top,
+                                             endPoint: .bottom))
+
+            if let selectedDate = selectedDate, viewModel.hasRevenue {
+                RuleMark(x: .value("Selected date", selectedDate))
+                    .foregroundStyle(Color(Constants.chartHighlightLineColor))
+
+                if let selectedRevenue = selectedRevenue {
+                    PointMark(x: .value("Selected date", selectedDate),
+                              y: .value("Selected revenue", selectedRevenue))
+                    .foregroundStyle(Color(Constants.chartHighlightLineColor))
+                }
+            }
+        }
+        .chartXAxis {
+            AxisMarks(values: .stride(by: viewModel.xAxisStride,
+                                      count: viewModel.xAxisStrideCount)) { date in
+                AxisValueLabel(format: viewModel.xAxisLabelFormatStyle(for: date.as(Date.self) ?? Date()))
+            }
+        }
+        .chartYAxis {
+            AxisMarks(position: .leading, values: .stride(by: viewModel.yAxisStride)) { value in
+                AxisGridLine()
+                AxisValueLabel(viewModel.yAxisLabel(for: value.as(Double.self) ?? 0))
+            }
+        }
+        .chartYAxis(viewModel.hasRevenue ? .visible : .hidden)
+        .chartOverlay { proxy in
+            GeometryReader { geometry in
+                Rectangle().fill(.clear).contentShape(Rectangle())
+                    .gesture(DragGesture()
+                        .onChanged { value in
+                            updateSelectedDate(at: value.location,
+                                               proxy: proxy,
+                                               geometry: geometry)
+                        }
+                    )
+                    .onTapGesture { location in
+                        updateSelectedDate(at: location,
+                                           proxy: proxy,
+                                           geometry: geometry)
+                    }
+            }
+        }
+        .padding(Constants.chartPadding)
+    }
+
+    private func updateSelectedDate(at location: CGPoint, proxy: ChartProxy, geometry: GeometryProxy) {
+        let xPosition = location.x - geometry[proxy.plotAreaFrame].origin.x
+        guard let date: Date = proxy.value(atX: xPosition) else {
+            return
+        }
+        selectedDate = viewModel.intervals
+            .sorted(by: {
+                abs($0.date.timeIntervalSince(date)) < abs($1.date.timeIntervalSince(date))
+            })
+            .first?.date
+        selectedRevenue = viewModel.intervals.first(where: { $0.date == selectedDate })?.revenue
+        if let index = viewModel.intervals.firstIndex(where: { $0.date == selectedDate }) {
+            onIntervalSelected(index)
+        }
+    }
+}
+
+private extension StoreStatsChart {
+    enum Constants {
+        static var chartLineColor: UIColor {
+            UIColor(light: .withColorStudio(.wooCommercePurple, shade: .shade50),
+                    dark: .withColorStudio(.wooCommercePurple, shade: .shade30))
+        }
+        static let chartHighlightLineColor: UIColor = .withColorStudio(.pink)
+        static let chartGradientTopColor: UIColor = UIColor(light: .withColorStudio(.wooCommercePurple, shade: .shade50).withAlphaComponent(0.1),
+                                                            dark: UIColor(red: 204.0/256, green: 204.0/256, blue: 204.0/256, alpha: 0.3))
+        static let chartGradientBottomColor: UIColor = .clear.withAlphaComponent(0)
+        static let chartPadding: CGFloat = 8
+        static let annotationPadding: CGFloat = 4
+    }
+}
+
+#Preview {
+    StoreStatsChart(viewModel: .init(intervals: [
+        .init(date: Date(), revenue: 1299),
+        .init(date: Date().addingTimeInterval(3000), revenue: 3245),
+    ], timeRange: .thisWeek)) { _ in }
+}

--- a/WooCommerce/Classes/ViewRelated/Dashboard/StoreStats/StoreStatsChartViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/StoreStats/StoreStatsChartViewModel.swift
@@ -1,0 +1,128 @@
+import Foundation
+import Yosemite
+import WooFoundation
+
+/// A struct for data to be displayed on a Swift chart.
+///
+struct StoreStatsChartData: Identifiable {
+    var id: String { UUID().uuidString }
+
+    let date: Date
+    let revenue: Double
+}
+
+/// View model for `StoreStatsChart`
+///
+final class StoreStatsChartViewModel: ObservableObject {
+
+    var intervals: [StoreStatsChartData]
+    private var timeRange: StatsTimeRangeV4
+    private let currencySettings: CurrencySettings
+    private let currencyFormatter: CurrencyFormatter
+
+    init(intervals: [StoreStatsChartData],
+         timeRange: StatsTimeRangeV4,
+         currencySettings: CurrencySettings = ServiceLocator.currencySettings,
+         currencyFormatter: CurrencyFormatter = CurrencyFormatter(currencySettings: ServiceLocator.currencySettings)) {
+        self.intervals = intervals
+        self.timeRange = timeRange
+        self.currencySettings = currencySettings
+        self.currencyFormatter = currencyFormatter
+    }
+}
+
+// MARK: - Chart details
+//
+extension StoreStatsChartViewModel {
+    var hasRevenue: Bool {
+        intervals.map { $0.revenue }.contains { $0 != 0 }
+    }
+
+    var xAxisStride: Calendar.Component {
+        switch timeRange {
+        case .today:
+            return .hour
+        case .thisWeek, .thisMonth:
+            return .day
+        case .thisYear:
+            return .month
+        case .custom(from: let from, to: let to):
+            guard let differenceInDays = StatsTimeRangeV4.differenceInDays(startDate: from, endDate: to) else {
+                return .hour
+            }
+            switch differenceInDays {
+            case .sameDay:
+                return .hour
+            case .from1To28, .from29To90:
+                return .day
+            case .from91daysTo3Years:
+                return .month
+            case .greaterThan3Years:
+                return .year
+            }
+        }
+    }
+
+    var xAxisStrideCount: Int {
+        switch timeRange {
+        case .today:
+            return 5
+        case .thisWeek:
+            return 7
+        case .thisMonth:
+            return 6
+        case .thisYear:
+            return 4
+        case .custom(from: let from, to: let to):
+            return 5
+        }
+    }
+
+    func xAxisLabelFormatStyle(for date: Date) -> Date.FormatStyle {
+        switch timeRange {
+        case .today:
+            return .dateTime.hour()
+        case .thisWeek, .thisMonth:
+            if date == intervals.first?.date {
+                return .dateTime.month(.abbreviated).day(.twoDigits)
+            }
+            return .dateTime.day(.twoDigits)
+        case .thisYear:
+            return .dateTime.month(.abbreviated)
+        case .custom(from: let from, to: let to):
+            switch timeRange.intervalGranularity {
+            case .daily:
+                return .dateTime.hour()
+            case .hourly, .weekly:
+                if date == intervals.first?.date {
+                    return .dateTime.month(.abbreviated).day(.twoDigits)
+                }
+                return .dateTime.day(.twoDigits)
+            case .monthly:
+                return .dateTime.month(.abbreviated)
+            case .yearly:
+                return .dateTime.year()
+            }
+        }
+    }
+
+    var yAxisStride: Double {
+        let minValue = intervals.map { $0.revenue }.min() ?? 0
+        let maxValue = intervals.map { $0.revenue }.max() ?? 0
+        return (minValue + maxValue) / 2
+    }
+
+    func yAxisLabel(for revenue: Double) -> String {
+        if revenue == 0.0 {
+            // Do not show the "0" label on the Y axis
+            return ""
+        } else {
+            let currencySymbol = currencySettings.symbol(from: currencySettings.currencyCode)
+            return currencyFormatter
+                .formatCurrency(using: revenue.humanReadableString(shouldHideDecimalsForIntegerAbbreviatedValue: true),
+                                currencyPosition: currencySettings.currencyPosition,
+                                currencySymbol: currencySymbol,
+                                isNegative: revenue.sign == .minus)
+        }
+    }
+}

--- a/WooCommerce/Classes/ViewRelated/Dashboard/StoreStats/StoreStatsChartViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/StoreStats/StoreStatsChartViewModel.swift
@@ -68,9 +68,9 @@ extension StoreStatsChartViewModel {
         case .today:
             return 5
         case .thisWeek:
-            return 7
+            return 1
         case .thisMonth:
-            return 6
+            return 5
         case .thisYear:
             return 4
         case .custom(from: let from, to: let to):
@@ -84,20 +84,20 @@ extension StoreStatsChartViewModel {
             return .dateTime.hour()
         case .thisWeek, .thisMonth:
             if date == intervals.first?.date {
-                return .dateTime.month(.abbreviated).day(.twoDigits)
+                return .dateTime.month(.abbreviated).day(.defaultDigits)
             }
-            return .dateTime.day(.twoDigits)
+            return .dateTime.day(.defaultDigits)
         case .thisYear:
             return .dateTime.month(.abbreviated)
         case .custom(from: let from, to: let to):
             switch timeRange.intervalGranularity {
-            case .daily:
+            case .hourly:
                 return .dateTime.hour()
-            case .hourly, .weekly:
+            case .daily, .weekly:
                 if date == intervals.first?.date {
-                    return .dateTime.month(.abbreviated).day(.twoDigits)
+                    return .dateTime.month(.abbreviated).day(.defaultDigits)
                 }
-                return .dateTime.day(.twoDigits)
+                return .dateTime.day(.defaultDigits)
             case .monthly:
                 return .dateTime.month(.abbreviated)
             case .yearly:

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -2437,6 +2437,7 @@
 		DECE13FB27993F6500816ECD /* TitleAndSubtitleAndStatusTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = DECE13F927993F6500816ECD /* TitleAndSubtitleAndStatusTableViewCell.swift */; };
 		DECE13FC27993F6500816ECD /* TitleAndSubtitleAndStatusTableViewCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = DECE13FA27993F6500816ECD /* TitleAndSubtitleAndStatusTableViewCell.xib */; };
 		DECE1400279A595200816ECD /* Coupon+Woo.swift in Sources */ = {isa = PBXBuildFile; fileRef = DECE13FF279A595200816ECD /* Coupon+Woo.swift */; };
+		DED039272BC7934F005D0571 /* StoreStatsChartViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DED039262BC7934F005D0571 /* StoreStatsChartViewModelTests.swift */; };
 		DED91DFA2AD78A3A00CDCC53 /* BlazeCampaignItemView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DED91DF92AD78A3A00CDCC53 /* BlazeCampaignItemView.swift */; };
 		DED9740B2AD7D09E00122EB4 /* BlazeCampaignListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DED9740A2AD7D09E00122EB4 /* BlazeCampaignListView.swift */; };
 		DED9740D2AD7D27000122EB4 /* BlazeCampaignListViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = DED9740C2AD7D27000122EB4 /* BlazeCampaignListViewModel.swift */; };
@@ -5199,6 +5200,7 @@
 		DECE13F927993F6500816ECD /* TitleAndSubtitleAndStatusTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TitleAndSubtitleAndStatusTableViewCell.swift; sourceTree = "<group>"; };
 		DECE13FA27993F6500816ECD /* TitleAndSubtitleAndStatusTableViewCell.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = TitleAndSubtitleAndStatusTableViewCell.xib; sourceTree = "<group>"; };
 		DECE13FF279A595200816ECD /* Coupon+Woo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Coupon+Woo.swift"; sourceTree = "<group>"; };
+		DED039262BC7934F005D0571 /* StoreStatsChartViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StoreStatsChartViewModelTests.swift; sourceTree = "<group>"; };
 		DED91DF92AD78A3A00CDCC53 /* BlazeCampaignItemView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BlazeCampaignItemView.swift; sourceTree = "<group>"; };
 		DED9740A2AD7D09E00122EB4 /* BlazeCampaignListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BlazeCampaignListView.swift; sourceTree = "<group>"; };
 		DED9740C2AD7D27000122EB4 /* BlazeCampaignListViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BlazeCampaignListViewModel.swift; sourceTree = "<group>"; };
@@ -6800,6 +6802,7 @@
 				028E1F712833E954001F8829 /* DashboardViewModelTests.swift */,
 				027F83EE29B048E2002688C6 /* DashboardTopPerformersViewModelTests.swift */,
 				DEC75CC72BC518D900763801 /* DashboardCustomizationViewModelTests.swift */,
+				DED039252BC79339005D0571 /* StoreStats */,
 			);
 			path = Dashboard;
 			sourceTree = "<group>";
@@ -11780,6 +11783,14 @@
 			path = DashboardCustomization;
 			sourceTree = "<group>";
 		};
+		DED039252BC79339005D0571 /* StoreStats */ = {
+			isa = PBXGroup;
+			children = (
+				DED039262BC7934F005D0571 /* StoreStatsChartViewModelTests.swift */,
+			);
+			path = StoreStats;
+			sourceTree = "<group>";
+		};
 		DED91DF72AD78A0C00CDCC53 /* Blaze */ = {
 			isa = PBXGroup;
 			children = (
@@ -15083,6 +15094,7 @@
 				0271E1642509C66200633F7A /* DefaultProductFormTableViewModelTests.swift in Sources */,
 				2602A64827BDBF8000B347F1 /* ProductInputTransformerTests.swift in Sources */,
 				02C27BD0282CDF9E0065471A /* CardPresentPaymentReceiptEmailCoordinatorTests.swift in Sources */,
+				DED039272BC7934F005D0571 /* StoreStatsChartViewModelTests.swift in Sources */,
 				2024966A2B0CC97100EE527D /* MockWooPaymentsDepositService.swift in Sources */,
 				DE61978D289A5326005E4362 /* WooSetupWebViewModelTests.swift in Sources */,
 				DE02ABAF2B5545C8008E0AC4 /* BlazeTargetLocationPickerViewModelTests.swift in Sources */,

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -2401,6 +2401,8 @@
 		DEA4269A2875440500265B0C /* PaymentMethodsScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEA426992875440500265B0C /* PaymentMethodsScreen.swift */; };
 		DEA6BCA92BC6A7050017D671 /* DGCharts in Frameworks */ = {isa = PBXBuildFile; productRef = DEA6BCA82BC6A7050017D671 /* DGCharts */; };
 		DEA6BCAC2BC6A7C30017D671 /* Algorithms in Frameworks */ = {isa = PBXBuildFile; productRef = DEA6BCAB2BC6A7C30017D671 /* Algorithms */; };
+		DEA6BCAF2BC6A9B10017D671 /* StoreStatsChart.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEA6BCAE2BC6A9B10017D671 /* StoreStatsChart.swift */; };
+		DEA6BCB12BC6AA040017D671 /* StoreStatsChartViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEA6BCB02BC6AA040017D671 /* StoreStatsChartViewModel.swift */; };
 		DEA88F502AA9D0100037273B /* AddEditProductCategoryViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEA88F4F2AA9D0100037273B /* AddEditProductCategoryViewModel.swift */; };
 		DEA88F522AAAC1180037273B /* AddEditProductCategoryViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEA88F512AAAC1180037273B /* AddEditProductCategoryViewModelTests.swift */; };
 		DEACB8852A64F74A00253F0F /* MediaPickingCoordinatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEACB8842A64F74A00253F0F /* MediaPickingCoordinatorTests.swift */; };
@@ -5161,6 +5163,8 @@
 		DEA0D0672BA82EA2007786F2 /* StatsGranularityV4+UI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "StatsGranularityV4+UI.swift"; sourceTree = "<group>"; };
 		DEA357122ADCC4C9006380BA /* BlazeCampaignListViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BlazeCampaignListViewModelTests.swift; sourceTree = "<group>"; };
 		DEA426992875440500265B0C /* PaymentMethodsScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaymentMethodsScreen.swift; sourceTree = "<group>"; };
+		DEA6BCAE2BC6A9B10017D671 /* StoreStatsChart.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StoreStatsChart.swift; sourceTree = "<group>"; };
+		DEA6BCB02BC6AA040017D671 /* StoreStatsChartViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StoreStatsChartViewModel.swift; sourceTree = "<group>"; };
 		DEA88F4F2AA9D0100037273B /* AddEditProductCategoryViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddEditProductCategoryViewModel.swift; sourceTree = "<group>"; };
 		DEA88F512AAAC1180037273B /* AddEditProductCategoryViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddEditProductCategoryViewModelTests.swift; sourceTree = "<group>"; };
 		DEACB8842A64F74A00253F0F /* MediaPickingCoordinatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MediaPickingCoordinatorTests.swift; sourceTree = "<group>"; };
@@ -10850,6 +10854,7 @@
 				028E1F6F2833DD0A001F8829 /* DashboardViewModel.swift */,
 				029D444822F13F8A00DEFA8A /* DashboardUI.swift */,
 				B946881129B8DD41000646B0 /* DashboardViewController+Activity.swift */,
+				DEA6BCAD2BC6A9A50017D671 /* StoreStats */,
 				DEC75CC02BC4E4E600763801 /* DashboardCustomization */,
 			);
 			path = Dashboard;
@@ -11713,6 +11718,15 @@
 				03191AE528E1DF0600670723 /* PluginDetailsViewModel.swift */,
 			);
 			path = Plugins;
+			sourceTree = "<group>";
+		};
+		DEA6BCAD2BC6A9A50017D671 /* StoreStats */ = {
+			isa = PBXGroup;
+			children = (
+				DEA6BCAE2BC6A9B10017D671 /* StoreStatsChart.swift */,
+				DEA6BCB02BC6AA040017D671 /* StoreStatsChartViewModel.swift */,
+			);
+			path = StoreStats;
 			sourceTree = "<group>";
 		};
 		DEC0293829C419F500FD0E2F /* Application Password */ = {
@@ -13827,6 +13841,7 @@
 				D85136C1231E09C300DD0539 /* ReviewsDataSourceProtocol.swift in Sources */,
 				DE653EAF2A72577500937C78 /* WooAnalyticsEvent+TestOrder.swift in Sources */,
 				CE4DDB7B20DD312400D32EC8 /* DateFormatter+Helpers.swift in Sources */,
+				DEA6BCAF2BC6A9B10017D671 /* StoreStatsChart.swift in Sources */,
 				45968545254069AE00D17B90 /* DownloadableFileBottomSheetListSelectorCommand.swift in Sources */,
 				262418372B9044FF009A3834 /* ApplicationPasswordTutorialViewModel.swift in Sources */,
 				7E7C5F7A2719A8F900315B61 /* EditProductCategoryListViewController.swift in Sources */,
@@ -14336,6 +14351,7 @@
 				EE1905882B57BBEC00617C53 /* BlazePaymentMethodsViewModel.swift in Sources */,
 				EE5B5BC12AB42F21009BCBD6 /* AddProductNameWithAIViewModel.swift in Sources */,
 				0201E4272945B01800C793C7 /* StoreCreationProfilerQuestionView.swift in Sources */,
+				DEA6BCB12BC6AA040017D671 /* StoreStatsChartViewModel.swift in Sources */,
 				EEAB47662A84C86900E55B25 /* StoreCreationProfilerUploadAnswersUseCase.swift in Sources */,
 				2667BFE1252FA117008099D4 /* RefundItemQuantityListSelectorCommand.swift in Sources */,
 				261AA30C2753119E009530FE /* PaymentMethodsViewModel.swift in Sources */,

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -16642,8 +16642,8 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/krzysztofzablocki/Inject.git";
 			requirement = {
-				kind = upToNextMajorVersion;
-				minimumVersion = 1.1.1;
+				kind = exactVersion;
+				version = 1.1.1;
 			};
 		};
 		DE9F2D2A2A1B1F5D004E5957 /* XCRemoteSwiftPackageReference "ConfettiSwiftUI" */ = {

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -1063,7 +1063,6 @@
 		3FF314F426FD4C4A0012E68E /* BaseScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = F997172B23DBCD8E00592D8E /* BaseScreen.swift */; };
 		3FF314F526FD4F430012E68E /* UITestsFoundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 3FF314DE26FC74450012E68E /* UITestsFoundation.framework */; };
 		3FF314F626FD4F490012E68E /* UITestsFoundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 3FF314DE26FC74450012E68E /* UITestsFoundation.framework */; };
-		3FFC5EAC2851942F00563C48 /* Charts in Frameworks */ = {isa = PBXBuildFile; productRef = 3FFC5EAB2851942F00563C48 /* Charts */; };
 		4506BD712461965300FE6377 /* ProductVisibilityViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4506BD6F2461965300FE6377 /* ProductVisibilityViewController.swift */; };
 		4506BD722461965300FE6377 /* ProductVisibilityViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = 4506BD702461965300FE6377 /* ProductVisibilityViewController.xib */; };
 		4508BF622660E34A00707869 /* ShippingLabelCarrierAndRatesTopBanner.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4508BF612660E34A00707869 /* ShippingLabelCarrierAndRatesTopBanner.swift */; };
@@ -2400,6 +2399,8 @@
 		DEA0D0682BA82EA2007786F2 /* StatsGranularityV4+UI.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEA0D0672BA82EA2007786F2 /* StatsGranularityV4+UI.swift */; };
 		DEA357132ADCC4C9006380BA /* BlazeCampaignListViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEA357122ADCC4C9006380BA /* BlazeCampaignListViewModelTests.swift */; };
 		DEA4269A2875440500265B0C /* PaymentMethodsScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEA426992875440500265B0C /* PaymentMethodsScreen.swift */; };
+		DEA6BCA92BC6A7050017D671 /* DGCharts in Frameworks */ = {isa = PBXBuildFile; productRef = DEA6BCA82BC6A7050017D671 /* DGCharts */; };
+		DEA6BCAC2BC6A7C30017D671 /* Algorithms in Frameworks */ = {isa = PBXBuildFile; productRef = DEA6BCAB2BC6A7C30017D671 /* Algorithms */; };
 		DEA88F502AA9D0100037273B /* AddEditProductCategoryViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEA88F4F2AA9D0100037273B /* AddEditProductCategoryViewModel.swift */; };
 		DEA88F522AAAC1180037273B /* AddEditProductCategoryViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEA88F512AAAC1180037273B /* AddEditProductCategoryViewModelTests.swift */; };
 		DEACB8852A64F74A00253F0F /* MediaPickingCoordinatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEACB8842A64F74A00253F0F /* MediaPickingCoordinatorTests.swift */; };
@@ -5481,7 +5482,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				DE9F2D2C2A1B1F5D004E5957 /* ConfettiSwiftUI in Frameworks */,
-				3FFC5EAC2851942F00563C48 /* Charts in Frameworks */,
+				DEA6BCAC2BC6A7C30017D671 /* Algorithms in Frameworks */,
 				D88FDB4525DD223B00CB0DBD /* Hardware.framework in Frameworks */,
 				263E37E12641AD8300260D3B /* Codegen in Frameworks */,
 				4598298128574688003A9AFE /* Inject in Frameworks */,
@@ -5489,6 +5490,7 @@
 				315E14F42698DA24000AD5FF /* PassKit.framework in Frameworks */,
 				174CA86A27D90A6200126524 /* AutomatticAbout in Frameworks */,
 				B5C3B5E720D189ED0072CB9D /* Yosemite.framework in Frameworks */,
+				DEA6BCA92BC6A7050017D671 /* DGCharts in Frameworks */,
 				B5C3B5E520D189EA0072CB9D /* Storage.framework in Frameworks */,
 				B9151B3F2840EB330036180F /* WooFoundation.framework in Frameworks */,
 				202496642B0B9E0D00EE527D /* ScrollViewSectionKit in Frameworks */,
@@ -12499,10 +12501,11 @@
 				263E37E02641AD8300260D3B /* Codegen */,
 				45455E312657C3F300BBB0C4 /* Shimmer */,
 				174CA86927D90A6200126524 /* AutomatticAbout */,
-				3FFC5EAB2851942F00563C48 /* Charts */,
 				4598298028574688003A9AFE /* Inject */,
 				DE9F2D2B2A1B1F5D004E5957 /* ConfettiSwiftUI */,
 				202496632B0B9E0D00EE527D /* ScrollViewSectionKit */,
+				DEA6BCA82BC6A7050017D671 /* DGCharts */,
+				DEA6BCAB2BC6A7C30017D671 /* Algorithms */,
 			);
 			productName = WooCommerce;
 			productReference = B56DB3C62049BFAA00D4AA8E /* WooCommerce.app */;
@@ -12674,11 +12677,12 @@
 				3FF2247126706AA3008FFA87 /* XCRemoteSwiftPackageReference "ScreenObject" */,
 				3F1CA81B26C3542600228BF2 /* XCRemoteSwiftPackageReference "XCUITestHelpers" */,
 				174CA86827D90A6200126524 /* XCRemoteSwiftPackageReference "AutomatticAbout-swift" */,
-				3FFC5EAA2851942F00563C48 /* XCRemoteSwiftPackageReference "Charts" */,
 				4598297F28574688003A9AFE /* XCRemoteSwiftPackageReference "Inject" */,
 				3F2C8A17285B038800B1A5BB /* XCRemoteSwiftPackageReference "test-collector-swift" */,
 				DE9F2D2A2A1B1F5D004E5957 /* XCRemoteSwiftPackageReference "ConfettiSwiftUI" */,
 				202496622B0B9E0D00EE527D /* XCRemoteSwiftPackageReference "ScrollViewSectionKit" */,
+				DEA6BCA72BC6A7050017D671 /* XCRemoteSwiftPackageReference "Charts" */,
+				DEA6BCAA2BC6A7C30017D671 /* XCRemoteSwiftPackageReference "swift-algorithms" */,
 			);
 			productRefGroup = B56DB3C72049BFAA00D4AA8E /* Products */;
 			projectDirPath = "";
@@ -16610,14 +16614,6 @@
 				minimumVersion = 0.2.3;
 			};
 		};
-		3FFC5EAA2851942F00563C48 /* XCRemoteSwiftPackageReference "Charts" */ = {
-			isa = XCRemoteSwiftPackageReference;
-			repositoryURL = "https://github.com/danielgindi/Charts";
-			requirement = {
-				kind = upToNextMajorVersion;
-				minimumVersion = 4.0.3;
-			};
-		};
 		45455E302657C3F300BBB0C4 /* XCRemoteSwiftPackageReference "SwiftUI-Shimmer" */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/markiv/SwiftUI-Shimmer";
@@ -16640,6 +16636,22 @@
 			requirement = {
 				kind = upToNextMajorVersion;
 				minimumVersion = 1.0.0;
+			};
+		};
+		DEA6BCA72BC6A7050017D671 /* XCRemoteSwiftPackageReference "Charts" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/danielgindi/Charts.git";
+			requirement = {
+				kind = upToNextMajorVersion;
+				minimumVersion = 5.1.0;
+			};
+		};
+		DEA6BCAA2BC6A7C30017D671 /* XCRemoteSwiftPackageReference "swift-algorithms" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/apple/swift-algorithms.git";
+			requirement = {
+				kind = upToNextMajorVersion;
+				minimumVersion = 1.2.0;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */
@@ -16713,11 +16725,6 @@
 			package = 3F1CA81B26C3542600228BF2 /* XCRemoteSwiftPackageReference "XCUITestHelpers" */;
 			productName = XCUITestHelpers;
 		};
-		3FFC5EAB2851942F00563C48 /* Charts */ = {
-			isa = XCSwiftPackageProductDependency;
-			package = 3FFC5EAA2851942F00563C48 /* XCRemoteSwiftPackageReference "Charts" */;
-			productName = Charts;
-		};
 		45455E312657C3F300BBB0C4 /* Shimmer */ = {
 			isa = XCSwiftPackageProductDependency;
 			package = 45455E302657C3F300BBB0C4 /* XCRemoteSwiftPackageReference "SwiftUI-Shimmer" */;
@@ -16736,6 +16743,16 @@
 			isa = XCSwiftPackageProductDependency;
 			package = DE9F2D2A2A1B1F5D004E5957 /* XCRemoteSwiftPackageReference "ConfettiSwiftUI" */;
 			productName = ConfettiSwiftUI;
+		};
+		DEA6BCA82BC6A7050017D671 /* DGCharts */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = DEA6BCA72BC6A7050017D671 /* XCRemoteSwiftPackageReference "Charts" */;
+			productName = DGCharts;
+		};
+		DEA6BCAB2BC6A7C30017D671 /* Algorithms */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = DEA6BCAA2BC6A7C30017D671 /* XCRemoteSwiftPackageReference "swift-algorithms" */;
+			productName = Algorithms;
 		};
 /* End XCSwiftPackageProductDependency section */
 	};

--- a/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/StoreStats/StoreStatsChartViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/StoreStats/StoreStatsChartViewModelTests.swift
@@ -1,0 +1,181 @@
+import XCTest
+import Yosemite
+import WooFoundation
+@testable import WooCommerce
+
+final class StoreStatsChartViewModelTests: XCTestCase {
+
+    func test_hasRevenue_returns_false_if_no_interval_has_revenue() {
+        // Given
+        let intervals: [StoreStatsChartData] = {
+            var day = 0
+            var data = [StoreStatsChartData]()
+            while day < 6 {
+                data.append(StoreStatsChartData(date: Date().adding(days: day)!, revenue: 0))
+                day += 1
+            }
+            return data
+        }()
+
+        // When
+        let viewModel = StoreStatsChartViewModel(intervals: intervals, timeRange: .thisWeek)
+
+        // Then
+        XCTAssertFalse(viewModel.hasRevenue)
+    }
+
+    func test_hasRevenue_returns_true_if_some_intervals_have_revenues() {
+        // Given
+        let intervals: [StoreStatsChartData] = {
+            var day = 0
+            var data = [StoreStatsChartData]()
+            while day < 6 {
+                data.append(StoreStatsChartData(date: Date().adding(days: day)!, revenue: Double.random(in: 0...100)))
+                day += 1
+            }
+            return data
+        }()
+
+        // When
+        let viewModel = StoreStatsChartViewModel(intervals: intervals, timeRange: .thisWeek)
+
+        // Then
+        XCTAssertTrue(viewModel.hasRevenue)
+    }
+
+    func test_xAxisStride_returns_correct_values_for_different_time_ranges() {
+        // Given
+        let timeRangesWithXAxisStride: [StatsTimeRangeV4: Calendar.Component] = [
+            .today: .hour,
+            .thisWeek: .day,
+            .thisMonth: .day,
+            .thisYear: .month,
+            .custom(from: Date(), to: Date().adding(days: 0)!): .hour,
+            .custom(from: Date(), to: Date().adding(days: 2)!): .day,
+            .custom(from: Date(), to: Date().adding(days: 100)!): .month,
+            .custom(from: Date(), to: Date().adding(days: 1460)!): .year // 4 years
+        ]
+
+        for timeRange in timeRangesWithXAxisStride.keys {
+            // When
+            let viewModel = StoreStatsChartViewModel(intervals: [], timeRange: timeRange)
+
+            // Then
+            XCTAssertEqual(viewModel.xAxisStride, timeRangesWithXAxisStride[timeRange])
+        }
+    }
+
+    func test_xAxisStrideCount_returns_correct_values_for_different_time_ranges() {
+        // Given
+        let timeRangesWithXAxisStrideCount: [StatsTimeRangeV4: Int] = [
+            .today: 5,
+            .thisWeek: 1,
+            .thisMonth: 5,
+            .thisYear: 4,
+            .custom(from: Date(), to: Date().adding(days: 0)!): 5,
+        ]
+
+        for timeRange in timeRangesWithXAxisStrideCount.keys {
+            // When
+            let viewModel = StoreStatsChartViewModel(intervals: [], timeRange: timeRange)
+
+            // Then
+            XCTAssertEqual(viewModel.xAxisStrideCount, timeRangesWithXAxisStrideCount[timeRange])
+        }
+    }
+
+    func test_xAxisLabelFormatStyle_returns_correct_values_for_non_first_dates_in_different_time_ranges() {
+        // Given
+        let timeRangesWithXAxisLabelFormatStyle: [StatsTimeRangeV4: Date.FormatStyle] = [
+            .today: .dateTime.hour(),
+            .thisWeek: .dateTime.day(.defaultDigits),
+            .thisMonth: .dateTime.day(.defaultDigits),
+            .thisYear: .dateTime.month(.abbreviated),
+            .custom(from: Date(), to: Date().adding(days: 0)!): .dateTime.hour(),
+            .custom(from: Date(), to: Date().adding(days: 2)!): .dateTime.day(.defaultDigits),
+            .custom(from: Date(), to: Date().adding(days: 100)!): .dateTime.month(.abbreviated),
+            .custom(from: Date(), to: Date().adding(days: 1460)!): .dateTime.year() // 4 years
+        ]
+
+        for timeRange in timeRangesWithXAxisLabelFormatStyle.keys {
+            // When
+            let viewModel = StoreStatsChartViewModel(intervals: [], timeRange: timeRange)
+
+            // Then
+            XCTAssertEqual(viewModel.xAxisLabelFormatStyle(for: Date().adding(days: 1)!),
+                           timeRangesWithXAxisLabelFormatStyle[timeRange])
+        }
+    }
+
+    func test_xAxisLabelFormatStyle_returns_correct_values_for_first_dates_in_different_time_ranges() {
+        // Given
+        let currentDate = Date()
+        let timeRanges: [StatsTimeRangeV4] = [
+            .thisWeek,
+            .thisMonth,
+            .custom(from: currentDate, to: currentDate.adding(days: 2)!)
+        ]
+        let intervals = [StoreStatsChartData(date: currentDate, revenue: 100)]
+
+        for timeRange in timeRanges {
+            // When
+            let viewModel = StoreStatsChartViewModel(intervals: intervals, timeRange: timeRange)
+
+            // Then
+            XCTAssertEqual(viewModel.xAxisLabelFormatStyle(for: currentDate),
+                           .dateTime.month(.abbreviated).day(.defaultDigits))
+        }
+    }
+
+    func test_yAxisStride_returns_correct_value() {
+        // Given
+        let currentDate = Date()
+        let intervals = [
+            StoreStatsChartData(date: currentDate, revenue: 100),
+            StoreStatsChartData(date: currentDate.adding(days: 1)!, revenue: 110),
+            StoreStatsChartData(date: currentDate.adding(days: 2)!, revenue: 0),
+            StoreStatsChartData(date: currentDate.adding(days: 3)!, revenue: 0),
+            StoreStatsChartData(date: currentDate.adding(days: 4)!, revenue: 130),
+            StoreStatsChartData(date: currentDate.adding(days: 5)!, revenue: 0),
+            StoreStatsChartData(date: currentDate.adding(days: 6)!, revenue: 200)
+        ]
+
+        // When
+        let viewModel = StoreStatsChartViewModel(intervals: intervals, timeRange: .thisWeek)
+
+        // Then
+        XCTAssertEqual(viewModel.yAxisStride, 100)
+    }
+
+    func test_yAxisLabel_is_correct_for_zero_revenue() {
+        // Given
+        let viewModel = StoreStatsChartViewModel(intervals: [], timeRange: .thisWeek)
+
+        // When
+        let label = viewModel.yAxisLabel(for: 0)
+
+        // Then
+        XCTAssertEqual(label, "")
+    }
+
+    func test_yAxisLabel_is_correct_for_non_zero_revenue() {
+        // Given
+        let currencySettings = CurrencySettings(currencyCode: .USD, currencyPosition: .left, thousandSeparator: ",", decimalSeparator: ".", numberOfDecimals: 2)
+        let viewModel = StoreStatsChartViewModel(intervals: [],
+                                                 timeRange: .thisWeek,
+                                                 currencySettings: currencySettings,
+                                                 currencyFormatter: CurrencyFormatter(currencySettings: currencySettings))
+
+        // When
+        let label = viewModel.yAxisLabel(for: 1000)
+
+        // Then
+        XCTAssertEqual(label, "$1k")
+
+        // When
+        let anotherLabel = viewModel.yAxisLabel(for: 100)
+
+        // Then
+        XCTAssertEqual(anotherLabel, "$100")
+    }
+}


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of #12465 
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
As part of the Dynamic Dashboard project, we have a new design for the store stats section. Updating the existing chart is non-trivial, and since we already dropped support for iOS 15, I figured we can make use of the Swift Chart experiment that I worked on in a previous HACK week project [paNNhX-tA-p2]. 

Changes include:
- Updated `Charts` library version to adopt the renaming of the library to avoid the conflict with Apple's Charts library.
- Added the missing `swift-algorithms` library since it was removed in a recent version of the `Charts` library but used in Analytics Hub implementation.
- Set a fixed version for Inject to avoid compiler issue when the library is updated.
- Added `StoreStatsChart` for the new SwiftUI chart.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
The new chart hasn't been added to any screen yet. You can test it by checking the preview in `StoreStatsChart`.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->
<img width="489" alt="Screenshot 2024-04-11 at 10 37 50" src="https://github.com/woocommerce/woocommerce-ios/assets/5533851/ca380e3c-10ee-4625-8e93-fcef8d91904d">


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.