### PR TITLE
[Dynamic Dashboard] Rename card and screen title

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Dashboard/DashboardCustomization/DashboardCard+UI.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/DashboardCustomization/DashboardCard+UI.swift
@@ -30,8 +30,8 @@ private extension DashboardCard {
         )
         static let topPerformers = NSLocalizedString(
             "dashboardCard.name.topPerformers",
-            value: "Top Performers",
-            comment: "Name for the Top Performers dashboard card in the Customize Dashboard screen"
+            value: "Top performers",
+            comment: "Name for the Top performers dashboard card in the Customize Dashboard screen"
         )
         static let blaze = NSLocalizedString(
             "dashboardCard.name.blaze",

--- a/WooCommerce/Classes/ViewRelated/Dashboard/DashboardCustomization/DashboardCard+UI.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/DashboardCustomization/DashboardCard+UI.swift
@@ -20,7 +20,7 @@ private extension DashboardCard {
     enum Localization {
         static let onboarding = NSLocalizedString(
             "dashboardCard.name.onboarding",
-            value: "Store Onboarding",
+            value: "Store setup",
             comment: "Name for the Store Onboarding dashboard card in the Customize Dashboard screen"
         )
         static let performance = NSLocalizedString(

--- a/WooCommerce/Classes/ViewRelated/Dashboard/DashboardCustomization/DashboardCard+UI.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/DashboardCustomization/DashboardCard+UI.swift
@@ -21,7 +21,7 @@ private extension DashboardCard {
         static let onboarding = NSLocalizedString(
             "dashboardCard.name.onboarding",
             value: "Store setup",
-            comment: "Name for the Store Onboarding dashboard card in the Customize Dashboard screen"
+            comment: "Name for the Store setup dashboard card in the Customize Dashboard screen"
         )
         static let performance = NSLocalizedString(
             "dashboardCard.name.performance",

--- a/WooCommerce/Classes/ViewRelated/Dashboard/DashboardCustomization/DashboardCustomizationView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/DashboardCustomization/DashboardCustomizationView.swift
@@ -46,7 +46,7 @@ private extension DashboardCustomizationView {
     enum Localization {
         static let title = NSLocalizedString(
             "dashboardCustomization.title",
-            value: "Customize Dashboard",
+            value: "Customize",
             comment: "Title for the screen to customize the dashboard screen"
         )
         static let saveButton = NSLocalizedString(

--- a/WooCommerce/Classes/ViewRelated/Dashboard/TopPerformers/TopPerformersDashboardView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/TopPerformers/TopPerformersDashboardView.swift
@@ -142,8 +142,8 @@ private extension TopPerformersDashboardView {
     enum Localization {
         static let title = NSLocalizedString(
             "topPerformersDashboardView.title",
-            value: "Top Performers",
-            comment: "Title of the Top Performers section on the Dashboard screen"
+            value: "Top performers",
+            comment: "Title of the Top performers section on the Dashboard screen"
         )
         static let hideCard = NSLocalizedString(
             "topPerformersDashboardView.hideCard",

--- a/WooCommerce/Resources/en.lproj/Localizable.strings
+++ b/WooCommerce/Resources/en.lproj/Localizable.strings
@@ -3291,20 +3291,11 @@ which should be translated separately and considered part of this sentence. */
 /* Name for the Blaze dashboard card in the Customize Dashboard screen */
 "dashboardCard.name.blaze" = "Blaze";
 
-/* Name for the Store Onboarding dashboard card in the Customize Dashboard screen */
-"dashboardCard.name.onboarding" = "Store Onboarding";
-
 /* Name for the Performance dashboard card in the Customize Dashboard screen */
 "dashboardCard.name.performance" = "Performance";
 
-/* Name for the Top Performers dashboard card in the Customize Dashboard screen */
-"dashboardCard.name.topPerformers" = "Top Performers";
-
 /* Button to save changes on the Customize Dashboard screen */
 "dashboardCustomization.saveButton" = "Save";
-
-/* Title for the screen to customize the dashboard screen */
-"dashboardCustomization.title" = "Customize Dashboard";
 
 /* Text on unavailable dashboard card on the Customize Dashboard screen */
 "dashboardCustomization.unavailable" = "Unavailable";
@@ -10119,9 +10110,6 @@ which should be translated separately and considered part of this sentence. */
 
 /* Menu item to dismiss the Top Performers section on the Dashboard screen */
 "topPerformersDashboardView.hideCard" = "Hide Top Performers";
-
-/* Title of the Top Performers section on the Dashboard screen */
-"topPerformersDashboardView.title" = "Top Performers";
 
 /* Button to navigate to Analytics Hub. */
 "topPerformersDashboardView.viewAll" = "View all store analytics";


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #12551
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

Renames cards and customization screen title to match the design.

Changes
- Update card titles and screen title. 
- Delete the old entries from Localization en version file to avoid displaying old values. This should be automatically added during release. 

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

- Launch and login into the app if needed
- From the dashboard ensure that the title of the top performers card is "Top performers"
- Tap "Edit" from the top right to launch customisation screen
- Validate that the screen title is "Customize"
- Validate that the top performers row reads "Top performers"
- Validate that the store onboarding/setup row reads "Store setup"

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

| Before | After |
|--------|--------|
| ![Simulator Screenshot - iPhone 13 Pro - 2024-04-24 at 19 01 27](https://github.com/woocommerce/woocommerce-ios/assets/524475/928ddf42-6661-4b33-9a1d-bcd00fccbcee) | ![Simulator Screenshot - iPhone 13 Pro - 2024-04-24 at 18 56 48](https://github.com/woocommerce/woocommerce-ios/assets/524475/e9ab41f3-c9c0-48a9-9e42-b52cc8c4a57a) |
| ![Simulator Screenshot - iPhone 13 Pro - 2024-04-24 at 19 01 30](https://github.com/woocommerce/woocommerce-ios/assets/524475/e2aa11cd-680c-4c7b-af36-e4122a7cbfad) | ![Simulator Screenshot - iPhone 13 Pro - 2024-04-24 at 18 56 41](https://github.com/woocommerce/woocommerce-ios/assets/524475/d6fb38d3-3ded-4c6e-9a8a-ac5fb48b2e08) | 

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
