### PR TITLE
[Shipping Lines] Update styles on Shipping screen in order form

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/CustomAmounts/FormattableAmountTextFieldViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/CustomAmounts/FormattableAmountTextFieldViewModel.swift
@@ -46,7 +46,7 @@ final class FormattableAmountTextFieldViewModel: ObservableObject {
     /// Defines the amount text color.
     ///
     var amountTextColor: UIColor {
-        amount.isEmpty ? .textSubtle : .text
+        amount.isEmpty ? .textPlaceholder : .text
     }
 
     /// Defines the amount text size.

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/CustomAmounts/FormattableAmountTextFieldViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/CustomAmounts/FormattableAmountTextFieldViewModel.swift
@@ -34,7 +34,7 @@ final class FormattableAmountTextFieldViewModel: ObservableObject {
             return false
         }
 
-        return amountDecimal > .zero
+        return allowNegativeNumber ? true : amountDecimal > .zero
     }
 
     /// Formatted amount to display. When empty displays a placeholder value.
@@ -51,13 +51,19 @@ final class FormattableAmountTextFieldViewModel: ObservableObject {
 
     /// Defines the amount text size.
     ///
-    var amountTextSize: AmountTextSize
+    let amountTextSize: AmountTextSize
+
+    /// Whether the amount is allowed to be negative.
+    ///
+    let allowNegativeNumber: Bool
 
     init(size: AmountTextSize = .extraLarge,
          locale: Locale = Locale.autoupdatingCurrent,
-         storeCurrencySettings: CurrencySettings = ServiceLocator.currencySettings) {
-        self.priceFieldFormatter = .init(locale: locale, storeCurrencySettings: storeCurrencySettings)
+         storeCurrencySettings: CurrencySettings = ServiceLocator.currencySettings,
+         allowNegativeNumber: Bool = false) {
+        self.priceFieldFormatter = .init(locale: locale, storeCurrencySettings: storeCurrencySettings, allowNegativeNumber: allowNegativeNumber)
         amountTextSize = size
+        self.allowNegativeNumber = allowNegativeNumber
     }
 
     func reset() {

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/CustomAmounts/FormattableAmountTextFieldViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/CustomAmounts/FormattableAmountTextFieldViewModel.swift
@@ -49,9 +49,15 @@ final class FormattableAmountTextFieldViewModel: ObservableObject {
         amount.isEmpty ? .textSubtle : .text
     }
 
-    init(locale: Locale = Locale.autoupdatingCurrent,
-        storeCurrencySettings: CurrencySettings = ServiceLocator.currencySettings) {
+    /// Defines the amount text size.
+    ///
+    var amountTextSize: AmountTextSize
+
+    init(size: AmountTextSize = .extraLarge,
+         locale: Locale = Locale.autoupdatingCurrent,
+         storeCurrencySettings: CurrencySettings = ServiceLocator.currencySettings) {
         self.priceFieldFormatter = .init(locale: locale, storeCurrencySettings: storeCurrencySettings)
+        amountTextSize = size
     }
 
     func reset() {
@@ -62,5 +68,21 @@ final class FormattableAmountTextFieldViewModel: ObservableObject {
         resetAmountWithNewValue = false
         amount = newAmount
         resetAmountWithNewValue = true
+    }
+}
+
+extension FormattableAmountTextFieldViewModel {
+    enum AmountTextSize {
+        case title2
+        case extraLarge
+
+        var fontSize: CGFloat {
+            switch self {
+            case .title2:
+                return UIFont.title2.pointSize
+            case .extraLarge:
+                return 56
+            }
+        }
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/EditableOrderViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/EditableOrderViewModel.swift
@@ -1108,6 +1108,13 @@ extension EditableOrderViewModel {
         let showNonEditableIndicators: Bool
 
         let shippingLineViewModel: ShippingLineDetailsViewModel
+        let saveShippingLineClosure: (ShippingLine?) -> Void
+        var shippingLineSelectionViewModel: ShippingLineSelectionDetailsViewModel {
+            ShippingLineSelectionDetailsViewModel(isExistingShippingLine: shouldShowShippingTotal,
+                                                  initialMethodTitle: shippingMethodTitle,
+                                                  shippingTotal: shippingMethodTotal,
+                                                  didSelectSave: saveShippingLineClosure)
+        }
         let addNewCouponLineClosure: (Coupon) -> Void
         let onGoToCouponsClosure: () -> Void
         let onTaxHelpButtonTappedClosure: () -> Void
@@ -1159,6 +1166,7 @@ extension EditableOrderViewModel {
             self.shippingTotal = currencyFormatter.formatAmount(shippingTotal) ?? "0.00"
             self.shippingMethodTitle = shippingMethodTitle
             self.shippingMethodTotal = currencyFormatter.formatAmount(shippingMethodTotal) ?? "0.00"
+            self.saveShippingLineClosure = saveShippingLineClosure
             self.shippingTax = currencyFormatter.formatAmount(shippingTax) ?? "0.00"
             self.shouldShowShippingTax = !(currencyFormatter.convertToDecimal(shippingTax) ?? NSDecimalNumber(0.0)).isZero()
             self.shouldShowTotalCustomAmounts = shouldShowTotalCustomAmounts

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/OrderForm.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/OrderForm.swift
@@ -303,7 +303,11 @@ struct OrderForm: View {
                                     shouldShowGiftCardForm: $shouldShowGiftCardForm)
                                 .disabled(viewModel.shouldShowNonEditableIndicators)
                                 .sheet(isPresented: $shouldShowShippingLineDetails) {
-                                    ShippingLineDetails(viewModel: viewModel.paymentDataViewModel.shippingLineViewModel)
+                                    if ServiceLocator.featureFlagService.isFeatureFlagEnabled(.enhancingOrderShippingLines) {
+                                        ShippingLineSelectionDetails(viewModel: viewModel.paymentDataViewModel.shippingLineSelectionViewModel)
+                                    } else {
+                                        ShippingLineDetails(viewModel: viewModel.paymentDataViewModel.shippingLineViewModel)
+                                    }
                                 }
                                 Divider()
                             }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/PaymentSection/Shipping/ShippingLineSelectionDetails.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/PaymentSection/Shipping/ShippingLineSelectionDetails.swift
@@ -52,6 +52,7 @@ struct ShippingLineSelectionDetails: View {
                 .buttonStyle(PrimaryButtonStyle())
                 .disabled(!viewModel.enableDoneButton)
                 .padding()
+                .background(Color(.systemBackground))
             })
             .navigationTitle(Localization.shipping)
             .navigationBarTitleDisplayMode(.inline)

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/PaymentSection/Shipping/ShippingLineSelectionDetails.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/PaymentSection/Shipping/ShippingLineSelectionDetails.swift
@@ -1,0 +1,123 @@
+import SwiftUI
+
+/// View to add/edit a single shipping line in an order, including shipping method selection, with the option to remove it.
+///
+struct ShippingLineSelectionDetails: View {
+
+    /// View model to drive the view content
+    ///
+    @StateObject var viewModel: ShippingLineSelectionDetailsViewModel
+
+    @Environment(\.dismiss) var dismiss
+
+    var body: some View {
+        NavigationView {
+            List {
+                // MARK: Amount
+                VStack(alignment: .leading) {
+                    Text(Localization.amountTitle)
+                        .font(.title3)
+                        .foregroundColor(Color(.textSubtle))
+                    FormattableAmountTextField(viewModel: viewModel.formattableAmountViewModel)
+                }
+                .accessibilityIdentifier("add-shipping-amount-field")
+
+                // MARK: Name
+                VStack(alignment: .leading) {
+                    Text(Localization.nameTitle)
+                        .font(.title3)
+                        .foregroundColor(Color(.textSubtle))
+                    TextField(Localization.namePlaceholder, text: $viewModel.methodTitle)
+                        .secondaryTitleStyle()
+                }
+                .accessibilityIdentifier("add-shipping-name-field")
+
+                // MARK: Delete Shipping Button
+                Button(Localization.deleteShippingButton) {
+                    viewModel.didSelectSave(nil)
+                    dismiss()
+                }
+                .foregroundColor(.init(uiColor: .error))
+                .buttonStyle(RoundedBorderedStyle(borderColor: .init(uiColor: .error)))
+                .renderedIf(viewModel.isExistingShippingLine)
+                .listRowSeparator(.hidden, edges: .bottom)
+            }
+            .listStyle(.plain)
+            .safeAreaInset(edge: .bottom, content: {
+                // MARK: Add Shipping Button
+                Button(Localization.doneButton(isEditing: viewModel.isExistingShippingLine)) {
+                    viewModel.saveData()
+                    dismiss()
+                }
+                .buttonStyle(PrimaryButtonStyle())
+                .disabled(!viewModel.enableDoneButton)
+                .padding()
+            })
+            .navigationTitle(viewModel.isExistingShippingLine ? Localization.shipping : Localization.addShipping)
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .cancellationAction) {
+                    Button(Localization.cancel) {
+                        dismiss()
+                    }
+                }
+            }
+        }
+    }
+}
+
+private extension ShippingLineSelectionDetails {
+    enum Localization {
+        static let addShipping = NSLocalizedString("order.shippingLineDetails.addShippingTitle",
+                                                   value: "Add Shipping",
+                                                   comment: "Title for the Shipping Line screen during order creation")
+        static let shipping = NSLocalizedString("order.shippingLineDetails.shippingTitle",
+                                                value: "Shipping",
+                                                comment: "Title for the Shipping Line Details screen during order creation")
+        static let cancel = NSLocalizedString("order.shippingLineDetails.cancel",
+                                              value: "Cancel",
+                                              comment: "Text for the cancel button in the Shipping Line Details screen")
+
+        static let amountTitle = NSLocalizedString("order.shippingLineDetails.amount",
+                                                 value: "Amount",
+                                                 comment: "Title above the amount field on the Shipping Line Details screen")
+
+        static let nameTitle = NSLocalizedString("order.shippingLineDetails.name",
+                                                 value: "Name",
+                                                 comment: "Title above the name field on the Shipping Line Details screen")
+        static let namePlaceholder = NSLocalizedString("order.shippingLineDetails.namePlaceholder",
+                                                       value: "Shipping",
+                                                       comment: "Placeholder for the name field on the Shipping Line Details screen")
+
+        static func doneButton(isEditing: Bool) -> String {
+            if isEditing {
+                return editShippingButton
+            } else {
+                return addShippingButton
+            }
+        }
+        static let editShippingButton = NSLocalizedString("order.shippingLineDetails.editShipping",
+                                                          value: "Edit Shipping",
+                                                          comment: "Button to edit a shipping line to the order during order creation")
+        static let addShippingButton = NSLocalizedString("order.shippingLineDetails.addShipping",
+                                                         value: "Add Shipping",
+                                                         comment: "Button to add a shipping line to the order during order creation")
+        static let deleteShippingButton = NSLocalizedString("order.shippingLineDetails.removeShipping",
+                                                            value: "Remove Shipping from Order",
+                                                            comment: "Button to remove a shipping line from the order during order creation")
+    }
+}
+
+#Preview("Add shipping") {
+    ShippingLineSelectionDetails(viewModel: ShippingLineSelectionDetailsViewModel(isExistingShippingLine: false,
+                                                                                  initialMethodTitle: "",
+                                                                                  shippingTotal: "",
+                                                                                  didSelectSave: { _ in }))
+}
+
+#Preview("Edit shipping") {
+    ShippingLineSelectionDetails(viewModel: ShippingLineSelectionDetailsViewModel(isExistingShippingLine: true,
+                                                                                  initialMethodTitle: "Shipping",
+                                                                                  shippingTotal: "10.00",
+                                                                                  didSelectSave: { _ in }))
+}

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/PaymentSection/Shipping/ShippingLineSelectionDetails.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/PaymentSection/Shipping/ShippingLineSelectionDetails.swift
@@ -20,7 +20,6 @@ struct ShippingLineSelectionDetails: View {
                         .foregroundColor(Color(.textSubtle))
                     FormattableAmountTextField(viewModel: viewModel.formattableAmountViewModel)
                 }
-                .accessibilityIdentifier("add-shipping-amount-field")
 
                 // MARK: Name
                 VStack(alignment: .leading) {
@@ -29,8 +28,8 @@ struct ShippingLineSelectionDetails: View {
                         .foregroundColor(Color(.textSubtle))
                     TextField(Localization.namePlaceholder, text: $viewModel.methodTitle)
                         .secondaryTitleStyle()
+                        .accessibilityIdentifier(Accessibility.nameField)
                 }
-                .accessibilityIdentifier("add-shipping-name-field")
 
                 // MARK: Delete Shipping Button
                 Button(Localization.deleteShippingButton) {
@@ -51,6 +50,7 @@ struct ShippingLineSelectionDetails: View {
                 }
                 .buttonStyle(PrimaryButtonStyle())
                 .disabled(!viewModel.enableDoneButton)
+                .accessibilityIdentifier(Accessibility.doneButton)
                 .padding()
                 .background(Color(.systemBackground))
             })
@@ -103,6 +103,11 @@ private extension ShippingLineSelectionDetails {
         static let deleteShippingButton = NSLocalizedString("order.shippingLineDetails.removeShipping",
                                                             value: "Remove Shipping from Order",
                                                             comment: "Button to remove a shipping line from the order during order creation")
+    }
+
+    enum Accessibility {
+        static let nameField = "add-shipping-name-field"
+        static let doneButton = "add-shipping-done-button"
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/PaymentSection/Shipping/ShippingLineSelectionDetails.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/PaymentSection/Shipping/ShippingLineSelectionDetails.swift
@@ -53,7 +53,7 @@ struct ShippingLineSelectionDetails: View {
                 .disabled(!viewModel.enableDoneButton)
                 .padding()
             })
-            .navigationTitle(viewModel.isExistingShippingLine ? Localization.shipping : Localization.addShipping)
+            .navigationTitle(Localization.shipping)
             .navigationBarTitleDisplayMode(.inline)
             .toolbar {
                 ToolbarItem(placement: .cancellationAction) {
@@ -68,9 +68,6 @@ struct ShippingLineSelectionDetails: View {
 
 private extension ShippingLineSelectionDetails {
     enum Localization {
-        static let addShipping = NSLocalizedString("order.shippingLineDetails.addShippingTitle",
-                                                   value: "Add Shipping",
-                                                   comment: "Title for the Shipping Line screen during order creation")
         static let shipping = NSLocalizedString("order.shippingLineDetails.shippingTitle",
                                                 value: "Shipping",
                                                 comment: "Title for the Shipping Line Details screen during order creation")

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/PaymentSection/Shipping/ShippingLineSelectionDetailsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/PaymentSection/Shipping/ShippingLineSelectionDetailsViewModel.swift
@@ -1,0 +1,102 @@
+import SwiftUI
+import WooFoundation
+import struct Yosemite.ShippingLine
+import Combine
+
+class ShippingLineSelectionDetailsViewModel: ObservableObject {
+
+    /// Closure to be invoked when the shipping line is updated.
+    ///
+    var didSelectSave: ((ShippingLine?) -> Void)
+
+    /// View model for the amount text field with currency symbol.
+    ///
+    let formattableAmountViewModel: FormattableAmountTextFieldViewModel
+
+    /// Stores the method title entered by the merchant.
+    ///
+    @Published var methodTitle: String
+
+    private let initialAmount: Decimal?
+    private let initialMethodTitle: String
+
+    /// Returns true when existing shipping line is edited.
+    ///
+    let isExistingShippingLine: Bool
+
+    /// Method title entered by user or placeholder if it's empty.
+    ///
+    private var finalMethodTitle: String {
+        methodTitle.isNotEmpty ? methodTitle : Localization.namePlaceholder
+    }
+
+    /// Returns true when there are valid pending changes.
+    ///
+    @Published var enableDoneButton: Bool = false
+
+    init(isExistingShippingLine: Bool,
+         initialMethodTitle: String,
+         shippingTotal: String,
+         locale: Locale = Locale.autoupdatingCurrent,
+         storeCurrencySettings: CurrencySettings = ServiceLocator.currencySettings,
+         didSelectSave: @escaping ((ShippingLine?) -> Void)) {
+        self.isExistingShippingLine = isExistingShippingLine
+        self.initialMethodTitle = initialMethodTitle
+        self.methodTitle = initialMethodTitle
+
+        let currencyFormatter = CurrencyFormatter(currencySettings: storeCurrencySettings)
+        if isExistingShippingLine, let initialAmount = currencyFormatter.convertToDecimal(shippingTotal) {
+            self.initialAmount = initialAmount as Decimal
+        } else {
+            self.initialAmount = nil
+        }
+
+        self.formattableAmountViewModel = FormattableAmountTextFieldViewModel(size: .title2, locale: locale, storeCurrencySettings: storeCurrencySettings)
+        if isExistingShippingLine {
+            formattableAmountViewModel.presetAmount(shippingTotal)
+        }
+
+        self.didSelectSave = didSelectSave
+
+        observeFormattableAmountForUIStates(with: currencyFormatter)
+    }
+
+    func observeFormattableAmountForUIStates(with currencyFormatter: CurrencyFormatter) {
+        // Maps the formatted amount to a boolean indicating whether the amount has been updated with a valid amount.
+        let amountUpdated: AnyPublisher<Bool, Never> = formattableAmountViewModel.$amount.map { [weak self] amount in
+            guard let self, let amountDecimal = currencyFormatter.convertToDecimal(amount) as? Decimal else {
+                return false
+            }
+            return amountDecimal != self.initialAmount
+        }.eraseToAnyPublisher()
+
+        amountUpdated.combineLatest($methodTitle)
+            .map { [weak self] (amountUpdated, methodTitle) in
+                guard let self else { return false }
+                let methodTitleUpdated = methodTitle != self.initialMethodTitle
+                return amountUpdated || methodTitleUpdated
+            }
+            .assign(to: &$enableDoneButton)
+    }
+
+    func saveData() {
+        // TODO-12578: Save selected shipping method ID
+        let shippingLine = ShippingLine(shippingID: 0,
+                                        methodTitle: finalMethodTitle,
+                                        methodID: "other",
+                                        total: formattableAmountViewModel.amount,
+                                        totalTax: "",
+                                        taxes: [])
+        didSelectSave(shippingLine)
+    }
+}
+
+// MARK: Constants
+
+extension ShippingLineSelectionDetailsViewModel {
+    enum Localization {
+        static let namePlaceholder = NSLocalizedString("order.shippingLineDetails.namePlaceholder",
+                                                       value: "Shipping",
+                                                       comment: "Placeholder for the name field on the Shipping Line Details screen in order form")
+    }
+}

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/PaymentSection/Shipping/ShippingLineSelectionDetailsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/PaymentSection/Shipping/ShippingLineSelectionDetailsViewModel.swift
@@ -51,7 +51,10 @@ class ShippingLineSelectionDetailsViewModel: ObservableObject {
             self.initialAmount = nil
         }
 
-        self.formattableAmountViewModel = FormattableAmountTextFieldViewModel(size: .title2, locale: locale, storeCurrencySettings: storeCurrencySettings)
+        self.formattableAmountViewModel = FormattableAmountTextFieldViewModel(size: .title2,
+                                                                              locale: locale,
+                                                                              storeCurrencySettings: storeCurrencySettings,
+                                                                              allowNegativeNumber: true)
         if isExistingShippingLine {
             formattableAmountViewModel.presetAmount(shippingTotal)
         }

--- a/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/FormattableAmountTextField.swift
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/FormattableAmountTextField.swift
@@ -16,7 +16,7 @@ struct FormattableAmountTextField: View {
         ZStack(alignment: .center) {
             // Hidden input text field
             BindableTextfield("", text: $viewModel.amount, focus: $focusAmountInput)
-                .keyboardType(.decimalPad)
+                .keyboardType(viewModel.allowNegativeNumber ? .numbersAndPunctuation : .decimalPad)
                 .opacity(0)
 
             // Visible & formatted label

--- a/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/FormattableAmountTextField.swift
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/FormattableAmountTextField.swift
@@ -21,7 +21,7 @@ struct FormattableAmountTextField: View {
 
             // Visible & formatted label
             Text(viewModel.formattedAmount)
-                .font(.system(size: Layout.amountFontSize(scale: scale), weight: .bold))
+                .font(.system(size: Layout.amountFontSize(size: viewModel.amountTextSize.fontSize, scale: scale), weight: .bold))
                 .foregroundColor(Color(viewModel.amountTextColor))
                 .minimumScaleFactor(0.1)
                 .lineLimit(1)
@@ -35,8 +35,8 @@ struct FormattableAmountTextField: View {
 
 private extension FormattableAmountTextField {
     enum Layout {
-        static func amountFontSize(scale: CGFloat) -> CGFloat {
-            56 * scale
+        static func amountFontSize(size: CGFloat, scale: CGFloat) -> CGFloat {
+            size * scale
         }
     }
 }

--- a/WooCommerce/UITestsFoundation/Screens/Orders/AddShippingScreen.swift
+++ b/WooCommerce/UITestsFoundation/Screens/Orders/AddShippingScreen.swift
@@ -3,10 +3,6 @@ import XCTest
 
 public final class AddShippingScreen: ScreenObject {
 
-    private let shippingAmountGetter: (XCUIApplication) -> XCUIElement = {
-        $0.textFields["add-shipping-amount-field"]
-    }
-
     private let shippingNameGetter: (XCUIApplication) -> XCUIElement = {
         $0.textFields["add-shipping-name-field"]
     }
@@ -15,25 +11,26 @@ public final class AddShippingScreen: ScreenObject {
         $0.buttons["add-shipping-done-button"]
     }
 
-    private var shippingAmountField: XCUIElement { shippingAmountGetter(app) }
-
     private var shippingNameField: XCUIElement { shippingNameGetter(app) }
 
     private var doneButton: XCUIElement { doneButtonGetter(app) }
 
     init(app: XCUIApplication = XCUIApplication()) throws {
         try super.init(
-            expectedElementGetters: [ shippingAmountGetter ],
+            expectedElementGetters: [ doneButtonGetter ],
             app: app
         )
     }
 
-    /// Enters a shipping amount.
+    /// Enters a shipping amount by tapping a button on the numeric keypad.
+    /// This is done instead of entering text because the text field for shipping amount
+    /// is custom with opacity 0, and gets no keyboard focus when tapped.
     /// - Returns: Add Shipping screen object.
     @discardableResult
     public func enterShippingAmount(_ amount: String) throws -> Self {
-        shippingAmountField.tap()
-        shippingAmountField.typeText(amount)
+        amount.forEach { character in
+            app.keyboards.keys[String(character)].firstMatch.tap()
+        }
         return self
     }
 
@@ -42,6 +39,7 @@ public final class AddShippingScreen: ScreenObject {
     @discardableResult
     public func enterShippingName(_ name: String) throws -> Self {
         shippingNameField.tap()
+        shippingNameField.tap() // For some reason this field doesn't get keyboard focus until the second tap, in the UI test only.
         shippingNameField.typeText(name)
         return self
     }

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -2045,6 +2045,8 @@
 		CE5F462A23AACA0A006B1A5C /* RefundDetailsDataSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE5F462923AACA0A006B1A5C /* RefundDetailsDataSource.swift */; };
 		CE5F462C23AACBC4006B1A5C /* RefundDetailsResultController.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE5F462B23AACBC4006B1A5C /* RefundDetailsResultController.swift */; };
 		CE606D7F2BDFD45A001CB424 /* ShippingMethodSelector.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE606D7E2BDFD45A001CB424 /* ShippingMethodSelector.swift */; };
+		CE606D812BE14000001CB424 /* ShippingLineSelectionDetails.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE606D802BE14000001CB424 /* ShippingLineSelectionDetails.swift */; };
+		CE606D832BE14010001CB424 /* ShippingLineSelectionDetailsViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE606D822BE14010001CB424 /* ShippingLineSelectionDetailsViewModel.swift */; };
 		CE63023D2BAAEF2C00E3325C /* CustomersListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE63023C2BAAEF2C00E3325C /* CustomersListView.swift */; };
 		CE63023F2BAAF04600E3325C /* TitleAndSubtitleAndDetailRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE63023E2BAAF04600E3325C /* TitleAndSubtitleAndDetailRow.swift */; };
 		CE6302412BAAFB5E00E3325C /* CustomersListViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE6302402BAAFB5E00E3325C /* CustomersListViewModel.swift */; };
@@ -4805,6 +4807,8 @@
 		CE5F462923AACA0A006B1A5C /* RefundDetailsDataSource.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RefundDetailsDataSource.swift; sourceTree = "<group>"; };
 		CE5F462B23AACBC4006B1A5C /* RefundDetailsResultController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RefundDetailsResultController.swift; sourceTree = "<group>"; };
 		CE606D7E2BDFD45A001CB424 /* ShippingMethodSelector.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShippingMethodSelector.swift; sourceTree = "<group>"; };
+		CE606D802BE14000001CB424 /* ShippingLineSelectionDetails.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShippingLineSelectionDetails.swift; sourceTree = "<group>"; };
+		CE606D822BE14010001CB424 /* ShippingLineSelectionDetailsViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShippingLineSelectionDetailsViewModel.swift; sourceTree = "<group>"; };
 		CE63023C2BAAEF2C00E3325C /* CustomersListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomersListView.swift; sourceTree = "<group>"; };
 		CE63023E2BAAF04600E3325C /* TitleAndSubtitleAndDetailRow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TitleAndSubtitleAndDetailRow.swift; sourceTree = "<group>"; };
 		CE6302402BAAFB5E00E3325C /* CustomersListViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomersListViewModel.swift; sourceTree = "<group>"; };
@@ -10790,6 +10794,8 @@
 			children = (
 				AEA3F90C27BE76B300B9F555 /* ShippingLineDetails.swift */,
 				AEA3F90E27BE8EB400B9F555 /* ShippingLineDetailsViewModel.swift */,
+				CE606D802BE14000001CB424 /* ShippingLineSelectionDetails.swift */,
+				CE606D822BE14010001CB424 /* ShippingLineSelectionDetailsViewModel.swift */,
 				CE606D7E2BDFD45A001CB424 /* ShippingMethodSelector.swift */,
 			);
 			path = Shipping;
@@ -13944,6 +13950,7 @@
 				E10459C627BBC22E00C1DCBA /* CardPresentConfigurationLoader.swift in Sources */,
 				B586906621A5F4B1001F1EFC /* UINavigationController+Woo.swift in Sources */,
 				45FBDF3A238D3F8B00127F77 /* ExtendedAddProductImageCollectionViewCell.swift in Sources */,
+				CE606D832BE14010001CB424 /* ShippingLineSelectionDetailsViewModel.swift in Sources */,
 				02C7EE8A2B21B951008B7DF8 /* ProductWithQuantityStepperViewModel.swift in Sources */,
 				02A410F52583A84C005E2925 /* SpacerTableViewCell.swift in Sources */,
 				02BBD6EB29A316FB00243BE2 /* StoreOnboardingCoordinator.swift in Sources */,
@@ -14884,6 +14891,7 @@
 				B95700AC2A72C1E4001BADF2 /* CustomerSelectorViewController.swift in Sources */,
 				ABC35F18E744C5576B986CB3 /* InPersonPaymentsUnavailableView.swift in Sources */,
 				ABC35528D2D6BE6F516E5CEF /* InPersonPaymentsOnboardingError.swift in Sources */,
+				CE606D812BE14000001CB424 /* ShippingLineSelectionDetails.swift in Sources */,
 				3F1FA84C28B60126009E246C /* StoreWidgets.intentdefinition in Sources */,
 				ABC3521A374A2355001E3CD6 /* CardReaderSettingsSearchingViewController.swift in Sources */,
 				B9F1489A2AD586E5008FC795 /* FormattableAmountTextFieldViewModel.swift in Sources */,

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -2047,6 +2047,7 @@
 		CE606D7F2BDFD45A001CB424 /* ShippingMethodSelector.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE606D7E2BDFD45A001CB424 /* ShippingMethodSelector.swift */; };
 		CE606D812BE14000001CB424 /* ShippingLineSelectionDetails.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE606D802BE14000001CB424 /* ShippingLineSelectionDetails.swift */; };
 		CE606D832BE14010001CB424 /* ShippingLineSelectionDetailsViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE606D822BE14010001CB424 /* ShippingLineSelectionDetailsViewModel.swift */; };
+		CE606D872BE29E89001CB424 /* ShippingLineSelectionDetailsViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE606D862BE29E89001CB424 /* ShippingLineSelectionDetailsViewModelTests.swift */; };
 		CE63023D2BAAEF2C00E3325C /* CustomersListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE63023C2BAAEF2C00E3325C /* CustomersListView.swift */; };
 		CE63023F2BAAF04600E3325C /* TitleAndSubtitleAndDetailRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE63023E2BAAF04600E3325C /* TitleAndSubtitleAndDetailRow.swift */; };
 		CE6302412BAAFB5E00E3325C /* CustomersListViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE6302402BAAFB5E00E3325C /* CustomersListViewModel.swift */; };
