### PR TITLE
Dynamic Dashboard: Fix issue displaying initial cards upon login

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Dashboard/DashboardViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/DashboardViewModel.swift
@@ -467,9 +467,14 @@ private extension DashboardViewModel {
             }
         }
 
-        // Reorder dashboardCards based on original ordering in savedCards
-        dashboardCards = savedCards.compactMap { savedCard in
-            updatedCards.first(where: { $0.type == savedCard.type })
+        /// If no saved cards are found, display the default cards.
+        if savedCards.isEmpty {
+            dashboardCards = updatedCards
+        } else {
+            // Reorder dashboardCards based on original ordering in savedCards
+            dashboardCards = savedCards.compactMap { savedCard in
+                updatedCards.first(where: { $0.type == savedCard.type })
+            }
         }
     }
 


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of #12743 
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
In #12811 - a faulty logic causes the dashboard card list to be empty when there are not initially saved cards in storage. This PR fixes that by checking for the saved cards before setting the value for dashboard card list.

Due to the complexity of injecting values for testing Blaze cards and other network requests and the tight time before code freeze of 18.8, unit tests for dashboard cards will be added in a separate PR.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
- Log out of the app and log back in to a store.
- Confirm that the dashboard screen displays the default cards:
  - If the store has not completed onboarding tasks, the Store setup card should be present.
  - If the store has at least one order, Performance and Top Performer cards should be present. Otherwise, share store card is present in place of these two.
  - If the store is eligible for Blaze, the Blaze card should be present.
 

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->
<img src="https://github.com/woocommerce/woocommerce-ios/assets/5533851/5cd114ad-675c-4b55-985a-f492567b4e98" width=320 />


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
