### PR TITLE
[Shipping Lines] Add "Other" shipping method option to list of available methods

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/PaymentSection/Shipping/ShippingLineSelectionDetailsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/PaymentSection/Shipping/ShippingLineSelectionDetailsViewModel.swift
@@ -155,7 +155,10 @@ private extension ShippingLineSelectionDetailsViewModel {
     func updateShippingMethodResultsController() {
         do {
             try shippingMethodResultsController.performFetch()
-            shippingMethods = [placeholderMethod] + shippingMethodResultsController.fetchedObjects
+            // The app previously set the shipping method ID to "other" when shipping was added in the app.
+            // This option is not included in the remote list of shipping methods so we add it here.
+            let otherMethod = ShippingMethod(siteID: siteID, methodID: "other", title: "Other")
+            shippingMethods = [placeholderMethod] + shippingMethodResultsController.fetchedObjects + [otherMethod]
         } catch {
             DDLogError("⛔️ Error fetching shipping methods from storage: \(error)")
         }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/ShippingLineSelectionDetailsViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/ShippingLineSelectionDetailsViewModelTests.swift
@@ -102,7 +102,6 @@ final class ShippingLineSelectionDetailsViewModelTests: XCTestCase {
 
         // Then
         XCTAssertTrue(viewModel.isExistingShippingLine)
-        XCTAssertEqual(viewModel.shippingMethods.count, 2) // Provided method + placeholder method
         XCTAssertEqual(viewModel.selectedMethod, shippingMethod)
         XCTAssertEqual(viewModel.selectedMethodColor, Color(.text))
         XCTAssertEqual(viewModel.formattableAmountViewModel.amount, "11.30")
@@ -373,11 +372,29 @@ final class ShippingLineSelectionDetailsViewModelTests: XCTestCase {
 
         // Then
         XCTAssertFalse(viewModel.isExistingShippingLine)
-        XCTAssertEqual(viewModel.shippingMethods.count, 1) // Placeholder method
         XCTAssertEqual(viewModel.selectedMethod.methodID, "")
         XCTAssertEqual(viewModel.selectedMethodColor, Color(.placeholderText))
         XCTAssertEqual(viewModel.formattableAmountViewModel.amount, "")
         XCTAssertEqual(viewModel.methodTitle, "")
+    }
+
+    func test_view_model_sets_expected_shipping_methods() {
+        // Given
+        let shippingMethod = ShippingMethod(siteID: sampleSiteID, methodID: "flat_rate", title: "Flat rate")
+        insert(shippingMethod)
+        let viewModel = ShippingLineSelectionDetailsViewModel(siteID: sampleSiteID,
+                                                              isExistingShippingLine: false,
+                                                              initialMethodID: "",
+                                                              initialMethodTitle: "",
+                                                              shippingTotal: "",
+                                                              locale: usLocale,
+                                                              storeCurrencySettings: usStoreSettings,
+                                                              storageManager: storageManager,
+                                                              didSelectSave: { _ in })
+
+        // Then
+        XCTAssertEqual(viewModel.shippingMethods.count, 3) // Placeholder method + provided method + "Other"
+        XCTAssertTrue(viewModel.shippingMethods.contains(shippingMethod))
     }
 
     func test_view_model_tracks_selected_shipping_method() {


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of: #12579
<!-- Id number of the GitHub issue this PR addresses. -->

## Why
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
We need to add the `other` shipping method to the list of methods in the Shipping screen to match the available options in wp-admin: pe5pgL-4UL-p2#comment-3992

## How

In `ShippingLineSelectionDetailsViewModel`, after fetching the available list of shipping methods we add an option with `other` as the method ID and `Other` as the title.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

1. Go to the Orders tab.
2. Create a new order.
3. Add a product to the order.
4. Tap "Add Shipping" to open the Shipping screen.
5. Tap "Method" to open the list of shipping methods.
6. Confirm the list of methods matches wp-admin, including an "Other" option.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->
App|wp-admin
-|-
<img src="https://github.com/woocommerce/woocommerce-ios/assets/8658164/c4973905-4720-4b07-a2f1-cf58aef4a8d1" width="300px">|![Screenshot 2024-05-09 at 12 11 34](https://github.com/woocommerce/woocommerce-ios/assets/8658164/8debbe90-d142-45e6-8401-57f0b2c1dfd2)

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.