@@ -4809,6 +4810,7 @@
 		CE606D7E2BDFD45A001CB424 /* ShippingMethodSelector.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShippingMethodSelector.swift; sourceTree = "<group>"; };
 		CE606D802BE14000001CB424 /* ShippingLineSelectionDetails.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShippingLineSelectionDetails.swift; sourceTree = "<group>"; };
 		CE606D822BE14010001CB424 /* ShippingLineSelectionDetailsViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShippingLineSelectionDetailsViewModel.swift; sourceTree = "<group>"; };
+		CE606D862BE29E89001CB424 /* ShippingLineSelectionDetailsViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShippingLineSelectionDetailsViewModelTests.swift; sourceTree = "<group>"; };
 		CE63023C2BAAEF2C00E3325C /* CustomersListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomersListView.swift; sourceTree = "<group>"; };
 		CE63023E2BAAF04600E3325C /* TitleAndSubtitleAndDetailRow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TitleAndSubtitleAndDetailRow.swift; sourceTree = "<group>"; };
 		CE6302402BAAFB5E00E3325C /* CustomersListViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomersListViewModel.swift; sourceTree = "<group>"; };
@@ -10122,6 +10124,7 @@
 				CC13C0CC278E086D00C0B5B5 /* ProductVariationSelectorViewModelTests.swift */,
 				AE90475B27A99D6000073E1D /* CreateOrderAddressFormViewModelTests.swift */,
 				AEA3F91227BEC40A00B9F555 /* ShippingLineDetailsViewModelTests.swift */,
