### PR TITLE
Dynamic Dashboard: Save and load last selected stock type for Stock card

### DIFF
--- a/Fakes/Fakes/Networking.generated.swift
+++ b/Fakes/Fakes/Networking.generated.swift
@@ -1411,7 +1411,7 @@ extension Networking.ProductImage {
 extension Networking.ProductReport {
     /// Returns a "ready to use" type filled with fake values.
     ///
-    static func fake() -> Networking.ProductReport {
+    public static func fake() -> Networking.ProductReport {
         .init(
             totals: .fake()
         )
@@ -1440,7 +1440,7 @@ extension Networking.ProductReportSegment.Subtotals {
 extension Networking.ProductReportTotals {
     /// Returns a "ready to use" type filled with fake values.
     ///
-    static func fake() -> Networking.ProductReportTotals {
+    public static func fake() -> Networking.ProductReportTotals {
         .init(
             segments: .fake()
         )

--- a/Networking/Networking/Model/Copiable/Models+Copiable.generated.swift
+++ b/Networking/Networking/Model/Copiable/Models+Copiable.generated.swift
@@ -2281,7 +2281,7 @@ extension Networking.ProductImage {
 }
 
 extension Networking.ProductReport {
-    func copy(
+    public func copy(
         totals: CopiableProp<ProductReportTotals> = .copy
     ) -> Networking.ProductReport {
         let totals = totals ?? self.totals
@@ -2323,7 +2323,7 @@ extension Networking.ProductReportSegment.Subtotals {
 }
 
 extension Networking.ProductReportTotals {
-    func copy(
+    public func copy(
         segments: CopiableProp<[ProductReportSegment]> = .copy
     ) -> Networking.ProductReportTotals {
         let segments = segments ?? self.segments

--- a/Storage/Storage/Model/Copiable/Models+Copiable.generated.swift
+++ b/Storage/Storage/Model/Copiable/Models+Copiable.generated.swift
@@ -113,7 +113,8 @@ extension Storage.GeneralStoreSettings {
         dashboardCards: NullableCopiableProp<[DashboardCard]> = .copy,
         lastSelectedPerformanceTimeRange: CopiableProp<String> = .copy,
         lastSelectedTopPerformersTimeRange: CopiableProp<String> = .copy,
-        lastSelectedMostActiveCouponsTimeRange: CopiableProp<String> = .copy
+        lastSelectedMostActiveCouponsTimeRange: CopiableProp<String> = .copy,
+        lastSelectedStockType: NullableCopiableProp<String> = .copy
     ) -> Storage.GeneralStoreSettings {
         let storeID = storeID ?? self.storeID
         let isTelemetryAvailable = isTelemetryAvailable ?? self.isTelemetryAvailable
@@ -130,6 +131,7 @@ extension Storage.GeneralStoreSettings {
         let lastSelectedPerformanceTimeRange = lastSelectedPerformanceTimeRange ?? self.lastSelectedPerformanceTimeRange
         let lastSelectedTopPerformersTimeRange = lastSelectedTopPerformersTimeRange ?? self.lastSelectedTopPerformersTimeRange
         let lastSelectedMostActiveCouponsTimeRange = lastSelectedMostActiveCouponsTimeRange ?? self.lastSelectedMostActiveCouponsTimeRange
+        let lastSelectedStockType = lastSelectedStockType ?? self.lastSelectedStockType
 
         return Storage.GeneralStoreSettings(
             storeID: storeID,
@@ -146,7 +148,8 @@ extension Storage.GeneralStoreSettings {
             dashboardCards: dashboardCards,
             lastSelectedPerformanceTimeRange: lastSelectedPerformanceTimeRange,
             lastSelectedTopPerformersTimeRange: lastSelectedTopPerformersTimeRange,
-            lastSelectedMostActiveCouponsTimeRange: lastSelectedMostActiveCouponsTimeRange
+            lastSelectedMostActiveCouponsTimeRange: lastSelectedMostActiveCouponsTimeRange,
+            lastSelectedStockType: lastSelectedStockType
         )
     }
 }

--- a/Storage/Storage/Model/GeneralStoreSettings.swift
+++ b/Storage/Storage/Model/GeneralStoreSettings.swift
@@ -68,6 +68,9 @@ public struct GeneralStoreSettings: Codable, Equatable, GeneratedCopiable {
     /// The raw value string of `MostActiveCouponsTimeRange` that indicates the last selected time range tab in Most active coupons card.
     public var lastSelectedMostActiveCouponsTimeRange: String
 
+    /// The raw value of stock type indicating the last selected type in the Stock dashboard card.
+    public var lastSelectedStockType: String?
+
     public init(storeID: String? = nil,
                 isTelemetryAvailable: Bool = false,
                 telemetryLastReportedTime: Date? = nil,
@@ -82,7 +85,8 @@ public struct GeneralStoreSettings: Codable, Equatable, GeneratedCopiable {
                 dashboardCards: [DashboardCard]? = nil,
                 lastSelectedPerformanceTimeRange: String = "",
                 lastSelectedTopPerformersTimeRange: String = "",
-                lastSelectedMostActiveCouponsTimeRange: String = "") {
+                lastSelectedMostActiveCouponsTimeRange: String = "",
+                lastSelectedStockType: String? = nil) {
         self.storeID = storeID
         self.isTelemetryAvailable = isTelemetryAvailable
         self.telemetryLastReportedTime = telemetryLastReportedTime
@@ -98,6 +102,7 @@ public struct GeneralStoreSettings: Codable, Equatable, GeneratedCopiable {
         self.lastSelectedPerformanceTimeRange = lastSelectedPerformanceTimeRange
         self.lastSelectedTopPerformersTimeRange = lastSelectedTopPerformersTimeRange
         self.lastSelectedMostActiveCouponsTimeRange = lastSelectedMostActiveCouponsTimeRange
+        self.lastSelectedStockType = lastSelectedStockType
     }
 
     public func erasingSelectedTaxRateID() -> GeneralStoreSettings {
@@ -114,7 +119,8 @@ public struct GeneralStoreSettings: Codable, Equatable, GeneratedCopiable {
                              analyticsHubCards: analyticsHubCards,
                              dashboardCards: dashboardCards,
                              lastSelectedPerformanceTimeRange: lastSelectedPerformanceTimeRange,
-                             lastSelectedTopPerformersTimeRange: lastSelectedTopPerformersTimeRange)
+                             lastSelectedTopPerformersTimeRange: lastSelectedTopPerformersTimeRange,
+                             lastSelectedStockType: lastSelectedStockType)
     }
 }
 
@@ -142,6 +148,7 @@ extension GeneralStoreSettings {
         self.lastSelectedPerformanceTimeRange = try container.decodeIfPresent(String.self, forKey: .lastSelectedPerformanceTimeRange) ?? ""
         self.lastSelectedTopPerformersTimeRange = try container.decodeIfPresent(String.self, forKey: .lastSelectedTopPerformersTimeRange) ?? ""
         self.lastSelectedMostActiveCouponsTimeRange = try container.decodeIfPresent(String.self, forKey: .lastSelectedMostActiveCouponsTimeRange) ?? ""
+        self.lastSelectedStockType = try container.decodeIfPresent(String.self, forKey: .lastSelectedStockType)
 
         // Decode new properties with `decodeIfPresent` and provide a default value if necessary.
     }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/ProductStock/ProductStockDashboardCardViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/ProductStock/ProductStockDashboardCardViewModel.swift
@@ -60,11 +60,11 @@ private extension ProductStockDashboardCardViewModel {
     func loadLastSelectedStockType() async -> StockType {
         await withCheckedContinuation { continuation in
             stores.dispatch(AppSettingsAction.loadLastSelectedStockType(siteID: siteID, onCompletion: { type in
-                guard let type else {
+                guard let type,
+                      let stockType = StockType(rawValue: type) else {
                     continuation.resume(returning: .lowStock)
                     return
                 }
-                let stockType = StockType(rawValue: type) ?? .lowStock
                 continuation.resume(returning: stockType)
             }))
         }

--- a/Yosemite/Yosemite/Actions/AppSettingsAction.swift
+++ b/Yosemite/Yosemite/Actions/AppSettingsAction.swift
@@ -300,4 +300,12 @@ public enum AppSettingsAction: Action {
     /// Loads the last selected time range for the Most Active coupons dashboard card.
     ///
     case loadLastSelectedMostActiveCouponsTimeRange(siteID: Int64, onCompletion: (StatsTimeRangeV4?) -> Void)
+
+    /// Stores the last selected stock type for the Stock dashboard card.
+    ///
+    case setLastSelectedStockType(siteID: Int64, type: String)
+
+    /// Loads the last selected stock type for the Stock dashboard card.
+    ///
+    case loadLastSelectedStockType(siteID: Int64, onCompletion: (String?) -> Void)
 }

--- a/Yosemite/Yosemite/Stores/AppSettingsStore.swift
+++ b/Yosemite/Yosemite/Stores/AppSettingsStore.swift
@@ -236,6 +236,10 @@ public class AppSettingsStore: Store {
             setLastSelectedMostActiveCouponsTimeRange(siteID: siteID, timeRange: timeRange)
         case let .loadLastSelectedMostActiveCouponsTimeRange(siteID, onCompletion):
             loadLastSelectedMostActiveCouponsTimeRange(siteID: siteID, onCompletion: onCompletion)
+        case let .setLastSelectedStockType(siteID, type):
+            setLastSelectedStockType(siteID: siteID, type: type)
+        case let .loadLastSelectedStockType(siteID, onCompletion):
+            loadLastSelectedStockType(siteID: siteID, onCompletion: onCompletion)
         }
     }
 }
@@ -1036,6 +1040,18 @@ private extension AppSettingsStore {
         let timeRangeRawValue = storeSettings.lastSelectedMostActiveCouponsTimeRange
         let timeRange = StatsTimeRangeV4(rawValue: timeRangeRawValue)
         onCompletion(timeRange)
+    }
+
+    func setLastSelectedStockType(siteID: Int64, type: String) {
+        let storeSettings = getStoreSettings(for: siteID)
+        let updatedSettings = storeSettings.copy(lastSelectedStockType: type)
+        setStoreSettings(settings: updatedSettings, for: siteID)
+    }
+
+    func loadLastSelectedStockType(siteID: Int64, onCompletion: (String?) -> Void) {
+        let storeSettings = getStoreSettings(for: siteID)
+        let stockType = storeSettings.lastSelectedStockType
+        onCompletion(stockType)
     }
 }
 

--- a/Yosemite/YosemiteTests/Stores/AppSettingsStoreTests.swift
+++ b/Yosemite/YosemiteTests/Stores/AppSettingsStoreTests.swift
@@ -1621,6 +1621,59 @@ extension AppSettingsStoreTests {
         // Then
         XCTAssertNil(loadedTimeRange)
     }
+
+    // MARK: - Last selected stock type for Stock dashboard card
+
+    func test_setLastSelectedStockType_works_correctly() throws {
+        // Given
+        let stockType = "lowstock"
+        let existingSettings = GeneralStoreSettingsBySite(storeSettingsBySite: [TestConstants.siteID: GeneralStoreSettings()])
+        try fileStorage?.write(existingSettings, to: expectedGeneralStoreSettingsFileURL)
+
+        // When
+        let action = AppSettingsAction.setLastSelectedStockType(siteID: TestConstants.siteID, type: stockType)
+        subject?.onAction(action)
+
+        // Then
+        let savedSettings: GeneralStoreSettingsBySite = try XCTUnwrap(fileStorage?.data(for: expectedGeneralStoreSettingsFileURL))
+        let settingsForSite = savedSettings.storeSettingsBySite[TestConstants.siteID]
+
+        assertEqual(stockType, settingsForSite?.lastSelectedStatsTimeRange)
+    }
+
+    func test_loadLastSelectedStockType_works_correctly() throws {
+        // Given
+        let stockType = "lowstock"
+        let storeSettings = GeneralStoreSettings(lastSelectedStockType: stockType)
+        let existingSettings = GeneralStoreSettingsBySite(storeSettingsBySite: [TestConstants.siteID: storeSettings])
+        try fileStorage?.write(existingSettings, to: expectedGeneralStoreSettingsFileURL)
+
+        // When
+        var loadedStockType: String?
+        let action = AppSettingsAction.loadLastSelectedStockType(siteID: TestConstants.siteID) { type in
+            loadedStockType = type
+        }
+        subject?.onAction(action)
+
+        // Then
+        assertEqual(stockType, loadedStockType)
+    }
+
+    func test_loadLastSelectedStockType_returns_nil_when_no_data_was_saved() throws {
+        // Given
+        let existingSettings = GeneralStoreSettingsBySite(storeSettingsBySite: [TestConstants.siteID: GeneralStoreSettings()])
+        try fileStorage?.write(existingSettings, to: expectedGeneralStoreSettingsFileURL)
+
+        // When
+        var loadedStockType: String?
+        let action = AppSettingsAction.loadLastSelectedStockType(siteID: TestConstants.siteID) { type in
+            loadedStockType = type
+        }
+        subject?.onAction(action)
+
+        // Then
+        XCTAssertNil(loadedStockType)
+    }
 }
 
 // MARK: - Utils

--- a/Yosemite/YosemiteTests/Stores/AppSettingsStoreTests.swift
+++ b/Yosemite/YosemiteTests/Stores/AppSettingsStoreTests.swift
@@ -1638,7 +1638,7 @@ extension AppSettingsStoreTests {
         let savedSettings: GeneralStoreSettingsBySite = try XCTUnwrap(fileStorage?.data(for: expectedGeneralStoreSettingsFileURL))
         let settingsForSite = savedSettings.storeSettingsBySite[TestConstants.siteID]
 
-        assertEqual(stockType, settingsForSite?.lastSelectedStatsTimeRange)
+        assertEqual(stockType, settingsForSite?.lastSelectedStockType)
     }
 
     func test_loadLastSelectedStockType_works_correctly() throws {


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #12797
Part of #12754 
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This PR updates `AppSettingsStore` and `AppSettingsAction` to support saving and loading last selected stock type for Stock card.

`ProductStockDashboardCardViewModel` has also been updated to load the last selected stock type upon initialization and set the selected stock type when it changes.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
- Log in to a store and enable the Stock card on My Store.
- Confirm that the initial selected stock type is Low stock.
- Switch to a different stock type.
- Relaunch the app, confirm that the last selected stock type is displayed instead of low stock.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

N/A

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
