### PR TITLE
[Watch] Share Currency Settings

### DIFF
--- a/WooCommerce/Classes/System/SessionManager.swift
+++ b/WooCommerce/Classes/System/SessionManager.swift
@@ -105,7 +105,7 @@ final class SessionManager: SessionManagerProtocol {
             defaults[.defaultStoreID] = newValue
             defaultStoreIDSubject.send(newValue)
 
-            watchDependenciesSynchronizer.update(storeID: defaultStoreID, 
+            watchDependenciesSynchronizer.update(storeID: defaultStoreID,
                                                  storeName: defaultSite?.name,
                                                  currencySettings: ServiceLocator.currencySettings,
                                                  credentials: defaultCredentials)
@@ -161,7 +161,7 @@ final class SessionManager: SessionManagerProtocol {
     ///
     @Published var defaultSite: Site? {
         didSet {
-            watchDependenciesSynchronizer.update(storeID: defaultStoreID, 
+            watchDependenciesSynchronizer.update(storeID: defaultStoreID,
                                                  storeName: defaultSite?.name,
                                                  currencySettings: ServiceLocator.currencySettings,
                                                  credentials: loadCredentials())

--- a/WooCommerce/Classes/System/SessionManager.swift
+++ b/WooCommerce/Classes/System/SessionManager.swift
@@ -70,11 +70,13 @@ final class SessionManager: SessionManagerProtocol {
             removeCredentials()
 
             guard let credentials = newValue else {
-                return watchDependenciesSynchronizer.update(storeID: nil, storeName: nil, credentials: nil)
+                return watchDependenciesSynchronizer.update(storeID: nil, storeName: nil, currencySettings: nil, credentials: nil)
             }
-
             saveCredentials(credentials)
-            watchDependenciesSynchronizer.update(storeID: defaultStoreID, storeName: defaultSite?.name, credentials: credentials)
+            watchDependenciesSynchronizer.update(storeID: defaultStoreID,
+                                                 storeName: defaultSite?.name,
+                                                 currencySettings: ServiceLocator.currencySettings,
+                                                 credentials: credentials)
         }
     }
 
@@ -103,7 +105,10 @@ final class SessionManager: SessionManagerProtocol {
             defaults[.defaultStoreID] = newValue
             defaultStoreIDSubject.send(newValue)
 
-            watchDependenciesSynchronizer.update(storeID: defaultStoreID, storeName: defaultSite?.name, credentials: defaultCredentials)
+            watchDependenciesSynchronizer.update(storeID: defaultStoreID, 
+                                                 storeName: defaultSite?.name,
+                                                 currencySettings: ServiceLocator.currencySettings,
+                                                 credentials: defaultCredentials)
         }
     }
 
@@ -156,7 +161,10 @@ final class SessionManager: SessionManagerProtocol {
     ///
     @Published var defaultSite: Site? {
         didSet {
-            watchDependenciesSynchronizer.update(storeID: defaultStoreID, storeName: defaultSite?.name, credentials: loadCredentials())
+            watchDependenciesSynchronizer.update(storeID: defaultStoreID, 
+                                                 storeName: defaultSite?.name,
+                                                 currencySettings: ServiceLocator.currencySettings,
+                                                 credentials: loadCredentials())
         }
     }
 

--- a/WooCommerce/Classes/System/WatchDependenciesSynchronizer.swift
+++ b/WooCommerce/Classes/System/WatchDependenciesSynchronizer.swift
@@ -1,5 +1,6 @@
 import WatchConnectivity
 import enum Networking.Credentials
+import class WooFoundation.CurrencySettings
 
 /// Type that syncs the necessary dependencies to the watch session.
 /// Dependencies:
@@ -32,13 +33,13 @@ final class WatchDependenciesSynchronizer: NSObject, WCSessionDelegate {
 
     /// Syncs credentials to the watch session.
     ///
-    func update(storeID: Int64?, storeName: String?, credentials: Credentials?) {
+    func update(storeID: Int64?, storeName: String?, currencySettings: CurrencySettings?, credentials: Credentials?) {
 
         let dependencies: WatchDependencies? = {
-            guard let storeID, let storeName, let credentials else {
+            guard let storeID, let storeName, let credentials, let currencySettings else {
                 return nil
             }
-            return .init(storeID: storeID, storeName: storeName, credentials: credentials)
+            return .init(storeID: storeID, storeName: storeName, currencySettings: currencySettings, credentials: credentials)
         }()
 
         // Enqueue dependencies if the session is not yet activated.
@@ -59,7 +60,10 @@ final class WatchDependenciesSynchronizer: NSObject, WCSessionDelegate {
         DDLogInfo("🔵 WatchSession activated \(activationState)")
 
         if case .queued(let watchDependencies) = queuedDependencies {
-            update(storeID: watchDependencies?.storeID, storeName: watchDependencies?.storeName, credentials: watchDependencies?.credentials)
+            update(storeID: watchDependencies?.storeID,
+                   storeName: watchDependencies?.storeName,
+                   currencySettings: watchDependencies?.currencySettings,
+                   credentials: watchDependencies?.credentials)
             self.queuedDependencies = .notQueued
         }
     }

--- a/WooCommerce/StoreWidgets/StoreInfoFormatter.swift
+++ b/WooCommerce/StoreWidgets/StoreInfoFormatter.swift
@@ -1,0 +1,51 @@
+import Foundation
+
+#if canImport(WooFoundation)
+import WooFoundation
+#elseif canImport(WooFoundationWatchOS)
+import WooFoundationWatchOS
+#endif
+
+/// Type to help formatting values for presentation.
+///
+struct StoreInfoFormatter {
+    /// Formats values using the given currency setting.
+    ///
+    static func formattedAmountString(for amountValue: Decimal, with currencySettings: CurrencySettings?) -> String {
+        let currencyFormatter = CurrencyFormatter(currencySettings: currencySettings ?? CurrencySettings())
+        return currencyFormatter.formatAmount(amountValue) ?? Constants.valuePlaceholderText
+    }
+
+    /// Formats values with a compact format using the given currency setting.
+    ///
+    static func formattedAmountCompactString(for amountValue: Decimal, with currencySettings: CurrencySettings?) -> String {
+        let currencyFormatter = CurrencyFormatter(currencySettings: currencySettings ?? CurrencySettings())
+        return currencyFormatter.formatHumanReadableAmount(amountValue) ?? Constants.valuePlaceholderText
+    }
+
+    /// Formats the conversion as a percentage.
+    ///
+    static func formattedConversionString(for conversionRate: Double) -> String {
+        let numberFormatter = NumberFormatter()
+        numberFormatter.numberStyle = .percent
+        numberFormatter.minimumFractionDigits = 1
+
+        // do not add 0 fraction digit if the percentage is round
+        let minimumFractionDigits = floor(conversionRate * 100.0) == conversionRate * 100.0 ? 0 : 1
+        numberFormatter.minimumFractionDigits = minimumFractionDigits
+        return numberFormatter.string(from: conversionRate as NSNumber) ?? Constants.valuePlaceholderText
+    }
+
+    /// Returns the current time formatted as `10:24 PM` or `22:24` depending on the phone settings.
+    ///
+    static func currentFormattedTime() -> String {
+        let timeFormatter = DateFormatter()
+        timeFormatter.timeStyle = .short
+        timeFormatter.dateStyle = .none
+        return timeFormatter.string(from: Date())
+    }
+
+    enum Constants {
+        static let valuePlaceholderText = "-"
+    }
+}

--- a/WooCommerce/StoreWidgets/StoreInfoProvider.swift
+++ b/WooCommerce/StoreWidgets/StoreInfoProvider.swift
@@ -164,12 +164,12 @@ private extension StoreInfoProvider {
     static func placeholderEntry(for dependencies: Dependencies?) -> StoreInfoEntry {
         StoreInfoEntry.data(.init(range: Localization.today,
                                   name: dependencies?.storeName ?? Localization.myShop,
-                                  revenue: Self.formattedAmountString(for: 132.234, with: dependencies?.storeCurrencySettings),
-                                  revenueCompact: Self.formattedAmountCompactString(for: 132.234, with: dependencies?.storeCurrencySettings),
+                                  revenue: StoreInfoFormatter.formattedAmountString(for: 132.234, with: dependencies?.storeCurrencySettings),
+                                  revenueCompact: StoreInfoFormatter.formattedAmountCompactString(for: 132.234, with: dependencies?.storeCurrencySettings),
                                   visitors: "67",
                                   orders: "23",
-                                  conversion: Self.formattedConversionString(for: 23/67),
-                                  updatedTime: Self.currentFormattedTime()))
+                                  conversion: StoreInfoFormatter.formattedConversionString(for: 23/67),
+                                  updatedTime: StoreInfoFormatter.currentFormattedTime()))
     }
 
     /// Real data entry.
@@ -179,56 +179,23 @@ private extension StoreInfoProvider {
             if let visitors = todayStats.totalVisitors {
                 return "\(visitors)"
             }
-            return Constants.valuePlaceholderText
+            return StoreInfoFormatter.Constants.valuePlaceholderText
         }()
         let conversion: String = {
             if let conversion = todayStats.conversion {
-                return Self.formattedConversionString(for: conversion)
+                return StoreInfoFormatter.formattedConversionString(for: conversion)
             }
-            return Constants.valuePlaceholderText
+            return StoreInfoFormatter.Constants.valuePlaceholderText
         }()
         return StoreInfoEntry.data(.init(range: Localization.today,
                                          name: dependencies.storeName,
-                                         revenue: Self.formattedAmountString(for: todayStats.revenue, with: dependencies.storeCurrencySettings),
-                                         revenueCompact: Self.formattedAmountCompactString(for: todayStats.revenue, with: dependencies.storeCurrencySettings),
+                                         revenue: StoreInfoFormatter.formattedAmountString(for: todayStats.revenue, with: dependencies.storeCurrencySettings),
+                                         revenueCompact: StoreInfoFormatter.formattedAmountCompactString(for: todayStats.revenue, 
+                                                                                                         with: dependencies.storeCurrencySettings),
                                          visitors: visitors,
                                          orders: "\(todayStats.totalOrders)",
                                          conversion: conversion,
-                                         updatedTime: Self.currentFormattedTime()))
-    }
-
-    static func formattedAmountString(for amountValue: Decimal, with currencySettings: CurrencySettings?) -> String {
-        let currencyFormatter = CurrencyFormatter(currencySettings: currencySettings ?? CurrencySettings())
-        return currencyFormatter.formatAmount(amountValue) ?? Constants.valuePlaceholderText
-    }
-
-    static func formattedAmountCompactString(for amountValue: Decimal, with currencySettings: CurrencySettings?) -> String {
-        let currencyFormatter = CurrencyFormatter(currencySettings: currencySettings ?? CurrencySettings())
-        return currencyFormatter.formatHumanReadableAmount(amountValue) ?? Constants.valuePlaceholderText
-    }
-
-    static func formattedConversionString(for conversionRate: Double) -> String {
-        let numberFormatter = NumberFormatter()
-        numberFormatter.numberStyle = .percent
-        numberFormatter.minimumFractionDigits = 1
-
-        // do not add 0 fraction digit if the percentage is round
-        let minimumFractionDigits = floor(conversionRate * 100.0) == conversionRate * 100.0 ? 0 : 1
-        numberFormatter.minimumFractionDigits = minimumFractionDigits
-        return numberFormatter.string(from: conversionRate as NSNumber) ?? Constants.valuePlaceholderText
-    }
-
-    /// Returns the current time formatted as `10:24 PM` or `22:24` depending on the phone settings.
-    ///
-    static func currentFormattedTime() -> String {
-        let timeFormatter = DateFormatter()
-        timeFormatter.timeStyle = .short
-        timeFormatter.dateStyle = .none
-        return timeFormatter.string(from: Date())
-    }
-
-    enum Constants {
-        static let valuePlaceholderText = "-"
+                                         updatedTime: StoreInfoFormatter.currentFormattedTime()))
     }
 
     enum Localization {

--- a/WooCommerce/StoreWidgets/StoreInfoProvider.swift
+++ b/WooCommerce/StoreWidgets/StoreInfoProvider.swift
@@ -190,7 +190,7 @@ private extension StoreInfoProvider {
         return StoreInfoEntry.data(.init(range: Localization.today,
                                          name: dependencies.storeName,
                                          revenue: StoreInfoFormatter.formattedAmountString(for: todayStats.revenue, with: dependencies.storeCurrencySettings),
-                                         revenueCompact: StoreInfoFormatter.formattedAmountCompactString(for: todayStats.revenue, 
+                                         revenueCompact: StoreInfoFormatter.formattedAmountCompactString(for: todayStats.revenue,
                                                                                                          with: dependencies.storeCurrencySettings),
                                          visitors: visitors,
                                          orders: "\(todayStats.totalOrders)",

--- a/WooCommerce/Woo Watch App/Dependencies/Environment+Dependencies.swift
+++ b/WooCommerce/Woo Watch App/Dependencies/Environment+Dependencies.swift
@@ -1,4 +1,5 @@
 import SwiftUI
+import class WooFoundationWatchOS.CurrencySettings
 
 /// Environment dependencies setup
 ///
@@ -21,6 +22,6 @@ extension WatchDependencies {
     /// Fake object, useful as a default value and for previews.
     ///
     static func fake() -> Self {
-        .init(storeID: .zero, storeName: "", credentials: .init(authToken: ""))
+        .init(storeID: .zero, storeName: "", currencySettings: CurrencySettings(), credentials: .init(authToken: ""))
     }
 }

--- a/WooCommerce/Woo Watch App/MyStore/MyStoreViewModel.swift
+++ b/WooCommerce/Woo Watch App/MyStore/MyStoreViewModel.swift
@@ -46,7 +46,7 @@ final class MyStoreViewModel: ObservableObject {
                 return StoreInfoFormatter.Constants.valuePlaceholderText
             }()
 
-            self.viewState = .loaded(revenue: StoreInfoFormatter.formattedAmountString(for: stats.revenue, with: nil),
+            self.viewState = .loaded(revenue: StoreInfoFormatter.formattedAmountString(for: stats.revenue, with: dependencies.currencySettings),
                                      totalOrders: "\(stats.totalOrders)",
                                      totalVisitors: visitors,
                                      conversion: conversion,

--- a/WooCommerce/Woo Watch App/MyStore/MyStoreViewModel.swift
+++ b/WooCommerce/Woo Watch App/MyStore/MyStoreViewModel.swift
@@ -1,11 +1,10 @@
 import Foundation
 import NetworkingWatchOS
+import WooFoundationWatchOS
 
 /// View Model for the MyStoreView
 ///
 final class MyStoreViewModel: ObservableObject {
-
-    static let valuePlaceholderText = "-"
 
     /// Enum that tracks the state of the view.
     ///
@@ -37,57 +36,24 @@ final class MyStoreViewModel: ObservableObject {
                 if let visitors = stats.totalVisitors {
                     return "\(visitors)"
                 }
-                return Self.valuePlaceholderText
+                return StoreInfoFormatter.Constants.valuePlaceholderText
             }()
 
             let conversion: String = {
                 if let conversion = stats.conversion {
-                    return Self.formattedConversionString(for: conversion)
+                    return StoreInfoFormatter.formattedConversionString(for: conversion)
                 }
-                return Self.valuePlaceholderText
+                return StoreInfoFormatter.Constants.valuePlaceholderText
             }()
 
-            self.viewState = .loaded(revenue: Self.formattedAmountString(for: stats.revenue),
+            self.viewState = .loaded(revenue: StoreInfoFormatter.formattedAmountString(for: stats.revenue, with: nil),
                                      totalOrders: "\(stats.totalOrders)",
                                      totalVisitors: visitors,
                                      conversion: conversion,
-                                     time: Self.currentFormattedTime())
+                                     time: StoreInfoFormatter.currentFormattedTime())
         } catch {
             DDLogError("⛔️ Error fetching watch today stats: \(error)")
             self.viewState = .error
         }
-    }
-}
-
-/// Copied from `StoreInfoProvider`. Should be moved into a single file for easier maintainability.
-///
-private extension MyStoreViewModel {
-    static func formattedAmountString(for amountValue: Decimal) -> String {
-        let numberFormatter = NumberFormatter()
-        numberFormatter.numberStyle = .currency
-        numberFormatter.minimumFractionDigits = 2
-        numberFormatter.currencyDecimalSeparator = "."
-        numberFormatter.currencyGroupingSeparator = ","
-        return numberFormatter.string(from: amountValue as NSNumber) ?? valuePlaceholderText
-    }
-
-    static func formattedConversionString(for conversionRate: Double) -> String {
-        let numberFormatter = NumberFormatter()
-        numberFormatter.numberStyle = .percent
-        numberFormatter.minimumFractionDigits = 1
-
-        // do not add 0 fraction digit if the percentage is round
-        let minimumFractionDigits = floor(conversionRate * 100.0) == conversionRate * 100.0 ? 0 : 1
-        numberFormatter.minimumFractionDigits = minimumFractionDigits
-        return numberFormatter.string(from: conversionRate as NSNumber) ?? valuePlaceholderText
-    }
-
-    /// Returns the current time formatted as `10:24 PM` or `22:24` depending on the device settings.
-    ///
-    static func currentFormattedTime() -> String {
-        let timeFormatter = DateFormatter()
-        timeFormatter.timeStyle = .short
-        timeFormatter.dateStyle = .none
-        return timeFormatter.string(from: Date.now)
     }
 }

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -911,6 +911,8 @@
 		269FFA482BF516BA004E6B86 /* Logging.swift in Sources */ = {isa = PBXBuildFile; fileRef = 933A27362222354600C2143A /* Logging.swift */; };
 		269FFA4B2BF544C9004E6B86 /* MyStoreViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 269FFA4A2BF544C9004E6B86 /* MyStoreViewModel.swift */; };
 		26A000772BE9D9030071DB1E /* WooConstants.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5D1AFBF20BC67C200DB0E8C /* WooConstants.swift */; };
+		26A0B2D32BF9A78C002E9620 /* StoreInfoFormatter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26A0B2D22BF9A78C002E9620 /* StoreInfoFormatter.swift */; };
+		26A0B2D42BF9A78C002E9620 /* StoreInfoFormatter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26A0B2D22BF9A78C002E9620 /* StoreInfoFormatter.swift */; };
 		26A280D62B45F00F00ACEE87 /* OrderNotificationViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26A280D52B45F00F00ACEE87 /* OrderNotificationViewModelTests.swift */; };
 		26A280D72B46027A00ACEE87 /* OrderNotificationView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26CA2BC52AAA1773003B16C2 /* OrderNotificationView.swift */; };
 		26A630ED253F3B5C00CBC3B1 /* RefundCreationUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26A630EC253F3B5C00CBC3B1 /* RefundCreationUseCase.swift */; };
@@ -3734,6 +3736,7 @@
 		269B46632A16D6ED00ADA872 /* UpdateAnalyticsSettingsUseCaseTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UpdateAnalyticsSettingsUseCaseTests.swift; sourceTree = "<group>"; };
 		269FFA452BF40768004E6B86 /* WooFoundationWatchOS.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = WooFoundationWatchOS.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		269FFA4A2BF544C9004E6B86 /* MyStoreViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MyStoreViewModel.swift; sourceTree = "<group>"; };
+		26A0B2D22BF9A78C002E9620 /* StoreInfoFormatter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StoreInfoFormatter.swift; sourceTree = "<group>"; };
 		26A280D52B45F00F00ACEE87 /* OrderNotificationViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OrderNotificationViewModelTests.swift; sourceTree = "<group>"; };
 		26A630EC253F3B5C00CBC3B1 /* RefundCreationUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RefundCreationUseCase.swift; sourceTree = "<group>"; };
 		26A630F2253F3CFE00CBC3B1 /* RefundCreationUseCaseTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RefundCreationUseCaseTests.swift; sourceTree = "<group>"; };
@@ -7895,6 +7898,7 @@
 				265C99E328B9C834005E6117 /* StoreInfoProvider.swift */,
 				260DE20828CA7CE2009ECD7C /* StoreInfoDataService.swift */,
 				265C99E528B9CB8E005E6117 /* StoreInfoViewModifiers.swift */,
+				26A0B2D22BF9A78C002E9620 /* StoreInfoFormatter.swift */,
 				3F1FA84728B60125009E246C /* StoreWidgets.intentdefinition */,
 				3F1FA84828B60126009E246C /* Assets.xcassets */,
 				26FFD32628C6A0A4002E5E5E /* Images.xcassets */,
@@ -13586,6 +13590,7 @@
 				26B984D42BEECC610052658C /* Environment+Dependencies.swift in Sources */,
 				26F81B1A2BE433A2009EC58E /* MyStoreView.swift in Sources */,
 				264E9E942BF1D1DF009C48FD /* AppLocalizedString.swift in Sources */,
+				26A0B2D42BF9A78C002E9620 /* StoreInfoFormatter.swift in Sources */,
 				26DD32D42BEBCDFB00F2C69C /* WooConstants.swift in Sources */,
 				269FFA4B2BF544C9004E6B86 /* MyStoreViewModel.swift in Sources */,
 				26B984D62BEECF260052658C /* ConnectView.swift in Sources */,
@@ -13610,6 +13615,7 @@
 				260DE20A28CA7CFE009ECD7C /* StoreInfoDataService.swift in Sources */,
 				AE56E73428E76CDB00A1292B /* StoreInfoInlineWidget.swift in Sources */,
 				3F1FA84B28B60126009E246C /* StoreWidgets.intentdefinition in Sources */,
+				26A0B2D32BF9A78C002E9620 /* StoreInfoFormatter.swift in Sources */,
 				AEBFD13F28E7655F00F598C6 /* StoreInfoView.swift in Sources */,
 				AE56E73628E7787700A1292B /* StoreInfoCircularWidget.swift in Sources */,
 				265C99E228B9BCD0005E6117 /* StoreInfoWidget.swift in Sources */,

--- a/WooFoundation/WooFoundation.xcodeproj/project.pbxproj
+++ b/WooFoundation/WooFoundation.xcodeproj/project.pbxproj
@@ -34,6 +34,9 @@
 		269FFA4D2BF5AFCF004E6B86 /* CurrencyCode.swift in Sources */ = {isa = PBXBuildFile; fileRef = B987B06E284540D300C53CF6 /* CurrencyCode.swift */; };
 		269FFA4F2BF5B040004E6B86 /* Codegen in Frameworks */ = {isa = PBXBuildFile; productRef = 269FFA4E2BF5B040004E6B86 /* Codegen */; };
 		269FFA502BF5B040004E6B86 /* Codegen in Embed Frameworks */ = {isa = PBXBuildFile; productRef = 269FFA4E2BF5B040004E6B86 /* Codegen */; settings = {ATTRIBUTES = (CodeSignOnCopy, ); }; };
+		26A0B2CF2BF9A51E002E9620 /* CurrencyFormatter.swift in Sources */ = {isa = PBXBuildFile; fileRef = B9C9C65B283E71C8001B879F /* CurrencyFormatter.swift */; };
+		26A0B2D02BF9A550002E9620 /* NSDecimalNumber+Helpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = B9C9C658283E7195001B879F /* NSDecimalNumber+Helpers.swift */; };
+		26A0B2D12BF9A58C002E9620 /* Double+Woo.swift in Sources */ = {isa = PBXBuildFile; fileRef = B9C9C65F283E71F4001B879F /* Double+Woo.swift */; };
 		26AF1F5328B8362800937BA9 /* UIColor+SemanticColors.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26AF1F4F28B8362800937BA9 /* UIColor+SemanticColors.swift */; };
 		26AF1F5428B8362800937BA9 /* ColorStudio.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26AF1F5028B8362800937BA9 /* ColorStudio.swift */; };
 		26AF1F5528B8362800937BA9 /* UIColor+ColorStudio.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26AF1F5128B8362800937BA9 /* UIColor+ColorStudio.swift */; };
