### PR TITLE
[Watch] Order list UI

### DIFF
--- a/WooCommerce/Woo Watch App/MyStore/MyStoreView.swift
+++ b/WooCommerce/Woo Watch App/MyStore/MyStoreView.swift
@@ -10,9 +10,14 @@ struct MyStoreView: View {
     // View Model to drive the view
     @StateObject var viewModel: MyStoreViewModel
 
-    init(dependencies: WatchDependencies) {
+    // Used to changed the tab programmatically
+    @Binding var watchTab: WooWatchTab
+
+    init(dependencies: WatchDependencies, watchTab: Binding<WooWatchTab>) {
         _viewModel = StateObject(wrappedValue: MyStoreViewModel(dependencies: dependencies))
+        self._watchTab = watchTab
     }
+
     var body: some View {
         // This VStack is needed so the `onAppear` task is properly executed.
         VStack {
@@ -89,7 +94,7 @@ struct MyStoreView: View {
             HStack {
 
                 Button(action: {
-                    print("Order button pressed")
+                    self.watchTab = .ordersList
                 }) {
                     HStack {
                         Images.document
@@ -195,8 +200,4 @@ fileprivate extension MyStoreView {
         static let person = Image(systemName: "person.2.fill")
         static let zigzag = Image(systemName: "point.bottomleft.forward.to.point.topright.filled.scurvepath")
     }
-}
-
-#Preview {
-    MyStoreView(dependencies: .fake())
 }

--- a/WooCommerce/Woo Watch App/Orders/OrdersListView.swift
+++ b/WooCommerce/Woo Watch App/Orders/OrdersListView.swift
@@ -14,7 +14,7 @@ struct OrdersListView: View {
     var body: some View {
         NavigationSplitView() {
             List() {
-                Section {
+                Section { // Temporary Views
                     OrderListCard()
                     OrderListCard()
                     OrderListCard()
@@ -25,20 +25,34 @@ struct OrdersListView: View {
                     OrderListCard()
                 }
             }
-            .navigationTitle("Orders")
+            .navigationTitle(Localization.title)
             .listStyle(.plain)
             .toolbar {
                 ToolbarItem(placement: .cancellationAction) {
                     Button {
                         self.watchTab = .myStore
                     } label: {
-                        Label("", systemImage: "house")
+                        Images.myStore
                     }
                 }
             }
         } detail: {
             Text("Order Detail")
         }
+    }
+}
+
+private extension OrdersListView {
+    enum Localization {
+        static let title = AppLocalizedString(
+            "watch.orders.title",
+            value: "Orders",
+            comment: "Title on the watch orders list screen."
+        )
+    }
+
+    enum Images {
+        static let myStore = Image(systemName: "house")
     }
 }
 

--- a/WooCommerce/Woo Watch App/Orders/OrdersListView.swift
+++ b/WooCommerce/Woo Watch App/Orders/OrdersListView.swift
@@ -3,7 +3,20 @@ import SwiftUI
 /// Entry point for the order list view
 ///
 struct OrdersListView: View {
+
+    // Used to changed the tab programmatically
+    @Binding var watchTab: WooWatchTab
+
+    init(watchTab: Binding<WooWatchTab>) {
+        self._watchTab = watchTab
+    }
+
     var body: some View {
-        Text("Order List...")
+        VStack {
+            Text("Order List...")
+            Button("Go back to my store view") {
+                self.watchTab = .myStore
+            }
+        }
     }
 }

--- a/WooCommerce/Woo Watch App/Orders/OrdersListView.swift
+++ b/WooCommerce/Woo Watch App/Orders/OrdersListView.swift
@@ -14,17 +14,28 @@ struct OrdersListView: View {
     var body: some View {
         NavigationSplitView() {
             List() {
-                OrderListCard()
-                OrderListCard()
-                OrderListCard()
-                OrderListCard()
-                OrderListCard()
-                OrderListCard()
-                OrderListCard()
-                OrderListCard()
+                Section {
+                    OrderListCard()
+                    OrderListCard()
+                    OrderListCard()
+                    OrderListCard()
+                    OrderListCard()
+                    OrderListCard()
+                    OrderListCard()
+                    OrderListCard()
+                }
             }
             .navigationTitle("Orders")
             .listStyle(.plain)
+            .toolbar {
+                ToolbarItem(placement: .cancellationAction) {
+                    Button {
+                        self.watchTab = .myStore
+                    } label: {
+                        Label("", systemImage: "house")
+                    }
+                }
+            }
         } detail: {
             Text("Order Detail")
         }

--- a/WooCommerce/Woo Watch App/Orders/OrdersListView.swift
+++ b/WooCommerce/Woo Watch App/Orders/OrdersListView.swift
@@ -1,0 +1,9 @@
+import SwiftUI
+
+/// Entry point for the order list view
+///
+struct OrdersListView: View {
+    var body: some View {
+        Text("Order List...")
+    }
+}

--- a/WooCommerce/Woo Watch App/Orders/OrdersListView.swift
+++ b/WooCommerce/Woo Watch App/Orders/OrdersListView.swift
@@ -12,11 +12,59 @@ struct OrdersListView: View {
     }
 
     var body: some View {
-        VStack {
-            Text("Order List...")
-            Button("Go back to my store view") {
-                self.watchTab = .myStore
+        NavigationSplitView() {
+            List() {
+                OrderListCard()
+                OrderListCard()
+                OrderListCard()
+                OrderListCard()
+                OrderListCard()
+                OrderListCard()
+                OrderListCard()
+                OrderListCard()
             }
+            .navigationTitle("Orders")
+            .listStyle(.plain)
+        } detail: {
+            Text("Order Detail")
         }
+    }
+}
+
+struct OrderListCard: View {
+    var body: some View {
+        VStack(alignment: .leading) {
+
+            HStack {
+                Text("25 Feb")
+                Spacer()
+                Text("#1031")
+            }
+            .font(.footnote)
+            .foregroundStyle(.secondary)
+
+            Text("Jemima Kirk")
+                .font(.body)
+
+            Text("$149.50")
+                .font(.body)
+                .bold()
+
+            Text("Pending payment")
+                .font(.footnote)
+                .foregroundStyle(Colors.wooPurple20)
+        }
+        .listRowBackground(
+            LinearGradient(gradient: Gradient(colors: [Colors.wooBackgroundStart, Colors.wooBackgroundEnd]), startPoint: .top, endPoint: .bottom)
+                .cornerRadius(10)
+        )
+    }
+}
+
+private extension OrderListCard {
+    enum Colors {
+        static let wooPurple20 = Color(red: 190/255.0, green: 160/255.0, blue: 242/255.0)
+        static let wooBackgroundStart = Color(red: 69/255.0, green: 43/255.0, blue: 100/255.0)
+        static let wooBackgroundEnd = Color(red: 49/255.0, green: 31/255.0, blue: 71/255.0)
     }
 }

--- a/WooCommerce/Woo Watch App/WooApp.swift
+++ b/WooCommerce/Woo Watch App/WooApp.swift
@@ -5,7 +5,7 @@ struct Woo_Watch_AppApp: App {
 
     @StateObject var phoneDependencySynchronizer = PhoneDependenciesSynchronizer()
 
-    @State private var selectedTab = WooWatchTab.ordersList
+    @State private var selectedTab = WooWatchTab.myStore
 
     var body: some Scene {
         WindowGroup {

--- a/WooCommerce/Woo Watch App/WooApp.swift
+++ b/WooCommerce/Woo Watch App/WooApp.swift
@@ -8,11 +8,35 @@ struct Woo_Watch_AppApp: App {
     var body: some Scene {
         WindowGroup {
             if let dependencies = phoneDependencySynchronizer.dependencies {
-                MyStoreView(dependencies: dependencies)
-                    .environment(\.dependencies, dependencies)
+                TabView {
+                    MyStoreView(dependencies: dependencies)
+                    OrdersListView()
+                }
+                .compatibleVerticalStyle()
+                .environment(\.dependencies, dependencies)
             } else {
                 ConnectView()
             }
         }
+    }
+}
+
+/// Backwards compatible vertical `tabViewStyle` modifier.
+///
+private struct VerticalPageModifier: ViewModifier {
+    func body(content: Content) -> some View {
+        if #available(watchOS 10.0, *) {
+            content
+                .tabViewStyle(.verticalPage)
+        } else {
+            content
+                .tabViewStyle(.carousel)
+        }
+    }
+}
+
+private extension View {
+    func compatibleVerticalStyle() -> some View {
+        self.modifier(VerticalPageModifier())
     }
 }

--- a/WooCommerce/Woo Watch App/WooApp.swift
+++ b/WooCommerce/Woo Watch App/WooApp.swift
@@ -5,7 +5,7 @@ struct Woo_Watch_AppApp: App {
 
     @StateObject var phoneDependencySynchronizer = PhoneDependenciesSynchronizer()
 
-    @State private var selectedTab = WooWatchTab.myStore
+    @State private var selectedTab = WooWatchTab.ordersList
 
     var body: some Scene {
         WindowGroup {

--- a/WooCommerce/Woo Watch App/WooApp.swift
+++ b/WooCommerce/Woo Watch App/WooApp.swift
@@ -5,12 +5,17 @@ struct Woo_Watch_AppApp: App {
 
     @StateObject var phoneDependencySynchronizer = PhoneDependenciesSynchronizer()
 
+    @State private var selectedTab = WooWatchTab.myStore
+
     var body: some Scene {
         WindowGroup {
             if let dependencies = phoneDependencySynchronizer.dependencies {
-                TabView {
-                    MyStoreView(dependencies: dependencies)
-                    OrdersListView()
+                TabView(selection: $selectedTab) {
+                    MyStoreView(dependencies: dependencies, watchTab: $selectedTab)
+                        .tag(WooWatchTab.myStore)
+
+                    OrdersListView(watchTab: $selectedTab)
+                        .tag(WooWatchTab.ordersList)
                 }
                 .compatibleVerticalStyle()
                 .environment(\.dependencies, dependencies)
@@ -19,6 +24,11 @@ struct Woo_Watch_AppApp: App {
             }
         }
     }
+}
+
+enum WooWatchTab: Int {
+    case myStore
+    case ordersList
 }
 
 /// Backwards compatible vertical `tabViewStyle` modifier.

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -913,6 +913,7 @@
 		26A000772BE9D9030071DB1E /* WooConstants.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5D1AFBF20BC67C200DB0E8C /* WooConstants.swift */; };
 		26A0B2D32BF9A78C002E9620 /* StoreInfoFormatter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26A0B2D22BF9A78C002E9620 /* StoreInfoFormatter.swift */; };
 		26A0B2D42BF9A78C002E9620 /* StoreInfoFormatter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26A0B2D22BF9A78C002E9620 /* StoreInfoFormatter.swift */; };
+		26A0B2D72BFBA536002E9620 /* OrdersListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26A0B2D62BFBA536002E9620 /* OrdersListView.swift */; };
 		26A280D62B45F00F00ACEE87 /* OrderNotificationViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26A280D52B45F00F00ACEE87 /* OrderNotificationViewModelTests.swift */; };
 		26A280D72B46027A00ACEE87 /* OrderNotificationView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26CA2BC52AAA1773003B16C2 /* OrderNotificationView.swift */; };
 		26A630ED253F3B5C00CBC3B1 /* RefundCreationUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26A630EC253F3B5C00CBC3B1 /* RefundCreationUseCase.swift */; };
@@ -3737,6 +3738,7 @@
 		269FFA452BF40768004E6B86 /* WooFoundationWatchOS.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = WooFoundationWatchOS.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		269FFA4A2BF544C9004E6B86 /* MyStoreViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MyStoreViewModel.swift; sourceTree = "<group>"; };
 		26A0B2D22BF9A78C002E9620 /* StoreInfoFormatter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StoreInfoFormatter.swift; sourceTree = "<group>"; };
+		26A0B2D62BFBA536002E9620 /* OrdersListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OrdersListView.swift; sourceTree = "<group>"; };
 		26A280D52B45F00F00ACEE87 /* OrderNotificationViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OrderNotificationViewModelTests.swift; sourceTree = "<group>"; };
 		26A630EC253F3B5C00CBC3B1 /* RefundCreationUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RefundCreationUseCase.swift; sourceTree = "<group>"; };
 		26A630F2253F3CFE00CBC3B1 /* RefundCreationUseCaseTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RefundCreationUseCaseTests.swift; sourceTree = "<group>"; };
@@ -7609,6 +7611,14 @@
 			path = MyStore;
 			sourceTree = "<group>";
 		};
+		26A0B2D52BFBA51D002E9620 /* Orders */ = {
+			isa = PBXGroup;
+			children = (
+				26A0B2D62BFBA536002E9620 /* OrdersListView.swift */,
+			);
+			path = Orders;
+			sourceTree = "<group>";
+		};
 		26A630F8253F62AD00CBC3B1 /* UseCases */ = {
 			isa = PBXGroup;
 			children = (
@@ -7785,6 +7795,7 @@
 				26F81B172BE433A2009EC58E /* WooApp.swift */,
 				26B984D52BEECF260052658C /* ConnectView.swift */,
 				269FFA492BF544B6004E6B86 /* MyStore */,
+				26A0B2D52BFBA51D002E9620 /* Orders */,
 				26F81B1B2BE433A3009EC58E /* Assets.xcassets */,
 				26F81B1D2BE433A3009EC58E /* Preview Content */,
 			);
@@ -13587,6 +13598,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				264E9E952BF400AD009C48FD /* StoreInfoDataService.swift in Sources */,
+				26A0B2D72BFBA536002E9620 /* OrdersListView.swift in Sources */,
 				26B984D42BEECC610052658C /* Environment+Dependencies.swift in Sources */,
 				26F81B1A2BE433A2009EC58E /* MyStoreView.swift in Sources */,
 				264E9E942BF1D1DF009C48FD /* AppLocalizedString.swift in Sources */,


### PR DESCRIPTION
closes #12499 

# Why

This PR Adds the UI for the my orders list screen

# How

- Added tab view layout for the mail app
- Added split view layout for the orders list screen.
- Adds hardcoded UI

# Screenshots 

<img width="301" alt="Screenshot 2024-05-20 at 11 25 04 PM" src="https://github.com/woocommerce/woocommerce-ios/assets/562080/fd492179-7522-444e-af6e-78d005c3c546">

---
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
