### PR TITLE
[Shipping Lines] Add Networking support to fetch shipping methods

### DIFF
--- a/Networking/Networking.xcodeproj/project.pbxproj
+++ b/Networking/Networking.xcodeproj/project.pbxproj
@@ -702,6 +702,7 @@
 		CE50346021B5799F007573C6 /* SitePlan.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE50345F21B5799F007573C6 /* SitePlan.swift */; };
 		CE50346721B5DCBE007573C6 /* site-plan.json in Resources */ = {isa = PBXBuildFile; fileRef = CE50346621B5DCBE007573C6 /* site-plan.json */; };
 		CE583A0E2109154500D73C1C /* OrderNoteMapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE583A0D2109154500D73C1C /* OrderNoteMapper.swift */; };
+		CE606D8B2BE38B04001CB424 /* shipping-methods.json in Resources */ = {isa = PBXBuildFile; fileRef = CE606D8A2BE38B04001CB424 /* shipping-methods.json */; };
 		CE6B969A2A0BCD09003C4B27 /* order-with-bundled-line-items.json in Resources */ = {isa = PBXBuildFile; fileRef = CE6B96992A0BCD09003C4B27 /* order-with-bundled-line-items.json */; };
 		CE6BFEE52236BF05005C79FB /* Product.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE6BFEE42236BF05005C79FB /* Product.swift */; };
 		CE6BFEE82236D133005C79FB /* ProductDimensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE6BFEE72236D133005C79FB /* ProductDimensions.swift */; };
@@ -1795,6 +1796,7 @@
 		CE50345F21B5799F007573C6 /* SitePlan.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SitePlan.swift; sourceTree = "<group>"; };
 		CE50346621B5DCBE007573C6 /* site-plan.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "site-plan.json"; sourceTree = "<group>"; };
 		CE583A0D2109154500D73C1C /* OrderNoteMapper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OrderNoteMapper.swift; sourceTree = "<group>"; };
+		CE606D8A2BE38B04001CB424 /* shipping-methods.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "shipping-methods.json"; sourceTree = "<group>"; };
 		CE6B96992A0BCD09003C4B27 /* order-with-bundled-line-items.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "order-with-bundled-line-items.json"; sourceTree = "<group>"; };
 		CE6BFEE42236BF05005C79FB /* Product.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Product.swift; sourceTree = "<group>"; };
 		CE6BFEE72236D133005C79FB /* ProductDimensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductDimensions.swift; sourceTree = "<group>"; };
@@ -3070,6 +3072,7 @@
 				456930AC2652AF00009ED69D /* shipping-label-carriers-and-rates-success.json */,
 				CC0786622678F79500BA9AC1 /* shipping-label-purchase-success.json */,
 				CC0786C6267BB10700BA9AC1 /* shipping-label-status-success.json */,
+				CE606D8A2BE38B04001CB424 /* shipping-methods.json */,
 				B56C1EB920EA7D2C00D749F9 /* sites.json */,
 				2670C3FD270F4E6A002FE931 /* sites-malformed.json */,
 				7426CA1221AF34A3004E9FFC /* site-api.json */,
@@ -4034,6 +4037,7 @@
 				022902D422E2436400059692 /* stats_module_disabled_error.json in Resources */,
 				4513382827A96DE700AE5E78 /* inbox-note.json in Resources */,
 				EEA1E2092AC3E08600A37ADD /* generate-product-success-no-dimensions-info.json in Resources */,
+				CE606D8B2BE38B04001CB424 /* shipping-methods.json in Resources */,
 				31A451D227863A2E00FE81AA /* stripe-account-restricted-pending.json in Resources */,
 				45CCFCEA27A2E59B0012E8CB /* inbox-note-list.json in Resources */,
 				025CA2C8238F4FF400B05C81 /* product-shipping-classes-load-all.json in Resources */,

--- a/Networking/Networking.xcodeproj/project.pbxproj
+++ b/Networking/Networking.xcodeproj/project.pbxproj
@@ -705,7 +705,9 @@
 		CE606D8B2BE38B04001CB424 /* shipping-methods.json in Resources */ = {isa = PBXBuildFile; fileRef = CE606D8A2BE38B04001CB424 /* shipping-methods.json */; };
 		CE606D8D2BE3927A001CB424 /* ShippingMethod.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE606D8C2BE3927A001CB424 /* ShippingMethod.swift */; };
 		CE606D8F2BE39426001CB424 /* ShippingMethodMapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE606D8E2BE39426001CB424 /* ShippingMethodMapper.swift */; };
