### PR TITLE
[Woo POS] Initial UI scaffolding

### DIFF
--- a/WooCommerce/Classes/AppDelegate.swift
+++ b/WooCommerce/Classes/AppDelegate.swift
@@ -249,6 +249,17 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     }
 }
 
+// MARK: - Helper method for WooCommerce POS
+//
+extension AppDelegate {
+    func shouldHideTabBar(_ hidden: Bool) {
+        guard let tabBarController = AppDelegate.shared.tabBarController else {
+            return
+        }
+        tabBarController.tabBar.isHidden = hidden
+    }
+}
+
 
 // MARK: - Initialization Methods
 //

--- a/WooCommerce/Classes/AppDelegate.swift
+++ b/WooCommerce/Classes/AppDelegate.swift
@@ -252,7 +252,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 // MARK: - Helper method for WooCommerce POS
 //
 extension AppDelegate {
-    func shouldHideTabBar(_ hidden: Bool) {
+    func setShouldHideTabBar(_ hidden: Bool) {
         guard let tabBarController = AppDelegate.shared.tabBarController else {
             return
         }

--- a/WooCommerce/Classes/Model/BetaFeature.swift
+++ b/WooCommerce/Classes/Model/BetaFeature.swift
@@ -59,7 +59,8 @@ extension BetaFeature {
         case .inAppPurchases:
             return ServiceLocator.featureFlagService.isFeatureFlagEnabled(.inAppPurchasesDebugMenu)
         case .pointOfSale:
-            return ServiceLocator.featureFlagService.isFeatureFlagEnabled(.displayPointOfSaleToggle)
+            return ServiceLocator.featureFlagService.isFeatureFlagEnabled(.displayPointOfSaleToggle) &&
+            UIDevice.current.userInterfaceIdiom == .pad
         default:
             return true
         }

--- a/WooCommerce/Classes/ViewRelated/Hub Menu/HubMenu.swift
+++ b/WooCommerce/Classes/ViewRelated/Hub Menu/HubMenu.swift
@@ -168,7 +168,7 @@ private extension HubMenu {
             case HubMenuViewModel.Customers.id:
                 CustomersListView(viewModel: .init(siteID: viewModel.siteID))
             case HubMenuViewModel.PointOfSaleEntryPoint.id:
-                PointOfSaleEntryPointView()
+                WooCommercePOS.PointOfSaleEntryPointView()
             default:
                 fatalError("🚨 Unsupported menu item")
             }

--- a/WooCommerce/Classes/ViewRelated/Hub Menu/HubMenu.swift
+++ b/WooCommerce/Classes/ViewRelated/Hub Menu/HubMenu.swift
@@ -168,8 +168,8 @@ private extension HubMenu {
             case HubMenuViewModel.Customers.id:
                 CustomersListView(viewModel: .init(siteID: viewModel.siteID))
             case HubMenuViewModel.PointOfSaleEntryPoint.id:
-                WooCommercePOS.PointOfSaleEntryPointView(hideAppTabBarsCallback: { hidden in
-                    AppDelegate.shared.tabBarController?.tabBar.isHidden = hidden
+                WooCommercePOS.PointOfSaleEntryPointView(hideAppTabBarsCallback: { isHidden in
+                    AppDelegate.shared.shouldHideTabBar(isHidden)
                 })
             default:
                 fatalError("🚨 Unsupported menu item")

--- a/WooCommerce/Classes/ViewRelated/Hub Menu/HubMenu.swift
+++ b/WooCommerce/Classes/ViewRelated/Hub Menu/HubMenu.swift
@@ -169,7 +169,7 @@ private extension HubMenu {
                 CustomersListView(viewModel: .init(siteID: viewModel.siteID))
             case HubMenuViewModel.PointOfSaleEntryPoint.id:
                 WooCommercePOS.PointOfSaleEntryPointView(hideAppTabBarsCallback: { isHidden in
-                    AppDelegate.shared.shouldHideTabBar(isHidden)
+                    AppDelegate.shared.setShouldHideTabBar(isHidden)
                 })
             default:
                 fatalError("🚨 Unsupported menu item")

--- a/WooCommerce/Classes/ViewRelated/Hub Menu/HubMenu.swift
+++ b/WooCommerce/Classes/ViewRelated/Hub Menu/HubMenu.swift
@@ -168,7 +168,7 @@ private extension HubMenu {
             case HubMenuViewModel.Customers.id:
                 CustomersListView(viewModel: .init(siteID: viewModel.siteID))
             case HubMenuViewModel.PointOfSaleEntryPoint.id:
-                WooCommercePOS.PointOfSaleEntryPointView(hideAppTabBarsCallback: { isHidden in
+                WooCommercePOS.PointOfSaleEntryPointView(hideAppTabBar: { isHidden in
                     AppDelegate.shared.setShouldHideTabBar(isHidden)
                 })
             default:

--- a/WooCommerce/Classes/ViewRelated/Hub Menu/HubMenu.swift
+++ b/WooCommerce/Classes/ViewRelated/Hub Menu/HubMenu.swift
@@ -168,7 +168,9 @@ private extension HubMenu {
             case HubMenuViewModel.Customers.id:
                 CustomersListView(viewModel: .init(siteID: viewModel.siteID))
             case HubMenuViewModel.PointOfSaleEntryPoint.id:
-                WooCommercePOS.PointOfSaleEntryPointView()
+                WooCommercePOS.PointOfSaleEntryPointView(hideAppTabBarsCallback: { hidden in
+                    AppDelegate.shared.tabBarController?.tabBar.isHidden = hidden
+                })
             default:
                 fatalError("🚨 Unsupported menu item")
             }

--- a/WooCommercePOS/WooCommercePOS.xcodeproj/project.pbxproj
+++ b/WooCommercePOS/WooCommercePOS.xcodeproj/project.pbxproj
@@ -105,7 +105,7 @@
 			isa = PBXGroup;
 			children = (
 				683AAAB92BEDD3CC001D91BE /* ViewModels */,
-				683AAAB82BEDD366001D91BE /* Adapters */,
+				683AAAB82BEDD366001D91BE /* Utils */,
 				683AAAB52BEDD24B001D91BE /* Models */,
 				200B84AC2BEB98EB00EAAB23 /* Presentation */,
 				200B84932BEB984700EAAB23 /* WooCommercePOS.h */,
@@ -152,12 +152,12 @@
 			path = Models;
 			sourceTree = "<group>";
 		};
-		683AAAB82BEDD366001D91BE /* Adapters */ = {
+		683AAAB82BEDD366001D91BE /* Utils */ = {
 			isa = PBXGroup;
 			children = (
 				686F19FC2BEF877000318150 /* ProductFactory.swift */,
 			);
-			path = Adapters;
+			path = Utils;
 			sourceTree = "<group>";
 		};
 		683AAAB92BEDD3CC001D91BE /* ViewModels */ = {

--- a/WooCommercePOS/WooCommercePOS.xcodeproj/project.pbxproj
+++ b/WooCommercePOS/WooCommercePOS.xcodeproj/project.pbxproj
@@ -12,8 +12,13 @@
 		200B84A02BEB984700EAAB23 /* WooCommercePOSTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 200B849F2BEB984700EAAB23 /* WooCommercePOSTests.swift */; };
 		200B84A12BEB984800EAAB23 /* WooCommercePOS.h in Headers */ = {isa = PBXBuildFile; fileRef = 200B84932BEB984700EAAB23 /* WooCommercePOS.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		200B84B02BEB99FE00EAAB23 /* PointOfSaleEntryPointView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 200B84AA2BEB98EB00EAAB23 /* PointOfSaleEntryPointView.swift */; };
-		200B84B12BEB9A0100EAAB23 /* PointOfSaleDashboard.swift in Sources */ = {isa = PBXBuildFile; fileRef = 200B84AB2BEB98EB00EAAB23 /* PointOfSaleDashboard.swift */; };
+		200B84B12BEB9A0100EAAB23 /* PointOfSaleDashboardView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 200B84AB2BEB98EB00EAAB23 /* PointOfSaleDashboardView.swift */; };
 		20CBA25C2BEBB2370006820C /* SwiftUI.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 20CBA25B2BEBB2370006820C /* SwiftUI.framework */; settings = {ATTRIBUTES = (Required, ); }; };
+		683AAABB2BEDD544001D91BE /* Product.swift in Sources */ = {isa = PBXBuildFile; fileRef = 683AAABA2BEDD544001D91BE /* Product.swift */; };
+		686F19F72BEF864300318150 /* ProductGridView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 686F19F62BEF864300318150 /* ProductGridView.swift */; };
+		686F19F92BEF869C00318150 /* OrderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 686F19F82BEF869C00318150 /* OrderView.swift */; };
+		686F19FB2BEF871100318150 /* PointOfSaleDashboardViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 686F19FA2BEF871100318150 /* PointOfSaleDashboardViewModel.swift */; };
+		686F19FD2BEF877000318150 /* ProductFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 686F19FC2BEF877000318150 /* ProductFactory.swift */; };
 		A4FA2C8B066BCBF514089458 /* Pods_WooCommercePOS.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 93F9ABF5FD8405FC05439FAA /* Pods_WooCommercePOS.framework */; };
 		F0EC3C7DA6DAE3FAE2CAC022 /* Pods_WooCommercePOSTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E72638A9ADBD80DC3ECDE6A8 /* Pods_WooCommercePOSTests.framework */; };
 /* End PBXBuildFile section */
@@ -35,11 +40,16 @@
 		200B849A2BEB984700EAAB23 /* WooCommercePOSTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = WooCommercePOSTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		200B849F2BEB984700EAAB23 /* WooCommercePOSTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WooCommercePOSTests.swift; sourceTree = "<group>"; };
 		200B84AA2BEB98EB00EAAB23 /* PointOfSaleEntryPointView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PointOfSaleEntryPointView.swift; sourceTree = "<group>"; };
-		200B84AB2BEB98EB00EAAB23 /* PointOfSaleDashboard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PointOfSaleDashboard.swift; sourceTree = "<group>"; };
+		200B84AB2BEB98EB00EAAB23 /* PointOfSaleDashboardView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PointOfSaleDashboardView.swift; sourceTree = "<group>"; };
 		20CBA25B2BEBB2370006820C /* SwiftUI.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = SwiftUI.framework; path = System/Library/Frameworks/SwiftUI.framework; sourceTree = SDKROOT; };
 		2E60C08ADBF7509B8DDF7DB1 /* Pods-WooCommercePOSTests.release-alpha.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-WooCommercePOSTests.release-alpha.xcconfig"; path = "Target Support Files/Pods-WooCommercePOSTests/Pods-WooCommercePOSTests.release-alpha.xcconfig"; sourceTree = "<group>"; };
 		46D98E5A6533112DCF03DA7C /* Pods-WooCommercePOSTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-WooCommercePOSTests.debug.xcconfig"; path = "Target Support Files/Pods-WooCommercePOSTests/Pods-WooCommercePOSTests.debug.xcconfig"; sourceTree = "<group>"; };
 		5DAF835EEF69449B9B4146B9 /* Pods-WooCommercePOS.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-WooCommercePOS.debug.xcconfig"; path = "Target Support Files/Pods-WooCommercePOS/Pods-WooCommercePOS.debug.xcconfig"; sourceTree = "<group>"; };
+		683AAABA2BEDD544001D91BE /* Product.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Product.swift; sourceTree = "<group>"; };
+		686F19F62BEF864300318150 /* ProductGridView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductGridView.swift; sourceTree = "<group>"; };
+		686F19F82BEF869C00318150 /* OrderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OrderView.swift; sourceTree = "<group>"; };
+		686F19FA2BEF871100318150 /* PointOfSaleDashboardViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PointOfSaleDashboardViewModel.swift; sourceTree = "<group>"; };
+		686F19FC2BEF877000318150 /* ProductFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductFactory.swift; sourceTree = "<group>"; };
 		74F14F901DA1882BDF151366 /* Pods-WooCommercePOS.release-alpha.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-WooCommercePOS.release-alpha.xcconfig"; path = "Target Support Files/Pods-WooCommercePOS/Pods-WooCommercePOS.release-alpha.xcconfig"; sourceTree = "<group>"; };
 		93F9ABF5FD8405FC05439FAA /* Pods_WooCommercePOS.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_WooCommercePOS.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		D94D86784E9CD1B473EC6AE8 /* Pods-WooCommercePOS.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-WooCommercePOS.release.xcconfig"; path = "Target Support Files/Pods-WooCommercePOS/Pods-WooCommercePOS.release.xcconfig"; sourceTree = "<group>"; };
@@ -92,7 +102,10 @@
 		200B84922BEB984700EAAB23 /* WooCommercePOS */ = {
 			isa = PBXGroup;
 			children = (
-				200B84AC2BEB98EB00EAAB23 /* Point Of Sale */,
+				683AAAB92BEDD3CC001D91BE /* ViewModels */,
+				683AAAB82BEDD366001D91BE /* Adapters */,
+				683AAAB52BEDD24B001D91BE /* Models */,
+				200B84AC2BEB98EB00EAAB23 /* Presentation */,
 				200B84932BEB984700EAAB23 /* WooCommercePOS.h */,
 				200B84942BEB984700EAAB23 /* WooCommercePOS.docc */,
 			);
@@ -107,13 +120,15 @@
 			path = WooCommercePOSTests;
 			sourceTree = "<group>";
 		};
-		200B84AC2BEB98EB00EAAB23 /* Point Of Sale */ = {
+		200B84AC2BEB98EB00EAAB23 /* Presentation */ = {
 			isa = PBXGroup;
 			children = (
 				200B84AA2BEB98EB00EAAB23 /* PointOfSaleEntryPointView.swift */,
-				200B84AB2BEB98EB00EAAB23 /* PointOfSaleDashboard.swift */,
+				200B84AB2BEB98EB00EAAB23 /* PointOfSaleDashboardView.swift */,
+				686F19F62BEF864300318150 /* ProductGridView.swift */,
+				686F19F82BEF869C00318150 /* OrderView.swift */,
 			);
-			path = "Point Of Sale";
+			path = Presentation;
 			sourceTree = "<group>";
 		};
 		20CBA25A2BEBB2370006820C /* Frameworks */ = {
@@ -124,6 +139,30 @@
 				E72638A9ADBD80DC3ECDE6A8 /* Pods_WooCommercePOSTests.framework */,
 			);
 			name = Frameworks;
+			sourceTree = "<group>";
+		};
+		683AAAB52BEDD24B001D91BE /* Models */ = {
+			isa = PBXGroup;
+			children = (
+				683AAABA2BEDD544001D91BE /* Product.swift */,
+			);
+			path = Models;
+			sourceTree = "<group>";
+		};
+		683AAAB82BEDD366001D91BE /* Adapters */ = {
+			isa = PBXGroup;
+			children = (
+				686F19FC2BEF877000318150 /* ProductFactory.swift */,
+			);
+			path = Adapters;
+			sourceTree = "<group>";
+		};
+		683AAAB92BEDD3CC001D91BE /* ViewModels */ = {
+			isa = PBXGroup;
+			children = (
+				686F19FA2BEF871100318150 /* PointOfSaleDashboardViewModel.swift */,
+			);
+			path = ViewModels;
 			sourceTree = "<group>";
 		};
 		E339D4263F0FE2171AFE2791 /* Pods */ = {
@@ -316,9 +355,14 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				200B84B12BEB9A0100EAAB23 /* PointOfSaleDashboard.swift in Sources */,
+				686F19FB2BEF871100318150 /* PointOfSaleDashboardViewModel.swift in Sources */,
+				200B84B12BEB9A0100EAAB23 /* PointOfSaleDashboardView.swift in Sources */,
+				683AAABB2BEDD544001D91BE /* Product.swift in Sources */,
+				686F19F72BEF864300318150 /* ProductGridView.swift in Sources */,
+				686F19F92BEF869C00318150 /* OrderView.swift in Sources */,
 				200B84952BEB984700EAAB23 /* WooCommercePOS.docc in Sources */,
 				200B84B02BEB99FE00EAAB23 /* PointOfSaleEntryPointView.swift in Sources */,
+				686F19FD2BEF877000318150 /* ProductFactory.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -379,7 +423,7 @@
 				DEBUG_INFORMATION_FORMAT = dwarf;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
 				ENABLE_TESTABILITY = YES;
-				ENABLE_USER_SCRIPT_SANDBOXING = YES;
+				ENABLE_USER_SCRIPT_SANDBOXING = NO;
 				GCC_C_LANGUAGE_STANDARD = gnu17;
 				GCC_DYNAMIC_NO_PIC = NO;
 				GCC_NO_COMMON_BLOCKS = YES;
@@ -445,7 +489,7 @@
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
 				ENABLE_NS_ASSERTIONS = NO;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
-				ENABLE_USER_SCRIPT_SANDBOXING = YES;
+				ENABLE_USER_SCRIPT_SANDBOXING = NO;
 				GCC_C_LANGUAGE_STANDARD = gnu17;
 				GCC_NO_COMMON_BLOCKS = YES;
 				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
@@ -614,7 +658,7 @@
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
 				ENABLE_NS_ASSERTIONS = NO;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
-				ENABLE_USER_SCRIPT_SANDBOXING = YES;
+				ENABLE_USER_SCRIPT_SANDBOXING = NO;
 				GCC_C_LANGUAGE_STANDARD = gnu17;
 				GCC_NO_COMMON_BLOCKS = YES;
 				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;

--- a/WooCommercePOS/WooCommercePOS.xcodeproj/project.pbxproj
+++ b/WooCommercePOS/WooCommercePOS.xcodeproj/project.pbxproj
@@ -14,6 +14,7 @@
 		200B84B02BEB99FE00EAAB23 /* PointOfSaleEntryPointView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 200B84AA2BEB98EB00EAAB23 /* PointOfSaleEntryPointView.swift */; };
 		200B84B12BEB9A0100EAAB23 /* PointOfSaleDashboardView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 200B84AB2BEB98EB00EAAB23 /* PointOfSaleDashboardView.swift */; };
 		20CBA25C2BEBB2370006820C /* SwiftUI.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 20CBA25B2BEBB2370006820C /* SwiftUI.framework */; settings = {ATTRIBUTES = (Required, ); }; };
+		683A39942BF0DACE008A485E /* ProductRowView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 683A39932BF0DACE008A485E /* ProductRowView.swift */; };
 		683AAABB2BEDD544001D91BE /* Product.swift in Sources */ = {isa = PBXBuildFile; fileRef = 683AAABA2BEDD544001D91BE /* Product.swift */; };
 		686F19F72BEF864300318150 /* ProductGridView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 686F19F62BEF864300318150 /* ProductGridView.swift */; };
 		686F19F92BEF869C00318150 /* OrderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 686F19F82BEF869C00318150 /* OrderView.swift */; };
