### PR TITLE
Menu: fix collect payment quick action or deeplink by `NavigationPath` in `NavigationStack`

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -2,6 +2,7 @@
 
 18.4
 -----
+- [*] Bug fix: tapping on the "Collect payment" quick action (long press on the app icon) or deeplink (http://woo.com/mobile/payments/collect-payment) now shows the order form instead of a blank view. [https://github.com/woocommerce/woocommerce-ios/pull/12559]
 - [internal] Blaze: Change campaign image minimum expected dimensions. [https://github.com/woocommerce/woocommerce-ios/pull/12544]
 
 

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Payments Menu/InPersonPaymentsMenu.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Payments Menu/InPersonPaymentsMenu.swift
@@ -425,7 +425,8 @@ struct InPersonPaymentsMenu_Previews: PreviewProvider {
             cardPresentPaymentsConfiguration: .init(country: .US),
             onboardingUseCase: CardPresentPaymentsOnboardingUseCase(),
             cardReaderSupportDeterminer: CardReaderSupportDeterminer(siteID: 0),
-            wooPaymentsDepositService: WooPaymentsDepositService(siteID: 0, credentials: .init(authToken: ""))))
+            wooPaymentsDepositService: WooPaymentsDepositService(siteID: 0, credentials: .init(authToken: ""))),
+        navigationPath: .constant(NavigationPath()))
     static var previews: some View {
         NavigationStack {
             InPersonPaymentsMenu(viewModel: viewModel)

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Payments Menu/InPersonPaymentsMenuViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Payments Menu/InPersonPaymentsMenuViewModel.swift
@@ -169,33 +169,7 @@ final class InPersonPaymentsMenuViewModel: ObservableObject {
             analytics.track(.paymentsMenuCollectPaymentTapped)
             return
         }
-        let orderViewModel = EditableOrderViewModel(siteID: siteID)
-        self.orderViewModel = orderViewModel
-        orderViewModel.onFinished = { [weak self] _ in
-            self?.presentCollectPayment = false
-        }
-        orderViewModel.onFinishAndCollectPayment = { [weak self] order, paymentMethodsViewModel in
-            guard let self else { return }
-            self.paymentMethodsViewModel = paymentMethodsViewModel
-            paymentMethodsNoticeSubscription = paymentMethodsViewModel.notice
-                .compactMap { $0 }
-                .sink { [weak self] notice in
-                    guard let self else { return }
-                    switch notice {
-                        case .created:
-                            dependencies.noticePresenter.enqueue(notice: .init(title: Localization.orderCreated, feedbackType: .success))
-                        case .completed:
-                            dependencies.noticePresenter.enqueue(notice: .init(title: Localization.orderCompleted, feedbackType: .success))
-                        case .error(let description):
-                            dependencies.noticePresenter.enqueue(notice: .init(title: description, feedbackType: .error))
-                    }
-                }
-            presentPaymentMethods = true
-        }
-
-        presentCustomAmountAfterDismissingCollectPaymentMigrationSheet = false
-        hasPresentedCollectPaymentMigrationSheet = false
-        presentCollectPayment = true
+        collectPayment()
         analytics.track(.paymentsMenuCollectPaymentTapped)
     }
 
@@ -268,6 +242,41 @@ final class InPersonPaymentsMenuViewModel: ObservableObject {
         }
         return onboardingViewModel
     }()
