### PR TITLE
[Order Details] Add view model for ShippingLineRowView

### DIFF
--- a/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsDataSource.swift
+++ b/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsDataSource.swift
@@ -1016,15 +1016,13 @@ private extension OrderDetailsDataSource {
 
     private func configureShippingLine(cell: HostingConfigurationTableViewCell<ShippingLineRowView>, at indexPath: IndexPath) {
         let shippingLine = shippingLines[indexPath.row]
-        let shippingMethod = siteShippingMethods.first(where: { $0.methodID == shippingLine.methodID })?.title
-        let shippingTotal = currencyFormatter.formatAmount(shippingLine.total) ?? shippingLine.total
+        let viewModel = ShippingLineRowViewModel(shippingLine: shippingLine, shippingMethods: siteShippingMethods, editable: false)
+        let view = ShippingLineRowView(viewModel: viewModel)
 
-        let view = ShippingLineRowView(shippingTitle: shippingLine.methodTitle,
-                                       shippingMethod: shippingMethod,
-                                       shippingAmount: shippingTotal,
-                                       editable: false)
-        let topMargin = indexPath.row == 0 ? Constants.cellDefaultMargin : 0 // Reduce cell padding between rows
+        // Reduce cell padding between rows
+        let topMargin = indexPath.row == 0 ? Constants.cellDefaultMargin : 0
         let insets = UIEdgeInsets(top: topMargin, left: Constants.cellDefaultMargin, bottom: Constants.cellDefaultMargin, right: Constants.cellDefaultMargin)
+
         cell.host(view, insets: insets)
         cell.hideSeparator()
         cell.selectionStyle = .none

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/Shipping/ShippingLineRowView.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/Shipping/ShippingLineRowView.swift
@@ -6,31 +6,19 @@ struct ShippingLineRowView: View {
     /// Scale of the view based on accessibility changes
     @ScaledMetric private var scale: CGFloat = 1.0
 
-    /// Title for the shipping line
-    let shippingTitle: String
-
-    /// Name of the shipping method for the shipping line
-    let shippingMethod: String?
-
-    /// Amount for the shipping line
-    let shippingAmount: String
-
-    /// Whether the row can be edited
-    let editable: Bool
-
-    /// Closure to be invoked when the shipping line is edited
-    let onEditShippingLine: () -> Void = {} // TODO-12581: Support editing shipping lines
+    /// View model to drive the view content
+    let viewModel: ShippingLineRowViewModel
 
     var body: some View {
         HStack(alignment: .top, spacing: Layout.contentSpacing) {
             VStack(alignment: .leading) {
-                Text(shippingTitle)
+                Text(viewModel.shippingTitle)
                     .bodyStyle()
                     .multilineTextAlignment(.leading)
                 // Avoids the shipping line name to be truncated when it's long enough
                     .fixedSize(horizontal: false, vertical: true)
 
-                if let shippingMethod {
+                if let shippingMethod = viewModel.shippingMethod {
                     Text(shippingMethod)
                         .subheadlineStyle()
                 }
@@ -38,7 +26,7 @@ struct ShippingLineRowView: View {
 
             Spacer()
 
-            Text(shippingAmount)
+            Text(viewModel.shippingAmount)
                 .bodyStyle()
 
             Image(systemName: "pencil")
@@ -48,12 +36,12 @@ struct ShippingLineRowView: View {
                 .foregroundColor(Color(.wooCommercePurple(.shade60)))
                 .accessibilityAddTraits(.isButton)
                 .accessibilityLabel(Localization.editButtonAccessibilityLabel)
-                .renderedIf(editable)
+                .renderedIf(viewModel.editable)
         }
         .padding(Layout.contentPadding)
         .contentShape(Rectangle())
         .onTapGesture {
-            onEditShippingLine()
+            viewModel.onEditShippingLine()
         }
         .background(
             RoundedRectangle(cornerRadius: Layout.cornerRadius)
@@ -85,9 +73,9 @@ extension ShippingLineRowView {
 }
 
 #Preview("Editable") {
-    ShippingLineRowView(shippingTitle: "Package 1", shippingMethod: "Flat Rate", shippingAmount: "$5.00", editable: true)
+    ShippingLineRowView(viewModel: ShippingLineRowViewModel(shippingTitle: "Package 1", shippingMethod: "Flat Rate", shippingAmount: "$5.00", editable: true))
 }
 
 #Preview("Not editable") {
-    ShippingLineRowView(shippingTitle: "Package 1", shippingMethod: "Flat Rate", shippingAmount: "$5.00", editable: false)
+    ShippingLineRowView(viewModel: ShippingLineRowViewModel(shippingTitle: "Package 1", shippingMethod: "Flat Rate", shippingAmount: "$5.00", editable: false))
 }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/Shipping/ShippingLineRowViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/Shipping/ShippingLineRowViewModel.swift
@@ -1,0 +1,44 @@
+import Foundation
+import WooFoundation
+import struct Yosemite.ShippingLine
+import struct Yosemite.ShippingMethod
+
+struct ShippingLineRowViewModel {
+    /// Title for the shipping line
+    let shippingTitle: String
+
+    /// Name of the shipping method for the shipping line
+    let shippingMethod: String?
+
+    /// Formatted amount for the shipping line
+    let shippingAmount: String
+
+    /// Whether the row can be edited
+    let editable: Bool
+
+    /// Closure to be invoked when the shipping line is edited
+    let onEditShippingLine: () -> Void = {} // TODO-12581: Support editing shipping lines
+
+    init(shippingTitle: String,
+         shippingMethod: String?,
+         shippingAmount: String,
+         editable: Bool) {
+        self.shippingTitle = shippingTitle
+        self.shippingMethod = shippingMethod
+        self.shippingAmount = shippingAmount
+        self.editable = editable
+    }
+
+    init(shippingLine: ShippingLine,
+         shippingMethods: [ShippingMethod],
+         editable: Bool,
+         currencyFormatter: CurrencyFormatter = CurrencyFormatter(currencySettings: ServiceLocator.currencySettings)) {
+        let formattedAmount = currencyFormatter.formatAmount(shippingLine.total) ?? shippingLine.total
+        let shippingMethod = shippingMethods.first(where: { $0.methodID == shippingLine.methodID })?.title
+
+        self.init(shippingTitle: shippingLine.methodTitle,
+                  shippingMethod: shippingMethod,
+                  shippingAmount: formattedAmount,
+                  editable: editable)
+    }
+}

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -2024,6 +2024,8 @@
 		CE27258021925AE8002B22EB /* ValueOneTableViewCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = CE27257E21925AE8002B22EB /* ValueOneTableViewCell.xib */; };
 		CE29A63029F2DACC003D2A00 /* OrderSubscriptionTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE29A62F29F2DACC003D2A00 /* OrderSubscriptionTableViewCell.swift */; };
 		CE29FEED2BFF771F007679C2 /* ShippingLineRowView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE29FEEC2BFF771F007679C2 /* ShippingLineRowView.swift */; };
+		CE29FEF42C009D7C007679C2 /* ShippingLineRowViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE29FEF32C009D7C007679C2 /* ShippingLineRowViewModel.swift */; };
+		CE29FEF62C009F5F007679C2 /* ShippingLineRowViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE29FEF52C009F5F007679C2 /* ShippingLineRowViewModelTests.swift */; };
 		CE2A9FBF23BFB1BE002BEC1C /* LedgerTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE2A9FBD23BFB1BD002BEC1C /* LedgerTableViewCell.swift */; };
 		CE2A9FC023BFB1BE002BEC1C /* LedgerTableViewCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = CE2A9FBE23BFB1BE002BEC1C /* LedgerTableViewCell.xib */; };
 		CE2A9FC623BFFADE002BEC1C /* RefundedProductsViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE2A9FC523BFFADE002BEC1C /* RefundedProductsViewModel.swift */; };
