### PR TITLE
[Watch] My Store Stats UI

### DIFF
--- a/WooCommerce/Woo Watch App/MyStore/MyStoreView.swift
+++ b/WooCommerce/Woo Watch App/MyStore/MyStoreView.swift
@@ -1,7 +1,7 @@
 import SwiftUI
 import NetworkingWatchOS
 
-struct ContentView: View {
+struct MyStoreView: View {
 
     @Environment(\.dependencies) private var dependencies
 
@@ -24,5 +24,5 @@ struct ContentView: View {
 }
 
 #Preview {
-    ContentView(dependencies: .fake())
+    MyStoreView(dependencies: .fake())
 }

--- a/WooCommerce/Woo Watch App/MyStore/MyStoreView.swift
+++ b/WooCommerce/Woo Watch App/MyStore/MyStoreView.swift
@@ -13,8 +13,36 @@ struct MyStoreView: View {
 
     var body: some View {
         VStack {
+
             Text(dependencies.storeName)
-            Text(viewModel.viewState.description)
+            Text("Revenue")
+            Text("$4,321.90")
+
+            Divider()
+
+            HStack {
+                Text("Today")
+                Spacer()
+                Text("As of 02:19")
+            }
+
+            HStack {
+                Button("56") {
+                    print("Order button pressed")
+                }
+
+                VStack {
+                    HStack {
+                        Text("112")
+                        /// Image
+                    }
+
+                    HStack {
+                        Text("50")
+                        // Image
+                    }
+                }
+            }
         }
         .padding()
         .task {

--- a/WooCommerce/Woo Watch App/MyStore/MyStoreView.swift
+++ b/WooCommerce/Woo Watch App/MyStore/MyStoreView.swift
@@ -1,10 +1,13 @@
 import SwiftUI
 import NetworkingWatchOS
 
+/// My Store Stats View
+///
 struct MyStoreView: View {
 
     @Environment(\.dependencies) private var dependencies
 
+    // View Model to drive the view
     @StateObject var viewModel: MyStoreViewModel
 
     init(dependencies: WatchDependencies) {
@@ -12,42 +15,129 @@ struct MyStoreView: View {
     }
 
     var body: some View {
-        VStack {
+        VStack() {
 
             Text(dependencies.storeName)
-            Text("Revenue")
+                .font(.body)
+                .foregroundStyle(Colors.wooPurple5)
+                .padding(.bottom, Layout.storeNamePadding)
+
+            Text(Localization.revenue)
+                .font(.caption2)
+                .foregroundStyle(Colors.wooPurple5)
+                .padding(.bottom, Layout.revenueTitlePadding)
+
             Text("$4,321.90")
+                .font(.title2)
+                .bold()
+                .padding(.bottom, Layout.revenueValuePadding)
 
             Divider()
+                .padding(.bottom, Layout.dividerPadding)
 
             HStack {
-                Text("Today")
+                Text(Localization.today)
                 Spacer()
                 Text("As of 02:19")
             }
+            .font(.footnote)
+            .foregroundStyle(.secondary)
+            .padding(.bottom, Layout.datePadding)
 
             HStack {
-                Button("56") {
-                    print("Order button pressed")
-                }
 
-                VStack {
+                Button(action: {
+                    print("Order button pressed")
+                }) {
                     HStack {
+                        Images.document
+                            .renderingMode(.original)
+                            .foregroundStyle(Colors.wooPurple10)
+
+                        Text("56")
+                            .font(.caption)
+                            .bold()
+                    }
+                    .padding(Layout.orderButtonPadding)
+                }
+                .buttonStyle(.plain)
+                .background(Colors.wooPurple80)
+                .cornerRadius(Layout.orderButtonCornerRadius)
+
+                Spacer()
+
+                VStack(spacing: Layout.iconsSpacing) {
+                    HStack(spacing: Layout.iconsSpacing) {
+
                         Text("112")
-                        /// Image
+                            .font(.caption)
+                            .bold()
+
+                        Images.person
+                            .renderingMode(.original)
+                            .foregroundStyle(Colors.wooPurple10)
                     }
 
-                    HStack {
-                        Text("50")
-                        // Image
+                    HStack(spacing: Layout.iconsSpacing) {
+
+                        Text("50%")
+                            .font(.caption2)
+                            .bold()
+
+                        Images.zigzag
+                            .renderingMode(.original)
+                            .foregroundStyle(Colors.wooPurple10)
                     }
                 }
             }
         }
         .padding()
+        .background(
+            LinearGradient(gradient: Gradient(colors: [Colors.wooPurpleBackground, .black]), startPoint: .top, endPoint: .bottom)
+        )
         .task {
             await viewModel.fetchStats()
         }
+    }
+}
+
+fileprivate extension MyStoreView {
+    enum Colors {
+        static let wooPurple5 = Color(red: 223/255.0, green: 209/255.0, blue: 251/255.0)
+        static let wooPurple80 = Color(red: 60/255.0, green: 40/255.0, blue: 97/255.0)
+        static let wooPurple10 = Color(red: 207/255.0, green: 185/255.0, blue: 246/255.0)
+        static let wooPurpleBackground = Color(red: 79/255.0, green: 54/255.0, blue: 125/255.0)
+        static let secondaryColor = Color(red: 79/255.0, green: 54/255.0, blue: 125/255.0)
+    }
+
+    enum Layout {
+        static let storeNamePadding = 8.0
+        static let revenueTitlePadding = 2.0
+        static let revenueValuePadding = 4.0
+        static let dividerPadding = 4.0
+        static let datePadding = 12.0
+        static let orderButtonPadding = 10.0
+        static let orderButtonCornerRadius = 18.0
+        static let iconsSpacing = 4.0
+    }
+
+    enum Localization {
+        static let revenue = AppLocalizedString(
+            "watch.mystore.revenue.title",
+            value: "Revenue",
+            comment: "Revenue title on the watch store stats screen."
+        )
+        static let today = AppLocalizedString(
+            "watch.mystore.today.title",
+            value: "Today",
+            comment: "Today title on the watch store stats screen."
+        )
+    }
+
+    enum Images {
+        static let document = Image(systemName: "doc.text.fill")
+        static let person = Image(systemName: "person.2.fill")
+        static let zigzag = Image(systemName: "point.bottomleft.forward.to.point.topright.filled.scurvepath")
     }
 }
 

--- a/WooCommerce/Woo Watch App/WooApp.swift
+++ b/WooCommerce/Woo Watch App/WooApp.swift
@@ -8,7 +8,7 @@ struct Woo_Watch_AppApp: App {
     var body: some Scene {
         WindowGroup {
             if let dependencies = phoneDependencySynchronizer.dependencies {
-                ContentView(dependencies: dependencies)
+                MyStoreView(dependencies: dependencies)
                     .environment(\.dependencies, dependencies)
             } else {
                 ConnectView()

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -987,7 +987,7 @@
 		26F65C9825DEDAF0008FAE29 /* GenerateVariationUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26F65C9725DEDAF0008FAE29 /* GenerateVariationUseCase.swift */; };
 		26F65C9E25DEDE67008FAE29 /* GenerateVariationUseCaseTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26F65C9D25DEDE67008FAE29 /* GenerateVariationUseCaseTests.swift */; };
 		26F81B182BE433A2009EC58E /* WooApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26F81B172BE433A2009EC58E /* WooApp.swift */; };
-		26F81B1A2BE433A2009EC58E /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26F81B192BE433A2009EC58E /* ContentView.swift */; };
+		26F81B1A2BE433A2009EC58E /* MyStoreView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26F81B192BE433A2009EC58E /* MyStoreView.swift */; };
 		26F81B1C2BE433A3009EC58E /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 26F81B1B2BE433A3009EC58E /* Assets.xcassets */; };
 		26F81B1F2BE433A3009EC58E /* Preview Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 26F81B1E2BE433A3009EC58E /* Preview Assets.xcassets */; };
 		26F81B222BE433A3009EC58E /* Woo Watch App.app in Embed Watch Content */ = {isa = PBXBuildFile; fileRef = 26F81B152BE433A2009EC58E /* Woo Watch App.app */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
@@ -3791,7 +3791,7 @@
 		26F65C9D25DEDE67008FAE29 /* GenerateVariationUseCaseTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GenerateVariationUseCaseTests.swift; sourceTree = "<group>"; };
 		26F81B152BE433A2009EC58E /* Woo Watch App.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "Woo Watch App.app"; sourceTree = BUILT_PRODUCTS_DIR; };
 		26F81B172BE433A2009EC58E /* WooApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WooApp.swift; sourceTree = "<group>"; };
-		26F81B192BE433A2009EC58E /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
+		26F81B192BE433A2009EC58E /* MyStoreView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MyStoreView.swift; sourceTree = "<group>"; };
 		26F81B1B2BE433A3009EC58E /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		26F81B1E2BE433A3009EC58E /* Preview Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = "Preview Assets.xcassets"; sourceTree = "<group>"; };
 		26F94E1B267A3E4500DB6CCF /* ProductAddOnsListViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductAddOnsListViewController.swift; sourceTree = "<group>"; };
@@ -7586,6 +7586,7 @@
 		269FFA492BF544B6004E6B86 /* MyStore */ = {
 			isa = PBXGroup;
 			children = (
+				26F81B192BE433A2009EC58E /* MyStoreView.swift */,
 				269FFA4A2BF544C9004E6B86 /* MyStoreViewModel.swift */,
 			);
 			path = MyStore;
@@ -7765,7 +7766,6 @@
 			children = (
 				26B984D22BEECC460052658C /* Dependencies */,
 				26F81B172BE433A2009EC58E /* WooApp.swift */,
-				26F81B192BE433A2009EC58E /* ContentView.swift */,
 				26B984D52BEECF260052658C /* ConnectView.swift */,
 				269FFA492BF544B6004E6B86 /* MyStore */,
 				26F81B1B2BE433A3009EC58E /* Assets.xcassets */,
@@ -13550,7 +13550,7 @@
 			files = (
 				264E9E952BF400AD009C48FD /* StoreInfoDataService.swift in Sources */,
 				26B984D42BEECC610052658C /* Environment+Dependencies.swift in Sources */,
-				26F81B1A2BE433A2009EC58E /* ContentView.swift in Sources */,
+				26F81B1A2BE433A2009EC58E /* MyStoreView.swift in Sources */,
 				264E9E942BF1D1DF009C48FD /* AppLocalizedString.swift in Sources */,
 				26DD32D42BEBCDFB00F2C69C /* WooConstants.swift in Sources */,
 				269FFA4B2BF544C9004E6B86 /* MyStoreViewModel.swift in Sources */,


### PR DESCRIPTION
closes #12497
closes #12496  

# Why

This PR adds the main UI for the MyStoreStats view on the apple watch. Most values are hardcoded and will be dynamic in the next PR.

# Demo

<img width="275" alt="Screenshot 2024-05-17 at 10 18 15 AM" src="https://github.com/woocommerce/woocommerce-ios/assets/562080/abed8c64-3bf1-4608-8c7c-cb25a6106fbb">


---
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
