### PR TITLE
[Woo POS] Create payment adaptor with placeholder implementation

### DIFF
--- a/WooCommerce/Classes/POS/Card Present Payments/CardPresentPaymentAdaptor.swift
+++ b/WooCommerce/Classes/POS/Card Present Payments/CardPresentPaymentAdaptor.swift
@@ -1,7 +1,6 @@
 import Combine
-import struct Yosemite.Order
 import Foundation
-import class WooFoundation.CurrencyFormatter
+import struct Yosemite.Order
 
 final class CardPresentPaymentsAdaptor: CardPresentPaymentFacade {
     var paymentEventPublisher: AnyPublisher<CardPresentPaymentEvent, Never> {

--- a/WooCommerce/Classes/POS/Card Present Payments/CardPresentPaymentAdaptor.swift
+++ b/WooCommerce/Classes/POS/Card Present Payments/CardPresentPaymentAdaptor.swift
@@ -1,0 +1,36 @@
+import Combine
+import struct Yosemite.Order
+import Foundation
+import class WooFoundation.CurrencyFormatter
+
+final class CardPresentPaymentsAdaptor: CardPresentPaymentFacade {
+    var paymentEventPublisher: AnyPublisher<CardPresentPaymentEvent, Never> {
+        paymentEventSubject.eraseToAnyPublisher()
+    }
+
+    var connectedReaderPublisher: AnyPublisher<CardPresentPaymentCardReader?, Never> {
+        connectedReaderSubject.eraseToAnyPublisher()
+    }
+
+    private let paymentEventSubject = CurrentValueSubject<CardPresentPaymentEvent, Never>(.idle)
+    private let connectedReaderSubject = CurrentValueSubject<CardPresentPaymentCardReader?, Never>(nil)
+
+    @MainActor
+    func connectReader(using connectionMethod: CardReaderConnectionMethod) async throws -> CardPresentPaymentReaderConnectionResult {
+        // TODO: replace it with reader connection
+        let mockReader = CardPresentPaymentCardReader(name: "Test Reader", batteryLevel: 0.5)
+        connectedReaderSubject.send(mockReader)
+        return .connected(mockReader)
+    }
+
+    func disconnectReader() {
+    }
+
+    func collectPayment(for order: Order, using connectionMethod: CardReaderConnectionMethod) async throws -> CardPresentPaymentResult {
+        // TODO: replace it with payment collection
+        .cancellation
+    }
+
+    func cancelPayment() {
+    }
+}

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -333,6 +333,7 @@
 		027111422913B9FC00F5269A /* AccountCreationFormViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 027111412913B9FC00F5269A /* AccountCreationFormViewModelTests.swift */; };
 		0271125D2887D4E900FCD13C /* LoggedOutAppSettingsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0271125C2887D4E900FCD13C /* LoggedOutAppSettingsTests.swift */; };
 		0271139A24DD15D800574A07 /* ProductsTabProductViewModel+VariationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0271139924DD15D800574A07 /* ProductsTabProductViewModel+VariationTests.swift */; };
+		027179E22C08817F0049F0BD /* CardPresentPaymentAdaptor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 027179E12C08817F0049F0BD /* CardPresentPaymentAdaptor.swift */; };
 		0271E1642509C66200633F7A /* DefaultProductFormTableViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0271E1632509C66200633F7A /* DefaultProductFormTableViewModelTests.swift */; };
 		0272C00322EE9C3200D7CA2C /* AsyncDictionary.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0272C00222EE9C3200D7CA2C /* AsyncDictionary.swift */; };
 		0273707E24C0047800167204 /* SequenceHelpersTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0273707D24C0047800167204 /* SequenceHelpersTests.swift */; };
@@ -3244,6 +3245,7 @@
 		027111412913B9FC00F5269A /* AccountCreationFormViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AccountCreationFormViewModelTests.swift; sourceTree = "<group>"; };
 		0271125C2887D4E900FCD13C /* LoggedOutAppSettingsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoggedOutAppSettingsTests.swift; sourceTree = "<group>"; };
 		0271139924DD15D800574A07 /* ProductsTabProductViewModel+VariationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ProductsTabProductViewModel+VariationTests.swift"; sourceTree = "<group>"; };
+		027179E12C08817F0049F0BD /* CardPresentPaymentAdaptor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardPresentPaymentAdaptor.swift; sourceTree = "<group>"; };
 		0271E1632509C66200633F7A /* DefaultProductFormTableViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefaultProductFormTableViewModelTests.swift; sourceTree = "<group>"; };
 		0272C00222EE9C3200D7CA2C /* AsyncDictionary.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AsyncDictionary.swift; sourceTree = "<group>"; };
 		0273707D24C0047800167204 /* SequenceHelpersTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SequenceHelpersTests.swift; sourceTree = "<group>"; };
@@ -7428,6 +7430,7 @@
 				2004E2CD2C077B0B00D62521 /* CardPresentPaymentCardReader.swift */,
 				2004E2D12C07878E00D62521 /* CardReaderConnectionMethod.swift */,
 				2004E2CF2C077D2800D62521 /* CardPresentPaymentTransaction.swift */,
+				027179E12C08817F0049F0BD /* CardPresentPaymentAdaptor.swift */,
 			);
 			path = "Card Present Payments";
 			sourceTree = "<group>";
@@ -14923,6 +14926,7 @@
 				0250BE8C2AC425F9006D067A /* OrderFormGiftCardRow.swift in Sources */,
 				0294F8AB25E8A12C005B537A /* WooTabNavigationController.swift in Sources */,
 				029F29FA24D93E9E004751CA /* EditableProductModel.swift in Sources */,
+				027179E22C08817F0049F0BD /* CardPresentPaymentAdaptor.swift in Sources */,
 				31FC8CE927B476BA004B9456 /* CardReaderSettingsResultsControllers.swift in Sources */,
 				022266BC2AE7707000614F34 /* ConfigurableBundleItemViewModel.swift in Sources */,
 				D449C52926DFBCCC00D75B02 /* WhatsNewHostingController.swift in Sources */,


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of #12867 
<!-- Id number of the GitHub issue this PR addresses. -->

## Why

By creating a placeholder version of the payment adaptor, we are able to start integrating with the UI while implementing the onboarding/connection/payment incrementally.

## How

`CardPresentPaymentsAdaptor` was created that implements `CardPresentPaymentFacade` with placeholder implementation. We will integrate with UI, onboarding/connection/payment in future PRs. I'm working on another PR that integrates with the connection status UI.


## Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->

The adaptor isn't used in the app, just CI passing is sufficient.

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.