### PR TITLE
[Order Details] Display multiple shipping lines in order details

### DIFF
--- a/Experiments/Experiments/DefaultFeatureFlagService.swift
+++ b/Experiments/Experiments/DefaultFeatureFlagService.swift
@@ -94,6 +94,8 @@ public struct DefaultFeatureFlagService: FeatureFlagService {
             return buildConfig == .localDeveloper || buildConfig == .alpha
         case .dynamicDashboardM2:
             return buildConfig == .localDeveloper || buildConfig == .alpha
+        case .multipleShippingLines:
+            return buildConfig == .localDeveloper || buildConfig == .alpha
         default:
             return true
         }

--- a/Experiments/Experiments/FeatureFlag.swift
+++ b/Experiments/Experiments/FeatureFlag.swift
@@ -207,4 +207,8 @@ public enum FeatureFlag: Int {
     /// Enables new dashboard cards on the My Store screen.
     ///
     case dynamicDashboardM2
+
+    /// Enables multiple shipping lines in order details and order creation/editing.
+    ///
+    case multipleShippingLines
 }

--- a/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsDataSource.swift
+++ b/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsDataSource.swift
@@ -1017,7 +1017,7 @@ private extension OrderDetailsDataSource {
         let shippingLine = shippingLines[indexPath.row]
         let shippingMethod = siteShippingMethods.first(where: { $0.methodID == shippingLine.methodID })?.title ?? ""
         let shippingTotal = currencyFormatter.formatAmount(shippingLine.total) ?? shippingLine.total
-        cell.configure(title: shippingLine.methodTitle, subtitle: shippingMethod, value: shippingTotal)
+        cell.configure(row: indexPath.row, title: shippingLine.methodTitle, subtitle: shippingMethod, value: shippingTotal)
         cell.selectionStyle = .none
     }
 

--- a/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsDataSource.swift
+++ b/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsDataSource.swift
@@ -165,6 +165,12 @@ final class OrderDetailsDataSource: NSObject {
         resultsControllers.addOnGroups
     }
 
+    /// Shipping Methods list
+    ///
+    var siteShippingMethods: [ShippingMethod] {
+        resultsControllers.siteShippingMethods
+    }
+
     /// Shipping Labels for an Order
     ///
     private(set) var shippingLabels: [ShippingLabel] = []
