### PR TITLE
[Subscriptions in Order Creation] Update Order Details, and new customer section

### DIFF
--- a/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsDataSource.swift
+++ b/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsDataSource.swift
@@ -526,15 +526,8 @@ private extension OrderDetailsDataSource {
         cell.selectionStyle = .default
 
         cell.accessibilityTraits = .button
-        cell.accessibilityLabel = NSLocalizedString(
-            "View Billing Information",
-            comment: "Accessibility label for the 'View Billing Information' button"
-        )
-
-        cell.accessibilityHint = NSLocalizedString(
-            "Show the billing details for this order.",
-            comment: "VoiceOver accessibility hint, informing the user that the button can be used to view billing information."
-        )
+        cell.accessibilityLabel = Accessibility.billingDetailsLabel
+        cell.accessibilityHint = Accessibility.billingDetailsHint
     }
 
     private func configureShippingNotice(cell: ImageAndTitleAndTextTableViewCell) {
@@ -1724,8 +1717,10 @@ extension OrderDetailsDataSource {
     }
 
     enum Footer {
-        static let showBilling = NSLocalizedString("View Billing Information",
-                                                   comment: "Button on bottom of Customer's information to show the billing details")
+        static let showBilling = NSLocalizedString(
+            "orderDetailsDataSource.footer.showBilling",
+            value: "View billing details",
+            comment: "Button on bottom of Customer's information to show the billing details")
         static let showShippingLabelDetails = NSLocalizedString("View Shipment Details",
                                                                 comment: "Button on bottom of shipping label package card to show shipping details")
     }
@@ -1740,6 +1735,16 @@ extension OrderDetailsDataSource {
             "orderDetailsDataSource.trashOrder.accessibilityHint",
             value: "Put this order in the trash.",
             comment: "VoiceOver accessibility hint, informing the user that the button can be used to view the order custom fields information."
+        )
+        static let billingDetailsLabel = NSLocalizedString(
+            "orderDetailsDataSource.billingDetails.accessibilityLabel",
+            value: "View billing details",
+            comment: "Accessibility label for the 'View billing details' button"
+        )
+        static let billingDetailsHint = NSLocalizedString(
+            "orderDetailsDataSource.billingDetails.accessibilityHint",
+            value: "Show the billing details for this order.",
+            comment: "VoiceOver accessibility hint, informing the user that the button can be used to view billing information."
         )
     }
 

--- a/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsDataSource.swift
+++ b/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsDataSource.swift
@@ -165,10 +165,6 @@ final class OrderDetailsDataSource: NSObject {
         resultsControllers.addOnGroups
     }
 
-    var customers: [Customer] {
-        resultsControllers.customerDetails
-    }
-
     /// Shipping Labels for an Order
     ///
     private(set) var shippingLabels: [ShippingLabel] = []
@@ -389,8 +385,6 @@ private extension OrderDetailsDataSource {
             configureShippingAddress(cell: cell)
         case let cell as CustomerNoteTableViewCell where row == .customerNote:
             configureCustomerNote(cell: cell)
-        case let cell as CustomerInfoTableViewCell where row == .customer:
-            configureCustomer(cell: cell)
         case let cell as CustomerNoteTableViewCell where row == .shippingMethod:
             configureShippingMethod(cell: cell)
         case let cell as WooBasicTableViewCell where row == .billingDetail:
@@ -971,24 +965,6 @@ private extension OrderDetailsDataSource {
         )
     }
 
