### PR TITLE
Dynamic Dashboard: Add UI for stock card

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Dashboard/DashboardView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/DashboardView.swift
@@ -193,7 +193,9 @@ private extension DashboardView {
                         }, onViewCouponDetail: { coupon in
                             onViewCouponDetail?(coupon)
                         })
-                    case .lastOrders, .stock:
+                    case .stock:
+                        ProductStockDashboardCard(viewModel: viewModel.productStockCardViewModel)
+                    case .lastOrders:
                         EmptyView()
                     }
 

--- a/WooCommerce/Classes/ViewRelated/Dashboard/DashboardViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/DashboardViewModel.swift
@@ -18,7 +18,6 @@ final class DashboardViewModel: ObservableObject {
     @Published var localAnnouncementViewModel: LocalAnnouncementViewModel? = nil
 
     let storeOnboardingViewModel: StoreOnboardingViewModel
-
     let blazeCampaignDashboardViewModel: BlazeCampaignDashboardViewModel
 
     let storePerformanceViewModel: StorePerformanceViewModel
@@ -26,6 +25,7 @@ final class DashboardViewModel: ObservableObject {
     let inboxViewModel: InboxDashboardCardViewModel
     let reviewsViewModel: ReviewsDashboardCardViewModel
     let mostActiveCouponsViewModel: MostActiveCouponsCardViewModel
+    let productStockCardViewModel: ProductStockDashboardCardViewModel
 
     @Published var justInTimeMessagesWebViewModel: WebViewSheetViewModel? = nil
 
@@ -110,6 +110,8 @@ final class DashboardViewModel: ObservableObject {
         self.inboxViewModel = InboxDashboardCardViewModel(siteID: siteID)
         self.reviewsViewModel = ReviewsDashboardCardViewModel(siteID: siteID)
         self.mostActiveCouponsViewModel = MostActiveCouponsCardViewModel(siteID: siteID)
+        self.productStockCardViewModel = ProductStockDashboardCardViewModel(siteID: siteID)
+
         self.themeInstaller = themeInstaller
         self.inAppFeedbackCardViewModel.onFeedbackGiven = { [weak self] feedback in
             self?.showingInAppFeedbackSurvey = feedback == .didntLike
@@ -162,6 +164,9 @@ final class DashboardViewModel: ObservableObject {
                 }
                 group.addTask { [weak self] in
                     await self?.mostActiveCouponsViewModel.reloadData()
+                }
+                group.addTask { [weak self] in
+                    await self?.productStockCardViewModel.reloadData()
                 }
             }
         }
@@ -296,33 +301,17 @@ private extension DashboardViewModel {
     }
 
     func setupDashboardCards() {
-        storeOnboardingViewModel.onDismiss = { [weak self] in
+        let showCustomizationScreen: (() -> Void) = { [weak self] in
             self?.showCustomizationScreen()
         }
-
-        blazeCampaignDashboardViewModel.onDismiss = { [weak self] in
-            self?.showCustomizationScreen()
-        }
-
-        storePerformanceViewModel.onDismiss = { [weak self] in
-            self?.showCustomizationScreen()
-        }
-
-        topPerformersViewModel.onDismiss = { [weak self] in
-            self?.showCustomizationScreen()
-        }
-
-        inboxViewModel.onDismiss = { [weak self] in
-            self?.showCustomizationScreen()
-        }
-
-        reviewsViewModel.onDismiss = { [weak self] in
-            self?.showCustomizationScreen()
-        }
-
-        mostActiveCouponsViewModel.onDismiss = { [weak self] in
-            self?.showCustomizationScreen()
-        }
+        storeOnboardingViewModel.onDismiss = showCustomizationScreen
+        blazeCampaignDashboardViewModel.onDismiss = showCustomizationScreen
+        storePerformanceViewModel.onDismiss = showCustomizationScreen
+        topPerformersViewModel.onDismiss = showCustomizationScreen
+        inboxViewModel.onDismiss = showCustomizationScreen
+        reviewsViewModel.onDismiss = showCustomizationScreen
+        mostActiveCouponsViewModel.onDismiss = showCustomizationScreen
+        productStockCardViewModel.onDismiss = showCustomizationScreen
     }
 
     func showCustomizationScreen() {
@@ -360,6 +349,7 @@ private extension DashboardViewModel {
             cards.append(DashboardCard(type: .inbox, availability: .show, enabled: false))
             cards.append(DashboardCard(type: .reviews, availability: .show, enabled: false))
             cards.append(DashboardCard(type: .coupons, availability: .show, enabled: false))
+            cards.append(DashboardCard(type: .stock, availability: .show, enabled: false))
         }
 
         return cards

--- a/WooCommerce/Classes/ViewRelated/Dashboard/ProductStock/ProductStockDashboardCard.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/ProductStock/ProductStockDashboardCard.swift
@@ -5,6 +5,7 @@ import struct Yosemite.DashboardCard
 ///
 struct ProductStockDashboardCard: View {
     @ObservedObject private var viewModel: ProductStockDashboardCardViewModel
+    @ScaledMetric private var scale: CGFloat = 1.0
 
     init(viewModel: ProductStockDashboardCardViewModel) {
         self.viewModel = viewModel
@@ -19,6 +20,9 @@ struct ProductStockDashboardCard: View {
                 .padding(.horizontal, Layout.padding)
 
             Divider()
+
+            stockList
+                .padding(.horizontal, Layout.padding)
         }
         .padding(.vertical, Layout.padding)
         .background(Color(.listForeground(modal: false)))
@@ -74,6 +78,46 @@ private extension ProductStockDashboardCard {
 
         }
     }
+
+    var stockList: some View {
+        VStack(spacing: Layout.padding) {
+            HStack {
+                Text(Localization.products)
+                    .subheadlineStyle()
+                    .fontWeight(.semibold)
+                Spacer()
+                Text(Localization.stockLevels)
+                    .subheadlineStyle()
+                    .fontWeight(.semibold)
+            }
+            ForEach(Array([0, 1, 2].enumerated()), id: \.element) { (index, element) in
+                HStack(alignment: .top) {
+                    Image(uiImage: .productPlaceholderImage)
+                        .resizable()
+                        .frame(width: Layout.thumbnailSize * scale,
+                               height: Layout.thumbnailSize * scale)
+                        .clipShape(RoundedRectangle(cornerSize: Layout.thumbnailCornerSize))
+                    VStack {
+                        HStack(alignment: .firstTextBaseline) {
+                            VStack(alignment: .leading) {
+                                Text("Little nap blend 250g")
+                                    .bodyStyle()
+                                Text("10 items sold last 30 days")
+                                    .subheadlineStyle()
+                            }
+                            Spacer()
+                            Text("3")
+                                .foregroundStyle(Color(.error))
+                                .bodyStyle()
+                                .fontWeight(.semibold)
+                        }
+                        Divider()
+                            .renderedIf(index < 2)
+                    }
+                }
+            }
+        }
+    }
 }
 
 private extension ProductStockDashboardCard {
@@ -81,7 +125,8 @@ private extension ProductStockDashboardCard {
         static let padding: CGFloat = 16
         static let cornerSize = CGSize(width: 8.0, height: 8.0)
         static let hideIconVerticalPadding: CGFloat = 8
-        static let emptyStateImageWidth: CGFloat = 168
+        static let thumbnailSize: CGFloat = 40
+        static let thumbnailCornerSize = CGSize(width: 4.0, height: 4.0)
     }
 
     enum Localization {
@@ -93,6 +138,16 @@ private extension ProductStockDashboardCard {
         static let status = NSLocalizedString(
             "productStockDashboardCard.status",
             value: "Status",
+            comment: "Header label on the Stock section on the My Store screen"
+        )
+        static let products = NSLocalizedString(
+            "productStockDashboardCard.products",
+            value: "Products",
+            comment: "Header label on the Stock section on the My Store screen"
+        )
+        static let stockLevels = NSLocalizedString(
+            "productStockDashboardCard.stockLevels",
+            value: "Stock levels",
             comment: "Header label on the Stock section on the My Store screen"
         )
     }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/ProductStock/ProductStockDashboardCard.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/ProductStock/ProductStockDashboardCard.swift
@@ -34,7 +34,7 @@ private extension ProductStockDashboardCard {
             Spacer()
             Menu {
                 Button(Localization.hideCard) {
-                    // TODO
+                    viewModel.dismissStock()
                 }
             } label: {
                 Image(systemName: "ellipsis")

--- a/WooCommerce/Classes/ViewRelated/Dashboard/ProductStock/ProductStockDashboardCard.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/ProductStock/ProductStockDashboardCard.swift
@@ -18,11 +18,15 @@ struct ProductStockDashboardCard: View {
 
             filterBar
                 .padding(.horizontal, Layout.padding)
+                .redacted(reason: viewModel.syncingData ? [.placeholder] : [])
+                .shimmering(active: viewModel.syncingData)
 
             Divider()
 
             stockList
                 .padding(.horizontal, Layout.padding)
+                .redacted(reason: viewModel.syncingData ? [.placeholder] : [])
+                .shimmering(active: viewModel.syncingData)
         }
         .padding(.vertical, Layout.padding)
         .background(Color(.listForeground(modal: false)))

--- a/WooCommerce/Classes/ViewRelated/Dashboard/ProductStock/ProductStockDashboardCard.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/ProductStock/ProductStockDashboardCard.swift
@@ -11,9 +11,14 @@ struct ProductStockDashboardCard: View {
     }
 
     var body: some View {
-        VStack(alignment: .leading, spacing: 0) {
+        VStack(alignment: .leading, spacing: Layout.padding) {
             header
                 .padding(.horizontal, Layout.padding)
+
+            filterBar
+                .padding(.horizontal, Layout.padding)
+
+            Divider()
         }
         .padding(.vertical, Layout.padding)
         .background(Color(.listForeground(modal: false)))
@@ -45,6 +50,30 @@ private extension ProductStockDashboardCard {
             .disabled(viewModel.syncingData)
         }
     }
+
+    var filterBar: some View {
+        HStack {
+            Text(Localization.status)
+                .foregroundStyle(Color.primaryText)
+                .subheadlineStyle()
+            Text(viewModel.selectedStockType.displayedName)
+                .subheadlineStyle()
+            Spacer()
+            Menu {
+                ForEach(ProductStockDashboardCardViewModel.StockType.allCases) { stockType in
+                    Button {
+                        viewModel.updateStockType(stockType)
+                    } label: {
+                        SelectableItemRow(title: stockType.displayedName, selected: stockType == viewModel.selectedStockType)
+                    }
+                }
+            } label: {
+                Image(systemName: "line.3.horizontal.decrease")
+                    .foregroundStyle(Color(.secondaryLabel))
+            }
+
+        }
+    }
 }
 
 private extension ProductStockDashboardCard {
@@ -59,7 +88,12 @@ private extension ProductStockDashboardCard {
         static let hideCard = NSLocalizedString(
             "productStockDashboardCard.hideCard",
             value: "Hide Stock",
-            comment: "Menu item to dismiss the Stock section on the Dashboard screen"
+            comment: "Menu item to dismiss the Stock section on the My Store screen"
+        )
+        static let status = NSLocalizedString(
+            "productStockDashboardCard.status",
+            value: "Status",
+            comment: "Header label on the Stock section on the My Store screen"
         )
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/ProductStock/ProductStockDashboardCard.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/ProductStock/ProductStockDashboardCard.swift
@@ -4,6 +4,12 @@ import struct Yosemite.DashboardCard
 /// View for displaying stock based on status on the dashboard.
 ///
 struct ProductStockDashboardCard: View {
+    @ObservedObject private var viewModel: ProductStockDashboardCardViewModel
+
+    init(viewModel: ProductStockDashboardCardViewModel) {
+        self.viewModel = viewModel
+    }
+
     var body: some View {
         VStack(alignment: .leading, spacing: 0) {
             header
@@ -19,6 +25,10 @@ struct ProductStockDashboardCard: View {
 private extension ProductStockDashboardCard {
     var header: some View {
         HStack {
+            Image(systemName: "exclamationmark.circle")
+                .foregroundStyle(Color.secondary)
+                .headlineStyle()
+                .renderedIf(viewModel.syncingError != nil)
             Text(DashboardCard.CardType.stock.name)
                 .headlineStyle()
             Spacer()
@@ -32,6 +42,7 @@ private extension ProductStockDashboardCard {
                     .padding(.leading, Layout.padding)
                     .padding(.vertical, Layout.hideIconVerticalPadding)
             }
+            .disabled(viewModel.syncingData)
         }
     }
 }
@@ -54,5 +65,5 @@ private extension ProductStockDashboardCard {
 }
 
 #Preview {
-    ProductStockDashboardCard()
+    ProductStockDashboardCard(viewModel: .init(siteID: 123))
 }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/ProductStock/ProductStockDashboardCard.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/ProductStock/ProductStockDashboardCard.swift
@@ -1,0 +1,58 @@
+import SwiftUI
+import struct Yosemite.DashboardCard
+
+/// View for displaying stock based on status on the dashboard.
+///
+struct ProductStockDashboardCard: View {
+    var body: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            header
+                .padding(.horizontal, Layout.padding)
+        }
+        .padding(.vertical, Layout.padding)
+        .background(Color(.listForeground(modal: false)))
+        .clipShape(RoundedRectangle(cornerSize: Layout.cornerSize))
+        .padding(.horizontal, Layout.padding)
+    }
+}
+
+private extension ProductStockDashboardCard {
+    var header: some View {
+        HStack {
+            Text(DashboardCard.CardType.stock.name)
+                .headlineStyle()
+            Spacer()
+            Menu {
+                Button(Localization.hideCard) {
+                    // TODO
+                }
+            } label: {
+                Image(systemName: "ellipsis")
+                    .foregroundStyle(Color.secondary)
+                    .padding(.leading, Layout.padding)
+                    .padding(.vertical, Layout.hideIconVerticalPadding)
+            }
+        }
+    }
+}
+
+private extension ProductStockDashboardCard {
+    enum Layout {
+        static let padding: CGFloat = 16
+        static let cornerSize = CGSize(width: 8.0, height: 8.0)
+        static let hideIconVerticalPadding: CGFloat = 8
+        static let emptyStateImageWidth: CGFloat = 168
+    }
+
+    enum Localization {
+        static let hideCard = NSLocalizedString(
+            "productStockDashboardCard.hideCard",
+            value: "Hide Stock",
+            comment: "Menu item to dismiss the Stock section on the Dashboard screen"
+        )
+    }
+}
+
+#Preview {
+    ProductStockDashboardCard()
+}

--- a/WooCommerce/Classes/ViewRelated/Dashboard/ProductStock/ProductStockDashboardCardViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/ProductStock/ProductStockDashboardCardViewModel.swift
@@ -1,0 +1,29 @@
+import Foundation
+import Yosemite
+import protocol Storage.StorageManagerType
+import protocol WooFoundation.Analytics
+
+/// View model for `ProductStockDashboardCard`
+///
+final class ProductStockDashboardCardViewModel: ObservableObject {
+    // Set externally to trigger callback upon hiding the Inbox card.
+    var onDismiss: (() -> Void)?
+
+    @Published private(set) var syncingData = false
+    @Published private(set) var syncingError: Error?
+
+    let siteID: Int64
+    private let stores: StoresManager
+    private let storageManager: StorageManagerType
+    private let analytics: Analytics
+
+    init(siteID: Int64,
+         stores: StoresManager = ServiceLocator.stores,
+         storageManager: StorageManagerType = ServiceLocator.storageManager,
+         analytics: Analytics = ServiceLocator.analytics) {
+        self.siteID = siteID
+        self.analytics = analytics
+        self.stores = stores
+        self.storageManager = storageManager
+    }
+}

--- a/WooCommerce/Classes/ViewRelated/Dashboard/ProductStock/ProductStockDashboardCardViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/ProductStock/ProductStockDashboardCardViewModel.swift
@@ -30,7 +30,11 @@ final class ProductStockDashboardCardViewModel: ObservableObject {
 
     @MainActor
     func reloadData() async {
-        // TODO
+        syncingData = true
+        syncingError = nil
+        // TODO: replace this with actual remote requests
+        try? await Task.sleep(nanoseconds: 1_000_000_000)
+        syncingData = false
     }
 
     func dismissStock() {

--- a/WooCommerce/Classes/ViewRelated/Dashboard/ProductStock/ProductStockDashboardCardViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/ProductStock/ProductStockDashboardCardViewModel.swift
@@ -26,4 +26,14 @@ final class ProductStockDashboardCardViewModel: ObservableObject {
         self.stores = stores
         self.storageManager = storageManager
     }
+
+    @MainActor
+    func reloadData() async {
+        // TODO
+    }
+
+    func dismissStock() {
+        analytics.track(event: .DynamicDashboard.hideCardTapped(type: .stock))
+        onDismiss?()
+    }
 }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/ProductStock/ProductStockDashboardCardViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/ProductStock/ProductStockDashboardCardViewModel.swift
@@ -11,6 +11,7 @@ final class ProductStockDashboardCardViewModel: ObservableObject {
 
     @Published private(set) var syncingData = false
     @Published private(set) var syncingError: Error?
+    @Published private(set) var selectedStockType: StockType = .lowStock
 
     let siteID: Int64
     private let stores: StoresManager
@@ -35,5 +36,52 @@ final class ProductStockDashboardCardViewModel: ObservableObject {
     func dismissStock() {
         analytics.track(event: .DynamicDashboard.hideCardTapped(type: .stock))
         onDismiss?()
+    }
+
+    func updateStockType(_ type: StockType) {
+        selectedStockType = type
+        Task {
+            await reloadData()
+        }
+    }
+}
+
+extension ProductStockDashboardCardViewModel {
+    enum StockType: String, CaseIterable, Identifiable {
+        case lowStock = "lowstock"
+        case outOfStock = "outofstock"
+        case onBackOrder = "onbackorder"
+
+        /// Identifiable conformance
+        var id: String { rawValue }
+
+        var displayedName: String {
+            switch self {
+            case .lowStock:
+                Localization.lowStock
+            case .outOfStock:
+                Localization.outOfStock
+            case .onBackOrder:
+                Localization.onBackOrder
+            }
+        }
+
+        private enum Localization {
+            static let lowStock = NSLocalizedString(
+                "productStockDashboardCardViewModel.stockType.lowStock",
+                value: "Low stock",
+                comment: "Title of a stock type displayed on the Stock section on My Store screen"
+            )
+            static let outOfStock = NSLocalizedString(
+                "productStockDashboardCardViewModel.stockType.outOfStock",
+                value: "Out of stock",
+                comment: "Title of a stock type displayed on the Stock section on My Store screen"
+            )
+            static let onBackOrder = NSLocalizedString(
+                "productStockDashboardCardViewModel.stockType.onBackOrder",
+                value: "On back order",
+                comment: "Title of a stock type displayed on the Stock section on My Store screen"
+            )
+        }
     }
 }

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -2264,6 +2264,7 @@
 		DE1B0310268EB2FB00804330 /* ReviewOrderViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE1B030F268EB2FB00804330 /* ReviewOrderViewModel.swift */; };
 		DE2004532BF4A37B00660A72 /* InboxDashboardCardViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE2004522BF4A37B00660A72 /* InboxDashboardCardViewModelTests.swift */; };
 		DE2004602BF7092900660A72 /* ProductStockDashboardCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE20045F2BF7092900660A72 /* ProductStockDashboardCard.swift */; };
+		DE2004622BF70A6600660A72 /* ProductStockDashboardCardViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE2004612BF70A6600660A72 /* ProductStockDashboardCardViewModel.swift */; };
 		DE23CFFA27462D8F003BE54E /* JCPJetpackInstallIntroView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE23CFF927462D8F003BE54E /* JCPJetpackInstallIntroView.swift */; };
 		DE26B5292775C76C00A2EA0A /* MockSyncingCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE26B5282775C76B00A2EA0A /* MockSyncingCoordinator.swift */; };
 		DE279BA426E9C4DC002BA963 /* ShippingLabelPackagesForm.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE279BA326E9C4DC002BA963 /* ShippingLabelPackagesForm.swift */; };
@@ -5045,6 +5046,7 @@
 		DE1B030F268EB2FB00804330 /* ReviewOrderViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReviewOrderViewModel.swift; sourceTree = "<group>"; };
 		DE2004522BF4A37B00660A72 /* InboxDashboardCardViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InboxDashboardCardViewModelTests.swift; sourceTree = "<group>"; };
 		DE20045F2BF7092900660A72 /* ProductStockDashboardCard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductStockDashboardCard.swift; sourceTree = "<group>"; };
+		DE2004612BF70A6600660A72 /* ProductStockDashboardCardViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductStockDashboardCardViewModel.swift; sourceTree = "<group>"; };
 		DE23CFF927462D8F003BE54E /* JCPJetpackInstallIntroView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JCPJetpackInstallIntroView.swift; sourceTree = "<group>"; };
 		DE26B5282775C76B00A2EA0A /* MockSyncingCoordinator.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MockSyncingCoordinator.swift; sourceTree = "<group>"; };
 		DE279BA326E9C4DC002BA963 /* ShippingLabelPackagesForm.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShippingLabelPackagesForm.swift; sourceTree = "<group>"; };
@@ -11534,6 +11536,7 @@
 			isa = PBXGroup;
 			children = (
 				DE20045F2BF7092900660A72 /* ProductStockDashboardCard.swift */,
+				DE2004612BF70A6600660A72 /* ProductStockDashboardCardViewModel.swift */,
 			);
 			path = ProductStock;
 			sourceTree = "<group>";
@@ -13445,6 +13448,7 @@
 				DE50294D28BEF8F100551736 /* JetpackConnectionWebViewModel.swift in Sources */,
 				DEF8CF0A29A71EE600800A60 /* JetpackSetupCoordinator.swift in Sources */,
 				02645D8827BA2E820065DC68 /* NSAttributedString+Attributes.swift in Sources */,
+				DE2004622BF70A6600660A72 /* ProductStockDashboardCardViewModel.swift in Sources */,
 				03B9E5292A14F136005C77F5 /* SilenceablePassthroughCardPresentPaymentAlertsPresenter.swift in Sources */,
 				024DF3092372CA00006658FE /* EditorViewProperties.swift in Sources */,
 				45F8C43B2680BC3500F1A6EC /* ShippingLabelDiscountInfoViewController.swift in Sources */,

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -2263,6 +2263,7 @@
 		DE1B030E268DD01A00804330 /* ReviewOrderViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = DE1B030C268DD01A00804330 /* ReviewOrderViewController.xib */; };
 		DE1B0310268EB2FB00804330 /* ReviewOrderViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE1B030F268EB2FB00804330 /* ReviewOrderViewModel.swift */; };
 		DE2004532BF4A37B00660A72 /* InboxDashboardCardViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE2004522BF4A37B00660A72 /* InboxDashboardCardViewModelTests.swift */; };
+		DE2004602BF7092900660A72 /* ProductStockDashboardCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE20045F2BF7092900660A72 /* ProductStockDashboardCard.swift */; };
 		DE23CFFA27462D8F003BE54E /* JCPJetpackInstallIntroView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE23CFF927462D8F003BE54E /* JCPJetpackInstallIntroView.swift */; };
 		DE26B5292775C76C00A2EA0A /* MockSyncingCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE26B5282775C76B00A2EA0A /* MockSyncingCoordinator.swift */; };
 		DE279BA426E9C4DC002BA963 /* ShippingLabelPackagesForm.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE279BA326E9C4DC002BA963 /* ShippingLabelPackagesForm.swift */; };
