### PR TITLE
[SiOC - customer creation] Show/add/edit customer address

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/CustomerSection/CreateOrderAddressFormViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/CustomerSection/CreateOrderAddressFormViewModel.swift
@@ -14,11 +14,13 @@ final class CreateOrderAddressFormViewModel: AddressFormViewModel, AddressFormVi
     private let onAddressUpdate: ((NewOrderAddressData) -> Void)?
 
     init(siteID: Int64,
+         showEmailField: Bool = true,
          addressData: NewOrderAddressData,
          onAddressUpdate: ((NewOrderAddressData) -> Void)?,
          storageManager: StorageManagerType = ServiceLocator.storageManager,
          stores: StoresManager = ServiceLocator.stores,
          analytics: Analytics = ServiceLocator.analytics) {
+        self.showEmailField = showEmailField
         self.onAddressUpdate = onAddressUpdate
 
         // don't prefill second set of fields if input addresses are identical
@@ -38,7 +40,7 @@ final class CreateOrderAddressFormViewModel: AddressFormViewModel, AddressFormVi
 
     // MARK: - Protocol conformance
 
-    let showEmailField: Bool = true
+    let showEmailField: Bool
 
     let showPhoneCountryCodeField: Bool = false
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/CustomerSection/CustomerCard/CollapsibleCustomerCard.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/CustomerSection/CustomerCard/CollapsibleCustomerCard.swift
@@ -32,7 +32,7 @@ struct CollapsibleCustomerCard: View {
 
                 Divider()
 
-                Text("Address")
+                CollapsibleCustomerCardAddressView(viewModel: viewModel.addressViewModel)
 
                 removeCustomerView()
                     .renderedIf(viewModel.canRemoveCustomer)

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/CustomerSection/CustomerCard/CollapsibleCustomerCard.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/CustomerSection/CustomerCard/CollapsibleCustomerCard.swift
@@ -95,6 +95,7 @@ struct CollapsibleCustomerCard_Previews: PreviewProvider {
                                                  isCustomerAccountRequired: true,
                                                  isEditable: true,
                                                  isCollapsed: false,
-                                                 removeCustomer: {}))
+                                                 removeCustomer: {},
+                                                 editAddress: {}))
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/CustomerSection/CustomerCard/CollapsibleCustomerCardAddressView.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/CustomerSection/CustomerCard/CollapsibleCustomerCardAddressView.swift
@@ -1,0 +1,148 @@
+import SwiftUI
+import Yosemite
+
+final class CollapsibleCustomerCardAddressViewModel: ObservableObject {
+    let state: CollapsibleCustomerCardAddressView.State
+    let editAddress: () -> Void
+
+    init(billingAddressFormatted: String?,
+         shippingAddressFormatted: String?,
+         editAddress: @escaping () -> Void) {
+        self.state = {
+            guard !billingAddressFormatted.isNilOrEmpty || !shippingAddressFormatted.isNilOrEmpty else {
+                return .addAddress
+            }
+            if billingAddressFormatted == shippingAddressFormatted {
+                return .sameBillingAndShippingAddress(address: billingAddressFormatted ?? "")
+            }
+            if let billingAddressFormatted, billingAddressFormatted.isNotEmpty {
+                if let shippingAddressFormatted, shippingAddressFormatted.isNotEmpty {
+                    return .differentBillingAndShippingAddresses(billing: billingAddressFormatted, shipping: shippingAddressFormatted)
+                } else {
+                    return .billingOnly(address: billingAddressFormatted)
+                }
+            } else if let shippingAddressFormatted, shippingAddressFormatted.isNotEmpty {
+                if let billingAddressFormatted, billingAddressFormatted.isNotEmpty {
+                    return .differentBillingAndShippingAddresses(billing: billingAddressFormatted, shipping: shippingAddressFormatted)
+                } else {
+                    return .shippingOnly(address: shippingAddressFormatted)
+                }
+            } else {
+                return .addAddress
+            }
+        }()
+        self.editAddress = editAddress
+    }
+}
+
+struct CollapsibleCustomerCardAddressView: View {
+    let viewModel: CollapsibleCustomerCardAddressViewModel
+
+    enum State {
+        case addAddress
+        case sameBillingAndShippingAddress(address: String)
+        case billingOnly(address: String)
+        case shippingOnly(address: String)
+        case differentBillingAndShippingAddresses(billing: String, shipping: String)
+    }
+
+    var body: some View {
+        switch viewModel.state {
+            case .addAddress:
+                addAddressView()
+            case let .sameBillingAndShippingAddress(address), let .billingOnly(address), let .shippingOnly(address):
+                VStack(alignment: .leading, spacing: Layout.addressVerticalSpacing) {
+                    editableAddressHeaderView(title: Localization.addressHeader)
+                    Text(address)
+                }
+            case let .differentBillingAndShippingAddresses(billing, shipping):
+                VStack(alignment: .leading, spacing: Layout.addressVerticalSpacing) {
+                    editableAddressHeaderView(title: Localization.billingAddressHeader)
+                    Text(billing)
+
+                    Text(Localization.shippingAddressHeader)
+                        .headlineStyle()
+                    Text(shipping)
+                }
+        }
+    }
+}
+
+private extension CollapsibleCustomerCardAddressView {
+    @ViewBuilder private func addAddressView() -> some View {
+        Button(Localization.addAddress, action: {
+            viewModel.editAddress()
+        })
+        .buttonStyle(PlusButtonStyle())
+    }
+
+    @ViewBuilder private func editableAddressHeaderView(title: String) -> some View {
+        HStack {
+            Text(title)
+                .headlineStyle()
+            Spacer()
+            Button(action: {
+                viewModel.editAddress()
+            }, label: {
+                Image(systemName: "pencil")
+            })
+            .buttonStyle(TextButtonStyle())
+        }
+    }
+}
+
+private extension CollapsibleCustomerCardAddressView {
+    enum Layout {
+        static let addressVerticalSpacing: CGFloat = 8
+    }
+
+    enum Localization {
+        static let addAddress = NSLocalizedString(
+            "collapsibleCustomerCard.addAddress.title",
+            value: "Add customer address",
+            comment: "Title of the button to add address in the order form customer card."
+        )
+        static let addressHeader = NSLocalizedString(
+            "collapsibleCustomerCard.editAddress.address.header",
+            value: "Address",
+            comment: "Address header text in the order form customer card when the billing and shipping addresses are the same."
+        )
+        static let billingAddressHeader = NSLocalizedString(
+            "collapsibleCustomerCard.editAddress.billing.header",
+            value: "Billing address",
+            comment: "Billing address header text in the order form customer card."
+        )
+        static let shippingAddressHeader = NSLocalizedString(
+            "collapsibleCustomerCard.editAddress.shipping.header",
+            value: "Shipping address",
+            comment: "Shipping address header text in the order form customer card."
+        )
+    }
+}
+
+struct CollapsibleCustomerCardAddressView_Previews: PreviewProvider {
+    static let address: Address = .init(firstName: "Customer",
+                                        lastName: "Woo",
+                                        company: nil,
+                                        address1: "60 30th St",
+                                        address2: nil,
+                                        city: "San Francisco",
+                                        state: "CA",
+                                        postcode: "94123",
+                                        country: "USA",
+                                        phone: nil,
+                                        email: nil)
+    static var previews: some View {
+        VStack {
+            CollapsibleCustomerCardAddressView(viewModel: .init(billingAddressFormatted: nil,
+                                                                shippingAddressFormatted: nil,
+                                                                editAddress: {}))
+            CollapsibleCustomerCardAddressView(viewModel: .init(billingAddressFormatted: "311 16th St\nSan Francisco",
+                                                                shippingAddressFormatted: nil,
+                                                                editAddress: {}))
+            CollapsibleCustomerCardAddressView(viewModel: .init(billingAddressFormatted: "311 16th St\nSan Francisco",
+                                                                shippingAddressFormatted: "508 19th St",
+                                                                editAddress: {}))
+        }
+    }
+}

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/CustomerSection/CustomerCard/CollapsibleCustomerCardAddressView.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/CustomerSection/CustomerCard/CollapsibleCustomerCardAddressView.swift
@@ -1,40 +1,6 @@
 import SwiftUI
