### PR TITLE
[Order Form] Allow shipping line without method to be added to order

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -2,7 +2,7 @@
 
 18.9
 -----
-
+- [*] Orders: Fixes an issue where adding shipping to an order without selecting a shipping method prevented the order from being created/updated. [https://github.com/woocommerce/woocommerce-ios/pull/12870]
 
 18.8
 -----

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/Synchronizer/ShippingInputTransformer.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/Synchronizer/ShippingInputTransformer.swift
@@ -22,7 +22,8 @@ struct ShippingInputTransformer {
 
         // If there is no existing shipping lines, we insert the input one.
         guard let existingShippingLine = order.shippingLines.first else {
-            return order.copy(shippingTotal: input.total, shippingLines: [input])
+            let newShippingLine = input.methodID?.isNotEmpty == true ? input : OrderFactory.noMethodShippingLine(input)
+            return order.copy(shippingTotal: input.total, shippingLines: [newShippingLine])
         }
 
         // Since we only support one shipping line, if we find one, we update the existing with the new input values.

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/Synchronizer/RemoteOrderSynchronizerTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/Synchronizer/RemoteOrderSynchronizerTests.swift
@@ -196,7 +196,7 @@ final class RemoteOrderSynchronizerTests: XCTestCase {
 
     func test_sending_shipping_input_updates_local_order() throws {
         // Given
-        let shippingLine = ShippingLine.fake().copy(shippingID: sampleShippingID)
+        let shippingLine = ShippingLine.fake().copy(shippingID: sampleShippingID, methodID: "free_shipping")
         let stores = MockStoresManager(sessionManager: .testingInstance)
         let synchronizer = RemoteOrderSynchronizer(siteID: sampleSiteID, flow: .creation, stores: stores)
 

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/Synchronizer/ShippingInputTransformerTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/Synchronizer/ShippingInputTransformerTests.swift
@@ -24,6 +24,20 @@ class ShippingInputTransformerTests: XCTestCase {
         XCTAssertEqual(updatedOrder.shippingTotal, input.total)
     }
 
+    func test_new_input_with_no_shipping_method_adds_expected_shipping_line_to_order() throws {
+        // Given
+        let order = Order.fake()
+        let input = ShippingLine.fake().copy(methodID: "", total: "10.00")
+
+        // When
+        let updatedOrder = ShippingInputTransformer.update(input: input, on: order)
+
+        // Then
+        let shippingLine = try XCTUnwrap(updatedOrder.shippingLines.first)
+        XCTAssertEqual(shippingLine, input.copy(methodID: " "))
+        XCTAssertEqual(updatedOrder.shippingTotal, input.total)
+    }
+
     func test_new_input_updates_first_shipping_line_from_order() throws {
         // Given
         let shipping = ShippingLine.fake().copy(shippingID: sampleShippingID, methodID: sampleMethodID, total: "10.00")

--- a/Yosemite/Yosemite/Stores/Order/OrderFactory.swift
+++ b/Yosemite/Yosemite/Stores/Order/OrderFactory.swift
@@ -95,6 +95,14 @@ public enum OrderFactory {
         shippingLine.copy(methodTitle: "", methodID: .some(nil), total: "0")
     }
 
+    /// Creates a shipping line suitable to add a shipping line without a method not yet saved remotely in an order.
+    ///
+    /// The API can't save the order when a new shipping line has an empty `methodID`; we send a space as a workaround.
+    ///
+    public static func noMethodShippingLine(_ shippingLine: ShippingLine) -> ShippingLine {
+        shippingLine.copy(methodID: " ")
+    }
+
     /// References a new empty order with constants `Date` values.
     ///
     public static let emptyNewOrder = Order.empty


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #12853
<!-- Id number of the GitHub issue this PR addresses. -->

## Why
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
Orders can contain shipping lines without any selected shipping method (showing as `N/A` in the web and app UI). The API includes these shipping lines with an empty string for the `methodID`.

However, when adding a new shipping line to an order, the API can't update the order if the new shipping line has an empty string for the `methodID`; in this case, we need to send e.g. a space for the `methodID` so the order can be saved.

## How

* Adds a new method `noMethodShippingLine(_:)` to `OrderFactory`, to transform a new shipping line so it can be saved remotely without a method ID.
* In `ShippingInputTransformer`, when a new shipping line is being added to the order, we transform it when the `methodID` is an empty string.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

1. Build and run the app with the `multipleShippingLines` feature flag disabled.
2. Create a new order and add a product.
3. Add shipping to the order, without selecting a shipping method.
4. Create the order and confirm it has a shipping line with no shipping method ("N/A").
5. Edit the order and confirm you can update the shipping line as expected (changing and saving any of its details).


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