+		CE606D912BE396D7001CB424 /* ShippingMethodsRemote.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE606D902BE396D7001CB424 /* ShippingMethodsRemote.swift */; };
 		CE606D932BE39889001CB424 /* ShippingMethodListMapperTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE606D922BE39889001CB424 /* ShippingMethodListMapperTests.swift */; };
+		CE606D952BE39B81001CB424 /* ShippingMethodsRemoteTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE606D942BE39B80001CB424 /* ShippingMethodsRemoteTests.swift */; };
 		CE6B969A2A0BCD09003C4B27 /* order-with-bundled-line-items.json in Resources */ = {isa = PBXBuildFile; fileRef = CE6B96992A0BCD09003C4B27 /* order-with-bundled-line-items.json */; };
 		CE6BFEE52236BF05005C79FB /* Product.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE6BFEE42236BF05005C79FB /* Product.swift */; };
 		CE6BFEE82236D133005C79FB /* ProductDimensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE6BFEE72236D133005C79FB /* ProductDimensions.swift */; };
@@ -1802,7 +1804,9 @@
 		CE606D8A2BE38B04001CB424 /* shipping-methods.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "shipping-methods.json"; sourceTree = "<group>"; };
 		CE606D8C2BE3927A001CB424 /* ShippingMethod.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShippingMethod.swift; sourceTree = "<group>"; };
 		CE606D8E2BE39426001CB424 /* ShippingMethodMapper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShippingMethodMapper.swift; sourceTree = "<group>"; };
+		CE606D902BE396D7001CB424 /* ShippingMethodsRemote.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShippingMethodsRemote.swift; sourceTree = "<group>"; };
 		CE606D922BE39889001CB424 /* ShippingMethodListMapperTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShippingMethodListMapperTests.swift; sourceTree = "<group>"; };
+		CE606D942BE39B80001CB424 /* ShippingMethodsRemoteTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShippingMethodsRemoteTests.swift; sourceTree = "<group>"; };
 		CE6B96992A0BCD09003C4B27 /* order-with-bundled-line-items.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "order-with-bundled-line-items.json"; sourceTree = "<group>"; };
 		CE6BFEE42236BF05005C79FB /* Product.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Product.swift; sourceTree = "<group>"; };
 		CE6BFEE72236D133005C79FB /* ProductDimensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductDimensions.swift; sourceTree = "<group>"; };
@@ -2427,6 +2431,7 @@
 				68BFF9012B677F1D00B15FF2 /* ReceiptRemoteTests.swift */,
 				7412A8F121B6E47A005D182A /* ReportRemoteTests.swift */,
 				743E84F9221742E300FAC9D7 /* ShipmentsRemoteTests.swift */,
+				CE606D942BE39B80001CB424 /* ShippingMethodsRemoteTests.swift */,
 				74AB5B5021AF426D00859C12 /* SiteAPIRemoteTests.swift */,
 				31D27C942602B737002EDB1D /* SitePluginsRemoteTests.swift */,
 				453305EE2459E46000264E50 /* SitePostsRemoteTests.swift */,
@@ -2589,6 +2594,7 @@
 				CE43066F234B99F50073CBFF /* RefundsRemote.swift */,
 				7412A8E921B6E192005D182A /* ReportRemote.swift */,
 				743E84E922171C5800FAC9D7 /* ShipmentsRemote.swift */,
+				CE606D902BE396D7001CB424 /* ShippingMethodsRemote.swift */,
 				7426CA0C21AF27B9004E9FFC /* SiteAPIRemote.swift */,
 				31D27C802602889C002EDB1D /* SitePluginsRemote.swift */,
 				74046E1A217A684D007DD7BF /* SiteSettingsRemote.swift */,
@@ -4680,6 +4686,7 @@
 				45CCFCE427A2DC270012E8CB /* InboxAction.swift in Sources */,
 				EE1CB9022B4BC85B00AD24D5 /* BlazeImpressions.swift in Sources */,
 				B5C6FCD420A373BB00A4F8E4 /* OrderMapper.swift in Sources */,
