### PR TITLE
Add code signing automation for Watch App and Watch Extension targets

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -46,17 +46,15 @@ MAIN_BUNDLE_IDENTIFIERS = [
   APP_STORE_VERSION_BUNDLE_IDENTIFIER,
   "#{APP_STORE_VERSION_BUNDLE_IDENTIFIER}.storewidgets",
   "#{APP_STORE_VERSION_BUNDLE_IDENTIFIER}.notificationcontentextension",
-  "#{APP_STORE_VERSION_BUNDLE_IDENTIFIER}.watchkitapp"
+  "#{APP_STORE_VERSION_BUNDLE_IDENTIFIER}.watchkitapp",
+  "#{APP_STORE_VERSION_BUNDLE_IDENTIFIER}.watchkitapp.widgets"
 ].freeze
 
 ALPHA_VERSION_BUNDLE_IDENTIFIER = 'com.automattic.alpha.woocommerce'
 # Registered in our Enterprise account, for App Center / Prototype Builds
-ALPHA_BUNDLE_IDENTIFIERS = [
-  ALPHA_VERSION_BUNDLE_IDENTIFIER,
-  "#{ALPHA_VERSION_BUNDLE_IDENTIFIER}.storewidgets",
-  "#{ALPHA_VERSION_BUNDLE_IDENTIFIER}.notificationcontentextension",
-  "#{ALPHA_VERSION_BUNDLE_IDENTIFIER}.watchkitapp"
-].freeze
+ALPHA_BUNDLE_IDENTIFIERS = MAIN_BUNDLE_IDENTIFIERS.map do |id|
+  id.gsub(APP_STORE_VERSION_BUNDLE_IDENTIFIER, ALPHA_VERSION_BUNDLE_IDENTIFIER)
+end.freeze
 
 # Shared options to use when invoking `gym` / `build_app`.
 #

--- a/fastlane/Matchfile
+++ b/fastlane/Matchfile
@@ -5,3 +5,4 @@
 # Store certs/profiles encrypted in Google Cloud
 storage_mode('s3')
 s3_bucket('a8c-fastlane-match')
+s3_region('us-east-2')


### PR DESCRIPTION
## Description
What it says in the title. Refer to pdnsEh-1H6-p2

## Testing instructions
If CI is green, we're good because it means it can fetch the new provisioning profiles, which obviously means they were created correctly.

<img width="1080" alt="image" src="https://github.com/woocommerce/woocommerce-ios/assets/1218433/5c97db5b-d8ba-4c35-a550-4c6a5d634228">


## Screenshots
N.A.

---

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary. N.A.