### PR TITLE
Dynamic Dashboard: Most active coupons card - Deleted coupon case

### DIFF
--- a/Networking/Networking/Remote/CouponsRemote.swift
+++ b/Networking/Networking/Remote/CouponsRemote.swift
@@ -44,6 +44,7 @@ public protocol CouponsRemoteProtocol {
                           completion: @escaping (Result<CouponReport, Error>) -> Void)
 
     func loadMostActiveCoupons(for siteID: Int64,
+                               numberOfCouponsToLoad: Int,
                                from startDate: Date,
                                to endDate: Date,
                                completion: @escaping (Result<[CouponReport], Error>) -> Void)
@@ -324,18 +325,20 @@ public final class CouponsRemote: Remote, CouponsRemoteProtocol {
     ///
     /// - Parameters:
     ///     - siteID: The ID of the  site from which we'll fetch the coupons report.
+    ///     - numberOfCouponsToLoad: Number of coupons to load.
     ///     - from: The start of the date range for which we'll fetch the coupons report.
     ///     - to: The end of the date range until which we'll fetch the coupons report.
     ///     - completion: Closure to be executed upon completion.
     ///
     public func loadMostActiveCoupons(for siteID: Int64,
+                                      numberOfCouponsToLoad: Int,
                                       from startDate: Date,
                                       to endDate: Date,
                                       completion: @escaping (Result<[CouponReport], Error>) -> Void) {
         let parameters: [String: Any] = {
             var params = [
                 ParameterKey.page: 1,
-                ParameterKey.perPage: 3,
+                ParameterKey.perPage: numberOfCouponsToLoad,
                 ParameterKey.order: ParameterValue.desc,
                 ParameterKey.orderBy: ParameterValue.ordersCount,
             ]

--- a/Networking/NetworkingTests/Remote/CouponsRemoteTests.swift
+++ b/Networking/NetworkingTests/Remote/CouponsRemoteTests.swift
@@ -319,6 +319,7 @@ final class CouponsRemoteTests: XCTestCase {
         // When
         let result = waitFor { promise in
             remote.loadMostActiveCoupons(for: self.sampleSiteID,
+                                         numberOfCouponsToLoad: 3,
                                          from: Date(),
                                          to: Date()
             ) { (result) in
@@ -345,6 +346,7 @@ final class CouponsRemoteTests: XCTestCase {
         // When
         let result = waitFor { promise in
             remote.loadMostActiveCoupons(for: self.sampleSiteID,
+                                         numberOfCouponsToLoad: 3,
                                          from: Date(),
                                          to: Date()
             ) { (result) in

--- a/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Coupons/MostActiveCouponsCardViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Coupons/MostActiveCouponsCardViewModelTests.swift
@@ -200,6 +200,34 @@ final class MostActiveCouponsCardViewModelTests: XCTestCase {
         // Then
         XCTAssertEqual(viewModel.rows.map({ $0.id }), [1, 2, 4])
     }
+
+    @MainActor
+    func test_number_of_coupon_reports_loaded_from_remote_is_double_of_what_will_be_displayed() async throws {
+        // Given
+        let viewModel = MostActiveCouponsCardViewModel(siteID: sampleSiteID,
+                                                       stores: stores,
+                                                       storageManager: storageManager)
+
+        var numberOfCouponsToLoad: Int?
+
+        // When
+        stores.whenReceivingAction(ofType: CouponAction.self) { action in
+            switch action {
+            case let .loadMostActiveCoupons(_, numberToLoad, _, _, completion):
+                numberOfCouponsToLoad = numberToLoad
+                completion(.success(self.sampleCouponReports))
+            case let .loadCoupons(_, _, completion):
+                completion(.success([]))
+            default:
+                break
+            }
+        }
+        await viewModel.reloadData()
+
+        // Then
+        let count = try XCTUnwrap(numberOfCouponsToLoad)
+        XCTAssertEqual(count, 6)
+    }
 }
 
 extension MostActiveCouponsCardViewModelTests {

--- a/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Coupons/MostActiveCouponsCardViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Coupons/MostActiveCouponsCardViewModelTests.swift
@@ -172,7 +172,7 @@ final class MostActiveCouponsCardViewModelTests: XCTestCase {
     }
 
     @MainActor
-    func test_next_available_coupon_report_is_displayed_if_coupon_not_found() async {
+    func test_next_available_active_coupon_is_displayed_when_coupon_deleted() async {
         // Given
         let viewModel = MostActiveCouponsCardViewModel(siteID: sampleSiteID,
                                                        stores: stores,

--- a/Yosemite/Yosemite/Actions/CouponAction.swift
+++ b/Yosemite/Yosemite/Actions/CouponAction.swift
@@ -60,14 +60,16 @@ public enum CouponAction: Action {
                           startDate: Date,
                           onCompletion: (Result<CouponReport, Error>) -> Void)
 
-    /// Loads top 3 most active coupons report within the specified time range and site ID.
+    /// Loads top most active coupons report within the specified time range and site ID.
     ///
     /// - `siteID`: site ID.
+    /// - `numberOfCouponsToLoad`: Number of coupons to load.
     /// - `timeRange`: Time range to fetch report for.
     /// - `siteTimezone`: site's timezone.
     /// - `onCompletion`: invoked when the reports are fetched.
     ///
     case loadMostActiveCoupons(siteID: Int64,
+                               numberOfCouponsToLoad: Int,
                                timeRange: StatsTimeRangeV4,
                                siteTimezone: TimeZone,
                                onCompletion: (Result<[CouponReport], Error>) -> Void)

--- a/Yosemite/Yosemite/Stores/CouponStore.swift
+++ b/Yosemite/Yosemite/Stores/CouponStore.swift
@@ -66,8 +66,9 @@ public final class CouponStore: Store {
             createCoupon(coupon, siteTimezone: siteTimezone, onCompletion: onCompletion)
         case .loadCouponReport(let siteID, let couponID, let startDate, let onCompletion):
             loadCouponReport(siteID: siteID, couponID: couponID, startDate: startDate, onCompletion: onCompletion)
-        case .loadMostActiveCoupons(let siteID, let timeRange, let siteTimezone, let onCompletion):
+        case .loadMostActiveCoupons(let siteID, let numberOfCouponsToLoad, let timeRange, let siteTimezone, let onCompletion):
             loadMostActiveCoupons(siteID: siteID,
+                                  numberOfCouponsToLoad: numberOfCouponsToLoad,
                                   timeRange: timeRange,
                                   siteTimezone: siteTimezone,
                                   onCompletion: onCompletion)
@@ -216,17 +217,20 @@ private extension CouponStore {
     /// Loads top 3 most active coupons report within the specified time range and site ID.
     ///
     /// - `siteID`: site ID.
+    /// - `numberOfCouponsToLoad`: Number of coupons to load.
     /// - `timeRange`: Time range to fetch report for.
     /// - `siteTimezone`: site's timezone
     /// - `onCompletion`: invoked when the reports are fetched.
     ///
     func loadMostActiveCoupons(siteID: Int64,
+                               numberOfCouponsToLoad: Int,
                                timeRange: StatsTimeRangeV4,
                                siteTimezone: TimeZone,
                                onCompletion: @escaping (Result<[CouponReport], Error>) -> Void) {
         let to = timeRange.latestDate(currentDate: Date(), siteTimezone: siteTimezone)
         let from = timeRange.earliestDate(latestDate: to, siteTimezone: siteTimezone)
         remote.loadMostActiveCoupons(for: siteID,
+                                     numberOfCouponsToLoad: numberOfCouponsToLoad,
                                      from: from,
                                      to: to,
                                      completion: onCompletion)

--- a/Yosemite/YosemiteTests/Mocks/Networking/Remote/MockCouponsRemote.swift
+++ b/Yosemite/YosemiteTests/Mocks/Networking/Remote/MockCouponsRemote.swift
@@ -40,6 +40,7 @@ final class MockCouponsRemote: CouponsRemoteProtocol {
 
     var didCallLoadMostActiveCoupons = false
     var spyLoadMostActiveCouponsSiteID: Int64?
+    var spyLoadMostActiveCouponsNumberOfCouponsToLoad: Int?
     var spyLoadMostActiveCouponsStartDate: Date?
     var spyLoadMostActiveCouponsEndDate: Date?
 
@@ -123,11 +124,13 @@ final class MockCouponsRemote: CouponsRemoteProtocol {
     }
 
     func loadMostActiveCoupons(for siteID: Int64,
+                               numberOfCouponsToLoad: Int,
                                from startDate: Date,
                                to endDate: Date,
                                completion: @escaping (Result<[CouponReport], Error>) -> Void) {
         didCallLoadMostActiveCoupons = true
         spyLoadMostActiveCouponsSiteID = siteID
+        spyLoadMostActiveCouponsNumberOfCouponsToLoad = numberOfCouponsToLoad
         spyLoadMostActiveCouponsStartDate = startDate
         spyLoadMostActiveCouponsEndDate = endDate
     }

--- a/Yosemite/YosemiteTests/Stores/CouponStoreTests.swift
+++ b/Yosemite/YosemiteTests/Stores/CouponStoreTests.swift
@@ -478,12 +478,14 @@ final class CouponStoreTests: XCTestCase {
         setUpUsingSpyRemote()
         // Given
         let currentDate = try date(from: "2020-11-05T23:59:59Z")
+        let numberOfCouponsToLoad = 3
         let from = currentDate.addingDays(-3)
         let to = currentDate.addingDays(3)
         let sampleTimeRange = StatsTimeRangeV4.custom(from: from,
                                                       to: to)
         let timeZone = try XCTUnwrap(TimeZone(secondsFromGMT: 0))
         let action = CouponAction.loadMostActiveCoupons(siteID: sampleSiteID,
+                                                        numberOfCouponsToLoad: numberOfCouponsToLoad,
                                                         timeRange: sampleTimeRange,
                                                         siteTimezone: timeZone) { _ in }
 
@@ -493,6 +495,7 @@ final class CouponStoreTests: XCTestCase {
         // Then
         XCTAssertTrue(remote.didCallLoadMostActiveCoupons)
         XCTAssertEqual(remote.spyLoadMostActiveCouponsSiteID, sampleSiteID)
+        XCTAssertEqual(remote.spyLoadMostActiveCouponsNumberOfCouponsToLoad, numberOfCouponsToLoad)
 
         let end = sampleTimeRange.latestDate(currentDate: currentDate,
                                             siteTimezone: timeZone)
@@ -516,6 +519,7 @@ final class CouponStoreTests: XCTestCase {
         // When
         let result: Result<[Networking.CouponReport], Error> = waitFor { promise in
             let action = CouponAction.loadMostActiveCoupons(siteID: self.sampleSiteID,
+                                                            numberOfCouponsToLoad: 3,
                                                             timeRange: sampleTimeRange,
                                                             siteTimezone: timeZone) { result in                 promise(result)
             }
@@ -537,6 +541,7 @@ final class CouponStoreTests: XCTestCase {
         // When
         let result: Result<[Networking.CouponReport], Error> = waitFor { promise in
             let action = CouponAction.loadMostActiveCoupons(siteID: self.sampleSiteID,
+                                                            numberOfCouponsToLoad: 3,
                                                             timeRange: sampleTimeRange,
                                                             siteTimezone: timeZone) { result in
                 promise(result)


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #12855 
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

Most active coupons card

Fetch 6 coupon reports instead of 3, and fallback to the next active coupon if an active coupon is deleted.

Changes
- Yosemite and Networking - Way to specify the number of coupon reports to fetch.
- In the view model, fallback to the next available active coupon to display in the dashboard card.
- Unit tests.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

- Create a JN site.
- Create 4 or more coupons.
- Create orders for all coupons.
- Enable the feature flag `dynamicDashboardM2` and build the app.
- Enable the Coupon card on the dashboard.
- Select "This Year" as the time range to include all orders/coupons.
- Confirm that the card now displays the 3 most active coupons. 
- Delete an active coupon.
- Confirm that the coupon card now displays the next active coupon and the total number of coupons displayed is still 3.


## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

Deleting coupon `discount46`

https://github.com/woocommerce/woocommerce-ios/assets/524475/95b086b5-adf5-414d-aade-22f3447053ed



---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
