### PR TITLE
Dynamic Dashboard: Update UI for the error screen of outdated Woo version

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Dashboard/StoreStats/StorePerformanceView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/StoreStats/StorePerformanceView.swift
@@ -6,6 +6,7 @@ import enum Yosemite.StatsTimeRangeV4
 struct StorePerformanceView: View {
     @ObservedObject private var viewModel: StorePerformanceViewModel
     @State private var showingCustomRangePicker = false
+    @State private var showingSupportForm = false
 
     var statsValueColor: Color {
         Color(viewModel.shouldHighlightStats ? .statsHighlighted : .text)
@@ -72,6 +73,9 @@ struct StorePerformanceView: View {
                              datesSelected: { start, end in
                 viewModel.didSelectTimeRange(.custom(from: start, to: end))
             })
+        }
+        .sheet(isPresented: $showingSupportForm) {
+            supportForm
         }
     }
 }
@@ -234,11 +238,26 @@ private extension StorePerformanceView {
                 .bodyStyle()
                 .multilineTextAlignment(.center)
             Button(Localization.ContentUnavailable.buttonTitle) {
-                // TODO: show support form
+                showingSupportForm = true
             }
             .buttonStyle(SecondaryButtonStyle())
         }
         .frame(maxWidth: .infinity)
+    }
+
+    var supportForm: some View {
+        NavigationView {
+            SupportForm(isPresented: $showingSupportForm,
+                        viewModel: SupportFormViewModel())
+            .toolbar {
+                ToolbarItem(placement: .confirmationAction) {
+                    Button(Localization.ContentUnavailable.done) {
+                        showingSupportForm = false
+                    }
+                }
+            }
+        }
+        .navigationViewStyle(.stack)
     }
 }
 
@@ -315,6 +334,11 @@ private extension StorePerformanceView {
                 "storePerformanceView.contentUnavailable.buttonTitle",
                 value: "Still need help? Contact us",
                 comment: "Button title to contact support to get help with deprecated stats module"
+            )
+            static let done = NSLocalizedString(
+                "storePerformanceView.contentUnavailable.dismissSupport",
+                value: "Done",
+                comment: "Button to dismiss the support form from the Dashboard stats error screen."
             )
         }
     }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/StoreStats/StorePerformanceView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/StoreStats/StorePerformanceView.swift
