### PR TITLE
[Hub Menu] Clean up feature flag for Customers in Hub menu

### DIFF
--- a/Experiments/Experiments/DefaultFeatureFlagService.swift
+++ b/Experiments/Experiments/DefaultFeatureFlagService.swift
@@ -82,8 +82,6 @@ public struct DefaultFeatureFlagService: FeatureFlagService {
             return true
         case .splitViewInProductsTab:
             return true
-        case .customersInHubMenu:
-            return true
         case .subscriptionsInOrderCreationUI:
             return buildConfig == .localDeveloper || buildConfig == .alpha
         case .subscriptionsInOrderCreationCustomers:

--- a/Experiments/Experiments/FeatureFlag.swift
+++ b/Experiments/Experiments/FeatureFlag.swift
@@ -184,10 +184,6 @@ public enum FeatureFlag: Int {
     ///
     case splitViewInProductsTab
 
-    /// Displays a Customers section in the Hub menu.
-    ///
-    case customersInHubMenu
-
     /// Enables visibility of Subscription product details when creating an order, within product selection, and order details.
     ///
     case subscriptionsInOrderCreationUI

--- a/WooCommerce/Classes/ViewRelated/Hub Menu/HubMenuViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Hub Menu/HubMenuViewModel.swift
@@ -202,9 +202,7 @@ final class HubMenuViewModel: ObservableObject {
             generalElements.removeAll(where: { $0.id == Blaze.id })
         }
 
-        if featureFlagService.isFeatureFlagEnabled(.customersInHubMenu) {
-            generalElements.append(Customers())
-        }
+        generalElements.append(Customers())
     }
 
     func showReviewDetails(using parcel: ProductReviewFromNoteParcel) {

--- a/WooCommerce/WooCommerceTests/Mocks/MockFeatureFlagService.swift
+++ b/WooCommerce/WooCommerceTests/Mocks/MockFeatureFlagService.swift
@@ -21,7 +21,6 @@ struct MockFeatureFlagService: FeatureFlagService {
     private let blazei3NativeCampaignCreation: Bool
     private let isBackendReceiptsEnabled: Bool
     private let sideBySideViewForOrderForm: Bool
-    private let isCustomersInHubMenuEnabled: Bool
     private let isSubscriptionsInOrderCreationCustomersEnabled: Bool
     private let isMultipleShippingLinesEnabled: Bool
 
@@ -44,7 +43,6 @@ struct MockFeatureFlagService: FeatureFlagService {
          blazei3NativeCampaignCreation: Bool = false,
          isBackendReceiptsEnabled: Bool = false,
          sideBySideViewForOrderForm: Bool = false,
-         isCustomersInHubMenuEnabled: Bool = false,
          isSubscriptionsInOrderCreationCustomersEnabled: Bool = false,
          isMultipleShippingLinesEnabled: Bool = false) {
         self.isInboxOn = isInboxOn
@@ -66,7 +64,6 @@ struct MockFeatureFlagService: FeatureFlagService {
         self.blazei3NativeCampaignCreation = blazei3NativeCampaignCreation
         self.isBackendReceiptsEnabled = isBackendReceiptsEnabled
         self.sideBySideViewForOrderForm = sideBySideViewForOrderForm
-        self.isCustomersInHubMenuEnabled = isCustomersInHubMenuEnabled
         self.isSubscriptionsInOrderCreationCustomersEnabled = isSubscriptionsInOrderCreationCustomersEnabled
         self.isMultipleShippingLinesEnabled = isMultipleShippingLinesEnabled
     }
@@ -109,8 +106,6 @@ struct MockFeatureFlagService: FeatureFlagService {
             return isBackendReceiptsEnabled
         case .sideBySideViewForOrderForm:
             return sideBySideViewForOrderForm
-        case .customersInHubMenu:
-            return isCustomersInHubMenuEnabled
         case .subscriptionsInOrderCreationCustomers:
             return isSubscriptionsInOrderCreationCustomersEnabled
         case .multipleShippingLines:

--- a/WooCommerce/WooCommerceTests/ViewRelated/HubMenu/HubMenuViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/HubMenu/HubMenuViewModelTests.swift
@@ -379,17 +379,16 @@ final class HubMenuViewModelTests: XCTestCase {
         }))
     }
 
-    func test_menuElements_do_not_include_customers_when_feature_flag_is_off() {
+    func test_menuElements_include_customers() {
         // Given
-        let featureFlagService = MockFeatureFlagService(isCustomersInHubMenuEnabled: false)
+        let viewModel = HubMenuViewModel(siteID: sampleSiteID,
+                                         tapToPayBadgePromotionChecker: TapToPayBadgePromotionChecker())
 
         // When
-        let viewModel = HubMenuViewModel(siteID: sampleSiteID,
-                                         tapToPayBadgePromotionChecker: TapToPayBadgePromotionChecker(),
-                                         featureFlagService: featureFlagService)
+        viewModel.setupMenuElements()
 
         // Then
-        XCTAssertNil(viewModel.generalElements.firstIndex(where: { item in
+        XCTAssertNotNil(viewModel.generalElements.firstIndex(where: { item in
             item.id == HubMenuViewModel.Customers.id
         }))
     }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

<!-- Id number of the GitHub issue this PR addresses. -->

## Description
The Customers section in the Hub menu was released two months ago in https://github.com/woocommerce/woocommerce-ios/pull/12349. This PR removes the feature flag.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

1. Build and run the app.
2. Open the hub menu.
3. Scroll down and confirm the Customers section appears at the bottom of the list.


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
