### PR TITLE
[Shipping Lines] Clean up feature flag for multiple shipping lines support

### DIFF
--- a/Experiments/Experiments/DefaultFeatureFlagService.swift
+++ b/Experiments/Experiments/DefaultFeatureFlagService.swift
@@ -90,8 +90,6 @@ public struct DefaultFeatureFlagService: FeatureFlagService {
             return buildConfig == .localDeveloper || buildConfig == .alpha
         case .dynamicDashboardM2:
             return buildConfig == .localDeveloper || buildConfig == .alpha
-        case .multipleShippingLines:
-            return true
         default:
             return true
         }

--- a/Experiments/Experiments/FeatureFlag.swift
+++ b/Experiments/Experiments/FeatureFlag.swift
@@ -199,8 +199,4 @@ public enum FeatureFlag: Int {
     /// Enables new dashboard cards on the My Store screen.
     ///
     case dynamicDashboardM2
-
-    /// Enables multiple shipping lines in order details and order creation/editing.
-    ///
-    case multipleShippingLines
 }

--- a/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsDataSource.swift
+++ b/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsDataSource.swift
@@ -398,8 +398,6 @@ private extension OrderDetailsDataSource {
             configureBillingDetail(cell: cell)
         case let cell as WooBasicTableViewCell where row == .shippingLabelDetail:
             configureShippingLabelDetail(cell: cell)
-        case let cell as ImageAndTitleAndTextTableViewCell where row == .shippingNotice:
-            configureShippingNotice(cell: cell)
         case let cell as WCShipInstallTableViewCell where row == .installWCShip:
             configureInstallWCShip(cell: cell)
         case let cell as ImageAndTitleAndTextTableViewCell where row == .shippingLabelCreationInfo(showsSeparator: true),
@@ -544,29 +542,6 @@ private extension OrderDetailsDataSource {
             "Show the billing details for this order.",
             comment: "VoiceOver accessibility hint, informing the user that the button can be used to view billing information."
         )
-    }
-
-    private func configureShippingNotice(cell: ImageAndTitleAndTextTableViewCell) {
-        let cellTextContent = NSLocalizedString(
-            "This order is using extensions to calculate shipping. The shipping methods shown might be incomplete.",
-            comment: "Shipping notice row label when there is more than one shipping method")
-
-        cell.update(with: .imageAndTitleOnly(fontStyle: .body),
-                    data: .init(title: cellTextContent,
-                                textTintColor: .text,
-                                image: Icons.shippingNoticeIcon,
-                                imageTintColor: .listIcon,
-                                numberOfLinesForTitle: 0,
-                                isActionable: false))
-
-        cell.selectionStyle = .none
-
-        cell.accessibilityTraits = .staticText
-        cell.accessibilityLabel = NSLocalizedString(
-            "This order is using extensions to calculate shipping. The shipping methods shown might be incomplete.",
-            comment: "Accessibility label for the Shipping notice")
-        cell.accessibilityHint = NSLocalizedString("Shipping notice about the order",
-                                                    comment: "VoiceOver accessibility label for the shipping notice about the order")
     }
 
     private func configureInstallWCShip(cell: WCShipInstallTableViewCell) {
@@ -1161,18 +1136,6 @@ extension OrderDetailsDataSource {
 
         let summary = Section(category: .summary, row: .summary)
 
-        let shippingNotice: Section? = {
-            // Hide the shipping method warning if order contains only virtual products
-            // or if the order contains only one shipping method
-            // or if multiple shipping lines are supported (feature flag)
-            if isMultiShippingLinesAvailable(for: order) == false ||
-                featureFlags.isFeatureFlagEnabled(.multipleShippingLines) {
-                return nil
-            }
-
-            return Section(category: .shippingNotice, title: nil, rightTitle: nil, footer: nil, rows: [.shippingNotice])
-        }()
-
         let products: Section? = {
             if items.isEmpty {
                 return nil
@@ -1473,7 +1436,6 @@ extension OrderDetailsDataSource {
         }()
 
         sections = ([summary,
-                     shippingNotice,
                      products,
                      customAmountsSection,
                      customFields,
@@ -1717,7 +1679,6 @@ extension OrderDetailsDataSource {
     }
 
     enum Icons {
-        static let shippingNoticeIcon = UIImage.noticeImage
         static let plusImage = UIImage.plusImage
     }
 
@@ -1788,7 +1749,6 @@ extension OrderDetailsDataSource {
     struct Section {
         enum Category {
             case summary
-            case shippingNotice
             case products
             case customAmounts
             case installWCShip
@@ -1906,7 +1866,6 @@ extension OrderDetailsDataSource {
         case shippingLabelReprintButton
         case shippingLabelTrackingNumber
         case shippingLine
-        case shippingNotice
         case addOrderNote
         case orderNoteHeader
         case orderNote
@@ -1976,8 +1935,6 @@ extension OrderDetailsDataSource {
                 return ImageAndTitleAndTextTableViewCell.reuseIdentifier
             case .shippingLabelReprintButton:
                 return ButtonTableViewCell.reuseIdentifier
-            case .shippingNotice:
-                return ImageAndTitleAndTextTableViewCell.reuseIdentifier
             case .addOrderNote:
                 return LargeHeightLeftImageTableViewCell.reuseIdentifier
             case .orderNoteHeader:

--- a/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsDataSource.swift
+++ b/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsDataSource.swift
@@ -184,12 +184,6 @@ final class OrderDetailsDataSource: NSObject {
         return order.shippingLines.sorted(by: { $0.shippingID < $1.shippingID })
     }
 
-    /// First Shipping method from an order
-    ///
-    private var shippingMethod: String {
-        return shippingLines.first?.methodTitle ?? String()
-    }
-
     /// Yosemite.OrderItem
     /// The original list of order items a user purchased
     ///
@@ -392,8 +386,6 @@ private extension OrderDetailsDataSource {
             configureShippingAddress(cell: cell)
         case let cell as CustomerNoteTableViewCell where row == .customerNote:
             configureCustomerNote(cell: cell)
-        case let cell as CustomerNoteTableViewCell where row == .shippingMethod:
-            configureShippingMethod(cell: cell)
         case let cell as WooBasicTableViewCell where row == .billingDetail:
             configureBillingDetail(cell: cell)
         case let cell as WooBasicTableViewCell where row == .shippingLabelDetail:
@@ -982,13 +974,6 @@ private extension OrderDetailsDataSource {
         cell.configureLayout()
     }
 
-    private func configureShippingMethod(cell: CustomerNoteTableViewCell) {
-        cell.headline = NSLocalizedString("Shipping Method",
-                                          comment: "Shipping method title for customer info cell")
-        cell.body = shippingMethod.strippedHTML
-        cell.selectionStyle = .none
-    }
-
     private func configureShippingLine(cell: HostingConfigurationTableViewCell<ShippingLineRowView>, at indexPath: IndexPath) {
         let shippingLine = shippingLines[indexPath.row]
         let viewModel = ShippingLineRowViewModel(shippingLine: shippingLine, shippingMethods: siteShippingMethods, editable: false)
@@ -1250,8 +1235,7 @@ extension OrderDetailsDataSource {
         }()
 
         let shippingLinesSection: Section? = {
-            guard shippingLines.count > 0
-                    && featureFlags.isFeatureFlagEnabled(.multipleShippingLines) else {
+            guard shippingLines.count > 0 else {
                 return nil
             }
 
@@ -1274,12 +1258,6 @@ extension OrderDetailsDataSource {
 
             if order.shippingAddress != nil && orderContainsOnlyVirtualProducts == false {
                 rows.append(.shippingAddress)
-            }
-
-            /// Shipping Lines (single shipping line)
-            if shippingLines.count > 0
-                && !featureFlags.isFeatureFlagEnabled(.multipleShippingLines) {
-                rows.append(.shippingMethod)
             }
 
             /// Billing Address
@@ -1843,7 +1821,6 @@ extension OrderDetailsDataSource {
         case issueRefundButton
         case customerNote
         case shippingAddress
-        case shippingMethod
         case billingDetail
         case payment
         case customerPaid
@@ -1897,8 +1874,6 @@ extension OrderDetailsDataSource {
                 return CustomerNoteTableViewCell.reuseIdentifier
             case .shippingAddress:
                 return CustomerInfoTableViewCell.reuseIdentifier
-            case .shippingMethod:
-                return CustomerNoteTableViewCell.reuseIdentifier
             case .billingDetail:
                 return WooBasicTableViewCell.reuseIdentifier
             case .payment:

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/EditableOrderViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/EditableOrderViewModel.swift
@@ -254,10 +254,6 @@ final class EditableOrderViewModel: ObservableObject {
     ///
     @Published private var isGiftCardSupported: Bool = false
 
-    /// Defines the multiple lines info message to show.
-    ///
-    @Published private(set) var multipleLinesMessage: String? = nil
-
     @Published var selectionSyncApproach: OrderItemSelectionSyncApproach = .onSelectorButtonTap
 
     enum OrderItemSelectionSyncApproach {
@@ -523,7 +519,6 @@ final class EditableOrderViewModel: ObservableObject {
         configurePaymentDataViewModel()
         configureCustomerNoteDataViewModel()
         configureNonEditableIndicators()
-        configureMultipleLinesMessage()
         resetAddressForm()
         syncInitialSelectedState()
         configureTaxRates()
@@ -1848,23 +1843,6 @@ private extension EditableOrderViewModel {
             .assign(to: &$shouldShowNonEditableIndicators)
     }
 
-    /// Binds the order state to the `multipleLineMessage` property.
-    ///
-    func configureMultipleLinesMessage() {
-        Publishers.CombineLatest(orderSynchronizer.orderPublisher, Just(flow))
-            .map { order, flow -> String? in
-                switch (flow, order.shippingLines.count) {
-                case (.creation, _):
-                    return nil
-                case (.editing, 2...Int.max): // Multiple shipping lines
-                    return Localization.multipleShippingLines
-                case (.editing, _): // Single/nil shipping & fee lines
-                    return nil
-                }
-            }
-            .assign(to: &$multipleLinesMessage)
-    }
-
     func configureTaxRates() {
         // Tax rates are not configurable if the order is not editable.
         // In the creation flow orders are initially (incorrectly) reported as not editable, so we have to check the flow here as well
@@ -2629,13 +2607,6 @@ private extension EditableOrderViewModel {
         static let invalidBillingSuggestion =
         NSLocalizedString("Please make sure you are running the latest version of WooCommerce and try again later.",
                           comment: "Recovery suggestion when we fail to update an address when creating or editing an order")
-
-        static let multipleShippingLines = NSLocalizedString("Shipping details are incomplete.\n" +
-                                                             "To edit all shipping details, view the order in your WooCommerce store admin.",
-                                                             comment: "Info message shown when the order contains multiple shipping lines")
-        static let multipleFeesAndShippingLines = NSLocalizedString("Fees & Shipping details are incomplete.\n" +
-                                                                    "To edit all the details, view the order in your WooCommerce store admin.",
-                                                                    comment: "Info message shown when the order contains multiple fees and shipping lines")
         static let couponsErrorNoticeTitle = NSLocalizedString("Unable to add coupon.",
                                                                  comment: "Info message when the user tries to add a coupon" +
                                                                  "that is not applicated to the products")

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/OrderForm.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/OrderForm.swift
@@ -302,25 +302,16 @@ struct OrderForm: View {
                             }
                             .renderedIf(viewModel.shippingUseCase.multipleShippingLinesEnabled)
 
-                            Group {
-                                if let title = viewModel.multipleLinesMessage,
-                                   !viewModel.shippingUseCase.multipleShippingLinesEnabled {
-                                    MultipleLinesMessage(title: title)
-                                    Spacer(minLength: Layout.sectionSpacing)
-                                }
-
-                                Divider()
-                                AddOrderComponentsSection(
-                                    viewModel: viewModel.paymentDataViewModel,
-                                    shippingUseCase: viewModel.shippingUseCase,
-                                    shouldShowCouponsInfoTooltip: $shouldShowInformationalCouponTooltip,
-                                    shouldShowShippingLineDetails: $shouldShowShippingLineDetails,
-                                    shouldShowGiftCardForm: $shouldShowGiftCardForm)
-                                .disabled(viewModel.shouldShowNonEditableIndicators)
-                                .sheet(isPresented: $shouldShowShippingLineDetails) {
-                                    ShippingLineSelectionDetails(viewModel: viewModel.shippingUseCase.paymentData.shippingLineSelectionViewModel)
-                                }
-                                Divider()
+                            AddOrderComponentsSection(
+                                viewModel: viewModel.paymentDataViewModel,
+                                shippingUseCase: viewModel.shippingUseCase,
+                                shouldShowCouponsInfoTooltip: $shouldShowInformationalCouponTooltip,
+                                shouldShowShippingLineDetails: $shouldShowShippingLineDetails,
+                                shouldShowGiftCardForm: $shouldShowGiftCardForm)
+                            .addingTopAndBottomDividers()
+                            .disabled(viewModel.shouldShowNonEditableIndicators)
+                            .sheet(isPresented: $shouldShowShippingLineDetails) {
+                                ShippingLineSelectionDetails(viewModel: viewModel.shippingUseCase.addShippingLineViewModel())
                             }
 
                             Spacer(minLength: Layout.sectionSpacing)
@@ -548,39 +539,6 @@ struct OrderForm: View {
             .buttonStyle(PrimaryLoadingButtonStyle(isLoading: loading))
             .accessibilityIdentifier(Accessibility.doneButtonIdentifier)
         }
-    }
-}
-
-/// Represents an information message to indicate about multiple shipping or fee lines.
-///
-private struct MultipleLinesMessage: View {
-
-    /// Message to display.
-    ///
-    let title: String
-
-    ///   Environment safe areas
-    ///
-    @Environment(\.safeAreaInsets) private var safeAreaInsets: EdgeInsets
-
-    var body: some View {
-        VStack(alignment: .leading, spacing: OrderForm.Layout.noSpacing) {
-            Divider()
-
-            HStack(spacing: OrderForm.Layout.sectionSpacing) {
-
-                Image(uiImage: .infoImage)
-                    .foregroundColor(Color(.brand))
-
-                Text(title)
-                    .bodyStyle()
-            }
-            .padding()
-            .padding(.horizontal, insets: safeAreaInsets)
-
-            Divider()
-        }
-        .background(Color(.listForeground(modal: true)))
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/OrderForm.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/OrderForm.swift
@@ -300,7 +300,7 @@ struct OrderForm: View {
                                     .disabled(viewModel.shouldShowNonEditableIndicators)
                                 Spacer(minLength: Layout.sectionSpacing)
                             }
-                            .renderedIf(viewModel.shippingUseCase.multipleShippingLinesEnabled)
+                            .renderedIf(viewModel.shippingUseCase.shippingLineRows.isNotEmpty)
 
                             AddOrderComponentsSection(
                                 viewModel: viewModel.paymentDataViewModel,

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/OrderForm.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/OrderForm.swift
@@ -403,7 +403,6 @@ struct OrderForm: View {
                 OrderPaymentSection(
                     viewModel: viewModel.paymentDataViewModel,
                     shippingUseCase: viewModel.shippingUseCase,
-                    shouldShowShippingLineDetails: $shouldShowShippingLineDetails,
                     shouldShowGiftCardForm: $shouldShowGiftCardForm)
                 .disabled(viewModel.shouldShowNonEditableIndicators)
             }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/PaymentSection/OrderPaymentSection.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/PaymentSection/OrderPaymentSection.swift
@@ -10,10 +10,6 @@ struct OrderPaymentSection: View {
     /// Use case for shipping lines on an order
     let shippingUseCase: EditableOrderShippingUseCase
 
-    /// Indicates if the shipping line details screen should be shown or not.
-    ///
-    @Binding private var shouldShowShippingLineDetails: Bool
-
     /// Indicates if the gift card code input sheet should be shown or not.
     ///
     @Binding private var shouldShowGiftCardForm: Bool
@@ -41,11 +37,9 @@ struct OrderPaymentSection: View {
 
     init(viewModel: EditableOrderViewModel.PaymentDataViewModel,
          shippingUseCase: EditableOrderShippingUseCase,
-         shouldShowShippingLineDetails: Binding<Bool>,
          shouldShowGiftCardForm: Binding<Bool>) {
         self.viewModel = viewModel
         self.shippingUseCase = shippingUseCase
-        self._shouldShowShippingLineDetails = shouldShowShippingLineDetails
         self._shouldShowGiftCardForm = shouldShowGiftCardForm
     }
 
@@ -99,18 +93,9 @@ private extension OrderPaymentSection {
     }
 
     @ViewBuilder var existingShippingRow: some View {
-        if shippingUseCase.paymentData.isShippingTotalEditable {
-            TitleAndValueRow(title: Localization.shippingTotal,
-                             titleSuffixImage: (image: rowsEditImage, color: Color(.primary)),
-                             value: .content(shippingUseCase.paymentData.shippingTotal),
-                             selectionStyle: editableRowsSelectionStyle) {
-                shouldShowShippingLineDetails = true
-            }.renderedIf(shippingUseCase.paymentData.shouldShowShippingTotal)
-        } else {
-            TitleAndValueRow(title: Localization.shippingTotal,
-                             value: .content(shippingUseCase.paymentData.shippingTotal))
-            .renderedIf(shippingUseCase.paymentData.shouldShowShippingTotal)
-        }
+        TitleAndValueRow(title: Localization.shippingTotal,
+                         value: .content(shippingUseCase.paymentData.shippingTotal))
+        .renderedIf(shippingUseCase.paymentData.shouldShowShippingTotal)
     }
 
     @ViewBuilder var productsRow: some View {
@@ -343,7 +328,6 @@ struct OrderPaymentSection_Previews: PreviewProvider {
 
         OrderPaymentSection(viewModel: viewModel,
                             shippingUseCase: shippingUseCase,
-                            shouldShowShippingLineDetails: .constant(false),
                             shouldShowGiftCardForm: .constant(false))
             .previewLayout(.sizeThatFits)
     }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/Shipping/EditableOrderShippingUseCase.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/Shipping/EditableOrderShippingUseCase.swift
@@ -9,7 +9,6 @@ import Combine
 final class EditableOrderShippingUseCase: ObservableObject {
     private var siteID: Int64
     private var analytics: Analytics
-    private var featureFlagService: FeatureFlagService
     private var storageManager: StorageManagerType
     private var stores: StoresManager
     private var orderSynchronizer: OrderSynchronizer
@@ -21,12 +20,6 @@ final class EditableOrderShippingUseCase: ObservableObject {
     /// Defines if the non editable indicators (banners, locks, fields) should be shown.
     ///
     @Published private(set) var shouldShowNonEditableIndicators: Bool = false
-
-    /// Multiple shipping lines support
-    ///
-    var multipleShippingLinesEnabled: Bool {
-        featureFlagService.isFeatureFlagEnabled(.multipleShippingLines)
-    }
 
     // MARK: View models
 
@@ -83,15 +76,13 @@ final class EditableOrderShippingUseCase: ObservableObject {
          analytics: Analytics = ServiceLocator.analytics,
          storageManager: StorageManagerType = ServiceLocator.storageManager,
          stores: StoresManager = ServiceLocator.stores,
-         currencySettings: CurrencySettings = ServiceLocator.currencySettings,
-         featureFlagService: FeatureFlagService = ServiceLocator.featureFlagService) {
+         currencySettings: CurrencySettings = ServiceLocator.currencySettings) {
         self.siteID = siteID
         self.flow = flow
         self.analytics = analytics
         self.storageManager = storageManager
         self.stores = stores
         self.orderSynchronizer = orderSynchronizer
-        self.featureFlagService = featureFlagService
 
         configurePaymentData()
         configureNonEditableIndicators()
@@ -152,10 +143,6 @@ private extension EditableOrderShippingUseCase {
     func configureShippingLineRowViewModels() {
         updateShippingMethodsResultsController()
         syncShippingMethods()
-
-        guard multipleShippingLinesEnabled else {
-            return
-        }
 
         orderSynchronizer.orderPublisher
             .map { $0.shippingLines }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/Shipping/OrderShippingSection.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/Shipping/OrderShippingSection.swift
@@ -38,7 +38,6 @@ struct OrderShippingSection: View {
         .padding()
         .background(Color(.listForeground(modal: true)))
         .addingTopAndBottomDividers()
-        .renderedIf(useCase.shippingLineRows.isNotEmpty)
         .sheet(isPresented: $showAddShippingLine, content: {
             ShippingLineSelectionDetails(viewModel: useCase.addShippingLineViewModel())
         })

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/Synchronizer/ShippingInputTransformer.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/Synchronizer/ShippingInputTransformer.swift
@@ -8,21 +8,6 @@ struct ShippingInputTransformer {
     /// Adds or updates a shipping line input into an existing order.
     ///
     static func update(input: ShippingLine, on order: Order) -> Order {
-        guard ServiceLocator.featureFlagService.isFeatureFlagEnabled(.multipleShippingLines) else {
-            // If there is no existing shipping lines, we insert the input one.
-            guard let existingShippingLine = order.shippingLines.first else {
-                let newShippingLine = input.methodID?.isNotEmpty == true ? input : OrderFactory.noMethodShippingLine(input)
-                return order.copy(shippingTotal: newShippingLine.total, shippingLines: [newShippingLine])
-            }
-
-            // Since we only support one shipping line, if we find one, we update the existing with the new input values.
-            var updatedLines = order.shippingLines
-            let updatedShippingLine = existingShippingLine.copy(methodTitle: input.methodTitle, methodID: input.methodID, total: input.total)
-            updatedLines[0] = updatedShippingLine
-
-            return order.copy(shippingTotal: calculateTotals(from: updatedLines), shippingLines: updatedLines)
-        }
-
         var updatedLines = order.shippingLines
 
         // If the order contains the shipping line, we update it with the new input values.

--- a/WooCommerce/WooCommerceTests/Mocks/MockFeatureFlagService.swift
+++ b/WooCommerce/WooCommerceTests/Mocks/MockFeatureFlagService.swift
@@ -22,7 +22,6 @@ struct MockFeatureFlagService: FeatureFlagService {
     private let isBackendReceiptsEnabled: Bool
     private let sideBySideViewForOrderForm: Bool
     private let isSubscriptionsInOrderCreationCustomersEnabled: Bool
-    private let isMultipleShippingLinesEnabled: Bool
     private let isDisplayPointOfSaleToggleEnabled: Bool
     private let isDynamicDashboardM2Enabled: Bool
 
@@ -46,7 +45,6 @@ struct MockFeatureFlagService: FeatureFlagService {
          isBackendReceiptsEnabled: Bool = false,
          sideBySideViewForOrderForm: Bool = false,
          isSubscriptionsInOrderCreationCustomersEnabled: Bool = false,
-         isMultipleShippingLinesEnabled: Bool = false,
          isDisplayPointOfSaleToggleEnabled: Bool = false,
          isDynamicDashboardM2Enabled: Bool = false) {
         self.isInboxOn = isInboxOn
@@ -69,7 +67,6 @@ struct MockFeatureFlagService: FeatureFlagService {
         self.isBackendReceiptsEnabled = isBackendReceiptsEnabled
         self.sideBySideViewForOrderForm = sideBySideViewForOrderForm
         self.isSubscriptionsInOrderCreationCustomersEnabled = isSubscriptionsInOrderCreationCustomersEnabled
-        self.isMultipleShippingLinesEnabled = isMultipleShippingLinesEnabled
         self.isDisplayPointOfSaleToggleEnabled = isDisplayPointOfSaleToggleEnabled
         self.isDynamicDashboardM2Enabled = isDynamicDashboardM2Enabled
     }
@@ -114,8 +111,6 @@ struct MockFeatureFlagService: FeatureFlagService {
             return sideBySideViewForOrderForm
         case .subscriptionsInOrderCreationCustomers:
             return isSubscriptionsInOrderCreationCustomersEnabled
-        case .multipleShippingLines:
-            return isMultipleShippingLinesEnabled
         case .displayPointOfSaleToggle:
             return isDisplayPointOfSaleToggleEnabled
         case .dynamicDashboardM2:

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/EditableOrderViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/EditableOrderViewModelTests.swift
@@ -1980,39 +1980,6 @@ final class EditableOrderViewModelTests: XCTestCase {
         XCTAssertFalse(viewModel.shouldShowNonEditableIndicators)
     }
 
-    func test_zero_fees_and_shipping_lines_order_displays_nil_message() {
-        // Given
-        let order = Order.fake()
-
-        // When
-        let viewModel = EditableOrderViewModel(siteID: sampleSiteID, flow: .editing(initialOrder: order))
-
-        // Then
-        XCTAssertNil(viewModel.multipleLinesMessage)
-    }
-
-    func test_one_shipping_and_fee_line_order_displays_nil_message() {
-        // Given
-        let order = Order.fake().copy(shippingLines: [.fake()], fees: [.fake()])
-
-        // When
-        let viewModel = EditableOrderViewModel(siteID: sampleSiteID, flow: .editing(initialOrder: order))
-
-        // Then
-        XCTAssertNil(viewModel.multipleLinesMessage)
-    }
-
-    func test_multiple_shipping_line_order_displays_info_message() {
-        // Given
-        let order = Order.fake().copy(shippingLines: [.fake(), .fake()])
-
-        // When
-        let viewModel = EditableOrderViewModel(siteID: sampleSiteID, flow: .editing(initialOrder: order))
-
-        // Then
-        XCTAssertNotNil(viewModel.multipleLinesMessage)
-    }
-
     func test_capturePermissionStatus_is_notDetermined_when_permissionChecker_is_notDetermined() {
         // Given
         let permissionChecker = MockCaptureDevicePermissionChecker(authorizationStatus: .notDetermined)

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/EditableOrderViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/EditableOrderViewModelTests.swift
@@ -3137,11 +3137,9 @@ final class EditableOrderViewModelTests: XCTestCase {
         // Given
         let shippingLine = ShippingLine.fake().copy(shippingID: 1, methodTitle: "Package 1")
         let order = Order.fake().copy(siteID: sampleSiteID, shippingLines: [shippingLine])
-        let featureFlagService = MockFeatureFlagService(isMultipleShippingLinesEnabled: true)
         let viewModel = EditableOrderViewModel(siteID: sampleSiteID,
                                                flow: .editing(initialOrder: order),
-                                               storageManager: storageManager,
-                                               featureFlagService: featureFlagService)
+                                               storageManager: storageManager)
 
         // When
         viewModel.shippingUseCase.shippingLineRows.first?.editShippingLine()

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/Shipping/EditableOrderShippingUseCaseTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/Shipping/EditableOrderShippingUseCaseTests.swift
@@ -27,8 +27,7 @@ final class EditableOrderShippingUseCaseTests: XCTestCase {
                                                    analytics: WooAnalytics(analyticsProvider: analytics),
                                                    storageManager: storageManager,
                                                    stores: stores,
-                                                   currencySettings: currencySettings,
-                                                   featureFlagService: MockFeatureFlagService(isMultipleShippingLinesEnabled: true))
+                                                   currencySettings: currencySettings)
     }
 
     // MARK: Initialization
@@ -67,8 +66,7 @@ final class EditableOrderShippingUseCaseTests: XCTestCase {
                                                        orderSynchronizer: RemoteOrderSynchronizer(siteID: sampleSiteID,
                                                                                                   flow: .editing(initialOrder: order),
                                                                                                   stores: stores),
-                                                       storageManager: storageManager,
-                                                       featureFlagService: MockFeatureFlagService(isMultipleShippingLinesEnabled: true))
+                                                       storageManager: storageManager)
 
         // Then
         assertEqual(1, useCase.shippingLineRows.count)
@@ -180,8 +178,7 @@ final class EditableOrderShippingUseCaseTests: XCTestCase {
                                                        flow: .editing(initialOrder: order),
                                                        orderSynchronizer: RemoteOrderSynchronizer(siteID: sampleSiteID,
                                                                                                   flow: .editing(initialOrder: order),
-                                                                                                  stores: stores),
-                                                       featureFlagService: MockFeatureFlagService(isMultipleShippingLinesEnabled: true))
+                                                                                                  stores: stores))
 
         // When
         useCase.shippingLineRows.first?.editShippingLine()

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/Synchronizer/ShippingInputTransformerTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/Synchronizer/ShippingInputTransformerTests.swift
@@ -10,13 +10,8 @@ class ShippingInputTransformerTests: XCTestCase {
     private let sampleShippingID: Int64 = 123
     private let sampleMethodID = "other"
 
-    // MARK: Multiple Shipping Lines Enabled
-
     func test_new_input_adds_shipping_line_to_order() throws {
         // Given
-        let featureFlagService = MockFeatureFlagService(isMultipleShippingLinesEnabled: true)
-        ServiceLocator.setFeatureFlagService(featureFlagService)
-
         let order = Order.fake()
         let input = ShippingLine.fake().copy(methodID: sampleMethodID, total: "10.00")
 
@@ -31,9 +26,6 @@ class ShippingInputTransformerTests: XCTestCase {
 
     func test_new_input_adds_expected_shipping_line_to_order() throws {
         // Given
-        let featureFlagService = MockFeatureFlagService(isMultipleShippingLinesEnabled: true)
-        ServiceLocator.setFeatureFlagService(featureFlagService)
-
         let order = Order.fake()
         let input = ShippingLine.fake().copy(methodID: "flat_rate", total: "10.00")
 
@@ -48,9 +40,6 @@ class ShippingInputTransformerTests: XCTestCase {
 
     func test_new_input_with_no_shipping_method_adds_expected_shipping_line_to_order() throws {
         // Given
-        let featureFlagService = MockFeatureFlagService(isMultipleShippingLinesEnabled: true)
-        ServiceLocator.setFeatureFlagService(featureFlagService)
-
         let order = Order.fake()
         let input = ShippingLine.fake().copy(methodID: "", total: "10.00")
 
@@ -65,9 +54,6 @@ class ShippingInputTransformerTests: XCTestCase {
 
     func test_new_input_updates_matching_shipping_line_from_order() throws {
         // Given
-        let featureFlagService = MockFeatureFlagService(isMultipleShippingLinesEnabled: true)
-        ServiceLocator.setFeatureFlagService(featureFlagService)
-
         let shipping = ShippingLine.fake().copy(shippingID: sampleShippingID, methodID: sampleMethodID, total: "10.00")
         let shipping2 = ShippingLine.fake().copy(shippingID: sampleShippingID + 1, methodID: sampleMethodID, total: "12.00")
         let order = Order.fake().copy(shippingLines: [shipping, shipping2])
@@ -85,105 +71,5 @@ class ShippingInputTransformerTests: XCTestCase {
 
         let shippingLine = try XCTUnwrap(updatedOrder.shippingLines.first)
         assertEqual(shippingLine, shipping)
-    }
-
-    // MARK: Multiple Shipping Lines Disabled
-
-    func test_new_input_adds_shipping_line_to_order_with_feature_flag_disabled() throws {
-        // Given
-        let featureFlagService = MockFeatureFlagService(isMultipleShippingLinesEnabled: false)
-        ServiceLocator.setFeatureFlagService(featureFlagService)
-
-        let order = Order.fake()
-        let input = ShippingLine.fake().copy(methodID: sampleMethodID, total: "10.00")
-
-        // When
-        let updatedOrder = ShippingInputTransformer.update(input: input, on: order)
-
-        // Then
-        let shippingLine = try XCTUnwrap(updatedOrder.shippingLines.first)
-        XCTAssertEqual(shippingLine, input)
-        XCTAssertEqual(updatedOrder.shippingTotal, input.total)
-    }
-
-    func test_new_input_adds_expected_shipping_line_to_order_with_feature_flag_disabled() throws {
-        // Given
-        let featureFlagService = MockFeatureFlagService(isMultipleShippingLinesEnabled: false)
-        ServiceLocator.setFeatureFlagService(featureFlagService)
-
-        let order = Order.fake()
-        let input = ShippingLine.fake().copy(methodID: "flat_rate", total: "10.00")
-
-        // When
-        let updatedOrder = ShippingInputTransformer.update(input: input, on: order)
-
-        // Then
-        let shippingLine = try XCTUnwrap(updatedOrder.shippingLines.first)
-        XCTAssertEqual(shippingLine, input)
-        XCTAssertEqual(updatedOrder.shippingTotal, input.total)
-    }
-
-    func test_new_input_with_no_shipping_method_adds_expected_shipping_line_to_order_with_feature_flag_disabled() throws {
-        // Given
-        let featureFlagService = MockFeatureFlagService(isMultipleShippingLinesEnabled: false)
-        ServiceLocator.setFeatureFlagService(featureFlagService)
-
-        let order = Order.fake()
-        let input = ShippingLine.fake().copy(methodID: "", total: "10.00")
-
-        // When
-        let updatedOrder = ShippingInputTransformer.update(input: input, on: order)
-
-        // Then
-        let shippingLine = try XCTUnwrap(updatedOrder.shippingLines.first)
-        XCTAssertEqual(shippingLine, input.copy(methodID: " "))
-        XCTAssertEqual(updatedOrder.shippingTotal, input.total)
-    }
-
-    func test_new_input_deletes_matching_shipping_line_from_order_with_feature_flag_disabled() throws {
-        // Given
-        let featureFlagService = MockFeatureFlagService(isMultipleShippingLinesEnabled: false)
-        ServiceLocator.setFeatureFlagService(featureFlagService)
-
-        let shipping = ShippingLine.fake().copy(shippingID: sampleShippingID, methodID: sampleMethodID, total: "10.00")
-        let shipping2 = ShippingLine.fake().copy(shippingID: sampleShippingID + 1, methodID: sampleMethodID, total: "12.00")
-        let order = Order.fake().copy(shippingLines: [shipping, shipping2])
-
-        // When
-        let updatedOrder = ShippingInputTransformer.remove(input: shipping2, from: order)
-
-        // Then
-        let shippingLineToRemove = try XCTUnwrap(updatedOrder.shippingLines[safe: 1])
-        XCTAssertNil(shippingLineToRemove.methodID)
-        XCTAssertEqual(shippingLineToRemove.shippingID, shipping2.shippingID)
-        XCTAssertEqual(shippingLineToRemove.total, "0")
-        XCTAssertEqual(updatedOrder.shippingTotal, "10.0")
-
-        let remainingShippingLine = try XCTUnwrap(updatedOrder.shippingLines.first)
-        XCTAssertEqual(shipping, remainingShippingLine)
-    }
-
-    func test_new_input_updates_first_shipping_line_from_order_with_feature_flag_disabled() throws {
-        // Given
-        let featureFlagService = MockFeatureFlagService(isMultipleShippingLinesEnabled: false)
-        ServiceLocator.setFeatureFlagService(featureFlagService)
-
-        let shipping = ShippingLine.fake().copy(shippingID: sampleShippingID, methodID: sampleMethodID, total: "10.00")
-        let shipping2 = ShippingLine.fake().copy(shippingID: sampleShippingID + 1, methodID: sampleMethodID, total: "12.00")
-        let order = Order.fake().copy(shippingLines: [shipping, shipping2])
-
-        // When
-        let input = ShippingLine.fake().copy(methodID: sampleMethodID, total: "12.00")
-        let updatedOrder = ShippingInputTransformer.update(input: input, on: order)
-
-        // Then
-        let shippingLine = try XCTUnwrap(updatedOrder.shippingLines.first)
-        XCTAssertEqual(shippingLine.shippingID, shipping.shippingID)
-        XCTAssertEqual(shippingLine.methodID, input.methodID)
-        XCTAssertEqual(shippingLine.total, input.total)
-        XCTAssertEqual(updatedOrder.shippingTotal, "24.0")
-
-        let shippingLine2 = try XCTUnwrap(updatedOrder.shippingLines[safe: 1])
-        XCTAssertEqual(shipping2, shippingLine2)
     }
 }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Details/OrderDetailsDataSourceTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Details/OrderDetailsDataSourceTests.swift
@@ -41,8 +41,7 @@ final class OrderDetailsDataSourceTests: XCTestCase {
         let dataSource = OrderDetailsDataSource(
             order: order,
             storageManager: storageManager,
-            cardPresentPaymentsConfiguration: Mocks.configuration,
-            featureFlags: MockFeatureFlagService(isMultipleShippingLinesEnabled: true)
+            cardPresentPaymentsConfiguration: Mocks.configuration
         )
 
         dataSource.configureResultsControllers { }
@@ -879,8 +878,7 @@ final class OrderDetailsDataSourceTests: XCTestCase {
         let order = Order.fake().copy(shippingLines: [.fake()])
         let dataSource = OrderDetailsDataSource(order: order,
                                                 storageManager: storageManager,
-                                                cardPresentPaymentsConfiguration: Mocks.configuration,
-                                                featureFlags: MockFeatureFlagService(isMultipleShippingLinesEnabled: true))
+                                                cardPresentPaymentsConfiguration: Mocks.configuration)
 
         // When
         dataSource.reloadSections()


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #12886
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This removes the enabled `multipleShippingLines` feature flag. It also removes related code that is no longer used:

* Notice in order details and order form about multiple shipping lines on the order.
* Shipping Method row in the Customer section of order details.
* Support for editing a shipping line from the Order totals (payment) section of the order form.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

Repeat the tests from https://github.com/woocommerce/woocommerce-ios/pull/12888 and confirm the feature continues to work as expected.

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
