### PR TITLE
[SiOC - customer creation] Customer search: CTA and integration with existing customer selector

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/CustomerSection/OrderCustomerSection.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/CustomerSection/OrderCustomerSection.swift
@@ -6,14 +6,39 @@ struct OrderCustomerSection: View {
     var body: some View {
         Group {
             if let cardViewModel = viewModel.cardViewModel {
-                CollapsibleCustomerCard(viewModel: cardViewModel)
-                    .padding()
+                VStack(alignment: .leading, spacing: Layout.spacingBetweenHeaderAndCard) {
+                    HStack {
+                        Text(Localization.customerHeader)
+                            .headlineStyle()
+                        Spacer()
+                        searchCustomerView
+                    }
+
+                    CollapsibleCustomerCard(viewModel: cardViewModel)
+                }
+                .padding()
             } else {
                 createCustomerView
                     .frame(minHeight: Layout.buttonHeight)
             }
         }
         .background(Color(.listForeground(modal: true)))
+        .sheet(isPresented: $viewModel.showsCustomerSearch) {
+            NavigationView {
+                CustomerSelectorView(
+                    siteID: viewModel.siteID,
+                    configuration: CustomerSelectorViewController.Configuration(
+                        title: Localization.customerSelectorTitle,
+                        disallowSelectingGuest: viewModel.isCustomerAccountRequired,
+                        disallowCreatingCustomer: true,
+                        showGuestLabel: false,
+                        shouldTrackCustomerAdded: true
+                    ),
+                    addressFormViewModel: viewModel.addressFormViewModel) { customer in
+                        viewModel.addCustomerFromSearch(customer)
+                    }
+            }
+        }
     }
 
     private var createCustomerView: some View {
@@ -23,18 +48,35 @@ struct OrderCustomerSection: View {
         .buttonStyle(PlusButtonStyle())
         .padding([.leading, .trailing])
     }
+
+    private var searchCustomerView: some View {
+        Button(action: {
+            viewModel.searchCustomer()
+        }, label: {
+            Image(systemName: "magnifyingglass")
+        })
+        .buttonStyle(TextButtonStyle())
+    }
 }
 
 // MARK: Constants
 private extension OrderCustomerSection {
     enum Layout {
         static let buttonHeight: CGFloat = 56.0
+        static let spacingBetweenHeaderAndCard: CGFloat = 16
     }
 
     enum Localization {
         static let addCustomerDetails = NSLocalizedString("orderForm.customerSection.addCustomer",
                                                           value: "Add Customer",
                                                           comment: "Title text of the button that adds customer data when creating a new order")
+        static let customerHeader = NSLocalizedString("orderForm.customerSection.customerHeader",
+                                                          value: "Customer",
+                                                          comment: "Header text of the  when creating a new order")
+        static let customerSelectorTitle = NSLocalizedString(
+            "configurationForOrderCustomerSection.customerSelectorTitle",
+            value: "Add customer details",
+            comment: "Title of the order customer selection screen.")
     }
 }
 
@@ -47,8 +89,28 @@ struct OrderCustomerSection_Previews: PreviewProvider {
     )
     static var previews: some View {
         Group {
-            OrderCustomerSection(viewModel: .init(customerData: customer, isCustomerAccountRequired: true, isEditable: true))
-            OrderCustomerSection(viewModel: .init(customerData: customer, isCustomerAccountRequired: false, isEditable: true))
+            OrderCustomerSection(viewModel: .init(siteID: 1,
+                                                  addressFormViewModel: .init(
+                                                    siteID: 1,
+                                                    addressData: .init(billingAddress: nil,
+                                                                       shippingAddress: nil),
+                                                    onAddressUpdate: nil
+                                                  ),
+                                                  customerData: customer,
+                                                  isCustomerAccountRequired: true,
+                                                  isEditable: true,
+                                                  addCustomer: { _ in }))
+            OrderCustomerSection(viewModel: .init(siteID: 1,
+                                                  addressFormViewModel: .init(
+                                                    siteID: 1,
+                                                    addressData: .init(billingAddress: nil,
+                                                                       shippingAddress: nil),
+                                                    onAddressUpdate: nil
+                                                  ),
+                                                  customerData: customer,
+                                                  isCustomerAccountRequired: false,
+                                                  isEditable: true,
+                                                  addCustomer: { _ in }))
         }
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/CustomerSection/OrderCustomerSection.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/CustomerSection/OrderCustomerSection.swift
@@ -69,14 +69,15 @@ private extension OrderCustomerSection {
     enum Localization {
         static let addCustomerDetails = NSLocalizedString("orderForm.customerSection.addCustomer",
                                                           value: "Add Customer",
-                                                          comment: "Title text of the button that adds customer data when creating a new order")
+                                                          comment: "Title text of the button that adds customer data in the order form.")
         static let customerHeader = NSLocalizedString("orderForm.customerSection.customerHeader",
-                                                          value: "Customer",
-                                                          comment: "Header text of the  when creating a new order")
+                                                      value: "Customer",
+                                                      comment: "Header text of the customer card in the order form.")
         static let customerSelectorTitle = NSLocalizedString(
-            "configurationForOrderCustomerSection.customerSelectorTitle",
+            "orderForm.customerSection.customerSelectorTitle",
             value: "Add customer details",
-            comment: "Title of the order customer selection screen.")
+            comment: "Title of the order customer selection screen in the order form.."
+        )
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/CustomerSection/OrderCustomerSectionViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/CustomerSection/OrderCustomerSectionViewModel.swift
@@ -1,18 +1,29 @@
 import SwiftUI
+import Yosemite
 
 /// View model for `OrderCustomerSection` view.
 final class OrderCustomerSectionViewModel: ObservableObject {
+    let siteID: Int64
     let isCustomerAccountRequired: Bool
     let isEditable: Bool
+    @Published var showsCustomerSearch: Bool = false
     @Published private(set) var cardViewModel: CollapsibleCustomerCardViewModel?
+    @Published private(set) var addressFormViewModel: CreateOrderAddressFormViewModel
     private let customerData: CollapsibleCustomerCardViewModel.CustomerData
+    private let addCustomer: (Customer) -> Void
 
-    init(customerData: CollapsibleCustomerCardViewModel.CustomerData,
+    init(siteID: Int64,
+         addressFormViewModel: CreateOrderAddressFormViewModel,
+         customerData: CollapsibleCustomerCardViewModel.CustomerData,
          isCustomerAccountRequired: Bool,
-         isEditable: Bool) {
+         isEditable: Bool,
+         addCustomer: @escaping (Customer) -> Void) {
+        self.siteID = siteID
+        self.addressFormViewModel = addressFormViewModel
         self.customerData = customerData
         self.isCustomerAccountRequired = isCustomerAccountRequired
         self.isEditable = isEditable
+        self.addCustomer = addCustomer
         if customerData.email?.isNotEmpty == true || customerData.shippingAddressFormatted?.isNotEmpty == true {
             self.cardViewModel = .init(customerData: customerData,
                                        isCustomerAccountRequired: isCustomerAccountRequired,
@@ -27,5 +38,15 @@ final class OrderCustomerSectionViewModel: ObservableObject {
                               isCustomerAccountRequired: isCustomerAccountRequired,
                               isEditable: isEditable,
                               isCollapsed: false)
+    }
+
+    /// Called when the user taps to search for a customer.
+    func searchCustomer() {
+        showsCustomerSearch = true
+    }
+
+    /// Called when the user selects a customer from search.
+    func addCustomerFromSearch(_ customer: Customer) {
+        addCustomer(customer)
     }
 }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #12652 
<!-- Id number of the GitHub issue this PR addresses. -->

## Why

Another way to add/edit a customer in order form other than entering the email/addresses manually is to select an existing customer. This is already supported in the app, and this PR creates a CTA based on the design and integrates with the existing customer search flow.

## How

The CTA is located above the customer card, at the trailing edge of the customer section header text in `OrderCustomerSection`. When the search icon is tapped, it opens a sheet of the customer selector under the `viewModel.showsCustomerSearch` boolean. The customer selector requires a `addressFormViewModel: CreateOrderAddressFormViewModel` parameter, even though it isn't used in the selector internally because we disallow editing customer details by `disallowCreatingCustomer: true`.

While testing, I encountered a bug where selecting a customer from the selector sheet (where `dismiss` is called in the view controller) would close both the sheet **and** the order form. It turned out that because I originally reinitialized the `OrderCustomerSectionViewModel` in `configureCustomerDataViewModel` whenever the order changes, the section view model's `showsCustomerSearch` boolean also got reset to `false` (default value), and thus the sheet is hidden automatically and order form got dismissed instead. To fix this issue, I updated `OrderCustomerSectionViewModel` to have the same lifetime as `EditableOrderViewModel` / order form and synced the customer data via a published variable.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

- [x] @jaclync tests the production flow when the feature flag is disabled

---

Prerequisite: the store has at least two different customers

### Create order

- Go to the orders tab
- Tap +
- Tap `Add Customer` --> there should be new space above the customer card with a search icon at the trailing edge
- Tap on the search icon --> it should show the customer selector sheet
- Tap on a customer (guest or customer with an account) --> the customer details should be filled into the customer card
- Tap `Create` --> the customer details should be saved to the new order remotely

### Edit order

- Go to the orders tab
- Tap on an existing order with a customer that has an email set
- Tap `Edit` --> a customer card should be shown
- Tap on the search icon --> it should show the customer selector sheet
- Tap on a different customer (guest or customer with an account) --> the customer details should be filled into the customer card, and the order's customer details should be saved remotely after the spinner disappears


## Screenshots
<!-- Include before and after images or gifs when appropriate. -->


https://github.com/woocommerce/woocommerce-ios/assets/1945542/3b777ec4-d9ac-4d4f-a54b-6abc5d087122



---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
