### PR TITLE
[Min/Max Quantities Edit Support] Tracking

### DIFF
--- a/WooCommerce/Classes/Analytics/WooAnalyticsEvent.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsEvent.swift
@@ -240,6 +240,7 @@ extension WooAnalyticsEvent {
             static let errorDescription = "error_description"
             static let field = "field"
             static let variationsCount = "variations_count"
+            static let hasChangedData = "has_changed_data"
         }
 
         enum BulkUpdateField: String {
@@ -365,6 +366,11 @@ extension WooAnalyticsEvent {
         static func expirationDateSettingsTapped() -> WooAnalyticsEvent {
             WooAnalyticsEvent(statName: .productVariationViewSubscriptionExpirationDateTapped, properties: [:])
         }
+
+        static func quantityRulesDoneButtonTapped(hasChangedData: Bool) -> WooAnalyticsEvent {
+            WooAnalyticsEvent(statName: .productVariationDetailsViewQuantityRulesDoneButtonTapped,
+                              properties: [Keys.hasChangedData: hasChangedData])
+        }
     }
 }
 
@@ -447,6 +453,11 @@ extension WooAnalyticsEvent {
         ///
         static func expirationDateSettingsTapped() -> WooAnalyticsEvent {
             WooAnalyticsEvent(statName: .productDetailsViewSubscriptionExpirationDateTapped, properties: [:])
+        }
+
+        static func quantityRulesDoneButtonTapped(hasChangedData: Bool) -> WooAnalyticsEvent {
+            WooAnalyticsEvent(statName: .productDetailsViewQuantityRulesDoneButtonTapped,
+                              properties: [Keys.hasChangedData: hasChangedData])
         }
 
         /// For Woo Subscriptions products, tracks when the subscription expiration details screen is closed.

--- a/WooCommerce/Classes/Analytics/WooAnalyticsStat.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsStat.swift
@@ -784,6 +784,10 @@ enum WooAnalyticsStat: String {
     case productSubscriptionExpirationDoneButtonTapped = "product_subscription_expiration_done_button_tapped"
     case productSubscriptionFreeTrialDoneButtonTapped = "product_subscription_free_trial_done_button_tapped"
 
+    // MARK: Quantity Rules product Events
+    case productDetailsViewQuantityRulesDoneButtonTapped = "product_detail_quantity_rules_done_button_tapped"
+    case productVariationDetailsViewQuantityRulesDoneButtonTapped = "product_variation_quantity_rules_done_button_tapped"
+
 
     // MARK: Product Images Events
     //

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormEventLogger.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormEventLogger.swift
@@ -35,4 +35,8 @@ struct ProductFormEventLogger: ProductFormEventLoggerProtocol {
     func logSubscriptionsExpirationDateTapped() {
         ServiceLocator.analytics.track(event: .ProductDetail.expirationDateSettingsTapped())
     }
+
+    func logQuantityRulesDoneButtonTapped(hasUnsavedChanges: Bool) {
+        ServiceLocator.analytics.track(event: .ProductDetail.quantityRulesDoneButtonTapped(hasChangedData: hasUnsavedChanges))
+    }
 }

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormEventLoggerProtocol.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormEventLoggerProtocol.swift
@@ -26,4 +26,7 @@ protocol ProductFormEventLoggerProtocol {
 
     /// Called to log an event when the subscriptions expiration row is tapped
     func logSubscriptionsExpirationDateTapped()
+
+    /// Called to log an event when the done button in the quantity rules view is tapped
+    func logQuantityRulesDoneButtonTapped(hasUnsavedChanges: Bool)
 }

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewController.swift
@@ -1996,15 +1996,23 @@ private extension ProductFormViewController {
 //
 private extension ProductFormViewController {
     func showQuantityRules() {
-        let quantityRulesViewModel = QuantityRulesViewModel(product: product) { [weak self] minQuantity, maxQuantity, groupOf in
-            self?.navigationController?.popViewController(animated: true)
-            self?.viewModel.updateQuantityRules(minQuantity: minQuantity, maxQuantity: maxQuantity, groupOf: groupOf)
+        let quantityRulesViewModel = QuantityRulesViewModel(product: product) { [weak self] rules, hasUnsavedChanges in
+            defer {
+                self?.navigationController?.popViewController(animated: true)
+            }
+
+            self?.eventLogger.logQuantityRulesDoneButtonTapped(hasUnsavedChanges: hasUnsavedChanges)
+
+            guard hasUnsavedChanges else {
+                return
+            }
+
+            self?.viewModel.updateQuantityRules(minQuantity: rules.minQuantity, maxQuantity: rules.maxQuantity, groupOf: rules.groupOf)
         }
         let viewController = QuantityRulesViewController(viewModel: quantityRulesViewModel)
         show(viewController, sender: self)
     }
 }
-
 
 // MARK: Constants
 //

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductVariationFormEventLogger.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductVariationFormEventLogger.swift
@@ -35,4 +35,8 @@ struct ProductVariationFormEventLogger: ProductFormEventLoggerProtocol {
     func logSubscriptionsExpirationDateTapped() {
         ServiceLocator.analytics.track(event: .Variations.expirationDateSettingsTapped())
     }
+
+    func logQuantityRulesDoneButtonTapped(hasUnsavedChanges: Bool) {
+        ServiceLocator.analytics.track(event: .Variations.quantityRulesDoneButtonTapped(hasChangedData: hasUnsavedChanges))
+    }
 }

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Quantity Rules/QuantityRules.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Quantity Rules/QuantityRules.swift
@@ -90,8 +90,8 @@ private extension QuantityRules {
 
 struct QuantityRules_Previews: PreviewProvider {
 
-    static let viewModel = QuantityRulesViewModel(minQuantity: "4", maxQuantity: "200", groupOf: "2", onCompletion: { minQuantity, maxQuantity, groupOf in })
-    static let noQuantityRules = QuantityRulesViewModel(minQuantity: "", maxQuantity: "", groupOf: "", onCompletion: { minQuantity, maxQuantity, groupOf in })
+    static let viewModel = QuantityRulesViewModel(minQuantity: "4", maxQuantity: "200", groupOf: "2", onCompletion: { rules, hasUnsavedChanges in })
+    static let noQuantityRules = QuantityRulesViewModel(minQuantity: "", maxQuantity: "", groupOf: "", onCompletion: { rules, hasUnsavedChanges in })
 
     static var previews: some View {
         QuantityRules(viewModel: viewModel)

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Quantity Rules/QuantityRulesViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Quantity Rules/QuantityRulesViewModel.swift
@@ -3,7 +3,22 @@ import Foundation
 /// View Model for `QuantityRules`
 ///
 final class QuantityRulesViewModel: ObservableObject {
-    typealias Completion = (_ minQuantity: String, _ maxQuantity: String, _ groupOf: String) -> Void
+     struct QuantityRules: Equatable {
+        let minQuantity: String
+        let maxQuantity: String
+        let groupOf: String
+
+        init(minQuantity: String,
+             maxQuantity: String,
+             groupOf: String) {
+            // Let's normalize them for easier comparison
+            self.minQuantity = minQuantity.isEmpty ? "0" : minQuantity
+            self.maxQuantity = maxQuantity.isEmpty ? "0" : maxQuantity
+            self.groupOf = groupOf.isEmpty ? "0" : groupOf
+        }
+    }
+
+    typealias Completion = (_ rules: QuantityRules, _ hasUnchangedValues: Bool) -> Void
 
     /// Minimum quantity
     ///
@@ -19,6 +34,8 @@ final class QuantityRulesViewModel: ObservableObject {
 
     private let onCompletion: Completion
 
+    private let originalInput: QuantityRules
+
     init(minQuantity: String?,
          maxQuantity: String?,
          groupOf: String?,
@@ -27,6 +44,7 @@ final class QuantityRulesViewModel: ObservableObject {
         self.maxQuantity = QuantityRulesViewModel.getDisplayValue(for: maxQuantity)
         self.groupOf = QuantityRulesViewModel.getDisplayValue(for: groupOf)
         self.onCompletion = onCompletion
+        self.originalInput = QuantityRules(minQuantity: minQuantity ?? "0", maxQuantity: maxQuantity ?? "0", groupOf: groupOf ?? "0")
     }
 
     convenience init(product: ProductFormDataModel,
@@ -38,7 +56,8 @@ final class QuantityRulesViewModel: ObservableObject {
     }
 
     func onDoneButtonPressed() {
-        onCompletion(minQuantity, maxQuantity, groupOf)
+        let newRules = QuantityRules(minQuantity: minQuantity, maxQuantity: maxQuantity, groupOf: groupOf)
+        onCompletion(newRules, newRules != originalInput)
     }
 }
 

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/Quantity Rules/QuantityRulesViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/Quantity Rules/QuantityRulesViewModelTests.swift
@@ -4,7 +4,7 @@ import XCTest
 final class QuantityRulesViewModelTests: XCTestCase {
     func test_view_model_returns_empty_string_for_nil_quantities() {
         // Given
-        let viewModel = QuantityRulesViewModel(minQuantity: nil, maxQuantity: nil, groupOf: nil) {_, _, _ in }
+        let viewModel = QuantityRulesViewModel(minQuantity: nil, maxQuantity: nil, groupOf: nil) {_, _ in }
 
         // Then
         XCTAssertEqual(viewModel.minQuantity, "")
@@ -14,7 +14,7 @@ final class QuantityRulesViewModelTests: XCTestCase {
 
     func test_view_model_returns_empty_string_for_empty_quantities() {
         // Given
-        let viewModel = QuantityRulesViewModel(minQuantity: "", maxQuantity: "", groupOf: "") {_, _, _ in }
+        let viewModel = QuantityRulesViewModel(minQuantity: "", maxQuantity: "", groupOf: "") {_, _ in }
 
         // Then
         XCTAssertEqual(viewModel.minQuantity, "")
@@ -24,7 +24,7 @@ final class QuantityRulesViewModelTests: XCTestCase {
 
     func test_view_model_returns_quantities_when_not_nil_or_empty() {
         // Given
-        let viewModel = QuantityRulesViewModel(minQuantity: "4", maxQuantity: "200", groupOf: "2") {_, _, _ in }
+        let viewModel = QuantityRulesViewModel(minQuantity: "4", maxQuantity: "200", groupOf: "2") {_, _ in }
 
         // Then
         XCTAssertEqual(viewModel.minQuantity, "4")
@@ -41,10 +41,10 @@ final class QuantityRulesViewModelTests: XCTestCase {
         var passedMaxQuantity: String?
         var passedGroupOfValue: String?
 
-        let viewModel = QuantityRulesViewModel(minQuantity: "4", maxQuantity: "200", groupOf: "2") { minQuantity, maxQuantity, groupOfValue in
-            passedMinQuantity = minQuantity
-            passedMaxQuantity = maxQuantity
-            passedGroupOfValue = groupOfValue
+        let viewModel = QuantityRulesViewModel(minQuantity: "4", maxQuantity: "200", groupOf: "2") { rules, hasUnchangedValues in
+            passedMinQuantity = rules.minQuantity
+            passedMaxQuantity = rules.maxQuantity
+            passedGroupOfValue = rules.groupOf
         }
 
         viewModel.minQuantity = newMinQuantity


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #12788 
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
With this PR we implement tracking for the Min/Max Quantities Edit Support.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
### Product

1. Go to the Products tab
2. Tap on a product with Quantity Rules
3. Tap on the Quantity Rules row.
4. Tap on Done with and without changing data. This event has to be tracked:

`🔵 Tracked product_detail_quantity_rules_done_button_tapped, properties: [AnyHashable("was_ecommerce_trial"): false, AnyHashable("is_wpcom_store"): true, AnyHashable("plan"): "business-bundle", AnyHashable("blog_id"): 214354650, AnyHashable("store_id"): "3db14754-cf30-4c42-857d-d754bca1dac1", AnyHashable("site_url"): "https://americanwootester.wpcomstaging.com", AnyHashable("has_changed_data"): true|false]
`

`has_changed_data` reflects whether we changed data

### Product Variation

1. Go to the Products tab
2. Tap on a product with variations
3. Navigate to a variation with Quantity Rules
4. Tap on the Quantity Rules row.
5. Tap on Done with and without changing data. This event has to be tracked:

`🔵 Tracked product_variation_quantity_rules_done_button_tapped, properties: [AnyHashable("store_id"): "3db14754-cf30-4c42-857d-d754bca1dac1", AnyHashable("site_url"): "https://americanwootester.wpcomstaging.com", AnyHashable("has_changed_data"): true|false, AnyHashable("plan"): "business-bundle", AnyHashable("is_wpcom_store"): true, AnyHashable("was_ecommerce_trial"): false, AnyHashable("blog_id"): 214354650]`

`has_changed_data` reflects whether we changed data


## Screenshots
<!-- Include before and after images or gifs when appropriate. -->


---
- [X] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
