### PR TITLE
[Watch] Fetch and display Order List Data 

### DIFF
--- a/Networking/Networking.xcodeproj/project.pbxproj
+++ b/Networking/Networking.xcodeproj/project.pbxproj
@@ -230,6 +230,7 @@
 		26373E202BFCF6A7008E6735 /* EntityDateModifiedMapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE865A9C2A41E1480049B03C /* EntityDateModifiedMapper.swift */; };
 		26373E242BFCF9F0008E6735 /* Encodable+Serialization.swift in Sources */ = {isa = PBXBuildFile; fileRef = 021C7BF623863D1800A3BCBD /* Encodable+Serialization.swift */; };
 		26373E2A2BFD08AF008E6735 /* WatchOS-Models+Copiable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26373E282BFD0880008E6735 /* WatchOS-Models+Copiable.swift */; };
+		26373E302BFD7CAC008E6735 /* OrderStatus.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE12FBD8221F3A6F00C59248 /* OrderStatus.swift */; };
 		263A6D9E2BEA9DF500C292B2 /* Logging.swift in Sources */ = {isa = PBXBuildFile; fileRef = 933A2731222234F800C2143A /* Logging.swift */; };
 		263A6D9F2BEA9E4200C292B2 /* DotcomValidator.swift in Sources */ = {isa = PBXBuildFile; fileRef = B53EF5332180F646003E146F /* DotcomValidator.swift */; };
 		263A6DA02BEA9E7300C292B2 /* Settings.swift in Sources */ = {isa = PBXBuildFile; fileRef = B557DA1920979D66005962F4 /* Settings.swift */; };
@@ -4576,6 +4577,7 @@
 				2680B0D72BED5A8800E7F1D8 /* ApplicationPasswordMapper.swift in Sources */,
 				2680B0D82BED5A8800E7F1D8 /* ApplicationPasswordNameAndUUIDMapper.swift in Sources */,
 				2680B0D62BED5A7F00E7F1D8 /* WordPressOrgNetwork.swift in Sources */,
+				26373E302BFD7CAC008E6735 /* OrderStatus.swift in Sources */,
 				2680B0D52BED5A7700E7F1D8 /* CookieNonceAuthenticator.swift in Sources */,
 				26373E1B2BFCF531008E6735 /* String+HTML.swift in Sources */,
 				2680B0D42BED5A6600E7F1D8 /* AppicationPasswordEncoder.swift in Sources */,

--- a/Networking/Networking.xcodeproj/project.pbxproj
+++ b/Networking/Networking.xcodeproj/project.pbxproj
@@ -223,6 +223,12 @@
 		26373E192BFCEF96008E6735 /* OrderListMapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = B567AF2A20A0FA4200AB6C62 /* OrderListMapper.swift */; };
 		26373E1A2BFCEFA7008E6735 /* OrderFeeTaxStatus.swift in Sources */ = {isa = PBXBuildFile; fileRef = D88E229325AC9B420023F3B1 /* OrderFeeTaxStatus.swift */; };
 		26373E1B2BFCF531008E6735 /* String+HTML.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02BDB83423EA98C800BCC63E /* String+HTML.swift */; };
+		26373E1C2BFCF62C008E6735 /* OrderNote.swift in Sources */ = {isa = PBXBuildFile; fileRef = 74C8F06320EEB44800B6EDC9 /* OrderNote.swift */; };
+		26373E1D2BFCF646008E6735 /* OrderMapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5C6FCD320A373BA00A4F8E4 /* OrderMapper.swift */; };
+		26373E1E2BFCF657008E6735 /* OrderNotesMapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 74C8F06720EEB7BC00B6EDC9 /* OrderNotesMapper.swift */; };
+		26373E1F2BFCF69A008E6735 /* OrderNoteMapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE583A0D2109154500D73C1C /* OrderNoteMapper.swift */; };
+		26373E202BFCF6A7008E6735 /* EntityDateModifiedMapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE865A9C2A41E1480049B03C /* EntityDateModifiedMapper.swift */; };
+		26373E242BFCF9F0008E6735 /* Encodable+Serialization.swift in Sources */ = {isa = PBXBuildFile; fileRef = 021C7BF623863D1800A3BCBD /* Encodable+Serialization.swift */; };
 		263A6D9E2BEA9DF500C292B2 /* Logging.swift in Sources */ = {isa = PBXBuildFile; fileRef = 933A2731222234F800C2143A /* Logging.swift */; };
 		263A6D9F2BEA9E4200C292B2 /* DotcomValidator.swift in Sources */ = {isa = PBXBuildFile; fileRef = B53EF5332180F646003E146F /* DotcomValidator.swift */; };
 		263A6DA02BEA9E7300C292B2 /* Settings.swift in Sources */ = {isa = PBXBuildFile; fileRef = B557DA1920979D66005962F4 /* Settings.swift */; };
@@ -4572,6 +4578,7 @@
 				2680B0D42BED5A6600E7F1D8 /* AppicationPasswordEncoder.swift in Sources */,
 				2680B0D32BED5A5400E7F1D8 /* OneTimeApplicationPasswordUseCase.swift in Sources */,
 				2680B0D12BED5A4C00E7F1D8 /* UnauthenticatedRequest.swift in Sources */,
+				26373E1C2BFCF62C008E6735 /* OrderNote.swift in Sources */,
 				2680B0D22BED5A4C00E7F1D8 /* AuthenticatedRESTRequest.swift in Sources */,
 				2680B0D02BED5A1900E7F1D8 /* WooConstants.swift in Sources */,
 				2680B0CF2BED59CE00E7F1D8 /* ApplicationPasswordStorage.swift in Sources */,
@@ -4617,18 +4624,21 @@
 				2680B0CE2BED592800E7F1D8 /* Secret.swift in Sources */,
 				263A6DA62BEA9FE600C292B2 /* PlaceholderDataValidator.swift in Sources */,
 				263A6DA52BEA9FCC00C292B2 /* String+URL.swift in Sources */,
+				26373E1F2BFCF69A008E6735 /* OrderNoteMapper.swift in Sources */,
 				263A6DA42BEA9F5A00C292B2 /* Dictionary+Woo.swift in Sources */,
 				263A6DA32BEA9EFD00C292B2 /* Result+Extensions.swift in Sources */,
 				263A6DA22BEA9E8F00C292B2 /* WordPressApiError.swift in Sources */,
 				263A6DA12BEA9E8000C292B2 /* WordPressApiValidator.swift in Sources */,
 				263A6DA02BEA9E7300C292B2 /* Settings.swift in Sources */,
 				263A6D9F2BEA9E4200C292B2 /* DotcomValidator.swift in Sources */,
+				26373E1D2BFCF646008E6735 /* OrderMapper.swift in Sources */,
 				263A6D9E2BEA9DF500C292B2 /* Logging.swift in Sources */,
 				26373E082BFCEA86008E6735 /* OrderItemAttribute.swift in Sources */,
 				26373E0C2BFCEAD1008E6735 /* ProductVariationAttribute.swift in Sources */,
 				269014D42BEA9335006056E0 /* UserAgent.swift in Sources */,
 				269014D22BEA9309006056E0 /* DotcomRequest.swift in Sources */,
 				269014D32BEA9309006056E0 /* AuthenticatedDotcomRequest.swift in Sources */,
+				26373E1E2BFCF657008E6735 /* OrderNotesMapper.swift in Sources */,
 				269014D12BEA92F8006056E0 /* DecodingError+CodingPath.swift in Sources */,
 				269014D02BEA92CD006056E0 /* URLRequestConvertible+Path.swift in Sources */,
 				269014CF2BEA928A006056E0 /* WooAPIVersion.swift in Sources */,
