### PR TITLE
Dynamic Dashboard: Revert workaround for updating variation name

### DIFF
--- a/Fakes/Fakes/Networking.generated.swift
+++ b/Fakes/Fakes/Networking.generated.swift
@@ -1429,8 +1429,7 @@ extension Networking.ProductReport.ExtendedInfo {
         .init(
             name: .fake(),
             image: .fake(),
-            stockQuantity: .fake(),
-            attributes: .fake()
+            stockQuantity: .fake()
         )
     }
 }

--- a/Networking/Networking/Model/Copiable/Models+Copiable.generated.swift
+++ b/Networking/Networking/Model/Copiable/Models+Copiable.generated.swift
@@ -2311,19 +2311,16 @@ extension Networking.ProductReport.ExtendedInfo {
     public func copy(
         name: CopiableProp<String> = .copy,
         image: NullableCopiableProp<String> = .copy,
-        stockQuantity: CopiableProp<Int> = .copy,
-        attributes: NullableCopiableProp<[ProductVariationAttribute]> = .copy
+        stockQuantity: CopiableProp<Int> = .copy
     ) -> Networking.ProductReport.ExtendedInfo {
         let name = name ?? self.name
         let image = image ?? self.image
         let stockQuantity = stockQuantity ?? self.stockQuantity
-        let attributes = attributes ?? self.attributes
 
         return Networking.ProductReport.ExtendedInfo(
             name: name,
             image: image,
-            stockQuantity: stockQuantity,
-            attributes: attributes
+            stockQuantity: stockQuantity
         )
     }
 }

--- a/Networking/Networking/Model/Product/ProductReport.swift
+++ b/Networking/Networking/Model/Product/ProductReport.swift
@@ -40,15 +40,7 @@ public struct ProductReport: Decodable, Equatable, GeneratedCopiable, GeneratedF
         let extendedInfo = try container.decode(ExtendedInfo.self, forKey: .extendedInfo)
         let imageURL = Self.extractSourceURL(from: (extendedInfo.image ?? ""))
         let stockQuantity = extendedInfo.stockQuantity
-        let name: String = {
-            guard variationID != nil,
-                  let attributes = extendedInfo.attributes,
-                  !attributes.isEmpty else {
-                return extendedInfo.name
-            }
-            let attributeText = attributes.map { $0.option }.joined(separator: ", ")
-            return [extendedInfo.name, attributeText].joined(separator: " - ")
-        }()
+        let name = extendedInfo.name
 
         self.init(productID: productID,
                   variationID: variationID,
@@ -64,23 +56,19 @@ public extension ProductReport {
         public let name: String
         public let image: String?
         public let stockQuantity: Int
-        public let attributes: [ProductVariationAttribute]?
 
         public init(name: String,
                     image: String?,
-                    stockQuantity: Int,
-                    attributes: [ProductVariationAttribute]?) {
+                    stockQuantity: Int) {
             self.name = name
             self.image = image
             self.stockQuantity = stockQuantity
-            self.attributes = attributes
         }
 
         private enum CodingKeys: String, CodingKey {
             case name
             case image
             case stockQuantity = "stock_quantity"
-            case attributes
         }
     }
 }