-import Yosemite
 
-final class CollapsibleCustomerCardAddressViewModel: ObservableObject {
-    let state: CollapsibleCustomerCardAddressView.State
-    let editAddress: () -> Void
-
-    init(billingAddressFormatted: String?,
-         shippingAddressFormatted: String?,
-         editAddress: @escaping () -> Void) {
-        self.state = {
-            guard !billingAddressFormatted.isNilOrEmpty || !shippingAddressFormatted.isNilOrEmpty else {
-                return .addAddress
-            }
-            if billingAddressFormatted == shippingAddressFormatted {
-                return .sameBillingAndShippingAddress(address: billingAddressFormatted ?? "")
-            }
-            if let billingAddressFormatted, billingAddressFormatted.isNotEmpty {
-                if let shippingAddressFormatted, shippingAddressFormatted.isNotEmpty {
-                    return .differentBillingAndShippingAddresses(billing: billingAddressFormatted, shipping: shippingAddressFormatted)
-                } else {
-                    return .billingOnly(address: billingAddressFormatted)
-                }
-            } else if let shippingAddressFormatted, shippingAddressFormatted.isNotEmpty {
-                if let billingAddressFormatted, billingAddressFormatted.isNotEmpty {
-                    return .differentBillingAndShippingAddresses(billing: billingAddressFormatted, shipping: shippingAddressFormatted)
-                } else {
-                    return .shippingOnly(address: shippingAddressFormatted)
-                }
-            } else {
-                return .addAddress
-            }
-        }()
-        self.editAddress = editAddress
-    }
-}
-
+/// Shows a customer's address if available, with a CTA to add/edit the address.
 struct CollapsibleCustomerCardAddressView: View {
     let viewModel: CollapsibleCustomerCardAddressViewModel
 
@@ -121,17 +87,6 @@ private extension CollapsibleCustomerCardAddressView {
 }
 
 struct CollapsibleCustomerCardAddressView_Previews: PreviewProvider {
-    static let address: Address = .init(firstName: "Customer",
-                                        lastName: "Woo",
-                                        company: nil,
-                                        address1: "60 30th St",
-                                        address2: nil,
-                                        city: "San Francisco",
-                                        state: "CA",
-                                        postcode: "94123",
-                                        country: "USA",
-                                        phone: nil,
-                                        email: nil)
     static var previews: some View {
         VStack {
             CollapsibleCustomerCardAddressView(viewModel: .init(billingAddressFormatted: nil,

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/CustomerSection/CustomerCard/CollapsibleCustomerCardAddressViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/CustomerSection/CustomerCard/CollapsibleCustomerCardAddressViewModel.swift
@@ -1,0 +1,36 @@
+import SwiftUI
+
+/// View model for `CollapsibleCustomerCardAddressView`.
+final class CollapsibleCustomerCardAddressViewModel: ObservableObject {
+    let state: CollapsibleCustomerCardAddressView.State
+    let editAddress: () -> Void
+
+    init(billingAddressFormatted: String?,
+         shippingAddressFormatted: String?,
+         editAddress: @escaping () -> Void) {
+        self.state = {
+            guard !billingAddressFormatted.isNilOrEmpty || !shippingAddressFormatted.isNilOrEmpty else {
+                return .addAddress
+            }
+            if billingAddressFormatted == shippingAddressFormatted {
+                return .sameBillingAndShippingAddress(address: billingAddressFormatted ?? "")
+            }
+            if let billingAddressFormatted, billingAddressFormatted.isNotEmpty {
+                if let shippingAddressFormatted, shippingAddressFormatted.isNotEmpty {
+                    return .differentBillingAndShippingAddresses(billing: billingAddressFormatted, shipping: shippingAddressFormatted)
+                } else {
+                    return .billingOnly(address: billingAddressFormatted)
+                }
+            } else if let shippingAddressFormatted, shippingAddressFormatted.isNotEmpty {
+                if let billingAddressFormatted, billingAddressFormatted.isNotEmpty {
+                    return .differentBillingAndShippingAddresses(billing: billingAddressFormatted, shipping: shippingAddressFormatted)
+                } else {
+                    return .shippingOnly(address: shippingAddressFormatted)
+                }
+            } else {
+                return .addAddress
+            }
+        }()
+        self.editAddress = editAddress
+    }
+}

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/CustomerSection/CustomerCard/CollapsibleCustomerCardViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/CustomerSection/CustomerCard/CollapsibleCustomerCardViewModel.swift
@@ -32,6 +32,12 @@ final class CollapsibleCustomerCardViewModel: ObservableObject {
     /// Called when the user taps to remove customer.
     let removeCustomer: () -> Void
 
+    private(set) lazy var addressViewModel: CollapsibleCustomerCardAddressViewModel = .init(
+        billingAddressFormatted: originalCustomerData.billingAddressFormatted,
+        shippingAddressFormatted: originalCustomerData.shippingAddressFormatted,
+        editAddress: {}
+    )
+
     private let originalCustomerData: CustomerData
 
     init(customerData: CustomerData,

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/CustomerSection/CustomerCard/CollapsibleCustomerCardViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/CustomerSection/CustomerCard/CollapsibleCustomerCardViewModel.swift
@@ -35,8 +35,10 @@ final class CollapsibleCustomerCardViewModel: ObservableObject {
     private(set) lazy var addressViewModel: CollapsibleCustomerCardAddressViewModel = .init(
         billingAddressFormatted: originalCustomerData.billingAddressFormatted,
         shippingAddressFormatted: originalCustomerData.shippingAddressFormatted,
-        editAddress: {}
+        editAddress: editAddress
     )
+    /// Called when the user taps to add/edit address.
+    private let editAddress: () -> Void
 
     private let originalCustomerData: CustomerData
 
@@ -44,7 +46,8 @@ final class CollapsibleCustomerCardViewModel: ObservableObject {
          isCustomerAccountRequired: Bool,
          isEditable: Bool,
          isCollapsed: Bool,
-         removeCustomer: @escaping () -> Void) {
+         removeCustomer: @escaping () -> Void,
+         editAddress: @escaping () -> Void) {
         self.isCustomerAccountRequired = isCustomerAccountRequired
         self.isEditable = isEditable
         self.isCollapsed = isCollapsed
@@ -52,6 +55,7 @@ final class CollapsibleCustomerCardViewModel: ObservableObject {
         self.email = customerData.email ?? ""
         self.originalCustomerData = customerData
         self.removeCustomer = removeCustomer
+        self.editAddress = editAddress
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/CustomerSection/OrderCustomerSection.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/CustomerSection/OrderCustomerSection.swift
@@ -39,6 +39,16 @@ struct OrderCustomerSection: View {
                     }
             }
         }
+        .sheet(isPresented: $viewModel.showsAddressForm) {
+            NavigationView {
+                EditOrderAddressForm(dismiss: { _ in
+                    viewModel.showsAddressForm.toggle()
+                },
+                                     viewModel: viewModel.addressFormViewModel)
+            }
+            .discardChangesPrompt(canDismiss: !viewModel.addressFormViewModel.hasPendingChanges,
+                                  didDismiss: viewModel.addressFormViewModel.userDidCancelFlow)
+        }
     }
 
     private var createCustomerView: some View {

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/CustomerSection/OrderCustomerSection.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/CustomerSection/OrderCustomerSection.swift
@@ -48,6 +48,9 @@ struct OrderCustomerSection: View {
             }
             .discardChangesPrompt(canDismiss: !viewModel.addressFormViewModel.hasPendingChanges,
                                   didDismiss: viewModel.addressFormViewModel.userDidCancelFlow)
+            .onDisappear {
+                viewModel.resetAddressForm()
+            }
         }
     }
 
@@ -111,7 +114,8 @@ struct OrderCustomerSection_Previews: PreviewProvider {
                                                   customerData: customer,
                                                   isCustomerAccountRequired: true,
                                                   isEditable: true,
-                                                  updateCustomer: { _ in }))
+                                                  updateCustomer: { _ in },
+                                                  resetAddressForm: {}))
             OrderCustomerSection(viewModel: .init(siteID: 1,
                                                   addressFormViewModel: .init(
                                                     siteID: 1,
@@ -122,7 +126,8 @@ struct OrderCustomerSection_Previews: PreviewProvider {
                                                   customerData: customer,
                                                   isCustomerAccountRequired: false,
                                                   isEditable: true,
-                                                  updateCustomer: { _ in }))
+                                                  updateCustomer: { _ in },
+                                                  resetAddressForm: {}))
         }
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/CustomerSection/OrderCustomerSectionViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/CustomerSection/OrderCustomerSectionViewModel.swift
@@ -14,6 +14,9 @@ final class OrderCustomerSectionViewModel: ObservableObject {
     @Published private(set) var addressFormViewModel: CreateOrderAddressFormViewModel
     private let updateCustomer: (Customer?) -> Void
 
+    // MARK: - Address
+    @Published var showsAddressForm: Bool = false
+
     @Published private(set) var cardViewModel: CollapsibleCustomerCardViewModel?
 
     init(siteID: Int64,
@@ -37,7 +40,8 @@ final class OrderCustomerSectionViewModel: ObservableObject {
                               isCustomerAccountRequired: isCustomerAccountRequired,
                               isEditable: isEditable,
                               isCollapsed: false,
-                              removeCustomer: removeCustomer)
+                              removeCustomer: removeCustomer,
+                              editAddress: editAddress)
     }
 
     /// Called when the user taps to search for a customer.
@@ -55,6 +59,10 @@ private extension OrderCustomerSectionViewModel {
     func removeCustomer() {
         updateCustomer(nil)
     }
+
+    func editAddress() {
+        showsAddressForm = true
+    }
 }
 
 private extension OrderCustomerSectionViewModel {
@@ -68,7 +76,8 @@ private extension OrderCustomerSectionViewModel {
                                                         isCustomerAccountRequired: isCustomerAccountRequired,
                                                         isEditable: isEditable,
                                                         isCollapsed: true,
-                                                        removeCustomer: removeCustomer)
+                                                        removeCustomer: removeCustomer,
+                                                        editAddress: editAddress)
             }
             .assign(to: &$cardViewModel)
     }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/CustomerSection/OrderCustomerSectionViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/CustomerSection/OrderCustomerSectionViewModel.swift
@@ -11,11 +11,12 @@ final class OrderCustomerSectionViewModel: ObservableObject {
     // MARK: - Customer search
     @Published var showsCustomerSearch: Bool = false
     @Published var customerData: CollapsibleCustomerCardViewModel.CustomerData
-    @Published private(set) var addressFormViewModel: CreateOrderAddressFormViewModel
+    @Published var addressFormViewModel: CreateOrderAddressFormViewModel
     private let updateCustomer: (Customer?) -> Void
 
     // MARK: - Address
     @Published var showsAddressForm: Bool = false
+    let resetAddressForm: () -> Void
 
     @Published private(set) var cardViewModel: CollapsibleCustomerCardViewModel?
 
@@ -24,13 +25,15 @@ final class OrderCustomerSectionViewModel: ObservableObject {
          customerData: CollapsibleCustomerCardViewModel.CustomerData,
          isCustomerAccountRequired: Bool,
          isEditable: Bool,
-         updateCustomer: @escaping (Customer?) -> Void) {
+         updateCustomer: @escaping (Customer?) -> Void,
+         resetAddressForm: @escaping () -> Void) {
         self.siteID = siteID
         self.addressFormViewModel = addressFormViewModel
         self.customerData = customerData
         self.isCustomerAccountRequired = isCustomerAccountRequired
         self.isEditable = isEditable
         self.updateCustomer = updateCustomer
+        self.resetAddressForm = resetAddressForm
         observeCustomerDataForCardViewModel()
     }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/EditableOrderViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/EditableOrderViewModel.swift
@@ -799,6 +799,7 @@ final class EditableOrderViewModel: ObservableObject {
         }
 
         customerSectionViewModel.addressFormViewModel = .init(siteID: siteID,
+                                                              showEmailField: false,
                                                               addressData: .init(billingAddress: orderSynchronizer.order.billingAddress,
                                                                                  shippingAddress: orderSynchronizer.order.shippingAddress),
                                                               onAddressUpdate: { [weak self] updatedAddressData in

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -397,6 +397,7 @@
 		029F29FA24D93E9E004751CA /* EditableProductModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 029F29F924D93E9E004751CA /* EditableProductModel.swift */; };
 		029F29FC24D94106004751CA /* EditableProductVariationModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 029F29FB24D94106004751CA /* EditableProductVariationModel.swift */; };
 		029F29FE24DA5B2D004751CA /* ProductInventorySettingsViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 029F29FD24DA5B2D004751CA /* ProductInventorySettingsViewModel.swift */; };
+		029F53182BEB33BC00E31A10 /* CollapsibleCustomerCardAddressView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 029F53172BEB33BC00E31A10 /* CollapsibleCustomerCardAddressView.swift */; };
 		02A275BA23FE50AA005C560F /* ProductUIImageLoader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02A275B923FE50AA005C560F /* ProductUIImageLoader.swift */; };
 		02A275BE23FE57DC005C560F /* ProductUIImageLoaderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02A275BD23FE57DC005C560F /* ProductUIImageLoaderTests.swift */; };
 		02A275C023FE58F6005C560F /* MockImageCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02A275BF23FE58F6005C560F /* MockImageCache.swift */; };