@@ -5043,6 +5044,7 @@
 		DE1B030C268DD01A00804330 /* ReviewOrderViewController.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = ReviewOrderViewController.xib; sourceTree = "<group>"; };
 		DE1B030F268EB2FB00804330 /* ReviewOrderViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReviewOrderViewModel.swift; sourceTree = "<group>"; };
 		DE2004522BF4A37B00660A72 /* InboxDashboardCardViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InboxDashboardCardViewModelTests.swift; sourceTree = "<group>"; };
+		DE20045F2BF7092900660A72 /* ProductStockDashboardCard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductStockDashboardCard.swift; sourceTree = "<group>"; };
 		DE23CFF927462D8F003BE54E /* JCPJetpackInstallIntroView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JCPJetpackInstallIntroView.swift; sourceTree = "<group>"; };
 		DE26B5282775C76B00A2EA0A /* MockSyncingCoordinator.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MockSyncingCoordinator.swift; sourceTree = "<group>"; };
 		DE279BA326E9C4DC002BA963 /* ShippingLabelPackagesForm.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShippingLabelPackagesForm.swift; sourceTree = "<group>"; };
@@ -10920,6 +10922,7 @@
 		CE85FD5120F677460080B73E /* Dashboard */ = {
 			isa = PBXGroup;
 			children = (
+				DE20045E2BF7090700660A72 /* ProductStock */,
 				EEC099342BF3C67200FBCF6C /* Coupons */,
 				8625C50F2BF2097E007F1901 /* Reviews */,
 				DE6F997C2BEE00A70007B2DD /* Inbox */,
@@ -11525,6 +11528,14 @@
 				DE1B030F268EB2FB00804330 /* ReviewOrderViewModel.swift */,
 			);
 			path = "Review Order";
+			sourceTree = "<group>";
+		};
+		DE20045E2BF7090700660A72 /* ProductStock */ = {
+			isa = PBXGroup;
+			children = (
+				DE20045F2BF7092900660A72 /* ProductStockDashboardCard.swift */,
+			);
+			path = ProductStock;
 			sourceTree = "<group>";
 		};
 		DE23CFF827462CD2003BE54E /* JCPJetpackInstall */ = {
@@ -13658,6 +13669,7 @@
 				311D21E8264AEDB900102316 /* CardPresentModalScanningForReader.swift in Sources */,
 				2688643D25D470C000821BA5 /* EditAttributesViewModel.swift in Sources */,
 				03A9F3B22A03E70700385673 /* AdaptiveAsyncImage.swift in Sources */,
+				DE2004602BF7092900660A72 /* ProductStockDashboardCard.swift in Sources */,
 				31C21FA426D9949000916E2E /* SeveralReadersFoundViewController.swift in Sources */,
 				45E1482527736D1E0099CF23 /* SettingsView.swift in Sources */,
 				02E3B62829026C8F007E0F13 /* AccountCreationForm.swift in Sources */,

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -2265,6 +2265,7 @@
 		DE2004532BF4A37B00660A72 /* InboxDashboardCardViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE2004522BF4A37B00660A72 /* InboxDashboardCardViewModelTests.swift */; };
 		DE2004602BF7092900660A72 /* ProductStockDashboardCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE20045F2BF7092900660A72 /* ProductStockDashboardCard.swift */; };
 		DE2004622BF70A6600660A72 /* ProductStockDashboardCardViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE2004612BF70A6600660A72 /* ProductStockDashboardCardViewModel.swift */; };