@@ -4650,9 +4660,11 @@
 				269014C32BEA9134006056E0 /* Mapper.swift in Sources */,
 				269014C22BEA912D006056E0 /* Request.swift in Sources */,
 				26373E182BFCEF79008E6735 /* KeyedDecodingContainer+Woo.swift in Sources */,
+				26373E202BFCF6A7008E6735 /* EntityDateModifiedMapper.swift in Sources */,
 				26DAAB592BEA8E1500CE399E /* Network.swift in Sources */,
 				26373E052BFCEA60008E6735 /* Order.swift in Sources */,
 				26DAAB582BEA8DFF00CE399E /* Remote.swift in Sources */,
+				26373E242BFCF9F0008E6735 /* Encodable+Serialization.swift in Sources */,
 				26DAAB572BEA8DC100CE399E /* Credentials.swift in Sources */,
 				26373E0B2BFCEAC9008E6735 /* OrderItemBundleItem.swift in Sources */,
 			);

--- a/Networking/Networking.xcodeproj/project.pbxproj
+++ b/Networking/Networking.xcodeproj/project.pbxproj
@@ -222,6 +222,7 @@
 		26373E182BFCEF79008E6735 /* KeyedDecodingContainer+Woo.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5C151BA217EC34100C7BDC1 /* KeyedDecodingContainer+Woo.swift */; };
 		26373E192BFCEF96008E6735 /* OrderListMapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = B567AF2A20A0FA4200AB6C62 /* OrderListMapper.swift */; };
 		26373E1A2BFCEFA7008E6735 /* OrderFeeTaxStatus.swift in Sources */ = {isa = PBXBuildFile; fileRef = D88E229325AC9B420023F3B1 /* OrderFeeTaxStatus.swift */; };
+		26373E1B2BFCF531008E6735 /* String+HTML.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02BDB83423EA98C800BCC63E /* String+HTML.swift */; };
 		263A6D9E2BEA9DF500C292B2 /* Logging.swift in Sources */ = {isa = PBXBuildFile; fileRef = 933A2731222234F800C2143A /* Logging.swift */; };
 		263A6D9F2BEA9E4200C292B2 /* DotcomValidator.swift in Sources */ = {isa = PBXBuildFile; fileRef = B53EF5332180F646003E146F /* DotcomValidator.swift */; };
 		263A6DA02BEA9E7300C292B2 /* Settings.swift in Sources */ = {isa = PBXBuildFile; fileRef = B557DA1920979D66005962F4 /* Settings.swift */; };
@@ -4567,6 +4568,7 @@
 				2680B0D82BED5A8800E7F1D8 /* ApplicationPasswordNameAndUUIDMapper.swift in Sources */,
 				2680B0D62BED5A7F00E7F1D8 /* WordPressOrgNetwork.swift in Sources */,
 				2680B0D52BED5A7700E7F1D8 /* CookieNonceAuthenticator.swift in Sources */,
+				26373E1B2BFCF531008E6735 /* String+HTML.swift in Sources */,
 				2680B0D42BED5A6600E7F1D8 /* AppicationPasswordEncoder.swift in Sources */,
 				2680B0D32BED5A5400E7F1D8 /* OneTimeApplicationPasswordUseCase.swift in Sources */,
 				2680B0D12BED5A4C00E7F1D8 /* UnauthenticatedRequest.swift in Sources */,

--- a/Networking/Networking.xcodeproj/project.pbxproj
+++ b/Networking/Networking.xcodeproj/project.pbxproj
@@ -229,6 +229,7 @@
 		26373E1F2BFCF69A008E6735 /* OrderNoteMapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE583A0D2109154500D73C1C /* OrderNoteMapper.swift */; };
 		26373E202BFCF6A7008E6735 /* EntityDateModifiedMapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE865A9C2A41E1480049B03C /* EntityDateModifiedMapper.swift */; };
 		26373E242BFCF9F0008E6735 /* Encodable+Serialization.swift in Sources */ = {isa = PBXBuildFile; fileRef = 021C7BF623863D1800A3BCBD /* Encodable+Serialization.swift */; };
+		26373E2A2BFD08AF008E6735 /* WatchOS-Models+Copiable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26373E282BFD0880008E6735 /* WatchOS-Models+Copiable.swift */; };
 		263A6D9E2BEA9DF500C292B2 /* Logging.swift in Sources */ = {isa = PBXBuildFile; fileRef = 933A2731222234F800C2143A /* Logging.swift */; };
 		263A6D9F2BEA9E4200C292B2 /* DotcomValidator.swift in Sources */ = {isa = PBXBuildFile; fileRef = B53EF5332180F646003E146F /* DotcomValidator.swift */; };
 		263A6DA02BEA9E7300C292B2 /* Settings.swift in Sources */ = {isa = PBXBuildFile; fileRef = B557DA1920979D66005962F4 /* Settings.swift */; };
@@ -1422,6 +1423,7 @@
 		262E5AD4255ACD6F000B2416 /* PaymentGatewayListMapperTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaymentGatewayListMapperTests.swift; sourceTree = "<group>"; };
 		263659DB2A264A3E00607A0D /* IPLocationRemote.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IPLocationRemote.swift; sourceTree = "<group>"; };
 		263659DD2A2694A000607A0D /* IPLocationRemoteTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IPLocationRemoteTests.swift; sourceTree = "<group>"; };
+		26373E282BFD0880008E6735 /* WatchOS-Models+Copiable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "WatchOS-Models+Copiable.swift"; sourceTree = "<group>"; };
 		263A6DA72BEAA0DB00C292B2 /* String+Helpers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "String+Helpers.swift"; sourceTree = "<group>"; };
 		265BCA01243056E3004E53EE /* categories-all.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "categories-all.json"; sourceTree = "<group>"; };
 		265EFBDB285257950033BD33 /* Order+Fallbacks.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Order+Fallbacks.swift"; sourceTree = "<group>"; };
@@ -2491,6 +2493,7 @@
 			isa = PBXGroup;
 			children = (
 				5726F158248E9D88005AE9B4 /* Models+Copiable.generated.swift */,
+				26373E282BFD0880008E6735 /* WatchOS-Models+Copiable.swift */,
 			);
 			path = Copiable;
 			sourceTree = "<group>";
@@ -4594,6 +4597,7 @@
 				263A6DBE2BEAA4A900C292B2 /* MIContainer.swift in Sources */,
 				263A6DBB2BEAA49B00C292B2 /* AnyCodable.swift in Sources */,
 				26373E0D2BFCEAFB008E6735 /* Address.swift in Sources */,
+				26373E2A2BFD08AF008E6735 /* WatchOS-Models+Copiable.swift in Sources */,
 				263A6DBC2BEAA49B00C292B2 /* AnyDecodable.swift in Sources */,
 				263A6DBD2BEAA49B00C292B2 /* AnyEncodable.swift in Sources */,
 				263A6DB92BEAA46F00C292B2 /* SiteSummaryStatsMapper.swift in Sources */,

--- a/Networking/Networking.xcodeproj/project.pbxproj
+++ b/Networking/Networking.xcodeproj/project.pbxproj
@@ -199,6 +199,29 @@
 		262E5AD5255ACD6F000B2416 /* PaymentGatewayListMapperTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 262E5AD4255ACD6F000B2416 /* PaymentGatewayListMapperTests.swift */; };
 		263659DC2A264A3E00607A0D /* IPLocationRemote.swift in Sources */ = {isa = PBXBuildFile; fileRef = 263659DB2A264A3E00607A0D /* IPLocationRemote.swift */; };
 		263659DE2A2694A000607A0D /* IPLocationRemoteTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 263659DD2A2694A000607A0D /* IPLocationRemoteTests.swift */; };