@@ -4813,6 +4815,8 @@
 		CE27257E21925AE8002B22EB /* ValueOneTableViewCell.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = ValueOneTableViewCell.xib; sourceTree = "<group>"; };
 		CE29A62F29F2DACC003D2A00 /* OrderSubscriptionTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OrderSubscriptionTableViewCell.swift; sourceTree = "<group>"; };
 		CE29FEEC2BFF771F007679C2 /* ShippingLineRowView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShippingLineRowView.swift; sourceTree = "<group>"; };
+		CE29FEF32C009D7C007679C2 /* ShippingLineRowViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShippingLineRowViewModel.swift; sourceTree = "<group>"; };
+		CE29FEF52C009F5F007679C2 /* ShippingLineRowViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShippingLineRowViewModelTests.swift; sourceTree = "<group>"; };
 		CE2A9FBD23BFB1BD002BEC1C /* LedgerTableViewCell.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LedgerTableViewCell.swift; sourceTree = "<group>"; };
 		CE2A9FBE23BFB1BE002BEC1C /* LedgerTableViewCell.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = LedgerTableViewCell.xib; sourceTree = "<group>"; };
 		CE2A9FC523BFFADE002BEC1C /* RefundedProductsViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RefundedProductsViewModel.swift; sourceTree = "<group>"; };
@@ -10243,6 +10247,7 @@
 			isa = PBXGroup;
 			children = (
 				B9F1489B2AD59F31008FC795 /* CustomAmounts */,
+				CE29FEF72C009F66007679C2 /* Shipping */,
 				B935D35D2A9F4EC30067B927 /* Taxes */,
 				B98968542A98F1DF007A2FBE /* PaymentSection */,
 				B95A45EA2A77D78F0073A91F /* CustomerSection */,