@@ -3137,6 +3138,7 @@
 		029F29F924D93E9E004751CA /* EditableProductModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditableProductModel.swift; sourceTree = "<group>"; };
 		029F29FB24D94106004751CA /* EditableProductVariationModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditableProductVariationModel.swift; sourceTree = "<group>"; };
 		029F29FD24DA5B2D004751CA /* ProductInventorySettingsViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductInventorySettingsViewModel.swift; sourceTree = "<group>"; };
+		029F53172BEB33BC00E31A10 /* CollapsibleCustomerCardAddressView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CollapsibleCustomerCardAddressView.swift; sourceTree = "<group>"; };
 		02A275B923FE50AA005C560F /* ProductUIImageLoader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductUIImageLoader.swift; sourceTree = "<group>"; };
 		02A275BD23FE57DC005C560F /* ProductUIImageLoaderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductUIImageLoaderTests.swift; sourceTree = "<group>"; };
 		02A275BF23FE58F6005C560F /* MockImageCache.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockImageCache.swift; sourceTree = "<group>"; };
@@ -6539,6 +6541,7 @@
 				029106C12BE34A8600C2248B /* CollapsibleCustomerCard.swift */,
 				029106C32BE34AA900C2248B /* CollapsibleCustomerCardViewModel.swift */,
 				02B7C4F52BE375D800F8E93A /* CollapsibleCustomerCardHeaderView.swift */,