+		26373E042BFCEA48008E6735 /* OrdersRemote.swift in Sources */ = {isa = PBXBuildFile; fileRef = B557DA0120975500005962F4 /* OrdersRemote.swift */; };
+		26373E052BFCEA60008E6735 /* Order.swift in Sources */ = {isa = PBXBuildFile; fileRef = B557DA1C20979E7D005962F4 /* Order.swift */; };
+		26373E062BFCEA70008E6735 /* OrderStatusEnum.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5BB1D1120A255EC00112D92 /* OrderStatusEnum.swift */; };
+		26373E072BFCEA7E008E6735 /* OrderItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5C6FCCE20A3592900A4F8E4 /* OrderItem.swift */; };
+		26373E082BFCEA86008E6735 /* OrderItemAttribute.swift in Sources */ = {isa = PBXBuildFile; fileRef = 021EAA5525493B3600AA8CCD /* OrderItemAttribute.swift */; };
+		26373E092BFCEA90008E6735 /* OrderItemProductAddOn.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02EBCB3D2AA03D520019085B /* OrderItemProductAddOn.swift */; };
+		26373E0A2BFCEAAF008E6735 /* OrderItemTax.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE430671234B9EB20073CBFF /* OrderItemTax.swift */; };
+		26373E0B2BFCEAC9008E6735 /* OrderItemBundleItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = 024124852AC93E470035A247 /* OrderItemBundleItem.swift */; };
+		26373E0C2BFCEAD1008E6735 /* ProductVariationAttribute.swift in Sources */ = {isa = PBXBuildFile; fileRef = 026CF619237D607A009563D4 /* ProductVariationAttribute.swift */; };
+		26373E0D2BFCEAFB008E6735 /* Address.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5BB1D0F20A237FB00112D92 /* Address.swift */; };
+		26373E0E2BFCEB0B008E6735 /* ShippingLine.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45E3EEBA237009CF00A826AC /* ShippingLine.swift */; };
+		26373E0F2BFCEB1B008E6735 /* ShippingLineTax.swift in Sources */ = {isa = PBXBuildFile; fileRef = 261870772540A252006522A1 /* ShippingLineTax.swift */; };
+		26373E102BFCED9E008E6735 /* OrderCouponLine.swift in Sources */ = {isa = PBXBuildFile; fileRef = 741B950020EBC8A700DD6E2D /* OrderCouponLine.swift */; };
+		26373E112BFCEDAE008E6735 /* OrderRefundCondensed.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEF88DAC233E95B000BED485 /* OrderRefundCondensed.swift */; };
+		26373E122BFCEDB7008E6735 /* OrderFeeLine.swift in Sources */ = {isa = PBXBuildFile; fileRef = D88E228F25AC990A0023F3B1 /* OrderFeeLine.swift */; };
+		26373E132BFCEDCD008E6735 /* OrderTaxLine.swift in Sources */ = {isa = PBXBuildFile; fileRef = BAB373712795A1FB00837B4A /* OrderTaxLine.swift */; };
+		26373E142BFCEDDA008E6735 /* OrderMetaData.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC6A1FF4270E042200F6AF4A /* OrderMetaData.swift */; };
+		26373E152BFCEDE9008E6735 /* OrderGiftCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEE9187C29F7D636004B23FF /* OrderGiftCard.swift */; };
+		26373E162BFCEDFD008E6735 /* OrderAttributionInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE8A302F2B72A3C8001D7C66 /* OrderAttributionInfo.swift */; };
+		26373E172BFCEF5D008E6735 /* Order+Fallbacks.swift in Sources */ = {isa = PBXBuildFile; fileRef = 265EFBDB285257950033BD33 /* Order+Fallbacks.swift */; };
+		26373E182BFCEF79008E6735 /* KeyedDecodingContainer+Woo.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5C151BA217EC34100C7BDC1 /* KeyedDecodingContainer+Woo.swift */; };
+		26373E192BFCEF96008E6735 /* OrderListMapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = B567AF2A20A0FA4200AB6C62 /* OrderListMapper.swift */; };
+		26373E1A2BFCEFA7008E6735 /* OrderFeeTaxStatus.swift in Sources */ = {isa = PBXBuildFile; fileRef = D88E229325AC9B420023F3B1 /* OrderFeeTaxStatus.swift */; };
 		263A6D9E2BEA9DF500C292B2 /* Logging.swift in Sources */ = {isa = PBXBuildFile; fileRef = 933A2731222234F800C2143A /* Logging.swift */; };
 		263A6D9F2BEA9E4200C292B2 /* DotcomValidator.swift in Sources */ = {isa = PBXBuildFile; fileRef = B53EF5332180F646003E146F /* DotcomValidator.swift */; };
 		263A6DA02BEA9E7300C292B2 /* Settings.swift in Sources */ = {isa = PBXBuildFile; fileRef = B557DA1920979D66005962F4 /* Settings.swift */; };
@@ -4551,7 +4574,9 @@
 				2680B0D02BED5A1900E7F1D8 /* WooConstants.swift in Sources */,
 				2680B0CF2BED59CE00E7F1D8 /* ApplicationPasswordStorage.swift in Sources */,
 				2680B0CB2BED58B200E7F1D8 /* ApplicationPasswordNameAndUUID.swift in Sources */,
+				26373E0A2BFCEAAF008E6735 /* OrderItemTax.swift in Sources */,
 				2680B0CC2BED58B200E7F1D8 /* ApplicationPassword.swift in Sources */,
+				26373E122BFCEDB7008E6735 /* OrderFeeLine.swift in Sources */,
 				26F2CADD2BED579100F9A5E7 /* ApplicationPasswordUseCase.swift in Sources */,
 				26F2CADA2BED578200F9A5E7 /* RequestProcessor.swift in Sources */,
 				26F2CADB2BED578200F9A5E7 /* RequestAuthenticator.swift in Sources */,
@@ -4559,11 +4584,15 @@
 				26F2CAD92BED574D00F9A5E7 /* AlamofireNetwork.swift in Sources */,
 				263A6DBE2BEAA4A900C292B2 /* MIContainer.swift in Sources */,
 				263A6DBB2BEAA49B00C292B2 /* AnyCodable.swift in Sources */,
+				26373E0D2BFCEAFB008E6735 /* Address.swift in Sources */,
 				263A6DBC2BEAA49B00C292B2 /* AnyDecodable.swift in Sources */,
 				263A6DBD2BEAA49B00C292B2 /* AnyEncodable.swift in Sources */,
 				263A6DB92BEAA46F00C292B2 /* SiteSummaryStatsMapper.swift in Sources */,
+				26373E112BFCEDAE008E6735 /* OrderRefundCondensed.swift in Sources */,
 				263A6DBA2BEAA46F00C292B2 /* SiteSummaryStats.swift in Sources */,
 				263A6DB62BEAA46000C292B2 /* SiteVisitStatsMapper.swift in Sources */,
+				26373E042BFCEA48008E6735 /* OrdersRemote.swift in Sources */,
+				26373E0F2BFCEB1B008E6735 /* ShippingLineTax.swift in Sources */,
 				263A6DB72BEAA46000C292B2 /* SiteVisitStats.swift in Sources */,
 				263A6DB82BEAA46000C292B2 /* SiteVisitStatsItem.swift in Sources */,
 				263A6DB52BEAA44D00C292B2 /* StatGranularity.swift in Sources */,
@@ -4573,9 +4602,14 @@
 				263A6DB12BEAA33900C292B2 /* WCAnalyticsStats.swift in Sources */,
 				263A6DAD2BEAA32800C292B2 /* OrderStatsV4Mapper.swift in Sources */,
 				263A6DAE2BEAA32800C292B2 /* OrderStatsV4.swift in Sources */,
