### PR TITLE
[Shipping Lines] Add UI for shipping feedback survey

### DIFF
--- a/WooCommerce/Classes/System/WooConstants.swift
+++ b/WooCommerce/Classes/System/WooConstants.swift
@@ -349,6 +349,14 @@ extension WooConstants {
         ///
         case jetpackStats = "https://jetpack.com/stats/"
 
+        /// URL for the Order Creation Shipping Lines feedback survey
+        ///
+#if DEBUG
+        case orderCreationShippingFeedback = "https://automattic.survey.fm/order-creation-shipping-lines-survey-testing"
+#else
+        case orderCreationShippingFeedback = "https://automattic.survey.fm/order-creation-shipping-lines-survey-production"
+#endif
+
         /// Returns the URL version of the receiver
         ///
         func asURL() -> URL {

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/EditableOrderViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/EditableOrderViewModel.swift
@@ -367,9 +367,7 @@ final class EditableOrderViewModel: ObservableObject {
 
     /// Use case to display, add, edit, or remove shipping lines.
     ///
-    lazy var shippingUseCase: EditableOrderShippingUseCase = {
-        EditableOrderShippingUseCase(siteID: siteID, flow: flow, orderSynchronizer: orderSynchronizer)
-    }()
+    @Published var shippingUseCase: EditableOrderShippingUseCase
 
     // MARK: Customer data properties
 
@@ -505,6 +503,8 @@ final class EditableOrderViewModel: ObservableObject {
             updateCustomer: { _ in },
             resetAddressForm: {}
         )
+
+        self.shippingUseCase = EditableOrderShippingUseCase(siteID: siteID, flow: flow, orderSynchronizer: orderSynchronizer)
 
         configureDisabledState()
         configureCollectPaymentDisabledState()

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/OrderForm.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/OrderForm.swift
@@ -383,30 +383,34 @@ struct OrderForm: View {
             }
         }
         .safeAreaInset(edge: .bottom) {
-            ExpandableBottomSheet(onChangeOfExpansion: viewModel.orderTotalsExpansionChanged) {
-                VStack {
-                    HStack {
-                        Text(Localization.orderTotal)
-                        Spacer()
-                        Text(viewModel.orderTotal)
-                    }
-                    .font(.headline)
-                    .padding()
+            VStack {
+                BannerPopover(isPresented: $viewModel.shippingUseCase.shouldShowFeedbackSurvey, config: viewModel.shippingUseCase.feedbackSurveyConfig)
 
-                    Divider()
-                        .padding([.leading], Layout.dividerLeadingPadding)
-
-                    completedButton
+                ExpandableBottomSheet(onChangeOfExpansion: viewModel.orderTotalsExpansionChanged) {
+                    VStack {
+                        HStack {
+                            Text(Localization.orderTotal)
+                            Spacer()
+                            Text(viewModel.orderTotal)
+                        }
+                        .font(.headline)
                         .padding()
+
+                        Divider()
+                            .padding([.leading], Layout.dividerLeadingPadding)
+
+                        completedButton
+                            .padding()
+                    }
+                } expandableContent: {
+                    OrderPaymentSection(
+                        viewModel: viewModel.paymentDataViewModel,
+                        shippingUseCase: viewModel.shippingUseCase,
+                        shouldShowGiftCardForm: $shouldShowGiftCardForm)
+                    .disabled(viewModel.shouldShowNonEditableIndicators)
                 }
-            } expandableContent: {
-                OrderPaymentSection(
-                    viewModel: viewModel.paymentDataViewModel,
-                    shippingUseCase: viewModel.shippingUseCase,
-                    shouldShowGiftCardForm: $shouldShowGiftCardForm)
-                .disabled(viewModel.shouldShowNonEditableIndicators)
+                .ignoresSafeArea(edges: .horizontal)
             }
-            .ignoresSafeArea(edges: .horizontal)
         }
         .navigationTitle(viewModel.title)
         .navigationBarTitleDisplayMode(.inline)

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/Shipping/EditableOrderShippingUseCase.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/Shipping/EditableOrderShippingUseCase.swift
@@ -193,12 +193,10 @@ private extension EditableOrderShippingUseCase {
     ///
     func configurePaymentData() {
         orderSynchronizer.orderPublisher
-            .map { [weak self] order in
-                guard let self else { return ShippingPaymentData() }
-
-                return ShippingPaymentData(shouldShowShippingTotal: order.shippingLines.filter { $0.methodID != nil }.isNotEmpty,
-                                           shippingTotal: order.shippingTotal.isNotEmpty ? order.shippingTotal : "0",
-                                           shippingTax: order.shippingTax.isNotEmpty ? order.shippingTax : "0")
+            .map { order in
+                ShippingPaymentData(shouldShowShippingTotal: order.shippingLines.filter { $0.methodID != nil }.isNotEmpty,
+                                    shippingTotal: order.shippingTotal.isNotEmpty ? order.shippingTotal : "0",
+                                    shippingTax: order.shippingTax.isNotEmpty ? order.shippingTax : "0")
             }
             .assign(to: &$paymentData)
     }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/Shipping/EditableOrderShippingUseCase.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/Shipping/EditableOrderShippingUseCase.swift
@@ -70,6 +70,19 @@ final class EditableOrderShippingUseCase: ObservableObject {
         }
     }
 
+    // MARK: Feedback survey
+
+    /// Defines whether the shipping lines feedback survey is presented.
+    ///
+    @Published var shouldShowFeedbackSurvey: Bool = false
+
+    /// Feedback survey configuration.
+    ///
+    let feedbackSurveyConfig = BannerPopover.Configuration(title: Localization.FeedbackSurvey.title,
+                                                           message: Localization.FeedbackSurvey.message,
+                                                           buttonTitle: Localization.FeedbackSurvey.buttonTitle,
+                                                           buttonURL: WooConstants.URLs.orderCreationShippingFeedback.asURL())
+
     init(siteID: Int64,
          flow: EditableOrderViewModel.Flow,
          orderSynchronizer: OrderSynchronizer,
@@ -100,6 +113,9 @@ final class EditableOrderShippingUseCase: ObservableObject {
     /// - Parameter shippingLine: New or updated shipping line object to save.
     func saveShippingLine(_ shippingLine: ShippingLine) {
         orderSynchronizer.setShipping.send(shippingLine)
+        // TODO-12586: Show feedback survey under limited conditions
+        // For testing, un-comment the following line:
+        // shouldShowFeedbackSurvey = true
         analytics.track(event: WooAnalyticsEvent.Orders.orderShippingMethodAdd(flow: flow.analyticsFlow,
                                                                                methodID: shippingLine.methodID ?? "",
                                                                                shippingLinesCount: Int64(orderSynchronizer.order.shippingLines.count)))
@@ -210,5 +226,21 @@ private extension EditableOrderShippingUseCase {
             }
         }
         stores.dispatch(action)
+    }
+}
+
+private extension EditableOrderShippingUseCase {
+    enum Localization {
+        enum FeedbackSurvey {
+            static let title = NSLocalizedString("editableOrderShippingUseCase.feedbackSurvey.title",
+                                                 value: "Shipping added!",
+                                                 comment: "Title for the feedback survey about adding shipping to an order")
+            static let message = NSLocalizedString("editableOrderShippingUseCase.feedbackSurvey.message",
+                                                   value: "Does Woo make shipping easy?",
+                                                   comment: "Message for the feedback survey about adding shipping to an order")
+            static let buttonTitle = NSLocalizedString("editableOrderShippingUseCase.feedbackSurvey.buttonTitle",
+                                                       value: "Share your feedback",
+                                                       comment: "Title for button to view the feedback survey about adding shipping to an order")
+        }
     }
 }

--- a/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/BannerPopover.swift
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/BannerPopover.swift
@@ -1,0 +1,97 @@
+import SwiftUI
+
+struct BannerPopover: View {
+    /// Whether the popover is presented.
+    ///
+    @Binding var isPresented: Bool
+
+    /// Configuration for the popover.
+    ///
+    var config: Configuration
+
+    /// View model for the link webview.
+    ///
+    /// Setting this view model displays the webview in a sheet.
+    ///
+    @State private var webviewViewModel: WebViewSheetViewModel?
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: Layout.spacing) {
+            HStack(alignment: .center) {
+                Text(config.title)
+                    .foregroundStyle(Color(.textInverted))
+                    .font(.headline)
+
+                Spacer()
+
+                Button {
+                    isPresented = false
+                } label: {
+                    Image(uiImage: .closeButton)
+                        .resizable()
+                        .frame(width: Layout.buttonSize, height: Layout.buttonSize)
+                        .foregroundStyle(Color(.invertedSecondaryLabel))
+                }
+            }
+
+            Text(config.message)
+                .foregroundStyle(Color(.textInverted))
+
+            Button {
+                webviewViewModel = WebViewSheetViewModel(url: config.buttonURL, navigationTitle: config.buttonTitle, authenticated: false)
+            } label: {
+                Text(config.buttonTitle)
+                    .foregroundStyle(Color(.wooCommercePurple(.shade20)))
+                    .bold()
+                    .padding([.top], Layout.spacing)
+            }
+        }
+        .padding()
+        .background {
+            RoundedRectangle(cornerRadius: Layout.cornerRadius)
+                .fill(Color(.invertedTooltipBackgroundColor))
+                .shadow(color: Color(.secondaryLabel), radius: Layout.shadowRadius, y: Layout.shadowYOffset)
+        }
+        .padding()
+        .frame(maxWidth: .infinity)
+        .transition(.opacity.animation(.easeInOut))
+        .renderedIf(isPresented)
+        .sheet(item: $webviewViewModel) { viewModel in
+            WebViewSheet(viewModel: viewModel) {
+                isPresented = false // Close the banner when the webview is dismissed
+                webviewViewModel = nil
+            }
+        }
+    }
+
+    struct Configuration {
+        /// Banner title.
+        let title: String
+
+        /// Banner message.
+        let message: String
+
+        /// Title for banner button.
+        let buttonTitle: String
+
+        /// URL for banner button.
+        let buttonURL: URL
+    }
+}
+
+private extension BannerPopover {
+    enum Layout {
+        static let spacing: CGFloat = 8
+        static let cornerRadius: CGFloat = 8
+        static let shadowRadius: CGFloat = 8
+        static let shadowYOffset: CGFloat = 2
+        static let buttonSize: CGFloat = 16
+    }
+}
+
+#Preview {
+    BannerPopover(isPresented: .constant(true), config: .init(title: "Take a survey!",
+                                                              message: "What do you think?",
+                                                              buttonTitle: "Share your feedback",
+                                                              buttonURL: WooConstants.URLs.blog.asURL()))
+}

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -2151,6 +2151,7 @@
 		CE8CCD43239AC06E009DBD22 /* RefundDetailsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE8CCD41239AC06E009DBD22 /* RefundDetailsViewController.swift */; };
 		CE8CCD44239AC06E009DBD22 /* RefundDetailsViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = CE8CCD42239AC06E009DBD22 /* RefundDetailsViewController.xib */; };
 		CE91BEA029FBE9E100B6E1AF /* QuantityRulesViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE91BE9F29FBE9E100B6E1AF /* QuantityRulesViewModelTests.swift */; };
