### PR TITLE
Watch: Add new order notification support

### DIFF
--- a/Networking/Networking.xcodeproj/project.pbxproj
+++ b/Networking/Networking.xcodeproj/project.pbxproj
@@ -328,6 +328,11 @@
 		26B542462BEAC6A6003A55B5 /* Pods_NetworkingWatchOS.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 6132DCC72AA9C070E2033628 /* Pods_NetworkingWatchOS.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		26BD9FCD2965EC3C004E0D15 /* product-variations-bulk-create.json in Resources */ = {isa = PBXBuildFile; fileRef = 26BD9FCC2965EC3C004E0D15 /* product-variations-bulk-create.json */; };
 		26BD9FCF2965EE71004E0D15 /* ProductVariationsBulkCreateMapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26BD9FCE2965EE71004E0D15 /* ProductVariationsBulkCreateMapper.swift */; };
+		26CFDEDD2C0295AD005ABC31 /* Note.swift in Sources */ = {isa = PBXBuildFile; fileRef = B59325C6217E22FC000B0E8E /* Note.swift */; };
+		26CFDEDE2C0295CB005ABC31 /* NoteBlock.swift in Sources */ = {isa = PBXBuildFile; fileRef = B59325D0217E4206000B0E8E /* NoteBlock.swift */; };
+		26CFDEDF2C0295D5005ABC31 /* NoteMedia.swift in Sources */ = {isa = PBXBuildFile; fileRef = B59325CF217E4206000B0E8E /* NoteMedia.swift */; };
+		26CFDEE02C0295E1005ABC31 /* NoteRange.swift in Sources */ = {isa = PBXBuildFile; fileRef = B59325D1217E4206000B0E8E /* NoteRange.swift */; };
+		26CFDEE12C0295EA005ABC31 /* MetaContainer.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5A2417C217F9ECC00595DEF /* MetaContainer.swift */; };
 		26DAAB522BEA8D3400CE399E /* NetworkingWatchOS.h in Headers */ = {isa = PBXBuildFile; fileRef = 26DAAB512BEA8D3400CE399E /* NetworkingWatchOS.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		26DAAB572BEA8DC100CE399E /* Credentials.swift in Sources */ = {isa = PBXBuildFile; fileRef = B557DA1720979D51005962F4 /* Credentials.swift */; };
 		26DAAB582BEA8DFF00CE399E /* Remote.swift in Sources */ = {isa = PBXBuildFile; fileRef = B557DA0020975500005962F4 /* Remote.swift */; };
@@ -4609,10 +4614,12 @@
 				26373E042BFCEA48008E6735 /* OrdersRemote.swift in Sources */,
 				26373E0F2BFCEB1B008E6735 /* ShippingLineTax.swift in Sources */,
 				263A6DB72BEAA46000C292B2 /* SiteVisitStats.swift in Sources */,
+				26CFDEDD2C0295AD005ABC31 /* Note.swift in Sources */,
 				263A6DB82BEAA46000C292B2 /* SiteVisitStatsItem.swift in Sources */,
 				263A6DB52BEAA44D00C292B2 /* StatGranularity.swift in Sources */,
 				263A6DB42BEAA43700C292B2 /* Mapper+DataEnvelope.swift in Sources */,
 				263A6DB32BEAA41D00C292B2 /* DateFormatter+Woo.swift in Sources */,
+				26CFDEDF2C0295D5005ABC31 /* NoteMedia.swift in Sources */,
 				263A6DB22BEAA3EC00C292B2 /* CodingUserInfoKey+Woo.swift in Sources */,
 				263A6DB12BEAA33900C292B2 /* WCAnalyticsStats.swift in Sources */,
 				263A6DAD2BEAA32800C292B2 /* OrderStatsV4Mapper.swift in Sources */,
@@ -4652,6 +4659,7 @@
 				269014CD2BEA926F006056E0 /* WordPressAPIVersion.swift in Sources */,
 				269014CC2BEA925F006056E0 /* RESTRequestConvertible.swift in Sources */,
 				26373E072BFCEA7E008E6735 /* OrderItem.swift in Sources */,
+				26CFDEE12C0295EA005ABC31 /* MetaContainer.swift in Sources */,
 				26373E152BFCEDE9008E6735 /* OrderGiftCard.swift in Sources */,
 				269014CB2BEA9253006056E0 /* JetpackRequest.swift in Sources */,
 				269014CA2BEA924B006056E0 /* NetworkError.swift in Sources */,
@@ -4667,6 +4675,8 @@
 				269014C22BEA912D006056E0 /* Request.swift in Sources */,
 				26373E182BFCEF79008E6735 /* KeyedDecodingContainer+Woo.swift in Sources */,
 				26373E202BFCF6A7008E6735 /* EntityDateModifiedMapper.swift in Sources */,
+				26CFDEE02C0295E1005ABC31 /* NoteRange.swift in Sources */,
+				26CFDEDE2C0295CB005ABC31 /* NoteBlock.swift in Sources */,
 				26DAAB592BEA8E1500CE399E /* Network.swift in Sources */,
 				26373E052BFCEA60008E6735 /* Order.swift in Sources */,
 				26DAAB582BEA8DFF00CE399E /* Remote.swift in Sources */,

--- a/Networking/Networking.xcodeproj/project.pbxproj
+++ b/Networking/Networking.xcodeproj/project.pbxproj
@@ -333,6 +333,11 @@
 		26CFDEDF2C0295D5005ABC31 /* NoteMedia.swift in Sources */ = {isa = PBXBuildFile; fileRef = B59325CF217E4206000B0E8E /* NoteMedia.swift */; };
 		26CFDEE02C0295E1005ABC31 /* NoteRange.swift in Sources */ = {isa = PBXBuildFile; fileRef = B59325D1217E4206000B0E8E /* NoteRange.swift */; };
 		26CFDEE12C0295EA005ABC31 /* MetaContainer.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5A2417C217F9ECC00595DEF /* MetaContainer.swift */; };
