### PR TITLE
[Watch] Add connecting screen

### DIFF
--- a/WooCommerce/Woo Watch App/ConnectView.swift
+++ b/WooCommerce/Woo Watch App/ConnectView.swift
@@ -1,0 +1,43 @@
+import SwiftUI
+import NetworkingWatchOS
+
+/// View that instructs the user how to connect to the phone.
+///
+struct ConnectView: View {
+
+    let message: String = Localization.connectMessage
+
+    var body: some View {
+        VStack(spacing: Layout.mainSpacing) {
+            Text(message)
+                .multilineTextAlignment(.center)
+
+            Image(systemName: "bolt.fill")
+                .renderingMode(.original)
+                .resizable()
+                .frame(width: Layout.boltSize.width, height: Layout.boltSize.height)
+                .foregroundStyle(Layout.ambarColor)
+        }
+        .padding()
+    }
+}
+
+extension ConnectView {
+    private enum Layout {
+        static let mainSpacing = 16.0
+        static let boltSize = CGSize(width: 16, height: 26)
+        static let ambarColor = Color(red: 255, green: 166, blue: 14)
+    }
+
+    private enum Localization {
+        static let connectMessage = AppLocalizedString(
+            "watch.connect.message",
+            value: "Open Woo on your iPhone, connect your store, and hold your Watch nearby",
+            comment: "Info message when connecting your watch to the phone for the first time."
+        )
+    }
+}
+
+#Preview {
+    ConnectView()
+}

--- a/WooCommerce/Woo Watch App/ContentView.swift
+++ b/WooCommerce/Woo Watch App/ContentView.swift
@@ -1,10 +1,9 @@
 import SwiftUI
 import NetworkingWatchOS
 
