### PR TITLE
[Subscriptions in Order Creation 3] Handle signup fee and trial length zero case

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Products/ProductSelector/ProductRowViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductSelector/ProductRowViewModel.swift
@@ -105,7 +105,7 @@ final class ProductRowViewModel: ObservableObject, Identifiable {
         // Signup fees
         var formattedSignUpFee: String = ""
 
-        if let signUpFee = productSubscriptionDetails?.signUpFee, !signUpFee.isEmpty {
+        if let signUpFee = productSubscriptionDetails?.signUpFee, !signUpFee.isEmpty, signUpFee != "0" {
             formattedSignUpFee = currencyFormatter.formatAmount(signUpFee) ?? ""
         }
 
@@ -117,14 +117,10 @@ final class ProductRowViewModel: ObservableObject, Identifiable {
             // If trial period is missing, we can skip formatting the rest
             guard let trialPeriod = trialPeriod else { return "" }
             switch trialLength {
-            case "":
-                // The API allows an empty value for trial length, with a non-nil trial period.
-                // eg: every -empty- days
+            case "", "0":
+                // The API allows empty and 0 as values for trial length, with a non-nil trial period.
+                // eg: "every -empty- days", or "every 0 days"
                 return ""
-            case "0":
-                // The API allows to input a 0-length trial length, with a non-nil trial period.
-                // eg: every zero days
-                return "0"
             case "1":
                 return trialPeriod.descriptionSingular
             default:
@@ -132,8 +128,8 @@ final class ProductRowViewModel: ObservableObject, Identifiable {
             }
         }()
 
-        let hasNoSignUpFees = formattedSignUpFee.isEmpty || formattedSignUpFee == "0"
-        let hasNoFreeTrial = formattedTrialDetails.isEmpty || formattedTrialDetails == "0"
+        let hasNoSignUpFees = formattedSignUpFee.isEmpty
+        let hasNoFreeTrial = formattedTrialDetails.isEmpty
 
         switch (hasNoSignUpFees, hasNoFreeTrial) {
         case (true, true):

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/ProductRowViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/ProductRowViewModelTests.swift
@@ -567,7 +567,7 @@ final class ProductRowViewModelTests: XCTestCase {
         XCTAssertEqual(viewModel.subscriptionConditionsLabel, expectedConditionsLabel)
     }
 
-    func test_subscriptionConditionsLabel_when_has_no_signup_fees_and_but_trial_period_then_returns_expected_details() {
+    func test_subscriptionConditionsLabel_when_has_no_signup_fees_but_has_trial_period_then_returns_expected_details() {
         // Given
         let rowID = Int64(0)
         let expectedTrialLength = "1"
@@ -628,6 +628,29 @@ final class ProductRowViewModelTests: XCTestCase {
 
         // Then
         XCTAssertTrue(viewModel.subscriptionConditionsLabel.isEmpty)
+    }
+
+    func test_subscriptionConditionsLabel_when_signup_fee_is_zero_then_returns_no_signup_fee_in_label() {
+        // Given
+        let rowID = Int64(0)
+        let signupFee = "0"
+        let expectedTrialLength = "1"
+        let expectedTrialPeriod = SubscriptionPeriod.week
+        let expectedConditionsLabel = "1 week free"
+
+        let subs: ProductSubscription = createFakeSubscription(signUpFee: signupFee,
+                                                               trialLength: expectedTrialLength,
+                                                               trialPeriod: expectedTrialPeriod)
+        let product = Product.fake().copy(productID: 12,
+                                          name: "A subscription product with zero signup fee",
+                                          productTypeKey: "subscription",
+                                          subscription: subs)
+
+        // When
+        let viewModel = ProductRowViewModel(id: rowID, product: product, productSubscriptionDetails: subs)
+
+        // Then
+        XCTAssertEqual(viewModel.subscriptionConditionsLabel, expectedConditionsLabel)
     }
 }
 


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #12471 

## Description
This PR tackles the review feedback on https://github.com/woocommerce/woocommerce-ios/pull/12447#pullrequestreview-1993198642 by considering `zero` and `empty` values the same when dealing with signup fees or trial length. This allows us to simplify the logic and hide them from the UI when appropriate, so only values >0 will be shown.

> I found a case where I have a $0.00 signup fee, maybe the string value was not "0" as expected?
> can we treat these two cases the same way?

| Before | After |
|--------|--------|
| ![2024-04-22 0 signup fee](https://github.com/woocommerce/woocommerce-ios/assets/3812076/9bd07d7e-98c8-419b-aed3-2b8a3bef312c) | ![2024-04-22 after 0 signup fee](https://github.com/woocommerce/woocommerce-ios/assets/3812076/2d55d4fe-ba3c-4f4c-9d81-b116e6aae318) | 

## Testing instructions
* On a store using WooCommerce Subscriptions, setup a product subscription with zero sign up fee and/or zero trial length. You can use the testing site https://indiemelon.mystagingwebsite.com/ if you prefer.
* Go to Orders > `+` > `+ Add Products`
* If using https://indiemelon.mystagingwebsite.com/,  search for "_virtual sub_" product where one of the products is titled _"no sign-up fee as zero"_.
* Observe that the `$0.00 signup` element isn't rendered anymore
