### PR TITLE
[Woo POS] Fix POS menu item visibility issues with unit tests

### DIFF
--- a/WooCommerce/Classes/Model/BetaFeature.swift
+++ b/WooCommerce/Classes/Model/BetaFeature.swift
@@ -1,3 +1,4 @@
+import Combine
 import Storage
 import protocol WooFoundation.WooAnalyticsEventPropertyType
 
@@ -52,21 +53,6 @@ extension BetaFeature {
         }
     }
 
-    var isAvailable: Bool {
-        switch self {
-        case .inAppPurchases:
-            return ServiceLocator.featureFlagService.isFeatureFlagEnabled(.inAppPurchasesDebugMenu)
-        case .pointOfSale:
-            return POSEligibilityChecker().isEligible()
-        default:
-            return true
-        }
-    }
-
-    static var availableFeatures: [Self] {
-        allCases.filter(\.isAvailable)
-    }
-
     func analyticsProperties(toggleState enabled: Bool) -> [String: WooAnalyticsEventPropertyType] {
         var properties = ["state": enabled ? "on" : "off"]
         if analyticsStat == .settingsBetaFeatureToggled {
@@ -78,10 +64,11 @@ extension BetaFeature {
 
 extension GeneralAppSettingsStorage {
     func betaFeatureEnabled(_ feature: BetaFeature) -> Bool {
-        guard feature.isAvailable else {
-            return false
-        }
-        return value(for: feature.settingsKey)
+        value(for: feature.settingsKey)
+    }
+
+    func betaFeatureEnabledPublisher(_ feature: BetaFeature) -> AnyPublisher<Bool, Never> {
+        publisher(for: feature.settingsKey)
     }
 
     func betaFeatureEnabledBinding(_ feature: BetaFeature) -> Binding<Bool> {

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Beta features/BetaFeaturesConfiguration.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Beta features/BetaFeaturesConfiguration.swift
@@ -1,7 +1,5 @@
 import SwiftUI
 import Yosemite
-import protocol Experiments.FeatureFlagService
-import struct Storage.GeneralAppSettingsStorage
 
 final class BetaFeaturesConfigurationViewController: UIHostingController<BetaFeaturesConfiguration> {
 
@@ -11,51 +9,6 @@ final class BetaFeaturesConfigurationViewController: UIHostingController<BetaFea
 
     required dynamic init?(coder aDecoder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
-    }
-}
-
-final class BetaFeaturesConfigurationViewModel: ObservableObject {
-    @Published private(set) var availableFeatures: [BetaFeature] = []
-    private let appSettings: GeneralAppSettingsStorage
-    private let featureFlagService: FeatureFlagService
-    private let posEligibilityChecker: POSEligibilityChecker
-
-    init(appSettings: GeneralAppSettingsStorage = ServiceLocator.generalAppSettings,
-         featureFlagService: FeatureFlagService = ServiceLocator.featureFlagService,
-         posEligibilityChecker: POSEligibilityChecker = POSEligibilityChecker(cardPresentPaymentsOnboarding: CardPresentPaymentsOnboardingUseCase(),
-                                                                              siteSettings: ServiceLocator.selectedSiteSettings,
-                                                                              currencySettings: ServiceLocator.currencySettings,
-                                                                              featureFlagService: ServiceLocator.featureFlagService)) {
-        self.appSettings = appSettings
-        self.featureFlagService = featureFlagService
-        self.posEligibilityChecker = posEligibilityChecker
-        observePOSEligibilityForAvailableFeatures()
-    }
-
-    func isOn(feature: BetaFeature) -> Binding<Bool> {
-        appSettings.betaFeatureEnabledBinding(feature)
-    }
-}
-
-private extension BetaFeaturesConfigurationViewModel {
-    func observePOSEligibilityForAvailableFeatures() {
-        posEligibilityChecker.$isEligible
-            .map { [weak self] isEligibleForPOS in
-                guard let self else {
-                    return []
-                }
-                return BetaFeature.allCases.filter { betaFeature in
-                    switch betaFeature {
-                        case .viewAddOns:
-                            return true
-                        case .inAppPurchases:
-                            return self.featureFlagService.isFeatureFlagEnabled(.inAppPurchasesDebugMenu)
-                        case .pointOfSale:
-                            return isEligibleForPOS
-                    }
-                }
-            }
-            .assign(to: &$availableFeatures)
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Beta features/BetaFeaturesConfiguration.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Beta features/BetaFeaturesConfiguration.swift
@@ -1,10 +1,12 @@
 import SwiftUI
 import Yosemite
+import protocol Experiments.FeatureFlagService
+import struct Storage.GeneralAppSettingsStorage
 
 final class BetaFeaturesConfigurationViewController: UIHostingController<BetaFeaturesConfiguration> {
 
     init() {
-        super.init(rootView: BetaFeaturesConfiguration())
+        super.init(rootView: BetaFeaturesConfiguration(viewModel: .init()))
     }
 
     required dynamic init?(coder aDecoder: NSCoder) {
@@ -12,14 +14,63 @@ final class BetaFeaturesConfigurationViewController: UIHostingController<BetaFea
     }
 }
 
+final class BetaFeaturesConfigurationViewModel: ObservableObject {
+    @Published private(set) var availableFeatures: [BetaFeature] = []
+    private let appSettings: GeneralAppSettingsStorage
+    private let featureFlagService: FeatureFlagService
+    private let posEligibilityChecker: POSEligibilityChecker
+
+    init(appSettings: GeneralAppSettingsStorage = ServiceLocator.generalAppSettings,
+         featureFlagService: FeatureFlagService = ServiceLocator.featureFlagService,
+         posEligibilityChecker: POSEligibilityChecker = POSEligibilityChecker(cardPresentPaymentsOnboarding: CardPresentPaymentsOnboardingUseCase(),
+                                                                              siteSettings: ServiceLocator.selectedSiteSettings,
+                                                                              currencySettings: ServiceLocator.currencySettings,
+                                                                              featureFlagService: ServiceLocator.featureFlagService)) {
+        self.appSettings = appSettings
+        self.featureFlagService = featureFlagService
+        self.posEligibilityChecker = posEligibilityChecker
+        observePOSEligibilityForAvailableFeatures()
+    }
+
+    func isOn(feature: BetaFeature) -> Binding<Bool> {
+        appSettings.betaFeatureEnabledBinding(feature)
+    }
+}
+
+private extension BetaFeaturesConfigurationViewModel {
+    func observePOSEligibilityForAvailableFeatures() {
+        posEligibilityChecker.$isEligible
+            .map { [weak self] isEligibleForPOS in
+                guard let self else {
+                    return []
+                }
+                return BetaFeature.allCases.filter { betaFeature in
+                    switch betaFeature {
+                        case .viewAddOns:
+                            return true
+                        case .inAppPurchases:
+                            return self.featureFlagService.isFeatureFlagEnabled(.inAppPurchasesDebugMenu)
+                        case .pointOfSale:
+                            return isEligibleForPOS
+                    }
+                }
+            }
+            .assign(to: &$availableFeatures)
+    }
+}
+
 struct BetaFeaturesConfiguration: View {
-    let appSettings = ServiceLocator.generalAppSettings
+    @StateObject private var viewModel: BetaFeaturesConfigurationViewModel
+
+    init(viewModel: BetaFeaturesConfigurationViewModel) {
+        self._viewModel = .init(wrappedValue: viewModel)
+    }
 
     var body: some View {
         List {
-            ForEach(BetaFeature.availableFeatures) { feature in
+            ForEach(viewModel.availableFeatures) { feature in
                 Section(footer: Text(feature.description)) {
-                    TitleAndToggleRow(title: feature.title, isOn: appSettings.betaFeatureEnabledBinding(feature))
+                    TitleAndToggleRow(title: feature.title, isOn: viewModel.isOn(feature: feature))
                 }
             }
         }
@@ -36,7 +87,7 @@ private enum Localization {
 struct BetaFeaturesConfiguration_Previews: PreviewProvider {
     static var previews: some View {
         NavigationView {
-            BetaFeaturesConfiguration()
+            BetaFeaturesConfiguration(viewModel: .init())
         }
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Beta features/BetaFeaturesConfigurationViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Beta features/BetaFeaturesConfigurationViewModel.swift
@@ -1,0 +1,48 @@
+import SwiftUI
+import protocol Experiments.FeatureFlagService
+import struct Storage.GeneralAppSettingsStorage
+
+final class BetaFeaturesConfigurationViewModel: ObservableObject {
+    @Published private(set) var availableFeatures: [BetaFeature] = []
+    private let appSettings: GeneralAppSettingsStorage
+    private let featureFlagService: FeatureFlagService
+    private let posEligibilityChecker: POSEligibilityChecker
+
+    init(appSettings: GeneralAppSettingsStorage = ServiceLocator.generalAppSettings,
+         featureFlagService: FeatureFlagService = ServiceLocator.featureFlagService,
+         posEligibilityChecker: POSEligibilityChecker = POSEligibilityChecker(cardPresentPaymentsOnboarding: CardPresentPaymentsOnboardingUseCase(),
+                                                                              siteSettings: ServiceLocator.selectedSiteSettings,
+                                                                              currencySettings: ServiceLocator.currencySettings,
+                                                                              featureFlagService: ServiceLocator.featureFlagService)) {
+        self.appSettings = appSettings
+        self.featureFlagService = featureFlagService
+        self.posEligibilityChecker = posEligibilityChecker
+        observePOSEligibilityForAvailableFeatures()
+    }
+
+    func isOn(feature: BetaFeature) -> Binding<Bool> {
+        appSettings.betaFeatureEnabledBinding(feature)
+    }
+}
+
+private extension BetaFeaturesConfigurationViewModel {
+    func observePOSEligibilityForAvailableFeatures() {
+        posEligibilityChecker.$isEligible
+            .map { [weak self] isEligibleForPOS in
+                guard let self else {
+                    return []
+                }
+                return BetaFeature.allCases.filter { betaFeature in
+                    switch betaFeature {
+                        case .viewAddOns:
+                            return true
+                        case .inAppPurchases:
+                            return self.featureFlagService.isFeatureFlagEnabled(.inAppPurchasesDebugMenu)
+                        case .pointOfSale:
+                            return isEligibleForPOS
+                    }
+                }
+            }
+            .assign(to: &$availableFeatures)
+    }
+}

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Beta features/BetaFeaturesConfigurationViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Beta features/BetaFeaturesConfigurationViewModel.swift
@@ -6,14 +6,16 @@ final class BetaFeaturesConfigurationViewModel: ObservableObject {
     @Published private(set) var availableFeatures: [BetaFeature] = []
     private let appSettings: GeneralAppSettingsStorage
     private let featureFlagService: FeatureFlagService
-    private let posEligibilityChecker: POSEligibilityChecker
+    private let posEligibilityChecker: POSEligibilityCheckerProtocol
 
     init(appSettings: GeneralAppSettingsStorage = ServiceLocator.generalAppSettings,
          featureFlagService: FeatureFlagService = ServiceLocator.featureFlagService,
-         posEligibilityChecker: POSEligibilityChecker = POSEligibilityChecker(cardPresentPaymentsOnboarding: CardPresentPaymentsOnboardingUseCase(),
-                                                                              siteSettings: ServiceLocator.selectedSiteSettings,
-                                                                              currencySettings: ServiceLocator.currencySettings,
-                                                                              featureFlagService: ServiceLocator.featureFlagService)) {
+         posEligibilityChecker: POSEligibilityCheckerProtocol = POSEligibilityChecker(
+            cardPresentPaymentsOnboarding: CardPresentPaymentsOnboardingUseCase(),
+            siteSettings: ServiceLocator.selectedSiteSettings,
+            currencySettings: ServiceLocator.currencySettings,
+            featureFlagService: ServiceLocator.featureFlagService
+         )) {
         self.appSettings = appSettings
         self.featureFlagService = featureFlagService
         self.posEligibilityChecker = posEligibilityChecker
@@ -27,7 +29,7 @@ final class BetaFeaturesConfigurationViewModel: ObservableObject {
 
 private extension BetaFeaturesConfigurationViewModel {
     func observePOSEligibilityForAvailableFeatures() {
-        posEligibilityChecker.$isEligible
+        posEligibilityChecker.isEligible
             .map { [weak self] isEligibleForPOS in
                 guard let self else {
                     return []

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/CardPresentPaymentsOnboardingUseCase.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/CardPresentPaymentsOnboardingUseCase.swift
@@ -54,7 +54,6 @@ final class CardPresentPaymentsOnboardingUseCase: CardPresentPaymentsOnboardingU
     let storageManager: StorageManagerType
     let stores: StoresManager
     let configurationLoader: CardPresentConfigurationLoader
-    let featureFlagService: FeatureFlagService
     private let cardPresentPluginsDataProvider: CardPresentPluginsDataProvider
     private let cardPresentPaymentOnboardingStateCache: CardPresentPaymentOnboardingStateCache
     private let analytics: Analytics
@@ -72,7 +71,6 @@ final class CardPresentPaymentsOnboardingUseCase: CardPresentPaymentsOnboardingU
     init(
         storageManager: StorageManagerType = ServiceLocator.storageManager,
         stores: StoresManager = ServiceLocator.stores,
-        featureFlagService: FeatureFlagService = ServiceLocator.featureFlagService,
         cardPresentPaymentOnboardingStateCache: CardPresentPaymentOnboardingStateCache = CardPresentPaymentOnboardingStateCache.shared,
         analytics: Analytics = ServiceLocator.analytics
     ) {
@@ -80,7 +78,6 @@ final class CardPresentPaymentsOnboardingUseCase: CardPresentPaymentsOnboardingU
         self.stores = stores
         self.configurationLoader = .init(stores: stores)
         self.cardPresentPluginsDataProvider = .init(storageManager: storageManager, stores: stores, configuration: configurationLoader.configuration)
-        self.featureFlagService = featureFlagService
         self.cardPresentPaymentOnboardingStateCache = cardPresentPaymentOnboardingStateCache
         self.analytics = analytics
 

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/POS/POSEligibilityChecker.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/POS/POSEligibilityChecker.swift
@@ -20,15 +20,18 @@ final class POSEligibilityChecker: POSEligibilityCheckerProtocol {
     @Published private var isEligibleValue: Bool = false
     private var onboardingStateSubscription: AnyCancellable?
 
+    private let userInterfaceIdiom: UIUserInterfaceIdiom
     private let cardPresentPaymentsOnboarding: CardPresentPaymentsOnboardingUseCaseProtocol
     private let siteSettings: SelectedSiteSettings
     private let currencySettings: CurrencySettings
     private let featureFlagService: FeatureFlagService
 
-    init(cardPresentPaymentsOnboarding: CardPresentPaymentsOnboardingUseCaseProtocol = CardPresentPaymentsOnboardingUseCase(),
+    init(userInterfaceIdiom: UIUserInterfaceIdiom = UIDevice.current.userInterfaceIdiom,
+         cardPresentPaymentsOnboarding: CardPresentPaymentsOnboardingUseCaseProtocol = CardPresentPaymentsOnboardingUseCase(),
          siteSettings: SelectedSiteSettings = ServiceLocator.selectedSiteSettings,
          currencySettings: CurrencySettings = ServiceLocator.currencySettings,
          featureFlagService: FeatureFlagService = ServiceLocator.featureFlagService) {
+        self.userInterfaceIdiom = userInterfaceIdiom
         self.siteSettings = siteSettings
         self.currencySettings = currencySettings
         self.cardPresentPaymentsOnboarding = cardPresentPaymentsOnboarding
@@ -40,8 +43,8 @@ final class POSEligibilityChecker: POSEligibilityCheckerProtocol {
 private extension POSEligibilityChecker {
     /// Returns whether the selected store is eligible for POS.
     func observeOnboardingStateForEligibilityCheck() {
-        // Conditions that are fixed per lifetime of the menu tab.
-        let isTablet = UIDevice.current.userInterfaceIdiom == .pad
+        // Conditions that are fixed for its lifetime.
+        let isTablet = userInterfaceIdiom == .pad
         let isFeatureFlagEnabled = featureFlagService.isFeatureFlagEnabled(.displayPointOfSaleToggle)
         guard isTablet && isFeatureFlagEnabled else {
             isEligibleValue = false
@@ -60,7 +63,7 @@ private extension POSEligibilityChecker {
     }
 
     func isEligibleFromSiteChecks() -> Bool {
-        // Conditions that can change if site settings are synced during the lifetime of the menu tab.
+        // Conditions that can change if site settings are synced during the lifetime.
         let isCountryCodeUS = SiteAddress(siteSettings: siteSettings.siteSettings).countryCode == .US
         let isCurrencyUSD = currencySettings.currencyCode == .USD
         return isCountryCodeUS && isCurrencyUSD

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/POS/POSEligibilityChecker.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/POS/POSEligibilityChecker.swift
@@ -18,7 +18,6 @@ final class POSEligibilityChecker: POSEligibilityCheckerProtocol {
     }
 
     @Published private var isEligibleValue: Bool = false
-    private var onboardingStateSubscription: AnyCancellable?
 
     private let userInterfaceIdiom: UIUserInterfaceIdiom
     private let cardPresentPaymentsOnboarding: CardPresentPaymentsOnboardingUseCaseProtocol

--- a/WooCommerce/Classes/ViewRelated/Hub Menu/HubMenu.swift
+++ b/WooCommerce/Classes/ViewRelated/Hub Menu/HubMenu.swift
@@ -34,9 +34,9 @@ struct HubMenu: View {
                 .navigationDestination(isPresented: $viewModel.showingCoupons) {
                     couponListView
                 }
-        }
-        .onAppear {
-            viewModel.setupMenuElements()
+                .onAppear {
+                    viewModel.setupMenuElements()
+                }
         }
     }
 

--- a/WooCommerce/Classes/ViewRelated/Hub Menu/HubMenuViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Hub Menu/HubMenuViewModel.swift
@@ -96,7 +96,7 @@ final class HubMenuViewModel: ObservableObject {
             siteID: siteID,
             dependencies: .init(
                 cardPresentPaymentsConfiguration: CardPresentConfigurationLoader().configuration,
-                onboardingUseCase: cardPresentPaymentsOnboarding,
+                onboardingUseCase: CardPresentPaymentsOnboardingUseCase(),
                 cardReaderSupportDeterminer: CardReaderSupportDeterminer(siteID: siteID),
                 wooPaymentsDepositService: WooPaymentsDepositService(siteID: siteID,
                                                                      credentials: ServiceLocator.stores.sessionManager.defaultCredentials!)),

--- a/WooCommerce/Classes/ViewRelated/Hub Menu/HubMenuViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Hub Menu/HubMenuViewModel.swift
@@ -123,7 +123,6 @@ final class HubMenuViewModel: ObservableObject {
                                                            featureFlagService: featureFlagService)
         observeSiteForUIUpdates()
         observePlanName()
-        setupPOSElement()
         tapToPayBadgePromotionChecker.$shouldShowTapToPayBadges.share().assign(to: &$shouldShowNewFeatureBadgeOnPayments)
     }
 
@@ -134,6 +133,7 @@ final class HubMenuViewModel: ObservableObject {
     /// Resets the menu elements displayed on the menu.
     ///
     func setupMenuElements() {
+        setupPOSElement()
         setupSettingsElements()
         setupGeneralElements()
     }

--- a/WooCommerce/Classes/ViewRelated/Hub Menu/HubMenuViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Hub Menu/HubMenuViewModel.swift
@@ -96,7 +96,7 @@ final class HubMenuViewModel: ObservableObject {
             siteID: siteID,
             dependencies: .init(
                 cardPresentPaymentsConfiguration: CardPresentConfigurationLoader().configuration,
-                onboardingUseCase: CardPresentPaymentsOnboardingUseCase(),
+                onboardingUseCase: cardPresentPaymentsOnboarding,
                 cardReaderSupportDeterminer: CardReaderSupportDeterminer(siteID: siteID),
                 wooPaymentsDepositService: WooPaymentsDepositService(siteID: siteID,
                                                                      credentials: ServiceLocator.stores.sessionManager.defaultCredentials!)),

--- a/WooCommerce/Classes/ViewRelated/Hub Menu/HubMenuViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Hub Menu/HubMenuViewModel.swift
@@ -68,7 +68,7 @@ final class HubMenuViewModel: ObservableObject {
     private let featureFlagService: FeatureFlagService
     private let generalAppSettings: GeneralAppSettingsStorage
     private let cardPresentPaymentsOnboarding: CardPresentPaymentsOnboardingUseCaseProtocol
-    private let posEligibilityChecker: POSEligibilityChecker
+    private let posEligibilityChecker: POSEligibilityCheckerProtocol
 
     private(set) var productReviewFromNoteParcel: ProductReviewFromNoteParcel?
 
@@ -145,7 +145,7 @@ final class HubMenuViewModel: ObservableObject {
     }
 
     private func setupPOSElement() {
-        Publishers.CombineLatest(generalAppSettings.betaFeatureEnabledPublisher(.pointOfSale), posEligibilityChecker.$isEligible)
+        Publishers.CombineLatest(generalAppSettings.betaFeatureEnabledPublisher(.pointOfSale), posEligibilityChecker.isEligible)
             .map { isBetaFeatureEnabled, isEligibleForPOS in
                 if isBetaFeatureEnabled && isEligibleForPOS {
                     return PointOfSaleEntryPoint()

--- a/WooCommerce/Classes/ViewRelated/Hub Menu/HubMenuViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Hub Menu/HubMenuViewModel.swift
@@ -145,6 +145,7 @@ final class HubMenuViewModel: ObservableObject {
     }
 
     private func setupPOSElement() {
+        cardPresentPaymentsOnboarding.refreshIfNecessary()
         Publishers.CombineLatest(generalAppSettings.betaFeatureEnabledPublisher(.pointOfSale), posEligibilityChecker.isEligible)
             .map { isBetaFeatureEnabled, isEligibleForPOS in
                 if isBetaFeatureEnabled && isEligibleForPOS {

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -171,6 +171,7 @@
 		023A059B24135F2600E3FC99 /* ReviewsViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = 023A059924135F2600E3FC99 /* ReviewsViewController.xib */; };
 		023B3EBA2A4E73BD003A720A /* LocalAnnouncementViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 023B3EB92A4E73BD003A720A /* LocalAnnouncementViewModelTests.swift */; };
 		023BD5842BFDCBF800A10D7B /* BetaFeaturesConfigurationViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 023BD5832BFDCBF800A10D7B /* BetaFeaturesConfigurationViewModel.swift */; };
+		023BD5882BFDCF3100A10D7B /* MockInMemoryStorage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 023BD5872BFDCF3100A10D7B /* MockInMemoryStorage.swift */; };
 		023D1DD124AB2D05002B03A3 /* ProductListSelectorViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 023D1DD024AB2D05002B03A3 /* ProductListSelectorViewController.swift */; };
 		023D692E2588BF0900F7DA72 /* ShippingLabelPaperSizeListSelectorCommand.swift in Sources */ = {isa = PBXBuildFile; fileRef = 023D692D2588BF0900F7DA72 /* ShippingLabelPaperSizeListSelectorCommand.swift */; };
 		023D69442588C6BD00F7DA72 /* ShippingLabelPaperSizeListSelectorCommandTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 023D69432588C6BD00F7DA72 /* ShippingLabelPaperSizeListSelectorCommandTests.swift */; };
@@ -2947,6 +2948,7 @@
 		023A059924135F2600E3FC99 /* ReviewsViewController.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = ReviewsViewController.xib; sourceTree = "<group>"; };
 		023B3EB92A4E73BD003A720A /* LocalAnnouncementViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocalAnnouncementViewModelTests.swift; sourceTree = "<group>"; };
 		023BD5832BFDCBF800A10D7B /* BetaFeaturesConfigurationViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BetaFeaturesConfigurationViewModel.swift; sourceTree = "<group>"; };
+		023BD5872BFDCF3100A10D7B /* MockInMemoryStorage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockInMemoryStorage.swift; sourceTree = "<group>"; };
 		023D1DD024AB2D05002B03A3 /* ProductListSelectorViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductListSelectorViewController.swift; sourceTree = "<group>"; };
 		023D692D2588BF0900F7DA72 /* ShippingLabelPaperSizeListSelectorCommand.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShippingLabelPaperSizeListSelectorCommand.swift; sourceTree = "<group>"; };
 		023D69432588C6BD00F7DA72 /* ShippingLabelPaperSizeListSelectorCommandTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShippingLabelPaperSizeListSelectorCommandTests.swift; sourceTree = "<group>"; };
@@ -8743,6 +8745,7 @@
 				EEFF47312B309221009BF302 /* MockStoreCreationStoreSwitchScheduler.swift */,
 				02D635782B58071C00B1CBF6 /* MockNote.swift */,
 				EE8A302A2B70B63E001D7C66 /* MockImageService.swift */,
+				023BD5872BFDCF3100A10D7B /* MockInMemoryStorage.swift */,
 			);
 			path = Mocks;
 			sourceTree = "<group>";
@@ -15563,6 +15566,7 @@
 				E1C6535C27BD1D0A003E87D4 /* CardPresentConfigurationLoaderTests.swift in Sources */,
 				2688644325D471C700821BA5 /* EditAttributesViewModelTests.swift in Sources */,
 				8697AFBF2B622DEA00EFAF21 /* BlazeAddParameterViewModelTests.swift in Sources */,
+				023BD5882BFDCF3100A10D7B /* MockInMemoryStorage.swift in Sources */,
 				DE001323279A793A00EB0350 /* CouponWooTests.swift in Sources */,
 				45B98E1F25DECC1C00A1232B /* ShippingLabelAddressFormViewModelTests.swift in Sources */,
 				028E1F722833E954001F8829 /* DashboardViewModelTests.swift in Sources */,

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -170,6 +170,7 @@
 		023A059A24135F2600E3FC99 /* ReviewsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 023A059824135F2600E3FC99 /* ReviewsViewController.swift */; };
 		023A059B24135F2600E3FC99 /* ReviewsViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = 023A059924135F2600E3FC99 /* ReviewsViewController.xib */; };
 		023B3EBA2A4E73BD003A720A /* LocalAnnouncementViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 023B3EB92A4E73BD003A720A /* LocalAnnouncementViewModelTests.swift */; };
+		023BD5842BFDCBF800A10D7B /* BetaFeaturesConfigurationViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 023BD5832BFDCBF800A10D7B /* BetaFeaturesConfigurationViewModel.swift */; };
 		023D1DD124AB2D05002B03A3 /* ProductListSelectorViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 023D1DD024AB2D05002B03A3 /* ProductListSelectorViewController.swift */; };
 		023D692E2588BF0900F7DA72 /* ShippingLabelPaperSizeListSelectorCommand.swift in Sources */ = {isa = PBXBuildFile; fileRef = 023D692D2588BF0900F7DA72 /* ShippingLabelPaperSizeListSelectorCommand.swift */; };
 		023D69442588C6BD00F7DA72 /* ShippingLabelPaperSizeListSelectorCommandTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 023D69432588C6BD00F7DA72 /* ShippingLabelPaperSizeListSelectorCommandTests.swift */; };
@@ -2945,6 +2946,7 @@
 		023A059824135F2600E3FC99 /* ReviewsViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReviewsViewController.swift; sourceTree = "<group>"; };
 		023A059924135F2600E3FC99 /* ReviewsViewController.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = ReviewsViewController.xib; sourceTree = "<group>"; };
 		023B3EB92A4E73BD003A720A /* LocalAnnouncementViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocalAnnouncementViewModelTests.swift; sourceTree = "<group>"; };
+		023BD5832BFDCBF800A10D7B /* BetaFeaturesConfigurationViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BetaFeaturesConfigurationViewModel.swift; sourceTree = "<group>"; };
 		023D1DD024AB2D05002B03A3 /* ProductListSelectorViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductListSelectorViewController.swift; sourceTree = "<group>"; };
 		023D692D2588BF0900F7DA72 /* ShippingLabelPaperSizeListSelectorCommand.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShippingLabelPaperSizeListSelectorCommand.swift; sourceTree = "<group>"; };
 		023D69432588C6BD00F7DA72 /* ShippingLabelPaperSizeListSelectorCommandTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShippingLabelPaperSizeListSelectorCommandTests.swift; sourceTree = "<group>"; };
@@ -6825,6 +6827,7 @@
 			isa = PBXGroup;
 			children = (
 				E1E649EA28461EDF0070B194 /* BetaFeaturesConfiguration.swift */,
+				023BD5832BFDCBF800A10D7B /* BetaFeaturesConfigurationViewModel.swift */,
 			);
 			path = "Beta features";
 			sourceTree = "<group>";
@@ -13671,6 +13674,7 @@
 				D85A3C5226C15DE200C0E026 /* InPersonPaymentsPluginNotSupportedVersionView.swift in Sources */,
 				EE57C11D297AC27300BC31E7 /* TrackEventRequestNotificationHandler.swift in Sources */,
 				DE5746312B43F6180034B10D /* BlazeCampaignCreationFormViewModel.swift in Sources */,
+				023BD5842BFDCBF800A10D7B /* BetaFeaturesConfigurationViewModel.swift in Sources */,
 				680E36B72BD8C49F00E8BCEA /* OrderSubscriptionTableViewCellViewModel.swift in Sources */,
 				CE63023D2BAAEF2C00E3325C /* CustomersListView.swift in Sources */,
 				CE583A0B2107937F00D73C1C /* TextViewTableViewCell.swift in Sources */,

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -171,7 +171,9 @@
 		023A059B24135F2600E3FC99 /* ReviewsViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = 023A059924135F2600E3FC99 /* ReviewsViewController.xib */; };
 		023B3EBA2A4E73BD003A720A /* LocalAnnouncementViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 023B3EB92A4E73BD003A720A /* LocalAnnouncementViewModelTests.swift */; };
 		023BD5842BFDCBF800A10D7B /* BetaFeaturesConfigurationViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 023BD5832BFDCBF800A10D7B /* BetaFeaturesConfigurationViewModel.swift */; };
+		023BD5862BFDCECF00A10D7B /* BetaFeaturesConfigurationViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 023BD5852BFDCECF00A10D7B /* BetaFeaturesConfigurationViewModelTests.swift */; };
 		023BD5882BFDCF3100A10D7B /* MockInMemoryStorage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 023BD5872BFDCF3100A10D7B /* MockInMemoryStorage.swift */; };
+		023BD58B2BFDCFCB00A10D7B /* POSEligibilityCheckerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 023BD58A2BFDCFCB00A10D7B /* POSEligibilityCheckerTests.swift */; };
 		023D1DD124AB2D05002B03A3 /* ProductListSelectorViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 023D1DD024AB2D05002B03A3 /* ProductListSelectorViewController.swift */; };
 		023D692E2588BF0900F7DA72 /* ShippingLabelPaperSizeListSelectorCommand.swift in Sources */ = {isa = PBXBuildFile; fileRef = 023D692D2588BF0900F7DA72 /* ShippingLabelPaperSizeListSelectorCommand.swift */; };
 		023D69442588C6BD00F7DA72 /* ShippingLabelPaperSizeListSelectorCommandTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 023D69432588C6BD00F7DA72 /* ShippingLabelPaperSizeListSelectorCommandTests.swift */; };
@@ -2948,7 +2950,9 @@
 		023A059924135F2600E3FC99 /* ReviewsViewController.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = ReviewsViewController.xib; sourceTree = "<group>"; };
 		023B3EB92A4E73BD003A720A /* LocalAnnouncementViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocalAnnouncementViewModelTests.swift; sourceTree = "<group>"; };
 		023BD5832BFDCBF800A10D7B /* BetaFeaturesConfigurationViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BetaFeaturesConfigurationViewModel.swift; sourceTree = "<group>"; };
+		023BD5852BFDCECF00A10D7B /* BetaFeaturesConfigurationViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BetaFeaturesConfigurationViewModelTests.swift; sourceTree = "<group>"; };
 		023BD5872BFDCF3100A10D7B /* MockInMemoryStorage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockInMemoryStorage.swift; sourceTree = "<group>"; };
+		023BD58A2BFDCFCB00A10D7B /* POSEligibilityCheckerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = POSEligibilityCheckerTests.swift; sourceTree = "<group>"; };
 		023D1DD024AB2D05002B03A3 /* ProductListSelectorViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductListSelectorViewController.swift; sourceTree = "<group>"; };
 		023D692D2588BF0900F7DA72 /* ShippingLabelPaperSizeListSelectorCommand.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShippingLabelPaperSizeListSelectorCommand.swift; sourceTree = "<group>"; };
 		023D69432588C6BD00F7DA72 /* ShippingLabelPaperSizeListSelectorCommandTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShippingLabelPaperSizeListSelectorCommandTests.swift; sourceTree = "<group>"; };
@@ -6002,6 +6006,14 @@
 				020732052988AC4D000A53C2 /* DomainContactInfoFormViewModel.swift */,
 			);
 			path = Domains;
+			sourceTree = "<group>";
+		};
+		023BD5892BFDCF9500A10D7B /* POS */ = {
+			isa = PBXGroup;
+			children = (
+				023BD58A2BFDCFCB00A10D7B /* POSEligibilityCheckerTests.swift */,
+			);
+			path = POS;
 			sourceTree = "<group>";
 		};
 		023D69BA2589BF2500F7DA72 /* Refund Shipping Label */ = {
@@ -9760,6 +9772,7 @@
 				EE0EE7A728B74EF300F6061E /* CustomHelpCenterContentTests.swift */,
 				2631D4F929ED108400F13F20 /* WPComPlanNameSanitizer.swift */,
 				B98FF43F2AAA096200326D16 /* AddressWooTests.swift */,
+				023BD5852BFDCECF00A10D7B /* BetaFeaturesConfigurationViewModelTests.swift */,
 			);
 			path = Model;
 			sourceTree = "<group>";
@@ -10068,6 +10081,7 @@
 		BA143222273662DE00E4B3AB /* Settings */ = {
 			isa = PBXGroup;
 			children = (
+				023BD5892BFDCF9500A10D7B /* POS */,
 				BAFEF51D273C2151005F94CC /* SettingsViewModelTests.swift */,
 				02AA586528531D0E0068B6F0 /* CloseAccountCoordinatorTests.swift */,
 				2609797A2A13D2B500442249 /* Privacy */,
@@ -15208,6 +15222,7 @@
 				B6440FB9292E74230012D506 /* AnalyticsHubTimeRangeSelectionTests.swift in Sources */,
 				B57C5C9E21B80E8300FF82B2 /* SessionManager+Internal.swift in Sources */,
 				2667BFDB252E659A008099D4 /* MockOrderItem.swift in Sources */,
+				023BD5862BFDCECF00A10D7B /* BetaFeaturesConfigurationViewModelTests.swift in Sources */,
 				DEC51AA0274F9922009F3DF4 /* JCPJetpackInstallStepsViewModelTests.swift in Sources */,
 				E1068058285C787100668B46 /* BetaFeaturesTests.swift in Sources */,
 				EE570A8D2BF5EE78006BA026 /* MostActiveCouponsCardViewModelTests.swift in Sources */,
@@ -15677,6 +15692,7 @@
 				CC923A1D2847A8E0008EEEBE /* OrderStatusListViewModelTests.swift in Sources */,
 				267C01D129E9B18E00FCC97B /* StorePlanSynchronizerTests.swift in Sources */,
 				EE45E2C42A4A85350085F227 /* TooltipPresenterTests.swift in Sources */,
+				023BD58B2BFDCFCB00A10D7B /* POSEligibilityCheckerTests.swift in Sources */,
 				0388E1A629E04433007DF84D /* PaymentsRouteTests.swift in Sources */,
 				EEC5C8DA2ADE2FD80071E852 /* BlazeCampaignDashboardViewModelTests.swift in Sources */,
 				D85B833D2230DC9D002168F3 /* StringWooTests.swift in Sources */,

--- a/WooCommerce/WooCommerceTests/Mocks/MockFeatureFlagService.swift
+++ b/WooCommerce/WooCommerceTests/Mocks/MockFeatureFlagService.swift
@@ -23,6 +23,7 @@ struct MockFeatureFlagService: FeatureFlagService {
     private let sideBySideViewForOrderForm: Bool
     private let isCustomersInHubMenuEnabled: Bool
     private let isSubscriptionsInOrderCreationCustomersEnabled: Bool
+    private let isDisplayPointOfSaleToggleEnabled: Bool
 
     init(isInboxOn: Bool = false,
          isUpdateOrderOptimisticallyOn: Bool = false,
@@ -44,7 +45,8 @@ struct MockFeatureFlagService: FeatureFlagService {
          isBackendReceiptsEnabled: Bool = false,
          sideBySideViewForOrderForm: Bool = false,
          isCustomersInHubMenuEnabled: Bool = false,
-         isSubscriptionsInOrderCreationCustomersEnabled: Bool = false) {
+         isSubscriptionsInOrderCreationCustomersEnabled: Bool = false,
+         isDisplayPointOfSaleToggleEnabled: Bool = false) {
         self.isInboxOn = isInboxOn
         self.isUpdateOrderOptimisticallyOn = isUpdateOrderOptimisticallyOn
         self.shippingLabelsOnboardingM1 = shippingLabelsOnboardingM1
@@ -66,6 +68,7 @@ struct MockFeatureFlagService: FeatureFlagService {
         self.sideBySideViewForOrderForm = sideBySideViewForOrderForm
         self.isCustomersInHubMenuEnabled = isCustomersInHubMenuEnabled
         self.isSubscriptionsInOrderCreationCustomersEnabled = isSubscriptionsInOrderCreationCustomersEnabled
+        self.isDisplayPointOfSaleToggleEnabled = isDisplayPointOfSaleToggleEnabled
     }
 
     func isFeatureFlagEnabled(_ featureFlag: FeatureFlag) -> Bool {
@@ -110,6 +113,8 @@ struct MockFeatureFlagService: FeatureFlagService {
             return isCustomersInHubMenuEnabled
         case .subscriptionsInOrderCreationCustomers:
             return isSubscriptionsInOrderCreationCustomersEnabled
+        case .displayPointOfSaleToggle:
+            return isDisplayPointOfSaleToggleEnabled
         default:
             return false
         }

--- a/WooCommerce/WooCommerceTests/Mocks/MockInMemoryStorage.swift
+++ b/WooCommerce/WooCommerceTests/Mocks/MockInMemoryStorage.swift
@@ -1,0 +1,24 @@
+import Storage
+
+final class MockInMemoryStorage: FileStorage {
+    private(set) var data: [URL: Codable] = [:]
+
+    func data<T>(for fileURL: URL) throws -> T where T: Decodable {
+        guard let data = data[fileURL] as? T else {
+            throw Errors.readFailed
+        }
+        return data
+    }
+
+    func write<T>(_ data: T, to fileURL: URL) throws where T: Encodable {
+        self.data[fileURL] = data as? Codable
+    }
+
+    func deleteFile(at fileURL: URL) throws {
+        data.removeValue(forKey: fileURL)
+    }
+
+    enum Errors: Error {
+        case readFailed
+    }
+}

--- a/WooCommerce/WooCommerceTests/Model/BetaFeaturesConfigurationViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/Model/BetaFeaturesConfigurationViewModelTests.swift
@@ -1,0 +1,58 @@
+import Combine
+import Storage
+import XCTest
+@testable import WooCommerce
+
+final class BetaFeaturesConfigurationViewModelTests: XCTestCase {
+    private var appSettings: GeneralAppSettingsStorage!
+
+    override func setUpWithError() throws {
+        appSettings = GeneralAppSettingsStorage.init(fileStorage: MockInMemoryStorage())
+    }
+
+    override func tearDownWithError() throws {
+        appSettings = nil
+    }
+
+    func test_availableFeatures_include_viewAddOns() {
+        // Given
+        let viewModel = BetaFeaturesConfigurationViewModel(appSettings: appSettings,
+                                                           posEligibilityChecker: MockPOSEligibilityChecker(isEligibleValue: true))
+
+        // Then
+        XCTAssertTrue(viewModel.availableFeatures.contains(.viewAddOns))
+    }
+
+    func test_availableFeatures_include_pos_when_eligible_for_pos() {
+        // Given
+        let posEligibilityChecker = MockPOSEligibilityChecker(isEligibleValue: true)
+        let viewModel = BetaFeaturesConfigurationViewModel(appSettings: appSettings, posEligibilityChecker: posEligibilityChecker)
+
+        // Then
+        XCTAssertTrue(viewModel.availableFeatures.contains(.pointOfSale))
+    }
+
+    func test_availableFeatures_do_not_include_pos_when_not_eligible_for_pos_anymore() {
+        // Given
+        let posEligibilityChecker = MockPOSEligibilityChecker(isEligibleValue: true)
+        let viewModel = BetaFeaturesConfigurationViewModel(appSettings: appSettings, posEligibilityChecker: posEligibilityChecker)
+
+        // When
+        posEligibilityChecker.isEligibleValue = false
+
+        // Then
+        XCTAssertFalse(viewModel.availableFeatures.contains(.pointOfSale))
+    }
+}
+
+private final class MockPOSEligibilityChecker: POSEligibilityCheckerProtocol {
+    @Published var isEligibleValue: Bool
+
+    init(isEligibleValue: Bool) {
+        self.isEligibleValue = isEligibleValue
+    }
+
+    var isEligible: AnyPublisher<Bool, Never> {
+        $isEligibleValue.eraseToAnyPublisher()
+    }
+}

--- a/WooCommerce/WooCommerceTests/Model/BetaFeaturesTests.swift
+++ b/WooCommerce/WooCommerceTests/Model/BetaFeaturesTests.swift
@@ -2,7 +2,7 @@ import XCTest
 import Storage
 @testable import WooCommerce
 
-class BetaFeaturesTests: XCTestCase {
+final class BetaFeaturesTests: XCTestCase {
     var appSettings: GeneralAppSettingsStorage!
 
     override func setUpWithError() throws {
@@ -30,28 +30,5 @@ class BetaFeaturesTests: XCTestCase {
         enabledBinding.wrappedValue = true
         let enabled = appSettings.betaFeatureEnabled(.viewAddOns)
         XCTAssertEqual(enabled, true)
-    }
-}
-
-private final class MockInMemoryStorage: FileStorage {
-    private(set) var data: [URL: Codable] = [:]
-
-    func data<T>(for fileURL: URL) throws -> T where T: Decodable {
-        guard let data = data[fileURL] as? T else {
-            throw Errors.readFailed
-        }
-        return data
-    }
-
-    func write<T>(_ data: T, to fileURL: URL) throws where T: Encodable {
-        self.data[fileURL] = data as? Codable
-    }
-
-    func deleteFile(at fileURL: URL) throws {
-        data.removeValue(forKey: fileURL)
-    }
-
-    enum Errors: Error {
-        case readFailed
     }
 }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Settings/POS/POSEligibilityCheckerTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Settings/POS/POSEligibilityCheckerTests.swift
@@ -1,0 +1,185 @@
+import Combine
+import WooFoundation
+import XCTest
+import Yosemite
+@testable import WooCommerce
+
+final class POSEligibilityCheckerTests: XCTestCase {
+    private var onboardingUseCase: MockCardPresentPaymentsOnboardingUseCase!
+    private var stores: MockStoresManager!
+    private var storageManager: MockStorageManager!
+    private var siteSettings: SelectedSiteSettings!
+    @Published private var isEligible: Bool = false
+
+    private let siteID: Int64 = 2
+
+    override func setUp() {
+        super.setUp()
+        onboardingUseCase = MockCardPresentPaymentsOnboardingUseCase(initial: .completed(plugin: .wcPayPreferred))
+        stores = MockStoresManager(sessionManager: .makeForTesting(authenticated: true))
+        stores.updateDefaultStore(storeID: siteID)
+        storageManager = MockStorageManager()
+        siteSettings = SelectedSiteSettings(stores: stores, storageManager: storageManager)
+    }
+
+    override func tearDown() {
+        siteSettings = nil
+        storageManager = nil
+        stores = nil
+        onboardingUseCase = nil
+        super.tearDown()
+    }
+
+    func test_site_with_all_conditions_is_eligible() throws {
+        // Given
+        let featureFlagService = MockFeatureFlagService(isDisplayPointOfSaleToggleEnabled: true)
+        setupCountry(country: .us)
+        let checker = POSEligibilityChecker(userInterfaceIdiom: .pad,
+                                            cardPresentPaymentsOnboarding: onboardingUseCase,
+                                            siteSettings: siteSettings,
+                                            currencySettings: Fixtures.usdCurrencySettings,
+                                            featureFlagService: featureFlagService)
+        checker.isEligible.assign(to: &$isEligible)
+
+        // Then
+        XCTAssertTrue(isEligible)
+    }
+
+    func test_non_iPad_devices_are_not_eligible() throws {
+        // Given
+        let featureFlagService = MockFeatureFlagService(isDisplayPointOfSaleToggleEnabled: true)
+        setupCountry(country: .us)
+        [UIUserInterfaceIdiom.phone, UIUserInterfaceIdiom.mac, UIUserInterfaceIdiom.tv, UIUserInterfaceIdiom.carPlay]
+            .forEach { userInterfaceIdiom in
+                let checker = POSEligibilityChecker(userInterfaceIdiom: userInterfaceIdiom,
+                                                    cardPresentPaymentsOnboarding: onboardingUseCase,
+                                                    siteSettings: siteSettings,
+                                                    currencySettings: Fixtures.usdCurrencySettings,
+                                                    featureFlagService: featureFlagService)
+                checker.isEligible.assign(to: &$isEligible)
+
+                // Then
+                XCTAssertFalse(isEligible)
+            }
+    }
+
+    func test_non_us_site_is_not_eligible() throws {
+        // Given
+        let featureFlagService = MockFeatureFlagService(isDisplayPointOfSaleToggleEnabled: true)
+        [Country.ca, Country.es, Country.gb].forEach { country in
+            // When
+            setupCountry(country: country)
+            let checker = POSEligibilityChecker(userInterfaceIdiom: .pad,
+                                                cardPresentPaymentsOnboarding: onboardingUseCase,
+                                                siteSettings: siteSettings,
+                                                currencySettings: Fixtures.usdCurrencySettings,
+                                                featureFlagService: featureFlagService)
+            checker.isEligible.assign(to: &$isEligible)
+
+            // Then
+            XCTAssertFalse(isEligible)
+        }
+    }
+
+    func test_non_usd_site_is_not_eligible() throws {
+        // Given
+        let featureFlagService = MockFeatureFlagService(isDisplayPointOfSaleToggleEnabled: true)
+        setupCountry(country: .us)
+        let checker = POSEligibilityChecker(userInterfaceIdiom: .pad,
+                                            cardPresentPaymentsOnboarding: onboardingUseCase,
+                                            siteSettings: siteSettings,
+                                            currencySettings: Fixtures.nonUSDCurrencySettings,
+                                            featureFlagService: featureFlagService)
+        checker.isEligible.assign(to: &$isEligible)
+
+        // Then
+        XCTAssertFalse(isEligible)
+    }
+
+    func test_is_not_eligible_when_feature_flag_is_disabled() throws {
+        // Given
+        let featureFlagService = MockFeatureFlagService(isDisplayPointOfSaleToggleEnabled: false)
+        setupCountry(country: .us)
+        let checker = POSEligibilityChecker(userInterfaceIdiom: .pad,
+                                            cardPresentPaymentsOnboarding: onboardingUseCase,
+                                            siteSettings: siteSettings,
+                                            currencySettings: Fixtures.usdCurrencySettings,
+                                            featureFlagService: featureFlagService)
+        checker.isEligible.assign(to: &$isEligible)
+
+        // Then
+        XCTAssertFalse(isEligible)
+    }
+
+    func test_is_not_eligible_when_onboarding_state_is_not_completed_wcpay() throws {
+        // Given
+        let featureFlagService = MockFeatureFlagService(isDisplayPointOfSaleToggleEnabled: true)
+        setupCountry(country: .us)
+        let checker = POSEligibilityChecker(userInterfaceIdiom: .pad,
+                                            cardPresentPaymentsOnboarding: onboardingUseCase,
+                                            siteSettings: siteSettings,
+                                            currencySettings: Fixtures.usdCurrencySettings,
+                                            featureFlagService: featureFlagService)
+        checker.isEligible.assign(to: &$isEligible)
+        XCTAssertTrue(isEligible)
+
+        // When onboarding state is loading
+        onboardingUseCase.state = .loading
+        // Then
+        XCTAssertFalse(isEligible)
+
+        // When onboarding state is stripeOnly
+        onboardingUseCase.state = .completed(plugin: .stripeOnly)
+        // Then
+        XCTAssertFalse(isEligible)
+
+        // When onboarding state is wcPayOnly
+        onboardingUseCase.state = .completed(plugin: .wcPayOnly)
+        // Then
+        XCTAssertTrue(isEligible)
+
+        // When onboarding state is stripePreferred
+        onboardingUseCase.state = .completed(plugin: .stripePreferred)
+        // Then
+        XCTAssertFalse(isEligible)
+
+        // When onboarding state is pluginNotInstalled
+        onboardingUseCase.state = .pluginNotInstalled
+        // Then
+        XCTAssertFalse(isEligible)
+    }
+}
+
+private extension POSEligibilityCheckerTests {
+    func setupCountry(country: Country) {
+        let setting = SiteSetting.fake()
+            .copy(
+                siteID: siteID,
+                settingID: "woocommerce_default_country",
+                value: country.rawValue,
+                settingGroupKey: SiteSettingGroup.general.rawValue
+            )
+        storageManager.insertSampleSiteSetting(readOnlySiteSetting: setting)
+        siteSettings.refresh()
+    }
+
+    enum Fixtures {
+        static let usdCurrencySettings = CurrencySettings(currencyCode: .USD,
+                                                          currencyPosition: .leftSpace,
+                                                          thousandSeparator: "",
+                                                          decimalSeparator: ".",
+                                                          numberOfDecimals: 3)
+        static let nonUSDCurrencySettings = CurrencySettings(currencyCode: .CAD,
+                                                             currencyPosition: .leftSpace,
+                                                             thousandSeparator: "",
+                                                             decimalSeparator: ".",
+                                                             numberOfDecimals: 3)
+    }
+
+    enum Country: String {
+        case us = "US:CA"
+        case ca = "CA:NS"
+        case gb = "GB"
+        case es = "ES"
+    }
+}


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of: #12779 
Closes #12780
<!-- Id number of the GitHub issue this PR addresses. -->

## Why

As we're coming to a conclusion (at least for the first iteration) on the POS eligibility conditions in p91TBi-beb-p2#comment-12134, we're good with the checks that were implemented in https://github.com/woocommerce/woocommerce-ios/pull/12783. Some basic test cases before closing this issue. In the meanwhile, there are two issues with the visibility of the POS menu item:
- **Sometimes** the onboarding state isn't up to date when landing on the Menu tab
- After toggling the POS feature switch in Settings > Experimental Features, the POS menu item's visibility isn't reflected right away and relies on switching to another tab and then back

Note that we haven't made a decision about whether to keep the feature switch in Settings > Experimental Features so we have to continue supporting it p91TBi-beb-p2#comment-12143.

🗒️ Apology on the 500 diffs, More than half of the diffs are on the unit tests, as setting up dependencies for the POS eligibility checker isn't super straightforward.

## How

The main cause for the visibility issue is that the onboarding state isn't refreshed if no other parts of the app has, and `POSEligibilityChecker` was just using the latest onboarding state value instead of observing the state publisher. In this PR, the major changes to `POSEligibilityChecker` are:
- `isEligible` boolean is now a publisher to emit values on changes
- Update `siteSettings` (for the country check) from `[SiteSetting]` to `SelectedSiteSettings` to allow potential changes that could be checked on the next onboarding state change
- For unit testing:
  - `POSEligibilityCheckerProtocol` was created for easier unit testing in its consumer
  - `UIUserInterfaceIdiom` is now DI'ed

Now the checks are broken into 3 parts:
  - Fixed checks: feature flag & device type
  - Site-specific checks: country & currency
  - Onboarding check: completed with WCPay only or preferred
The checker first checks the fixed conditions, and then observes the onboarding state. On onboarding state changes, it first performs the site-specific checks and then the onboarding state check.

This observable isEligible boolean is tricky for the BetaFeaturesConfiguration screen. Before this PR, the availability of beta features is fixed. However, as we can't easily DI `POSEligibilityChecker` because the Settings (where BetaFeaturesConfiguration screen is in) is in UIKit with a SwiftUI wrapper, the BetaFeaturesConfiguration screen has to now observe the eligibility check as well. I thought about opening up a readonly `isEligible` boolean value type, but the onboarding state observation will result in the latest value async and thus missed in the BetaFeaturesConfiguration screen. In the end, I created a view model for `BetaFeaturesConfiguration` that observes the eligibility value to show the available features.

I originally wanted to share the onboarding use case with `InPersonPaymentsMenuViewModel`, but got some SwiftUI warning about `Publishing changes from within view updates is not allowed, this will cause undefined behavior.`, so I decided to revert it.

Please feel free to share any suggestions on a different approach!

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

There are a few scenarios that @jaclync will test again after approval:

- Tablet device
  - [x] Go to the Menu tab on iPhone --> no POS row should be shown in the menu tab, and in Experimental Features the POS feature switch should not be shown
  - [x] Go to the Menu tab on iPad --> in Experimental Features the POS feature switch should be shown, and when the switch is enabled, the POS row should be shown in the menu tab if the store is eligible for POS

Continue with an iPad with the POS feature switch enabled for the following cases:

- USD currency (WC Settings > General)
  - [x] Switch to a store with non-USD currency --> after revisiting the Menu tab, the POS row should **not** be shown
- US store location (WC Settings > General)
  - [x] Switch to a store not based in the US --> after revisiting the Menu tab, the POS row should **not** be shown
- Woo Payments plugin enabled and user setup complete
  - [x] Switch to a store based in the US and using USD, but the WCPay isn't active or its onboarding isn't complete --> after revisiting the Menu tab, the POS row should **not** be shown

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->


https://github.com/woocommerce/woocommerce-ios/assets/1945542/6bc7d370-9422-4956-8cfd-d1c2ce2ece2e



---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.