@@ -45,6 +46,7 @@
 		2E60C08ADBF7509B8DDF7DB1 /* Pods-WooCommercePOSTests.release-alpha.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-WooCommercePOSTests.release-alpha.xcconfig"; path = "Target Support Files/Pods-WooCommercePOSTests/Pods-WooCommercePOSTests.release-alpha.xcconfig"; sourceTree = "<group>"; };
 		46D98E5A6533112DCF03DA7C /* Pods-WooCommercePOSTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-WooCommercePOSTests.debug.xcconfig"; path = "Target Support Files/Pods-WooCommercePOSTests/Pods-WooCommercePOSTests.debug.xcconfig"; sourceTree = "<group>"; };
 		5DAF835EEF69449B9B4146B9 /* Pods-WooCommercePOS.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-WooCommercePOS.debug.xcconfig"; path = "Target Support Files/Pods-WooCommercePOS/Pods-WooCommercePOS.debug.xcconfig"; sourceTree = "<group>"; };
+		683A39932BF0DACE008A485E /* ProductRowView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductRowView.swift; sourceTree = "<group>"; };
 		683AAABA2BEDD544001D91BE /* Product.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Product.swift; sourceTree = "<group>"; };
 		686F19F62BEF864300318150 /* ProductGridView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductGridView.swift; sourceTree = "<group>"; };
 		686F19F82BEF869C00318150 /* OrderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OrderView.swift; sourceTree = "<group>"; };
@@ -127,6 +129,7 @@
 				200B84AB2BEB98EB00EAAB23 /* PointOfSaleDashboardView.swift */,
 				686F19F62BEF864300318150 /* ProductGridView.swift */,
 				686F19F82BEF869C00318150 /* OrderView.swift */,