+				26373E132BFCEDCD008E6735 /* OrderTaxLine.swift in Sources */,
 				263A6DAF2BEAA32800C292B2 /* OrderStatsV4Totals.swift in Sources */,
+				26373E192BFCEF96008E6735 /* OrderListMapper.swift in Sources */,
+				26373E062BFCEA70008E6735 /* OrderStatusEnum.swift in Sources */,
 				263A6DB02BEAA32800C292B2 /* OrderStatsV4Interval.swift in Sources */,
 				263A6DAC2BEAA31400C292B2 /* StatsGranularityV4.swift in Sources */,
+				26373E1A2BFCEFA7008E6735 /* OrderFeeTaxStatus.swift in Sources */,
+				26373E172BFCEF5D008E6735 /* Order+Fallbacks.swift in Sources */,
 				263A6DAB2BEAA30500C292B2 /* SiteStatsRemote.swift in Sources */,
 				263A6DAA2BEAA2E700C292B2 /* OrderStatsRemoteV4.swift in Sources */,
 				2680B0CE2BED592800E7F1D8 /* Secret.swift in Sources */,
@@ -4588,6 +4622,8 @@
 				263A6DA02BEA9E7300C292B2 /* Settings.swift in Sources */,
 				263A6D9F2BEA9E4200C292B2 /* DotcomValidator.swift in Sources */,
 				263A6D9E2BEA9DF500C292B2 /* Logging.swift in Sources */,
+				26373E082BFCEA86008E6735 /* OrderItemAttribute.swift in Sources */,
+				26373E0C2BFCEAD1008E6735 /* ProductVariationAttribute.swift in Sources */,
 				269014D42BEA9335006056E0 /* UserAgent.swift in Sources */,
 				269014D22BEA9309006056E0 /* DotcomRequest.swift in Sources */,
 				269014D32BEA9309006056E0 /* AuthenticatedDotcomRequest.swift in Sources */,
@@ -4597,16 +4633,26 @@
 				269014CE2BEA9278006056E0 /* RESTRequest.swift in Sources */,
 				269014CD2BEA926F006056E0 /* WordPressAPIVersion.swift in Sources */,
 				269014CC2BEA925F006056E0 /* RESTRequestConvertible.swift in Sources */,
+				26373E072BFCEA7E008E6735 /* OrderItem.swift in Sources */,
+				26373E152BFCEDE9008E6735 /* OrderGiftCard.swift in Sources */,
 				269014CB2BEA9253006056E0 /* JetpackRequest.swift in Sources */,
 				269014CA2BEA924B006056E0 /* NetworkError.swift in Sources */,
+				26373E092BFCEA90008E6735 /* OrderItemProductAddOn.swift in Sources */,
+				26373E162BFCEDFD008E6735 /* OrderAttributionInfo.swift in Sources */,
+				26373E142BFCEDDA008E6735 /* OrderMetaData.swift in Sources */,
+				26373E0E2BFCEB0B008E6735 /* ShippingLine.swift in Sources */,
 				263A6DA92BEAA0DE00C292B2 /* String+Helpers.swift in Sources */,
 				269014C52BEA914B006056E0 /* DotcomError.swift in Sources */,
 				269014C42BEA9142006056E0 /* ResponseDataValidator.swift in Sources */,
+				26373E102BFCED9E008E6735 /* OrderCouponLine.swift in Sources */,
 				269014C32BEA9134006056E0 /* Mapper.swift in Sources */,
 				269014C22BEA912D006056E0 /* Request.swift in Sources */,
+				26373E182BFCEF79008E6735 /* KeyedDecodingContainer+Woo.swift in Sources */,
 				26DAAB592BEA8E1500CE399E /* Network.swift in Sources */,
+				26373E052BFCEA60008E6735 /* Order.swift in Sources */,
 				26DAAB582BEA8DFF00CE399E /* Remote.swift in Sources */,
 				26DAAB572BEA8DC100CE399E /* Credentials.swift in Sources */,
