### PR TITLE
[Watch] Add Customer Section on Order Details

### DIFF
--- a/WooCommerce/Classes/Model/Address+Woo.swift
+++ b/WooCommerce/Classes/Model/Address+Woo.swift
@@ -38,8 +38,8 @@ extension Address {
         return output.joined(separator: "\n")
     }
 
-#if !os(watchOS)
-    /// Returns the Postal Address, formated and ready for display.
+
+    /// Returns the Postal Address, formatted and ready for display.
     ///
     var formattedPostalAddress: String? {
         return postalAddress.formatted(as: .mailingAddress)
@@ -92,6 +92,7 @@ extension Address {
         self == .empty
     }
 
+#if !os(watchOS)
     /// Erases the address components that are also part of a Tax Rate. Call this if you want to unlink an address from a tax rate.
     ///
     func resettingTaxRateComponents() -> Address {
@@ -124,7 +125,7 @@ extension Address {
 #endif
 }
 
-#if !os(watchOS)
+
 // MARK: - Private Methods
 //
 private extension Address {
@@ -159,6 +160,7 @@ private extension Address {
 
 
     func refineAddressState() -> Address {
+#if !os(watchOS)
         // https://github.com/woocommerce/woocommerce-ios/issues/5851
         // The backend gives us the state code in the state field.
         // For these countries we should show the state name instead, as the code is not identifiable (e.g. JP01 -> Hokkaido)
@@ -168,6 +170,10 @@ private extension Address {
         }
 
         return copy(state: stateName)
+#else
+        // Watch app does not have a local storage of countries.
+        // In this case we don't apply any special treatment
+        return self
+#endif
     }
 }
-#endif

--- a/WooCommerce/Woo Watch App/Orders/OrderDetailView.swift
+++ b/WooCommerce/Woo Watch App/Orders/OrderDetailView.swift
@@ -24,6 +24,10 @@ struct OrderDetailView: View {
                 productsView
                     .tag(Tab.products)
             }
+
+            // Third
+            customerView
+                .tag(Tab.customer)
         }
         .toolbar {
             ToolbarItem(placement: .confirmationAction) {
@@ -137,31 +141,35 @@ struct OrderDetailView: View {
 
     /// Third View Customer & Address section
     ///
-    @ViewBuilder private var customerView: some View  {
+    @ViewBuilder private var customerView: some View {
         List {
             Section {
-                // name
-                Text(order.name)
-                    .font(.body)
+                VStack(alignment: .leading, spacing: Layout.nameSectionSpacing) {
+                    // name
+                    Text(order.name)
+                        .font(.body)
 
-                // Email if exists
-                Text("willemdafoe@gmail.com")
-                    .font(.footnote)
-                    .foregroundStyle(.secondary)
+                    // Email if exists
+                    if order.email.isNotEmpty {
+                        Text(order.email)
+                            .font(.footnote)
+                            .foregroundStyle(.secondary)
+                    }
 
-                Divider()
+                    Divider()
+                        .padding(.top, Layout.customerDividerPadding)
+                }
 
                 // Address
-                Text("Address")
+                Text(order.address)
                     .font(.caption2)
-
             } header: {
                 Text(Localization.customer)
                     .font(.caption2)
+                    .padding(.bottom)
             }
             .listStyle(.plain)
             .listRowBackground(Color.clear)
-            .listRowInsets(.init(top: 0, leading: Layout.itemlistPadding, bottom: 0, trailing: Layout.itemlistPadding))
         }
     }
 }
@@ -170,10 +178,12 @@ private extension OrderDetailView {
     enum Tab: Int {
         case summary
         case products
+        case customer
     }
 
     enum Layout {
         static let nameSectionSpacing = 2.0
+        static let customerDividerPadding = 6.0
         static let mainSectionsPadding = 10.0
         static let itemCountPadding = 6.0
         static let itemRowSpacing = 8.0

--- a/WooCommerce/Woo Watch App/Orders/OrderDetailView.swift
+++ b/WooCommerce/Woo Watch App/Orders/OrderDetailView.swift
@@ -134,6 +134,36 @@ struct OrderDetailView: View {
             }
         }
     }
+
+    /// Third View Customer & Address section
+    ///
+    @ViewBuilder private var customerView: some View  {
+        List {
+            Section {
+                // name
+                Text(order.name)
+                    .font(.body)
+
+                // Email if exists
+                Text("willemdafoe@gmail.com")
+                    .font(.footnote)
+                    .foregroundStyle(.secondary)
+
+                Divider()
+
+                // Address
+                Text("Address")
+                    .font(.caption2)
+
+            } header: {
+                Text(Localization.customer)
+                    .font(.caption2)
+            }
+            .listStyle(.plain)
+            .listRowBackground(Color.clear)
+            .listRowInsets(.init(top: 0, leading: Layout.itemlistPadding, bottom: 0, trailing: Layout.itemlistPadding))
+        }
+    }
 }
 
 private extension OrderDetailView {
@@ -168,6 +198,12 @@ private extension OrderDetailView {
             )
             return LocalizedString(format: format, count)
         }
+
+        static let customer = AppLocalizedString(
+            "watch.orders.detail.customer",
+            value: "Customer",
+            comment: "Customer title in the order detail screen."
+        )
     }
 
     enum Colors {

--- a/WooCommerce/Woo Watch App/Orders/OrdersListView.swift
+++ b/WooCommerce/Woo Watch App/Orders/OrdersListView.swift
@@ -56,6 +56,8 @@ struct OrdersListView: View {
                                        name: "----- -----",
                                        total: "----",
                                        status: "------- ------",
+                                       email: "-----",
+                                       address: "-----",
                                        items: []))
         }
         .redacted(reason: .placeholder)

--- a/WooCommerce/Woo Watch App/Orders/OrdersListViewModel.swift
+++ b/WooCommerce/Woo Watch App/Orders/OrdersListViewModel.swift
@@ -52,6 +52,8 @@ final class OrdersListViewModel: ObservableObject {
                                         name: orderViewModel.customerName,
                                         total: orderViewModel.total ?? "$\(order.total)",
                                         status: orderViewModel.statusString.capitalized,
+                                        email: order.billingAddress?.email ?? "",
+                                        address: order.shippingAddress?.formattedPostalAddress ?? "",
                                         items: items)
         }
     }