+				683A39932BF0DACE008A485E /* ProductRowView.swift */,
 			);
 			path = Presentation;
 			sourceTree = "<group>";
@@ -359,6 +362,7 @@
 				200B84B12BEB9A0100EAAB23 /* PointOfSaleDashboardView.swift in Sources */,
 				683AAABB2BEDD544001D91BE /* Product.swift in Sources */,
 				686F19F72BEF864300318150 /* ProductGridView.swift in Sources */,
+				683A39942BF0DACE008A485E /* ProductRowView.swift in Sources */,
 				686F19F92BEF869C00318150 /* OrderView.swift in Sources */,
 				200B84952BEB984700EAAB23 /* WooCommercePOS.docc in Sources */,
 				200B84B02BEB99FE00EAAB23 /* PointOfSaleEntryPointView.swift in Sources */,

--- a/WooCommercePOS/WooCommercePOS.xcodeproj/project.pbxproj
+++ b/WooCommercePOS/WooCommercePOS.xcodeproj/project.pbxproj
@@ -17,7 +17,7 @@
 		683A39942BF0DACE008A485E /* ProductRowView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 683A39932BF0DACE008A485E /* ProductRowView.swift */; };
 		683AAABB2BEDD544001D91BE /* Product.swift in Sources */ = {isa = PBXBuildFile; fileRef = 683AAABA2BEDD544001D91BE /* Product.swift */; };
 		686F19F72BEF864300318150 /* ProductGridView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 686F19F62BEF864300318150 /* ProductGridView.swift */; };