--- a/Networking/NetworkingTests/Mapper/ProductReportListMapperTests.swift
+++ b/Networking/NetworkingTests/Mapper/ProductReportListMapperTests.swift
@@ -40,7 +40,7 @@ final class ProductReportListMapperTests: XCTestCase {
         let firstItem = try XCTUnwrap(list.first)
         XCTAssertEqual(firstItem.productID, 248)
         XCTAssertEqual(firstItem.variationID, 280)
-        XCTAssertEqual(firstItem.name, "Fantastic Concrete Shirt - ex, 7, Pink")
+        XCTAssertEqual(firstItem.name, "Fantastic Concrete Shirt")
         XCTAssertEqual(firstItem.itemsSold, 8)
         XCTAssertEqual(firstItem.stockQuantity, 24)
         XCTAssertEqual(firstItem.imageURL?.absoluteString, "https://test.ninja/wp-content/uploads/2024/05/img-laboriosam-300x300.png")

--- a/Networking/NetworkingTests/Remote/ProductsRemoteTests.swift
+++ b/Networking/NetworkingTests/Remote/ProductsRemoteTests.swift
@@ -838,7 +838,7 @@ final class ProductsRemoteTests: XCTestCase {
         let firstItem = try XCTUnwrap(products.first)
         XCTAssertEqual(firstItem.productID, 248)
         XCTAssertEqual(firstItem.variationID, 280)
-        XCTAssertEqual(firstItem.name, "Fantastic Concrete Shirt - ex, 7, Pink")
+        XCTAssertEqual(firstItem.name, "Fantastic Concrete Shirt")
         XCTAssertEqual(firstItem.itemsSold, 8)
         XCTAssertEqual(firstItem.imageURL?.absoluteString, "https://test.ninja/wp-content/uploads/2024/05/img-laboriosam-300x300.png")
     }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/ProductStock/ProductStockDashboardCardViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/ProductStock/ProductStockDashboardCardViewModel.swift
@@ -40,7 +40,7 @@ final class ProductStockDashboardCardViewModel: ObservableObject {
             let stock = try await fetchStock(type: selectedStockType)
             try await fetchAndSaveReportsToMemory(for: stock)
             reports = stock.compactMap { item in
-                savedReports[item.productID]?.copy(name: item.name)
+                savedReports[item.productID]
             }
             .sorted { $0.stockQuantity < $1.stockQuantity }
         } catch {

--- a/WooCommerce/Classes/ViewRelated/Dashboard/ProductStock/ProductStockDashboardCardViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/ProductStock/ProductStockDashboardCardViewModel.swift
@@ -40,7 +40,7 @@ final class ProductStockDashboardCardViewModel: ObservableObject {
             let stock = try await fetchStock(type: selectedStockType)
             try await fetchAndSaveReportsToMemory(for: stock)
             reports = stock.compactMap { item in
-                savedReports[item.productID]
+                savedReports[item.productID]?.copy(name: item.name)
             }
             .sorted { $0.stockQuantity < $1.stockQuantity }
         } catch {

--- a/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/ProductStockDashboardCardViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/ProductStockDashboardCardViewModelTests.swift
@@ -30,8 +30,8 @@ final class ProductStockDashboardCardViewModelTests: XCTestCase {
         let stores = MockStoresManager(sessionManager: .makeForTesting())
         let viewModel = ProductStockDashboardCardViewModel(siteID: siteID, stores: stores)
 
-        let product = ProductStock.fake().copy(siteID: siteID, productID: 32)
-        let variation = ProductStock.fake().copy(siteID: siteID, productID: 44, parentID: 40)
+        let product = ProductStock.fake().copy(siteID: siteID, productID: 32, name: "Steamed bun")
+        let variation = ProductStock.fake().copy(siteID: siteID, productID: 44, parentID: 40, name: "Pizza - Large, Seafood, Spicy")
 
         let thumbnailURL = "https://example.com/image.jpg"
         let productReport = ProductReport.fake().copy(productID: product.productID,

--- a/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/ProductStockDashboardCardViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/ProductStockDashboardCardViewModelTests.swift
@@ -30,8 +30,8 @@ final class ProductStockDashboardCardViewModelTests: XCTestCase {
         let stores = MockStoresManager(sessionManager: .makeForTesting())
         let viewModel = ProductStockDashboardCardViewModel(siteID: siteID, stores: stores)
 
-        let product = ProductStock.fake().copy(siteID: siteID, productID: 32, name: "Steamed bun")
-        let variation = ProductStock.fake().copy(siteID: siteID, productID: 44, parentID: 40, name: "Pizza - Large, Seafood, Spicy")
+        let product = ProductStock.fake().copy(siteID: siteID, productID: 32)
+        let variation = ProductStock.fake().copy(siteID: siteID, productID: 44, parentID: 40)
 
         let thumbnailURL = "https://example.com/image.jpg"
         let productReport = ProductReport.fake().copy(productID: product.productID,
@@ -41,6 +41,7 @@ final class ProductStockDashboardCardViewModelTests: XCTestCase {
                                                       stockQuantity: 4)
         let variationReport = ProductReport.fake().copy(productID: variation.parentID,
                                                         variationID: variation.productID,
+                                                        name: "Pizza - Large, Seafood, Spicy",
                                                         imageURL: nil,
                                                         itemsSold: 8,
                                                         stockQuantity: 3)


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #12887 
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
There's a bug (p1716558525261959-slack-C06FSDTSN82) in the stock report API that the variation names are not correct for products with 3 or more attributes. I added a workaround to update the variation name using the product attributes as listed in the product report API. This causes a duplicate of attributes in variation names of product with less than 3 attributes.

This PR fixes this by removing the above workaround while waiting for the backend team to fix the bug for the API. This means we have to accept that for products with 3 or more attributes, their variation names don't include detailed attributes for the time being.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->
- Create variable products on your test store: one with 2 attributes and another with 3 attributes. Generate variations using these attributes.
- Update the stock count for at least one variation of the above products to a low number e.g. 1 or 2.
- On the app, enable the Stock card on the dashboard.
- Select the low stock status and confirm that the list displays the variation items above:
  - For variations of products with less than 3 attributes, their names should include the detailed attributes.
  - For variations of products with 3 or more attributes, their names are as the same as their parents' names.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->
Before | After 
--- | ---
<img src="https://github.com/woocommerce/woocommerce-ios/assets/5533851/9eb37a93-b787-4102-ab01-a3c46d1958ea" width=320 /> | <img src="https://github.com/woocommerce/woocommerce-ios/assets/5533851/f6aa2182-cb09-49f8-a7b5-ab1472dfc618" width=320 />


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.