### PR TITLE
Dynamic Dashboard: Add new cards badge and New Cards Notice card.

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Dashboard/DashboardView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/DashboardView.swift
@@ -101,10 +101,19 @@ struct DashboardView: View {
                 }
             }
             ToolbarItem(placement: .topBarTrailing) {
-                Button(Localization.edit) {
+                Button(action: {
                     ServiceLocator.analytics.track(event: .DynamicDashboard.editLayoutButtonTapped())
                     viewModel.showingCustomization = true
-                }
+                }, label: {
+                    Text(Localization.edit)
+                        .overlay(alignment: .topTrailing) {
+                            Circle()
+                                .fill(Color(.accent))
+                                .frame(width: Layout.dotBadgeSize)
+                                .padding(Layout.dotBadgePadding)
+                                .offset(Layout.dotBadgeOffset)
+                        }
+                })
             }
         }
         .toolbarBackground(Color.clear, for: .navigationBar)
@@ -329,6 +338,10 @@ private extension DashboardView {
         static let imagePadding: CGFloat = 40
         static let textPadding: CGFloat = 8
         static let cornerRadius: CGFloat = 8
+        static let dotBadgePadding = EdgeInsets(top: 6, leading: 0, bottom: 0, trailing: 2)
+        static let dotBadgeSize: CGFloat = 6
+        static let dotBadgeOffset = CGSize(width: 7, height: -7)
+
     }
     enum Localization {
         static let title = NSLocalizedString(

--- a/WooCommerce/Classes/ViewRelated/Dashboard/DashboardView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/DashboardView.swift
@@ -245,12 +245,12 @@ private extension DashboardView {
                 }
             }
 
-            if !viewModel.hasOrders {
-                shareStoreCard
+            if viewModel.showNewCardsNotice {
+                newCardsNoticeCard
             }
 
-            if viewModel.showNewCardsNotice {
-                // TODO show new cards notice
+            if !viewModel.hasOrders {
+                shareStoreCard
             }
         }
     }
@@ -289,6 +289,31 @@ private extension DashboardView {
             RoundedRectangle(cornerRadius: Layout.cornerRadius)
                 .stroke(Color(.border), lineWidth: 1)
         )
+        .padding(.horizontal, Layout.padding)
+    }
+
+    var newCardsNoticeCard: some View {
+        VStack(spacing: Layout.padding) {
+            Text(Localization.NewCardsNoticeCard.title)
+                .headlineStyle()
+                .multilineTextAlignment(.center)
+                .padding(.horizontal, Layout.elementPadding)
+                .padding(.top, Layout.padding)
+
+            Text(Localization.NewCardsNoticeCard.subtitle)
+                .bodyStyle()
+                .multilineTextAlignment(.center)
+                .padding(.horizontal, Layout.elementPadding)
+
+            Button(Localization.NewCardsNoticeCard.addSectionsButtonLabel) {
+                viewModel.showCustomizationScreen()
+            }
+            .buttonStyle(PrimaryButtonStyle())
+            .padding(.horizontal, Layout.elementPadding)
+            .padding(.bottom, Layout.padding)
+        }
+        .background(Color(.listForeground(modal: false)))
+        .clipShape(RoundedRectangle(cornerSize: Layout.cornerSize))
         .padding(.horizontal, Layout.padding)
     }
 
@@ -349,6 +374,7 @@ private extension DashboardView {
         static let imagePadding: CGFloat = 40
         static let textPadding: CGFloat = 8
         static let cornerRadius: CGFloat = 8
+        static let cornerSize = CGSize(width: 8.0, height: 8.0)
         static let dotBadgePadding = EdgeInsets(top: 6, leading: 0, bottom: 0, trailing: 2)
         static let dotBadgeSize: CGFloat = 6
         static let dotBadgeOffset = CGSize(width: 7, height: -7)
@@ -393,6 +419,26 @@ private extension DashboardView {
                 "dashboardView.shareStoreCard.shareButtonLabel",
                 value: "Share Your Store",
                 comment: "Label of the button to share the store"
+            )
+        }
+
+        enum NewCardsNoticeCard {
+            static let title = NSLocalizedString(
+                "dashboardView.newCardsNoticeCard.title",
+                value: "Looking for more insights?",
+                comment: "Title of the New Cards Notice card"
+            )
+
+            static let subtitle = NSLocalizedString(
+                "dashboardView.newCardsNoticeCard.subtitle",
+                value: "Add new sections to customize your store management experience",
+                comment: "Subtitle of the New Cards Notice card"
+            )
+
+            static let addSectionsButtonLabel = NSLocalizedString(
+                "dashboardView.newCardsNoticeCard.addSectionsButtonLabel",
+                value: "Add new sections",
+                comment: "Label of the button to add sections"
             )
         }
     }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/DashboardView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/DashboardView.swift