-		686F19F92BEF869C00318150 /* OrderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 686F19F82BEF869C00318150 /* OrderView.swift */; };
+		686F19F92BEF869C00318150 /* CartView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 686F19F82BEF869C00318150 /* CartView.swift */; };
 		686F19FB2BEF871100318150 /* PointOfSaleDashboardViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 686F19FA2BEF871100318150 /* PointOfSaleDashboardViewModel.swift */; };
 		686F19FD2BEF877000318150 /* ProductFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 686F19FC2BEF877000318150 /* ProductFactory.swift */; };
 		A4FA2C8B066BCBF514089458 /* Pods_WooCommercePOS.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 93F9ABF5FD8405FC05439FAA /* Pods_WooCommercePOS.framework */; };
@@ -49,7 +49,7 @@
 		683A39932BF0DACE008A485E /* ProductRowView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductRowView.swift; sourceTree = "<group>"; };
 		683AAABA2BEDD544001D91BE /* Product.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Product.swift; sourceTree = "<group>"; };
 		686F19F62BEF864300318150 /* ProductGridView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductGridView.swift; sourceTree = "<group>"; };
-		686F19F82BEF869C00318150 /* OrderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OrderView.swift; sourceTree = "<group>"; };
+		686F19F82BEF869C00318150 /* CartView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CartView.swift; sourceTree = "<group>"; };
 		686F19FA2BEF871100318150 /* PointOfSaleDashboardViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PointOfSaleDashboardViewModel.swift; sourceTree = "<group>"; };
 		686F19FC2BEF877000318150 /* ProductFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductFactory.swift; sourceTree = "<group>"; };
 		74F14F901DA1882BDF151366 /* Pods-WooCommercePOS.release-alpha.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-WooCommercePOS.release-alpha.xcconfig"; path = "Target Support Files/Pods-WooCommercePOS/Pods-WooCommercePOS.release-alpha.xcconfig"; sourceTree = "<group>"; };
@@ -128,7 +128,7 @@
 				200B84AA2BEB98EB00EAAB23 /* PointOfSaleEntryPointView.swift */,
 				200B84AB2BEB98EB00EAAB23 /* PointOfSaleDashboardView.swift */,
 				686F19F62BEF864300318150 /* ProductGridView.swift */,
-				686F19F82BEF869C00318150 /* OrderView.swift */,
+				686F19F82BEF869C00318150 /* CartView.swift */,
 				683A39932BF0DACE008A485E /* ProductRowView.swift */,
 			);
 			path = Presentation;
@@ -363,7 +363,7 @@
 				683AAABB2BEDD544001D91BE /* Product.swift in Sources */,
 				686F19F72BEF864300318150 /* ProductGridView.swift in Sources */,
 				683A39942BF0DACE008A485E /* ProductRowView.swift in Sources */,
-				686F19F92BEF869C00318150 /* OrderView.swift in Sources */,
+				686F19F92BEF869C00318150 /* CartView.swift in Sources */,
 				200B84952BEB984700EAAB23 /* WooCommercePOS.docc in Sources */,
 				200B84B02BEB99FE00EAAB23 /* PointOfSaleEntryPointView.swift in Sources */,
 				686F19FD2BEF877000318150 /* ProductFactory.swift in Sources */,