+				CE606D912BE396D7001CB424 /* ShippingMethodsRemote.swift in Sources */,
 				EE1CB90B2B4BC8C500AD24D5 /* BlazeImpressionsMapper.swift in Sources */,
 				D88D5A49230BC8C7007B6E01 /* ProductReviewStatus.swift in Sources */,
 				036563DB2906938600D84BFD /* JustInTimeMessage.swift in Sources */,
@@ -4842,6 +4849,7 @@
 				CE865AA52A4209A70049B03C /* EntityDateModifiedMapperTests.swift in Sources */,
 				DEDA8DAB2B18407D0076BF0F /* WordPressThemeRemoteTests.swift in Sources */,
 				B505F6D720BEE58800BB1B69 /* AccountRemoteTests.swift in Sources */,
+				CE606D952BE39B81001CB424 /* ShippingMethodsRemoteTests.swift in Sources */,
 				DE42F9632967C8B900D514C2 /* ReportOrderTotalsMapperTests.swift in Sources */,
 				453305EB2459E01A00264E50 /* PostMapperTests.swift in Sources */,
 				8617EDA62B3C093200BD9D1B /* BlazeImpressionsMapperTests.swift in Sources */,

--- a/Networking/Networking.xcodeproj/project.pbxproj
+++ b/Networking/Networking.xcodeproj/project.pbxproj
@@ -703,6 +703,7 @@
 		CE50346721B5DCBE007573C6 /* site-plan.json in Resources */ = {isa = PBXBuildFile; fileRef = CE50346621B5DCBE007573C6 /* site-plan.json */; };
 		CE583A0E2109154500D73C1C /* OrderNoteMapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE583A0D2109154500D73C1C /* OrderNoteMapper.swift */; };
 		CE606D8B2BE38B04001CB424 /* shipping-methods.json in Resources */ = {isa = PBXBuildFile; fileRef = CE606D8A2BE38B04001CB424 /* shipping-methods.json */; };
+		CE606D8D2BE3927A001CB424 /* ShippingMethod.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE606D8C2BE3927A001CB424 /* ShippingMethod.swift */; };
 		CE6B969A2A0BCD09003C4B27 /* order-with-bundled-line-items.json in Resources */ = {isa = PBXBuildFile; fileRef = CE6B96992A0BCD09003C4B27 /* order-with-bundled-line-items.json */; };
 		CE6BFEE52236BF05005C79FB /* Product.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE6BFEE42236BF05005C79FB /* Product.swift */; };
 		CE6BFEE82236D133005C79FB /* ProductDimensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE6BFEE72236D133005C79FB /* ProductDimensions.swift */; };
@@ -1797,6 +1798,7 @@
 		CE50346621B5DCBE007573C6 /* site-plan.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "site-plan.json"; sourceTree = "<group>"; };
 		CE583A0D2109154500D73C1C /* OrderNoteMapper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OrderNoteMapper.swift; sourceTree = "<group>"; };
 		CE606D8A2BE38B04001CB424 /* shipping-methods.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "shipping-methods.json"; sourceTree = "<group>"; };
+		CE606D8C2BE3927A001CB424 /* ShippingMethod.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShippingMethod.swift; sourceTree = "<group>"; };
 		CE6B96992A0BCD09003C4B27 /* order-with-bundled-line-items.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "order-with-bundled-line-items.json"; sourceTree = "<group>"; };
 		CE6BFEE42236BF05005C79FB /* Product.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Product.swift; sourceTree = "<group>"; };
 		CE6BFEE72236D133005C79FB /* ProductDimensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductDimensions.swift; sourceTree = "<group>"; };
@@ -2699,6 +2701,7 @@
 				D823D90F22377B4F00C90817 /* ShipmentTrackingProviderGroup.swift */,
 				45E3EEBA237009CF00A826AC /* ShippingLine.swift */,
 				261870772540A252006522A1 /* ShippingLineTax.swift */,
+				CE606D8C2BE3927A001CB424 /* ShippingMethod.swift */,
 				B56C1EB720EA76F500D749F9 /* Site.swift */,
 				7426CA0E21AF2C90004E9FFC /* SiteAPI.swift */,
 				4568E2232459D3230007E478 /* Post.swift */,
