### PR TITLE
[Watch] Show correct stats data

### DIFF
--- a/WooCommerce/Woo Watch App/MyStore/MyStoreView.swift
+++ b/WooCommerce/Woo Watch App/MyStore/MyStoreView.swift
@@ -15,8 +15,43 @@ struct MyStoreView: View {
     }
 
     var body: some View {
-        VStack() {
+        VStack {
+            switch viewModel.viewState {
+            case .idle:
+                EmptyView()
+            case .loading:
+                dataView(revenue: "------", orders: "--", visitors: "--", conversion: "--")
+                    .redacted(reason: .placeholder)
+            case .error:
+                errorView
+            case let .loaded(revenue, totalOrders, totalVisitors, conversion):
+                dataView(revenue: revenue, orders: totalOrders, visitors: totalVisitors, conversion: conversion)
+            }
+        }
+        .padding()
+        .background(
+            LinearGradient(gradient: Gradient(colors: [Colors.wooPurpleBackground, .black]), startPoint: .top, endPoint: .bottom)
+        )
+        .task {
+            await viewModel.fetchStats()
+        }
+    }
 
+    @ViewBuilder var errorView: some View {
+        VStack {
+            Spacer()
+            Text(Localization.error)
+            Spacer()
+            Button(Localization.retry) {
+                Task {
+                    await viewModel.fetchStats()
+                }
+            }
+        }
+    }
+
+    @ViewBuilder func dataView(revenue: String, orders: String, visitors: String, conversion: String) -> some View {
+        VStack {
             Text(dependencies.storeName)
                 .font(.body)
                 .foregroundStyle(Colors.wooPurple5)
@@ -27,7 +62,7 @@ struct MyStoreView: View {
                 .foregroundStyle(Colors.wooPurple5)
                 .padding(.bottom, Layout.revenueTitlePadding)
 
-            Text("$4,321.90")
+            Text(revenue)
                 .font(.title2)
                 .bold()
                 .padding(.bottom, Layout.revenueValuePadding)
@@ -54,7 +89,7 @@ struct MyStoreView: View {
                             .renderingMode(.original)
                             .foregroundStyle(Colors.wooPurple10)
 
-                        Text("56")
+                        Text(orders)
                             .font(.caption)
                             .bold()
                     }
@@ -69,7 +104,7 @@ struct MyStoreView: View {
                 VStack(spacing: Layout.iconsSpacing) {
                     HStack(spacing: Layout.iconsSpacing) {
 
-                        Text("112")
+                        Text(visitors)
                             .font(.caption)
                             .bold()
 
@@ -80,7 +115,7 @@ struct MyStoreView: View {
 
                     HStack(spacing: Layout.iconsSpacing) {
 
-                        Text("50%")
+                        Text(conversion)
                             .font(.caption2)
                             .bold()
 
@@ -90,13 +125,6 @@ struct MyStoreView: View {
                     }
                 }
             }
-        }
-        .padding()
-        .background(
-            LinearGradient(gradient: Gradient(colors: [Colors.wooPurpleBackground, .black]), startPoint: .top, endPoint: .bottom)
-        )
-        .task {
-            await viewModel.fetchStats()
         }
     }
 }
@@ -131,6 +159,16 @@ fileprivate extension MyStoreView {
             "watch.mystore.today.title",
             value: "Today",
             comment: "Today title on the watch store stats screen."
+        )
+        static let error = AppLocalizedString(
+            "watch.mystore.error.title",
+            value: "There was an error loading the store's data",
+            comment: "Loading title on the watch store stats screen."
+        )
+        static let retry = AppLocalizedString(
+            "watch.mystore.retry.title",
+            value: "Retry",
+            comment: "Retry on the watch store stats screen."
         )
     }
 

--- a/WooCommerce/Woo Watch App/MyStore/MyStoreViewModel.swift
+++ b/WooCommerce/Woo Watch App/MyStore/MyStoreViewModel.swift
@@ -47,7 +47,7 @@ final class MyStoreViewModel: ObservableObject {
                 return Self.valuePlaceholderText
             }()
 
-            self.viewState = .loaded(revenue: Self.formattedAmountString(for: 32456.23),
+            self.viewState = .loaded(revenue: Self.formattedAmountString(for: stats.revenue),
                                      totalOrders: "\(stats.totalOrders)",
                                      totalVisitors: visitors,
                                      conversion: conversion,

--- a/WooCommerce/Woo Watch App/MyStore/MyStoreViewModel.swift
+++ b/WooCommerce/Woo Watch App/MyStore/MyStoreViewModel.swift
@@ -5,28 +5,15 @@ import NetworkingWatchOS
 ///
 final class MyStoreViewModel: ObservableObject {
 
+    static let valuePlaceholderText = "-"
+
     /// Enum that tracks the state of the view.
     ///
     enum ViewState {
         case idle
         case loading
         case error
-        case loaded(revenue: String, totalOrders: String, totalVisitors: String, conversion: String)
-
-        /// Temporary description.
-        ///
-        var description: String {
-            switch self {
-            case .idle:
-                return ""
-            case .loading:
-                return "Loading"
-            case .error:
-                return "Error"
-            case let .loaded(revenue, totalOrders, totalVisitors, conversion):
-                return "Revenue: \(revenue)\nOrders: \(totalOrders)\nVisitors: \(totalVisitors)\nConversion: \(conversion)\n"
-            }
-        }
+        case loaded(revenue: String, totalOrders: String, totalVisitors: String, conversion: String, time: String)
     }
 
     private let dependencies: WatchDependencies
@@ -45,13 +32,62 @@ final class MyStoreViewModel: ObservableObject {
         let service = StoreInfoDataService(credentials: dependencies.credentials)
         do {
             let stats = try await service.fetchTodayStats(for: dependencies.storeID)
-            self.viewState = .loaded(revenue: "\(stats.revenue)",
+
+            let visitors: String = {
+                if let visitors = stats.totalVisitors {
+                    return "\(visitors)"
+                }
+                return Self.valuePlaceholderText
+            }()
+
+            let conversion: String = {
+                if let conversion = stats.conversion {
+                    return Self.formattedConversionString(for: conversion)
+                }
+                return Self.valuePlaceholderText
+            }()
+
+            self.viewState = .loaded(revenue: Self.formattedAmountString(for: 32456.23),
                                      totalOrders: "\(stats.totalOrders)",
-                                     totalVisitors: "\(stats.totalVisitors ?? 0)",
-                                     conversion: "\(stats.conversion ?? 0.0)")
+                                     totalVisitors: visitors,
+                                     conversion: conversion,
+                                     time: Self.currentFormattedTime())
         } catch {
             DDLogError("⛔️ Error fetching watch today stats: \(error)")
             self.viewState = .error
         }
+    }
+}
+
+/// Copied from `StoreInfoProvider`. Should be moved into a single file for easier maintainability.
+///
+private extension MyStoreViewModel {
+    static func formattedAmountString(for amountValue: Decimal) -> String {
+        let numberFormatter = NumberFormatter()
+        numberFormatter.numberStyle = .currency
+        numberFormatter.minimumFractionDigits = 2
+        numberFormatter.currencyDecimalSeparator = "."
+        numberFormatter.currencyGroupingSeparator = ","
+        return numberFormatter.string(from: amountValue as NSNumber) ?? valuePlaceholderText
+    }
+
+    static func formattedConversionString(for conversionRate: Double) -> String {
+        let numberFormatter = NumberFormatter()
+        numberFormatter.numberStyle = .percent
+        numberFormatter.minimumFractionDigits = 1
+
+        // do not add 0 fraction digit if the percentage is round
+        let minimumFractionDigits = floor(conversionRate * 100.0) == conversionRate * 100.0 ? 0 : 1
+        numberFormatter.minimumFractionDigits = minimumFractionDigits
+        return numberFormatter.string(from: conversionRate as NSNumber) ?? valuePlaceholderText
+    }
+
+    /// Returns the current time formatted as `10:24 PM` or `22:24` depending on the device settings.
+    ///
+    static func currentFormattedTime() -> String {
+        let timeFormatter = DateFormatter()
+        timeFormatter.timeStyle = .short
+        timeFormatter.dateStyle = .none
+        return timeFormatter.string(from: Date.now)
     }
 }


### PR DESCRIPTION
closes #12772

# Why

This PR
- Shows a loading screen while the data is fetched
- Shows the correct data once is fetched
- Shows an error screen if the data can't be loaded.

# Demo

## Success
https://github.com/woocommerce/woocommerce-ios/assets/562080/aeb1b089-1163-4a2e-a7a0-f8c31c2370df


https://github.com/woocommerce/woocommerce-ios/assets/562080/1f3deb35-3ec6-45d7-a896-74fcc24828fc



---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
