### PR TITLE
Watch: Add tracks events

### DIFF
--- a/WooCommerce/Classes/Analytics/WooAnalyticsStat.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsStat.swift
@@ -1,4 +1,6 @@
+#if canImport(WordPressShared)
 import WordPressShared
+#endif
 
 /// This enum contains all of the events we track in the WooCommerce app.
 ///
@@ -1200,6 +1202,15 @@ enum WooAnalyticsStat: String {
     case connectivityToolRequestResponse = "connectivity_tool_request_response"
     case connectivityToolReadMoreTapped = "connectivity_tool_read_more_tapped"
     case connectivityToolContactSupportTapped = "connectivity_tool_contact_support_tapped"
+
+    // MARK: Watch App
+    case watchAppOpened = "watch_app_opened"
+    case watchStoreDataSynced = "watch_store_data_synced"
+    case watchConnectingOpened = "watch_connecting_opened"
+    case watchMyStoreOpened = "watch_my_store_opened"
+    case watchOrdersListOpened = "watch_orders_list_opened"
+    case watchPushNotificationTapped = "watch_push_notification_tapped"
+    case watchOrderDetailOpened = "watch_order_detail_opened"
 }
 
 extension WooAnalyticsStat {
@@ -1214,7 +1225,7 @@ extension WooAnalyticsStat {
     var shouldSendSiteProperties: Bool {
         switch self {
         // Application events
-        case .applicationClosed, .applicationOpened, .applicationUpgraded, .applicationInstalled:
+        case .applicationClosed, .applicationOpened, .applicationUpgraded, .applicationInstalled, .watchAppOpened:
             return false
         // Authentication Events
         case .signedIn, .logout, .openedLogin, .loginFailed,
@@ -1229,7 +1240,7 @@ extension WooAnalyticsStat {
              .onePasswordFailed, .onePasswordLogin, .onePasswordSignup, .twoFactorCodeRequested, .twoFactorSentSMS,
              .loginJetpackRequiredScreenViewed, .loginJetpackRequiredViewInstructionsButtonTapped,
              .loginWhatIsJetpackHelpScreenViewed, .loginWhatIsJetpackHelpScreenOkButtonTapped,
-             .loginWhatIsJetpackHelpScreenLearnMoreButtonTapped:
+             .loginWhatIsJetpackHelpScreenLearnMoreButtonTapped, .watchConnectingOpened, .watchStoreDataSynced:
             return false
         default:
             return true
@@ -1237,6 +1248,7 @@ extension WooAnalyticsStat {
     }
 }
 
+#if canImport(WordPressShared)
 extension WooAnalyticsStat {
 
     /// Converts the provided WPAnalyticsStat into a WooAnalyticsStat.
@@ -1333,3 +1345,4 @@ extension WooAnalyticsStat {
         return wooEvent
     }
 }
+#endif

--- a/WooCommerce/Classes/System/WatchDependenciesSynchronizer.swift
+++ b/WooCommerce/Classes/System/WatchDependenciesSynchronizer.swift
@@ -76,3 +76,15 @@ final class WatchDependenciesSynchronizer: NSObject, WCSessionDelegate {
         // No op
     }
 }
+
+extension WatchDependenciesSynchronizer {
+    func session(_ session: WCSession, didReceiveUserInfo userInfo: [String: Any] = [:]) {
+
+        // The user info could contain a track event. Send it if we found one.
+        guard let rawEvent = userInfo[WooConstants.watchTracksKey] as? String,
+              let analyticEvent = WooAnalyticsStat(rawValue: rawEvent) else {
+            return DDLogError("⛔️ Unsupported watch tracks event: \(userInfo)")
+        }
+        ServiceLocator.analytics.track(analyticEvent)
+    }
+}

--- a/WooCommerce/Classes/System/WooConstants.swift
+++ b/WooCommerce/Classes/System/WooConstants.swift
@@ -79,6 +79,10 @@ public enum WooConstants {
     static let appLoginURLPrefix = "woocommerce://app-login"
 
     static let wooPaymentsPluginPath = "woocommerce-payments/woocommerce-payments.php"
+
+    /// Key used to identify track events sent between the phone and the watch.
+    ///
+    static let watchTracksKey = "watch-tracks-event"
 }
 
 // MARK: URLs

--- a/WooCommerce/Woo Watch App/App/AppDelegate.swift
+++ b/WooCommerce/Woo Watch App/App/AppDelegate.swift
@@ -6,8 +6,13 @@ import struct NetworkingWatchOS.Note
 
 class AppDelegate: NSObject, ObservableObject, WKApplicationDelegate {
 
+    /// Helper to send tracks events.
+    /// This type should be assigned from the main WooApp file.
+    ///
+    var tracksProvider: WatchTracksProvider?
+
     /// Stores and modifies app bindings.
-    /// This type should be replaced from the main WatchApp file.
+    /// This type should be replaced from the main WooApp file.
     ///
     var appBindings: AppBindings = AppBindings()
 
@@ -34,6 +39,9 @@ class AppDelegate: NSObject, ObservableObject, WKApplicationDelegate {
 
 extension AppDelegate: UNUserNotificationCenterDelegate {
     func userNotificationCenter(_ center: UNUserNotificationCenter, didReceive response: UNNotificationResponse) async {
+
+        tracksProvider?.sendTracksEvent(.watchPushNotificationTapped)
+
         // The Watch app only supports order notifications.
         guard let notification = PushNotification.from(userInfo: response.notification.request.content.userInfo),
               notification.kind == Note.Kind.storeOrder else {

--- a/WooCommerce/Woo Watch App/App/WatchTracksProvider.swift
+++ b/WooCommerce/Woo Watch App/App/WatchTracksProvider.swift
@@ -1,0 +1,9 @@
+//
+//  WatchTracksProvider.swift
+//  Woo Watch App
+//
+//  Created by Ernesto Carrion on 30/05/24.
+//  Copyright © 2024 Automattic. All rights reserved.
+//
+
+import Foundation

--- a/WooCommerce/Woo Watch App/App/WatchTracksProvider.swift
+++ b/WooCommerce/Woo Watch App/App/WatchTracksProvider.swift
@@ -1,9 +1,38 @@
-//
-//  WatchTracksProvider.swift
-//  Woo Watch App
-//
-//  Created by Ernesto Carrion on 30/05/24.
-//  Copyright © 2024 Automattic. All rights reserved.
-//
-
 import Foundation
+import WatchConnectivity
+
+/// Delegate track events to the paired counterpart using the `WCSession`
+///
+final class WatchTracksProvider: NSObject, ObservableObject {
+
+    /// Store events that could not be sent when the because was not active
+    ///
+    private var queuedEvents: [WooAnalyticsStat] = []
+
+    /// Tries to resend queued events.
+    /// Call this method when the `WCSession` is activated.
+    ///
+    func flushQueuedEvents() {
+        let eventsToFlush = queuedEvents
+        queuedEvents.removeAll()
+
+        for eventToFlush in eventsToFlush {
+            sendTracksEvent(eventToFlush)
+        }
+    }
+
+    /// Send the event to the paired device.
+    /// Discussion: This method uses the `transferUserInfo` to guarantee it's delivery to the paired counterpart. When testing use real device.
+    ///
+    func sendTracksEvent(_ event: WooAnalyticsStat) {
+        guard WCSession.default.activationState == .activated else {
+            DDLogInfo("🔵 Track event queued: \(event.rawValue)")
+            queuedEvents.append(event)
+            return
+        }
+
+        WCSession.default.transferUserInfo([WooConstants.watchTracksKey: "\(event.rawValue)"])
+        DDLogInfo("🔵 Track event delegated: \(event.rawValue)")
+    }
+}
+

--- a/WooCommerce/Woo Watch App/App/WatchTracksProvider.swift
+++ b/WooCommerce/Woo Watch App/App/WatchTracksProvider.swift
@@ -35,4 +35,3 @@ final class WatchTracksProvider: NSObject, ObservableObject {
         DDLogInfo("🔵 Track event delegated: \(event.rawValue)")
     }
 }
-

--- a/WooCommerce/Woo Watch App/App/WooApp.swift
+++ b/WooCommerce/Woo Watch App/App/WooApp.swift
@@ -46,6 +46,7 @@ struct Woo_Watch_AppApp: App {
 
                 // Assign other delegate dependencies.
                 delegate.tracksProvider = tracksProvider
+                phoneDependencySynchronizer.tracksProvider = tracksProvider
 
                 // Tracks
                 tracksProvider.sendTracksEvent(.watchAppOpened)

--- a/WooCommerce/Woo Watch App/App/WooApp.swift
+++ b/WooCommerce/Woo Watch App/App/WooApp.swift
@@ -9,31 +9,46 @@ struct Woo_Watch_AppApp: App {
 
     @StateObject var appBindings = AppBindings()
 
+    @StateObject var tracksProvider = WatchTracksProvider()
+
     // Refactor: Include this variable into AppBindings
     @State private var selectedTab = WooWatchTab.myStore
 
     var body: some Scene {
         WindowGroup {
-            if let dependencies = phoneDependencySynchronizer.dependencies {
-                TabView(selection: $selectedTab) {
-                    MyStoreView(dependencies: dependencies, watchTab: $selectedTab)
-                        .tag(WooWatchTab.myStore)
+            Group {
+                if let dependencies = phoneDependencySynchronizer.dependencies {
 
-                    OrdersListView(dependencies: dependencies, watchTab: $selectedTab)
-                        .tag(WooWatchTab.ordersList)
+                    TabView(selection: $selectedTab) {
+                        MyStoreView(dependencies: dependencies, watchTab: $selectedTab)
+                            .tag(WooWatchTab.myStore)
+
+                        OrdersListView(dependencies: dependencies, watchTab: $selectedTab)
+                            .tag(WooWatchTab.ordersList)
+                    }
+                    .sheet(item: $appBindings.orderNotification, content: { orderNotification in
+                        OrderDetailLoader(dependencies: dependencies, pushNotification: orderNotification)
+                    })
+                    .compatibleVerticalStyle()
+                    .environment(\.dependencies, dependencies)
+
+                } else {
+
+                    ConnectView()
+
                 }
-                .sheet(item: $appBindings.orderNotification, content: { orderNotification in
-                    OrderDetailLoader(dependencies: dependencies, pushNotification: orderNotification)
-                })
-                .compatibleVerticalStyle()
-                .environment(\.dependencies, dependencies)
-                .task {
-                    // For some reason I can't use the bindings directly from our AppDelegate.
-                    // We need to store them in this type assign them to the delegate for further modification.
-                    delegate.appBindings = appBindings
-                }
-            } else {
-                ConnectView()
+            }
+            .environmentObject(tracksProvider)
+            .task {
+                // For some reason I can't use the bindings directly from our AppDelegate.
+                // We need to store them in this type assign them to the delegate for further modification.
+                delegate.appBindings = appBindings
+
+                // Assign other delegate dependencies.
+                delegate.tracksProvider = tracksProvider
+
+                // Tracks
+                tracksProvider.sendTracksEvent(.watchAppOpened)
             }
         }
     }

--- a/WooCommerce/Woo Watch App/ConnectView.swift
+++ b/WooCommerce/Woo Watch App/ConnectView.swift
@@ -5,6 +5,8 @@ import NetworkingWatchOS
 ///
 struct ConnectView: View {
 
+    @EnvironmentObject private var tracksProvider: WatchTracksProvider
+
     let message: String = Localization.connectMessage
 
     var body: some View {
@@ -19,6 +21,9 @@ struct ConnectView: View {
                 .foregroundStyle(Layout.ambarColor)
         }
         .padding()
+        .task {
+            tracksProvider.sendTracksEvent(.watchConnectingOpened)
+        }
     }
 }
 

--- a/WooCommerce/Woo Watch App/Dependencies/PhoneDependenciesSynchronizer.swift
+++ b/WooCommerce/Woo Watch App/Dependencies/PhoneDependenciesSynchronizer.swift
@@ -10,6 +10,8 @@ final class PhoneDependenciesSynchronizer: NSObject, ObservableObject, WCSession
 
     @Published var dependencies: WatchDependencies?
 
+    var tracksProvider: WatchTracksProvider?
+
     /// Secure store.
     private let keychain: Keychain
 
@@ -36,6 +38,8 @@ final class PhoneDependenciesSynchronizer: NSObject, ObservableObject, WCSession
         DispatchQueue.main.async {
             self.storeDependencies(appContext: session.receivedApplicationContext)
             self.reloadDependencies()
+
+            self.tracksProvider?.flushQueuedEvents()
         }
     }
 
@@ -90,5 +94,7 @@ final class PhoneDependenciesSynchronizer: NSObject, ObservableObject, WCSession
         userDefaults[.defaultCredentialsType] = dependencies?.credentials.rawType
         userDefaults[.defaultSiteAddress] = dependencies?.credentials.siteAddress
         keychain[WooConstants.authToken] = dependencies?.credentials.secret
+
+        tracksProvider?.sendTracksEvent(.watchStoreDataSynced)
     }
 }

--- a/WooCommerce/Woo Watch App/MyStore/MyStoreView.swift
+++ b/WooCommerce/Woo Watch App/MyStore/MyStoreView.swift
@@ -7,6 +7,8 @@ struct MyStoreView: View {
 
     @Environment(\.dependencies) private var dependencies
 
+    @EnvironmentObject private var tracksProvider: WatchTracksProvider
+
     // View Model to drive the view
     @StateObject var viewModel: MyStoreViewModel
 
@@ -40,6 +42,7 @@ struct MyStoreView: View {
         )
         .onAppear() {
             Task {
+                tracksProvider.sendTracksEvent(.watchMyStoreOpened)
                 await viewModel.fetchStats()
             }
         }

--- a/WooCommerce/Woo Watch App/Orders/OrderDetailView.swift
+++ b/WooCommerce/Woo Watch App/Orders/OrderDetailView.swift
@@ -4,6 +4,8 @@ import SwiftUI
 ///
 struct OrderDetailView: View {
 
+    @EnvironmentObject private var tracksProvider: WatchTracksProvider
+
     /// Order to render
     ///
     let order: OrdersListView.Order
@@ -40,6 +42,9 @@ struct OrderDetailView: View {
             LinearGradient(gradient: Gradient(colors: [Colors.wooPurpleBackground, .black]), startPoint: .top, endPoint: .bottom)
         )
         .compatibleVerticalStyle()
+        .onAppear() {
+            tracksProvider.sendTracksEvent(.watchOrderDetailOpened)
+        }
     }
 
     /// First View: Summary

--- a/WooCommerce/Woo Watch App/Orders/OrdersListView.swift
+++ b/WooCommerce/Woo Watch App/Orders/OrdersListView.swift
@@ -4,6 +4,8 @@ import SwiftUI
 ///
 struct OrdersListView: View {
 
+    @EnvironmentObject private var tracksProvider: WatchTracksProvider
+
     // Used to changed the tab programmatically
     @Binding var watchTab: WooWatchTab
 
@@ -43,6 +45,9 @@ struct OrdersListView: View {
         }
         .task {
             await viewModel.fetchOrders()
+        }
+        .onAppear {
+            tracksProvider.sendTracksEvent(.watchOrdersListOpened)
         }
     }
 

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -815,6 +815,7 @@
 		261AA30C2753119E009530FE /* PaymentMethodsViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 261AA30B2753119E009530FE /* PaymentMethodsViewModel.swift */; };
 		261AA30E275506DE009530FE /* PaymentMethodsViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 261AA30D275506DE009530FE /* PaymentMethodsViewModelTests.swift */; };
 		261B526E29B795DB00DF7AB6 /* SupportFormMetadataProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 261B526D29B795DB00DF7AB6 /* SupportFormMetadataProvider.swift */; };
+		261C21552C08D8E20051AF19 /* WatchTracksProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 261C21542C08D8E20051AF19 /* WatchTracksProvider.swift */; };
 		261E91A029C961EE00A5C118 /* SubscriptionsViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 261E919F29C961EE00A5C118 /* SubscriptionsViewModel.swift */; };
 		261E91A329C9882600A5C118 /* SubscriptionsViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 261E91A229C9882600A5C118 /* SubscriptionsViewModelTests.swift */; };
 		261F1A7929C2AB2E001D9861 /* FreeTrialBannerViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 261F1A7829C2AB2E001D9861 /* FreeTrialBannerViewModel.swift */; };
@@ -909,6 +910,7 @@
 		26838356296F702B00CCF60A /* GenerateAllVariationsPresenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26838355296F702B00CCF60A /* GenerateAllVariationsPresenter.swift */; };
 		26838358296F9A1E00CCF60A /* GenerateAllVariationsUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26838357296F9A1E00CCF60A /* GenerateAllVariationsUseCase.swift */; };
 		2683835A296F9C1A00CCF60A /* GenerateAllVariationsUseCaseTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26838359296F9C1A00CCF60A /* GenerateAllVariationsUseCaseTests.swift */; };