@@ -4631,6 +4634,7 @@
 				D88E229425AC9B420023F3B1 /* OrderFeeTaxStatus.swift in Sources */,
 				B5DAEFF02180DD5A0002356A /* NotificationsRemote.swift in Sources */,
 				261C466B2A6738EE00734070 /* AppicationPasswordEncoder.swift in Sources */,
+				CE606D8D2BE3927A001CB424 /* ShippingMethod.swift in Sources */,
 				DEDA8DA12B182E850076BF0F /* WordPressTheme.swift in Sources */,
 				2665032A261F41510079A159 /* ProductAddOn.swift in Sources */,
 				020D07BE23D8570800FD9580 /* MediaListMapper.swift in Sources */,

--- a/Networking/Networking.xcodeproj/project.pbxproj
+++ b/Networking/Networking.xcodeproj/project.pbxproj
@@ -704,6 +704,8 @@
 		CE583A0E2109154500D73C1C /* OrderNoteMapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE583A0D2109154500D73C1C /* OrderNoteMapper.swift */; };
 		CE606D8B2BE38B04001CB424 /* shipping-methods.json in Resources */ = {isa = PBXBuildFile; fileRef = CE606D8A2BE38B04001CB424 /* shipping-methods.json */; };
 		CE606D8D2BE3927A001CB424 /* ShippingMethod.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE606D8C2BE3927A001CB424 /* ShippingMethod.swift */; };
+		CE606D8F2BE39426001CB424 /* ShippingMethodMapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE606D8E2BE39426001CB424 /* ShippingMethodMapper.swift */; };
+		CE606D932BE39889001CB424 /* ShippingMethodListMapperTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE606D922BE39889001CB424 /* ShippingMethodListMapperTests.swift */; };
 		CE6B969A2A0BCD09003C4B27 /* order-with-bundled-line-items.json in Resources */ = {isa = PBXBuildFile; fileRef = CE6B96992A0BCD09003C4B27 /* order-with-bundled-line-items.json */; };
 		CE6BFEE52236BF05005C79FB /* Product.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE6BFEE42236BF05005C79FB /* Product.swift */; };
 		CE6BFEE82236D133005C79FB /* ProductDimensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE6BFEE72236D133005C79FB /* ProductDimensions.swift */; };
@@ -1799,6 +1801,8 @@
 		CE583A0D2109154500D73C1C /* OrderNoteMapper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OrderNoteMapper.swift; sourceTree = "<group>"; };
 		CE606D8A2BE38B04001CB424 /* shipping-methods.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "shipping-methods.json"; sourceTree = "<group>"; };
 		CE606D8C2BE3927A001CB424 /* ShippingMethod.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShippingMethod.swift; sourceTree = "<group>"; };
+		CE606D8E2BE39426001CB424 /* ShippingMethodMapper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShippingMethodMapper.swift; sourceTree = "<group>"; };
+		CE606D922BE39889001CB424 /* ShippingMethodListMapperTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShippingMethodListMapperTests.swift; sourceTree = "<group>"; };
 		CE6B96992A0BCD09003C4B27 /* order-with-bundled-line-items.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "order-with-bundled-line-items.json"; sourceTree = "<group>"; };
 		CE6BFEE42236BF05005C79FB /* Product.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Product.swift; sourceTree = "<group>"; };
 		CE6BFEE72236D133005C79FB /* ProductDimensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductDimensions.swift; sourceTree = "<group>"; };
@@ -3278,6 +3282,7 @@
 				CC9A24F32642CF37005DE56E /* ShippingLabelCreationEligibilityMapper.swift */,
 				CC0786602677B2DA00BA9AC1 /* ShippingLabelPurchaseMapper.swift */,
 				CC0786C4267BAF0F00BA9AC1 /* ShippingLabelStatusMapper.swift */,
+				CE606D8E2BE39426001CB424 /* ShippingMethodMapper.swift */,
 				FE28F6E326842848004465C7 /* UserMapper.swift */,
 				077F39D326A58DE700ABEADC /* SystemStatusMapper.swift */,
 				DEC51AE827687AAF009F3DF4 /* SystemPluginMapper.swift */,
@@ -3447,6 +3452,7 @@
 				CC9A254926442D26005DE56E /* ShippingLabelCreationEligibilityMapperTests.swift */,
 				CC07866426790B1100BA9AC1 /* ShippingLabelPurchaseMapperTests.swift */,
 				CC0786C8267BB32800BA9AC1 /* ShippingLabelStatusMapperTests.swift */,
