### PR TITLE
Dynamic Dashboard: Various states and tracking for Reviews card

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Dashboard/Reviews/ReviewDashboardEmptyView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Reviews/ReviewDashboardEmptyView.swift
@@ -1,0 +1,39 @@
+import SwiftUI
+
+/// Shown when the Reviews dashboard card can't show any cards.
+struct ReviewDashboardEmptyView: View {
+    let isFiltered: Bool
+
+    var body: some View {
+        VStack(alignment: .center, spacing: Layout.defaultSpacing) {
+            Image(uiImage: .emptyReviewsImage)
+            Text(isFiltered ? Localization.noFilteredReviewsText : Localization.noReviewsText)
+                .subheadlineStyle()
+        }
+        .padding(.all, Layout.defaultSpacing)
+    }
+}
+
+private extension ReviewDashboardEmptyView {
+    enum Localization {
+        static let noReviewsText = NSLocalizedString(
+            "mostActiveCouponsEmptyView.noReviewsText",
+            value: "Get your first reviews",
+            comment: "Message shown in the Reviews Dashboard Card if the site has no review"
+        )
+
+        static let noFilteredReviewsText = NSLocalizedString(
+            "mostActiveCouponsEmptyView.noFilteredReviewsText",
+            value: "No reviews found.",
+            comment: "Message shown in the Reviews Dashboard Card if the list is filtered and there is no review."
+        )
+    }
+
+    enum Layout {
+        static let defaultSpacing: CGFloat = 16
+    }
+}
+
+#Preview {
+    ReviewDashboardEmptyView(isFiltered: false)
+}

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Reviews/ReviewsDashboardCard.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Reviews/ReviewsDashboardCard.swift
@@ -39,6 +39,7 @@ struct ReviewsDashboardCard: View {
                     .redacted(reason: viewModel.syncingData ? [.placeholder] : [])
                     .shimmering(active: viewModel.syncingData)
                 Divider()
+                    .renderedIf(viewModel.syncingData == false)
 
                 if viewModel.syncingData || viewModel.data.isNotEmpty {
                     ForEach(viewModel.data, id: \.review.reviewID) { reviewViewModel in

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Reviews/ReviewsDashboardCard.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Reviews/ReviewsDashboardCard.swift
@@ -25,30 +25,40 @@ struct ReviewsDashboardCard: View {
             header
                 .padding(.horizontal, Layout.padding)
 
-            reviewsFilterBar
+            if let error = viewModel.syncingError {
+                DashboardCardErrorView(onRetry: {
+                    ServiceLocator.analytics.track(event: .DynamicDashboard.cardRetryTapped(type: .reviews))
+                    Task {
+                        await viewModel.reloadData()
+                    }
+                })
                 .padding(.horizontal, Layout.padding)
-                .redacted(reason: viewModel.syncingData ? [.placeholder] : [])
-                .shimmering(active: viewModel.syncingData)
-            Divider()
-
-            if viewModel.syncingData || viewModel.data.isNotEmpty {
-                ForEach(viewModel.data, id: \.review.reviewID) { reviewViewModel in
-                    reviewRow(for: reviewViewModel,
-                              isLastItem: reviewViewModel == viewModel.data.last)
-                }
-                .redacted(reason: viewModel.syncingData ? [.placeholder] : [])
-                .shimmering(active: viewModel.syncingData)
             } else {
-                emptyView(isFiltered: viewModel.currentFilter != .all)
-            }
-
-            if viewModel.shouldShowAllReviewsButton {
-                Divider()
-
-                viewAllReviewsButton
+                reviewsFilterBar
                     .padding(.horizontal, Layout.padding)
                     .redacted(reason: viewModel.syncingData ? [.placeholder] : [])
                     .shimmering(active: viewModel.syncingData)
+                Divider()
+
+                if viewModel.syncingData || viewModel.data.isNotEmpty {
+                    ForEach(viewModel.data, id: \.review.reviewID) { reviewViewModel in
+                        reviewRow(for: reviewViewModel,
+                                  isLastItem: reviewViewModel == viewModel.data.last)
+                    }
+                    .redacted(reason: viewModel.syncingData ? [.placeholder] : [])
+                    .shimmering(active: viewModel.syncingData)
+                } else {
+                    emptyView(isFiltered: viewModel.currentFilter != .all)
+                }
+
+                if viewModel.shouldShowAllReviewsButton {
+                    Divider()
+
+                    viewAllReviewsButton
+                        .padding(.horizontal, Layout.padding)
+                        .redacted(reason: viewModel.syncingData ? [.placeholder] : [])
+                        .shimmering(active: viewModel.syncingData)
+                }
             }
         }
         .padding(.vertical, Layout.padding)

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Reviews/ReviewsDashboardCard.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Reviews/ReviewsDashboardCard.swift
@@ -31,13 +31,15 @@ struct ReviewsDashboardCard: View {
                 .shimmering(active: viewModel.syncingData)
             Divider()
 
-            if viewModel.data.isNotEmpty {
+            if viewModel.syncingData || viewModel.data.isNotEmpty {
                 ForEach(viewModel.data, id: \.review.reviewID) { reviewViewModel in
                     reviewRow(for: reviewViewModel,
                               isLastItem: reviewViewModel == viewModel.data.last)
                 }
                 .redacted(reason: viewModel.syncingData ? [.placeholder] : [])
                 .shimmering(active: viewModel.syncingData)
+            } else {
+                emptyView(isFiltered: viewModel.currentFilter != .all)
             }
 
             if viewModel.shouldShowAllReviewsButton {
@@ -208,6 +210,13 @@ private extension ReviewsDashboardCard {
             }
         }
         .disabled(viewModel.syncingData)
+    }
+
+    func emptyView(isFiltered: Bool) -> some View {
+        VStack(spacing: 0) {
+            ReviewDashboardEmptyView(isFiltered: isFiltered)
+                .frame(maxWidth: .infinity)
+        }
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Reviews/ReviewsDashboardCardViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Reviews/ReviewsDashboardCardViewModel.swift
@@ -81,7 +81,7 @@ final class ReviewsDashboardCardViewModel: ObservableObject {
     }()
 
     func dismissReviews() {
-        // TODO: add tracking
+        analytics.track(event: .DynamicDashboard.hideCardTapped(type: .reviews))
         onDismiss?()
     }
 

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -1528,6 +1528,7 @@
 		86DBBB0BDEA3488E2BEBB314 /* Pods_WooCommerce.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = BABE5E07DD787ECA6D2A76DE /* Pods_WooCommerce.framework */; };
 		86DE68822B4BA47A00B437A6 /* BlazeAdDestinationSettingViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 86DE68812B4BA47900B437A6 /* BlazeAdDestinationSettingViewModel.swift */; };
 		86E1D3192BFB470C00BA29B7 /* ReviewDashboardEmptyView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 86E1D3182BFB470C00BA29B7 /* ReviewDashboardEmptyView.swift */; };
+		86E1D31C2BFB64E400BA29B7 /* ReviewsDashboardCardViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 86E1D31B2BFB64E400BA29B7 /* ReviewsDashboardCardViewModelTests.swift */; };
 		86E40AED2B597DEC00990365 /* BlazeCampaignCreationCoordinatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 86E40AEC2B597DEC00990365 /* BlazeCampaignCreationCoordinatorTests.swift */; };
 		86F0896F2B307D7E00D668A1 /* ThemesPreviewViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 86F0896E2B307D7E00D668A1 /* ThemesPreviewViewModelTests.swift */; };
 		8CD41D4A21F8A7E300CF3C2B /* RELEASE-NOTES.txt in Resources */ = {isa = PBXBuildFile; fileRef = 8CD41D4921F8A7E300CF3C2B /* RELEASE-NOTES.txt */; };
