### PR TITLE
[Extensions] Increase tap target to entire row when showing "Explore" button for inactive extensions

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/Customize/AnalyticsHubCustomizeView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/Customize/AnalyticsHubCustomizeView.swift
@@ -14,6 +14,9 @@ struct AnalyticsHubCustomizeView: View {
                                       contentKeyPath: \.name,
                                       selectedItems: $viewModel.selectedCards,
                                       inactiveItems: viewModel.inactiveCards,
+                                      inactiveItemTapGesture: { card in
+            openWebview(for: viewModel.promoURL(for: card))
+        },
                                       inactiveAccessoryView: { card in
             exploreButton(with: viewModel.promoURL(for: card))
         })
@@ -47,7 +50,7 @@ private extension AnalyticsHubCustomizeView {
     @ViewBuilder func exploreButton(with promoURL: URL?) -> some View {
         if let promoURL {
             Button {
-                selectedPromoURL = promoURL
+                openWebview(for: promoURL)
             } label: {
                 Text(Localization.explore)
                     .foregroundColor(Color(.primary))
@@ -58,6 +61,12 @@ private extension AnalyticsHubCustomizeView {
         } else {
             EmptyView()
         }
+    }
+
+    /// Opens the provided URL in a webview.
+    ///
+    func openWebview(for promoURL: URL?) {
+        selectedPromoURL = promoURL
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Filters/FilterListViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Filters/FilterListViewController.swift
@@ -428,8 +428,9 @@ private extension FilterListViewController {
 
         func handleSelectedChange(selected: FilterType, viewController: ViewController) {
             // Do not allow selection for an unavailable promotable type.
+            // Instead, just launch a webview to promote it.
             if let promotable = selected as? PromotableProductType, !promotable.isAvailable {
-                return
+                return launchPromoteWebview(for: promotable)
             }
 
             onItemSelectedSubject.send(selected)
@@ -454,17 +455,21 @@ private extension FilterListViewController {
             configuration.buttonSize = .mini
             configuration.title = NSLocalizedString("Explore", comment: "Button title to explore an extension that isn't installed")
 
-            let action = UIAction { action in
-                if let url = promotableType.promoteUrl, let viewController = self.hostViewController {
-                    WebviewHelper.launch(url, with: viewController)
-                    ServiceLocator.analytics.track(event: .ProductListFilter.productFilterListExploreButtonTapped(type: promotableType))
-                }
+            let action = UIAction { [weak self] action in
+                self?.launchPromoteWebview(for: promotableType)
             }
 
             let button = UIButton(configuration: configuration, primaryAction: action)
             button.sizeToFit()
 
             return button
+        }
+
+        func launchPromoteWebview(for promotableType: PromotableProductType) {
+            if let url = promotableType.promoteUrl, let viewController = hostViewController {
+                WebviewHelper.launch(url, with: viewController)
+                ServiceLocator.analytics.track(event: .ProductListFilter.productFilterListExploreButtonTapped(type: promotableType))
+            }
         }
     }
 }

--- a/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/MultiSelectionReorderableList.swift
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/MultiSelectionReorderableList.swift
@@ -14,6 +14,9 @@ struct MultiSelectionReorderableList<T: Hashable, Content: View>: View {
     /// Items in addition to the list of `contents` that can't be moved or selected.
     private let inactiveItems: [T]
 
+    /// Optional closure to provide a tap gesture for inactive item rows.
+    private let inactiveItemTapGesture: ((T) -> Void)?
+
     /// Accessory view to display next to inactive items.
     @ViewBuilder private let inactiveAccessoryView: (T) -> Content
 
@@ -21,22 +24,26 @@ struct MultiSelectionReorderableList<T: Hashable, Content: View>: View {
          contentKeyPath: KeyPath<T, String>,
          selectedItems: Binding<Set<T>>,
          inactiveItems: [T] = [],
+         inactiveItemTapGesture: ((T) -> Void)? = nil,
          inactiveAccessoryView: @escaping (T) -> Content) {
         self._contents = contents
         self.contentKeyPath = contentKeyPath
         self._selectedItems = selectedItems
         self.inactiveItems = inactiveItems
+        self.inactiveItemTapGesture = inactiveItemTapGesture
         self.inactiveAccessoryView = inactiveAccessoryView
     }
 
     init(contents: Binding<[T]>,
          contentKeyPath: KeyPath<T, String>,
          selectedItems: Binding<Set<T>>,
-         inactiveItems: [T] = []) where Content == EmptyView {
+         inactiveItems: [T] = [],
+         inactiveItemTapGesture: ((T) -> Void)? = nil) where Content == EmptyView {
         self.init(contents: contents,
                   contentKeyPath: contentKeyPath,
                   selectedItems: selectedItems,
                   inactiveItems: inactiveItems,
+                  inactiveItemTapGesture: inactiveItemTapGesture,
                   inactiveAccessoryView: { _ in EmptyView() })
     }
 
@@ -62,6 +69,10 @@ struct MultiSelectionReorderableList<T: Hashable, Content: View>: View {
                         Text(item[keyPath: contentKeyPath])
                         Spacer()
                         inactiveAccessoryView(item)
+                    }
+                    .contentShape(Rectangle())
+                    .onTapGesture {
+                        inactiveItemTapGesture?(item)
                     }
                 }
                 .frame(height: Layout.inactiveRowHeight)


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #12509
<!-- Id number of the GitHub issue this PR addresses. -->

## Why
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
In the Analytics Hub customize screen and the Products tab product type filter, we show an "Explore" button if a supported extension is not active on the store.

This increases the tap target from just the "Explore" button to the entire row, based on design feedback.

## How
Products tab:

* In `FilterListViewController` (which uses a `UITableView`), we now call the same method to launch a webview when either the Explore button is tapped or the cell itself is selected.

Analytics Hub:

* In `MultiSelectionReorderableList` (a SwiftUI component), we now have an optional closure to provide a tap gesture for inactive rows in the list.
* In `AnalyticsHubCustomizeView`, we now call the same method to open a webview when either the Explore button or the list row is tapped.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

Using a test store without all canonical extensions active (e.g. the Product Bundles extension is inactive):

1. Build and run the app.
2. Open the Products tab.
3. Tap "Filter" to open the products filter.
4. Select Product Type.
5. On a row with the Explore button, confirm tapping either the button or the row itself opens the expected webview.
6. Open the My Store tab.
7. Open the dashboard settings (the cog icon) and confirm the inactive dashboard card rows continue to work as before. (This screen also uses `MultiSelectionReorderableList`.)
8. Open the Analytics Hub.
9. Customize the analytics (with the "Edit" button).
10. On a row with the Explore button, confirm tapping either the button or the row itself opens the expected webview.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->
Tap targets:

Before|After
-|-
![Before-ProductsFilter](https://github.com/woocommerce/woocommerce-ios/assets/8658164/686e9297-a8c8-4d9e-8a2c-941d133dfbb0)|![After-ProductsFilter](https://github.com/woocommerce/woocommerce-ios/assets/8658164/062fb056-5f05-419d-b058-e8ccf16ea43c)
![Before-CustomizeAnalytics](https://github.com/woocommerce/woocommerce-ios/assets/8658164/3b5d0964-208f-4836-bd58-3cd33ded5392)|![After-CustomizeAnalytics](https://github.com/woocommerce/woocommerce-ios/assets/8658164/51c053e8-2fde-43d8-8ace-b484d892da39)

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
