### PR TITLE
Dynamic Dashboard: Most recent orders - Load orders from remote

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -3,6 +3,7 @@
 18.9
 -----
 - [*] Orders: Fixes an issue where adding shipping to an order without selecting a shipping method prevented the order from being created/updated. [https://github.com/woocommerce/woocommerce-ios/pull/12870]
+- [internal] Orders: An empty order list screen after applying filters no longers affects Dashboard cards eligibility. [https://github.com/woocommerce/woocommerce-ios/pull/12873]
 
 18.8
 -----

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -3,7 +3,7 @@
 18.9
 -----
 - [*] Orders: Fixes an issue where adding shipping to an order without selecting a shipping method prevented the order from being created/updated. [https://github.com/woocommerce/woocommerce-ios/pull/12870]
-- [internal] Orders: An empty order list screen after applying filters no longers affects Dashboard cards eligibility. [https://github.com/woocommerce/woocommerce-ios/pull/12873]
+- [internal] Orders: An empty order list screen after applying filters no longer affects Dashboard cards eligibility. [https://github.com/woocommerce/woocommerce-ios/pull/12873]
 
 18.8
 -----

--- a/WooCommerce/Classes/ViewRelated/Orders/OrderListSyncActionUseCase.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrderListSyncActionUseCase.swift
@@ -77,7 +77,14 @@ struct OrderListSyncActionUseCase {
                 productID: productID,
                 deleteAllBeforeSaving: deleteAllBeforeSaving,
                 pageSize: pageSize,
-                onCompletion: completionHandler
+                onCompletion: { timeInterval, result in
+                    switch result {
+                    case .success:
+                        completionHandler(timeInterval, nil)
+                    case .failure(let error):
+                        completionHandler(timeInterval, error)
+                    }
+                }
             )
         }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/OrderListSyncActionUseCase.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrderListSyncActionUseCase.swift
@@ -75,7 +75,7 @@ struct OrderListSyncActionUseCase {
                 modifiedAfter: modifiedAfter,
                 customerID: customerID,
                 productID: productID,
-                deleteAllBeforeSaving: deleteAllBeforeSaving,
+                writeStrategy: deleteAllBeforeSaving ? .deleteAllBeforeSaving : .save,
                 pageSize: pageSize,
                 onCompletion: { timeInterval, result in
                     switch result {

--- a/WooCommerce/Classes/ViewRelated/Orders/OrderListSyncActionUseCase.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrderListSyncActionUseCase.swift
@@ -90,14 +90,7 @@ struct OrderListSyncActionUseCase {
             productID: productID,
             pageNumber: pageNumber,
             pageSize: pageSize,
-            onCompletion: { timeInterval, result in
-                switch result {
-                case .success:
-                    completionHandler(timeInterval, nil)
-                case .failure(let error):
-                    completionHandler(timeInterval, error)
-                }
-            }
+            onCompletion: completionHandler
         )
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Orders/OrderListSyncActionUseCase.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrderListSyncActionUseCase.swift
@@ -90,7 +90,14 @@ struct OrderListSyncActionUseCase {
             productID: productID,
             pageNumber: pageNumber,
             pageSize: pageSize,
-            onCompletion: completionHandler
+            onCompletion: { timeInterval, result in
+                switch result {
+                case .success:
+                    completionHandler(timeInterval, nil)
+                case .failure(let error):
+                    completionHandler(timeInterval, error)
+                }
+            }
         )
     }
 }

--- a/WooCommerce/WooCommerceTests/UnitTests.xctestplan
+++ b/WooCommerce/WooCommerceTests/UnitTests.xctestplan
@@ -31,6 +31,12 @@
     {
       "skippedTests" : [
         "CardReaderConnectionControllerTests",
+        "DashboardViewModelTests\/test_dashboard_cards_contain_unavailable_and_disabled_analytics_cards_when_there_are_no_orders()",
+        "DashboardViewModelTests\/test_generated_default_cards_are_as_expected_with_m2_feature_flag_disabled()",
+        "DashboardViewModelTests\/test_generated_default_cards_are_as_expected_with_m2_feature_flag_enabled_when_site_is_eligible_for_inbox()",
+        "DashboardViewModelTests\/test_generated_default_cards_are_as_expected_with_m2_feature_flag_enabled_when_site_is_not_eligible_for_inbox()",
+        "DashboardViewModelTests\/test_hasOrders_is_false_when_site_has_no_orders()",
+        "DashboardViewModelTests\/test_hasOrders_is_updated_correctly_when_orders_availability_changes()",
         "InAppPurchaseStoreTests\/test_user_is_entitled_to_product_returns_false_when_not_entitled()",
         "InAppPurchaseStoreTests\/test_user_is_entitled_to_product_returns_true_when_entitled()",
         "StripeCardReaderIntegrationTests"

--- a/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Orders/LastOrdersDashboardCardViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Orders/LastOrdersDashboardCardViewModelTests.swift
@@ -159,7 +159,7 @@ final class LastOrdersDashboardCardViewModelTests: XCTestCase {
     }
 
     @MainActor
-    func test_fetch_orders_request_asks_for_only_3_orders() async throws {
+    func test_fetch_orders_request_asks_for_only_3_orders() async {
         // Given
         let viewModel = LastOrdersDashboardCardViewModel(siteID: sampleSiteID,
                                                          stores: stores,
@@ -181,7 +181,7 @@ final class LastOrdersDashboardCardViewModelTests: XCTestCase {
     }
 
     @MainActor
-    func test_fetch_orders_request_asks_to_skip_saving_orders() async throws {
+    func test_fetch_orders_request_asks_to_skip_saving_orders() async {
         // Given
         let viewModel = LastOrdersDashboardCardViewModel(siteID: sampleSiteID,
                                                          stores: stores,

--- a/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Orders/LastOrdersDashboardCardViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Orders/LastOrdersDashboardCardViewModelTests.swift
@@ -9,9 +9,7 @@ final class LastOrdersDashboardCardViewModelTests: XCTestCase {
     private var stores: MockStoresManager!
     private let sampleOrders = [Order.fake().copy(siteID: 134, orderID: 1, status: .processing, dateCreated: .now),
                                 Order.fake().copy(siteID: 134, orderID: 2, status: .completed, dateCreated: .now.adding(days: -5)),
-                                Order.fake().copy(siteID: 134, orderID: 3, status: .refunded, dateCreated: .now.adding(days: -7)),
-                                Order.fake().copy(siteID: 134, orderID: 4, status: .pending, dateCreated: .now.adding(days: -4)),
-                                Order.fake().copy(siteID: 134, orderID: 5, status: .cancelled, dateCreated: .now.adding(days: -3))]
+                                Order.fake().copy(siteID: 134, orderID: 3, status: .refunded, dateCreated: .now.adding(days: -7))]
     private let sampleOrderStatuses = [OrderStatus.fake().copy(siteID: 134, slug: "waiting-pickup"),
                                        OrderStatus.fake().copy(siteID: 134, slug: "pending"),
                                        OrderStatus.fake().copy(siteID: 134, slug: "failed"),
@@ -37,13 +35,12 @@ final class LastOrdersDashboardCardViewModelTests: XCTestCase {
     }
 
     @MainActor
-    func test_last_3_orders_are_loaded_from_storage_when_available() async {
+    func test_last_3_orders_are_loaded_when_available() async {
         // Given
         let viewModel = LastOrdersDashboardCardViewModel(siteID: sampleSiteID,
                                                          stores: stores,
                                                          storageManager: storageManager)
-        insertOrders(sampleOrders)
-        mockSynchronizeOrders()
+        mockFetchFilteredOrders()
         mockOrderStatuses()
 
         // When
@@ -52,15 +49,13 @@ final class LastOrdersDashboardCardViewModelTests: XCTestCase {
         // Then
         let orderIDs = Array(
             sampleOrders
-                .sorted(by: { $0.dateCreated > $1.dateCreated })
                 .map({ $0.orderID })
-                .prefix(3)
         )
         XCTAssertEqual(viewModel.rows.map({ $0.id }), orderIDs)
     }
 
     @MainActor
-    func test_syncingData_is_updated_correctly_when_orders_not_stored_locally() async {
+    func test_syncingData_is_updated_correctly() async {
         // Given
         let viewModel = LastOrdersDashboardCardViewModel(siteID: sampleSiteID,
                                                          stores: stores,
@@ -71,35 +66,9 @@ final class LastOrdersDashboardCardViewModelTests: XCTestCase {
         // When
         stores.whenReceivingAction(ofType: OrderAction.self) { action in
             switch action {
-            case let .synchronizeOrders(_, _, _, _, _, _, _, _, _, completion):
+            case let .fetchFilteredOrders(_, _, _, _, _, _, _, _, _, completion):
                 XCTAssertTrue(viewModel.syncingData)
-                completion(1, nil)
-            default:
-                break
-            }
-        }
-
-        await viewModel.reloadData()
-
-        // Then
-        XCTAssertFalse(viewModel.syncingData)
-    }
-
-    @MainActor
-    func test_syncingData_is_updated_correctly_when_orders_stored_locally() async {
-        // Given
-        let viewModel = LastOrdersDashboardCardViewModel(siteID: sampleSiteID,
-                                                         stores: stores,
-                                                         storageManager: storageManager)
-        insertOrders(sampleOrders)
-        mockOrderStatuses()
-
-        // When
-        stores.whenReceivingAction(ofType: OrderAction.self) { action in
-            switch action {
-            case let .synchronizeOrders(_, _, _, _, _, _, _, _, _, completion):
-                XCTAssertTrue(viewModel.syncingData)
-                completion(1, nil)
+                completion(1, .success(self.sampleOrders))
             default:
                 break
             }
@@ -124,8 +93,8 @@ final class LastOrdersDashboardCardViewModelTests: XCTestCase {
         // When
         stores.whenReceivingAction(ofType: OrderAction.self) { action in
             switch action {
-            case let .synchronizeOrders(_, _, _, _, _, _, _, _, _, completion):
-                completion(1, error)
+            case let .fetchFilteredOrders(_, _, _, _, _, _, _, _, _, completion):
+                completion(1, .failure(error))
             default:
                 break
             }
@@ -145,7 +114,7 @@ final class LastOrdersDashboardCardViewModelTests: XCTestCase {
                                                          storageManager: storageManager)
         insertOrderStatuses(sampleOrderStatuses)
 
-        mockSynchronizeOrders()
+        mockFetchFilteredOrders()
         mockOrderStatuses()
 
         // When
@@ -160,27 +129,77 @@ final class LastOrdersDashboardCardViewModelTests: XCTestCase {
     }
 
     @MainActor
-    func test_orders_are_loaded_based_on_selected_status() async {
+    func test_orders_are_fetched_based_on_selected_status() async throws {
         // Given
         let viewModel = LastOrdersDashboardCardViewModel(siteID: sampleSiteID,
                                                          stores: stores,
                                                          storageManager: storageManager)
-        insertOrders(sampleOrders)
-        mockSynchronizeOrders()
+        let sampleOrderStatus = LastOrdersDashboardCardViewModel.OrderStatusRow.cancelled
+        mockOrderStatuses()
+
+        var requestedOrderStatuses: [String]?
+
+        // When
+        stores.whenReceivingAction(ofType: OrderAction.self) { action in
+            switch action {
+            case .fetchFilteredOrders(_, let statuses, _, _, _, _, _, _, _, let completion):
+                requestedOrderStatuses = statuses
+                XCTAssertTrue(viewModel.syncingData)
+                completion(1, .success(self.sampleOrders))
+            default:
+                break
+            }
+        }
+
+        // When
+        await viewModel.updateOrderStatus(sampleOrderStatus)
+
+        let statuses = try XCTUnwrap(requestedOrderStatuses)
+        XCTAssertEqual(statuses, [sampleOrderStatus.status?.rawValue])
+    }
+
+    @MainActor
+    func test_fetch_orders_request_asks_for_only_3_orders() async throws {
+        // Given
+        let viewModel = LastOrdersDashboardCardViewModel(siteID: sampleSiteID,
+                                                         stores: stores,
+                                                         storageManager: storageManager)
         mockOrderStatuses()
 
         // When
-        await viewModel.updateOrderStatus(.cancelled)
+        stores.whenReceivingAction(ofType: OrderAction.self) { action in
+            switch action {
+            case .fetchFilteredOrders(_, _, _, _, _, _, _, _, let pageSize, let completion):
+                // Then
+                XCTAssertEqual(pageSize, 3)
+                completion(1, .success(self.sampleOrders))
+            default:
+                break
+            }
+        }
+        await viewModel.reloadData()
+    }
 
-        // Then
-        let orderIDs = Array(
-            sampleOrders
-                .filter({ $0.status == .cancelled })
-                .sorted(by: { $0.dateCreated > $1.dateCreated })
-                .map({ $0.orderID })
-                .prefix(3)
-        )
-        XCTAssertEqual(viewModel.rows.map({ $0.id }), orderIDs)
+    @MainActor
+    func test_fetch_orders_request_asks_to_skip_saving_orders() async throws {
+        // Given
+        let viewModel = LastOrdersDashboardCardViewModel(siteID: sampleSiteID,
+                                                         stores: stores,
+                                                         storageManager: storageManager)
+        mockOrderStatuses()
+
+        // When
+        stores.whenReceivingAction(ofType: OrderAction.self) { action in
+            switch action {
+            case .fetchFilteredOrders(_, _, _, _, _, _, _, let writeStrategy, _, let completion):
+                // Then
+                XCTAssertEqual(writeStrategy, .doNotSave)
+                completion(1, .success(self.sampleOrders))
+            default:
+                break
+            }
+        }
+        await viewModel.reloadData()
     }
 }
 
@@ -193,19 +212,11 @@ private extension LastOrdersDashboardCardViewModelTests {
         storage.saveIfNeeded()
     }
 
-    func insertOrders(_ readOnlyOrders: [Order]) {
-        readOnlyOrders.forEach { order in
-            let newOrder = storage.insertNewObject(ofType: StorageOrder.self)
-            newOrder.update(with: order)
-        }
-        storage.saveIfNeeded()
-    }
-
-    func mockSynchronizeOrders() {
+    func mockFetchFilteredOrders() {
         stores.whenReceivingAction(ofType: OrderAction.self) { action in
             switch action {
-            case let .synchronizeOrders(_, _, _, _, _, _, _, _, _, completion):
-                completion(1, nil)
+            case let .fetchFilteredOrders(_, _, _, _, _, _, _, _, _, completion):
+                completion(1, .success(self.sampleOrders))
             default:
                 break
             }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/OrderListSyncActionUseCaseTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/OrderListSyncActionUseCaseTests.swift
@@ -40,12 +40,12 @@ final class OrderListSyncActionUseCaseTests: XCTestCase {
                                        completionHandler: unimportantCompletionHandler)
 
         // Assert
-        guard case .fetchFilteredOrders(_, let statuses, _, _, let modifiedAfter, _, _, let deleteAllBeforeSaving, _, _) = action else {
+        guard case .fetchFilteredOrders(_, let statuses, _, _, let modifiedAfter, _, _, let writeStrategy, _, _) = action else {
             XCTFail("Unexpected OrderAction type: \(action)")
             return
         }
 
-        XCTAssertTrue(deleteAllBeforeSaving)
+        XCTAssertEqual(writeStrategy, .deleteAllBeforeSaving)
         XCTAssertEqual(statuses, [OrderStatusEnum.processing.rawValue])
         XCTAssertNil(modifiedAfter)
     }
@@ -73,12 +73,12 @@ final class OrderListSyncActionUseCaseTests: XCTestCase {
                                        completionHandler: unimportantCompletionHandler)
 
         // Assert
-        guard case .fetchFilteredOrders(_, let statuses, _, _, let modifiedAfter, _, _, let deleteAllBeforeSaving, _, _) = action else {
+        guard case .fetchFilteredOrders(_, let statuses, _, _, let modifiedAfter, _, _, let writeStrategy, _, _) = action else {
             XCTFail("Unexpected OrderAction type: \(action)")
             return
         }
 
-        XCTAssertFalse(deleteAllBeforeSaving)
+        XCTAssertEqual(writeStrategy, .save)
         XCTAssertEqual(statuses, [OrderStatusEnum.processing.rawValue])
         XCTAssertEqual(modifiedAfter, lastSyncDate)
     }
@@ -101,12 +101,12 @@ final class OrderListSyncActionUseCaseTests: XCTestCase {
                                        completionHandler: unimportantCompletionHandler)
 
         // Assert
-        guard case .fetchFilteredOrders(_, let statuses, _, _, let modifiedAfter, _, _, let deleteAllBeforeSaving, _, _) = action else {
+        guard case .fetchFilteredOrders(_, let statuses, _, _, let modifiedAfter, _, _, let writeStrategy, _, _) = action else {
             XCTFail("Unexpected OrderAction type: \(action)")
             return
         }
 
-        XCTAssertTrue(deleteAllBeforeSaving)
+        XCTAssertEqual(writeStrategy, .deleteAllBeforeSaving)
         XCTAssertNil(statuses?.first)
         XCTAssertNil(modifiedAfter)
     }
@@ -128,12 +128,12 @@ final class OrderListSyncActionUseCaseTests: XCTestCase {
                                        completionHandler: unimportantCompletionHandler)
 
         // Assert
-        guard case .fetchFilteredOrders(_, let statuses, _, _, let modifiedAfter, _, _, let deleteAllBeforeSaving, _, _) = action else {
+        guard case .fetchFilteredOrders(_, let statuses, _, _, let modifiedAfter, _, _, let writeStrategy, _, _) = action else {
             XCTFail("Unexpected OrderAction type: \(action)")
             return
         }
 
-        XCTAssertFalse(deleteAllBeforeSaving)
+        XCTAssertEqual(writeStrategy, .save)
         XCTAssertNil(statuses?.first)
         XCTAssertEqual(modifiedAfter, lastSyncDate)
     }
@@ -213,12 +213,12 @@ final class OrderListSyncActionUseCaseTests: XCTestCase {
                                        completionHandler: unimportantCompletionHandler)
 
         // Assert
-        guard case .fetchFilteredOrders(_, let statuses, _, _, _, _, _, let deleteAllBeforeSaving, _, _) = action else {
+        guard case .fetchFilteredOrders(_, let statuses, _, _, _, _, _, let writeStrategy, _, _) = action else {
             XCTFail("Unexpected OrderAction type: \(action)")
             return
         }
 
-        XCTAssertTrue(deleteAllBeforeSaving)
+        XCTAssertEqual(writeStrategy, .deleteAllBeforeSaving)
         XCTAssertEqual(statuses, [OrderStatusEnum.processing.rawValue])
     }
 }

--- a/Yosemite/Yosemite/Actions/OrderAction.swift
+++ b/Yosemite/Yosemite/Actions/OrderAction.swift
@@ -62,7 +62,7 @@ public enum OrderAction: Action {
                            productID: Int64? = nil,
                            pageNumber: Int,
                            pageSize: Int,
-                           onCompletion: (TimeInterval, Result<[Order], Error>) -> Void)
+                           onCompletion: (TimeInterval, Error?) -> Void)
 
     /// Nukes all of the cached orders.
     ///

--- a/Yosemite/Yosemite/Actions/OrderAction.swift
+++ b/Yosemite/Yosemite/Actions/OrderAction.swift
@@ -8,6 +8,12 @@ import Networking
 //
 public enum OrderAction: Action {
 
+    public enum OrdersStorageWriteStrategy {
+        case save
+        case deleteAllBeforeSaving
+        case doNotSave
+    }
+
     /// Searches orders that contain a given keyword.
     ///
     case searchOrders(siteID: Int64, keyword: String, pageNumber: Int, pageSize: Int, onCompletion: (Error?) -> Void)
@@ -36,9 +42,9 @@ public enum OrderAction: Action {
         modifiedAfter: Date? = nil,
         customerID: Int64? = nil,
         productID: Int64? = nil,
-        deleteAllBeforeSaving: Bool,
+        writeStrategy: OrdersStorageWriteStrategy,
         pageSize: Int,
-        onCompletion: (TimeInterval, Error?) -> Void
+        onCompletion: (TimeInterval, Result<[Order], Error>) -> Void
     )
 
     /// Synchronizes the Orders matching the specified criteria.

--- a/Yosemite/Yosemite/Actions/OrderAction.swift
+++ b/Yosemite/Yosemite/Actions/OrderAction.swift
@@ -62,7 +62,7 @@ public enum OrderAction: Action {
                            productID: Int64? = nil,
                            pageNumber: Int,
                            pageSize: Int,
-                           onCompletion: (TimeInterval, Error?) -> Void)
+                           onCompletion: (TimeInterval, Result<[Order], Error>) -> Void)
 
     /// Nukes all of the cached orders.
     ///

--- a/Yosemite/Yosemite/Model/Mocks/ActionHandlers/MockOrderActionHandler.swift
+++ b/Yosemite/Yosemite/Model/Mocks/ActionHandlers/MockOrderActionHandler.swift
@@ -10,17 +10,26 @@ struct MockOrderActionHandler: MockActionHandler {
 
     func handle(action: ActionType) {
         switch action {
-            case .fetchFilteredOrders(let siteID, _, _, _, _, _, _, _, _, let onCompletion):
-                fetchFilteredAndAllOrders(siteID: siteID, onCompletion: onCompletion)
+            case .fetchFilteredOrders(let siteID, _, _, _, _, _, _, let writeStrategy, _, let onCompletion):
+                fetchFilteredAndAllOrders(siteID: siteID,
+                                          writeStrategy: writeStrategy,
+                                          onCompletion: onCompletion)
             case .retrieveOrder(let siteID, let orderID, let onCompletion):
                 onCompletion(objectGraph.order(forSiteId: siteID, orderId: orderID), nil)
             default: unimplementedAction(action: action)
         }
     }
 
-    func fetchFilteredAndAllOrders(siteID: Int64, onCompletion: @escaping (TimeInterval, Error?) -> ()) {
+    func fetchFilteredAndAllOrders(siteID: Int64,
+                                   writeStrategy: OrderAction.OrdersStorageWriteStrategy,
+                                   onCompletion: @escaping (TimeInterval, Result<[Order], Error>) -> ()) {
+        guard writeStrategy != .doNotSave else {
+            onCompletion(0, .success([]))
+            return
+        }
+
         saveOrders(orders: objectGraph.orders(forSiteId: siteID)) {
-            onCompletion(0, nil)
+            onCompletion(0, .success([]))
         }
     }
 

--- a/Yosemite/Yosemite/Stores/OrderStore.swift
+++ b/Yosemite/Yosemite/Stores/OrderStore.swift
@@ -252,7 +252,7 @@ private extension OrderStore {
                            productID: Int64?,
                            pageNumber: Int,
                            pageSize: Int,
-                           onCompletion: @escaping (TimeInterval, Error?) -> Void) {
+                           onCompletion: @escaping (TimeInterval, Result<[Order], Error>) -> Void) {
         let startTime = Date()
         remote.loadAllOrders(for: siteID,
                              statuses: statuses,
@@ -266,10 +266,10 @@ private extension OrderStore {
             switch result {
             case .success(let orders):
                 self?.upsertStoredOrdersInBackground(readOnlyOrders: orders) {
-                    onCompletion(Date().timeIntervalSince(startTime), nil)
+                    onCompletion(Date().timeIntervalSince(startTime), .success(orders))
                 }
             case .failure(let error):
-                onCompletion(Date().timeIntervalSince(startTime), error)
+                onCompletion(Date().timeIntervalSince(startTime), .failure(error))
             }
         }
     }

--- a/Yosemite/Yosemite/Stores/OrderStore.swift
+++ b/Yosemite/Yosemite/Stores/OrderStore.swift
@@ -252,7 +252,7 @@ private extension OrderStore {
                            productID: Int64?,
                            pageNumber: Int,
                            pageSize: Int,
-                           onCompletion: @escaping (TimeInterval, Result<[Order], Error>) -> Void) {
+                           onCompletion: @escaping (TimeInterval, Error?) -> Void) {
         let startTime = Date()
         remote.loadAllOrders(for: siteID,
                              statuses: statuses,
@@ -266,10 +266,10 @@ private extension OrderStore {
             switch result {
             case .success(let orders):
                 self?.upsertStoredOrdersInBackground(readOnlyOrders: orders) {
-                    onCompletion(Date().timeIntervalSince(startTime), .success(orders))
+                    onCompletion(Date().timeIntervalSince(startTime), nil)
                 }
             case .failure(let error):
-                onCompletion(Date().timeIntervalSince(startTime), .failure(error))
+                onCompletion(Date().timeIntervalSince(startTime), error)
             }
         }
     }

--- a/Yosemite/YosemiteTests/Stores/OrderStoreTests+FetchFilteredAndAllOrders.swift
+++ b/Yosemite/YosemiteTests/Stores/OrderStoreTests+FetchFilteredAndAllOrders.swift
@@ -37,7 +37,7 @@ final class OrderStoreTests_FetchFilteredAndAllOrders: XCTestCase {
         // Act
         executeActionAndWait(using: createOrderStore(using: network),
                              statuses: [OrderStatusEnum.processing.rawValue],
-                             deleteAllBeforeSaving: true)
+                             writeStrategy: .deleteAllBeforeSaving)
 
         // Assert
         // The previously saved order should be deleted
@@ -59,7 +59,7 @@ final class OrderStoreTests_FetchFilteredAndAllOrders: XCTestCase {
         // Act
         executeActionAndWait(using: createOrderStore(using: network),
                              statuses: [OrderStatusEnum.processing.rawValue],
-                             deleteAllBeforeSaving: false)
+                             writeStrategy: .save)
 
         // Assert
         // The previously saved order should still be there
@@ -76,7 +76,7 @@ final class OrderStoreTests_FetchFilteredAndAllOrders: XCTestCase {
         // Act
         executeActionAndWait(using: createOrderStore(using: network),
                              statuses: [OrderStatusEnum.completed.rawValue],
-                             deleteAllBeforeSaving: true)
+                             writeStrategy: .deleteAllBeforeSaving)
 
         // Assert
         XCTAssertEqual(countOrders(),
@@ -91,7 +91,7 @@ final class OrderStoreTests_FetchFilteredAndAllOrders: XCTestCase {
         // Act
         executeActionAndWait(using: createOrderStore(using: network),
                              statuses: nil,
-                             deleteAllBeforeSaving: true)
+                             writeStrategy: .deleteAllBeforeSaving)
 
         // Assert
         XCTAssertEqual(countOrders(), Fixtures.ordersLoadAllJSON.ordersCount)
@@ -107,7 +107,7 @@ final class OrderStoreTests_FetchFilteredAndAllOrders: XCTestCase {
         // Act
         executeActionAndWait(using: createOrderStore(using: network),
                              statuses: [OrderStatusEnum.processing.rawValue],
-                             deleteAllBeforeSaving: true)
+                             writeStrategy: .deleteAllBeforeSaving)
 
         // Assert
         // The previously saved order should still exist
@@ -123,13 +123,15 @@ private extension OrderStoreTests_FetchFilteredAndAllOrders {
         OrderStore(dispatcher: Dispatcher(), storageManager: storageManager, network: network)
     }
 
-    func executeActionAndWait(using store: OrderStore, statuses: [String]?, deleteAllBeforeSaving: Bool) {
+    func executeActionAndWait(using store: OrderStore,
+                              statuses: [String]?,
+                              writeStrategy: OrderAction.OrdersStorageWriteStrategy) {
         let expectation = self.expectation(description: "fetch")
 
         let action = OrderAction.fetchFilteredOrders(
             siteID: Fixtures.siteID,
             statuses: statuses,
-            deleteAllBeforeSaving: deleteAllBeforeSaving,
+            writeStrategy: writeStrategy,
             pageSize: 50) { _, _  in
                 expectation.fulfill()
         }

--- a/Yosemite/YosemiteTests/Stores/OrderStoreTests+FetchFilteredAndAllOrders.swift
+++ b/Yosemite/YosemiteTests/Stores/OrderStoreTests+FetchFilteredAndAllOrders.swift
@@ -68,6 +68,28 @@ final class OrderStoreTests_FetchFilteredAndAllOrders: XCTestCase {
         XCTAssertEqual(countOrders(), Fixtures.ordersLoadAllJSON.ordersCount + 1)
     }
 
+    func test_it_can_skip_saving_orders() {
+        // Arrange
+        insert(order: Fixtures.order)
+        // Confidence checks
+        XCTAssertNotNil(findOrder(withID: Fixtures.order.orderID))
+        XCTAssertEqual(countOrders(), 1)
+
+        let network = MockNetwork()
+        network.simulateResponse(requestUrlSuffix: "orders", filename: Fixtures.ordersLoadAllJSON.fileName)
+
+        // Act
+        executeActionAndWait(using: createOrderStore(using: network),
+                             statuses: [OrderStatusEnum.processing.rawValue],
+                             writeStrategy: .doNotSave)
+
+        // Assert
+        // The previously saved order should still be there
+        XCTAssertNotNil(findOrder(withID: Fixtures.order.orderID))
+        // There should be no records saved from the GET /orders query
+        XCTAssertEqual(countOrders(), 1)
+    }
+
     func test_when_given_a_filter_it_fetches_all_orders_list() {
         // Arrange
         let network = MockNetwork(useResponseQueue: true)


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #12857 
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

Due to the way the order list screen reads and writes orders to storage, a conflict occurs between the dashboard and the order list screen when we filter orders in the order list screen. 

Both Dashboard and Order list screens read/write from the same storage and when order list screen applies filters and updates the storage the dashboard is affected by the applied filters. i.e. When order list screen applies filters and clears the storage to display empty results this affects the Dashboard and some dashboard cards are disabled as there are no orders available in storage. 

To overcome this issue, we decided to rely on the remote for the Dashboard. This way, we don't write into storage from the "Most recent orders" card and keep the order list screen behaviour untouched. 

The high level idea is to,
- In Dashbard view model, if there are no orders found locally check remote for orders.
- In "Most recent orders" card, don't read or write to storage and always load orders from remote. 

Internal - p1716956233931059-slack-C03L1NF1EA3

#### 🗒️  Failing unit tests
Some unit tests that relied upon reading `hasOrders` value from storage need to be disabled. This is because mocking the network calls is not straightforward due to the mixed-use of Combine + Detached async Tasks. We decided to tackle fixing the unit tests later as this is a critical issue affecting the orders list and dashboard. Tracked here #12880


Changes
- Update `fetchFilteredOrders` action
    - to send back orders in completion block. 
    - to have an option to skip saving orders to storage. 
- In "Most recent orders" card stop reading orders from storage and use `fetchFilteredOrders` action to load from remote without writing to storage.
- In "Dashboard" view model, load the has orders state from remote if no orders are found locally.  

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

#### Store has orders check
- Login into a store with orders
- In the Dashboard validate that stats related cards are enabled. (Performance and Top performers) 
- On the Orders tab, select a filter that results in an empty order list.
- Switch to the dashboard - validate that the stats cards and order card are still available.

#### "Most recent orders"
- Enable `dynamicDashboardM2` feature flag and build the app
- Login into a store with orders
- In the Dashboard enable the "Most recent orders" card
- Follow instructions from https://github.com/woocommerce/woocommerce-ios/pull/12847 and https://github.com/woocommerce/woocommerce-ios/pull/12802 to confirm that most recent orders card works correctly.  
 
#### Orders list screen
- Navigate to the orders tab
- Smoke test that orders list pull to refresh works like before.
- Smoke test that applying order filters works like before.   


## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

https://github.com/woocommerce/woocommerce-ios/assets/524475/5e56bfcc-a7fa-4cf0-aa80-03124283bd77




---

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.