### PR TITLE
[Woo POS] UI: Reader connection presentation flow with simulated happy path

### DIFF
--- a/WooCommercePOS/WooCommercePOS.xcodeproj/project.pbxproj
+++ b/WooCommercePOS/WooCommercePOS.xcodeproj/project.pbxproj
@@ -7,6 +7,14 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		02EF7BEB2BF45D4F00A8A597 /* CardReaderConnectionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02EF7BEA2BF45D4F00A8A597 /* CardReaderConnectionView.swift */; };
+		02EF7BEE2BF45D7A00A8A597 /* ScanningForReaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02EF7BED2BF45D7A00A8A597 /* ScanningForReaderView.swift */; };
+		02EF7BF02BF45DC000A8A597 /* ConnectingToReaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02EF7BEF2BF45DC000A8A597 /* ConnectingToReaderView.swift */; };
+		02EF7BF22BF45DE600A8A597 /* ConnectingFailedView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02EF7BF12BF45DE600A8A597 /* ConnectingFailedView.swift */; };
+		02EF7BF82BF460C900A8A597 /* FoundReadersView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02EF7BF72BF460C900A8A597 /* FoundReadersView.swift */; };
+		02EF7BFA2BF460F400A8A597 /* ReaderUpdateFailedView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02EF7BF92BF460F400A8A597 /* ReaderUpdateFailedView.swift */; };
+		02EF7BFC2BF4610600A8A597 /* ScanningForReaderFailedView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02EF7BFB2BF4610600A8A597 /* ScanningForReaderFailedView.swift */; };
+		02EF7BFE2BF464CF00A8A597 /* ReaderUpdateInProgressView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02EF7BFD2BF464CF00A8A597 /* ReaderUpdateInProgressView.swift */; };
 		200B84952BEB984700EAAB23 /* WooCommercePOS.docc in Sources */ = {isa = PBXBuildFile; fileRef = 200B84942BEB984700EAAB23 /* WooCommercePOS.docc */; };
 		200B849B2BEB984700EAAB23 /* WooCommercePOS.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 200B84902BEB984700EAAB23 /* WooCommercePOS.framework */; };
 		200B84A02BEB984700EAAB23 /* WooCommercePOSTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 200B849F2BEB984700EAAB23 /* WooCommercePOSTests.swift */; };
@@ -36,6 +44,14 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		02EF7BEA2BF45D4F00A8A597 /* CardReaderConnectionView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardReaderConnectionView.swift; sourceTree = "<group>"; };
+		02EF7BED2BF45D7A00A8A597 /* ScanningForReaderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScanningForReaderView.swift; sourceTree = "<group>"; };
+		02EF7BEF2BF45DC000A8A597 /* ConnectingToReaderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConnectingToReaderView.swift; sourceTree = "<group>"; };
+		02EF7BF12BF45DE600A8A597 /* ConnectingFailedView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConnectingFailedView.swift; sourceTree = "<group>"; };
+		02EF7BF72BF460C900A8A597 /* FoundReadersView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FoundReadersView.swift; sourceTree = "<group>"; };
+		02EF7BF92BF460F400A8A597 /* ReaderUpdateFailedView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReaderUpdateFailedView.swift; sourceTree = "<group>"; };
+		02EF7BFB2BF4610600A8A597 /* ScanningForReaderFailedView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScanningForReaderFailedView.swift; sourceTree = "<group>"; };
+		02EF7BFD2BF464CF00A8A597 /* ReaderUpdateInProgressView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReaderUpdateInProgressView.swift; sourceTree = "<group>"; };
 		200B84902BEB984700EAAB23 /* WooCommercePOS.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = WooCommercePOS.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		200B84932BEB984700EAAB23 /* WooCommercePOS.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = WooCommercePOS.h; sourceTree = "<group>"; };
 		200B84942BEB984700EAAB23 /* WooCommercePOS.docc */ = {isa = PBXFileReference; lastKnownFileType = folder.documentationcatalog; path = WooCommercePOS.docc; sourceTree = "<group>"; };
