### PR TITLE
[Migrate simple payments] Fix card reader payment methods from Menu > Payments > Collect Payment

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -2,6 +2,7 @@
 
 18.8
 -----
+- [*] Menu > Payments > Collect Payment: fix the the "card reader" & "Tap To Pay" payment methods where it was no-op before. [https://github.com/woocommerce/woocommerce-ios/pull/12801]
 - [internal] Optimize API calls sent for Dashboard screen. [https://github.com/woocommerce/woocommerce-ios/pull/12775]
 
 

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Payments Menu/InPersonPaymentsMenu.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Payments Menu/InPersonPaymentsMenu.swift
@@ -226,9 +226,10 @@ struct InPersonPaymentsMenu: View {
                 }
                 .navigationDestination(isPresented: $viewModel.presentPaymentMethods) {
                     if let paymentMethodsViewModel = viewModel.paymentMethodsViewModel {
-                        PaymentMethodsView(dismiss: {
+                        PaymentMethodsWrapperHosted(viewModel: paymentMethodsViewModel,
+                                                    dismiss: {
                             viewModel.dismissPaymentCollection()
-                        }, viewModel: paymentMethodsViewModel)
+                        })
                     } else {
                         EmptyView()
                     }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Payments Menu/PaymentMethodsWrapperHostingController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Payments Menu/PaymentMethodsWrapperHostingController.swift
@@ -1,0 +1,34 @@
+import SwiftUI
+
+/// A pure wrapper UIKit hosting controller of `PaymentMethodsView` to provide `PaymentMethodsView`'s `rootViewController` in order for card reader payment methods to work,
+/// as a pure SwiftUI flow doesn't have a `UIViewController` to pass around.
+/// To use it in SwiftUI, `PaymentMethodsWrapperHosted` is the wrapper's SwiftUI version.
+final class PaymentMethodsWrapperHostingController: UIHostingController<PaymentMethodsView> {
+    init(dismiss: @escaping () -> Void,
+         viewModel: PaymentMethodsViewModel) {
+        super.init(rootView: PaymentMethodsView(dismiss: dismiss, viewModel: viewModel))
+    }
+
+    required dynamic init?(coder aDecoder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+
+        // Needed to present IPP collect amount alerts, which are displayed in UIKit view controllers.
+        rootView.rootViewController = self
+    }
+}
+
+// MARK: - SwiftUI compatibility
+struct PaymentMethodsWrapperHosted: UIViewControllerRepresentable {
+    let viewModel: PaymentMethodsViewModel
+    let dismiss: () -> Void
+
+    func makeUIViewController(context: Context) -> some UIViewController {
+        PaymentMethodsWrapperHostingController(dismiss: dismiss, viewModel: viewModel)
+    }
+
+    func updateUIViewController(_ uiViewController: UIViewControllerType, context: Context) {}
+}

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Payments Menu/PaymentMethodsWrapperHostingController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Payments Menu/PaymentMethodsWrapperHostingController.swift
@@ -1,7 +1,7 @@
 import SwiftUI
 
-/// A pure wrapper UIKit hosting controller of `PaymentMethodsView` to provide `PaymentMethodsView`'s `rootViewController` in order for card reader payment methods to work,
-/// as a pure SwiftUI flow doesn't have a `UIViewController` to pass around.
+/// A pure wrapper UIKit hosting controller of `PaymentMethodsView` to provide `PaymentMethodsView`'s `rootViewController` in order
+/// for card reader payment methods to work, as a pure SwiftUI flow doesn't have a `UIViewController` to pass around.
 /// To use it in SwiftUI, `PaymentMethodsWrapperHosted` is the wrapper's SwiftUI version.
 final class PaymentMethodsWrapperHostingController: UIHostingController<PaymentMethodsView> {
     init(dismiss: @escaping () -> Void,

--- a/WooCommerce/Classes/ViewRelated/Orders/Payment Methods/PaymentMethodsView.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Payment Methods/PaymentMethodsView.swift
@@ -139,6 +139,11 @@ struct PaymentMethodsView: View {
             }
                 .background(FullScreenCoverClearBackgroundView())
         }
+        .onAppear {
+            guard rootViewController != nil else {
+                return viewModel.logNoRootViewControllerError()
+            }
+        }
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Payment Methods/PaymentMethodsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Payment Methods/PaymentMethodsViewModel.swift
@@ -279,6 +279,17 @@ final class PaymentMethodsViewModel: ObservableObject {
         trackFlowCanceled()
     }
 
+    /// Logs an error when `PaymentMethodsView.rootViewController` is missing.
+    func logNoRootViewControllerError() {
+        let logProperties: [String: Any] = ["flow": flow.rawValue]
+        ServiceLocator.crashLogging.logMessage(
+            "Missing `rootViewController` in `PaymentMethodsView` can result in a broken IPP experience",
+            properties: logProperties,
+            level: .error
+        )
+        assertionFailure("Missing `rootViewController` in `PaymentMethodsView` can result in a broken IPP experience in flow: \(flow.rawValue)")
+    }
+
     /// Defines if the swipe-to-dismiss gesture on the payment flow should be enabled
     ///
     var shouldEnableSwipeToDismiss: Bool {

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -236,6 +236,7 @@
 		025678052575EA1B009D7E6C /* ProductDetailsCellViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 025678042575EA1B009D7E6C /* ProductDetailsCellViewModelTests.swift */; };
 		025678C125773236009D7E6C /* Collection+ShippingLabel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 025678C025773236009D7E6C /* Collection+ShippingLabel.swift */; };
 		025678C725773399009D7E6C /* Collection+ShippingLabelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 025678C625773399009D7E6C /* Collection+ShippingLabelTests.swift */; };
+		02577A7F2BFC4BB300B63FE6 /* PaymentMethodsWrapperHostingController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02577A7E2BFC4BB300B63FE6 /* PaymentMethodsWrapperHostingController.swift */; };
 		0258B4D82B1590A3008FEA07 /* ConfigurableBundleNoticeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0258B4D72B1590A3008FEA07 /* ConfigurableBundleNoticeView.swift */; };
 		0258B4DA2B159A0F008FEA07 /* Publisher+WithPrevious.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0258B4D92B159A0F008FEA07 /* Publisher+WithPrevious.swift */; };
 		0258B66D2518778300EB5CF2 /* ProductFormViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0258B66C2518778300EB5CF2 /* ProductFormViewModelTests.swift */; };