@@ -1009,9 +1015,9 @@ private extension OrderDetailsDataSource {
 
     private func configureShippingLine(cell: TitleAndSubtitleAndValueCardTableViewCell, at indexPath: IndexPath) {
         let shippingLine = shippingLines[indexPath.row]
+        let shippingMethod = siteShippingMethods.first(where: { $0.methodID == shippingLine.methodID })?.title ?? ""
         let shippingTotal = currencyFormatter.formatAmount(shippingLine.total) ?? shippingLine.total
-        // TODO-12582: Update subtitle with method name (from method ID)
-        cell.configure(title: shippingLine.methodTitle, subtitle: shippingLine.methodTitle, value: shippingTotal)
+        cell.configure(title: shippingLine.methodTitle, subtitle: shippingMethod, value: shippingTotal)
         cell.selectionStyle = .none
     }
 

--- a/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsDataSource.swift
+++ b/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsDataSource.swift
@@ -1140,7 +1140,9 @@ extension OrderDetailsDataSource {
         let shippingNotice: Section? = {
             // Hide the shipping method warning if order contains only virtual products
             // or if the order contains only one shipping method
-            if isMultiShippingLinesAvailable(for: order) == false {
+            // or if multiple shipping lines are supported (feature flag)
+            if isMultiShippingLinesAvailable(for: order) == false ||
+                featureFlags.isFeatureFlagEnabled(.multipleShippingLines) {
                 return nil
             }
 

--- a/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsViewModel.swift
+++ b/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsViewModel.swift
@@ -360,7 +360,7 @@ extension OrderDetailsViewModel {
     /// Registers all of the available TableViewCells
     ///
     func registerTableViewCells(_ tableView: UITableView) {
-        let cells = [
+        let cellsWithNib = [
             LargeHeightLeftImageTableViewCell.self,
             LeftImageTableViewCell.self,
             CustomerNoteTableViewCell.self,
@@ -381,8 +381,16 @@ extension OrderDetailsViewModel {
             TitleAndValueTableViewCell.self
         ]
 
-        for cellClass in cells {
+        let cellsWithoutNib = [
+            TitleAndSubtitleAndValueCardTableViewCell.self
+        ]
+
+        for cellClass in cellsWithNib {
             tableView.registerNib(for: cellClass)
+        }
+
+        for cellClass in cellsWithoutNib {
+            tableView.register(cellClass)
         }
     }
 

--- a/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsViewModel.swift
+++ b/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsViewModel.swift
@@ -281,6 +281,12 @@ extension OrderDetailsViewModel {
             group.leave()
         }
 
+        group.enter()
+        syncShippingMethods { _ in
+            onReloadSections?()
+            group.leave()
+        }
+
         group.notify(queue: .main) { [weak self] in
 
             /// Update state to synced
@@ -693,6 +699,19 @@ extension OrderDetailsViewModel {
             }
             self.stores.dispatch(action)
         }
+    }
+
+    func syncShippingMethods(onCompletion: ((Error?) -> ())? = nil) {
+        let action = ShippingMethodAction.synchronizeShippingMethods(siteID: order.siteID) { result in
+            switch result {
+            case .success:
+                onCompletion?(nil)
+            case let .failure(error):
+                DDLogError("⛔️ Error synchronizing shipping methods: \(error)")
+                onCompletion?(error)
+            }
+        }
+        stores.dispatch(action)
     }
 
     @MainActor

--- a/WooCommerce/Classes/ViewRelated/Orders/Cells/TitleAndSubtitleAndValueCardTableViewCell.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Cells/TitleAndSubtitleAndValueCardTableViewCell.swift
@@ -1,0 +1,108 @@
+import Foundation
+import UIKit
+
+final class TitleAndSubtitleAndValueCardTableViewCell: UITableViewCell {
+
+    /// Title label
+    ///
+    private let titleLabel = UILabel()
+
+    /// Subtitle label
+    ///
+    private let subtitleLabel = UILabel()
+
+    /// Value label
+    ///
+    private let valueLabel = UILabel()
+
+    /// Main view for the cell, to create a border
+    ///
+    private lazy var mainView: UIView = {
+        let view = UIView()
+        view.translatesAutoresizingMaskIntoConstraints = false
+        view.layer.cornerRadius = Constants.cornerRadius
+        view.layer.borderWidth = Constants.borderWidth
+        view.layer.borderColor = UIColor.border.cgColor
+        return view
+    }()
+
+    /// Main stack view
+    ///
+    private lazy var stackView: UIStackView = {
+        let stackView = UIStackView()
+        stackView.translatesAutoresizingMaskIntoConstraints = false
+        stackView.axis = .horizontal
+        stackView.distribution = .equalSpacing
+        stackView.spacing = Constants.spacingBetweenTitlesAndValue
+        return stackView
+    }()
+
+    /// Stack view for title and subtitle
+    ///
+    private lazy var titleAndSubtitleStackView: UIStackView = {
+        let stackView = UIStackView()
+        stackView.translatesAutoresizingMaskIntoConstraints = false
+        stackView.axis = .vertical
+        stackView.distribution = .equalSpacing
+        stackView.alignment = .leading
+        return stackView
+    }()
+
+    override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
+        super.init(style: style, reuseIdentifier: reuseIdentifier)
+        configureDefaultBackgroundConfiguration()
+        enableMultipleLines()
+        configureSubviews()
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    override func updateConfiguration(using state: UICellConfigurationState) {
+        super.updateConfiguration(using: state)
+        updateDefaultBackgroundConfiguration(using: state)
+    }
+}
+
+// MARK: UI Update
+extension TitleAndSubtitleAndValueCardTableViewCell {
+    func configure(title: String, subtitle: String, value: String) {
+        titleLabel.text = title
+        titleLabel.applyBodyStyle()
+
+        subtitleLabel.text = subtitle
+        subtitleLabel.applyFootnoteStyle()
+
+        valueLabel.text = value
+        valueLabel.applyBodyStyle()
+    }
+}
+
+private extension TitleAndSubtitleAndValueCardTableViewCell {
+    /// Needed specially when dealing with big accessibility traits
+    ///
+    func enableMultipleLines() {
+        titleLabel.numberOfLines = 0
+        subtitleLabel.numberOfLines = 0
+        valueLabel.numberOfLines = 0
+    }
+
+    func configureSubviews() {
+        contentView.addSubview(mainView)
+        contentView.pinSubviewToSafeArea(mainView, insets: Constants.insets)
+
+        mainView.addSubview(stackView)
+        mainView.pinSubviewToAllEdges(stackView, insets: Constants.insets)
+
+        stackView.addArrangedSubviews([titleAndSubtitleStackView, valueLabel])
+        titleAndSubtitleStackView.addArrangedSubviews([titleLabel, subtitleLabel])
+    }
+
+    enum Constants {
+        static let spacingBetweenTitlesAndValue: CGFloat = 12
+        static let cornerRadius: CGFloat = 5
+        static let borderWidth: CGFloat = 1
+        static let insets = UIEdgeInsets(top: 16, left: 16, bottom: 16, right: 16)
+    }
+}

--- a/WooCommerce/Classes/ViewRelated/Orders/Cells/TitleAndSubtitleAndValueCardTableViewCell.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Cells/TitleAndSubtitleAndValueCardTableViewCell.swift
@@ -48,6 +48,12 @@ final class TitleAndSubtitleAndValueCardTableViewCell: UITableViewCell {
         return stackView
     }()
 
+    /// Default top anchor constraint for content view
+    ///
+    private lazy var contentViewTopAnchorConstraint: NSLayoutConstraint = {
+        contentView.topAnchor.constraint(equalTo: mainView.topAnchor, constant: -Constants.insets.top)
+    }()
+
     override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
         super.init(style: style, reuseIdentifier: reuseIdentifier)
         configureDefaultBackgroundConfiguration()
@@ -67,7 +73,7 @@ final class TitleAndSubtitleAndValueCardTableViewCell: UITableViewCell {
 
 // MARK: UI Update
 extension TitleAndSubtitleAndValueCardTableViewCell {
-    func configure(title: String, subtitle: String, value: String) {
+    func configure(row: Int, title: String, subtitle: String, value: String) {
         titleLabel.text = title
         titleLabel.applyBodyStyle()
 
@@ -76,6 +82,19 @@ extension TitleAndSubtitleAndValueCardTableViewCell {
 
         valueLabel.text = value
         valueLabel.applyBodyStyle()
+
+        hideSeparator()
+        setInsets(for: row)
+    }
+
+    /// Removes the default top anchor inset when the cell isn't the first row in the section.
+    ///
+    func setInsets(for row: Int) {
+        if row == 0 {
+            contentViewTopAnchorConstraint.constant = -Constants.insets.top
+        } else {
+            contentViewTopAnchorConstraint.constant = 0
+        }
     }
 }
 
@@ -90,7 +109,12 @@ private extension TitleAndSubtitleAndValueCardTableViewCell {
 
     func configureSubviews() {
         contentView.addSubview(mainView)
-        contentView.pinSubviewToSafeArea(mainView, insets: Constants.insets)
+        NSLayoutConstraint.activate([
+            contentViewTopAnchorConstraint,
+            contentView.leadingAnchor.constraint(equalTo: mainView.leadingAnchor, constant: -Constants.insets.left),
+            contentView.trailingAnchor.constraint(equalTo: mainView.trailingAnchor, constant: Constants.insets.right),
+            contentView.bottomAnchor.constraint(equalTo: mainView.bottomAnchor, constant: Constants.insets.bottom),
+        ])
 
         mainView.addSubview(stackView)
         mainView.pinSubviewToAllEdges(stackView, insets: Constants.insets)

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -2070,6 +2070,7 @@
 		CE8CCD43239AC06E009DBD22 /* RefundDetailsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE8CCD41239AC06E009DBD22 /* RefundDetailsViewController.swift */; };
 		CE8CCD44239AC06E009DBD22 /* RefundDetailsViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = CE8CCD42239AC06E009DBD22 /* RefundDetailsViewController.xib */; };
 		CE91BEA029FBE9E100B6E1AF /* QuantityRulesViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE91BE9F29FBE9E100B6E1AF /* QuantityRulesViewModelTests.swift */; };
+		CE996D2B2BEE592800F0E5B0 /* TitleAndSubtitleAndValueCardTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE996D2A2BEE592800F0E5B0 /* TitleAndSubtitleAndValueCardTableViewCell.swift */; };
 		CEA16F3A20FD0C8C0061B4E1 /* WooAnalytics.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEA16F3920FD0C8C0061B4E1 /* WooAnalytics.swift */; };
 		CEA455C12BB3446D00D932CF /* BundlesReportCardViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEA455C02BB3446D00D932CF /* BundlesReportCardViewModel.swift */; };
 		CEA455C52BB44F9E00D932CF /* ProductsReportItem+Woo.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEA455C42BB44F9E00D932CF /* ProductsReportItem+Woo.swift */; };
@@ -4849,6 +4850,7 @@
 		CE8CCD41239AC06E009DBD22 /* RefundDetailsViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RefundDetailsViewController.swift; sourceTree = "<group>"; };
 		CE8CCD42239AC06E009DBD22 /* RefundDetailsViewController.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = RefundDetailsViewController.xib; sourceTree = "<group>"; };
 		CE91BE9F29FBE9E100B6E1AF /* QuantityRulesViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QuantityRulesViewModelTests.swift; sourceTree = "<group>"; };
+		CE996D2A2BEE592800F0E5B0 /* TitleAndSubtitleAndValueCardTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TitleAndSubtitleAndValueCardTableViewCell.swift; sourceTree = "<group>"; };
 		CEA16F3920FD0C8C0061B4E1 /* WooAnalytics.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WooAnalytics.swift; sourceTree = "<group>"; };
 		CEA455C02BB3446D00D932CF /* BundlesReportCardViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BundlesReportCardViewModel.swift; sourceTree = "<group>"; };
 		CEA455C42BB44F9E00D932CF /* ProductsReportItem+Woo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ProductsReportItem+Woo.swift"; sourceTree = "<group>"; };
@@ -11157,6 +11159,7 @@
 				CE1CCB4A20570B1F000EE3AC /* OrderTableViewCell.swift */,
 				B5FD110D21D3CB8500560344 /* OrderTableViewCell.xib */,
 				A6557217258B7510008AE7CA /* OrderListCellViewModel.swift */,
+				CE996D2A2BEE592800F0E5B0 /* TitleAndSubtitleAndValueCardTableViewCell.swift */,
 			);
 			path = Cells;
 			sourceTree = "<group>";
@@ -14869,6 +14872,7 @@
 				AE7C957D27C3F187007E8E12 /* FeeOrDiscountLineDetailsViewModel.swift in Sources */,
 				4520A15C2721B2A9001FA573 /* FilterOrderListViewModel.swift in Sources */,
 				B582F95920FFCEAA0060934A /* UITableViewHeaderFooterView+Helpers.swift in Sources */,
+				CE996D2B2BEE592800F0E5B0 /* TitleAndSubtitleAndValueCardTableViewCell.swift in Sources */,
 				B933CCB02AA6220E00938F3F /* TaxRateRow.swift in Sources */,
 				57532CAC24BFF4DA0032B84E /* MessageComposerPresenter.swift in Sources */,
 				DE4D23AE29B1B0EF003A4B5D /* WPCom2FALoginViewModel.swift in Sources */,

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Details/OrderDetailsDataSourceTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Details/OrderDetailsDataSourceTests.swift
@@ -31,7 +31,7 @@ final class OrderDetailsDataSourceTests: XCTestCase {
         super.tearDown()
     }
 
-    func test_payment_section_is_shown_right_after_the_products_custom_amounts_and_refunded_products_sections() {
+    func test_payment_section_is_shown_right_after_the_products_custom_amounts_refunded_products_and_shipping_sections() {
         // Given
         let order = makeOrder()
 
@@ -55,6 +55,7 @@ final class OrderDetailsDataSourceTests: XCTestCase {
             Title.products,
             Title.customAmounts,
             Title.refundedProducts,
+            Title.shippingLines,
             Title.payment,
             Title.information,
             Title.orderAttribution,
@@ -856,6 +857,33 @@ final class OrderDetailsDataSourceTests: XCTestCase {
         // Then
         let attributionSection = try section(withTitle: Title.orderAttribution, from: dataSource)
         let row = row(row: .attributionSessionPageViews, in: attributionSection)
+        XCTAssertNotNil(row)
+    }
+
+    func test_shipping_section_hidden_when_order_has_no_shipping_lines() {
+        // Given
+        let order = Order.fake()
+        let dataSource = OrderDetailsDataSource(order: order, storageManager: storageManager, cardPresentPaymentsConfiguration: Mocks.configuration)
+
+        // When
+        dataSource.reloadSections()
+
+        // Then
+        let shippingSection = section(withCategory: .shippingLines, from: dataSource)
+        XCTAssertNil(shippingSection)
+    }
+
+    func test_shipping_section_shows_shipping_line_row_when_order_has_shipping_line() throws {
+        // Given
+        let order = Order.fake().copy(shippingLines: [.fake()])
+        let dataSource = OrderDetailsDataSource(order: order, storageManager: storageManager, cardPresentPaymentsConfiguration: Mocks.configuration)
+
+        // When
+        dataSource.reloadSections()
+
+        // Then
+        let shippingSection = try section(withTitle: Title.shippingLines, from: dataSource)
+        let row = row(row: .shippingLine, in: shippingSection)
         XCTAssertNotNil(row)
     }
 }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #12582
<!-- Id number of the GitHub issue this PR addresses. -->

## Why
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This adds support (behind a feature flag) for showing multiple shipping lines in order details.

Previously, we only supported showing the first shipping line on an order. Now, we show a Shipping section with all the shipping lines on an order.

## How

* Adds a new feature flag for multiple shipping lines support.
* Adds a new UITableViewCell `TitleAndSubtitleAndValueCardTableViewCell` to display a title, subtitle, and value in a card style (with a border).
* Adds the new shipping section:
   * Adds the new section and row to `OrderDetailsDataSource`, and configures each row based on the corresponding shipping line on the order.
   * Updates `OrderDetailsResultsControllers` to include a shipping methods ResultsController, to fetch the list of shipping methods for the store. This allows us to get the name of the shipping method corresponding to each shipping line on the order.
   * Updates `OrderDetailsViewModel` to register the new cell and sync the shipping methods for the store (in case they haven't been synced before).

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

With the feature flag disabled:

1. Build and run the app.
2. Open an order with multiple shipping lines.
3. Confirm the shipping line notice appears and the shipping method for a single shipping line is shown in the Customer section.

With the feature flag enabled:

1. Build and run the app.
2. Open an order with multiple shipping lines.
3. Confirm the shipping line notice does NOT appear and a shipping section appears with all shipping lines on the order.

Bonus:

* Repeat the steps above for an order with a single shipping line.
* Repeat the steps above for an order without shipping lines, and confirm no shipping section appears.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->
Before|After
-|-
![Simulator Screenshot - iPhone 15 Plus - 2024-05-20 at 17 21 47](https://github.com/woocommerce/woocommerce-ios/assets/8658164/d7269920-c714-4cee-9cfe-51fcc245fa83)|![Simulator Screenshot - iPhone 15 Plus - 2024-05-20 at 17 22 39](https://github.com/woocommerce/woocommerce-ios/assets/8658164/6d1ead15-344d-4346-b737-79cabcebf43a)


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