@@ -83,6 +99,29 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		02EF7BE92BF45D2500A8A597 /* CardReaderConnection */ = {
+			isa = PBXGroup;
+			children = (
+				02EF7BEC2BF45D5400A8A597 /* UI States */,
+				02EF7BEA2BF45D4F00A8A597 /* CardReaderConnectionView.swift */,
+			);
+			path = CardReaderConnection;
+			sourceTree = "<group>";
+		};
+		02EF7BEC2BF45D5400A8A597 /* UI States */ = {
+			isa = PBXGroup;
+			children = (
+				02EF7BED2BF45D7A00A8A597 /* ScanningForReaderView.swift */,
+				02EF7BFB2BF4610600A8A597 /* ScanningForReaderFailedView.swift */,
+				02EF7BEF2BF45DC000A8A597 /* ConnectingToReaderView.swift */,
+				02EF7BF12BF45DE600A8A597 /* ConnectingFailedView.swift */,
+				02EF7BF72BF460C900A8A597 /* FoundReadersView.swift */,
+				02EF7BFD2BF464CF00A8A597 /* ReaderUpdateInProgressView.swift */,
+				02EF7BF92BF460F400A8A597 /* ReaderUpdateFailedView.swift */,
+			);
+			path = "UI States";
+			sourceTree = "<group>";
+		};
 		200B84862BEB984700EAAB23 = {
 			isa = PBXGroup;
 			children = (
@@ -127,6 +166,7 @@
 		200B84AC2BEB98EB00EAAB23 /* Presentation */ = {
 			isa = PBXGroup;
 			children = (
+				02EF7BE92BF45D2500A8A597 /* CardReaderConnection */,
 				200B84AA2BEB98EB00EAAB23 /* PointOfSaleEntryPointView.swift */,
 				200B84AB2BEB98EB00EAAB23 /* PointOfSaleDashboardView.swift */,
 				686F19F62BEF864300318150 /* ProductGridView.swift */,
@@ -362,13 +402,21 @@
 			buildActionMask = 2147483647;
 			files = (
 				686F19FB2BEF871100318150 /* PointOfSaleDashboardViewModel.swift in Sources */,
+				02EF7BFC2BF4610600A8A597 /* ScanningForReaderFailedView.swift in Sources */,
 				200B84B12BEB9A0100EAAB23 /* PointOfSaleDashboardView.swift in Sources */,
+				02EF7BFA2BF460F400A8A597 /* ReaderUpdateFailedView.swift in Sources */,
 				683AAABB2BEDD544001D91BE /* Product.swift in Sources */,
 				686F19F72BEF864300318150 /* ProductGridView.swift in Sources */,
+				02EF7BEE2BF45D7A00A8A597 /* ScanningForReaderView.swift in Sources */,
 				683A39942BF0DACE008A485E /* ProductRowView.swift in Sources */,
+				02EF7BF82BF460C900A8A597 /* FoundReadersView.swift in Sources */,
 				686F19F92BEF869C00318150 /* CartView.swift in Sources */,
+				02EF7BEB2BF45D4F00A8A597 /* CardReaderConnectionView.swift in Sources */,
 				200B84952BEB984700EAAB23 /* WooCommercePOS.docc in Sources */,
+				02EF7BF22BF45DE600A8A597 /* ConnectingFailedView.swift in Sources */,
+				02EF7BFE2BF464CF00A8A597 /* ReaderUpdateInProgressView.swift in Sources */,
 				DAD3013F2BF2102D001AED4F /* Color+WooCommercePOS.swift in Sources */,
+				02EF7BF02BF45DC000A8A597 /* ConnectingToReaderView.swift in Sources */,
 				200B84B02BEB99FE00EAAB23 /* PointOfSaleEntryPointView.swift in Sources */,
 				686F19FD2BEF877000318150 /* ProductFactory.swift in Sources */,
 			);

--- a/WooCommercePOS/WooCommercePOS.xcodeproj/project.pbxproj
+++ b/WooCommercePOS/WooCommercePOS.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		02CA04B22BF4930800A791D1 /* CardReaderConnectionViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02CA04B12BF4930800A791D1 /* CardReaderConnectionViewModel.swift */; };
 		02EF7BEB2BF45D4F00A8A597 /* CardReaderConnectionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02EF7BEA2BF45D4F00A8A597 /* CardReaderConnectionView.swift */; };
 		02EF7BEE2BF45D7A00A8A597 /* ScanningForReaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02EF7BED2BF45D7A00A8A597 /* ScanningForReaderView.swift */; };
 		02EF7BF02BF45DC000A8A597 /* ConnectingToReaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02EF7BEF2BF45DC000A8A597 /* ConnectingToReaderView.swift */; };
@@ -44,6 +45,7 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		02CA04B12BF4930800A791D1 /* CardReaderConnectionViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardReaderConnectionViewModel.swift; sourceTree = "<group>"; };
 		02EF7BEA2BF45D4F00A8A597 /* CardReaderConnectionView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardReaderConnectionView.swift; sourceTree = "<group>"; };
 		02EF7BED2BF45D7A00A8A597 /* ScanningForReaderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScanningForReaderView.swift; sourceTree = "<group>"; };
 		02EF7BEF2BF45DC000A8A597 /* ConnectingToReaderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConnectingToReaderView.swift; sourceTree = "<group>"; };
@@ -104,6 +106,7 @@
 			children = (
 				02EF7BEC2BF45D5400A8A597 /* UI States */,
 				02EF7BEA2BF45D4F00A8A597 /* CardReaderConnectionView.swift */,
+				02CA04B12BF4930800A791D1 /* CardReaderConnectionViewModel.swift */,
 			);
 			path = CardReaderConnection;
 			sourceTree = "<group>";
@@ -409,6 +412,7 @@
 				686F19F72BEF864300318150 /* ProductGridView.swift in Sources */,
 				02EF7BEE2BF45D7A00A8A597 /* ScanningForReaderView.swift in Sources */,
 				683A39942BF0DACE008A485E /* ProductRowView.swift in Sources */,
