### PR TITLE
Watch: Adds Order Detail View

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Orders/Cells/OrderListCellViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Cells/OrderListCellViewModel.swift
@@ -32,6 +32,8 @@ struct OrderListCellViewModel {
         Localization.title(orderNumber: order.number, customerName: customerName)
     }
 
+    /// For example, Pamela Nguyen
+    ///
     var customerName: String {
         if let fullName = order.billingAddress?.fullName, fullName.isNotEmpty {
             return fullName
@@ -56,6 +58,14 @@ struct OrderListCellViewModel {
         return formatter.string(from: order.dateCreated)
     }
 
+    /// Time where the order was created
+    ///
+    var timeCreated: String {
+        let formatter: DateFormatter = .timeFormatter
+        formatter.timeZone = .siteTimezone
+        return formatter.string(from: order.dateCreated)
+    }
+
     /// Status of the order
     ///
     var status: OrderStatusEnum {
@@ -68,6 +78,14 @@ struct OrderListCellViewModel {
     /// So if orderStatus doesn't have a name, let's use the order.status to display those as slugs.
     var statusString: String {
         return orderStatus?.name ?? order.status.rawValue
+    }
+
+    /// The localized unabbreviated total for a given order item, which includes the currency.
+    ///
+    /// Example: $48,415,504.20
+    ///
+    func total(for orderItem: OrderItem) -> String {
+        currencyFormatter.formatAmount(orderItem.total, with: order.currency) ?? "$\(orderItem.total)"
     }
 
 #if !os(watchOS)

--- a/WooCommerce/Woo Watch App/Orders/OrderDetailView.swift
+++ b/WooCommerce/Woo Watch App/Orders/OrderDetailView.swift
@@ -1,0 +1,10 @@
+import SwiftUI
+
+/// View for the order detail
+///
+struct OrderDetailView: View {
+    var body: some View {
+        Text("Order Detail")
+    }
+}
+

--- a/WooCommerce/Woo Watch App/Orders/OrderDetailView.swift
+++ b/WooCommerce/Woo Watch App/Orders/OrderDetailView.swift
@@ -9,43 +9,13 @@ struct OrderDetailView: View {
     let order: OrdersListView.Order
 
     var body: some View {
-        ScrollView {
-            VStack(alignment: .leading) {
+        TabView {
+            // First
+            summaryView
 
-                HStack {
-                    Text(order.date)
-                    Spacer()
-                    Text(order.time)
-                }
-                .font(.caption2)
-                .foregroundStyle(.secondary)
-
-                Divider()
-
-                VStack(alignment: .leading, spacing: Layout.nameSectionSpacing) {
-                    Text(order.name)
-                        .font(.title3)
-
-                    Text(order.total)
-                        .font(.title2)
-                        .bold()
-
-                    Text(order.status)
-                        .font(.footnote)
-                        .foregroundStyle(Colors.gray5)
-                }
-                .padding(.bottom, Layout.mainSectionsPadding)
-
-                Text(Localization.products(order.itemCount).lowercased())
-                    .font(.caption2)
-                    .padding(.bottom, Layout.mainSectionsPadding)
-
-                VStack {
-                    ForEach(order.items) { orderItem in
-                        itemRow(orderItem)
-                        Divider()
-                    }
-                }
+            // Second
+            if order.itemCount > 0 {
+                productsView
             }
         }
         .padding(.horizontal)
@@ -61,15 +31,79 @@ struct OrderDetailView: View {
         )
     }
 
+    /// First View: Summary
+    ///
+    @ViewBuilder private var summaryView: some View {
+        VStack(alignment: .leading) {
+
+            // Date & Time
+            HStack {
+                Text(order.date)
+                Spacer()
+                Text(order.time)
+            }
+            .font(.caption2)
+            .foregroundStyle(.secondary)
+
+            Divider()
+
+            // Name, total, status
+            VStack(alignment: .leading, spacing: Layout.nameSectionSpacing) {
+                Text(order.name)
+                    .font(.body)
+
+                Text(order.total)
+                    .font(.title2)
+                    .bold()
+
+                Text(order.status)
+                    .font(.footnote)
+                    .foregroundStyle(Colors.gray5)
+            }
+            .padding(.bottom, Layout.mainSectionsPadding)
+
+            // Products button
+            Button(Localization.products(order.itemCount).lowercased()) {
+                print("product Button tapped")
+            }
+            .font(.caption2)
+            .buttonStyle(.borderless)
+            .frame(maxWidth: .greatestFiniteMagnitude, alignment: .leading)
+            .padding()
+            .background(Colors.whiteTransparent)
+            .cornerRadius(Layout.buttonCornerRadius)
+        }
+    }
+
+    /// Second View: Product List
+    ///
+    @ViewBuilder private var productsView: some View {
+        List {
+            Section {
+                ForEach(order.items) { orderItem in
+                    itemRow(orderItem)
+                }
+            } header: {
+                Text(Localization.products(order.itemCount))
+                    .font(.caption2)
+                    .padding(.bottom)
+            }
+        }
+    }
+
+    /// Item Row of the product list
+    ///
     @ViewBuilder private func itemRow(_ item: OrdersListView.OrderItem) -> some View {
         HStack(alignment: .top, spacing: Layout.itemRowSpacing) {
 
+            // Item count
             Text(item.count.formatted(.number))
                 .font(.caption2)
                 .foregroundStyle(Colors.wooPurple20)
                 .padding(Layout.itemCountPadding)
                 .background(Circle().fill(Colors.whiteTransparent))
 
+            // Name and total
             VStack(alignment: .leading) {
                 Text(item.name)
                     .font(.caption2)
@@ -91,14 +125,23 @@ private extension OrderDetailView {
         static let mainSectionsPadding = 10.0
         static let itemCountPadding = 6.0
         static let itemRowSpacing = 8.0
+        static let buttonCornerRadius = 10.0
     }
 
     enum Localization {
         static func products(_ count: Int) -> LocalizedString {
+            if count == 1 {
+                return AppLocalizedString(
+                    "watch.orders.detail.product-count-singular",
+                    value: "%d Product",
+                    comment: "Singular format for the number of products in the order detail screen."
+                )
+            }
+
             let format = AppLocalizedString(
                 "watch.orders.detail.product-count",
                 value: "%d Products",
-                comment: "Format for the number of products in the order detail screen."
+                comment: "Plural format for the number of products in the order detail screen."
             )
             return LocalizedString(format: format, count)
         }

--- a/WooCommerce/Woo Watch App/Orders/OrderDetailView.swift
+++ b/WooCommerce/Woo Watch App/Orders/OrderDetailView.swift
@@ -17,6 +17,7 @@ struct OrderDetailView: View {
             // First
             summaryView
                 .tag(Tab.summary)
+                .padding(.horizontal)
 
             // Second
             if order.itemCount > 0 {
@@ -24,7 +25,6 @@ struct OrderDetailView: View {
                     .tag(Tab.products)
             }
         }
-        .padding(.horizontal)
         .toolbar {
             ToolbarItem(placement: .confirmationAction) {
                 Text(order.number)
@@ -94,36 +94,44 @@ struct OrderDetailView: View {
             } header: {
                 Text(Localization.products(order.itemCount))
                     .font(.caption2)
-                    .padding(.bottom)
             }
+            .listStyle(.plain)
+            .listRowBackground(Color.clear)
+            .listRowInsets(.init(top: 0, leading: Layout.itemlistPadding, bottom: 0, trailing: Layout.itemlistPadding))
         }
     }
 
     /// Item Row of the product list
     ///
     @ViewBuilder private func itemRow(_ item: OrdersListView.OrderItem) -> some View {
-        HStack(alignment: .top, spacing: Layout.itemRowSpacing) {
+        VStack(alignment: .leading, spacing: .zero) {
+            HStack(alignment: .top, spacing: Layout.itemRowSpacing) {
 
-            // Item count
-            Text(item.count.formatted(.number))
-                .font(.caption2)
-                .foregroundStyle(Colors.wooPurple20)
-                .padding(Layout.itemCountPadding)
-                .background(Circle().fill(Colors.whiteTransparent))
-
-            // Name and total
-            VStack(alignment: .leading) {
-                Text(item.name)
+                // Item count
+                Text(item.count.formatted(.number))
                     .font(.caption2)
+                    .foregroundStyle(Colors.wooPurple20)
+                    .padding(Layout.itemCountPadding)
+                    .background(Circle().fill(Colors.whiteTransparent))
 
-                Text(item.total)
-                    .font(.caption2)
-                    .foregroundStyle(.secondary)
+                // Name and total
+                VStack(alignment: .leading) {
+                    Text(item.name)
+                        .font(.caption2)
+
+                    Text(item.total)
+                        .font(.caption2)
+                        .foregroundStyle(.secondary)
+                }
+
+                Spacer()
             }
+            .padding(.vertical)
 
-            Spacer()
+            if item.showDivider {
+                Divider()
+            }
         }
-        .padding(.vertical)
     }
 }
 
@@ -139,6 +147,7 @@ private extension OrderDetailView {
         static let itemCountPadding = 6.0
         static let itemRowSpacing = 8.0
         static let buttonCornerRadius = 10.0
+        static let itemlistPadding = 5.0
     }
 
     enum Localization {

--- a/WooCommerce/Woo Watch App/Orders/OrderDetailView.swift
+++ b/WooCommerce/Woo Watch App/Orders/OrderDetailView.swift
@@ -3,14 +3,19 @@ import SwiftUI
 /// View for the order detail
 ///
 struct OrderDetailView: View {
+
+    /// Order to render
+    ///
+    let order: OrdersListView.Order
+
     var body: some View {
         ScrollView {
             VStack(alignment: .leading) {
 
                 HStack {
-                    Text("25 Feb")
+                    Text(order.date)
                     Spacer()
-                    Text("12:14 pm")
+                    Text(order.time)
                 }
                 .font(.caption2)
                 .foregroundStyle(.secondary)
@@ -18,36 +23,35 @@ struct OrderDetailView: View {
                 Divider()
 
                 VStack(alignment: .leading, spacing: Layout.nameSectionSpacing) {
-                    Text("Willem Dafoe")
+                    Text(order.name)
                         .font(.title3)
 
-                    Text("$149.50")
+                    Text(order.total)
                         .font(.title2)
                         .bold()
 
-                    Text("Pending payment")
+                    Text(order.status)
                         .font(.footnote)
                         .foregroundStyle(Colors.gray5)
                 }
                 .padding(.bottom, Layout.mainSectionsPadding)
 
-                Text("3 products")
+                Text(Localization.products(order.itemCount).lowercased())
                     .font(.caption2)
                     .padding(.bottom, Layout.mainSectionsPadding)
 
                 VStack {
-                    itemRow()
-                    Divider()
-                    itemRow()
-                    Divider()
-                    itemRow()
+                    ForEach(order.items) { orderItem in
+                        itemRow(orderItem)
+                        Divider()
+                    }
                 }
             }
         }
         .padding(.horizontal)
         .toolbar {
             ToolbarItem(placement: .confirmationAction) {
-                Text("#1031")
+                Text(order.number)
                     .font(.body)
                     .foregroundStyle(Colors.wooPurple20)
             }
@@ -57,19 +61,19 @@ struct OrderDetailView: View {
         )
     }
 
-    @ViewBuilder private func itemRow() -> some View {
+    @ViewBuilder private func itemRow(_ item: OrdersListView.OrderItem) -> some View {
         VStack(alignment: .leading, spacing: .zero) {
-            Text("Little Nap Blend 250g")
+            Text(item.name)
                 .font(.caption2)
 
             HStack {
-                Text("$99.00")
+                Text(item.total)
                     .font(.caption2)
                     .foregroundStyle(.secondary)
 
                 Spacer()
 
-                Text("3")
+                Text(item.count.formatted(.number))
                     .font(.caption2)
                     .foregroundStyle(Colors.wooPurple20)
                     .padding(Layout.itemCountPadding)
@@ -84,6 +88,17 @@ private extension OrderDetailView {
         static let nameSectionSpacing = 2.0
         static let mainSectionsPadding = 10.0
         static let itemCountPadding = 6.0
+    }
+
+    enum Localization {
+        static func products(_ count: Int) -> LocalizedString {
+            let format = AppLocalizedString(
+                "watch.orders.detail.product-count",
+                value: "%d Products",
+                comment: "Format for the number of products in the order detail screen."
+            )
+            return LocalizedString(format: format, count)
+        }
     }
 
     enum Colors {

--- a/WooCommerce/Woo Watch App/Orders/OrderDetailView.swift
+++ b/WooCommerce/Woo Watch App/Orders/OrderDetailView.swift
@@ -8,14 +8,20 @@ struct OrderDetailView: View {
     ///
     let order: OrdersListView.Order
 
+    /// Tracks the selected tab.
+    ///
+    @State private var selectedTab = Tab.summary
+
     var body: some View {
-        TabView {
+        TabView(selection: $selectedTab) {
             // First
             summaryView
+                .tag(Tab.summary)
 
             // Second
             if order.itemCount > 0 {
                 productsView
+                    .tag(Tab.products)
             }
         }
         .padding(.horizontal)
@@ -64,7 +70,9 @@ struct OrderDetailView: View {
 
             // Products button
             Button(Localization.products(order.itemCount).lowercased()) {
-                print("product Button tapped")
+                if order.itemCount > 0 {
+                    self.selectedTab = .products
+                }
             }
             .font(.caption2)
             .buttonStyle(.borderless)
@@ -120,6 +128,11 @@ struct OrderDetailView: View {
 }
 
 private extension OrderDetailView {
+    enum Tab: Int {
+        case summary
+        case products
+    }
+
     enum Layout {
         static let nameSectionSpacing = 2.0
         static let mainSectionsPadding = 10.0
@@ -133,7 +146,7 @@ private extension OrderDetailView {
             if count == 1 {
                 return AppLocalizedString(
                     "watch.orders.detail.product-count-singular",
-                    value: "%d Product",
+                    value: "1 Product",
                     comment: "Singular format for the number of products in the order detail screen."
                 )
             }

--- a/WooCommerce/Woo Watch App/Orders/OrderDetailView.swift
+++ b/WooCommerce/Woo Watch App/Orders/OrderDetailView.swift
@@ -4,7 +4,92 @@ import SwiftUI
 ///
 struct OrderDetailView: View {
     var body: some View {
-        Text("Order Detail")
+        ScrollView {
+            VStack(alignment: .leading) {
+
+                HStack {
+                    Text("25 Feb")
+                    Spacer()
+                    Text("12:14 pm")
+                }
+                .font(.caption2)
+                .foregroundStyle(.secondary)
+
+                Divider()
+
+                VStack(alignment: .leading, spacing: Layout.nameSectionSpacing) {
+                    Text("Willem Dafoe")
+                        .font(.title3)
+
+                    Text("$149.50")
+                        .font(.title2)
+                        .bold()
+
+                    Text("Pending payment")
+                        .font(.footnote)
+                        .foregroundStyle(Colors.gray5)
+                }
+                .padding(.bottom, Layout.mainSectionsPadding)
+
+                Text("3 products")
+                    .font(.caption2)
+                    .padding(.bottom, Layout.mainSectionsPadding)
+
+                VStack {
+                    itemRow()
+                    Divider()
+                    itemRow()
+                    Divider()
+                    itemRow()
+                }
+            }
+        }
+        .padding(.horizontal)
+        .toolbar {
+            ToolbarItem(placement: .confirmationAction) {
+                Text("#1031")
+                    .font(.body)
+                    .foregroundStyle(Colors.wooPurple20)
+            }
+        }
+        .background(
+            LinearGradient(gradient: Gradient(colors: [Colors.wooPurpleBackground, .black]), startPoint: .top, endPoint: .bottom)
+        )
+    }
+
+    @ViewBuilder private func itemRow() -> some View {
+        VStack(alignment: .leading, spacing: .zero) {
+            Text("Little Nap Blend 250g")
+                .font(.caption2)
+
+            HStack {
+                Text("$99.00")
+                    .font(.caption2)
+                    .foregroundStyle(.secondary)
+
+                Spacer()
+
+                Text("3")
+                    .font(.caption2)
+                    .foregroundStyle(Colors.wooPurple20)
+                    .padding(Layout.itemCountPadding)
+                    .background(Circle().fill(Colors.whiteTransparent))
+            }
+        }
     }
 }
 
+private extension OrderDetailView {
+    enum Layout {
+        static let nameSectionSpacing = 2.0
+        static let mainSectionsPadding = 10.0
+        static let itemCountPadding = 6.0
+    }
+
+    enum Colors {
+        static let wooPurpleBackground = Color(red: 79/255.0, green: 54/255.0, blue: 125/255.0)
+        static let gray5 = Color(red: 220/255.0, green: 220/255.0, blue: 222/255.0)
+        static let wooPurple20 = Color(red: 190/255.0, green: 160/255.0, blue: 242/255.0)
+        static let whiteTransparent = Color(white: 1.0, opacity: 0.12)
+    }
+}

--- a/WooCommerce/Woo Watch App/Orders/OrderDetailView.swift
+++ b/WooCommerce/Woo Watch App/Orders/OrderDetailView.swift
@@ -57,6 +57,7 @@ struct OrderDetailView: View {
             VStack(alignment: .leading, spacing: Layout.nameSectionSpacing) {
                 Text(order.name)
                     .font(.body)
+                    .fixedSize(horizontal: false, vertical: true)
 
                 Text(order.total)
                     .font(.title2)

--- a/WooCommerce/Woo Watch App/Orders/OrderDetailView.swift
+++ b/WooCommerce/Woo Watch App/Orders/OrderDetailView.swift
@@ -62,24 +62,26 @@ struct OrderDetailView: View {
     }
 
     @ViewBuilder private func itemRow(_ item: OrdersListView.OrderItem) -> some View {
-        VStack(alignment: .leading, spacing: .zero) {
-            Text(item.name)
-                .font(.caption2)
+        HStack(alignment: .top, spacing: Layout.itemRowSpacing) {
 
-            HStack {
+            Text(item.count.formatted(.number))
+                .font(.caption2)
+                .foregroundStyle(Colors.wooPurple20)
+                .padding(Layout.itemCountPadding)
+                .background(Circle().fill(Colors.whiteTransparent))
+
+            VStack(alignment: .leading) {
+                Text(item.name)
+                    .font(.caption2)
+
                 Text(item.total)
                     .font(.caption2)
                     .foregroundStyle(.secondary)
-
-                Spacer()
-
-                Text(item.count.formatted(.number))
-                    .font(.caption2)
-                    .foregroundStyle(Colors.wooPurple20)
-                    .padding(Layout.itemCountPadding)
-                    .background(Circle().fill(Colors.whiteTransparent))
             }
+
+            Spacer()
         }
+        .padding(.vertical)
     }
 }
 
@@ -88,6 +90,7 @@ private extension OrderDetailView {
         static let nameSectionSpacing = 2.0
         static let mainSectionsPadding = 10.0
         static let itemCountPadding = 6.0
+        static let itemRowSpacing = 8.0
     }
 
     enum Localization {

--- a/WooCommerce/Woo Watch App/Orders/OrdersListView.swift
+++ b/WooCommerce/Woo Watch App/Orders/OrdersListView.swift
@@ -88,7 +88,7 @@ struct OrdersListView: View {
             .listRowBackground(OrderListCard.background)
         }
         .navigationDestination(for: Order.self) { order in
-            OrderDetailView()
+            OrderDetailView(order: order)
         }
     }
 }

--- a/WooCommerce/Woo Watch App/Orders/OrdersListView.swift
+++ b/WooCommerce/Woo Watch App/Orders/OrdersListView.swift
@@ -51,10 +51,12 @@ struct OrdersListView: View {
     @ViewBuilder var loadingView: some View {
         List {
             OrderListCard(order: .init(date: "----",
+                                       time: "----",
                                        number: "----",
                                        name: "----- -----",
-                                       price: "----",
-                                       status: "------- ------"))
+                                       total: "----",
+                                       status: "------- ------",
+                                       items: []))
         }
         .redacted(reason: .placeholder)
     }
@@ -135,7 +137,7 @@ struct OrderListCard: View {
             Text(order.name)
                 .font(.body)
 
-            Text(order.price)
+            Text(order.total)
                 .font(.body)
                 .bold()
 

--- a/WooCommerce/Woo Watch App/Orders/OrdersListView.swift
+++ b/WooCommerce/Woo Watch App/Orders/OrdersListView.swift
@@ -16,7 +16,7 @@ struct OrdersListView: View {
     }
 
     var body: some View {
-        NavigationSplitView() {
+        NavigationStack() {
             Group {
                 switch viewModel.viewState {
                 case .idle:
@@ -40,8 +40,6 @@ struct OrdersListView: View {
                     }
                 }
             }
-        } detail: {
-            Text("Order Detail")
         }
         .task {
             await viewModel.fetchOrders()
@@ -81,8 +79,14 @@ struct OrdersListView: View {
     @ViewBuilder private func dataView(orders: [Order]) -> some View {
         List() {
             ForEach(orders, id: \.number) { order in
-                OrderListCard(order: order)
+                NavigationLink(value: order) {
+                    OrderListCard(order: order)
+                }
             }
+            .listRowBackground(OrderListCard.background)
+        }
+        .navigationDestination(for: Order.self) { order in
+            OrderDetailView()
         }
     }
 }
@@ -139,10 +143,12 @@ struct OrderListCard: View {
                 .font(.footnote)
                 .foregroundStyle(Colors.wooPurple20)
         }
-        .listRowBackground(
-            LinearGradient(gradient: Gradient(colors: [Colors.wooBackgroundStart, Colors.wooBackgroundEnd]), startPoint: .top, endPoint: .bottom)
-                .cornerRadius(10)
-        )
+        .listRowBackground(Self.background)
+    }
+
+    static var background: some View {
+        LinearGradient(gradient: Gradient(colors: [Colors.wooBackgroundStart, Colors.wooBackgroundEnd]), startPoint: .top, endPoint: .bottom)
+            .cornerRadius(10)
     }
 }
 

--- a/WooCommerce/Woo Watch App/Orders/OrdersListViewModel.swift
+++ b/WooCommerce/Woo Watch App/Orders/OrdersListViewModel.swift
@@ -36,13 +36,22 @@ final class OrdersListViewModel: ObservableObject {
     ///
     private static func viewOrders(from remoteOrders: [Order], currencySettings: CurrencySettings) -> [OrdersListView.Order] {
         remoteOrders.map { order in
-            // TODO: Provide real list of site statuses.
             let orderViewModel = OrderListCellViewModel(order: order, status: nil, currencySettings: currencySettings)
+
+            let items = order.items.map { orderItem in
+                OrdersListView.OrderItem(id: orderItem.itemID,
+                                         name: orderItem.total,
+                                         total: orderViewModel.total(for: orderItem),
+                                         count: orderItem.quantity)
+            }
+
             return OrdersListView.Order(date: orderViewModel.dateCreated,
+                                        time: orderViewModel.timeCreated,
                                         number: "#\(order.number)",
                                         name: orderViewModel.customerName,
-                                        price: orderViewModel.total ?? "$\(order.total)",
-                                        status: orderViewModel.statusString.capitalized)
+                                        total: orderViewModel.total ?? "$\(order.total)",
+                                        status: orderViewModel.statusString.capitalized,
+                                        items: items)
         }
     }
 }
@@ -60,18 +69,33 @@ extension OrdersListView {
         case error
     }
 
-    /// Represents an order item.
+    /// Represents an order.
     ///
     struct Order: Identifiable, Hashable {
         let date: String
+        let time: String
         let number: String
         let name: String
-        let price: String
+        let total: String
         let status: String
+        let items: [OrderItem]
 
         // SwiftUI ID
         var id: String {
             number
         }
+
+        var itemCount: Int {
+            items.count
+        }
+    }
+
+    /// Represents an order item.
+    ///
+    struct OrderItem: Identifiable, Hashable {
+        let id: Int64
+        let name: String
+        let total: String
+        let count: Decimal
     }
 }

--- a/WooCommerce/Woo Watch App/Orders/OrdersListViewModel.swift
+++ b/WooCommerce/Woo Watch App/Orders/OrdersListViewModel.swift
@@ -38,11 +38,12 @@ final class OrdersListViewModel: ObservableObject {
         remoteOrders.map { order in
             let orderViewModel = OrderListCellViewModel(order: order, status: nil, currencySettings: currencySettings)
 
-            let items = order.items.map { orderItem in
+            let items = order.items.enumerated().map { index, orderItem in
                 OrdersListView.OrderItem(id: orderItem.itemID,
                                          name: orderItem.name,
                                          total: orderViewModel.total(for: orderItem),
-                                         count: orderItem.quantity)
+                                         count: orderItem.quantity,
+                                         showDivider: index < (order.items.count - 1) )
             }
 
             return OrdersListView.Order(date: orderViewModel.dateCreated,
@@ -97,5 +98,6 @@ extension OrdersListView {
         let name: String
         let total: String
         let count: Decimal
+        let showDivider: Bool
     }
 }

--- a/WooCommerce/Woo Watch App/Orders/OrdersListViewModel.swift
+++ b/WooCommerce/Woo Watch App/Orders/OrdersListViewModel.swift
@@ -40,7 +40,7 @@ final class OrdersListViewModel: ObservableObject {
 
             let items = order.items.map { orderItem in
                 OrdersListView.OrderItem(id: orderItem.itemID,
-                                         name: orderItem.total,
+                                         name: orderItem.name,
                                          total: orderViewModel.total(for: orderItem),
                                          count: orderItem.quantity)
             }

--- a/WooCommerce/Woo Watch App/Orders/OrdersListViewModel.swift
+++ b/WooCommerce/Woo Watch App/Orders/OrdersListViewModel.swift
@@ -62,11 +62,16 @@ extension OrdersListView {
 
     /// Represents an order item.
     ///
-    struct Order {
+    struct Order: Identifiable, Hashable {
         let date: String
         let number: String
         let name: String
         let price: String
         let status: String
+
+        // SwiftUI ID
+        var id: String {
+            number
+        }
     }
 }

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -970,6 +970,7 @@
 		26CA47202BFD823200E54348 /* Date+Woo.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5290ED8219B3FA900A6AF7F /* Date+Woo.swift */; };
 		26CA47212BFD82AE00E54348 /* DateFormatter+Helpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE4DDB7A20DD312400D32EC8 /* DateFormatter+Helpers.swift */; };
 		26CA47222BFD82B900E54348 /* TimeZone+Woo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 453227B623C4D6EC00D816B3 /* TimeZone+Woo.swift */; };
+		26CA47242BFE4C1C00E54348 /* OrderDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26CA47232BFE4C1B00E54348 /* OrderDetailView.swift */; };
 		26CCBE0B2523B3650073F94D /* RefundProductsTotalTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26CCBE0A2523B3650073F94D /* RefundProductsTotalTableViewCell.swift */; };
 		26CCBE0D2523C2560073F94D /* RefundProductsTotalTableViewCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = 26CCBE0C2523C2560073F94D /* RefundProductsTotalTableViewCell.xib */; };
 		26CE6F342B7D4C27008DB858 /* Error+Timeout.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26CE6F332B7D4C27008DB858 /* Error+Timeout.swift */; };
@@ -3789,6 +3790,7 @@
 		26C98F9729C1246F00F96503 /* WPComSitePlan+FreeTrial.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "WPComSitePlan+FreeTrial.swift"; sourceTree = "<group>"; };
 		26C98F9A29C18ACE00F96503 /* StorePlanBanner.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StorePlanBanner.swift; sourceTree = "<group>"; };
 		26CA2BC52AAA1773003B16C2 /* OrderNotificationView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OrderNotificationView.swift; sourceTree = "<group>"; };
+		26CA47232BFE4C1B00E54348 /* OrderDetailView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OrderDetailView.swift; sourceTree = "<group>"; };
 		26CCBE0A2523B3650073F94D /* RefundProductsTotalTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RefundProductsTotalTableViewCell.swift; sourceTree = "<group>"; };
 		26CCBE0C2523C2560073F94D /* RefundProductsTotalTableViewCell.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = RefundProductsTotalTableViewCell.xib; sourceTree = "<group>"; };
 		26CE6F332B7D4C27008DB858 /* Error+Timeout.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Error+Timeout.swift"; sourceTree = "<group>"; };
@@ -7644,6 +7646,7 @@
 				26A0B2D62BFBA536002E9620 /* OrdersListView.swift */,
 				26373E2D2BFD2F46008E6735 /* OrdersListViewModel.swift */,
 				26373E2B2BFD13E0008E6735 /* OrdersDataService.swift */,
+				26CA47232BFE4C1B00E54348 /* OrderDetailView.swift */,
 			);
 			path = Orders;
 			sourceTree = "<group>";
@@ -13651,6 +13654,7 @@
 				26373E2C2BFD13E0008E6735 /* OrdersDataService.swift in Sources */,
 				26FFC50C2BED7C5A0067B3A4 /* WatchDependencies.swift in Sources */,
 				26CA471F2BFD81E900E54348 /* String+Helpers.swift in Sources */,
+				26CA47242BFE4C1C00E54348 /* OrderDetailView.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};


### PR DESCRIPTION
Closes: #12501

# Why

This PR adds the order detail view. Tt includes the Summary & Products section. The customer section will come in the next PR. 

# How

- Created a new `OrderDetailView`
- Update the `OrderListView.Order` type to include all relevant information
- Update UI according to latest designs

# Demo

https://github.com/woocommerce/woocommerce-ios/assets/562080/b7540f8a-50d9-4312-8557-d664864733c5


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