+				CE606D922BE39889001CB424 /* ShippingMethodListMapperTests.swift */,
 				02C254D22563992900A04423 /* OrderShippingLabelListMapperTests.swift */,
 				FE28F6E926842E49004465C7 /* UserMapperTests.swift */,
 				DE34051C28BDF1C900CF0D97 /* JetpackConnectionURLMapperTests.swift */,
@@ -4498,6 +4504,7 @@
 				02C254B0256378D000A04423 /* ShippingLabelRefundStatus.swift in Sources */,
 				4568E2242459D3230007E478 /* Post.swift in Sources */,
 				DEEF8E6829C858AD00D47411 /* OneTimeApplicationPasswordUseCase.swift in Sources */,
+				CE606D8F2BE39426001CB424 /* ShippingMethodMapper.swift in Sources */,
 				4513382427A951B300AE5E78 /* InboxNoteMapper.swift in Sources */,
 				B9CFF6522AB2118900C2F616 /* TaxRateMapper.swift in Sources */,
 				DE2095BF279583A100171F1C /* CouponReportListMapper.swift in Sources */,
@@ -4842,6 +4849,7 @@
 				2670C3FC270F4E06002FE931 /* SiteListMapperTests.swift in Sources */,
 				EE065AD02B8E56C2009848CB /* BlazeCampaignListItemsMapperTests.swift in Sources */,
 				02E2AF2F2AFD1C3A00EE6FE8 /* AlamofireNetworkTests.swift in Sources */,
+				CE606D932BE39889001CB424 /* ShippingMethodListMapperTests.swift in Sources */,
 				CEB9BF2F2BB18F430007978A /* ProductBundleStatsRemoteTests.swift in Sources */,
 				025CA2C6238F4F3500B05C81 /* ProductShippingClassRemoteTests.swift in Sources */,
 				EE078D932AD2F1E500C1199E /* JWTokenMapperTests.swift in Sources */,

--- a/Networking/Networking/Mapper/ShippingMethodMapper.swift
+++ b/Networking/Networking/Mapper/ShippingMethodMapper.swift
@@ -1,0 +1,38 @@
+import Foundation
+
+/// Mapper: ShippingMethod List
+///
+struct ShippingMethodListMapper: Mapper {
+    /// Site Identifier associated to the order that will be parsed.
+    /// We're injecting this field via `JSONDecoder.userInfo` because SiteID is not returned in the endpoints used to retrieve ShippingMethod models.
+    ///
+    let siteID: Int64
+
+    /// (Attempts) to convert a dictionary into ShippingMethod.
+    ///
+    func map(response: Data) throws -> [ShippingMethod] {
+        let decoder = JSONDecoder()
+        decoder.userInfo = [
+            .siteID: siteID
+        ]
+
+        if hasDataEnvelope(in: response) {
+            return try decoder.decode(ShippingMethodEnvelope.self, from: response).methods
+        } else {
+            return try decoder.decode([ShippingMethod].self, from: response)
+        }
+    }
+}
+
+/// UserEnvelope Disposable Entity
+///
+/// `Fetch Shipping Methods` endpoint returns the requested objects in the `data` key. This entity
+/// allows us to parse all the things with JSONDecoder.
+///
+private struct ShippingMethodEnvelope: Decodable {
+    let methods: [ShippingMethod]
+
+    private enum CodingKeys: String, CodingKey {
+        case methods = "data"
+    }
+}

--- a/Networking/Networking/Model/ShippingMethod.swift
+++ b/Networking/Networking/Model/ShippingMethod.swift
@@ -1,0 +1,13 @@
+import Foundation
+
+/// Represents a Shipping Method Entity.
+///
+public struct ShippingMethod: Codable, Equatable {
+    /// Shipping Method ID
+    ///
+    public let id: String
+
+    /// Shipping Method Title
+    ///
+    public let title: String
+}