+				02CA04B22BF4930800A791D1 /* CardReaderConnectionViewModel.swift in Sources */,
 				02EF7BF82BF460C900A8A597 /* FoundReadersView.swift in Sources */,
 				686F19F92BEF869C00318150 /* CartView.swift in Sources */,
 				02EF7BEB2BF45D4F00A8A597 /* CardReaderConnectionView.swift in Sources */,

--- a/WooCommercePOS/WooCommercePOS.xcodeproj/project.pbxproj
+++ b/WooCommercePOS/WooCommercePOS.xcodeproj/project.pbxproj
@@ -8,6 +8,8 @@
 
 /* Begin PBXBuildFile section */
 		02CA04B22BF4930800A791D1 /* CardReaderConnectionViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02CA04B12BF4930800A791D1 /* CardReaderConnectionViewModel.swift */; };
+		02CA04B42BF4977000A791D1 /* ReaderNotConnectedView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02CA04B32BF4977000A791D1 /* ReaderNotConnectedView.swift */; };
+		02CA04B62BF4977F00A791D1 /* ReaderConnectedView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02CA04B52BF4977F00A791D1 /* ReaderConnectedView.swift */; };
 		02EF7BEB2BF45D4F00A8A597 /* CardReaderConnectionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02EF7BEA2BF45D4F00A8A597 /* CardReaderConnectionView.swift */; };
 		02EF7BEE2BF45D7A00A8A597 /* ScanningForReaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02EF7BED2BF45D7A00A8A597 /* ScanningForReaderView.swift */; };
 		02EF7BF02BF45DC000A8A597 /* ConnectingToReaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02EF7BEF2BF45DC000A8A597 /* ConnectingToReaderView.swift */; };
