### PR TITLE
[Dynamic Dashboard] Dashboard store performance empty view

### DIFF
--- a/WooCommerce/Classes/Extensions/UIImage+Woo.swift
+++ b/WooCommerce/Classes/Extensions/UIImage+Woo.swift
@@ -1529,7 +1529,9 @@ extension UIImage {
         UIImage(systemName: "exclamationmark.circle", withConfiguration: Configurations.barButtonItemSymbol)!.withRenderingMode(.alwaysTemplate)
     }
 
-
+    static var magnifyingGlassNotFound: UIImage {
+        UIImage(imageLiteralResourceName: "magnifying-glass-not-found")
+    }
 }
 
 private extension UIImage {

--- a/WooCommerce/Classes/ViewRelated/Dashboard/StoreStats/StorePerformanceView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/StoreStats/StorePerformanceView.swift
@@ -246,7 +246,8 @@ private extension StorePerformanceView {
             }
             .frame(height: Layout.chartViewHeight)
 
-            if let granularityText = viewModel.granularityText {
+            if viewModel.chartViewModel.hasRevenue,
+               let granularityText = viewModel.granularityText {
                 Text(granularityText)
                     .font(Font(StyleManager.statsTitleFont))
             }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/StoreStats/StorePerformanceView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/StoreStats/StorePerformanceView.swift
@@ -8,8 +8,11 @@ struct StorePerformanceView: View {
     @State private var showingCustomRangePicker = false
     @State private var showingSupportForm = false
 
-    var statsValueColor: Color {
-        Color(viewModel.shouldHighlightStats ? .statsHighlighted : .text)
+    private var statsValueColor: Color {
+        guard viewModel.chartViewModel.hasRevenue else {
+            return Color(.textSubtle)
+        }
+        return Color(viewModel.shouldHighlightStats ? .statsHighlighted : .text)
     }
 
     private let canHideCard: Bool
@@ -159,24 +162,34 @@ private extension StorePerformanceView {
                     .largeTitleStyle()
 
                 Text(Localization.revenue)
+                    .if(!viewModel.chartViewModel.hasRevenue) { $0.foregroundStyle(Color(.textSubtle)) }
                     .font(Font(StyleManager.statsTitleFont))
             }
 
             HStack(alignment: .bottom) {
-                statsItemView(title: Localization.orders,
-                              value: viewModel.orderStatsText,
-                              redactMode: .none)
-                    .frame(maxWidth: .infinity)
+                Group {
+                    statsItemView(title: Localization.orders,
+                                  value: viewModel.orderStatsText,
+                                  redactMode: .none)
+                        .frame(maxWidth: .infinity)
 
-                statsItemView(title: Localization.visitors,
-                              value: viewModel.visitorStatsText,
-                              redactMode: .withIcon)
-                    .frame(maxWidth: .infinity)
+                    statsItemView(title: Localization.visitors,
+                                  value: viewModel.visitorStatsText,
+                                  redactMode: .withIcon)
+                        .frame(maxWidth: .infinity)
 
-                statsItemView(title: Localization.conversion,
-                              value: viewModel.conversionStatsText,
-                              redactMode: .withoutIcon)
+                    statsItemView(title: Localization.conversion,
+                                  value: viewModel.conversionStatsText,
+                                  redactMode: .withoutIcon)
+                        .frame(maxWidth: .infinity)
+
+                }
+                .renderedIf(viewModel.chartViewModel.hasRevenue)
+
+                Text(Localization.noRevenueText)
+                    .subheadlineStyle()
                     .frame(maxWidth: .infinity)
+                    .renderedIf(!viewModel.chartViewModel.hasRevenue)
             }
         }
     }
@@ -336,6 +349,11 @@ private extension StorePerformanceView {
             "storePerformanceView.revenue",
             value: "Revenue",
             comment: "Revenue stat label on dashboard."
+        )
+        static let noRevenueText = NSLocalizedString(
+            "storePerformanceView.noRevenueText",
+            value: "No revenue for selected dates",
+            comment: "Text on the store stats chart on the Dashboard screen when there is no revenue"
         )
         static let orders = NSLocalizedString(
             "storePerformanceView.orders",

--- a/WooCommerce/Classes/ViewRelated/Dashboard/StoreStats/StoreStatsChart.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/StoreStats/StoreStatsChart.swift
@@ -29,9 +29,6 @@ struct StoreStatsChart: View {
             if !viewModel.hasRevenue {
                 RuleMark(y: .value(Localization.zeroRevenue, 0))
                     .foregroundStyle(Constants.noRevenueLineColor)
-                    .annotation(position: .overlay, alignment: .center) {
-                        Image(.magnifyingGlassNotFound)
-                    }
             }
 
             // Gradient area
@@ -96,6 +93,7 @@ struct StoreStatsChart: View {
             }
         }
         .padding(Constants.chartPadding)
+        .if(!viewModel.hasRevenue) { $0.overlay { emptyChartOverlay } }
     }
 
     private func updateSelectedDate(at location: CGPoint, proxy: ChartProxy, geometry: GeometryProxy) {
@@ -131,6 +129,26 @@ struct StoreStatsChart: View {
 }
 
 private extension StoreStatsChart {
+    var emptyChartOverlay: some View {
+        // Simulate an empty chart
+        VStack {
+            Divider()
+            Spacer()
+            Divider()
+            Spacer()
+            Divider()
+            Spacer()
+        }
+        .overlay {
+            Image(.magnifyingGlassNotFound)
+                .opacity(Constants.EmptyChartOverlay.opacity)
+                .padding(.bottom, Constants.EmptyChartOverlay.bottomPadding)
+        }
+        .renderedIf(!viewModel.hasRevenue)
+    }
+}
+
+private extension StoreStatsChart {
     enum Localization {
         static let xValue = NSLocalizedString(
             "storeStatsChart.xValue",
@@ -160,10 +178,7 @@ private extension StoreStatsChart {
     }
 
     enum Constants {
-        static var noRevenueLineColor = Color(
-            light: Color.withColorStudio(name: .gray, shade: .shade5),
-            dark: Color.withColorStudio(name: .gray, shade: .shade80)
-        )
+        static var noRevenueLineColor = Color(.listForeground(modal: false))
         static var chartLineColor = Color(
             light: .withColorStudio(name: .wooCommercePurple, shade: .shade50),
             dark: .withColorStudio(name: .wooCommercePurple, shade: .shade30)
@@ -175,6 +190,11 @@ private extension StoreStatsChart {
         )
         static let chartGradientBottomColor = Color.clear
         static let chartPadding: CGFloat = 8
+
+        enum EmptyChartOverlay {
+            static let opacity: CGFloat = 0.5
+            static let bottomPadding: CGFloat = 32
+        }
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Dashboard/StoreStats/StoreStatsChart.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/StoreStats/StoreStatsChart.swift
@@ -30,10 +30,7 @@ struct StoreStatsChart: View {
                 RuleMark(y: .value(Localization.zeroRevenue, 0))
                     .foregroundStyle(Constants.noRevenueLineColor)
                     .annotation(position: .overlay, alignment: .center) {
-                        Text("No revenue this period")
-                            .font(.footnote)
-                            .padding(Constants.annotationPadding)
-                            .background(Color(.listForeground(modal: false)))
+                        Image(.magnifyingGlassNotFound)
                     }
             }
 
@@ -150,11 +147,6 @@ private extension StoreStatsChart {
             value: "Zero revenue",
             comment: "Value for the y-Axis of the store stats chart on the Dashboard screen when there is no revenue"
         )
-        static let noRevenueText = NSLocalizedString(
-            "storeStatsChart.noRevenueText",
-            value: "No revenue this period",
-            comment: "Text on the store stats chart on the Dashboard screen when there is no revenue"
-        )
         static let xSelectedValue = NSLocalizedString(
             "storeStatsChart.xSelectedValue",
             value: "Selected date",
@@ -183,7 +175,6 @@ private extension StoreStatsChart {
         )
         static let chartGradientBottomColor = Color.clear
         static let chartPadding: CGFloat = 8
-        static let annotationPadding: CGFloat = 4
     }
 }
 

--- a/WooCommerce/Resources/Images.xcassets/magnifying-glass-not-found.imageset/Contents.json
+++ b/WooCommerce/Resources/Images.xcassets/magnifying-glass-not-found.imageset/Contents.json
@@ -1,0 +1,12 @@
+{
+  "images" : [
+    {
+      "filename" : "magnifying-glass-not-found.pdf",
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/WooCommerce/Resources/Images.xcassets/magnifying-glass-not-found.imageset/magnifying-glass-not-found.pdf
+++ b/WooCommerce/Resources/Images.xcassets/magnifying-glass-not-found.imageset/magnifying-glass-not-found.pdf
@@ -1,0 +1,130 @@
+%PDF-1.7
+
+1 0 obj
+  << /Filter /FlateDecode
+     /Type /XObject
+     /Length 2 0 R
+     /Group << /Type /Group
+               /S /Transparency
+            >>
+     /Subtype /Form
+     /Resources << >>
+     /BBox [ 0.000000 0.000000 88.000000 88.000000 ]
+  >>
+stream
+xïTÀé1º˜W‰&øb˚
+HúÅOh-â]	≠ƒ˜Sôn:ÕÓvrOu™Ï≤ì<|z¸Ûs}¸˙˘C˘¯myòˇ÷óÂ˜“™7sÀ2ÇP„r—ˇP◊jﬁÑ∏òU3¶»≤>Å*ÑçØÉóıyë⁄-î[!ê∫Iã28Ì∫N‡Ø	^∏∫:ux–oÇg˙èÂ˚Úº|πﬂçZ•Ó¶ˆ7‘qJ=H(ÎûÏ’l=Bû¯∑—ì¿ùÜƒ+•6ñrÒÃj∫JI£¿∆◊¡0§\C4≤Aj±¿P	Öcù¿ì!é ‘≤¿…øçû¶!˙'uh¬~∞ ÒÌ
+ëv+™*Ç·oÜˆyºÜ!Í’≈l§Æ…X~∏USTÅ"G9Ω(Á‹Iã@›…ïnbÎ¬Yì2öÿíiáô[(R;sZaÆÕdLÖ°cM¢`∆,B"P~8Xz!≠ﬁ±CkU≤[œBê:„H√.*mH‚|¨ãUÁP’fF8?â$.Æ£w^H*{RÎCÕl]îáØ[g(’≠∑⁄u˜†Dk:zÂ#B_µü≥∑¡˜j‘,I4·i¡µàdC'∫HÑè)ûòÙA•y√YGB XE©rz2ªú°#Ï&9({‚â≠8¶8QDçâzläâ÷û0Ët2è—∆â"c‚ij98ª‚(7Á‚H}@8_8-èL/T‡ÃíçÊD#ÎDœçõè7Äµ%…Ñ†Ç-cˇ∫‡¡Îch)"∆c™É°úzÓœ≠î[ö`và¸N∏†õ»&71®y'
+ôΩ@Dª æÓ>¿Ÿ3OlE'∂”¯‘ÊV
+endstream
+endobj
+
+2 0 obj
+  628
+endobj
+
+3 0 obj
+  << /Type /XObject
+     /Length 4 0 R
+     /Group << /Type /Group
+               /S /Transparency
+            >>
+     /Subtype /Form
+     /Resources << >>
+     /BBox [ 0.000000 0.000000 88.000000 88.000000 ]
+  >>
+stream
+/DeviceRGB CS
+/DeviceRGB cs
+q
+1.000000 0.000000 -0.000000 1.000000 0.000000 0.000000 cm
+0.000000 0.000000 0.000000 scn
+0.000000 88.000000 m
+88.000000 88.000000 l
+88.000000 0.000000 l
+0.000000 0.000000 l
+0.000000 88.000000 l
+h
+f
+n
+Q
+
+endstream
+endobj
+
+4 0 obj
+  232
+endobj
+
+5 0 obj
+  << /XObject << /X1 1 0 R >>
+     /ExtGState << /E1 << /SMask << /Type /Mask
+                                    /G 3 0 R
+                                    /S /Alpha
+                                 >>
+                          /Type /ExtGState
+                       >> >>
+  >>
+endobj
+
+6 0 obj
+  << /Length 7 0 R >>
+stream
+/DeviceRGB CS
+/DeviceRGB cs
+q
+/E1 gs
+/X1 Do
+Q
+
+endstream
+endobj
+
+7 0 obj
+  46
+endobj
+
+8 0 obj
+  << /Annots []
+     /Type /Page
+     /MediaBox [ 0.000000 0.000000 88.000000 88.000000 ]
+     /Resources 5 0 R
+     /Contents 6 0 R
+     /Parent 9 0 R
+  >>
+endobj
+
+9 0 obj
+  << /Kids [ 8 0 R ]
+     /Count 1
+     /Type /Pages
+  >>
+endobj
+
+10 0 obj
+  << /Pages 9 0 R
+     /Type /Catalog
+  >>
+endobj
+
+xref
+0 11
+0000000000 65535 f
+0000000010 00000 n
+0000000912 00000 n
+0000000934 00000 n
+0000001414 00000 n
+0000001436 00000 n
+0000001734 00000 n
+0000001836 00000 n
+0000001857 00000 n
+0000002030 00000 n
+0000002104 00000 n
+trailer
+<< /ID [ (some) (id) ]
+   /Root 10 0 R
+   /Size 11
+>>
+startxref
+2164
+%%EOF

--- a/WooCommerce/WooCommerceTests/Extensions/IconsTests.swift
+++ b/WooCommerce/WooCommerceTests/Extensions/IconsTests.swift
@@ -940,4 +940,8 @@ final class IconsTests: XCTestCase {
     func test_exclamationImage_is_not_nil() {
         XCTAssertNotNil(UIImage.exclamationImage)
     }
+
+    func test_magnifyingGlassNotFound_is_not_nil() {
+        XCTAssertNotNil(UIImage.magnifyingGlassNotFound)
+    }
 }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #12557 
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

Updates the empty state design of Store performance card. 

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

- Lanch and login into the app.
- Enable the "Performance" card in the dashboard if needed.
- Tap the calendar icon from the "Performance" card and switch to a date range that doesn't have any revenue.
- You should see the new empty view with the magnifying glass.
- Switch to a range with revenue and validate that the view looks as before.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->
| No revenue | Store has revenue |
|--------|--------|
| ![Simulator Screenshot - iPhone 13 Pro - 2024-04-25 at 22 18 38](https://github.com/woocommerce/woocommerce-ios/assets/524475/00693105-63ea-45c5-b074-526eeba1776e) | ![Simulator Screenshot - iPhone 13 Pro - 2024-04-25 at 22 18 32](https://github.com/woocommerce/woocommerce-ios/assets/524475/d593ba58-e9bd-452f-a2b6-c254db98bd14) | 

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
