### PR TITLE
Dynamic Dashboard: Restore Blaze card on dashboard after creating a new campaign

### DIFF
--- a/WooCommerce/Classes/Blaze/BlazeCampaignCreationCoordinator.swift
+++ b/WooCommerce/Classes/Blaze/BlazeCampaignCreationCoordinator.swift
@@ -31,6 +31,7 @@ final class BlazeCampaignCreationCoordinator: Coordinator {
     private let productID: Int64?
     private let source: BlazeSource
     private let shouldShowIntro: Bool
+    private let stores: StoresManager
     private let storageManager: StorageManagerType
     private let featureFlagService: FeatureFlagService
     private let analytics: Analytics
@@ -46,6 +47,7 @@ final class BlazeCampaignCreationCoordinator: Coordinator {
          productID: Int64? = nil,
          source: BlazeSource,
          shouldShowIntro: Bool,
+         stores: StoresManager = ServiceLocator.stores,
          storageManager: StorageManagerType = ServiceLocator.storageManager,
          featureFlagService: FeatureFlagService = ServiceLocator.featureFlagService,
          navigationController: UINavigationController,
@@ -57,6 +59,7 @@ final class BlazeCampaignCreationCoordinator: Coordinator {
         self.productID = productID
         self.source = source
         self.shouldShowIntro = shouldShowIntro
+        self.stores = stores
         self.storageManager = storageManager
         self.featureFlagService = featureFlagService
         self.navigationController = navigationController
@@ -171,9 +174,12 @@ private extension BlazeCampaignCreationCoordinator {
                                                            productID: productID,
                                                            storage: storageManager,
                                                            onCompletion: { [weak self] in
-            self?.onCampaignCreated()
-            self?.dismissCampaignCreation {
-                self?.showSuccessView()
+            Task { @MainActor [weak self] in
+                await self?.restoreBlazeOnDashboardIfNeeded()
+                self?.onCampaignCreated()
+                self?.dismissCampaignCreation {
+                    self?.showSuccessView()
+                }
             }
         })
         let controller = BlazeCampaignCreationFormHostingController(viewModel: viewModel)
@@ -195,9 +201,12 @@ private extension BlazeCampaignCreationCoordinator {
                                              source: source,
                                              siteURL: siteURL,
                                              productID: productID) { [weak self] in
-            self?.onCampaignCreated()
-            self?.dismissCampaignCreation {
-                self?.showSuccessView()
+            Task { @MainActor [weak self] in
+                await self?.restoreBlazeOnDashboardIfNeeded()
+                self?.onCampaignCreated()
+                self?.dismissCampaignCreation {
+                    self?.showSuccessView()
+                }
             }
         }
         let webViewController = AuthenticatedWebViewController(viewModel: webViewModel)
@@ -307,6 +316,25 @@ private extension BlazeCampaignCreationCoordinator {
             sheet.prefersGrabberVisible = true
             sheet.detents = [.medium(), .large()]
         })
+    }
+
+    @MainActor
+    func restoreBlazeOnDashboardIfNeeded() async {
+        guard var cards = await loadDashboardCards(),
+              let cardIndex = cards.firstIndex(where: { $0.type == .blaze && !$0.enabled }) else {
+            return
+        }
+        cards[cardIndex] = DashboardCard(type: .blaze, enabled: true)
+        stores.dispatch(AppSettingsAction.setDashboardCards(siteID: siteID, cards: cards))
+    }
+
+    @MainActor
+    func loadDashboardCards() async -> [DashboardCard]? {
+        await withCheckedContinuation { continuation in
+            stores.dispatch(AppSettingsAction.loadDashboardCards(siteID: siteID, onCompletion: { cards in
+                continuation.resume(returning: cards)
+            }))
+        }
     }
 }
 

--- a/WooCommerce/Classes/Blaze/BlazeWebViewModel.swift
+++ b/WooCommerce/Classes/Blaze/BlazeWebViewModel.swift
@@ -86,7 +86,6 @@ extension BlazeWebViewModel: AuthenticatedWebViewModel {
         if currentStep == Constants.completionStep && !isCompleted {
             ServiceLocator.analytics.track(event: .Blaze.blazeFlowCompleted(source: source, step: currentStep))
             isCompleted = true
-            // TODO: make Blaze card appear on the dashboard again
             onCampaignCreated?()
         }
     }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Blaze/BlazeCampaignDashboardViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Blaze/BlazeCampaignDashboardViewModel.swift
@@ -169,7 +169,6 @@ final class BlazeCampaignDashboardViewModel: ObservableObject {
     }
 
     func didCreateCampaign() {
-        // TODO: restore blaze card on dashboard screen
         Task {
             await reload()
         }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/DashboardViewHostingController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/DashboardViewHostingController.swift
@@ -59,6 +59,11 @@ final class DashboardViewHostingController: UIHostingController<DashboardView> {
         }
     }
 
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+        viewModel.refreshDashboardCards()
+    }
+
     override var shouldShowOfflineBanner: Bool {
         return true
     }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/DashboardViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/DashboardViewModel.swift
@@ -304,6 +304,22 @@ final class DashboardViewModel: ObservableObject {
         }
     }
 
