### PR TITLE
Dynamic Dashboard: Update Yosemite with stock report fetching

### DIFF
--- a/Networking/Networking/Remote/ProductsRemote.swift
+++ b/Networking/Networking/Remote/ProductsRemote.swift
@@ -51,7 +51,7 @@ public protocol ProductsRemoteProtocol {
     func loadNumberOfProducts(siteID: Int64) async throws -> Int64
 
     func loadStock(for siteID: Int64,
-                   with stockStatus: ProductStockStatus,
+                   with stockType: String,
                    pageNumber: Int,
                    pageSize: Int,
                    orderBy: ProductsRemote.OrderKey,
@@ -414,14 +414,14 @@ public final class ProductsRemote: Remote, ProductsRemoteProtocol {
     }
 
     public func loadStock(for siteID: Int64,
-                          with stockStatus: ProductStockStatus,
+                          with stockType: String,
                           pageNumber: Int,
                           pageSize: Int,
                           orderBy: ProductsRemote.OrderKey,
                           order: ProductsRemote.Order) async throws -> [ProductStock] {
         let path = Path.stockReports
         let parameters: [String: Any] = [
-            ParameterKey.type: stockStatus.rawValue,
+            ParameterKey.type: stockType,
             ParameterKey.page: String(pageNumber),
             ParameterKey.perPage: String(pageSize),
             ParameterKey.order: order,

--- a/Networking/NetworkingTests/Remote/ProductsRemoteTests.swift
+++ b/Networking/NetworkingTests/Remote/ProductsRemoteTests.swift
@@ -737,7 +737,7 @@ final class ProductsRemoteTests: XCTestCase {
         network.simulateResponse(requestUrlSuffix: "reports/stock", filename: "product-stock")
 
         // When
-        let stock = try await remote.loadStock(for: 8, with: .outOfStock, pageNumber: 1, pageSize: 3, orderBy: .name, order: .descending)
+        let stock = try await remote.loadStock(for: 8, with: "outOfStock", pageNumber: 1, pageSize: 3, orderBy: .name, order: .descending)
 
         // Then
         XCTAssertEqual(stock.count, 1)
@@ -756,7 +756,7 @@ final class ProductsRemoteTests: XCTestCase {
         let remote = ProductsRemote(network: network)
 
         // When
-        await assertThrowsError({ _ = try await remote.loadStock(for: 8, with: .outOfStock, pageNumber: 1, pageSize: 3, orderBy: .name, order: .descending) },
+        await assertThrowsError({ _ = try await remote.loadStock(for: 8, with: "outofstock", pageNumber: 1, pageSize: 3, orderBy: .name, order: .descending) },
                                 errorAssert: {
             // Then
             $0 as? NetworkError == .notFound()

--- a/Yosemite/Yosemite/Actions/ProductAction.swift
+++ b/Yosemite/Yosemite/Actions/ProductAction.swift
@@ -191,9 +191,16 @@ public enum ProductAction: Action {
                            completion: (Result<AIProduct, Error>) -> Void)
 
     /// Fetches stock based on the given status for a site
+    /// - Parameter siteID: Site ID to fetch stock for.
+    /// - Parameter stockType: Raw type of stock to query.
+    /// - Parameter pageNumber: The index of the content page to query.
+    /// - Parameter pageSize: The max amount of items to return per page.
+    /// - Parameter orderBy: The key to sort returned items.
+    /// - Parameter order: Whether to sort returned items ASC or DESC.
+    /// - Parameter completion: Closure to trigger when fetching completes.
     ///
     case fetchStockReport(siteID: Int64,
-                          stockStatus: ProductStockStatus,
+                          stockType: String,
                           pageNumber: Int,
                           pageSize: Int,
                           orderBy: ProductsRemote.OrderKey,

--- a/Yosemite/Yosemite/Actions/ProductAction.swift
+++ b/Yosemite/Yosemite/Actions/ProductAction.swift
@@ -189,4 +189,14 @@ public enum ProductAction: Action {
                            categories: [ProductCategory],
                            tags: [ProductTag],
                            completion: (Result<AIProduct, Error>) -> Void)
+
+    /// Fetches stock based on the given status for a site
+    ///
+    case fetchStockReport(siteID: Int64,
+                          stockStatus: ProductStockStatus,
+                          pageNumber: Int,
+                          pageSize: Int,
+                          orderBy: ProductsRemote.OrderKey,
+                          order: ProductsRemote.Order,
+                          completion: (Result<[ProductStock], Error>) -> Void)
 }

--- a/Yosemite/Yosemite/Stores/ProductStore.swift
+++ b/Yosemite/Yosemite/Stores/ProductStore.swift
@@ -156,9 +156,9 @@ public class ProductStore: Store {
                               categories: categories,
                               tags: tags,
                               completion: completion)
-        case let .fetchStockReport(siteID, stockStatus, pageNumber, pageSize, orderBy, order, completion):
+        case let .fetchStockReport(siteID, stockType, pageNumber, pageSize, orderBy, order, completion):
             fetchStockReport(siteID: siteID,
-                             stockStatus: stockStatus,
+                             stockType: stockType,
                              pageNumber: pageNumber,
                              pageSize: pageSize,
                              orderBy: orderBy,
@@ -741,7 +741,7 @@ private extension ProductStore {
     }
 
     func fetchStockReport(siteID: Int64,
-                          stockStatus: ProductStockStatus,
+                          stockType: String,
                           pageNumber: Int,
                           pageSize: Int,
                           orderBy: ProductsRemote.OrderKey,
@@ -750,7 +750,7 @@ private extension ProductStore {
         Task { @MainActor in
             do {
                 let stock = try await remote.loadStock(for: siteID,
-                                                       with: stockStatus,
+                                                       with: stockType,
                                                        pageNumber: pageNumber,
                                                        pageSize: pageSize,
                                                        orderBy: orderBy,

--- a/Yosemite/Yosemite/Stores/ProductStore.swift
+++ b/Yosemite/Yosemite/Stores/ProductStore.swift
@@ -156,6 +156,14 @@ public class ProductStore: Store {
                               categories: categories,
                               tags: tags,
                               completion: completion)
+        case let .fetchStockReport(siteID, stockStatus, pageNumber, pageSize, orderBy, order, completion):
+            fetchStockReport(siteID: siteID,
+                             stockStatus: stockStatus,
+                             pageNumber: pageNumber,
+                             pageSize: pageSize,
+                             orderBy: orderBy,
+                             order: order,
+                             completion: completion)
         }
     }
 }
@@ -729,6 +737,28 @@ private extension ProductStore {
                 return product
             }
             completion(result)
+        }
+    }
+
+    func fetchStockReport(siteID: Int64,
+                          stockStatus: ProductStockStatus,
+                          pageNumber: Int,
+                          pageSize: Int,
+                          orderBy: ProductsRemote.OrderKey,
+                          order: ProductsRemote.Order,
+                          completion: @escaping (Result<[ProductStock], Error>) -> Void) {
+        Task { @MainActor in
+            do {
+                let stock = try await remote.loadStock(for: siteID,
+                                                       with: stockStatus,
+                                                       pageNumber: pageNumber,
+                                                       pageSize: pageSize,
+                                                       orderBy: orderBy,
+                                                       order: order)
+                completion(.success(stock))
+            } catch {
+                completion(.failure(error))
+            }
         }
     }
 }

--- a/Yosemite/YosemiteTests/Stores/ProductStoreTests.swift
+++ b/Yosemite/YosemiteTests/Stores/ProductStoreTests.swift
@@ -2831,6 +2831,70 @@ final class ProductStoreTests: XCTestCase {
         XCTAssertTrue(result.isFailure)
         XCTAssertEqual(result.failure as? NetworkError, .timeout())
     }
+
+    // MARK: - Fetch stock
+
+    func test_fetchStock_returns_stock_on_success() throws {
+        // Given
+        let stock = ProductStock.fake().copy(siteID: sampleSiteID,
+                                             productID: 13,
+                                             name: "Steamed bun",
+                                             sku: "1353",
+                                             manageStock: true,
+                                             stockQuantity: 4,
+                                             stockStatusKey: "instock")
+        let mockRemote = MockProductsRemote()
+        mockRemote.whenFetchingStock(thenReturn: .success([stock]))
+        let productStore = ProductStore(dispatcher: dispatcher,
+                                        storageManager: storageManager,
+                                        network: network,
+                                        remote: mockRemote)
+
+        // When
+        let result = waitFor { promise in
+            productStore.onAction(ProductAction.fetchStockReport(siteID: self.sampleSiteID,
+                                                                 stockType: "lowstock",
+                                                                 pageNumber: 1,
+                                                                 pageSize: 3,
+                                                                 orderBy: .date,
+                                                                 order: .descending,
+                                                                 completion: { result in
+                promise(result)
+            }))
+        }
+
+        // Then
+        let receivedStock = try XCTUnwrap(result.get())
+        XCTAssertEqual(receivedStock.count, 1)
+        XCTAssertEqual(receivedStock.first, stock)
+    }
+
+    func test_fetchStock_returns_error_on_failure() throws {
+        // Given
+        let mockRemote = MockProductsRemote()
+        mockRemote.whenFetchingStock(thenReturn: .failure(NetworkError.timeout()))
+        let productStore = ProductStore(dispatcher: dispatcher,
+                                        storageManager: storageManager,
+                                        network: network,
+                                        remote: mockRemote)
+
+        // When
+        let result = waitFor { promise in
+            productStore.onAction(ProductAction.fetchStockReport(siteID: self.sampleSiteID,
+                                                                 stockType: "lowstock",
+                                                                 pageNumber: 1,
+                                                                 pageSize: 3,
+                                                                 orderBy: .date,
+                                                                 order: .descending,
+                                                                 completion: { result in
+                promise(result)
+            }))
+        }
+
+        // Then
+        XCTAssertTrue(result.isFailure)
+        XCTAssertEqual(result.failure as? NetworkError, .timeout())
+    }
 }
 
 // MARK: - Private Helpers


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #12748 
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This PR updates `ProductStore` and `ProductAction` to support fetching stock reports. Since this endpoint supports both stock status and `lowstock` option, I also updated `ProductsRemote` to accept a raw stock type instead of only stock status.

Due to the complexity of optimizing the stock card [p1715916527632179/1715228241.268569-slack-C03L1NF1EA3], we're only saving stock reports in-memory for now, so no storage change is added.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
Just CI passing is sufficient.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->
N/A


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.