+}
+
+// MARK: - Collect payment
+
+private extension InPersonPaymentsMenuViewModel {
+    func collectPayment() {
+        let orderViewModel = EditableOrderViewModel(siteID: siteID)
+        self.orderViewModel = orderViewModel
+        orderViewModel.onFinished = { [weak self] _ in
+            self?.presentCollectPayment = false
+        }
+        orderViewModel.onFinishAndCollectPayment = { [weak self] order, paymentMethodsViewModel in
+            guard let self else { return }
+            self.paymentMethodsViewModel = paymentMethodsViewModel
+            paymentMethodsNoticeSubscription = paymentMethodsViewModel.notice
+                .compactMap { $0 }
+                .sink { [weak self] notice in
+                    guard let self else { return }
+                    switch notice {
+                        case .created:
+                            dependencies.noticePresenter.enqueue(notice: .init(title: Localization.orderCreated, feedbackType: .success))
+                        case .completed:
+                            dependencies.noticePresenter.enqueue(notice: .init(title: Localization.orderCompleted, feedbackType: .success))
+                        case .error(let description):
+                            dependencies.noticePresenter.enqueue(notice: .init(title: description, feedbackType: .error))
+                    }
+                }
+            presentPaymentMethods = true
+        }
+
+        presentCustomAmountAfterDismissingCollectPaymentMigrationSheet = false
+        hasPresentedCollectPaymentMigrationSheet = false
+        presentPaymentMethods = false
+        presentCollectPayment = true
+    }
 }
 
 // MARK: - Background onboarding

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Payments Menu/InPersonPaymentsMenuViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Payments Menu/InPersonPaymentsMenuViewModel.swift
@@ -26,7 +26,6 @@ final class InPersonPaymentsMenuViewModel: ObservableObject {
     @Published private(set) var selectedPaymentGatewayName: String?
     @Published private(set) var selectedPaymentGatewayPlugin: CardPresentPaymentsPlugin?
     @Published var presentCollectPaymentWithSimplePayments: Bool = false
-    /// Whether the payment collection flow is shown, bound to the order creation screen.
     /// Whether the payment collection migration sheet is presented, bound to the migration sheet.
     @Published var presentCollectPaymentMigrationSheet: Bool = false
     /// Whether the migration sheet has been presented per payment collection session.

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Payments Menu/InPersonPaymentsMenuViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Payments Menu/InPersonPaymentsMenuViewModel.swift
@@ -8,6 +8,7 @@ import Combine
 @MainActor
 final class InPersonPaymentsMenuViewModel: ObservableObject {
     @Binding var navigationPath: NavigationPath
+    private var navigationPathBeforePaymentCollection: NavigationPath?
 
     @Published private(set) var shouldShowTapToPaySection: Bool = true
     @Published private(set) var shouldShowCardReaderSection: Bool = true
@@ -129,8 +130,9 @@ final class InPersonPaymentsMenuViewModel: ObservableObject {
 
     /// Called when payment collection is shown to leave the payment collection flow.
     func dismissPaymentCollection() {
-        // TODO: not the best solution if navigationPath has other views after payment collection
-        navigationPath.removeLast()
+        while navigationPath != navigationPathBeforePaymentCollection {
+            navigationPath.removeLast()
+        }
     }
 
     private func updateOutputProperties() async {
@@ -284,6 +286,7 @@ private extension InPersonPaymentsMenuViewModel {
         presentCustomAmountAfterDismissingCollectPaymentMigrationSheet = false
         hasPresentedCollectPaymentMigrationSheet = false
         presentPaymentMethods = false
+        navigationPathBeforePaymentCollection = navigationPath
         navigationPath.append(InPersonPaymentsMenuNavigationDestination.collectPayment)
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Payments Menu/InPersonPaymentsMenuViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Payments Menu/InPersonPaymentsMenuViewModel.swift
@@ -7,6 +7,8 @@ import Combine
 
 @MainActor
 final class InPersonPaymentsMenuViewModel: ObservableObject {
+    @Binding var navigationPath: NavigationPath
+
     @Published private(set) var shouldShowTapToPaySection: Bool = true
     @Published private(set) var shouldShowCardReaderSection: Bool = true
     @Published private(set) var shouldShowPaymentOptionsSection: Bool = false
@@ -106,9 +108,11 @@ final class InPersonPaymentsMenuViewModel: ObservableObject {
 
     init(siteID: Int64,
          dependencies: Dependencies,
+         navigationPath: Binding<NavigationPath>,
          payInPersonToggleViewModel: InPersonPaymentsCashOnDeliveryToggleRowViewModelProtocol = InPersonPaymentsCashOnDeliveryToggleRowViewModel()) {
         self.siteID = siteID
         self.dependencies = dependencies
+        self._navigationPath = navigationPath
         self.payInPersonToggleViewModel = payInPersonToggleViewModel
         observeOnboardingChanges()
         runCardPresentPaymentsOnboardingIfPossible()

--- a/WooCommerce/Classes/ViewRelated/Hub Menu/HubMenu.swift
+++ b/WooCommerce/Classes/ViewRelated/Hub Menu/HubMenu.swift
@@ -18,7 +18,7 @@ struct HubMenu: View {
     }
 
     var body: some View {
-        NavigationStack {
+        NavigationStack(path: $viewModel.navigationPath) {
             /// TODO: switch to `navigationDestination(item:destination)`
             /// when we drop support for iOS 16.
             menuList

--- a/WooCommerce/Classes/ViewRelated/Hub Menu/HubMenu.swift
+++ b/WooCommerce/Classes/ViewRelated/Hub Menu/HubMenu.swift
@@ -25,11 +25,11 @@ struct HubMenu: View {
                 .navigationDestination(for: String.self) { id in
                     detailView(menuID: id)
                 }
+                .navigationDestination(for: HubMenuNavigationDestination.self) { destination in
+                    detailView(destination: destination)
+                }
                 .navigationDestination(isPresented: $viewModel.showingReviewDetail) {
                     reviewDetailView
-                }
-                .navigationDestination(isPresented: $viewModel.showingPayments) {
-                    paymentsView
                 }
                 .navigationDestination(isPresented: $viewModel.showingCoupons) {
                     couponListView
@@ -169,6 +169,17 @@ private extension HubMenu {
                 CustomersListView(viewModel: .init(siteID: viewModel.siteID))
             default:
                 fatalError("🚨 Unsupported menu item")
+            }
+        }
+        .navigationBarTitleDisplayMode(.inline)
+    }
+
+    @ViewBuilder
+    func detailView(destination: HubMenuNavigationDestination) -> some View {
+        Group {
+            switch destination {
+                case .payments:
+                    paymentsView
             }
         }
         .navigationBarTitleDisplayMode(.inline)

--- a/WooCommerce/Classes/ViewRelated/Hub Menu/HubMenuViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Hub Menu/HubMenuViewController.swift
@@ -39,7 +39,7 @@ final class HubMenuViewController: UIHostingController<HubMenu> {
     }
 
     func showPaymentsMenu() {
-        viewModel.showingPayments = true
+        viewModel.showPayments()
     }
 
     func showCoupons() {

--- a/WooCommerce/Classes/ViewRelated/Hub Menu/HubMenuViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Hub Menu/HubMenuViewModel.swift
@@ -26,6 +26,8 @@ final class HubMenuViewModel: ObservableObject {
         return url
     }
 
+    @Published var navigationPath = NavigationPath()
+
     @Published private(set) var storeTitle = Localization.myStore
 
     @Published private(set) var planName = ""
@@ -71,14 +73,24 @@ final class HubMenuViewModel: ObservableObject {
     let tapToPayBadgePromotionChecker: TapToPayBadgePromotionChecker
 
     lazy var inPersonPaymentsMenuViewModel: InPersonPaymentsMenuViewModel = {
-        InPersonPaymentsMenuViewModel(
+        // There is no straightforward way to convert a @Published var to a Binding value because we cannot use $self.
+        let navigationPathBinding = Binding(
+            get: { [weak self] in
+                self?.navigationPath ?? NavigationPath()
+            },
+            set: { [weak self] in
+                self?.navigationPath = $0
+            }
+        )
+        return InPersonPaymentsMenuViewModel(
             siteID: siteID,
             dependencies: .init(
                 cardPresentPaymentsConfiguration: CardPresentConfigurationLoader().configuration,
                 onboardingUseCase: CardPresentPaymentsOnboardingUseCase(),
                 cardReaderSupportDeterminer: CardReaderSupportDeterminer(siteID: siteID),
                 wooPaymentsDepositService: WooPaymentsDepositService(siteID: siteID,
-                                                                      credentials: ServiceLocator.stores.sessionManager.defaultCredentials!)))
+                                                                     credentials: ServiceLocator.stores.sessionManager.defaultCredentials!)),
+            navigationPath: navigationPathBinding)
     }()
 
     init(siteID: Int64,

--- a/WooCommerce/Classes/ViewRelated/Hub Menu/HubMenuViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Hub Menu/HubMenuViewModel.swift
@@ -12,6 +12,11 @@ extension NSNotification.Name {
     public static let hubMenuViewDidAppear = Foundation.Notification.Name(rawValue: "com.woocommerce.ios.hubMenuViewDidAppear")
 }
 
+/// Destination views that the hub menu can navigate to.
+enum HubMenuNavigationDestination {
+    case payments
+}
+
 /// View model for `HubMenu`.
 ///
 @MainActor
@@ -51,7 +56,6 @@ final class HubMenuViewModel: ObservableObject {
     @Published var selectedMenuID: String?
 
     @Published var showingReviewDetail = false
-    @Published var showingPayments = false
     @Published var showingCoupons = false
 
     @Published var shouldAuthenticateAdminPage = false
@@ -120,6 +124,12 @@ final class HubMenuViewModel: ObservableObject {
     func setupMenuElements() {
         setupSettingsElements()
         setupGeneralElements()
+    }
+
+    /// Shows the payments menu from the hub menu root view.
+    func showPayments() {
+        navigationPath = .init()
+        navigationPath.append(HubMenuNavigationDestination.payments)
     }
 
     private func setupSettingsElements() {

--- a/WooCommerce/WooCommerceTests/ViewRelated/HubMenu/HubMenuViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/HubMenu/HubMenuViewModelTests.swift
@@ -1,3 +1,4 @@
+import SwiftUI
 import XCTest
 
 @testable import WooCommerce
@@ -391,6 +392,23 @@ final class HubMenuViewModelTests: XCTestCase {
         XCTAssertNil(viewModel.generalElements.firstIndex(where: { item in
             item.id == HubMenuViewModel.Customers.id
         }))
+    }
+
+    func test_showPayments_replaces_navigationPath_with_payments() {
+        // Given
+        var navigationPath = NavigationPath(["testPath1", "testPath2"])
+        navigationPath.append(HubMenuNavigationDestination.payments)
+        let viewModel = HubMenuViewModel(siteID: sampleSiteID,
+                                         tapToPayBadgePromotionChecker: TapToPayBadgePromotionChecker())
+        viewModel.navigationPath = navigationPath
+        XCTAssertEqual(viewModel.navigationPath.count, 3)
+
+        // When
+        viewModel.showPayments()
+
+        // Then
+        XCTAssertEqual(viewModel.navigationPath.count, 1)
+        XCTAssertEqual(viewModel.navigationPath, NavigationPath([HubMenuNavigationDestination.payments]))
     }
 }
 


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #12542 
<!-- Id number of the GitHub issue this PR addresses. -->

## Why

Before this PR, quick action or deeplink to collect payment is broken with an empty view shown instead of the order form. The first fix https://github.com/woocommerce/woocommerce-ios/pull/12559/commits/33744a7cdcca341242dedeef297a56b59d5d7d9b is to set up the order form view model similar to when the Collect Payment CTA is tapped in the payments view. However, the issue persisted after the first time deeplinking to the order form. After the first workaround PR by observing `onAppear` in https://github.com/woocommerce/woocommerce-ios/pull/12550, I realized that this workaround only works for views with non-zero async tasks in the view's `task` modifier when I created a sample project with placeholder UI for a p2. This workaround becomes limited and can break if we decide to remove the async tasks in the future. Thus, I kept reading more about how we can push multiple views to the navigation stack at the same time.

## How

### Limitation of `navigationDestination(isPresented:destination:)`

After lots of reading and trials & errors from a new sample project (which I can reproduce the blank view for the second pushed view), pushing a view programmatically with `navigationDestination(isPresented:destination:)` only works well when pushing **one** view. In its [Apple doc](https://developer.apple.com/documentation/swiftui/view/navigationdestination(ispresented:destination:)), the `isPresented` parameter is:

> A binding to a Boolean value that indicates whether destination is currently presented.

There is no clear clarification about whether this is why pushing more than one view results in a blank view, but it's possible that this "whether destination is currently presented" behavior conflicts with the animation when pushing the first view and it resets the `isPresented` of the second view.

### Learning about `NavigationPath` and `navigationDestination(for:destination:)`

In iOS 16, `NavigationPath` was introduced in SwiftUI for managing the navigation stack `NavigationStack` with full control of the views in the stack. This works for us as the app is now iOS 16+. There are still limitations on the control of animation and APIs of `NavigationStack` like we can't access the exact values of the items. But for our deeplink use case, being able to programmatically set the items in the hub menu navigation stack is sufficient.

For the deeplink use case, we can focus on the following navigation scenarios:
- When tapping on Menu > Payments's `Collect Payment` CTA, append the order form to collect payment
- When tapping on a deeplink or quick action to collect payment, reset the Menu tab's navigation path to Payments and then append the order form
- When dismissing the order form, the order form and any subsequent views are popped from the navigation stack

Therefore, we need two value types to represent the **navigation destination** from the **Menu view** and from the **Payments view** to implement the navigation scenarios. Then we replace the existing `navigationDestination(isPresented:destination:)` with `navigationDestination(for:destination:)` to support programmatic navigation between the Menu <-> Payments <-> Order form (and any subsequent views) screens.

`navigationDestination(for:destination:)` requires the data to be `Hashable`, and I found an enum to be the most straightforward and readable. In `HubMenu` view, we actually already use `navigationDestination(for:destination:)` but it's using `String` type and can be ambiguous if we decide to support other scenarios with string types.

### Major code changes

In this PR, the two new navigation destination enums are:
- `HubMenuNavigationDestination`: cases of views that the Menu view can navigate to - so far just `payments` to keep the changes small
- `InPersonPaymentsMenuNavigationDestination`: cases of views that the Payments view can navigate to - so far just `collectPayment`

Then, we replace the existing `navigationDestination(isPresented:destination:)` with `navigationDestination(for:destination:)`. This removes the `isPresented` binding booleans from the view models, and instead, it appends/removes item(s) (`HubMenuNavigationDestination`/`InPersonPaymentsMenuNavigationDestination`) from the new navigation path `NavigationPath` when pushing/popping views in the view models.

Passing a `@Published var` navigation path from one view model to its child view model as `@Binding` was also nontrivial, I ended up creating a `Binding` manually but maybe there's a better way.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

### Without visiting the Menu tab

- Open the app
- Log in to a store if needed
- Tap on `Collect payment` quick action (long press on the app icon) or a deeplink like `http://woo.com/mobile/payments/collect-payment` --> the app should navigate to the Menu tab > Payments > order form with the migration half sheet/modal shown shortly

### On the Menu tab

- Go back to the root of the Menu tab
- Tap on `Collect payment` quick action (long press on the app icon) or a deeplink like `http://woo.com/mobile/payments/collect-payment` --> the app should navigate to the Menu tab > Payments > order form with the migration half sheet/modal shown shortly

### On the Menu tab > Payments

- Go back to the root of the Menu tab
- Tap `Payments`
- Tap on `Collect payment` quick action (long press on the app icon) or a deeplink like `http://woo.com/mobile/payments/collect-payment` --> the app should navigate to the Menu tab > Payments > order form with the migration half sheet/modal shown shortly

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->


https://github.com/woocommerce/woocommerce-ios/assets/1945542/182c0baa-e4ff-4054-a5e8-89cbb6ffbf6f




---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
