### PR TITLE
[Migrate simple payments] Payments > About TTP: update copy & align text

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/AboutTapToPayView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/AboutTapToPayView.swift
@@ -109,7 +109,7 @@ private extension AboutTapToPayView {
             "describes the steps required to take a payment.")
 
         static let howItWorksStep1 = NSLocalizedString(
-            "1. Create an order or collect a payment",
+            "1. Create an order",
             comment: "Step 1 of the 'How it works' list, instructing the merchant to prepare an order for payment")
 
         static let howItWorksStep2 = NSLocalizedString(

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/AboutTapToPayView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/AboutTapToPayView.swift
@@ -10,7 +10,7 @@ struct AboutTapToPayView: View {
     var body: some View {
         VStack(spacing: 0) {
             ScrollView(.vertical) {
-                VStack {
+                VStack(alignment: .leading) {
                     VStack(alignment: .leading, spacing: Layout.spacing) {
                         Text(Localization.aboutTapToPayHeading)
                             .font(.title2.bold())


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #12608
<!-- Id number of the GitHub issue this PR addresses. -->

## Why

As Andrei suggested in p1714383172408719-slack-C06C3CZFHGD, we'd like to update the existing About Tap To Pay screen so that:

- The first point just mentions "Create an order"
- Align the main text and the footer

## How

After a bit of debugging, the misalignment came from not setting the VStack's alignment to `leading`.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

Hand testing is optional, as it requires a certain device and we can verify in SwiftUI Previews

Prerequisite: the physical device is eligible for Tap To Pay - iPhone XS or later

- Log in to a store eligible for IPP
- Go to the Menu tab > Payments
- Tap `About Tap To Pay` --> the first point should say "Create an order", and the footer requirement text should align on the leading edge with the rest of the content

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

before | after
-- | --
<img width="322" alt="Screenshot 2024-04-30 at 10 24 46 AM" src="https://github.com/woocommerce/woocommerce-ios/assets/1945542/e26860a4-7d69-419e-a07f-a80dcb17004d"> | <img width="324" alt="Screenshot 2024-04-30 at 10 25 02 AM" src="https://github.com/woocommerce/woocommerce-ios/assets/1945542/cf27d52a-4b7d-4f56-bd9b-953833656871">


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.