@@ -46,6 +48,8 @@
 
 /* Begin PBXFileReference section */
 		02CA04B12BF4930800A791D1 /* CardReaderConnectionViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardReaderConnectionViewModel.swift; sourceTree = "<group>"; };
+		02CA04B32BF4977000A791D1 /* ReaderNotConnectedView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReaderNotConnectedView.swift; sourceTree = "<group>"; };
+		02CA04B52BF4977F00A791D1 /* ReaderConnectedView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReaderConnectedView.swift; sourceTree = "<group>"; };
 		02EF7BEA2BF45D4F00A8A597 /* CardReaderConnectionView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardReaderConnectionView.swift; sourceTree = "<group>"; };
 		02EF7BED2BF45D7A00A8A597 /* ScanningForReaderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScanningForReaderView.swift; sourceTree = "<group>"; };
 		02EF7BEF2BF45DC000A8A597 /* ConnectingToReaderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConnectingToReaderView.swift; sourceTree = "<group>"; };
@@ -114,6 +118,7 @@
 		02EF7BEC2BF45D5400A8A597 /* UI States */ = {
 			isa = PBXGroup;
 			children = (
+				02CA04B32BF4977000A791D1 /* ReaderNotConnectedView.swift */,
 				02EF7BED2BF45D7A00A8A597 /* ScanningForReaderView.swift */,
 				02EF7BFB2BF4610600A8A597 /* ScanningForReaderFailedView.swift */,
 				02EF7BEF2BF45DC000A8A597 /* ConnectingToReaderView.swift */,
@@ -121,6 +126,7 @@
 				02EF7BF72BF460C900A8A597 /* FoundReadersView.swift */,
 				02EF7BFD2BF464CF00A8A597 /* ReaderUpdateInProgressView.swift */,
 				02EF7BF92BF460F400A8A597 /* ReaderUpdateFailedView.swift */,
+				02CA04B52BF4977F00A791D1 /* ReaderConnectedView.swift */,
 			);
 			path = "UI States";
 			sourceTree = "<group>";
@@ -405,6 +411,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				686F19FB2BEF871100318150 /* PointOfSaleDashboardViewModel.swift in Sources */,
+				02CA04B42BF4977000A791D1 /* ReaderNotConnectedView.swift in Sources */,
 				02EF7BFC2BF4610600A8A597 /* ScanningForReaderFailedView.swift in Sources */,
 				200B84B12BEB9A0100EAAB23 /* PointOfSaleDashboardView.swift in Sources */,
 				02EF7BFA2BF460F400A8A597 /* ReaderUpdateFailedView.swift in Sources */,
@@ -416,6 +423,7 @@
 				02EF7BF82BF460C900A8A597 /* FoundReadersView.swift in Sources */,
 				686F19F92BEF869C00318150 /* CartView.swift in Sources */,
 				02EF7BEB2BF45D4F00A8A597 /* CardReaderConnectionView.swift in Sources */,
+				02CA04B62BF4977F00A791D1 /* ReaderConnectedView.swift in Sources */,
 				200B84952BEB984700EAAB23 /* WooCommercePOS.docc in Sources */,
 				02EF7BF22BF45DE600A8A597 /* ConnectingFailedView.swift in Sources */,
 				02EF7BFE2BF464CF00A8A597 /* ReaderUpdateInProgressView.swift in Sources */,

--- a/WooCommercePOS/WooCommercePOS/Presentation/CardReaderConnection/CardReaderConnectionView.swift
+++ b/WooCommercePOS/WooCommercePOS/Presentation/CardReaderConnection/CardReaderConnectionView.swift
@@ -20,6 +20,7 @@ enum CardReaderConnectionUIState {
 
     case scanningForReader(cancel: () -> Void)
     case scanningFailed(error: Error, close: () -> Void)
+    // TODO: update `CardReaderConnectionController` to add reader ID to match design
     case connectingToReader
     case connectingFailed(error: CardReaderConnectionError,
                           retrySearch: () -> Void,

--- a/WooCommercePOS/WooCommercePOS/Presentation/CardReaderConnection/CardReaderConnectionView.swift
+++ b/WooCommercePOS/WooCommercePOS/Presentation/CardReaderConnection/CardReaderConnectionView.swift
@@ -29,14 +29,6 @@ enum CardReaderConnectionUIState {
     case updatingFailed(error: CardReaderUpdateError, tryAgain: (() -> Void)?, close: () -> Void)
 }
 
-final class CardReaderConnectionViewModel: ObservableObject {
-    @Published private(set) var state: CardReaderConnectionUIState
-
-    init(state: CardReaderConnectionUIState) {
-        self.state = state
-    }
-}
-
 struct CardReaderConnectionView: View {
     @StateObject var viewModel: CardReaderConnectionViewModel
 

--- a/WooCommercePOS/WooCommercePOS/Presentation/CardReaderConnection/CardReaderConnectionView.swift
+++ b/WooCommercePOS/WooCommercePOS/Presentation/CardReaderConnection/CardReaderConnectionView.swift
@@ -1,0 +1,118 @@
+import SwiftUI
+
+enum CardReaderConnectionError: Error {
+    case error(Error)
+    case incompleteAddress
+    case invalidPostalCode
+    case criticallyLowBattery
+}
+
+enum CardReaderUpdateError: Error {
+    case unknown
+    case lowBattery
+}
+
+enum CardReaderConnectionUIState {
+    case scanningForReader(cancel: () -> Void)
+    case scanningFailed(error: Error, close: () -> Void)
+    case connectingToReader
+    case connectingFailed(error: CardReaderConnectionError,
+                          retrySearch: () -> Void,
+                          cancelSearch: () -> Void)
+    case readersFound(readerIDs: [String],
+                      connect: (String) -> Void,
+                      continueSearch: () -> Void,
+                      cancelSearch: () -> Void)
+    case updateInProgress(requiredUpdate: Bool,
+                          progress: Float,
+                          cancel: (() -> Void)?)
+    case updatingFailed(error: CardReaderUpdateError, tryAgain: (() -> Void)?, close: () -> Void)
+}
+
+final class CardReaderConnectionViewModel: ObservableObject {
+    @Published private(set) var state: CardReaderConnectionUIState
+
+    init(state: CardReaderConnectionUIState) {
+        self.state = state
+    }
+}
+
+struct CardReaderConnectionView: View {
+    @StateObject var viewModel: CardReaderConnectionViewModel
+
+    init(viewModel: CardReaderConnectionViewModel) {
+        self._viewModel = .init(wrappedValue: viewModel)
+    }
+
+    var body: some View {
+        switch viewModel.state {
+            case .scanningForReader(let cancel):
+                ScanningForReaderView()
+            case .scanningFailed(let error, let close):
+                ScanningForReaderFailedView()
+            case .connectingToReader:
+                ConnectingToReaderView()
+            case .connectingFailed(let error, let retrySearch, let cancelSearch):
+                ConnectingFailedView()
+            case .readersFound(let readerIDs, let connect, let continueSearch, let cancelSearch):
+                FoundReadersView(readerIDs: readerIDs)
+            case .updateInProgress(let requiredUpdate, let progress, let cancel):
+                ReaderUpdateInProgressView()
+            case .updatingFailed(let error, let tryAgain, let close):
+                ReaderUpdateFailedView()
+        }
+    }
+}
+
+#if DEBUG
+
+extension CardReaderConnectionUIState: CaseIterable, Hashable {
+    static var allCases: [CardReaderConnectionUIState] {
+        [
+            .scanningForReader(cancel: {}),
+            .scanningFailed(error: NSError(domain: "", code: 0), close: {})
+        ]
+    }
+
+    static func == (lhs: CardReaderConnectionUIState, rhs: CardReaderConnectionUIState) -> Bool {
+        lhs.hashValue == rhs.hashValue
+    }
+
+    func hash(into hasher: inout Hasher) {
+        switch self {
+            case .scanningForReader:
+                hasher.combine("scanningForReader")
+            case .scanningFailed:
+                hasher.combine("scanningFailed")
+            case .connectingToReader:
+                hasher.combine("connectingToReader")
+            case .connectingFailed:
+                hasher.combine("connectingFailed")
+            case .readersFound:
+                hasher.combine("readersFound")
+            case .updateInProgress:
+                hasher.combine("updateInProgress")
+            case .updatingFailed:
+                hasher.combine("updatingFailed")
+        }
+    }
+}
+
+#Preview {
+    @State var selectedState: CardReaderConnectionUIState = .connectingToReader
+
+    return
+        VStack {
+            Picker(selection: $selectedState, label: EmptyView()) {
+                ForEach(CardReaderConnectionUIState.allCases, id: \.self) { state in
+                    Text(String(describing: state))
+                }
+            }
+            .pickerStyle(.segmented)
+        }
+        .sheet(isPresented: .constant(true)) {
+            CardReaderConnectionView(viewModel: .init(state: selectedState))
+        }
+}
+
+#endif

--- a/WooCommercePOS/WooCommercePOS/Presentation/CardReaderConnection/CardReaderConnectionView.swift
+++ b/WooCommercePOS/WooCommercePOS/Presentation/CardReaderConnection/CardReaderConnectionView.swift
@@ -50,17 +50,17 @@ struct CardReaderConnectionView: View {
                     ReaderConnectedView(readerID: readerID, disconnect: disconnect)
                 case .scanningForReader(let cancel):
                     ScanningForReaderView(cancel: cancel)
-                case .scanningFailed(_, _):
+                case .scanningFailed:
                     ScanningForReaderFailedView()
                 case .connectingToReader:
                     ConnectingToReaderView()
-                case .connectingFailed(_, _, _):
+                case .connectingFailed:
                     ConnectingFailedView()
                 case .readersFound(let readerIDs, let connect, let continueSearch):
                     FoundReadersView(readerIDs: readerIDs, connect: connect, continueSearch: continueSearch)
-                case .updateInProgress(_, _, _):
+                case .updateInProgress:
                     ReaderUpdateInProgressView()
-                case .updatingFailed(_, _, _):
+                case .updatingFailed:
                     ReaderUpdateFailedView()
             }
         }

--- a/WooCommercePOS/WooCommercePOS/Presentation/CardReaderConnection/CardReaderConnectionViewModel.swift
+++ b/WooCommercePOS/WooCommercePOS/Presentation/CardReaderConnection/CardReaderConnectionViewModel.swift
@@ -26,7 +26,7 @@ final class CardReaderConnectionViewModel: ObservableObject {
                 Task { @MainActor in
                     try await Task.sleep(nanoseconds: UInt64(2 * 1_000_000_000))
                     self?.state = .connected(readerID: readerID, disconnect: {
-                        // TODO: implement reader disconnection action
+                        // TODO: implement reader disconnection action in `CardReaderConnectionController` to match design
                         self?.state = .notConnected(search: {
                             self?.checkReaderConnection()
                         })

--- a/WooCommercePOS/WooCommercePOS/Presentation/CardReaderConnection/CardReaderConnectionViewModel.swift
+++ b/WooCommercePOS/WooCommercePOS/Presentation/CardReaderConnection/CardReaderConnectionViewModel.swift
@@ -6,4 +6,39 @@ final class CardReaderConnectionViewModel: ObservableObject {
     init(state: CardReaderConnectionUIState) {
         self.state = state
     }
+
+    /// TODO: replace this with card reader connection implementation.
+    /// Simulates a successful
+    func checkReaderConnection() {
+        Task { @MainActor in
+            state = .scanningForReader(cancel: { [weak self] in
+                self?.state = .notConnected(search: { [weak self] in
+                    self?.checkReaderConnection()
+                })
+            })
+
+            try await Task.sleep(nanoseconds: UInt64(2 * 1_000_000_000))
+
+            state = .readersFound(readerIDs: ["Mock reader 1"],
+                                  connect: { [weak self] readerID in
+                self?.state = .connectingToReader
+
+                Task { @MainActor in
+                    try await Task.sleep(nanoseconds: UInt64(2 * 1_000_000_000))
+                    self?.state = .connected(readerID: readerID, disconnect: {
+                        // TODO: implement reader disconnection action
+                        self?.state = .notConnected(search: {
+                            self?.checkReaderConnection()
+                        })
+                    })
+                }
+            }, continueSearch: { [weak self] in
+                self?.state = .scanningForReader(cancel: { [weak self] in
+                    self?.state = .notConnected(search: {
+                        self?.checkReaderConnection()
+                    })
+                })
+            })
+        }
+    }
 }

--- a/WooCommercePOS/WooCommercePOS/Presentation/CardReaderConnection/CardReaderConnectionViewModel.swift
+++ b/WooCommercePOS/WooCommercePOS/Presentation/CardReaderConnection/CardReaderConnectionViewModel.swift
@@ -7,8 +7,8 @@ final class CardReaderConnectionViewModel: ObservableObject {
         self.state = state
     }
 
-    /// TODO: replace this with card reader connection implementation.
-    /// Simulates a successful
+    /// TODO: replace this with card reader connection implementation `CardReaderConnectionController`
+    /// Simulates a successful card reader connection flow.
     func checkReaderConnection() {
         Task { @MainActor in
             state = .scanningForReader(cancel: { [weak self] in

--- a/WooCommercePOS/WooCommercePOS/Presentation/CardReaderConnection/CardReaderConnectionViewModel.swift
+++ b/WooCommercePOS/WooCommercePOS/Presentation/CardReaderConnection/CardReaderConnectionViewModel.swift
@@ -1,0 +1,9 @@
+import SwiftUI
+
+final class CardReaderConnectionViewModel: ObservableObject {
+    @Published private(set) var state: CardReaderConnectionUIState
+
+    init(state: CardReaderConnectionUIState) {
+        self.state = state
+    }
+}

--- a/WooCommercePOS/WooCommercePOS/Presentation/CardReaderConnection/UI States/ConnectingFailedView.swift
+++ b/WooCommercePOS/WooCommercePOS/Presentation/CardReaderConnection/UI States/ConnectingFailedView.swift
@@ -1,0 +1,11 @@
+import SwiftUI
+
+struct ConnectingFailedView: View {
+    var body: some View {
+        Text("Connection to reader failed")
+    }
+}
+
+#Preview {
+    ConnectingFailedView()
+}

--- a/WooCommercePOS/WooCommercePOS/Presentation/CardReaderConnection/UI States/ConnectingToReaderView.swift
+++ b/WooCommercePOS/WooCommercePOS/Presentation/CardReaderConnection/UI States/ConnectingToReaderView.swift
@@ -1,0 +1,11 @@
+import SwiftUI
+
+struct ConnectingToReaderView: View {
+    var body: some View {
+        Text("Connecting to reader...")
+    }
+}
+
+#Preview {
+    ConnectingToReaderView()
+}

--- a/WooCommercePOS/WooCommercePOS/Presentation/CardReaderConnection/UI States/FoundReadersView.swift
+++ b/WooCommercePOS/WooCommercePOS/Presentation/CardReaderConnection/UI States/FoundReadersView.swift
@@ -1,0 +1,22 @@
+import SwiftUI
+
+struct FoundReadersView: View {
+    let readerIDs: [String]
+
+    var body: some View {
+        List {
+            ForEach(readerIDs, id: \.self) { readerID in
+                HStack {
+                    Text(readerID)
+                    Button("Connect") {
+                        // TODO: connect action
+                    }
+                }
+            }
+        }
+    }
+}
+
+#Preview {
+    FoundReadersView(readerIDs: ["Test reader 1", "Test reader 2"])
+}

--- a/WooCommercePOS/WooCommercePOS/Presentation/CardReaderConnection/UI States/FoundReadersView.swift
+++ b/WooCommercePOS/WooCommercePOS/Presentation/CardReaderConnection/UI States/FoundReadersView.swift
@@ -2,21 +2,29 @@ import SwiftUI
 
 struct FoundReadersView: View {
     let readerIDs: [String]
+    let connect: (String) -> Void
+    let continueSearch: () -> Void
 
     var body: some View {
+        Text("Found readers")
         List {
             ForEach(readerIDs, id: \.self) { readerID in
                 HStack {
                     Text(readerID)
                     Button("Connect") {
-                        // TODO: connect action
+                        connect(readerID)
                     }
                 }
+            }
+            Button("Keep Scanning") {
+                continueSearch()
             }
         }
     }
 }
 
 #Preview {
-    FoundReadersView(readerIDs: ["Test reader 1", "Test reader 2"])
+    FoundReadersView(readerIDs: ["Test reader 1", "Test reader 2"],
+                     connect: { _ in },
+                     continueSearch: {})
 }

--- a/WooCommercePOS/WooCommercePOS/Presentation/CardReaderConnection/UI States/ReaderConnectedView.swift
+++ b/WooCommercePOS/WooCommercePOS/Presentation/CardReaderConnection/UI States/ReaderConnectedView.swift
@@ -1,0 +1,19 @@
+import SwiftUI
+
+struct ReaderConnectedView: View {
+    let readerID: String
+    let disconnect: () -> Void
+
+    var body: some View {
+        Text("Connected")
+        Text(readerID)
+            .bold()
+        Button("Disconnect") {
+            disconnect()
+        }
+    }
+}
+
+#Preview {
+    ReaderConnectedView(readerID: "Test reader", disconnect: {})
+}

--- a/WooCommercePOS/WooCommercePOS/Presentation/CardReaderConnection/UI States/ReaderNotConnectedView.swift
+++ b/WooCommercePOS/WooCommercePOS/Presentation/CardReaderConnection/UI States/ReaderNotConnectedView.swift
@@ -1,0 +1,16 @@
+import SwiftUI
+
+struct ReaderNotConnectedView: View {
+    let searchForReaders: () -> Void
+
+    var body: some View {
+        Text("Not connected to a reader")
+        Button("Search for readers") {
+            searchForReaders()
+        }
+    }
+}
+
+#Preview {
+    ReaderNotConnectedView(searchForReaders: {})
+}

--- a/WooCommercePOS/WooCommercePOS/Presentation/CardReaderConnection/UI States/ReaderUpdateFailedView.swift
+++ b/WooCommercePOS/WooCommercePOS/Presentation/CardReaderConnection/UI States/ReaderUpdateFailedView.swift
@@ -1,0 +1,11 @@
+import SwiftUI
+
+struct ReaderUpdateFailedView: View {
+    var body: some View {
+        Text("Reader update failed")
+    }
+}
+
+#Preview {
+    ReaderUpdateFailedView()
+}

--- a/WooCommercePOS/WooCommercePOS/Presentation/CardReaderConnection/UI States/ReaderUpdateInProgressView.swift
+++ b/WooCommercePOS/WooCommercePOS/Presentation/CardReaderConnection/UI States/ReaderUpdateInProgressView.swift
@@ -1,0 +1,11 @@
+import SwiftUI
+
+struct ReaderUpdateInProgressView: View {
+    var body: some View {
+        Text("Updating reader...")
+    }
+}
+
+#Preview {
+    ReaderUpdateInProgressView()
+}

--- a/WooCommercePOS/WooCommercePOS/Presentation/CardReaderConnection/UI States/ScanningForReaderFailedView.swift
+++ b/WooCommercePOS/WooCommercePOS/Presentation/CardReaderConnection/UI States/ScanningForReaderFailedView.swift
@@ -1,0 +1,11 @@
+import SwiftUI
+
+struct ScanningForReaderFailedView: View {
+    var body: some View {
+        Text("Reader scanning failed")
+    }
+}
+
+#Preview {
+    ScanningForReaderFailedView()
+}

--- a/WooCommercePOS/WooCommercePOS/Presentation/CardReaderConnection/UI States/ScanningForReaderView.swift
+++ b/WooCommercePOS/WooCommercePOS/Presentation/CardReaderConnection/UI States/ScanningForReaderView.swift
@@ -1,11 +1,16 @@
 import SwiftUI
 
 struct ScanningForReaderView: View {
+    let cancel: () -> Void
+
     var body: some View {
         Text("Scanning for reader...")
+        Button("Cancel search") {
+            cancel()
+        }
     }
 }
 
 #Preview {
-    ScanningForReaderView()
+    ScanningForReaderView(cancel: {})
 }