+				029F53172BEB33BC00E31A10 /* CollapsibleCustomerCardAddressView.swift */,
 			);
 			path = CustomerCard;
 			sourceTree = "<group>";
@@ -13872,6 +13875,7 @@
 				E10459C627BBC22E00C1DCBA /* CardPresentConfigurationLoader.swift in Sources */,
 				B586906621A5F4B1001F1EFC /* UINavigationController+Woo.swift in Sources */,
 				45FBDF3A238D3F8B00127F77 /* ExtendedAddProductImageCollectionViewCell.swift in Sources */,
+				029F53182BEB33BC00E31A10 /* CollapsibleCustomerCardAddressView.swift in Sources */,
 				CE606D832BE14010001CB424 /* ShippingLineSelectionDetailsViewModel.swift in Sources */,
 				02C7EE8A2B21B951008B7DF8 /* ProductWithQuantityStepperViewModel.swift in Sources */,
 				02A410F52583A84C005E2925 /* SpacerTableViewCell.swift in Sources */,

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -434,6 +434,7 @@
 		02B2829027C352DA004A332A /* RefreshableScrollView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02B2828F27C352DA004A332A /* RefreshableScrollView.swift */; };
 		02B2829227C4808D004A332A /* InfiniteScrollIndicator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02B2829127C4808D004A332A /* InfiniteScrollIndicator.swift */; };
 		02B2C831249C4C8D0040C83C /* TextFieldTextAlignmentTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02B2C830249C4C8D0040C83C /* TextFieldTextAlignmentTests.swift */; };
