### PR TITLE
[Experiment] Card payments adaptor

### DIFF
--- a/WooCommerce/Classes/CardPresentPayments/CardPaymentsAdaptor.swift
+++ b/WooCommerce/Classes/CardPresentPayments/CardPaymentsAdaptor.swift
@@ -17,8 +17,7 @@ class CardPresentPaymentsAdaptor {
     }
 
     func collectPayment(for order: Order,
-                        using discoveryMethod: CardReaderDiscoveryMethod,
-                        eventStream: AsyncStream<CardPresentPaymentEvent>) async -> CardPresentPaymentResult {
+                        using discoveryMethod: CardReaderDiscoveryMethod) async -> CardPresentPaymentResult {
         let orderPaymentUseCase = await CollectOrderPaymentUseCase(siteID: siteID,
                                                                    order: order,
                                                                    formattedAmount: currencyFormatter.formatAmount(order.total, with: order.currency) ?? "",

--- a/WooCommerce/Classes/CardPresentPayments/CardPaymentsAdaptor.swift
+++ b/WooCommerce/Classes/CardPresentPayments/CardPaymentsAdaptor.swift
@@ -1,0 +1,95 @@
+import Foundation
+import Yosemite
+import class WooFoundation.CurrencyFormatter
+
+enum CardPresentPaymentResult {
+    case success(Order)
+    case failure(CardPaymentErrorProtocol)
+    case cancellation
+}
+
+class CardPresentPaymentsAdaptor {
+    private let currencyFormatter: CurrencyFormatter = CurrencyFormatter(currencySettings: ServiceLocator.currencySettings)
+    private let siteID: Int64
+
+    init(siteID: Int64) {
+        self.siteID = siteID
+    }
+
+    func collectPayment(for order: Order,
+                        using discoveryMethod: CardReaderDiscoveryMethod,
+                        eventStream: AsyncStream<CardPresentPaymentEvent>) async -> CardPresentPaymentResult {
+        let orderPaymentUseCase = await CollectOrderPaymentUseCase(siteID: siteID,
+                                                                   order: order,
+                                                                   formattedAmount: currencyFormatter.formatAmount(order.total, with: order.currency) ?? "",
+                                                                   // moved from EditableOrderViewModel.collectPayment(for: Order)
+                                                                   rootViewController: UIViewController(), 
+                                                                   // We don't want to use this at all, but it's currently required by the existing code.
+                                                                   // TODO: replace `rootViewController` with a protocol containing the UIVC functions we need, and implement that here.
+                                                                   onboardingPresenter: self,
+                                                                   configuration: CardPresentConfigurationLoader().configuration,
+                                                                   alertsPresenter: self)
+        return await withCheckedContinuation { continuation in
+            orderPaymentUseCase.collectPayment(using: discoveryMethod) { error in
+                if let error = error as? CardPaymentErrorProtocol {
+                    continuation.resume(returning: .failure(error))
+                } else {
+                    continuation.resume(returning: .failure(CardPaymentsAdaptorError.unknownPaymentError(underlyingError: error)))
+                }
+            } onCancel: {
+                continuation.resume(returning: .cancellation)
+            } onPaymentCompletion: {
+                // no-op – not used in PaymentMethodsViewModel anyway so this can be removed
+            } onCompleted: {
+                continuation.resume(returning: .success(order))
+            }
+        }
+    }
+
+    enum CardPaymentsAdaptorError: Error, CardPaymentErrorProtocol {
+        var retryApproach: CardPaymentRetryApproach {
+            .restart
+        }
+
+        case unknownPaymentError(underlyingError: Error)
+    }
+}
+
+extension CardPresentPaymentsAdaptor: CardPresentPaymentsOnboardingPresenting {
+    func showOnboardingIfRequired(from: UIViewController, readyToCollectPayment: @escaping () -> Void) {
+        
+    }
+    
+    func refresh() {
+        // TODO: Refresh onboarding
+    }
+}
+
+extension CardPresentPaymentsAdaptor: CardPresentPaymentAlertsPresenting {
+    func present(viewModel: CardPresentPaymentsModalViewModel) {
+        <#code#>
+    }
+    
+    func foundSeveralReaders(readerIDs: [String], connect: @escaping (String) -> Void, cancelSearch: @escaping () -> Void) {
+
+    }
+    
+    func updateSeveralReadersList(readerIDs: [String]) {
+
+    }
+    
+    func dismiss() {
+        <#code#>
+    }
+}
+
+enum CardPresentPaymentEvent {
+    case presentAlert(CardPresentPaymentsAdaptorPaymentAlert)
+    case presentReaderList(_ readerIDs: [String])
+    case showOnboarding
+}
+
+struct CardPresentPaymentsAdaptorPaymentAlert {
+    
+}
+

--- a/WooCommerce/Classes/ViewRelated/CardPresentPayments/CardPresentPaymentPreflightController.swift
+++ b/WooCommerce/Classes/ViewRelated/CardPresentPayments/CardPresentPaymentPreflightController.swift
@@ -81,6 +81,8 @@ final class CardPresentPaymentPreflightController: CardPresentPaymentPreflightCo
          alertsPresenter: CardPresentPaymentAlertsPresenting,
          onboardingPresenter: CardPresentPaymentsOnboardingPresenting,
          tapToPayReconnectionController: TapToPayReconnectionController = ServiceLocator.tapToPayReconnectionController,
+         bluetoothConnectionController: CardReaderConnectionController? = nil,
+         builtInConnectionController: BuiltInCardReaderConnectionController? = nil,
          stores: StoresManager = ServiceLocator.stores,
          analytics: Analytics = ServiceLocator.analytics) {
         self.siteID = siteID
@@ -97,7 +99,7 @@ final class CardPresentPaymentPreflightController: CardPresentPaymentPreflightCo
                                                                      connectionType: .userInitiated,
                                                                      stores: stores,
                                                                      analytics: analytics)
-        self.connectionController = CardReaderConnectionController(
+        self.connectionController = bluetoothConnectionController ?? CardReaderConnectionController(
             forSiteID: siteID,
             knownReaderProvider: CardReaderSettingsKnownReaderStorage(),
             alertsPresenter: alertsPresenter,
@@ -105,7 +107,7 @@ final class CardPresentPaymentPreflightController: CardPresentPaymentPreflightCo
             configuration: configuration,
             analyticsTracker: analyticsTracker)
 
-        self.builtInConnectionController = BuiltInCardReaderConnectionController(
+        self.builtInConnectionController = builtInConnectionController ?? BuiltInCardReaderConnectionController(
             forSiteID: siteID,
             alertsPresenter: alertsPresenter,
             alertsProvider: BuiltInReaderConnectionAlertsProvider(),

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -730,6 +730,7 @@
 		202D2A5A2AC5933100E4ABC0 /* TopTabView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 202D2A592AC5933100E4ABC0 /* TopTabView.swift */; };
 		203A5C312AC5ADD700BF29A1 /* WooPaymentsDepositsOverviewView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 203A5C302AC5ADD700BF29A1 /* WooPaymentsDepositsOverviewView.swift */; };
 		204C9C742B6BDFFB007A94E0 /* UIUserInterfaceSizeClass+Helpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 204C9C732B6BDFFB007A94E0 /* UIUserInterfaceSizeClass+Helpers.swift */; };
+		2063E4DD2BF36EF000AAE96B /* CardPaymentsAdaptor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2063E4DC2BF36EF000AAE96B /* CardPaymentsAdaptor.swift */; };
 		209AD3D02AC1EDDA00825D76 /* WooPaymentsDepositsCurrencyOverviewViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 209AD3CF2AC1EDDA00825D76 /* WooPaymentsDepositsCurrencyOverviewViewModel.swift */; };
 		209AD3D22AC1EDF600825D76 /* WooPaymentsDepositsCurrencyOverviewView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 209AD3D12AC1EDF600825D76 /* WooPaymentsDepositsCurrencyOverviewView.swift */; };
 		209B15672AD85F070094152A /* OperatingSystemVersion+Localization.swift in Sources */ = {isa = PBXBuildFile; fileRef = 209B15662AD85F070094152A /* OperatingSystemVersion+Localization.swift */; };