--- a/WooCommercePOS/WooCommercePOS/Presentation/CardReaderConnection/UI States/ScanningForReaderView.swift
+++ b/WooCommercePOS/WooCommercePOS/Presentation/CardReaderConnection/UI States/ScanningForReaderView.swift
@@ -4,8 +4,8 @@ struct ScanningForReaderView: View {
     let cancel: () -> Void
 
     var body: some View {
-        Text("Scanning for reader...")
-        Button("Cancel search") {
+        Text("Searching for reader")
+        Button("Cancel") {
             cancel()
         }
     }

--- a/WooCommercePOS/WooCommercePOS/Presentation/CardReaderConnection/UI States/ScanningForReaderView.swift
+++ b/WooCommercePOS/WooCommercePOS/Presentation/CardReaderConnection/UI States/ScanningForReaderView.swift
@@ -1,0 +1,11 @@
+import SwiftUI
+
+struct ScanningForReaderView: View {
+    var body: some View {
+        Text("Scanning for reader...")
+    }
+}
+
+#Preview {
+    ScanningForReaderView()
+}

--- a/WooCommercePOS/WooCommercePOS/Presentation/CartView.swift
+++ b/WooCommercePOS/WooCommercePOS/Presentation/CartView.swift
@@ -22,5 +22,6 @@ struct CartView: View {
 }
 
 #Preview {
-    CartView(viewModel: PointOfSaleDashboardViewModel(products: ProductFactory.makeFakeProducts()))
+    CartView(viewModel: PointOfSaleDashboardViewModel(products: ProductFactory.makeFakeProducts(),
+                                                      cardReaderConnectionViewModel: .init(state: .connectingToReader)))
 }