@@ -664,10 +667,13 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				26A0B2D02BF9A550002E9620 /* NSDecimalNumber+Helpers.swift in Sources */,
 				264E9EA32BF403E1009C48FD /* Date+StartAndEnd.swift in Sources */,
+				26A0B2CF2BF9A51E002E9620 /* CurrencyFormatter.swift in Sources */,
 				269FFA4C2BF5AFC8004E6B86 /* CurrencySettings.swift in Sources */,
 				269FFA4D2BF5AFCF004E6B86 /* CurrencyCode.swift in Sources */,
 				264E9EA42BF4040E009C48FD /* Logging.swift in Sources */,
+				26A0B2D12BF9A58C002E9620 /* Double+Woo.swift in Sources */,
 				264E9EA52BF40411009C48FD /* LogErrorAndExit.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;


### PR DESCRIPTION

closes #12777 

# Why

This PR shares the store currency settings with the watch to properly format the my store stats view.

# How

- Share and store watch dependencies (with updated currency settings)
- Shared formatting code between widget and watch targets
- Use stored currency settings to format content on the watch

# Demo

USD | PEN
--- | ---
<img width="299" alt="usd" src="https://github.com/woocommerce/woocommerce-ios/assets/562080/a32258e7-035e-45e5-b3f3-49d8a05bc6ca"> | <img width="269" alt="pen" src="https://github.com/woocommerce/woocommerce-ios/assets/562080/b6aa6918-153e-4826-a289-4f9db8269285">


---
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
