### PR TITLE
Fix notifications issues

### DIFF
--- a/WooCommerce/Classes/AppDelegate.swift
+++ b/WooCommerce/Classes/AppDelegate.swift
@@ -74,6 +74,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         setupWormholy()
         setupKeyboardStateProvider()
         handleLaunchArguments()
+        setupUserNotificationCenter()
 
         // Components that require prior Auth
         setupZendesk()
@@ -365,6 +366,10 @@ private extension AppDelegate {
             pushNotesManager.registerForRemoteNotifications()
             pushNotesManager.ensureAuthorizationIsRequested(includesProvisionalAuth: false, onCompletion: nil)
         #endif
+    }
+
+    func setupUserNotificationCenter() {
+        UNUserNotificationCenter.current().delegate = self
     }
 
     func setupUniversalLinkRouter() {


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

In #12443, in-app notifications (when the app is in the foreground) were inadvertently broken, and so was navigation/handling of background notifications.

This was because we removed the delegate link to the UNUserNotificationCenter, so the delegate methods `AppDelegate.userNotificationCenter(_:didReceive:)` and `AppDelegate.userNotificationCenter(_:willPresent:)` were never called, and so not forwarded to the `pushNotesManager`.

This commit restores the delegate configuration.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

1. launch the app
2. select a store connected via jetpack, and leave the app open
3. on another device, make a purchase for anything
4. The app should show a notice saying you've got a new order, with a view button...

Repeat the test with the app in the background. Tapping the notification should open the order.



---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