+		268631CF2C07D38C00521364 /* WooAnalyticsStat.swift in Sources */ = {isa = PBXBuildFile; fileRef = 74213449210A323C00C13890 /* WooAnalyticsStat.swift */; };
 		2687165524D21BC80042F6AE /* SurveySubmittedViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2687165324D21BC80042F6AE /* SurveySubmittedViewController.swift */; };
 		2687165624D21BC80042F6AE /* SurveySubmittedViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = 2687165424D21BC80042F6AE /* SurveySubmittedViewController.xib */; };
 		2687165A24D350C20042F6AE /* SurveyCoordinatingController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2687165924D350C20042F6AE /* SurveyCoordinatingController.swift */; };
@@ -3721,6 +3723,7 @@
 		261AA30B2753119E009530FE /* PaymentMethodsViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaymentMethodsViewModel.swift; sourceTree = "<group>"; };
 		261AA30D275506DE009530FE /* PaymentMethodsViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaymentMethodsViewModelTests.swift; sourceTree = "<group>"; };
 		261B526D29B795DB00DF7AB6 /* SupportFormMetadataProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SupportFormMetadataProvider.swift; sourceTree = "<group>"; };
+		261C21542C08D8E20051AF19 /* WatchTracksProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WatchTracksProvider.swift; sourceTree = "<group>"; };
 		261E919F29C961EE00A5C118 /* SubscriptionsViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SubscriptionsViewModel.swift; sourceTree = "<group>"; };
 		261E91A229C9882600A5C118 /* SubscriptionsViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SubscriptionsViewModelTests.swift; sourceTree = "<group>"; };
 		261F1A7829C2AB2E001D9861 /* FreeTrialBannerViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FreeTrialBannerViewModel.swift; sourceTree = "<group>"; };
@@ -7887,6 +7890,7 @@
 				26F81B172BE433A2009EC58E /* WooApp.swift */,
 				26CFDED92C029322005ABC31 /* AppDelegate.swift */,
 				26CFDEDB2C02932C005ABC31 /* AppBindings.swift */,