--- a/WooCommercePOS/WooCommercePOS/Presentation/PointOfSaleDashboardView.swift
+++ b/WooCommercePOS/WooCommercePOS/Presentation/PointOfSaleDashboardView.swift
@@ -31,7 +31,7 @@ struct PointOfSaleDashboardView: View {
             })
             ToolbarItem(placement: .principal, content: {
                 Button("Reader not connected") {
-                    debugPrint("Not implemented")
+                    viewModel.showCardReaderConnection()
                 }
             })
             ToolbarItem(placement: .primaryAction, content: {
@@ -40,9 +40,13 @@ struct PointOfSaleDashboardView: View {
                 }
             })
         }
+        .sheet(isPresented: $viewModel.showsCardReaderSheet, content: {
+            CardReaderConnectionView(viewModel: viewModel.cardReaderConnectionViewModel)
+        })
     }
 }
 
 #Preview {
-    PointOfSaleDashboardView(viewModel: PointOfSaleDashboardViewModel(products: ProductFactory.makeFakeProducts()))
+    PointOfSaleDashboardView(viewModel: PointOfSaleDashboardViewModel(products: ProductFactory.makeFakeProducts(),
+                                                                      cardReaderConnectionViewModel: .init(state: .connectingToReader)))
 }

--- a/WooCommercePOS/WooCommercePOS/Presentation/PointOfSaleEntryPointView.swift
+++ b/WooCommercePOS/WooCommercePOS/Presentation/PointOfSaleEntryPointView.swift
@@ -5,7 +5,7 @@ public struct PointOfSaleEntryPointView: View {
     // Temporary. DI proper product models once we have a data layer
     private let viewModel: PointOfSaleDashboardViewModel = {
         let products = ProductFactory.makeFakeProducts()
-        let viewModel = PointOfSaleDashboardViewModel(products: products)
+        let viewModel = PointOfSaleDashboardViewModel(products: products, cardReaderConnectionViewModel: .init(state: .scanningForReader(cancel: {})))
 
         return viewModel
     }()

--- a/WooCommercePOS/WooCommercePOS/Presentation/ProductGridView.swift
+++ b/WooCommercePOS/WooCommercePOS/Presentation/ProductGridView.swift
@@ -35,5 +35,6 @@ struct ProductGridView: View {
 }
 
 #Preview {
-    ProductGridView(viewModel: PointOfSaleDashboardViewModel(products: ProductFactory.makeFakeProducts()))
+    ProductGridView(viewModel: PointOfSaleDashboardViewModel(products: ProductFactory.makeFakeProducts(),
+                                                             cardReaderConnectionViewModel: .init(state: .connectingToReader)))
 }

