### PR TITLE
[Shipping Lines] Handle shipping method selection in shipping line details

### DIFF
--- a/Networking/Networking/Model/ShippingMethod.swift
+++ b/Networking/Networking/Model/ShippingMethod.swift
@@ -2,7 +2,7 @@ import Foundation
 
 /// Represents a Shipping Method Entity.
 ///
-public struct ShippingMethod: Decodable, Equatable {
+public struct ShippingMethod: Decodable, Equatable, Hashable {
     public let siteID: Int64
 
     /// Shipping Method ID

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/AnalyticsTimeRangeCard.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/AnalyticsTimeRangeCard.swift
@@ -37,12 +37,15 @@ struct AnalyticsTimeRangeCard: View {
     var body: some View {
         createTimeRangeContent()
             .sheet(isPresented: $showTimeRangeSelectionView) {
-                SingleSelectionList(title: Localization.timeRangeSelectionTitle,
-                                    items: Range.allCases,
-                                    contentKeyPath: \.description,
-                                    selected: internalSelectionBinding()) { selection in
-                    onSelected(selection)
+                NavigationStack {
+                    SingleSelectionList(title: Localization.timeRangeSelectionTitle,
+                                        items: Range.allCases,
+                                        contentKeyPath: \.description,
+                                        selected: internalSelectionBinding()) { selection in
+                        onSelected(selection)
+                    }
                 }
+                .wooNavigationBarStyle()
                 .sheet(isPresented: $showCustomRangeSelectionView) {
                     RangedDatePicker(startDate: selectionType.startDate, endDate: selectionType.endDate) { start, end in
                         showTimeRangeSelectionView = false // Dismiss the initial sheet for a smooth transition

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/PaymentSection/Shipping/ShippingLineSelectionDetails.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/PaymentSection/Shipping/ShippingLineSelectionDetails.swift
@@ -15,7 +15,12 @@ struct ShippingLineSelectionDetails: View {
             List {
                 // MARK: Shipping Method
                 NavigationLink {
-                    EmptyView() // TODO-12578: Navigate to shipping method selector
+                    SingleSelectionList(title: Localization.methodTitle,
+                                        items: viewModel.shippingMethods,
+                                        contentKeyPath: \.title,
+                                        selected: $viewModel.selectedMethod,
+                                        showDoneButton: false,
+                                        backgroundColor: nil)
                 } label: {
                     VStack(alignment: .leading) {
                         Text(Localization.methodTitle)

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/PaymentSection/Shipping/ShippingLineSelectionDetails.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/PaymentSection/Shipping/ShippingLineSelectionDetails.swift
@@ -11,7 +11,7 @@ struct ShippingLineSelectionDetails: View {
     @Environment(\.dismiss) var dismiss
 
     var body: some View {
-        NavigationView {
+        NavigationStack {
             List {
                 // MARK: Shipping Method
                 NavigationLink {

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/Synchronizer/ShippingInputTransformer.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/Synchronizer/ShippingInputTransformer.swift
@@ -27,7 +27,7 @@ struct ShippingInputTransformer {
 
         // Since we only support one shipping line, if we find one, we update the existing with the new input values.
         var updatedLines = order.shippingLines
-        let updatedShippingLine = existingShippingLine.copy(methodTitle: input.methodTitle, total: input.total)
+        let updatedShippingLine = existingShippingLine.copy(methodTitle: input.methodTitle, methodID: input.methodID, total: input.total)
         updatedLines[0] = updatedShippingLine
 
         return order.copy(shippingTotal: calculateTotals(from: updatedLines), shippingLines: updatedLines)

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/Synchronizer/ShippingInputTransformer.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/Synchronizer/ShippingInputTransformer.swift
@@ -27,7 +27,8 @@ struct ShippingInputTransformer {
 
         // Since we only support one shipping line, if we find one, we update the existing with the new input values.
         var updatedLines = order.shippingLines
-        let updatedShippingLine = existingShippingLine.copy(methodTitle: input.methodTitle, methodID: input.methodID, total: input.total)
+        let methodID = ServiceLocator.featureFlagService.isFeatureFlagEnabled(.enhancingOrderShippingLines) ? input.methodID : existingShippingLine.methodID
+        let updatedShippingLine = existingShippingLine.copy(methodTitle: input.methodTitle, methodID: methodID, total: input.total)
         updatedLines[0] = updatedShippingLine
 
         return order.copy(shippingTotal: calculateTotals(from: updatedLines), shippingLines: updatedLines)

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Customs/ItemDetails/ShippingLabelCustomsFormItemDetails.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Customs/ItemDetails/ShippingLabelCustomsFormItemDetails.swift
@@ -143,10 +143,13 @@ struct ShippingLabelCustomsFormItemDetails: View {
                         isShowingCountries.toggle()
                     }
                     .sheet(isPresented: $isShowingCountries, content: {
-                        SingleSelectionList(title: Localization.originTitle,
-                                            items: viewModel.allCountries,
-                                            contentKeyPath: \.name,
-                                            selected: $viewModel.originCountry)
+                        NavigationStack {
+                            SingleSelectionList(title: Localization.originTitle,
+                                                items: viewModel.allCountries,
+                                                contentKeyPath: \.name,
+                                                selected: $viewModel.originCountry)
+                        }
+                        .wooNavigationBarStyle()
                     })
                     Divider()
                         .padding(.leading, Constants.horizontalSpacing)

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Customs/ShippingLabelCustomsFormInput.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Customs/ShippingLabelCustomsFormInput.swift
@@ -79,10 +79,13 @@ struct ShippingLabelCustomsFormInput: View {
                 showingContentTypes.toggle()
             }
             .sheet(isPresented: $showingContentTypes, content: {
-                SingleSelectionList(title: Localization.contentTypeTitle,
-                                    items: ShippingLabelCustomsForm.ContentsType.allCases,
-                                    contentKeyPath: \.localizedName,
-                                    selected: $viewModel.contentsType)
+                NavigationStack {
+                    SingleSelectionList(title: Localization.contentTypeTitle,
+                                        items: ShippingLabelCustomsForm.ContentsType.allCases,
+                                        contentKeyPath: \.localizedName,
+                                        selected: $viewModel.contentsType)
+                }
+                .wooNavigationBarStyle()
             })
             Divider()
                 .padding(.leading, Constants.horizontalPadding)
@@ -114,10 +117,13 @@ struct ShippingLabelCustomsFormInput: View {
                 showingRestrictionTypes.toggle()
             }
             .sheet(isPresented: $showingRestrictionTypes, content: {
-                SingleSelectionList(title: Localization.restrictionTypeTitle,
-                                    items: ShippingLabelCustomsForm.RestrictionType.allCases,
-                                    contentKeyPath: \.localizedName,
-                                    selected: $viewModel.restrictionType)
+                NavigationStack {
+                    SingleSelectionList(title: Localization.restrictionTypeTitle,
+                                        items: ShippingLabelCustomsForm.RestrictionType.allCases,
+                                        contentKeyPath: \.localizedName,
+                                        selected: $viewModel.restrictionType)
+                }
+                .wooNavigationBarStyle()
             })
             Divider()
                 .padding(.leading, Constants.horizontalPadding)

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Package Details/Multi-package/SinglePackageHazmatDeclaration.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Package Details/Multi-package/SinglePackageHazmatDeclaration.swift
@@ -46,10 +46,13 @@ struct SinglePackageHazmatDeclaration: View {
                         }
                         .padding(.horizontal, Constants.horizontalPadding)
                         .sheet(isPresented: $isShowingHazmatSelection) {
-                            SingleSelectionList(title: Localization.selectHazmatCategory,
-                                                items: viewModel.selectableHazmatCategories,
-                                                contentKeyPath: \.localizedName,
-                                                selected: $viewModel.selectedHazmatCategory)
+                            NavigationStack {
+                                SingleSelectionList(title: Localization.selectHazmatCategory,
+                                                    items: viewModel.selectableHazmatCategories,
+                                                    contentKeyPath: \.localizedName,
+                                                    selected: $viewModel.selectedHazmatCategory)
+                            }
+                            .wooNavigationBarStyle()
                         }
                     })
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Package Details/Package Selection/Package Creation/ShippingLabelCustomPackageForm.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/Create Shipping Label Form/Package Details/Package Selection/Package Creation/ShippingLabelCustomPackageForm.swift
@@ -24,10 +24,13 @@ struct ShippingLabelCustomPackageForm: View {
                             showingPackageTypes.toggle()
                         }
                         .sheet(isPresented: $showingPackageTypes, content: {
-                            SingleSelectionList(title: Localization.packageTypeLabel,
-                                                items: ShippingLabelCustomPackageFormViewModel.PackageType.allCases,
-                                                contentKeyPath: \.localizedName,
-                                                selected: $viewModel.packageType)
+                            NavigationStack {
+                                SingleSelectionList(title: Localization.packageTypeLabel,
+                                                    items: ShippingLabelCustomPackageFormViewModel.PackageType.allCases,
+                                                    contentKeyPath: \.localizedName,
+                                                    selected: $viewModel.packageType)
+                            }
+                            .wooNavigationBarStyle()
                         })
 
                         Divider()

--- a/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/SingleSelectionList.swift
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/SingleSelectionList.swift
@@ -43,39 +43,35 @@ struct SingleSelectionList<T: Hashable>: View {
     }
 
     var body: some View {
-        NavigationView {
-            List {
-                ForEach(items, id: contentKeyPath) { item in
-                    SelectableItemRow(
-                        title: item[keyPath: contentKeyPath],
-                        selected: item == selected,
-                        displayMode: .compact,
-                        alignment: .trailing)
-                    .onTapGesture {
-                        selected = item
-                        onSelection?(item)
-                    }
+        List {
+            ForEach(items, id: contentKeyPath) { item in
+                SelectableItemRow(
+                    title: item[keyPath: contentKeyPath],
+                    selected: item == selected,
+                    displayMode: .compact,
+                    alignment: .trailing)
+                .onTapGesture {
+                    selected = item
+                    onSelection?(item)
                 }
-                .listRowInsets(.zero)
             }
-            .listStyle(.plain)
-            .background(backgroundColor.ignoresSafeArea())
-            .navigationTitle(title)
-            .navigationBarTitleDisplayMode(.inline)
-            .if(showDoneButton, transform: { view in
-                view.toolbar(content: {
-                    ToolbarItem(placement: .confirmationAction) {
-                        Button(action: {
-                            dismiss()
-                        }, label: {
-                            Text(NSLocalizedString("Done", comment: "Done navigation button in selection list screens"))
-                        })
-                    }
-                })
-            })
+            .listRowInsets(.zero)
         }
-        .navigationViewStyle(StackNavigationViewStyle())
-        .wooNavigationBarStyle()
+        .listStyle(.plain)
+        .background(backgroundColor.ignoresSafeArea())
+        .navigationTitle(title)
+        .navigationBarTitleDisplayMode(.inline)
+        .if(showDoneButton, transform: { view in
+            view.toolbar(content: {
+                ToolbarItem(placement: .confirmationAction) {
+                    Button(action: {
+                        dismiss()
+                    }, label: {
+                        Text(NSLocalizedString("Done", comment: "Done navigation button in selection list screens"))
+                    })
+                }
+            })
+        })
     }
 }
 

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/ShippingLineSelectionDetailsViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/ShippingLineSelectionDetailsViewModelTests.swift
@@ -213,6 +213,34 @@ final class ShippingLineSelectionDetailsViewModelTests: XCTestCase {
         XCTAssertFalse(viewModel.enableDoneButton)
     }
 
+    func test_view_model_disables_done_button_for_prefilled_data_and_enables_with_method_changes() {
+        // Given
+        let flatRateMethod = ShippingMethod(siteID: sampleSiteID, methodID: "flat_rate", title: "Flat rate")
+        let localPickupMethod = ShippingMethod(siteID: sampleSiteID, methodID: "local_pickup", title: "Local pickup")
+        let viewModel = ShippingLineSelectionDetailsViewModel(siteID: sampleSiteID,
+                                                              shippingMethods: [flatRateMethod, localPickupMethod],
+                                                              isExistingShippingLine: true,
+                                                              initialMethodID: flatRateMethod.methodID,
+                                                              initialMethodTitle: "Flat Rate",
+                                                              shippingTotal: "$11.30",
+                                                              locale: usLocale,
+                                                              storeCurrencySettings: usStoreSettings,
+                                                              didSelectSave: { _ in })
+        XCTAssertFalse(viewModel.enableDoneButton)
+
+        // When
+        viewModel.selectedMethod = localPickupMethod
+
+        // Then
+        XCTAssertTrue(viewModel.enableDoneButton)
+
+        // When
+        viewModel.selectedMethod = flatRateMethod
+
+        // Then
+        XCTAssertFalse(viewModel.enableDoneButton)
+    }
+
     func test_view_model_creates_shippping_line_with_data_from_fields() {
         // Given
         var savedShippingLine: ShippingLine?
@@ -232,11 +260,13 @@ final class ShippingLineSelectionDetailsViewModelTests: XCTestCase {
         // When
         viewModel.formattableAmountViewModel.amount = "$11.30"
         viewModel.methodTitle = "Flat Rate"
+        viewModel.selectedMethod = shippingMethod
         viewModel.saveData()
 
         // Then
         XCTAssertEqual(savedShippingLine?.total, "11.30")
         XCTAssertEqual(savedShippingLine?.methodTitle, "Flat Rate")
+        XCTAssertEqual(savedShippingLine?.methodID, shippingMethod.methodID)
     }
 
     func test_view_model_creates_shippping_line_with_negative_data_from_fields() {
@@ -312,6 +342,7 @@ final class ShippingLineSelectionDetailsViewModelTests: XCTestCase {
         viewModel.saveData()
         XCTAssertEqual(savedShippingLine?.total, "11.30")
         XCTAssertNotEqual(savedShippingLine?.methodTitle, "") // "Shipping" placeholder string is localized -> not reliable for comparison here.
+        XCTAssertEqual(savedShippingLine?.methodID, "")
     }
 
     func test_view_model_amount_placeholder_has_expected_value() {

--- a/Yosemite/Yosemite/Stores/Order/OrderFactory.swift
+++ b/Yosemite/Yosemite/Stores/Order/OrderFactory.swift
@@ -92,7 +92,7 @@ public enum OrderFactory {
     /// Creates a shipping line suitable to delete a shipping line already saved remotely in an order.
     ///
     public static func deletedShippingLine(_ shippingLine: ShippingLine) -> ShippingLine {
-        shippingLine.copy(methodID: .some(nil), total: "0")
+        shippingLine.copy(methodTitle: "", methodID: .some(nil), total: "0")
     }
 
     /// References a new empty order with constants `Date` values.


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of: #12578
<!-- Id number of the GitHub issue this PR addresses. -->

## Why
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This adds the UI to select a new shipping method for the shipping line on an order, and ensures the order is updated with the selected method.

## How
* Removes `NavigationView` from the reusable view `SingleSelectionList` and instead adds `NavigationStack` as needed where the view is used. This ensures the view has a navigation bar when it's displayed in a sheet, but also allows it to be used within an existing navigation stack.
* Uses `SingleSelectionList` in `ShippingLineSelectionDetails`, to open a list of the available shipping methods. (For now, this is a static list; it will eventually be synced from remote.)
* Updates `ShippingLineSelectionDetailsViewModel`:
   * Observes changes to the selected method (as well as the amount and method title) to set the "Done" button state.
   * Saves the selected method ID when the shipping line is saved.
* Updates the order synchronizer (in `ShippingInputTransformer` and `OrderFactory`) to ensure all of the shipping line details (amount, method title, and method ID) are included when a shipping line is added, updated, or removed.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

1. Build and run the app with the feature flag enabled.
2. Create a new order.
3. Add a product to the order.
4. Select "Add Shipping".
5. Select a shipping method and add an amount (and optionally a method title).
6. Save the new shipping line.
7. In the order totals bottom sheet, select Shipping and confirm the shipping line details appear as expected.
8. Edit the selected shipping method (and optionally the amount/title).
9. Save the updated shipping line and repeat step 7.
10. Remove the shipping from the order.
11. Select "Add Shipping" and confirm the empty shipping line details screen appears.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

https://github.com/woocommerce/woocommerce-ios/assets/8658164/9f084e8a-ee7b-442f-aae2-b8099e4530d3



---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
