### PR TITLE
[Order Form] Update custom amounts section to match latest designs

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/CustomAmounts/CustomAmountRowView.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/CustomAmounts/CustomAmountRowView.swift
@@ -12,8 +12,7 @@ struct CustomAmountRowView: View {
     var body: some View {
         HStack(alignment: .center, spacing: Layout.contentSpacing) {
             Text(viewModel.name)
-                .foregroundColor(.init(UIColor.text))
-                .subheadlineStyle()
+                .bodyStyle()
                 .multilineTextAlignment(.leading)
                 // Avoids the custom amount name to be truncated when it's long enough
                 .fixedSize(horizontal: false, vertical: true)
@@ -21,17 +20,20 @@ struct CustomAmountRowView: View {
             Spacer()
 
             Text(viewModel.total)
-                .foregroundColor(.init(UIColor.text))
-                .subheadlineStyle()
+                .bodyStyle()
 
-            Image(systemName: "pencil")
-                .resizable()
-                .frame(width: Layout.editIconImageSize * scale,
-                       height: Layout.editIconImageSize * scale)
-                .foregroundColor(Color(.wooCommercePurple(.shade60)))
-                .accessibilityAddTraits(.isButton)
-                .accessibilityLabel(Localization.editButtonAccessibilityLabel)
-                .renderedIf(editable)
+
+            Button {
+                viewModel.onEditCustomAmount()
+            } label: {
+                Image(systemName: "pencil")
+                    .resizable()
+                    .frame(width: Layout.editIconImageSize * scale,
+                           height: Layout.editIconImageSize * scale)
+            }
+            .tint(Color(.primary))
+            .accessibilityLabel(Localization.editButtonAccessibilityLabel)
+            .renderedIf(editable)
         }
         .padding(Layout.contentPadding)
         .contentShape(Rectangle())
@@ -56,7 +58,7 @@ extension CustomAmountRowView {
         static let contentPadding: CGFloat = 16
         static let cornerRadius: CGFloat = 8
         static let borderLineWidth: CGFloat = 0.5
-        static let editIconImageSize: CGFloat = 16
+        static let editIconImageSize: CGFloat = 24
     }
 
     enum Localization {


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of: #12581
<!-- Id number of the GitHub issue this PR addresses. -->

## Why
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This updates the design for the custom amounts row in order creation/editing to match the latest designs (larger font/edit button).

It also fixes an issue where the edit (pencil) icon wasn't disabled when the order was syncing remotely.

## How

* Updates the row text to use body style.
* Increases the edit icon image size.
* Updates the edit icon to be a button with a `tint` modifier for its color. This ensures the tint color is applied when the button is active, but the icon is grey when the button is disabled. (This doesn't affect the row's tap gesture, so the entire row is still tappable.)

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

1. Build and run the app.
2. Go to the Orders tab.
3. Create a new order.
4. Add a custom amount.
5. Confirm the row is disabled and the edit button is grey when the order is syncing remotely.
6. After the order is synced, confirm you can tap anywhere in the row to edit the custom amount.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->
Custom amount and shipping (now with matching design):

<img src="https://github.com/woocommerce/woocommerce-ios/assets/8658164/a55b23f6-30c1-45ab-94af-678c264790be" width="400px">

Before|After
-|-
![Simulator Screenshot - iPhone 15 Plus - 2024-05-24 at 15 38 44](https://github.com/woocommerce/woocommerce-ios/assets/8658164/2c8f19fd-cf68-4302-865d-8a94e5006acc)|![Simulator Screenshot - iPhone 15 Plus - 2024-05-24 at 15 48 27](https://github.com/woocommerce/woocommerce-ios/assets/8658164/4338d93c-0657-419b-bcbe-ebe9bf4ce175)
![Simulator Screenshot - iPhone 15 Plus - 2024-05-24 at 15 38 41](https://github.com/woocommerce/woocommerce-ios/assets/8658164/6f3b0ca9-ce9f-4991-b891-5fcafd0734d3)|![Simulator Screenshot - iPhone 15 Plus - 2024-05-24 at 15 48 24](https://github.com/woocommerce/woocommerce-ios/assets/8658164/623ea414-ca75-414a-a317-d27b5b701e26)


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