+		02B334A12BEB712600A46774 /* CollapsibleCustomerCardAddressViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02B334A02BEB712600A46774 /* CollapsibleCustomerCardAddressViewModel.swift */; };
 		02B41A96296D09D100FE3311 /* DomainSettingsListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02B41A95296D09D100FE3311 /* DomainSettingsListView.swift */; };
 		02B60DF72A586C7F004C47FF /* AddProductFromImageFormImageView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02B60DF62A586C7F004C47FF /* AddProductFromImageFormImageView.swift */; };
 		02B60DFB2A58809F004C47FF /* View+MediaSourceActionSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02B60DFA2A58809F004C47FF /* View+MediaSourceActionSheet.swift */; };
@@ -3174,6 +3175,7 @@
 		02B2828F27C352DA004A332A /* RefreshableScrollView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RefreshableScrollView.swift; sourceTree = "<group>"; };
 		02B2829127C4808D004A332A /* InfiniteScrollIndicator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InfiniteScrollIndicator.swift; sourceTree = "<group>"; };
 		02B2C830249C4C8D0040C83C /* TextFieldTextAlignmentTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TextFieldTextAlignmentTests.swift; sourceTree = "<group>"; };
+		02B334A02BEB712600A46774 /* CollapsibleCustomerCardAddressViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CollapsibleCustomerCardAddressViewModel.swift; sourceTree = "<group>"; };
 		02B41A95296D09D100FE3311 /* DomainSettingsListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DomainSettingsListView.swift; sourceTree = "<group>"; };
 		02B60DF62A586C7F004C47FF /* AddProductFromImageFormImageView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddProductFromImageFormImageView.swift; sourceTree = "<group>"; };
 		02B60DFA2A58809F004C47FF /* View+MediaSourceActionSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "View+MediaSourceActionSheet.swift"; sourceTree = "<group>"; };
@@ -6542,6 +6544,7 @@
 				029106C32BE34AA900C2248B /* CollapsibleCustomerCardViewModel.swift */,
 				02B7C4F52BE375D800F8E93A /* CollapsibleCustomerCardHeaderView.swift */,
 				029F53172BEB33BC00E31A10 /* CollapsibleCustomerCardAddressView.swift */,