@@ -10783,6 +10788,15 @@
 			isa = PBXGroup;
 			children = (
 				CE29FEEC2BFF771F007679C2 /* ShippingLineRowView.swift */,
+				CE29FEF32C009D7C007679C2 /* ShippingLineRowViewModel.swift */,
+			);
+			path = Shipping;
+			sourceTree = "<group>";
+		};
+		CE29FEF72C009F66007679C2 /* Shipping */ = {
+			isa = PBXGroup;
+			children = (
+				CE29FEF52C009F5F007679C2 /* ShippingLineRowViewModelTests.swift */,
 			);
 			path = Shipping;
 			sourceTree = "<group>";
@@ -15019,6 +15033,7 @@
 				B95864082A657D2F002C4C6E /* EnhancedCouponListViewController.swift in Sources */,
 				CEA16F3A20FD0C8C0061B4E1 /* WooAnalytics.swift in Sources */,
 				023053492374528A00487A64 /* AztecBlockquoteFormatBarCommand.swift in Sources */,
+				CE29FEF42C009D7C007679C2 /* ShippingLineRowViewModel.swift in Sources */,
 				201F5AC52AD4061800EF6C55 /* AboutTapToPayViewModel.swift in Sources */,
 				0282DD98233CA093006A5FDB /* OrderSearchUICommand.swift in Sources */,
 				B541B21A2189F3A2008FE7C1 /* StringFormatter.swift in Sources */,
@@ -15397,6 +15412,7 @@
 				EEADF626281A65A9001B40F1 /* DefaultShippingValueLocalizerTests.swift in Sources */,
 				FE3E427726A8545B00C596CE /* MockRoleEligibilityUseCase.swift in Sources */,
 				02F67FF525806E0100C3BAD2 /* ShippingLabelTrackingURLGeneratorTests.swift in Sources */,
+				CE29FEF62C009F5F007679C2 /* ShippingLineRowViewModelTests.swift in Sources */,
 				20CCBF212B0E15C0003102E6 /* WooPaymentsDepositsCurrencyOverviewViewModelTests.swift in Sources */,
 				2602A64227BD89CE00B347F1 /* NewOrderInitialStatusResolverTests.swift in Sources */,
 				0235354E2999D17A00BF77D3 /* DomainSettingsViewModelTests.swift in Sources */,

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/Shipping/ShippingLineRowViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/Shipping/ShippingLineRowViewModelTests.swift
@@ -1,0 +1,41 @@
+import XCTest
+import WooFoundation
+import Yosemite
+@testable import WooCommerce
+
+final class ShippingLineRowViewModelTests: XCTestCase {
+
+    func test_view_model_inits_with_expected_values() {
+        // Given
+        let shippingTitle = "Package 1"
+        let shippingMethod = "Flat Rate"
+        let shippingAmount = "$5.00"
+
+        // When
+        let viewModel = ShippingLineRowViewModel(shippingTitle: shippingTitle, shippingMethod: shippingMethod, shippingAmount: shippingAmount, editable: true)
+
+        // Then
+        assertEqual(shippingTitle, viewModel.shippingTitle)
+        assertEqual(shippingMethod, viewModel.shippingMethod)
+        assertEqual(shippingAmount, viewModel.shippingAmount)
+        XCTAssertTrue(viewModel.editable)
+    }
+
+    func test_view_model_inits_from_shipping_line_with_expected_values() {
+        // Given
+        let shippingLine = ShippingLine(shippingID: 1, methodTitle: "Package 1", methodID: "flat_rate", total: "5", totalTax: "0", taxes: [])
+        let shippingMethod = ShippingMethod(siteID: 12345, methodID: "flat_rate", title: "Flat Rate")
+
+        // When
+        let viewModel = ShippingLineRowViewModel(shippingLine: shippingLine,
+                                                 shippingMethods: [shippingMethod],
+                                                 editable: false,
+                                                 currencyFormatter: CurrencyFormatter(currencySettings: CurrencySettings()))
+
+        // Then
+        assertEqual(shippingLine.methodTitle, viewModel.shippingTitle)
+        assertEqual(shippingMethod.title, viewModel.shippingMethod)
+        assertEqual("$5.00", viewModel.shippingAmount)
+        XCTAssertFalse(viewModel.editable)
+    }
+}


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of: #12581
<!-- Id number of the GitHub issue this PR addresses. -->

## Why
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This adds a view model for `ShippingLineRowView`, for more consistency and testability when initializing the view with a shipping line and list of shipping methods.

## How
* Adds `ShippingLineRowViewModel`, containing all the data required by `ShippingLineRowView`. This view model has a simple init method (useful for e.g. SwiftUI previews) and an init method that takes a shipping line and list of shipping methods and finds/formats the data as needed.
* Adds tests to confirm the view model inits the properties as expected.
* Updates `OrderDetailsDataSource` to use the view model.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

1. Build and run the app.
2. Go to the Orders tab.
3. Open an order with at least one shipping line.
4. Confirm the shipping section appears with the same shipping details as before.

## Screenshots

Before|After
-|-
![Simulator Screenshot - iPhone 15 Plus - 2024-05-24 at 13 55 08](https://github.com/woocommerce/woocommerce-ios/assets/8658164/95779f2d-e426-40e4-b4e8-b325706323c9)|![Simulator Screenshot - iPhone 15 Plus - 2024-05-24 at 13 52 59](https://github.com/woocommerce/woocommerce-ios/assets/8658164/049f8213-9656-44b1-b507-384b3f1a453f)


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