+				CE606D862BE29E89001CB424 /* ShippingLineSelectionDetailsViewModelTests.swift */,
 				AE7C957E27C417FA007E8E12 /* FeeOrDiscountLineDetailsViewModelTests.swift */,
 				2602A64027BD89B300B347F1 /* Synchronizer */,
 				EEB221A629B9B5B300662A12 /* CouponLineDetailsViewModelTests.swift */,
@@ -15322,6 +15325,7 @@
 				456738972743DE9A00743054 /* OrderDateRangeFilterTests.swift in Sources */,
 				A650BE872578E76600C655E0 /* MockStorageManager.swift in Sources */,
 				B9001CE42B1E11A300EC87B2 /* CashPaymentTenderViewModelTests.swift in Sources */,
+				CE606D872BE29E89001CB424 /* ShippingLineSelectionDetailsViewModelTests.swift in Sources */,
 				029700EF24FE38F000D242F8 /* ScrollWatcherTests.swift in Sources */,
 				0236BCA425087B660043EB43 /* ProductFormRemoteActionUseCaseTests.swift in Sources */,
 				CC13C0CD278E086D00C0B5B5 /* ProductVariationSelectorViewModelTests.swift in Sources */,

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/ShippingLineSelectionDetailsViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/ShippingLineSelectionDetailsViewModelTests.swift
@@ -1,0 +1,271 @@
+import XCTest
+import Combine
+import WooFoundation
+@testable import WooCommerce
+@testable import struct Yosemite.ShippingLine
+
+final class ShippingLineSelectionDetailsViewModelTests: XCTestCase {
+
+    private let usLocale = Locale(identifier: "en_US")
+    private let usStoreSettings = CurrencySettings() // Default is US settings
+
+    func test_view_model_formats_amount_correctly() {
+        // Given
+        let viewModel = ShippingLineSelectionDetailsViewModel(isExistingShippingLine: false,
+                                                              initialMethodTitle: "",
+                                                              shippingTotal: "",
+                                                              locale: usLocale,
+                                                              storeCurrencySettings: usStoreSettings,
+                                                              didSelectSave: { _ in })
+
+        // When
+        viewModel.formattableAmountViewModel.amount = "hi:11.3005.02-"
+
+        // Then
+        XCTAssertEqual(viewModel.formattableAmountViewModel.amount, "11.30")
+        XCTAssertTrue(viewModel.enableDoneButton)
+    }
+
+    func test_view_model_formats_negative_amount_correctly() {
+        // Given
+        let viewModel = ShippingLineSelectionDetailsViewModel(isExistingShippingLine: false,
+                                                     initialMethodTitle: "",
+                                                     shippingTotal: "",
+                                                     locale: usLocale,
+                                                     storeCurrencySettings: usStoreSettings,
+                                                     didSelectSave: { _ in })
+
+        // When
+        viewModel.formattableAmountViewModel.amount = "-hi:11.3005.02-"
+
+        // Then
+        XCTAssertEqual(viewModel.formattableAmountViewModel.amount, "-11.30")
+        XCTAssertTrue(viewModel.enableDoneButton)
+    }
+
+    func test_view_model_formats_amount_with_custom_currency_settings() {
+        // Given
+        let customSettings = CurrencySettings(currencyCode: .GBP,
+                                              currencyPosition: .rightSpace,
+                                              thousandSeparator: ".",
+                                              decimalSeparator: ",",
+                                              numberOfDecimals: 3)
+
+        let viewModel = ShippingLineSelectionDetailsViewModel(isExistingShippingLine: false,
+                                                     initialMethodTitle: "",
+                                                     shippingTotal: "",
+                                                     locale: usLocale,
+                                                     storeCurrencySettings: customSettings,
+                                                     didSelectSave: { _ in })
+
+        // When
+        viewModel.formattableAmountViewModel.amount = "12.203"
+
+        // Then
+        XCTAssertEqual(viewModel.formattableAmountViewModel.amount, "12,203")
+        XCTAssertTrue(viewModel.formattableAmountViewModel.formattedAmount.contains("12,203"))
+        XCTAssertEqual(viewModel.formattableAmountViewModel.formattedAmount.last, "£")
+    }
+
+    func test_view_model_prefills_input_data_correctly() {
+        // Given
+        let viewModel = ShippingLineSelectionDetailsViewModel(isExistingShippingLine: true,
+                                                     initialMethodTitle: "Flat Rate",
+                                                     shippingTotal: "$11.30",
+                                                     locale: usLocale,
+                                                     storeCurrencySettings: usStoreSettings,
+                                                     didSelectSave: { _ in })
+
+        // Then
+        XCTAssertTrue(viewModel.isExistingShippingLine)
+        XCTAssertEqual(viewModel.formattableAmountViewModel.amount, "11.30")
+        XCTAssertEqual(viewModel.methodTitle, "Flat Rate")
+    }
+
+    func test_view_model_prefills_negative_input_data_correctly() {
+        // Given
+        let viewModel = ShippingLineSelectionDetailsViewModel(isExistingShippingLine: true,
+                                                     initialMethodTitle: "Flat Rate",
+                                                     shippingTotal: "-$11.30",
+                                                     locale: usLocale,
+                                                     storeCurrencySettings: usStoreSettings,
+                                                     didSelectSave: { _ in })
+
+        // Then
+        XCTAssertTrue(viewModel.isExistingShippingLine)
+        XCTAssertEqual(viewModel.formattableAmountViewModel.amount, "-11.30")
+        XCTAssertEqual(viewModel.methodTitle, "Flat Rate")
+    }
+
+    func test_view_model_does_not_prefill_zero_amount_without_existing_shipping_line() {
+        // Given
+        let viewModel = ShippingLineSelectionDetailsViewModel(isExistingShippingLine: false,
+                                                     initialMethodTitle: "",
+                                                     shippingTotal: "0",
+                                                     locale: usLocale,
+                                                     storeCurrencySettings: usStoreSettings,
+                                                     didSelectSave: { _ in })
+
+        // Then
+        XCTAssertTrue(viewModel.formattableAmountViewModel.amount.isEmpty)
+    }
+
+    func test_view_model_disables_done_button_for_empty_state_and_enables_with_input() {
+        // Given
+        let viewModel = ShippingLineSelectionDetailsViewModel(isExistingShippingLine: false,
+                                                     initialMethodTitle: "",
+                                                     shippingTotal: "",
+                                                     locale: usLocale,
+                                                     storeCurrencySettings: usStoreSettings,
+                                                     didSelectSave: { _ in })
+        XCTAssertFalse(viewModel.enableDoneButton)
+
+        // When
+        viewModel.formattableAmountViewModel.amount = "11.30"
+
+        // Then
+        XCTAssertTrue(viewModel.enableDoneButton)
+
+        // When
+        viewModel.formattableAmountViewModel.amount = ""
+
+        // Then
+        XCTAssertFalse(viewModel.enableDoneButton)
+    }
+
+    func test_view_model_disables_done_button_for_prefilled_data_and_enables_with_changes() {
+        // Given
+        let viewModel = ShippingLineSelectionDetailsViewModel(isExistingShippingLine: true,
+                                                     initialMethodTitle: "Flat Rate",
+                                                     shippingTotal: "$11.30",
+                                                     locale: usLocale,
+                                                     storeCurrencySettings: usStoreSettings,
+                                                     didSelectSave: { _ in })
+        XCTAssertFalse(viewModel.enableDoneButton)
+
+        // When
+        viewModel.formattableAmountViewModel.amount = "11.50"
+
+        // Then
+        XCTAssertTrue(viewModel.enableDoneButton)
+
+        // When
+        viewModel.formattableAmountViewModel.amount = "11.30"
+
+        // Then
+        XCTAssertFalse(viewModel.enableDoneButton)
+    }
+
+    func test_view_model_creates_shippping_line_with_data_from_fields() {
+        // Given
+        var savedShippingLine: ShippingLine?
+        let viewModel = ShippingLineSelectionDetailsViewModel(isExistingShippingLine: false,
+                                                     initialMethodTitle: "",
+                                                     shippingTotal: "",
+                                                     locale: usLocale,
+                                                     storeCurrencySettings: usStoreSettings,
+                                                     didSelectSave: { newShippingLine in
+            savedShippingLine = newShippingLine
+        })
+
+        // When
+        viewModel.formattableAmountViewModel.amount = "$11.30"
+        viewModel.methodTitle = "Flat Rate"
+        viewModel.saveData()
+
+        // Then
+        XCTAssertEqual(savedShippingLine?.total, "11.30")
+        XCTAssertEqual(savedShippingLine?.methodTitle, "Flat Rate")
+    }
+
+    func test_view_model_creates_shippping_line_with_negative_data_from_fields() {
+        // Given
+        var savedShippingLine: ShippingLine?
+        let viewModel = ShippingLineSelectionDetailsViewModel(isExistingShippingLine: false,
+                                                     initialMethodTitle: "",
+                                                     shippingTotal: "",
+                                                     locale: usLocale,
+                                                     storeCurrencySettings: usStoreSettings,
+                                                     didSelectSave: { newShippingLine in
+            savedShippingLine = newShippingLine
+        })
+
+        // When
+        viewModel.formattableAmountViewModel.amount = "-11.30"
+        viewModel.methodTitle = "Flat Rate"
+        viewModel.saveData()
+
+        // Then
+        XCTAssertEqual(savedShippingLine?.total, "-11.30")
+        XCTAssertEqual(savedShippingLine?.methodTitle, "Flat Rate")
+    }
+
+    func test_view_model_allows_saving_zero_amount_and_creates_correct_shippping_line() {
+        // Given
+        var savedShippingLine: ShippingLine?
+        let viewModel = ShippingLineSelectionDetailsViewModel(isExistingShippingLine: false,
+                                                     initialMethodTitle: "",
+                                                     shippingTotal: "",
+                                                     locale: usLocale,
+                                                     storeCurrencySettings: usStoreSettings,
+                                                     didSelectSave: { newShippingLine in
+            savedShippingLine = newShippingLine
+        })
+
+        // When
+        viewModel.formattableAmountViewModel.amount = "0"
+        viewModel.saveData()
+
+        // Then
+        XCTAssertTrue(viewModel.enableDoneButton)
+        XCTAssertEqual(savedShippingLine?.total, "0")
+    }
+
+    func test_view_model_creates_shippping_line_with_placeholder_for_method_title() {
+        // Given
+        var savedShippingLine: ShippingLine?
+        let viewModel = ShippingLineSelectionDetailsViewModel(isExistingShippingLine: false,
+                                                     initialMethodTitle: "",
+                                                     shippingTotal: "",
+                                                     locale: usLocale,
+                                                     storeCurrencySettings: usStoreSettings,
+                                                     didSelectSave: { newShippingLine in
+            savedShippingLine = newShippingLine
+        })
+
+        // When
+        viewModel.formattableAmountViewModel.amount = "$11.30"
+        viewModel.methodTitle = ""
+
+        // Then
+        viewModel.saveData()
+        XCTAssertEqual(savedShippingLine?.total, "11.30")
+        XCTAssertNotEqual(savedShippingLine?.methodTitle, "") // "Shipping" placeholder string is localized -> not reliable for comparison here.
+    }
+
+    func test_view_model_amount_placeholder_has_expected_value() {
+        // Given
+        let viewModel = ShippingLineSelectionDetailsViewModel(isExistingShippingLine: false,
+                                                     initialMethodTitle: "",
+                                                     shippingTotal: "",
+                                                     locale: usLocale,
+                                                     storeCurrencySettings: usStoreSettings,
+                                                     didSelectSave: { _ in })
+
+        // Then
+        XCTAssertEqual(viewModel.formattableAmountViewModel.formattedAmount, "$0.00")
+    }
+
+    func test_view_model_initializes_correctly_with_no_existing_shipping_line() {
+        // Given
+        let viewModel = ShippingLineSelectionDetailsViewModel(isExistingShippingLine: false,
+                                                     initialMethodTitle: "",
+                                                     shippingTotal: "",
+                                                     locale: usLocale,
+                                                     storeCurrencySettings: usStoreSettings,
+                                                     didSelectSave: { _ in })
+
+        // Then
+        XCTAssertFalse(viewModel.isExistingShippingLine)
+    }
+}


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of: #12578
<!-- Id number of the GitHub issue this PR addresses. -->