-
 struct ContentView: View {
 
-    let message: String
+    let message: String = "Hello Woo"
 
     var body: some View {
         VStack {
@@ -22,5 +21,5 @@ struct ContentView: View {
 }
 
 #Preview {
-    ContentView(message: "Holi")
+    ContentView()
 }

--- a/WooCommerce/Woo Watch App/ContentView.swift
+++ b/WooCommerce/Woo Watch App/ContentView.swift
@@ -3,7 +3,7 @@ import NetworkingWatchOS
 
 struct ContentView: View {
 
-    let message: String = "Hello Woo"
+    let message: String = "Logged In"
 
     var body: some View {
         VStack {

--- a/WooCommerce/Woo Watch App/Dependencies/Environment+Dependencies.swift
+++ b/WooCommerce/Woo Watch App/Dependencies/Environment+Dependencies.swift
@@ -1,0 +1,19 @@
+import SwiftUI
+
+/// Environment dependencies setup
+///
+private enum DependenciesKey: EnvironmentKey {
+    static let defaultValue: WatchDependencies = WatchDependencies(storeID: nil, credentials: nil)
+}
+
+extension EnvironmentValues {
+    var dependencies: WatchDependencies {
+        get {
+            self[DependenciesKey.self]
+        }
+        set {
+            self[DependenciesKey.self] = newValue
+        }
+    }
+}
+

--- a/WooCommerce/Woo Watch App/Dependencies/Environment+Dependencies.swift
+++ b/WooCommerce/Woo Watch App/Dependencies/Environment+Dependencies.swift
@@ -16,4 +16,3 @@ extension EnvironmentValues {
         }
     }
 }
-

--- a/WooCommerce/Woo Watch App/Dependencies/PhoneDependenciesSynchronizer.swift
+++ b/WooCommerce/Woo Watch App/Dependencies/PhoneDependenciesSynchronizer.swift
@@ -7,7 +7,7 @@ import NetworkingWatchOS
 ///
 final class PhoneDependenciesSynchronizer: NSObject, ObservableObject, WCSessionDelegate {
 
-    @Published var message = "Not Logged In"
+    @Published var dependencies = WatchDependencies(storeID: nil, credentials: nil)
 
     /// Secure store.
     private let keychain: Keychain
@@ -20,7 +20,7 @@ final class PhoneDependenciesSynchronizer: NSObject, ObservableObject, WCSession
         self.userDefaults = UserDefaults.standard
         super.init()
 
-        updateMessage()
+        reloadDependencies()
 
         if WCSession.isSupported() {
             let session = WCSession.default
@@ -40,7 +40,7 @@ final class PhoneDependenciesSynchronizer: NSObject, ObservableObject, WCSession
 
         DispatchQueue.main.async {
             self.storeDependencies(appContext: session.receivedApplicationContext)
-            self.updateMessage()
+            self.reloadDependencies()
         }
     }
 
@@ -49,19 +49,14 @@ final class PhoneDependenciesSynchronizer: NSObject, ObservableObject, WCSession
     func session(_ session: WCSession, didReceiveApplicationContext applicationContext: [String: Any]) {
         DispatchQueue.main.async {
             self.storeDependencies(appContext: applicationContext)
-            self.updateMessage()
+            self.reloadDependencies()
         }
     }
 
     /// Update UI from stored dependencies
     ///
-    private func updateMessage() {
-        let dependencies = loadDependencies()
-        if let storeID = dependencies.storeID, dependencies.credentials != nil {
-            message = "Store ID: \(storeID)"
-        } else {
-            message = "Not Logged In"
-        }
+    private func reloadDependencies() {
+        self.dependencies = loadDependencies()
     }
 
     /// Load stored dependencies

--- a/WooCommerce/Woo Watch App/Dependencies/PhoneDependenciesSynchronizer.swift
+++ b/WooCommerce/Woo Watch App/Dependencies/PhoneDependenciesSynchronizer.swift
@@ -32,8 +32,6 @@ final class PhoneDependenciesSynchronizer: NSObject, ObservableObject, WCSession
     /// Get the latest application context when the session activates
     ///
     func session(_ session: WCSession, activationDidCompleteWith activationState: WCSessionActivationState, error: Error?) {
-        print("current app context: \(session.receivedApplicationContext)")
-
         guard !session.receivedApplicationContext.isEmpty else {
             return
         }

--- a/WooCommerce/Woo Watch App/WooApp.swift
+++ b/WooCommerce/Woo Watch App/WooApp.swift
@@ -7,8 +7,13 @@ struct Woo_Watch_AppApp: App {
 
     var body: some Scene {
         WindowGroup {
-            ContentView()
-                .environment(\.dependencies, phoneDependencySynchronizer.dependencies)
+            if phoneDependencySynchronizer.dependencies.credentials != nil {
+                ContentView()
+                    .environment(\.dependencies, phoneDependencySynchronizer.dependencies)
+            } else {
+                ConnectView()
+            }
+
         }
     }
 }

--- a/WooCommerce/Woo Watch App/WooApp.swift
+++ b/WooCommerce/Woo Watch App/WooApp.swift
@@ -7,7 +7,8 @@ struct Woo_Watch_AppApp: App {
 
     var body: some Scene {
         WindowGroup {
-            ContentView(message: phoneDependencySynchronizer.message)
+            ContentView()
+                .environment(\.dependencies, phoneDependencySynchronizer.dependencies)
         }
     }
 }

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -822,6 +822,7 @@
 		2647F7B529280A7F00D59FDF /* AnalyticsHubView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2647F7B429280A7F00D59FDF /* AnalyticsHubView.swift */; };
 		2647F7BA292BE2F900D59FDF /* AnalyticsReportCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2647F7B9292BE2F900D59FDF /* AnalyticsReportCard.swift */; };
 		264957A329C520860095AA4C /* SubscriptionsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 264957A229C520860095AA4C /* SubscriptionsView.swift */; };
+		264E9E942BF1D1DF009C48FD /* AppLocalizedString.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F50FE4228CAEBA800C89201 /* AppLocalizedString.swift */; };
 		265284022624937600F91BA1 /* AddOnCrossreferenceUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 265284012624937600F91BA1 /* AddOnCrossreferenceUseCase.swift */; };
 		265284092624ACE900F91BA1 /* AddOnCrossreferenceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 265284082624ACE900F91BA1 /* AddOnCrossreferenceTests.swift */; };
 		2655905B27863D1300BB8457 /* MockCollectOrderPaymentUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2655905A27863D1300BB8457 /* MockCollectOrderPaymentUseCase.swift */; };
