### PR TITLE
[Tooling] Push hotfix branch on `new_hotfix_release`

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -428,6 +428,10 @@ platform :ios do
       version_long: build_code_hotfix
     )
     commit_version_bump
+
+    # Push the newly created hotfix branch
+    push_to_git_remote(tags: false)
+
     UI.success("Done! New Release Version: #{release_version_current}. New Build Code: #{build_code_current}")
   end
 


### PR DESCRIPTION
While running together with the team the `18.4.1` hotfix tasks on ReleasesV2, I have noticed that the step `Create Hotfix Branch` (lane `new_hotfix_release`) didn't push the newly created hotfix branch to remote, and I had to do it manually.
This PR adds a call to push the new hotfix branch.

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