+				02B334A02BEB712600A46774 /* CollapsibleCustomerCardAddressViewModel.swift */,
 			);
 			path = CustomerCard;
 			sourceTree = "<group>";
@@ -14560,6 +14563,7 @@
 				0396CFAD2981476900E91436 /* CardPresentModalBuiltInConnectingFailed.swift in Sources */,
 				02C1853B27FF0D9C00ABD764 /* RefundSubmissionUseCase.swift in Sources */,
 				02DFD5062B2048C50048CD70 /* ProductStepperViewModel.swift in Sources */,
+				02B334A12BEB712600A46774 /* CollapsibleCustomerCardAddressViewModel.swift in Sources */,
 				26C98F9B29C18ACE00F96503 /* StorePlanBanner.swift in Sources */,
 				E10BD16D27CF890800CE6449 /* InPersonPaymentsCountryNotSupportedStripe.swift in Sources */,
 				68E674AB2A4DAB8C0034BA1E /* CompletedUpgradeView.swift in Sources */,

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/EditableOrderViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/EditableOrderViewModelTests.swift
@@ -18,9 +18,11 @@ final class EditableOrderViewModelTests: XCTestCase {
         super.setUp()
         stores = MockStoresManager(sessionManager: .testingInstance)
         storageManager = MockStorageManager()
+        let featureFlagService = MockFeatureFlagService(isSubscriptionsInOrderCreationCustomersEnabled: false)
         viewModel = EditableOrderViewModel(siteID: sampleSiteID,
                                            stores: stores,
                                            storageManager: storageManager,
+                                           featureFlagService: featureFlagService,
                                            quantityDebounceDuration: 0)
     }
 
