### PR TITLE
Dynamic dashboard: Hide new card notice under feature flag

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Dashboard/DashboardView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/DashboardView.swift
@@ -282,9 +282,10 @@ private extension DashboardView {
                 }
                 .buttonStyle(PrimaryButtonStyle())
                 .padding(.horizontal, Layout.elementPadding)
-                .padding(.vertical, Layout.elementPadding)
+                .padding(.top, Layout.elementPadding)
             }
         }
+        .padding(.bottom, Layout.elementPadding)
         .overlay(
             RoundedRectangle(cornerRadius: Layout.cornerRadius)
                 .stroke(Color(.border), lineWidth: 1)

--- a/WooCommerce/Classes/ViewRelated/Dashboard/DashboardViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/DashboardViewModel.swift
@@ -541,7 +541,10 @@ private extension DashboardViewModel {
 
             // Get any remaining available cards and disable them.
             let remainingCards = Set(updatedCards).subtracting(savedCards)
-                .filter { $0.availability == .show }
+                .filter { card in
+                    card.availability == .show &&
+                    !savedCards.contains(where: { $0.type == card.type })
+                }
                 .map { $0.copy(enabled: false) }
 
             // Append the remaining cards to the end of the list
@@ -555,6 +558,9 @@ private extension DashboardViewModel {
     /// Can optionally pass local cards in case they are recently loaded before calling this function.
     @MainActor
     func configureNewCardsNotice(with localCards: [DashboardCard]? = nil) async {
+        guard featureFlagService.isFeatureFlagEnabled(.dynamicDashboardM2) else {
+            return
+        }
         var cards: [DashboardCard]
 
         if let localCards {


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #12860
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

This PR makes sure that new card notice is available only when M2 feature flag is enabled.
Also: fixed a missing padding on the share store card for a private store.


## Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: https://woomobilep2.wordpress.com/2024/05/06/woocommerce-mobile-quality-report-march-april/#comment-12036 -->

- Disable the feature flag `dynamicDashboardM2`
- Log out of the app and log in again to a WPCom store without any order.
- Confirm that the new card notice is not displayed on the Edit button and Dashboard screen.
- Confirm that share store card is displayed and the layout looks correct.
- Set the store to coming soon or private in wp-admin > Settings.
- Switch to another store and back or re-log in to the same store.
- Confirm that the share store card without the share button has the correct padding.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

Share store card:

Before | After | With button
--- | --- | ---
<img src="https://github.com/woocommerce/woocommerce-ios/assets/5533851/fb54be5d-3d6b-49ef-989f-fc1e1c005737" width=320 /> | <img src="https://github.com/woocommerce/woocommerce-ios/assets/5533851/c649ab57-61b2-4dde-9a39-e8df480886ad" width=320 /> | <img src="https://github.com/woocommerce/woocommerce-ios/assets/5533851/7a0a787c-492e-4494-b6b9-c192a27a23d9" width=320 />



---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