@@ -908,6 +909,7 @@
 		26B542442BEAC68B003A55B5 /* Codegen in Embed Frameworks */ = {isa = PBXBuildFile; productRef = 26B542422BEAC68B003A55B5 /* Codegen */; settings = {ATTRIBUTES = (CodeSignOnCopy, ); }; };
 		26B71DB6293FE490004D8052 /* RangedDatePicker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26B71DB5293FE490004D8052 /* RangedDatePicker.swift */; };
 		26B984D42BEECC610052658C /* Environment+Dependencies.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26B984D32BEECC610052658C /* Environment+Dependencies.swift */; };
+		26B984D62BEECF260052658C /* ConnectView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26B984D52BEECF260052658C /* ConnectView.swift */; };
 		26B98758273C5BE30090E8CA /* EditCustomerNoteViewModelProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26B98757273C5BE30090E8CA /* EditCustomerNoteViewModelProtocol.swift */; };
 		26B9875D273C6A830090E8CA /* SimplePaymentsNoteViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26B9875C273C6A830090E8CA /* SimplePaymentsNoteViewModel.swift */; };
 		26B9875F273CB6AA0090E8CA /* SimplePaymentsNoteViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26B9875E273CB6AA0090E8CA /* SimplePaymentsNoteViewModelTests.swift */; };
@@ -3689,6 +3691,7 @@
 		26B3EC632745916F0075EAE6 /* BindableTextField.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BindableTextField.swift; sourceTree = "<group>"; };
 		26B71DB5293FE490004D8052 /* RangedDatePicker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RangedDatePicker.swift; sourceTree = "<group>"; };
 		26B984D32BEECC610052658C /* Environment+Dependencies.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Environment+Dependencies.swift"; sourceTree = "<group>"; };
+		26B984D52BEECF260052658C /* ConnectView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConnectView.swift; sourceTree = "<group>"; };
 		26B98757273C5BE30090E8CA /* EditCustomerNoteViewModelProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditCustomerNoteViewModelProtocol.swift; sourceTree = "<group>"; };
 		26B9875C273C6A830090E8CA /* SimplePaymentsNoteViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SimplePaymentsNoteViewModel.swift; sourceTree = "<group>"; };
 		26B9875E273CB6AA0090E8CA /* SimplePaymentsNoteViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SimplePaymentsNoteViewModelTests.swift; sourceTree = "<group>"; };
@@ -7604,6 +7607,7 @@
 				26B984D22BEECC460052658C /* Dependencies */,
 				26F81B172BE433A2009EC58E /* WooApp.swift */,
 				26F81B192BE433A2009EC58E /* ContentView.swift */,
+				26B984D52BEECF260052658C /* ConnectView.swift */,
 				26F81B1B2BE433A3009EC58E /* Assets.xcassets */,
 				26F81B1D2BE433A3009EC58E /* Preview Content */,
 			);
@@ -13356,7 +13360,9 @@
 			files = (
 				26B984D42BEECC610052658C /* Environment+Dependencies.swift in Sources */,
 				26F81B1A2BE433A2009EC58E /* ContentView.swift in Sources */,
+				264E9E942BF1D1DF009C48FD /* AppLocalizedString.swift in Sources */,
 				26DD32D42BEBCDFB00F2C69C /* WooConstants.swift in Sources */,
+				26B984D62BEECF260052658C /* ConnectView.swift in Sources */,
 				26DD32D62BEBCE3900F2C69C /* UserDefaults+Woo.swift in Sources */,
 				26F81B182BE433A2009EC58E /* WooApp.swift in Sources */,
 				2604C3BA2BE977F000250465 /* PhoneDependenciesSynchronizer.swift in Sources */,

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -907,6 +907,7 @@
 		26B542432BEAC68B003A55B5 /* Codegen in Frameworks */ = {isa = PBXBuildFile; productRef = 26B542422BEAC68B003A55B5 /* Codegen */; };
 		26B542442BEAC68B003A55B5 /* Codegen in Embed Frameworks */ = {isa = PBXBuildFile; productRef = 26B542422BEAC68B003A55B5 /* Codegen */; settings = {ATTRIBUTES = (CodeSignOnCopy, ); }; };
 		26B71DB6293FE490004D8052 /* RangedDatePicker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26B71DB5293FE490004D8052 /* RangedDatePicker.swift */; };
