### PR TITLE
[Order Form] Open shipping details screen to add/edit a shipping line with multiple shipping lines

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/EditableOrderViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/EditableOrderViewModel.swift
@@ -1113,7 +1113,7 @@ final class EditableOrderViewModel: ObservableObject {
     }
 
     func addShippingLineViewModel() -> ShippingLineSelectionDetailsViewModel {
-        return ShippingLineSelectionDetailsViewModel(siteID: siteID, didSelectSave: saveShippingLine)
+        return ShippingLineSelectionDetailsViewModel(siteID: siteID, shippingLine: nil, didSelectSave: saveShippingLine)
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/EditableOrderViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/EditableOrderViewModel.swift
@@ -1107,6 +1107,10 @@ final class EditableOrderViewModel: ObservableObject {
 
         return viewModel
     }
+
+    func addShippingLineViewModel() -> ShippingLineSelectionDetailsViewModel {
+        return ShippingLineSelectionDetailsViewModel(siteID: siteID, didSelectSave: saveShippingLine)
+    }
 }
 
 // MARK: - Types

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/EditableOrderViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/EditableOrderViewModel.swift
@@ -1271,6 +1271,7 @@ extension EditableOrderViewModel {
              shouldShowShippingTotal: Bool = false,
              shippingTotal: String = "0",
              isShippingTotalEditable: Bool = true,
+             shippingID: Int64? = nil,
              shippingMethodID: String = "",
              shippingMethodTitle: String = "",
              shippingMethodTotal: String = "",
@@ -1340,7 +1341,7 @@ extension EditableOrderViewModel {
                                                                       shippingTotal: shippingMethodTotal,
                                                                       didSelectSave: saveShippingLineClosure)
             self.shippingLineSelectionViewModel = ShippingLineSelectionDetailsViewModel(siteID: siteID,
-                                                                                        isExistingShippingLine: shouldShowShippingTotal,
+                                                                                        shippingID: shippingID,
                                                                                         initialMethodID: shippingMethodID,
                                                                                         initialMethodTitle: shippingMethodTitle,
                                                                                         shippingTotal: shippingMethodTotal,
@@ -1709,7 +1710,7 @@ private extension EditableOrderViewModel {
                             return
                         }
                         selectedShippingLine = ShippingLineSelectionDetailsViewModel(siteID: siteID,
-                                                                                     isExistingShippingLine: true,
+                                                                                     shippingID: shippingLine.shippingID,
                                                                                      initialMethodID: shippingLine.methodID ?? "",
                                                                                      initialMethodTitle: shippingLine.methodTitle,
                                                                                      shippingTotal: shippingLine.total,
@@ -1855,8 +1856,7 @@ private extension EditableOrderViewModel {
 
                 let orderTotals = OrderTotalsCalculator(for: order, using: self.currencyFormatter)
 
-                let shippingMethodID = order.shippingLines.first?.methodID ?? ""
-                let shippingMethodTitle = order.shippingLines.first?.methodTitle ?? ""
+                let shippingLine = order.shippingLines.first
 
                 let isDataSyncing: Bool = {
                     switch state {
@@ -1904,8 +1904,9 @@ private extension EditableOrderViewModel {
                                             shouldShowShippingTotal: order.shippingLines.filter { $0.methodID != nil }.isNotEmpty,
                                             shippingTotal: order.shippingTotal.isNotEmpty ? order.shippingTotal : "0",
                                             isShippingTotalEditable: !multipleShippingLinesEnabled,
-                                            shippingMethodID: shippingMethodID,
-                                            shippingMethodTitle: shippingMethodTitle,
+                                            shippingID: shippingLine?.shippingID,
+                                            shippingMethodID: shippingLine?.methodID ?? "",
+                                            shippingMethodTitle: shippingLine?.methodTitle ?? "",
                                             shippingMethodTotal: order.shippingLines.first?.total ?? "0",
                                             shippingTax: order.shippingTax.isNotEmpty ? order.shippingTax : "0",
                                             shouldShowTotalCustomAmounts: order.fees.filter { $0.name != nil }.isNotEmpty,

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/EditableOrderViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/EditableOrderViewModel.swift
@@ -390,6 +390,10 @@ final class EditableOrderViewModel: ObservableObject {
     ///
     private var allShippingMethods: [ShippingMethod] = []
 
+    /// View model to edit a selected shipping line.
+    ///
+    @Published var selectedShippingLine: ShippingLineSelectionDetailsViewModel? = nil
+
     // MARK: Customer data properties
 
     /// View model for the customer section.
@@ -1699,7 +1703,18 @@ private extension EditableOrderViewModel {
 
                     return ShippingLineRowViewModel(shippingLine: shippingLine,
                                                     shippingMethods: self.allShippingMethods,
-                                                    editable: !isNonEditable)
+                                                    editable: !isNonEditable,
+                                                    onEditShippingLine: { [weak self] shippingID in
+                        guard let self else {
+                            return
+                        }
+                        selectedShippingLine = ShippingLineSelectionDetailsViewModel(siteID: siteID,
+                                                                                     isExistingShippingLine: true,
+                                                                                     initialMethodID: shippingLine.methodID ?? "",
+                                                                                     initialMethodTitle: shippingLine.methodTitle,
+                                                                                     shippingTotal: shippingLine.total,
+                                                                                     didSelectSave: saveShippingLine)
+                    })
                 }
             }
             .assign(to: &$shippingLineRows)

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/PaymentSection/Shipping/ShippingLineSelectionDetails.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/PaymentSection/Shipping/ShippingLineSelectionDetails.swift
@@ -138,7 +138,7 @@ private extension ShippingLineSelectionDetails {
 
 #Preview("Add shipping") {
     ShippingLineSelectionDetails(viewModel: ShippingLineSelectionDetailsViewModel(siteID: 1,
-                                                                                  isExistingShippingLine: false,
+                                                                                  shippingID: nil,
                                                                                   initialMethodID: "",
                                                                                   initialMethodTitle: "",
                                                                                   shippingTotal: "",
@@ -147,7 +147,7 @@ private extension ShippingLineSelectionDetails {
 
 #Preview("Edit shipping") {
     ShippingLineSelectionDetails(viewModel: ShippingLineSelectionDetailsViewModel(siteID: 1,
-                                                                                  isExistingShippingLine: true,
+                                                                                  shippingID: 1,
                                                                                   initialMethodID: "flat_rate",
                                                                                   initialMethodTitle: "Shipping",
                                                                                   shippingTotal: "10.00",

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/PaymentSection/Shipping/ShippingLineSelectionDetailsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/PaymentSection/Shipping/ShippingLineSelectionDetailsViewModel.swift
@@ -37,6 +37,7 @@ class ShippingLineSelectionDetailsViewModel: ObservableObject, Identifiable {
         methodTitle.isNotEmpty ? methodTitle : Localization.namePlaceholder
     }
 
+    private let shippingID: Int64
     private let initialMethodID: String
     private let initialAmount: Decimal?
     private let initialMethodTitle: String
@@ -67,7 +68,7 @@ class ShippingLineSelectionDetailsViewModel: ObservableObject, Identifiable {
     @Published var enableDoneButton: Bool = false
 
     init(siteID: Int64,
-         isExistingShippingLine: Bool = false,
+         shippingID: Int64? = nil,
          initialMethodID: String = "",
          initialMethodTitle: String = "",
          shippingTotal: String = "",
@@ -77,9 +78,10 @@ class ShippingLineSelectionDetailsViewModel: ObservableObject, Identifiable {
          analytics: Analytics = ServiceLocator.analytics,
          didSelectSave: @escaping ((ShippingLine?) -> Void)) {
         self.siteID = siteID
+        self.shippingID = shippingID ?? 0
         self.storageManager = storageManager
         self.analytics = analytics
-        self.isExistingShippingLine = isExistingShippingLine
+        self.isExistingShippingLine = shippingID != nil
         self.initialMethodID = initialMethodID
         self.initialMethodTitle = initialMethodTitle
         self.methodTitle = initialMethodTitle
@@ -108,7 +110,7 @@ class ShippingLineSelectionDetailsViewModel: ObservableObject, Identifiable {
     }
 
     func saveData() {
-        let shippingLine = ShippingLine(shippingID: 0,
+        let shippingLine = ShippingLine(shippingID: shippingID,
                                         methodTitle: finalMethodTitle,
                                         methodID: selectedMethod.methodID,
                                         total: formattableAmountViewModel.amount,

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/PaymentSection/Shipping/ShippingLineSelectionDetailsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/PaymentSection/Shipping/ShippingLineSelectionDetailsViewModel.swift
@@ -68,10 +68,10 @@ class ShippingLineSelectionDetailsViewModel: ObservableObject, Identifiable {
     @Published var enableDoneButton: Bool = false
 
     init(siteID: Int64,
-         shippingID: Int64? = nil,
-         initialMethodID: String = "",
-         initialMethodTitle: String = "",
-         shippingTotal: String = "",
+         shippingID: Int64?,
+         initialMethodID: String,
+         initialMethodTitle: String,
+         shippingTotal: String,
          locale: Locale = Locale.autoupdatingCurrent,
          storeCurrencySettings: CurrencySettings = ServiceLocator.currencySettings,
          storageManager: StorageManagerType = ServiceLocator.storageManager,
@@ -107,6 +107,25 @@ class ShippingLineSelectionDetailsViewModel: ObservableObject, Identifiable {
 
         configureShippingMethods()
         observeShippingLineDetailsForUIStates(with: currencyFormatter)
+    }
+
+    convenience init(siteID: Int64,
+                     shippingLine: ShippingLine?,
+                     locale: Locale = Locale.autoupdatingCurrent,
+                     storeCurrencySettings: CurrencySettings = ServiceLocator.currencySettings,
+                     storageManager: StorageManagerType = ServiceLocator.storageManager,
+                     analytics: Analytics = ServiceLocator.analytics,
+                     didSelectSave: @escaping ((ShippingLine?) -> Void)) {
+        self.init(siteID: siteID,
+                  shippingID: shippingLine?.shippingID,
+                  initialMethodID: shippingLine?.methodID ?? "",
+                  initialMethodTitle: shippingLine?.methodTitle ?? "",
+                  shippingTotal: shippingLine?.total ?? "",
+                  locale: locale,
+                  storeCurrencySettings: storeCurrencySettings,
+                  storageManager: storageManager,
+                  analytics: analytics,
+                  didSelectSave: didSelectSave)
     }
 
     func saveData() {

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/PaymentSection/Shipping/ShippingLineSelectionDetailsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/PaymentSection/Shipping/ShippingLineSelectionDetailsViewModel.swift
@@ -4,7 +4,7 @@ import Yosemite
 import protocol Storage.StorageManagerType
 import Combine
 
-class ShippingLineSelectionDetailsViewModel: ObservableObject {
+class ShippingLineSelectionDetailsViewModel: ObservableObject, Identifiable {
     private var siteID: Int64
     private let storageManager: StorageManagerType
     private let analytics: Analytics

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/PaymentSection/Shipping/ShippingLineSelectionDetailsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/PaymentSection/Shipping/ShippingLineSelectionDetailsViewModel.swift
@@ -67,10 +67,10 @@ class ShippingLineSelectionDetailsViewModel: ObservableObject {
     @Published var enableDoneButton: Bool = false
 
     init(siteID: Int64,
-         isExistingShippingLine: Bool,
-         initialMethodID: String,
-         initialMethodTitle: String,
-         shippingTotal: String,
+         isExistingShippingLine: Bool = false,
+         initialMethodID: String = "",
+         initialMethodTitle: String = "",
+         shippingTotal: String = "",
          locale: Locale = Locale.autoupdatingCurrent,
          storeCurrencySettings: CurrencySettings = ServiceLocator.currencySettings,
          storageManager: StorageManagerType = ServiceLocator.storageManager,

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/Shipping/OrderShippingSection.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/Shipping/OrderShippingSection.swift
@@ -41,6 +41,9 @@ struct OrderShippingSection: View {
         .sheet(isPresented: $showAddShippingLine, content: {
             ShippingLineSelectionDetails(viewModel: viewModel.addShippingLineViewModel())
         })
+        .sheet(item: $viewModel.selectedShippingLine, content: { selectedShippingLine in
+            ShippingLineSelectionDetails(viewModel: selectedShippingLine)
+        })
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/Shipping/OrderShippingSection.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/Shipping/OrderShippingSection.swift
@@ -4,6 +4,8 @@ struct OrderShippingSection: View {
     /// View model to drive the view content
     @ObservedObject var viewModel: EditableOrderViewModel
 
+    @State private var showAddShippingLine: Bool = false
+
     @Environment(\.safeAreaInsets) private var safeAreaInsets: EdgeInsets
 
     var body: some View {
@@ -36,12 +38,15 @@ struct OrderShippingSection: View {
         .padding()
         .background(Color(.listForeground(modal: true)))
         .addingTopAndBottomDividers()
+        .sheet(isPresented: $showAddShippingLine, content: {
+            ShippingLineSelectionDetails(viewModel: viewModel.addShippingLineViewModel())
+        })
     }
 }
 
 private extension OrderShippingSection {
     func addShippingLine() {
-        // TODO-12583: Add a new shipping line (opens `ShippingLineSelectionDetails`)
+        showAddShippingLine = true
         // TODO-12584: Track that add shipping has been tapped
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/Shipping/ShippingLineRowView.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/Shipping/ShippingLineRowView.swift
@@ -30,7 +30,7 @@ struct ShippingLineRowView: View {
                 .bodyStyle()
 
             Button {
-                viewModel.onEditShippingLine()
+                viewModel.editShippingLine()
             } label: {
                 Image(systemName: "pencil")
                     .resizable()
@@ -44,7 +44,7 @@ struct ShippingLineRowView: View {
         .padding(Layout.contentPadding)
         .contentShape(Rectangle())
         .onTapGesture {
-            viewModel.onEditShippingLine()
+            viewModel.editShippingLine()
         }
         .background(
             RoundedRectangle(cornerRadius: Layout.cornerRadius)
@@ -58,7 +58,7 @@ struct ShippingLineRowView: View {
     }
 }
 
-extension ShippingLineRowView {
+private extension ShippingLineRowView {
     enum Layout {
         static let contentSpacing: CGFloat = 16
         static let contentPadding: CGFloat = 16
@@ -80,7 +80,8 @@ extension ShippingLineRowView {
                                                             shippingTitle: "Package 1",
                                                             shippingMethod: "Flat Rate",
                                                             shippingAmount: "$5.00",
-                                                            editable: true))
+                                                            editable: true,
+                                                            onEditShippingLine: { _ in }))
 }
 
 #Preview("Not editable") {
@@ -88,5 +89,6 @@ extension ShippingLineRowView {
                                                             shippingTitle: "Package 1",
                                                             shippingMethod: "Flat Rate",
                                                             shippingAmount: "$5.00",
-                                                            editable: false))
+                                                            editable: false,
+                                                            onEditShippingLine: { _ in }))
 }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/Shipping/ShippingLineRowViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/Shipping/ShippingLineRowViewModel.swift
@@ -4,7 +4,7 @@ import struct Yosemite.ShippingLine
 import struct Yosemite.ShippingMethod
 
 struct ShippingLineRowViewModel: Identifiable {
-    /// ID for the row view model
+    /// Shipping line ID
     let id: Int64
 
     /// Title for the shipping line
@@ -20,24 +20,27 @@ struct ShippingLineRowViewModel: Identifiable {
     let editable: Bool
 
     /// Closure to be invoked when the shipping line is edited
-    let onEditShippingLine: () -> Void = {} // TODO-12581: Support editing shipping lines
+    let onEditShippingLine: (Int64) -> Void
 
     init(id: Int64,
          shippingTitle: String,
          shippingMethod: String?,
          shippingAmount: String,
-         editable: Bool) {
+         editable: Bool,
+         onEditShippingLine: @escaping (Int64) -> Void) {
         self.id = id
         self.shippingTitle = shippingTitle
         self.shippingMethod = shippingMethod
         self.shippingAmount = shippingAmount
         self.editable = editable
+        self.onEditShippingLine = onEditShippingLine
     }
 
     init(shippingLine: ShippingLine,
          shippingMethods: [ShippingMethod],
          editable: Bool,
-         currencyFormatter: CurrencyFormatter = CurrencyFormatter(currencySettings: ServiceLocator.currencySettings)) {
+         currencyFormatter: CurrencyFormatter = CurrencyFormatter(currencySettings: ServiceLocator.currencySettings),
+         onEditShippingLine: @escaping (Int64) -> Void = { _ in }) {
         let formattedAmount = currencyFormatter.formatAmount(shippingLine.total) ?? shippingLine.total
         let shippingMethod = shippingMethods.first(where: { $0.methodID == shippingLine.methodID })?.title
 
@@ -45,6 +48,13 @@ struct ShippingLineRowViewModel: Identifiable {
                   shippingTitle: shippingLine.methodTitle,
                   shippingMethod: shippingMethod,
                   shippingAmount: formattedAmount,
-                  editable: editable)
+                  editable: editable,
+                  onEditShippingLine: onEditShippingLine)
+    }
+
+    /// Edit the shipping line
+    ///
+    func editShippingLine() {
+        onEditShippingLine(id)
     }
 }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/EditableOrderViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/EditableOrderViewModelTests.swift
@@ -3346,6 +3346,24 @@ final class EditableOrderViewModelTests: XCTestCase {
         // Then
         XCTAssertFalse(newShippingLineViewModel.isExistingShippingLine)
     }
+
+    func test_editing_existing_shipping_line_sets_expected_selectedShippingLine() throws {
+        // Given
+        let shippingLine = ShippingLine.fake().copy(shippingID: 1, methodTitle: "Package 1")
+        let order = Order.fake().copy(siteID: sampleSiteID, shippingLines: [shippingLine])
+        let featureFlagService = MockFeatureFlagService(isMultipleShippingLinesEnabled: true)
+        let viewModel = EditableOrderViewModel(siteID: sampleSiteID,
+                                               flow: .editing(initialOrder: order),
+                                               storageManager: storageManager,
+                                               featureFlagService: featureFlagService)
+
+        // When
+        viewModel.shippingLineRows.first?.editShippingLine()
+
+        // Then
+        let editShippingLineViewModel = try XCTUnwrap(viewModel.selectedShippingLine)
+        assertEqual(shippingLine.methodTitle, editShippingLineViewModel.methodTitle)
+    }
 }
 
 private extension EditableOrderViewModelTests {

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/EditableOrderViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/EditableOrderViewModelTests.swift
@@ -3333,6 +3333,19 @@ final class EditableOrderViewModelTests: XCTestCase {
         assertEqual(shippingLine.methodTitle, shippingLineRow.shippingTitle)
         assertEqual(shippingMethod.title, shippingLineRow.shippingMethod)
     }
+
+    func test_addShippingLineViewModel_returns_view_model_for_new_shipping_line() {
+        // Given
+        let featureFlagService = MockFeatureFlagService(isMultipleShippingLinesEnabled: true)
+        let viewModel = EditableOrderViewModel(siteID: sampleSiteID,
+                                               featureFlagService: featureFlagService)
+
+        // When
+        let newShippingLineViewModel = viewModel.addShippingLineViewModel()
+
+        // Then
+        XCTAssertFalse(newShippingLineViewModel.isExistingShippingLine)
+    }
 }
 
 private extension EditableOrderViewModelTests {

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/Shipping/ShippingLineRowViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/Shipping/ShippingLineRowViewModelTests.swift
@@ -16,7 +16,8 @@ final class ShippingLineRowViewModelTests: XCTestCase {
                                                  shippingTitle: shippingTitle,
                                                  shippingMethod: shippingMethod,
                                                  shippingAmount: shippingAmount,
-                                                 editable: true)
+                                                 editable: true,
+                                                 onEditShippingLine: { _ in })
 
         // Then
         assertEqual(shippingTitle, viewModel.shippingTitle)
@@ -41,5 +42,24 @@ final class ShippingLineRowViewModelTests: XCTestCase {
         assertEqual(shippingMethod.title, viewModel.shippingMethod)
         assertEqual("$5.00", viewModel.shippingAmount)
         XCTAssertFalse(viewModel.editable)
+    }
+
+    func test_editShippingLine_calls_onEditShippingLine_with_expected_shippingID() {
+        // Given
+        let shippingLine = ShippingLine(shippingID: 1, methodTitle: "Package 1", methodID: "flat_rate", total: "5", totalTax: "0", taxes: [])
+        let shippingMethod = ShippingMethod(siteID: 12345, methodID: "flat_rate", title: "Flat Rate")
+        var editShippingID: Int64?
+        let viewModel = ShippingLineRowViewModel(shippingLine: shippingLine,
+                                                 shippingMethods: [shippingMethod],
+                                                 editable: false,
+                                                 currencyFormatter: CurrencyFormatter(currencySettings: CurrencySettings())) { shippingID in
+            editShippingID = shippingID
+        }
+
+        // When
+        viewModel.editShippingLine()
+
+        // Then
+        assertEqual(shippingLine.shippingID, editShippingID)
     }
 }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/ShippingLineSelectionDetailsViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/ShippingLineSelectionDetailsViewModelTests.swift
@@ -25,6 +25,7 @@ final class ShippingLineSelectionDetailsViewModelTests: XCTestCase {
     func test_view_model_formats_amount_correctly() {
         // Given
         let viewModel = ShippingLineSelectionDetailsViewModel(siteID: sampleSiteID,
+                                                              shippingLine: nil,
                                                               locale: usLocale,
                                                               storeCurrencySettings: usStoreSettings,
                                                               didSelectSave: { _ in })
@@ -40,6 +41,7 @@ final class ShippingLineSelectionDetailsViewModelTests: XCTestCase {
     func test_view_model_formats_negative_amount_correctly() {
         // Given
         let viewModel = ShippingLineSelectionDetailsViewModel(siteID: sampleSiteID,
+                                                              shippingLine: nil,
                                                               locale: usLocale,
                                                               storeCurrencySettings: usStoreSettings,
                                                               didSelectSave: { _ in })
@@ -61,6 +63,7 @@ final class ShippingLineSelectionDetailsViewModelTests: XCTestCase {
                                               numberOfDecimals: 3)
 
         let viewModel = ShippingLineSelectionDetailsViewModel(siteID: sampleSiteID,
+                                                              shippingLine: nil,
                                                               locale: usLocale,
                                                               storeCurrencySettings: customSettings,
                                                               didSelectSave: { _ in })
@@ -78,11 +81,9 @@ final class ShippingLineSelectionDetailsViewModelTests: XCTestCase {
         // Given
         let shippingMethod = ShippingMethod(siteID: sampleSiteID, methodID: "flat_rate", title: "Flat rate")
         insert(shippingMethod)
+        let shippingLine = ShippingLine.fake().copy(shippingID: 1, methodTitle: "Flat Rate", methodID: shippingMethod.methodID, total: "$11.30")
         let viewModel = ShippingLineSelectionDetailsViewModel(siteID: sampleSiteID,
-                                                              shippingID: 1,
-                                                              initialMethodID: shippingMethod.methodID,
-                                                              initialMethodTitle: "Flat Rate",
-                                                              shippingTotal: "$11.30",
+                                                              shippingLine: shippingLine,
                                                               locale: usLocale,
                                                               storeCurrencySettings: usStoreSettings,
                                                               storageManager: storageManager,
@@ -93,16 +94,14 @@ final class ShippingLineSelectionDetailsViewModelTests: XCTestCase {
         XCTAssertEqual(viewModel.selectedMethod, shippingMethod)
         XCTAssertEqual(viewModel.selectedMethodColor, Color(.text))
         XCTAssertEqual(viewModel.formattableAmountViewModel.amount, "11.30")
-        XCTAssertEqual(viewModel.methodTitle, "Flat Rate")
+        XCTAssertEqual(viewModel.methodTitle, shippingLine.methodTitle)
     }
 
     func test_view_model_prefills_negative_input_data_correctly() {
         // Given
+        let shippingLine = ShippingLine.fake().copy(shippingID: 1, methodTitle: "Flat Rate", methodID: "", total: "-$11.30")
         let viewModel = ShippingLineSelectionDetailsViewModel(siteID: sampleSiteID,
-                                                              shippingID: 1,
-                                                              initialMethodID: "",
-                                                              initialMethodTitle: "Flat Rate",
-                                                              shippingTotal: "-$11.30",
+                                                              shippingLine: shippingLine,
                                                               locale: usLocale,
                                                               storeCurrencySettings: usStoreSettings,
                                                               didSelectSave: { _ in })
@@ -116,6 +115,9 @@ final class ShippingLineSelectionDetailsViewModelTests: XCTestCase {
     func test_view_model_does_not_prefill_zero_amount_without_existing_shipping_line() {
         // Given
         let viewModel = ShippingLineSelectionDetailsViewModel(siteID: sampleSiteID,
+                                                              shippingID: nil,
+                                                              initialMethodID: "",
+                                                              initialMethodTitle: "",
                                                               shippingTotal: "0",
                                                               locale: usLocale,
                                                               storeCurrencySettings: usStoreSettings,
@@ -128,6 +130,7 @@ final class ShippingLineSelectionDetailsViewModelTests: XCTestCase {
     func test_view_model_disables_done_button_for_empty_state_and_enables_with_amount_input() {
         // Given
         let viewModel = ShippingLineSelectionDetailsViewModel(siteID: sampleSiteID,
+                                                              shippingLine: nil,
                                                               locale: usLocale,
                                                               storeCurrencySettings: usStoreSettings,
                                                               didSelectSave: { _ in })
@@ -148,11 +151,9 @@ final class ShippingLineSelectionDetailsViewModelTests: XCTestCase {
 
     func test_view_model_disables_done_button_for_prefilled_data_and_enables_with_amount_changes() {
         // Given
+        let shippingLine = ShippingLine.fake().copy(shippingID: 1, methodTitle: "Flat Rate", methodID: "", total: "$11.30")
         let viewModel = ShippingLineSelectionDetailsViewModel(siteID: sampleSiteID,
-                                                              shippingID: 1,
-                                                              initialMethodID: "",
-                                                              initialMethodTitle: "Flat Rate",
-                                                              shippingTotal: "$11.30",
+                                                              shippingLine: shippingLine,
                                                               locale: usLocale,
                                                               storeCurrencySettings: usStoreSettings,
                                                               didSelectSave: { _ in })
@@ -173,11 +174,9 @@ final class ShippingLineSelectionDetailsViewModelTests: XCTestCase {
 
     func test_view_model_disables_done_button_for_prefilled_data_and_enables_with_method_title_changes() {
         // Given
+        let shippingLine = ShippingLine.fake().copy(shippingID: 1, methodTitle: "Flat Rate", methodID: "", total: "$11.30")
         let viewModel = ShippingLineSelectionDetailsViewModel(siteID: sampleSiteID,
-                                                              shippingID: 1,
-                                                              initialMethodID: "",
-                                                              initialMethodTitle: "Flat Rate",
-                                                              shippingTotal: "$11.30",
+                                                              shippingLine: shippingLine,
                                                               locale: usLocale,
                                                               storeCurrencySettings: usStoreSettings,
                                                               didSelectSave: { _ in })
@@ -190,7 +189,7 @@ final class ShippingLineSelectionDetailsViewModelTests: XCTestCase {
         XCTAssertTrue(viewModel.enableDoneButton)
 
         // When
-        viewModel.methodTitle = "Flat Rate"
+        viewModel.methodTitle = shippingLine.methodTitle
 
         // Then
         XCTAssertFalse(viewModel.enableDoneButton)
@@ -201,11 +200,9 @@ final class ShippingLineSelectionDetailsViewModelTests: XCTestCase {
         let flatRateMethod = ShippingMethod(siteID: sampleSiteID, methodID: "flat_rate", title: "Flat rate")
         let localPickupMethod = ShippingMethod(siteID: sampleSiteID, methodID: "local_pickup", title: "Local pickup")
         insert([flatRateMethod, localPickupMethod])
+        let shippingLine = ShippingLine.fake().copy(shippingID: 1, methodTitle: "Flat Rate", methodID: flatRateMethod.methodID, total: "$11.30")
         let viewModel = ShippingLineSelectionDetailsViewModel(siteID: sampleSiteID,
-                                                              shippingID: 1,
-                                                              initialMethodID: flatRateMethod.methodID,
-                                                              initialMethodTitle: "Flat Rate",
-                                                              shippingTotal: "$11.30",
+                                                              shippingLine: shippingLine,
                                                               locale: usLocale,
                                                               storeCurrencySettings: usStoreSettings,
                                                               storageManager: storageManager,
@@ -231,6 +228,7 @@ final class ShippingLineSelectionDetailsViewModelTests: XCTestCase {
         let shippingMethod = ShippingMethod(siteID: sampleSiteID, methodID: "flat_rate", title: "Flat rate")
         insert(shippingMethod)
         let viewModel = ShippingLineSelectionDetailsViewModel(siteID: sampleSiteID,
+                                                              shippingLine: nil,
                                                               locale: usLocale,
                                                               storeCurrencySettings: usStoreSettings,
                                                               didSelectSave: { newShippingLine in
@@ -253,6 +251,7 @@ final class ShippingLineSelectionDetailsViewModelTests: XCTestCase {
         // Given
         var savedShippingLine: Yosemite.ShippingLine?
         let viewModel = ShippingLineSelectionDetailsViewModel(siteID: sampleSiteID,
+                                                              shippingLine: nil,
                                                               locale: usLocale,
                                                               storeCurrencySettings: usStoreSettings,
                                                               didSelectSave: { newShippingLine in
@@ -273,6 +272,7 @@ final class ShippingLineSelectionDetailsViewModelTests: XCTestCase {
         // Given
         var savedShippingLine: Yosemite.ShippingLine?
         let viewModel = ShippingLineSelectionDetailsViewModel(siteID: sampleSiteID,
+                                                              shippingLine: nil,
                                                               locale: usLocale,
                                                               storeCurrencySettings: usStoreSettings,
                                                               didSelectSave: { newShippingLine in
@@ -292,6 +292,7 @@ final class ShippingLineSelectionDetailsViewModelTests: XCTestCase {
         // Given
         var savedShippingLine: Yosemite.ShippingLine?
         let viewModel = ShippingLineSelectionDetailsViewModel(siteID: sampleSiteID,
+                                                              shippingLine: nil,
                                                               locale: usLocale,
                                                               storeCurrencySettings: usStoreSettings,
                                                               didSelectSave: { newShippingLine in
@@ -312,6 +313,7 @@ final class ShippingLineSelectionDetailsViewModelTests: XCTestCase {
     func test_view_model_amount_placeholder_has_expected_value() {
         // Given
         let viewModel = ShippingLineSelectionDetailsViewModel(siteID: sampleSiteID,
+                                                              shippingLine: nil,
                                                               locale: usLocale,
                                                               storeCurrencySettings: usStoreSettings,
                                                               didSelectSave: { _ in })
@@ -323,6 +325,7 @@ final class ShippingLineSelectionDetailsViewModelTests: XCTestCase {
     func test_view_model_initializes_correctly_with_no_existing_shipping_line() {
         // Given
         let viewModel = ShippingLineSelectionDetailsViewModel(siteID: sampleSiteID,
+                                                              shippingLine: nil,
                                                               locale: usLocale,
                                                               storeCurrencySettings: usStoreSettings,
                                                               didSelectSave: { _ in })
@@ -340,6 +343,7 @@ final class ShippingLineSelectionDetailsViewModelTests: XCTestCase {
         let shippingMethod = ShippingMethod(siteID: sampleSiteID, methodID: "flat_rate", title: "Flat rate")
         insert(shippingMethod)
         let viewModel = ShippingLineSelectionDetailsViewModel(siteID: sampleSiteID,
+                                                              shippingLine: nil,
                                                               locale: usLocale,
                                                               storeCurrencySettings: usStoreSettings,
                                                               storageManager: storageManager,
@@ -354,6 +358,7 @@ final class ShippingLineSelectionDetailsViewModelTests: XCTestCase {
         // Given
         let analytics = MockAnalyticsProvider()
         let viewModel = ShippingLineSelectionDetailsViewModel(siteID: sampleSiteID,
+                                                              shippingLine: nil,
                                                               locale: usLocale,
                                                               storeCurrencySettings: usStoreSettings,
                                                               analytics: WooAnalytics(analyticsProvider: analytics),

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/ShippingLineSelectionDetailsViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/ShippingLineSelectionDetailsViewModelTests.swift
@@ -25,10 +25,6 @@ final class ShippingLineSelectionDetailsViewModelTests: XCTestCase {
     func test_view_model_formats_amount_correctly() {
         // Given
         let viewModel = ShippingLineSelectionDetailsViewModel(siteID: sampleSiteID,
-                                                              isExistingShippingLine: false,
-                                                              initialMethodID: "",
-                                                              initialMethodTitle: "",
-                                                              shippingTotal: "",
                                                               locale: usLocale,
                                                               storeCurrencySettings: usStoreSettings,
                                                               didSelectSave: { _ in })
@@ -44,10 +40,6 @@ final class ShippingLineSelectionDetailsViewModelTests: XCTestCase {
     func test_view_model_formats_negative_amount_correctly() {
         // Given
         let viewModel = ShippingLineSelectionDetailsViewModel(siteID: sampleSiteID,
-                                                              isExistingShippingLine: false,
-                                                              initialMethodID: "",
-                                                              initialMethodTitle: "",
-                                                              shippingTotal: "",
                                                               locale: usLocale,
                                                               storeCurrencySettings: usStoreSettings,
                                                               didSelectSave: { _ in })
@@ -69,10 +61,6 @@ final class ShippingLineSelectionDetailsViewModelTests: XCTestCase {
                                               numberOfDecimals: 3)
 
         let viewModel = ShippingLineSelectionDetailsViewModel(siteID: sampleSiteID,
-                                                              isExistingShippingLine: false,
-                                                              initialMethodID: "",
-                                                              initialMethodTitle: "",
-                                                              shippingTotal: "",
                                                               locale: usLocale,
                                                               storeCurrencySettings: customSettings,
                                                               didSelectSave: { _ in })
@@ -91,7 +79,7 @@ final class ShippingLineSelectionDetailsViewModelTests: XCTestCase {
         let shippingMethod = ShippingMethod(siteID: sampleSiteID, methodID: "flat_rate", title: "Flat rate")
         insert(shippingMethod)
         let viewModel = ShippingLineSelectionDetailsViewModel(siteID: sampleSiteID,
-                                                              isExistingShippingLine: true,
+                                                              shippingID: 1,
                                                               initialMethodID: shippingMethod.methodID,
                                                               initialMethodTitle: "Flat Rate",
                                                               shippingTotal: "$11.30",
@@ -111,7 +99,7 @@ final class ShippingLineSelectionDetailsViewModelTests: XCTestCase {
     func test_view_model_prefills_negative_input_data_correctly() {
         // Given
         let viewModel = ShippingLineSelectionDetailsViewModel(siteID: sampleSiteID,
-                                                              isExistingShippingLine: true,
+                                                              shippingID: 1,
                                                               initialMethodID: "",
                                                               initialMethodTitle: "Flat Rate",
                                                               shippingTotal: "-$11.30",
@@ -128,9 +116,6 @@ final class ShippingLineSelectionDetailsViewModelTests: XCTestCase {
     func test_view_model_does_not_prefill_zero_amount_without_existing_shipping_line() {
         // Given
         let viewModel = ShippingLineSelectionDetailsViewModel(siteID: sampleSiteID,
-                                                              isExistingShippingLine: false,
-                                                              initialMethodID: "",
-                                                              initialMethodTitle: "",
                                                               shippingTotal: "0",
                                                               locale: usLocale,
                                                               storeCurrencySettings: usStoreSettings,
@@ -143,10 +128,6 @@ final class ShippingLineSelectionDetailsViewModelTests: XCTestCase {
     func test_view_model_disables_done_button_for_empty_state_and_enables_with_amount_input() {
         // Given
         let viewModel = ShippingLineSelectionDetailsViewModel(siteID: sampleSiteID,
-                                                              isExistingShippingLine: false,
-                                                              initialMethodID: "",
-                                                              initialMethodTitle: "",
-                                                              shippingTotal: "",
                                                               locale: usLocale,
                                                               storeCurrencySettings: usStoreSettings,
                                                               didSelectSave: { _ in })
@@ -168,7 +149,7 @@ final class ShippingLineSelectionDetailsViewModelTests: XCTestCase {
     func test_view_model_disables_done_button_for_prefilled_data_and_enables_with_amount_changes() {
         // Given
         let viewModel = ShippingLineSelectionDetailsViewModel(siteID: sampleSiteID,
-                                                              isExistingShippingLine: true,
+                                                              shippingID: 1,
                                                               initialMethodID: "",
                                                               initialMethodTitle: "Flat Rate",
                                                               shippingTotal: "$11.30",
@@ -193,7 +174,7 @@ final class ShippingLineSelectionDetailsViewModelTests: XCTestCase {
     func test_view_model_disables_done_button_for_prefilled_data_and_enables_with_method_title_changes() {
         // Given
         let viewModel = ShippingLineSelectionDetailsViewModel(siteID: sampleSiteID,
-                                                              isExistingShippingLine: true,
+                                                              shippingID: 1,
                                                               initialMethodID: "",
                                                               initialMethodTitle: "Flat Rate",
                                                               shippingTotal: "$11.30",
@@ -221,7 +202,7 @@ final class ShippingLineSelectionDetailsViewModelTests: XCTestCase {
         let localPickupMethod = ShippingMethod(siteID: sampleSiteID, methodID: "local_pickup", title: "Local pickup")
         insert([flatRateMethod, localPickupMethod])
         let viewModel = ShippingLineSelectionDetailsViewModel(siteID: sampleSiteID,
-                                                              isExistingShippingLine: true,
+                                                              shippingID: 1,
                                                               initialMethodID: flatRateMethod.methodID,
                                                               initialMethodTitle: "Flat Rate",
                                                               shippingTotal: "$11.30",
@@ -250,10 +231,6 @@ final class ShippingLineSelectionDetailsViewModelTests: XCTestCase {
         let shippingMethod = ShippingMethod(siteID: sampleSiteID, methodID: "flat_rate", title: "Flat rate")
         insert(shippingMethod)
         let viewModel = ShippingLineSelectionDetailsViewModel(siteID: sampleSiteID,
-                                                              isExistingShippingLine: false,
-                                                              initialMethodID: "",
-                                                              initialMethodTitle: "",
-                                                              shippingTotal: "",
                                                               locale: usLocale,
                                                               storeCurrencySettings: usStoreSettings,
                                                               didSelectSave: { newShippingLine in
@@ -276,10 +253,6 @@ final class ShippingLineSelectionDetailsViewModelTests: XCTestCase {
         // Given
         var savedShippingLine: Yosemite.ShippingLine?
         let viewModel = ShippingLineSelectionDetailsViewModel(siteID: sampleSiteID,
-                                                              isExistingShippingLine: false,
-                                                              initialMethodID: "",
-                                                              initialMethodTitle: "",
-                                                              shippingTotal: "",
                                                               locale: usLocale,
                                                               storeCurrencySettings: usStoreSettings,
                                                               didSelectSave: { newShippingLine in
@@ -300,10 +273,6 @@ final class ShippingLineSelectionDetailsViewModelTests: XCTestCase {
         // Given
         var savedShippingLine: Yosemite.ShippingLine?
         let viewModel = ShippingLineSelectionDetailsViewModel(siteID: sampleSiteID,
-                                                              isExistingShippingLine: false,
-                                                              initialMethodID: "",
-                                                              initialMethodTitle: "",
-                                                              shippingTotal: "",
                                                               locale: usLocale,
                                                               storeCurrencySettings: usStoreSettings,
                                                               didSelectSave: { newShippingLine in
@@ -323,10 +292,6 @@ final class ShippingLineSelectionDetailsViewModelTests: XCTestCase {
         // Given
         var savedShippingLine: Yosemite.ShippingLine?
         let viewModel = ShippingLineSelectionDetailsViewModel(siteID: sampleSiteID,
-                                                              isExistingShippingLine: false,
-                                                              initialMethodID: "",
-                                                              initialMethodTitle: "",
-                                                              shippingTotal: "",
                                                               locale: usLocale,
                                                               storeCurrencySettings: usStoreSettings,
                                                               didSelectSave: { newShippingLine in
@@ -347,10 +312,6 @@ final class ShippingLineSelectionDetailsViewModelTests: XCTestCase {
     func test_view_model_amount_placeholder_has_expected_value() {
         // Given
         let viewModel = ShippingLineSelectionDetailsViewModel(siteID: sampleSiteID,
-                                                              isExistingShippingLine: false,
-                                                              initialMethodID: "",
-                                                              initialMethodTitle: "",
-                                                              shippingTotal: "",
                                                               locale: usLocale,
                                                               storeCurrencySettings: usStoreSettings,
                                                               didSelectSave: { _ in })
@@ -362,10 +323,6 @@ final class ShippingLineSelectionDetailsViewModelTests: XCTestCase {
     func test_view_model_initializes_correctly_with_no_existing_shipping_line() {
         // Given
         let viewModel = ShippingLineSelectionDetailsViewModel(siteID: sampleSiteID,
-                                                              isExistingShippingLine: false,
-                                                              initialMethodID: "",
-                                                              initialMethodTitle: "",
-                                                              shippingTotal: "",
                                                               locale: usLocale,
                                                               storeCurrencySettings: usStoreSettings,
                                                               didSelectSave: { _ in })
@@ -383,10 +340,6 @@ final class ShippingLineSelectionDetailsViewModelTests: XCTestCase {
         let shippingMethod = ShippingMethod(siteID: sampleSiteID, methodID: "flat_rate", title: "Flat rate")
         insert(shippingMethod)
         let viewModel = ShippingLineSelectionDetailsViewModel(siteID: sampleSiteID,
-                                                              isExistingShippingLine: false,
-                                                              initialMethodID: "",
-                                                              initialMethodTitle: "",
-                                                              shippingTotal: "",
                                                               locale: usLocale,
                                                               storeCurrencySettings: usStoreSettings,
                                                               storageManager: storageManager,
@@ -401,10 +354,6 @@ final class ShippingLineSelectionDetailsViewModelTests: XCTestCase {
         // Given
         let analytics = MockAnalyticsProvider()
         let viewModel = ShippingLineSelectionDetailsViewModel(siteID: sampleSiteID,
-                                                              isExistingShippingLine: false,
-                                                              initialMethodID: "",
-                                                              initialMethodTitle: "",
-                                                              shippingTotal: "",
                                                               locale: usLocale,
                                                               storeCurrencySettings: usStoreSettings,
                                                               analytics: WooAnalytics(analyticsProvider: analytics),


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of: #12583
<!-- Id number of the GitHub issue this PR addresses. -->

## Why
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This adds the logic to navigate to the add/edit shipping screens during order creation/editing, with multiple shipping lines:

* Opens the empty shipping screen to add a new shipping line
   * When the "Add shipping" button is tapped (on an order without any shipping lines)
   * When the "+" button is tapped (on an order with shipping lines)
* Opens the shipping screen with the selected shipping line details when the pencil icon is tapped
* Retains the behavior for a single shipping line when the feature flag is disabled

Note: This doesn't yet change the remote synchronizer to support multiple shipping lines, so any changes for orders with multiple shipping lines won't be saved correctly; this will come in a separate PR.

## How

* Updates `EditableOrderViewModel` to handle adding and editing shipping lines:
   * `addShippingLineViewModel()` provides a view model for an empty shipping details screen, to add a new shipping line.
   * `selectedShippingLine` holds a view model for a shipping details screen for an existing shipping line; this property is set in the `onEditShippingLine` closure on `ShippingLineRowViewModel`.
* Updates `ShippingLineRowViewModel` to set `onEditShippingLine` with a provided closure; this is then used when a shipping line row is tapped.
* Updates `OrderShippingSection` to open a sheet with the shipping details screen for a new or existing shipping line, using the new method/property from `EditableOrderViewModel`.
* Adds related unit tests.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

Single shipping line (existing behavior):

1. Build and run the app with the `multipleShippingLines` feature flag disabled.
2. Create a new order and add a product.
3. Tap "Add shipping" and add a shipping line to the order.
4. Open the Order totals section and tap the shipping row to edit it.
5. Make changes to the shipping details and confirm your changes are saved.
6. Remove the shipping line and confirm the order is saved.

Multiple shipping lines - new order:

1. Build and run the app with the `multipleShippingLines` feature flag enabled.
2. Create a new order and add a product.
3. Tap "Add shipping" and add a shipping line to the order.
4. Open the Order totals section and confirm the shipping line is not editable.
5. Tap the "+" icon and confirm a new shipping details screen is opened. (Note that at this point a new line can't be added; close the screen without saving a new line.)
6. In the Shipping section of the order form, tap the pencil icon next to the shipping line to edit it.
7. Make changes to the shipping details and confirm your changes are saved.
8. Remove the shipping line and confirm the order is saved.

Multiple shipping lines - existing order:

1. Build and run the app with the `multipleShippingLines` feature flag enabled.
2. Open an existing order with multiple shipping lines.
3. Tap "Edit" to edit the order.
4. Confirm the Shipping section loads all of the shipping lines.
5. Tap the "+" icon and confirm a new shipping details screen is opened. (Note that at this point a new line can't be added; close the screen without saving a new line.)
6. Tap the pencil icon next to each shipping line and confirm the shipping details screen opens with the expected details for that shipping line.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->


https://github.com/woocommerce/woocommerce-ios/assets/8658164/4109e3da-4324-483e-b3ec-9ce478741f71


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