@@ -4275,6 +4276,7 @@
 		86A4EBBC2B2F1306008011F5 /* ThemesPreviewViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ThemesPreviewViewModel.swift; sourceTree = "<group>"; };
 		86DE68812B4BA47900B437A6 /* BlazeAdDestinationSettingViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BlazeAdDestinationSettingViewModel.swift; sourceTree = "<group>"; };
 		86E1D3182BFB470C00BA29B7 /* ReviewDashboardEmptyView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReviewDashboardEmptyView.swift; sourceTree = "<group>"; };
+		86E1D31B2BFB64E400BA29B7 /* ReviewsDashboardCardViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReviewsDashboardCardViewModelTests.swift; sourceTree = "<group>"; };
 		86E40AEC2B597DEC00990365 /* BlazeCampaignCreationCoordinatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BlazeCampaignCreationCoordinatorTests.swift; sourceTree = "<group>"; };
 		86F0896E2B307D7E00D668A1 /* ThemesPreviewViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ThemesPreviewViewModelTests.swift; sourceTree = "<group>"; };
 		8A659E65308A3D9DD79A95F9 /* Pods-WooCommerceTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-WooCommerceTests.release.xcconfig"; path = "../Pods/Target Support Files/Pods-WooCommerceTests/Pods-WooCommerceTests.release.xcconfig"; sourceTree = "<group>"; };
@@ -6903,6 +6905,7 @@
 		02E4FD7F2306AA770049610C /* Dashboard */ = {
 			isa = PBXGroup;
 			children = (
+				86E1D31A2BFB64CD00BA29B7 /* Reviews */,
 				EE570A8B2BF5EE68006BA026 /* Coupons */,
 				EEC5C8D82ADE2FB80071E852 /* Blaze */,
 				02D7E7CA2A4CE4E20003049A /* LocalAnnouncements */,
@@ -8998,6 +9001,14 @@
 				867EA0AE2B8F15740064BCA7 /* CustomerFilter+Analytics.swift */,
 			);
 			path = "Customer Filter";
+			sourceTree = "<group>";
+		};
+		86E1D31A2BFB64CD00BA29B7 /* Reviews */ = {
+			isa = PBXGroup;
+			children = (
+				86E1D31B2BFB64E400BA29B7 /* ReviewsDashboardCardViewModelTests.swift */,
+			);
+			path = Reviews;
 			sourceTree = "<group>";
 		};
 		88A44ABE866401E6DB03AC60 /* Frameworks */ = {
@@ -15683,6 +15694,7 @@
 				6850C5F42B6A11CA0026A93B /* ReceiptViewModelTests.swift in Sources */,
 				4596854B254071C000D17B90 /* DownloadableFileBottomSheetListSelectorCommandTests.swift in Sources */,
 				26B9875F273CB6AA0090E8CA /* SimplePaymentsNoteViewModelTests.swift in Sources */,
+				86E1D31C2BFB64E400BA29B7 /* ReviewsDashboardCardViewModelTests.swift in Sources */,
 				0201E4312946FFDB00C793C7 /* StoreCreationCategoryQuestionViewModelTests.swift in Sources */,
 				EE8DCA8028BF964700F23B23 /* MockAuthentication.swift in Sources */,
 				02EFF81A2ABC28BA0015ABB2 /* GiftCardInputViewModelTests.swift in Sources */,

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -1527,6 +1527,7 @@
 		86A4EBBD2B2F1306008011F5 /* ThemesPreviewViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 86A4EBBC2B2F1306008011F5 /* ThemesPreviewViewModel.swift */; };
 		86DBBB0BDEA3488E2BEBB314 /* Pods_WooCommerce.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = BABE5E07DD787ECA6D2A76DE /* Pods_WooCommerce.framework */; };
 		86DE68822B4BA47A00B437A6 /* BlazeAdDestinationSettingViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 86DE68812B4BA47900B437A6 /* BlazeAdDestinationSettingViewModel.swift */; };
