### PR TITLE
[Dynamic Dashboard] Initialize Reviews Card UI

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Dashboard/DashboardView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/DashboardView.swift
@@ -173,7 +173,9 @@ private extension DashboardView {
                         })
                     case .inbox:
                         InboxDashboardCard(viewModel: viewModel.inboxViewModel)
-                    case .coupons, .lastOrders, .stock, .reviews:
+                    case .reviews:
+                        ReviewsDashboardCard()
+                    case .coupons, .lastOrders, .stock:
                         EmptyView()
                     }
 

--- a/WooCommerce/Classes/ViewRelated/Dashboard/DashboardView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/DashboardView.swift
@@ -174,7 +174,7 @@ private extension DashboardView {
                     case .inbox:
                         InboxDashboardCard(viewModel: viewModel.inboxViewModel)
                     case .reviews:
-                        ReviewsDashboardCard()
+                        ReviewsDashboardCard(viewModel: viewModel.reviewsViewModel)
                     case .coupons, .lastOrders, .stock:
                         EmptyView()
                     }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/DashboardViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/DashboardViewModel.swift
@@ -336,6 +336,7 @@ private extension DashboardViewModel {
         if dynamicDashboardM2 {
             // TODO: check eligibility and update `enabled` accordingly
             cards.append(DashboardCard(type: .inbox, availability: .show, enabled: false))
+            cards.append(DashboardCard(type: .reviews, availability: .show, enabled: false))
         }
 
         return cards

--- a/WooCommerce/Classes/ViewRelated/Dashboard/DashboardViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/DashboardViewModel.swift
@@ -23,6 +23,7 @@ final class DashboardViewModel: ObservableObject {
     let storePerformanceViewModel: StorePerformanceViewModel
     let topPerformersViewModel: TopPerformersDashboardViewModel
     let inboxViewModel: InboxDashboardCardViewModel
+    let reviewsViewModel: ReviewsDashboardCardViewModel
 
     @Published var justInTimeMessagesWebViewModel: WebViewSheetViewModel? = nil
 
@@ -105,6 +106,7 @@ final class DashboardViewModel: ObservableObject {
         self.topPerformersViewModel = .init(siteID: siteID,
                                             usageTracksEventEmitter: usageTracksEventEmitter)
         self.inboxViewModel = InboxDashboardCardViewModel(siteID: siteID)
+        self.reviewsViewModel = ReviewsDashboardCardViewModel(siteID: siteID)
         self.themeInstaller = themeInstaller
         self.inAppFeedbackCardViewModel.onFeedbackGiven = { [weak self] feedback in
             self?.showingInAppFeedbackSurvey = feedback == .didntLike

--- a/WooCommerce/Classes/ViewRelated/Dashboard/DashboardViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/DashboardViewModel.swift
@@ -303,6 +303,10 @@ private extension DashboardViewModel {
         inboxViewModel.onDismiss = { [weak self] in
             self?.showCustomizationScreen()
         }
+
+        reviewsViewModel.onDismiss = { [weak self] in
+            self?.showCustomizationScreen()
+        }
     }
 
     func showCustomizationScreen() {

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Reviews/ReviewsDashboardCard.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Reviews/ReviewsDashboardCard.swift
@@ -1,0 +1,58 @@
+import SwiftUI
+import struct Yosemite.DashboardCard
+
+/// SwiftUI view for the Reviews dashboard card
+///
+struct ReviewsDashboardCard: View {
+    var body: some View {
+        VStack(alignment: .leading, spacing: Layout.padding) {
+            header
+                .padding(.horizontal, Layout.padding)
+        }
+        .padding(.vertical, Layout.padding)
+        .background(Color(.listForeground(modal: false)))
+        .clipShape(RoundedRectangle(cornerSize: Layout.cornerSize))
+        .padding(.horizontal, Layout.padding)
+    }
+}
+
+private extension ReviewsDashboardCard {
+    var header: some View {
+        HStack {
+            Text(DashboardCard.CardType.reviews.name)
+                .headlineStyle()
+            Spacer()
+            Menu {
+                Button(Localization.hideCard) {
+                    // TODO
+                }
+            } label: {
+                Image(systemName: "ellipsis")
+                    .foregroundStyle(Color.secondary)
+                    .padding(.leading, Layout.padding)
+                    .padding(.vertical, Layout.hideIconVerticalPadding)
+            }
+        }
+    }
+}
+
+private extension ReviewsDashboardCard {
+    enum Layout {
+        static let padding: CGFloat = 16
+        static let cornerSize = CGSize(width: 8.0, height: 8.0)
+        static let hideIconVerticalPadding: CGFloat = 8
+    }
+
+    enum Localization {
+        static let hideCard = NSLocalizedString(
+            "reviewsDashboardCard.hideCard",
+            value: "Hide Reviews",
+            comment: "Menu item to dismiss the Reviews card on the Dashboard screen"
+        )
+        static let viewAll = NSLocalizedString(
+            "reviewsDashboardCard.viewAll",
+            value: "View all reviews",
+            comment: "Button to navigate to Reviews list screen."
+        )
+    }
+}

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Reviews/ReviewsDashboardCard.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Reviews/ReviewsDashboardCard.swift
@@ -31,7 +31,7 @@ private extension ReviewsDashboardCard {
             Spacer()
             Menu {
                 Button(Localization.hideCard) {
-                    // TODO
+                    viewModel.dismissReviews()
                 }
             } label: {
                 Image(systemName: "ellipsis")

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Reviews/ReviewsDashboardCard.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Reviews/ReviewsDashboardCard.swift
@@ -26,6 +26,10 @@ struct ReviewsDashboardCard: View {
 private extension ReviewsDashboardCard {
     var header: some View {
         HStack {
+            Image(systemName: "exclamationmark.circle")
+                .foregroundStyle(Color.secondary)
+                .headlineStyle()
+                .renderedIf(viewModel.syncingError != nil)
             Text(DashboardCard.CardType.reviews.name)
                 .headlineStyle()
             Spacer()
@@ -39,6 +43,7 @@ private extension ReviewsDashboardCard {
                     .padding(.leading, Layout.padding)
                     .padding(.vertical, Layout.hideIconVerticalPadding)
             }
+            .disabled(viewModel.syncingData)
         }
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Reviews/ReviewsDashboardCard.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Reviews/ReviewsDashboardCard.swift
@@ -4,6 +4,13 @@ import struct Yosemite.DashboardCard
 /// SwiftUI view for the Reviews dashboard card
 ///
 struct ReviewsDashboardCard: View {
+    private let viewModel: ReviewsDashboardCardViewModel
+
+    init(viewModel: ReviewsDashboardCardViewModel) {
+        self.viewModel = viewModel
+    }
+
+
     var body: some View {
         VStack(alignment: .leading, spacing: Layout.padding) {
             header

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Reviews/ReviewsDashboardCardViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Reviews/ReviewsDashboardCardViewModel.swift
@@ -1,0 +1,33 @@
+import Foundation
+import Yosemite
+import protocol Storage.StorageManagerType
+
+/// View model for `ReviewsDashboardCard`
+///
+final class ReviewsDashboardCardViewModel: ObservableObject {
+    // Set externally to trigger callback upon hiding the Reviews card
+    var onDismiss: (() -> Void)?
+
+    @Published private(set) var syncingData = false
+    @Published private(set) var syncingError: Error?
+
+    private let siteID: Int64
+    private let stores: StoresManager
+    private let storage: StorageManagerType
+    private let analytics: Analytics
+
+    init(siteID: Int64,
+         stores: StoresManager = ServiceLocator.stores,
+         storage: StorageManagerType = ServiceLocator.storageManager,
+         analytics: Analytics = ServiceLocator.analytics) {
+        self.siteID = siteID
+        self.stores = stores
+        self.storage = storage
+        self.analytics = analytics
+    }
+
+    func dismissReviews() {
+        // TODO: add tracking
+        onDismiss?()
+    }
+}

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -1490,6 +1490,7 @@
 		860476E82B6CA0FC00AF0AEB /* BottomSheetProductType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 860476E72B6CA0FC00AF0AEB /* BottomSheetProductType.swift */; };
 		860B85F12ADE3A0E00E85884 /* BulletPointView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 860B85F02ADE3A0E00E85884 /* BulletPointView.swift */; };
 		8625C5112BF20990007F1901 /* ReviewsDashboardCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8625C5102BF20990007F1901 /* ReviewsDashboardCard.swift */; };
+		8625C5132BF20CC6007F1901 /* ReviewsDashboardCardViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8625C5122BF20CC6007F1901 /* ReviewsDashboardCardViewModel.swift */; };
 		863012A72B288F60004EC9DC /* ThemesPreviewView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 863012A62B288F60004EC9DC /* ThemesPreviewView.swift */; };
 		864213022AE77C730036E5A6 /* UIImage+Resizing.swift in Sources */ = {isa = PBXBuildFile; fileRef = 864213012AE77C730036E5A6 /* UIImage+Resizing.swift */; };
 		8646A9BA2B46C7CA001F606C /* BlazeAdDestinationSettingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8646A9B92B46C7CA001F606C /* BlazeAdDestinationSettingView.swift */; };
@@ -4206,6 +4207,7 @@
 		860476E72B6CA0FC00AF0AEB /* BottomSheetProductType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BottomSheetProductType.swift; sourceTree = "<group>"; };
 		860B85F02ADE3A0E00E85884 /* BulletPointView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BulletPointView.swift; sourceTree = "<group>"; };
 		8625C5102BF20990007F1901 /* ReviewsDashboardCard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReviewsDashboardCard.swift; sourceTree = "<group>"; };
+		8625C5122BF20CC6007F1901 /* ReviewsDashboardCardViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReviewsDashboardCardViewModel.swift; sourceTree = "<group>"; };
 		863012A62B288F60004EC9DC /* ThemesPreviewView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ThemesPreviewView.swift; sourceTree = "<group>"; };
 		864213012AE77C730036E5A6 /* UIImage+Resizing.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIImage+Resizing.swift"; sourceTree = "<group>"; };
 		8646A9B92B46C7CA001F606C /* BlazeAdDestinationSettingView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BlazeAdDestinationSettingView.swift; sourceTree = "<group>"; };
@@ -8824,6 +8826,7 @@
 			isa = PBXGroup;
 			children = (
 				8625C5102BF20990007F1901 /* ReviewsDashboardCard.swift */,
+				8625C5122BF20CC6007F1901 /* ReviewsDashboardCardViewModel.swift */,
 			);
 			path = Reviews;
 			sourceTree = "<group>";
@@ -14680,6 +14683,7 @@
 				029106C42BE34AA900C2248B /* CollapsibleCustomerCardViewModel.swift in Sources */,
 				03EF24FE28C0B356006A033E /* CardPresentPaymentsPlugin+CashOnDelivery.swift in Sources */,
 				DEC2961F26BD1605005A056B /* ShippingLabelCustomsFormListViewModel.swift in Sources */,
+				8625C5132BF20CC6007F1901 /* ReviewsDashboardCardViewModel.swift in Sources */,
 				0225091D2A5DAEA0000AEBD2 /* WooAnalyticsEvent+ProductCreation.swift in Sources */,
 				D843D5D722485B19001BFA55 /* ShippingProvidersViewModel.swift in Sources */,
 				B649BC7E2A1C295B007AB988 /* View+HighlightModifier.swift in Sources */,

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -1489,6 +1489,7 @@
 		860476E12B6A31D500AF0AEB /* ManualProductTypeOptions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 860476E02B6A31D500AF0AEB /* ManualProductTypeOptions.swift */; };
 		860476E82B6CA0FC00AF0AEB /* BottomSheetProductType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 860476E72B6CA0FC00AF0AEB /* BottomSheetProductType.swift */; };
 		860B85F12ADE3A0E00E85884 /* BulletPointView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 860B85F02ADE3A0E00E85884 /* BulletPointView.swift */; };
+		8625C5112BF20990007F1901 /* ReviewsDashboardCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8625C5102BF20990007F1901 /* ReviewsDashboardCard.swift */; };
 		863012A72B288F60004EC9DC /* ThemesPreviewView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 863012A62B288F60004EC9DC /* ThemesPreviewView.swift */; };
 		864213022AE77C730036E5A6 /* UIImage+Resizing.swift in Sources */ = {isa = PBXBuildFile; fileRef = 864213012AE77C730036E5A6 /* UIImage+Resizing.swift */; };
 		8646A9BA2B46C7CA001F606C /* BlazeAdDestinationSettingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8646A9B92B46C7CA001F606C /* BlazeAdDestinationSettingView.swift */; };