@@ -1825,7 +1827,8 @@ final class EditableOrderViewModelTests: XCTestCase {
             shipping: sampleAddress2()
         )
 
-        let viewModel = EditableOrderViewModel(siteID: sampleSiteID, stores: stores)
+        let featureFlagService = MockFeatureFlagService(isSubscriptionsInOrderCreationCustomersEnabled: false)
+        let viewModel = EditableOrderViewModel(siteID: sampleSiteID, stores: stores, featureFlagService: featureFlagService)
         let taxRate = TaxRate.fake().copy(siteID: sampleSiteID, name: "test tax rate", country: "US", state: "CA", postcodes: ["12345"], cities: ["San Diego"])
         viewModel.addCustomerAddressToOrder(customer: customer)
         viewModel.onTaxRateSelected(taxRate)
@@ -1859,7 +1862,8 @@ final class EditableOrderViewModelTests: XCTestCase {
             shipping: sampleAddress2()
         )
 
-        let viewModel = EditableOrderViewModel(siteID: sampleSiteID, stores: stores)
+        let featureFlagService = MockFeatureFlagService(isSubscriptionsInOrderCreationCustomersEnabled: false)
+        let viewModel = EditableOrderViewModel(siteID: sampleSiteID, stores: stores, featureFlagService: featureFlagService)
         let taxRate = TaxRate.fake().copy(siteID: sampleSiteID, name: "test tax rate", country: "US", state: "CA", postcodes: ["12345"], cities: ["San Diego"])
 
         viewModel.addCustomerAddressToOrder(customer: customer)
