### PR TITLE
Dynamic Dashboard: Improve performance for Performance card

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Dashboard/StoreStats/StorePerformanceView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/StoreStats/StorePerformanceView.swift
@@ -9,7 +9,7 @@ struct StorePerformanceView: View {
     @State private var showingSupportForm = false
 
     private var statsValueColor: Color {
-        guard viewModel.chartViewModel.hasRevenue else {
+        guard viewModel.hasRevenue else {
             return Color(.textSubtle)
         }
         return Color(viewModel.shouldHighlightStats ? .statsHighlighted : .text)
@@ -158,7 +158,7 @@ private extension StorePerformanceView {
                     .largeTitleStyle()
 
                 Text(Localization.revenue)
-                    .if(!viewModel.chartViewModel.hasRevenue) { $0.foregroundStyle(Color(.textSubtle)) }
+                    .if(!viewModel.hasRevenue) { $0.foregroundStyle(Color(.textSubtle)) }
                     .font(Font(StyleManager.statsTitleFont))
             }
 
@@ -180,12 +180,12 @@ private extension StorePerformanceView {
                         .frame(maxWidth: .infinity)
 
                 }
-                .renderedIf(viewModel.chartViewModel.hasRevenue)
+                .renderedIf(viewModel.hasRevenue)
 
                 Text(Localization.noRevenueText)
                     .subheadlineStyle()
                     .frame(maxWidth: .infinity)
-                    .renderedIf(!viewModel.chartViewModel.hasRevenue)
+                    .renderedIf(!viewModel.hasRevenue)
             }
         }
     }
@@ -235,17 +235,20 @@ private extension StorePerformanceView {
         }
     }
 
+    @ViewBuilder
     var chartView: some View {
-        VStack {
-            StoreStatsChart(viewModel: viewModel.chartViewModel) { selectedIndex in
-                viewModel.didSelectStatsInterval(at: selectedIndex)
-            }
-            .frame(height: Layout.chartViewHeight)
+        if let chartViewModel = viewModel.chartViewModel {
+            VStack {
+                StoreStatsChart(viewModel: chartViewModel) { selectedIndex in
+                    viewModel.didSelectStatsInterval(at: selectedIndex)
+                }
+                .frame(height: Layout.chartViewHeight)
 
-            if viewModel.chartViewModel.hasRevenue,
-               let granularityText = viewModel.granularityText {
-                Text(granularityText)
-                    .font(Font(StyleManager.statsTitleFont))
+                if viewModel.hasRevenue,
+                   let granularityText = viewModel.granularityText {
+                    Text(granularityText)
+                        .font(Font(StyleManager.statsTitleFont))
+                }
             }
         }
     }


### PR DESCRIPTION

<!-- Remember about a good descriptive title. -->

Closes: #12680 
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
In `StorePerformanceViewModel` we are keeping chartViewModel a computed variable and access this from the SwiftUI view a few times, causing the view model to be initialized again a lot of times when rendering the card.

This PR fixes this by initializing `chartViewModel` only upon new interval data.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
- Build and run the app.
- Log in to a store and enable Performance card.
- Switch between intervals and confirm that the card still works incorrectly.
- Optionally add a log in `StoreStatsChatViewModel`'s initializer to confirm that the view model is only initialized when necessary.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->
<img src="https://github.com/woocommerce/woocommerce-ios/assets/5533851/7c2e142b-a047-4583-bc9a-8b4ca3618487" width=320 />

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