+		86E1D3192BFB470C00BA29B7 /* ReviewDashboardEmptyView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 86E1D3182BFB470C00BA29B7 /* ReviewDashboardEmptyView.swift */; };
 		86E40AED2B597DEC00990365 /* BlazeCampaignCreationCoordinatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 86E40AEC2B597DEC00990365 /* BlazeCampaignCreationCoordinatorTests.swift */; };
 		86F0896F2B307D7E00D668A1 /* ThemesPreviewViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 86F0896E2B307D7E00D668A1 /* ThemesPreviewViewModelTests.swift */; };
 		8CD41D4A21F8A7E300CF3C2B /* RELEASE-NOTES.txt in Resources */ = {isa = PBXBuildFile; fileRef = 8CD41D4921F8A7E300CF3C2B /* RELEASE-NOTES.txt */; };
@@ -4273,6 +4274,7 @@
 		8697AFBE2B622DEA00EFAF21 /* BlazeAddParameterViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BlazeAddParameterViewModelTests.swift; sourceTree = "<group>"; };
 		86A4EBBC2B2F1306008011F5 /* ThemesPreviewViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ThemesPreviewViewModel.swift; sourceTree = "<group>"; };
 		86DE68812B4BA47900B437A6 /* BlazeAdDestinationSettingViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BlazeAdDestinationSettingViewModel.swift; sourceTree = "<group>"; };
+		86E1D3182BFB470C00BA29B7 /* ReviewDashboardEmptyView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReviewDashboardEmptyView.swift; sourceTree = "<group>"; };
 		86E40AEC2B597DEC00990365 /* BlazeCampaignCreationCoordinatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BlazeCampaignCreationCoordinatorTests.swift; sourceTree = "<group>"; };
 		86F0896E2B307D7E00D668A1 /* ThemesPreviewViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ThemesPreviewViewModelTests.swift; sourceTree = "<group>"; };
 		8A659E65308A3D9DD79A95F9 /* Pods-WooCommerceTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-WooCommerceTests.release.xcconfig"; path = "../Pods/Target Support Files/Pods-WooCommerceTests/Pods-WooCommerceTests.release.xcconfig"; sourceTree = "<group>"; };
@@ -8973,6 +8975,7 @@
 			children = (
 				8625C5102BF20990007F1901 /* ReviewsDashboardCard.swift */,
 				8625C5122BF20CC6007F1901 /* ReviewsDashboardCardViewModel.swift */,
+				86E1D3182BFB470C00BA29B7 /* ReviewDashboardEmptyView.swift */,
 			);
 			path = Reviews;
 			sourceTree = "<group>";
