### PR TITLE
[Experiment] Card payments adaptor stream

### DIFF
--- a/WooCommerce/Classes/CardPresentPayments/CardPaymentsAdaptor.swift
+++ b/WooCommerce/Classes/CardPresentPayments/CardPaymentsAdaptor.swift
@@ -1,0 +1,95 @@
+import Foundation
+import Yosemite
+import class WooFoundation.CurrencyFormatter
+
+enum CardPresentPaymentResult {
+    case success(Order)
+    case failure(CardPaymentErrorProtocol)
+    case cancellation
+}
+
+class CardPresentPaymentsAdaptor {
+    private let currencyFormatter: CurrencyFormatter = CurrencyFormatter(currencySettings: ServiceLocator.currencySettings)
+    private let siteID: Int64
+
+    init(siteID: Int64) {
+        self.siteID = siteID
+    }
+
+    func collectPayment(for order: Order,
+                        using discoveryMethod: CardReaderDiscoveryMethod,
+                        eventStream: AsyncStream<CardPresentPaymentEvent>) async -> CardPresentPaymentResult {
+        let orderPaymentUseCase = await CollectOrderPaymentUseCase(siteID: siteID,
+                                                                   order: order,
+                                                                   formattedAmount: currencyFormatter.formatAmount(order.total, with: order.currency) ?? "",
+                                                                   // moved from EditableOrderViewModel.collectPayment(for: Order)
+                                                                   rootViewController: UIViewController(), 
+                                                                   // We don't want to use this at all, but it's currently required by the existing code.
+                                                                   // TODO: replace `rootViewController` with a protocol containing the UIVC functions we need, and implement that here.
+                                                                   onboardingPresenter: self,
+                                                                   configuration: CardPresentConfigurationLoader().configuration,
+                                                                   alertsPresenter: self)
+        return await withCheckedContinuation { continuation in
+            orderPaymentUseCase.collectPayment(using: discoveryMethod) { error in
+                if let error = error as? CardPaymentErrorProtocol {
+                    continuation.resume(returning: .failure(error))
+                } else {
+                    continuation.resume(returning: .failure(CardPaymentsAdaptorError.unknownPaymentError(underlyingError: error)))
+                }
+            } onCancel: {
+                continuation.resume(returning: .cancellation)
+            } onPaymentCompletion: {
+                // no-op – not used in PaymentMethodsViewModel anyway so this can be removed
+            } onCompleted: {
+                continuation.resume(returning: .success(order))
+            }
+        }
+    }
+
+    enum CardPaymentsAdaptorError: Error, CardPaymentErrorProtocol {
+        var retryApproach: CardPaymentRetryApproach {
+            .restart
+        }
+
+        case unknownPaymentError(underlyingError: Error)
+    }
+}
+
+extension CardPresentPaymentsAdaptor: CardPresentPaymentsOnboardingPresenting {
+    func showOnboardingIfRequired(from: UIViewController, readyToCollectPayment: @escaping () -> Void) {
+        
+    }
+    
+    func refresh() {
+        // TODO: Refresh onboarding
+    }
+}
+
+extension CardPresentPaymentsAdaptor: CardPresentPaymentAlertsPresenting {
+    func present(viewModel: CardPresentPaymentsModalViewModel) {
+        <#code#>
+    }
+    
+    func foundSeveralReaders(readerIDs: [String], connect: @escaping (String) -> Void, cancelSearch: @escaping () -> Void) {
+
+    }
+    
+    func updateSeveralReadersList(readerIDs: [String]) {
+
+    }
+    
+    func dismiss() {
+        <#code#>
+    }
+}
+
+enum CardPresentPaymentEvent {
+    case presentAlert(CardPresentPaymentsAdaptorPaymentAlert)
+    case presentReaderList(_ readerIDs: [String])
+    case showOnboarding
+}
+
+struct CardPresentPaymentsAdaptorPaymentAlert {
+    
+}
+

--- a/WooCommerce/Classes/CardPresentPayments/CardPaymentsAdaptor.swift
+++ b/WooCommerce/Classes/CardPresentPayments/CardPaymentsAdaptor.swift
@@ -10,6 +10,13 @@ class CardPresentPaymentsAdaptor {
         self.siteID = siteID
     }
 
+    /// The problem with this approach is that making the usecase also makes the preflight controller, which makes the two connection controllers.
+    /// Each of these require the `alertPresenter`, and some require the `onboardingPresenter`.
+    /// 
+    /// Since this design has a short-lived `eventAdaptor` fulfilling both roles, we can't make a long-lived connection controller
+    /// unless we change it to allow the alertsPresenter to be changed when `collectPayment` is called a second time.
+    ///
+    /// Having short-lived connection controllers means we would need another way to set a single source of truth for the reader connection.
     func collectPayment(for order: Order,
                         using discoveryMethod: CardReaderDiscoveryMethod) -> AsyncStream<CardPresentPaymentEvent> {
         let eventStream = AsyncStream<CardPresentPaymentEvent> { streamContinuation in

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -730,6 +730,7 @@
 		202D2A5A2AC5933100E4ABC0 /* TopTabView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 202D2A592AC5933100E4ABC0 /* TopTabView.swift */; };
 		203A5C312AC5ADD700BF29A1 /* WooPaymentsDepositsOverviewView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 203A5C302AC5ADD700BF29A1 /* WooPaymentsDepositsOverviewView.swift */; };
 		204C9C742B6BDFFB007A94E0 /* UIUserInterfaceSizeClass+Helpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 204C9C732B6BDFFB007A94E0 /* UIUserInterfaceSizeClass+Helpers.swift */; };