+				26373E0B2BFCEAC9008E6735 /* OrderItemBundleItem.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Networking/Networking/Extensions/String+HTML.swift
+++ b/Networking/Networking/Extensions/String+HTML.swift
@@ -1,6 +1,8 @@
 import Foundation
 
+#if canImport(Aztec)
 import class Aztec.HTMLParser
+#endif
 
 /// String: HTML Stripping
 ///
@@ -11,6 +13,12 @@ extension String {
     /// NOTE: I can be very slow ⏳ — using it in a background thread is strongly recommended.
     ///
     public var strippedHTML: String {
+#if canImport(Aztec)
         HTMLParser().parse(self).rawText()
+#else
+        // This conditional compiling is because Aztec is not available on WatchOS and our watch app does not access this code yet.
+        // We should consider adding HTML-stripping support when needed.
+        return self
+#endif
     }
 }

--- a/Networking/Networking/Model/Copiable/WatchOS-Models+Copiable.swift
+++ b/Networking/Networking/Model/Copiable/WatchOS-Models+Copiable.swift
@@ -1,0 +1,46 @@
+import Codegen
+
+/// This piece of code is copied from Models+Copiable.generated
+/// Ideally we should add full copiable support to NetworkingWatchOS but some updates to the swift template are needed.
+///
+extension NetworkingWatchOS.Address {
+    public func copy(
+        firstName: CopiableProp<String> = .copy,
+        lastName: CopiableProp<String> = .copy,
+        company: NullableCopiableProp<String> = .copy,
+        address1: CopiableProp<String> = .copy,
+        address2: NullableCopiableProp<String> = .copy,
+        city: CopiableProp<String> = .copy,
+        state: CopiableProp<String> = .copy,
+        postcode: CopiableProp<String> = .copy,
+        country: CopiableProp<String> = .copy,
+        phone: NullableCopiableProp<String> = .copy,
+        email: NullableCopiableProp<String> = .copy
+    ) -> NetworkingWatchOS.Address {
+        let firstName = firstName ?? self.firstName
+        let lastName = lastName ?? self.lastName
+        let company = company ?? self.company
+        let address1 = address1 ?? self.address1
+        let address2 = address2 ?? self.address2
+        let city = city ?? self.city
+        let state = state ?? self.state
+        let postcode = postcode ?? self.postcode
+        let country = country ?? self.country
+        let phone = phone ?? self.phone
+        let email = email ?? self.email
+
+        return NetworkingWatchOS.Address(
+            firstName: firstName,
+            lastName: lastName,
+            company: company,
+            address1: address1,
+            address2: address2,
+            city: city,
+            state: state,
+            postcode: postcode,
+            country: country,
+            phone: phone,
+            email: email
+        )
+    }
+}

--- a/WooCommerce/Classes/Extensions/CNContact+Helpers.swift
+++ b/WooCommerce/Classes/Extensions/CNContact+Helpers.swift
@@ -1,6 +1,5 @@
 import Foundation
 import Contacts
-import Yosemite
 
 extension CNPostalAddress {
     func formatted(as style: CNPostalAddressFormatterStyle) -> String? {

--- a/WooCommerce/Classes/Extensions/String+Helpers.swift
+++ b/WooCommerce/Classes/Extensions/String+Helpers.swift
@@ -103,6 +103,7 @@ extension String {
     }
 }
 
+#if !os(watchOS)
 extension String {
     /// Sends the string to the general pasteboard and triggers a success haptic.
     /// If the string is nil, nothing is sent to the pasteboard.
@@ -123,3 +124,4 @@ extension String {
         UINotificationFeedbackGenerator().notificationOccurred(.success)
     }
 }
+#endif

--- a/WooCommerce/Classes/Extensions/TimeZone+Woo.swift
+++ b/WooCommerce/Classes/Extensions/TimeZone+Woo.swift
@@ -8,6 +8,10 @@ extension TimeZone {
     /// Returns the TimeZone using the timezone configured in the current website
     ///
     static var siteTimezone: TimeZone {
+#if !os(watchOS)
         return ServiceLocator.stores.sessionManager.defaultSite?.siteTimezone ?? .current
+#else
+        return .current // WatchOS currently does not have a notion of ServiceLocator or the current site timezone
+#endif
     }
 }

--- a/WooCommerce/Classes/Model/Address+Woo.swift
+++ b/WooCommerce/Classes/Model/Address+Woo.swift
@@ -1,6 +1,11 @@
 import Foundation
 import Contacts
+
+#if canImport(Yosemite)
 import Yosemite
+#elseif canImport(NetworkingWatchOS)
+import NetworkingWatchOS
+#endif
 
 
 // Yosemite.Address Helper Methods
@@ -33,6 +38,7 @@ extension Address {
         return output.joined(separator: "\n")
     }
 
+#if !os(watchOS)
     /// Returns the Postal Address, formated and ready for display.
     ///
     var formattedPostalAddress: String? {
@@ -115,9 +121,10 @@ extension Address {
                            postcode: taxRate.postcodes.first ?? taxRate.postcode,
                            country: taxRate.country)
     }
+#endif
 }
 
-
+#if !os(watchOS)
 // MARK: - Private Methods
 //
 private extension Address {
@@ -132,6 +139,7 @@ private extension Address {
 
         return address1 + "\n" + address2
     }
+
 
     /// Returns a CNPostalAddress with the receiver's properties
     ///
@@ -149,6 +157,7 @@ private extension Address {
         return address
     }
 
+
     func refineAddressState() -> Address {
         // https://github.com/woocommerce/woocommerce-ios/issues/5851
         // The backend gives us the state code in the state field.
@@ -161,3 +170,4 @@ private extension Address {
         return copy(state: stateName)
     }
 }
+#endif

--- a/WooCommerce/Classes/ViewRelated/Orders/Cells/OrderListCellViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Cells/OrderListCellViewModel.swift
@@ -29,14 +29,14 @@ struct OrderListCellViewModel {
     /// For example, #560 Pamela Nguyen
     ///
     var title: String {
-        let customerName: String = {
-            if let fullName = order.billingAddress?.fullName, fullName.isNotEmpty {
-                return fullName
-            }
-            return Localization.guestName
-        }()
+        Localization.title(orderNumber: order.number, customerName: customerName)
+    }
 
-        return Localization.title(orderNumber: order.number, customerName: customerName)
+    var customerName: String {
+        if let fullName = order.billingAddress?.fullName, fullName.isNotEmpty {
+            return fullName
+        }
+        return Localization.guestName
     }
 
     /// The localized unabbreviated total which includes the currency.

--- a/WooCommerce/Classes/ViewRelated/Orders/Cells/OrderListCellViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Cells/OrderListCellViewModel.swift
@@ -1,18 +1,29 @@
 import Foundation
+
+#if canImport(Yosemite)
 import Yosemite
+#elseif canImport(NetworkingWatchOS)
+import NetworkingWatchOS
+#endif
+
+#if canImport(WooFoundation)
 import WooFoundation
+#elseif canImport(WooFoundationWatchOS)
+import WooFoundationWatchOS
+#endif
+
 
 // MARK: - View Model for individual cells on the Order List screen
 //
 struct OrderListCellViewModel {
     private let order: Order
     private let orderStatus: OrderStatus?
+    private let currencyFormatter: CurrencyFormatter
 
-    private let currencyFormatter = CurrencyFormatter(currencySettings: ServiceLocator.currencySettings)
-
-    init(order: Order, status: OrderStatus?) {
+    init(order: Order, status: OrderStatus?, currencySettings: CurrencySettings) {
         self.order = order
-        orderStatus = status
+        self.orderStatus = status
+        self.currencyFormatter = CurrencyFormatter(currencySettings: currencySettings)
     }
 
     /// For example, #560 Pamela Nguyen
@@ -59,6 +70,7 @@ struct OrderListCellViewModel {
         return orderStatus?.name ?? order.status.rawValue
     }
 
+#if !os(watchOS)
     /// Accessory view that renders the cell's disclosure indicator
     ///
     var accessoryView: UIImageView? {
@@ -69,6 +81,7 @@ struct OrderListCellViewModel {
         accessoryView.tintColor = .tertiaryLabel
         return accessoryView
     }
+#endif
 }
 
 // MARK: - Constants

--- a/WooCommerce/Classes/ViewRelated/Orders/OrderListViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrderListViewModel.swift
@@ -341,7 +341,7 @@ extension OrderListViewModel {
 
         let status = lookUpOrderStatus(for: order)
 
-        return OrderListCellViewModel(order: order, status: status)
+        return OrderListCellViewModel(order: order, status: status, currencySettings: ServiceLocator.currencySettings)
     }
 
     /// Creates an `OrderDetailsViewModel` for the `Order` pointed to by `objectID`.

--- a/WooCommerce/Classes/ViewRelated/Search/Order/OrderSearchUICommand.swift
+++ b/WooCommerce/Classes/ViewRelated/Search/Order/OrderSearchUICommand.swift
@@ -63,7 +63,7 @@ final class OrderSearchUICommand: SearchUICommand {
 
     func createCellViewModel(model: Order) -> OrderListCellViewModel {
         let orderStatus = lookUpOrderStatus(for: model)
-        return OrderListCellViewModel(order: model, status: orderStatus)
+        return OrderListCellViewModel(order: model, status: orderStatus, currencySettings: ServiceLocator.currencySettings)
     }
 
     /// Synchronizes the Orders matching a given Keyword

--- a/WooCommerce/Woo Watch App/Orders/OrdersDataService.swift
+++ b/WooCommerce/Woo Watch App/Orders/OrdersDataService.swift
@@ -4,15 +4,6 @@ import NetworkingWatchOS
 ///
 final class OrdersDataService {
 
-    //    /// Data extracted from networking types.
-    //    ///
-    //    struct Stats {
-    //        let revenue: Decimal
-    //        let totalOrders: Int
-    //        let totalVisitors: Int?
-    //        let conversion: Double?
-    //    }
-
     /// Orders remote
     ///
     private let ordersRemote: OrdersRemote

--- a/WooCommerce/Woo Watch App/Orders/OrdersDataService.swift
+++ b/WooCommerce/Woo Watch App/Orders/OrdersDataService.swift
@@ -1,0 +1,38 @@
+import NetworkingWatchOS
+
+/// This wrapper to fetch orders resources.
+///
+final class OrdersDataService {
+
+    //    /// Data extracted from networking types.
+    //    ///
+    //    struct Stats {
+    //        let revenue: Decimal
+    //        let totalOrders: Int
+    //        let totalVisitors: Int?
+    //        let conversion: Double?
+    //    }
+
+    /// Orders remote
+    ///
+    private let ordersRemote: OrdersRemote
+
+    /// Network helper.
+    ///
+    private let network: AlamofireNetwork
+
+    init(credentials: Credentials) {
+        network = AlamofireNetwork(credentials: credentials)
+        ordersRemote = OrdersRemote(network: network)
+    }
+
+    /// Async wrapper that fetches orders for a store ID.
+    ///
+    func loadAllOrders(for storeID: Int64, pageNumber: Int, pageSize: Int) async throws -> [Order] {
+        try await withCheckedThrowingContinuation { continuation in
+            ordersRemote.loadAllOrders(for: storeID, pageNumber: pageNumber, pageSize: pageSize) { result in
+                continuation.resume(with: result)
+            }
+        }
+    }
+}

--- a/WooCommerce/Woo Watch App/Orders/OrdersListView.swift
+++ b/WooCommerce/Woo Watch App/Orders/OrdersListView.swift
@@ -7,7 +7,11 @@ struct OrdersListView: View {
     // Used to changed the tab programmatically
     @Binding var watchTab: WooWatchTab
 
-    init(watchTab: Binding<WooWatchTab>) {
+    // View Model to drive the view
+    @StateObject var viewModel: OrdersListViewModel
+
+    init(dependencies: WatchDependencies, watchTab: Binding<WooWatchTab>) {
+        _viewModel = StateObject(wrappedValue: OrdersListViewModel(dependencies: dependencies))
         self._watchTab = watchTab
     }
 
@@ -38,6 +42,9 @@ struct OrdersListView: View {
             }
         } detail: {
             Text("Order Detail")
+        }
+        .task {
+            await viewModel.fetchOrders()
         }
     }
 }

--- a/WooCommerce/Woo Watch App/Orders/OrdersListView.swift
+++ b/WooCommerce/Woo Watch App/Orders/OrdersListView.swift
@@ -48,6 +48,8 @@ struct OrdersListView: View {
         }
     }
 
+    /// Loading: Redacted OrderListCard
+    ///
     @ViewBuilder var loadingView: some View {
         List {
             OrderListCard(order: .init(date: "----",
@@ -74,6 +76,8 @@ struct OrdersListView: View {
         }
     }
 
+    /// Data: List with live order content.
+    ///
     @ViewBuilder private func dataView(orders: [Order]) -> some View {
         List() {
             ForEach(orders, id: \.number) { order in
@@ -107,6 +111,8 @@ private extension OrdersListView {
     }
 }
 
+/// View that represents each Order Item in the list.
+///
 struct OrderListCard: View {
 
     let order: OrdersListView.Order

--- a/WooCommerce/Woo Watch App/Orders/OrdersListView.swift
+++ b/WooCommerce/Woo Watch App/Orders/OrdersListView.swift
@@ -112,7 +112,7 @@ struct OrderListCard: View {
     let order: OrdersListView.Order
 
     var body: some View {
-        VStack(alignment: .leading) {
+        VStack(alignment: .leading, spacing: 2) {
 
             HStack {
                 Text(order.date)

--- a/WooCommerce/Woo Watch App/Orders/OrdersListViewModel.swift
+++ b/WooCommerce/Woo Watch App/Orders/OrdersListViewModel.swift
@@ -32,11 +32,13 @@ final class OrdersListViewModel: ObservableObject {
 
     private static func viewOrders(from remoteOrders: [Order], currencySettings: CurrencySettings) -> [OrdersListView.Order] {
         remoteOrders.map { order in
-            OrdersListView.Order(date: order.dateCreated.description,
-                                 number: "#\(order.number)",
-                                 name: ((order.billingAddress?.firstName ?? "") + " " + (order.billingAddress?.lastName ?? "")),
-                                 price: "$\(order.total)",
-                                 status: order.status.rawValue)
+            // TODO: Provide real list of site statuses.
+            let orderViewModel = OrderListCellViewModel(order: order, status: nil, currencySettings: currencySettings)
+            return OrdersListView.Order(date: orderViewModel.dateCreated,
+                                        number: "#\(order.number)",
+                                        name: orderViewModel.customerName,
+                                        price: orderViewModel.total ?? "$\(order.total)",
+                                        status: orderViewModel.statusString.capitalized)
         }
     }
 }

--- a/WooCommerce/Woo Watch App/Orders/OrdersListViewModel.swift
+++ b/WooCommerce/Woo Watch App/Orders/OrdersListViewModel.swift
@@ -16,6 +16,8 @@ final class OrdersListViewModel: ObservableObject {
         self.dependencies = dependencies
     }
 
+    /// Fetch orders from a the remote source and updates the view state accordingly.
+    ///
     @MainActor
     func fetchOrders() async {
         self.viewState = .loading
@@ -30,6 +32,8 @@ final class OrdersListViewModel: ObservableObject {
         }
     }
 
+    /// Convert remote orders into view orders.
+    ///
     private static func viewOrders(from remoteOrders: [Order], currencySettings: CurrencySettings) -> [OrdersListView.Order] {
         remoteOrders.map { order in
             // TODO: Provide real list of site statuses.
@@ -43,9 +47,12 @@ final class OrdersListViewModel: ObservableObject {
     }
 }
 
-
+/// Data types that feed the OrdersListView
+///
 extension OrdersListView {
 
+    /// Represents the possible view states
+    ///
     enum State {
         case idle
         case loading
@@ -53,6 +60,8 @@ extension OrdersListView {
         case error
     }
 
+    /// Represents an order item.
+    ///
     struct Order {
         let date: String
         let number: String

--- a/WooCommerce/Woo Watch App/Orders/OrdersListViewModel.swift
+++ b/WooCommerce/Woo Watch App/Orders/OrdersListViewModel.swift
@@ -1,9 +1,14 @@
 import Foundation
 import NetworkingWatchOS
+import WooFoundationWatchOS
 
 /// View Model for the OrdersListView
 ///
 final class OrdersListViewModel: ObservableObject {
+
+    /// Represent the current state of the view
+    ///
+    @Published private(set) var viewState = OrdersListView.State.idle
 
     private let dependencies: WatchDependencies
 
@@ -13,12 +18,44 @@ final class OrdersListViewModel: ObservableObject {
 
     @MainActor
     func fetchOrders() async {
+        self.viewState = .loading
         let service = OrdersDataService(credentials: dependencies.credentials)
         do {
             let orders = try await service.loadAllOrders(for: dependencies.storeID, pageNumber: 1, pageSize: 50)
-            print(orders)
+            let viewOrders = Self.viewOrders(from: orders, currencySettings: dependencies.currencySettings)
+            self.viewState = .loaded(orders: viewOrders)
         } catch {
+            self.viewState = .error
             DDLogError("⛔️ Error fetching orders. \(error)")
         }
+    }
+
+    private static func viewOrders(from remoteOrders: [Order], currencySettings: CurrencySettings) -> [OrdersListView.Order] {
+        remoteOrders.map { order in
+            OrdersListView.Order(date: order.dateCreated.description,
+                                 number: "#\(order.number)",
+                                 name: ((order.billingAddress?.firstName ?? "") + " " + (order.billingAddress?.lastName ?? "")),
+                                 price: "$\(order.total)",
+                                 status: order.status.rawValue)
+        }
+    }
+}
+
+
+extension OrdersListView {
+
+    enum State {
+        case idle
+        case loading
+        case loaded(orders: [Order])
+        case error
+    }
+
+    struct Order {
+        let date: String
+        let number: String
+        let name: String
+        let price: String
+        let status: String
     }
 }

--- a/WooCommerce/Woo Watch App/Orders/OrdersListViewModel.swift
+++ b/WooCommerce/Woo Watch App/Orders/OrdersListViewModel.swift
@@ -1,0 +1,24 @@
+import Foundation
+import NetworkingWatchOS
+
+/// View Model for the OrdersListView
+///
+final class OrdersListViewModel: ObservableObject {
+
+    private let dependencies: WatchDependencies
+
+    init(dependencies: WatchDependencies) {
+        self.dependencies = dependencies
+    }
+
+    @MainActor
+    func fetchOrders() async {
+        let service = OrdersDataService(credentials: dependencies.credentials)
+        do {
+            let orders = try await service.loadAllOrders(for: dependencies.storeID, pageNumber: 1, pageSize: 50)
+            print(orders)
+        } catch {
+            DDLogError("⛔️ Error fetching orders. \(error)")
+        }
+    }
+}

--- a/WooCommerce/Woo Watch App/WooApp.swift
+++ b/WooCommerce/Woo Watch App/WooApp.swift
@@ -14,7 +14,7 @@ struct Woo_Watch_AppApp: App {
                     MyStoreView(dependencies: dependencies, watchTab: $selectedTab)
                         .tag(WooWatchTab.myStore)
 
-                    OrdersListView(watchTab: $selectedTab)
+                    OrdersListView(dependencies: dependencies, watchTab: $selectedTab)
                         .tag(WooWatchTab.ordersList)
                 }
                 .compatibleVerticalStyle()

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -834,6 +834,7 @@
 		263491D5299C923400594566 /* SupportFormViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 263491D4299C923300594566 /* SupportFormViewModelTests.swift */; };
 		26373E2C2BFD13E0008E6735 /* OrdersDataService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26373E2B2BFD13E0008E6735 /* OrdersDataService.swift */; };
 		26373E2E2BFD2F46008E6735 /* OrdersListViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26373E2D2BFD2F46008E6735 /* OrdersListViewModel.swift */; };
