### PR TITLE
Remove legacy feature flags of the onboarding flow

### DIFF
--- a/Experiments/Experiments/DefaultFeatureFlagService.swift
+++ b/Experiments/Experiments/DefaultFeatureFlagService.swift
@@ -40,8 +40,6 @@ public struct DefaultFeatureFlagService: FeatureFlagService {
             return true
         case .jetpackSetupWithApplicationPassword:
             return true
-        case .dashboardOnboarding:
-            return true
         case .productBundles:
             return true
         case .manualErrorHandlingForSiteCredentialLogin:

--- a/Experiments/Experiments/DefaultFeatureFlagService.swift
+++ b/Experiments/Experiments/DefaultFeatureFlagService.swift
@@ -54,8 +54,6 @@ public struct DefaultFeatureFlagService: FeatureFlagService {
             return !isUITesting
         case .readOnlyGiftCards:
             return true
-        case .hideStoreOnboardingTaskList:
-            return true
         case .readOnlyMinMaxQuantities:
             return true
         case .euShippingNotification:

--- a/Experiments/Experiments/FeatureFlag.swift
+++ b/Experiments/Experiments/FeatureFlag.swift
@@ -92,10 +92,6 @@ public enum FeatureFlag: Int {
     ///
     case jetpackSetupWithApplicationPassword
 
-    /// Whether to enable the onboarding checklist in the dashboard for WPCOM stores.
-    ///
-    case dashboardOnboarding
-
     /// Enables the ability to add products to orders by SKU scanning
     ///
     case addProductToOrderViaSKUScanner

--- a/Experiments/Experiments/FeatureFlag.swift
+++ b/Experiments/Experiments/FeatureFlag.swift
@@ -124,10 +124,6 @@ public enum FeatureFlag: Int {
     ///
     case readOnlyGiftCards
 
-    /// Ability to hide store onboarding task list
-    ///
-    case hideStoreOnboardingTaskList
-
     /// Enables read-only support for the Min/Max Quantities extension
     ///
     case readOnlyMinMaxQuantities

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Onboarding/StoreOnboardingViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Onboarding/StoreOnboardingViewModel.swift
@@ -50,14 +50,11 @@ class StoreOnboardingViewModel: ObservableObject {
         !isExpanded && !isRedacted && (taskViewModels.count > tasksForDisplay.count)
     }
 
-    let isHideStoreOnboardingTaskListFeatureEnabled: Bool
-
     let isExpanded: Bool
 
     private let siteID: Int64
 
     private let stores: StoresManager
-    private let featureFlagService: FeatureFlagService
 
     private var state: State
 
@@ -87,7 +84,6 @@ class StoreOnboardingViewModel: ObservableObject {
          stores: StoresManager = ServiceLocator.stores,
          defaults: UserDefaults = .standard,
          analytics: Analytics = ServiceLocator.analytics,
-         featureFlagService: FeatureFlagService = ServiceLocator.featureFlagService,
          waitingTimeTracker: AppStartupWaitingTimeTracker = ServiceLocator.startupWaitingTimeTracker) {
         self.siteID = siteID
         self.isExpanded = isExpanded
@@ -95,8 +91,6 @@ class StoreOnboardingViewModel: ObservableObject {
         self.state = .loading
         self.defaults = defaults
         self.analytics = analytics
-        self.featureFlagService = featureFlagService
-        isHideStoreOnboardingTaskListFeatureEnabled = featureFlagService.isFeatureFlagEnabled(.hideStoreOnboardingTaskList)
         self.waitingTimeTracker = waitingTimeTracker
 
         $noTasksAvailableForDisplay

--- a/WooCommerce/WooCommerceTests/Mocks/MockFeatureFlagService.swift
+++ b/WooCommerce/WooCommerceTests/Mocks/MockFeatureFlagService.swift
@@ -7,7 +7,6 @@ struct MockFeatureFlagService: FeatureFlagService {
     private let shippingLabelsOnboardingM1: Bool
     private let isDomainSettingsEnabled: Bool
     private let isSupportRequestEnabled: Bool
-    private let isDashboardStoreOnboardingEnabled: Bool
     private let jetpackSetupWithApplicationPassword: Bool
     private let isProductDescriptionAIEnabled: Bool
     private let isProductDescriptionAIFromStoreOnboardingEnabled: Bool
@@ -30,7 +29,6 @@ struct MockFeatureFlagService: FeatureFlagService {
          shippingLabelsOnboardingM1: Bool = false,
          isDomainSettingsEnabled: Bool = false,
          isSupportRequestEnabled: Bool = false,
-         isDashboardStoreOnboardingEnabled: Bool = false,
          jetpackSetupWithApplicationPassword: Bool = false,
          isProductDescriptionAIEnabled: Bool = false,
          isProductDescriptionAIFromStoreOnboardingEnabled: Bool = false,
@@ -52,7 +50,6 @@ struct MockFeatureFlagService: FeatureFlagService {
         self.shippingLabelsOnboardingM1 = shippingLabelsOnboardingM1
         self.isDomainSettingsEnabled = isDomainSettingsEnabled
         self.isSupportRequestEnabled = isSupportRequestEnabled
-        self.isDashboardStoreOnboardingEnabled = isDashboardStoreOnboardingEnabled
         self.jetpackSetupWithApplicationPassword = jetpackSetupWithApplicationPassword
         self.isProductDescriptionAIEnabled = isProductDescriptionAIEnabled
         self.isProductDescriptionAIFromStoreOnboardingEnabled = isProductDescriptionAIFromStoreOnboardingEnabled
@@ -83,8 +80,6 @@ struct MockFeatureFlagService: FeatureFlagService {
             return isDomainSettingsEnabled
         case .supportRequests:
             return isSupportRequestEnabled
-        case .dashboardOnboarding:
-            return isDashboardStoreOnboardingEnabled
         case .jetpackSetupWithApplicationPassword:
             return jetpackSetupWithApplicationPassword
         case .productDescriptionAI:

--- a/WooCommerce/WooCommerceTests/Mocks/MockFeatureFlagService.swift
+++ b/WooCommerce/WooCommerceTests/Mocks/MockFeatureFlagService.swift
@@ -12,7 +12,6 @@ struct MockFeatureFlagService: FeatureFlagService {
     private let isProductDescriptionAIEnabled: Bool
     private let isProductDescriptionAIFromStoreOnboardingEnabled: Bool
     private let isReadOnlyGiftCardsEnabled: Bool
-    private let isHideStoreOnboardingTaskListFeatureEnabled: Bool
     private let isBlazeEnabled: Bool
     private let isShareProductAIEnabled: Bool
     private let betterCustomerSelectionInOrder: Bool
@@ -36,7 +35,6 @@ struct MockFeatureFlagService: FeatureFlagService {
          isProductDescriptionAIEnabled: Bool = false,
          isProductDescriptionAIFromStoreOnboardingEnabled: Bool = false,
          isReadOnlyGiftCardsEnabled: Bool = false,
-         isHideStoreOnboardingTaskListFeatureEnabled: Bool = false,
          isBlazeEnabled: Bool = false,
          isShareProductAIEnabled: Bool = false,
          betterCustomerSelectionInOrder: Bool = false,
@@ -59,7 +57,6 @@ struct MockFeatureFlagService: FeatureFlagService {
         self.isProductDescriptionAIEnabled = isProductDescriptionAIEnabled
         self.isProductDescriptionAIFromStoreOnboardingEnabled = isProductDescriptionAIFromStoreOnboardingEnabled
         self.isReadOnlyGiftCardsEnabled = isReadOnlyGiftCardsEnabled
-        self.isHideStoreOnboardingTaskListFeatureEnabled = isHideStoreOnboardingTaskListFeatureEnabled
         self.isBlazeEnabled = isBlazeEnabled
         self.isShareProductAIEnabled = isShareProductAIEnabled
         self.betterCustomerSelectionInOrder = betterCustomerSelectionInOrder
@@ -96,8 +93,6 @@ struct MockFeatureFlagService: FeatureFlagService {
             return isProductDescriptionAIFromStoreOnboardingEnabled
         case .readOnlyGiftCards:
             return isReadOnlyGiftCardsEnabled
-        case .hideStoreOnboardingTaskList:
-            return isHideStoreOnboardingTaskListFeatureEnabled
         case .shareProductAI:
             return isShareProductAIEnabled
         case .betterCustomerSelectionInOrder:

--- a/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/DashboardViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/DashboardViewModelTests.swift
@@ -292,47 +292,6 @@ final class DashboardViewModelTests: XCTestCase {
         XCTAssertNotNil(viewModel.localAnnouncementViewModel)
     }
 
-    // MARK: Store onboarding
-
-    func test_showOnboarding_is_false_when_feature_flag_is_turned_off_and_completedAllStoreOnboardingTasks_is_false() async throws {
-        // Given
-        let uuid = UUID().uuidString
-        let defaults = try XCTUnwrap(UserDefaults(suiteName: uuid))
-        defaults[.completedAllStoreOnboardingTasks] = false
-        let viewModel = DashboardViewModel(siteID: 0,
-                                           stores: stores,
-                                           featureFlags: MockFeatureFlagService(isDashboardStoreOnboardingEnabled: false),
-                                           userDefaults: defaults)
-        // Then
-        XCTAssertFalse(viewModel.showOnboarding)
-    }
-
-    func test_showOnboarding_is_false_when_feature_flag_is_turned_off_and_completedAllStoreOnboardingTasks_is_true() async throws {
-        // Given
-        let uuid = UUID().uuidString
-        let defaults = try XCTUnwrap(UserDefaults(suiteName: uuid))
-        defaults[.completedAllStoreOnboardingTasks] = true
-        let viewModel = DashboardViewModel(siteID: 0,
-                                           stores: stores,
-                                           featureFlags: MockFeatureFlagService(isDashboardStoreOnboardingEnabled: false),
-                                           userDefaults: defaults)
-        // Then
-        XCTAssertFalse(viewModel.showOnboarding)
-    }
-
-    func test_showOnboarding_is_false_when_feature_flag_is_turned_on_and_completedAllStoreOnboardingTasks_is_true() async throws {
-        // Given
-        let uuid = UUID().uuidString
-        let defaults = try XCTUnwrap(UserDefaults(suiteName: uuid))
-        defaults[.completedAllStoreOnboardingTasks] = true
-        let viewModel = DashboardViewModel(siteID: 0,
-                                           stores: stores,
-                                           featureFlags: MockFeatureFlagService(isDashboardStoreOnboardingEnabled: true),
-                                           userDefaults: defaults)
-        // Then
-        XCTAssertFalse(viewModel.showOnboarding)
-    }
-
     func test_siteURLToShare_return_nil_if_site_is_not_public() {
         // Given
         let sessionManager = SessionManager.makeForTesting()

--- a/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Onboarding/StoreOnboardingViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Onboarding/StoreOnboardingViewModelTests.swift
@@ -517,35 +517,6 @@ final class StoreOnboardingViewModelTests: XCTestCase {
         XCTAssertTrue(sut.tasksForDisplay.count == 5)
     }
 
-    @MainActor
-    func test_the_badge_text_is_nil_for_all_tasks_when_productDescriptionAIFromStoreOnboarding_feature_is_disabled() async {
-        // Given
-        stores.updateDefaultStore(storeID: 6)
-        stores.updateDefaultStore(.fake().copy(siteID: 6, isWordPressComStore: true))
-        let sut = StoreOnboardingViewModel(siteID: 0,
-                                           isExpanded: true,
-                                           stores: stores,
-                                           defaults: defaults,
-                                           featureFlagService: MockFeatureFlagService(isProductDescriptionAIFromStoreOnboardingEnabled: false))
-        let tasks: [StoreOnboardingTask] = [
-            .init(isComplete: false, type: .addFirstProduct),
-            .init(isComplete: false, type: .storeDetails),
-            .init(isComplete: false, type: .launchStore),
-            .init(isComplete: true, type: .customizeDomains),
-            .init(isComplete: false, type: .payments)
-        ]
-        mockLoadOnboardingTasks(result: .success(tasks))
-
-        // When
-        await sut.reloadTasks()
-
-        // Then
-        XCTAssertEqual(sut.tasksForDisplay.count, 5)
-        sut.tasksForDisplay.forEach { taskViewModel in
-            XCTAssertNil(taskViewModel.badgeText)
-        }
-    }
-
     // MARK: completedAllStoreOnboardingTasks user defaults
 
     func test_completedAllStoreOnboardingTasks_is_nil_when_there_are_pending_tasks() async {


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #12596 
Also closes: #12597 
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This PR removes the two legacy feature flags of the onboarding flow: `dashboardOnboarding` and `hideStoreOnboardingTaskList` since onboarding has become a permanent feature on the dashboard screen and it can be hidden as part of the dynamic dashboard project.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
All the implementation logic using the feature flags have already been removed, so just CI passing is sufficient. You can optionally smoke test the dynamic dashboard features if needed.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->
N/A

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
