### PR TITLE
Watch: Improve the way dependencies sync

### DIFF
--- a/WooCommerce/Classes/System/SessionManager.swift
+++ b/WooCommerce/Classes/System/SessionManager.swift
@@ -69,14 +69,11 @@ final class SessionManager: SessionManagerProtocol {
 
             removeCredentials()
 
-            guard let credentials = newValue else {
-                return watchDependenciesSynchronizer.update(storeID: nil, storeName: nil, currencySettings: nil, credentials: nil)
+            if let credentials = newValue {
+                saveCredentials(credentials)
             }
-            saveCredentials(credentials)
-            watchDependenciesSynchronizer.update(storeID: defaultStoreID,
-                                                 storeName: defaultSite?.name,
-                                                 currencySettings: ServiceLocator.currencySettings,
-                                                 credentials: credentials)
+
+            watchDependenciesSynchronizer.credentials = newValue
         }
     }
 
@@ -105,10 +102,7 @@ final class SessionManager: SessionManagerProtocol {
             defaults[.defaultStoreID] = newValue
             defaultStoreIDSubject.send(newValue)
 
-            watchDependenciesSynchronizer.update(storeID: defaultStoreID,
-                                                 storeName: defaultSite?.name,
-                                                 currencySettings: ServiceLocator.currencySettings,
-                                                 credentials: defaultCredentials)
+            watchDependenciesSynchronizer.storeID = defaultStoreID
         }
     }
 