+		26373E2F2BFD7C18008E6735 /* OrderListCellViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = A6557217258B7510008AE7CA /* OrderListCellViewModel.swift */; };
 		263C4CC02963784900CA7E05 /* ProductVariationGenerator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 263C4CBF2963784900CA7E05 /* ProductVariationGenerator.swift */; };
 		263E37E12641AD8300260D3B /* Codegen in Frameworks */ = {isa = PBXBuildFile; productRef = 263E37E02641AD8300260D3B /* Codegen */; };
 		263E37E22641AD8300260D3B /* Codegen in Embed Frameworks */ = {isa = PBXBuildFile; productRef = 263E37E02641AD8300260D3B /* Codegen */; settings = {ATTRIBUTES = (CodeSignOnCopy, ); }; };
@@ -963,6 +964,12 @@
 		26CA2BC42AA92CA9003B16C2 /* AppLocalizedString.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F50FE4228CAEBA800C89201 /* AppLocalizedString.swift */; };
 		26CA2BC62AAA1773003B16C2 /* OrderNotificationView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26CA2BC52AAA1773003B16C2 /* OrderNotificationView.swift */; };
 		26CA2BC72AAA17A2003B16C2 /* SwiftUI.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 5744BEB0248FE44C000A6FE2 /* SwiftUI.framework */; };