+		26CFDEE72C038C8C005ABC31 /* NotificationsRemote.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5DAEFEF2180DD5A0002356A /* NotificationsRemote.swift */; };
+		26CFDEE82C038C9D005ABC31 /* SuccessResultMapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = B53EF53B21814900003E146F /* SuccessResultMapper.swift */; };
+		26CFDEE92C038CAE005ABC31 /* NoteListMapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = B59325CB217E2B4C000B0E8E /* NoteListMapper.swift */; };
+		26CFDEEA2C038CBE005ABC31 /* NoteHash.swift in Sources */ = {isa = PBXBuildFile; fileRef = B554FA902180BCFC00C54DFF /* NoteHash.swift */; };
+		26CFDEEB2C038CC8005ABC31 /* NoteHashListMapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = B554FA8E2180BC7000C54DFF /* NoteHashListMapper.swift */; };
 		26DAAB522BEA8D3400CE399E /* NetworkingWatchOS.h in Headers */ = {isa = PBXBuildFile; fileRef = 26DAAB512BEA8D3400CE399E /* NetworkingWatchOS.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		26DAAB572BEA8DC100CE399E /* Credentials.swift in Sources */ = {isa = PBXBuildFile; fileRef = B557DA1720979D51005962F4 /* Credentials.swift */; };
 		26DAAB582BEA8DFF00CE399E /* Remote.swift in Sources */ = {isa = PBXBuildFile; fileRef = B557DA0020975500005962F4 /* Remote.swift */; };
@@ -4586,9 +4591,11 @@
 				2680B0D52BED5A7700E7F1D8 /* CookieNonceAuthenticator.swift in Sources */,
 				26373E1B2BFCF531008E6735 /* String+HTML.swift in Sources */,
 				2680B0D42BED5A6600E7F1D8 /* AppicationPasswordEncoder.swift in Sources */,
+				26CFDEEA2C038CBE005ABC31 /* NoteHash.swift in Sources */,
 				2680B0D32BED5A5400E7F1D8 /* OneTimeApplicationPasswordUseCase.swift in Sources */,
 				2680B0D12BED5A4C00E7F1D8 /* UnauthenticatedRequest.swift in Sources */,
 				26373E1C2BFCF62C008E6735 /* OrderNote.swift in Sources */,
+				26CFDEEB2C038CC8005ABC31 /* NoteHashListMapper.swift in Sources */,
 				2680B0D22BED5A4C00E7F1D8 /* AuthenticatedRESTRequest.swift in Sources */,
 				2680B0D02BED5A1900E7F1D8 /* WooConstants.swift in Sources */,
 				2680B0CF2BED59CE00E7F1D8 /* ApplicationPasswordStorage.swift in Sources */,
@@ -4629,16 +4636,19 @@
 				26373E192BFCEF96008E6735 /* OrderListMapper.swift in Sources */,
 				26373E062BFCEA70008E6735 /* OrderStatusEnum.swift in Sources */,
 				263A6DB02BEAA32800C292B2 /* OrderStatsV4Interval.swift in Sources */,
+				26CFDEE72C038C8C005ABC31 /* NotificationsRemote.swift in Sources */,
 				263A6DAC2BEAA31400C292B2 /* StatsGranularityV4.swift in Sources */,
 				26373E1A2BFCEFA7008E6735 /* OrderFeeTaxStatus.swift in Sources */,
 				26373E172BFCEF5D008E6735 /* Order+Fallbacks.swift in Sources */,
 				263A6DAB2BEAA30500C292B2 /* SiteStatsRemote.swift in Sources */,
+				26CFDEE82C038C9D005ABC31 /* SuccessResultMapper.swift in Sources */,
 				263A6DAA2BEAA2E700C292B2 /* OrderStatsRemoteV4.swift in Sources */,
 				2680B0CE2BED592800E7F1D8 /* Secret.swift in Sources */,
 				263A6DA62BEA9FE600C292B2 /* PlaceholderDataValidator.swift in Sources */,
 				263A6DA52BEA9FCC00C292B2 /* String+URL.swift in Sources */,
 				26373E1F2BFCF69A008E6735 /* OrderNoteMapper.swift in Sources */,
 				263A6DA42BEA9F5A00C292B2 /* Dictionary+Woo.swift in Sources */,
+				26CFDEE92C038CAE005ABC31 /* NoteListMapper.swift in Sources */,
 				263A6DA32BEA9EFD00C292B2 /* Result+Extensions.swift in Sources */,
 				263A6DA22BEA9E8F00C292B2 /* WordPressApiError.swift in Sources */,
 				263A6DA12BEA9E8000C292B2 /* WordPressApiValidator.swift in Sources */,

--- a/WooCommerce/Classes/Extensions/Dictionary+Woo.swift
+++ b/WooCommerce/Classes/Extensions/Dictionary+Woo.swift
@@ -42,14 +42,14 @@ extension Dictionary {
     ///
     /// - Returns: Value as a Integer (when possible!)
     ///
-    public func integer(forKey key: Key) -> Int? {
+    public func integer(forKey key: Key) -> Int64? {
         switch self[key] {
-        case let integer as Int:
+        case let integer as Int64:
             return integer
         case let string as String:
-            return Int(string)
+            return Int64(string)
         case let number as NSNumber:
-            return number.intValue
+            return number.int64Value
         default:
             return nil
         }

--- a/WooCommerce/Classes/Notifications/PushNotificationsManager.swift
+++ b/WooCommerce/Classes/Notifications/PushNotificationsManager.swift
@@ -622,24 +622,6 @@ private extension PushNotificationsManager {
     }
 }
 
-// MARK: - PushNotification Extension
-
-private extension PushNotification {
-    static func from(userInfo: [AnyHashable: Any]) -> PushNotification? {
-        guard let noteID = userInfo.integer(forKey: APNSKey.identifier),
-              let siteID = userInfo.integer(forKey: APNSKey.siteID),
-              let alert = userInfo.dictionary(forKey: APNSKey.aps)?.dictionary(forKey: APNSKey.alert),
-              let title = alert.string(forKey: APNSKey.alertTitle),
-              let type = userInfo.string(forKey: APNSKey.type),
-              let noteKind = Note.Kind(rawValue: type) else {
-                  return nil
-              }
-        let subtitle = alert.string(forKey: APNSKey.alertSubtitle)
-        let message = alert.string(forKey: APNSKey.alertMessage)
-        return PushNotification(noteID: noteID, siteID: siteID, kind: noteKind, title: title, subtitle: subtitle, message: message)
-    }
-}
-
 // MARK: - UNNotificationContent Extension
 
 private extension UNNotificationContent {
@@ -661,17 +643,6 @@ enum AppIconBadgeNumber {
 
 // MARK: - Private Types
 //
-private enum APNSKey {
-    static let aps = "aps"
-    static let alert = "alert"
-    static let alertTitle = "title"
-    static let alertSubtitle = "subtitle"
-    static let alertMessage = "body"
-    static let identifier = "note_id"
-    static let type = "type"
-    static let siteID = "blog"
-    static let postID = "post_id"
-}
 
 private enum AnalyticKey {
     static let identifier = "push_notification_note_id"

--- a/WooCommerce/Classes/ServiceLocator/PushNotification.swift
+++ b/WooCommerce/Classes/ServiceLocator/PushNotification.swift
@@ -1,6 +1,10 @@
-
 import Foundation
+
+#if canImport(Yosemite)
 import struct Yosemite.Note
+#elseif canImport(NetworkingWatchOS)
+import struct NetworkingWatchOS.Note
+#endif
 
 /// Emitted by `PushNotificationsManager` when a remote notification is received while
 /// the app is active.
@@ -24,4 +28,40 @@ struct PushNotification {
     /// The `alert.message` value received from the Remote Notification's `userInfo`.
     ///
     let message: String?
+}
+
+extension PushNotification {
+    static func from(userInfo: [AnyHashable: Any]) -> PushNotification? {
+        guard let noteID = userInfo.integer(forKey: APNSKey.identifier),
+              let siteID = userInfo.integer(forKey: APNSKey.siteID),
+              let alert = userInfo.dictionary(forKey: APNSKey.aps)?.dictionary(forKey: APNSKey.alert),
+              let title = alert.string(forKey: APNSKey.alertTitle),
+              let type = userInfo.string(forKey: APNSKey.type),
+              let noteKind = Note.Kind(rawValue: type) else {
+                  return nil
+              }
+        let subtitle = alert.string(forKey: APNSKey.alertSubtitle)
+        let message = alert.string(forKey: APNSKey.alertMessage)
+        return PushNotification(noteID: noteID, siteID: siteID, kind: noteKind, title: title, subtitle: subtitle, message: message)
+    }
+}
+
+enum APNSKey {
+    static let aps = "aps"
+    static let alert = "alert"
+    static let alertTitle = "title"
+    static let alertSubtitle = "subtitle"
+    static let alertMessage = "body"
+    static let identifier = "note_id"
+    static let type = "type"
+    static let siteID = "blog"
+    static let postID = "post_id"
+}
+
+/// SwiftUI Identifiable conformance
+///
+extension PushNotification: Identifiable {
+    var id: Int {
+        noteID
+    }
 }

--- a/WooCommerce/Classes/ServiceLocator/PushNotification.swift
+++ b/WooCommerce/Classes/ServiceLocator/PushNotification.swift
@@ -12,10 +12,10 @@ import struct NetworkingWatchOS.Note
 struct PushNotification {
     /// The `note_id` value received from the Remote Notification's `userInfo`.
     ///
-    let noteID: Int
+    let noteID: Int64
     /// The `blog` value received from the Remote Notification's `userInfo`.
     ///
-    let siteID: Int
+    let siteID: Int64
     /// The `type` value received from the Remote Notification's `userInfo`.
     ///
     let kind: Note.Kind
@@ -61,7 +61,7 @@ enum APNSKey {
 /// SwiftUI Identifiable conformance
 ///
 extension PushNotification: Identifiable {
-    var id: Int {
+    var id: Int64 {
         noteID
     }
 }

--- a/WooCommerce/NotificationExtension/OrderNotificationDataService.swift
+++ b/WooCommerce/NotificationExtension/OrderNotificationDataService.swift
@@ -1,0 +1,95 @@
+import Foundation
+
+#if canImport(Networking)
+import Networking
+#elseif canImport(NetworkingWatchOS)
+import NetworkingWatchOS
+#endif
+
+/// This wrapper to fetch orders from a notification.
+///
+final class OrderNotificationDataService {
+    /// Possible error states.
+    ///
+    enum Error: Swift.Error {
+        case network(Swift.Error)
+        case unavailableNote
+        case unsupportedNotification
+        case unknown
+    }
+
+    /// Orders remote
+    ///
+    private let ordersRemote: OrdersRemote
+
+    /// Notifications remote
+    ///
+    private let notesRemote: NotificationsRemote
+
+    /// Network helper.
+    ///
+    private let network: AlamofireNetwork
+
+    init(credentials: Credentials) {
+        network = AlamofireNetwork(credentials: credentials)
+        ordersRemote = OrdersRemote(network: network)
+        notesRemote = NotificationsRemote(network: network)
+    }
+
+    /// Loads the order associated with the given note id if possible.
+    ///
+    @MainActor
+    func loadOrderFrom(noteID: Int64) async throws -> (Note, Order) {
+        let note = try await loadNotification(noteID: noteID)
+        let order = try await loadOrder(from: note)
+        return (note, order)
+    }
+
+    /// Loads a Note object from a remote source.
+    ///
+    @MainActor
+    private func loadNotification(noteID: Int64) async throws -> Note {
+        return try await withCheckedThrowingContinuation { continuation in
+            notesRemote.loadNotes(noteIDs: [noteID]) { result in
+                switch result {
+                case .success(let notes):
+                    if let note = notes.first {
+                        continuation.resume(returning: note)
+                    } else {
+                        continuation.resume(throwing: Error.unavailableNote)
+                    }
+                case .failure(let error):
+                    continuation.resume(throwing: error)
+                }
+            }
+        }
+    }
+
+    /// Loads an Order object from a given Note object.
+    ///
+    @MainActor
+    private func loadOrder(from notification: Note) async throws -> Order {
+
+        /// Notification must contain order and site ID.
+        ///
+        guard let siteID = notification.meta.identifier(forKey: .site),
+              let orderID = notification.meta.identifier(forKey: .order) else {
+            throw Error.unsupportedNotification
+        }
+
+        /// Load notification from a remote source.
+        ///
+        return try await withCheckedThrowingContinuation { continuation in
+            ordersRemote.loadOrder(for: Int64(siteID), orderID: Int64(orderID)) { order, error in
+                switch (order, error) {
+                case (let order?, nil):
+                    continuation.resume(returning: order)
+                case (_, let error?):
+                    continuation.resume(throwing: Error.network(error))
+                default:
+                    continuation.resume(throwing: Error.unknown)
+                }
+            }
+        }
+    }
+}

--- a/WooCommerce/NotificationExtension/OrderNotificationViewController.swift
+++ b/WooCommerce/NotificationExtension/OrderNotificationViewController.swift
@@ -20,8 +20,7 @@ final class OrderNotificationViewController: UIViewController, UNNotificationCon
             do {
 
                 // Load notification, order and render order view.
-                let note = try await viewModel.loadNotification(notification)
-                let order = try await viewModel.loadOrder(for: note)
+                let (note, order) = try await viewModel.loadOrder(from: notification)
                 let content = viewModel.formatContent(note: note, order: order)
                 addOrderNotificationView(with: content)
                 loadingIndicator?.isHidden = true

--- a/WooCommerce/Woo Watch App/App/AppBindings.swift
+++ b/WooCommerce/Woo Watch App/App/AppBindings.swift
@@ -1,0 +1,11 @@
+import Foundation
+
+/// Keeps track of all the bindings that are needed through the app lifecycle.
+/// This type is meant to be passed as an environment variable
+///
+class AppBindings: NSObject, ObservableObject {
+    
+    /// Determines when an order notification arrives and should be presented.
+    ///
+    @Published var presentNote = false
+}

--- a/WooCommerce/Woo Watch App/App/AppBindings.swift
+++ b/WooCommerce/Woo Watch App/App/AppBindings.swift
@@ -4,7 +4,7 @@ import Foundation
 /// This type is meant to be passed as an environment variable
 ///
 class AppBindings: NSObject, ObservableObject {
-    
+
     /// Determines when an order notification arrives and should be presented.
     ///
     @Published var orderNotification: PushNotification?

--- a/WooCommerce/Woo Watch App/App/AppBindings.swift
+++ b/WooCommerce/Woo Watch App/App/AppBindings.swift
@@ -7,5 +7,5 @@ class AppBindings: NSObject, ObservableObject {
     
     /// Determines when an order notification arrives and should be presented.
     ///
-    @Published var presentNote = false
+    @Published var orderNotification: PushNotification?
 }

--- a/WooCommerce/Woo Watch App/App/AppDelegate.swift
+++ b/WooCommerce/Woo Watch App/App/AppDelegate.swift
@@ -1,5 +1,6 @@
 import WatchKit
 import UserNotifications
+import struct NetworkingWatchOS.Note
 
 
 class AppDelegate: NSObject, ObservableObject, WKApplicationDelegate {
@@ -19,9 +20,12 @@ class AppDelegate: NSObject, ObservableObject, WKApplicationDelegate {
 
 extension AppDelegate: UNUserNotificationCenterDelegate {
     func userNotificationCenter(_ center: UNUserNotificationCenter, didReceive response: UNNotificationResponse) async {
-        print("receive notification response")
-        if response.notification.request.content.categoryIdentifier == "store_order" {
-            appBindings.presentNote = true
+        /// The Watch app only supports order notifications.
+        guard let notification = PushNotification.from(userInfo: response.notification.request.content.userInfo),
+              notification.kind == Note.Kind.storeOrder else {
+            return
         }
+
+        appBindings.orderNotification = notification
     }
 }

--- a/WooCommerce/Woo Watch App/App/AppDelegate.swift
+++ b/WooCommerce/Woo Watch App/App/AppDelegate.swift
@@ -13,8 +13,21 @@ class AppDelegate: NSObject, ObservableObject, WKApplicationDelegate {
     /// Setup code after the app finishes launching
     ///
     func applicationDidFinishLaunching() {
+        // Set up logging
+        setupCocoaLumberjack()
+
         // Sets the notification delegate
         UNUserNotificationCenter.current().delegate = self
+    }
+
+    /// Sets up CocoaLumberjack logging.
+    ///
+    func setupCocoaLumberjack() {
+        let fileLogger = DDFileLogger()
+        fileLogger.rollingFrequency = TimeInterval(60*60*24)  // 24 hours
+        fileLogger.logFileManager.maximumNumberOfLogFiles = 7
+        DDLog.add(DDOSLogger.sharedInstance)
+        DDLog.add(fileLogger)
     }
 }
 

--- a/WooCommerce/Woo Watch App/App/AppDelegate.swift
+++ b/WooCommerce/Woo Watch App/App/AppDelegate.swift
@@ -1,0 +1,27 @@
+import WatchKit
+import UserNotifications
+
+
+class AppDelegate: NSObject, ObservableObject, WKApplicationDelegate {
+
+    /// Stores and modifies app bindings.
+    /// This type should be replaced from the main WatchApp file.
+    ///
+    var appBindings: AppBindings = AppBindings()
+
+    /// Setup code after the app finishes launching
+    ///
+    func applicationDidFinishLaunching() {
+        // Sets the notification delegate
+        UNUserNotificationCenter.current().delegate = self
+    }
+}
+
+extension AppDelegate: UNUserNotificationCenterDelegate {
+    func userNotificationCenter(_ center: UNUserNotificationCenter, didReceive response: UNNotificationResponse) async {
+        print("receive notification response")
+        if response.notification.request.content.categoryIdentifier == "store_order" {
+            appBindings.presentNote = true
+        }
+    }
+}

--- a/WooCommerce/Woo Watch App/App/AppDelegate.swift
+++ b/WooCommerce/Woo Watch App/App/AppDelegate.swift
@@ -1,5 +1,6 @@
 import WatchKit
 import UserNotifications
+import CocoaLumberjack
 import struct NetworkingWatchOS.Note
 
 
@@ -33,12 +34,13 @@ class AppDelegate: NSObject, ObservableObject, WKApplicationDelegate {
 
 extension AppDelegate: UNUserNotificationCenterDelegate {
     func userNotificationCenter(_ center: UNUserNotificationCenter, didReceive response: UNNotificationResponse) async {
-        /// The Watch app only supports order notifications.
+        // The Watch app only supports order notifications.
         guard let notification = PushNotification.from(userInfo: response.notification.request.content.userInfo),
               notification.kind == Note.Kind.storeOrder else {
             return
         }
 
+        // Trigger order notification app binding
         appBindings.orderNotification = notification
     }
 }

--- a/WooCommerce/Woo Watch App/App/WooApp.swift
+++ b/WooCommerce/Woo Watch App/App/WooApp.swift
@@ -23,11 +23,7 @@ struct Woo_Watch_AppApp: App {
                         .tag(WooWatchTab.ordersList)
                 }
                 .sheet(item: $appBindings.orderNotification, content: { orderNotification in
-                    VStack {
-                        Text("\(orderNotification.title)")
-                        Text("\(orderNotification.subtitle ?? "")")
-                        Text("\(orderNotification.message ?? "")")
-                    }
+                    OrderDetailLoader(dependencies: dependencies, pushNotification: orderNotification)
                 })
                 .compatibleVerticalStyle()
                 .environment(\.dependencies, dependencies)
@@ -50,7 +46,7 @@ enum WooWatchTab: Int {
 
 /// Backwards compatible vertical `tabViewStyle` modifier.
 ///
-private struct VerticalPageModifier: ViewModifier {
+struct VerticalPageModifier: ViewModifier {
     func body(content: Content) -> some View {
         if #available(watchOS 10.0, *) {
             content
@@ -62,7 +58,7 @@ private struct VerticalPageModifier: ViewModifier {
     }
 }
 
-private extension View {
+extension View {
     func compatibleVerticalStyle() -> some View {
         self.modifier(VerticalPageModifier())
     }

--- a/WooCommerce/Woo Watch App/App/WooApp.swift
+++ b/WooCommerce/Woo Watch App/App/WooApp.swift
@@ -3,8 +3,13 @@ import SwiftUI
 @main
 struct Woo_Watch_AppApp: App {
 
+    @WKApplicationDelegateAdaptor var delegate: AppDelegate
+
     @StateObject var phoneDependencySynchronizer = PhoneDependenciesSynchronizer()
 
+    @StateObject var appBindings = AppBindings()
+
+    // Refactor: Include this variable into AppBindings
     @State private var selectedTab = WooWatchTab.myStore
 
     var body: some Scene {
@@ -17,8 +22,16 @@ struct Woo_Watch_AppApp: App {
                     OrdersListView(dependencies: dependencies, watchTab: $selectedTab)
                         .tag(WooWatchTab.ordersList)
                 }
+                .sheet(isPresented: $appBindings.presentNote, content: {
+                    Text("New notification arrived and we should present nada yeaaaahhhh")
+                })
                 .compatibleVerticalStyle()
                 .environment(\.dependencies, dependencies)
+                .task {
+                    // For some reason I can't use the bindings directly from our AppDelegate.
+                    // We need to store them in this type assign them to the delegate for further modification.
+                    delegate.appBindings = appBindings
+                }
             } else {
                 ConnectView()
             }

--- a/WooCommerce/Woo Watch App/App/WooApp.swift
+++ b/WooCommerce/Woo Watch App/App/WooApp.swift
@@ -22,8 +22,12 @@ struct Woo_Watch_AppApp: App {
                     OrdersListView(dependencies: dependencies, watchTab: $selectedTab)
                         .tag(WooWatchTab.ordersList)
                 }
-                .sheet(isPresented: $appBindings.presentNote, content: {
-                    Text("New notification arrived and we should present nada yeaaaahhhh")
+                .sheet(item: $appBindings.orderNotification, content: { orderNotification in
+                    VStack {
+                        Text("\(orderNotification.title)")
+                        Text("\(orderNotification.subtitle ?? "")")
+                        Text("\(orderNotification.message ?? "")")
+                    }
                 })
                 .compatibleVerticalStyle()
                 .environment(\.dependencies, dependencies)

--- a/WooCommerce/Woo Watch App/Orders/OrderDetailLoader.swift
+++ b/WooCommerce/Woo Watch App/Orders/OrderDetailLoader.swift
@@ -1,0 +1,83 @@
+import SwiftUI
+import NetworkingWatchOS
+
+/// Loads an order form a notification
+///
+struct OrderDetailLoader: View {
+
+    @StateObject var viewModel: OrderDetailLoaderViewModel
+
+    init(dependencies: WatchDependencies, pushNotification: PushNotification) {
+        _viewModel = StateObject(wrappedValue: OrderDetailLoaderViewModel(dependencies: dependencies, pushNotification: pushNotification))
+    }
+
+    var body: some View {
+        Group {
+            switch viewModel.viewState {
+            case .idle:
+                Rectangle().hidden() // To properly trigger .task{} modifier
+            case .loading:
+                OrderDetailView(order: .placeholder)
+                    .redacted(reason: .placeholder)
+            case .loaded(let order):
+                OrderDetailView(order: order)
+            case .error:
+                Text(AppLocalizedString(
+                    "watch.notification.order.error",
+                    value: "There was an error loading the notification",
+                    comment: "Title when there is an error loading an order notification on the watch app"
+                ))
+            }
+        }
+        .task {
+            await viewModel.fetchOrder()
+        }
+    }
+}
+
+
+/// View Model for the OrderDetailLoader
+///
+final class OrderDetailLoaderViewModel: ObservableObject {
+
+    /// Represents the possible view states
+    ///
+    enum State {
+        case idle
+        case loading
+        case loaded(order: OrdersListView.Order)
+        case error
+    }
+
+    private let dependencies: WatchDependencies
+
+    private let pushNotification: PushNotification
+
+    @Published var viewState: State = .idle
+
+    init(dependencies: WatchDependencies, pushNotification: PushNotification) {
+        self.dependencies = dependencies
+        self.pushNotification = pushNotification
+    }
+
+    /// Fetch order based on the provided push notification. Updates the view state as needed.
+    ///
+    func fetchOrder() async {
+        self.viewState = .loading
+        let dataService = OrderNotificationDataService(credentials: dependencies.credentials)
+        do {
+            let (_, remoteOrder) = try await dataService.loadOrderFrom(noteID: pushNotification.noteID)
+            let viewOrders = OrdersListViewModel.viewOrders(from: [remoteOrder], currencySettings: dependencies.currencySettings)
+
+            // Should always succeed.
+            if let viewOrder = viewOrders.first {
+                self.viewState = .loaded(order: viewOrder)
+            } else {
+                self.viewState = .error
+            }
+        } catch {
+            self.viewState = .error
+            DDLogError("⛔️ Could not fetch the order associated with the notification. \(error)")
+        }
+    }
+}

--- a/WooCommerce/Woo Watch App/Orders/OrderDetailView.swift
+++ b/WooCommerce/Woo Watch App/Orders/OrderDetailView.swift
@@ -39,6 +39,7 @@ struct OrderDetailView: View {
         .background(
             LinearGradient(gradient: Gradient(colors: [Colors.wooPurpleBackground, .black]), startPoint: .top, endPoint: .bottom)
         )
+        .compatibleVerticalStyle()
     }
 
     /// First View: Summary

--- a/WooCommerce/Woo Watch App/Orders/OrdersListView.swift
+++ b/WooCommerce/Woo Watch App/Orders/OrdersListView.swift
@@ -50,15 +50,7 @@ struct OrdersListView: View {
     ///
     @ViewBuilder var loadingView: some View {
         List {
-            OrderListCard(order: .init(date: "----",
-                                       time: "----",
-                                       number: "----",
-                                       name: "----- -----",
-                                       total: "----",
-                                       status: "------- ------",
-                                       email: "-----",
-                                       address: "-----",
-                                       items: []))
+            OrderListCard(order: .placeholder)
         }
         .redacted(reason: .placeholder)
     }

--- a/WooCommerce/Woo Watch App/Orders/OrdersListViewModel.swift
+++ b/WooCommerce/Woo Watch App/Orders/OrdersListViewModel.swift
@@ -34,7 +34,7 @@ final class OrdersListViewModel: ObservableObject {
 
     /// Convert remote orders into view orders.
     ///
-    private static func viewOrders(from remoteOrders: [Order], currencySettings: CurrencySettings) -> [OrdersListView.Order] {
+    static func viewOrders(from remoteOrders: [Order], currencySettings: CurrencySettings) -> [OrdersListView.Order] {
         remoteOrders.map { order in
             let orderViewModel = OrderListCellViewModel(order: order, status: nil, currencySettings: currencySettings)
 
@@ -93,6 +93,18 @@ extension OrdersListView {
         var itemCount: Int {
             items.count
         }
+
+        /// Empty order used as a redacted placeholder.
+        ///
+        static let placeholder: Order = Order(date: "----",
+                                              time: "----",
+                                              number: "----",
+                                              name: "----- -----",
+                                              total: "----",
+                                              status: "------- ------",
+                                              email: "-----",
+                                              address: "-----",
+                                              items: [])
     }
 
     /// Represents an order item.

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -982,6 +982,8 @@
 		26CE6F342B7D4C27008DB858 /* Error+Timeout.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26CE6F332B7D4C27008DB858 /* Error+Timeout.swift */; };
 		26CE6F392B7E71AA008DB858 /* ConnectivityTool.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26CE6F382B7E71AA008DB858 /* ConnectivityTool.swift */; };
 		26CFDB2727357E8000AB940B /* SimplePaymentsSummary.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26CFDB2627357E8000AB940B /* SimplePaymentsSummary.swift */; };
+		26CFDEDA2C029322005ABC31 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26CFDED92C029322005ABC31 /* AppDelegate.swift */; };
+		26CFDEDC2C02932C005ABC31 /* AppBindings.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26CFDEDB2C02932C005ABC31 /* AppBindings.swift */; };
 		26D1E9E82949818B00A7DC62 /* AnalyticsHubTimeRageAdapter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26D1E9E72949818B00A7DC62 /* AnalyticsHubTimeRageAdapter.swift */; };
 		26D57CF72B59820600E8EFB8 /* View+ContainerBackground.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26D57CF62B59820600E8EFB8 /* View+ContainerBackground.swift */; };
 		26D9E54428C107F80098DF26 /* WooFoundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 26D9E54328C107F80098DF26 /* WooFoundation.framework */; };
@@ -3813,6 +3815,8 @@
 		26CE6F332B7D4C27008DB858 /* Error+Timeout.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Error+Timeout.swift"; sourceTree = "<group>"; };
 		26CE6F382B7E71AA008DB858 /* ConnectivityTool.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConnectivityTool.swift; sourceTree = "<group>"; };
 		26CFDB2627357E8000AB940B /* SimplePaymentsSummary.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SimplePaymentsSummary.swift; sourceTree = "<group>"; };
+		26CFDED92C029322005ABC31 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
+		26CFDEDB2C02932C005ABC31 /* AppBindings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppBindings.swift; sourceTree = "<group>"; };
 		26D1E9E72949818B00A7DC62 /* AnalyticsHubTimeRageAdapter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnalyticsHubTimeRageAdapter.swift; sourceTree = "<group>"; };
 		26D57CF62B59820600E8EFB8 /* View+ContainerBackground.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "View+ContainerBackground.swift"; sourceTree = "<group>"; };
 		26D9E54328C107F80098DF26 /* WooFoundation.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = WooFoundation.framework; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -7798,6 +7802,16 @@
 			path = "Connectivity Tool";
 			sourceTree = "<group>";
 		};
+		26CFDED82C02930C005ABC31 /* App */ = {
+			isa = PBXGroup;
+			children = (
+				26F81B172BE433A2009EC58E /* WooApp.swift */,
+				26CFDED92C029322005ABC31 /* AppDelegate.swift */,
+				26CFDEDB2C02932C005ABC31 /* AppBindings.swift */,
+			);
+			path = App;
+			sourceTree = "<group>";
+		};
 		26DB7E3228636CF200506173 /* Order Edition */ = {
 			isa = PBXGroup;
 			children = (
@@ -7857,7 +7871,7 @@
 			isa = PBXGroup;
 			children = (
 				26B984D22BEECC460052658C /* Dependencies */,
-				26F81B172BE433A2009EC58E /* WooApp.swift */,
+				26CFDED82C02930C005ABC31 /* App */,
 				26B984D52BEECF260052658C /* ConnectView.swift */,
 				269FFA492BF544B6004E6B86 /* MyStore */,
 				26A0B2D52BFBA51D002E9620 /* Orders */,
@@ -13696,6 +13710,7 @@
 				26B984D42BEECC610052658C /* Environment+Dependencies.swift in Sources */,
 				26F81B1A2BE433A2009EC58E /* MyStoreView.swift in Sources */,
 				26373E2F2BFD7C18008E6735 /* OrderListCellViewModel.swift in Sources */,
+				26CFDEDA2C029322005ABC31 /* AppDelegate.swift in Sources */,
 				264E9E942BF1D1DF009C48FD /* AppLocalizedString.swift in Sources */,
 				26A0B2D42BF9A78C002E9620 /* StoreInfoFormatter.swift in Sources */,
 				26DD32D42BEBCDFB00F2C69C /* WooConstants.swift in Sources */,
@@ -13707,6 +13722,7 @@
 				269FFA482BF516BA004E6B86 /* Logging.swift in Sources */,
 				26F81B182BE433A2009EC58E /* WooApp.swift in Sources */,
 				26CA47212BFD82AE00E54348 /* DateFormatter+Helpers.swift in Sources */,
+				26CFDEDC2C02932C005ABC31 /* AppBindings.swift in Sources */,
 				2604C3BA2BE977F000250465 /* PhoneDependenciesSynchronizer.swift in Sources */,
 				26A000772BE9D9030071DB1E /* WooConstants.swift in Sources */,
 				26373E2C2BFD13E0008E6735 /* OrdersDataService.swift in Sources */,

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -986,6 +986,8 @@
 		26CFDEDC2C02932C005ABC31 /* AppBindings.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26CFDEDB2C02932C005ABC31 /* AppBindings.swift */; };
 		26CFDEE22C029A5A005ABC31 /* PushNotification.swift in Sources */ = {isa = PBXBuildFile; fileRef = 575472802452185300A94C3C /* PushNotification.swift */; };
 		26CFDEE32C029AD2005ABC31 /* Dictionary+Woo.swift in Sources */ = {isa = PBXBuildFile; fileRef = B57C5C9521B80E5400FF82B2 /* Dictionary+Woo.swift */; };
+		26CFDEE52C038C39005ABC31 /* OrderNotificationDataService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26CFDEE42C038C39005ABC31 /* OrderNotificationDataService.swift */; };
+		26CFDEE62C038C7D005ABC31 /* OrderNotificationDataService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26CFDEE42C038C39005ABC31 /* OrderNotificationDataService.swift */; };
 		26D1E9E82949818B00A7DC62 /* AnalyticsHubTimeRageAdapter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26D1E9E72949818B00A7DC62 /* AnalyticsHubTimeRageAdapter.swift */; };
 		26D57CF72B59820600E8EFB8 /* View+ContainerBackground.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26D57CF62B59820600E8EFB8 /* View+ContainerBackground.swift */; };
 		26D9E54428C107F80098DF26 /* WooFoundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 26D9E54328C107F80098DF26 /* WooFoundation.framework */; };
@@ -3819,6 +3821,7 @@
 		26CFDB2627357E8000AB940B /* SimplePaymentsSummary.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SimplePaymentsSummary.swift; sourceTree = "<group>"; };
 		26CFDED92C029322005ABC31 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		26CFDEDB2C02932C005ABC31 /* AppBindings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppBindings.swift; sourceTree = "<group>"; };
+		26CFDEE42C038C39005ABC31 /* OrderNotificationDataService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OrderNotificationDataService.swift; sourceTree = "<group>"; };
 		26D1E9E72949818B00A7DC62 /* AnalyticsHubTimeRageAdapter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnalyticsHubTimeRageAdapter.swift; sourceTree = "<group>"; };
 		26D57CF62B59820600E8EFB8 /* View+ContainerBackground.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "View+ContainerBackground.swift"; sourceTree = "<group>"; };
 		26D9E54328C107F80098DF26 /* WooFoundation.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = WooFoundation.framework; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -7406,6 +7409,7 @@
 				26EE795E2AA7924700857293 /* NotificationExtension.entitlements */,
 				2608370D2AA66E4B0004A12B /* OrderNotificationViewController.swift */,
 				2679F02C2AAADB1C00AF80C5 /* OrderNotificationViewModel.swift */,
+				26CFDEE42C038C39005ABC31 /* OrderNotificationDataService.swift */,
 				26CA2BC52AAA1773003B16C2 /* OrderNotificationView.swift */,
 				2608370F2AA66E4B0004A12B /* MainInterface.storyboard */,
 				260837122AA66E4B0004A12B /* Info.plist */,
@@ -13695,6 +13699,7 @@
 				26CA2BC62AAA1773003B16C2 /* OrderNotificationView.swift in Sources */,
 				26CA2BC42AA92CA9003B16C2 /* AppLocalizedString.swift in Sources */,
 				2608370E2AA66E4B0004A12B /* OrderNotificationViewController.swift in Sources */,
+				26CFDEE52C038C39005ABC31 /* OrderNotificationDataService.swift in Sources */,
 				26EE79602AA795EC00857293 /* WooConstants.swift in Sources */,
 				2679F02D2AAADB1C00AF80C5 /* OrderNotificationViewModel.swift in Sources */,
 			);
@@ -13731,6 +13736,7 @@
 				26A000772BE9D9030071DB1E /* WooConstants.swift in Sources */,
 				26373E2C2BFD13E0008E6735 /* OrdersDataService.swift in Sources */,
 				26FFC50C2BED7C5A0067B3A4 /* WatchDependencies.swift in Sources */,
+				26CFDEE62C038C7D005ABC31 /* OrderNotificationDataService.swift in Sources */,
 				26CA471F2BFD81E900E54348 /* String+Helpers.swift in Sources */,
 				26CA47242BFE4C1C00E54348 /* OrderDetailView.swift in Sources */,
 			);

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -984,6 +984,8 @@
 		26CFDB2727357E8000AB940B /* SimplePaymentsSummary.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26CFDB2627357E8000AB940B /* SimplePaymentsSummary.swift */; };
 		26CFDEDA2C029322005ABC31 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26CFDED92C029322005ABC31 /* AppDelegate.swift */; };
 		26CFDEDC2C02932C005ABC31 /* AppBindings.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26CFDEDB2C02932C005ABC31 /* AppBindings.swift */; };
+		26CFDEE22C029A5A005ABC31 /* PushNotification.swift in Sources */ = {isa = PBXBuildFile; fileRef = 575472802452185300A94C3C /* PushNotification.swift */; };
+		26CFDEE32C029AD2005ABC31 /* Dictionary+Woo.swift in Sources */ = {isa = PBXBuildFile; fileRef = B57C5C9521B80E5400FF82B2 /* Dictionary+Woo.swift */; };
 		26D1E9E82949818B00A7DC62 /* AnalyticsHubTimeRageAdapter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26D1E9E72949818B00A7DC62 /* AnalyticsHubTimeRageAdapter.swift */; };
 		26D57CF72B59820600E8EFB8 /* View+ContainerBackground.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26D57CF62B59820600E8EFB8 /* View+ContainerBackground.swift */; };
 		26D9E54428C107F80098DF26 /* WooFoundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 26D9E54328C107F80098DF26 /* WooFoundation.framework */; };
@@ -13702,9 +13704,11 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				26CFDEE22C029A5A005ABC31 /* PushNotification.swift in Sources */,
 				26CA47222BFD82B900E54348 /* TimeZone+Woo.swift in Sources */,
 				264E9E952BF400AD009C48FD /* StoreInfoDataService.swift in Sources */,
 				26CA471C2BFD7FE600E54348 /* Address+Woo.swift in Sources */,
+				26CFDEE32C029AD2005ABC31 /* Dictionary+Woo.swift in Sources */,
 				26373E2E2BFD2F46008E6735 /* OrdersListViewModel.swift in Sources */,
 				26A0B2D72BFBA536002E9620 /* OrdersListView.swift in Sources */,
 				26B984D42BEECC610052658C /* Environment+Dependencies.swift in Sources */,

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -823,6 +823,7 @@
 		262418332B8D3630009A3834 /* ApplicationPasswordTutorial.swift in Sources */ = {isa = PBXBuildFile; fileRef = 262418322B8D3630009A3834 /* ApplicationPasswordTutorial.swift */; };
 		262418372B9044FF009A3834 /* ApplicationPasswordTutorialViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 262418362B9044FF009A3834 /* ApplicationPasswordTutorialViewModel.swift */; };
 		262619F12C03AB9600BD733B /* OrderDetailLoader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 262619F02C03AB9600BD733B /* OrderDetailLoader.swift */; };
+		262619F22C03BD9200BD733B /* OrderNotificationDataService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26CFDEE42C038C39005ABC31 /* OrderNotificationDataService.swift */; };
 		26281776278F0B0100C836D3 /* View+NoticesModifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26281775278F0B0100C836D3 /* View+NoticesModifier.swift */; };
 		262A098B2628C51D0033AD20 /* OrderAddOnListViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 262A098A2628C51D0033AD20 /* OrderAddOnListViewModel.swift */; };
 		262A0999262908A60033AD20 /* OrderAddOnListI1Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 262A0998262908A60033AD20 /* OrderAddOnListI1Tests.swift */; };
@@ -15877,6 +15878,7 @@
 				02691780232600A6002AFC20 /* ProductsTabProductViewModelTests.swift in Sources */,
 				DE69C54F27BCB4B7000BB888 /* CouponRestrictionsViewModelTests.swift in Sources */,
 				024F1452250B65A40003030A /* AddProductCoordinatorTests.swift in Sources */,
+				262619F22C03BD9200BD733B /* OrderNotificationDataService.swift in Sources */,
 				021AC6662AF3432300E7FB97 /* ConfigurableBundleProductViewModelTests.swift in Sources */,
 				26B3EC622744772A0075EAE6 /* SimplePaymentsSummaryViewModelTests.swift in Sources */,
 				D85DD1D7257F359800861AA8 /* NotWPErrorViewModelTests.swift in Sources */,

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -912,6 +912,7 @@
 		269098B627D2C09D001FEB07 /* ShippingInputTransformerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 269098B527D2C09D001FEB07 /* ShippingInputTransformerTests.swift */; };
 		269098B827D68CCD001FEB07 /* FeesInputTransformer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 269098B727D68CCD001FEB07 /* FeesInputTransformer.swift */; };
 		269098BA27D6922E001FEB07 /* FeesInputTransformerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 269098B927D6922E001FEB07 /* FeesInputTransformerTests.swift */; };
