### PR TITLE
[Tooling] Improve the "internal pods not on stable version" annotation

### DIFF
--- a/.buildkite/commands/prototype-build.sh
+++ b/.buildkite/commands/prototype-build.sh
@@ -12,8 +12,5 @@ install_swiftpm_dependencies
 echo "--- :closed_lock_with_key: Installing Secrets"
 bundle exec fastlane run configure_apply
 
-echo "--- Test unstable internal pods annotation"
-bundle exec fastlane test_check_pods_references
-
 echo "--- :hammer_and_wrench: Building"
 bundle exec fastlane build_and_upload_prototype_build

--- a/.buildkite/commands/prototype-build.sh
+++ b/.buildkite/commands/prototype-build.sh
@@ -12,5 +12,8 @@ install_swiftpm_dependencies
 echo "--- :closed_lock_with_key: Installing Secrets"
 bundle exec fastlane run configure_apply
 
+echo "--- Test unstable internal pods annotation"
+bundle exec fastlane test_check_pods_references
+
 echo "--- :hammer_and_wrench: Building"
 bundle exec fastlane build_and_upload_prototype_build

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -1471,8 +1471,7 @@ end
 def check_pods_references
   result = ios_check_beta_deps(lockfile: File.join(PROJECT_ROOT_FOLDER, 'Podfile.lock'))
 
-  # Will crash if :pods doesn't exist in result.
-  # Seems fair, given the shape of the result Hash should not change unless via a major version bump.
-  style = result[:pods].empty? ? 'success' : 'warning'
-  buildkite_annotate(context: 'pods-check', style: style, message: result[:message]) if is_ci
+  style = result[:pods].nil? || result[:pods].empty? ? 'success' : 'warning'
+  message = "### Checking Internal Dependencies are all on a **stable** version\n\n#{result[:message]}"
+  buildkite_annotate(context: 'pods-check', style: style, message: message) if is_ci
 end

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -1475,7 +1475,3 @@ def check_pods_references
   message = "### Checking Internal Dependencies are all on a **stable** version\n\n#{result[:message]}"
   buildkite_annotate(context: 'pods-check', style: style, message: message) if is_ci
 end
-
-lane :test_check_pods_references do
-  check_pods_references
-end

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -1475,3 +1475,7 @@ def check_pods_references
   message = "### Checking Internal Dependencies are all on a **stable** version\n\n#{result[:message]}"
   buildkite_annotate(context: 'pods-check', style: style, message: message) if is_ci
 end
+
+lane :test_check_pods_references do
+  check_pods_references
+end


### PR DESCRIPTION
## What

From feedback and discussions in Slack (p1713196666919479/1713193106.071799-slack-C06CKSPHYA1), it seems that adding some h3 title in the annotation about the `ios_check_beta_pods` result would help make it clearer which annotation to look at when going through the release scenario.

## Testing

In https://github.com/woocommerce/woocommerce-ios/pull/12484/commits/c407476936a138346e8834924dbe3189cfbc6dab I've made the `check_pods_references` helper method be called during Prototype builds, just to validate that the annotation would look good.

This resulted in the annotation looking as expected:
<img width="1158" alt="image" src="https://github.com/woocommerce/woocommerce-ios/assets/216089/0b734404-91da-463e-8ac4-5d517f95d976">

Note: the case for when there are pods to be updated has been tested as part of the similar change made on https://github.com/wordpress-mobile/WordPress-iOS/pull/23009