### PR TITLE
[Tooling] Run Danger & SwiftLint on the Linter Agent

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -2,7 +2,7 @@
 common_params:
   # Common plugin settings to use with the `plugins` key.
   - &common_plugins
-    - automattic/a8c-ci-toolkit#3.1.0
+    - automattic/a8c-ci-toolkit#3.3.0
   # Common environment values to use with the `env` key.
   - &common_env
     # Be sure to also update the `.xcode-version` file when updating the Xcode image/version here
@@ -54,13 +54,12 @@ steps:
   - group: Linters
     steps:
       - label: ":swift: SwiftLint"
-        command: run_swiftlint --strict
-        plugins: *common_plugins
+        command: swiftlint
         notify:
           - github_commit_status:
               context: "SwiftLint"
         agents:
-          queue: "default"
+          queue: "linter"
 
       - label: "🧹 Lint Translations"
         command: "gplint /workdir/WooCommerce/Resources/AppStoreStrings.pot"

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -53,6 +53,16 @@ steps:
   #################
   - group: Linters
     steps:
+      - label: "☢️ Danger - PR Check"
+        command: danger
+        key: danger
+        if: "build.pull_request.id != null"
+        retry:
+          manual:
+            permit_on_passed: true
+        agents:
+          queue: "linter"
+
       - label: ":swift: SwiftLint"
         command: swiftlint
         notify:

--- a/.github/workflows/run-danger.yml
+++ b/.github/workflows/run-danger.yml
@@ -2,7 +2,7 @@ name: ☢️ Trigger Danger On Buildkite
 
 on:
   pull_request:
-    types: [ready_for_review, labeled, unlabeled, milestoned, demilestoned]
+    types: [labeled, unlabeled, milestoned, demilestoned]
 
 jobs:
   dangermattic:

--- a/.github/workflows/run-danger.yml
+++ b/.github/workflows/run-danger.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   dangermattic:
     if: ${{ (github.event.pull_request.draft == false) }}
-    uses: Automattic/dangermattic/.github/workflows/reusable-retry-buildkite-step-on-events.yml@iangmaia/gha-triggering-danger
+    uses: Automattic/dangermattic/.github/workflows/reusable-retry-buildkite-step-on-events.yml@v1.1.0
     with:
       org-slug: "automattic"
       pipeline-slug: "woocommerce-ios"

--- a/.github/workflows/run-danger.yml
+++ b/.github/workflows/run-danger.yml
@@ -1,13 +1,17 @@
-name: ☢️ Danger
+name: ☢️ Trigger Danger On Buildkite
 
 on:
   pull_request:
-    types: [opened, reopened, ready_for_review, synchronize, edited, labeled, unlabeled, milestoned, demilestoned]
+    types: [ready_for_review, labeled, unlabeled, milestoned, demilestoned]
 
 jobs:
   dangermattic:
-    # runs on draft PRs only for opened / synchronize events
-    if: ${{ (github.event.pull_request.draft == false) || (github.event.pull_request.draft == true && contains(fromJSON('["opened", "synchronize"]'), github.event.action)) }}
-    uses: Automattic/dangermattic/.github/workflows/reusable-run-danger.yml@v1.0.0
+    if: ${{ (github.event.pull_request.draft == false) }}
+    uses: Automattic/dangermattic/.github/workflows/reusable-retry-buildkite-step-on-events.yml@iangmaia/gha-triggering-danger
+    with:
+      org-slug: "automattic"
+      pipeline-slug: "woocommerce-ios"
+      retry-step-key: "danger"
+      build-commit-sha: "${{ github.event.pull_request.head.sha }}"
     secrets:
-      github-token: ${{ secrets.DANGERMATTIC_GITHUB_TOKEN }}
+      buildkite-api-token: ${{ secrets.TRIGGER_BK_BUILD_TOKEN }}

--- a/Dangerfile
+++ b/Dangerfile
@@ -3,7 +3,8 @@
 github.dismiss_out_of_range_messages
 
 # `files: []` forces rubocop to scan all files, not just the ones modified in the PR
-rubocop.lint(files: [], force_exclusion: true, inline_comment: true, fail_on_inline_comment: true, include_cop_names: true)
+# Added a custom `rubocop_cmd` to prevent RuboCop from running using `bundle exec`, which we don't want on the linter agent
+rubocop.lint(files: [], force_exclusion: true, inline_comment: true, fail_on_inline_comment: true, include_cop_names: true, rubocop_cmd: ': | rubocop')
 
 manifest_pr_checker.check_all_manifest_lock_updated
 


### PR DESCRIPTION
This PR uses the new Linter Agent on Buildkite to run the Danger and SwiftLint jobs.

Because Danger will now run on Buildkite, this PR uses a new GitHub Actions workflow (see https://github.com/Automattic/dangermattic/pull/64 for more details) to retry the Buildkite jobs when the PR state (such as the milestone and labels) changes.