### PR TITLE
[Order Details] Display multiple shipping lines in order details

### DIFF
--- a/Experiments/Experiments/DefaultFeatureFlagService.swift
+++ b/Experiments/Experiments/DefaultFeatureFlagService.swift
@@ -94,6 +94,8 @@ public struct DefaultFeatureFlagService: FeatureFlagService {
             return buildConfig == .localDeveloper || buildConfig == .alpha
         case .dynamicDashboardM2:
             return buildConfig == .localDeveloper || buildConfig == .alpha
+        case .multipleShippingLines:
+            return buildConfig == .localDeveloper || buildConfig == .alpha
         default:
             return true
         }

--- a/Experiments/Experiments/FeatureFlag.swift
+++ b/Experiments/Experiments/FeatureFlag.swift
@@ -207,4 +207,8 @@ public enum FeatureFlag: Int {
     /// Enables new dashboard cards on the My Store screen.
     ///
     case dynamicDashboardM2
+
+    /// Enables multiple shipping lines in order details and order creation/editing.
+    ///
+    case multipleShippingLines
 }

--- a/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsDataSource.swift
+++ b/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsDataSource.swift
@@ -1,4 +1,5 @@
 import Foundation
+import SwiftUI
 import UIKit
 import Yosemite
 import Experiments
@@ -475,7 +476,7 @@ private extension OrderDetailsDataSource {
             configureAttributionSessionPageViews(cell: cell, at: indexPath)
         case let cell as WooBasicTableViewCell where row == .trashOrder:
             configureTrashOrder(cell: cell, at: indexPath)
-        case let cell as TitleAndSubtitleAndValueCardTableViewCell where row == .shippingLine:
+        case let cell as HostingConfigurationTableViewCell<ShippingLineRowView> where row == .shippingLine:
             configureShippingLine(cell: cell, at: indexPath)
         default:
             fatalError("Unidentified customer info row type")
@@ -1007,12 +1008,20 @@ private extension OrderDetailsDataSource {
         cell.selectionStyle = .none
     }
 
-    private func configureShippingLine(cell: TitleAndSubtitleAndValueCardTableViewCell, at indexPath: IndexPath) {
+    private func configureShippingLine(cell: HostingConfigurationTableViewCell<ShippingLineRowView>, at indexPath: IndexPath) {
         let shippingLine = shippingLines[indexPath.row]
         let shippingTotal = currencyFormatter.formatAmount(shippingLine.total) ?? shippingLine.total
         // TODO-12582: Update subtitle with method name (from method ID)
-        cell.configure(title: shippingLine.methodTitle, subtitle: shippingLine.methodTitle, value: shippingTotal)
+        let view = ShippingLineRowView(shippingTitle: shippingLine.methodTitle,
+                                       shippingMethod: shippingLine.methodTitle,
+                                       shippingAmount: shippingTotal,
+                                       editable: false)
+        let topMargin = indexPath.row == 0 ? Constants.cellDefaultMargin : 0 // Reduce cell padding between rows
+        let insets = UIEdgeInsets(top: topMargin, left: Constants.cellDefaultMargin, bottom: Constants.cellDefaultMargin, right: Constants.cellDefaultMargin)
+        cell.host(view, insets: insets)
+        cell.hideSeparator()
         cell.selectionStyle = .none
+
     }
 
     private func configureSummary(cell: SummaryTableViewCell) {
@@ -1987,7 +1996,7 @@ extension OrderDetailsDataSource {
             case .trashOrder:
                 return WooBasicTableViewCell.reuseIdentifier
             case .shippingLine:
-                return TitleAndSubtitleAndValueCardTableViewCell.reuseIdentifier
+                return HostingConfigurationTableViewCell<ShippingLineRowView>.reuseIdentifier
             }
         }
     }
@@ -2011,5 +2020,6 @@ extension OrderDetailsDataSource {
         static let addOrderCell = 1
         static let paymentCell = 1
         static let paidByCustomerCell = 1
+        static let cellDefaultMargin: CGFloat = 16
     }
 }