+		2063E4DD2BF36EF000AAE96B /* CardPaymentsAdaptor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2063E4DC2BF36EF000AAE96B /* CardPaymentsAdaptor.swift */; };
 		209AD3D02AC1EDDA00825D76 /* WooPaymentsDepositsCurrencyOverviewViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 209AD3CF2AC1EDDA00825D76 /* WooPaymentsDepositsCurrencyOverviewViewModel.swift */; };
 		209AD3D22AC1EDF600825D76 /* WooPaymentsDepositsCurrencyOverviewView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 209AD3D12AC1EDF600825D76 /* WooPaymentsDepositsCurrencyOverviewView.swift */; };
 		209B15672AD85F070094152A /* OperatingSystemVersion+Localization.swift in Sources */ = {isa = PBXBuildFile; fileRef = 209B15662AD85F070094152A /* OperatingSystemVersion+Localization.swift */; };
@@ -3471,6 +3472,7 @@
 		202D2A592AC5933100E4ABC0 /* TopTabView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TopTabView.swift; sourceTree = "<group>"; };
 		203A5C302AC5ADD700BF29A1 /* WooPaymentsDepositsOverviewView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WooPaymentsDepositsOverviewView.swift; sourceTree = "<group>"; };
 		204C9C732B6BDFFB007A94E0 /* UIUserInterfaceSizeClass+Helpers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIUserInterfaceSizeClass+Helpers.swift"; sourceTree = "<group>"; };
+		2063E4DC2BF36EF000AAE96B /* CardPaymentsAdaptor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardPaymentsAdaptor.swift; sourceTree = "<group>"; };
 		209AD3CF2AC1EDDA00825D76 /* WooPaymentsDepositsCurrencyOverviewViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WooPaymentsDepositsCurrencyOverviewViewModel.swift; sourceTree = "<group>"; };
 		209AD3D12AC1EDF600825D76 /* WooPaymentsDepositsCurrencyOverviewView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WooPaymentsDepositsCurrencyOverviewView.swift; sourceTree = "<group>"; };
 		209B15662AD85F070094152A /* OperatingSystemVersion+Localization.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "OperatingSystemVersion+Localization.swift"; sourceTree = "<group>"; };
@@ -7033,6 +7035,14 @@
 			path = "Deposits Overview";
 			sourceTree = "<group>";
 		};
+		2063E4DB2BF36EBF00AAE96B /* CardPresentPayments */ = {
+			isa = PBXGroup;
+			children = (
+				2063E4DC2BF36EF000AAE96B /* CardPaymentsAdaptor.swift */,
+			);
+			path = CardPresentPayments;
+			sourceTree = "<group>";
+		};
 		20AE33C32B0510AD00527B60 /* Destinations */ = {
 			isa = PBXGroup;
 			children = (
@@ -9259,6 +9269,7 @@
 		B56DB3F12049C0B800D4AA8E /* Classes */ = {
 			isa = PBXGroup;
 			children = (
+				2063E4DB2BF36EBF00AAE96B /* CardPresentPayments */,
 				20AE33C32B0510AD00527B60 /* Destinations */,
 				02D7E7BF2A4CA8E50003049A /* LocalAnnouncements */,
 				B9F3DAAB29BB714900DDD545 /* App Intents */,
@@ -13708,6 +13719,7 @@
 				DEA0D0682BA82EA2007786F2 /* StatsGranularityV4+UI.swift in Sources */,
 				DE69C54D27BB719A000BB888 /* CouponRestrictions.swift in Sources */,
 				E1D4E84426776A6B00256B83 /* HeadlineTableViewCell.swift in Sources */,
+				2063E4DD2BF36EF000AAE96B /* CardPaymentsAdaptor.swift in Sources */,
 				B555530F21B57DE700449E71 /* ApplicationAdapter.swift in Sources */,
 				025C00682550DE4700FAC222 /* ProductSKUInputScannerViewController.swift in Sources */,
 				20DA6DDB2B681175002AA0FB /* AdaptiveModalContainer.swift in Sources */,


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of: #12734

## Description
This is another (incomplete) take on #12735, but using a stream for outputting the events.

There are issues with this approach, particularly because the stream's lifecycle should probably match the lifecycle of the `collectPayment` call, and everything that does. However, I struggled to make the connection controllers long-lived under those circumstances.

It's probably still possible, so I thought I'd share this as another similar solution for thoughts...  but #12735 is more promising right now, I think.

CC. @iamgabrielma @bozidarsevo @jaclync 
