### PR TITLE
[Blaze] Update ad image min size

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -2,6 +2,7 @@
 
 18.4
 -----
+- [internal] Blaze: Change campaign image minimum expected dimensions. [https://github.com/woocommerce/woocommerce-ios/pull/12544]
 
 
 18.3
@@ -11,9 +12,9 @@
 18.2
 -----
 - [*] Menu > Payments > Collect Payment: the simple payments flow has been migrated to order form with custom amount. [https://github.com/woocommerce/woocommerce-ios/pull/12455]
-- [*] Login: Allow login using site credentials for Jetpack connected stores. [https://github.com/woocommerce/woocommerce-ios/issues/12429]
+- [*] Login: Allow login using site credentials for Jetpack connected stores. [https://github.com/woocommerce/woocommerce-ios/pull/12429]
 - [internal] Updated all `woo.com` URLs to use `woocommerce.com` domain. [https://github.com/woocommerce/woocommerce-ios/pull/12452]
-- [*] Blaze: Validate that campaign image has minimum expected dimensions. [https://github.com/woocommerce/woocommerce-ios/issues/12470]
+- [*] Blaze: Validate that campaign image has minimum expected dimensions. [https://github.com/woocommerce/woocommerce-ios/pull/12470]
 
 18.1
 -----

--- a/WooCommerce/Classes/ViewRelated/Blaze/BlazeEditAd/BlazeEditAdView.swift
+++ b/WooCommerce/Classes/ViewRelated/Blaze/BlazeEditAd/BlazeEditAdView.swift
@@ -257,7 +257,7 @@ private extension BlazeEditAdView {
             )
             static let imageSizeError = NSLocalizedString(
                 "blazeEditAdView.image.imageSizeError",
-                value: "Please select an image with minimum dimensions of 600 × 600 px.",
+                value: "Please select an image with minimum dimensions of 400 × 400 px.",
                 comment: "Error message displayed when selected campaign image is not large enough."
             )
             static let ok = NSLocalizedString(

--- a/WooCommerce/Classes/ViewRelated/Blaze/BlazeEditAd/BlazeEditAdView.swift
+++ b/WooCommerce/Classes/ViewRelated/Blaze/BlazeEditAd/BlazeEditAdView.swift
@@ -65,7 +65,7 @@ struct BlazeEditAdView: View {
             .navigationBarTitleDisplayMode(.inline)
         }
         .navigationViewStyle(StackNavigationViewStyle())
-        .alert(Text(Localization.Image.imageSizeError), isPresented: $viewModel.shouldDisplayImageSizeErrorAlert) {
+        .alert(Text(Localization.Image.imageSizeErrorMessage), isPresented: $viewModel.shouldDisplayImageSizeErrorAlert) {
             Button(Localization.Image.ok, role: .cancel) { }
         }
     }
@@ -255,8 +255,8 @@ private extension BlazeEditAdView {
                 value: "Change image",
                 comment: "Change image button title in the Blaze Edit Ad screen."
             )
-            static let imageSizeError = NSLocalizedString(
-                "blazeEditAdView.image.imageSizeError",
+            static let imageSizeErrorMessage = NSLocalizedString(
+                "blazeEditAdView.image.imageSizeErrorMessage",
                 value: "Please select an image with minimum dimensions of 400 × 400 px.",
                 comment: "Error message displayed when selected campaign image is not large enough."
             )

--- a/WooCommerce/Classes/ViewRelated/Blaze/BlazeEditAd/BlazeEditAdView.swift
+++ b/WooCommerce/Classes/ViewRelated/Blaze/BlazeEditAd/BlazeEditAdView.swift
@@ -261,7 +261,7 @@ private extension BlazeEditAdView {
                 comment: "Error message displayed when selected campaign image is not large enough."
             )
             static let ok = NSLocalizedString(
-                "blazeEditAdView.image.imageSizeError",
+                "blazeEditAdView.image.ok",
                 value: "OK",
                 comment: "Button to dismiss the image view alert."
             )

--- a/WooCommerce/Classes/ViewRelated/Blaze/BlazeEditAd/BlazeEditAdViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Blaze/BlazeEditAd/BlazeEditAdViewModel.swift
@@ -17,9 +17,9 @@ final class BlazeEditAdViewModel: ObservableObject {
 
     @Published var shouldDisplayImageSizeErrorAlert = false
 
-    /// API expects the image dimensions to be minimum 600*600
+    /// API expects the image dimensions to be minimum 400*400
     ///
-    let minImageSize = CGSize(width: 600, height: 600)
+    let minImageSize = CGSize(width: 400, height: 400)
 
     // Tagline
     @Published var tagline: String = ""

--- a/WooCommerce/WooCommerceTests/ViewRelated/Blaze/BlazeEditAdViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Blaze/BlazeEditAdViewModelTests.swift
@@ -41,7 +41,7 @@ final class BlazeEditAdViewModelTests: XCTestCase {
 
         // When
         sut.onAddImage = { _ in
-            // Image less than expected size 600*600
+            // Image less than expected size 400*400
             MediaPickerImage(image: UIImage.gridicon(.calendar, size: .init(width: 100, height: 100)),
                              source: .media(media: .fake()))
         }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #12543 
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

Blaze campaign creation API has a minimum requirement for the image dimensions. The min dimensions requirement has been changed from 600 * 600 to 400 * 400. 

This PR updates our validation checks and error messages to reflect the above change. The error message in the alert should be updated after the localization and translation [process](https://github.com/woocommerce/woocommerce-ios/blob/trunk/docs/localization.md#localization). Kindly let me know if you know of a process/script to update the Localizable.strings files locally. 

## Testing instructions


Prerequisites
- Woo Store eligible for Blaze
- A published product with an image with dimensions less than 400*400. 
- An image with dimensions less than 400*400 in your device/simulator library.

Steps
- Login into a Woo store eligible for Blaze.
- Navigate to the Products tab and tap on the product with the image with dimensions less than 400*400. 
- You should see the "Promote with Blaze" button.
- Tap "Promote with Blaze" -> "Confirm Details". 
- You should see an error alert asking you to select an image with minimum dimensions of 400*400. 
- Tap "Edit ad" and navigate to the edit screen.
- Tap "Change image" and choose an image with dimensions less than 400*400. 
- You should see an error alert asking you to select an image with minimum dimensions of 400*400.


## Screenshots
<!-- Include before and after images or gifs when appropriate. -->
<img src="https://github.com/woocommerce/woocommerce-ios/assets/524475/db3d2484-868c-4426-ac51-2f687d3bb7cb" width="320"/>

The text in the alert should be updated after the localization and translation [process](https://github.com/woocommerce/woocommerce-ios/blob/trunk/docs/localization.md#localization). 

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