+    func refreshDashboardCards() {
+        storeOnboardingViewModel.$canShowInDashboard
+            .combineLatest(blazeCampaignDashboardViewModel.$canShowInDashboard, $hasOrders)
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] canShowOnboarding, canShowBlaze, hasOrders in
+                guard let self else { return }
+                Task {
+                    await self.updateDashboardCards(canShowOnboarding: canShowOnboarding,
+                                                    canShowBlaze: canShowBlaze,
+                                                    canShowAnalytics: hasOrders
+                    )
+                }
+            }
+            .store(in: &subscriptions)
+    }
+
     func didCustomizeDashboardCards(_ cards: [DashboardCard]) {
         let activeCardTypes = cards
             .filter { $0.enabled }
@@ -385,20 +401,6 @@ private extension DashboardViewModel {
         topPerformersViewModel.onDismiss = { [weak self] in
             self?.showCustomizationScreen()
         }
-
-        storeOnboardingViewModel.$canShowInDashboard
-            .combineLatest(blazeCampaignDashboardViewModel.$canShowInDashboard, $hasOrders)
-            .receive(on: DispatchQueue.main)
-            .sink { [weak self] canShowOnboarding, canShowBlaze, hasOrders in
-                guard let self else { return }
-                Task {
-                    await self.updateDashboardCards(canShowOnboarding: canShowOnboarding,
-                                                    canShowBlaze: canShowBlaze,
-                                                    canShowAnalytics: hasOrders
-                    )
-                }
-            }
-            .store(in: &subscriptions)
     }
 
     func showCustomizationScreen() {

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewController.swift
@@ -1154,7 +1154,7 @@ private extension ProductFormViewController {
             shouldShowIntro: viewModel.shouldShowBlazeIntroView,
             navigationController: navigationController,
             onCampaignCreated: {
-                // TODO: make Blaze card appear on the dashboard again
+                // no-op
             }
         )
         coordinator.start()


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #12588 
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This PR adds an update to the completion of Blaze campaign creation to enable the Blaze card on the My Store screen. My Store now updates dashboard cards upon appearing so we can always have the most updated layout.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
- Log in to a store eligible for Blaze.
- Hide the Blaze card from My Store if it's not hidden already.
- Navigate to Menu tab > Blaze > create a new campaign or navigate to Products tab > select any published product to promote.
- Complete the campaign creation steps. 
- After the creation succeeds, navigate to My Store tab.
- Confirm that the Blaze card is now displayed.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

https://github.com/woocommerce/woocommerce-ios/assets/5533851/af3b6392-0881-42d4-95f6-a4e9018bef5a



---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