--- a/Networking/Networking/Remote/ShippingMethodsRemote.swift
+++ b/Networking/Networking/Remote/ShippingMethodsRemote.swift
@@ -1,0 +1,31 @@
+import Foundation
+
+/// ShippingMethodsRemote: Remote Endpoints
+///
+public final class ShippingMethodsRemote: Remote {
+
+    /// Retrieves all of the shipping methods for a given store.
+    /// - Parameter siteID: Site for which we'll fetch the shipping methods.
+    /// - Returns: A list of shipping methods.
+    public func loadShippingMethods(for siteID: Int64) async throws -> [ShippingMethod] {
+        let request = JetpackRequest(wooApiVersion: .mark3,
+                                     method: .get,
+                                     siteID: siteID,
+                                     path: Constants.path,
+                                     parameters: nil,
+                                     availableAsRESTRequest: true)
+        let mapper = ShippingMethodListMapper(siteID: siteID)
+
+        return try await  enqueue(request, mapper: mapper)
+    }
+}
+
+
+// MARK: - Constants
+//
+private extension ShippingMethodsRemote {
+
+    enum Constants {
+        static let path: String    = "shipping_methods"
+    }
+}

--- a/Networking/NetworkingTests/Mapper/ShippingMethodListMapperTests.swift
+++ b/Networking/NetworkingTests/Mapper/ShippingMethodListMapperTests.swift
@@ -1,0 +1,44 @@
+import XCTest
+@testable import Networking
+
+final class ShippingMethodListMapperTests: XCTestCase {
+
+    private let sampleSiteID: Int64 = 12345
+
+    /// Verifies that the whole list is parsed.
+    ///
+    func test_shipping_method_list_is_properly_parsed() throws {
+        // Given
+        let shippingMethods = try mapLoadShippingMethodsResponse()
+
+        // Assert
+        assertEqual(6, shippingMethods.count)
+
+        // Then
+        let method = try XCTUnwrap(shippingMethods.first)
+
+        // Assert
+        assertEqual("flat_rate", method.id)
+        assertEqual("Flat rate", method.title)
+    }
+}
+
+// MARK: - Test Helpers
+private extension ShippingMethodListMapperTests {
+
+    /// Returns the mapShippingMethodListMapper output upon receiving `filename` (Data Encoded)
+    ///
+    func mapShippingMethods(from filename: String) throws -> [ShippingMethod] {
+        guard let response = Loader.contentsOf(filename) else {
+            return []
+        }
+
+        return try ShippingMethodListMapper(siteID: sampleSiteID).map(response: response)
+    }
+
+    /// Returns the ShippingMethodListMapper output from `shipping-methods.json`
+    ///
+    func mapLoadShippingMethodsResponse() throws -> [ShippingMethod] {
+        return try mapShippingMethods(from: "shipping-methods")
+    }
+}

--- a/Networking/NetworkingTests/Remote/ShippingMethodsRemoteTests.swift
+++ b/Networking/NetworkingTests/Remote/ShippingMethodsRemoteTests.swift
@@ -1,0 +1,53 @@
+import XCTest
+@testable import Networking
+import TestKit
+
+/// ShippingMethodsRemote Unit Tests
+///
+final class ShippingMethodsRemoteTests: XCTestCase {
+
+    /// Dummy Network Wrapper
+    ///
+    private let network = MockNetwork()
+
+    /// Dummy Site ID
+    ///
+    private let sampleSiteID: Int64 = 12345
+
+    /// Repeat always!
+    ///
+    override func setUp() {
+        network.removeAllSimulatedResponses()
+    }
+
+    // MARK: - Load shipping methods
+
+    /// Verifies that loadShippingMethods properly parses the sample response.
+    ///
+    func test_loadShippingMethods_properly_returns_shipping_methods() async throws {
+        // Given
+        let remote = ShippingMethodsRemote(network: network)
+        network.simulateResponse(requestUrlSuffix: "shipping_methods", filename: "shipping-methods")
+
+        // When
+        let shippingMethods = try await remote.loadShippingMethods(for: sampleSiteID)
+
+        // Then
+        XCTAssertEqual(shippingMethods.count, 6)
+    }
+
+    /// Verifies that loadShippingMethods properly relays Networking Layer errors.
+    ///
+    func test_loadShippingMethods_properly_relays_networking_errors() async {
+        // Given
+        let remote = ShippingMethodsRemote(network: network)
+        let expectedError = NetworkError.unacceptableStatusCode(statusCode: 403)
+        network.simulateError(requestUrlSuffix: "shipping_methods", error: expectedError)
+
+        // When & Then
+        await assertThrowsError({
+            _ = try await remote.loadShippingMethods(for: self.sampleSiteID)
+        }, errorAssert: { ($0 as? NetworkError) == expectedError })
+    }
+
+}