@@ -28,11 +28,11 @@ struct StorePerformanceView: View {
     }
 
     var body: some View {
-        if viewModel.statsVersion == .v4 {
-            VStack(alignment: .leading, spacing: Layout.padding) {
-                header
-                    .padding(.horizontal, Layout.padding)
+        VStack(alignment: .leading, spacing: Layout.padding) {
+            header
+                .padding(.horizontal, Layout.padding)
 
+            if viewModel.statsVersion == .v4 {
                 timeRangeBar
                     .padding(.horizontal, Layout.padding)
                     .redacted(reason: viewModel.syncingData ? [.placeholder] : [])
@@ -56,22 +56,22 @@ struct StorePerformanceView: View {
                     .padding(.horizontal, Layout.padding)
                     .redacted(reason: viewModel.syncingData ? [.placeholder] : [])
                     .shimmering(active: viewModel.syncingData)
-
+            } else {
+                contentUnavailableView
+                    .padding(.horizontal, Layout.padding)
             }
-            .padding(.vertical, Layout.padding)
-            .background(Color(.listForeground(modal: false)))
-            .clipShape(RoundedRectangle(cornerSize: Layout.cornerSize))
-            .padding(.horizontal, Layout.padding)
-            .sheet(isPresented: $showingCustomRangePicker) {
-                RangedDatePicker(startDate: viewModel.startDateForCustomRange,
-                                 endDate: viewModel.endDateForCustomRange,
-                                 customApplyButtonTitle: viewModel.buttonTitleForCustomRange,
-                                 datesSelected: { start, end in
-                    viewModel.didSelectTimeRange(.custom(from: start, to: end))
-                })
-            }
-        } else {
-            ViewControllerContainer(DeprecatedDashboardStatsViewController())
+        }
+        .padding(.vertical, Layout.padding)
+        .background(Color(.listForeground(modal: false)))
+        .clipShape(RoundedRectangle(cornerSize: Layout.cornerSize))
+        .padding(.horizontal, Layout.padding)
+        .sheet(isPresented: $showingCustomRangePicker) {
+            RangedDatePicker(startDate: viewModel.startDateForCustomRange,
+                             endDate: viewModel.endDateForCustomRange,
+                             customApplyButtonTitle: viewModel.buttonTitleForCustomRange,
+                             datesSelected: { start, end in
+                viewModel.didSelectTimeRange(.custom(from: start, to: end))
+            })
         }
     }
 }
@@ -125,7 +125,7 @@ private extension StorePerformanceView {
 
     var statsView: some View {
         VStack(spacing: Layout.padding) {
-            VStack(spacing: Layout.statValuePadding) {
+            VStack(spacing: Layout.contentVerticalSpacing) {
                 Text(viewModel.revenueStatsText)
                     .fontWeight(.semibold)
                     .foregroundStyle(statsValueColor)
@@ -155,7 +155,7 @@ private extension StorePerformanceView {
     }
 
     func statsItemView(title: String, value: String, redactMode: RedactMode) -> some View {
-        VStack(spacing: Layout.statValuePadding) {
+        VStack(spacing: Layout.contentVerticalSpacing) {
             if redactMode == .none || viewModel.siteVisitStatMode == .default {
                 Text(value)
                     .font(Font(StyleManager.statsFont))
@@ -224,6 +224,22 @@ private extension StorePerformanceView {
             }
         }
     }
+
+    var contentUnavailableView: some View {
+        VStack(alignment: .center, spacing: Layout.padding) {
+            Image(uiImage: .noStoreImage)
+            Text(Localization.ContentUnavailable.title)
+                .headlineStyle()
+            Text(Localization.ContentUnavailable.details)
+                .bodyStyle()
+                .multilineTextAlignment(.center)
+            Button(Localization.ContentUnavailable.buttonTitle) {
+                // TODO: show support form
+            }
+            .buttonStyle(SecondaryButtonStyle())
+        }
+        .frame(maxWidth: .infinity)
+    }
 }
 
 private extension StorePerformanceView {
@@ -239,7 +255,7 @@ private extension StorePerformanceView {
         static let cornerSize = CGSize(width: 8.0, height: 8.0)
         static let strokeWidth: CGFloat = 0.5
         static let chartViewHeight: CGFloat = 176
-        static let statValuePadding: CGFloat = 8
+        static let contentVerticalSpacing: CGFloat = 8
         static let redactedViewCornerSize = CGSize(width: 2.0, height: 2.0)
         static let redactedViewWidth: CGFloat = 32
         static let redactedViewHeight: CGFloat = 10
@@ -284,6 +300,23 @@ private extension StorePerformanceView {
             value: "View all store analytics",
             comment: "Button to navigate to Analytics Hub."
         )
+        enum ContentUnavailable {
+            static let title = NSLocalizedString(
+                "storePerformanceView.contentUnavailable.title",
+                value: "We can’t display your store’s analytics",
+                comment: "Title when we can't show stats because user is on a deprecated WooCommerce Version"
+            )
+            static let details = NSLocalizedString(
+                "storePerformanceView.contentUnavailable.details",
+                value: "Make sure you are running the latest version of WooCommerce on your site.",
+                comment: "Text that explains how to update WooCommerce to get the latest stats"
+            )
+            static let buttonTitle = NSLocalizedString(
+                "storePerformanceView.contentUnavailable.buttonTitle",
+                value: "Still need help? Contact us",
+                comment: "Button title to contact support to get help with deprecated stats module"
+            )
+        }
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Dashboard/StoreStats/StorePerformanceView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/StoreStats/StorePerformanceView.swift
@@ -332,7 +332,8 @@ private extension StorePerformanceView {
             )
             static let details = NSLocalizedString(
                 "storePerformanceView.contentUnavailable.details",
-                value: "Make sure you are running the latest version of WooCommerce on your site.",
+                value: "Make sure you are running the latest version of WooCommerce on your site" +
+                " and enabling Analytics in WooCommerce Settings.",
                 comment: "Text that explains how to update WooCommerce to get the latest stats"
             )
             static let buttonTitle = NSLocalizedString(

--- a/WooCommerce/Classes/ViewRelated/Dashboard/StoreStats/StorePerformanceView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/StoreStats/StorePerformanceView.swift
@@ -83,6 +83,11 @@ struct StorePerformanceView: View {
 private extension StorePerformanceView {
     var header: some View {
         HStack {
+            Image(systemName: "exclamationmark.circle")
+                .foregroundStyle(Color.secondary)
+                .headlineStyle()
+                .renderedIf(viewModel.statsVersion == .v3) // and in error state too
+
             Text(Localization.title)
                 .headlineStyle()
             Spacer()


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #12517 
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
Previously when a store uses an outdated statistic module (outdated Woo version), we were showing `DeprecatedDashboardStatsViewController`. This view does not match the new design of the dashboard screen, so this PR creates a new custom view to match the error state of the Performance card.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
- Enable the feature flag `dynamicDashboard`.
- You can downgrade your test store to an old version using WooCommerce Beta plugin, or simply updating the check in the `StorePeformanceView` to display the `contentUnavailableView` when detecting statistic module version 4.
- Build the app and confirm that the Performance card displays the view as screenshot below. I'm using the old image from the `DeprecatedDashboardStatsViewController` - we can change to a different one when we get the suggestion from Joe.
- Confirm that the contact support button displays the support form properly.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->
<img src="https://github.com/woocommerce/woocommerce-ios/assets/5533851/bf5ea918-789a-4fd3-8d7e-4e6f9372d13b" width=320 />

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