--- a/WooCommercePOS/WooCommercePOS/Adapters/ProductFactory.swift
+++ b/WooCommercePOS/WooCommercePOS/Adapters/ProductFactory.swift
@@ -1,0 +1,11 @@
+
+final class ProductFactory {
+    static func makeFakeProducts() -> [WooCommercePOS.Product] {
+        return [
+            Product(itemID: UUID(), productID: 1, name: "Product 1", price: "2"),
+            Product(itemID: UUID(), productID: 2, name: "Product 2", price: "2"),
+            Product(itemID: UUID(), productID: 3, name: "Product 3", price: "2"),
+            Product(itemID: UUID(), productID: 4, name: "Product 4", price: "2"),
+            ]
+    }
+}

--- a/WooCommercePOS/WooCommercePOS/Models/Product.swift
+++ b/WooCommercePOS/WooCommercePOS/Models/Product.swift
@@ -1,0 +1,14 @@
+
+public struct Product {
+    public let itemID: UUID
+    public let productID: Int64
+    public let name: String
+    public let price: String
+
+    public init(itemID: UUID, productID: Int64, name: String, price: String) {
+        self.itemID = itemID
+        self.productID = productID
+        self.name = name
+        self.price = price
+    }
+}

--- a/WooCommercePOS/WooCommercePOS/Point Of Sale/PointOfSaleDashboard.swift
+++ b/WooCommercePOS/WooCommercePOS/Point Of Sale/PointOfSaleDashboard.swift
@@ -1,7 +1,0 @@
-import SwiftUI
-
-struct PointOfSaleDashboard: View {
-    var body: some View {
-        Text("WooCommerce Point Of Sale")
-    }
-}

--- a/WooCommercePOS/WooCommercePOS/Presentation/CartView.swift
+++ b/WooCommercePOS/WooCommercePOS/Presentation/CartView.swift
@@ -1,6 +1,6 @@
 import SwiftUI
 
-struct OrderView: View {
+struct CartView: View {
     @ObservedObject private var viewModel: PointOfSaleDashboardViewModel
 
     init(viewModel: PointOfSaleDashboardViewModel) {
@@ -14,12 +14,12 @@ struct OrderView: View {
             ProductRowView()
             Spacer()
             Button("Pay now") {
-                viewModel.callbackFromOrder()
+                viewModel.submitCart()
             }
         }
     }
 }
 
 #Preview {
-    OrderView(viewModel: PointOfSaleDashboardViewModel(products: ProductFactory.makeFakeProducts()))
+    CartView(viewModel: PointOfSaleDashboardViewModel(products: ProductFactory.makeFakeProducts()))
 }

--- a/WooCommercePOS/WooCommercePOS/Presentation/OrderView.swift
+++ b/WooCommercePOS/WooCommercePOS/Presentation/OrderView.swift
@@ -19,3 +19,7 @@ struct OrderView: View {
         }
     }
 }
+
+#Preview {
+    OrderView(viewModel: PointOfSaleDashboardViewModel(products: ProductFactory.makeFakeProducts()))
+}

