### PR TITLE
Dynamic Dashboard: Hide Unavailable Cards From Customize Screen

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Dashboard/DashboardCustomization/DashboardCustomizationView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/DashboardCustomization/DashboardCustomizationView.swift
@@ -15,7 +15,7 @@ struct DashboardCustomizationView: View {
             MultiSelectionReorderableList(contents: $viewModel.allCards,
                                           contentKeyPath: \.name,
                                           selectedItems: $viewModel.selectedCards,
-                                          inactiveItems: viewModel.inactiveCards,
+                                          inactiveItems: [], // Intentionally empty to not show inactive cards.
                                           inactiveAccessoryView: { card in
                 BadgeView(text: Localization.unavailable,
                           customizations: BadgeView.Customizations(textColor: .white,

--- a/WooCommerce/Classes/ViewRelated/Dashboard/DashboardCustomization/DashboardCustomizationViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/DashboardCustomization/DashboardCustomizationViewModel.swift
@@ -30,21 +30,14 @@ final class DashboardCustomizationViewModel: ObservableObject {
     ///
     private let onSave: (([DashboardCard]) -> Void)?
 
-    /// Inactive dashboard cards. These cards are excluded from being selected or reordered.
-    ///
-    let inactiveCards: [DashboardCard]
-
     /// - Parameters:
     ///   - allCards: An ordered list of all possible dashboard cards, with their settings.
     ///   - inactiveCards: Optional list of inactive (unavailable) dashboard cards, to exclude them from selecting/reordering.
     ///   - onSave: Optional closure to perform when the changes are saved.
     init(allCards: [DashboardCard],
-         inactiveCards: [DashboardCard] = [],
          analytics: Analytics = ServiceLocator.analytics,
          onSave: (([DashboardCard]) -> Void)? = nil) {
-        self.inactiveCards = inactiveCards
-
-        let availableCards = DashboardCustomizationViewModel.availableCards(from: allCards, excluding: inactiveCards)
+        let availableCards = allCards
         let groupedCards = DashboardCustomizationViewModel.groupSelectedCards(in: availableCards)
         self.allCards = groupedCards
         self.originalCards = groupedCards
@@ -67,22 +60,11 @@ final class DashboardCustomizationViewModel: ObservableObject {
 
         // TODO: add tracking
 
-        // Add back any inactive cards
-        updatedCards.append(contentsOf: inactiveCards)
-
         onSave?(updatedCards)
     }
 }
 
 private extension DashboardCustomizationViewModel {
-    /// Removes inactive cards from the list of all cards to display in the view.
-    ///
-    static func availableCards(from allCards: [DashboardCard], excluding inactiveCards: [DashboardCard]) -> [DashboardCard] {
-        var allCardsToDisplay = allCards
-        allCardsToDisplay.removeAll(where: inactiveCards.contains)
-        return allCardsToDisplay
-    }
-
     /// Groups the selected cards at the start of the list of all cards.
     /// This preserves the relative order of selected and unselected cards.
     ///

--- a/WooCommerce/Classes/ViewRelated/Dashboard/DashboardView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/DashboardView.swift
@@ -127,7 +127,6 @@ struct DashboardView: View {
         .sheet(isPresented: $showingCustomization) {
             DashboardCustomizationView(viewModel: DashboardCustomizationViewModel(
                 allCards: viewModel.dashboardCards,
-                inactiveCards: viewModel.unavailableDashboardCards,
                 onSave: { viewModel.didCustomizeDashboardCards($0) }
             ))
         }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/DashboardCustomizationViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/DashboardCustomizationViewModelTests.swift
@@ -9,7 +9,7 @@ final class DashboardCustomizationViewModelTests: XCTestCase {
         let onboarding = DashboardCard(type: .onboarding, enabled: false)
         let stats = DashboardCard(type: .performance, enabled: true)
         let blaze = DashboardCard(type: .blaze, enabled: false)
-        let vm = DashboardCustomizationViewModel(allCards: [onboarding, stats, blaze], inactiveCards: [blaze])
+        let vm = DashboardCustomizationViewModel(allCards: [onboarding, stats, blaze])
 
         // Then
         assertEqual([stats, onboarding], vm.allCards)
@@ -62,8 +62,7 @@ final class DashboardCustomizationViewModelTests: XCTestCase {
 
         // When
         let actualCards = waitFor { promise in
-            let vm = DashboardCustomizationViewModel(allCards: [onboarding, stats, blaze],
-                                                    inactiveCards: [blaze]) { updatedCards in
+            let vm = DashboardCustomizationViewModel(allCards: [onboarding, stats, blaze]) { updatedCards in
                 promise(updatedCards)
             }
 
@@ -73,7 +72,7 @@ final class DashboardCustomizationViewModelTests: XCTestCase {
         }
 
         // Then
-        let expectedCards = [stats.copy(enabled: true), onboarding.copy(enabled: false), blaze]
+        let expectedCards = [stats.copy(enabled: true), onboarding.copy(enabled: false)]
         assertEqual(expectedCards, actualCards)
     }
 


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #12526

Do not merge until target branch is trunk.

<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

This PR hides unavailable cards from Customize screen.

Technical notes and reasonings:
1. As the app does not need to show inactive/unavailable cards anymore, then there is no need to keep track of `unavailableDashboardCards` in `DashboardViewModel`. Instead, `dashboardCards` is used to keep track of available cards. Unavailable ones are simply not included.
2. `updateDashboardCards()` is now responsible to set which cards are available, based on the `canShow...` parameters
3. `updateDashboardCards()` now also takes into account locally saved cards before updating based on the `canShow...` parameters. This is to address the situation mentioned in https://github.com/woocommerce/woocommerce-ios/pull/12521/files#r1574171456
4. `DashboardCustomizationViewModel` is updated to not keep track of `inactiveCards`, since they don't have to be shown anymore.


## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

### Initial state test:

1. Use a test site that has no orders,
2. Open Dashboard, then tap "Edit" to go to Dashboard Customize screen,
3. Ensure "Top Performers" and "Performance" are not shown,
5. Optionally, try another test site that has orders but no Blaze (e.g: having no Jetpack connection),
6. Open Dashboard, then tap "Edit" to go to Dashboard Customize screen,
7. Ensure Blaze is not shown

### State changes test:
1. Use a test site that has no orders but has at least one product,
2. Ensure that "Top Performers" and "Performance" are not shown, and "Share Your Store" is shown.
3. Tap "Edit" to go to Dashboard Customize screen,
4. Ensure "Top Performers" and "Performance" are not shown,
5. Go to "Orders" tab, create an order successfully,
6. Go back to "My Store" tab, 
8. Ensure that "Top Performers" and "Performance" are shown, "Share Your Store" is not shown.
9. Tap "Edit" to go to Dashboard Customize screen,
10. Ensure "Top Performers" and "Performance" are not shown,
11. Go back to "Orders" tab, open the Order and select "Move to Trash" to delete it,
12. Go back to "My Store" tab, 
13. Ensure that "Top Performers" and "Performance" are not shown, and "Share Your Store" is shown.
14. Tap "Edit" to go to Dashboard Customize screen,
15. Ensure "Top Performers" and "Performance" are not shown,

## Video
<!-- Include before and after images or gifs when appropriate. -->

The test below uses a site that has no orders and is not eligible for Blaze, so none of the analytics and Blaze cards are shown:

https://github.com/woocommerce/woocommerce-ios/assets/266376/d4c9d7ef-d754-4b69-8676-69357ca299d9

State changes test:


https://github.com/woocommerce/woocommerce-ios/assets/266376/f0d4e802-aed0-415c-9fe7-af42732b738f

