### PR TITLE
Hotfix: Chart Crash on Negative Values on Dynamic Dashboard

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -3,6 +3,9 @@
 18.5
 -----
 
+18.4.1
+-----
+- [***] The application crashes when the `Charts` library attempts to calculate stride values for the y-axis with negative numbers, typically occurring when the data contains negative revenue (refunds). The issue is traced to the `NumberBins.init(size:range:)` method within the library, causing a crash seconds after app launch when viewing stats in the new Dynamic Dashboard.
 
 18.4
 -----

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -5,7 +5,7 @@
 
 18.4.1
 -----
-- [***] The application crashes when the `Charts` library attempts to calculate stride values for the y-axis with negative numbers, typically occurring when the data contains negative revenue (refunds). The issue is traced to the `NumberBins.init(size:range:)` method within the library, causing a crash seconds after app launch when viewing stats in the new Dynamic Dashboard.
+- [***] The application crashes when the `Charts` library attempts to calculate stride values for the y-axis with negative numbers, typically occurring when the data contains negative revenue (refunds). The issue is traced to the `NumberBins.init(size:range:)` method within the library, causing a crash seconds after app launch when viewing stats in the new Dynamic Dashboard. [https://github.com/woocommerce/woocommerce-ios/pull/12672]
 
 18.4
 -----

--- a/WooCommerce/Classes/ViewRelated/Dashboard/StoreStats/StoreStatsChartViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/StoreStats/StoreStatsChartViewModel.swift
@@ -128,7 +128,7 @@ extension StoreStatsChartViewModel {
     var yAxisStride: Double {
         let minValue = intervals.map { $0.revenue }.min() ?? 0
         let maxValue = intervals.map { $0.revenue }.max() ?? 0
-        return (minValue + maxValue) / 2
+        return (abs(minValue) + abs(maxValue)) / 2
     }
 
     func yAxisLabel(for revenue: Double) -> String {

--- a/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/StoreStats/StoreStatsChartViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/StoreStats/StoreStatsChartViewModelTests.swift
@@ -150,6 +150,22 @@ final class StoreStatsChartViewModelTests: XCTestCase {
         XCTAssertEqual(viewModel.yAxisStride, 100)
     }
 
+    func test_yAxisStride_can_handle_negative_revenue_values() {
+        // Given
+        let currentDate = Date()
+        let intervals = [
+            StoreStatsChartData(date: currentDate, revenue: 100),
+            StoreStatsChartData(date: currentDate.adding(days: 1)!, revenue: -10),
+            StoreStatsChartData(date: currentDate.adding(days: 2)!, revenue: 130),
+        ]
+
+        // When
+        let viewModel = StoreStatsChartViewModel(intervals: intervals, timeRange: .thisWeek)
+
+        // Then
+        XCTAssertEqual(viewModel.yAxisStride, 70)
+    }
+
     func test_yAxisLabel_is_correct_for_zero_revenue() {
         // Given
         let viewModel = StoreStatsChartViewModel(intervals: [], timeRange: .thisWeek)


### PR DESCRIPTION
Closes #12661

#### Problem
This pull request addresses a crash in the `yAxisStride` calculation within the `StoreStatsChartViewModel`. Previously, the stride calculation did not properly account for negative values, which could occur in datasets that included refunds or other negative revenue amounts. This led to a crash when the chart attempted to render with an incorrect stride value. The issue is traced to the `NumberBins.init(size:range:)` method within the framework, causing a crash a few seconds after app launch when viewing stats in the Dynamic Dashboard.


#### Steps to Reproduce
1. Log into the specific store with negative revenue data.
2. Select a date range that includes the negative values.
3. Observe the crash after the stats are fetched and displayed.

#### Solution
- The stride calculation has been updated to correctly handle the full range of data, including negative values. The new calculation determines the stride based on the actual range between the minimum and maximum revenue values.
- The stride is now guaranteed to be a positive value, which prevents the charting library from encountering errors when rendering the y-axis.

#### Changes Made
The stride calculation now uses the absolute values of the minimum and maximum to ensure that the stride is always a positive number.


#### Impact
This hotfix resolves the app crash related to the `Charts` framework and allows users to view their stats without interruption, even with negative data points.

#### Release
This is a critical hotfix, and we are proceeding with an immediate release of version 18.4.1 to address this issue.


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
