### PR TITLE
[Shipping Lines] Add shipping methods tracks M2

### DIFF
--- a/WooCommerce/Classes/Analytics/WooAnalyticsEvent.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsEvent.swift
@@ -559,6 +559,7 @@ extension WooAnalyticsEvent {
             static let orderID = "id"
             static let productTypes = "product_types"
             static let hasMultipleShippingLines = "has_multiple_shipping_lines"
+            static let shippingLinesCount = "shipping_lines_count"
             static let hasMultipleFeeLines = "has_multiple_fee_lines"
             static let itemType = "item_type"
             static let source = "source"
@@ -816,8 +817,13 @@ extension WooAnalyticsEvent {
             ])
         }
 
-        static func orderCreationSuccess(millisecondsSinceSinceOrderAddNew: Int64?, couponsCount: Int64, usesGiftCard: Bool) -> WooAnalyticsEvent {
-            var properties: [String: WooAnalyticsEventPropertyType] = [Keys.couponsCount: couponsCount, Keys.usesGiftCard: usesGiftCard]
+        static func orderCreationSuccess(millisecondsSinceSinceOrderAddNew: Int64?,
+                                         couponsCount: Int64,
+                                         usesGiftCard: Bool,
+                                         shippingLinesCount: Int64) -> WooAnalyticsEvent {
+            var properties: [String: WooAnalyticsEventPropertyType] = [Keys.couponsCount: couponsCount,
+                                                                       Keys.usesGiftCard: usesGiftCard,
+                                                                       Keys.shippingLinesCount: shippingLinesCount]
 
             if let lapseSinceLastOrderAddNew = millisecondsSinceSinceOrderAddNew {
                 properties[GlobalKeys.millisecondsSinceOrderAddNew] = lapseSinceLastOrderAddNew

--- a/WooCommerce/Classes/Analytics/WooAnalyticsEvent.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsEvent.swift
@@ -919,6 +919,12 @@ extension WooAnalyticsEvent {
             WooAnalyticsEvent(statName: .orderDetailsGiftCardShown, properties: [:])
         }
 
+        /// Tracks when shipping is displayed in order details.
+        ///
+        static func shippingShown(shippingLinesCount: Int64) -> WooAnalyticsEvent {
+            WooAnalyticsEvent(statName: .orderDetailsShippingMethodsShown, properties: [Keys.shippingLinesCount: shippingLinesCount])
+        }
+
         /// Tracked when the Configure button is shown in the order form.
         ///
         static func orderFormBundleProductConfigureCTAShown(flow: Flow, source: BundleProductConfigurationSource) -> WooAnalyticsEvent {

--- a/WooCommerce/Classes/Analytics/WooAnalyticsEvent.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsEvent.swift
@@ -740,9 +740,10 @@ extension WooAnalyticsEvent {
             WooAnalyticsEvent(statName: .orderShippingMethodSelected, properties: [Keys.shippingMethod: methodID])
         }
 
-        static func orderShippingMethodAdd(flow: Flow, methodID: String) -> WooAnalyticsEvent {
+        static func orderShippingMethodAdd(flow: Flow, methodID: String, shippingLinesCount: Int64) -> WooAnalyticsEvent {
             WooAnalyticsEvent(statName: .orderShippingMethodAdd, properties: [Keys.flow: flow.rawValue,
-                                                                              Keys.shippingMethod: methodID])
+                                                                              Keys.shippingMethod: methodID,
+                                                                              Keys.shippingLinesCount: shippingLinesCount])
         }
 
         static func orderShippingMethodRemove(flow: Flow) -> WooAnalyticsEvent {

--- a/WooCommerce/Classes/Analytics/WooAnalyticsStat.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsStat.swift
@@ -512,6 +512,7 @@ enum WooAnalyticsStat: String {
     case orderDetailWaitingTimeLoaded = "order_detail_waiting_time_loaded"
     case orderDetailsSubscriptionsShown = "order_details_subscriptions_shown"
     case orderDetailsGiftCardShown = "order_details_gift_card_shown"
+    case orderDetailsShippingMethodsShown = "order_details_shipping_methods_shown"
     case orderFormBundleProductConfigureCTAShown = "order_form_bundle_product_configure_cta_shown"
     case orderFormBundleProductConfigureCTATapped = "order_form_bundle_product_configure_cta_tapped"
     case orderFormBundleProductConfigurationChanged = "order_form_bundle_product_configuration_changed"

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/EditableOrderViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/EditableOrderViewModel.swift
@@ -2099,7 +2099,8 @@ private extension EditableOrderViewModel {
         analytics.track(event: WooAnalyticsEvent.Orders.orderCreationSuccess(millisecondsSinceSinceOrderAddNew:
                                                                                 try? orderDurationRecorder.millisecondsSinceOrderAddNew(),
                                                                              couponsCount: Int64(orderSynchronizer.order.coupons.count),
-                                                                             usesGiftCard: usesGiftCard))
+                                                                             usesGiftCard: usesGiftCard,
+                                                                             shippingLinesCount: Int64(orderSynchronizer.order.shippingLines.count)))
     }
 
     /// Tracks an order creation failure

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/Shipping/EditableOrderShippingUseCase.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/Shipping/EditableOrderShippingUseCase.swift
@@ -152,7 +152,9 @@ final class EditableOrderShippingUseCase: ObservableObject {
     /// - Parameter shippingLine: New or updated shipping line object to save.
     func saveShippingLine(_ shippingLine: ShippingLine) {
         orderSynchronizer.setShipping.send(shippingLine)
-        analytics.track(event: WooAnalyticsEvent.Orders.orderShippingMethodAdd(flow: flow.analyticsFlow, methodID: shippingLine.methodID ?? ""))
+        analytics.track(event: WooAnalyticsEvent.Orders.orderShippingMethodAdd(flow: flow.analyticsFlow,
+                                                                               methodID: shippingLine.methodID ?? "",
+                                                                               shippingLinesCount: Int64(orderSynchronizer.order.shippingLines.count)))
     }
 
     /// Removes a shipping line.

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/OrderDetailsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/OrderDetailsViewController.swift
@@ -90,6 +90,7 @@ final class OrderDetailsViewController: UIViewController {
         configureViewModel()
         updateTopBannerView()
         trackGiftCardsShown()
+        trackShippingShown()
     }
 
     override func viewWillAppear(_ animated: Bool) {
@@ -727,6 +728,16 @@ private extension OrderDetailsViewController {
             return
         }
         ServiceLocator.analytics.track(event: .Orders.giftCardsShown())
+    }
+
+    /// Tracks when the Shipping section will be shown.
+    ///
+    func trackShippingShown() {
+        let shippingLinesCount = viewModel.dataSource.order.shippingLines.count
+        guard shippingLinesCount > 0 else {
+            return
+        }
+        ServiceLocator.analytics.track(event: .Orders.shippingShown(shippingLinesCount: Int64(shippingLinesCount)))
     }
 }
 

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/Shipping/EditableOrderShippingUseCaseTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/Shipping/EditableOrderShippingUseCaseTests.swift
@@ -271,6 +271,7 @@ final class EditableOrderShippingUseCaseTests: XCTestCase {
         XCTAssertEqual(analytics.receivedEvents, [WooAnalyticsStat.orderShippingMethodAdd.rawValue])
         assertEqual("creation", analytics.receivedProperties.first?["flow"] as? String)
         assertEqual("flat_rate", analytics.receivedProperties.first?["shipping_method"] as? String)
+        assertEqual(1, analytics.receivedProperties.first?["shipping_lines_count"] as? Int64)
     }
 
     func test_shipping_method_tracked_when_removed() throws {


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #12584
<!-- Id number of the GitHub issue this PR addresses. -->

## Why
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
We want to track the number of shipping lines on an order when an order is created, or edited, or viewed.

## How
-  Updates the event `order_creation_success` to include the custom property `shipping_lines_count` to track the number of shipping lines within that order.
-  Updates the event `order_shipping_method_add` to include the custom property `shipping_lines_count` to track the number of shipping lines within that order.
-  Adds a new event `order_details_shipping_methods_shown` with the custom property `shipping_lines_count` to track the number of shipping lines within that order. This event is triggered when the order details view is loaded.
   - Event registration: https://github.com/Automattic/tracks-events-registration/pull/2448

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

Creating an order:

1. Build and run the app.
2. Create a new order and add a product.
3. Add one or more shipping lines to the order.
4. Create the order and confirm the event `order_creation_success` is tracked with the property `shipping_lines_count` showing the correct number of shipping lines on the order.

Editing an order:

1. Build and run the app.
2. Open an existing order and tap "Edit" to edit it.
3. Add one or more shipping lines to the order and confirm the event `order_shipping_method_add` is tracked with the property `shipping_lines_count` showing the correct number of shipping lines on the order.

Viewing an order.

1. Build and run the app.
2. Open an order on the Orders tab.
3. Confirm the event `order_details_shipping_methods_shown` is tracked with the property `shipping_lines_count` showing the correct number of shipping lines on the order.

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