--- a/WooCommercePOS/WooCommercePOS/ViewModels/PointOfSaleDashboardViewModel.swift
+++ b/WooCommercePOS/WooCommercePOS/ViewModels/PointOfSaleDashboardViewModel.swift
@@ -4,8 +4,13 @@ final class PointOfSaleDashboardViewModel: ObservableObject {
     @Published var products: [Product]
     @Published var productsInOrder: [Product] = []
 
-    init(products: [Product]) {
+    @Published var showsCardReaderSheet: Bool = false
+    @ObservedObject private(set) var cardReaderConnectionViewModel: CardReaderConnectionViewModel
+
+    init(products: [Product],
+         cardReaderConnectionViewModel: CardReaderConnectionViewModel) {
         self.products = products
+        self.cardReaderConnectionViewModel = cardReaderConnectionViewModel
     }
 
     func addProductToCart(_ product: Product) {
@@ -14,5 +19,9 @@ final class PointOfSaleDashboardViewModel: ObservableObject {
 
     func submitCart() {
         debugPrint("Not implemented")
+    }
+
+    func showCardReaderConnection() {
+        showsCardReaderSheet = true
     }
 }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Simulated flow for #12711 
<!-- Id number of the GitHub issue this PR addresses. -->

## Why

Before having a concrete design, we can start working on the card reader connection flow with a mocked state machine. In a WIP PR https://github.com/woocommerce/woocommerce-ios/pull/12723, I worked on extracting the UI logic from `CardReaderConnectionController` so that we can reuse the state machine logic while the UI/UX differs from the existing app. From that WIP work, we know [a list of UI states](https://github.com/woocommerce/woocommerce-ios/pull/12723/files#diff-c23b4d7a4b0cb4f9f0c6cd32f5e5879f1efefe03201a97b185e76d184941e187R29-R30) and we can build the reader connection flow based on that list.

## How

All of the changes in this PR are in the POS framework (noted as `pos`).

After reviewing the code for the UI states in `CardReaderConnectionController`, I concluded them into the following smaller list combining a few similar states and defined a new UI state `CardReaderConnectionUIState` in `pos`:


- General connected/disconneceted states:
  - notConnected(search: () -> Void)
  - connected(readerID: String, disconnect: () -> Void)
- States from card reader connection based on `CardReaderConnectionController`
  - scanningForReader(cancel: () -> Void)
  - scanningFailed(error: Error, close: () -> Void)
  - connectingToReader
  - connectingFailed(error: CardReaderConnectionError, retrySearch: () -> Void, cancelSearch: () -> Void)
  - readersFound(readerIDs: [String], connect: (String) -> Void, continueSearch: () -> Void)
  - updateInProgress(requiredUpdate: Bool, progress: Float, cancel: (() -> Void)?)
  - updatingFailed(error: CardReaderUpdateError, tryAgain: (() -> Void)?, close: () -> Void)

Then, each UI state corresponds to a new SwiftUI view that follows the latest design when available.

To integrate with the POS dashboard, `CardReaderConnectionView` and its view model were created and shown in a sheet when the user taps on the "Reader not connected" CTA in the navigation bar.

To simulate the happy path for searching & connecting to a reader, `CardReaderConnectionViewModel. checkReaderConnection` is called on view's `onAppear` to mock the UI state transition.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

- Go to the Menu tab
- Ensure the POS feature switch is enabled (if not, go to Settings > Experimental Features, then enable "Point of Sale")
- Tap `Point of Sale` menu item
- Tap `Reader not connected` in the navigation bar --> the searching view should be shown first, then after 2 seconds, a list of 1 reader should be shown
- Tap `Connect` --> the connecting view should be shown first, then after 2 seconds, the connected view is shown

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->


https://github.com/woocommerce/woocommerce-ios/assets/1945542/614bd07a-7c06-4a89-ae08-60f3fb2ea20c



---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
