### PR TITLE
[Shipping Lines] Display shipping method in shipping line details

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/EditableOrderViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/EditableOrderViewModel.swift
@@ -1130,6 +1130,7 @@ extension EditableOrderViewModel {
         let shippingTotal: String
 
         // We only support one (the first) shipping line
+        let shippingMethodID: String
         let shippingMethodTitle: String
         let shippingMethodTotal: String
 
@@ -1173,6 +1174,7 @@ extension EditableOrderViewModel {
         let saveShippingLineClosure: (ShippingLine?) -> Void
         var shippingLineSelectionViewModel: ShippingLineSelectionDetailsViewModel {
             ShippingLineSelectionDetailsViewModel(isExistingShippingLine: shouldShowShippingTotal,
+                                                  initialMethodID: shippingMethodID,
                                                   initialMethodTitle: shippingMethodTitle,
                                                   shippingTotal: shippingMethodTotal,
                                                   didSelectSave: saveShippingLineClosure)
@@ -1189,6 +1191,7 @@ extension EditableOrderViewModel {
              itemsTotal: String = "0",
              shouldShowShippingTotal: Bool = false,
              shippingTotal: String = "0",
+             shippingMethodID: String = "",
              shippingMethodTitle: String = "",
              shippingMethodTotal: String = "",
              shippingTax: String = "0",
@@ -1226,6 +1229,7 @@ extension EditableOrderViewModel {
             self.itemsTotal = currencyFormatter.formatAmount(itemsTotal) ?? "0.00"
             self.shouldShowShippingTotal = shouldShowShippingTotal
             self.shippingTotal = currencyFormatter.formatAmount(shippingTotal) ?? "0.00"
+            self.shippingMethodID = shippingMethodID
             self.shippingMethodTitle = shippingMethodTitle
             self.shippingMethodTotal = currencyFormatter.formatAmount(shippingMethodTotal) ?? "0.00"
             self.saveShippingLineClosure = saveShippingLineClosure
@@ -1690,6 +1694,7 @@ private extension EditableOrderViewModel {
 
                 let orderTotals = OrderTotalsCalculator(for: order, using: self.currencyFormatter)
 
+                let shippingMethodID = order.shippingLines.first?.methodID ?? ""
                 let shippingMethodTitle = order.shippingLines.first?.methodTitle ?? ""
 
                 let isDataSyncing: Bool = {
@@ -1737,6 +1742,7 @@ private extension EditableOrderViewModel {
                                             itemsTotal: orderTotals.itemsTotal.stringValue,
                                             shouldShowShippingTotal: order.shippingLines.filter { $0.methodID != nil }.isNotEmpty,
                                             shippingTotal: order.shippingTotal.isNotEmpty ? order.shippingTotal : "0",
+                                            shippingMethodID: shippingMethodID,
                                             shippingMethodTitle: shippingMethodTitle,
                                             shippingMethodTotal: order.shippingLines.first?.total ?? "0",
                                             shippingTax: order.shippingTax.isNotEmpty ? order.shippingTax : "0",

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/PaymentSection/Shipping/ShippingLineSelectionDetails.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/PaymentSection/Shipping/ShippingLineSelectionDetails.swift
@@ -113,6 +113,7 @@ private extension ShippingLineSelectionDetails {
 
 #Preview("Add shipping") {
     ShippingLineSelectionDetails(viewModel: ShippingLineSelectionDetailsViewModel(isExistingShippingLine: false,
+                                                                                  initialMethodID: "",
                                                                                   initialMethodTitle: "",
                                                                                   shippingTotal: "",
                                                                                   didSelectSave: { _ in }))
@@ -120,6 +121,7 @@ private extension ShippingLineSelectionDetails {
 
 #Preview("Edit shipping") {
     ShippingLineSelectionDetails(viewModel: ShippingLineSelectionDetailsViewModel(isExistingShippingLine: true,
+                                                                                  initialMethodID: "Flat rate",
                                                                                   initialMethodTitle: "Shipping",
                                                                                   shippingTotal: "10.00",
                                                                                   didSelectSave: { _ in }))

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/PaymentSection/Shipping/ShippingLineSelectionDetails.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/PaymentSection/Shipping/ShippingLineSelectionDetails.swift
@@ -13,6 +13,20 @@ struct ShippingLineSelectionDetails: View {
     var body: some View {
         NavigationView {
             List {
+                // MARK: Shipping Method
+                NavigationLink {
+                    EmptyView() // TODO-12578: Navigate to shipping method selector
+                } label: {
+                    VStack(alignment: .leading) {
+                        Text(Localization.methodTitle)
+                            .font(.title3)
+                            .foregroundColor(Color(.textSubtle))
+                        Text(viewModel.selectedMethod.title)
+                            .font(.title2.bold())
+                            .foregroundColor(viewModel.selectedMethodColor)
+                    }
+                }
+
                 // MARK: Amount
                 VStack(alignment: .leading) {
                     Text(Localization.amountTitle)
@@ -76,6 +90,10 @@ private extension ShippingLineSelectionDetails {
                                               value: "Cancel",
                                               comment: "Text for the cancel button in the Shipping Line Details screen")
 
+        static let methodTitle = NSLocalizedString("order.shippingLineDetails.method",
+                                                 value: "Method",
+                                                 comment: "Title above the shipping method field on the Shipping Line Details screen")
+
         static let amountTitle = NSLocalizedString("order.shippingLineDetails.amount",
                                                  value: "Amount",
                                                  comment: "Title above the amount field on the Shipping Line Details screen")
@@ -112,7 +130,9 @@ private extension ShippingLineSelectionDetails {
 }
 
 #Preview("Add shipping") {
-    ShippingLineSelectionDetails(viewModel: ShippingLineSelectionDetailsViewModel(isExistingShippingLine: false,
+    ShippingLineSelectionDetails(viewModel: ShippingLineSelectionDetailsViewModel(siteID: 1,
+                                                                                  shippingMethods: [],
+                                                                                  isExistingShippingLine: false,
                                                                                   initialMethodID: "",
                                                                                   initialMethodTitle: "",
                                                                                   shippingTotal: "",
@@ -120,8 +140,10 @@ private extension ShippingLineSelectionDetails {
 }
 
 #Preview("Edit shipping") {
-    ShippingLineSelectionDetails(viewModel: ShippingLineSelectionDetailsViewModel(isExistingShippingLine: true,
-                                                                                  initialMethodID: "Flat rate",
+    ShippingLineSelectionDetails(viewModel: ShippingLineSelectionDetailsViewModel(siteID: 1,
+                                                                                  shippingMethods: [],
+                                                                                  isExistingShippingLine: true,
+                                                                                  initialMethodID: "flat_rate",
                                                                                   initialMethodTitle: "Shipping",
                                                                                   shippingTotal: "10.00",
                                                                                   didSelectSave: { _ in }))

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/PaymentSection/Shipping/ShippingLineSelectionDetailsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/PaymentSection/Shipping/ShippingLineSelectionDetailsViewModel.swift
@@ -17,6 +17,7 @@ class ShippingLineSelectionDetailsViewModel: ObservableObject {
     ///
     @Published var methodTitle: String
 
+    private let initialMethodID: String
     private let initialAmount: Decimal?
     private let initialMethodTitle: String
 
@@ -35,12 +36,14 @@ class ShippingLineSelectionDetailsViewModel: ObservableObject {
     @Published var enableDoneButton: Bool = false
 
     init(isExistingShippingLine: Bool,
+         initialMethodID: String,
          initialMethodTitle: String,
          shippingTotal: String,
          locale: Locale = Locale.autoupdatingCurrent,
          storeCurrencySettings: CurrencySettings = ServiceLocator.currencySettings,
          didSelectSave: @escaping ((ShippingLine?) -> Void)) {
         self.isExistingShippingLine = isExistingShippingLine
+        self.initialMethodID = initialMethodID
         self.initialMethodTitle = initialMethodTitle
         self.methodTitle = initialMethodTitle
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/PaymentSection/Shipping/ShippingLineSelectionDetailsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/PaymentSection/Shipping/ShippingLineSelectionDetailsViewModel.swift
@@ -1,9 +1,11 @@
 import SwiftUI
 import WooFoundation
 import struct Yosemite.ShippingLine
+import struct Yosemite.ShippingMethod
 import Combine
 
 class ShippingLineSelectionDetailsViewModel: ObservableObject {
+    private var siteID: Int64
 
     /// Closure to be invoked when the shipping line is updated.
     ///
@@ -13,9 +15,25 @@ class ShippingLineSelectionDetailsViewModel: ObservableObject {
     ///
     let formattableAmountViewModel: FormattableAmountTextFieldViewModel
 
+    /// Stores the method selected by the merchant.
+    ///
+    @Published var selectedMethod: ShippingMethod
+
+    /// Text color for the selected method.
+    ///
+    var selectedMethodColor: Color {
+        Color(selectedMethod.methodID == "" ? .placeholderText : .text)
+    }
+
     /// Stores the method title entered by the merchant.
     ///
     @Published var methodTitle: String
+
+    /// Method title entered by user or placeholder if it's empty.
+    ///
+    private var finalMethodTitle: String {
+        methodTitle.isNotEmpty ? methodTitle : Localization.namePlaceholder
+    }
 
     private let initialMethodID: String
     private let initialAmount: Decimal?
@@ -25,27 +43,31 @@ class ShippingLineSelectionDetailsViewModel: ObservableObject {
     ///
     let isExistingShippingLine: Bool
 
-    /// Method title entered by user or placeholder if it's empty.
+    /// Available shipping methods on the store.
     ///
-    private var finalMethodTitle: String {
-        methodTitle.isNotEmpty ? methodTitle : Localization.namePlaceholder
-    }
+    let shippingMethods: [ShippingMethod]
 
     /// Returns true when there are valid pending changes.
     ///
     @Published var enableDoneButton: Bool = false
 
-    init(isExistingShippingLine: Bool,
+    init(siteID: Int64,
+         shippingMethods: [ShippingMethod],
+         isExistingShippingLine: Bool,
          initialMethodID: String,
          initialMethodTitle: String,
          shippingTotal: String,
          locale: Locale = Locale.autoupdatingCurrent,
          storeCurrencySettings: CurrencySettings = ServiceLocator.currencySettings,
          didSelectSave: @escaping ((ShippingLine?) -> Void)) {
+        self.siteID = siteID
         self.isExistingShippingLine = isExistingShippingLine
         self.initialMethodID = initialMethodID
         self.initialMethodTitle = initialMethodTitle
         self.methodTitle = initialMethodTitle
+        let placeholderMethod = ShippingMethod(siteID: siteID, methodID: "", title: Localization.placeholderMethodTitle)
+        self.shippingMethods = [placeholderMethod] + shippingMethods
+        self.selectedMethod = shippingMethods.first(where: { $0.methodID == initialMethodID }) ?? placeholderMethod
 
         let currencyFormatter = CurrencyFormatter(currencySettings: storeCurrencySettings)
         if isExistingShippingLine, let initialAmount = currencyFormatter.convertToDecimal(shippingTotal) {
@@ -104,5 +126,8 @@ extension ShippingLineSelectionDetailsViewModel {
         static let namePlaceholder = NSLocalizedString("order.shippingLineDetails.namePlaceholder",
                                                        value: "Shipping",
                                                        comment: "Placeholder for the name field on the Shipping Line Details screen in order form")
+        static let placeholderMethodTitle = NSLocalizedString("order.shippingLineDetails.placeholderMethodTitle",
+                                                              value: "N/A",
+                                                              comment: "Title for the placeholder shipping method on the Shipping Line Details screen")
     }
 }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/ShippingLineSelectionDetailsViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/ShippingLineSelectionDetailsViewModelTests.swift
@@ -12,6 +12,7 @@ final class ShippingLineSelectionDetailsViewModelTests: XCTestCase {
     func test_view_model_formats_amount_correctly() {
         // Given
         let viewModel = ShippingLineSelectionDetailsViewModel(isExistingShippingLine: false,
+                                                              initialMethodID: "",
                                                               initialMethodTitle: "",
                                                               shippingTotal: "",
                                                               locale: usLocale,
@@ -29,11 +30,12 @@ final class ShippingLineSelectionDetailsViewModelTests: XCTestCase {
     func test_view_model_formats_negative_amount_correctly() {
         // Given
         let viewModel = ShippingLineSelectionDetailsViewModel(isExistingShippingLine: false,
-                                                     initialMethodTitle: "",
-                                                     shippingTotal: "",
-                                                     locale: usLocale,
-                                                     storeCurrencySettings: usStoreSettings,
-                                                     didSelectSave: { _ in })
+                                                              initialMethodID: "",
+                                                              initialMethodTitle: "",
+                                                              shippingTotal: "",
+                                                              locale: usLocale,
+                                                              storeCurrencySettings: usStoreSettings,
+                                                              didSelectSave: { _ in })
 
         // When
         viewModel.formattableAmountViewModel.amount = "-hi:11.3005.02-"
@@ -52,11 +54,12 @@ final class ShippingLineSelectionDetailsViewModelTests: XCTestCase {
                                               numberOfDecimals: 3)
 
         let viewModel = ShippingLineSelectionDetailsViewModel(isExistingShippingLine: false,
-                                                     initialMethodTitle: "",
-                                                     shippingTotal: "",
-                                                     locale: usLocale,
-                                                     storeCurrencySettings: customSettings,
-                                                     didSelectSave: { _ in })
+                                                              initialMethodID: "",
+                                                              initialMethodTitle: "",
+                                                              shippingTotal: "",
+                                                              locale: usLocale,
+                                                              storeCurrencySettings: customSettings,
+                                                              didSelectSave: { _ in })
 
         // When
         viewModel.formattableAmountViewModel.amount = "12.203"
@@ -70,11 +73,12 @@ final class ShippingLineSelectionDetailsViewModelTests: XCTestCase {
     func test_view_model_prefills_input_data_correctly() {
         // Given
         let viewModel = ShippingLineSelectionDetailsViewModel(isExistingShippingLine: true,
-                                                     initialMethodTitle: "Flat Rate",
-                                                     shippingTotal: "$11.30",
-                                                     locale: usLocale,
-                                                     storeCurrencySettings: usStoreSettings,
-                                                     didSelectSave: { _ in })
+                                                              initialMethodID: "",
+                                                              initialMethodTitle: "Flat Rate",
+                                                              shippingTotal: "$11.30",
+                                                              locale: usLocale,
+                                                              storeCurrencySettings: usStoreSettings,
+                                                              didSelectSave: { _ in })
 
         // Then
         XCTAssertTrue(viewModel.isExistingShippingLine)
@@ -85,11 +89,12 @@ final class ShippingLineSelectionDetailsViewModelTests: XCTestCase {
     func test_view_model_prefills_negative_input_data_correctly() {
         // Given
         let viewModel = ShippingLineSelectionDetailsViewModel(isExistingShippingLine: true,
-                                                     initialMethodTitle: "Flat Rate",
-                                                     shippingTotal: "-$11.30",
-                                                     locale: usLocale,
-                                                     storeCurrencySettings: usStoreSettings,
-                                                     didSelectSave: { _ in })
+                                                              initialMethodID: "",
+                                                              initialMethodTitle: "Flat Rate",
+                                                              shippingTotal: "-$11.30",
+                                                              locale: usLocale,
+                                                              storeCurrencySettings: usStoreSettings,
+                                                              didSelectSave: { _ in })
 
         // Then
         XCTAssertTrue(viewModel.isExistingShippingLine)
@@ -100,11 +105,12 @@ final class ShippingLineSelectionDetailsViewModelTests: XCTestCase {
     func test_view_model_does_not_prefill_zero_amount_without_existing_shipping_line() {
         // Given
         let viewModel = ShippingLineSelectionDetailsViewModel(isExistingShippingLine: false,
-                                                     initialMethodTitle: "",
-                                                     shippingTotal: "0",
-                                                     locale: usLocale,
-                                                     storeCurrencySettings: usStoreSettings,
-                                                     didSelectSave: { _ in })
+                                                              initialMethodID: "",
+                                                              initialMethodTitle: "",
+                                                              shippingTotal: "0",
+                                                              locale: usLocale,
+                                                              storeCurrencySettings: usStoreSettings,
+                                                              didSelectSave: { _ in })
 
         // Then
         XCTAssertTrue(viewModel.formattableAmountViewModel.amount.isEmpty)
@@ -113,11 +119,12 @@ final class ShippingLineSelectionDetailsViewModelTests: XCTestCase {
     func test_view_model_disables_done_button_for_empty_state_and_enables_with_input() {
         // Given
         let viewModel = ShippingLineSelectionDetailsViewModel(isExistingShippingLine: false,
-                                                     initialMethodTitle: "",
-                                                     shippingTotal: "",
-                                                     locale: usLocale,
-                                                     storeCurrencySettings: usStoreSettings,
-                                                     didSelectSave: { _ in })
+                                                              initialMethodID: "",
+                                                              initialMethodTitle: "",
+                                                              shippingTotal: "",
+                                                              locale: usLocale,
+                                                              storeCurrencySettings: usStoreSettings,
+                                                              didSelectSave: { _ in })
         XCTAssertFalse(viewModel.enableDoneButton)
 
         // When
@@ -136,11 +143,12 @@ final class ShippingLineSelectionDetailsViewModelTests: XCTestCase {
     func test_view_model_disables_done_button_for_prefilled_data_and_enables_with_changes() {
         // Given
         let viewModel = ShippingLineSelectionDetailsViewModel(isExistingShippingLine: true,
-                                                     initialMethodTitle: "Flat Rate",
-                                                     shippingTotal: "$11.30",
-                                                     locale: usLocale,
-                                                     storeCurrencySettings: usStoreSettings,
-                                                     didSelectSave: { _ in })
+                                                              initialMethodID: "",
+                                                              initialMethodTitle: "Flat Rate",
+                                                              shippingTotal: "$11.30",
+                                                              locale: usLocale,
+                                                              storeCurrencySettings: usStoreSettings,
+                                                              didSelectSave: { _ in })
         XCTAssertFalse(viewModel.enableDoneButton)
 
         // When
@@ -160,11 +168,12 @@ final class ShippingLineSelectionDetailsViewModelTests: XCTestCase {
         // Given
         var savedShippingLine: ShippingLine?
         let viewModel = ShippingLineSelectionDetailsViewModel(isExistingShippingLine: false,
-                                                     initialMethodTitle: "",
-                                                     shippingTotal: "",
-                                                     locale: usLocale,
-                                                     storeCurrencySettings: usStoreSettings,
-                                                     didSelectSave: { newShippingLine in
+                                                              initialMethodID: "",
+                                                              initialMethodTitle: "",
+                                                              shippingTotal: "",
+                                                              locale: usLocale,
+                                                              storeCurrencySettings: usStoreSettings,
+                                                              didSelectSave: { newShippingLine in
             savedShippingLine = newShippingLine
         })
 
@@ -182,11 +191,12 @@ final class ShippingLineSelectionDetailsViewModelTests: XCTestCase {
         // Given
         var savedShippingLine: ShippingLine?
         let viewModel = ShippingLineSelectionDetailsViewModel(isExistingShippingLine: false,
-                                                     initialMethodTitle: "",
-                                                     shippingTotal: "",
-                                                     locale: usLocale,
-                                                     storeCurrencySettings: usStoreSettings,
-                                                     didSelectSave: { newShippingLine in
+                                                              initialMethodID: "",
+                                                              initialMethodTitle: "",
+                                                              shippingTotal: "",
+                                                              locale: usLocale,
+                                                              storeCurrencySettings: usStoreSettings,
+                                                              didSelectSave: { newShippingLine in
             savedShippingLine = newShippingLine
         })
 
@@ -204,11 +214,12 @@ final class ShippingLineSelectionDetailsViewModelTests: XCTestCase {
         // Given
         var savedShippingLine: ShippingLine?
         let viewModel = ShippingLineSelectionDetailsViewModel(isExistingShippingLine: false,
-                                                     initialMethodTitle: "",
-                                                     shippingTotal: "",
-                                                     locale: usLocale,
-                                                     storeCurrencySettings: usStoreSettings,
-                                                     didSelectSave: { newShippingLine in
+                                                              initialMethodID: "",
+                                                              initialMethodTitle: "",
+                                                              shippingTotal: "",
+                                                              locale: usLocale,
+                                                              storeCurrencySettings: usStoreSettings,
+                                                              didSelectSave: { newShippingLine in
             savedShippingLine = newShippingLine
         })
 
@@ -225,11 +236,12 @@ final class ShippingLineSelectionDetailsViewModelTests: XCTestCase {
         // Given
         var savedShippingLine: ShippingLine?
         let viewModel = ShippingLineSelectionDetailsViewModel(isExistingShippingLine: false,
-                                                     initialMethodTitle: "",
-                                                     shippingTotal: "",
-                                                     locale: usLocale,
-                                                     storeCurrencySettings: usStoreSettings,
-                                                     didSelectSave: { newShippingLine in
+                                                              initialMethodID: "",
+                                                              initialMethodTitle: "",
+                                                              shippingTotal: "",
+                                                              locale: usLocale,
+                                                              storeCurrencySettings: usStoreSettings,
+                                                              didSelectSave: { newShippingLine in
             savedShippingLine = newShippingLine
         })
 
@@ -246,11 +258,12 @@ final class ShippingLineSelectionDetailsViewModelTests: XCTestCase {
     func test_view_model_amount_placeholder_has_expected_value() {
         // Given
         let viewModel = ShippingLineSelectionDetailsViewModel(isExistingShippingLine: false,
-                                                     initialMethodTitle: "",
-                                                     shippingTotal: "",
-                                                     locale: usLocale,
-                                                     storeCurrencySettings: usStoreSettings,
-                                                     didSelectSave: { _ in })
+                                                              initialMethodID: "",
+                                                              initialMethodTitle: "",
+                                                              shippingTotal: "",
+                                                              locale: usLocale,
+                                                              storeCurrencySettings: usStoreSettings,
+                                                              didSelectSave: { _ in })
 
         // Then
         XCTAssertEqual(viewModel.formattableAmountViewModel.formattedAmount, "$0.00")
@@ -259,11 +272,12 @@ final class ShippingLineSelectionDetailsViewModelTests: XCTestCase {
     func test_view_model_initializes_correctly_with_no_existing_shipping_line() {
         // Given
         let viewModel = ShippingLineSelectionDetailsViewModel(isExistingShippingLine: false,
-                                                     initialMethodTitle: "",
-                                                     shippingTotal: "",
-                                                     locale: usLocale,
-                                                     storeCurrencySettings: usStoreSettings,
-                                                     didSelectSave: { _ in })
+                                                              initialMethodID: "",
+                                                              initialMethodTitle: "",
+                                                              shippingTotal: "",
+                                                              locale: usLocale,
+                                                              storeCurrencySettings: usStoreSettings,
+                                                              didSelectSave: { _ in })
 
         // Then
         XCTAssertFalse(viewModel.isExistingShippingLine)


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of: #12578
<!-- Id number of the GitHub issue this PR addresses. -->

## Why
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This adds a "Method" field to the shipping line details screen, to display the selected shipping method for that order shipping line.

Note: We don't yet fetch the shipping methods from the store or handle new shipping method selection. That will be added in another PR.

## How
* `ShippingLineSelectionDetails` now has a section to display the selected shipping method.
* In `EditableOrderViewModel`, we now pass a list of available shipping methods (a static list for now; this will eventually be synced from the store) and the shipping method ID for the shipping line (from the order shipping line).
* In `ShippingLineSelectionDetailsViewModel`:
   * We set `shippingMethods` with the list of available shipping methods plus a placeholder shipping method (when no method is selected). Using a placeholder method will allow us to easily include this option (shown as "N/A") in the list of shipping methods to choose from in the UI.
   * We set `selectedMethod` using the shipping method ID from the shipping line. (The order shipping line only provides the method ID, so we select it from the list of available methods.)
   * We set `selectedMethodColor` based on the selected method, so a placeholder text color is shown if the placeholder method is selected.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

New order / no shipping line:

1. Build and run the app with the feature flag enabled.
2. Create a new order.
3. Add a product to the order.
4. Select "Add Shipping".
5. Confirm the shipping line details screen opens with a "Method" field showing "N/A" as the placeholder.

Order with a shipping line:

Prerequisite: Create an order in wp-admin. Add shipping and edit the shipping line to select a shipping method. Note: We don't yet fetch the actual shipping methods for the store, so you'll need to select "Flat rate," "Free shipping," "Local pickup," or "Other" as the shipping method to see it reflected in the app. Save the order and proceed with the steps below.

1. Build and run the app with the feature flag enabled.
2. On the Orders tab, select an existing order with shipping that has a selected method (added in wp-admin).
3. Select "Edit" to edit the order.
4. In the order totals bottom sheet, select Shipping to edit it.
5. Confirm the shipping line details screen opens with a "Method" field showing the selected shipping method.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->
No method selected|Selected method
-|-
![Simulator Screenshot - iPhone 15 Plus - 2024-05-08 at 12 08 02](https://github.com/woocommerce/woocommerce-ios/assets/8658164/d37c246c-240a-44e6-938e-dcb1f9b352a0)|![Simulator Screenshot - iPhone 15 Plus - 2024-05-08 at 12 19 21](https://github.com/woocommerce/woocommerce-ios/assets/8658164/8f7f944f-e4ab-48af-9c5f-3d7bff6ebbe5)

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
