### PR TITLE
Fix Menu Scroll Jump Issue in Hub Menu

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Hub Menu/HubMenu.swift
+++ b/WooCommerce/Classes/ViewRelated/Hub Menu/HubMenu.swift
@@ -282,13 +282,6 @@ private extension HubMenu {
             HStack(spacing: HubMenu.Constants.padding) {
 
                 HStack(spacing: .zero) {
-                    /// iOS 16, aligns the list dividers to the first text position.
-                    /// This tricks the system by rendering an empty text and forcing the list to align the divider to it.
-                    /// Without this, the divider will be rendered from the title and will not cover the icon.
-                    /// Ideally we would want to use the `alignmentGuide` modifier but that is only available on iOS 16.
-                    ///
-                    Text("")
-
                     ZStack {
                         // Icon
                         Group {
@@ -324,6 +317,8 @@ private extension HubMenu {
                         }
                     }
                 }
+                // Adjusts the list row separator to align with the leading edge of this view.
+                .alignmentGuide(.listRowSeparatorLeading) { d in d[.leading] }
 
 
                 // Title & Description

--- a/WooCommerce/Classes/ViewRelated/Hub Menu/HubMenu.swift
+++ b/WooCommerce/Classes/ViewRelated/Hub Menu/HubMenu.swift
@@ -132,7 +132,6 @@ private extension HubMenu {
         }
         .listStyle(.insetGrouped)
         .background(Color(.listBackground))
-        .toolbar(.hidden, for: .navigationBar)
         .accentColor(Color(.listSelectedBackground))
     }
 

--- a/WooCommerce/Classes/ViewRelated/Hub Menu/HubMenuViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Hub Menu/HubMenuViewController.swift
@@ -66,7 +66,7 @@ final class HubMenuViewController: UIHostingController<HubMenu> {
         // We want to hide navigation bar *only* on HubMenu screen. But on iOS 16, the `navigationBarHidden(true)`
         // modifier on `HubMenu` view hides the navigation bar for the whole navigation stack.
         // Here we manually hide or show navigation bar when entering or leaving the HubMenu screen.
-        self.navigationController?.setNavigationBarHidden(true, animated: animated)
+        navigationController?.setNavigationBarHidden(true, animated: animated)
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Hub Menu/HubMenuViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Hub Menu/HubMenuViewController.swift
@@ -66,17 +66,7 @@ final class HubMenuViewController: UIHostingController<HubMenu> {
         // We want to hide navigation bar *only* on HubMenu screen. But on iOS 16, the `navigationBarHidden(true)`
         // modifier on `HubMenu` view hides the navigation bar for the whole navigation stack.
         // Here we manually hide or show navigation bar when entering or leaving the HubMenu screen.
-        if #available(iOS 16.0, *) {
-            self.navigationController?.setNavigationBarHidden(true, animated: animated)
-        }
-    }
-
-    override func viewWillDisappear(_ animated: Bool) {
-        super.viewWillDisappear(animated)
-
-        if #available(iOS 16.0, *) {
-            self.navigationController?.setNavigationBarHidden(false, animated: animated)
-        }
+        self.navigationController?.setNavigationBarHidden(true, animated: animated)
     }
 }
 


### PR DESCRIPTION
Closes: #12640

## Description
Users experienced an unexpected "bump" to the top of the menu view when attempting to scroll down. This issue, in reality, happens every time a user accesses the Hub Menu, and then navigates to the sub-settings views, and then presses back.

## Testing instructions
1. Open the app and tap on the Menu.
2. Navigate to one of the settings.
3. Press back.
4. Scroll down on the Hub menu.

#### Changes Made:
- Removed the `.toolbar(.hidden, for: .navigationBar)` modifier from the `HubMenu` view, which was causing the navigation bar to be hidden also if it was already hidden and affecting the layout of the list.
- Cleaned up and simplified the code by removing unnecessary comments and adjustments related to list row separator alignment that were no longer needed from iOS 16 (unrelated to this bug).
- Ensured the navigation bar is hidden on the `HubMenuViewController` to maintain a consistent layout and avoid the scroll jumping issue. Removed `viewWillDisappear` since it was never called after migrating the view to SwiftUI.

## Video
| Before             |  After |
:-------------------------:|:-------------------------:
<img src="https://github.com/woocommerce/woocommerce-ios/assets/495617/d2cdd670-db2e-486e-a184-05dfc5766e9d" width=300 /> | <img src="https://github.com/woocommerce/woocommerce-ios/assets/495617/b6bd5b09-e725-4f32-8402-f2cb909ca4d0" width=300 />





---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