@@ -13988,6 +13991,7 @@
 				260520F22B83B1B7005D5D59 /* ConnectivityToolViewModel.swift in Sources */,
 				0235595024496853004BE2B8 /* BottomSheetListSelectorViewController.swift in Sources */,
 				57A49128250A7EB2000FEF21 /* OrderListViewController.swift in Sources */,
+				86E1D3192BFB470C00BA29B7 /* ReviewDashboardEmptyView.swift in Sources */,
 				DE34771327F174C8009CA300 /* StatusView.swift in Sources */,
 				45DB704A26121F3C0064A6CF /* TitleAndValueRow.swift in Sources */,
 				039298C82A45EE3900F393D5 /* MyStoreRoute.swift in Sources */,

--- a/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Reviews/ReviewsDashboardCardViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Reviews/ReviewsDashboardCardViewModelTests.swift
@@ -1,0 +1,71 @@
+import XCTest
+import Yosemite
+@testable import WooCommerce
+import protocol Storage.StorageManagerType
+import protocol Storage.StorageType
+
+final class ReviewsDashboardCardViewModelTests: XCTestCase {
+    private let sampleSiteID: Int64 = 1337
+    private var stores: MockStoresManager!
+
+    private let sampleReviews: [ProductReview] = [ProductReview.fake().copy(siteID: 1337, reviewID: 1),
+                                 ProductReview.fake().copy(siteID: 1337, reviewID: 2),
+                                 ProductReview.fake().copy(siteID: 1337, reviewID: 3)]
+
+    /// Mock Storage: InMemory
+    private var storageManager: StorageManagerType!
+
+    /// View storage for tests
+    private var storage: StorageType {
+        storageManager.viewStorage
+    }
+
+    override func setUp() {
+        super.setUp()
+        storageManager = MockStorageManager()
+        stores = MockStoresManager(sessionManager: SessionManager.makeForTesting())
+    }
+
+    override func tearDown() {
+        stores = nil
+        storageManager = nil
+        super.tearDown()
+    }
+
+    @MainActor
+    func test_reviews_are_loaded_from_storage_when_available() async {
+        // Given
+        let viewModel = ReviewsDashboardCardViewModel(siteID: sampleSiteID,
+                                                      stores: stores,
+                                                      storageManager: storageManager)
+
+        insertReviews(sampleReviews)
+
+        // When
+        stores.whenReceivingAction(ofType: ProductReviewAction.self) { action in
+            switch action {
+            case let .synchronizeProductReviews(_, _, _, _, _, onCompletion):
+                onCompletion(.success(self.sampleReviews))
+            default:
+                break
+            }
+        }
+        await viewModel.reloadData()
+
+        // Then
+        waitUntil {
+            viewModel.data.count == 3
+        }
+    }
+}
+
+
+extension ReviewsDashboardCardViewModelTests {
+    func insertReviews(_ readOnlyReviews: [ProductReview]) {
+        readOnlyReviews.forEach { review in
+            let newReview = storage.insertNewObject(ofType: StorageProductReview.self)
+            newReview.update(with: review)
+        }
+        storage.saveIfNeeded()
+    }
+}


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #12742
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

This PR completes the Reviews card task by adding the following:
1. Updates loading behavior to:
    1. prefer fetching local review data first and show it, if available,
    2. show partial review data if fetched data becomes available even before fetching product name or notifications
2. Finalizing UI for loading state,
4. UI for error state,
5. UI for empty state (both for when there's no reviews at all in the site, and when there's no reviews after filtering)
6. Trackings

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

### Error case:
<img src="https://github.com/woocommerce/woocommerce-ios/assets/266376/5f7c92b3-6f7f-44b7-9a95-369c09845936" width="42%">

| Empty state case: absolutely no reviews | Empty state case:  no filtered reviews |
|-|-|
| ![Simulator Screenshot - iPhone 15 iOS 17 4 - 2024-05-22 at 09 42 07](https://github.com/woocommerce/woocommerce-ios/assets/266376/66e14eea-d587-4b2c-9e14-e0d046115054) | ![Simulator Screenshot - iPhone 15 iOS 17 4 - 2024-05-20 at 16 47 53](https://github.com/woocommerce/woocommerce-ios/assets/266376/48d35042-5b62-4015-9d73-75bea5ad38a6) |


| Loading state case: no reviews ever loaded | Loading state case: some reviews were shown before |
|-|-|
| ![Simulator Screenshot - iPhone 15 iOS 17 4 - 2024-05-20 at 16 54 32](https://github.com/woocommerce/woocommerce-ios/assets/266376/de7ef8c3-8984-488d-8fe8-ac52e56e8bf4) | ![Simulator Screenshot - iPhone 15 iOS 17 4 - 2024-05-20 at 16 54 21](https://github.com/woocommerce/woocommerce-ios/assets/266376/3a37992b-0b51-4f58-bb68-8700e744cc67)  |




---
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
