### PR TITLE
Fix: Inconsistent Padding Issues in `DashboardCardErrorView` Across Multiple Views

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Dashboard/Blaze/BlazeCampaignDashboardView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Blaze/BlazeCampaignDashboardView.swift
@@ -108,7 +108,7 @@ struct BlazeCampaignDashboardView: View {
                         await viewModel.reload()
                     }
                 })
-                .padding(Layout.padding)
+                .padding(.horizontal, Layout.padding)
             case .loading:
                 EmptyView()
             }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Onboarding/StoreOnboardingView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Onboarding/StoreOnboardingView.swift
@@ -149,7 +149,7 @@ struct StoreOnboardingView: View {
                             await viewModel.reloadTasks()
                         }
                     })
-                    .padding(Layout.padding)
+                    .padding(.horizontal, Layout.padding)
                 } else {
                     // Task list
                     VStack(alignment: .leading, spacing: 0) {

--- a/WooCommerce/Classes/ViewRelated/Dashboard/StoreStats/StorePerformanceView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/StoreStats/StorePerformanceView.swift
@@ -35,7 +35,7 @@ struct StorePerformanceView: View {
 
             if viewModel.loadingError != nil {
                 errorStateView
-                    .padding(.leading, Layout.padding)
+                    .padding(.horizontal, Layout.padding)
             } else if viewModel.statsVersion == .v4 {
                 timeRangeBar
                     .padding(.horizontal, Layout.padding)

--- a/WooCommerce/Classes/ViewRelated/Dashboard/TopPerformers/TopPerformersDashboardView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/TopPerformers/TopPerformersDashboardView.swift
@@ -30,7 +30,7 @@ struct TopPerformersDashboardView: View {
                         await viewModel.reloadData()
                     }
                 })
-                .padding(.leading, Layout.padding)
+                .padding(.horizontal, Layout.padding)
             } else {
                 timeRangeBar
                     .padding(.horizontal, Layout.padding)


### PR DESCRIPTION
## Description

This PR resolves an issue where `DashboardCardErrorView` was displaying inconsistent padding across different views when tested under specific network conditions. The problem was particularly noticeable when the "Network Link Conditioner" was enabled with the "100% Loss" profile, simulating a complete network loss scenario. In some views, there was an absence of padding, while in others, padding was only present on the leading side. This inconsistency affected the following views of the Dashboard:

- `StoreOnboardingView`
- `StorePerformanceView`
- `TopPerformersDashboardView`
- `BlazeCampaignDashboardView`

## Steps to Reproduce

1. Enable "Network Link Conditioner" on your testing device or simulator.
2. Set the profile to "100% Loss" to simulate a complete network disconnect.
3. Navigate to the views mentioned above and observe the padding inconsistency in the cards of the Dashboard.

## Screenshots
| Before             |  After |
:-------------------------:|:-------------------------:
![Simulator Screenshot - iPhone 15 Pro - 2024-04-30 at 11 06 00](https://github.com/woocommerce/woocommerce-ios/assets/495617/f1b10ee9-69b2-4c0d-b971-148a28c956d1) | ![Simulator Screenshot - iPhone 15 Pro - 2024-04-30 at 12 03 01](https://github.com/woocommerce/woocommerce-ios/assets/495617/69c9f74c-cb57-42e9-b0ff-a8f7e529cac5)
