### PR TITLE
[Order Form] Add UI for multiple shipping lines during order creation/editing

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/EditableOrderViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/EditableOrderViewModel.swift
@@ -367,6 +367,23 @@ final class EditableOrderViewModel: ObservableObject {
         return selectedProductsCount + selectedProductVariationsCount
     }
 
+    // MARK: Shipping line properties
+
+    /// View models for each shipping line in the order.
+    ///
+    @Published private(set) var shippingLineRows: [ShippingLineRowViewModel] = []
+
+    /// Shipping Methods Results Controller.
+    ///
+    private lazy var shippingMethodsResultsController: ResultsController<StorageShippingMethod> = {
+        let predicate = NSPredicate(format: "siteID == %lld", siteID)
+        return ResultsController<StorageShippingMethod>(storageManager: storageManager, matching: predicate, sortedBy: [])
+    }()
+
+    /// All shipping methods for the store.
+    ///
+    private var allShippingMethods: [ShippingMethod] = []
+
     // MARK: Customer data properties
 
     /// View model for the customer section.
@@ -524,6 +541,7 @@ final class EditableOrderViewModel: ObservableObject {
         configureStatusBadgeViewModel()
         configureProductRowViewModels()
         configureCustomAmountRowViewModels()
+        configureShippingLineRowViewModels()
         configureCustomerDataViewModel()
         configurePaymentDataViewModel()
         configureCustomerNoteDataViewModel()
@@ -538,7 +556,6 @@ final class EditableOrderViewModel: ObservableObject {
         forwardSyncApproachToSynchronizer()
         observeChangesFromProductSelectorButtonTapSelectionSync()
         observeChangesInCustomerDetails()
-        syncShippingMethods()
     }
 
     /// Observes and keeps track of changes within the Customer Details
@@ -1650,6 +1667,31 @@ private extension EditableOrderViewModel {
             .assign(to: &$customAmountRows)
     }
 
+    func configureShippingLineRowViewModels() {
+        updateShippingMethodsResultsController()
+        syncShippingMethods()
+
+        guard featureFlagService.isFeatureFlagEnabled(.multipleShippingLines) else {
+            return
+        }
+
+        orderSynchronizer.orderPublisher
+            .map { $0.shippingLines }
+            .removeDuplicates()
+            .combineLatest($shouldShowNonEditableIndicators)
+            .map { [weak self] (shippingLines, isNonEditable) -> [ShippingLineRowViewModel] in
+                guard let self else { return [] }
+                return shippingLines.compactMap { shippingLine in
+                    guard !shippingLine.isDeleted else { return nil }
+
+                    return ShippingLineRowViewModel(shippingLine: shippingLine,
+                                                    shippingMethods: self.allShippingMethods,
+                                                    editable: !isNonEditable)
+                }
+            }
+            .assign(to: &$shippingLineRows)
+    }
+
     /// If given an initial product ID on initialization, updates the Order with the item
     ///
     func configureOrderWithinitialItemIfNeeded() {
@@ -1929,8 +1971,11 @@ private extension EditableOrderViewModel {
         guard ServiceLocator.featureFlagService.isFeatureFlagEnabled(.orderShippingMethodSelection) else {
             return
         }
-        let action = ShippingMethodAction.synchronizeShippingMethods(siteID: siteID) { result in
-            if let error = result.failure {
+        let action = ShippingMethodAction.synchronizeShippingMethods(siteID: siteID) { [weak self] result in
+            switch result {
+            case .success:
+                self?.updateShippingMethodsResultsController()
+            case let .failure(error):
                 DDLogError("⛔️ Error retrieving available shipping methods: \(error)")
             }
         }
@@ -2397,6 +2442,15 @@ private extension EditableOrderViewModel {
             allProductVariations = Set(productVariationsResultsController.fetchedObjects)
         } catch {
             DDLogError("⛔️ Error fetching product variations for order: \(error)")
+        }
+    }
+
+    func updateShippingMethodsResultsController() {
+        do {
+            try shippingMethodsResultsController.performFetch()
+            allShippingMethods = shippingMethodsResultsController.fetchedObjects
+        } catch {
+            DDLogError("⛔️ Error fetching shipping methods for order: \(error)")
         }
     }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/EditableOrderViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/EditableOrderViewModel.swift
@@ -369,6 +369,12 @@ final class EditableOrderViewModel: ObservableObject {
 
     // MARK: Shipping line properties
 
+    /// Multiple shipping lines support
+    ///
+    var multipleShippingLinesEnabled: Bool {
+        featureFlagService.isFeatureFlagEnabled(.multipleShippingLines)
+    }
+
     /// View models for each shipping line in the order.
     ///
     @Published private(set) var shippingLineRows: [ShippingLineRowViewModel] = []
@@ -1671,7 +1677,7 @@ private extension EditableOrderViewModel {
         updateShippingMethodsResultsController()
         syncShippingMethods()
 
-        guard featureFlagService.isFeatureFlagEnabled(.multipleShippingLines) else {
+        guard multipleShippingLinesEnabled else {
             return
         }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/EditableOrderViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/EditableOrderViewModel.swift
@@ -1205,6 +1205,7 @@ extension EditableOrderViewModel {
 
         let shouldShowShippingTotal: Bool
         let shippingTotal: String
+        let isShippingTotalEditable: Bool
 
         // We only support one (the first) shipping line
         let shippingMethodTitle: String
@@ -1261,6 +1262,7 @@ extension EditableOrderViewModel {
              itemsTotal: String = "0",
              shouldShowShippingTotal: Bool = false,
              shippingTotal: String = "0",
+             isShippingTotalEditable: Bool = true,
              shippingMethodID: String = "",
              shippingMethodTitle: String = "",
              shippingMethodTotal: String = "",
@@ -1342,6 +1344,7 @@ extension EditableOrderViewModel {
             self.addGiftCardClosure = addGiftCardClosure
             self.setGiftCardClosure = setGiftCardClosure
             self.addShippingTappedClosure = addShippingTappedClosure
+            self.isShippingTotalEditable = isShippingTotalEditable
         }
 
         /// Indicates whether the Coupons informational tooltip button should be shown
@@ -1881,6 +1884,7 @@ private extension EditableOrderViewModel {
                                             itemsTotal: orderTotals.itemsTotal.stringValue,
                                             shouldShowShippingTotal: order.shippingLines.filter { $0.methodID != nil }.isNotEmpty,
                                             shippingTotal: order.shippingTotal.isNotEmpty ? order.shippingTotal : "0",
+                                            isShippingTotalEditable: !multipleShippingLinesEnabled,
                                             shippingMethodID: shippingMethodID,
                                             shippingMethodTitle: shippingMethodTitle,
                                             shippingMethodTotal: order.shippingLines.first?.total ?? "0",

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/OrderForm.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/OrderForm.swift
@@ -296,7 +296,14 @@ struct OrderForm: View {
                             Spacer(minLength: Layout.sectionSpacing)
 
                             Group {
-                                if let title = viewModel.multipleLinesMessage {
+                                OrderShippingSection(viewModel: viewModel)
+                                Spacer(minLength: Layout.sectionSpacing)
+                            }
+                            .renderedIf(viewModel.shippingLineRows.isNotEmpty && viewModel.multipleShippingLinesEnabled)
+
+                            Group {
+                                if let title = viewModel.multipleLinesMessage,
+                                   !viewModel.multipleShippingLinesEnabled {
                                     MultipleLinesMessage(title: title)
                                     Spacer(minLength: Layout.sectionSpacing)
                                 }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/OrderForm.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/OrderForm.swift
@@ -297,6 +297,7 @@ struct OrderForm: View {
 
                             Group {
                                 OrderShippingSection(viewModel: viewModel)
+                                    .disabled(viewModel.shouldShowNonEditableIndicators)
                                 Spacer(minLength: Layout.sectionSpacing)
                             }
                             .renderedIf(viewModel.shippingLineRows.isNotEmpty && viewModel.multipleShippingLinesEnabled)

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/PaymentSection/OrderPaymentSection.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/PaymentSection/OrderPaymentSection.swift
@@ -94,13 +94,19 @@ private extension OrderPaymentSection {
     }
 
     @ViewBuilder var existingShippingRow: some View {
-        TitleAndValueRow(title: Localization.shippingTotal,
-                         titleSuffixImage: (image: rowsEditImage, color: Color(.primary)),
-                         value: .content(viewModel.shippingTotal),
-                         selectionStyle: editableRowsSelectionStyle) {
-            shouldShowShippingLineDetails = true
+        if viewModel.isShippingTotalEditable {
+            TitleAndValueRow(title: Localization.shippingTotal,
+                             titleSuffixImage: (image: rowsEditImage, color: Color(.primary)),
+                             value: .content(viewModel.shippingTotal),
+                             selectionStyle: editableRowsSelectionStyle) {
+                shouldShowShippingLineDetails = true
+            }
+            .renderedIf(viewModel.shouldShowShippingTotal)
+        } else {
+            TitleAndValueRow(title: Localization.shippingTotal,
+                             value: .content(viewModel.shippingTotal))
+            .renderedIf(viewModel.shouldShowShippingTotal)
         }
-        .renderedIf(viewModel.shouldShowShippingTotal)
     }
 
     @ViewBuilder var productsRow: some View {

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/Shipping/OrderShippingSection.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/Shipping/OrderShippingSection.swift
@@ -1,0 +1,55 @@
+import SwiftUI
+
+struct OrderShippingSection: View {
+    /// View model to drive the view content
+    @ObservedObject var viewModel: EditableOrderViewModel
+
+    @Environment(\.safeAreaInsets) private var safeAreaInsets: EdgeInsets
+
+    var body: some View {
+        VStack {
+            HStack {
+                Text(Localization.shipping)
+                    .accessibilityAddTraits(.isHeader)
+                    .headlineStyle()
+
+                Spacer()
+
+                Image(uiImage: .lockImage)
+                    .foregroundColor(Color(.primary))
+                    .renderedIf(viewModel.shouldShowNonEditableIndicators)
+
+                Button(action: {
+                    addShippingLine()
+                }) {
+                    Image(uiImage: .plusImage)
+                }
+                .scaledToFit()
+                .renderedIf(!viewModel.shouldShowNonEditableIndicators)
+            }
+
+            ForEach(viewModel.shippingLineRows) { shippingLineRow in
+                ShippingLineRowView(viewModel: shippingLineRow)
+            }
+        }
+        .padding(.horizontal, insets: safeAreaInsets)
+        .padding()
+        .background(Color(.listForeground(modal: true)))
+        .addingTopAndBottomDividers()
+    }
+}
+
+private extension OrderShippingSection {
+    func addShippingLine() {
+        // TODO-12583: Add a new shipping line (opens `ShippingLineSelectionDetails`)
+        // TODO-12584: Track that add shipping has been tapped
+    }
+}
+
+private extension OrderShippingSection {
+    enum Localization {
+        static let shipping = NSLocalizedString("orderForm.shipping",
+                                                value: "Shipping",
+                                                comment: "Heading for the section that shows the Shipping Lines when creating or editing an order")
+    }
+}

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/Shipping/ShippingLineRowView.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/Shipping/ShippingLineRowView.swift
@@ -73,9 +73,17 @@ extension ShippingLineRowView {
 }
 
 #Preview("Editable") {
-    ShippingLineRowView(viewModel: ShippingLineRowViewModel(shippingTitle: "Package 1", shippingMethod: "Flat Rate", shippingAmount: "$5.00", editable: true))
+    ShippingLineRowView(viewModel: ShippingLineRowViewModel(id: 1,
+                                                            shippingTitle: "Package 1",
+                                                            shippingMethod: "Flat Rate",
+                                                            shippingAmount: "$5.00",
+                                                            editable: true))
 }
 
 #Preview("Not editable") {
-    ShippingLineRowView(viewModel: ShippingLineRowViewModel(shippingTitle: "Package 1", shippingMethod: "Flat Rate", shippingAmount: "$5.00", editable: false))
+    ShippingLineRowView(viewModel: ShippingLineRowViewModel(id: 1,
+                                                            shippingTitle: "Package 1",
+                                                            shippingMethod: "Flat Rate",
+                                                            shippingAmount: "$5.00",
+                                                            editable: false))
 }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/Shipping/ShippingLineRowView.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/Shipping/ShippingLineRowView.swift
@@ -29,14 +29,17 @@ struct ShippingLineRowView: View {
             Text(viewModel.shippingAmount)
                 .bodyStyle()
 
-            Image(systemName: "pencil")
-                .resizable()
-                .frame(width: Layout.editIconImageSize * scale,
-                       height: Layout.editIconImageSize * scale)
-                .foregroundColor(Color(.wooCommercePurple(.shade60)))
-                .accessibilityAddTraits(.isButton)
-                .accessibilityLabel(Localization.editButtonAccessibilityLabel)
-                .renderedIf(viewModel.editable)
+            Button {
+                viewModel.onEditShippingLine()
+            } label: {
+                Image(systemName: "pencil")
+                    .resizable()
+                    .frame(width: Layout.editIconImageSize * scale,
+                           height: Layout.editIconImageSize * scale)
+            }
+            .tint(Color(.primary))
+            .accessibilityLabel(Localization.editButtonAccessibilityLabel)
+            .renderedIf(viewModel.editable)
         }
         .padding(Layout.contentPadding)
         .contentShape(Rectangle())

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/Shipping/ShippingLineRowViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/Shipping/ShippingLineRowViewModel.swift
@@ -3,7 +3,10 @@ import WooFoundation
 import struct Yosemite.ShippingLine
 import struct Yosemite.ShippingMethod
 
-struct ShippingLineRowViewModel {
+struct ShippingLineRowViewModel: Identifiable {
+    /// ID for the row view model
+    let id: Int64
+
     /// Title for the shipping line
     let shippingTitle: String
 
@@ -19,10 +22,12 @@ struct ShippingLineRowViewModel {
     /// Closure to be invoked when the shipping line is edited
     let onEditShippingLine: () -> Void = {} // TODO-12581: Support editing shipping lines
 
-    init(shippingTitle: String,
+    init(id: Int64,
+         shippingTitle: String,
          shippingMethod: String?,
          shippingAmount: String,
          editable: Bool) {
+        self.id = id
         self.shippingTitle = shippingTitle
         self.shippingMethod = shippingMethod
         self.shippingAmount = shippingAmount
@@ -36,7 +41,8 @@ struct ShippingLineRowViewModel {
         let formattedAmount = currencyFormatter.formatAmount(shippingLine.total) ?? shippingLine.total
         let shippingMethod = shippingMethods.first(where: { $0.methodID == shippingLine.methodID })?.title
 
-        self.init(shippingTitle: shippingLine.methodTitle,
+        self.init(id: shippingLine.shippingID,
+                  shippingTitle: shippingLine.methodTitle,
                   shippingMethod: shippingMethod,
                   shippingAmount: formattedAmount,
                   editable: editable)

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -2024,6 +2024,7 @@
 		CE27258021925AE8002B22EB /* ValueOneTableViewCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = CE27257E21925AE8002B22EB /* ValueOneTableViewCell.xib */; };
 		CE29A63029F2DACC003D2A00 /* OrderSubscriptionTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE29A62F29F2DACC003D2A00 /* OrderSubscriptionTableViewCell.swift */; };
 		CE29FEED2BFF771F007679C2 /* ShippingLineRowView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE29FEEC2BFF771F007679C2 /* ShippingLineRowView.swift */; };
+		CE29FEF22C009867007679C2 /* OrderShippingSection.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE29FEF12C009867007679C2 /* OrderShippingSection.swift */; };
 		CE29FEF42C009D7C007679C2 /* ShippingLineRowViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE29FEF32C009D7C007679C2 /* ShippingLineRowViewModel.swift */; };
 		CE29FEF62C009F5F007679C2 /* ShippingLineRowViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE29FEF52C009F5F007679C2 /* ShippingLineRowViewModelTests.swift */; };
 		CE2A9FBF23BFB1BE002BEC1C /* LedgerTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE2A9FBD23BFB1BD002BEC1C /* LedgerTableViewCell.swift */; };
@@ -4815,6 +4816,7 @@
 		CE27257E21925AE8002B22EB /* ValueOneTableViewCell.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = ValueOneTableViewCell.xib; sourceTree = "<group>"; };
 		CE29A62F29F2DACC003D2A00 /* OrderSubscriptionTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OrderSubscriptionTableViewCell.swift; sourceTree = "<group>"; };
 		CE29FEEC2BFF771F007679C2 /* ShippingLineRowView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShippingLineRowView.swift; sourceTree = "<group>"; };
+		CE29FEF12C009867007679C2 /* OrderShippingSection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OrderShippingSection.swift; sourceTree = "<group>"; };
 		CE29FEF32C009D7C007679C2 /* ShippingLineRowViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShippingLineRowViewModel.swift; sourceTree = "<group>"; };
 		CE29FEF52C009F5F007679C2 /* ShippingLineRowViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShippingLineRowViewModelTests.swift; sourceTree = "<group>"; };
 		CE2A9FBD23BFB1BD002BEC1C /* LedgerTableViewCell.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LedgerTableViewCell.swift; sourceTree = "<group>"; };
@@ -10789,6 +10791,7 @@
 			children = (
 				CE29FEEC2BFF771F007679C2 /* ShippingLineRowView.swift */,
 				CE29FEF32C009D7C007679C2 /* ShippingLineRowViewModel.swift */,
+				CE29FEF12C009867007679C2 /* OrderShippingSection.swift */,
 			);
 			path = Shipping;
 			sourceTree = "<group>";
@@ -14052,6 +14055,7 @@
 				027B8BB823FE0CB30040944E /* DefaultProductUIImageLoader.swift in Sources */,
 				CC254F3226C2BCCF005F3C82 /* ShippingLabelAddNewPackageViewModel.swift in Sources */,
 				0202B6922387AB0C00F3EBE0 /* WooTab+Tag.swift in Sources */,
+				CE29FEF22C009867007679C2 /* OrderShippingSection.swift in Sources */,
 				D8736B5A22F07D7100A14A29 /* MainTabViewModel.swift in Sources */,
 				02619858256B53DD00E321E9 /* AggregatedShippingLabelOrderItems.swift in Sources */,
 				260520F22B83B1B7005D5D59 /* ConnectivityToolViewModel.swift in Sources */,

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/Shipping/ShippingLineRowViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/Shipping/ShippingLineRowViewModelTests.swift
@@ -12,7 +12,11 @@ final class ShippingLineRowViewModelTests: XCTestCase {
         let shippingAmount = "$5.00"
 
         // When
-        let viewModel = ShippingLineRowViewModel(shippingTitle: shippingTitle, shippingMethod: shippingMethod, shippingAmount: shippingAmount, editable: true)
+        let viewModel = ShippingLineRowViewModel(id: 1,
+                                                 shippingTitle: shippingTitle,
+                                                 shippingMethod: shippingMethod,
+                                                 shippingAmount: shippingAmount,
+                                                 editable: true)
 
         // Then
         assertEqual(shippingTitle, viewModel.shippingTitle)

--- a/Yosemite/Yosemite/Stores/Order/OrderFactory.swift
+++ b/Yosemite/Yosemite/Stores/Order/OrderFactory.swift
@@ -105,3 +105,9 @@ public extension OrderFeeLine {
         self == OrderFactory.deletedFeeLine(self)
     }
 }
+
+public extension ShippingLine {
+    var isDeleted: Bool {
+        self == OrderFactory.deletedShippingLine(self)
+    }
+}


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of: #12581
<!-- Id number of the GitHub issue this PR addresses. -->

## Why
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
We want to be able to display multiple shipping lines when creating/editing an order:

* Continue to show the "Add shipping" button when the order has no shipping lines.
* Show a Shipping section with each shipping line in the order, with buttons to add or edit shipping lines.
* In the Order totals section, show a non-editable shipping total.

This PR makes these UI changes when the `multipleShippingLines` feature flag is enabled. (For now, the buttons to add or edit shipping lines are non-actionable.)

## How

* Adds `Identifiable` conformance to `ShippingLineRowViewModel`, so it can be easily used with `ForEach`.
* Adds an `OrderShippingSection` view:
   * Displays a lock icon if the order is not editable.
   * Displays a plus icon if the order is editable (to add another shipping line to the order).
   * Displays a `ShippingLineRowView` for each shipping line on the order.
* Updates `EditableOrderViewModel` to provide the data needed in `OrderShippingSection`:
   * Adds properties and a method to fetch all of the store's shipping methods from storage, and update them after syncing the shipping methods remotely. (So the shipping method names can be shown for each shipping line.)
   * Configures the `ShippingLineRowViewModels` whenever the order shipping lines or order editable status changes.
* Updates `OrderForm`:
   * Renders `OrderShippingSection` when the order has shipping lines and the feature flag is enabled. (This section is disabled with grey icons when the order is syncing remotely.)
   * Hides the multiple shipping lines notice when the feature flag is enabled.
* Updates `OrderPaymentSection` (used for the Order totals section) to make the Shipping row non-editable when the feature flag is enabled.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

New order:

1. Build and run the app.
2. Go to the Orders tab.
3. Create a new order and add a product.
4. Confirm the "Add shipping" button shows as usual.
5. Tap "Add shipping" and add a shipping line to the order.
6. Confirm a Shipping section appears with the shipping line details.
7. Open the Order totals section and confirm the shipping total shows with no option to edit it.

Order with multiple shipping lines:

1. Build and run the app.
2. Go to the Orders tab.
3. Open an order with multiple shipping lines.
4. Confirm a Shipping section appears with each of the order shipping lines.
5. Confirm no message appears about multiple shipping lines.
6. Open the Order totals section and confirm the shipping total shows with no option to edit it.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->
Before|After
-|-
![Simulator Screenshot - iPhone 15 Plus - 2024-05-24 at 15 06 27](https://github.com/woocommerce/woocommerce-ios/assets/8658164/24ba04a8-c34a-479e-9449-a853985ca734)|![Simulator Screenshot - iPhone 15 Plus - 2024-05-24 at 14 45 35](https://github.com/woocommerce/woocommerce-ios/assets/8658164/d5c7b731-a376-46e6-b8f0-eb37ee264176)
![Simulator Screenshot - iPhone 15 Plus - 2024-05-24 at 15 06 58](https://github.com/woocommerce/woocommerce-ios/assets/8658164/bed65add-e134-4c12-8103-234dfcbe2338)|![Simulator Screenshot - iPhone 15 Plus - 2024-05-24 at 14 46 14](https://github.com/woocommerce/woocommerce-ios/assets/8658164/f47b8278-396f-43d6-8e3c-413d04460c8f)
![Simulator Screenshot - iPhone 15 Plus - 2024-05-24 at 15 07 24](https://github.com/woocommerce/woocommerce-ios/assets/8658164/3115651a-06d0-4100-9603-cc1d7972d167)|![Simulator Screenshot - iPhone 15 Plus - 2024-05-24 at 14 46 40](https://github.com/woocommerce/woocommerce-ios/assets/8658164/bb3497ef-9edf-4486-a206-36a0b1173cf3)

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
