### PR TITLE
[SiOC - customer creation] Add CTA to remove customer from order

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/CustomerSection/CustomerCard/CollapsibleCustomerCard.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/CustomerSection/CustomerCard/CollapsibleCustomerCard.swift
@@ -19,11 +19,14 @@ struct CollapsibleCustomerCard: View {
                                               emailPlaceholder: viewModel.emailPlaceholder,
                                               shippingAddress: viewModel.shippingAddress)
         }, content: {
-            VStack(alignment: .leading) {
+            VStack(alignment: .leading, spacing: Layout.expandedContentVerticalSpacing) {
                 Divider()
-                Text(Localization.emailAddressTitle)
-                TextField(Localization.emailAddressPlaceholder, text: $viewModel.email)
-                    .textFieldStyle(RoundedBorderTextFieldStyle(focused: true))
+
+                VStack(alignment: .leading) {
+                    Text(Localization.emailAddressTitle)
+                    TextField(Localization.emailAddressPlaceholder, text: $viewModel.email)
+                        .textFieldStyle(RoundedBorderTextFieldStyle(focused: true))
+                }
 
                 Text("Create new customer toggle")
 
@@ -34,7 +37,7 @@ struct CollapsibleCustomerCard: View {
                 removeCustomerView()
                     .renderedIf(viewModel.canRemoveCustomer)
             }
-            .padding(.horizontal)
+            .padding(Layout.expandedContentPadding)
         })
     }
 }
@@ -59,6 +62,8 @@ private extension CollapsibleCustomerCard {
 private extension CollapsibleCustomerCard {
     enum Layout {
         static let headerAdditionalPadding: EdgeInsets = .init(top: 8, leading: 0, bottom: 8, trailing: 0)
+        static let expandedContentPadding: EdgeInsets = .init(top: 0, leading: 16, bottom: 16, trailing: 16)
+        static let expandedContentVerticalSpacing: CGFloat = 16
     }
 
     enum Localization {

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/CustomerSection/CustomerCard/CollapsibleCustomerCard.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/CustomerSection/CustomerCard/CollapsibleCustomerCard.swift
@@ -30,10 +30,29 @@ struct CollapsibleCustomerCard: View {
                 Divider()
 
                 Text("Address")
-                Text("Remove customer from order")
+
+                removeCustomerView()
+                    .renderedIf(viewModel.canRemoveCustomer)
             }
             .padding(.horizontal)
         })
+    }
+}
+
+private extension CollapsibleCustomerCard {
+    @ViewBuilder private func removeCustomerView() -> some View {
+        Button {
+            viewModel.removeCustomer()
+        } label: {
+            HStack(alignment: .center) {
+                Label {
+                    Text(Localization.removeCustomer)
+                } icon: {
+                    Image(systemName: "multiply.circle")
+                }
+            }
+        }
+        .foregroundColor(Color(uiColor: .withColorStudio(.red, shade: .shade60)))
     }
 }
 
@@ -53,17 +72,24 @@ private extension CollapsibleCustomerCard {
             value: "Enter email address",
             comment: "Title of the email text field in the order form customer card."
         )