+		2699E3A22C00F53A00B50495 /* o.caf in Resources */ = {isa = PBXBuildFile; fileRef = B5F571AF21BF149D0010D1B8 /* o.caf */; };
 		269A2F47295CC683000828A8 /* GenerateVariationsSelectorCommand.swift in Sources */ = {isa = PBXBuildFile; fileRef = 269A2F46295CC683000828A8 /* GenerateVariationsSelectorCommand.swift */; };
 		269B46622A16D68A00ADA872 /* UpdateAnalyticsSettingsUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 269B46612A16D68A00ADA872 /* UpdateAnalyticsSettingsUseCase.swift */; };
 		269B46642A16D6ED00ADA872 /* UpdateAnalyticsSettingsUseCaseTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 269B46632A16D6ED00ADA872 /* UpdateAnalyticsSettingsUseCaseTests.swift */; };
@@ -13149,6 +13150,7 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				2699E3A22C00F53A00B50495 /* o.caf in Resources */,
 				26F81B1F2BE433A3009EC58E /* Preview Assets.xcassets in Resources */,
 				26F81B1C2BE433A3009EC58E /* Assets.xcassets in Resources */,
 			);

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -822,6 +822,7 @@
 		261F1A7C29C2B09D001D9861 /* FreeTrialBannerViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 261F1A7B29C2B09D001D9861 /* FreeTrialBannerViewModelTests.swift */; };
 		262418332B8D3630009A3834 /* ApplicationPasswordTutorial.swift in Sources */ = {isa = PBXBuildFile; fileRef = 262418322B8D3630009A3834 /* ApplicationPasswordTutorial.swift */; };
 		262418372B9044FF009A3834 /* ApplicationPasswordTutorialViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 262418362B9044FF009A3834 /* ApplicationPasswordTutorialViewModel.swift */; };
