### PR TITLE
[Shipping Lines] Release support for multiple shipping lines on an order

### DIFF
--- a/Experiments/Experiments/DefaultFeatureFlagService.swift
+++ b/Experiments/Experiments/DefaultFeatureFlagService.swift
@@ -93,7 +93,7 @@ public struct DefaultFeatureFlagService: FeatureFlagService {
         case .dynamicDashboardM2:
             return buildConfig == .localDeveloper || buildConfig == .alpha
         case .multipleShippingLines:
-            return buildConfig == .localDeveloper || buildConfig == .alpha
+            return true
         default:
             return true
         }

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -3,6 +3,7 @@
 18.9
 -----
 - [*] Orders: Fixes an issue where adding shipping to an order without selecting a shipping method prevented the order from being created/updated. [https://github.com/woocommerce/woocommerce-ios/pull/12870]
+- [**] Orders: Multiple shipping lines can now be viewed, added, edited, or removed on orders; previously only the first shipping line on an order was supported. [https://github.com/woocommerce/woocommerce-ios/pull/12888]
 
 18.8
 -----


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of: #12886
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This releases support for viewing, adding, editing, and removing multiple shipping lines on an order.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

1. Build and run the app.
2. Create a new order and add a product.
3. Tap "Add shipping" to enter and save a shipping line on the order.
4. Confirm a Shipping section appears with the new shipping line.
5. Tap the + icon to enter and save another shipping line on the order.
6. Confirm both shipping lines appear in the Shipping section.
7. Confirm the Order totals section shows the total shipping amount on the order.
8. Open a shipping line and confirm you can edit and save the updated details.
9. Confirm you can add and remove a shipping line on the order.
10. With multiple shipping lines added to the order, tap the "Create" button and confirm the order is created remotely with all of the shipping lines.
11. In the order details, confirm a Shipping section appears with all of the shipping lines on the order.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

https://github.com/woocommerce/woocommerce-ios/assets/8658164/bde07487-da46-4c5f-803b-3145349094c8



---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