@@ -79,6 +81,8 @@ extension OrdersListView {
         let name: String
         let total: String
         let status: String
+        let email: String
+        let address: String
         let items: [OrderItem]
 
         // SwiftUI ID

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -3769,6 +3769,7 @@
 		26AC0DD82941081500859074 /* AnalyticsHubCustomRangeData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnalyticsHubCustomRangeData.swift; sourceTree = "<group>"; };
 		26AE31AF251E602D004B1BCE /* RefundShippingDetailsTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RefundShippingDetailsTableViewCell.swift; sourceTree = "<group>"; };
 		26AE31B1251E604A004B1BCE /* RefundShippingDetailsTableViewCell.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = RefundShippingDetailsTableViewCell.xib; sourceTree = "<group>"; };
+		26B0FDE12BFFBAC500A0D937 /* Contacts.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Contacts.framework; path = Platforms/WatchOS.platform/Developer/SDKs/WatchOS10.0.sdk/System/Library/Frameworks/Contacts.framework; sourceTree = DEVELOPER_DIR; };
 		26B119B824D0B38F00FED5C7 /* SurveyViewController.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = SurveyViewController.xib; sourceTree = "<group>"; };
 		26B119BA24D0B62E00FED5C7 /* SurveyViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SurveyViewController.swift; sourceTree = "<group>"; };
 		26B119BF24D0C69500FED5C7 /* SurveyViewControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SurveyViewControllerTests.swift; sourceTree = "<group>"; };
@@ -9180,6 +9181,7 @@
 		88A44ABE866401E6DB03AC60 /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
+				26B0FDE12BFFBAC500A0D937 /* Contacts.framework */,
 				269FFA452BF40768004E6B86 /* WooFoundationWatchOS.framework */,
 				263E641F2BEB419B0059D84B /* NetworkingWatchOS.framework */,
 				200B84AD2BEB99AC00EAAB23 /* WooCommercePOS.framework */,


### PR DESCRIPTION
Closes: #12501 

# Why

This PR adds the Customer & Address Section to the Order Detail View

# Screenshot

![Simulator Screenshot - Apple Watch Series 9 (45mm) - 2024-05-23 at 14 46 20](https://github.com/woocommerce/woocommerce-ios/assets/562080/c2ee13b9-327c-460c-96a7-f09e8f60e738)


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