+		CE9F60122C09D53500652E0A /* BannerPopover.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE9F60112C09D53500652E0A /* BannerPopover.swift */; };
 		CEA16F3A20FD0C8C0061B4E1 /* WooAnalytics.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEA16F3920FD0C8C0061B4E1 /* WooAnalytics.swift */; };
 		CEA455C12BB3446D00D932CF /* BundlesReportCardViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEA455C02BB3446D00D932CF /* BundlesReportCardViewModel.swift */; };
 		CEA455C52BB44F9E00D932CF /* ProductsReportItem+Woo.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEA455C42BB44F9E00D932CF /* ProductsReportItem+Woo.swift */; };
@@ -5039,6 +5040,7 @@
 		CE8CCD41239AC06E009DBD22 /* RefundDetailsViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RefundDetailsViewController.swift; sourceTree = "<group>"; };
 		CE8CCD42239AC06E009DBD22 /* RefundDetailsViewController.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = RefundDetailsViewController.xib; sourceTree = "<group>"; };
 		CE91BE9F29FBE9E100B6E1AF /* QuantityRulesViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QuantityRulesViewModelTests.swift; sourceTree = "<group>"; };
+		CE9F60112C09D53500652E0A /* BannerPopover.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BannerPopover.swift; sourceTree = "<group>"; };
 		CEA16F3920FD0C8C0061B4E1 /* WooAnalytics.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WooAnalytics.swift; sourceTree = "<group>"; };
 		CEA455C02BB3446D00D932CF /* BundlesReportCardViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BundlesReportCardViewModel.swift; sourceTree = "<group>"; };
 		CEA455C42BB44F9E00D932CF /* ProductsReportItem+Woo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ProductsReportItem+Woo.swift"; sourceTree = "<group>"; };
@@ -8639,6 +8641,7 @@
 				20DA6DDA2B681175002AA0FB /* AdaptiveModalContainer.swift */,
 				CE63024D2BAC664900E3325C /* EmailView.swift */,
 				DE8AA0B42BBEBE590084D2CC /* ViewControllerContainer.swift */,
