### PR TITLE
Dynamic Dashboard: Navigation from "Most recent orders" card

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Dashboard/DashboardViewHostingController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/DashboardViewHostingController.swift
@@ -266,12 +266,14 @@ private extension DashboardViewHostingController {
 // MARK: Last orders
 private extension DashboardViewHostingController {
     func configureLastOrdersView() {
-        rootView.onViewAllOrders = {
-            // TODO: 12655
+        rootView.onViewAllOrders = { [weak self] in
+            guard let self else { return }
+            MainTabBarController.switchToOrdersTab()
         }
 
-        rootView.onViewOrderDetail = { _ in
-            // TODO: 12655
+        rootView.onViewOrderDetail = { [weak self] order in
+            guard let self else { return }
+            MainTabBarController.navigateToOrderDetails(with: order.orderID, siteID: viewModel.siteID)
         }
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/DashboardViewHostingController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/DashboardViewHostingController.swift
@@ -266,8 +266,7 @@ private extension DashboardViewHostingController {
 // MARK: Last orders
 private extension DashboardViewHostingController {
     func configureLastOrdersView() {
-        rootView.onViewAllOrders = { [weak self] in
-            guard let self else { return }
+        rootView.onViewAllOrders = {
             MainTabBarController.switchToOrdersTab()
         }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/OrderListViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrderListViewController.swift
@@ -296,19 +296,15 @@ private extension OrderListViewController {
         viewModel.snapshot.sink { [weak self] snapshot in
             guard let self = self else { return }
 
-            /// Check that view is loaded and displayed to prevent UI tests failing while synching orders from other screens.
-            guard isViewLoaded == true && view.window != nil else {
-                return
-            }
-
             dataSource?.apply(snapshot)
 
             transitionToResultsUpdatedState()
 
-            if self.splitViewController?.isCollapsed == false {
+            /// Check that view is loaded and displayed to prevent UI tests failing while synching orders from other screens.
+            if isViewLoaded == true && view.window != nil,
+               self.splitViewController?.isCollapsed == false {
                 self.checkSelectedItem()
             }
-
         }.store(in: &cancellables)
 
         /// Update the top banner when needed


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #12792
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

Enables navigation to order detail and order list screens from the "Most recent orders" dashboard card. 

Changes
- Update the change we added earlier for fixing UI tests. https://github.com/woocommerce/woocommerce-ios/pull/12851/commits/6a69f14c5497300a66b36fad028b679f552fda99
    - Earlier, in this PR https://github.com/woocommerce/woocommerce-ios/pull/12802, we skipped updating the screen's state and other logic related to loading orders if it is not loaded and displayed. This created undesired side effects when programmatically navigating to orders screen from other tabs. (Resulted in Empty orders screen)
    - Now, we are skipping only the order selection if the screen is not loaded. This is enough for passing UI tests. 
- Navigate to order detail and order list screens.
    - I am using MainTabBarController's static methods to account for the split view controller-based navigations. 

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
- Create a JN site with orders. 
- Enable the feature flag `dynamicDashboardM2` and build and login into the app.
- Enable the "Most recent orders" card on the dashboard.
- Confirm that the card now displays the 3 most recent orders. 
- Tap on "View all orders" button and confirm that you are navigated to the orders tab.
- Navigate back to the dashboard and tap on any order from the "Most recent orders" card. Confirm that you are navigated to the order detail page. 


## Screenshots
<!-- Include before and after images or gifs when appropriate. -->
#### iPhone

https://github.com/woocommerce/woocommerce-ios/assets/524475/a15be00b-4c73-46bb-986d-37f0e280a42e



#### iPad

https://github.com/woocommerce/woocommerce-ios/assets/524475/dea1775f-60ab-46ed-add3-3168e72a20b5


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