@@ -1900,7 +1904,8 @@ final class EditableOrderViewModelTests: XCTestCase {
 
     func test_addCustomerAddressToOrder_resets_addressFormViewModel_with_new_data() {
         // Given
-        let viewModel = EditableOrderViewModel(siteID: sampleSiteID, stores: stores)
+        let featureFlagService = MockFeatureFlagService(isSubscriptionsInOrderCreationCustomersEnabled: false)
+        let viewModel = EditableOrderViewModel(siteID: sampleSiteID, stores: stores, featureFlagService: featureFlagService)
         let customer = Customer.fake().copy(
             email: "scrambled@scrambled.com",
             firstName: "Johnny",
@@ -1967,7 +1972,8 @@ final class EditableOrderViewModelTests: XCTestCase {
 
     func test_resetAddressForm_discards_pending_address_field_changes() {
         // Given
-        let viewModel = EditableOrderViewModel(siteID: sampleSiteID, stores: stores)
+        let featureFlagService = MockFeatureFlagService(isSubscriptionsInOrderCreationCustomersEnabled: false)
+        let viewModel = EditableOrderViewModel(siteID: sampleSiteID, stores: stores, featureFlagService: featureFlagService)
 
         // Given there is a saved change and a pending change
         viewModel.addressFormViewModel.fields.firstName = sampleAddress1().firstName
@@ -2575,7 +2581,8 @@ final class EditableOrderViewModelTests: XCTestCase {
             }
         })
 
-        let viewModel = EditableOrderViewModel(siteID: sampleSiteID, stores: stores)
+        let featureFlagService = MockFeatureFlagService(isSubscriptionsInOrderCreationCustomersEnabled: false)
+        let viewModel = EditableOrderViewModel(siteID: sampleSiteID, stores: stores, featureFlagService: featureFlagService)
 
         waitUntil {
             viewModel.addressFormViewModel.fields.state.isNotEmpty
@@ -2619,7 +2626,8 @@ final class EditableOrderViewModelTests: XCTestCase {
             }
         })
 
-        let viewModel = EditableOrderViewModel(siteID: sampleSiteID, stores: stores)
+        let featureFlagService = MockFeatureFlagService(isSubscriptionsInOrderCreationCustomersEnabled: false)
+        let viewModel = EditableOrderViewModel(siteID: sampleSiteID, stores: stores, featureFlagService: featureFlagService)
 
         waitUntil {
             viewModel.addressFormViewModel.fields.state.isNotEmpty


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #12665
<!-- Id number of the GitHub issue this PR addresses. -->

## Why

When the customer card in the order form is expanded, we want to show the latest address if any with a CTA to add/edit  the address.

## How

The address form is the existing `CreateOrderAddressFormViewModel`, but with the email field hidden by adding a parameter `showEmailField` with default to `true`.

A new `CollapsibleCustomerCardAddressView` with a view model were created with a few UI states based on the existing shipping/billing addresses (available in previews). The CTA tap action enables a new state `OrderCustomerSectionViewModel.showsAddressForm` to show the address form.

The address updates are synced remotely by following the legacy approach given the time constraint to wrap it up today. The approach is by creating `addressFormViewModel: CreateOrderAddressFormViewModel` with `onAddressUpdate` callback that emits the address update. It requires resetting `addressFormViewModel` whenever `resetAddressForm` is called, which means we can't easily extract the address logic outside of `EditableOrderViewModel`. Within `EditableOrderViewModel`, the address form fields are also observed for in-flight updates. Just some tech debt considerations for the future.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

### Create order

- Go to the orders tab
- Tap +
- Tap `Add Customer` --> a CTA `Add customer address` should be shown
- Tap `Add customer address` --> an address form should be shown without the email field
- Enter some details to the address, then tap `Done` --> the customer details should be saved remotely

### Edit order

- Go to the orders tab
- Tap on an order with an existing customer address
- Tap `Edit`
- Tap to expand the customer card --> the existing customer address should be shown with a pencil CTA
- Tap the pencil CTA --> an address form should be shown without the email field, with the existing address prefilled
- Change the shipping/billing address, then tap `Done` --> the customer details should be saved remotely

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->


one address | different billing & shipping addresses | no address
-- | -- | --
<img src="https://github.com/woocommerce/woocommerce-ios/assets/1945542/02587b99-370c-45a9-9ad4-346c8df8358e" width="300" /> | <img src="https://github.com/woocommerce/woocommerce-ios/assets/1945542/bdb1ddd7-bd77-45aa-ae7d-4d12e181cb06" width="300" /> | <img src="https://github.com/woocommerce/woocommerce-ios/assets/1945542/a3e487b2-b0d2-4cf0-a172-182dc86da4e8" width="300" />


https://github.com/woocommerce/woocommerce-ios/assets/1945542/f96cca79-9eee-4ef4-af60-dfdf82a811db



---
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
