### PR TITLE
Fix trunk build error from merging a PR after new code was merged

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Dashboard/Inbox/InboxDashboardCardViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Inbox/InboxDashboardCardViewModel.swift
@@ -1,6 +1,7 @@
 import Foundation
 import Yosemite
 import protocol Storage.StorageManagerType
+import protocol WooFoundation.Analytics
 
 /// View model for `InboxDashboardCard`.
 ///


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Fixes build error from merging https://github.com/woocommerce/woocommerce-ios/pull/12685 after new code referencing `Analytics` was merged after the last PR update
<!-- Id number of the GitHub issue this PR addresses. -->

## Why

In PR https://github.com/woocommerce/woocommerce-ios/pull/12685 that I merged moments ago, it moves `Analytics` protocol to WooFoundation framework while a new class `InboxDashboardCardViewModel` was merged after the last PR update so that it's missing an import.

Thanks to @iamgabrielma for noticing this error!

## How

Adding `import protocol WooFoundation.Analytics` to `InboxDashboardCardViewModel` as it references the protocol.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

Just CI is sufficient! @jaclync will also do a confidence check of the app.


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
