### PR TITLE
Dynamic dashboard: Add eligibility check for inbox card

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Dashboard/DashboardViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/DashboardViewModel.swift
@@ -506,10 +506,18 @@ private extension DashboardViewModel {
         if savedCards.isEmpty {
             dashboardCards = updatedCards
         } else {
+
             // Reorder dashboardCards based on original ordering in savedCards
-            dashboardCards = savedCards.compactMap { savedCard in
+            let reorderedCards = savedCards.compactMap { savedCard in
                 updatedCards.first(where: { $0.type == savedCard.type })
             }
+
+            // Get any remaining cards and disable them.
+            let remainingCards = Set(updatedCards).subtracting(savedCards)
+                .map { $0.copy(enabled: false) }
+
+            // Append the remaining cards to the end of the list
+            dashboardCards = reorderedCards + remainingCards
         }
     }
 

--- a/WooCommerce/Classes/ViewRelated/Dashboard/DashboardViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/DashboardViewModel.swift
@@ -132,7 +132,6 @@ final class DashboardViewModel: ObservableObject {
         setupDashboardCards()
         installPendingThemeIfNeeded()
         observeDashboardCardsAndReload()
-        checkInboxEligibility()
     }
 
     /// Must be called by the `View` during the `onAppear()` event. This will
@@ -162,6 +161,7 @@ final class DashboardViewModel: ObservableObject {
     ///
     @MainActor
     func syncDashboardEssentialData() async {
+        checkInboxEligibility()
         await withTaskGroup(of: Void.self) { group in
             group.addTask { [weak self] in
                 guard let self else { return }

--- a/WooCommerce/Classes/ViewRelated/Inbox/InboxEligibilityUseCase.swift
+++ b/WooCommerce/Classes/ViewRelated/Inbox/InboxEligibilityUseCase.swift
@@ -14,7 +14,6 @@ protocol InboxEligibilityChecker {
     ///
     func isEligibleForInbox(siteID: Int64, completion: @escaping (Bool) -> Void)
 
-    
     /// Asynchronously determines whether the store is eligible for inbox feature.
     /// - Parameters:
     ///   - siteID: the ID of the site to check for Inbox eligibility.

--- a/WooCommerce/Classes/ViewRelated/Inbox/InboxEligibilityUseCase.swift
+++ b/WooCommerce/Classes/ViewRelated/Inbox/InboxEligibilityUseCase.swift
@@ -5,7 +5,20 @@ import Experiments
 
 /// Checks whether a store is eligible for Inbox feature.
 /// Since mobile requires API support for filtering, only stores with a minimum WC plugin version are eligible.
-final class InboxEligibilityUseCase {
+///
+protocol InboxEligibilityChecker {
+    /// Determines whether the store is eligible for inbox feature.
+    /// - Parameters:
+    ///   - siteID: the ID of the site to check for Inbox eligibility.
+    ///   - completion: called when the Inbox eligibility is determined.
+    ///
+    func isEligibleForInbox(siteID: Int64, completion: @escaping (Bool) -> Void)
+
+}
+
+/// Default implementation to check whether a store is eligible for Inbox feature.
+///
+final class InboxEligibilityUseCase: InboxEligibilityChecker {
     private let stores: StoresManager
     private let featureFlagService: FeatureFlagService
 

--- a/WooCommerce/Classes/ViewRelated/Inbox/InboxEligibilityUseCase.swift
+++ b/WooCommerce/Classes/ViewRelated/Inbox/InboxEligibilityUseCase.swift
@@ -14,6 +14,13 @@ protocol InboxEligibilityChecker {
     ///
     func isEligibleForInbox(siteID: Int64, completion: @escaping (Bool) -> Void)
 
+    
+    /// Asynchronously determines whether the store is eligible for inbox feature.
+    /// - Parameters:
+    ///   - siteID: the ID of the site to check for Inbox eligibility.
+    ///
+    func isEligibleForInbox(siteID: Int64) async -> Bool
+
 }
 
 /// Default implementation to check whether a store is eligible for Inbox feature.
@@ -48,6 +55,18 @@ final class InboxEligibilityUseCase: InboxEligibilityChecker {
             completion(isInboxSupportedByWCPlugin)
         }
         stores.dispatch(action)
+    }
+
+    @MainActor
+    func isEligibleForInbox(siteID: Int64) async -> Bool {
+        await withCheckedContinuation { [weak self] continuation in
+            guard let self else {
+                return continuation.resume(returning: false)
+            }
+            isEligibleForInbox(siteID: siteID) { isEligible in
+                continuation.resume(returning: isEligible)
+            }
+        }
     }
 }
 

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -2279,6 +2279,7 @@
 		DE2004602BF7092900660A72 /* ProductStockDashboardCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE20045F2BF7092900660A72 /* ProductStockDashboardCard.swift */; };
 		DE2004622BF70A6600660A72 /* ProductStockDashboardCardViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE2004612BF70A6600660A72 /* ProductStockDashboardCardViewModel.swift */; };
 		DE2004642BF744F200660A72 /* ProductStockDashboardCardViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE2004632BF744F200660A72 /* ProductStockDashboardCardViewModelTests.swift */; };
+		DE2004782C05C36900660A72 /* MockInboxEligibilityChecker.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE2004772C05C36900660A72 /* MockInboxEligibilityChecker.swift */; };
 		DE23CFFA27462D8F003BE54E /* JCPJetpackInstallIntroView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE23CFF927462D8F003BE54E /* JCPJetpackInstallIntroView.swift */; };
 		DE26B5292775C76C00A2EA0A /* MockSyncingCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE26B5282775C76B00A2EA0A /* MockSyncingCoordinator.swift */; };
 		DE279BA426E9C4DC002BA963 /* ShippingLabelPackagesForm.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE279BA326E9C4DC002BA963 /* ShippingLabelPackagesForm.swift */; };
