### PR TITLE
Dynamic Dashboard: Update Store Performance card for custom ranges

### DIFF
--- a/Experiments/Experiments/DefaultFeatureFlagService.swift
+++ b/Experiments/Experiments/DefaultFeatureFlagService.swift
@@ -91,7 +91,7 @@ public struct DefaultFeatureFlagService: FeatureFlagService {
         case .migrateSimplePaymentsToOrderCreation:
             return true
         case .dynamicDashboard:
-            return (buildConfig == .localDeveloper || buildConfig == .alpha) && !isUITesting
+            return buildConfig == .localDeveloper || buildConfig == .alpha
         case .subscriptionsInOrderCreationUI:
             return buildConfig == .localDeveloper || buildConfig == .alpha
         default:

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Stats v4/StoreStatsPeriodViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Stats v4/StoreStatsPeriodViewModel.swift
@@ -204,13 +204,13 @@ private extension StoreStatsPeriodViewModel {
                 return nil
             }
         }
-        guard let selectedIndex = selectedIntervalIndex else {
+        guard let selectedIndex = selectedIntervalIndex,
+              let date = orderStatsIntervals[safe: selectedIndex]?.dateStart(timeZone: siteTimezone) else {
             return StatsTimeRangeBarViewModel(startDate: startDate,
                                               endDate: endDate,
                                               timeRange: timeRange,
                                               timezone: siteTimezone)
         }
-        let date = orderStatsIntervals[selectedIndex].dateStart(timeZone: siteTimezone)
         return StatsTimeRangeBarViewModel(startDate: startDate,
                                           endDate: endDate,
                                           selectedDate: date,

--- a/WooCommerce/Classes/ViewRelated/Dashboard/StoreStats/StorePerformanceView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/StoreStats/StorePerformanceView.swift
@@ -109,12 +109,21 @@ private extension StorePerformanceView {
     var timeRangeBar: some View {
         HStack {
             AdaptiveStack(horizontalAlignment: .leading) {
-                Text(viewModel.timeRange.tabTitle)
+                Text(viewModel.timeRange.isCustomTimeRange ?
+                     Localization.custom : viewModel.timeRange.tabTitle)
                     .foregroundStyle(Color(.text))
                     .subheadlineStyle()
-                if let selectedDateText = viewModel.selectedDateText {
-                    Text(selectedDateText)
+                if viewModel.timeRange.isCustomTimeRange {
+                    Button {
+                        showingCustomRangePicker = true
+                    } label: {
+                        HStack {
+                            Text(viewModel.timeRangeText)
+                            Image(systemName: "pencil")
+                        }
+                        .foregroundStyle(Color.accentColor)
                         .subheadlineStyle()
+                    }
                 } else {
                     Text(viewModel.timeRangeText)
                         .subheadlineStyle()
@@ -135,6 +144,11 @@ private extension StorePerformanceView {
     var statsView: some View {
         VStack(spacing: Layout.padding) {
             VStack(spacing: Layout.contentVerticalSpacing) {
+                if let selectedDateText = viewModel.selectedDateText {
+                    Text(selectedDateText)
+                        .font(Font(StyleManager.statsTitleFont))
+                }
+
                 Text(viewModel.revenueStatsText)
                     .fontWeight(.semibold)
                     .foregroundStyle(statsValueColor)
@@ -298,6 +312,11 @@ private extension StorePerformanceView {
             "storePerformanceView.hideCard",
             value: "Hide Performance",
             comment: "Menu item to dismiss the store performance section on the Dashboard screen"
+        )
+        static let custom = NSLocalizedString(
+            "storePerformanceView.custom",
+            value: "Custom",
+            comment: "Title of the custom time range on the store performance card on the Dashboard screen"
         )
         static let revenue = NSLocalizedString(
             "storePerformanceView.revenue",

--- a/WooCommerce/WooCommerceUITests/Tests/StatsTests.swift
+++ b/WooCommerce/WooCommerceUITests/Tests/StatsTests.swift
@@ -14,7 +14,8 @@ final class StatsTests: XCTestCase {
         try LoginFlow.login()
     }
 
-    func test_load_stats_screen() throws {
+    /// TODO: Update tests after the new stats screen is released.
+    func skipped_test_load_stats_screen() throws {
         try TabNavComponent().goToMyStoreScreen()
             .verifyTodayStatsLoaded()
             .goToThisWeekTab()
@@ -25,7 +26,8 @@ final class StatsTests: XCTestCase {
             .verifyThisYearStatsLoaded()
     }
 
-    func test_view_detailed_chart_stats() throws {
+    /// TODO: Update tests after the new stats screen is released.
+    func skipped_test_view_detailed_chart_stats() throws {
         let myStoreScreen = try MyStoreScreen()
 
         var dailyRevenue = try TabNavComponent()


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #12525 
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This PR updates the store performance card when a custom range is selected following the discussion p1713428650239389-slack-C03L1NF1EA3.

Changes include: 
- Updated the time range title to "Custom" when a custom range is selected to match the design.
- Made the date range a button to open the date picker.
- Displayed the selected date on top of the revenue stat.
- Also:
  - Fixed a potential crash when subscripting the order stats to create time range bar view model.
  - Disable outdated UI tests for dashboard stats.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
- Enable the feature flag `dynamicDashboard` and build the app.
- Log in to a store and enable the Performance card on the Dashboard screen.
- Select a custom range on the Performance card, preferably a range with existing orders/revenues.
- Confirm that the custom range is displayed as a button, and tapping the button should open the date picker for change the date range.
- Tap any point on the chart and confirm that the selected date is displayed on top of the revenue stat. Tap that point again, the selected date should disappear.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

<img src="https://github.com/woocommerce/woocommerce-ios/assets/5533851/e3ebdd84-1800-429b-9e69-3e5d5839d1d1" width=320 />


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.