### PR TITLE
Fix incorrect action name for setfrozentag following the update of release-toolkit

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -232,7 +232,7 @@ platform :ios do
       from_branch: DEFAULT_BRANCH,
       to_branch: "release/#{new_version}"
     )
-    setfrozentag(
+    set_milestone_frozen_marker(
       repository: GITHUB_REPO,
       milestone: new_version
     )


### PR DESCRIPTION

<!-- Remember about a good descriptive title. -->

<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
In #12472, release-toolkit was updated but the fastfile still uses the outdated action `setfrozentag` in one place.

This PR replaces the outdated name following the [renaming](https://github.com/wordpress-mobile/release-toolkit/pull/548) from a recent version of release-toolkit.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
Not sure what's the testing steps could be, but this might help unblock code freeze for v18.2.

#12472 mentioned this testing instructions, I'm not sure if it is applicable for this PR:

> See https://github.com/wordpress-mobile/WordPress-iOS/pull/22990 for the annotation in action. That PR is on WordPress, but the logic in the Fastfile is the same. I'm 99.9% sure that the behavior will be the same on this CI setup.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->
N/A

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
