### PR TITLE
[Subscriptions in Order Creation 3] Add quantity badge to collapsible cards. Account for quantity on price display.

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/CollapsibleProductCard.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/CollapsibleProductCard.swift
@@ -118,6 +118,10 @@ private struct CollapsibleProductRowCard: View {
         }
     }
 
+    private var shouldShowBadgeCounter: Bool {
+        ServiceLocator.featureFlagService.isFeatureFlagEnabled(.subscriptionsInOrderCreationUI)
+    }
+
     init(viewModel: CollapsibleProductRowCardViewModel,
          flow: WooAnalyticsEvent.Orders.Flow,
          shouldDisableDiscountEditing: Bool,
@@ -146,6 +150,13 @@ private struct CollapsibleProductRowCard: View {
                                           productImageCornerRadius: Layout.productImageCornerRadius,
                                           foregroundColor: Color(UIColor.listSmallIcon))
                     .padding(.leading, viewModel.hasParentProduct ? Layout.childLeadingPadding : 0)
+                    .overlay(alignment: .topTrailing) {
+                        BadgeView(text: "\(viewModel.stepperViewModel.quantity)",
+                                  customizations: .init(textColor: .white, backgroundColor: .black),
+                                  backgroundShape: .circle)
+                        .offset(x: 8, y: -8)
+                        .renderedIf(shouldShowBadgeCounter)
+                    }
                     VStack(alignment: .leading) {
                         Text(viewModel.name)
                             .font(viewModel.hasParentProduct ? .subheadline : .none)

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/CollapsibleProductCard.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/CollapsibleProductCard.swift
@@ -151,10 +151,10 @@ private struct CollapsibleProductRowCard: View {
                                           foregroundColor: Color(UIColor.listSmallIcon))
                     .padding(.leading, viewModel.hasParentProduct ? Layout.childLeadingPadding : 0)
                     .overlay(alignment: .topTrailing) {
-                        BadgeView(text: "\(viewModel.stepperViewModel.quantity)",
-                                  customizations: .init(textColor: .white, backgroundColor: .black),
-                                  backgroundShape: .circle)
-                        .offset(x: 8, y: -8)
+                        BadgeView(text: badgeQuantity,
+                                  customizations: .init(textColor: Color(.textInverted), backgroundColor: .black),
+                                  backgroundShape: badgeStyle)
+                        .offset(x: Layout.badgeOffset, y: -Layout.badgeOffset)
                         .renderedIf(shouldShowBadgeCounter)
                     }
                     VStack(alignment: .leading) {
@@ -381,6 +381,26 @@ private extension CollapsibleProductRowCard {
 }
 
 private extension CollapsibleProductRowCard {
+    /// Displays the product quantity in the product card badge while is within 2 digits,
+    /// for higher quantities displays "99+"
+    var badgeQuantity: String {
+        if viewModel.stepperViewModel.quantity < 100 {
+           return "\(viewModel.stepperViewModel.quantity)"
+        } else {
+            return "99+"
+        }
+    }
+
+    /// Displays a different badge background shape based on the product quantity
+    /// Circular for 2-digit quantities, rounded for 3-digit quantities or more
+    var badgeStyle: BadgeView.BackgroundShape {
+        if viewModel.stepperViewModel.quantity < 100 {
+            return .circle
+        } else {
+            return .roundedRectangle(cornerRadius: Layout.badgeOffset)
+        }
+    }
+
     enum Layout {
         static let padding: CGFloat = 16
         static let childLeadingPadding: CGFloat = 16.0
@@ -392,6 +412,7 @@ private extension CollapsibleProductRowCard {
         static let iconSize: CGFloat = 16
         static let deleteIconSize: CGFloat = 24.0
         static let rowMinHeight: CGFloat = 40.0
+        static let badgeOffset: CGFloat = 8.0
     }
 
     enum Localization {

--- a/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/BadgeView.swift
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/BadgeView.swift
@@ -27,7 +27,7 @@ struct BadgeView: View {
         case circle
 
         static var defaultShape: BackgroundShape {
-            .roundedRectangle(cornerRadius: 8)
+            .roundedRectangle(cornerRadius: Layout.cornerRadius)
         }
     }
 
@@ -99,13 +99,13 @@ private extension BadgeView {
             if #available(iOS 17, *) {
                 Circle()
                     .fill(customizations.backgroundColor)
-                    .stroke(Color.white, lineWidth: 1)
+                    .stroke(Color.white, lineWidth: Layout.borderLineWidth)
             } else {
                 ZStack {
                     Circle()
                         .fill(customizations.backgroundColor)
                     Circle()
-                        .stroke(Color.white, lineWidth: 1)
+                        .stroke(Color.white, lineWidth: Layout.borderLineWidth)
                 }
             }
         case .roundedRectangle(let cornerRadius):
@@ -126,7 +126,8 @@ private extension BadgeView {
     enum Layout {
         static let horizontalPadding: CGFloat = 6
         static let verticalPadding: CGFloat = 4
-        static let cornerRadius: CGFloat = 8
+        static let borderLineWidth: CGFloat = 1
+        static var cornerRadius: CGFloat { 8 }
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/BadgeView.swift
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/BadgeView.swift
@@ -20,7 +20,7 @@ struct BadgeView: View {
             }
         }
     }
-    
+
     /// Internal background shape of the badge
     enum BackgroundShape {
         case roundedRectangle(cornerRadius: CGFloat)

--- a/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/BadgeView.swift
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/BadgeView.swift
@@ -20,6 +20,16 @@ struct BadgeView: View {
             }
         }
     }
+    
+    /// Internal background shape of the badge
+    enum BackgroundShape {
+        case roundedRectangle(cornerRadius: CGFloat)
+        case circle
+
+        static var defaultShape: BackgroundShape {
+            .roundedRectangle(cornerRadius: 8)
+        }
+    }
 
     /// UI customizations for the badge.
     struct Customizations {
@@ -35,15 +45,20 @@ struct BadgeView: View {
 
     private let type: BadgeType
     private let customizations: Customizations
+    private let backgroundShape: BackgroundShape
 
     init(type: BadgeType) {
         self.type = type
         self.customizations = .init()
+        self.backgroundShape = BackgroundShape.defaultShape
     }
 
-    init(text: String, customizations: Customizations = .init()) {
+    init(text: String,
+         customizations: Customizations = .init(),
+         backgroundShape: BackgroundShape = BackgroundShape.defaultShape) {
         self.type = .customText(text: text)
         self.customizations = customizations
+        self.backgroundShape = backgroundShape
     }
 
     var body: some View {
@@ -56,9 +71,7 @@ struct BadgeView: View {
                 .padding(.trailing, Layout.horizontalPadding)
                 .padding(.top, Layout.verticalPadding)
                 .padding(.bottom, Layout.verticalPadding)
-                .background(RoundedRectangle(cornerRadius: Layout.cornerRadius)
-                    .fill(customizations.backgroundColor)
-                )
+                .background(backgroundView())
         } else if case .remoteImage(let lightUrl, let darkUrl) = type {
             AdaptiveAsyncImage(anyAppearanceUrl: lightUrl, darkUrl: darkUrl, scale: 3) { imagePhase in
                 switch imagePhase {
@@ -78,6 +91,30 @@ struct BadgeView: View {
     }
 }
 
+private extension BadgeView {
+    @ViewBuilder
+    func backgroundView() -> some View {
+        switch backgroundShape {
+        case .circle:
+            if #available(iOS 17, *) {
+                Circle()
+                    .fill(customizations.backgroundColor)
+                    .stroke(Color.white, lineWidth: 1)
+            } else {
+                ZStack {
+                    Circle()
+                        .fill(customizations.backgroundColor)
+                    Circle()
+                        .stroke(Color.white, lineWidth: 1)
+                }
+            }
+        case .roundedRectangle(let cornerRadius):
+            RoundedRectangle(cornerRadius: cornerRadius)
+                .fill(customizations.backgroundColor)
+        }
+    }
+}
+
 private extension BadgeView.BadgeType {
     enum Localization {
         static let newTitle = NSLocalizedString("New", comment: "Title of the badge shown when advertising a new feature")
@@ -93,6 +130,7 @@ private extension BadgeView {
     }
 }
 
+#if DEBUG
 struct BadgeView_Previews: PreviewProvider {
     static var previews: some View {
         VStack {
@@ -103,3 +141,4 @@ struct BadgeView_Previews: PreviewProvider {
         }
     }
 }
+#endif

--- a/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/BadgeView.swift
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/BadgeView.swift
@@ -127,7 +127,7 @@ private extension BadgeView {
         static let horizontalPadding: CGFloat = 6
         static let verticalPadding: CGFloat = 4
         static let borderLineWidth: CGFloat = 1
-        static var cornerRadius: CGFloat { 8 }
+        static let cornerRadius: CGFloat = 8
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/CollapsibleView.swift
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/CollapsibleView.swift
@@ -44,7 +44,7 @@ struct CollapsibleView<Label: View, Content: View>: View {
                     isCollapsed.toggle()
                 }
             }, label: {
-                HStack {
+                HStack(alignment: .top) {
                     label
                     Spacer()
                     if isCollapsible {

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/CollapsibleProductRowCardViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/CollapsibleProductRowCardViewModelTests.swift
@@ -396,6 +396,7 @@ final class CollapsibleProductRowCardViewModelTests: XCTestCase {
                                         name: product.name,
                                         price: productPrice)
 
+        // Then
         XCTAssertEqual(viewModel.price, productPrice)
         XCTAssertEqual(viewModel.subscriptionPrice, nil)
         XCTAssertEqual(viewModel.productSubscriptionDetails, nil)
@@ -416,6 +417,7 @@ final class CollapsibleProductRowCardViewModelTests: XCTestCase {
                                         name: product.name,
                                         price: productPrice)
 
+        // Then
         XCTAssertEqual(viewModel.price, productPrice)
         XCTAssertEqual(viewModel.subscriptionPrice, nil)
         XCTAssertEqual(viewModel.productSubscriptionDetails, zeroPriceProductSubscription)
@@ -437,6 +439,62 @@ final class CollapsibleProductRowCardViewModelTests: XCTestCase {
                                         name: product.name,
                                         price: productPrice)
 
+        // Then
+        XCTAssertEqual(viewModel.price, productPrice)
+        XCTAssertEqual(viewModel.subscriptionPrice, expectedFormattedPrice)
+        XCTAssertEqual(viewModel.productSubscriptionDetails, productSubscription)
+    }
+
+    func test_productRow_when_item_has_product_price_different_than_subscription_price_then_product_price_is_used() {
+        // Given
+        let productPrice = "5"
+        let subscriptionPrice = "10"
+        let productQuantity = Decimal(10)
+        let expectedFormattedPrice = "$50.00"
+
+        let productSubscription: ProductSubscription? = createFakeSubscription(price: subscriptionPrice)
+        let product = Product.fake().copy(productID: 12,
+                                          name: "A subscription product",
+                                          price: productPrice,
+                                          subscription: productSubscription)
+
+        // When
+        let viewModel = createViewModel(id: product.productID,
+                                        productSubscriptionDetails: product.subscription,
+                                        name: product.name,
+                                        price: productPrice,
+                                        stepperViewModel: .init(quantity: productQuantity,
+                                                                name: "",
+                                                                quantityUpdatedCallback: { _ in }))
+
+        // Then
+        XCTAssertEqual(viewModel.price, productPrice)
+        XCTAssertEqual(viewModel.subscriptionPrice, expectedFormattedPrice)
+        XCTAssertEqual(viewModel.productSubscriptionDetails, productSubscription)
+    }
+
+    func test_productRow_when_item_has_more_than_one_quantity_then_subscriptionPrice_is_formatted_properly() {
+        // Given
+        let productPrice = "10"
+        let productQuantity = Decimal(10)
+        let expectedFormattedPrice = "$100.00"
+
+        let productSubscription = createFakeSubscription(price: productPrice)
+        let product = Product.fake().copy(productID: 12,
+                                          name: "A subscription product",
+                                          price: productPrice,
+                                          subscription: productSubscription)
+
+        // When
+        let viewModel = createViewModel(id: product.productID,
+                                        productSubscriptionDetails: product.subscription,
+                                        name: product.name,
+                                        price: productPrice,
+                                        stepperViewModel: .init(quantity: productQuantity,
+                                                                name: "",
+                                                                quantityUpdatedCallback: { _ in }))
+
+        // Then
         XCTAssertEqual(viewModel.price, productPrice)
         XCTAssertEqual(viewModel.subscriptionPrice, expectedFormattedPrice)
         XCTAssertEqual(viewModel.productSubscriptionDetails, productSubscription)
@@ -458,6 +516,7 @@ final class CollapsibleProductRowCardViewModelTests: XCTestCase {
                                         name: product.name,
                                         price: productPrice)
 
+        // Then
         XCTAssertEqual(viewModel.price, productPrice)
         XCTAssertEqual(viewModel.productSubscriptionDetails?.price, subscriptionPrice)
     }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #12439 
## Description

This PR addresses 3 items related to quantities:

* Adds a badge with the item selected quantity to the image thumbnail in collapsible product cards.
* Updates the total price of a subscription to account when quantity is > 1: Up until now we only shown the "price per unit" for a subscription, adding more items to the order wouldn't update the total price in the card.
* Updates the total price of a subscription to account for on-sale product pricing: Subscription regular price can be different from the actual product price (eg: on-sale price could be $10 while the regular price remains as $14), we're sure to display the product price when there's discrepancies.

| Before ($14 is wrong, should be $10) | After |
|--------|--------|
| ![Simulator Screenshot - iPhone 15 - 2024-04-19 at 08 32 00](https://github.com/woocommerce/woocommerce-ios/assets/3812076/103e33c6-1996-4427-a723-f556b112259a) | ![Simulator Screenshot - iPhone 15 - 2024-04-23 at 12 33 39](https://github.com/woocommerce/woocommerce-ios/assets/3812076/73ec09f0-4689-458e-885a-291813693383) | 

## Changes
- Added an overlay with a `BadgeView` to the product thumbnail, then we pass the selected quantity inside the badge.
- Updated the `subscriptionPrice` computation to account for quantities and if the product price is different than the subscription price.
- Adjusted the chevron icon in the collapsible product cards to appear in the top, rather than the center of the component.
- Additional unit tests to confirm we're showing the correct pricing when there's more than 1 subscription and when the price differs from the regular subscription price. 

## Testing instructions
* On a store using WooCommerce Subscriptions, create a simple subscription with different price and "sale" price. For easiness you can use the testing site https://indiemelon.mystagingwebsite.com/ , that already has a bunch of subscriptions setup.
* Go to `Orders` > `+` > `+ Add products` > Search for "on sale". Observe the product selector will show the subscription price ($14. This will change in the future, for now we'll leave it for testing):

<img width="426" alt="Screenshot 2024-04-23 at 13 02 07" src="https://github.com/woocommerce/woocommerce-ios/assets/3812076/a85714fa-0726-469b-a3e0-58e21c356adc">

* Add it to the order, observe the order will show the sale price ($10):

<img width=450 src="https://github.com/woocommerce/woocommerce-ios/assets/3812076/c97a7254-6a44-463f-a82a-9b7b191df514" />

* Expand the product card and update the quantity up to any value within 99, observe the badge updates with the exact quantity. Update the quantity to 3+ digits, observe that the quantity in the badge display as `99+` instead:

| Quantity < 100  | Quantity > 100 |
|--------|--------|
| ![simulator_screenshot_54412047-4CFE-4CD3-A6D4-51B131974D5D](https://github.com/woocommerce/woocommerce-ios/assets/3812076/d31de3d8-2cb3-4241-b3b3-07f1b34ab54e) | ![simulator_screenshot_64DE967E-7A39-4AFB-8A1E-820D18BA5460](https://github.com/woocommerce/woocommerce-ios/assets/3812076/05ec8251-2e72-4f76-8591-794b80537b1a) |
