### PR TITLE
Dynamic Dashboard: Tracking events

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -10,6 +10,7 @@
 - [*] Orders: Fixes an issue where adding shipping to an order without selecting a shipping method prevented the order from being created/updated. [https://github.com/woocommerce/woocommerce-ios/pull/12870]
 - [**] Orders: Multiple shipping lines can now be viewed, added, edited, or removed on orders; previously only the first shipping line on an order was supported. [https://github.com/woocommerce/woocommerce-ios/pull/12888]
 - [internal] Orders: An empty order list screen after applying filters no longer affects Dashboard cards eligibility. [https://github.com/woocommerce/woocommerce-ios/pull/12873]
+- [***] Now you can add more sections to the My Store screen including contents for the last orders, top products with low stock, top active coupons and more! [https://github.com/woocommerce/woocommerce-ios/pull/12890]
 
 18.8
 -----

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -10,7 +10,6 @@
 - [*] Orders: Fixes an issue where adding shipping to an order without selecting a shipping method prevented the order from being created/updated. [https://github.com/woocommerce/woocommerce-ios/pull/12870]
 - [**] Orders: Multiple shipping lines can now be viewed, added, edited, or removed on orders; previously only the first shipping line on an order was supported. [https://github.com/woocommerce/woocommerce-ios/pull/12888]
 - [internal] Orders: An empty order list screen after applying filters no longer affects Dashboard cards eligibility. [https://github.com/woocommerce/woocommerce-ios/pull/12873]
-- [***] Now you can add more sections to the My Store screen including contents for the last orders, top products with low stock, top active coupons and more! [https://github.com/woocommerce/woocommerce-ios/pull/12890]
 
 18.8
 -----

--- a/WooCommerce/Classes/Analytics/WooAnalyticsEvent+DynamicDashboard.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsEvent+DynamicDashboard.swift
@@ -6,11 +6,13 @@ extension WooAnalyticsEvent {
         private enum Keys: String {
             case type
             case cards
+            case newCardAvailable = "new_card_available"
         }
 
         /// When the user taps the button to edit the dashboard layout.
-        static func editLayoutButtonTapped() -> WooAnalyticsEvent {
-            WooAnalyticsEvent(statName: .dynamicDashboardEditLayoutButtonTapped, properties: [:])
+        static func editLayoutButtonTapped(isNewCardAvailable: Bool) -> WooAnalyticsEvent {
+            WooAnalyticsEvent(statName: .dynamicDashboardEditLayoutButtonTapped,
+                              properties: [Keys.newCardAvailable.rawValue: isNewCardAvailable])
         }
 
         /// When the user taps on the Hide button in the ellipsis menu of any dashboard card
@@ -30,6 +32,17 @@ extension WooAnalyticsEvent {
         static func cardRetryTapped(type: DashboardCard.CardType) -> WooAnalyticsEvent {
             WooAnalyticsEvent(statName: .dynamicDashboardCardRetryTapped,
                               properties: [Keys.type.rawValue: type.analyticName])
+        }
+
+        /// When the user interacts with the dashboard cards by tapping on any action buttons.
+        static func dashboardCardInteracted(type: DashboardCard.CardType) -> WooAnalyticsEvent {
+            WooAnalyticsEvent(statName: .dynamicDashboardCardInteracted,
+                              properties: [Keys.type.rawValue: type.analyticName])
+        }
+
+        /// When the user taps the Add new sections button on the new cards suggestion.
+        static func dashboardCardAddNewSectionsTapped() -> WooAnalyticsEvent {
+            WooAnalyticsEvent(statName: .dynamicDashboardAddNewSectionsTapped, properties: [:])
         }
     }
 }
@@ -52,7 +65,7 @@ extension DashboardCard.CardType {
         case .reviews:
             "reviews"
         case .lastOrders:
-            "last_orders"
+            "orders"
         case .coupons:
             "coupons"
         }

--- a/WooCommerce/Classes/Analytics/WooAnalyticsStat.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsStat.swift
@@ -185,6 +185,8 @@ enum WooAnalyticsStat: String {
     case dynamicDashboardHideCardTapped = "dynamic_dashboard_hide_card_tapped"
     case dynamicDashboardEditorSaveTapped = "dynamic_dashboard_editor_save_tapped"
     case dynamicDashboardCardRetryTapped = "dynamic_dashboard_card_retry_tapped"
+    case dynamicDashboardCardInteracted = "dynamic_dashboard_card_interacted"
+    case dynamicDashboardAddNewSectionsTapped = "dynamic_dashboard_add_new_sections_tapped"
 
     // MARK: Analytics Hub Events
     //

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Coupons/MostActiveCouponsCard.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Coupons/MostActiveCouponsCard.swift
@@ -116,6 +116,7 @@ private extension MostActiveCouponsCard {
             // Rows
             ForEach(viewModel.rows) { item in
                 MostActiveCouponRow(viewModel: item, tapHandler: {
+                    ServiceLocator.analytics.track(event: .DynamicDashboard.dashboardCardInteracted(type: .coupons))
                     onViewCouponDetail(item.coupon)
                 })
             }
@@ -143,6 +144,7 @@ private extension MostActiveCouponsCard {
 
                 if viewModel.timeRange.isCustomTimeRange {
                     Button {
+                        ServiceLocator.analytics.track(event: .DynamicDashboard.dashboardCardInteracted(type: .coupons))
                         showingCustomRangePicker = true
                     } label: {
                         HStack {
@@ -159,6 +161,8 @@ private extension MostActiveCouponsCard {
             }
             Spacer()
             StatsTimeRangePicker(currentTimeRange: viewModel.timeRange) { newTimeRange in
+                ServiceLocator.analytics.track(event: .DynamicDashboard.dashboardCardInteracted(type: .coupons))
+
                 if newTimeRange.isCustomTimeRange {
                     showingCustomRangePicker = true
                 } else {
@@ -171,6 +175,9 @@ private extension MostActiveCouponsCard {
 
     var viewAllCouponsButton: some View {
         Button {
+
+            ServiceLocator.analytics.track(event: .DynamicDashboard.dashboardCardInteracted(type: .coupons))
+
             onViewAllCoupons()
         } label: {
             HStack {

--- a/WooCommerce/Classes/ViewRelated/Dashboard/DashboardView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/DashboardView.swift
@@ -102,7 +102,7 @@ struct DashboardView: View {
             }
             ToolbarItem(placement: .topBarTrailing) {
                 Button(action: {
-                    ServiceLocator.analytics.track(event: .DynamicDashboard.editLayoutButtonTapped())
+                    ServiceLocator.analytics.track(event: .DynamicDashboard.editLayoutButtonTapped(isNewCardAvailable: viewModel.showNewCardsNotice))
                     viewModel.showCustomizationScreen()
                 }, label: {
                     Text(Localization.edit)
@@ -307,6 +307,8 @@ private extension DashboardView {
                 .padding(.horizontal, Layout.elementPadding)
 
             Button(Localization.NewCardsNoticeCard.addSectionsButtonLabel) {
+                ServiceLocator.analytics.track(event: .DynamicDashboard.dashboardCardAddNewSectionsTapped())
+
                 viewModel.showCustomizationScreen()
             }
             .buttonStyle(PrimaryButtonStyle())

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Inbox/InboxDashboardCard.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Inbox/InboxDashboardCard.swift
@@ -107,6 +107,7 @@ private extension InboxDashboardCard {
 
     var viewAllButton: some View {
         Button {
+            ServiceLocator.analytics.track(event: .DynamicDashboard.dashboardCardInteracted(type: .inbox))
             onShowAllInboxMessages()
         } label: {
             HStack {

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Orders/LastOrdersDashboardCard.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Orders/LastOrdersDashboardCard.swift
@@ -71,6 +71,8 @@ private extension LastOrdersDashboardCard {
 
     var viewAllOrdersButton: some View {
         Button {
+            ServiceLocator.analytics.track(event: .DynamicDashboard.dashboardCardInteracted(type: .lastOrders))
+
             onViewAllOrders()
         } label: {
             HStack {
@@ -117,6 +119,8 @@ private extension LastOrdersDashboardCard {
             Menu {
                 ForEach(viewModel.allStatuses) { status in
                     Button {
+                        ServiceLocator.analytics.track(event: .DynamicDashboard.dashboardCardInteracted(type: .lastOrders))
+
                         Task { @MainActor in
                             await viewModel.updateOrderStatus(status)
                         }
@@ -136,6 +140,8 @@ private extension LastOrdersDashboardCard {
         VStack(alignment: .leading, spacing: Layout.padding) {
             ForEach(viewModel.rows) { element in
                 LastOrderDashboardRow(viewModel: element, tapHandler: {
+                    ServiceLocator.analytics.track(event: .DynamicDashboard.dashboardCardInteracted(type: .lastOrders))
+
                     onViewOrderDetail(element.order)
                 })
             }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/ProductStock/ProductStockDashboardCard.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/ProductStock/ProductStockDashboardCard.swift
@@ -105,6 +105,7 @@ private extension ProductStockDashboardCard {
             Menu {
                 ForEach(ProductStockDashboardCardViewModel.StockType.allCases) { stockType in
                     Button {
+                        ServiceLocator.analytics.track(event: .DynamicDashboard.dashboardCardInteracted(type: .stock))
                         viewModel.updateStockType(stockType)
                     } label: {
                         SelectableItemRow(title: stockType.displayedName, selected: stockType == viewModel.selectedStockType)
@@ -131,6 +132,8 @@ private extension ProductStockDashboardCard {
             }
             ForEach(viewModel.reports) { element in
                 Button {
+                    ServiceLocator.analytics.track(event: .DynamicDashboard.dashboardCardInteracted(type: .stock))
+
                     selectedItem = element
                 } label: {
                     HStack(alignment: .top) {

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Reviews/ReviewsDashboardCard.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Reviews/ReviewsDashboardCard.swift
@@ -99,6 +99,8 @@ private extension ReviewsDashboardCard {
             Menu {
                 ForEach(viewModel.filters, id: \.self) { filter in
                     Button {
+                        ServiceLocator.analytics.track(event: .DynamicDashboard.dashboardCardInteracted(type: .reviews))
+
                         Task {
                             await viewModel.filterReviews(by: filter)
                         }
@@ -125,6 +127,8 @@ private extension ReviewsDashboardCard {
 
     func reviewRow(for viewModel: ReviewViewModel, isLastItem: Bool) -> some View {
         Button {
+            ServiceLocator.analytics.track(event: .DynamicDashboard.dashboardCardInteracted(type: .reviews))
+
             onViewReviewDetail(viewModel)
         } label: {
             HStack(alignment: .firstTextBaseline, spacing: Layout.padding) {
@@ -212,6 +216,8 @@ private extension ReviewsDashboardCard {
 
     var viewAllReviewsButton: some View {
         Button {
+            ServiceLocator.analytics.track(event: .DynamicDashboard.dashboardCardInteracted(type: .reviews))
+
             onViewAllReviews()
         } label: {
             HStack {


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of: #12877 
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

Adds tracking events for Dynamic Dashboard M2 cards.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

New cards available
- Login into the app
- In the Dashboard screen, you should see "Add new section" card at the bottom
- Tap on the "Add new section" button and confirm that `dynamic_dashboard_add_new_sections_tapped` event is tracked
- Switch to a new store and ensure that you see "Add new section" card at the bottom
- Tap the "Edit" button and confirm that the `dynamic_dashboard_edit_layout_button_tapped` event is tracked with `new_card_available` value as `true`. When there are no new cards available `new_card_available` value will be `false` in the event. 

Inbox
- Add Inbox card to the dashboard
- Tap "View all messages" button 
- Confirm that `dynamic_dashboard_card_interacted` event is tracked with `type` as `inbox`. 

Most recent orders
- Add "Most recent orders" card to the dashboard
- Tap "View all orders" button 
- Confirm that `dynamic_dashboard_card_interacted` event is tracked with `type` as `orders`. 
- Switch "Status" and confirm that `dynamic_dashboard_card_interacted` event is tracked with `type` as `orders`. 
- Tap on an order and confirm that `dynamic_dashboard_card_interacted` event is tracked with `type` as `orders`. 

Most recent reviews
- Add "Most recent reviews" card to the dashboard
- Tap "View all reviews" button 
- Confirm that `dynamic_dashboard_card_interacted` event is tracked with `type` as `reviews`. 
- Switch "Status" and confirm that `dynamic_dashboard_card_interacted` event is tracked with `type` as `reviews`. 
- Tap on a review and confirm that `dynamic_dashboard_card_interacted` event is tracked with `type` as `reviews`. 

Most active coupons
- Add "Most active coupons" card to the dashboard
- Tap "View all coupons" button 
- Confirm that `dynamic_dashboard_card_interacted` event is tracked with `type` as `coupons`. 
- Switch time range and confirm that `dynamic_dashboard_card_interacted` event is tracked with `type` as `coupons`. 
- Tap on a coupon and confirm that `dynamic_dashboard_card_interacted` event is tracked with `type` as `coupons`. 

Stock
- Add "Stock" card to the dashboard
- Switch stock status and confirm that `dynamic_dashboard_card_interacted` event is tracked with `type` as `stock`. 
- Tap on a coupon and confirm that `dynamic_dashboard_card_interacted` event is tracked with `type` as `stock`. 

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

| Most recent reviews | Stock | Most active coupons | Most recent orders | Inbox |
|--------|--------|--------|--------|--------|
| <img width="349" alt="image" src="https://github.com/woocommerce/woocommerce-ios/assets/524475/bd7b0e97-403f-42d3-b57f-48b7911dd083"> | <img width="354" alt="image" src="https://github.com/woocommerce/woocommerce-ios/assets/524475/1faaa404-d2e4-4c3a-b39e-22d8e10cfddb"> | <img width="353" alt="image" src="https://github.com/woocommerce/woocommerce-ios/assets/524475/0de6547f-7865-437c-bbaa-b110495b7b61"> | <img width="356" alt="image" src="https://github.com/woocommerce/woocommerce-ios/assets/524475/33bbc271-ce14-4931-8be8-57b833c26068"> | <img width="344" alt="image" src="https://github.com/woocommerce/woocommerce-ios/assets/524475/603cb375-3318-455f-a6d8-f4022b37039e"> | 

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
