### PR TITLE
[Woo POS] Add view controller presenting protocol to allow passing `UIViewController` or a Null implementation

### DIFF
--- a/WooCommerce/Classes/Extensions/ViewControllerPresenting.swift
+++ b/WooCommerce/Classes/Extensions/ViewControllerPresenting.swift
@@ -1,5 +1,7 @@
 import UIKit
 
+/// Abstracts `UIViewController` usage in features (currently in card present payments) so that the UI/UX can also be implemented in
+/// SwiftUI while not affecting the pre-existing UIKit implementation.
 protocol ViewControllerPresenting {
     func present(_ viewControllerToPresent: UIViewController, animated: Bool, completion: (() -> Void)?)
     func present(_ viewControllerToPresent: UIViewController, animated: Bool)
@@ -18,4 +20,32 @@ extension UIViewController: ViewControllerPresenting {
     func dismiss(animated: Bool) {
         dismiss(animated: animated, completion: nil)
     }
+}
+
+/// When used instead of `UIViewController`, UI/UX is expected to be implemented separately from the original UIKit implementation with
+/// the `UIViewController`.
+final class NullViewControllerPresenting: ViewControllerPresenting {
+    func present(_ viewControllerToPresent: UIViewController, animated: Bool) {
+        // no-op
+    }
+
+    func dismiss(animated: Bool) {
+        // no-op
+    }
+
+    func present(_ viewControllerToPresent: UIViewController, animated: Bool, completion: (() -> Void)?) {
+        // no-op
+    }
+
+    func dismiss(animated: Bool, completion: (() -> Void)?) {
+        // no-op
+    }
+
+    func show(_ vc: UIViewController, sender: Any?) {
+        // no-op
+    }
+
+    var presentedViewController: UIViewController?
+
+    var navigationController: UINavigationController?
 }

--- a/WooCommerce/Classes/Extensions/ViewControllerPresenting.swift
+++ b/WooCommerce/Classes/Extensions/ViewControllerPresenting.swift
@@ -1,0 +1,21 @@
+import UIKit
+
+protocol ViewControllerPresenting {
+    func present(_ viewControllerToPresent: UIViewController, animated: Bool, completion: (() -> Void)?)
+    func present(_ viewControllerToPresent: UIViewController, animated: Bool)
+    func dismiss(animated: Bool, completion: (() -> Void)?)
+    func dismiss(animated: Bool)
+    func show(_ vc: UIViewController, sender: Any?)
+    var presentedViewController: UIViewController? { get }
+    var navigationController: UINavigationController? { get }
+}
+
+extension UIViewController: ViewControllerPresenting {
+    func present(_ viewControllerToPresent: UIViewController, animated: Bool) {
+        present(viewControllerToPresent, animated: animated, completion: nil)
+    }
+
+    func dismiss(animated: Bool) {
+        dismiss(animated: animated, completion: nil)
+    }
+}

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -758,6 +758,7 @@
 		2004E2CE2C077B0B00D62521 /* CardPresentPaymentCardReader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2004E2CD2C077B0B00D62521 /* CardPresentPaymentCardReader.swift */; };
 		2004E2D02C077D2800D62521 /* CardPresentPaymentTransaction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2004E2CF2C077D2800D62521 /* CardPresentPaymentTransaction.swift */; };
 		2004E2D22C07878E00D62521 /* CardReaderConnectionMethod.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2004E2D12C07878E00D62521 /* CardReaderConnectionMethod.swift */; };
+		2004E2DE2C08EB2100D62521 /* ViewControllerPresenting.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2004E2DB2C08E95B00D62521 /* ViewControllerPresenting.swift */; };
 		201F5AC52AD4061800EF6C55 /* AboutTapToPayViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 201F5AC42AD4061800EF6C55 /* AboutTapToPayViewModel.swift */; };
 		20203AB22B31EEF1009D0C11 /* ExpandableBottomSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 20203AB12B31EEF1009D0C11 /* ExpandableBottomSheet.swift */; };
 		202496642B0B9E0D00EE527D /* ScrollViewSectionKit in Frameworks */ = {isa = PBXBuildFile; productRef = 202496632B0B9E0D00EE527D /* ScrollViewSectionKit */; };