@@ -3471,6 +3472,7 @@
 		202D2A592AC5933100E4ABC0 /* TopTabView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TopTabView.swift; sourceTree = "<group>"; };
 		203A5C302AC5ADD700BF29A1 /* WooPaymentsDepositsOverviewView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WooPaymentsDepositsOverviewView.swift; sourceTree = "<group>"; };
 		204C9C732B6BDFFB007A94E0 /* UIUserInterfaceSizeClass+Helpers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIUserInterfaceSizeClass+Helpers.swift"; sourceTree = "<group>"; };
+		2063E4DC2BF36EF000AAE96B /* CardPaymentsAdaptor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardPaymentsAdaptor.swift; sourceTree = "<group>"; };
 		209AD3CF2AC1EDDA00825D76 /* WooPaymentsDepositsCurrencyOverviewViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WooPaymentsDepositsCurrencyOverviewViewModel.swift; sourceTree = "<group>"; };
 		209AD3D12AC1EDF600825D76 /* WooPaymentsDepositsCurrencyOverviewView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WooPaymentsDepositsCurrencyOverviewView.swift; sourceTree = "<group>"; };
 		209B15662AD85F070094152A /* OperatingSystemVersion+Localization.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "OperatingSystemVersion+Localization.swift"; sourceTree = "<group>"; };
@@ -7033,6 +7035,14 @@
 			path = "Deposits Overview";
 			sourceTree = "<group>";
 		};
+		2063E4DB2BF36EBF00AAE96B /* CardPresentPayments */ = {
+			isa = PBXGroup;
+			children = (
+				2063E4DC2BF36EF000AAE96B /* CardPaymentsAdaptor.swift */,
+			);
+			path = CardPresentPayments;
+			sourceTree = "<group>";
+		};
 		20AE33C32B0510AD00527B60 /* Destinations */ = {
 			isa = PBXGroup;
 			children = (
@@ -9259,6 +9269,7 @@
 		B56DB3F12049C0B800D4AA8E /* Classes */ = {
 			isa = PBXGroup;
 			children = (
+				2063E4DB2BF36EBF00AAE96B /* CardPresentPayments */,
 				20AE33C32B0510AD00527B60 /* Destinations */,
 				02D7E7BF2A4CA8E50003049A /* LocalAnnouncements */,
 				B9F3DAAB29BB714900DDD545 /* App Intents */,
@@ -13708,6 +13719,7 @@
 				DEA0D0682BA82EA2007786F2 /* StatsGranularityV4+UI.swift in Sources */,
 				DE69C54D27BB719A000BB888 /* CouponRestrictions.swift in Sources */,
 				E1D4E84426776A6B00256B83 /* HeadlineTableViewCell.swift in Sources */,
+				2063E4DD2BF36EF000AAE96B /* CardPaymentsAdaptor.swift in Sources */,
 				B555530F21B57DE700449E71 /* ApplicationAdapter.swift in Sources */,
 				025C00682550DE4700FAC222 /* ProductSKUInputScannerViewController.swift in Sources */,
 				20DA6DDB2B681175002AA0FB /* AdaptiveModalContainer.swift in Sources */,


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of: #12734 

## Description
This is WIP.

I've wrapped all the existing payments code in an adaptor, and provided an interface to start a payment (only.)

Note that this is in the App target, and intended to be used from there. Using it from the POS target would take extra work, which may, or may not, be worthwhile.

The output alerts/onboarding can be handled by providing a class that conforms to `CardPresentPaymentsAlertHandling`. Not all this UI would need to be new, we could reuse the existing SwiftUI screens but present them differently. The idea is that is the _most_ that would be new.

The adaptor is intended to perhaps be used as a singleton, or at least be as long lived as a particular store is selected. That way, the same connection controllers are used every time we take a payment (through the adaptor), and we should have just one source of truth for that.

I'm going to continue working on this and actually try to use it from a view tomorrow. This isn't the only possible approach, and nothing's definite, but I'd love your thoughts on it so far.

@bozidarsevo @jaclync @iamgabrielma