### PR TITLE
[Order Creation] Reset scan button from spinner after scan completes

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Orders/OrdersRootViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrdersRootViewController.swift
@@ -280,6 +280,7 @@ final class OrdersRootViewController: UIViewController {
                 case let .failure(error):
                     self.displayScannedProductErrorNotice(error, code: scannedBarcode)
                 }
+                navigationItem.leftBarButtonItem = createAddOrderByProductScanningButtonItem()
             }
         }, onPermissionsDenied: { [weak self] in
             self?.analytics.track(event: WooAnalyticsEvent.BarcodeScanning.barcodeScanningFailure(from: .orderList, reason: .cameraAccessNotPermitted))

--- a/WooCommerce/Classes/ViewRelated/Orders/OrdersRootViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrdersRootViewController.swift
@@ -116,7 +116,7 @@ final class OrdersRootViewController: UIViewController {
     override var shouldShowOfflineBanner: Bool {
         // Should show the offline banner only when there's no orderDetailsViewController in memory
         // otherwise, it will be shown within the order details view, so there's no need to duplicate it
-        if let orderDetailsViewController {
+        if orderDetailsViewController != nil {
             return false
         } else {
             return true


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #12568
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

Previously, after using the scan button from the Orders tab, it would show a spinner which would never be removed.

This PR resets the scan button on the order list to a scan button, after the scan completes.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

1. Launch the app and switch to a store with products that have a barcode associated
2. Tap orders
3. Tap the scan button in the top left
4. Scan a barcode, or cancel the scan
5. Observe that in either case, including when the scan fails, the spinner is shown and then dismissed so that the scan button can be used again.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->


https://github.com/woocommerce/woocommerce-ios/assets/2472348/0d3d68a4-8aad-458a-be88-3cab1edce22f


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
