### PR TITLE
WooCommerce Version Cell Misalignment with Adjacent Cells

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Settings/SettingsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Settings/SettingsViewController.swift
@@ -140,7 +140,7 @@ private extension SettingsViewController {
             configureSwitchStore(cell: cell)
         case let cell as BasicTableViewCell where row == .plugins:
             configurePlugins(cell: cell)
-        case let cell as HostingTableViewCell<PluginDetailsRowView> where row == .woocommerceDetails:
+        case let cell as HostingTableViewCell<PluginDetailsRowContent> where row == .woocommerceDetails:
             configureWooCommmerceDetails(cell: cell)
         case let cell as BasicTableViewCell where row == .domain:
             configureDomain(cell: cell)
@@ -191,10 +191,12 @@ private extension SettingsViewController {
         cell.textLabel?.text = Localization.plugins
     }
 
-    func configureWooCommmerceDetails(cell: HostingTableViewCell<PluginDetailsRowView>) {
-        let view = PluginDetailsRowView.init(viewModel: woocommercePluginViewModel)
+    func configureWooCommmerceDetails(cell: HostingTableViewCell<PluginDetailsRowContent>) {
+        let view = PluginDetailsRowContent.init(viewModel: woocommercePluginViewModel)
         cell.host(view, parent: self)
-        cell.selectionStyle = .none
+        let hasUpdates = woocommercePluginViewModel.updateURL != nil
+        cell.accessoryType = hasUpdates ? .disclosureIndicator : .none
+        cell.selectionStyle = hasUpdates ? .default : .none
     }
 
     func configureSupport(cell: BasicTableViewCell) {
@@ -433,6 +435,16 @@ private extension SettingsViewController {
         present(controller, animated: true)
     }
 
+    func openWoocommerceDetails() {
+        guard let url = woocommercePluginViewModel.updateURL else {
+            return
+        }
+        let vc = SFSafariViewController(url: url)
+        vc.modalPresentationStyle = .formSheet
+
+        present(vc, animated: true)
+    }
+
     func privacyWasPressed() {
         ServiceLocator.analytics.track(.settingsPrivacySettingsTapped)
         guard let viewController = UIStoryboard.dashboard.instantiateViewController(ofClass: PrivacySettingsViewController.self) else {
@@ -611,6 +623,8 @@ extension SettingsViewController: UITableViewDelegate {
             switchStoreWasPressed()
         case .plugins:
             sitePluginsWasPressed()
+        case .woocommerceDetails:
+            openWoocommerceDetails()
         case .support:
             supportWasPressed()
         case .domain:
@@ -739,7 +753,7 @@ extension SettingsViewController {
             case .plugins:
                 return BasicTableViewCell.self
             case .woocommerceDetails:
-                return HostingTableViewCell<PluginDetailsRowView>.self
+                return HostingTableViewCell<PluginDetailsRowContent>.self
             case .support:
                 return BasicTableViewCell.self
             case .domain:

--- a/WooCommerce/Classes/ViewRelated/ReusableViews/HostingTableViewCell.swift
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/HostingTableViewCell.swift
@@ -28,9 +28,26 @@ class HostingTableViewCell<Content: View>: UITableViewCell {
         parent.addChild(swiftUICellViewController)
         contentView.addSubview(swiftUICellView)
         swiftUICellView.translatesAutoresizingMaskIntoConstraints = false
-        contentView.pinSubviewToAllEdges(swiftUICellView)
+        contentView.pinSubviewToAllEdgeMargins(swiftUICellView)
 
         swiftUICellViewController.didMove(toParent: parent)
         swiftUICellView.layoutIfNeeded()
+    }
+
+    override func awakeFromNib() {
+        super.awakeFromNib()
+
+        configureBackground()
+    }
+
+    override func updateConfiguration(using state: UICellConfigurationState) {
+        super.updateConfiguration(using: state)
+        updateDefaultBackgroundConfiguration(using: state)
+    }
+}
+
+private extension HostingTableViewCell {
+    func configureBackground() {
+        configureDefaultBackgroundConfiguration()
     }
 }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #12515
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

- Use **PluginDetailsRowContent** instead of **PluginDetailsRowView** to have cleaner margins and proper detail indicator

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

- test with a store that does not have and does have WooCommerce update
- open Menu
- tap Settings
- check that WooCommerce cell is properly aligned and has info about current version and if there is an update available

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

| Before      | After |
| ----------- | ----------- |
| ![Simulator Screenshot - iPhone 15 Pro - 2024-04-30 at 16 05 17](https://github.com/woocommerce/woocommerce-ios/assets/6242034/41192d2b-f546-4c42-9b35-f89ea0f66451)      | ![Simulator Screenshot - iPhone 15 Pro - 2024-04-30 at 16 02 20](https://github.com/woocommerce/woocommerce-ios/assets/6242034/e3bc46e2-0b55-475f-80b7-26cd4c433a38)  |
| ![Simulator Screenshot - iPhone 15 Pro - 2024-04-30 at 16 04 28](https://github.com/woocommerce/woocommerce-ios/assets/6242034/012ad187-89d2-4fcb-b9fd-f400b45e5f53)   | ![Simulator Screenshot - iPhone 15 Pro - 2024-04-30 at 16 02 54](https://github.com/woocommerce/woocommerce-ios/assets/6242034/fb47714a-f93f-4ee0-8f63-242868849748) |

---
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
