### PR TITLE
Menu: fix collect payment quick action or deeplink

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -2,6 +2,7 @@
 
 18.4
 -----
+- [*] Bug fix: tapping on the "Collect payment" quick action (long press on the app icon) or deeplink (http://woo.com/mobile/payments/collect-payment) now shows the order form instead of a blank view. [https://github.com/woocommerce/woocommerce-ios/pull/12550]
 - [internal] Blaze: Change campaign image minimum expected dimensions. [https://github.com/woocommerce/woocommerce-ios/pull/12544]
 
 

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Payments Menu/InPersonPaymentsMenu.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Payments Menu/InPersonPaymentsMenu.swift
@@ -257,9 +257,6 @@ struct InPersonPaymentsMenu: View {
             }
         }
         .navigationTitle(InPersonPaymentsView.Localization.title)
-        .onAppear {
-            viewModel.onAppearSubject.send(())
-        }
     }
 
     @ViewBuilder

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Payments Menu/InPersonPaymentsMenu.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Payments Menu/InPersonPaymentsMenu.swift
@@ -257,6 +257,9 @@ struct InPersonPaymentsMenu: View {
             }
         }
         .navigationTitle(InPersonPaymentsView.Localization.title)
+        .onAppear {
+            viewModel.onAppearSubject.send(())
+        }
     }
 
     @ViewBuilder

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Payments Menu/InPersonPaymentsMenuViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Payments Menu/InPersonPaymentsMenuViewModel.swift
@@ -169,33 +169,7 @@ final class InPersonPaymentsMenuViewModel: ObservableObject {
             analytics.track(.paymentsMenuCollectPaymentTapped)
             return
         }
-        let orderViewModel = EditableOrderViewModel(siteID: siteID)
-        self.orderViewModel = orderViewModel
-        orderViewModel.onFinished = { [weak self] _ in
-            self?.presentCollectPayment = false
-        }
-        orderViewModel.onFinishAndCollectPayment = { [weak self] order, paymentMethodsViewModel in
-            guard let self else { return }
-            self.paymentMethodsViewModel = paymentMethodsViewModel
-            paymentMethodsNoticeSubscription = paymentMethodsViewModel.notice
-                .compactMap { $0 }
-                .sink { [weak self] notice in
-                    guard let self else { return }
-                    switch notice {
-                        case .created:
-                            dependencies.noticePresenter.enqueue(notice: .init(title: Localization.orderCreated, feedbackType: .success))
-                        case .completed:
-                            dependencies.noticePresenter.enqueue(notice: .init(title: Localization.orderCompleted, feedbackType: .success))
-                        case .error(let description):
-                            dependencies.noticePresenter.enqueue(notice: .init(title: description, feedbackType: .error))
-                    }
-                }
-            presentPaymentMethods = true
-        }
-
-        presentCustomAmountAfterDismissingCollectPaymentMigrationSheet = false
-        hasPresentedCollectPaymentMigrationSheet = false
-        presentCollectPayment = true
+        collectPayment()
         analytics.track(.paymentsMenuCollectPaymentTapped)
     }
 
@@ -268,6 +242,41 @@ final class InPersonPaymentsMenuViewModel: ObservableObject {
         }
         return onboardingViewModel
     }()
