### PR TITLE
[Dynamic Dashboard] Present customization screen to dismiss card

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Dashboard/DashboardView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/DashboardView.swift
@@ -11,7 +11,6 @@ struct DashboardView: View {
     @State private var currentSite: Site?
     @State private var dismissedJetpackBenefitBanner = false
     @State private var showingSupportForm = false
-    @State private var showingCustomization = false
     @State private var troubleshootURL: URL?
     @State private var storePlanState: StorePlanSyncState = .loading
     @State private var connectivityStatus: ConnectivityStatus = .notReachable
@@ -86,7 +85,7 @@ struct DashboardView: View {
             }
             ToolbarItem(placement: .topBarTrailing) {
                 Button(Localization.edit) {
-                    showingCustomization = true
+                    viewModel.showingCustomization = true
                 }
             }
         }
@@ -124,7 +123,7 @@ struct DashboardView: View {
                 viewModel.maybeSyncAnnouncementsAfterWebViewDismissed()
             }
         }
-        .sheet(isPresented: $showingCustomization) {
+        .sheet(isPresented: $viewModel.showingCustomization) {
             DashboardCustomizationView(viewModel: DashboardCustomizationViewModel(
                 allCards: viewModel.dashboardCards,
                 inactiveCards: viewModel.unavailableDashboardCards,

--- a/WooCommerce/Classes/ViewRelated/Dashboard/DashboardViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/DashboardViewModel.swift
@@ -38,6 +38,8 @@ final class DashboardViewModel: ObservableObject {
 
     @Published private(set) var canHideMoreDashboardCards = false
 
+    @Published var showingCustomization = false
+
     let siteID: Int64
     private let stores: StoresManager
     private let featureFlagService: FeatureFlagService

--- a/WooCommerce/Classes/ViewRelated/Dashboard/DashboardViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/DashboardViewModel.swift
@@ -364,19 +364,19 @@ private extension DashboardViewModel {
 
     func setupDashboardCards() {
         storeOnboardingViewModel.onDismiss = { [weak self] in
-            self?.hideDashboardCard(type: .onboarding)
+            self?.showCustomizationScreen()
         }
 
         blazeCampaignDashboardViewModel.onDismiss = { [weak self] in
-            self?.hideDashboardCard(type: .blaze)
+            self?.showCustomizationScreen()
         }
 
         storePerformanceViewModel.onDismiss = { [weak self] in
-            self?.hideDashboardCard(type: .performance)
+            self?.showCustomizationScreen()
         }
 
         topPerformersViewModel.onDismiss = { [weak self] in
-            self?.hideDashboardCard(type: .topPerformers)
+            self?.showCustomizationScreen()
         }
 
         storeOnboardingViewModel.$canShowInDashboard
@@ -397,11 +397,8 @@ private extension DashboardViewModel {
             .assign(to: &$canHideMoreDashboardCards)
     }
 
-    func hideDashboardCard(type: DashboardCard.CardType) {
-        if let index = dashboardCards.firstIndex(where: { $0.type == type }) {
-            dashboardCards[index] = dashboardCards[index].copy(enabled: false)
-        }
-        stores.dispatch(AppSettingsAction.setDashboardCards(siteID: siteID, cards: dashboardCards))
+    func showCustomizationScreen() {
+        showingCustomization = true
     }
 
     /// We are using separate user defaults for different cards -


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #12548 
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

To prevent the user from dismissing all cards from the dashboard using the ellipsis menu of a card we decided to present the customization screen from the ellipsis menu. This change also makes the customization screen more discoverable. 

## Testing instructions

Feature flag on
- Enable the `dynamicDashboard` feature flag and login into the app.
- From the dashboard tap on any card's "…" button and then tap "Hide <card_name>" button. 
- Validate that the dashboard customisation screen is presented.
- Try enabling and disabling cards. Save and validate that the changes are reflected in the dashboard.

Feature flag off
- [x] @selanthiraiyan Test that the dismissing behaviour works as before when `dynamicDashboard` feature flag is off. 

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->
![Simulator Screen Recording - iPhone 13 Pro - 2024-04-24 at 14 42 32](https://github.com/woocommerce/woocommerce-ios/assets/524475/b4aac1c0-a573-4a37-825c-6d391b561ab0)


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
