### PR TITLE
[Shipping Lines] Fetch shipping methods from remote

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/EditableOrderViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/EditableOrderViewModel.swift
@@ -533,6 +533,7 @@ final class EditableOrderViewModel: ObservableObject {
         forwardSyncApproachToSynchronizer()
         observeChangesFromProductSelectorButtonTapSelectionSync()
         observeChangesInCustomerDetails()
+        syncShippingMethods()
     }
 
     /// Observes and keeps track of changes within the Customer Details
@@ -1710,7 +1711,6 @@ private extension EditableOrderViewModel {
                 .assign(to: &$customerNoteDataViewModel)
     }
 
-
     /// Updates payment section view model based on items in the order and order sync state.
     ///
     func configurePaymentDataViewModel() {
@@ -1866,6 +1866,20 @@ private extension EditableOrderViewModel {
                 }
             }
             .assign(to: &$multipleLinesMessage)
+    }
+
+    /// Synchronizes available shipping methods for editing the order shipping lines.
+    ///
+    func syncShippingMethods() {
+        guard ServiceLocator.featureFlagService.isFeatureFlagEnabled(.enhancingOrderShippingLines) else {
+            return
+        }
+        let action = ShippingMethodAction.synchronizeShippingMethods(siteID: siteID) { result in
+            if let error = result.failure {
+                DDLogError("⛔️ Error retrieving available shipping methods: \(error)")
+            }
+        }
+        stores.dispatch(action)
     }
 
     func configureTaxRates() {

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/EditableOrderViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/EditableOrderViewModel.swift
@@ -1198,7 +1198,6 @@ extension EditableOrderViewModel {
         init(siteID: Int64 = 0,
              shouldShowProductsTotal: Bool = false,
              itemsTotal: String = "0",
-             availableShippingMethods: [ShippingMethod] = [],
              shouldShowShippingTotal: Bool = false,
              shippingTotal: String = "0",
              shippingMethodID: String = "",
@@ -1269,7 +1268,6 @@ extension EditableOrderViewModel {
                                                                       shippingTotal: shippingMethodTotal,
                                                                       didSelectSave: saveShippingLineClosure)
             self.shippingLineSelectionViewModel = ShippingLineSelectionDetailsViewModel(siteID: siteID,
-                                                                                        shippingMethods: availableShippingMethods,
                                                                                         isExistingShippingLine: shouldShowShippingTotal,
                                                                                         initialMethodID: shippingMethodID,
                                                                                         initialMethodTitle: shippingMethodTitle,
@@ -1737,12 +1735,6 @@ private extension EditableOrderViewModel {
 
                 let shippingMethodID = order.shippingLines.first?.methodID ?? ""
                 let shippingMethodTitle = order.shippingLines.first?.methodTitle ?? ""
-                let availableShippingMethods = [ // TODO-12578: Replace with actual shipping methods
-                    ShippingMethod(siteID: siteID, methodID: "flat_rate", title: "Flat rate"),
-                    ShippingMethod(siteID: siteID, methodID: "free_shipping", title: "Free shipping"),
-                    ShippingMethod(siteID: siteID, methodID: "local_pickup", title: "Local pickup"),
-                    ShippingMethod(siteID: siteID, methodID: "other", title: "Other")
-                ]
 
                 let isDataSyncing: Bool = {
                     switch state {
@@ -1787,7 +1779,6 @@ private extension EditableOrderViewModel {
                 return PaymentDataViewModel(siteID: self.siteID,
                                             shouldShowProductsTotal: order.items.isNotEmpty,
                                             itemsTotal: orderTotals.itemsTotal.stringValue,
-                                            availableShippingMethods: availableShippingMethods,
                                             shouldShowShippingTotal: order.shippingLines.filter { $0.methodID != nil }.isNotEmpty,
                                             shippingTotal: order.shippingTotal.isNotEmpty ? order.shippingTotal : "0",
                                             shippingMethodID: shippingMethodID,

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/PaymentSection/Shipping/ShippingLineSelectionDetails.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/PaymentSection/Shipping/ShippingLineSelectionDetails.swift
@@ -136,7 +136,6 @@ private extension ShippingLineSelectionDetails {
 
 #Preview("Add shipping") {
     ShippingLineSelectionDetails(viewModel: ShippingLineSelectionDetailsViewModel(siteID: 1,
-                                                                                  shippingMethods: [],
                                                                                   isExistingShippingLine: false,
                                                                                   initialMethodID: "",
                                                                                   initialMethodTitle: "",
@@ -146,7 +145,6 @@ private extension ShippingLineSelectionDetails {
 
 #Preview("Edit shipping") {
     ShippingLineSelectionDetails(viewModel: ShippingLineSelectionDetailsViewModel(siteID: 1,
-                                                                                  shippingMethods: [],
                                                                                   isExistingShippingLine: true,
                                                                                   initialMethodID: "flat_rate",
                                                                                   initialMethodTitle: "Shipping",

--- a/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/SingleSelectionList.swift
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/SingleSelectionList.swift
@@ -44,7 +44,7 @@ struct SingleSelectionList<T: Hashable>: View {
 
     var body: some View {
         List {
-            ForEach(items, id: contentKeyPath) { item in
+            ForEach(items, id: \.self) { item in
                 SelectableItemRow(
                     title: item[keyPath: contentKeyPath],
                     selected: item == selected,

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/EditableOrderViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/EditableOrderViewModelTests.swift
@@ -3275,6 +3275,24 @@ final class EditableOrderViewModelTests: XCTestCase {
         //Then
         XCTAssertTrue(viewModel.hasChanges)
     }
+
+    func test_init_syncs_available_shipping_methods() {
+        // Given
+        var shippingMethodsSynced = false
+        stores.whenReceivingAction(ofType: ShippingMethodAction.self) { action in
+            switch action {
+            case let .synchronizeShippingMethods(_, completion):
+                shippingMethodsSynced = true
+                completion(.success(()))
+            }
+        }
+
+        // When
+        let viewModel = EditableOrderViewModel(siteID: sampleSiteID, stores: stores)
+
+        // Then
+        XCTAssertTrue(shippingMethodsSynced)
+    }
 }
 
 private extension EditableOrderViewModelTests {


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of: #12578
<!-- Id number of the GitHub issue this PR addresses. -->

## Why
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This connects the new shipping line UI with the Yosemite support to fetch available shipping methods from storage/remote:

1. When the order form (to create/edit an order) is opened, we sync the available shipping methods from remote into storage.
2. When the shipping line details are opened, we fetch the shipping methods from storage.

That way, we can select a shipping method from all the available shipping methods on the store.

## How

* In `EditableOrderViewModel`:
   * We remove the static list of shipping methods.
   * We add a method to sync the shipping methods from remote. I added the syncing here so we only sync the shipping methods once when an order is being edited. (We expect the shipping methods to be updated rarely but want to be sure we have the latest changes while editing an order.)
* In `ShippingLineSelectionDetails`:
   * We fetch the available shipping methods from storage.
   * We initialize the selected method using the fetched shipping methods.

This also includes a small update to `SingleSelectionList`:

* After fetching shipping methods from remote, I noticed that the selection wasn't working due to two shipping methods having the same name ("Local pickup").
* Because the view requires that the items are hashable, I updated the `ForEach` loop to use `\.self` instead of `contentKeyPath` as the item ID. That way, the list can include two different items with the same content (in this case, two shipping methods with the same name but different IDs).

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

New order / no selected method:

1. Build and run the app with the feature flag enabled.
2. Create a new order.
3. Add a product to the order.
4. Select "Add Shipping."
5. Select "Method" and confirm the list of shipping methods is loaded.
6. Add an amount and save the shipping on the order.
7. In the order totals section, select "Shipping."
8. Confirm the shipping details open with the correct selected method displayed.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

https://github.com/woocommerce/woocommerce-ios/assets/8658164/df21ed57-65a5-4c48-a27a-0b67a3a80864



---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
