### PR TITLE
Dynamic Dashboard: Update header view for dashboard screen

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Dashboard/Blaze/BlazeCampaignDashboardView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Blaze/BlazeCampaignDashboardView.swift
@@ -91,7 +91,6 @@ struct BlazeCampaignDashboardView: View {
         VStack(alignment: .leading, spacing: Layout.verticalSpacing) {
             header
                 .padding(.horizontal, Layout.padding)
-                .redacted(reason: viewModel.shouldRedactView ? .placeholder : [])
 
             if case .showProduct(let product) = viewModel.state {
                 ProductInfoView(product: product)

--- a/WooCommerce/Classes/ViewRelated/Dashboard/DashboardView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/DashboardView.swift
@@ -77,7 +77,7 @@ struct DashboardView: View {
         .background(Color(.listBackground))
         .navigationTitle(Localization.title)
         .toolbar {
-            ToolbarItem(placement: .topBarLeading) {
+            ToolbarItem(placement: .topBarTrailing) {
                 if let url = viewModel.siteURLToShare {
                     ShareLink(item: url) {
                         Image(systemName: "square.and.arrow.up")

--- a/WooCommerce/Classes/ViewRelated/Dashboard/DashboardView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/DashboardView.swift
@@ -60,7 +60,6 @@ struct DashboardView: View {
                 .subheadlineStyle()
                 .padding([.horizontal, .bottom], Layout.padding)
                 .frame(maxWidth: .infinity, alignment: .leading)
-                .background(Color(.listForeground(modal: false)))
                 .renderedIf(verticalSizeClass == .regular)
 
             // Error banner
@@ -73,7 +72,7 @@ struct DashboardView: View {
 
             // Card views
             dashboardCards
-                .padding(.vertical, Layout.padding)
+                .padding(.bottom, Layout.padding)
         }
         .background(Color(.listBackground))
         .navigationTitle(Localization.title)
@@ -93,6 +92,8 @@ struct DashboardView: View {
                 }
             }
         }
+        .toolbarBackground(Color(.listBackground), for: .navigationBar)
+        .toolbar(.visible, for: .navigationBar)
         .onReceive(ServiceLocator.stores.site) { currentSite in
             self.currentSite = currentSite
         }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/DashboardView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/DashboardView.swift
@@ -77,7 +77,7 @@ struct DashboardView: View {
         .background(Color(.listBackground))
         .navigationTitle(Localization.title)
         .toolbar {
-            ToolbarItem(placement: .topBarTrailing) {
+            ToolbarItem(placement: .topBarLeading) {
                 if let url = viewModel.siteURLToShare {
                     ShareLink(item: url) {
                         Image(systemName: "square.and.arrow.up")
@@ -85,10 +85,8 @@ struct DashboardView: View {
                 }
             }
             ToolbarItem(placement: .topBarTrailing) {
-                Button {
+                Button(Localization.edit) {
                     showingCustomization = true
-                } label: {
-                    Image(systemName: "gearshape")
                 }
             }
         }
@@ -260,6 +258,11 @@ private extension DashboardView {
             "dashboardView.storePlanBanner.expired",
             value: "Your site plan has ended.",
             comment: "Title on the banner when the site's WooExpress plan has expired"
+        )
+        static let edit = NSLocalizedString(
+            "dashboardView.edit",
+            value: "Edit",
+            comment: "Title of the button to edit the layout of the Dashboard screen."
         )
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/StoreStats/StorePerformanceView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/StoreStats/StorePerformanceView.swift
@@ -169,6 +169,7 @@ private extension StorePerformanceView {
         .contentShape(Rectangle())
         .onTapGesture {
             guard redactMode != .none,
+                !viewModel.syncingData,
                 viewModel.unavailableVisitStatsDueToCustomRange,
                 viewModel.siteVisitStatMode == .redactedDueToCustomRange else {
                 return
@@ -223,6 +224,7 @@ private extension StorePerformanceView {
                     .foregroundStyle(Color(.tertiaryLabel))
             }
         }
+        .disabled(viewModel.syncingData)
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Dashboard/StoreStats/StorePerformanceView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/StoreStats/StorePerformanceView.swift
@@ -32,8 +32,6 @@ struct StorePerformanceView: View {
             VStack(alignment: .leading, spacing: Layout.padding) {
                 header
                     .padding(.horizontal, Layout.padding)
-                    .redacted(reason: viewModel.syncingData ? [.placeholder] : [])
-                    .shimmering(active: viewModel.syncingData)
 
                 timeRangeBar
                     .padding(.horizontal, Layout.padding)

--- a/WooCommerce/Classes/ViewRelated/Dashboard/StoreStats/StorePerformanceViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/StoreStats/StorePerformanceViewModel.swift
@@ -475,7 +475,7 @@ private extension StorePerformanceViewModel {
         static let thirtyDaysInSeconds: TimeInterval = 86400*30
 
         /// The wait time before the `StoreStatsUsageTracksEventEmitter.interacted()` is called.
-        static let chartValueSelectedEventsDebounce: TimeInterval = 1.0
+        static let chartValueSelectedEventsDebounce: TimeInterval = 0.5
     }
     enum Localization {
         static let addCustomRange = NSLocalizedString(

--- a/WooCommerce/Classes/ViewRelated/Dashboard/StoreStats/StorePerformanceViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/StoreStats/StorePerformanceViewModel.swift
@@ -97,6 +97,23 @@ final class StorePerformanceViewModel: ObservableObject {
 
     func didSelectStatsInterval(at index: Int?) {
         chartValueSelectedEventsSubject.send(index)
+        periodViewModel?.selectedIntervalIndex = index
+        shouldHighlightStats = index != nil
+
+        if unavailableVisitStatsDueToCustomRange {
+            // If time range is less than 2 days, redact data when selected and show when deselected.
+            // Otherwise, show data when selected and redact when deselected.
+            guard case let .custom(from, to) = timeRange,
+                  let differenceInDays = StatsTimeRangeV4.differenceInDays(startDate: from, endDate: to) else {
+                return
+            }
+
+            if differenceInDays == .sameDay {
+                siteVisitStatMode = index != nil ? .hidden : .default
+            } else {
+                siteVisitStatMode = index != nil ? .default : .redactedDueToCustomRange
+            }
+        }
     }
 
     @MainActor
@@ -312,24 +329,6 @@ private extension StorePerformanceViewModel {
     }
 
     func handleSelectedChartValue(at index: Int?) {
-        periodViewModel?.selectedIntervalIndex = index
-        shouldHighlightStats = index != nil
-
-        if unavailableVisitStatsDueToCustomRange {
-            // If time range is less than 2 days, redact data when selected and show when deselected.
-            // Otherwise, show data when selected and redact when deselected.
-            guard case let .custom(from, to) = timeRange,
-                  let differenceInDays = StatsTimeRangeV4.differenceInDays(startDate: from, endDate: to) else {
-                return
-            }
-
-            if differenceInDays == .sameDay {
-                siteVisitStatMode = index != nil ? .hidden : .default
-            } else {
-                siteVisitStatMode = index != nil ? .default : .redactedDueToCustomRange
-            }
-        }
-
         if timeRange.isCustomTimeRange {
             analytics.track(event: .DashboardCustomRange.interacted())
         }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/StoreStats/StoreStatsChart.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/StoreStats/StoreStatsChart.swift
@@ -76,15 +76,23 @@ struct StoreStatsChart: View {
                 Rectangle().fill(.clear).contentShape(Rectangle())
                     .gesture(DragGesture()
                         .onChanged { value in
+                            // Only show selection and don't trigger updating selected index.
                             updateSelectedDate(at: value.location,
                                                proxy: proxy,
                                                geometry: geometry)
+                        }
+                        .onEnded { value in
+                            updateSelectedDate(at: value.location,
+                                               proxy: proxy,
+                                               geometry: geometry)
+                            updateSelectedIndex()
                         }
                     )
                     .onTapGesture { location in
                         updateSelectedDate(at: location,
                                            proxy: proxy,
                                            geometry: geometry)
+                        updateSelectedIndex()
                     }
             }
         }
@@ -106,6 +114,9 @@ struct StoreStatsChart: View {
             })
             .first?.date
         selectedRevenue = viewModel.intervals.first(where: { $0.date == selectedDate })?.revenue
+    }
+
+    private func updateSelectedIndex() {
         if let index = viewModel.intervals.firstIndex(where: { $0.date == selectedDate }) {
             if index == selectedIndex {
                 onIntervalSelected(nil)

--- a/WooCommerce/Classes/ViewRelated/Dashboard/TopPerformers/TopPerformersDashboardView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/TopPerformers/TopPerformersDashboardView.swift
@@ -116,6 +116,7 @@ private extension TopPerformersDashboardView {
                     .foregroundStyle(Color(.tertiaryLabel))
             }
         }
+        .disabled(viewModel.syncingData)
     }
 
     var topPerformersList: some View {

--- a/WooCommerce/Classes/ViewRelated/Dashboard/TopPerformers/TopPerformersDashboardView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/TopPerformers/TopPerformersDashboardView.swift
@@ -25,8 +25,6 @@ struct TopPerformersDashboardView: View {
         VStack(alignment: .leading, spacing: Layout.padding) {
             header
                 .padding(.horizontal, Layout.padding)
-                .redacted(reason: viewModel.syncingData ? [.placeholder] : [])
-                .shimmering(active: viewModel.syncingData)
 
             timeRangeBar
                 .padding(.horizontal, Layout.padding)

--- a/WooCommerce/WooCommerceTests/ViewModels/Authentication/AccountCreationFormViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewModels/Authentication/AccountCreationFormViewModelTests.swift
@@ -74,6 +74,7 @@ final class AccountCreationFormViewModelTests: XCTestCase {
 
     // MARK: - `createAccount`
 
+    @MainActor
     func test_createAccount_success_sets_state_to_authenticated() async {
         // Given
         mockAccountCreationSuccess(result: .init(authToken: "token", username: "username"))
@@ -86,6 +87,7 @@ final class AccountCreationFormViewModelTests: XCTestCase {
         XCTAssertTrue(stores.isAuthenticated)
     }
 
+    @MainActor
     func test_createAccount_password_failure_sets_passwordErrorMessage() async {
         // Given
         mockAccountCreationFailure(error: .invalidPassword(message: "too complex to guess"))
@@ -101,6 +103,7 @@ final class AccountCreationFormViewModelTests: XCTestCase {
         XCTAssertEqual(viewModel.passwordErrorMessage, "too complex to guess")
     }
 
+    @MainActor
     func test_createAccount_invalidEmail_failure_sets_emailErrorMessage() async {
         // Given
         mockAccountCreationFailure(error: .invalidEmail)
@@ -113,6 +116,7 @@ final class AccountCreationFormViewModelTests: XCTestCase {
         XCTAssertNotNil(viewModel.emailErrorMessage)
     }
 
+    @MainActor
     func test_shouldTransitionToPasswordField_is_updated_to_true_when_account_creation_fails_with_invalidPassword() async {
         // Given
         mockAccountCreationFailure(error: .invalidPassword(message: ""))
@@ -139,6 +143,7 @@ final class AccountCreationFormViewModelTests: XCTestCase {
         XCTAssertEqual(viewModel.currentField, .password)
     }
 
+    @MainActor
     func test_passwordErrorMessage_is_cleared_after_changing_password_input() async {
         // Given
         mockAccountCreationFailure(error: .invalidPassword(message: "too complex to guess"))
@@ -153,6 +158,7 @@ final class AccountCreationFormViewModelTests: XCTestCase {
         }
     }
 
+    @MainActor
     func test_emailErrorMessage_is_cleared_after_changing_email_input() async {
         // Given
         mockAccountCreationFailure(error: .emailExists)
@@ -169,6 +175,7 @@ final class AccountCreationFormViewModelTests: XCTestCase {
 
     // MARK: - analytics
 
+    @MainActor
     func test_createAccount_success_tracks_expected_events() async {
         // Given
         mockAccountCreationSuccess(result: .init(authToken: "", username: ""))
@@ -180,6 +187,7 @@ final class AccountCreationFormViewModelTests: XCTestCase {
         XCTAssertEqual(analyticsProvider.receivedEvents, ["signup_submitted", "signup_success"])
     }
 
+    @MainActor
     func test_createAccount_failure_tracks_expected_events() async {
         // Given
         mockAccountCreationFailure(error: .emailExists)
@@ -191,6 +199,7 @@ final class AccountCreationFormViewModelTests: XCTestCase {
         XCTAssertEqual(analyticsProvider.receivedEvents, ["signup_submitted", "signup_failed"])
     }
 
+    @MainActor
     func test_createAccount_failure_with_invalid_password_is_not_tracked_if_currentField_is_email() async {
         // Given
         mockAccountCreationFailure(error: .invalidPassword(message: nil))
@@ -203,6 +212,7 @@ final class AccountCreationFormViewModelTests: XCTestCase {
         XCTAssertEqual(analyticsProvider.receivedEvents, ["signup_submitted"])
     }
 
+    @MainActor
     func test_createAccount_failure_with_invalid_password_is_tracked_if_currentField_is_password() async {
         // Given
         mockAccountCreationFailure(error: .invalidPassword(message: nil))


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #12517 
Also closes #12511 
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This PR adds updates to the dashboard screen UI:
- Set the background color of the navigation bar to be the same as the whole view to match the design.
- Moved the share bar button to the left and changed the edit button title.
- Removed the redacting of the card title when data is being reloaded.
- Reduced the debounce time of the selected chart index to make the chart update faster upon selection.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
- Enable the `dynamicDashboard` feature flag and build the app.
- Log in to a store and confirm that the dashboard screen header matches the design.
- Enable the Performance card and select any place on the chart (if there is existing data). Confirm that the selection works for both tapping and dragging on the chart.
- Pull-to-refresh the dashboard screen, confirm that the card titles are not redacted.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->
<img src="https://github.com/woocommerce/woocommerce-ios/assets/5533851/1ff1f9bf-f4d5-4565-83ee-436be8d3d99e" width=320 />


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