+		DE2004642BF744F200660A72 /* ProductStockDashboardCardViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE2004632BF744F200660A72 /* ProductStockDashboardCardViewModelTests.swift */; };
 		DE23CFFA27462D8F003BE54E /* JCPJetpackInstallIntroView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE23CFF927462D8F003BE54E /* JCPJetpackInstallIntroView.swift */; };
 		DE26B5292775C76C00A2EA0A /* MockSyncingCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE26B5282775C76B00A2EA0A /* MockSyncingCoordinator.swift */; };
 		DE279BA426E9C4DC002BA963 /* ShippingLabelPackagesForm.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE279BA326E9C4DC002BA963 /* ShippingLabelPackagesForm.swift */; };
@@ -5047,6 +5048,7 @@
 		DE2004522BF4A37B00660A72 /* InboxDashboardCardViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InboxDashboardCardViewModelTests.swift; sourceTree = "<group>"; };
 		DE20045F2BF7092900660A72 /* ProductStockDashboardCard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductStockDashboardCard.swift; sourceTree = "<group>"; };
 		DE2004612BF70A6600660A72 /* ProductStockDashboardCardViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductStockDashboardCardViewModel.swift; sourceTree = "<group>"; };
+		DE2004632BF744F200660A72 /* ProductStockDashboardCardViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductStockDashboardCardViewModelTests.swift; sourceTree = "<group>"; };
 		DE23CFF927462D8F003BE54E /* JCPJetpackInstallIntroView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JCPJetpackInstallIntroView.swift; sourceTree = "<group>"; };
 		DE26B5282775C76B00A2EA0A /* MockSyncingCoordinator.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MockSyncingCoordinator.swift; sourceTree = "<group>"; };
 		DE279BA326E9C4DC002BA963 /* ShippingLabelPackagesForm.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShippingLabelPackagesForm.swift; sourceTree = "<group>"; };
@@ -6910,6 +6912,7 @@
 				027F83EE29B048E2002688C6 /* TopPerformersPeriodViewModelTests.swift */,
 				DEC75CC72BC518D900763801 /* DashboardCustomizationViewModelTests.swift */,
 				DE2004522BF4A37B00660A72 /* InboxDashboardCardViewModelTests.swift */,