@@ -3009,6 +3010,7 @@
 		025678042575EA1B009D7E6C /* ProductDetailsCellViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductDetailsCellViewModelTests.swift; sourceTree = "<group>"; };
 		025678C025773236009D7E6C /* Collection+ShippingLabel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Collection+ShippingLabel.swift"; sourceTree = "<group>"; };
 		025678C625773399009D7E6C /* Collection+ShippingLabelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Collection+ShippingLabelTests.swift"; sourceTree = "<group>"; };
+		02577A7E2BFC4BB300B63FE6 /* PaymentMethodsWrapperHostingController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaymentMethodsWrapperHostingController.swift; sourceTree = "<group>"; };
 		0258B4D72B1590A3008FEA07 /* ConfigurableBundleNoticeView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConfigurableBundleNoticeView.swift; sourceTree = "<group>"; };
 		0258B4D92B159A0F008FEA07 /* Publisher+WithPrevious.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Publisher+WithPrevious.swift"; sourceTree = "<group>"; };
 		0258B66C2518778300EB5CF2 /* ProductFormViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductFormViewModelTests.swift; sourceTree = "<group>"; };
@@ -7233,6 +7235,7 @@
 				20D5CB502AFCF856009A39C3 /* PaymentsRow.swift */,
 				20D5CB522AFCF8E7009A39C3 /* PaymentsToggleRow.swift */,
 				0240737F2BBAAF7400C00441 /* SimplePaymentsMigrationView.swift */,
+				02577A7E2BFC4BB300B63FE6 /* PaymentMethodsWrapperHostingController.swift */,
 			);
 			path = "Payments Menu";
 			sourceTree = "<group>";
@@ -14513,6 +14516,7 @@
 				CE263DE8206ACE3E0015A693 /* MainTabBarController.swift in Sources */,
 				20A3AFE32B10EF860033AF2D /* CardReaderSettingsFlowPresentingView.swift in Sources */,
 				CE14452E2188C11700A991D8 /* ZendeskManager.swift in Sources */,
+				02577A7F2BFC4BB300B63FE6 /* PaymentMethodsWrapperHostingController.swift in Sources */,
 				02BA53432A380D7D0069224D /* ProductDescriptionAICoordinator.swift in Sources */,
 				FE28F7122684CA29004465C7 /* RoleErrorViewController.swift in Sources */,
 				B5BE75DB213F1D1E00909A14 /* OverlayMessageView.swift in Sources */,


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #12790 
<!-- Id number of the GitHub issue this PR addresses. -->

## Why

A merchant reported that the IPP flow from Menu > Payments > Collect Payment entry point stopped working, while the same flow in the orders tab worked. With @joshheald's helpful information peaMlT-Ec-p2#comment-1526, the issue was from not passing a `rootViewController` to `PaymentMethodsView`. It was probably missed from the beginning, but the card reader flow wasn't tested before the release since "card reader" and "Tap to Pay" are the only two payment methods that use the `rootViewController` with UIKit views (I thought I tested this but maybe at an early stage).

## How

To fix this, I created `PaymentMethodsWrapperHostingController` (UIKit) and `PaymentMethodsWrapperHosted` (SwiftUI) to provide a root view controller to `PaymentMethodsView` to fix card reader payment method flow (as suggested in Josh's first point peaMlT-Ec-p2#comment-1526). There is also another existing hosting controller and its SwiftUI version in `PaymentMethodsHostingController`/`PaymentMethodsHostingView`, but there's more logic in it than what's needed in the Payments menu flow so I created "wrapper" versions (feel free to suggest other names).

It's quite dangerous how `PaymentMethodsView.rootViewController` isn't easy to enforce and missing it could result in a broken IPP flow. I thought about `assertionFailure` somewhere but couldn't find a good place to do it. Not mixing SwiftUI and UIKit with optional view controller setup would be great in the future.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

- [x] @jaclync tests on a device for card reader payment method
- [x] @jaclync tests on a device for Tap To Pay payment method
---
Prerequisite: a card reader is available

- Go to Menu > Payments > Collect Payment
- Enter a custom amount, or add some products to the order
- Tap `Collect Payment` in the order form
- Tap `Card Reader` --> the card reader flow should start
- Continue to the payment flow --> the payment should be successful and it should navigate back to the Payments menu

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->


https://github.com/woocommerce/woocommerce-ios/assets/1945542/e18ad31e-9846-446f-a4f1-665dd59a17b5



---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