+				CE9F60112C09D53500652E0A /* BannerPopover.swift */,
 			);
 			path = "SwiftUI Components";
 			sourceTree = "<group>";
@@ -15437,6 +15440,7 @@
 				45977EBA2603F632006CDFB8 /* MapsHelper.swift in Sources */,
 				86023FAA2B15CAD800A28F07 /* ThemesEligibilityUseCase.swift in Sources */,
 				DE792E1826EF35F40071200C /* ConnectivityObserver.swift in Sources */,
+				CE9F60122C09D53500652E0A /* BannerPopover.swift in Sources */,
 				B9B0391628A6824200DC1C83 /* PermanentNoticePresenter.swift in Sources */,
 				45693189265403A1009ED69D /* ShippingLabelCarriersViewModel.swift in Sources */,
 				0211254125778BDF0075AD2A /* ShippingLabelDetailsViewController.swift in Sources */,


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #12585
<!-- Id number of the GitHub issue this PR addresses. -->

## Why
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This adds the UI to display a feedback survey about adding shipping lines on an order.

Note: This UI is not yet displayed in the app, but it can be enabled for testing with a one-line change.

## How

* Adds a reusable `BannerPopover` SwiftUI view. This view takes a binding variable to determine if the view is presented and a config for its content.
* Adds the required properties for the banner to `EditableOrderUseCase`. This is also where we control when to display the banner (can be enabled for testing in `saveShippingLine_:)` on line 118).
* Adds the survey URL to `WooConstants`.
* Updates how the shipping use case is initialized in `EditableOrderViewModel`. This ensures the binding for `EditableOrderUseCase.shouldShowFeedbackSurvey` works as expected in the order form.
* Adds the `BannerPopover` view to `OrderForm` above the order totals section (although the banner is never rendered at this point, except with the testing steps below).

