### PR TITLE
[Min/Max Quantities Edit Support] Adapt Networking and Model to the new REST API

### DIFF
--- a/Networking/Networking/Model/Product/Product.swift
+++ b/Networking/Networking/Model/Product/Product.swift
@@ -837,7 +837,6 @@ private extension Product {
     }
 
     enum MetadataKeys {
-        static let allowCombination   = "allow_combination"
         static let headStartPost      = "_headstart_post"
     }
 }

--- a/Networking/Networking/Model/Product/Product.swift
+++ b/Networking/Networking/Model/Product/Product.swift
@@ -542,7 +542,11 @@ public struct Product: Codable, GeneratedCopiable, Equatable, GeneratedFakeable 
         let minAllowedQuantity = container.failsafeDecodeIfPresent(stringForKey: .minAllowedQuantity)
         let maxAllowedQuantity = container.failsafeDecodeIfPresent(stringForKey: .maxAllowedQuantity)
         let groupOfQuantity = container.failsafeDecodeIfPresent(stringForKey: .groupOfQuantity)
-        let combineVariationQuantities = container.failsafeDecodeIfPresent(stringForKey: .combineVariations) == Values.combineVariationQuantitiesTrueValue
+
+        var combineVariationQuantities: Bool?
+        if let combineVariationQuantitiesString = container.failsafeDecodeIfPresent(stringForKey: .combineVariations) {
+            combineVariationQuantities = combineVariationQuantitiesString == Values.combineVariationQuantitiesTrueValue
+        }
 
         self.init(siteID: siteID,
                   productID: productID,

--- a/Networking/Networking/Model/Product/Product.swift
+++ b/Networking/Networking/Model/Product/Product.swift
@@ -539,21 +539,10 @@ public struct Product: Codable, GeneratedCopiable, Equatable, GeneratedFakeable 
         let subscription = try? metaDataExtractor?.extractProductSubscription()
 
         // Min/Max Quantities properties
-        //let minAllowedQuantity = metaDataExtractor?.extractStringValue(forKey: MetadataKeys.minAllowedQuantity)
         let minAllowedQuantity = container.failsafeDecodeIfPresent(stringForKey: .minAllowedQuantity)
         let maxAllowedQuantity = container.failsafeDecodeIfPresent(stringForKey: .maxAllowedQuantity)
         let groupOfQuantity = container.failsafeDecodeIfPresent(stringForKey: .groupOfQuantity)
-        let combineVariationQuantities = container.failsafeDecodeIfPresent(stringForKey: .combineVariations) == "yes" ? true : false
-
-
-//        let maxAllowedQuantity = metaDataExtractor?.extractStringValue(forKey: MetadataKeys.maxAllowedQuantity)
-//        let groupOfQuantity = metaDataExtractor?.extractStringValue(forKey: MetadataKeys.groupOfQuantity)
-//        let combineVariationQuantities: Bool? = {
-//            guard let allowCombination = metaDataExtractor?.extractStringValue(forKey: MetadataKeys.allowCombination) else {
-//                return nil
-//            }
-//            return (allowCombination as NSString).boolValue
-//        }()
+        let combineVariationQuantities = container.failsafeDecodeIfPresent(stringForKey: .combineVariations) == Values.combineVariationQuantitiesTrueValue
 
         self.init(siteID: siteID,
                   productID: productID,
@@ -844,9 +833,6 @@ private extension Product {
     }
 
     enum MetadataKeys {
-        static let minAllowedQuantity = "minimum_allowed_quantity"
-        static let maxAllowedQuantity = "maximum_allowed_quantity"
-        static let groupOfQuantity    = "group_of_quantity"
         static let allowCombination   = "allow_combination"
         static let headStartPost      = "_headstart_post"
     }
@@ -860,9 +846,9 @@ private extension Product {
     enum Values {
         static let manageStockParent = "parent"
         static let headStartValue = "_hs_extra"
+        static let combineVariationQuantitiesTrueValue = "yes"
     }
 }
-
 
 // MARK: - Decoding Errors
 //

--- a/Networking/Networking/Model/Product/Product.swift
+++ b/Networking/Networking/Model/Product/Product.swift
@@ -539,15 +539,21 @@ public struct Product: Codable, GeneratedCopiable, Equatable, GeneratedFakeable 
         let subscription = try? metaDataExtractor?.extractProductSubscription()
 
         // Min/Max Quantities properties
-        let minAllowedQuantity = metaDataExtractor?.extractStringValue(forKey: MetadataKeys.minAllowedQuantity)
-        let maxAllowedQuantity = metaDataExtractor?.extractStringValue(forKey: MetadataKeys.maxAllowedQuantity)
-        let groupOfQuantity = metaDataExtractor?.extractStringValue(forKey: MetadataKeys.groupOfQuantity)
-        let combineVariationQuantities: Bool? = {
-            guard let allowCombination = metaDataExtractor?.extractStringValue(forKey: MetadataKeys.allowCombination) else {
-                return nil
-            }
-            return (allowCombination as NSString).boolValue
-        }()
+        //let minAllowedQuantity = metaDataExtractor?.extractStringValue(forKey: MetadataKeys.minAllowedQuantity)
+        let minAllowedQuantity = container.failsafeDecodeIfPresent(stringForKey: .minAllowedQuantity)
+        let maxAllowedQuantity = container.failsafeDecodeIfPresent(stringForKey: .maxAllowedQuantity)
+        let groupOfQuantity = container.failsafeDecodeIfPresent(stringForKey: .groupOfQuantity)
+        let combineVariationQuantities = container.failsafeDecodeIfPresent(stringForKey: .combineVariations) == "yes" ? true : false
+
+
+//        let maxAllowedQuantity = metaDataExtractor?.extractStringValue(forKey: MetadataKeys.maxAllowedQuantity)
+//        let groupOfQuantity = metaDataExtractor?.extractStringValue(forKey: MetadataKeys.groupOfQuantity)
+//        let combineVariationQuantities: Bool? = {
+//            guard let allowCombination = metaDataExtractor?.extractStringValue(forKey: MetadataKeys.allowCombination) else {
+//                return nil
+//            }
+//            return (allowCombination as NSString).boolValue
+//        }()
 
         self.init(siteID: siteID,
                   productID: productID,
@@ -830,6 +836,11 @@ private extension Product {
         case bundledItems                   = "bundled_items"
 
         case compositeComponents    = "composite_components"
+
+        case minAllowedQuantity     = "min_quantity"
+        case maxAllowedQuantity     = "max_quantity"
+        case groupOfQuantity        = "group_of_quantity"
+        case combineVariations      = "combine_variations"
     }
 
     enum MetadataKeys {

--- a/Networking/NetworkingTests/Responses/product-min-max-quantities.json
+++ b/Networking/NetworkingTests/Responses/product-min-max-quantities.json
@@ -51,6 +51,12 @@
         "shipping_taxable": true,
         "shipping_class": "",
         "shipping_class_id": 0,
+        "group_of_quantity": 2,
+        "min_quantity": 4,
+        "max_quantity": 200,
+        "exclude_order_quantity_value_rules":"no",
+        "exclude_category_quantity_rules":"no",
+        "combine_variations":"no",
         "reviews_allowed": true,
         "average_rating": "0.00",
         "rating_count": 0,
@@ -95,41 +101,6 @@
                 "id": 14135,
                 "key": "_last_editor_used_jetpack",
                 "value": "classic-editor"
-            },
-            {
-                "id": 14230,
-                "key": "group_of_quantity",
-                "value": "2"
-            },
-            {
-                "id": 14231,
-                "key": "minimum_allowed_quantity",
-                "value": "4"
-            },
-            {
-                "id": 14232,
-                "key": "maximum_allowed_quantity",
-                "value": "200"
-            },
-            {
-                "id": 14233,
-                "key": "allow_combination",
-                "value": "no"
-            },
-            {
-                "id": 14234,
-                "key": "minmax_do_not_count",
-                "value": "no"
-            },
-            {
-                "id": 14235,
-                "key": "minmax_cart_exclude",
-                "value": "yes"
-            },
-            {
-                "id": 14236,
-                "key": "minmax_category_group_of_exclude",
-                "value": "no"
             }
         ],
         "stock_status": "instock",

--- a/WooCommerce/Classes/Extensions/Optional+String.swift
+++ b/WooCommerce/Classes/Extensions/Optional+String.swift
@@ -7,4 +7,12 @@ extension Optional where Wrapped == String {
         }
         return self.isEmpty
     }
+
+    var isNilOrEmptyOrZero: Bool {
+        guard !isNilOrEmpty else {
+            return true
+        }
+
+        return self == "0"
+    }
 }