-    private func configureCustomer(cell: CustomerInfoTableViewCell) {
-        cell.title = Title.customer
-
-        guard let customer = resultsControllers.customerDetails.first(where: { $0.customerID == order.customerID }),
-        !customer.isGuest else {
-            cell.name = "Guest"
-            cell.address = "----"
-            cell.configureLayout()
-            return
-        }
-
-        if let firstName = customer.firstName, let lastName = customer.lastName {
-            cell.name = String.localizedStringWithFormat(Title.customerName, firstName, lastName)
-        }
-        cell.address = customer.email
-        cell.configureLayout()
-    }
-
     private func configureShippingAddress(cell: CustomerInfoTableViewCell) {
         let shippingAddress = order.shippingAddress
 
@@ -1278,9 +1254,6 @@ extension OrderDetailsDataSource {
 
         let customerInformation: Section? = {
             var rows: [Row] = []
-            /// Customer lines
-            rows.append(.customer)
-
             /// Shipping Address
             /// Almost always visible to allow editing.
             let orderContainsOnlyVirtualProducts = self.products.filter { (product) -> Bool in
@@ -1723,7 +1696,6 @@ extension OrderDetailsDataSource {
         case refundedProducts
         case issueRefundButton
         case customerNote
-        case customer
         case shippingAddress
         case shippingMethod
         case billingDetail
@@ -1777,8 +1749,6 @@ extension OrderDetailsDataSource {
                 return IssueRefundTableViewCell.reuseIdentifier
             case .customerNote:
                 return CustomerNoteTableViewCell.reuseIdentifier
-            case .customer:
-                return CustomerInfoTableViewCell.reuseIdentifier
             case .shippingAddress:
                 return CustomerInfoTableViewCell.reuseIdentifier
             case .shippingMethod:
@@ -1948,10 +1918,6 @@ private extension OrderDetailsDataSource {
     }
 
     enum Title {
-        static let customer = NSLocalizedString(
-            "orderDetailsDataSource.title.customer",
-            value: "Customer",
-            comment: "Title for the customer row, within the customer information section")
         static let products = NSLocalizedString("Products", comment: "Product section title if there is more than one product.")
         static let customAmounts = NSLocalizedString("orderDetails.customAmounts.section.pluralTitle",
                                                      value: "Custom Amounts",
@@ -1969,10 +1935,6 @@ private extension OrderDetailsDataSource {
             "orderDetailsDataSource.title.shippingAddress",
             value: "Shipping method",
             comment: "Title for the shipping method row, within the customer information section")
-        static let customerName = NSLocalizedString(
-            "orderDetailsDataSource.title.customerName",
-            value: "%1$@ %2$@",
-            comment: "Customer first and last names within the customer information section, reads as 'Jane Doe'")
         static let information = NSLocalizedString("Customer", comment: "Customer info section title")
         static let payment = NSLocalizedString("Payment Totals", comment: "Payment section title")
         static let notes = NSLocalizedString("Order Notes", comment: "Order notes section title")

--- a/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsDataSource.swift
+++ b/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsDataSource.swift
@@ -992,8 +992,7 @@ private extension OrderDetailsDataSource {
     }
 
     private func configureShippingMethod(cell: CustomerNoteTableViewCell) {
-        cell.headline = NSLocalizedString("Shipping Method",
-                                          comment: "Shipping method title for customer info cell")
+        cell.headline = Title.shippingMethod
         cell.body = shippingMethod.strippedHTML
         cell.selectionStyle = .none
     }
@@ -1928,8 +1927,14 @@ private extension OrderDetailsDataSource {
         static let giftCards = NSLocalizedString("Gift Cards", comment: "Gift Cards section title")
         static let tracking = NSLocalizedString("Tracking", comment: "Order tracking section title")
         static let customerNote = NSLocalizedString("Customer Provided Note", comment: "Customer note section title")
-        static let shippingAddress = NSLocalizedString("Shipping Details",
-                                                       comment: "Shipping title for customer info cell")
+        static let shippingAddress = NSLocalizedString(
+            "orderDetailsDataSource.title.shippingAddress",
+            value: "Shipping address",
+            comment: "Title for the shipping address row, within the customer information section")
+        static let shippingMethod = NSLocalizedString(
+            "orderDetailsDataSource.title.shippingAddress",
+            value: "Shipping method",
+            comment: "Title for the shipping method row, within the customer information section")
         static let information = NSLocalizedString("Customer", comment: "Customer info section title")
         static let payment = NSLocalizedString("Payment Totals", comment: "Payment section title")
         static let notes = NSLocalizedString("Order Notes", comment: "Order notes section title")

--- a/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsDataSource.swift
+++ b/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsDataSource.swift
@@ -1843,7 +1843,7 @@ private extension OrderDetailsDataSource {
 }
 
 // MARK: - Localization
-private extension OrderDetailsDataSource {
+extension OrderDetailsDataSource {
     enum Localization {
         enum AttributionInfo {
             static let origin = NSLocalizedString(

--- a/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsDataSource.swift
+++ b/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsDataSource.swift
@@ -1599,155 +1599,8 @@ extension OrderDetailsDataSource {
     }
 }
 
-
-// MARK: - Constants
+// MARK: - TableView configuration helpers
 extension OrderDetailsDataSource {
-    enum Localization {
-        enum AttributionInfo {
-            static let origin = NSLocalizedString(
-                "orderDetailsDataSource.attributionInfo.origin",
-                value: "Origin",
-                comment: "Title in Order Attribution Section on Order Details screen."
-            )
-            static let unknown = NSLocalizedString(
-                "orderDetailsDataSource.attributionInfo.unknown",
-                value: "Unknown",
-                comment: "Origin in Order Attribution Section on Order Details screen."
-            )
-            static let sourceType = NSLocalizedString(
-                "orderDetailsDataSource.attributionInfo.sourceType",
-                value: "Source type",
-                comment: "Title in Order Attribution Section on Order Details screen."
-            )
-            static let campaign = NSLocalizedString(
-                "orderDetailsDataSource.attributionInfo.campaign",
-                value: "Campaign",
-                comment: "Title in Order Attribution Section on Order Details screen."
-            )
-            static let source = NSLocalizedString(
-                "orderDetailsDataSource.attributionInfo.source",
-                value: "Source",
-                comment: "Title in Order Attribution Section on Order Details screen."
-            )
-            static let medium = NSLocalizedString(
-                "orderDetailsDataSource.attributionInfo.medium",
-                value: "Medium",
-                comment: "Title in Order Attribution Section on Order Details screen."
-            )
-            static let deviceType = NSLocalizedString(
-                "orderDetailsDataSource.attributionInfo.deviceType",
-                value: "Device type",
-                comment: "Title in Order Attribution Section on Order Details screen."
-            )
-            static let sessionPageViews = NSLocalizedString(
-                "orderDetailsDataSource.attributionInfo.sessionPageViews",
-                value: "Session page views",
-                comment: "Title in Order Attribution Section on Order Details screen."
-            )
-        }
-    }
-
-    enum Titles {
-        static let markComplete = NSLocalizedString("Mark Order Complete", comment: "Fulfill Order Action Button")
-        static let addNoteText = NSLocalizedString("Add a note",
-                                                   comment: "Button text for adding a new order note")
-        static let paidByCustomer = NSLocalizedString("Paid",
-                                                      comment: "The title for the customer payment cell")
-        static let refunded = NSLocalizedString("Refunded",
-                                                comment: "The title for the refunded amount cell")
-        static let netAmount = NSLocalizedString("Net Payment", comment: "The title for the net amount paid cell")
-        static let collectPayment = NSLocalizedString("Collect Payment", comment: "Text on the button that starts collecting a card present payment.")
-        static let createShippingLabel = NSLocalizedString("Create Shipping Label", comment: "Text on the button that starts shipping label creation")
-        static let reprintShippingLabel = NSLocalizedString("Print Shipping Label", comment: "Text on the button that prints a shipping label")
-        static let seeReceipt = NSLocalizedString(
-            "OrderDetailsDataSource.configureSeeReceipt.button.title",
-            value: "See Receipt",
-            comment: "Text on the button title to see the order's receipt")
-        static let seeLegacyReceipt = NSLocalizedString("See Receipt", comment: "Text on the button to see a saved receipt")
-        static let trashOrder = NSLocalizedString(
-                     "orderDetailsDataSource.trashOrder.button.title",
-                     value: "Move to trash",
-                     comment: "Text on the button title to trash an order")
-    }
-
-    enum Icons {
-        static let shippingNoticeIcon = UIImage.noticeImage
-        static let plusImage = UIImage.plusImage
-    }
-
-    enum Title {
-        static let products = NSLocalizedString("Products", comment: "Product section title if there is more than one product.")
-        static let customAmounts = NSLocalizedString("orderDetails.customAmounts.section.pluralTitle",
-                                                     value: "Custom Amounts",
-                                                     comment: "Custom Amount section title if there is more than one custom amount.")
-        static let refundedProducts = NSLocalizedString("Refunded Products", comment: "Section title")
-        static let subscriptions = NSLocalizedString("Subscriptions", comment: "Subscriptions section title")
-        static let giftCards = NSLocalizedString("Gift Cards", comment: "Gift Cards section title")
-        static let tracking = NSLocalizedString("Tracking", comment: "Order tracking section title")
-        static let customerNote = NSLocalizedString("Customer Provided Note", comment: "Customer note section title")
-        static let shippingAddress = NSLocalizedString("Shipping Details",
-                                                       comment: "Shipping title for customer info cell")
-        static let information = NSLocalizedString("Customer", comment: "Customer info section title")
-        static let payment = NSLocalizedString("Payment Totals", comment: "Payment section title")
-        static let notes = NSLocalizedString("Order Notes", comment: "Order notes section title")
-        static let customFields = NSLocalizedString("View Custom Fields", comment: "Custom Fields section title")
-        static let shippingLabelCreationInfoAction =
-            NSLocalizedString("Learn more about creating labels with your mobile device",
-                              comment: "Title of button in order details > info link for creating a shipping label on the mobile device.")
-        static let shippingLabelPackageFormat =
-            NSLocalizedString("Package %d",
-                              comment: "Order shipping label package section title format. The number indicates the index of the shipping label package.")
-        static let shippingLabelTrackingNumberTitle = NSLocalizedString("Tracking number", comment: "Order shipping label tracking number row title.")
-        static let shippingLabelRefundedDetailsFormat =
-            NSLocalizedString("%1$@ • %2$@",
-                              comment: "Order refunded shipping label title. The first variable shows the refunded amount (e.g. $12.90). " +
-                                "The second variable shows the requested date (e.g. Jan 12, 2020 12:34 PM).")
-        static let shippingLabelRefundedTitleFormat =
-            NSLocalizedString("%@ label refund requested",
-                              comment: "Order refunded shipping label title. The string variable shows the shipping label service name (e.g. USPS).")
-        static let shippingLabelPrintingInfoAction =
-            NSLocalizedString("Don’t know how to print from your mobile device?",
-                              comment: "Title of button in order details > shipping label that shows the instructions on how to print " +
-                                "a shipping label on the mobile device.")
-        static let orderAttribution = NSLocalizedString(
-            "orderDetailsDataSource.attributionInfo.orderAttribution",
-            value: "Order attribution",
-            comment: "Title of Order Attribution Section in Order Details screen."
-        )
-    }
-
-    enum Footer {
-        static let showBilling = NSLocalizedString(
-            "orderDetailsDataSource.footer.showBilling",
-            value: "View billing details",
-            comment: "Button on bottom of Customer's information to show the billing details")
-        static let showShippingLabelDetails = NSLocalizedString("View Shipment Details",
-                                                                comment: "Button on bottom of shipping label package card to show shipping details")
-    }
-
-    enum Accessibility {
-        static let trashOrderLabel = NSLocalizedString(
-            "orderDetailsDataSource.trashOrder.accessibilityLabel",
-            value: "Trash Order Button",
-            comment: "Accessibility label for the 'Trash order' button"
-        )
-        static let trashOrderHint = NSLocalizedString(
-            "orderDetailsDataSource.trashOrder.accessibilityHint",
-            value: "Put this order in the trash.",
-            comment: "VoiceOver accessibility hint, informing the user that the button can be used to view the order custom fields information."
-        )
-        static let billingDetailsLabel = NSLocalizedString(
-            "orderDetailsDataSource.billingDetails.accessibilityLabel",
-            value: "View billing details",
-            comment: "Accessibility label for the 'View billing details' button"
-        )
-        static let billingDetailsHint = NSLocalizedString(
-            "orderDetailsDataSource.billingDetails.accessibilityHint",
-            value: "Show the billing details for this order.",
-            comment: "VoiceOver accessibility hint, informing the user that the button can be used to view billing information."
-        )
-    }
-
     struct Section {
         enum Category {
             case summary
@@ -1979,10 +1832,162 @@ extension OrderDetailsDataSource {
         case editShippingAddress
         case trashOrder
     }
+}
 
+// MARK: - Constants
+private extension OrderDetailsDataSource {
     enum Constants {
         static let addOrderCell = 1
         static let paymentCell = 1
         static let paidByCustomerCell = 1
+    }
+}
+
+// MARK: - Localization
+private extension OrderDetailsDataSource {
+    enum Localization {
+        enum AttributionInfo {
+            static let origin = NSLocalizedString(
+                "orderDetailsDataSource.attributionInfo.origin",
+                value: "Origin",
+                comment: "Title in Order Attribution Section on Order Details screen."
+            )
+            static let unknown = NSLocalizedString(
+                "orderDetailsDataSource.attributionInfo.unknown",
+                value: "Unknown",
+                comment: "Origin in Order Attribution Section on Order Details screen."
+            )
+            static let sourceType = NSLocalizedString(
+                "orderDetailsDataSource.attributionInfo.sourceType",
+                value: "Source type",
+                comment: "Title in Order Attribution Section on Order Details screen."
+            )
+            static let campaign = NSLocalizedString(
+                "orderDetailsDataSource.attributionInfo.campaign",
+                value: "Campaign",
+                comment: "Title in Order Attribution Section on Order Details screen."
+            )
+            static let source = NSLocalizedString(
+                "orderDetailsDataSource.attributionInfo.source",
+                value: "Source",
+                comment: "Title in Order Attribution Section on Order Details screen."
+            )
+            static let medium = NSLocalizedString(
+                "orderDetailsDataSource.attributionInfo.medium",
+                value: "Medium",
+                comment: "Title in Order Attribution Section on Order Details screen."
+            )
+            static let deviceType = NSLocalizedString(
+                "orderDetailsDataSource.attributionInfo.deviceType",
+                value: "Device type",
+                comment: "Title in Order Attribution Section on Order Details screen."
+            )
+            static let sessionPageViews = NSLocalizedString(
+                "orderDetailsDataSource.attributionInfo.sessionPageViews",
+                value: "Session page views",
+                comment: "Title in Order Attribution Section on Order Details screen."
+            )
+        }
+    }
+
+    enum Titles {
+        static let markComplete = NSLocalizedString("Mark Order Complete", comment: "Fulfill Order Action Button")
+        static let addNoteText = NSLocalizedString("Add a note",
+                                                   comment: "Button text for adding a new order note")
+        static let paidByCustomer = NSLocalizedString("Paid",
+                                                      comment: "The title for the customer payment cell")
+        static let refunded = NSLocalizedString("Refunded",
+                                                comment: "The title for the refunded amount cell")
+        static let netAmount = NSLocalizedString("Net Payment", comment: "The title for the net amount paid cell")
+        static let collectPayment = NSLocalizedString("Collect Payment", comment: "Text on the button that starts collecting a card present payment.")
+        static let createShippingLabel = NSLocalizedString("Create Shipping Label", comment: "Text on the button that starts shipping label creation")
+        static let reprintShippingLabel = NSLocalizedString("Print Shipping Label", comment: "Text on the button that prints a shipping label")
+        static let seeReceipt = NSLocalizedString(
+            "OrderDetailsDataSource.configureSeeReceipt.button.title",
+            value: "See Receipt",
+            comment: "Text on the button title to see the order's receipt")
+        static let seeLegacyReceipt = NSLocalizedString("See Receipt", comment: "Text on the button to see a saved receipt")
+        static let trashOrder = NSLocalizedString(
+                     "orderDetailsDataSource.trashOrder.button.title",
+                     value: "Move to trash",
+                     comment: "Text on the button title to trash an order")
+    }
+
+    enum Icons {
+        static let shippingNoticeIcon = UIImage.noticeImage
+        static let plusImage = UIImage.plusImage
+    }
+
+    enum Title {
+        static let products = NSLocalizedString("Products", comment: "Product section title if there is more than one product.")
+        static let customAmounts = NSLocalizedString("orderDetails.customAmounts.section.pluralTitle",
+                                                     value: "Custom Amounts",
+                                                     comment: "Custom Amount section title if there is more than one custom amount.")
+        static let refundedProducts = NSLocalizedString("Refunded Products", comment: "Section title")
+        static let subscriptions = NSLocalizedString("Subscriptions", comment: "Subscriptions section title")
+        static let giftCards = NSLocalizedString("Gift Cards", comment: "Gift Cards section title")
+        static let tracking = NSLocalizedString("Tracking", comment: "Order tracking section title")
+        static let customerNote = NSLocalizedString("Customer Provided Note", comment: "Customer note section title")
+        static let shippingAddress = NSLocalizedString("Shipping Details",
+                                                       comment: "Shipping title for customer info cell")
+        static let information = NSLocalizedString("Customer", comment: "Customer info section title")
+        static let payment = NSLocalizedString("Payment Totals", comment: "Payment section title")
+        static let notes = NSLocalizedString("Order Notes", comment: "Order notes section title")
+        static let customFields = NSLocalizedString("View Custom Fields", comment: "Custom Fields section title")
+        static let shippingLabelCreationInfoAction =
+            NSLocalizedString("Learn more about creating labels with your mobile device",
+                              comment: "Title of button in order details > info link for creating a shipping label on the mobile device.")
+        static let shippingLabelPackageFormat =
+            NSLocalizedString("Package %d",
+                              comment: "Order shipping label package section title format. The number indicates the index of the shipping label package.")
+        static let shippingLabelTrackingNumberTitle = NSLocalizedString("Tracking number", comment: "Order shipping label tracking number row title.")
+        static let shippingLabelRefundedDetailsFormat =
+            NSLocalizedString("%1$@ • %2$@",
+                              comment: "Order refunded shipping label title. The first variable shows the refunded amount (e.g. $12.90). " +
+                                "The second variable shows the requested date (e.g. Jan 12, 2020 12:34 PM).")
+        static let shippingLabelRefundedTitleFormat =
+            NSLocalizedString("%@ label refund requested",
+                              comment: "Order refunded shipping label title. The string variable shows the shipping label service name (e.g. USPS).")
+        static let shippingLabelPrintingInfoAction =
+            NSLocalizedString("Don’t know how to print from your mobile device?",
+                              comment: "Title of button in order details > shipping label that shows the instructions on how to print " +
+                                "a shipping label on the mobile device.")
+        static let orderAttribution = NSLocalizedString(
+            "orderDetailsDataSource.attributionInfo.orderAttribution",
+            value: "Order attribution",
+            comment: "Title of Order Attribution Section in Order Details screen."
+        )
+    }
+
+    enum Footer {
+        static let showBilling = NSLocalizedString(
+            "orderDetailsDataSource.footer.showBilling",
+            value: "View billing details",
+            comment: "Button on bottom of Customer's information to show the billing details")
+        static let showShippingLabelDetails = NSLocalizedString("View Shipment Details",
+                                                                comment: "Button on bottom of shipping label package card to show shipping details")
+    }
+
+    enum Accessibility {
+        static let trashOrderLabel = NSLocalizedString(
+            "orderDetailsDataSource.trashOrder.accessibilityLabel",
+            value: "Trash Order Button",
+            comment: "Accessibility label for the 'Trash order' button"
+        )
+        static let trashOrderHint = NSLocalizedString(
+            "orderDetailsDataSource.trashOrder.accessibilityHint",
+            value: "Put this order in the trash.",
+            comment: "VoiceOver accessibility hint, informing the user that the button can be used to view the order custom fields information."
+        )
+        static let billingDetailsLabel = NSLocalizedString(
+            "orderDetailsDataSource.billingDetails.accessibilityLabel",
+            value: "View billing details",
+            comment: "Accessibility label for the 'View billing details' button"
+        )
+        static let billingDetailsHint = NSLocalizedString(
+            "orderDetailsDataSource.billingDetails.accessibilityHint",
+            value: "Show the billing details for this order.",
+            comment: "VoiceOver accessibility hint, informing the user that the button can be used to view billing information."
+        )
     }
 }

--- a/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsDataSource.swift
+++ b/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsDataSource.swift
@@ -1262,17 +1262,11 @@ extension OrderDetailsDataSource {
 
         let customerInformation: Section? = {
             var rows: [Row] = []
-
-            /// Customer Note
-            /// Always visible to allow adding & editing.
-            rows.append(.customerNote)
-
             /// Shipping Address
             /// Almost always visible to allow editing.
             let orderContainsOnlyVirtualProducts = self.products.filter { (product) -> Bool in
                 return items.first(where: { $0.productID == product.productID}) != nil
             }.allSatisfy { $0.virtual == true }
-
 
             if order.shippingAddress != nil && orderContainsOnlyVirtualProducts == false {
                 rows.append(.shippingAddress)
@@ -1286,6 +1280,10 @@ extension OrderDetailsDataSource {
             /// Billing Address
             /// Always visible to allow editing.
             rows.append(.billingDetail)
+
+            /// Customer Note
+            /// Always visible to allow adding & editing.
+            rows.append(.customerNote)
 
             /// Return `nil` if there is no rows to display.
             guard rows.isNotEmpty else {

--- a/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsDataSource.swift
+++ b/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsDataSource.swift
@@ -165,6 +165,10 @@ final class OrderDetailsDataSource: NSObject {
         resultsControllers.addOnGroups
     }
 
+    var customers: [Customer] {
+        resultsControllers.customerDetails
+    }
+
     /// Shipping Labels for an Order
     ///
     private(set) var shippingLabels: [ShippingLabel] = []
@@ -385,6 +389,8 @@ private extension OrderDetailsDataSource {
             configureShippingAddress(cell: cell)
         case let cell as CustomerNoteTableViewCell where row == .customerNote:
             configureCustomerNote(cell: cell)
+        case let cell as CustomerInfoTableViewCell where row == .customer:
+            configureCustomer(cell: cell)
         case let cell as CustomerNoteTableViewCell where row == .shippingMethod:
             configureShippingMethod(cell: cell)
         case let cell as WooBasicTableViewCell where row == .billingDetail:
@@ -965,6 +971,24 @@ private extension OrderDetailsDataSource {
         )
     }
 
+    private func configureCustomer(cell: CustomerInfoTableViewCell) {
+        cell.title = Title.customer
+
+        guard let customer = resultsControllers.customerDetails.first(where: { $0.customerID == order.customerID }),
+        !customer.isGuest else {
+            cell.name = "Guest"
+            cell.address = "----"
+            cell.configureLayout()
+            return
+        }
+
+        if let firstName = customer.firstName, let lastName = customer.lastName {
+            cell.name = String.localizedStringWithFormat(Title.customerName, firstName, lastName)
+        }
+        cell.address = customer.email
+        cell.configureLayout()
+    }
+
     private func configureShippingAddress(cell: CustomerInfoTableViewCell) {
         let shippingAddress = order.shippingAddress
 
@@ -1254,6 +1278,9 @@ extension OrderDetailsDataSource {
 
         let customerInformation: Section? = {
             var rows: [Row] = []
+            /// Customer lines
+            rows.append(.customer)
+
             /// Shipping Address
             /// Almost always visible to allow editing.
             let orderContainsOnlyVirtualProducts = self.products.filter { (product) -> Bool in
@@ -1696,6 +1723,7 @@ extension OrderDetailsDataSource {
         case refundedProducts
         case issueRefundButton
         case customerNote
+        case customer
         case shippingAddress
         case shippingMethod
         case billingDetail
@@ -1749,6 +1777,8 @@ extension OrderDetailsDataSource {
                 return IssueRefundTableViewCell.reuseIdentifier
             case .customerNote:
                 return CustomerNoteTableViewCell.reuseIdentifier
+            case .customer:
+                return CustomerInfoTableViewCell.reuseIdentifier
             case .shippingAddress:
                 return CustomerInfoTableViewCell.reuseIdentifier
             case .shippingMethod:
@@ -1918,6 +1948,10 @@ private extension OrderDetailsDataSource {
     }
 
     enum Title {
+        static let customer = NSLocalizedString(
+            "orderDetailsDataSource.title.customer",
+            value: "Customer",
+            comment: "Title for the customer row, within the customer information section")
         static let products = NSLocalizedString("Products", comment: "Product section title if there is more than one product.")
         static let customAmounts = NSLocalizedString("orderDetails.customAmounts.section.pluralTitle",
                                                      value: "Custom Amounts",
@@ -1935,6 +1969,10 @@ private extension OrderDetailsDataSource {
             "orderDetailsDataSource.title.shippingAddress",
             value: "Shipping method",
             comment: "Title for the shipping method row, within the customer information section")
+        static let customerName = NSLocalizedString(
+            "orderDetailsDataSource.title.customerName",
+            value: "%1$@ %2$@",
+            comment: "Customer first and last names within the customer information section, reads as 'Jane Doe'")
         static let information = NSLocalizedString("Customer", comment: "Customer info section title")
         static let payment = NSLocalizedString("Payment Totals", comment: "Payment section title")
         static let notes = NSLocalizedString("Order Notes", comment: "Order notes section title")

--- a/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsResultsControllers.swift
+++ b/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsResultsControllers.swift
@@ -74,12 +74,6 @@ final class OrderDetailsResultsControllers {
                                                        sortedBy: [dateCreatedDescriptor, shippingLabelIDDescriptor])
     }()
 
-    private lazy var customerDetailsResultsController: ResultsController<StorageCustomer> = {
-        let predicate = NSPredicate(format: "siteID == %lld", siteID)
-        let descriptor = NSSortDescriptor(keyPath: \StorageCustomer.customerID, ascending: false)
-        return ResultsController<StorageCustomer>(storageManager: storageManager, matching: predicate, sortedBy: [descriptor])
-    }()
-
     /// AddOnGroup ResultsController.
     ///
     private lazy var addOnGroupResultsController: ResultsController<StorageAddOnGroup> = {
@@ -130,10 +124,6 @@ final class OrderDetailsResultsControllers {
         return shippingLabelResultsController.fetchedObjects
     }
 
-    var customerDetails: [Customer] {
-        return customerDetailsResultsController.fetchedObjects
-    }
-
     /// Site's add-on groups.
     ///
     var addOnGroups: [AddOnGroup] {
@@ -168,7 +158,6 @@ final class OrderDetailsResultsControllers {
         configureRefundResultsController(onReload: onReload)
         configureShippingLabelResultsController(onReload: onReload)
         configureAddOnGroupResultsController(onReload: onReload)
-        configureCustomerRC(onReload: onReload)
         configureSitePluginsResultsController(onReload: onReload)
         configureFeeLinesResultsController(onReload: onReload)
     }
@@ -319,24 +308,6 @@ private extension OrderDetailsResultsControllers {
         }
     }
 
-    private func configureCustomerRC(onReload: @escaping () -> Void) {
-        customerDetailsResultsController.onDidChangeContent = {
-            onReload()
-        }
-
-        customerDetailsResultsController.onDidResetContent = { [weak self] in
-            guard let self = self else { return }
-            self.refetchAllResultsControllers()
-            onReload()
-        }
-
-        do {
-            try customerDetailsResultsController.performFetch()
-        } catch {
-            DDLogError("⛔️ Unable to fetch Customer for \(siteID): \(error)")
-        }
-    }
-
     private func configureSitePluginsResultsController(onReload: @escaping () -> Void) {
         sitePluginsResultsController.onDidChangeContent = {
             onReload()
@@ -382,7 +353,6 @@ private extension OrderDetailsResultsControllers {
         try? trackingResultsController.performFetch()
         try? statusResultsController.performFetch()
         try? shippingLabelResultsController.performFetch()
-        try? customerDetailsResultsController.performFetch()
         try? addOnGroupResultsController.performFetch()
         try? sitePluginsResultsController.performFetch()
     }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #12440

On hold until the Customer bit has been implemented. Discussion: p1714034761901509-slack-C06C3CZFHGD . Additionally:

> For the mobile apps, unless we plan to fetch the subscription (shown in wp-admin Subscriptions if there’s API support) when we detect a subscription product in the order, we probably want to disable editing the addresses for sub orders because this only updates the order in Orders but not in Subscriptions

## Description
This PR addresses updating the Order Details row for billing, shipping, and customer details following the design proposal on Q9tkFMtymZz0yhfLLbKhig-fi-2176_61285 , under `i1 - 06 - Order details`

<img width="328" alt="Screenshot 2024-04-25 at 15 41 05" src="https://github.com/woocommerce/woocommerce-ios/assets/3812076/6af3e788-86b5-45df-bc8d-45da56b41a37">

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->