--- a/WooCommercePOS/WooCommercePOS/Presentation/OrderView.swift
+++ b/WooCommercePOS/WooCommercePOS/Presentation/OrderView.swift
@@ -15,6 +15,7 @@ struct OrderView: View {
             Text("Product XYZ")
             Text("Product XYZ")
             Text("Product XYZ")
+            Spacer()
             Button("Pay now") {
                 viewModel.callbackFromOrder()
             }

--- a/WooCommercePOS/WooCommercePOS/Presentation/OrderView.swift
+++ b/WooCommercePOS/WooCommercePOS/Presentation/OrderView.swift
@@ -1,0 +1,23 @@
+import SwiftUI
+
+struct OrderView: View {
+    @ObservedObject private var viewModel: PointOfSaleDashboardViewModel
+
+    init(viewModel: PointOfSaleDashboardViewModel) {
+        self.viewModel = viewModel
+    }
+
+    var body: some View {
+        VStack {
+            Text("Product XYZ")
+            Text("Product XYZ")
+            Text("Product XYZ")
+            Text("Product XYZ")
+            Text("Product XYZ")
+            Text("Product XYZ")
+            Button("Pay now") {
+                viewModel.callbackFromOrder()
+            }
+        }
+    }
+}

--- a/WooCommercePOS/WooCommercePOS/Presentation/OrderView.swift
+++ b/WooCommercePOS/WooCommercePOS/Presentation/OrderView.swift
@@ -9,12 +9,9 @@ struct OrderView: View {
 
     var body: some View {
         VStack {
-            Text("Product XYZ")
-            Text("Product XYZ")
-            Text("Product XYZ")
-            Text("Product XYZ")
-            Text("Product XYZ")
-            Text("Product XYZ")
+            ProductRowView()
+            ProductRowView()
+            ProductRowView()
             Spacer()
             Button("Pay now") {
                 viewModel.callbackFromOrder()

--- a/WooCommercePOS/WooCommercePOS/Presentation/PointOfSaleDashboardView.swift
+++ b/WooCommercePOS/WooCommercePOS/Presentation/PointOfSaleDashboardView.swift
@@ -1,6 +1,8 @@
 import SwiftUI
 
 struct PointOfSaleDashboardView: View {
+    @Environment(\.presentationMode) var presentationMode
+
     @ObservedObject private var viewModel: PointOfSaleDashboardViewModel
 
     init(viewModel: PointOfSaleDashboardViewModel) {
@@ -22,17 +24,17 @@ struct PointOfSaleDashboardView: View {
         .toolbar {
             ToolbarItem(placement: .topBarLeading, content: {
                 Button("Exit POS") {
-                    // TODO
+                    presentationMode.wrappedValue.dismiss()
                 }
             })
             ToolbarItem(placement: .principal, content: {
                 Button("Reader not connected") {
-                    // TODO
+                    debugPrint("Not implemented")
                 }
             })
             ToolbarItem(placement: .primaryAction, content: {
                 Button("History") {
-                    // TODO
+                    debugPrint("Not implemented")
                 }
             })
         }

--- a/WooCommercePOS/WooCommercePOS/Presentation/PointOfSaleDashboardView.swift
+++ b/WooCommercePOS/WooCommercePOS/Presentation/PointOfSaleDashboardView.swift
@@ -40,3 +40,7 @@ struct PointOfSaleDashboardView: View {
         }
     }
 }
+
+#Preview {
+    PointOfSaleDashboardView(viewModel: PointOfSaleDashboardViewModel(products: ProductFactory.makeFakeProducts()))
+}

--- a/WooCommercePOS/WooCommercePOS/Presentation/PointOfSaleDashboardView.swift
+++ b/WooCommercePOS/WooCommercePOS/Presentation/PointOfSaleDashboardView.swift
@@ -15,5 +15,23 @@ struct PointOfSaleDashboardView: View {
                 OrderView(viewModel: viewModel)
             }
         }
+        .navigationBarBackButtonHidden(true)
+        .toolbar {
+            ToolbarItem(placement: .topBarLeading, content: {
+                Button("Exit POS") {
+                    // TODO
+                }
+            })
+            ToolbarItem(placement: .principal, content: {
+                Button("Reader not connected") {
+                    // TODO
+                }
+            })
+            ToolbarItem(placement: .primaryAction, content: {
+                Button("History") {
+                    // TODO
+                }
+            })
+        }
     }
 }

--- a/WooCommercePOS/WooCommercePOS/Presentation/PointOfSaleDashboardView.swift
+++ b/WooCommercePOS/WooCommercePOS/Presentation/PointOfSaleDashboardView.swift
@@ -1,0 +1,19 @@
+import SwiftUI
+
+struct PointOfSaleDashboardView: View {
+    @ObservedObject private var viewModel: PointOfSaleDashboardViewModel
+
+    init(viewModel: PointOfSaleDashboardViewModel) {
+        self.viewModel = viewModel
+    }
+
+    var body: some View {
+        VStack {
+            Text("WooCommerce Point Of Sale")
+            HStack {
+                ProductGridView(viewModel: viewModel)
+                OrderView(viewModel: viewModel)
+            }
+        }
+    }
+}

--- a/WooCommercePOS/WooCommercePOS/Presentation/PointOfSaleDashboardView.swift
+++ b/WooCommercePOS/WooCommercePOS/Presentation/PointOfSaleDashboardView.swift
@@ -12,7 +12,10 @@ struct PointOfSaleDashboardView: View {
             Text("WooCommerce Point Of Sale")
             HStack {
                 ProductGridView(viewModel: viewModel)
+                    .frame(maxWidth: .infinity)
+                Spacer()
                 OrderView(viewModel: viewModel)
+                    .frame(maxWidth: .infinity)
             }
         }
         .navigationBarBackButtonHidden(true)

--- a/WooCommercePOS/WooCommercePOS/Presentation/PointOfSaleDashboardView.swift
+++ b/WooCommercePOS/WooCommercePOS/Presentation/PointOfSaleDashboardView.swift
@@ -16,7 +16,7 @@ struct PointOfSaleDashboardView: View {
                 ProductGridView(viewModel: viewModel)
                     .frame(maxWidth: .infinity)
                 Spacer()
-                OrderView(viewModel: viewModel)
+                CartView(viewModel: viewModel)
                     .frame(maxWidth: .infinity)
             }
         }

--- a/WooCommercePOS/WooCommercePOS/Presentation/PointOfSaleEntryPointView.swift
+++ b/WooCommercePOS/WooCommercePOS/Presentation/PointOfSaleEntryPointView.swift
@@ -21,9 +21,9 @@ public struct PointOfSaleEntryPointView: View {
 
     public var body: some View {
         PointOfSaleDashboardView(viewModel: viewModel)
-            .onAppear(perform: {
+            .onAppear {
                 hideAppTabBar(true)
-            })
+            }
             .onDisappear {
                 hideAppTabBar(false)
             }

--- a/WooCommercePOS/WooCommercePOS/Presentation/PointOfSaleEntryPointView.swift
+++ b/WooCommercePOS/WooCommercePOS/Presentation/PointOfSaleEntryPointView.swift
@@ -9,7 +9,7 @@ public struct PointOfSaleEntryPointView: View {
 
         return viewModel
     }()
-    
+
     private var hideAppTabBarsCallback: ((Bool) -> Void)? = nil
 
     // Necessary to expose the View's entry point to WooCommerce

--- a/WooCommercePOS/WooCommercePOS/Presentation/PointOfSaleEntryPointView.swift
+++ b/WooCommercePOS/WooCommercePOS/Presentation/PointOfSaleEntryPointView.swift
@@ -29,3 +29,7 @@ public struct PointOfSaleEntryPointView: View {
             }
     }
 }
+
+#Preview {
+    PointOfSaleEntryPointView(hideAppTabBarsCallback: { _ in })
+}

