### PR TITLE
Dynamic Dashboard: Store card order in app settings

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Dashboard/DashboardViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/DashboardViewModel.swift
@@ -327,27 +327,39 @@ private extension DashboardViewModel {
         $showOnboarding.combineLatest($showBlazeCampaignView)
             .receive(on: RunLoop.main)
             .sink { [weak self] showOnboarding, showBlazeCampaignView in
-                self?.updateDashboardCards(showOnboarding: showOnboarding,
-                                           showBlazeCampaignView: showBlazeCampaignView)
+                guard let self else { return }
+                Task {
+                    await self.updateDashboardCards(showOnboarding: showOnboarding,
+                                               showBlazeCampaignView: showBlazeCampaignView)
+                }
             }
             .store(in: &subscriptions)
     }
 
-    /// TODO-12403: Update persistence for dashboard cards.
     /// We are using separate user defaults for different cards -
     /// this should be updated to general app settings.
-    func updateDashboardCards(showOnboarding: Bool, showBlazeCampaignView: Bool) {
-        let onboardingCard = DashboardCard(type: .onboarding, enabled: showOnboarding)
-        let statsCard = DashboardCard(type: .statsAndTopPerformers, enabled: true)
-        let blazeCard = DashboardCard(type: .blaze, enabled: showBlazeCampaignView)
-        dashboardCards = [onboardingCard, statsCard, blazeCard]
+    ///
+    @MainActor
+    func updateDashboardCards(showOnboarding: Bool, showBlazeCampaignView: Bool) async {
+        dashboardCards = await {
+            if let stored = await loadDashboardCards() {
+                return stored
+            } else {
+                return [DashboardCard(type: .onboarding, enabled: showOnboarding),
+                        DashboardCard(type: .statsAndTopPerformers, enabled: true),
+                        DashboardCard(type: .blaze, enabled: showBlazeCampaignView)]
+            }
+        }()
+
         unavailableDashboardCards = []
 
-        if !showOnboarding && !userDefaults.shouldHideStoreOnboardingTaskList {
+        if let onboardingCard = dashboardCards.first(where: { $0.type == .onboarding }),
+           !showOnboarding && !userDefaults.shouldHideStoreOnboardingTaskList {
             unavailableDashboardCards.append(onboardingCard)
         }
 
-        if !showBlazeCampaignView && !userDefaults.hasDismissedBlazeSectionOnMyStore {
+        if let blazeCard = dashboardCards.first(where: { $0.type == .blaze }),
+           !showBlazeCampaignView && !userDefaults.hasDismissedBlazeSectionOnMyStore {
             unavailableDashboardCards.append(blazeCard)
         }
     }
@@ -365,6 +377,15 @@ private extension DashboardViewModel {
     @MainActor
     func updateJetpackBannerVisibilityFromAppSettings() async {
         jetpackBannerVisibleFromAppSettings = await loadJetpackBannerVisibilityFromAppSettings()
+    }
+
+    @MainActor
+    func loadDashboardCards() async -> [DashboardCard]? {
+        await withCheckedContinuation { continuation in
+            stores.dispatch(AppSettingsAction.loadDashboardCards(siteID: siteID, onCompletion: { cards in
+                continuation.resume(returning: cards)
+            }))
+        }
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Dashboard/DashboardViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/DashboardViewModel.swift
@@ -266,6 +266,7 @@ final class DashboardViewModel: ObservableObject {
     }
 
     func didCustomizeDashboardCards(_ cards: [DashboardCard]) {
+        stores.dispatch(AppSettingsAction.setDashboardCards(siteID: siteID, cards: cards))
         dashboardCards = cards
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Settings/SettingsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Settings/SettingsViewModel.swift
@@ -289,8 +289,9 @@ private extension SettingsViewModel {
                 rows.append(.installJetpack)
             }
 
-            if !defaults.completedAllStoreOnboardingTasks,
-                featureFlagService.isFeatureFlagEnabled(.hideStoreOnboardingTaskList) {
+            if !featureFlagService.isFeatureFlagEnabled(.dynamicDashboard), // The store setup list visibility and arrangement can be controlled from dashboard
+               !defaults.completedAllStoreOnboardingTasks,
+               featureFlagService.isFeatureFlagEnabled(.hideStoreOnboardingTaskList) {
                 rows.append(.storeSetupList)
             }
 

--- a/WooCommerce/WooCommerceTests/Mocks/MockFeatureFlagService.swift
+++ b/WooCommerce/WooCommerceTests/Mocks/MockFeatureFlagService.swift
@@ -25,6 +25,7 @@ struct MockFeatureFlagService: FeatureFlagService {
     private let sideBySideViewForOrderForm: Bool
     private let isCustomersInHubMenuEnabled: Bool
     private let isMigrateSimplePaymentsToOrderCreationEnabled: Bool
+    private let isDynamicDashboardEnabled: Bool
 
     init(isInboxOn: Bool = false,
          isUpdateOrderOptimisticallyOn: Bool = false,
@@ -48,7 +49,8 @@ struct MockFeatureFlagService: FeatureFlagService {
          isBackendReceiptsEnabled: Bool = false,
          sideBySideViewForOrderForm: Bool = false,
          isCustomersInHubMenuEnabled: Bool = false,
-         isMigrateSimplePaymentsToOrderCreationEnabled: Bool = false) {
+         isMigrateSimplePaymentsToOrderCreationEnabled: Bool = false,
+         isDynamicDashboardEnabled: Bool = false) {
         self.isInboxOn = isInboxOn
         self.isUpdateOrderOptimisticallyOn = isUpdateOrderOptimisticallyOn
         self.shippingLabelsOnboardingM1 = shippingLabelsOnboardingM1
@@ -72,6 +74,7 @@ struct MockFeatureFlagService: FeatureFlagService {
         self.sideBySideViewForOrderForm = sideBySideViewForOrderForm
         self.isCustomersInHubMenuEnabled = isCustomersInHubMenuEnabled
         self.isMigrateSimplePaymentsToOrderCreationEnabled = isMigrateSimplePaymentsToOrderCreationEnabled
+        self.isDynamicDashboardEnabled = isDynamicDashboardEnabled
     }
 
     func isFeatureFlagEnabled(_ featureFlag: FeatureFlag) -> Bool {
@@ -120,6 +123,8 @@ struct MockFeatureFlagService: FeatureFlagService {
             return isCustomersInHubMenuEnabled
         case .migrateSimplePaymentsToOrderCreation:
             return isMigrateSimplePaymentsToOrderCreationEnabled
+        case .dynamicDashboard:
+            return isDynamicDashboardEnabled
         default:
             return false
         }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Settings/SettingsViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Settings/SettingsViewModelTests.swift
@@ -286,6 +286,24 @@ final class SettingsViewModelTests: XCTestCase {
         XCTAssertFalse(viewModel.sections.contains { $0.rows.contains(SettingsViewController.Row.storeSetupList) })
     }
 
+    func test_store_setup_list_row_is_hidden_when_dynamic_dashboard_feature_is_on() {
+        // Given
+        let featureFlagService = MockFeatureFlagService(isHideStoreOnboardingTaskListFeatureEnabled: true,
+                                                        isDynamicDashboardEnabled: true)
+        sessionManager.defaultSite = Site.fake()
+        defaults[UserDefaults.Key.completedAllStoreOnboardingTasks] = false
+        let viewModel = SettingsViewModel(stores: stores,
+                                          storageManager: storageManager,
+                                          featureFlagService: featureFlagService,
+                                          defaults: defaults)
+
+        // When
+        viewModel.onViewDidLoad()
+
+        // Then
+        XCTAssertFalse(viewModel.sections.contains { $0.rows.contains(SettingsViewController.Row.storeSetupList) })
+    }
+
     // MARK: - `isStoreSetupSettingSwitchOn`
 
     func test_isStoreSetupSettingSwitchOn_is_true_when_shouldHideStoreOnboardingTaskList_is_false() {


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #12461 
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

Store and retrieve dashboard card orders in app settings. 

#### Changes
- Load and store dashboard cards order from app settings.
- I decided to remove the "Store Setup List" from "Settings" to avoid conflict between the dynamic dashboard and user defaults. 
- Unit tests

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

- Create a JN site
- Login into the app
- Tap the Settings button on the top right of the Dashboard screen.
- Enable/disable or drag to reorder the cards.
- Tap Save and confirm that the layout of the dashboard screen is updated accordingly.
- Quit and relaunch the app and validate that the dashboard layout is restored as per your selection. 
- Switch stores and switch back to the JN site and validate that the dashboard layout is restored as per your selection. .

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

#### Removed "Store Setup List" from "Settings"
| Before | After |
|--------|--------|
| ![Simulator Screenshot - iPhone 13 Pro - 2024-04-13 at 18 39 10](https://github.com/woocommerce/woocommerce-ios/assets/524475/b6b2482a-21ee-44e6-8d4e-ede6d454f8cd) | ![Simulator Screenshot - iPhone 13 Pro - 2024-04-13 at 18 38 28](https://github.com/woocommerce/woocommerce-ios/assets/524475/2d1fcffc-77e8-4ada-9a3f-a4bafcd1e0bd)| 

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
