### PR TITLE
Dynamic Dashboard: Fix crash on Stock card

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Dashboard/ProductStock/ProductStockDashboardCardViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/ProductStock/ProductStockDashboardCardViewModel.swift
@@ -179,7 +179,7 @@ private extension ProductStockDashboardCardViewModel {
     }
 
     // In some cases, variation reports can have invalid product ID.
-    // Fix that by restore the parent ID from the stock item.
+    // Fix that by restoring the parent ID from the stock item.
     func updatedVariationReports(from reports: [ProductReport], using stock: [ProductStock]) -> [ProductReport] {
         reports.map { report in
             guard let variationID = report.variationID,

--- a/WooCommerce/Classes/ViewRelated/Dashboard/ProductStock/ProductStockDashboardCardViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/ProductStock/ProductStockDashboardCardViewModel.swift
@@ -139,8 +139,11 @@ private extension ProductStockDashboardCardViewModel {
         let variationsToFetchReports = groupedStockByVariations[true] ?? []
         let productsToFetchReports = groupedStockByVariations[false] ?? []
 
-        try await withThrowingTaskGroup(of: Void.self) { [weak self] group in
-            guard let self else { return }
+        let reports = try await withThrowingTaskGroup(of: [ProductReport].self, returning: [ProductReport].self) { [weak self] group in
+            guard let self else {
+                return []
+            }
+            var allReports: [ProductReport] = []
 
             if variationsToFetchReports.isNotEmpty {
                 group.addTask {
@@ -148,36 +151,43 @@ private extension ProductStockDashboardCardViewModel {
                         productIDs: Array(Set(variationsToFetchReports.map { $0.parentID })),
                         variationIDs: variationsToFetchReports.map { $0.productID }
                     )
-                    for report in reports {
-                        if let variationID = report.variationID {
-                            // In some cases, variation reports can have invalid product ID.
-                            // Fix that by restore the parent ID from the stock item.
-                            let updatedReport: ProductReport = {
-                                guard report.productID == 0,
-                                      let parentID = variationsToFetchReports.first(where: { $0.productID == variationID })?.productID else {
-                                    return report
-                                }
-                                return report.copy(productID: parentID)
-                            }()
-                            self.savedReports[variationID] = updatedReport
-                        }
-                    }
+                    return self.updatedVariationReports(from: reports, using: variationsToFetchReports)
                 }
             }
 
             if productsToFetchReports.isNotEmpty {
                 group.addTask {
-                    let reports = try await self.fetchProductReports(productIDs: productsToFetchReports.map { $0.productID })
-                    for report in reports {
-                        self.savedReports[report.productID] = report
-                    }
+                    try await self.fetchProductReports(productIDs: productsToFetchReports.map { $0.productID })
                 }
             }
 
             while !group.isEmpty {
-                // rethrow any failure.
-                try await group.next()
+                // gather the results and re-throw any failure.
+                if let items = try await group.next() {
+                    allReports.append(contentsOf: items)
+                }
             }
+
+            return allReports
+        }
+
+        /// Saves loaded reports to memory
+        for report in reports {
+            let id = report.variationID ?? report.productID
+            savedReports[id] = report
+        }
+    }
+
+    // In some cases, variation reports can have invalid product ID.
+    // Fix that by restore the parent ID from the stock item.
+    func updatedVariationReports(from reports: [ProductReport], using stock: [ProductStock]) -> [ProductReport] {
+        reports.map { report in
+            guard let variationID = report.variationID,
+                  report.productID == 0,
+                  let parentID = stock.first(where: { $0.productID == variationID })?.productID else {
+                return report
+            }
+            return report.copy(productID: parentID)
         }
     }
 }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #12871 
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
When testing the Stock card, I encountered once a crash when the card was being loaded. I checked the stack trace and found this:

```
Thread 14 Crashed:
0   libobjc.A.dylib               	       0x18005f014 objc_msgSend + 20
1   libswiftCore.dylib            	       0x193021e98 Dictionary._Variant.setValue(_:forKey:) + 88
2   libswiftCore.dylib            	       0x192fe4fec Dictionary.subscript.setter + 296
3   WooCommerce                   	       0x1044ded5c closure #2 in closure #2 in ProductStockDashboardCardViewModel.fetchAndSaveReportsToMemory(for:) + 580 (ProductStockDashboardCardViewModel.swift:172)
4   WooCommerce                   	       0x1044e0535 partial apply for closure #2 in closure #2 in ProductStockDashboardCardViewModel.fetchAndSaveReportsToMemory(for:) + 1
5   libswift_Concurrency.dylib    	       0x209a030cd completeTaskWithClosure(swift::AsyncContext*, swift::SwiftError*) + 1
```

The log indicates a data race when working with a dictionary in `ProductStockDashboardCardViewModel.fetchAndSaveReportsToMemory`. In this method, I was updating the same dictionary in two concurrent async tasks, which is likely to be the cause of the data race.

The solution is to gather the product reports from both async tasks and updated the in-memory cache of reports after both tasks are done.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

- In a test store, create a simple product and a variable product if you haven't already.
- Update the stock quantity of these products to be low (1 or 2 items)
- On the app, enable the Stock card and choose Low stock.
- Reload the screen a few times and confirm that the correct items are displayed and the app doesn't crash while loading data.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

<img src="https://github.com/woocommerce/woocommerce-ios/assets/5533851/cd1a99a4-6977-40f9-8ba8-8595eef3fbb6" width=320 />

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