+		26B984D42BEECC610052658C /* Environment+Dependencies.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26B984D32BEECC610052658C /* Environment+Dependencies.swift */; };
 		26B98758273C5BE30090E8CA /* EditCustomerNoteViewModelProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26B98757273C5BE30090E8CA /* EditCustomerNoteViewModelProtocol.swift */; };
 		26B9875D273C6A830090E8CA /* SimplePaymentsNoteViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26B9875C273C6A830090E8CA /* SimplePaymentsNoteViewModel.swift */; };
 		26B9875F273CB6AA0090E8CA /* SimplePaymentsNoteViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26B9875E273CB6AA0090E8CA /* SimplePaymentsNoteViewModelTests.swift */; };
@@ -3687,6 +3688,7 @@
 		26B3EC612744772A0075EAE6 /* SimplePaymentsSummaryViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SimplePaymentsSummaryViewModelTests.swift; sourceTree = "<group>"; };
 		26B3EC632745916F0075EAE6 /* BindableTextField.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BindableTextField.swift; sourceTree = "<group>"; };
 		26B71DB5293FE490004D8052 /* RangedDatePicker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RangedDatePicker.swift; sourceTree = "<group>"; };
+		26B984D32BEECC610052658C /* Environment+Dependencies.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Environment+Dependencies.swift"; sourceTree = "<group>"; };
 		26B98757273C5BE30090E8CA /* EditCustomerNoteViewModelProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditCustomerNoteViewModelProtocol.swift; sourceTree = "<group>"; };
 		26B9875C273C6A830090E8CA /* SimplePaymentsNoteViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SimplePaymentsNoteViewModel.swift; sourceTree = "<group>"; };
 		26B9875E273CB6AA0090E8CA /* SimplePaymentsNoteViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SimplePaymentsNoteViewModelTests.swift; sourceTree = "<group>"; };
@@ -7462,6 +7464,15 @@
 			path = Survey;
 			sourceTree = "<group>";
 		};
+		26B984D22BEECC460052658C /* Dependencies */ = {
+			isa = PBXGroup;
+			children = (
+				2604C3B92BE977F000250465 /* PhoneDependenciesSynchronizer.swift */,
+				26B984D32BEECC610052658C /* Environment+Dependencies.swift */,
+			);
+			path = Dependencies;
+			sourceTree = "<group>";
+		};
 		26B9875B273C6A670090E8CA /* Summary */ = {
 			isa = PBXGroup;
 			children = (
@@ -7590,9 +7601,9 @@
 		26F81B162BE433A2009EC58E /* Woo Watch App */ = {
 			isa = PBXGroup;
 			children = (
+				26B984D22BEECC460052658C /* Dependencies */,
 				26F81B172BE433A2009EC58E /* WooApp.swift */,
 				26F81B192BE433A2009EC58E /* ContentView.swift */,
-				2604C3B92BE977F000250465 /* PhoneDependenciesSynchronizer.swift */,
 				26F81B1B2BE433A3009EC58E /* Assets.xcassets */,
 				26F81B1D2BE433A3009EC58E /* Preview Content */,
 			);
@@ -13343,6 +13354,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				26B984D42BEECC610052658C /* Environment+Dependencies.swift in Sources */,
 				26F81B1A2BE433A2009EC58E /* ContentView.swift in Sources */,
 				26DD32D42BEBCDFB00F2C69C /* WooConstants.swift in Sources */,
 				26DD32D62BEBCE3900F2C69C /* UserDefaults+Woo.swift in Sources */,


### PR DESCRIPTION
Closes: #12494 

## Why

This PR shows the connect screen when the watch can't find any stored credential

# How

- Set credentials dependencies as an environment value.
- Decide what main screen to show based on the stored credentials.

## Screenshots

https://github.com/woocommerce/woocommerce-ios/assets/562080/90813f34-ef2b-47bc-9fd6-498b7071d89f


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