+				261C21542C08D8E20051AF19 /* WatchTracksProvider.swift */,
 			);
 			path = App;
 			sourceTree = "<group>";
@@ -13864,6 +13868,7 @@
 				262619F12C03AB9600BD733B /* OrderDetailLoader.swift in Sources */,
 				26B984D42BEECC610052658C /* Environment+Dependencies.swift in Sources */,
 				26F81B1A2BE433A2009EC58E /* MyStoreView.swift in Sources */,
+				268631CF2C07D38C00521364 /* WooAnalyticsStat.swift in Sources */,
 				26373E2F2BFD7C18008E6735 /* OrderListCellViewModel.swift in Sources */,
 				26CFDEDA2C029322005ABC31 /* AppDelegate.swift in Sources */,
 				264E9E942BF1D1DF009C48FD /* AppLocalizedString.swift in Sources */,
@@ -13885,6 +13890,7 @@
 				26CFDEE62C038C7D005ABC31 /* OrderNotificationDataService.swift in Sources */,
 				26CA471F2BFD81E900E54348 /* String+Helpers.swift in Sources */,
 				26CA47242BFE4C1C00E54348 /* OrderDetailView.swift in Sources */,
+				261C21552C08D8E20051AF19 /* WatchTracksProvider.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};


### PR DESCRIPTION
# Why 

This PR adds tracks support to the Watch App

# How

Created a `WatchTracksProvider` class that sends events to the iOS App, and then the iOS app sends the tracks events as regular events.

This strategy is to avoid duplicating the configuration code in both apps. A further improvement could be to share this configuration code and send events directly from the watch app.

# Events

- https://github.com/Automattic/tracks-events-registration/pull/2449
- https://github.com/Automattic/tracks-events-registration/pull/2450
- https://github.com/Automattic/tracks-events-registration/pull/2451
- https://github.com/Automattic/tracks-events-registration/pull/2452
- https://github.com/Automattic/tracks-events-registration/pull/2453
- https://github.com/Automattic/tracks-events-registration/pull/2454
- https://github.com/Automattic/tracks-events-registration/pull/2455

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