+		26CA471C2BFD7FE600E54348 /* Address+Woo.swift in Sources */ = {isa = PBXBuildFile; fileRef = B57B67892107546E00AF8905 /* Address+Woo.swift */; };
+		26CA471D2BFD805900E54348 /* CNContact+Helpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE4296B820A5E9E400B2AFBD /* CNContact+Helpers.swift */; };
+		26CA471F2BFD81E900E54348 /* String+Helpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 74D0A52F2139CF1300E2919F /* String+Helpers.swift */; };
+		26CA47202BFD823200E54348 /* Date+Woo.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5290ED8219B3FA900A6AF7F /* Date+Woo.swift */; };
+		26CA47212BFD82AE00E54348 /* DateFormatter+Helpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE4DDB7A20DD312400D32EC8 /* DateFormatter+Helpers.swift */; };
+		26CA47222BFD82B900E54348 /* TimeZone+Woo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 453227B623C4D6EC00D816B3 /* TimeZone+Woo.swift */; };
 		26CCBE0B2523B3650073F94D /* RefundProductsTotalTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26CCBE0A2523B3650073F94D /* RefundProductsTotalTableViewCell.swift */; };
 		26CCBE0D2523C2560073F94D /* RefundProductsTotalTableViewCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = 26CCBE0C2523C2560073F94D /* RefundProductsTotalTableViewCell.xib */; };
 		26CE6F342B7D4C27008DB858 /* Error+Timeout.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26CE6F332B7D4C27008DB858 /* Error+Timeout.swift */; };
@@ -13614,23 +13621,30 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				26CA47222BFD82B900E54348 /* TimeZone+Woo.swift in Sources */,
 				264E9E952BF400AD009C48FD /* StoreInfoDataService.swift in Sources */,
+				26CA471C2BFD7FE600E54348 /* Address+Woo.swift in Sources */,
 				26373E2E2BFD2F46008E6735 /* OrdersListViewModel.swift in Sources */,
 				26A0B2D72BFBA536002E9620 /* OrdersListView.swift in Sources */,
 				26B984D42BEECC610052658C /* Environment+Dependencies.swift in Sources */,
 				26F81B1A2BE433A2009EC58E /* MyStoreView.swift in Sources */,
+				26373E2F2BFD7C18008E6735 /* OrderListCellViewModel.swift in Sources */,
 				264E9E942BF1D1DF009C48FD /* AppLocalizedString.swift in Sources */,
 				26A0B2D42BF9A78C002E9620 /* StoreInfoFormatter.swift in Sources */,
 				26DD32D42BEBCDFB00F2C69C /* WooConstants.swift in Sources */,
 				269FFA4B2BF544C9004E6B86 /* MyStoreViewModel.swift in Sources */,
+				26CA47202BFD823200E54348 /* Date+Woo.swift in Sources */,
 				26B984D62BEECF260052658C /* ConnectView.swift in Sources */,
 				26DD32D62BEBCE3900F2C69C /* UserDefaults+Woo.swift in Sources */,
+				26CA471D2BFD805900E54348 /* CNContact+Helpers.swift in Sources */,
 				269FFA482BF516BA004E6B86 /* Logging.swift in Sources */,
 				26F81B182BE433A2009EC58E /* WooApp.swift in Sources */,
+				26CA47212BFD82AE00E54348 /* DateFormatter+Helpers.swift in Sources */,
 				2604C3BA2BE977F000250465 /* PhoneDependenciesSynchronizer.swift in Sources */,
 				26A000772BE9D9030071DB1E /* WooConstants.swift in Sources */,
 				26373E2C2BFD13E0008E6735 /* OrdersDataService.swift in Sources */,
 				26FFC50C2BED7C5A0067B3A4 /* WatchDependencies.swift in Sources */,
+				26CA471F2BFD81E900E54348 /* String+Helpers.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -832,6 +832,7 @@
 		2631D4FA29ED108400F13F20 /* WPComPlanNameSanitizer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2631D4F929ED108400F13F20 /* WPComPlanNameSanitizer.swift */; };
 		2631D4FE29F2141D00F13F20 /* StorePlanBannerPresenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2631D4FD29F2141D00F13F20 /* StorePlanBannerPresenter.swift */; };
 		263491D5299C923400594566 /* SupportFormViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 263491D4299C923300594566 /* SupportFormViewModelTests.swift */; };
+		26373E2C2BFD13E0008E6735 /* OrdersDataService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26373E2B2BFD13E0008E6735 /* OrdersDataService.swift */; };
 		263C4CC02963784900CA7E05 /* ProductVariationGenerator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 263C4CBF2963784900CA7E05 /* ProductVariationGenerator.swift */; };
 		263E37E12641AD8300260D3B /* Codegen in Frameworks */ = {isa = PBXBuildFile; productRef = 263E37E02641AD8300260D3B /* Codegen */; };
 		263E37E22641AD8300260D3B /* Codegen in Embed Frameworks */ = {isa = PBXBuildFile; productRef = 263E37E02641AD8300260D3B /* Codegen */; settings = {ATTRIBUTES = (CodeSignOnCopy, ); }; };
