### PR TITLE
Dynamic Dashboard: Add separate configs for last selected time range of performance and top performers cards

### DIFF
--- a/Storage/Storage/Model/Copiable/Models+Copiable.generated.swift
+++ b/Storage/Storage/Model/Copiable/Models+Copiable.generated.swift
@@ -104,7 +104,9 @@ extension Storage.GeneralStoreSettings {
         firstInPersonPaymentsTransactionsByReaderType: CopiableProp<[CardReaderType: Date]> = .copy,
         selectedTaxRateID: NullableCopiableProp<Int64> = .copy,
         analyticsHubCards: NullableCopiableProp<[AnalyticsCard]> = .copy,
-        dashboardCards: NullableCopiableProp<[DashboardCard]> = .copy
+        dashboardCards: NullableCopiableProp<[DashboardCard]> = .copy,
+        lastSelectedPerformanceTimeRange: CopiableProp<String> = .copy,
+        lastSelectedTopPerformersTimeRange: CopiableProp<String> = .copy
     ) -> Storage.GeneralStoreSettings {
         let storeID = storeID ?? self.storeID
         let isTelemetryAvailable = isTelemetryAvailable ?? self.isTelemetryAvailable
@@ -118,6 +120,8 @@ extension Storage.GeneralStoreSettings {
         let selectedTaxRateID = selectedTaxRateID ?? self.selectedTaxRateID
         let analyticsHubCards = analyticsHubCards ?? self.analyticsHubCards
         let dashboardCards = dashboardCards ?? self.dashboardCards
+        let lastSelectedPerformanceTimeRange = lastSelectedPerformanceTimeRange ?? self.lastSelectedPerformanceTimeRange
+        let lastSelectedTopPerformersTimeRange = lastSelectedTopPerformersTimeRange ?? self.lastSelectedTopPerformersTimeRange
 
         return Storage.GeneralStoreSettings(
             storeID: storeID,
@@ -131,7 +135,9 @@ extension Storage.GeneralStoreSettings {
             firstInPersonPaymentsTransactionsByReaderType: firstInPersonPaymentsTransactionsByReaderType,
             selectedTaxRateID: selectedTaxRateID,
             analyticsHubCards: analyticsHubCards,
-            dashboardCards: dashboardCards
+            dashboardCards: dashboardCards,
+            lastSelectedPerformanceTimeRange: lastSelectedPerformanceTimeRange,
+            lastSelectedTopPerformersTimeRange: lastSelectedTopPerformersTimeRange
         )
     }
 }

--- a/Storage/Storage/Model/GeneralStoreSettings.swift
+++ b/Storage/Storage/Model/GeneralStoreSettings.swift
@@ -59,6 +59,12 @@ public struct GeneralStoreSettings: Codable, Equatable, GeneratedCopiable {
     /// The set of cards for the Dashboard screen, with their enabled status and sort order.
     public let dashboardCards: [DashboardCard]?
 
+    /// The raw value string of `StatsTimeRangeV4` that indicates the last selected time range tab in Performance dashboard card.
+    public var lastSelectedPerformanceTimeRange: String
+
+    /// The raw value string of `StatsTimeRangeV4` that indicates the last selected time range tab in Top Performers dashboard card.
+    public var lastSelectedTopPerformersTimeRange: String
+
     public init(storeID: String? = nil,
                 isTelemetryAvailable: Bool = false,
                 telemetryLastReportedTime: Date? = nil,
@@ -70,7 +76,9 @@ public struct GeneralStoreSettings: Codable, Equatable, GeneratedCopiable {
                 firstInPersonPaymentsTransactionsByReaderType: [CardReaderType: Date] = [:],
                 selectedTaxRateID: Int64? = nil,
                 analyticsHubCards: [AnalyticsCard]? = nil,
-                dashboardCards: [DashboardCard]? = nil) {
+                dashboardCards: [DashboardCard]? = nil,
+                lastSelectedPerformanceTimeRange: String = "",
+                lastSelectedTopPerformersTimeRange: String = "") {
         self.storeID = storeID
         self.isTelemetryAvailable = isTelemetryAvailable
         self.telemetryLastReportedTime = telemetryLastReportedTime
@@ -83,6 +91,8 @@ public struct GeneralStoreSettings: Codable, Equatable, GeneratedCopiable {
         self.selectedTaxRateID = selectedTaxRateID
         self.analyticsHubCards = analyticsHubCards
         self.dashboardCards = dashboardCards
+        self.lastSelectedPerformanceTimeRange = lastSelectedPerformanceTimeRange
+        self.lastSelectedTopPerformersTimeRange = lastSelectedTopPerformersTimeRange
     }
 
     public func erasingSelectedTaxRateID() -> GeneralStoreSettings {
@@ -97,7 +107,9 @@ public struct GeneralStoreSettings: Codable, Equatable, GeneratedCopiable {
                              firstInPersonPaymentsTransactionsByReaderType: firstInPersonPaymentsTransactionsByReaderType,
                              selectedTaxRateID: nil,
                              analyticsHubCards: analyticsHubCards,
-                             dashboardCards: dashboardCards)
+                             dashboardCards: dashboardCards,
+                             lastSelectedPerformanceTimeRange: lastSelectedPerformanceTimeRange,
+                             lastSelectedTopPerformersTimeRange: lastSelectedTopPerformersTimeRange)
     }
 }
 
@@ -121,6 +133,9 @@ extension GeneralStoreSettings {
         self.selectedTaxRateID = try container.decodeIfPresent(Int64.self, forKey: .selectedTaxRateID)
         self.analyticsHubCards = try container.decodeIfPresent([AnalyticsCard].self, forKey: .analyticsHubCards)
         self.dashboardCards = try container.decodeIfPresent([DashboardCard].self, forKey: .dashboardCards)
+
+        self.lastSelectedPerformanceTimeRange = try container.decodeIfPresent(String.self, forKey: .lastSelectedPerformanceTimeRange) ?? ""
+        self.lastSelectedTopPerformersTimeRange = try container.decodeIfPresent(String.self, forKey: .lastSelectedTopPerformersTimeRange) ?? ""
 
         // Decode new properties with `decodeIfPresent` and provide a default value if necessary.
     }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/StoreStats/StorePerformanceViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/StoreStats/StorePerformanceViewModel.swift
@@ -256,7 +256,7 @@ private extension StorePerformanceViewModel {
     @MainActor
     func loadLastTimeRange() async -> StatsTimeRangeV4? {
         await withCheckedContinuation { continuation in
-            let action = AppSettingsAction.loadLastSelectedStatsTimeRange(siteID: siteID) { timeRange in
+            let action = AppSettingsAction.loadLastSelectedPerformanceTimeRange(siteID: siteID) { timeRange in
                 continuation.resume(returning: timeRange)
             }
             stores.dispatch(action)
@@ -264,7 +264,7 @@ private extension StorePerformanceViewModel {
     }
 
     func saveLastTimeRange(_ timeRange: StatsTimeRangeV4) {
-        let action = AppSettingsAction.setLastSelectedStatsTimeRange(siteID: siteID, timeRange: timeRange)
+        let action = AppSettingsAction.setLastSelectedPerformanceTimeRange(siteID: siteID, timeRange: timeRange)
         stores.dispatch(action)
     }
 

--- a/WooCommerce/Classes/ViewRelated/Dashboard/TopPerformers/TopPerformersDashboardViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/TopPerformers/TopPerformersDashboardViewModel.swift
@@ -126,7 +126,7 @@ private extension TopPerformersDashboardViewModel {
     @MainActor
     func loadLastTimeRange() async -> StatsTimeRangeV4? {
         await withCheckedContinuation { continuation in
-            let action = AppSettingsAction.loadLastSelectedStatsTimeRange(siteID: siteID) { timeRange in
+            let action = AppSettingsAction.loadLastSelectedTopPerformersTimeRange(siteID: siteID) { timeRange in
                 continuation.resume(returning: timeRange)
             }
             stores.dispatch(action)
@@ -134,7 +134,7 @@ private extension TopPerformersDashboardViewModel {
     }
 
     func saveLastTimeRange(_ timeRange: StatsTimeRangeV4) {
-        let action = AppSettingsAction.setLastSelectedStatsTimeRange(siteID: siteID, timeRange: timeRange)
+        let action = AppSettingsAction.setLastSelectedTopPerformersTimeRange(siteID: siteID, timeRange: timeRange)
         stores.dispatch(action)
     }
 

--- a/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/StoreStats/StorePerformanceViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/StoreStats/StorePerformanceViewModelTests.swift
@@ -64,7 +64,7 @@ final class StorePerformanceViewModelTests: XCTestCase {
         let stores = MockStoresManager(sessionManager: .makeForTesting())
         stores.whenReceivingAction(ofType: AppSettingsAction.self) { action in
             switch action {
-            case let .loadLastSelectedStatsTimeRange(_, onCompletion):
+            case let .loadLastSelectedPerformanceTimeRange(_, onCompletion):
                 onCompletion(StatsTimeRangeV4.thisWeek)
             default:
                 break
@@ -87,7 +87,7 @@ final class StorePerformanceViewModelTests: XCTestCase {
         let stores = MockStoresManager(sessionManager: .makeForTesting())
         stores.whenReceivingAction(ofType: AppSettingsAction.self) { action in
             switch action {
-            case let .setLastSelectedStatsTimeRange(_, timeRange):
+            case let .setLastSelectedPerformanceTimeRange(_, timeRange):
                 savedTimeRange = timeRange
             default:
                 break

--- a/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/TopPerformers/TopPerformersDashboardViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/TopPerformers/TopPerformersDashboardViewModelTests.swift
@@ -38,7 +38,7 @@ final class TopPerformersDashboardViewModelTests: XCTestCase {
         let stores = MockStoresManager(sessionManager: .makeForTesting())
         stores.whenReceivingAction(ofType: AppSettingsAction.self) { action in
             switch action {
-            case let .loadLastSelectedStatsTimeRange(_, onCompletion):
+            case let .loadLastSelectedTopPerformersTimeRange(_, onCompletion):
                 onCompletion(StatsTimeRangeV4.thisWeek)
             default:
                 break
@@ -61,7 +61,7 @@ final class TopPerformersDashboardViewModelTests: XCTestCase {
         let stores = MockStoresManager(sessionManager: .makeForTesting())
         stores.whenReceivingAction(ofType: AppSettingsAction.self) { action in
             switch action {
-            case let .setLastSelectedStatsTimeRange(_, timeRange):
+            case let .setLastSelectedTopPerformersTimeRange(_, timeRange):
                 savedTimeRange = timeRange
             default:
                 break

--- a/Yosemite/Yosemite/Actions/AppSettingsAction.swift
+++ b/Yosemite/Yosemite/Actions/AppSettingsAction.swift
@@ -268,4 +268,20 @@ public enum AppSettingsAction: Action {
     /// Loads the stored, ordered array of cards for the Dashboard screen.
     ///
     case loadDashboardCards(siteID: Int64, onCompletion: ([DashboardCard]?) -> Void)
+
+    /// Stores the last selected time range for the Performance dashboard card.
+    ///
+    case setLastSelectedPerformanceTimeRange(siteID: Int64, timeRange: StatsTimeRangeV4)
+
+    /// Loads the last selected time range for the Performance dashboard card.
+    ///
+    case loadLastSelectedPerformanceTimeRange(siteID: Int64, onCompletion: (StatsTimeRangeV4?) -> Void)
+
+    /// Stores the last selected time range for the Top Performers dashboard card.
+    ///
+    case setLastSelectedTopPerformersTimeRange(siteID: Int64, timeRange: StatsTimeRangeV4)
+
+    /// Loads the last selected time range for the Top Performers dashboard card.
+    ///
+    case loadLastSelectedTopPerformersTimeRange(siteID: Int64, onCompletion: (StatsTimeRangeV4?) -> Void)
 }

--- a/Yosemite/Yosemite/Stores/AppSettingsStore.swift
+++ b/Yosemite/Yosemite/Stores/AppSettingsStore.swift
@@ -220,6 +220,14 @@ public class AppSettingsStore: Store {
             loadDashboardCards(siteID: siteID, onCompletion: onCompletion)
         case let .setDashboardCards(siteID, cards):
             setDashboardCards(siteID: siteID, cards: cards)
+        case let .setLastSelectedPerformanceTimeRange(siteID, timeRange):
+            setLastSelectedPerformanceTimeRange(siteID: siteID, timeRange: timeRange)
+        case let .loadLastSelectedPerformanceTimeRange(siteID, onCompletion):
+            loadLastSelectedPerformanceTimeRange(siteID: siteID, onCompletion: onCompletion)
+        case let .setLastSelectedTopPerformersTimeRange(siteID, timeRange):
+            setLastSelectedTopPerformersTimeRange(siteID: siteID, timeRange: timeRange)
+        case let .loadLastSelectedTopPerformersTimeRange(siteID, onCompletion):
+            loadLastSelectedTopPerformersTimeRange(siteID: siteID, onCompletion: onCompletion)
         }
     }
 }
@@ -926,7 +934,7 @@ private extension AppSettingsStore {
 
         let updatedSettings: GeneralStoreSettings
         if let taxRateID = id {
-            updatedSettings = storeSettings.copy(selectedTaxRateID: id)
+            updatedSettings = storeSettings.copy(selectedTaxRateID: taxRateID)
         } else {
             updatedSettings = storeSettings.erasingSelectedTaxRateID()
         }
@@ -964,6 +972,32 @@ private extension AppSettingsStore {
 
     func loadDashboardCards(siteID: Int64, onCompletion: ([DashboardCard]?) -> Void) {
         onCompletion(getStoreSettings(for: siteID).dashboardCards)
+    }
+
+    func setLastSelectedPerformanceTimeRange(siteID: Int64, timeRange: StatsTimeRangeV4) {
+        let storeSettings = getStoreSettings(for: siteID)
+        let updatedSettings = storeSettings.copy(lastSelectedPerformanceTimeRange: timeRange.rawValue)
+        setStoreSettings(settings: updatedSettings, for: siteID)
+    }
+
+    func loadLastSelectedPerformanceTimeRange(siteID: Int64, onCompletion: (StatsTimeRangeV4?) -> Void) {
+        let storeSettings = getStoreSettings(for: siteID)
+        let timeRangeRawValue = storeSettings.lastSelectedPerformanceTimeRange
+        let timeRange = StatsTimeRangeV4(rawValue: timeRangeRawValue)
+        onCompletion(timeRange)
+    }
+
+    func setLastSelectedTopPerformersTimeRange(siteID: Int64, timeRange: StatsTimeRangeV4) {
+        let storeSettings = getStoreSettings(for: siteID)
+        let updatedSettings = storeSettings.copy(lastSelectedTopPerformersTimeRange: timeRange.rawValue)
+        setStoreSettings(settings: updatedSettings, for: siteID)
+    }
+
+    func loadLastSelectedTopPerformersTimeRange(siteID: Int64, onCompletion: (StatsTimeRangeV4?) -> Void) {
+        let storeSettings = getStoreSettings(for: siteID)
+        let timeRangeRawValue = storeSettings.lastSelectedTopPerformersTimeRange
+        let timeRange = StatsTimeRangeV4(rawValue: timeRangeRawValue)
+        onCompletion(timeRange)
     }
 }
 

--- a/Yosemite/YosemiteTests/Stores/AppSettingsStoreTests.swift
+++ b/Yosemite/YosemiteTests/Stores/AppSettingsStoreTests.swift
@@ -1424,6 +1424,112 @@ extension AppSettingsStoreTests {
         // Then
         XCTAssertNil(loadedDashboardCards)
     }
+
+    // MARK: - Last selected time range for Performance card
+
+    func test_setLastSelectedPerformanceTimeRange_works_correctly() throws {
+        // Given
+        let timeRange = StatsTimeRangeV4.thisYear
+        let existingSettings = GeneralStoreSettingsBySite(storeSettingsBySite: [TestConstants.siteID: GeneralStoreSettings()])
+        try fileStorage?.write(existingSettings, to: expectedGeneralStoreSettingsFileURL)
+
+        // When
+        let action = AppSettingsAction.setLastSelectedPerformanceTimeRange(siteID: TestConstants.siteID, timeRange: timeRange)
+        subject?.onAction(action)
+
+        // Then
+        let savedSettings: GeneralStoreSettingsBySite = try XCTUnwrap(fileStorage?.data(for: expectedGeneralStoreSettingsFileURL))
+        let settingsForSite = savedSettings.storeSettingsBySite[TestConstants.siteID]
+
+        assertEqual(timeRange.rawValue, settingsForSite?.lastSelectedPerformanceTimeRange)
+    }
+
+    func test_loadLastSelectedPerformanceTimeRange_works_correctly() throws {
+        // Given
+        let timeRange = StatsTimeRangeV4.thisYear
+        let storeSettings = GeneralStoreSettings(lastSelectedPerformanceTimeRange: timeRange.rawValue)
+        let existingSettings = GeneralStoreSettingsBySite(storeSettingsBySite: [TestConstants.siteID: storeSettings])
+        try fileStorage?.write(existingSettings, to: expectedGeneralStoreSettingsFileURL)
+
+        // When
+        var loadedTimeRange: StatsTimeRangeV4?
+        let action = AppSettingsAction.loadLastSelectedPerformanceTimeRange(siteID: TestConstants.siteID) { timeRange in
+            loadedTimeRange = timeRange
+        }
+        subject?.onAction(action)
+
+        // Then
+        assertEqual(timeRange, loadedTimeRange)
+    }
+
+    func test_loadLastSelectedPerformanceTimeRange_returns_nil_when_no_data_was_saved() throws {
+        // Given
+        let existingSettings = GeneralStoreSettingsBySite(storeSettingsBySite: [TestConstants.siteID: GeneralStoreSettings()])
+        try fileStorage?.write(existingSettings, to: expectedGeneralStoreSettingsFileURL)
+
+        // When
+        var loadedTimeRange: StatsTimeRangeV4?
+        let action = AppSettingsAction.loadLastSelectedPerformanceTimeRange(siteID: TestConstants.siteID) { timeRange in
+            loadedTimeRange = timeRange
+        }
+        subject?.onAction(action)
+
+        // Then
+        XCTAssertNil(loadedTimeRange)
+    }
+
+    // MARK: - Last selected time range for Top Performers card
+
+    func test_setLastSelectedTopPerformersTimeRange_works_correctly() throws {
+        // Given
+        let timeRange = StatsTimeRangeV4.thisWeek
+        let existingSettings = GeneralStoreSettingsBySite(storeSettingsBySite: [TestConstants.siteID: GeneralStoreSettings()])
+        try fileStorage?.write(existingSettings, to: expectedGeneralStoreSettingsFileURL)
+
+        // When
+        let action = AppSettingsAction.setLastSelectedTopPerformersTimeRange(siteID: TestConstants.siteID, timeRange: timeRange)
+        subject?.onAction(action)
+
+        // Then
+        let savedSettings: GeneralStoreSettingsBySite = try XCTUnwrap(fileStorage?.data(for: expectedGeneralStoreSettingsFileURL))
+        let settingsForSite = savedSettings.storeSettingsBySite[TestConstants.siteID]
+
+        assertEqual(timeRange.rawValue, settingsForSite?.lastSelectedTopPerformersTimeRange)
+    }
+
+    func test_loadLastSelectedTopPerformersTimeRange_works_correctly() throws {
+        // Given
+        let timeRange = StatsTimeRangeV4.thisWeek
+        let storeSettings = GeneralStoreSettings(lastSelectedTopPerformersTimeRange: timeRange.rawValue)
+        let existingSettings = GeneralStoreSettingsBySite(storeSettingsBySite: [TestConstants.siteID: storeSettings])
+        try fileStorage?.write(existingSettings, to: expectedGeneralStoreSettingsFileURL)
+
+        // When
+        var loadedTimeRange: StatsTimeRangeV4?
+        let action = AppSettingsAction.loadLastSelectedTopPerformersTimeRange(siteID: TestConstants.siteID) { timeRange in
+            loadedTimeRange = timeRange
+        }
+        subject?.onAction(action)
+
+        // Then
+        assertEqual(timeRange, loadedTimeRange)
+    }
+
+    func test_loadLastSelectedTopPerformersTimeRange_returns_nil_when_no_data_was_saved() throws {
+        // Given
+        let existingSettings = GeneralStoreSettingsBySite(storeSettingsBySite: [TestConstants.siteID: GeneralStoreSettings()])
+        try fileStorage?.write(existingSettings, to: expectedGeneralStoreSettingsFileURL)
+
+        // When
+        var loadedTimeRange: StatsTimeRangeV4?
+        let action = AppSettingsAction.loadLastSelectedTopPerformersTimeRange(siteID: TestConstants.siteID) { timeRange in
+            loadedTimeRange = timeRange
+        }
+        subject?.onAction(action)
+
+        // Then
+        XCTAssertNil(loadedTimeRange)
+    }
 }
 
 // MARK: - Utils


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #12487 
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This PR completes the separate of the store performance and top performers cards by adding separate app settings for the last selected time range for each card. Changes include:

- Added new settings in `GeneralAppSettings`.
- Updated `AppSettingAction` and `AppSettingsStore` with the new configs.
- Updated `StorePerformanceViewModel` and `TopPerformanceDashboardViewModel` to load and save respective settings.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
- Enable the feature flag `dynamicDashboard` and build the app.
- Log in to a store and enable both Performance and Top Performers cards.
- Switch the time range on both cards and confirm that they are separate.
- Extra: test the app with the feature flag `dynamicDashboard` disabled and confirm that the app still works correctly as before.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->
<img src="https://github.com/woocommerce/woocommerce-ios/assets/5533851/a836a0ab-a715-4b64-a5e4-77c8ed39ad60" width=320 />


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