+		262619F12C03AB9600BD733B /* OrderDetailLoader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 262619F02C03AB9600BD733B /* OrderDetailLoader.swift */; };
 		26281776278F0B0100C836D3 /* View+NoticesModifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26281775278F0B0100C836D3 /* View+NoticesModifier.swift */; };
 		262A098B2628C51D0033AD20 /* OrderAddOnListViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 262A098A2628C51D0033AD20 /* OrderAddOnListViewModel.swift */; };
 		262A0999262908A60033AD20 /* OrderAddOnListI1Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 262A0998262908A60033AD20 /* OrderAddOnListI1Tests.swift */; };
@@ -3689,6 +3690,7 @@
 		261F1A7B29C2B09D001D9861 /* FreeTrialBannerViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FreeTrialBannerViewModelTests.swift; sourceTree = "<group>"; };
 		262418322B8D3630009A3834 /* ApplicationPasswordTutorial.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ApplicationPasswordTutorial.swift; sourceTree = "<group>"; };
 		262418362B9044FF009A3834 /* ApplicationPasswordTutorialViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ApplicationPasswordTutorialViewModel.swift; sourceTree = "<group>"; };
+		262619F02C03AB9600BD733B /* OrderDetailLoader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OrderDetailLoader.swift; sourceTree = "<group>"; };
 		26281775278F0B0100C836D3 /* View+NoticesModifier.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "View+NoticesModifier.swift"; sourceTree = "<group>"; };
 		262A098A2628C51D0033AD20 /* OrderAddOnListViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OrderAddOnListViewModel.swift; sourceTree = "<group>"; };
 		262A0998262908A60033AD20 /* OrderAddOnListI1Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OrderAddOnListI1Tests.swift; sourceTree = "<group>"; };
@@ -7690,6 +7692,7 @@
 				26373E2D2BFD2F46008E6735 /* OrdersListViewModel.swift */,
 				26373E2B2BFD13E0008E6735 /* OrdersDataService.swift */,
 				26CA47232BFE4C1B00E54348 /* OrderDetailView.swift */,