@@ -4204,6 +4205,7 @@
 		860476E02B6A31D500AF0AEB /* ManualProductTypeOptions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ManualProductTypeOptions.swift; sourceTree = "<group>"; };
 		860476E72B6CA0FC00AF0AEB /* BottomSheetProductType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BottomSheetProductType.swift; sourceTree = "<group>"; };
 		860B85F02ADE3A0E00E85884 /* BulletPointView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BulletPointView.swift; sourceTree = "<group>"; };
+		8625C5102BF20990007F1901 /* ReviewsDashboardCard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReviewsDashboardCard.swift; sourceTree = "<group>"; };
 		863012A62B288F60004EC9DC /* ThemesPreviewView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ThemesPreviewView.swift; sourceTree = "<group>"; };
 		864213012AE77C730036E5A6 /* UIImage+Resizing.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIImage+Resizing.swift"; sourceTree = "<group>"; };
 		8646A9B92B46C7CA001F606C /* BlazeAdDestinationSettingView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BlazeAdDestinationSettingView.swift; sourceTree = "<group>"; };
@@ -8818,6 +8820,14 @@
 			path = Themes;
 			sourceTree = "<group>";
 		};
+		8625C50F2BF2097E007F1901 /* Reviews */ = {
+			isa = PBXGroup;
+			children = (
+				8625C5102BF20990007F1901 /* ReviewsDashboardCard.swift */,
+			);
+			path = Reviews;
+			sourceTree = "<group>";
+		};
 		8646A9B82B46C79A001F606C /* AdDestination */ = {
 			isa = PBXGroup;
 			children = (
@@ -10773,6 +10783,7 @@
 		CE85FD5120F677460080B73E /* Dashboard */ = {
 			isa = PBXGroup;
 			children = (
+				8625C50F2BF2097E007F1901 /* Reviews */,
 				DE6F997C2BEE00A70007B2DD /* Inbox */,
 				EEBA029F2ADD5F0E001FE8E4 /* Blaze */,
 				2647F7B329280A5000D59FDF /* Analytics Hub */,
@@ -14013,6 +14024,7 @@
 				CCFBBCFA29C4C85F0081B595 /* ComponentSettingsViewModel.swift in Sources */,
 				02C37B7B2967096800F0CF9E /* DomainSettingsView.swift in Sources */,
 				CC4B252B27CFCEE2008D2E6E /* OrderTotalsCalculator.swift in Sources */,
+				8625C5112BF20990007F1901 /* ReviewsDashboardCard.swift in Sources */,
 				0247F512286F73EA009C177E /* WooAnalyticsEvent+ImageUpload.swift in Sources */,
 				202D2A5A2AC5933100E4ABC0 /* TopTabView.swift in Sources */,
 				B57C744A20F5649300EEFC87 /* EmptyStoresTableViewCell.swift in Sources */,


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

part of #12712
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

This PR initializes the creation of the Reviews card UI. It adds:
1. ReviewsDashboardCard view
2. ReviewsDashboardCardViewModel
3. Basic functionalities to hide card and also make it appear in the customization screen.

The card is just a header for now and has no content.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
1. Run app,
2. Tap "Edit" on Dashboard screen, ensure "Most recent reviews" are available and un-checked by default,
3. Check it and tap Save,
5. Ensure "Most recent reviews" card show up at the bottom (just header for now)
6. Use the triple dot icon and ensure "Hide reviews" appear,
7. Tap "Hide reviews", ensure the customization screen is shown.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

| Dashboard screen when card is shown | Customization screen |
|-|-|
| ![Simulator Screenshot - iPhone 15 iOS 17 4 - 2024-05-13 at 16 35 58](https://github.com/woocommerce/woocommerce-ios/assets/266376/214e040a-042f-4ff7-ab97-c5fc12aa38f2) | ![Simulator Screenshot - iPhone 15 iOS 17 4 - 2024-05-13 at 16 35 45](https://github.com/woocommerce/woocommerce-ios/assets/266376/c2a66548-396c-4e11-a76c-5e1190487698) |