+        static let removeCustomer = NSLocalizedString(
+            "collapsibleCustomerCard.removeCustomerButton.title",
+            value: "Remove customer from order",
+            comment: "Title of the button to remove customer from an order in the order form customer card."
+        )
     }
 }
 
 struct CollapsibleCustomerCard_Previews: PreviewProvider {
     static var previews: some View {
-        CollapsibleCustomerCard(viewModel: .init(customerData: .init(email: nil,
+        CollapsibleCustomerCard(viewModel: .init(customerData: .init(customerID: nil,
+                                                                     email: nil,
                                                                      fullName: nil,
                                                                      billingAddressFormatted: nil,
                                                                      shippingAddressFormatted: nil),
                                                  isCustomerAccountRequired: true,
                                                  isEditable: true,
-                                                 isCollapsed: false))
+                                                 isCollapsed: false,
+                                                 removeCustomer: {}))
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/CustomerSection/CustomerCard/CollapsibleCustomerCardViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/CustomerSection/CustomerCard/CollapsibleCustomerCardViewModel.swift
@@ -3,6 +3,7 @@ import SwiftUI
 /// View model for `CollapsibleCustomerCard` view.
 final class CollapsibleCustomerCardViewModel: ObservableObject {
     struct CustomerData {
+        let customerID: Int64?
         let email: String?
         let fullName: String?
         let billingAddressFormatted: String?
@@ -23,18 +24,28 @@ final class CollapsibleCustomerCardViewModel: ObservableObject {
             .joined(separator: "\n")
     }
 
+    /// Whether the Remove Customer CTA can be shown.
+    var canRemoveCustomer: Bool {
+        (originalCustomerData.customerID ?? Constants.guestCustomerID) != Constants.guestCustomerID
+    }
+
+    /// Called when the user taps to remove customer.
+    let removeCustomer: () -> Void
+
     private let originalCustomerData: CustomerData
 
     init(customerData: CustomerData,
          isCustomerAccountRequired: Bool,
          isEditable: Bool,
-         isCollapsed: Bool) {
+         isCollapsed: Bool,
+         removeCustomer: @escaping () -> Void) {
         self.isCustomerAccountRequired = isCustomerAccountRequired
         self.isEditable = isEditable
         self.isCollapsed = isCollapsed
         self.emailPlaceholder = Localization.emailPlaceholder(isRequired: isCustomerAccountRequired)
         self.email = customerData.email ?? ""
         self.originalCustomerData = customerData
+        self.removeCustomer = removeCustomer
     }
 }
 
@@ -54,5 +65,11 @@ private extension CollapsibleCustomerCardViewModel {
             value: "Email address",
             comment: "Placeholder of the email in the header of a customer card in order form when an account is not required."
         )
+    }
+
+    enum Constants {
+        /// Order's customer ID is default to 0 based on the API doc:
+        /// https://woocommerce.github.io/woocommerce-rest-api-docs/#order-properties
+        static let guestCustomerID: Int64 = 0
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/CustomerSection/OrderCustomerSection.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/CustomerSection/OrderCustomerSection.swift
@@ -83,6 +83,7 @@ private extension OrderCustomerSection {
 
 struct OrderCustomerSection_Previews: PreviewProvider {
     static let customer: CollapsibleCustomerCardViewModel.CustomerData = .init(
+        customerID: 0,
         email: "customer@woo.com",
         fullName: "T Woo",
         billingAddressFormatted: "123 60th St\nUSA",
@@ -100,7 +101,7 @@ struct OrderCustomerSection_Previews: PreviewProvider {
                                                   customerData: customer,
                                                   isCustomerAccountRequired: true,
                                                   isEditable: true,
-                                                  addCustomer: { _ in }))
+                                                  updateCustomer: { _ in }))
             OrderCustomerSection(viewModel: .init(siteID: 1,
                                                   addressFormViewModel: .init(
                                                     siteID: 1,
@@ -111,7 +112,7 @@ struct OrderCustomerSection_Previews: PreviewProvider {
                                                   customerData: customer,
                                                   isCustomerAccountRequired: false,
                                                   isEditable: true,
-                                                  addCustomer: { _ in }))
+                                                  updateCustomer: { _ in }))
         }
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/CustomerSection/OrderCustomerSectionViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/CustomerSection/OrderCustomerSectionViewModel.swift
@@ -12,7 +12,7 @@ final class OrderCustomerSectionViewModel: ObservableObject {
     @Published var showsCustomerSearch: Bool = false
     @Published var customerData: CollapsibleCustomerCardViewModel.CustomerData
     @Published private(set) var addressFormViewModel: CreateOrderAddressFormViewModel
-    private let addCustomer: (Customer) -> Void
+    private let updateCustomer: (Customer?) -> Void
 
     @Published private(set) var cardViewModel: CollapsibleCustomerCardViewModel?
 
@@ -21,13 +21,13 @@ final class OrderCustomerSectionViewModel: ObservableObject {
          customerData: CollapsibleCustomerCardViewModel.CustomerData,
          isCustomerAccountRequired: Bool,
          isEditable: Bool,
-         addCustomer: @escaping (Customer) -> Void) {
+         updateCustomer: @escaping (Customer?) -> Void) {
         self.siteID = siteID
         self.addressFormViewModel = addressFormViewModel
         self.customerData = customerData
         self.isCustomerAccountRequired = isCustomerAccountRequired
         self.isEditable = isEditable
-        self.addCustomer = addCustomer
+        self.updateCustomer = updateCustomer
         observeCustomerDataForCardViewModel()
     }
 
@@ -36,7 +36,8 @@ final class OrderCustomerSectionViewModel: ObservableObject {
         cardViewModel = .init(customerData: customerData,
                               isCustomerAccountRequired: isCustomerAccountRequired,
                               isEditable: isEditable,
-                              isCollapsed: false)
+                              isCollapsed: false,
+                              removeCustomer: removeCustomer)
     }
 
     /// Called when the user taps to search for a customer.
@@ -46,7 +47,13 @@ final class OrderCustomerSectionViewModel: ObservableObject {
 
     /// Called when the user selects a customer from search.
     func addCustomerFromSearch(_ customer: Customer) {
-        addCustomer(customer)
+        updateCustomer(customer)
+    }
+}
+
+private extension OrderCustomerSectionViewModel {
+    func removeCustomer() {
+        updateCustomer(nil)
     }
 }
 
@@ -60,7 +67,8 @@ private extension OrderCustomerSectionViewModel {
                 return CollapsibleCustomerCardViewModel(customerData: customerData,
                                                         isCustomerAccountRequired: isCustomerAccountRequired,
                                                         isEditable: isEditable,
-                                                        isCollapsed: true)
+                                                        isCollapsed: true,
+                                                        removeCustomer: removeCustomer)
             }
             .assign(to: &$cardViewModel)
     }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/EditableOrderViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/EditableOrderViewModel.swift
@@ -827,7 +827,7 @@ final class EditableOrderViewModel: ObservableObject {
         resetAddressForm()
     }
 
-    func removeCustomerFromOrder() {
+    private func removeCustomerFromOrder() {
         orderSynchronizer.removeCustomerID.send(())
         let input = Self.createAddressesInputIfPossible(billingAddress: .empty, shippingAddress: .empty)
         orderSynchronizer.setAddresses.send(input)

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/Synchronizer/OrderSynchronizer.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/Synchronizer/OrderSynchronizer.swift
@@ -148,6 +148,10 @@ protocol OrderSynchronizer {
     ///
     var setCustomerID: PassthroughSubject<Int64, Never> { get }
 
+    /// Removes customer from the order.
+    ///
+    var removeCustomerID: PassthroughSubject<Void, Never> { get }
+
     /// Trigger to retry a remote sync.
     ///
     var retryTrigger: PassthroughSubject<Void, Never> { get }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/Synchronizer/RemoteOrderSynchronizer.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/Synchronizer/RemoteOrderSynchronizer.swift
@@ -55,6 +55,8 @@ final class RemoteOrderSynchronizer: OrderSynchronizer {
 
     let setCustomerID = PassthroughSubject<Int64, Never>()
 
+    let removeCustomerID = PassthroughSubject<Void, Never>()
+
     var retryTrigger = PassthroughSubject<Void, Never>()
 
     // MARK: Private properties
@@ -306,6 +308,15 @@ private extension RemoteOrderSynchronizer {
         setCustomerID.withLatestFrom(orderPublisher)
             .map { customerID, order in
                 order.copy(customerID: customerID)
+            }
+            .sink { [weak self] order in
+                self?.order = order
+            }
+            .store(in: &subscriptions)
+
+        removeCustomerID.withLatestFrom(orderPublisher)
+            .map { _, order in
+                order.copy(customerID: 0)
             }
             .sink { [weak self] order in
                 self?.order = order

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/Synchronizer/RemoteOrderSynchronizerTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/Synchronizer/RemoteOrderSynchronizerTests.swift
@@ -709,6 +709,50 @@ final class RemoteOrderSynchronizerTests: XCTestCase {
         XCTAssertTrue(update.fields.contains(.customerID))
     }
 
+    func test_removing_customer_id_sets_customer_id_to_0() {
+        // Given
+        let order = Order.fake().copy(orderID: sampleOrderID, customerID: 16)
+        let stores = MockStoresManager(sessionManager: .testingInstance)
+        let synchronizer = RemoteOrderSynchronizer(siteID: sampleSiteID, flow: .editing(initialOrder: order), stores: stores)
+
+        // When
+        stores.whenReceivingAction(ofType: OrderAction.self) { action in
+            // Then
+            XCTFail("Unexpected action: \(action)")
+        }
+        synchronizer.removeCustomerID.send(())
+
+        // Then
+        XCTAssertEqual(synchronizer.order.customerID, 0)
+    }
+
+    func test_removing_customer_id_does_not_trigger_sync_in_creation_flow() {
+        // Given
+        let stores = MockStoresManager(sessionManager: .testingInstance)
+        let synchronizer = RemoteOrderSynchronizer(siteID: sampleSiteID, flow: .creation, stores: stores)
+
+        // When
+        stores.whenReceivingAction(ofType: OrderAction.self) { action in
+            // Then
+            XCTFail("Unexpected action: \(action)")
+        }
+        synchronizer.removeCustomerID.send(())
+    }
+
+    func test_removing_customer_id_does_not_trigger_sync_in_edit_flow() {
+        // Given
+        let order = Order.fake().copy(orderID: sampleOrderID)
+        let stores = MockStoresManager(sessionManager: .testingInstance)
+        let synchronizer = RemoteOrderSynchronizer(siteID: sampleSiteID, flow: .editing(initialOrder: order), stores: stores)
+
+        // When
+        stores.whenReceivingAction(ofType: OrderAction.self) { action in
+            // Then
+            XCTFail("Unexpected action: \(action)")
+        }
+        synchronizer.removeCustomerID.send(())
+    }
+
     func test_states_are_properly_set_upon_success_order_creation() {
         // Given
         let product = Product.fake().copy(productID: sampleProductID)


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #12658
<!-- Id number of the GitHub issue this PR addresses. -->

## Why

This PR adds a CTA `Remove customer from order` when a non-guest customer is set, and when it's tapped it removes the customer account and the addresses. For some reason, the email isn't reset, but we can also decide whether to also remove the email and look into how to do this.

## How

- Showed the Remove Customer CTA in `CollapsibleCustomerCard.removeCustomerView`
- DI'ed `removeCustomer` to the view model `CollapsibleCustomerCardViewModel`, and added `customerID` to the customer data struct to check if the CTA is shown
- To integrate with the order form in `EditableOrderViewModel`, a new sync action `OrderSynchronizer .removeCustomerID` was added. Then in `EditableOrderViewModel`, it triggers `removeCustomerID` and then sets the addresses to empty with sync in editing mode
- Updated padding in `CollapsibleCustomerCard`

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

Prerequisite: the store has at least 1 customer with an account, and an order that is attached to a customer

- Go to the orders tab
- Tap on an order with a customer account
- Tap `Edit`
- Tap to expand the customer card --> `Remove customer from order` CTA should be shown
- Tap `Remove customer from order` --> the customer should be removed from the order in core, with addresses unset (🗒️ there's an issue where the email/phone is still kept, I left it as a separate subtask in https://github.com/woocommerce/woocommerce-ios/issues/12592)

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->


https://github.com/woocommerce/woocommerce-ios/assets/1945542/a7ed56f5-70bd-4f28-b70c-082853d76c51

dark | light
-- | --
<img src="https://github.com/woocommerce/woocommerce-ios/assets/1945542/8f8ba535-b7ff-4d94-b8ff-0eddb7690c4e" width="300" /> | <img src="https://github.com/woocommerce/woocommerce-ios/assets/1945542/573c7b60-28ec-493f-92cf-bbb9187eb514" width="300" />

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