## Why
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This updates the styles on the Add/Edit Shipping screen in the order form, when the `enhancingOrderShippingLines` feature flag is enabled.

## How

* Adds a new `ShippingLineSelectionDetails` view and view model. I decided to use a new view because the style changes also meant some significant changes in the view's logic and data handling. This will make it easier to remove the old view when we release these changes.
* Migrates the unit tests from `ShippingLineDetailsViewModel` to test the same functionality in `ShippingLineSelectionDetailsViewModel`.
* Adds the new view model to `EditableOrderViewModel`.
* Updates `OrderForm` to navigate to the new view when the feature flag is enabled.
* The new view uses `FormattableAmountTextField` for editing the shipping amount. I updated that view and its view model:
   * Add support for different font sizes.
   * Update the placeholder to use the placeholder text color.
   * Optionally allow negative numbers (and provide a keyboard for entering negative numbers if allowed).
* Updates UI tests for adding shipping on the new screen.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
1. Build and run the app.
2. Create a new order.
3. Add a product to the order.
4. Tap the "Add Shipping" button to open the shipping details screen.
5. Confirm you can add a shipping amount (positive or negative) and name.
6. Add the shipping to the order.
7. In the order total section, select the shipping row to edit it.
8. Confirm you can edit the shipping amount and name.
9. Confirm you can remove the shipping from the order.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

