### PR TITLE
Dynamic Dashboard: Preserve existing ordering when refreshing cards.

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Dashboard/DashboardViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/DashboardViewModel.swift
@@ -458,13 +458,18 @@ private extension DashboardViewModel {
         // This is needed because even if a user already disabled an available card and saved it, in `initialCards`
         // the same card might be set to be enabled. To respect user's setting, we need to check the saved state and re-apply it.
         let savedCards = await loadDashboardCards() ?? []
-        dashboardCards = initialCards.map { initialCard in
+        let updatedCards = initialCards.map { initialCard in
             if let savedCard = savedCards.first(where: { $0.type == initialCard.type }),
                savedCard.availability == .show && initialCard.availability == .show {
                 return initialCard.copy(enabled: savedCard.enabled)
             } else {
                 return initialCard
             }
+        }
+
+        // Reorder dashboardCards based on original ordering in savedCards
+        dashboardCards = savedCards.compactMap { savedCard in
+            updatedCards.first(where: { $0.type == savedCard.type })
         }
     }
 


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #12743
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

Previously, when refreshing Dashboard when there's a mix of default and new cards, the default cards will always be shown at the top again even if the new cards were set to be displayed at the top previously.

This PR fixes that so the user's cards ordering is preserved.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
1. Start app
2. Edit dashboard, then enable and put an m2 card  (e.g: Inbox or Coupons) at the top of the list,
3. Save,
4. On the dashboard, do a pull-to-refresh
5. Ensure that the enabled m2 card on step 2 stays at the top.
6. restart app
7. Ensure that the enabled m2 card on step 2 stays at the top.