@@ -103,15 +103,17 @@ struct DashboardView: View {
             ToolbarItem(placement: .topBarTrailing) {
                 Button(action: {
                     ServiceLocator.analytics.track(event: .DynamicDashboard.editLayoutButtonTapped())
-                    viewModel.showingCustomization = true
+                    viewModel.showCustomizationScreen()
                 }, label: {
                     Text(Localization.edit)
                         .overlay(alignment: .topTrailing) {
-                            Circle()
-                                .fill(Color(.accent))
-                                .frame(width: Layout.dotBadgeSize)
-                                .padding(Layout.dotBadgePadding)
-                                .offset(Layout.dotBadgeOffset)
+                            if viewModel.showNewCardsNotice {
+                                Circle()
+                                    .fill(Color(.accent))
+                                    .frame(width: Layout.dotBadgeSize)
+                                    .padding(Layout.dotBadgePadding)
+                                    .offset(Layout.dotBadgeOffset)
+                            }
                         }
                 })
             }
@@ -150,7 +152,12 @@ struct DashboardView: View {
                 viewModel.maybeSyncAnnouncementsAfterWebViewDismissed()
             }
         }
-        .sheet(isPresented: $viewModel.showingCustomization) {
+        .sheet(isPresented: $viewModel.showingCustomization,
+               onDismiss: {
+            Task {
+                await viewModel.handleCustomizationDismissal()
+            }
+        }) {
             DashboardCustomizationView(viewModel: DashboardCustomizationViewModel(
                 allCards: viewModel.availableCards,
                 inactiveCards: viewModel.unavailableCards,
@@ -240,6 +247,10 @@ private extension DashboardView {
 
             if !viewModel.hasOrders {
                 shareStoreCard
+            }
+
+            if viewModel.showNewCardsNotice {
+                // TODO show new cards notice
             }
         }
     }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/DashboardViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/DashboardViewModel.swift
@@ -63,7 +63,6 @@ final class DashboardViewModel: ObservableObject {
     @Published var showingCustomization = false
 
     @Published var showNewCardsNotice = false
-    private var shouldSaveCurrentCards = false
 
     let siteID: Int64
     private let stores: StoresManager
@@ -257,11 +256,13 @@ final class DashboardViewModel: ObservableObject {
     }
 
     func showCustomizationScreen() {
-        if shouldSaveCurrentCards {
+        // The app should remove the notice once a user opens the Customize screen (whether they end up customizing or not).
+        // To do so, we save the current dashboard cards once when opening Customize. The current cards will already have
+        // been generated with the new cards included, so saving it ensures that the notice is hidden in subsequent checks.
+        if showNewCardsNotice {
             stores.dispatch(AppSettingsAction.setDashboardCards(siteID: siteID, cards: dashboardCards))
-            shouldSaveCurrentCards = false
+            showNewCardsNotice = false
         }
-
         showingCustomization = true
     }
 
@@ -562,11 +563,6 @@ private extension DashboardViewModel {
             showNewCardsNotice = false
         } else {
             showNewCardsNotice = true
-
-            // The app should remove the notice once a user opens the Customize screen (whether they end up customizing or not).
-            // To do so, schedule saving the current dashboard cards once when opening Customize. The cards will already have
-            // the new cards included, so doing it will ensure the notice is hidden in subsequent checks.
-            shouldSaveCurrentCards = true
         }
     }
 

--- a/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/DashboardViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/DashboardViewModelTests.swift
@@ -658,6 +658,82 @@ final class DashboardViewModelTests: XCTestCase {
         let topPerformersCard = try XCTUnwrap(viewModel.dashboardCards.first(where: {$0.type == .topPerformers }))
         XCTAssertFalse(topPerformersCard.enabled)
     }
+
+    // MARK: Show New Cards Notice
+
+    func test_showNewCardsNotice_is_false_when_all_new_cards_are_already_in_saved_cards() async {
+        // Given
+        let viewModel = DashboardViewModel(siteID: sampleSiteID, stores: stores)
+        let completeCardsSet: [DashboardCard] = [
+            .init(type: .inbox, availability: .show, enabled: true),
+            .init(type: .reviews, availability: .show, enabled: true),
+            .init(type: .coupons, availability: .show, enabled: true),
+            .init(type: .stock, availability: .show, enabled: true),
+            .init(type: .lastOrders, availability: .show, enabled: true)
+        ]
+        mockLoadDashboardCards(withStoredCards: completeCardsSet)
+
+        // When
+        viewModel.refreshDashboardCards()
+
+        // Then
+        waitUntil {
+            viewModel.dashboardCards.isNotEmpty
+        }
+        XCTAssertFalse(viewModel.showNewCardsNotice)
+    }
+
+    func test_showNewCardsNotice_is_true_when_not_all_new_cards_are_in_saved_cards() async {
+        // Given
+        let viewModel = DashboardViewModel(siteID: sampleSiteID, stores: stores)
+        let incompleteNewCardsSet: [DashboardCard] = []
+        mockLoadDashboardCards(withStoredCards: incompleteNewCardsSet)
+
+        // When
+        viewModel.refreshDashboardCards()
+
+        // Then
+        waitUntil {
+            viewModel.dashboardCards.isNotEmpty
+        }
+
+        XCTAssertTrue(viewModel.showNewCardsNotice)
+    }
+
+    func test_showNewCardsNotice_beomes_false_after_true_then_showing_customization_and_dismissing_it() async {
+        // Given
+        let incompleteNewCardsSet: [DashboardCard] = [
+            .init(type: .inbox, availability: .show, enabled: false),
+            .init(type: .reviews, availability: .show, enabled: false)
+        ]
+        let viewModel = DashboardViewModel(siteID: sampleSiteID, stores: stores)
+        mockLoadDashboardCards(withStoredCards: incompleteNewCardsSet)
+
+        // When
+        viewModel.refreshDashboardCards()
+
+        waitUntil {
+            viewModel.dashboardCards.isNotEmpty
+        }
+
+        XCTAssertTrue(viewModel.showNewCardsNotice)
+        viewModel.showCustomizationScreen() // Simulate showing Customize screen
+
+        // Simulate saving complete cards since initially we mocked it with empty array
+        let completeCardsSet: [DashboardCard] = [
+            .init(type: .inbox, availability: .show, enabled: true),
+            .init(type: .reviews, availability: .show, enabled: true),
+            .init(type: .coupons, availability: .show, enabled: true),
+            .init(type: .stock, availability: .show, enabled: true),
+            .init(type: .lastOrders, availability: .show, enabled: true)
+        ]
+        mockLoadDashboardCards(withStoredCards: completeCardsSet)
+
+        await viewModel.handleCustomizationDismissal() // Simulate dismissing Customize screen
+
+        // Then
+        XCTAssertFalse(viewModel.showNewCardsNotice) // Check it's false after dismissing Customize screen
+    }
 }
 
 private extension DashboardViewModelTests {

--- a/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/DashboardViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/DashboardViewModelTests.swift
@@ -700,7 +700,7 @@ final class DashboardViewModelTests: XCTestCase {
         XCTAssertTrue(viewModel.showNewCardsNotice)
     }
 
-    func test_showNewCardsNotice_beomes_false_after_true_then_showing_customization_and_dismissing_it() async {
+    func test_showNewCardsNotice_changes_from_true_to_false_after_showing_customize_screen_and_dismissing_it() async {
         // Given
         let incompleteNewCardsSet: [DashboardCard] = [
             .init(type: .inbox, availability: .show, enabled: false),


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #12860
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

This PR adds a way to nudge users that there are new cards. To avoid disrupting user's flow, these cards are hidden by default, and they can be enabled manually inside the Customize screen. The nudges are done via:
1. Adding a purple dot badge next to the "Edit" button,
2. Adding a new, temporary "card" saying "Looking for more insights?", with a button to open Customize screen.

Both the dot and temporary card are removed automatically once a user opens the Customize screen.

(CI says there's a unit test issue but it seems unrelated to this PR)

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

1. Start from a logged out state to clear up saved cards, which will be needed for this test.
4. Log in,
5. In Dashboard, ensure the Edit button on top right has a purple dot badge as a notice. Check screenshot.
6. Scroll down if needed and ensure you see a card that says "Looking for more insights?". Check screenshot.
7. Tap "Edit" button on top right to open the Customize screen.
8. Dismiss the Customize screen, ensure the purple badge and the "Looking for more insights?" card are now gone.
9. Switch to a new site (or log out and log back in again), 
10. Tap the "Add new sections" button in the "Looking for more insights" card, ensure it opens the Customize screen.
11. Dismiss the Customize screen, ensure the card and badge are now gone.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

Check out the badge next to the "Next" button, and the "Looking for more insights" card at the bottom:

<img src="https://github.com/woocommerce/woocommerce-ios/assets/266376/52ab8e12-b891-4d20-b010-a36996c600b6" width="42%">