+				262619F02C03AB9600BD733B /* OrderDetailLoader.swift */,
 			);
 			path = Orders;
 			sourceTree = "<group>";
@@ -13716,6 +13719,7 @@
 				26CFDEE32C029AD2005ABC31 /* Dictionary+Woo.swift in Sources */,
 				26373E2E2BFD2F46008E6735 /* OrdersListViewModel.swift in Sources */,
 				26A0B2D72BFBA536002E9620 /* OrdersListView.swift in Sources */,
+				262619F12C03AB9600BD733B /* OrderDetailLoader.swift in Sources */,
 				26B984D42BEECC610052658C /* Environment+Dependencies.swift in Sources */,
 				26F81B1A2BE433A2009EC58E /* MyStoreView.swift in Sources */,
 				26373E2F2BFD7C18008E6735 /* OrderListCellViewModel.swift in Sources */,


### PR DESCRIPTION
Closes: #12505

# Why

This PR adds the ability to tap on a notification, open the app, and show the user such an order.

# How

- Create App Delegate
- Create App Bindings
- Listen to incoming notifications
- Fetch order for notification
- Show order detail as a modal.

# Demo


https://github.com/woocommerce/woocommerce-ios/assets/562080/61f2244a-29cc-4277-8beb-20ba25b8cd4d



---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