## Testing information

1. Un-comment line 118 in `EditableOrderUseCase`. (This renders the banner when a shipping line is saved.)
2. Create a new order and add a product.
3. Tap "Add shipping" and save new shipping details.
4. Confirm the banner survey appears above the order totals.
5. Tap "Share your feedback" and confirm a webview opens with the survey.
6. Close the webview and confirm the banner is also dismissed.

Bonus:
* Repeat the steps above but instead of opening the survey, tap the "X" on the banner and confirm it closes.
* Repeat the steps in landscape and confirm the banner/survey is displayed as expected.
* Repeat the steps on an iPad and confirm the banner/survey is displayed as expected.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->
Light|Dark|Landscape
-|-|-
![Simulator Screenshot - iPhone 15 Plus - 2024-05-31 at 15 52 31](https://github.com/woocommerce/woocommerce-ios/assets/8658164/b50b49f3-01ff-486a-a99f-a56e0daa2f9b)|![Simulator Screenshot - iPhone 15 Plus - 2024-05-31 at 15 52 37](https://github.com/woocommerce/woocommerce-ios/assets/8658164/6dcad9b0-22d0-446f-8944-0553900fcd84)|![Simulator Screenshot - iPhone 15 Plus - 2024-05-31 at 15 53 16](https://github.com/woocommerce/woocommerce-ios/assets/8658164/7fc74f2e-6a13-40fe-8fb8-02c3c1c87419)

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.