### PR TITLE
Update privacy banner layout, push buttons to the bottom

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Privacy/PrivacyBannerViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Privacy/PrivacyBannerViewController.swift
@@ -29,8 +29,11 @@ final class PrivacyBannerViewController: UIHostingController<PrivacyBanner> {
         // Make the banner scrollable when the banner height is bigger than the screen height.
         // Send it in the next run loop to avoid a recursive `viewDidLayoutSubviews`.
         bannerIntrinsicHeight = view.intrinsicContentSize.height
-        DispatchQueue.main.async {
-            self.rootView.shouldScroll = self.bannerIntrinsicHeight > self.view.frame.height
+        let shouldScroll = self.bannerIntrinsicHeight > self.view.frame.height
+        if self.rootView.shouldScroll != shouldScroll {
+            DispatchQueue.main.async {
+                self.rootView.shouldScroll = shouldScroll
+            }
         }
     }
 }
@@ -90,6 +93,11 @@ struct PrivacyBanner: View {
                 .subheadlineStyle()
                 .padding(.trailing, Layout.toggleDescriptionMargin)
 
+            /// Push buttons to the bottom
+            ///
+            if UIDevice.isPad() {
+                Spacer()
+            }
             HStack {
                 Button(Localization.goToSettings) {
                     Task {
@@ -107,10 +115,11 @@ struct PrivacyBanner: View {
                 .buttonStyle(PrimaryLoadingButtonStyle(isLoading: viewModel.isLoading))
             }
             .padding(.top)
-
             /// Push all content to the top
             ///
-            Spacer()
+            if !UIDevice.isPad() {
+                Spacer()
+            }
         }
         .padding()
         .disabled(!viewModel.isViewEnabled)


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #12603
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

- pushing buttons to the bottom if we are on iPad, otherwise pushing them to top

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

- Get Privacy banner to show
- If it does not show when you open the app you can force it by going to `PrivacyBannerPresentationUseCase.swift` and in `shouldShowPrivacyBanner` just immediately return `true`

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

| Before      | After |
| ----------- | ----------- |
| ![Simulator Screenshot - iPad Pro (11-inch) (4th generation) - 2024-04-29 at 13 07 30](https://github.com/woocommerce/woocommerce-ios/assets/6242034/8ac6257d-6e8e-4fd9-ba19-bde230fe62e9)      | ![Simulator Screenshot - iPad Pro (11-inch) (4th generation) - 2024-04-29 at 13 19 00](https://github.com/woocommerce/woocommerce-ios/assets/6242034/c69536bb-e9ad-4a52-b6c1-c971b9bb5af9)       |

---

- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
