### PR TITLE
[Woo POS] Update conditions for showing POS entry point

### DIFF
--- a/WooCommerce/Classes/Model/BetaFeature.swift
+++ b/WooCommerce/Classes/Model/BetaFeature.swift
@@ -57,8 +57,7 @@ extension BetaFeature {
         case .inAppPurchases:
             return ServiceLocator.featureFlagService.isFeatureFlagEnabled(.inAppPurchasesDebugMenu)
         case .pointOfSale:
-            return ServiceLocator.featureFlagService.isFeatureFlagEnabled(.displayPointOfSaleToggle) &&
-            UIDevice.current.userInterfaceIdiom == .pad
+            return POSEligibilityChecker().isEligible()
         default:
             return true
         }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/POS/POSEligibilityChecker.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/POS/POSEligibilityChecker.swift
@@ -1,0 +1,49 @@
+import Foundation
+import UIKit
+import class WooFoundation.CurrencySettings
+import enum WooFoundation.CountryCode
+import protocol Experiments.FeatureFlagService
+import struct Yosemite.SiteSetting
+
+/// Determines whether the POS entry point can be shown based on the selected store and feature gates.
+final class POSEligibilityChecker {
+    private let isBetaFeatureEnabled: Bool
+    private let cardPresentPaymentsOnboarding: CardPresentPaymentsOnboardingUseCaseProtocol
+    private let siteSettings: [SiteSetting]
+    private let currencySettings: CurrencySettings
+    private let featureFlagService: FeatureFlagService
+
+    init(isBetaFeatureEnabled: Bool,
+         cardPresentPaymentsOnboarding: CardPresentPaymentsOnboardingUseCaseProtocol = CardPresentPaymentsOnboardingUseCase(),
+         siteSettings: [SiteSetting],
+         currencySettings: CurrencySettings,
+         featureFlagService: FeatureFlagService) {
+        self.isBetaFeatureEnabled = isBetaFeatureEnabled
+        self.siteSettings = siteSettings
+        self.currencySettings = currencySettings
+        self.cardPresentPaymentsOnboarding = cardPresentPaymentsOnboarding
+        self.featureFlagService = featureFlagService
+    }
+
+    /// Returns whether the selected store is eligible for POS.
+    func isEligible() -> Bool {
+        // Always checks the main POS feature flag before any other checks.
+        guard featureFlagService.isFeatureFlagEnabled(.displayPointOfSaleToggle) else {
+            return false
+        }
+
+        let isCountryCodeUS = SiteAddress(siteSettings: siteSettings).countryCode == CountryCode.US
+        let isCurrencyUSD = currencySettings.currencyCode == .USD
+
+        // Feature switch enabled
+        return isBetaFeatureEnabled
+        // Tablet device
+        && UIDevice.current.userInterfaceIdiom == .pad
+        // Woo Payments plugin enabled and user setup complete
+        && (cardPresentPaymentsOnboarding.state == .completed(plugin: .wcPayOnly) || cardPresentPaymentsOnboarding.state == .completed(plugin: .wcPayPreferred))
+        // USD currency
+        && isCurrencyUSD
+        // US store location
+        && isCountryCodeUS
+    }
+}

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/POS/POSEligibilityChecker.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/POS/POSEligibilityChecker.swift
@@ -7,18 +7,15 @@ import struct Yosemite.SiteSetting
 
 /// Determines whether the POS entry point can be shown based on the selected store and feature gates.
 final class POSEligibilityChecker {
-    private let isBetaFeatureEnabled: Bool
     private let cardPresentPaymentsOnboarding: CardPresentPaymentsOnboardingUseCaseProtocol
     private let siteSettings: [SiteSetting]
     private let currencySettings: CurrencySettings
     private let featureFlagService: FeatureFlagService
 
-    init(isBetaFeatureEnabled: Bool,
-         cardPresentPaymentsOnboarding: CardPresentPaymentsOnboardingUseCaseProtocol = CardPresentPaymentsOnboardingUseCase(),
-         siteSettings: [SiteSetting],
-         currencySettings: CurrencySettings,
-         featureFlagService: FeatureFlagService) {
-        self.isBetaFeatureEnabled = isBetaFeatureEnabled
+    init(cardPresentPaymentsOnboarding: CardPresentPaymentsOnboardingUseCaseProtocol = CardPresentPaymentsOnboardingUseCase(),
+         siteSettings: [SiteSetting] = ServiceLocator.selectedSiteSettings.siteSettings,
+         currencySettings: CurrencySettings = ServiceLocator.currencySettings,
+         featureFlagService: FeatureFlagService = ServiceLocator.featureFlagService) {
         self.siteSettings = siteSettings
         self.currencySettings = currencySettings
         self.cardPresentPaymentsOnboarding = cardPresentPaymentsOnboarding
@@ -35,10 +32,8 @@ final class POSEligibilityChecker {
         let isCountryCodeUS = SiteAddress(siteSettings: siteSettings).countryCode == CountryCode.US
         let isCurrencyUSD = currencySettings.currencyCode == .USD
 
-        // Feature switch enabled
-        return isBetaFeatureEnabled
         // Tablet device
-        && UIDevice.current.userInterfaceIdiom == .pad
+        return UIDevice.current.userInterfaceIdiom == .pad
         // Woo Payments plugin enabled and user setup complete
         && (cardPresentPaymentsOnboarding.state == .completed(plugin: .wcPayOnly) || cardPresentPaymentsOnboarding.state == .completed(plugin: .wcPayPreferred))
         // USD currency

--- a/WooCommerce/Classes/ViewRelated/Hub Menu/HubMenu.swift
+++ b/WooCommerce/Classes/ViewRelated/Hub Menu/HubMenu.swift
@@ -85,78 +85,49 @@ private extension HubMenu {
             // Point of Sale
             if let menu = viewModel.posElement {
                 Section {
-                    Button {
-                        handleTap(menu: menu)
-                    } label: {
-                        Row(title: menu.title,
-                            titleBadge: nil,
-                            iconBadge: menu.iconBadge,
-                            description: menu.description,
-                            icon: .local(menu.icon),
-                            chevron: .leading)
-                        .foregroundColor(Color(menu.iconColor))
-                    }
-                    .accessibilityIdentifier(menu.accessibilityIdentifier)
-                    .overlay {
-                        NavigationLink(value: menu.id) {
-                            EmptyView()
-                        }
-                        .opacity(0)
-                    }
+                    menuItemView(menu: menu)
                 }
             }
 
             // Settings Section
             Section(Localization.settings) {
                 ForEach(viewModel.settingsElements, id: \.id) { menu in
-                    Button {
-                        handleTap(menu: menu)
-                    } label: {
-                        Row(title: menu.title,
-                            titleBadge: nil,
-                            iconBadge: menu.iconBadge,
-                            description: menu.description,
-                            icon: .local(menu.icon),
-                            chevron: .leading)
-                        .foregroundColor(Color(menu.iconColor))
-                    }
-                    .accessibilityIdentifier(menu.accessibilityIdentifier)
-                    .overlay {
-                        NavigationLink(value: menu.id) {
-                            EmptyView()
-                        }
-                        .opacity(0)
-                    }
+                    menuItemView(menu: menu)
                 }
             }
 
             // General Section
             Section(Localization.general) {
                 ForEach(viewModel.generalElements, id: \.id) { menu in
-                    Button {
-                        handleTap(menu: menu)
-                    } label: {
-                        Row(title: menu.title,
-                            titleBadge: nil,
-                            iconBadge: menu.iconBadge,
-                            description: menu.description,
-                            icon: .local(menu.icon),
-                            chevron: .leading)
-                        .foregroundColor(Color(menu.iconColor))
-                    }
-                    .accessibilityIdentifier(menu.accessibilityIdentifier)
-                    .overlay {
-                        NavigationLink(value: menu.id) {
-                            EmptyView()
-                        }
-                        .opacity(0)
-                    }
+                    menuItemView(menu: menu)
                 }
             }
         }
         .listStyle(.insetGrouped)
         .background(Color(.listBackground))
         .accentColor(Color(.listSelectedBackground))
+    }
+
+    @ViewBuilder
+    func menuItemView(menu: HubMenuItem) -> some View {
+        Button {
+            handleTap(menu: menu)
+        } label: {
+            Row(title: menu.title,
+                titleBadge: nil,
+                iconBadge: menu.iconBadge,
+                description: menu.description,
+                icon: .local(menu.icon),
+                chevron: .leading)
+            .foregroundColor(Color(menu.iconColor))
+        }
+        .accessibilityIdentifier(menu.accessibilityIdentifier)
+        .overlay {
+            NavigationLink(value: menu.id) {
+                EmptyView()
+            }
+            .opacity(0)
+        }
     }
 
     @ViewBuilder

--- a/WooCommerce/Classes/ViewRelated/Hub Menu/HubMenu.swift
+++ b/WooCommerce/Classes/ViewRelated/Hub Menu/HubMenu.swift
@@ -82,6 +82,30 @@ private extension HubMenu {
                 .disabled(!viewModel.switchStoreEnabled)
             }
 
+            // Point of Sale
+            if let menu = viewModel.posElement {
+                Section {
+                    Button {
+                        handleTap(menu: menu)
+                    } label: {
+                        Row(title: menu.title,
+                            titleBadge: nil,
+                            iconBadge: menu.iconBadge,
+                            description: menu.description,
+                            icon: .local(menu.icon),
+                            chevron: .leading)
+                        .foregroundColor(Color(menu.iconColor))
+                    }
+                    .accessibilityIdentifier(menu.accessibilityIdentifier)
+                    .overlay {
+                        NavigationLink(value: menu.id) {
+                            EmptyView()
+                        }
+                        .opacity(0)
+                    }
+                }
+            }
+
             // Settings Section
             Section(Localization.settings) {
                 ForEach(viewModel.settingsElements, id: \.id) { menu in

--- a/WooCommerce/Classes/ViewRelated/Hub Menu/HubMenuViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Hub Menu/HubMenuViewModel.swift
@@ -138,12 +138,12 @@ final class HubMenuViewModel: ObservableObject {
     }
 
     private func setupPOSElement() {
-        let eligibilityChecker = POSEligibilityChecker(isBetaFeatureEnabled: generalAppSettings.betaFeatureEnabled(.pointOfSale),
-                                                       cardPresentPaymentsOnboarding: CardPresentPaymentsOnboardingUseCase(),
+        let isBetaFeatureEnabled = generalAppSettings.betaFeatureEnabled(.pointOfSale)
+        let eligibilityChecker = POSEligibilityChecker(cardPresentPaymentsOnboarding: CardPresentPaymentsOnboardingUseCase(),
                                                        siteSettings: ServiceLocator.selectedSiteSettings.siteSettings,
                                                        currencySettings: ServiceLocator.currencySettings,
                                                        featureFlagService: featureFlagService)
-        if eligibilityChecker.isEligible() {
+        if isBetaFeatureEnabled && eligibilityChecker.isEligible() {
             posElement = PointOfSaleEntryPoint()
         } else {
             posElement = nil

--- a/WooCommerce/Classes/ViewRelated/Hub Menu/HubMenuViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Hub Menu/HubMenuViewModel.swift
@@ -41,6 +41,10 @@ final class HubMenuViewModel: ObservableObject {
 
     @Published private(set) var woocommerceAdminURL = WooConstants.URLs.blog.asURL()
 
+    /// POS Section Element
+    ///
+    @Published private(set) var posElement: HubMenuItem?
+
     /// Settings Elements
     ///
     @Published private(set) var settingsElements: [HubMenuItem] = []
@@ -122,6 +126,7 @@ final class HubMenuViewModel: ObservableObject {
     /// Resets the menu elements displayed on the menu.
     ///
     func setupMenuElements() {
+        setupPOSElement()
         setupSettingsElements()
         setupGeneralElements()
     }
@@ -130,6 +135,19 @@ final class HubMenuViewModel: ObservableObject {
     func showPayments() {
         navigationPath = .init()
         navigationPath.append(HubMenuNavigationDestination.payments)
+    }
+
+    private func setupPOSElement() {
+        let eligibilityChecker = POSEligibilityChecker(isBetaFeatureEnabled: generalAppSettings.betaFeatureEnabled(.pointOfSale),
+                                                       cardPresentPaymentsOnboarding: CardPresentPaymentsOnboardingUseCase(),
+                                                       siteSettings: ServiceLocator.selectedSiteSettings.siteSettings,
+                                                       currencySettings: ServiceLocator.currencySettings,
+                                                       featureFlagService: featureFlagService)
+        if eligibilityChecker.isEligible() {
+            posElement = PointOfSaleEntryPoint()
+        } else {
+            posElement = nil
+        }
     }
 
     private func setupSettingsElements() {
@@ -152,9 +170,6 @@ final class HubMenuViewModel: ObservableObject {
                            Reviews()]
         if generalAppSettings.betaFeatureEnabled(.inAppPurchases) {
             generalElements.append(InAppPurchases())
-        }
-        if generalAppSettings.betaFeatureEnabled(.pointOfSale) {
-            generalElements.append(PointOfSaleEntryPoint())
         }
 
         let inboxUseCase = InboxEligibilityUseCase(stores: stores, featureFlagService: featureFlagService)

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -560,6 +560,7 @@
 		02E4908929AE49B9005942AE /* TopPerformersEmptyView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02E4908829AE49B9005942AE /* TopPerformersEmptyView.swift */; };
 		02E4908D29AF216E005942AE /* TopPerformersPeriodView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02E4908C29AF216E005942AE /* TopPerformersPeriodView.swift */; };
 		02E493EF245C1087000AEA9E /* ProductFormBottomSheetListSelectorCommandTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02E493EE245C1087000AEA9E /* ProductFormBottomSheetListSelectorCommandTests.swift */; };
+		02E4A0832BFB1C4F006D4F87 /* POSEligibilityChecker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02E4A0822BFB1C4F006D4F87 /* POSEligibilityChecker.swift */; };
 		02E4AF7126FC4F16002AD9F4 /* ProductReviewFromNoteParcelFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02E4AF7026FC4F16002AD9F4 /* ProductReviewFromNoteParcelFactory.swift */; };
 		02E4FD7E2306A8180049610C /* StatsTimeRangeBarViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02E4FD7D2306A8180049610C /* StatsTimeRangeBarViewModel.swift */; };
 		02E4FD812306AA890049610C /* StatsTimeRangeBarViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02E4FD802306AA890049610C /* StatsTimeRangeBarViewModelTests.swift */; };
@@ -3333,6 +3334,7 @@
 		02E4908829AE49B9005942AE /* TopPerformersEmptyView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TopPerformersEmptyView.swift; sourceTree = "<group>"; };
 		02E4908C29AF216E005942AE /* TopPerformersPeriodView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TopPerformersPeriodView.swift; sourceTree = "<group>"; };
 		02E493EE245C1087000AEA9E /* ProductFormBottomSheetListSelectorCommandTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductFormBottomSheetListSelectorCommandTests.swift; sourceTree = "<group>"; };
+		02E4A0822BFB1C4F006D4F87 /* POSEligibilityChecker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = POSEligibilityChecker.swift; sourceTree = "<group>"; };
 		02E4AF7026FC4F16002AD9F4 /* ProductReviewFromNoteParcelFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductReviewFromNoteParcelFactory.swift; sourceTree = "<group>"; };
 		02E4FD7D2306A8180049610C /* StatsTimeRangeBarViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StatsTimeRangeBarViewModel.swift; sourceTree = "<group>"; };
 		02E4FD802306AA890049610C /* StatsTimeRangeBarViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StatsTimeRangeBarViewModelTests.swift; sourceTree = "<group>"; };
@@ -6896,6 +6898,14 @@
 				02E3B62C290631B3007E0F13 /* AccountCreationFormViewModel.swift */,
 			);
 			path = Authentication;
+			sourceTree = "<group>";
+		};
+		02E4A0842BFB1D1F006D4F87 /* POS */ = {
+			isa = PBXGroup;
+			children = (
+				02E4A0822BFB1C4F006D4F87 /* POSEligibilityChecker.swift */,
+			);
+			path = POS;
 			sourceTree = "<group>";
 		};
 		02E4FD7F2306AA770049610C /* Dashboard */ = {
@@ -10974,6 +10984,7 @@
 				E138D4F2269ED99A006EA5C6 /* In-Person Payments */,
 				CE27257A219249B5002B22EB /* Help */,
 				CE22E3F821714639005A6BEF /* Privacy */,
+				02E4A0842BFB1D1F006D4F87 /* POS */,
 				03191AE828E20C9200670723 /* PluginDetailsRowView.swift */,
 			);
 			path = Settings;
@@ -14683,6 +14694,7 @@
 				B57C744E20F56E3800EEFC87 /* UITableViewCell+Helpers.swift in Sources */,
 				0295355B245ADF8100BDC42B /* FilterType+Products.swift in Sources */,
 				02CA63DA23D1ADD100BBF148 /* CameraCaptureCoordinator.swift in Sources */,
+				02E4A0832BFB1C4F006D4F87 /* POSEligibilityChecker.swift in Sources */,
 				DE8BEB962ABC19B100F5E56C /* ProductDetailPreviewView.swift in Sources */,
 				260C31602524ECA900157BC2 /* IssueRefundViewController.swift in Sources */,
 				4521397027FF53E400964ED3 /* CouponExpiryDateView.swift in Sources */,


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of: #12780 
<!-- Id number of the GitHub issue this PR addresses. -->

## Why

As the conditions had been implemented in Android https://github.com/woocommerce/woocommerce-android/pull/11513 and mentioned in the weekly update decisions section p91TBi-bfp-p2#decisions, I'm following the same checks in iOS:

- tablet device
- USD currency
- US store location
- Woo Payments plugin enabled and user setup complete
- Feature Flag enabled

## How

To consolidate the checks, `POSEligibilityChecker` was created to check if a store is eligible for POS

- Tablet device: `UIDevice.current.userInterfaceIdiom == .pad` as in the beta feature switch
- USD currency: from `ServiceLocator.currencySettings` currency settings singleton
- US store location: from `ServiceLocator.selectedSiteSettings.siteSettings` site settings singleton
- Woo Payments plugin enabled and user setup complete: from `CardPresentPaymentsOnboardingUseCase.state`
  - It just checks the current state without triggering a refresh
  - POS is only eligible if WCPay i the only/preferred plugin in the onboarding completed state
- Feature Flag enabled: checks the POS entry point feature flag `displayPointOfSaleToggle` - we can consider renaming it after the decision of whether to keep the feature switch or red dot notification is made p91TBi-beb-p2#comment-12129

Then, `POSEligibilityChecker().isEligible()` is called when:
- Determining whether the POS feature switch is available (as the red dot vs. feature switch decision is pending p91TBi-beb-p2#comment-12129)
- Determining whether to show the POS entry point in `HubMenuViewModel` - the feature switch could have been enabled before this PR, and the eligibility check should be in place to prevent the entry point from being shown

In `HubMenuViewModel`, the POS entry point was also updated from a row in the General section to a new section without a title below the store switch to minimize the chance of merge conflicts with https://github.com/woocommerce/woocommerce-ios/issues/12779.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

There are a few scenarios that @jaclync will test again after approval:

- Tablet device
  - [x] Go to the Menu tab on iPhone --> no POS row should be shown in the menu tab, and in Experimental Features the POS feature switch should not be shown
  - [x] Go to the Menu tab on iPad --> in Experimental Features the POS feature switch should be shown, and when the switch is enabled, the POS row should be shown in the menu tab if the store is eligible for POS

Continue with an iPad with the POS feature switch enabled for the following cases:

- USD currency (WC Settings > General)
  - [x] Switch to a store with non-USD currency --> after revisiting the Menu tab, the POS row should **not** be shown
- US store location (WC Settings > General)
  - [x] Switch to a store not based in the US --> after revisiting the Menu tab, the POS row should **not** be shown
- Woo Payments plugin enabled and user setup complete
  - [x] Switch to a store based in the US and using USD, but the WCPay isn't active or its onboarding isn't complete --> after revisiting the Menu tab, the POS row should **not** be shown

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

<img src="https://github.com/woocommerce/woocommerce-ios/assets/1945542/1c7b61d0-7514-4c2f-b5a8-08772b00a9fc" width="500" />


https://github.com/woocommerce/woocommerce-ios/assets/1945542/96ce5c21-3434-4320-930b-c063a4d72a52



---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.