@@ -3670,6 +3671,7 @@
 		2631D4F929ED108400F13F20 /* WPComPlanNameSanitizer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WPComPlanNameSanitizer.swift; sourceTree = "<group>"; };
 		2631D4FD29F2141D00F13F20 /* StorePlanBannerPresenter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StorePlanBannerPresenter.swift; sourceTree = "<group>"; };
 		263491D4299C923300594566 /* SupportFormViewModelTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SupportFormViewModelTests.swift; sourceTree = "<group>"; };
+		26373E2B2BFD13E0008E6735 /* OrdersDataService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OrdersDataService.swift; sourceTree = "<group>"; };
 		263C4CBF2963784900CA7E05 /* ProductVariationGenerator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductVariationGenerator.swift; sourceTree = "<group>"; };
 		263E641F2BEB419B0059D84B /* NetworkingWatchOS.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = NetworkingWatchOS.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		263EAF992A15D513008C66CB /* PrivacyBannerViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PrivacyBannerViewModel.swift; sourceTree = "<group>"; };
@@ -7625,6 +7627,7 @@
 			isa = PBXGroup;
 			children = (
 				26A0B2D62BFBA536002E9620 /* OrdersListView.swift */,
+				26373E2B2BFD13E0008E6735 /* OrdersDataService.swift */,
 			);
 			path = Orders;
 			sourceTree = "<group>";
@@ -13622,6 +13625,7 @@
 				26F81B182BE433A2009EC58E /* WooApp.swift in Sources */,
 				2604C3BA2BE977F000250465 /* PhoneDependenciesSynchronizer.swift in Sources */,
 				26A000772BE9D9030071DB1E /* WooConstants.swift in Sources */,
+				26373E2C2BFD13E0008E6735 /* OrdersDataService.swift in Sources */,
 				26FFC50C2BED7C5A0067B3A4 /* WatchDependencies.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -833,6 +833,7 @@
 		2631D4FE29F2141D00F13F20 /* StorePlanBannerPresenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2631D4FD29F2141D00F13F20 /* StorePlanBannerPresenter.swift */; };
 		263491D5299C923400594566 /* SupportFormViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 263491D4299C923300594566 /* SupportFormViewModelTests.swift */; };
 		26373E2C2BFD13E0008E6735 /* OrdersDataService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26373E2B2BFD13E0008E6735 /* OrdersDataService.swift */; };
+		26373E2E2BFD2F46008E6735 /* OrdersListViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26373E2D2BFD2F46008E6735 /* OrdersListViewModel.swift */; };
 		263C4CC02963784900CA7E05 /* ProductVariationGenerator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 263C4CBF2963784900CA7E05 /* ProductVariationGenerator.swift */; };
 		263E37E12641AD8300260D3B /* Codegen in Frameworks */ = {isa = PBXBuildFile; productRef = 263E37E02641AD8300260D3B /* Codegen */; };
 		263E37E22641AD8300260D3B /* Codegen in Embed Frameworks */ = {isa = PBXBuildFile; productRef = 263E37E02641AD8300260D3B /* Codegen */; settings = {ATTRIBUTES = (CodeSignOnCopy, ); }; };
@@ -3672,6 +3673,7 @@
 		2631D4FD29F2141D00F13F20 /* StorePlanBannerPresenter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StorePlanBannerPresenter.swift; sourceTree = "<group>"; };
 		263491D4299C923300594566 /* SupportFormViewModelTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SupportFormViewModelTests.swift; sourceTree = "<group>"; };
 		26373E2B2BFD13E0008E6735 /* OrdersDataService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OrdersDataService.swift; sourceTree = "<group>"; };
+		26373E2D2BFD2F46008E6735 /* OrdersListViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OrdersListViewModel.swift; sourceTree = "<group>"; };
 		263C4CBF2963784900CA7E05 /* ProductVariationGenerator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductVariationGenerator.swift; sourceTree = "<group>"; };
 		263E641F2BEB419B0059D84B /* NetworkingWatchOS.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = NetworkingWatchOS.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		263EAF992A15D513008C66CB /* PrivacyBannerViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PrivacyBannerViewModel.swift; sourceTree = "<group>"; };
@@ -7627,6 +7629,7 @@
 			isa = PBXGroup;
 			children = (
 				26A0B2D62BFBA536002E9620 /* OrdersListView.swift */,
+				26373E2D2BFD2F46008E6735 /* OrdersListViewModel.swift */,
 				26373E2B2BFD13E0008E6735 /* OrdersDataService.swift */,
 			);
 			path = Orders;
@@ -13612,6 +13615,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				264E9E952BF400AD009C48FD /* StoreInfoDataService.swift in Sources */,
+				26373E2E2BFD2F46008E6735 /* OrdersListViewModel.swift in Sources */,
 				26A0B2D72BFBA536002E9620 /* OrdersListView.swift in Sources */,
 				26B984D42BEECC610052658C /* Environment+Dependencies.swift in Sources */,
 				26F81B1A2BE433A2009EC58E /* MyStoreView.swift in Sources */,

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/OrderListCellViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/OrderListCellViewModelTests.swift
@@ -12,7 +12,7 @@ final class OrderListCellViewModelTests: XCTestCase {
         let expectedYearString = DateFormatter.yearFormatter.string(from: order.dateCreated)
 
         // When
-        let viewModel = OrderListCellViewModel(order: order, status: nil)
+        let viewModel = OrderListCellViewModel(order: order, status: nil, currencySettings: ServiceLocator.currencySettings)
 
         // Then
         let formatted = viewModel.dateCreated
@@ -26,7 +26,7 @@ final class OrderListCellViewModelTests: XCTestCase {
         let expectedYearString = DateFormatter.yearFormatter.string(from: order.dateCreated)
 
         // When
-        let viewModel = OrderListCellViewModel(order: order, status: nil)
+        let viewModel = OrderListCellViewModel(order: order, status: nil, currencySettings: ServiceLocator.currencySettings)
 
         // Then
         let formatted = viewModel.dateCreated
@@ -43,7 +43,7 @@ final class OrderListCellViewModelTests: XCTestCase {
                                       total: 0)
 
         // When
-        let viewModel = OrderListCellViewModel(order: order, status: orderStatus)
+        let viewModel = OrderListCellViewModel(order: order, status: orderStatus, currencySettings: ServiceLocator.currencySettings)
 
         // Then
         XCTAssertEqual(viewModel.status, .custom(orderStatus.slug))
@@ -55,7 +55,7 @@ final class OrderListCellViewModelTests: XCTestCase {
         let order = MockOrders().sampleOrder()
 
         // When
-        let viewModel = OrderListCellViewModel(order: order, status: nil)
+        let viewModel = OrderListCellViewModel(order: order, status: nil, currencySettings: ServiceLocator.currencySettings)
 
         // Then
         XCTAssertEqual(viewModel.status, order.status)
@@ -68,7 +68,7 @@ final class OrderListCellViewModelTests: XCTestCase {
         let expectedImage = UIImage(systemName: "chevron.forward")
 
         // When
-        let viewModel = OrderListCellViewModel(order: order, status: nil)
+        let viewModel = OrderListCellViewModel(order: order, status: nil, currencySettings: ServiceLocator.currencySettings)
 
         // Then
         guard let accessoryView = viewModel.accessoryView else {


### PR DESCRIPTION
Closes: #12500 

# Why


This PR fetches and displays the first 50 orders in the watch app.

# How

- Reuse the OrdersRemote to fetch the data
- Reuse `OrderListCellViewModel` to transform the data presentation
- Adjust the necessary files to make them compile on whatchOS.

# Demo

https://github.com/woocommerce/woocommerce-ios/assets/562080/d1c08d8d-3c38-4f59-961e-16ab45e723b4

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
