### PR TITLE
Dynamic dashboard: Fix thread priority inversion warning

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Dashboard/StoreStats/StorePerformanceViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/StoreStats/StorePerformanceViewModel.swift
@@ -54,6 +54,9 @@ final class StorePerformanceViewModel: ObservableObject {
     private var currentDate = Date()
     private let chartValueSelectedEventsSubject = PassthroughSubject<Int?, Never>()
 
+    private var waitingTracker: WaitingTimeTracker?
+    private let syncingDidFinishPublisher = PassthroughSubject<Void, Never>()
+
     // To check whether the tab is showing the visitors and conversion views as redacted for custom range.
     // This redaction is only shown on Custom Range tab with WordPress.com or Jetpack connected sites,
     // while Jetpack CP sites has its own redacted for Jetpack state, and non-Jetpack sites simply has them empty.
@@ -84,6 +87,7 @@ final class StorePerformanceViewModel: ObservableObject {
         self.usageTracksEventEmitter = usageTracksEventEmitter
         self.analytics = analytics
 
+        observeSyncingCompletion()
         observeTimeRange()
         observeChartValueSelectedEvents()
 
@@ -125,7 +129,7 @@ final class StorePerformanceViewModel: ObservableObject {
     func reloadData() async {
         syncingData = true
         loadingError = nil
-        let waitingTracker = WaitingTimeTracker(trackScenario: .dashboardMainStats)
+        waitingTracker = WaitingTimeTracker(trackScenario: .dashboardMainStats)
         do {
             try await syncAllStats()
             trackDashboardStatsSyncComplete()
@@ -148,7 +152,7 @@ final class StorePerformanceViewModel: ObservableObject {
             handleSyncError(error: error)
         }
         syncingData = false
-        waitingTracker.end()
+        syncingDidFinishPublisher.send()
     }
 
     func hideStorePerformance() {
@@ -214,6 +218,15 @@ extension StorePerformanceViewModel {
 // MARK: - Private helpers
 //
 private extension StorePerformanceViewModel {
+    func observeSyncingCompletion() {
+        syncingDidFinishPublisher
+            .receive(on: DispatchQueue.global(qos: .background))
+            .sink { [weak self] in
+                self?.waitingTracker?.end()
+            }
+            .store(in: &subscriptions)
+    }
+
     func observeTimeRange() {
         $timeRange
             .compactMap { [weak self] timeRange -> StoreStatsPeriodViewModel? in


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #12536 
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
When syncing stats on the dashboard screen, we track the performance after the syncing completes. These were called immediately inside the `reloadData` methods on `StorePerformanceViewModel` and `TopPerformersDashboardViewModel`. Both methods are async and marked with `@MainActor` for the results to be returned on the main thread.

When sending Tracks events, the events are created and saved to CoreData using `performAndWait`. If I understand correctly, this is to make it safe to send events continuously and synchronously. However, this happens on a background thread and blocks the async methods running on the main thread, causing potential UI hang, thus Xcode logs a warning for thread priority inversion.

To fix this issue, I created a separate publisher to keep track when syncing stats completes, and observe the data stream in a background thread before sending Tracks events. This makes sure that Tracks doesn't block the async method on the main thread.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
- Build and run the app.
- Log in to a store and enable both Performance and Top Performers cards.
- Leave the app idle for 3-5 minutes. Confirm that there is no warning in Xcode log about priority inversions by Thread Performance Checker.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->
N/A

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
