### PR TITLE
[Order Form] Add sync support for adding, editing, or removing multiple shipping lines on an order

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/PaymentSection/Shipping/ShippingLineDetails.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/PaymentSection/Shipping/ShippingLineDetails.swift
@@ -66,7 +66,7 @@ struct ShippingLineDetails: View {
                     if viewModel.isExistingShippingLine {
                         Section {
                             Button(Localization.remove) {
-                                viewModel.didSelectSave(nil)
+                                viewModel.removeShippingLine()
                                 presentation.wrappedValue.dismiss()
                             }
                             .padding()
@@ -129,10 +129,11 @@ private extension ShippingLineDetails {
 
 struct ShippingLineDetails_Previews: PreviewProvider {
     static var previews: some View {
-        let viewModel = ShippingLineDetailsViewModel(isExistingShippingLine: true,
+        let viewModel = ShippingLineDetailsViewModel(shippingID: 1,
                                                      initialMethodTitle: "Shipping",
                                                      shippingTotal: "10",
-                                                     didSelectSave: { _ in })
+                                                     didSelectSave: { _ in },
+                                                     didSelectRemove: { _ in })
         ShippingLineDetails(viewModel: viewModel)
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/PaymentSection/Shipping/ShippingLineDetailsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/PaymentSection/Shipping/ShippingLineDetailsViewModel.swift
@@ -4,9 +4,13 @@ import struct Yosemite.ShippingLine
 
 class ShippingLineDetailsViewModel: ObservableObject {
 
-    /// Closure to be invoked when the shipping line is updated.
+    /// Closure to be invoked when the shipping line is added or updated.
     ///
-    var didSelectSave: ((ShippingLine?) -> Void)
+    var didSelectSave: ((ShippingLine) -> Void)
+
+    /// Closure to be invoked when the shipping line is removed.
+    ///
+    var didSelectRemove: ((ShippingLine) -> Void)
 
     /// Helper to format price field input.
     ///
@@ -37,6 +41,7 @@ class ShippingLineDetailsViewModel: ObservableObject {
     ///
     @Published var methodTitle: String
 
+    private let shippingID: Int64
     private let initialAmount: Decimal?
     private let initialMethodTitle: String
 
@@ -63,17 +68,19 @@ class ShippingLineDetailsViewModel: ObservableObject {
         return !(amountUpdated || methodTitleUpdated)
     }
 
-    init(isExistingShippingLine: Bool,
+    init(shippingID: Int64?,
          initialMethodTitle: String,
          shippingTotal: String,
          locale: Locale = Locale.autoupdatingCurrent,
          storeCurrencySettings: CurrencySettings = ServiceLocator.currencySettings,
-         didSelectSave: @escaping ((ShippingLine?) -> Void)) {
+         didSelectSave: @escaping ((ShippingLine) -> Void),
+         didSelectRemove: @escaping ((ShippingLine) -> Void)) {
         self.priceFieldFormatter = .init(locale: locale, storeCurrencySettings: storeCurrencySettings, allowNegativeNumber: true)
         self.currencySymbol = storeCurrencySettings.symbol(from: storeCurrencySettings.currencyCode)
         self.currencyPosition = storeCurrencySettings.currencyPosition
 
-        self.isExistingShippingLine = isExistingShippingLine
+        self.isExistingShippingLine = shippingID != nil
+        self.shippingID = shippingID ?? 0
         self.initialMethodTitle = initialMethodTitle
         self.methodTitle = initialMethodTitle
 
@@ -89,16 +96,27 @@ class ShippingLineDetailsViewModel: ObservableObject {
         }
 
         self.didSelectSave = didSelectSave
+        self.didSelectRemove = didSelectRemove
     }
 
     func saveData() {
-        let shippingLine = ShippingLine(shippingID: 0,
+        let shippingLine = ShippingLine(shippingID: shippingID,
                                         methodTitle: finalMethodTitle,
                                         methodID: "other",
                                         total: amount,
                                         totalTax: "",
                                         taxes: [])
         didSelectSave(shippingLine)
+    }
+
+    func removeShippingLine() {
+        let shippingLine = ShippingLine(shippingID: shippingID,
+                                        methodTitle: finalMethodTitle,
+                                        methodID: "other",
+                                        total: amount,
+                                        totalTax: "",
+                                        taxes: [])
+        didSelectRemove(shippingLine)
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/PaymentSection/Shipping/ShippingLineSelectionDetails.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/PaymentSection/Shipping/ShippingLineSelectionDetails.swift
@@ -54,7 +54,7 @@ struct ShippingLineSelectionDetails: View {
 
                 // MARK: Delete Shipping Button
                 Button(Localization.deleteShippingButton) {
-                    viewModel.didSelectSave(nil)
+                    viewModel.removeShippingLine()
                     dismiss()
                 }
                 .foregroundColor(.init(uiColor: .error))
@@ -142,7 +142,8 @@ private extension ShippingLineSelectionDetails {
                                                                                   initialMethodID: "",
                                                                                   initialMethodTitle: "",
                                                                                   shippingTotal: "",
-                                                                                  didSelectSave: { _ in }))
+                                                                                  didSelectSave: { _ in },
+                                                                                  didSelectRemove: { _ in }))
 }
 
 #Preview("Edit shipping") {
@@ -151,5 +152,6 @@ private extension ShippingLineSelectionDetails {
                                                                                   initialMethodID: "flat_rate",
                                                                                   initialMethodTitle: "Shipping",
                                                                                   shippingTotal: "10.00",
-                                                                                  didSelectSave: { _ in }))
+                                                                                  didSelectSave: { _ in },
+                                                                                  didSelectRemove: { _ in }))
 }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/PaymentSection/Shipping/ShippingLineSelectionDetailsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/PaymentSection/Shipping/ShippingLineSelectionDetailsViewModel.swift
@@ -9,9 +9,13 @@ class ShippingLineSelectionDetailsViewModel: ObservableObject, Identifiable {
     private let storageManager: StorageManagerType
     private let analytics: Analytics
 
-    /// Closure to be invoked when the shipping line is updated.
+    /// Closure to be invoked when the shipping line is added or updated.
     ///
-    var didSelectSave: ((ShippingLine?) -> Void)
+    var didSelectSave: ((ShippingLine) -> Void)
+
+    /// Closure to be invoked when the shipping line is removed.
+    ///
+    var didSelectRemove: ((ShippingLine) -> Void)
 
     /// View model for the amount text field with currency symbol.
     ///
@@ -76,7 +80,8 @@ class ShippingLineSelectionDetailsViewModel: ObservableObject, Identifiable {
          storeCurrencySettings: CurrencySettings = ServiceLocator.currencySettings,
          storageManager: StorageManagerType = ServiceLocator.storageManager,
          analytics: Analytics = ServiceLocator.analytics,
-         didSelectSave: @escaping ((ShippingLine?) -> Void)) {
+         didSelectSave: @escaping ((ShippingLine) -> Void),
+         didSelectRemove: @escaping ((ShippingLine) -> Void)) {
         self.siteID = siteID
         self.shippingID = shippingID ?? 0
         self.storageManager = storageManager
@@ -104,6 +109,7 @@ class ShippingLineSelectionDetailsViewModel: ObservableObject, Identifiable {
         }
 
         self.didSelectSave = didSelectSave
+        self.didSelectRemove = didSelectRemove
 
         configureShippingMethods()
         observeShippingLineDetailsForUIStates(with: currencyFormatter)
@@ -115,7 +121,8 @@ class ShippingLineSelectionDetailsViewModel: ObservableObject, Identifiable {
                      storeCurrencySettings: CurrencySettings = ServiceLocator.currencySettings,
                      storageManager: StorageManagerType = ServiceLocator.storageManager,
                      analytics: Analytics = ServiceLocator.analytics,
-                     didSelectSave: @escaping ((ShippingLine?) -> Void)) {
+                     didSelectSave: @escaping ((ShippingLine) -> Void),
+                     didSelectRemove: @escaping ((ShippingLine) -> Void)) {
         self.init(siteID: siteID,
                   shippingID: shippingLine?.shippingID,
                   initialMethodID: shippingLine?.methodID ?? "",
@@ -125,7 +132,8 @@ class ShippingLineSelectionDetailsViewModel: ObservableObject, Identifiable {
                   storeCurrencySettings: storeCurrencySettings,
                   storageManager: storageManager,
                   analytics: analytics,
-                  didSelectSave: didSelectSave)
+                  didSelectSave: didSelectSave,
+                  didSelectRemove: didSelectRemove)
     }
 
     func saveData() {
@@ -136,6 +144,16 @@ class ShippingLineSelectionDetailsViewModel: ObservableObject, Identifiable {
                                         totalTax: "",
                                         taxes: [])
         didSelectSave(shippingLine)
+    }
+
+    func removeShippingLine() {
+        let shippingLine = ShippingLine(shippingID: shippingID,
+                                        methodTitle: finalMethodTitle,
+                                        methodID: selectedMethod.methodID,
+                                        total: formattableAmountViewModel.amount,
+                                        totalTax: "",
+                                        taxes: [])
+        didSelectRemove(shippingLine)
     }
 
     /// Tracks when a shipping method is selected

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/Synchronizer/OrderSynchronizer.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/Synchronizer/OrderSynchronizer.swift
@@ -113,9 +113,13 @@ protocol OrderSynchronizer {
     ///
     var setAddresses: PassthroughSubject<OrderSyncAddressesInput?, Never> { get }
 
-    /// Sets or removes a shipping line.
+    /// Sets a shipping line.
     ///
-    var setShipping: PassthroughSubject<ShippingLine?, Never> { get }
+    var setShipping: PassthroughSubject<ShippingLine, Never> { get }
+
+    /// Removes a shipping line.
+    ///
+    var removeShipping: PassthroughSubject<ShippingLine, Never> { get }
 
     /// Adds a fee to the order.
     ///

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/Shipping/EditableOrderShippingUseCaseTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/Shipping/EditableOrderShippingUseCaseTests.swift
@@ -119,7 +119,7 @@ final class EditableOrderShippingUseCaseTests: XCTestCase {
         XCTAssertEqual(useCase.paymentData.shippingTotal, "$10.00")
 
         // When
-        useCase.saveShippingLine(nil)
+        useCase.removeShippingLine(shippingLine)
 
         // Then
         XCTAssertFalse(useCase.paymentData.shouldShowShippingTotal)
@@ -141,7 +141,7 @@ final class EditableOrderShippingUseCaseTests: XCTestCase {
         XCTAssertEqual(useCase.paymentData.shippingTotal, "-$5.00")
 
         // When
-        useCase.saveShippingLine(nil)
+        useCase.removeShippingLine(shippingLine)
 
         // Then
         XCTAssertFalse(useCase.paymentData.shouldShowShippingTotal)
@@ -275,7 +275,7 @@ final class EditableOrderShippingUseCaseTests: XCTestCase {
 
     func test_shipping_method_tracked_when_removed() throws {
         // When
-        useCase.saveShippingLine(nil)
+        useCase.removeShippingLine(ShippingLine.fake())
 
         // Then
         XCTAssertEqual(analytics.receivedEvents, [WooAnalyticsStat.orderShippingMethodRemove.rawValue])

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/ShippingLineDetailsViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/ShippingLineDetailsViewModelTests.swift
@@ -12,12 +12,13 @@ final class ShippingLineDetailsViewModelTests: XCTestCase {
 
     func test_view_model_formats_amount_correctly() {
         // Given
-        let viewModel = ShippingLineDetailsViewModel(isExistingShippingLine: false,
+        let viewModel = ShippingLineDetailsViewModel(shippingID: nil,
                                                      initialMethodTitle: "",
                                                      shippingTotal: "",
                                                      locale: usLocale,
                                                      storeCurrencySettings: usStoreSettings,
-                                                     didSelectSave: { _ in })
+                                                     didSelectSave: { _ in },
+                                                     didSelectRemove: { _ in })
 
         // When
         viewModel.amount = "hi:11.3005.02-"
@@ -29,12 +30,13 @@ final class ShippingLineDetailsViewModelTests: XCTestCase {
 
     func test_view_model_formats_negative_amount_correctly() {
         // Given
-        let viewModel = ShippingLineDetailsViewModel(isExistingShippingLine: false,
+        let viewModel = ShippingLineDetailsViewModel(shippingID: nil,
                                                      initialMethodTitle: "",
                                                      shippingTotal: "",
                                                      locale: usLocale,
                                                      storeCurrencySettings: usStoreSettings,
-                                                     didSelectSave: { _ in })
+                                                     didSelectSave: { _ in },
+                                                     didSelectRemove: { _ in })
 
         // When
         viewModel.amount = "-hi:11.3005.02-"
@@ -52,12 +54,13 @@ final class ShippingLineDetailsViewModelTests: XCTestCase {
                                               decimalSeparator: ",",
                                               numberOfDecimals: 3)
 
-        let viewModel = ShippingLineDetailsViewModel(isExistingShippingLine: false,
+        let viewModel = ShippingLineDetailsViewModel(shippingID: nil,
                                                      initialMethodTitle: "",
                                                      shippingTotal: "",
                                                      locale: usLocale,
                                                      storeCurrencySettings: customSettings,
-                                                     didSelectSave: { _ in })
+                                                     didSelectSave: { _ in },
+                                                     didSelectRemove: { _ in })
 
         // When
         viewModel.amount = "12.203"
@@ -70,12 +73,13 @@ final class ShippingLineDetailsViewModelTests: XCTestCase {
 
     func test_view_model_prefills_input_data_correctly() {
         // Given
-        let viewModel = ShippingLineDetailsViewModel(isExistingShippingLine: true,
+        let viewModel = ShippingLineDetailsViewModel(shippingID: 1,
                                                      initialMethodTitle: "Flat Rate",
                                                      shippingTotal: "$11.30",
                                                      locale: usLocale,
                                                      storeCurrencySettings: usStoreSettings,
-                                                     didSelectSave: { _ in })
+                                                     didSelectSave: { _ in },
+                                                     didSelectRemove: { _ in })
 
         // Then
         XCTAssertTrue(viewModel.isExistingShippingLine)
@@ -85,12 +89,13 @@ final class ShippingLineDetailsViewModelTests: XCTestCase {
 
     func test_view_model_prefills_negative_input_data_correctly() {
         // Given
-        let viewModel = ShippingLineDetailsViewModel(isExistingShippingLine: true,
+        let viewModel = ShippingLineDetailsViewModel(shippingID: 1,
                                                      initialMethodTitle: "Flat Rate",
                                                      shippingTotal: "-$11.30",
                                                      locale: usLocale,
                                                      storeCurrencySettings: usStoreSettings,
-                                                     didSelectSave: { _ in })
+                                                     didSelectSave: { _ in },
+                                                     didSelectRemove: { _ in })
 
         // Then
         XCTAssertTrue(viewModel.isExistingShippingLine)
@@ -100,12 +105,13 @@ final class ShippingLineDetailsViewModelTests: XCTestCase {
 
     func test_view_model_does_not_prefill_zero_amount_without_existing_shipping_line() {
         // Given
-        let viewModel = ShippingLineDetailsViewModel(isExistingShippingLine: false,
+        let viewModel = ShippingLineDetailsViewModel(shippingID: nil,
                                                      initialMethodTitle: "",
                                                      shippingTotal: "0",
                                                      locale: usLocale,
                                                      storeCurrencySettings: usStoreSettings,
-                                                     didSelectSave: { _ in })
+                                                     didSelectSave: { _ in },
+                                                     didSelectRemove: { _ in })
 
         // Then
         XCTAssertTrue(viewModel.amount.isEmpty)
@@ -113,12 +119,13 @@ final class ShippingLineDetailsViewModelTests: XCTestCase {
 
     func test_view_model_disables_done_button_for_empty_state_and_enables_with_input() {
         // Given
-        let viewModel = ShippingLineDetailsViewModel(isExistingShippingLine: false,
+        let viewModel = ShippingLineDetailsViewModel(shippingID: nil,
                                                      initialMethodTitle: "",
                                                      shippingTotal: "",
                                                      locale: usLocale,
                                                      storeCurrencySettings: usStoreSettings,
-                                                     didSelectSave: { _ in })
+                                                     didSelectSave: { _ in },
+                                                     didSelectRemove: { _ in })
         XCTAssertTrue(viewModel.shouldDisableDoneButton)
 
         // When
@@ -136,12 +143,13 @@ final class ShippingLineDetailsViewModelTests: XCTestCase {
 
     func test_view_model_disables_done_button_for_prefilled_data_and_enables_with_changes() {
         // Given
-        let viewModel = ShippingLineDetailsViewModel(isExistingShippingLine: true,
+        let viewModel = ShippingLineDetailsViewModel(shippingID: 1,
                                                      initialMethodTitle: "Flat Rate",
                                                      shippingTotal: "$11.30",
                                                      locale: usLocale,
                                                      storeCurrencySettings: usStoreSettings,
-                                                     didSelectSave: { _ in })
+                                                     didSelectSave: { _ in },
+                                                     didSelectRemove: { _ in })
         XCTAssertTrue(viewModel.shouldDisableDoneButton)
 
         // When
@@ -160,14 +168,15 @@ final class ShippingLineDetailsViewModelTests: XCTestCase {
     func test_view_model_creates_shippping_line_with_data_from_fields() {
         // Given
         var savedShippingLine: ShippingLine?
-        let viewModel = ShippingLineDetailsViewModel(isExistingShippingLine: false,
+        let viewModel = ShippingLineDetailsViewModel(shippingID: nil,
                                                      initialMethodTitle: "",
                                                      shippingTotal: "",
                                                      locale: usLocale,
                                                      storeCurrencySettings: usStoreSettings,
                                                      didSelectSave: { newShippingLine in
             savedShippingLine = newShippingLine
-        })
+        },
+                                                     didSelectRemove: { _ in })
 
         // When
         viewModel.amount = "$11.30"
@@ -182,14 +191,15 @@ final class ShippingLineDetailsViewModelTests: XCTestCase {
     func test_view_model_creates_shippping_line_with_negative_data_from_fields() {
         // Given
         var savedShippingLine: ShippingLine?
-        let viewModel = ShippingLineDetailsViewModel(isExistingShippingLine: false,
+        let viewModel = ShippingLineDetailsViewModel(shippingID: nil,
                                                      initialMethodTitle: "",
                                                      shippingTotal: "",
                                                      locale: usLocale,
                                                      storeCurrencySettings: usStoreSettings,
                                                      didSelectSave: { newShippingLine in
             savedShippingLine = newShippingLine
-        })
+        },
+                                                     didSelectRemove: { _ in })
 
         // When
         viewModel.amount = "-11.30"
@@ -204,14 +214,15 @@ final class ShippingLineDetailsViewModelTests: XCTestCase {
     func test_view_model_allows_saving_zero_amount_and_creates_correct_shippping_line() {
         // Given
         var savedShippingLine: ShippingLine?
-        let viewModel = ShippingLineDetailsViewModel(isExistingShippingLine: false,
+        let viewModel = ShippingLineDetailsViewModel(shippingID: nil,
                                                      initialMethodTitle: "",
                                                      shippingTotal: "",
                                                      locale: usLocale,
                                                      storeCurrencySettings: usStoreSettings,
                                                      didSelectSave: { newShippingLine in
             savedShippingLine = newShippingLine
-        })
+        },
+                                                     didSelectRemove: { _ in })
 
         // When
         viewModel.amount = "0"
@@ -225,14 +236,15 @@ final class ShippingLineDetailsViewModelTests: XCTestCase {
     func test_view_model_creates_shippping_line_with_placeholder_for_method_title() {
         // Given
         var savedShippingLine: ShippingLine?
-        let viewModel = ShippingLineDetailsViewModel(isExistingShippingLine: false,
+        let viewModel = ShippingLineDetailsViewModel(shippingID: nil,
                                                      initialMethodTitle: "",
                                                      shippingTotal: "",
                                                      locale: usLocale,
                                                      storeCurrencySettings: usStoreSettings,
                                                      didSelectSave: { newShippingLine in
             savedShippingLine = newShippingLine
-        })
+        },
+                                                     didSelectRemove: { _ in })
 
         // When
         viewModel.amount = "$11.30"
@@ -246,12 +258,13 @@ final class ShippingLineDetailsViewModelTests: XCTestCase {
 
     func test_view_model_amount_placeholder_has_expected_value() {
         // Given
-        let viewModel = ShippingLineDetailsViewModel(isExistingShippingLine: false,
+        let viewModel = ShippingLineDetailsViewModel(shippingID: nil,
                                                      initialMethodTitle: "",
                                                      shippingTotal: "",
                                                      locale: usLocale,
                                                      storeCurrencySettings: usStoreSettings,
-                                                     didSelectSave: { _ in })
+                                                     didSelectSave: { _ in },
+                                                     didSelectRemove: { _ in })
 
         // Then
         XCTAssertEqual(viewModel.amountPlaceholder, "0")
@@ -259,14 +272,34 @@ final class ShippingLineDetailsViewModelTests: XCTestCase {
 
     func test_view_model_initializes_correctly_with_no_existing_shipping_line() {
         // Given
-        let viewModel = ShippingLineDetailsViewModel(isExistingShippingLine: false,
+        let viewModel = ShippingLineDetailsViewModel(shippingID: nil,
                                                      initialMethodTitle: "",
                                                      shippingTotal: "",
                                                      locale: usLocale,
                                                      storeCurrencySettings: usStoreSettings,
-                                                     didSelectSave: { _ in })
+                                                     didSelectSave: { _ in },
+                                                     didSelectRemove: { _ in })
 
         // Then
         XCTAssertFalse(viewModel.isExistingShippingLine)
+    }
+
+    func test_removeShippingLine_returns_shipping_line_with_expected_shipping_id() {
+        // Given
+        var removedShippingLine: Yosemite.ShippingLine?
+        let existingShippingLine = ShippingLine.fake().copy(shippingID: 1)
+        let viewModel = ShippingLineDetailsViewModel(shippingID: existingShippingLine.shippingID,
+                                                     initialMethodTitle: existingShippingLine.methodTitle,
+                                                     shippingTotal: existingShippingLine.total,
+                                                     didSelectSave: { _ in },
+                                                     didSelectRemove: { shippingLine in
+            removedShippingLine = shippingLine
+        })
+
+        // When
+        viewModel.removeShippingLine()
+
+        // Then
+        assertEqual(existingShippingLine.shippingID, removedShippingLine?.shippingID)
     }
 }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/ShippingLineSelectionDetailsViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/ShippingLineSelectionDetailsViewModelTests.swift
@@ -28,7 +28,8 @@ final class ShippingLineSelectionDetailsViewModelTests: XCTestCase {
                                                               shippingLine: nil,
                                                               locale: usLocale,
                                                               storeCurrencySettings: usStoreSettings,
-                                                              didSelectSave: { _ in })
+                                                              didSelectSave: { _ in },
+                                                              didSelectRemove: { _ in })
 
         // When
         viewModel.formattableAmountViewModel.amount = "hi:11.3005.02-"
@@ -44,7 +45,8 @@ final class ShippingLineSelectionDetailsViewModelTests: XCTestCase {
                                                               shippingLine: nil,
                                                               locale: usLocale,
                                                               storeCurrencySettings: usStoreSettings,
-                                                              didSelectSave: { _ in })
+                                                              didSelectSave: { _ in },
+                                                              didSelectRemove: { _ in })
 
         // When
         viewModel.formattableAmountViewModel.amount = "-hi:11.3005.02-"
@@ -66,7 +68,8 @@ final class ShippingLineSelectionDetailsViewModelTests: XCTestCase {
                                                               shippingLine: nil,
                                                               locale: usLocale,
                                                               storeCurrencySettings: customSettings,
-                                                              didSelectSave: { _ in })
+                                                              didSelectSave: { _ in },
+                                                              didSelectRemove: { _ in })
 
         // When
         viewModel.formattableAmountViewModel.amount = "12.203"
@@ -87,7 +90,8 @@ final class ShippingLineSelectionDetailsViewModelTests: XCTestCase {
                                                               locale: usLocale,
                                                               storeCurrencySettings: usStoreSettings,
                                                               storageManager: storageManager,
-                                                              didSelectSave: { _ in })
+                                                              didSelectSave: { _ in },
+                                                              didSelectRemove: { _ in })
 
         // Then
         XCTAssertTrue(viewModel.isExistingShippingLine)
@@ -104,7 +108,8 @@ final class ShippingLineSelectionDetailsViewModelTests: XCTestCase {
                                                               shippingLine: shippingLine,
                                                               locale: usLocale,
                                                               storeCurrencySettings: usStoreSettings,
-                                                              didSelectSave: { _ in })
+                                                              didSelectSave: { _ in },
+                                                              didSelectRemove: { _ in })
 
         // Then
         XCTAssertTrue(viewModel.isExistingShippingLine)
@@ -121,7 +126,8 @@ final class ShippingLineSelectionDetailsViewModelTests: XCTestCase {
                                                               shippingTotal: "0",
                                                               locale: usLocale,
                                                               storeCurrencySettings: usStoreSettings,
-                                                              didSelectSave: { _ in })
+                                                              didSelectSave: { _ in },
+                                                              didSelectRemove: { _ in })
 
         // Then
         XCTAssertTrue(viewModel.formattableAmountViewModel.amount.isEmpty)
@@ -133,7 +139,8 @@ final class ShippingLineSelectionDetailsViewModelTests: XCTestCase {
                                                               shippingLine: nil,
                                                               locale: usLocale,
                                                               storeCurrencySettings: usStoreSettings,
-                                                              didSelectSave: { _ in })
+                                                              didSelectSave: { _ in },
+                                                              didSelectRemove: { _ in })
         XCTAssertFalse(viewModel.enableDoneButton)
 
         // When
@@ -156,7 +163,8 @@ final class ShippingLineSelectionDetailsViewModelTests: XCTestCase {
                                                               shippingLine: shippingLine,
                                                               locale: usLocale,
                                                               storeCurrencySettings: usStoreSettings,
-                                                              didSelectSave: { _ in })
+                                                              didSelectSave: { _ in },
+                                                              didSelectRemove: { _ in })
         XCTAssertFalse(viewModel.enableDoneButton)
 
         // When
@@ -179,7 +187,8 @@ final class ShippingLineSelectionDetailsViewModelTests: XCTestCase {
                                                               shippingLine: shippingLine,
                                                               locale: usLocale,
                                                               storeCurrencySettings: usStoreSettings,
-                                                              didSelectSave: { _ in })
+                                                              didSelectSave: { _ in },
+                                                              didSelectRemove: { _ in })
         XCTAssertFalse(viewModel.enableDoneButton)
 
         // When
@@ -206,7 +215,8 @@ final class ShippingLineSelectionDetailsViewModelTests: XCTestCase {
                                                               locale: usLocale,
                                                               storeCurrencySettings: usStoreSettings,
                                                               storageManager: storageManager,
-                                                              didSelectSave: { _ in })
+                                                              didSelectSave: { _ in },
+                                                              didSelectRemove: { _ in })
         XCTAssertFalse(viewModel.enableDoneButton)
 
         // When
@@ -233,7 +243,8 @@ final class ShippingLineSelectionDetailsViewModelTests: XCTestCase {
                                                               storeCurrencySettings: usStoreSettings,
                                                               didSelectSave: { newShippingLine in
             savedShippingLine = newShippingLine
-        })
+        },
+                                                              didSelectRemove: { _ in })
 
         // When
         viewModel.formattableAmountViewModel.amount = "$11.30"
@@ -256,7 +267,8 @@ final class ShippingLineSelectionDetailsViewModelTests: XCTestCase {
                                                               storeCurrencySettings: usStoreSettings,
                                                               didSelectSave: { newShippingLine in
             savedShippingLine = newShippingLine
-        })
+        },
+                                                              didSelectRemove: { _ in })
 
         // When
         viewModel.formattableAmountViewModel.amount = "-11.30"
@@ -277,7 +289,8 @@ final class ShippingLineSelectionDetailsViewModelTests: XCTestCase {
                                                               storeCurrencySettings: usStoreSettings,
                                                               didSelectSave: { newShippingLine in
             savedShippingLine = newShippingLine
-        })
+        },
+                                                              didSelectRemove: { _ in })
 
         // When
         viewModel.formattableAmountViewModel.amount = "0"
@@ -297,7 +310,8 @@ final class ShippingLineSelectionDetailsViewModelTests: XCTestCase {
                                                               storeCurrencySettings: usStoreSettings,
                                                               didSelectSave: { newShippingLine in
             savedShippingLine = newShippingLine
-        })
+        },
+                                                              didSelectRemove: { _ in })
 
         // When
         viewModel.formattableAmountViewModel.amount = "$11.30"
@@ -316,7 +330,8 @@ final class ShippingLineSelectionDetailsViewModelTests: XCTestCase {
                                                               shippingLine: nil,
                                                               locale: usLocale,
                                                               storeCurrencySettings: usStoreSettings,
-                                                              didSelectSave: { _ in })
+                                                              didSelectSave: { _ in },
+                                                              didSelectRemove: { _ in })
 
         // Then
         XCTAssertEqual(viewModel.formattableAmountViewModel.formattedAmount, "$0.00")
@@ -328,7 +343,8 @@ final class ShippingLineSelectionDetailsViewModelTests: XCTestCase {
                                                               shippingLine: nil,
                                                               locale: usLocale,
                                                               storeCurrencySettings: usStoreSettings,
-                                                              didSelectSave: { _ in })
+                                                              didSelectSave: { _ in },
+                                                              didSelectRemove: { _ in })
 
         // Then
         XCTAssertFalse(viewModel.isExistingShippingLine)
@@ -347,7 +363,8 @@ final class ShippingLineSelectionDetailsViewModelTests: XCTestCase {
                                                               locale: usLocale,
                                                               storeCurrencySettings: usStoreSettings,
                                                               storageManager: storageManager,
-                                                              didSelectSave: { _ in })
+                                                              didSelectSave: { _ in },
+                                                              didSelectRemove: { _ in })
 
         // Then
         XCTAssertEqual(viewModel.shippingMethods.count, 3) // Placeholder method + provided method + "Other"
@@ -362,7 +379,8 @@ final class ShippingLineSelectionDetailsViewModelTests: XCTestCase {
                                                               locale: usLocale,
                                                               storeCurrencySettings: usStoreSettings,
                                                               analytics: WooAnalytics(analyticsProvider: analytics),
-                                                              didSelectSave: { _ in })
+                                                              didSelectSave: { _ in },
+                                                              didSelectRemove: { _ in })
 
         // When
         let shippingMethod = ShippingMethod(siteID: sampleSiteID, methodID: "flat_rate", title: "Flat rate")
@@ -371,6 +389,24 @@ final class ShippingLineSelectionDetailsViewModelTests: XCTestCase {
         // Then
         XCTAssertEqual(analytics.receivedEvents, [WooAnalyticsStat.orderShippingMethodSelected.rawValue])
         assertEqual(shippingMethod.methodID, analytics.receivedProperties.first?["shipping_method"] as? String)
+    }
+
+    func test_removeShippingLine_returns_shipping_line_with_expected_shipping_id() {
+        // Given
+        var removedShippingLine: Yosemite.ShippingLine?
+        let existingShippingLine = ShippingLine.fake().copy(shippingID: 1)
+        let viewModel = ShippingLineSelectionDetailsViewModel(siteID: sampleSiteID,
+                                                              shippingLine: existingShippingLine,
+                                                              didSelectSave: { _ in },
+                                                              didSelectRemove: { shippingLine in
+            removedShippingLine = shippingLine
+        })
+
+        // When
+        viewModel.removeShippingLine()
+
+        // Then
+        assertEqual(existingShippingLine.shippingID, removedShippingLine?.shippingID)
     }
 }
 

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/Synchronizer/RemoteOrderSynchronizerTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/Synchronizer/RemoteOrderSynchronizerTests.swift
@@ -207,7 +207,7 @@ final class RemoteOrderSynchronizerTests: XCTestCase {
         XCTAssertEqual(synchronizer.order.shippingLines, [shippingLine])
     }
 
-    func test_sending_nil_shipping_input_updates_local_order() throws {
+    func test_removing_shipping_input_updates_local_order() throws {
         // Given
         let shippingLine = ShippingLine.fake().copy(shippingID: sampleShippingID)
         let stores = MockStoresManager(sessionManager: .testingInstance)
@@ -215,7 +215,7 @@ final class RemoteOrderSynchronizerTests: XCTestCase {
 
         // When
         synchronizer.setShipping.send(shippingLine)
-        synchronizer.setShipping.send(nil)
+        synchronizer.removeShipping.send(shippingLine)
 
         // Then
         let firstLine = try XCTUnwrap(synchronizer.order.shippingLines.first)

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/Synchronizer/ShippingInputTransformerTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/Synchronizer/ShippingInputTransformerTests.swift
@@ -10,8 +10,90 @@ class ShippingInputTransformerTests: XCTestCase {
     private let sampleShippingID: Int64 = 123
     private let sampleMethodID = "other"
 
+    // MARK: Multiple Shipping Lines Enabled
+
     func test_new_input_adds_shipping_line_to_order() throws {
         // Given
+        let featureFlagService = MockFeatureFlagService(isMultipleShippingLinesEnabled: true)
+        ServiceLocator.setFeatureFlagService(featureFlagService)
+
+        let order = Order.fake()
+        let input = ShippingLine.fake().copy(methodID: sampleMethodID, total: "10.00")
+
+        // When
+        let updatedOrder = ShippingInputTransformer.update(input: input, on: order)
+
+        // Then
+        let shippingLine = try XCTUnwrap(updatedOrder.shippingLines.first)
+        assertEqual(input, shippingLine)
+        assertEqual("10.0", updatedOrder.shippingTotal)
+    }
+
+    func test_new_input_adds_expected_shipping_line_to_order() throws {
+        // Given
+        let featureFlagService = MockFeatureFlagService(isMultipleShippingLinesEnabled: true)
+        ServiceLocator.setFeatureFlagService(featureFlagService)
+
+        let order = Order.fake()
+        let input = ShippingLine.fake().copy(methodID: "flat_rate", total: "10.00")
+
+        // When
+        let updatedOrder = ShippingInputTransformer.update(input: input, on: order)
+
+        // Then
+        let shippingLine = try XCTUnwrap(updatedOrder.shippingLines.first)
+        assertEqual(input, shippingLine)
+        assertEqual("10.0", updatedOrder.shippingTotal)
+    }
+
+    func test_new_input_with_no_shipping_method_adds_expected_shipping_line_to_order() throws {
+        // Given
+        let featureFlagService = MockFeatureFlagService(isMultipleShippingLinesEnabled: true)
+        ServiceLocator.setFeatureFlagService(featureFlagService)
+
+        let order = Order.fake()
+        let input = ShippingLine.fake().copy(methodID: "", total: "10.00")
+
+        // When
+        let updatedOrder = ShippingInputTransformer.update(input: input, on: order)
+
+        // Then
+        let shippingLine = try XCTUnwrap(updatedOrder.shippingLines.first)
+        assertEqual(input.copy(methodID: " "), shippingLine)
+        assertEqual("10.0", updatedOrder.shippingTotal)
+    }
+
+    func test_new_input_updates_matching_shipping_line_from_order() throws {
+        // Given
+        let featureFlagService = MockFeatureFlagService(isMultipleShippingLinesEnabled: true)
+        ServiceLocator.setFeatureFlagService(featureFlagService)
+
+        let shipping = ShippingLine.fake().copy(shippingID: sampleShippingID, methodID: sampleMethodID, total: "10.00")
+        let shipping2 = ShippingLine.fake().copy(shippingID: sampleShippingID + 1, methodID: sampleMethodID, total: "12.00")
+        let order = Order.fake().copy(shippingLines: [shipping, shipping2])
+
+        // When
+        let input = shipping2.copy(total: "10.00")
+        let updatedOrder = ShippingInputTransformer.update(input: input, on: order)
+
+        // Then
+        let updatedShippingLine = try XCTUnwrap(updatedOrder.shippingLines[safe: 1])
+        assertEqual(input.shippingID, updatedShippingLine.shippingID)
+        assertEqual(input.methodID, updatedShippingLine.methodID)
+        assertEqual(input.total, updatedShippingLine.total)
+        assertEqual("20.0", updatedOrder.shippingTotal)
+
+        let shippingLine = try XCTUnwrap(updatedOrder.shippingLines.first)
+        assertEqual(shippingLine, shipping)
+    }
+
+    // MARK: Multiple Shipping Lines Disabled
+
+    func test_new_input_adds_shipping_line_to_order_with_feature_flag_disabled() throws {
+        // Given
+        let featureFlagService = MockFeatureFlagService(isMultipleShippingLinesEnabled: false)
+        ServiceLocator.setFeatureFlagService(featureFlagService)
+
         let order = Order.fake()
         let input = ShippingLine.fake().copy(methodID: sampleMethodID, total: "10.00")
 
@@ -24,8 +106,28 @@ class ShippingInputTransformerTests: XCTestCase {
         XCTAssertEqual(updatedOrder.shippingTotal, input.total)
     }
 
-    func test_new_input_with_no_shipping_method_adds_expected_shipping_line_to_order() throws {
+    func test_new_input_adds_expected_shipping_line_to_order_with_feature_flag_disabled() throws {
         // Given
+        let featureFlagService = MockFeatureFlagService(isMultipleShippingLinesEnabled: false)
+        ServiceLocator.setFeatureFlagService(featureFlagService)
+
+        let order = Order.fake()
+        let input = ShippingLine.fake().copy(methodID: "flat_rate", total: "10.00")
+
+        // When
+        let updatedOrder = ShippingInputTransformer.update(input: input, on: order)
+
+        // Then
+        let shippingLine = try XCTUnwrap(updatedOrder.shippingLines.first)
+        XCTAssertEqual(shippingLine, input)
+        XCTAssertEqual(updatedOrder.shippingTotal, input.total)
+    }
+
+    func test_new_input_with_no_shipping_method_adds_expected_shipping_line_to_order_with_feature_flag_disabled() throws {
+        // Given
+        let featureFlagService = MockFeatureFlagService(isMultipleShippingLinesEnabled: false)
+        ServiceLocator.setFeatureFlagService(featureFlagService)
+
         let order = Order.fake()
         let input = ShippingLine.fake().copy(methodID: "", total: "10.00")
 
@@ -38,8 +140,34 @@ class ShippingInputTransformerTests: XCTestCase {
         XCTAssertEqual(updatedOrder.shippingTotal, input.total)
     }
 
-    func test_new_input_updates_first_shipping_line_from_order() throws {
+    func test_new_input_deletes_matching_shipping_line_from_order_with_feature_flag_disabled() throws {
         // Given
+        let featureFlagService = MockFeatureFlagService(isMultipleShippingLinesEnabled: false)
+        ServiceLocator.setFeatureFlagService(featureFlagService)
+
+        let shipping = ShippingLine.fake().copy(shippingID: sampleShippingID, methodID: sampleMethodID, total: "10.00")
+        let shipping2 = ShippingLine.fake().copy(shippingID: sampleShippingID + 1, methodID: sampleMethodID, total: "12.00")
+        let order = Order.fake().copy(shippingLines: [shipping, shipping2])
+
+        // When
+        let updatedOrder = ShippingInputTransformer.remove(input: shipping2, from: order)
+
+        // Then
+        let shippingLineToRemove = try XCTUnwrap(updatedOrder.shippingLines[safe: 1])
+        XCTAssertNil(shippingLineToRemove.methodID)
+        XCTAssertEqual(shippingLineToRemove.shippingID, shipping2.shippingID)
+        XCTAssertEqual(shippingLineToRemove.total, "0")
+        XCTAssertEqual(updatedOrder.shippingTotal, "10.0")
+
+        let remainingShippingLine = try XCTUnwrap(updatedOrder.shippingLines.first)
+        XCTAssertEqual(shipping, remainingShippingLine)
+    }
+
+    func test_new_input_updates_first_shipping_line_from_order_with_feature_flag_disabled() throws {
+        // Given
+        let featureFlagService = MockFeatureFlagService(isMultipleShippingLinesEnabled: false)
+        ServiceLocator.setFeatureFlagService(featureFlagService)
+
         let shipping = ShippingLine.fake().copy(shippingID: sampleShippingID, methodID: sampleMethodID, total: "10.00")
         let shipping2 = ShippingLine.fake().copy(shippingID: sampleShippingID + 1, methodID: sampleMethodID, total: "12.00")
         let order = Order.fake().copy(shippingLines: [shipping, shipping2])
@@ -54,26 +182,6 @@ class ShippingInputTransformerTests: XCTestCase {
         XCTAssertEqual(shippingLine.methodID, input.methodID)
         XCTAssertEqual(shippingLine.total, input.total)
         XCTAssertEqual(updatedOrder.shippingTotal, "24.0")
-
-        let shippingLine2 = try XCTUnwrap(updatedOrder.shippingLines[safe: 1])
-        XCTAssertEqual(shipping2, shippingLine2)
-    }
-
-    func test_new_input_deletes_first_shipping_line_from_order() throws {
-        // Given
-        let shipping = ShippingLine.fake().copy(shippingID: sampleShippingID, methodID: sampleMethodID, total: "10.00")
-        let shipping2 = ShippingLine.fake().copy(shippingID: sampleShippingID + 1, methodID: sampleMethodID, total: "12.00")
-        let order = Order.fake().copy(shippingLines: [shipping, shipping2])
-
-        // When
-        let updatedOrder = ShippingInputTransformer.update(input: nil, on: order)
-
-        // Then
-        let shippingLine = try XCTUnwrap(updatedOrder.shippingLines.first)
-        XCTAssertNil(shippingLine.methodID)
-        XCTAssertEqual(shippingLine.shippingID, shipping.shippingID)
-        XCTAssertEqual(shippingLine.total, "0")
-        XCTAssertEqual(updatedOrder.shippingTotal, "12.0")
 
         let shippingLine2 = try XCTUnwrap(updatedOrder.shippingLines[safe: 1])
         XCTAssertEqual(shipping2, shippingLine2)


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #12583
<!-- Id number of the GitHub issue this PR addresses. -->

## Why
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
The current order sync logic only supports adding, editing, or removing a single shipping line on an order. This PR adds support for multiple shipping lines.

## How
Instead of assuming there is only a single shipping line on an order, we now use the shipping line's `shippingID` to identify it so we can add, edit, or remove it in the order synchronizer.

Removing a shipping line:

* Adds a `removeShipping` trigger to `OrderSynchronizer`, so we can remove a specific shipping line from an order.
* Adds a `remove(_:from:)` method to `ShippingInputTransformer` to remove a shipping line from an order based on its `shippingID`.
* Adds support in `RemoteOrderSynchronizer` for the new `removeShipping` trigger, using the new method in `ShippingInputTransformer`.
* Updates `EditableOrderShippingUseCase` and the related views/view models to use the new `removeShipping` trigger. (All view models now track the `shippingID` for the shipping line, so the correct shipping line can be removed.)

Adding/updating a shipping line:

* The `update(_:on:)` method in `ShippingInputTransformer` now takes a non-optional shipping line and only adds or edit the shipping line. When the feature flag is disabled it works as before, but with the feature flag enabled it now checks for the existence of the provided input and either adds or updates that shipping line as needed.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

Previous behavior:

1. Build and run the app with the `multipleShippingLines` feature flag disabled.
2. Create an order and add a product.
3. Add a shipping line and confirm the order is saved with the shipping line.
4. Edit the shipping line and confirm the order is saved with the updated shipping line.
5. Remove the shipping line and confirm the order is saved without shipping.

New behavior:

1. Build and run the app with the `multipleShippingLines` feature flag enabled.
2. Create an order and add a product.
3. Add a shipping line and confirm the order is saved with the shipping line.
4. Add a second shipping line and confirm the order is saved with both the shipping lines.
5. Edit a shipping line and confirm the order is saved with the updated shipping line, without changing the other shipping line on the order.
6. Remove a shipping line and confirm the order is saved without that shipping line, without changing the other shipping line on the order.


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