--- a/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsDataSource.swift
+++ b/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsDataSource.swift
@@ -1016,7 +1016,7 @@ private extension OrderDetailsDataSource {
 
     private func configureShippingLine(cell: HostingConfigurationTableViewCell<ShippingLineRowView>, at indexPath: IndexPath) {
         let shippingLine = shippingLines[indexPath.row]
-        let shippingMethod = siteShippingMethods.first(where: { $0.methodID == shippingLine.methodID })?.title ?? ""
+        let shippingMethod = siteShippingMethods.first(where: { $0.methodID == shippingLine.methodID })?.title
         let shippingTotal = currencyFormatter.formatAmount(shippingLine.total) ?? shippingLine.total
 
         let view = ShippingLineRowView(shippingTitle: shippingLine.methodTitle,

--- a/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsDataSource.swift
+++ b/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsDataSource.swift
@@ -1140,7 +1140,9 @@ extension OrderDetailsDataSource {
         let shippingNotice: Section? = {
             // Hide the shipping method warning if order contains only virtual products
             // or if the order contains only one shipping method
-            if isMultiShippingLinesAvailable(for: order) == false {
+            // or if multiple shipping lines are supported (feature flag)
+            if isMultiShippingLinesAvailable(for: order) == false ||
+                featureFlags.isFeatureFlagEnabled(.multipleShippingLines) {
                 return nil
             }
 

--- a/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsDataSource.swift
+++ b/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsDataSource.swift
@@ -166,6 +166,12 @@ final class OrderDetailsDataSource: NSObject {
         resultsControllers.addOnGroups
     }
 
+    /// Shipping Methods list
+    ///
+    var siteShippingMethods: [ShippingMethod] {
+        resultsControllers.siteShippingMethods
+    }
+
     /// Shipping Labels for an Order
     ///
     private(set) var shippingLabels: [ShippingLabel] = []
@@ -1010,10 +1016,11 @@ private extension OrderDetailsDataSource {
 
     private func configureShippingLine(cell: HostingConfigurationTableViewCell<ShippingLineRowView>, at indexPath: IndexPath) {
         let shippingLine = shippingLines[indexPath.row]
+        let shippingMethod = siteShippingMethods.first(where: { $0.methodID == shippingLine.methodID })?.title ?? ""
         let shippingTotal = currencyFormatter.formatAmount(shippingLine.total) ?? shippingLine.total
-        // TODO-12582: Update subtitle with method name (from method ID)
+
         let view = ShippingLineRowView(shippingTitle: shippingLine.methodTitle,
-                                       shippingMethod: shippingLine.methodTitle,
+                                       shippingMethod: shippingMethod,
                                        shippingAmount: shippingTotal,
                                        editable: false)
         let topMargin = indexPath.row == 0 ? Constants.cellDefaultMargin : 0 // Reduce cell padding between rows

--- a/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsViewModel.swift
+++ b/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsViewModel.swift
@@ -360,7 +360,7 @@ extension OrderDetailsViewModel {
     /// Registers all of the available TableViewCells
     ///
     func registerTableViewCells(_ tableView: UITableView) {
-        let cells = [
+        let cellsWithNib = [
             LargeHeightLeftImageTableViewCell.self,
             LeftImageTableViewCell.self,
             CustomerNoteTableViewCell.self,
@@ -381,8 +381,16 @@ extension OrderDetailsViewModel {
             TitleAndValueTableViewCell.self
         ]
 
-        for cellClass in cells {
+        let cellsWithoutNib = [
+            TitleAndSubtitleAndValueCardTableViewCell.self
+        ]
+
+        for cellClass in cellsWithNib {
             tableView.registerNib(for: cellClass)
+        }
+
+        for cellClass in cellsWithoutNib {
+            tableView.register(cellClass)
         }
     }
 

--- a/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsViewModel.swift
+++ b/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsViewModel.swift
@@ -382,7 +382,7 @@ extension OrderDetailsViewModel {
         ]
 
         let cellsWithoutNib = [
-            TitleAndSubtitleAndValueCardTableViewCell.self
+            HostingConfigurationTableViewCell<ShippingLineRowView>.self
         ]
 
         for cellClass in cellsWithNib {

--- a/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsViewModel.swift
+++ b/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsViewModel.swift
@@ -281,6 +281,12 @@ extension OrderDetailsViewModel {
             group.leave()
         }
 
+        group.enter()
+        syncShippingMethods { _ in
+            onReloadSections?()
+            group.leave()
+        }
+
         group.notify(queue: .main) { [weak self] in
 
             /// Update state to synced
@@ -693,6 +699,19 @@ extension OrderDetailsViewModel {
             }
             self.stores.dispatch(action)
         }
+    }
+
+    func syncShippingMethods(onCompletion: ((Error?) -> ())? = nil) {
+        let action = ShippingMethodAction.synchronizeShippingMethods(siteID: order.siteID) { result in
+            switch result {
+            case .success:
+                onCompletion?(nil)
+            case let .failure(error):
+                DDLogError("⛔️ Error synchronizing shipping methods: \(error)")
+                onCompletion?(error)
+            }
+        }
+        stores.dispatch(action)
     }
 
     @MainActor

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/Shipping/ShippingLineRowView.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/Shipping/ShippingLineRowView.swift
@@ -10,7 +10,7 @@ struct ShippingLineRowView: View {
     let shippingTitle: String
 
     /// Name of the shipping method for the shipping line
-    let shippingMethod: String
+    let shippingMethod: String?
 
     /// Amount for the shipping line
     let shippingAmount: String
@@ -30,8 +30,10 @@ struct ShippingLineRowView: View {
                 // Avoids the shipping line name to be truncated when it's long enough
                     .fixedSize(horizontal: false, vertical: true)
 
-                Text(shippingMethod)
-                    .subheadlineStyle()
+                if let shippingMethod {
+                    Text(shippingMethod)
+                        .subheadlineStyle()
+                }
             }
 
             Spacer()

--- a/WooCommerce/Classes/ViewRelated/ReusableViews/HostingTableViewCell.swift
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/HostingTableViewCell.swift
@@ -51,3 +51,40 @@ private extension HostingTableViewCell {
         configureDefaultBackgroundConfiguration()
     }
 }
+
+/// Use this cell to host a SwiftUI view into a `UITableViewCell` so it can be displayed in a `UITableView` instance
+///
+/// This cell can be used when the parent view controller is not available in the current context
+///
+class HostingConfigurationTableViewCell<Content: View>: UITableViewCell {
+    func host(_ view: Content, insets: UIEdgeInsets? = nil) {
+        var hostingConfiguration = UIHostingConfiguration {
+            view
+        }
+
+        // Override default hosting cell padding with custom insets
+        if let insets {
+            hostingConfiguration = hostingConfiguration
+                .margins(.top, insets.top)
+                .margins(.bottom, insets.bottom)
+                .margins(.leading, insets.left)
+                .margins(.trailing, insets.right)
+        }
+
+        self.contentConfiguration = hostingConfiguration
+    }
+
+    override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
+        super.init(style: style, reuseIdentifier: reuseIdentifier)
+        configureDefaultBackgroundConfiguration()
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    override func updateConfiguration(using state: UICellConfigurationState) {
+        super.updateConfiguration(using: state)
+        updateDefaultBackgroundConfiguration(using: state)
+    }
+}

--- a/WooCommerce/WooCommerceTests/Mocks/MockFeatureFlagService.swift
+++ b/WooCommerce/WooCommerceTests/Mocks/MockFeatureFlagService.swift
@@ -23,6 +23,7 @@ struct MockFeatureFlagService: FeatureFlagService {
     private let sideBySideViewForOrderForm: Bool
     private let isCustomersInHubMenuEnabled: Bool
     private let isSubscriptionsInOrderCreationCustomersEnabled: Bool
+    private let isMultipleShippingLinesEnabled: Bool
 
     init(isInboxOn: Bool = false,
          isUpdateOrderOptimisticallyOn: Bool = false,
@@ -44,7 +45,8 @@ struct MockFeatureFlagService: FeatureFlagService {
          isBackendReceiptsEnabled: Bool = false,
          sideBySideViewForOrderForm: Bool = false,
          isCustomersInHubMenuEnabled: Bool = false,
-         isSubscriptionsInOrderCreationCustomersEnabled: Bool = false) {
+         isSubscriptionsInOrderCreationCustomersEnabled: Bool = false,
+         isMultipleShippingLinesEnabled: Bool = false) {
         self.isInboxOn = isInboxOn
         self.isUpdateOrderOptimisticallyOn = isUpdateOrderOptimisticallyOn
         self.shippingLabelsOnboardingM1 = shippingLabelsOnboardingM1
@@ -66,6 +68,7 @@ struct MockFeatureFlagService: FeatureFlagService {
         self.sideBySideViewForOrderForm = sideBySideViewForOrderForm
         self.isCustomersInHubMenuEnabled = isCustomersInHubMenuEnabled
         self.isSubscriptionsInOrderCreationCustomersEnabled = isSubscriptionsInOrderCreationCustomersEnabled
+        self.isMultipleShippingLinesEnabled = isMultipleShippingLinesEnabled
     }
 
     func isFeatureFlagEnabled(_ featureFlag: FeatureFlag) -> Bool {
@@ -110,6 +113,8 @@ struct MockFeatureFlagService: FeatureFlagService {
             return isCustomersInHubMenuEnabled
         case .subscriptionsInOrderCreationCustomers:
             return isSubscriptionsInOrderCreationCustomersEnabled
+        case .multipleShippingLines:
+            return isMultipleShippingLinesEnabled
         default:
             return false
         }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Details/OrderDetailsDataSourceTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Details/OrderDetailsDataSourceTests.swift
@@ -31,7 +31,7 @@ final class OrderDetailsDataSourceTests: XCTestCase {
         super.tearDown()
     }
 
-    func test_payment_section_is_shown_right_after_the_products_custom_amounts_and_refunded_products_sections() {
+    func test_payment_section_is_shown_right_after_the_products_custom_amounts_refunded_products_and_shipping_sections() {
         // Given
         let order = makeOrder()
 
@@ -41,7 +41,8 @@ final class OrderDetailsDataSourceTests: XCTestCase {
         let dataSource = OrderDetailsDataSource(
             order: order,
             storageManager: storageManager,
-            cardPresentPaymentsConfiguration: Mocks.configuration
+            cardPresentPaymentsConfiguration: Mocks.configuration,
+            featureFlags: MockFeatureFlagService(isMultipleShippingLinesEnabled: true)
         )
 
         dataSource.configureResultsControllers { }
@@ -55,6 +56,7 @@ final class OrderDetailsDataSourceTests: XCTestCase {
             Title.products,
             Title.customAmounts,
             Title.refundedProducts,
+            Title.shippingLines,
             Title.payment,
             Title.information,
             Title.orderAttribution,
@@ -856,6 +858,36 @@ final class OrderDetailsDataSourceTests: XCTestCase {
         // Then
         let attributionSection = try section(withTitle: Title.orderAttribution, from: dataSource)
         let row = row(row: .attributionSessionPageViews, in: attributionSection)
+        XCTAssertNotNil(row)
+    }
+
+    func test_shipping_section_hidden_when_order_has_no_shipping_lines() {
+        // Given
+        let order = Order.fake()
+        let dataSource = OrderDetailsDataSource(order: order, storageManager: storageManager, cardPresentPaymentsConfiguration: Mocks.configuration)
+
+        // When
+        dataSource.reloadSections()
+
+        // Then
+        let shippingSection = section(withCategory: .shippingLines, from: dataSource)
+        XCTAssertNil(shippingSection)
+    }
+
+    func test_shipping_section_shows_shipping_line_row_when_order_has_shipping_line() throws {
+        // Given
+        let order = Order.fake().copy(shippingLines: [.fake()])
+        let dataSource = OrderDetailsDataSource(order: order,
+                                                storageManager: storageManager,
+                                                cardPresentPaymentsConfiguration: Mocks.configuration,
+                                                featureFlags: MockFeatureFlagService(isMultipleShippingLinesEnabled: true))
+
+        // When
+        dataSource.reloadSections()
+
+        // Then
+        let shippingSection = try section(withTitle: Title.shippingLines, from: dataSource)
+        let row = row(row: .shippingLine, in: shippingSection)
         XCTAssertNotNil(row)
     }
 }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #12582
⚠️ Based on https://github.com/woocommerce/woocommerce-ios/pull/12822 ⚠️ 
<!-- Id number of the GitHub issue this PR addresses. -->

## Why
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This adds support (behind a feature flag) for showing multiple shipping lines in order details.

Previously, we only supported showing the first shipping line on an order. Now, we show a Shipping section with all the shipping lines on an order.

## How

* Adds a new feature flag for multiple shipping lines support.
* Adds a `HostingConfigurationTableViewCell<Content: View>` view that wraps a SwiftUI view in a `UITableViewCell`. This uses a `UIHostingConfiguration` instead of `UIHostingController`; it can be used when `HostingTableViewCell<Content: View>` can't be used because the parent view isn't available in the current context.
* Adds the new shipping section:
   * Adds the new section and row to `OrderDetailsDataSource`, and configures each row based on the corresponding shipping line on the order.
   * Updates `OrderDetailsResultsControllers` to include a shipping methods ResultsController, to fetch the list of shipping methods for the store. This allows us to get the name of the shipping method corresponding to each shipping line on the order.
   * Updates `OrderDetailsViewModel` to register the new cell and sync the shipping methods for the store (in case they haven't been synced before).

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

With the feature flag disabled:

1. Build and run the app.
2. Open an order with multiple shipping lines.
3. Confirm the shipping line notice appears and the shipping method for a single shipping line is shown in the Customer section.

With the feature flag enabled:

1. Build and run the app.
2. Open an order with multiple shipping lines.
3. Confirm the shipping line notice does NOT appear and a shipping section appears with all shipping lines on the order.

Bonus:

* Repeat the steps above for an order with a single shipping line.
* Repeat the steps above for an order without shipping lines, and confirm no shipping section appears.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->
Before|After
-|-
![Simulator Screenshot - iPhone 15 Plus - 2024-05-20 at 17 21 47](https://github.com/woocommerce/woocommerce-ios/assets/8658164/d7269920-c714-4cee-9cfe-51fcc245fa83)|![Simulator Screenshot - iPhone 15 Plus - 2024-05-23 at 16 42 32](https://github.com/woocommerce/woocommerce-ios/assets/8658164/90cd8852-c428-4887-bdd4-d149d6c669fd)

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
