### PR TITLE
[Shipping Lines] Consolidate logic for adding a shipping line in use case

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/AddOrderComponentsSection/AddOrderComponentsSection.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/AddOrderComponentsSection/AddOrderComponentsSection.swift
@@ -5,7 +5,7 @@ struct AddOrderComponentsSection: View {
     let viewModel: EditableOrderViewModel.PaymentDataViewModel
 
     /// Use case for shipping lines on an order
-    private let shippingUseCase: EditableOrderShippingUseCase
+    @ObservedObject private var shippingUseCase: EditableOrderShippingUseCase
 
     /// Indicates if the coupon line details screen should be shown or not.
     ///
@@ -23,10 +23,6 @@ struct AddOrderComponentsSection: View {
     ///
     @State private var shouldShowGoToCouponsAlert: Bool = false
 
-    /// Indicates if the shipping line details screen should be shown or not.
-    ///
-    @Binding private var shouldShowShippingLineDetails: Bool
-
     ///   Environment safe areas
     ///
     @Environment(\.safeAreaInsets) var safeAreaInsets: EdgeInsets
@@ -36,12 +32,10 @@ struct AddOrderComponentsSection: View {
     init(viewModel: EditableOrderViewModel.PaymentDataViewModel,
          shippingUseCase: EditableOrderShippingUseCase,
          shouldShowCouponsInfoTooltip: Binding<Bool>,
-         shouldShowShippingLineDetails: Binding<Bool>,
          shouldShowGiftCardForm: Binding<Bool>) {
         self.viewModel = viewModel
         self.shippingUseCase = shippingUseCase
         self._shouldShowCouponsInfoTooltip = shouldShowCouponsInfoTooltip
-        self._shouldShowShippingLineDetails = shouldShowShippingLineDetails
         self._shouldShowGiftCardForm = shouldShowGiftCardForm
     }
 
@@ -128,14 +122,16 @@ private extension AddOrderComponentsSection {
 
     @ViewBuilder var addShippingRow: some View {
         Button(Localization.addShipping) {
-            shouldShowShippingLineDetails = true
-            shippingUseCase.trackAddShippingTapped()
+            shippingUseCase.addShippingLine()
         }
         .buttonStyle(PlusButtonStyle())
         .padding()
         .accessibilityIdentifier("add-shipping-button")
         .disabled(viewModel.orderIsEmpty)
         .renderedIf(!shippingUseCase.paymentData.shouldShowShippingTotal)
+        .sheet(item: $shippingUseCase.addShippingLineViewModel, content: { addShippingLine in
+            ShippingLineSelectionDetails(viewModel: addShippingLine)
+        })
     }
 
     @ViewBuilder var addGiftCardRow: some View {
@@ -243,7 +239,6 @@ struct AddOrderComponentsSection_Previews: PreviewProvider {
         AddOrderComponentsSection(viewModel: viewModel,
                                   shippingUseCase: shippingUseCase,
                                   shouldShowCouponsInfoTooltip: .constant(true),
-                                  shouldShowShippingLineDetails: .constant(false),
                                   shouldShowGiftCardForm: .constant(false))
             .previewLayout(.sizeThatFits)
     }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/OrderForm.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/OrderForm.swift
@@ -223,8 +223,6 @@ struct OrderForm: View {
 
     @State private var shouldShowGiftCardForm = false
 
-    @State private var shouldShowShippingLineDetails = false
-
     @Environment(\.adaptiveModalContainerPresentationStyle) var presentationStyle
 
     @Environment(\.horizontalSizeClass) var horizontalSizeClass
@@ -306,13 +304,9 @@ struct OrderForm: View {
                                 viewModel: viewModel.paymentDataViewModel,
                                 shippingUseCase: viewModel.shippingUseCase,
                                 shouldShowCouponsInfoTooltip: $shouldShowInformationalCouponTooltip,
-                                shouldShowShippingLineDetails: $shouldShowShippingLineDetails,
                                 shouldShowGiftCardForm: $shouldShowGiftCardForm)
                             .addingTopAndBottomDividers()
                             .disabled(viewModel.shouldShowNonEditableIndicators)
-                            .sheet(isPresented: $shouldShowShippingLineDetails) {
-                                ShippingLineSelectionDetails(viewModel: viewModel.shippingUseCase.addShippingLineViewModel())
-                            }
 
                             Spacer(minLength: Layout.sectionSpacing)
                         }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/Shipping/EditableOrderShippingUseCase.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/Shipping/EditableOrderShippingUseCase.swift
@@ -31,6 +31,10 @@ final class EditableOrderShippingUseCase: ObservableObject {
     ///
     @Published var selectedShippingLine: ShippingLineSelectionDetailsViewModel? = nil
 
+    /// View model to add a new shipping line.
+    ///
+    @Published var addShippingLineViewModel: ShippingLineSelectionDetailsViewModel? = nil
+
     // MARK: Shipping methods
 
     /// Shipping Methods Results Controller.
@@ -102,12 +106,6 @@ final class EditableOrderShippingUseCase: ObservableObject {
         configureShippingLineRowViewModels()
     }
 
-    /// Returns a view model for adding a shipping line to an order.
-    ///
-    func addShippingLineViewModel() -> ShippingLineSelectionDetailsViewModel {
-        return ShippingLineSelectionDetailsViewModel(siteID: siteID, shippingLine: nil, didSelectSave: saveShippingLine, didSelectRemove: removeShippingLine)
-    }
-
     /// Saves a shipping line.
     ///
     /// - Parameter shippingLine: New or updated shipping line object to save.
@@ -129,9 +127,13 @@ final class EditableOrderShippingUseCase: ObservableObject {
         analytics.track(event: WooAnalyticsEvent.Orders.orderShippingMethodRemove(flow: flow.analyticsFlow))
     }
 
-    /// Tracks when the "Add shipping" button is tapped.
+    /// Handles when the "Add shipping" button is tapped.
     ///
-    func trackAddShippingTapped() {
+    func addShippingLine() {
+        addShippingLineViewModel = ShippingLineSelectionDetailsViewModel(siteID: siteID,
+                                                                         shippingLine: nil,
+                                                                         didSelectSave: saveShippingLine,
+                                                                         didSelectRemove: removeShippingLine)
         analytics.track(event: .Orders.orderAddShippingTapped())
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/Shipping/OrderShippingSection.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/Shipping/OrderShippingSection.swift
@@ -50,7 +50,7 @@ struct OrderShippingSection: View {
 private extension OrderShippingSection {
     func addShippingLine() {
         showAddShippingLine = true
-        // TODO-12584: Track that add shipping has been tapped
+        useCase.trackAddShippingTapped()
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/Shipping/OrderShippingSection.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/Shipping/OrderShippingSection.swift
@@ -4,8 +4,6 @@ struct OrderShippingSection: View {
     /// Use case to add, edit, or remove shipping lines
     @ObservedObject var useCase: EditableOrderShippingUseCase
 
-    @State private var showAddShippingLine: Bool = false
-
     @Environment(\.safeAreaInsets) private var safeAreaInsets: EdgeInsets
 
     var body: some View {
@@ -22,7 +20,7 @@ struct OrderShippingSection: View {
                     .renderedIf(useCase.shouldShowNonEditableIndicators)
 
                 Button(action: {
-                    addShippingLine()
+                    useCase.addShippingLine()
                 }) {
                     Image(uiImage: .plusImage)
                 }
@@ -38,19 +36,12 @@ struct OrderShippingSection: View {
         .padding()
         .background(Color(.listForeground(modal: true)))
         .addingTopAndBottomDividers()
-        .sheet(isPresented: $showAddShippingLine, content: {
-            ShippingLineSelectionDetails(viewModel: useCase.addShippingLineViewModel())
+        .sheet(item: $useCase.addShippingLineViewModel, content: { addShippingLine in
+            ShippingLineSelectionDetails(viewModel: addShippingLine)
         })
         .sheet(item: $useCase.selectedShippingLine, content: { selectedShippingLine in
             ShippingLineSelectionDetails(viewModel: selectedShippingLine)
         })
-    }
-}
-
-private extension OrderShippingSection {
-    func addShippingLine() {
-        showAddShippingLine = true
-        useCase.trackAddShippingTapped()
     }
 }
 

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/Shipping/EditableOrderShippingUseCaseTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/Shipping/EditableOrderShippingUseCaseTests.swift
@@ -148,12 +148,13 @@ final class EditableOrderShippingUseCaseTests: XCTestCase {
 
     // MARK: Add shipping line
 
-    func test_addShippingLineViewModel_returns_view_model_for_new_shipping_line() {
+    func test_addShippingLine_sets_view_model_for_new_shipping_line() {
         // When
-        let newShippingLineViewModel = useCase.addShippingLineViewModel()
+        useCase.addShippingLine()
 
         // Then
-        XCTAssertFalse(newShippingLineViewModel.isExistingShippingLine)
+        XCTAssertNotNil(useCase.addShippingLineViewModel)
+        XCTAssertFalse(try XCTUnwrap (useCase.addShippingLineViewModel).isExistingShippingLine)
     }
 
     // MARK: Shipping line rows
@@ -249,15 +250,15 @@ final class EditableOrderShippingUseCaseTests: XCTestCase {
 
     // MARK: Analytics
 
-    func test_trackAddShippingTapped_tracks_expected_event() {
+    func test_addShippingLine_tracks_expected_event() {
         // When
-        useCase.trackAddShippingTapped()
+        useCase.addShippingLine()
 
         // Then
         XCTAssertEqual(analytics.receivedEvents, [WooAnalyticsStat.orderAddShippingTapped.rawValue])
     }
 
-    func test_shipping_method_tracked_when_added() throws {
+    func test_saveShippingLine_tracks_expected_event_and_properties() throws {
         // Given
         let shippingLine = ShippingLine.fake().copy(methodID: "flat_rate")
 
@@ -271,7 +272,7 @@ final class EditableOrderShippingUseCaseTests: XCTestCase {
         assertEqual(1, analytics.receivedProperties.first?["shipping_lines_count"] as? Int64)
     }
 
-    func test_shipping_method_tracked_when_removed() throws {
+    func test_removeShippingLine_tracks_expected_event() throws {
         // When
         useCase.removeShippingLine(ShippingLine.fake())
 


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

<!-- Id number of the GitHub issue this PR addresses. -->

## Why
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This is a followup to https://github.com/woocommerce/woocommerce-ios/pull/12876, which added `EditableOrderShippingUseCase` with the logic for handling shipping lines on an order.

There was some logic around adding shipping lines remaining outside the use case, in particular the logic for when to show the add shipping line details screen. This PR consolidates that logic in the use case for consistency.

## How
* `EditableOrderShippingUseCase` now has a method `addShippingLine()` that sets the view model for the add shipping line details screen and tracks the expected analytics event.
* The views that support adding a new shipping line (`AddOrderComponentsSection` and `OrderShippingSection`) now don't handle that logic individually. Instead:
   * They call `EditableOrderShippingUseCase.addShippingLine()` when the add shipping button is tapped.
   * They include a sheet that is presented when the add shipping line details view model is set in the use case.

## Testing information
This is a refactor and should not affect the app behavior. Repeat the tests from https://github.com/woocommerce/woocommerce-ios/pull/12874 and confirm everything continues to work as expected.


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.