### PR TITLE
[Shipping Lines] Add shipping methods tracks events

### DIFF
--- a/WooCommerce/Classes/Analytics/WooAnalyticsEvent.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsEvent.swift
@@ -720,6 +720,10 @@ extension WooAnalyticsEvent {
             WooAnalyticsEvent(statName: .orderProductDiscountEditButtonTapped, properties: [:])
         }
 
+        static func orderShippingMethodSelected(methodID: String) -> WooAnalyticsEvent {
+            WooAnalyticsEvent(statName: .orderShippingMethodSelected, properties: [Keys.shippingMethod: methodID])
+        }
+
         static func orderShippingMethodAdd(flow: Flow, methodID: String) -> WooAnalyticsEvent {
             WooAnalyticsEvent(statName: .orderShippingMethodAdd, properties: [Keys.flow: flow.rawValue,
                                                                               Keys.shippingMethod: methodID])

--- a/WooCommerce/Classes/Analytics/WooAnalyticsEvent.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsEvent.swift
@@ -560,6 +560,7 @@ extension WooAnalyticsEvent {
             static let taxStatus = "tax_status"
             static let expanded = "expanded"
             static let horizontalSizeClass = "horizontal_size_class"
+            static let shippingMethod = "shipping_method"
         }
 
         static func ordersSelected(horizontalSizeClass: UIUserInterfaceSizeClass) -> WooAnalyticsEvent {
@@ -719,8 +720,9 @@ extension WooAnalyticsEvent {
             WooAnalyticsEvent(statName: .orderProductDiscountEditButtonTapped, properties: [:])
         }
 
-        static func orderShippingMethodAdd(flow: Flow) -> WooAnalyticsEvent {
-            WooAnalyticsEvent(statName: .orderShippingMethodAdd, properties: [Keys.flow: flow.rawValue])
+        static func orderShippingMethodAdd(flow: Flow, methodID: String) -> WooAnalyticsEvent {
+            WooAnalyticsEvent(statName: .orderShippingMethodAdd, properties: [Keys.flow: flow.rawValue,
+                                                                              Keys.shippingMethod: methodID])
         }
 
         static func orderShippingMethodRemove(flow: Flow) -> WooAnalyticsEvent {

--- a/WooCommerce/Classes/Analytics/WooAnalyticsEvent.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsEvent.swift
@@ -720,6 +720,10 @@ extension WooAnalyticsEvent {
             WooAnalyticsEvent(statName: .orderProductDiscountEditButtonTapped, properties: [:])
         }
 
+        static func orderAddShippingTapped() -> WooAnalyticsEvent {
+            WooAnalyticsEvent(statName: .orderAddShippingTapped, properties: [:])
+        }
+
         static func orderShippingMethodSelected(methodID: String) -> WooAnalyticsEvent {
             WooAnalyticsEvent(statName: .orderShippingMethodSelected, properties: [Keys.shippingMethod: methodID])
         }

--- a/WooCommerce/Classes/Analytics/WooAnalyticsStat.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsStat.swift
@@ -500,6 +500,7 @@ public enum WooAnalyticsStat: String {
     case orderProductDiscountRemove = "order_product_discount_remove"
     case orderProductDiscountAddButtonTapped = "order_product_discount_add_button_tapped"
     case orderProductDiscountEditButtonTapped = "order_product_discount_edit_button_tapped"
+    case orderAddShippingTapped = "order_add_shipping_tapped"
     case orderShippingMethodSelected = "order_shipping_method_selected"
     case orderShippingMethodAdd = "order_shipping_method_add"
     case orderShippingMethodRemove = "order_shipping_method_remove"

--- a/WooCommerce/Classes/Analytics/WooAnalyticsStat.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsStat.swift
@@ -500,6 +500,7 @@ public enum WooAnalyticsStat: String {
     case orderProductDiscountRemove = "order_product_discount_remove"
     case orderProductDiscountAddButtonTapped = "order_product_discount_add_button_tapped"
     case orderProductDiscountEditButtonTapped = "order_product_discount_edit_button_tapped"
+    case orderShippingMethodSelected = "order_shipping_method_selected"
     case orderShippingMethodAdd = "order_shipping_method_add"
     case orderShippingMethodRemove = "order_shipping_method_remove"
     case orderSyncFailed = "order_sync_failed"

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/AddOrderComponentsSection/AddOrderComponentsSection.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/AddOrderComponentsSection/AddOrderComponentsSection.swift
@@ -124,6 +124,7 @@ private extension AddOrderComponentsSection {
     @ViewBuilder var addShippingRow: some View {
         Button(Localization.addShipping) {
             shouldShowShippingLineDetails = true
+            viewModel.addShippingTappedClosure()
         }
         .buttonStyle(PlusButtonStyle())
         .padding()

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/EditableOrderViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/EditableOrderViewModel.swift
@@ -409,8 +409,8 @@ final class EditableOrderViewModel: ObservableObject {
     func saveShippingLine(_ shippingLine: ShippingLine?) {
         orderSynchronizer.setShipping.send(shippingLine)
 
-        if shippingLine != nil {
-            analytics.track(event: WooAnalyticsEvent.Orders.orderShippingMethodAdd(flow: flow.analyticsFlow))
+        if let shippingLine {
+            analytics.track(event: WooAnalyticsEvent.Orders.orderShippingMethodAdd(flow: flow.analyticsFlow, methodID: shippingLine.methodID ?? ""))
         } else {
             analytics.track(event: WooAnalyticsEvent.Orders.orderShippingMethodRemove(flow: flow.analyticsFlow))
         }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/EditableOrderViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/EditableOrderViewModel.swift
@@ -1231,6 +1231,7 @@ extension EditableOrderViewModel {
         let onDismissWpAdminWebViewClosure: () -> Void
         let addGiftCardClosure: () -> Void
         let setGiftCardClosure: (_ code: String?) -> Void
+        let addShippingTappedClosure: () -> Void
 
         init(siteID: Int64 = 0,
              shouldShowProductsTotal: Bool = false,
@@ -1269,6 +1270,7 @@ extension EditableOrderViewModel {
              onDismissWpAdminWebViewClosure: @escaping () -> Void = {},
              addGiftCardClosure: @escaping () -> Void = {},
              setGiftCardClosure: @escaping (_ code: String?) -> Void = { _ in },
+             addShippingTappedClosure: @escaping () -> Void = {},
              currencyFormatter: CurrencyFormatter = CurrencyFormatter(currencySettings: ServiceLocator.currencySettings)) {
             self.siteID = siteID
             self.shouldShowProductsTotal = shouldShowProductsTotal
@@ -1316,6 +1318,7 @@ extension EditableOrderViewModel {
             self.onDismissWpAdminWebViewClosure = onDismissWpAdminWebViewClosure
             self.addGiftCardClosure = addGiftCardClosure
             self.setGiftCardClosure = setGiftCardClosure
+            self.addShippingTappedClosure = addShippingTappedClosure
         }
 
         /// Indicates whether the Coupons informational tooltip button should be shown
@@ -1879,6 +1882,9 @@ private extension EditableOrderViewModel {
                                                 self.orderSynchronizer.setGiftCard.send(code)
                                                 self.analytics.track(event: .Orders.orderFormGiftCardSet(flow: self.flow.analyticsFlow,
                                                                                                          isRemoved: code == nil))
+                                            },
+                                            addShippingTappedClosure: { [weak self] in
+                                                self?.analytics.track(event: .Orders.orderAddShippingTapped())
                                             },
                                             currencyFormatter: self.currencyFormatter)
             }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/PaymentSection/Shipping/ShippingLineSelectionDetails.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/PaymentSection/Shipping/ShippingLineSelectionDetails.swift
@@ -20,7 +20,9 @@ struct ShippingLineSelectionDetails: View {
                                         contentKeyPath: \.title,
                                         selected: $viewModel.selectedMethod,
                                         showDoneButton: false,
-                                        backgroundColor: nil)
+                                        backgroundColor: nil) { method in
+                        viewModel.trackShippingMethodSelected(method)
+                    }
                 } label: {
                     VStack(alignment: .leading) {
                         Text(Localization.methodTitle)

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/PaymentSection/Shipping/ShippingLineSelectionDetailsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/PaymentSection/Shipping/ShippingLineSelectionDetailsViewModel.swift
@@ -7,6 +7,7 @@ import Combine
 class ShippingLineSelectionDetailsViewModel: ObservableObject {
     private var siteID: Int64
     private let storageManager: StorageManagerType
+    private let analytics: Analytics
 
     /// Closure to be invoked when the shipping line is updated.
     ///
@@ -73,9 +74,11 @@ class ShippingLineSelectionDetailsViewModel: ObservableObject {
          locale: Locale = Locale.autoupdatingCurrent,
          storeCurrencySettings: CurrencySettings = ServiceLocator.currencySettings,
          storageManager: StorageManagerType = ServiceLocator.storageManager,
+         analytics: Analytics = ServiceLocator.analytics,
          didSelectSave: @escaping ((ShippingLine?) -> Void)) {
         self.siteID = siteID
         self.storageManager = storageManager
+        self.analytics = analytics
         self.isExistingShippingLine = isExistingShippingLine
         self.initialMethodID = initialMethodID
         self.initialMethodTitle = initialMethodTitle
@@ -112,6 +115,12 @@ class ShippingLineSelectionDetailsViewModel: ObservableObject {
                                         totalTax: "",
                                         taxes: [])
         didSelectSave(shippingLine)
+    }
+
+    /// Tracks when a shipping method is selected
+    ///
+    func trackShippingMethodSelected(_ selectedMethod: ShippingMethod) {
+        analytics.track(event: .Orders.orderShippingMethodSelected(methodID: selectedMethod.methodID))
     }
 }
 

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/EditableOrderViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/EditableOrderViewModelTests.swift
@@ -1298,6 +1298,18 @@ final class EditableOrderViewModelTests: XCTestCase {
         XCTAssertEqual(event.value as? String, "product_selector")
     }
 
+    func test_payment_data_view_model_when_calling_add_shipping_tapped_tracks_expected_event() {
+        // Given
+        let analytics = MockAnalyticsProvider()
+        let viewModel = EditableOrderViewModel(siteID: sampleSiteID, analytics: WooAnalytics(analyticsProvider: analytics))
+
+        // When
+        viewModel.paymentDataViewModel.addShippingTappedClosure()
+
+        // Then
+        XCTAssertEqual(analytics.receivedEvents, [WooAnalyticsStat.orderAddShippingTapped.rawValue])
+    }
+
     func test_shipping_method_tracked_when_added() throws {
         // Given
         let analytics = MockAnalyticsProvider()

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/EditableOrderViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/EditableOrderViewModelTests.swift
@@ -1302,16 +1302,15 @@ final class EditableOrderViewModelTests: XCTestCase {
         // Given
         let analytics = MockAnalyticsProvider()
         let viewModel = EditableOrderViewModel(siteID: sampleSiteID, analytics: WooAnalytics(analyticsProvider: analytics))
-        let shippingLine = ShippingLine.fake()
+        let shippingLine = ShippingLine.fake().copy(methodID: "flat_rate")
 
         // When
         viewModel.saveShippingLine(shippingLine)
 
         // Then
         XCTAssertEqual(analytics.receivedEvents, [WooAnalyticsStat.orderShippingMethodAdd.rawValue])
-
-        let properties = try XCTUnwrap(analytics.receivedProperties.first?["flow"] as? String)
-        XCTAssertEqual(properties, "creation")
+        assertEqual("creation", analytics.receivedProperties.first?["flow"] as? String)
+        assertEqual("flat_rate", analytics.receivedProperties.first?["shipping_method"] as? String)
     }
 
     func test_shipping_method_tracked_when_removed() throws {

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/ShippingLineSelectionDetailsViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/ShippingLineSelectionDetailsViewModelTests.swift
@@ -379,6 +379,28 @@ final class ShippingLineSelectionDetailsViewModelTests: XCTestCase {
         XCTAssertEqual(viewModel.formattableAmountViewModel.amount, "")
         XCTAssertEqual(viewModel.methodTitle, "")
     }
+
+    func test_view_model_tracks_selected_shipping_method() {
+        // Given
+        let analytics = MockAnalyticsProvider()
+        let viewModel = ShippingLineSelectionDetailsViewModel(siteID: sampleSiteID,
+                                                              isExistingShippingLine: false,
+                                                              initialMethodID: "",
+                                                              initialMethodTitle: "",
+                                                              shippingTotal: "",
+                                                              locale: usLocale,
+                                                              storeCurrencySettings: usStoreSettings,
+                                                              analytics: WooAnalytics(analyticsProvider: analytics),
+                                                              didSelectSave: { _ in })
+
+        // When
+        let shippingMethod = ShippingMethod(siteID: sampleSiteID, methodID: "flat_rate", title: "Flat rate")
+        viewModel.trackShippingMethodSelected(shippingMethod)
+
+        // Then
+        XCTAssertEqual(analytics.receivedEvents, [WooAnalyticsStat.orderShippingMethodSelected.rawValue])
+        assertEqual(shippingMethod.methodID, analytics.receivedProperties.first?["shipping_method"] as? String)
+    }
 }
 
 private extension ShippingLineSelectionDetailsViewModelTests {


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #12580
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
We want to track 3 events around shipping method selection:

* Updated event:
   * `order_shipping_method_add` with the custom property `shipping_method` containing the id of the selected shipping method in lowercase (`ups`|`flat_rate`|`free_shipping`…).
   * Event registration: https://github.com/Automattic/tracks-events-registration/pull/2400 
* New event:
   * `order_shipping_method_selected`, triggered every time a merchant selects a new shipping method.
   * This event contains a custom property `shipping_method` with the id of the selected shipping method in lowercase (`ups`|`flat_rate`|`free_shipping`…).
   * Event registration: https://github.com/Automattic/tracks-events-registration/pull/2401
* New event:
   * `order_add_shipping_tapped`, triggered every time a merchant taps on the add shipping button.
   * Event registration: https://github.com/Automattic/tracks-events-registration/pull/2402

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

1. Go to the Orders tab.
2. Create a new order.
3. Add a product to the order.
4. Tap the "Add Shipping" button and confirm the `order_add_shipping_tapped` event is tracked.
5. On the shipping screen, tap "Method" to open the shipping methods list.
6. Select a new method and confirm the `order_shipping_method_selected` event is tracked with the custom prop `shipping_method` with the correct shipping method ID.
7. Add a shipping amount.
8. Tap "Add Shipping" to add the shipping method to the order, and confirm the `order_shipping_method_add` event is tracked with the custom prop `shipping_method` with the correct shipping method ID.

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
