### PR TITLE
Avoid changing dashboard cards multiple times

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Dashboard/DashboardViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/DashboardViewModel.swift
@@ -414,7 +414,7 @@ private extension DashboardViewModel {
     func updateDashboardCards(canShowOnboarding: Bool,
                               canShowBlaze: Bool,
                               canShowAnalytics: Bool) async {
-        dashboardCards = await {
+        var dashboardCards = await {
             if var stored = await loadDashboardCards() {
                 let analyticCardTypes: [DashboardCard.CardType] = [.performance, .topPerformers]
                 stored = canShowAnalytics ? stored : stored.filter { !analyticCardTypes.contains($0.type) }
@@ -438,15 +438,21 @@ private extension DashboardViewModel {
             dashboardCards.removeAll { $0.type == .blaze }
         }
 
+        self.dashboardCards = dashboardCards
+
         // Set cards to show "Unavailable" state in Customize screen when should not be shown.
         // Currently this applies to Top Performers and Performance cards.
         // For the other cards, when they should not be shown, they are simply not shown in Customize.
-        unavailableDashboardCards = []
-        if !canShowAnalytics {
-            unavailableDashboardCards.append(DashboardCard(type: .performance, enabled: false))
-            unavailableDashboardCards.append(DashboardCard(type: .topPerformers, enabled: false))
-        }
+        unavailableDashboardCards = {
+            if !canShowAnalytics {
+                [DashboardCard(type: .performance, enabled: false),
+                 DashboardCard(type: .topPerformers, enabled: false)]
+            } else {
+                []
+            }
+        }()
     }
+
     @MainActor
     func updateHasOrdersStatus() async {
         do {


### PR DESCRIPTION

<!-- Remember about a good descriptive title. -->

Closes: #12610 
<!-- Id number of the GitHub issue this PR addresses. -->

## Description


I suspect that it could be related to [this code](https://github.com/woocommerce/woocommerce-ios/blob/trunk/WooCommerce/Classes/ViewRelated/Dashboard/DashboardViewModel.swift#L431-L439). Let me know your thoughts.

My hypothesis,

*Reason for crash*
* We set up the `dashboardCards` value from an `await` call.
* The view will try to render itself once the `dashboardCards` value is set.
* Right after the `dashboardCards` value is set, we try to remove values from `dashboardCards` array. This removal for some reason happens when the view is going through `dashboardCards` in a for loop to render itself. (Note that the method `updateDashboardCards` is actually async.)

*Possible solution*
What if we refactor the code to write to `dashboardCards` and `unavailableDashboardCards` only once from the `updateDashboardCards` method? We can push this onto a branch and ask Paolo to reproduce the crash.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->


---
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