Existing styles (feature flag disabled)|New styles (feature flag enabled)
-|-
![Simulator Screenshot - iPhone 15 Pro - 2024-04-30 at 17 31 52](https://github.com/woocommerce/woocommerce-ios/assets/8658164/73633ff4-5415-455a-bccf-d5acf880ba1d)|![Simulator Screenshot - iPhone 15 Pro - 2024-04-30 at 17 40 58](https://github.com/woocommerce/woocommerce-ios/assets/8658164/30b1effe-edde-41da-9d97-634b1506e39b)
![Simulator Screenshot - iPhone 15 Pro - 2024-04-30 at 17 31 57](https://github.com/woocommerce/woocommerce-ios/assets/8658164/ef93ddae-4622-461b-87be-0567d5a5a46a)|![Simulator Screenshot - iPhone 15 Pro - 2024-04-30 at 17 41 12](https://github.com/woocommerce/woocommerce-ios/assets/8658164/6b3df55c-3c0d-48f7-b1aa-303379e3aa62)
![Simulator Screenshot - iPhone 15 Pro - 2024-04-30 at 17 32 14](https://github.com/woocommerce/woocommerce-ios/assets/8658164/a8516cc2-2471-462f-883b-42deea4627c2)|![Simulator Screenshot - iPhone 15 Pro - 2024-04-30 at 17 29 22](https://github.com/woocommerce/woocommerce-ios/assets/8658164/efead274-dbbd-4941-94f1-9c23e17faa61)


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