--- a/WooCommerce/Classes/Extensions/String+ProductQuantityRules.swift
+++ b/WooCommerce/Classes/Extensions/String+ProductQuantityRules.swift
@@ -1,0 +1,9 @@
+import Foundation
+
+extension String {
+    /// Returns whether the product quantity rule (e.g. mininum or maximum quantities the product can be ordered) has a valid value
+    ///
+    var isAValidProductQuantityRuleValue: Bool {
+        self.isNotEmpty && self != "0"
+    }
+}

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/DefaultProductFormTableViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/DefaultProductFormTableViewModel.swift
@@ -645,15 +645,15 @@ private extension DefaultProductFormTableViewModel {
 
         var quantityDetails = [String]()
 
-        if let minQuantity = product.minAllowedQuantity, minQuantity.isNotEmpty {
+        if let minQuantity = product.minAllowedQuantity, minQuantity.isAValidProductQuantityRuleValue {
             let minQuantityDescription = String.localizedStringWithFormat(Localization.minQuantityFormat, minQuantity)
             quantityDetails.append(minQuantityDescription)
         }
-        if let maxQuantity = product.maxAllowedQuantity, maxQuantity.isNotEmpty {
+        if let maxQuantity = product.maxAllowedQuantity, maxQuantity.isAValidProductQuantityRuleValue {
             let maxQuantityDescription = String.localizedStringWithFormat(Localization.maxQuantityFormat, maxQuantity)
             quantityDetails.append(maxQuantityDescription)
         }
-        if !quantityDetails.containsMoreThanOne, let groupOf = product.groupOfQuantity, groupOf.isNotEmpty {
+        if !quantityDetails.containsMoreThanOne, let groupOf = product.groupOfQuantity, groupOf.isAValidProductQuantityRuleValue {
             let groupOfDescription = String.localizedStringWithFormat(Localization.groupOfFormat, groupOf)
             quantityDetails.append(groupOfDescription)
         }

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/EditableProductModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/EditableProductModel.swift
@@ -180,7 +180,7 @@ extension EditableProductModel: ProductFormDataModel, TaxClassRequestable {
     }
 
     var hasQuantityRules: Bool {
-        let hasNoRules = minAllowedQuantity.isNilOrEmpty && maxAllowedQuantity.isNilOrEmpty && groupOfQuantity.isNilOrEmpty
+        let hasNoRules = minAllowedQuantity.isNilOrEmptyOrZero && maxAllowedQuantity.isNilOrEmptyOrZero && groupOfQuantity.isNilOrEmptyOrZero
         return !hasNoRules
     }
 

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Quantity Rules/QuantityRulesViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Quantity Rules/QuantityRulesViewModel.swift
@@ -35,7 +35,7 @@ private extension QuantityRulesViewModel {
     /// Returns a description of the provided quantity, using the placeholder if the quantity is nil or empty.
     ///
     static func getDescription(for quantity: String?, withPlaceholder placeholder: String) -> String {
-        guard let quantity, quantity.isNotEmpty else {
+        guard let quantity, quantity.isAValidProductQuantityRuleValue else {
             return placeholder
         }
         return quantity

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -1799,6 +1799,7 @@
 		B99B30CD2A85200D0066743D /* AddressFormViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = B99B30CC2A85200D0066743D /* AddressFormViewModel.swift */; };
 		B99B87A72AEFCF0A006B8AB1 /* Order+Empty.swift in Sources */ = {isa = PBXBuildFile; fileRef = B99B87A62AEFCF0A006B8AB1 /* Order+Empty.swift */; };
 		B9A0F7A62B1735B10035A153 /* UpdateProductInventoryViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B9A0F7A52B1735B10035A153 /* UpdateProductInventoryViewModelTests.swift */; };
+		B9ACF6882BEE4FC60076E6BC /* String+ProductQuantityRules.swift in Sources */ = {isa = PBXBuildFile; fileRef = B9ACF6872BEE4FC60076E6BC /* String+ProductQuantityRules.swift */; };
 		B9B0391628A6824200DC1C83 /* PermanentNoticePresenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = B9B0391528A6824200DC1C83 /* PermanentNoticePresenter.swift */; };
 		B9B0391828A6838400DC1C83 /* PermanentNoticeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B9B0391728A6838400DC1C83 /* PermanentNoticeView.swift */; };
 		B9B0391A28A68ADE00DC1C83 /* ConstraintsUpdatingHostingController.swift in Sources */ = {isa = PBXBuildFile; fileRef = B9B0391928A68ADE00DC1C83 /* ConstraintsUpdatingHostingController.swift */; };
@@ -4539,6 +4540,7 @@
 		B99B30CC2A85200D0066743D /* AddressFormViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddressFormViewModel.swift; sourceTree = "<group>"; };
 		B99B87A62AEFCF0A006B8AB1 /* Order+Empty.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Order+Empty.swift"; sourceTree = "<group>"; };
 		B9A0F7A52B1735B10035A153 /* UpdateProductInventoryViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UpdateProductInventoryViewModelTests.swift; sourceTree = "<group>"; };
+		B9ACF6872BEE4FC60076E6BC /* String+ProductQuantityRules.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "String+ProductQuantityRules.swift"; sourceTree = "<group>"; };
 		B9B0391528A6824200DC1C83 /* PermanentNoticePresenter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PermanentNoticePresenter.swift; sourceTree = "<group>"; };
 		B9B0391728A6838400DC1C83 /* PermanentNoticeView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PermanentNoticeView.swift; sourceTree = "<group>"; };
 		B9B0391928A68ADE00DC1C83 /* ConstraintsUpdatingHostingController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConstraintsUpdatingHostingController.swift; sourceTree = "<group>"; };
@@ -10539,6 +10541,7 @@
 				204C9C732B6BDFFB007A94E0 /* UIUserInterfaceSizeClass+Helpers.swift */,
 				EE8A30442B74948C001D7C66 /* OrderAttributionInfo+Origin.swift */,
 				26CE6F332B7D4C27008DB858 /* Error+Timeout.swift */,
+				B9ACF6872BEE4FC60076E6BC /* String+ProductQuantityRules.swift */,
 			);
 			path = Extensions;
 			sourceTree = "<group>";
@@ -14129,6 +14132,7 @@
 				45C11B7C2508E156006C2089 /* SelectedSiteSettings.swift in Sources */,
 				B5A56BF3219F46470065A902 /* UIButton+Animations.swift in Sources */,
 				03AA165E2719B7EF005CCB7B /* ReceiptActionCoordinator.swift in Sources */,
+				B9ACF6882BEE4FC60076E6BC /* String+ProductQuantityRules.swift in Sources */,
 				B54FBE552111F70700390F57 /* ResultsController+UIKit.swift in Sources */,
 				CE2409F1215D12D30091F887 /* WooNavigationController.swift in Sources */,
 				0250BE8C2AC425F9006D067A /* OrderFormGiftCardRow.swift in Sources */,


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #12670 
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
With this PR we adapt the Product networking logic to the new Min/Max Quantities API and model. We keep the read support UI counterpart as it was before, but adapt the view model to the model.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
### Store without the Min/Max Quantities plugin installed. We don't show the Min/Max Quantities row in product details:

1. Go to a store without the Min/Max Quantities installed.
2. Open the app, and go to the products tab.
3. Tap on any product.
4. You don't see any row about the Min/Max Quantities:

![Simulator Screen Recording - iPhone 15 Pro - 2024-05-13 at 12 36 40](https://github.com/woocommerce/woocommerce-ios/assets/1864060/db3a9c54-c342-443f-b582-ca93eb838496)

### Store with the Min/Max Quantities plugin installed but a product with no rules. We don't show the Min/Max Quantities row in product details:

1. Go to a store without the Min/Max Quantities installed.
2. Open the app, and go to the products tab.
3. Tap on any product.
4. You don't see any row about the Min/Max Quantities:

![Simulator Screen Recording - iPhone 15 Pro - 2024-05-13 at 12 47 41](https://github.com/woocommerce/woocommerce-ios/assets/1864060/ce121bd9-77a9-4963-811a-4d0f26f40896)

### Store with the Min/Max Quantities plugin installed and a product with rules. We show the Min/Max Quantities row in product details and allow navigation:

1. Go to a store without the Min/Max Quantities installed.
2. Open the app, and go to the products tab.
3. Tap on any product.
4. You don't see the row about the Min/Max Quantities. Tap on that.
5. You navigate to the Min/Max Quantities detail.


https://github.com/woocommerce/woocommerce-ios/assets/1864060/515934dc-a4a5-4dbc-976d-51242ce7b422

<img width="1047" alt="image" src="https://github.com/woocommerce/woocommerce-ios/assets/1864060/7ec7f025-9cc3-43cd-9006-9925d0362968">


## Screenshots
<!-- Include before and after images or gifs when appropriate. -->


---
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