@@ -161,10 +155,7 @@ final class SessionManager: SessionManagerProtocol {
     ///
     @Published var defaultSite: Site? {
         didSet {
-            watchDependenciesSynchronizer.update(storeID: defaultStoreID,
-                                                 storeName: defaultSite?.name,
-                                                 currencySettings: ServiceLocator.currencySettings,
-                                                 credentials: loadCredentials())
+            watchDependenciesSynchronizer.storeName = defaultSite?.name
         }
     }
 

--- a/WooCommerce/Classes/System/SessionManager.swift
+++ b/WooCommerce/Classes/System/SessionManager.swift
@@ -54,7 +54,16 @@ final class SessionManager: SessionManagerProtocol {
 
     /// Makes sure the credentials are in sync with the watch session.
     ///
-    private let watchDependenciesSynchronizer = WatchDependenciesSynchronizer()
+    private lazy var watchDependenciesSynchronizer = {
+        let storedDependencies: WatchDependencies? = {
+            guard let storeID = self.defaultStoreID, let storeName = self.defaultSite?.name, let credentials = self.loadCredentials() else {
+                return nil
+            }
+            return WatchDependencies(storeID: storeID, storeName: storeName, currencySettings: ServiceLocator.currencySettings, credentials: credentials)
+        }()
+
+        return WatchDependenciesSynchronizer(storedDependencies: storedDependencies)
+    }()
 
     /// Default Credentials.
     ///

--- a/WooCommerce/Classes/System/WatchDependencies.swift
+++ b/WooCommerce/Classes/System/WatchDependencies.swift
@@ -16,7 +16,7 @@ import class WooFoundationWatchOS.CurrencySettings
 
 /// WatchOS session dependencies.
 ///
-public struct WatchDependencies {
+public struct WatchDependencies: Equatable {
 
     // Dictionary Keys
     private enum Keys {

--- a/WooCommerce/Classes/System/WatchDependenciesSynchronizer.swift
+++ b/WooCommerce/Classes/System/WatchDependenciesSynchronizer.swift
@@ -1,25 +1,34 @@
 import WatchConnectivity
+import Combine
 import enum Networking.Credentials
 import class WooFoundation.CurrencySettings
 
 /// Type that syncs the necessary dependencies to the watch session.
-/// Dependencies:
-/// - Store ID
-/// - Credentials
 ///
 final class WatchDependenciesSynchronizer: NSObject, WCSessionDelegate {
-
-    private enum SyncState {
-        case notQueued
-        case queued(WatchDependencies?)
-    }
 
     /// Current WatchKit Session
     private let watchSession: WCSession
 
-    /// Dependencies waiting to be synced.
-    /// Used when we are waiting for the watch session to activate.
-    private var queuedDependencies: SyncState = .notQueued
+    /// Subscriptions store for combine publishers
+    ///
+    private var subscriptions = Set<AnyCancellable>()
+
+    /// Update this value to sync a new storeID with the paired counterpart.
+    ///
+    @Published var storeID: Int64?
+
+    /// Update this value to sync a new store name with the paired counterpart.
+    ///
+    @Published var storeName: String?
+
+    /// Update this value to sync new credentials with the paired counterpart.
+    ///
+    @Published var credentials: Credentials?
+
+    /// Tracks if the current watch session is active or not
+    ///
+    @Published private var isSessionActive: Bool = false
 
     init(watchSession: WCSession = WCSession.default) {
         self.watchSession = watchSession
@@ -29,43 +38,44 @@ final class WatchDependenciesSynchronizer: NSObject, WCSessionDelegate {
             watchSession.delegate = self
             watchSession.activate()
         }
+
+        bindAndSyncDependencies()
     }
 
-    /// Syncs credentials to the watch session.
+    /// Gather all the necessary dependencies inputs and syncs them when the session is active.
     ///
-    func update(storeID: Int64?, storeName: String?, currencySettings: CurrencySettings?, credentials: Credentials?) {
+    private func bindAndSyncDependencies() {
 
-        let dependencies: WatchDependencies? = {
-            guard let storeID, let storeName, let credentials, let currencySettings else {
-                return nil
+        // Convert all inputs into a dependencies type.
+        // Additionally filter any duplicates and debounce signal by 0.5s
+        // TODO: currencySettings should be treated as a new input but unfortunately there is no way to access it yet other than the ServiceLocator
+        let watchDependencies = Publishers.CombineLatest4($storeID, $storeName, $credentials, Just(ServiceLocator.currencySettings))
+            .map { storeID, storeName, credentials, currencySettings -> WatchDependencies? in
+                guard let storeID, let storeName, let credentials else {
+                    return nil
+                }
+                return .init(storeID: storeID, storeName: storeName, currencySettings: currencySettings, credentials: credentials)
             }
-            return .init(storeID: storeID, storeName: storeName, currencySettings: currencySettings, credentials: credentials)
-        }()
+            .removeDuplicates()
+            .debounce(for: 0.5, scheduler: DispatchQueue.main)
 
-        // Enqueue dependencies if the session is not yet activated.
-        guard watchSession.activationState == .activated else {
-            queuedDependencies = .queued(dependencies)
-            return
-        }
-
-        do {
-            let dependenciesDic = dependencies?.toDictionary() ?? [:]
-            try watchSession.updateApplicationContext(dependenciesDic)
-        } catch {
-            DDLogError("⛔️ Error synchronizing credentials into watch session: \(error)")
-        }
+        // Syncs the dependencies to the paired counterpart when the session becomes available.
+        Publishers.CombineLatest(watchDependencies, $isSessionActive)
+            .sink { [watchSession] dependencies, isSessionActive in
+                guard isSessionActive else { return }
+                do {
+                    let dependenciesDic = dependencies?.toDictionary() ?? [:]
+                    try watchSession.updateApplicationContext(dependenciesDic)
+                } catch {
+                    DDLogError("⛔️ Error synchronizing credentials into watch session: \(error)")
+                }
+            }
+            .store(in: &subscriptions)
     }
 
     func session(_ session: WCSession, activationDidCompleteWith activationState: WCSessionActivationState, error: Error?) {
         DDLogInfo("🔵 WatchSession activated \(activationState)")
-
-        if case .queued(let watchDependencies) = queuedDependencies {
-            update(storeID: watchDependencies?.storeID,
-                   storeName: watchDependencies?.storeName,
-                   currencySettings: watchDependencies?.currencySettings,
-                   credentials: watchDependencies?.credentials)
-            self.queuedDependencies = .notQueued
-        }
+        self.isSessionActive = activationState == .activated
     }
 
     func sessionDidBecomeInactive(_ session: WCSession) {
@@ -73,11 +83,17 @@ final class WatchDependenciesSynchronizer: NSObject, WCSessionDelegate {
     }
 
     func sessionDidDeactivate(_ session: WCSession) {
-        // No op
+        // Try to guarantee an active session
+        self.isSessionActive = false
+        watchSession.activate()
     }
 }
 
+// MARK: Tracks Delegate
 extension WatchDependenciesSynchronizer {
+    /// Tracks are being sent by the paired counterpart to be sent by the iOS App.
+    /// This is in order to not duplicate tracks configuration which involve quite a lot of information to be transmitted to the watch.
+    ///
     func session(_ session: WCSession, didReceiveUserInfo userInfo: [String: Any] = [:]) {
 
         // The user info could contain a track event. Send it if we found one.

--- a/WooCommerce/Classes/System/WatchDependenciesSynchronizer.swift
+++ b/WooCommerce/Classes/System/WatchDependenciesSynchronizer.swift
@@ -30,16 +30,20 @@ final class WatchDependenciesSynchronizer: NSObject, WCSessionDelegate {
     ///
     @Published private var isSessionActive: Bool = false
 
-    init(watchSession: WCSession = WCSession.default) {
+    init(watchSession: WCSession = WCSession.default, storedDependencies: WatchDependencies?) {
         self.watchSession = watchSession
         super.init()
+
+        self.storeID = storedDependencies?.storeID
+        self.storeName = storedDependencies?.storeName
+        self.credentials = storedDependencies?.credentials
+
+        bindAndSyncDependencies()
 
         if WCSession.isSupported() {
             watchSession.delegate = self
             watchSession.activate()
         }
-
-        bindAndSyncDependencies()
     }
 
     /// Gather all the necessary dependencies inputs and syncs them when the session is active.

--- a/WooCommerce/Woo Watch App/App/WooApp.swift
+++ b/WooCommerce/Woo Watch App/App/WooApp.swift
@@ -31,6 +31,7 @@ struct Woo_Watch_AppApp: App {
                     })
                     .compatibleVerticalStyle()
                     .environment(\.dependencies, dependencies)
+                    .id(dependencies.storeID) // Forces a redraw when the store id changes
 
                 } else {
 

--- a/WooCommerce/Woo Watch App/Dependencies/PhoneDependenciesSynchronizer.swift
+++ b/WooCommerce/Woo Watch App/Dependencies/PhoneDependenciesSynchronizer.swift
@@ -87,6 +87,12 @@ final class PhoneDependenciesSynchronizer: NSObject, ObservableObject, WCSession
     ///
     private func storeDependencies(appContext: [String: Any]) {
         let dependencies = WatchDependencies(dictionary: appContext)
+
+        // Only store the dependencies if we get new values to store.
+        guard self.dependencies != dependencies else {
+            return
+        }
+
         userDefaults[.defaultStoreID] = dependencies?.storeID
         userDefaults[.defaultStoreName] = dependencies?.storeName
         userDefaults[.defaultUsername] = dependencies?.credentials.username

--- a/WooFoundation/WooFoundation/Currency/CurrencyCode.swift
+++ b/WooFoundation/WooFoundation/Currency/CurrencyCode.swift
@@ -2,7 +2,7 @@ import Foundation
 import Codegen
 /// The 3-letter country code for supported currencies
 ///
-public enum CurrencyCode: String, CaseIterable, Codable, GeneratedFakeable {
+public enum CurrencyCode: String, CaseIterable, Codable, GeneratedFakeable, Equatable {
     // A
     case AED, AFN, ALL, AMD, ANG, AOA, ARS, AUD, AWG, AZN,
     // B

--- a/WooFoundation/WooFoundation/Currency/CurrencySettings.swift
+++ b/WooFoundation/WooFoundation/Currency/CurrencySettings.swift
@@ -2,7 +2,7 @@ import Foundation
 
 /// Site-wide settings for displaying prices/money
 ///
-public class CurrencySettings: Codable {
+public class CurrencySettings: Codable, Equatable {
 
     // MARK: - Enums
 
@@ -425,5 +425,13 @@ public class CurrencySettings: Codable {
         try container.encode(groupingSeparator, forKey: .groupingSeparator)
         try container.encode(decimalSeparator, forKey: .decimalSeparator)
         try container.encode(fractionDigits, forKey: .fractionDigits)
+    }
+
+    public static func == (lhs: CurrencySettings, rhs: CurrencySettings) -> Bool {
+        lhs.currencyCode == rhs.currencyCode &&
+        lhs.currencyPosition == rhs.currencyPosition &&
+        lhs.decimalSeparator == rhs.decimalSeparator &&
+        lhs.fractionDigits == rhs.fractionDigits &&
+        lhs.groupingSeparator == rhs.groupingSeparator
     }
 }


### PR DESCRIPTION
#closes 12898

# Why

This PR improves the way dependencies are synchronized between iOS and the watchOS in order to make the connection more reliable

# How

- Update the synchronizer to provide a simpler interface for updating dependencies.
- Use Combine publishers to sync changes when any input changes and wait for the session to be active before making any sync attempt. This eliminates the need of explicitly queue dependencies.
- Update the watch app main view to add the store id as the ID. This in order 

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
