### PR TITLE
Update outdated internal references after legacy API deprecation

### DIFF
--- a/Networking/Networking/Settings/WooAPIVersion.swift
+++ b/Networking/Networking/Settings/WooAPIVersion.swift
@@ -25,8 +25,7 @@ public enum WooAPIVersion: String {
     ///
     case mark4 = "wc/v4"
 
-    /// WooCommerce Analytics from the WooCommerce Admin plugin.
-    /// Only works for WC Admin v0.22 and up.
+    /// WooCommerce Analytics.
     ///
     case wcAnalytics = "wc-analytics"
 

--- a/WooFoundation/WooFoundation/Currency/CurrencySettings.swift
+++ b/WooFoundation/WooFoundation/Currency/CurrencySettings.swift
@@ -64,7 +64,7 @@ public class CurrencySettings: Codable {
     ///
     public func symbol(from code: CurrencyCode) -> String {
         // Currency codes pulled from WC:
-        // https://woocommerce.com/wc-apidocs/source-function-get_woocommerce_currency.html#473
+        // https://woocommerce.github.io/code-reference/files/woocommerce-includes-wc-core-functions.html#source-view.662
         switch code {
         case .AED:
             return "\u{62f}.\u{625}"


### PR DESCRIPTION
This PR just updates some internal references to either outdated legacy API or WC Admin before was merged into core. No code has been changed.

Context: peaMlT-EU-p2