### PR TITLE
[Dashboard] Remove `WaitingTimeTracker` to avoid crash

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Dashboard/DashboardViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/DashboardViewModel.swift
@@ -159,7 +159,6 @@ final class DashboardViewModel: ObservableObject {
                    latestDateToInclude: Date,
                    forceRefresh: Bool,
                    onCompletion: ((Result<Void, Error>) -> Void)? = nil) {
-        let waitingTracker = WaitingTimeTracker(trackScenario: .dashboardMainStats)
         let earliestDateToInclude = timeRange.earliestDate(latestDate: latestDateToInclude, siteTimezone: siteTimezone)
         let action = StatsActionV4.retrieveStats(siteID: siteID,
                                                  timeRange: timeRange,
@@ -172,7 +171,6 @@ final class DashboardViewModel: ObservableObject {
             guard let self = self else { return }
             switch result {
             case .success:
-                waitingTracker.end()
                 self.statsVersion = .v4
             case .failure(let error):
                 DDLogError("⛔️ Dashboard (Order Stats) — Error synchronizing order stats v4: \(error)")
@@ -245,7 +243,6 @@ final class DashboardViewModel: ObservableObject {
                              latestDateToInclude: Date,
                              forceRefresh: Bool,
                              onCompletion: ((Result<Void, Error>) -> Void)? = nil) {
-        let waitingTracker = WaitingTimeTracker(trackScenario: .dashboardTopPerformers)
         let earliestDateToInclude = timeRange.earliestDate(latestDate: latestDateToInclude, siteTimezone: siteTimezone)
         let action = StatsActionV4.retrieveTopEarnerStats(siteID: siteID,
                                                           timeRange: timeRange,
@@ -258,7 +255,6 @@ final class DashboardViewModel: ObservableObject {
                                                           onCompletion: { result in
             switch result {
             case .success:
-                waitingTracker.end()
                 ServiceLocator.analytics.track(event:
                         .Dashboard.dashboardTopPerformersLoaded(timeRange: timeRange))
             case .failure(let error):

--- a/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/StoreStats/StoreStatsChartViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/StoreStats/StoreStatsChartViewModelTests.swift
@@ -45,15 +45,16 @@ final class StoreStatsChartViewModelTests: XCTestCase {
 
     func test_xAxisStride_returns_correct_values_for_different_time_ranges() {
         // Given
+        let date = Date(timeIntervalSince1970: 1713571200) // April 20 2024
         let timeRangesWithXAxisStride: [StatsTimeRangeV4: Calendar.Component] = [
             .today: .hour,
             .thisWeek: .day,
             .thisMonth: .day,
             .thisYear: .month,
-            .custom(from: Date(), to: Date().adding(days: 0)!): .hour,
-            .custom(from: Date(), to: Date().adding(days: 2)!): .day,
-            .custom(from: Date(), to: Date().adding(days: 100)!): .month,
-            .custom(from: Date(), to: Date().adding(days: 1460)!): .year // 4 years
+            .custom(from: date, to: date.adding(days: 0)!): .hour,
+            .custom(from: date, to: date.adding(days: 2)!): .day,
+            .custom(from: date, to: date.adding(days: 100)!): .month,
+            .custom(from: date, to: date.adding(days: 1460)!): .year // 4 years
         ]
 
         for timeRange in timeRangesWithXAxisStride.keys {
@@ -67,12 +68,13 @@ final class StoreStatsChartViewModelTests: XCTestCase {
 
     func test_xAxisStrideCount_returns_correct_values_for_different_time_ranges() {
         // Given
+        let date = Date(timeIntervalSince1970: 1713571200) // April 20 2024
         let timeRangesWithXAxisStrideCount: [StatsTimeRangeV4: Int] = [
             .today: 5,
             .thisWeek: 1,
             .thisMonth: 5,
             .thisYear: 3,
-            .custom(from: Date(), to: Date().adding(days: 0)!): 6,
+            .custom(from: date, to: date.adding(days: 0)!): 6,
         ]
 
         for timeRange in timeRangesWithXAxisStrideCount.keys {
@@ -86,15 +88,16 @@ final class StoreStatsChartViewModelTests: XCTestCase {
 
     func test_xAxisLabelFormatStyle_returns_correct_values_for_non_first_dates_in_different_time_ranges() {
         // Given
+        let date = Date(timeIntervalSince1970: 1713571200) // April 20 2024
         let timeRangesWithXAxisLabelFormatStyle: [StatsTimeRangeV4: Date.FormatStyle] = [
             .today: .dateTime.hour(),
             .thisWeek: .dateTime.day(.defaultDigits),
             .thisMonth: .dateTime.day(.defaultDigits),
             .thisYear: .dateTime.month(.abbreviated),
-            .custom(from: Date(), to: Date().adding(days: 0)!): .dateTime.hour(),
-            .custom(from: Date(), to: Date().adding(days: 2)!): .dateTime.day(.defaultDigits),
-            .custom(from: Date(), to: Date().adding(days: 100)!): .dateTime.month(.abbreviated),
-            .custom(from: Date(), to: Date().adding(days: 1460)!): .dateTime.year() // 4 years
+            .custom(from: date, to: date.adding(days: 0)!): .dateTime.hour(),
+            .custom(from: date, to: date.adding(days: 2)!): .dateTime.day(.defaultDigits),
+            .custom(from: date, to: date.adding(days: 100)!): .dateTime.month(.abbreviated),
+            .custom(from: date, to: date.adding(days: 1460)!): .dateTime.year() // 4 years
         ]
 
         for timeRange in timeRangesWithXAxisLabelFormatStyle.keys {


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #12610 
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

Remove `WaitingTimeTracker` usage from `DashboardViewModel` to avoid a thread related crash. 

This `WaitingTimeTracker` usage from `DashboardViewModel` will be removed as part of this PR https://github.com/woocommerce/woocommerce-ios/pull/12602. But to avoid bringing that large PR as a beta fix I am raising this PR which only removes `WaitingTimeTracker` usage from `DashboardViewModel`. 


Internal - p1714405823152069-slack-C03L1NF1EA3

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

Smoke test that the Dashboard or My Store screen works as expected. 

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->
NA

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.