@@ -5083,6 +5084,7 @@
 		DE20045F2BF7092900660A72 /* ProductStockDashboardCard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductStockDashboardCard.swift; sourceTree = "<group>"; };
 		DE2004612BF70A6600660A72 /* ProductStockDashboardCardViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductStockDashboardCardViewModel.swift; sourceTree = "<group>"; };
 		DE2004632BF744F200660A72 /* ProductStockDashboardCardViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductStockDashboardCardViewModelTests.swift; sourceTree = "<group>"; };
+		DE2004772C05C36900660A72 /* MockInboxEligibilityChecker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockInboxEligibilityChecker.swift; sourceTree = "<group>"; };
 		DE23CFF927462D8F003BE54E /* JCPJetpackInstallIntroView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JCPJetpackInstallIntroView.swift; sourceTree = "<group>"; };
 		DE26B5282775C76B00A2EA0A /* MockSyncingCoordinator.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MockSyncingCoordinator.swift; sourceTree = "<group>"; };
 		DE279BA326E9C4DC002BA963 /* ShippingLabelPackagesForm.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShippingLabelPackagesForm.swift; sourceTree = "<group>"; };
@@ -8783,6 +8785,7 @@
 				02D635782B58071C00B1CBF6 /* MockNote.swift */,
 				EE8A302A2B70B63E001D7C66 /* MockImageService.swift */,
 				023BD5872BFDCF3100A10D7B /* MockInMemoryStorage.swift */,
+				DE2004772C05C36900660A72 /* MockInboxEligibilityChecker.swift */,
 			);
 			path = Mocks;
 			sourceTree = "<group>";
@@ -15440,6 +15443,7 @@
 				26C0D1E42B460E9000F6EDA5 /* AppLocalizedString.swift in Sources */,
 				DEDA8D972B034C260076BF0F /* ProductSubscriptionPeriodPickerUseCaseTests.swift in Sources */,
 				02A275C623FE9EFC005C560F /* MockFeatureFlagService.swift in Sources */,
+				DE2004782C05C36900660A72 /* MockInboxEligibilityChecker.swift in Sources */,
 				31F635DC273AF0B100E14F10 /* VersionHelpersTests.swift in Sources */,
 				EEADF626281A65A9001B40F1 /* DefaultShippingValueLocalizerTests.swift in Sources */,
 				FE3E427726A8545B00C596CE /* MockRoleEligibilityUseCase.swift in Sources */,

--- a/WooCommerce/WooCommerceTests/Mocks/MockInboxEligibilityChecker.swift
+++ b/WooCommerce/WooCommerceTests/Mocks/MockInboxEligibilityChecker.swift
@@ -1,0 +1,14 @@
+import Foundation
+@testable import WooCommerce
+
+final class MockInboxEligibilityChecker: InboxEligibilityChecker {
+    var isEligible = false
+
+    func isEligibleForInbox(siteID: Int64, completion: @escaping (Bool) -> Void) {
+        completion(isEligible)
+    }
+
+    func isEligibleForInbox(siteID: Int64) async -> Bool {
+        return isEligible
+    }
+}