+				DE2004632BF744F200660A72 /* ProductStockDashboardCardViewModelTests.swift */,
 				DE74A4552BCFB5890009C415 /* TopPerformers */,
 				DED039252BC79339005D0571 /* StoreStats */,
 			);
@@ -15490,6 +15493,7 @@
 				094C161227B0604700B25F51 /* ProductVariationFormViewModelTests.swift in Sources */,
 				EEAA45FD293073FE0047D125 /* JetpackInstallStepTests.swift in Sources */,
 				CECC759923D6160000486676 /* AggregateDataHelperTests.swift in Sources */,
+				DE2004642BF744F200660A72 /* ProductStockDashboardCardViewModelTests.swift in Sources */,
 				454453C82755171E00464AC5 /* HubMenuCoordinatorTests.swift in Sources */,
 				5767E940256D9A4A00CFA652 /* OrderListViewModelTests.swift in Sources */,
 				26A630F3253F3CFE00CBC3B1 /* RefundCreationUseCaseTests.swift in Sources */,

--- a/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/ProductStockDashboardCardViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/ProductStockDashboardCardViewModelTests.swift
@@ -1,0 +1,25 @@
+import XCTest
+@testable import WooCommerce
+
+final class ProductStockDashboardCardViewModelTests: XCTestCase {
+
+    func test_initial_stock_type_is_low_stock() {
+        // Given
+        let viewModel = ProductStockDashboardCardViewModel(siteID: 123)
+
+        // Then
+        XCTAssertEqual(viewModel.selectedStockType, .lowStock)
+    }
+
+    func test_updateStockType_updates_selected_stock_type() {
+        // Given
+        let viewModel = ProductStockDashboardCardViewModel(siteID: 123)
+
+        // When
+        viewModel.updateStockType(.outOfStock)
+
+        // Then
+        XCTAssertEqual(viewModel.selectedStockType, .outOfStock)
+    }
+
+}


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of #12748 
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This PR adds UI for the stock card. This includes:
- Header, filter bar, and the stock list UI. No real data is fetched yet.
- Basic logic for showing/hiding the card on the dashboard.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
- Enable the feature flag `dynamicDashboardM2` and build the app.
- Confirm that the dashboard looks as before initially.
- Tap Edit button, confirm that there's an option for Stock. Enable that option and save changes.
- Confirm that there's a new section for Stock on the dashboard screen and that the layout matches the design (with the extra bar for switching stock types).
- Tap the filter button, confirm that there are 3 options: Low stock, Out of stock, and On back order. 
- Switch between the options, the correct item should be selected on the menu and the stock type name is displayed on the card.
- Pull to refresh, confirm that the card is redacted and shimmers while the simulated loading is in progress.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->
| Normal state | Loading state |
| --- | --- |
| <img src="https://github.com/woocommerce/woocommerce-ios/assets/5533851/b251a584-f15f-4848-8f2f-a296341cbce1" width=320 /> | <img src="https://github.com/woocommerce/woocommerce-ios/assets/5533851/8098e5e1-1aaf-4497-a5bc-1228d5a54b6d" width=320 />


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