@@ -3560,6 +3561,7 @@
 		2004E2CD2C077B0B00D62521 /* CardPresentPaymentCardReader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardPresentPaymentCardReader.swift; sourceTree = "<group>"; };
 		2004E2CF2C077D2800D62521 /* CardPresentPaymentTransaction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardPresentPaymentTransaction.swift; sourceTree = "<group>"; };
 		2004E2D12C07878E00D62521 /* CardReaderConnectionMethod.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardReaderConnectionMethod.swift; sourceTree = "<group>"; };
+		2004E2DB2C08E95B00D62521 /* ViewControllerPresenting.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ViewControllerPresenting.swift; sourceTree = "<group>"; };
 		200B84AD2BEB99AC00EAAB23 /* WooCommercePOS.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = WooCommercePOS.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		201F5AC42AD4061800EF6C55 /* AboutTapToPayViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AboutTapToPayViewModel.swift; sourceTree = "<group>"; };
 		20203AB12B31EEF1009D0C11 /* ExpandableBottomSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExpandableBottomSheet.swift; sourceTree = "<group>"; };
@@ -10695,6 +10697,7 @@
 		CE1CCB4C20572444000EE3AC /* Extensions */ = {
 			isa = PBXGroup;
 			children = (
+				2004E2DB2C08E95B00D62521 /* ViewControllerPresenting.swift */,
 				DE50294828BEF4CF00551736 /* WordPressOrgCredentials+Authenticator.swift */,
 				EE3D1E932B8EC1E00016B132 /* BlazeCampaignListItem+Customizations.swift */,
 				B58B4ABF2108FF6100076FDD /* Array+Helpers.swift */,
@@ -14484,6 +14487,7 @@
 				45CE2D322625AA9A00E3CA00 /* ShippingLabelPackageList.swift in Sources */,
 				AEFF77A42978389400667F7A /* PriceInputViewController.swift in Sources */,
 				02535CBB25823F7A00E137BB /* ShippingLabelPaperSize+UI.swift in Sources */,
+				2004E2DE2C08EB2100D62521 /* ViewControllerPresenting.swift in Sources */,
 				CCD2E67E25DD4DC900BD975D /* ProductVariationsViewModel.swift in Sources */,
 				02C2756824F4E77F00286C04 /* ProductShippingSettingsViewModel.swift in Sources */,
 				E12AF69926BA8ADC00C371C1 /* CardPresentPaymentsOnboardingUseCase.swift in Sources */,


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of #12864 
<!-- Id number of the GitHub issue this PR addresses. -->

## Why
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

As nicely explained in https://github.com/woocommerce/woocommerce-ios/issues/12864:

> We won't have a UIViewController to pass in to the adaptor from POS mode, instead, we should pass a "Null object", which implements a `Presenting` interface but doesn't do anything when its methods are called.
> This will prevent any accidental misuse of a UIVC if we were to pass a real one in.

In features that are currently using `UIViewController` for navigation/presentation, we want to offer a way to implement the navigation/presentation differently like in SwiftUI with customized UI/UX to some extent while maintaining the existing `UIViewController` implementation for the app usage. By abstracting `UIViewController` with a protocol and an implementation in `UIViewController`, we can replace the current `UIViewController` dependency in the shared use cases in POS and App so that POS can have a different UI/UX implementation while not affecting the App.

See @joshheald's onboarding usage in #12897.

## How

Created a protocol `ViewControllerPresenting`, with `UIViewController` implementing this, plus a null implementation `NullViewControllerPresenting` when the use case isn't passing a `UIViewController` for presentation.

## Testing instructions
<!-- Step by step testing instructions. When necessary break out individual scenarios that need testing, consider including a checklist for the reviewer to go through. -->

CI is sufficient as the new protocol isn't used yet.

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