--- a/WooCommercePOS/WooCommercePOS/Presentation/PointOfSaleEntryPointView.swift
+++ b/WooCommercePOS/WooCommercePOS/Presentation/PointOfSaleEntryPointView.swift
@@ -11,9 +11,15 @@ public struct PointOfSaleEntryPointView: View {
 
     public var body: some View {
         VStack {}
+        // TODO: Remove the full screen modal
+        // TODO: Move iPhone logic outside and do not render the entry point.
         .fullScreenCover(isPresented: $showFullScreen) {
             if UIDevice.current.userInterfaceIdiom == .pad {
-                PointOfSaleDashboard()
+                // TODO: Pass proper product models once we have data layer
+                let products = ProductFactory.makeFakeProducts()
+                let viewModel = PointOfSaleDashboardViewModel(products: products)
+
+                PointOfSaleDashboardView(viewModel: viewModel)
             } else {
                 Button(action: {
                     presentationMode.wrappedValue.dismiss()

--- a/WooCommercePOS/WooCommercePOS/Presentation/PointOfSaleEntryPointView.swift
+++ b/WooCommercePOS/WooCommercePOS/Presentation/PointOfSaleEntryPointView.swift
@@ -10,22 +10,22 @@ public struct PointOfSaleEntryPointView: View {
         return viewModel
     }()
 
-    private var shouldHideWooAppTabBar: ((Bool) -> Void)? = nil
+    private let hideAppTabBar: ((Bool) -> Void)
 
     // Necessary to expose the View's entry point to WooCommerce
     // Otherwise the current switch on `HubMenu` where this View is created
     // will error with "No exact matches in reference to static method 'buildExpression'"
-    public init(hideAppTabBarsCallback: ((Bool) -> Void)? = nil) {
-        self.shouldHideWooAppTabBar = hideAppTabBarsCallback
+    public init(hideAppTabBarsCallback: @escaping ((Bool) -> Void)) {
+        self.hideAppTabBar = hideAppTabBarsCallback
     }
 
     public var body: some View {
         PointOfSaleDashboardView(viewModel: viewModel)
             .onAppear(perform: {
-                shouldHideWooAppTabBar?(true)
+                hideAppTabBar(true)
             })
             .onDisappear {
-                shouldHideWooAppTabBar?(false)
+                hideAppTabBar(false)
             }
     }
 }

--- a/WooCommercePOS/WooCommercePOS/Presentation/PointOfSaleEntryPointView.swift
+++ b/WooCommercePOS/WooCommercePOS/Presentation/PointOfSaleEntryPointView.swift
@@ -9,13 +9,23 @@ public struct PointOfSaleEntryPointView: View {
 
         return viewModel
     }()
+    
+    private var hideAppTabBarsCallback: ((Bool) -> Void)? = nil
 
     // Necessary to expose the View's entry point to WooCommerce
     // Otherwise the current switch on `HubMenu` where this View is created
     // will error with "No exact matches in reference to static method 'buildExpression'"
-    public init() {}
+    public init(hideAppTabBarsCallback: ((Bool) -> Void)? = nil) {
+        self.hideAppTabBarsCallback = hideAppTabBarsCallback
+    }
 
     public var body: some View {
         PointOfSaleDashboardView(viewModel: viewModel)
+            .onAppear(perform: {
+                hideAppTabBarsCallback?(true)
+            })
+            .onDisappear {
+                hideAppTabBarsCallback?(false)
+            }
     }
 }

--- a/WooCommercePOS/WooCommercePOS/Presentation/PointOfSaleEntryPointView.swift
+++ b/WooCommercePOS/WooCommercePOS/Presentation/PointOfSaleEntryPointView.swift
@@ -10,22 +10,22 @@ public struct PointOfSaleEntryPointView: View {
         return viewModel
     }()
 
-    private var hideAppTabBarsCallback: ((Bool) -> Void)? = nil
+    private var shouldHideWooAppTabBar: ((Bool) -> Void)? = nil
 
     // Necessary to expose the View's entry point to WooCommerce
     // Otherwise the current switch on `HubMenu` where this View is created
     // will error with "No exact matches in reference to static method 'buildExpression'"
     public init(hideAppTabBarsCallback: ((Bool) -> Void)? = nil) {
-        self.hideAppTabBarsCallback = hideAppTabBarsCallback
+        self.shouldHideWooAppTabBar = hideAppTabBarsCallback
     }
 
     public var body: some View {
         PointOfSaleDashboardView(viewModel: viewModel)
             .onAppear(perform: {
-                hideAppTabBarsCallback?(true)
+                shouldHideWooAppTabBar?(true)
             })
             .onDisappear {
-                hideAppTabBarsCallback?(false)
+                shouldHideWooAppTabBar?(false)
             }
     }
 }

--- a/WooCommercePOS/WooCommercePOS/Presentation/PointOfSaleEntryPointView.swift
+++ b/WooCommercePOS/WooCommercePOS/Presentation/PointOfSaleEntryPointView.swift
@@ -15,8 +15,8 @@ public struct PointOfSaleEntryPointView: View {
     // Necessary to expose the View's entry point to WooCommerce
     // Otherwise the current switch on `HubMenu` where this View is created
     // will error with "No exact matches in reference to static method 'buildExpression'"
-    public init(hideAppTabBarsCallback: @escaping ((Bool) -> Void)) {
-        self.hideAppTabBar = hideAppTabBarsCallback
+    public init(hideAppTabBar: @escaping ((Bool) -> Void)) {
+        self.hideAppTabBar = hideAppTabBar
     }
 
     public var body: some View {
@@ -31,5 +31,5 @@ public struct PointOfSaleEntryPointView: View {
 }
 
 #Preview {
-    PointOfSaleEntryPointView(hideAppTabBarsCallback: { _ in })
+    PointOfSaleEntryPointView(hideAppTabBar: { _ in })
 }

--- a/WooCommercePOS/WooCommercePOS/Presentation/PointOfSaleEntryPointView.swift
+++ b/WooCommercePOS/WooCommercePOS/Presentation/PointOfSaleEntryPointView.swift
@@ -1,35 +1,21 @@
 import SwiftUI
 
 public struct PointOfSaleEntryPointView: View {
-    @State private var showFullScreen = true
+    // TODO:
+    // Temporary. DI proper product models once we have a data layer
+    private let viewModel: PointOfSaleDashboardViewModel = {
+        let products = ProductFactory.makeFakeProducts()
+        let viewModel = PointOfSaleDashboardViewModel(products: products)
 
-    @Environment(\.presentationMode) var presentationMode
+        return viewModel
+    }()
 
-    public init(showFullScreen: Bool = true) {
-        self.showFullScreen = showFullScreen
-    }
+    // Necessary to expose the View's entry point to WooCommerce
+    // Otherwise the current switch on `HubMenu` where this View is created
+    // will error with "No exact matches in reference to static method 'buildExpression'"
+    public init() {}
 
     public var body: some View {
-        VStack {}
-        // TODO: Remove the full screen modal
-        // TODO: Move iPhone logic outside and do not render the entry point.
-        .fullScreenCover(isPresented: $showFullScreen) {
-            if UIDevice.current.userInterfaceIdiom == .pad {
-                // TODO: Pass proper product models once we have data layer
-                let products = ProductFactory.makeFakeProducts()
-                let viewModel = PointOfSaleDashboardViewModel(products: products)
-
-                PointOfSaleDashboardView(viewModel: viewModel)
-            } else {
-                Button(action: {
-                    presentationMode.wrappedValue.dismiss()
-                }, label: {
-                    Text("Please use iPad")
-                })
-            }
-        }
-        .onAppear {
-            showFullScreen = true
-        }
+        PointOfSaleDashboardView(viewModel: viewModel)
     }
 }

--- a/WooCommercePOS/WooCommercePOS/Presentation/ProductGridView.swift
+++ b/WooCommercePOS/WooCommercePOS/Presentation/ProductGridView.swift
@@ -15,7 +15,7 @@ struct ProductGridView: View {
             LazyVGrid(columns: columns, spacing: 20) {
                 ForEach(viewModel.products, id: \.productID) { product in
                     Button(action: {
-                        viewModel.callbackFromProductSelector(product)
+                        viewModel.addProductToCart(product)
                     }, label: {
                         VStack {
                             Text(product.name)

--- a/WooCommercePOS/WooCommercePOS/Presentation/ProductGridView.swift
+++ b/WooCommercePOS/WooCommercePOS/Presentation/ProductGridView.swift
@@ -31,3 +31,7 @@ struct ProductGridView: View {
         }
     }
 }
+
+#Preview {
+    ProductGridView(viewModel: PointOfSaleDashboardViewModel(products: ProductFactory.makeFakeProducts()))
+}

--- a/WooCommercePOS/WooCommercePOS/Presentation/ProductGridView.swift
+++ b/WooCommercePOS/WooCommercePOS/Presentation/ProductGridView.swift
@@ -1,0 +1,33 @@
+import SwiftUI
+
+struct ProductGridView: View {
+    @ObservedObject var viewModel: PointOfSaleDashboardViewModel
+
+    init(viewModel: PointOfSaleDashboardViewModel) {
+        self.viewModel = viewModel
+    }
+
+    var body: some View {
+        let columns: [GridItem] = Array(repeating: .init(.flexible()),
+                                        count: viewModel.products.count)
+
+        ScrollView {
+            LazyVGrid(columns: columns, spacing: 20) {
+                ForEach(viewModel.products, id: \.productID) { product in
+                    Button(action: {
+                        viewModel.callbackFromProductSelector(product)
+                    }, label: {
+                        VStack {
+                            Text(product.name)
+                            // TODO: CurrencyFormatter
+                            Text(product.price)
+                        }
+                        .padding()
+                        .background(Color.cyan)
+                        .frame(minWidth: 0, maxWidth: .infinity, minHeight: 100)
+                    })
+                }
+            }
+        }
+    }
+}

--- a/WooCommercePOS/WooCommercePOS/Presentation/ProductRowView.swift
+++ b/WooCommercePOS/WooCommercePOS/Presentation/ProductRowView.swift
@@ -7,3 +7,7 @@ struct ProductRowView: View {
             .border(Color.gray, width: 1)
     }
 }
+
+#Preview {
+    ProductRowView()
+}

--- a/WooCommercePOS/WooCommercePOS/Presentation/ProductRowView.swift
+++ b/WooCommercePOS/WooCommercePOS/Presentation/ProductRowView.swift
@@ -1,0 +1,9 @@
+import SwiftUI
+
+struct ProductRowView: View {
+    var body: some View {
+        Text("Product XYZ")
+            .frame(maxWidth: .infinity)
+            .border(Color.gray, width: 1)
+    }
+}

--- a/WooCommercePOS/WooCommercePOS/Utils/ProductFactory.swift
+++ b/WooCommercePOS/WooCommercePOS/Utils/ProductFactory.swift
@@ -1,6 +1,7 @@
-
+/// Temporary fake product factory
+///
 final class ProductFactory {
-    static func makeFakeProducts() -> [WooCommercePOS.Product] {
+    static func makeFakeProducts() -> [Product] {
         return [
             Product(itemID: UUID(), productID: 1, name: "Product 1", price: "2"),
             Product(itemID: UUID(), productID: 2, name: "Product 2", price: "2"),

--- a/WooCommercePOS/WooCommercePOS/ViewModels/PointOfSaleDashboardViewModel.swift
+++ b/WooCommercePOS/WooCommercePOS/ViewModels/PointOfSaleDashboardViewModel.swift
@@ -8,11 +8,11 @@ final class PointOfSaleDashboardViewModel: ObservableObject {
         self.products = products
     }
 
-    func callbackFromProductSelector(_ product: Product) {
+    func addProductToCart(_ product: Product) {
         debugPrint("Not implemented")
     }
 
-    func callbackFromOrder() {
+    func submitCart() {
         debugPrint("Not implemented")
     }
 }

--- a/WooCommercePOS/WooCommercePOS/ViewModels/PointOfSaleDashboardViewModel.swift
+++ b/WooCommercePOS/WooCommercePOS/ViewModels/PointOfSaleDashboardViewModel.swift
@@ -9,10 +9,10 @@ final class PointOfSaleDashboardViewModel: ObservableObject {
     }
 
     func callbackFromProductSelector(_ product: Product) {
-        debugPrint("Product selector callback: \(product.name)")
+        debugPrint("Not implemented")
     }
 
     func callbackFromOrder() {
-        debugPrint("Order callback")
+        debugPrint("Not implemented")
     }
 }

--- a/WooCommercePOS/WooCommercePOS/ViewModels/PointOfSaleDashboardViewModel.swift
+++ b/WooCommercePOS/WooCommercePOS/ViewModels/PointOfSaleDashboardViewModel.swift
@@ -1,0 +1,18 @@
+import SwiftUI
+
+final class PointOfSaleDashboardViewModel: ObservableObject {
+    @Published var products: [Product]
+    @Published var productsInOrder: [Product] = []
+
+    init(products: [Product]) {
+        self.products = products
+    }
+
+    func callbackFromProductSelector(_ product: Product) {
+        debugPrint("Product selector callback: \(product.name)")
+    }
+
+    func callbackFromOrder() {
+        debugPrint("Order callback")
+    }
+}


### PR DESCRIPTION
Closes: https://github.com/woocommerce/woocommerce-ios/issues/12701

https://github.com/woocommerce/woocommerce-ios/pull/12685 needs to be merged first.


## Description
This PR builds up on top of the initial entry point and updates the following:

- Updates the `PointOfSaleDashboardView` to be presented as a non-modal view.
- Updates `BetaFeature` so the experimental toggle and feature row are only shown in iPads, previously we would just present a modal warning it was not supported.
- Implements some general structure from the wireframes ( p91TBi-bcW-p2 ) by adding a `ProductGridView`, an `OrderView`, and a `ProductRowView`. All of them entirely un-styled yet. Those can be tackled separately.
- Adds a dummy `ProductFactory` util and a `Product` model so we can render something from a data layer.
- Adds top navigation with 3 initial toolbar buttons, only `Exit POS` is functional at the moment, dismissing the POS view and moving back to the Woo App.
- Adds a callback when we allocate and deallocate the POS dashboard from memory by toggling the Woo app bottom tab bar visibility when appropriate.

![Simulator Screen Recording - iPad Pro (12 9-inch) (6th generation) - 2024-05-12 at 18 50 42](https://github.com/woocommerce/woocommerce-ios/assets/3812076/036b577c-3f7e-4adc-989c-b2fd548bf3a4)

## Testing instructions
* On iPhone, navigate to Menu > Settings > Experimental features and observe the POS toggle is not there. The settings row does not appear either.
* On Tablet, with the experimental toggle enabled (switch stores if the row doesn't appear), open the POS and observe that:
  * The bottom navigation bar disappears, and the top navigation bar consists of 3 buttons
  * By tapping on "Exit POS" we're brought back to the Woo app and the bottom navigation re-appears and works as expected. Navigate through the items, and back and forth between the app and the pos to confirm works as expected.