--- a/Networking/NetworkingTests/Responses/shipping-methods.json
+++ b/Networking/NetworkingTests/Responses/shipping-methods.json
@@ -1,0 +1,106 @@
+{
+    "data": [
+        {
+            "id": "flat_rate",
+            "title": "Flat rate",
+            "description": "Lets you charge a fixed rate for shipping.",
+            "_links": {
+                "self": [
+                    {
+                        "href": "https://woo-practically-automatic-witch.wpcomstaging.com/wp-json/wc/v3/shipping_methods/flat_rate"
+                    }
+                ],
+                "collection": [
+                    {
+                        "href": "https://woo-practically-automatic-witch.wpcomstaging.com/wp-json/wc/v3/shipping_methods"
+                    }
+                ]
+            }
+        },
+        {
+            "id": "free_shipping",
+            "title": "Free shipping",
+            "description": "Free shipping is a special method which can be triggered with coupons and minimum spends.",
+            "_links": {
+                "self": [
+                    {
+                        "href": "https://woo-practically-automatic-witch.wpcomstaging.com/wp-json/wc/v3/shipping_methods/free_shipping"
+                    }
+                ],
+                "collection": [
+                    {
+                        "href": "https://woo-practically-automatic-witch.wpcomstaging.com/wp-json/wc/v3/shipping_methods"
+                    }
+                ]
+            }
+        },
+        {
+            "id": "local_pickup",
+            "title": "Local pickup",
+            "description": "Allow customers to pick up orders themselves. By default, when using local pickup store base taxes will apply regardless of customer address.",
+            "_links": {
+                "self": [
+                    {
+                        "href": "https://woo-practically-automatic-witch.wpcomstaging.com/wp-json/wc/v3/shipping_methods/local_pickup"
+                    }
+                ],
+                "collection": [
+                    {
+                        "href": "https://woo-practically-automatic-witch.wpcomstaging.com/wp-json/wc/v3/shipping_methods"
+                    }
+                ]
+            }
+        },
+        {
+            "id": "ups",
+            "title": "UPS",
+            "description": "The UPS extension obtains rates dynamically from the UPS API during cart/checkout.",
+            "_links": {
+                "self": [
+                    {
+                        "href": "https://woo-practically-automatic-witch.wpcomstaging.com/wp-json/wc/v3/shipping_methods/ups"
+                    }
+                ],
+                "collection": [
+                    {
+                        "href": "https://woo-practically-automatic-witch.wpcomstaging.com/wp-json/wc/v3/shipping_methods"
+                    }
+                ]
+            }
+        },
+        {
+            "id": "usps",
+            "title": "USPS",
+            "description": "The USPS extension obtains rates dynamically from the USPS API during cart/checkout.",
+            "_links": {
+                "self": [
+                    {
+                        "href": "https://woo-practically-automatic-witch.wpcomstaging.com/wp-json/wc/v3/shipping_methods/usps"
+                    }
+                ],
+                "collection": [
+                    {
+                        "href": "https://woo-practically-automatic-witch.wpcomstaging.com/wp-json/wc/v3/shipping_methods"
+                    }
+                ]
+            }
+        },
+        {
+            "id": "pickup_location",
+            "title": "Local pickup",
+            "description": "Allow customers to choose a local pickup location during checkout.",
+            "_links": {
+                "self": [
+                    {
+                        "href": "https://woo-practically-automatic-witch.wpcomstaging.com/wp-json/wc/v3/shipping_methods/pickup_location"
+                    }
+                ],
+                "collection": [
+                    {
+                        "href": "https://woo-practically-automatic-witch.wpcomstaging.com/wp-json/wc/v3/shipping_methods"
+                    }
+                ]
+            }
+        }
+    ]
+}


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #12579
<!-- Id number of the GitHub issue this PR addresses. -->

## Why
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
We want to fetch a list of the available shipping methods on a store, so the merchant can select a method when adding shipping to an order. This adds networking support to fetch the shipping methods.

## How
* Adds a `ShippingMethod` networking entity with the method ID and title.
* Adds `ShippingMethodsRemote` and a `loadShippingMethods(for:)` method to fetch the methods from remote.
* Adds a `ShippingMethodListMapper` to map the response from the remote endpoint.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

This endpoint is not yet used in the app; confirm unit tests pass.


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