+}
+
+// MARK: - Collect payment
+
+private extension InPersonPaymentsMenuViewModel {
+    func collectPayment() {
+        let orderViewModel = EditableOrderViewModel(siteID: siteID)
+        self.orderViewModel = orderViewModel
+        orderViewModel.onFinished = { [weak self] _ in
+            self?.presentCollectPayment = false
+        }
+        orderViewModel.onFinishAndCollectPayment = { [weak self] order, paymentMethodsViewModel in
+            guard let self else { return }
+            self.paymentMethodsViewModel = paymentMethodsViewModel
+            paymentMethodsNoticeSubscription = paymentMethodsViewModel.notice
+                .compactMap { $0 }
+                .sink { [weak self] notice in
+                    guard let self else { return }
+                    switch notice {
+                        case .created:
+                            dependencies.noticePresenter.enqueue(notice: .init(title: Localization.orderCreated, feedbackType: .success))
+                        case .completed:
+                            dependencies.noticePresenter.enqueue(notice: .init(title: Localization.orderCompleted, feedbackType: .success))
+                        case .error(let description):
+                            dependencies.noticePresenter.enqueue(notice: .init(title: description, feedbackType: .error))
+                    }
+                }
+            presentPaymentMethods = true
+        }
+
+        presentCustomAmountAfterDismissingCollectPaymentMigrationSheet = false
+        hasPresentedCollectPaymentMigrationSheet = false
+        presentPaymentMethods = false
+        presentCollectPayment = true
+    }
 }
 
 // MARK: - Background onboarding

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Payments Menu/InPersonPaymentsMenuViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Payments Menu/InPersonPaymentsMenuViewModel.swift
@@ -166,6 +166,7 @@ final class InPersonPaymentsMenuViewModel: ObservableObject {
     func onAppear() async {
         runCardPresentPaymentsOnboardingIfPossible()
         await updateOutputProperties()
+        onAppearSubject.send(())
     }
 
     func collectPaymentTapped() {

--- a/WooCommerce/Classes/ViewRelated/Hub Menu/HubMenuViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Hub Menu/HubMenuViewController.swift
@@ -95,8 +95,12 @@ extension HubMenuViewController: DeepLinkNavigator {
     func navigate(to destination: any DeepLinkDestinationProtocol) {
         switch destination {
         case is PaymentsMenuDestination:
+            let isShowingPayments = viewModel.showingPayments
             showPaymentsMenu()
             viewModel.inPersonPaymentsMenuViewModel.navigate(to: destination)
+            if isShowingPayments {
+                viewModel.inPersonPaymentsMenuViewModel.onAppearSubject.send(())
+            }
         case is HubMenuDestination:
             handleHubMenuDeepLink(to: destination)
         default:

--- a/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Settings/In-Person Payments/InPersonPaymentsMenuViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Settings/In-Person Payments/InPersonPaymentsMenuViewModelTests.swift
@@ -283,7 +283,7 @@ final class InPersonPaymentsMenuViewModelTests: XCTestCase {
         XCTAssertTrue(sut.presentCollectPayment)
     }
 
-    func test_navigate_to_collectPayment_sets_presentCollectPaymentWithSimplePayments_to_true_when_feature_is_disabled() {
+    func test_navigate_to_collectPayment_sets_presentCollectPaymentWithSimplePayments_to_true_when_feature_is_disabled_and_view_appears() {
         // Given
         let featureFlagService = MockFeatureFlagService(isMigrateSimplePaymentsToOrderCreationEnabled: false)
         let dependencies = InPersonPaymentsMenuViewModel.Dependencies(cardPresentPaymentsConfiguration: .init(country: .US),
@@ -294,14 +294,20 @@ final class InPersonPaymentsMenuViewModelTests: XCTestCase {
         sut = InPersonPaymentsMenuViewModel(siteID: sampleStoreID,
                                             dependencies: dependencies)
 
-        // When
+        // When view has not appeared
         sut.navigate(to: PaymentsMenuDestination.collectPayment)
+
+        // Then
+        XCTAssertFalse(sut.presentCollectPaymentWithSimplePayments)
+
+        // When view appears
+        sut.onAppearSubject.send(())
 
         // Then
         XCTAssertTrue(sut.presentCollectPaymentWithSimplePayments)
     }
 
-    func test_navigate_to_collectPayment_sets_presentCollectPayment_to_true() {
+    func test_navigate_to_collectPayment_sets_presentCollectPayment_to_true_when_view_appears() {
         // Given
         let featureFlagService = MockFeatureFlagService(isMigrateSimplePaymentsToOrderCreationEnabled: true)
         let dependencies = InPersonPaymentsMenuViewModel.Dependencies(cardPresentPaymentsConfiguration: .init(country: .US),
@@ -312,8 +318,14 @@ final class InPersonPaymentsMenuViewModelTests: XCTestCase {
         sut = InPersonPaymentsMenuViewModel(siteID: sampleStoreID,
                                             dependencies: dependencies)
 
-        // When
+        // When view has not appeared
         sut.navigate(to: PaymentsMenuDestination.collectPayment)
+
+        // Then
+        XCTAssertFalse(sut.presentCollectPayment)
+
+        // When view appears
+        sut.onAppearSubject.send(())
 
         // Then
         XCTAssertTrue(sut.presentCollectPayment)


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #12542 
<!-- Id number of the GitHub issue this PR addresses. -->

## Why

Before this PR, quick action or deeplink to collect payment is broken with an empty view shown instead of the order form. The first fix https://github.com/woocommerce/woocommerce-ios/commit/3c1cc2157058add82d746b700a33187aafa61d44 is to set up the order form view model similar to when the Collect Payment CTA is tapped in the payments view. However, the issue persisted after the first time deeplinking to the order form. After some debugging by replacing `InPersonPaymentsMenu` as the intermediate screen and `OrderFormPresentationWrapper` with a blank view and a minimal new view model, it appeared that the problem wasn't inside these views as an empty view was still shown after the first time. The root issue seems to be two nested `navigationDestination` in different views, and I couldn't find the best practice or solution to show nested navigation (Menu > Payments > Order form) at once after reading up a few posts online. This PR is the workaround I came up with, please feel free to suggest any other solution.

## How

Since the problem seems to be from showing the second navigation destination while the first one is still shown animatedly, I thought we could wait for the first destination to appear before showing the second one. To achieve this, `onAppearSubject: PassthroughSubject` was added to `InPersonPaymentsMenuViewModel` and is emitted when:
- `InPersonPaymentsMenu` view appears, after the end of its pre-existing async task `viewModel.onAppear`
  - 🗒️ It has to be called at the end of the async task. If it's moved to the beginning, a blank view is shown when deeplinking while the app is on the Menu tab (the second scenario in the testing steps)
- If the payments view is already visible when the deeplink occurs, it should be emitted after the observation in view model's `navigate(to:)`

Then, in the view model's `navigate(to:)` deeplink function, it now waits for the first view `onAppear` signal to navigate to the next destination.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

### Without visiting the Menu tab

- Open the app
- Log in to a store if needed
- Tap on `Collect payment` quick action (long press on the app icon) or a deeplink like `http://woo.com/mobile/payments/collect-payment` --> the app should navigate to the Menu tab > Payments > order form with the migration half sheet/modal shown shortly

### On the Menu tab

- Go back to the root of the Menu tab
- Tap on `Collect payment` quick action (long press on the app icon) or a deeplink like `http://woo.com/mobile/payments/collect-payment` --> the app should navigate to the Menu tab > Payments > order form with the migration half sheet/modal shown shortly

### On the Menu tab > Payments

- Go back to the root of the Menu tab
- Tap `Payments`
- Tap on `Collect payment` quick action (long press on the app icon) or a deeplink like `http://woo.com/mobile/payments/collect-payment` --> the app should navigate to the Menu tab > Payments > order form with the migration half sheet/modal shown shortly

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->


https://github.com/woocommerce/woocommerce-ios/assets/1945542/3b8d6156-2c3a-466d-8020-cdf69ca7655b



---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
