### PR TITLE
Dynamic dashboard: unit tests for dashboard cards generating and loading

### DIFF
--- a/WooCommerce/WooCommerceTests/Mocks/MockFeatureFlagService.swift
+++ b/WooCommerce/WooCommerceTests/Mocks/MockFeatureFlagService.swift
@@ -24,6 +24,7 @@ struct MockFeatureFlagService: FeatureFlagService {
     private let isSubscriptionsInOrderCreationCustomersEnabled: Bool
     private let isMultipleShippingLinesEnabled: Bool
     private let isDisplayPointOfSaleToggleEnabled: Bool
+    private let isDynamicDashboardM2Enabled: Bool
 
     init(isInboxOn: Bool = false,
          isUpdateOrderOptimisticallyOn: Bool = false,
@@ -46,7 +47,8 @@ struct MockFeatureFlagService: FeatureFlagService {
          sideBySideViewForOrderForm: Bool = false,
          isSubscriptionsInOrderCreationCustomersEnabled: Bool = false,
          isMultipleShippingLinesEnabled: Bool = false,
-         isDisplayPointOfSaleToggleEnabled: Bool = false) {
+         isDisplayPointOfSaleToggleEnabled: Bool = false,
+         isDynamicDashboardM2Enabled: Bool = false) {
         self.isInboxOn = isInboxOn
         self.isUpdateOrderOptimisticallyOn = isUpdateOrderOptimisticallyOn
         self.shippingLabelsOnboardingM1 = shippingLabelsOnboardingM1
@@ -69,6 +71,7 @@ struct MockFeatureFlagService: FeatureFlagService {
         self.isSubscriptionsInOrderCreationCustomersEnabled = isSubscriptionsInOrderCreationCustomersEnabled
         self.isMultipleShippingLinesEnabled = isMultipleShippingLinesEnabled
         self.isDisplayPointOfSaleToggleEnabled = isDisplayPointOfSaleToggleEnabled
+        self.isDynamicDashboardM2Enabled = isDynamicDashboardM2Enabled
     }
 
     func isFeatureFlagEnabled(_ featureFlag: FeatureFlag) -> Bool {
@@ -115,6 +118,8 @@ struct MockFeatureFlagService: FeatureFlagService {
             return isMultipleShippingLinesEnabled
         case .displayPointOfSaleToggle:
             return isDisplayPointOfSaleToggleEnabled
+        case .dynamicDashboardM2:
+            return isDynamicDashboardM2Enabled
         default:
             return false
         }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/DashboardViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/DashboardViewModelTests.swift
@@ -429,10 +429,9 @@ final class DashboardViewModelTests: XCTestCase {
 
         // Then
         waitUntil {
-            viewModel.dashboardCards.isNotEmpty
+            viewModel.dashboardCards == expectedCards
         }
 
-        XCTAssertEqual(viewModel.dashboardCards, expectedCards)
     }
 
     func test_generated_default_cards_are_as_expected_with_m2_feature_flag_disabled() {

--- a/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/DashboardViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/DashboardViewModelTests.swift
@@ -403,6 +403,41 @@ final class DashboardViewModelTests: XCTestCase {
             viewModel.hasOrders == true
         }
     }
+
+    func test_generated_default_cards_are_as_expected() {
+        // Given
+        let featureFlagService = MockFeatureFlagService(isDynamicDashboardM2Enabled: true)
+
+        let viewModel = DashboardViewModel(siteID: sampleSiteID, stores: stores, featureFlags: featureFlagService)
+        stores.whenReceivingAction(ofType: AppSettingsAction.self) { action in
+            switch action {
+            case let .loadDashboardCards(_, onCompletion):
+                onCompletion([])
+            default:
+                break
+            }
+        }
+
+        let expectedCards = [DashboardCard(type: .onboarding, availability: .show, enabled: true),
+                             DashboardCard(type: .performance, availability: .unavailable, enabled: false),
+                             DashboardCard(type: .topPerformers, availability: .unavailable, enabled: false),
+                             DashboardCard(type: .blaze, availability: .hide, enabled: false),
+                             DashboardCard(type: .inbox, availability: .show, enabled: false),
+                             DashboardCard(type: .reviews, availability: .show, enabled: false),
+                             DashboardCard(type: .coupons, availability: .show, enabled: false),
+                             DashboardCard(type: .stock, availability: .show, enabled: false)]
+
+        // When
+        viewModel.refreshDashboardCards()
+
+        // Then
+        waitUntil {
+            viewModel.dashboardCards.isNotEmpty
+        }
+
+        XCTAssertEqual(viewModel.dashboardCards.count, 8)
+        XCTAssertEqual(viewModel.dashboardCards, expectedCards)
+    }
 }
 
 private extension DashboardViewModelTests {

--- a/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/DashboardViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/DashboardViewModelTests.swift
@@ -455,6 +455,27 @@ final class DashboardViewModelTests: XCTestCase {
         }
     }
 
+    func test_dashboard_cards_contain_unavailable_and_disabled_analytics_cards_when_there_are_no_orders() {
+        // Given
+        let featureFlagService = MockFeatureFlagService(isDynamicDashboardM2Enabled: false)
+        let viewModel = DashboardViewModel(siteID: sampleSiteID, stores: stores, featureFlags: featureFlagService)
+        mockLoadDashboardCards(withStoredCards: [])
+
+        // Analytics cards need to say "Unavailable" in the Customize screen and be disabled so they don't appear on Dashboard
+        // This is set as availability: .unavailable and enabled: false in the expected cards.
+        let expectedPerformanceCard = DashboardCard(type: .performance, availability: .unavailable, enabled: false)
+        let expectedTopPerformersCard = DashboardCard(type: .topPerformers, availability: .unavailable, enabled: false)
+
+        // When
+        viewModel.refreshDashboardCards()
+
+        // Then
+        waitUntil {
+            viewModel.dashboardCards.contains(expectedPerformanceCard) &&
+            viewModel.dashboardCards.contains(expectedTopPerformersCard)
+        }
+    }
+
     func test_dashboard_cards_contain_enabled_analytics_cards_when_there_is_order() {
         // Given
         let featureFlagService = MockFeatureFlagService(isDynamicDashboardM2Enabled: true)
@@ -464,7 +485,7 @@ final class DashboardViewModelTests: XCTestCase {
         let viewModel = DashboardViewModel(siteID: sampleSiteID, stores: stores, storageManager: storage, featureFlags: featureFlagService)
         mockLoadDashboardCards(withStoredCards: [])
 
-        // The expected cards need to be availability: .show and enabled: true
+        // Analytics cards need to be set with availability: .show and enabled: true to make them available and shown.
         let expectedPerformanceCard = DashboardCard(type: .performance, availability: .show, enabled: true)
         let expectedTopPerformersCard = DashboardCard(type: .topPerformers, availability: .show, enabled: true)
 

--- a/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/DashboardViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/DashboardViewModelTests.swift
@@ -451,10 +451,8 @@ final class DashboardViewModelTests: XCTestCase {
 
         // Then
         waitUntil {
-            viewModel.dashboardCards.isNotEmpty
+            viewModel.dashboardCards == expectedCards
         }
-
-        XCTAssertEqual(viewModel.dashboardCards, expectedCards)
     }
 
     func test_dashboard_cards_contain_enabled_analytics_cards_when_there_is_order() {
@@ -521,10 +519,8 @@ final class DashboardViewModelTests: XCTestCase {
 
         // Then
         waitUntil {
-            viewModel.dashboardCards.isNotEmpty
+            viewModel.dashboardCards == storedCards
         }
-
-        XCTAssertEqual(viewModel.dashboardCards, storedCards)
     }
 
     func test_dashboard_cards_respects_existing_ordering_from_saved_cards() {

--- a/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/DashboardViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/DashboardViewModelTests.swift
@@ -473,11 +473,9 @@ final class DashboardViewModelTests: XCTestCase {
 
         // Then
         waitUntil {
-            viewModel.dashboardCards.isNotEmpty
+            viewModel.dashboardCards.contains(expectedPerformanceCard) &&
+            viewModel.dashboardCards.contains(expectedTopPerformersCard)
         }
-
-        XCTAssertTrue(viewModel.dashboardCards.contains(expectedPerformanceCard))
-        XCTAssertTrue(viewModel.dashboardCards.contains(expectedTopPerformersCard))
     }
 
     func test_dashboard_cards_has_disabled_onboarding_card_if_all_tasks_are_completed() {
@@ -494,10 +492,8 @@ final class DashboardViewModelTests: XCTestCase {
 
         // Then
         waitUntil {
-            viewModel.dashboardCards.isNotEmpty
+            viewModel.dashboardCards.first(where: {$0.type == .onboarding })!.enabled == false
         }
-
-        XCTAssertFalse(viewModel.dashboardCards.first(where: {$0.type == .onboarding })!.enabled)
     }
 
     func test_dashboard_cards_is_loaded_from_storage_if_they_exist() {
@@ -544,12 +540,9 @@ final class DashboardViewModelTests: XCTestCase {
 
         // Then
         waitUntil {
-            viewModel.dashboardCards.isNotEmpty
+            // Equality implies identical ordering
+            viewModel.dashboardCards == storedCards
         }
-
-        XCTAssertEqual(viewModel.dashboardCards[0], storedCards[0])
-        XCTAssertEqual(viewModel.dashboardCards[1], storedCards[1])
-        XCTAssertEqual(viewModel.dashboardCards[2], storedCards[2])
     }
 
     func test_dashboard_cards_respects_enabled_setting_from_saved_cards() {
@@ -573,11 +566,9 @@ final class DashboardViewModelTests: XCTestCase {
 
         // Then
         waitUntil {
-            viewModel.dashboardCards.isNotEmpty
+            viewModel.dashboardCards.first(where: {$0.type == .performance })!.enabled == true &&
+            viewModel.dashboardCards.first(where: {$0.type == .topPerformers })!.enabled == false
         }
-
-        XCTAssertTrue(viewModel.dashboardCards.first(where: {$0.type == .performance })!.enabled)
-        XCTAssertFalse(viewModel.dashboardCards.first(where: {$0.type == .topPerformers })!.enabled)
     }
 }
 

--- a/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/DashboardViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/DashboardViewModelTests.swift
@@ -413,14 +413,7 @@ final class DashboardViewModelTests: XCTestCase {
         let featureFlagService = MockFeatureFlagService(isDynamicDashboardM2Enabled: true)
 
         let viewModel = DashboardViewModel(siteID: sampleSiteID, stores: stores, featureFlags: featureFlagService)
-        stores.whenReceivingAction(ofType: AppSettingsAction.self) { action in
-            switch action {
-            case let .loadDashboardCards(_, onCompletion):
-                onCompletion([])
-            default:
-                break
-            }
-        }
+        mockLoadDashboardCards()
 
         let expectedCards = [DashboardCard(type: .onboarding, availability: .show, enabled: true),
                              DashboardCard(type: .performance, availability: .unavailable, enabled: false),
@@ -447,14 +440,7 @@ final class DashboardViewModelTests: XCTestCase {
         let featureFlagService = MockFeatureFlagService(isDynamicDashboardM2Enabled: false)
 
         let viewModel = DashboardViewModel(siteID: sampleSiteID, stores: stores, featureFlags: featureFlagService)
-        stores.whenReceivingAction(ofType: AppSettingsAction.self) { action in
-            switch action {
-            case let .loadDashboardCards(_, onCompletion):
-                onCompletion([])
-            default:
-                break
-            }
-        }
+        mockLoadDashboardCards()
 
         let expectedCards = [DashboardCard(type: .onboarding, availability: .show, enabled: true),
                              DashboardCard(type: .performance, availability: .unavailable, enabled: false),
@@ -511,14 +497,8 @@ final class DashboardViewModelTests: XCTestCase {
         userDefaults[.completedAllStoreOnboardingTasks] = true
 
         let viewModel = DashboardViewModel(siteID: sampleSiteID, stores: stores, featureFlags: featureFlagService, userDefaults: userDefaults)
-        stores.whenReceivingAction(ofType: AppSettingsAction.self) { action in
-            switch action {
-            case let .loadDashboardCards(_, onCompletion):
-                onCompletion([])
-            default:
-                break
-            }
-        }
+
+        mockLoadDashboardCards()
 
         // When
         viewModel.refreshDashboardCards()
@@ -543,14 +523,7 @@ final class DashboardViewModelTests: XCTestCase {
                            DashboardCard(type: .performance, availability: .show, enabled: true),
                            DashboardCard(type: .topPerformers, availability: .show, enabled: true)]
 
-        stores.whenReceivingAction(ofType: AppSettingsAction.self) { action in
-            switch action {
-            case let .loadDashboardCards(_, onCompletion):
-                onCompletion(storedCards)
-            default:
-                break
-            }
-        }
+        mockLoadDashboardCards(withStoredCards: storedCards)
 
         // When
         viewModel.refreshDashboardCards()
@@ -577,14 +550,7 @@ final class DashboardViewModelTests: XCTestCase {
                            DashboardCard(type: .onboarding, availability: .show, enabled: true),
                            DashboardCard(type: .performance, availability: .show, enabled: true)]
 
-        stores.whenReceivingAction(ofType: AppSettingsAction.self) { action in
-            switch action {
-            case let .loadDashboardCards(_, onCompletion):
-                onCompletion(storedCards)
-            default:
-                break
-            }
-        }
+        mockLoadDashboardCards(withStoredCards: storedCards)
 
         // When
         viewModel.refreshDashboardCards()
@@ -613,14 +579,7 @@ final class DashboardViewModelTests: XCTestCase {
                            DashboardCard(type: .performance, availability: .show, enabled: true),
                            DashboardCard(type: .topPerformers, availability: .show, enabled: false)]
 
-        stores.whenReceivingAction(ofType: AppSettingsAction.self) { action in
-            switch action {
-            case let .loadDashboardCards(_, onCompletion):
-                onCompletion(storedCards)
-            default:
-                break
-            }
-        }
+        mockLoadDashboardCards(withStoredCards: storedCards)
 
         // When
         viewModel.refreshDashboardCards()
@@ -642,6 +601,18 @@ private extension DashboardViewModelTests {
                 return XCTFail()
             }
             completion(result)
+        }
+    }
+
+    /// Returns mocked saved cards or empty.
+    func mockLoadDashboardCards(withStoredCards cards: [DashboardCard]? = nil) {
+        stores.whenReceivingAction(ofType: AppSettingsAction.self) { action in
+            switch action {
+            case let .loadDashboardCards(_, onCompletion):
+                onCompletion(cards ?? [])
+            default:
+                break
+            }
         }
     }
 

--- a/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/DashboardViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/DashboardViewModelTests.swift
@@ -505,7 +505,7 @@ final class DashboardViewModelTests: XCTestCase {
         XCTAssertTrue(viewModel.dashboardCards.contains(expectedTopPerformersCard))
     }
 
-    func test_dashboard_cards_has_disabled_onboarding_card_if_all_tasks_are_completed() throws {
+    func test_dashboard_cards_has_disabled_onboarding_card_if_all_tasks_are_completed() {
         // Given
         let featureFlagService = MockFeatureFlagService(isDynamicDashboardM2Enabled: false)
         userDefaults[.completedAllStoreOnboardingTasks] = true

--- a/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/DashboardViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/DashboardViewModelTests.swift
@@ -478,7 +478,7 @@ final class DashboardViewModelTests: XCTestCase {
         }
     }
 
-    func test_dashboard_cards_has_disabled_onboarding_card_if_all_tasks_are_completed() {
+    func test_dashboard_cards_has_disabled_onboarding_card_if_all_tasks_are_completed() throws {
         // Given
         let featureFlagService = MockFeatureFlagService(isDynamicDashboardM2Enabled: false)
         userDefaults[.completedAllStoreOnboardingTasks] = true
@@ -492,8 +492,11 @@ final class DashboardViewModelTests: XCTestCase {
 
         // Then
         waitUntil {
-            viewModel.dashboardCards.first(where: {$0.type == .onboarding })!.enabled == false
+            viewModel.dashboardCards.isNotEmpty
         }
+
+        let onboardingCard = try XCTUnwrap(viewModel.dashboardCards.first(where: {$0.type == .onboarding }))
+        XCTAssertFalse(onboardingCard.enabled)
     }
 
     func test_dashboard_cards_is_loaded_from_storage_if_they_exist() {
@@ -545,7 +548,7 @@ final class DashboardViewModelTests: XCTestCase {
         }
     }
 
-    func test_dashboard_cards_respects_enabled_setting_from_saved_cards() {
+    func test_dashboard_cards_respects_enabled_setting_from_saved_cards() throws {
         // Given
         let featureFlagService = MockFeatureFlagService(isDynamicDashboardM2Enabled: false)
         let storage = MockStorageManager()
@@ -566,9 +569,14 @@ final class DashboardViewModelTests: XCTestCase {
 
         // Then
         waitUntil {
-            viewModel.dashboardCards.first(where: {$0.type == .performance })!.enabled == true &&
-            viewModel.dashboardCards.first(where: {$0.type == .topPerformers })!.enabled == false
+            viewModel.dashboardCards.isNotEmpty
         }
+
+        let performanceCard = try XCTUnwrap(viewModel.dashboardCards.first(where: {$0.type == .performance }))
+        XCTAssertTrue(performanceCard.enabled)
+
+        let topPerformersCard = try XCTUnwrap(viewModel.dashboardCards.first(where: {$0.type == .topPerformers }))
+        XCTAssertFalse(topPerformersCard.enabled)
     }
 }
 

--- a/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/DashboardViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/DashboardViewModelTests.swift
@@ -465,15 +465,7 @@ final class DashboardViewModelTests: XCTestCase {
         let insertOrder = Order.fake().copy(siteID: sampleSiteID)
         storage.insertSampleOrder(readOnlyOrder: insertOrder)
         let viewModel = DashboardViewModel(siteID: sampleSiteID, stores: stores, storageManager: storage, featureFlags: featureFlagService)
-
-        stores.whenReceivingAction(ofType: AppSettingsAction.self) { action in
-            switch action {
-            case let .loadDashboardCards(_, onCompletion):
-                onCompletion([])
-            default:
-                break
-            }
-        }
+        mockLoadDashboardCards()
 
         // The expected cards need to be availability: .show and enabled: true
         let expectedPerformanceCard = DashboardCard(type: .performance, availability: .show, enabled: true)

--- a/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/DashboardViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/DashboardViewModelTests.swift
@@ -413,7 +413,7 @@ final class DashboardViewModelTests: XCTestCase {
         let featureFlagService = MockFeatureFlagService(isDynamicDashboardM2Enabled: true)
 
         let viewModel = DashboardViewModel(siteID: sampleSiteID, stores: stores, featureFlags: featureFlagService)
-        mockLoadDashboardCards()
+        mockLoadDashboardCards(withStoredCards: [])
 
         let expectedCards = [DashboardCard(type: .onboarding, availability: .show, enabled: true),
                              DashboardCard(type: .performance, availability: .unavailable, enabled: false),
@@ -439,7 +439,7 @@ final class DashboardViewModelTests: XCTestCase {
         let featureFlagService = MockFeatureFlagService(isDynamicDashboardM2Enabled: false)
 
         let viewModel = DashboardViewModel(siteID: sampleSiteID, stores: stores, featureFlags: featureFlagService)
-        mockLoadDashboardCards()
+        mockLoadDashboardCards(withStoredCards: [])
 
         let expectedCards = [DashboardCard(type: .onboarding, availability: .show, enabled: true),
                              DashboardCard(type: .performance, availability: .unavailable, enabled: false),
@@ -462,7 +462,7 @@ final class DashboardViewModelTests: XCTestCase {
         let insertOrder = Order.fake().copy(siteID: sampleSiteID)
         storage.insertSampleOrder(readOnlyOrder: insertOrder)
         let viewModel = DashboardViewModel(siteID: sampleSiteID, stores: stores, storageManager: storage, featureFlags: featureFlagService)
-        mockLoadDashboardCards()
+        mockLoadDashboardCards(withStoredCards: [])
 
         // The expected cards need to be availability: .show and enabled: true
         let expectedPerformanceCard = DashboardCard(type: .performance, availability: .show, enabled: true)
@@ -487,7 +487,7 @@ final class DashboardViewModelTests: XCTestCase {
 
         let viewModel = DashboardViewModel(siteID: sampleSiteID, stores: stores, featureFlags: featureFlagService, userDefaults: userDefaults)
 
-        mockLoadDashboardCards()
+        mockLoadDashboardCards(withStoredCards: [])
 
         // When
         viewModel.refreshDashboardCards()
@@ -591,12 +591,12 @@ private extension DashboardViewModelTests {
         }
     }
 
-    /// Returns mocked saved cards or empty.
-    func mockLoadDashboardCards(withStoredCards cards: [DashboardCard]? = nil) {
+    /// Mock saved cards. Pass empty array to simulate no saved cards situation.
+    func mockLoadDashboardCards(withStoredCards cards: [DashboardCard]) {
         stores.whenReceivingAction(ofType: AppSettingsAction.self) { action in
             switch action {
             case let .loadDashboardCards(_, onCompletion):
-                onCompletion(cards ?? [])
+                onCompletion(cards)
             default:
                 break
             }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #12839
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This PR adds various unit tests related to how default dashboard cards are generated/shown, as well as dashboard cards state loading from store, and so on.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

Please check and see if the unit tests make sense, and make sure CI passes.
