### PR TITLE
[Shipping Lines] Release shipping method selection in Shipping screen

### DIFF
--- a/Experiments/Experiments/DefaultFeatureFlagService.swift
+++ b/Experiments/Experiments/DefaultFeatureFlagService.swift
@@ -88,7 +88,7 @@ public struct DefaultFeatureFlagService: FeatureFlagService {
             return buildConfig == .localDeveloper || buildConfig == .alpha
         case .subscriptionsInOrderCreationCustomers:
             return (buildConfig == .localDeveloper || buildConfig == .alpha) && !isUITesting
-        case .enhancingOrderShippingLines:
+        case .orderShippingMethodSelection:
             return buildConfig == .localDeveloper || buildConfig == .alpha
         case .displayPointOfSaleToggle:
             return buildConfig == .localDeveloper || buildConfig == .alpha

--- a/Experiments/Experiments/DefaultFeatureFlagService.swift
+++ b/Experiments/Experiments/DefaultFeatureFlagService.swift
@@ -89,7 +89,7 @@ public struct DefaultFeatureFlagService: FeatureFlagService {
         case .subscriptionsInOrderCreationCustomers:
             return (buildConfig == .localDeveloper || buildConfig == .alpha) && !isUITesting
         case .orderShippingMethodSelection:
-            return buildConfig == .localDeveloper || buildConfig == .alpha
+            return true
         case .displayPointOfSaleToggle:
             return buildConfig == .localDeveloper || buildConfig == .alpha
         default:

--- a/Experiments/Experiments/FeatureFlag.swift
+++ b/Experiments/Experiments/FeatureFlag.swift
@@ -196,9 +196,9 @@ public enum FeatureFlag: Int {
     ///
     case subscriptionsInOrderCreationCustomers
 
-    /// Enables new shipping line features in order details and order creation/editing.
+    /// Enables shipping method selection in order creation/editing.
     ///
-    case enhancingOrderShippingLines
+    case orderShippingMethodSelection
 
     /// Makes the Experimental Feature toggle "Point Of Sale" menu visible, under app settings.
     ///

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -5,6 +5,7 @@
 - [*] Change text color in badge view in order products list to fix the dark mode readability. [https://github.com/woocommerce/woocommerce-ios/pull/12630]
 - [*] Speculative fix for a crash when opening order notifications [https://github.com/woocommerce/woocommerce-ios/pull/12643]
 - [internal] Show In-App feedback card in dashboard. [https://github.com/woocommerce/woocommerce-ios/pull/12636]
+- [*] Shipping: A shipping method can now be selected when adding or editing shipping on an order. [https://github.com/woocommerce/woocommerce-ios/pull/12688]
 
 18.5
 -----

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/EditableOrderViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/EditableOrderViewModel.swift
@@ -1926,7 +1926,7 @@ private extension EditableOrderViewModel {
     /// Synchronizes available shipping methods for editing the order shipping lines.
     ///
     func syncShippingMethods() {
-        guard ServiceLocator.featureFlagService.isFeatureFlagEnabled(.enhancingOrderShippingLines) else {
+        guard ServiceLocator.featureFlagService.isFeatureFlagEnabled(.orderShippingMethodSelection) else {
             return
         }
         let action = ShippingMethodAction.synchronizeShippingMethods(siteID: siteID) { result in

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/OrderForm.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/OrderForm.swift
@@ -309,7 +309,7 @@ struct OrderForm: View {
                                     shouldShowGiftCardForm: $shouldShowGiftCardForm)
                                 .disabled(viewModel.shouldShowNonEditableIndicators)
                                 .sheet(isPresented: $shouldShowShippingLineDetails) {
-                                    if ServiceLocator.featureFlagService.isFeatureFlagEnabled(.enhancingOrderShippingLines) {
+                                    if ServiceLocator.featureFlagService.isFeatureFlagEnabled(.orderShippingMethodSelection) {
                                         ShippingLineSelectionDetails(viewModel: viewModel.paymentDataViewModel.shippingLineSelectionViewModel)
                                     } else {
                                         ShippingLineDetails(viewModel: viewModel.paymentDataViewModel.shippingLineViewModel)

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/Synchronizer/ShippingInputTransformer.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/Synchronizer/ShippingInputTransformer.swift
@@ -27,7 +27,7 @@ struct ShippingInputTransformer {
 
         // Since we only support one shipping line, if we find one, we update the existing with the new input values.
         var updatedLines = order.shippingLines
-        let methodID = ServiceLocator.featureFlagService.isFeatureFlagEnabled(.enhancingOrderShippingLines) ? input.methodID : existingShippingLine.methodID
+        let methodID = ServiceLocator.featureFlagService.isFeatureFlagEnabled(.orderShippingMethodSelection) ? input.methodID : existingShippingLine.methodID
         let updatedShippingLine = existingShippingLine.copy(methodTitle: input.methodTitle, methodID: methodID, total: input.total)
         updatedLines[0] = updatedShippingLine
 


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->
<!-- Id number of the GitHub issue this PR addresses. -->

## Why
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

This PR releases the first milestone of the Enhancing Order Shipping Lines project, which adds support for selecting a shipping method when adding/editing shipping on an order.

## How

* Updates the feature flag name to `orderShippingMethodSelection`, since we'll release this milestone separately from later project milestones. (We can add separate feature flags for those features/releases.)
* Enables the feature flag.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

Basic testing steps:

1. Go to the Orders tab.
2. Create a new order and add a product, or select an existing order and tap "Edit".
3. In the other form, tap "Add Shipping" to add a shipping line to the order, or tap "Shipping" in order totals to edit a shipping line on the order.

Scenarios to test:

* Adding shipping to a new order.
* Editing shipping on an existing order.
* Removing shipping from an order.

Expected functionality:

- The Add shipping screen allows you to select the shipping method, setting the shipping name and the shipping cost.
- The Select shipping method screen displays all configured shipping methods in the store plus the other option
- The Remove shipping from order button is displayed when there is an existing shipping line in the order.
- Editing a shipping line fills the Add shipping screen with the values of the previous shipping set (shipping method, name and cost)
- Track every time the shipping method selection changes
- Track when a shipping line is added to the order
- Track when the add shipping button is pressed

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->
**Add shipping**

https://github.com/woocommerce/woocommerce-ios/assets/8658164/71a03389-4368-465e-b022-9055e502e1df


**Edit shipping**

https://github.com/woocommerce/woocommerce-ios/assets/8658164/d948fcf9-cb35-49e1-88b6-4ecbd0537615


**Remove shipping**

https://github.com/woocommerce/woocommerce-ios/assets/8658164/80aef04a-b0b5-464c-82e2-f184ad48d0a0


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