--- a/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/DashboardViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/DashboardViewModelTests.swift
@@ -408,11 +408,16 @@ final class DashboardViewModelTests: XCTestCase {
 
     // MARK: Dashboard cards
 
-    func test_generated_default_cards_are_as_expected_with_m2_feature_flag_enabled() {
+    func test_generated_default_cards_are_as_expected_with_m2_feature_flag_enabled_when_site_is_eligible_for_inbox() {
         // Given
         let featureFlagService = MockFeatureFlagService(isDynamicDashboardM2Enabled: true)
+        let inboxEligibilityChecker = MockInboxEligibilityChecker()
+        inboxEligibilityChecker.isEligible = true
 
-        let viewModel = DashboardViewModel(siteID: sampleSiteID, stores: stores, featureFlags: featureFlagService)
+        let viewModel = DashboardViewModel(siteID: sampleSiteID,
+                                           stores: stores,
+                                           featureFlags: featureFlagService,
+                                           inboxEligibilityChecker: inboxEligibilityChecker)
         mockLoadDashboardCards(withStoredCards: [])
 
         let expectedCards = [DashboardCard(type: .onboarding, availability: .show, enabled: true),
@@ -420,6 +425,38 @@ final class DashboardViewModelTests: XCTestCase {
                              DashboardCard(type: .topPerformers, availability: .unavailable, enabled: false),
                              DashboardCard(type: .blaze, availability: .hide, enabled: false),
                              DashboardCard(type: .inbox, availability: .show, enabled: false),
+                             DashboardCard(type: .reviews, availability: .show, enabled: false),
+                             DashboardCard(type: .coupons, availability: .show, enabled: false),
+                             DashboardCard(type: .stock, availability: .show, enabled: false),
+                             DashboardCard(type: .lastOrders, availability: .unavailable, enabled: false)]
+
+        // When
+        viewModel.refreshDashboardCards()
+
+        // Then
+        waitUntil {
+            viewModel.dashboardCards == expectedCards
+        }
+
+    }
+
+    func test_generated_default_cards_are_as_expected_with_m2_feature_flag_enabled_when_site_is_not_eligible_for_inbox() {
+        // Given
+        let featureFlagService = MockFeatureFlagService(isDynamicDashboardM2Enabled: true)
+        let inboxEligibilityChecker = MockInboxEligibilityChecker()
+        inboxEligibilityChecker.isEligible = false
+
+        let viewModel = DashboardViewModel(siteID: sampleSiteID,
+                                           stores: stores,
+                                           featureFlags: featureFlagService,
+                                           inboxEligibilityChecker: inboxEligibilityChecker)
+        mockLoadDashboardCards(withStoredCards: [])
+
+        let expectedCards = [DashboardCard(type: .onboarding, availability: .show, enabled: true),
+                             DashboardCard(type: .performance, availability: .unavailable, enabled: false),
+                             DashboardCard(type: .topPerformers, availability: .unavailable, enabled: false),
+                             DashboardCard(type: .blaze, availability: .hide, enabled: false),
+                             DashboardCard(type: .inbox, availability: .hide, enabled: false),
                              DashboardCard(type: .reviews, availability: .show, enabled: false),
                              DashboardCard(type: .coupons, availability: .show, enabled: false),
                              DashboardCard(type: .stock, availability: .show, enabled: false),


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #12843 
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This PR adds a check for whether a site is eligible for seeing inbox messages before adding the card as an option for the dynamic dashboard. Changes include:
- Added an interface for `InboxEligibilityUseCase` for testing purpose.
- Inject `InboxEligibilityUseCase` to `DashboardViewModel`.
- Updated `DashboardViewModel` to check for inbox eligibility and update inbox card accordingly.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

**Ineligible case**

- If the minimum WC version of the store you have is above 5.0.0: In code `InboxEligibilityUseCase.swift`, update the `wcPluginMinimumVersion` constant to be higher than the minimum WC version of your store.
- Launch the app
- Tap Edit on the dashboard and confirm that the Inbox option is unavailable

**Eligible case**

- Continue from the ineligible case above, log in or switch to the store with the maximum WC version.
- Or revert the change in `InboxEligibilityUseCase.swift` if your store's WC version is higher than the minimum version.
- Launch the app
- Tap Edit on the dashboard and confirm the Inbox option is available.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->
Ineligible | Eligible
--- | ---
<img src="https://github.com/woocommerce/woocommerce-ios/assets/5533851/28b1af57-0360-4f9b-97c4-a035e156836d" width=320 /> | <img src="https://github.com/woocommerce/woocommerce-ios/assets/5533851/dbf13bd2-a35b-4f75-b8f6-594f64f357b9" width=320 />


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
