### PR TITLE
[Shipping Lines] Simplify view model for adding or editing shipping line details

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/AddOrderComponentsSection/AddOrderComponentsSection.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/AddOrderComponentsSection/AddOrderComponentsSection.swift
@@ -129,8 +129,8 @@ private extension AddOrderComponentsSection {
         .accessibilityIdentifier("add-shipping-button")
         .disabled(viewModel.orderIsEmpty)
         .renderedIf(!shippingUseCase.paymentData.shouldShowShippingTotal)
-        .sheet(item: $shippingUseCase.addShippingLineViewModel, content: { addShippingLine in
-            ShippingLineSelectionDetails(viewModel: addShippingLine)
+        .sheet(item: $shippingUseCase.shippingLineDetails, content: { viewModel in
+            ShippingLineSelectionDetails(viewModel: viewModel)
         })
     }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/Shipping/EditableOrderShippingUseCase.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/Shipping/EditableOrderShippingUseCase.swift
@@ -27,13 +27,9 @@ final class EditableOrderShippingUseCase: ObservableObject {
     ///
     @Published private(set) var shippingLineRows: [ShippingLineRowViewModel] = []
 
-    /// View model to edit a selected shipping line.
+    /// View model for shipping line details.
     ///
-    @Published var selectedShippingLine: ShippingLineSelectionDetailsViewModel? = nil
-
-    /// View model to add a new shipping line.
-    ///
-    @Published var addShippingLineViewModel: ShippingLineSelectionDetailsViewModel? = nil
+    @Published var shippingLineDetails: ShippingLineSelectionDetailsViewModel? = nil
 
     // MARK: Shipping methods
 
@@ -130,10 +126,10 @@ final class EditableOrderShippingUseCase: ObservableObject {
     /// Handles when the "Add shipping" button is tapped.
     ///
     func addShippingLine() {
-        addShippingLineViewModel = ShippingLineSelectionDetailsViewModel(siteID: siteID,
-                                                                         shippingLine: nil,
-                                                                         didSelectSave: saveShippingLine,
-                                                                         didSelectRemove: removeShippingLine)
+        shippingLineDetails = ShippingLineSelectionDetailsViewModel(siteID: siteID,
+                                                                    shippingLine: nil,
+                                                                    didSelectSave: saveShippingLine,
+                                                                    didSelectRemove: removeShippingLine)
         analytics.track(event: .Orders.orderAddShippingTapped())
     }
 }
@@ -178,13 +174,13 @@ private extension EditableOrderShippingUseCase {
                         guard let self else {
                             return
                         }
-                        selectedShippingLine = ShippingLineSelectionDetailsViewModel(siteID: siteID,
-                                                                                     shippingID: shippingLine.shippingID,
-                                                                                     initialMethodID: shippingLine.methodID ?? "",
-                                                                                     initialMethodTitle: shippingLine.methodTitle,
-                                                                                     shippingTotal: shippingLine.total,
-                                                                                     didSelectSave: saveShippingLine,
-                                                                                     didSelectRemove: removeShippingLine)
+                        shippingLineDetails = ShippingLineSelectionDetailsViewModel(siteID: siteID,
+                                                                                    shippingID: shippingLine.shippingID,
+                                                                                    initialMethodID: shippingLine.methodID ?? "",
+                                                                                    initialMethodTitle: shippingLine.methodTitle,
+                                                                                    shippingTotal: shippingLine.total,
+                                                                                    didSelectSave: saveShippingLine,
+                                                                                    didSelectRemove: removeShippingLine)
                     })
                 }
             }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/Shipping/OrderShippingSection.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/Shipping/OrderShippingSection.swift
@@ -36,11 +36,8 @@ struct OrderShippingSection: View {
         .padding()
         .background(Color(.listForeground(modal: true)))
         .addingTopAndBottomDividers()
-        .sheet(item: $useCase.addShippingLineViewModel, content: { addShippingLine in
-            ShippingLineSelectionDetails(viewModel: addShippingLine)
-        })
-        .sheet(item: $useCase.selectedShippingLine, content: { selectedShippingLine in
-            ShippingLineSelectionDetails(viewModel: selectedShippingLine)
+        .sheet(item: $useCase.shippingLineDetails, content: { viewModel in
+            ShippingLineSelectionDetails(viewModel: viewModel)
         })
     }
 }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/EditableOrderViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/EditableOrderViewModelTests.swift
@@ -3133,7 +3133,7 @@ final class EditableOrderViewModelTests: XCTestCase {
         XCTAssertTrue(viewModel.hasChanges)
     }
 
-    func test_editing_existing_shipping_line_sets_expected_selectedShippingLine() throws {
+    func test_editing_existing_shipping_line_sets_expected_shippingLineDetails_view_model() throws {
         // Given
         let shippingLine = ShippingLine.fake().copy(shippingID: 1, methodTitle: "Package 1")
         let order = Order.fake().copy(siteID: sampleSiteID, shippingLines: [shippingLine])
@@ -3145,7 +3145,7 @@ final class EditableOrderViewModelTests: XCTestCase {
         viewModel.shippingUseCase.shippingLineRows.first?.editShippingLine()
 
         // Then
-        let editShippingLineViewModel = try XCTUnwrap(viewModel.shippingUseCase.selectedShippingLine)
+        let editShippingLineViewModel = try XCTUnwrap(viewModel.shippingUseCase.shippingLineDetails)
         assertEqual(shippingLine.methodTitle, editShippingLineViewModel.methodTitle)
     }
 }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/Shipping/EditableOrderShippingUseCaseTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/Shipping/EditableOrderShippingUseCaseTests.swift
@@ -148,13 +148,13 @@ final class EditableOrderShippingUseCaseTests: XCTestCase {
 
     // MARK: Add shipping line
 
-    func test_addShippingLine_sets_view_model_for_new_shipping_line() {
+    func test_addShippingLine_sets_view_model_for_new_shipping_line() throws {
         // When
         useCase.addShippingLine()
 
         // Then
-        XCTAssertNotNil(useCase.addShippingLineViewModel)
-        XCTAssertFalse(try XCTUnwrap (useCase.addShippingLineViewModel).isExistingShippingLine)
+        let viewModel = try XCTUnwrap(useCase.shippingLineDetails)
+        XCTAssertFalse(viewModel.isExistingShippingLine)
     }
 
     // MARK: Shipping line rows
@@ -171,7 +171,7 @@ final class EditableOrderShippingUseCaseTests: XCTestCase {
         assertEqual(shippingLine.methodTitle, useCase.shippingLineRows.first?.shippingTitle)
     }
 
-    func test_selectedShippingLine_set_when_shipping_line_row_is_edited() {
+    func test_expected_view_model_set_when_shipping_line_row_is_edited() throws {
         // Given
         let shippingLine = ShippingLine.fake().copy(methodTitle: "Flat Rate")
         let order = Order.fake().copy(siteID: sampleSiteID, shippingLines: [shippingLine])
@@ -185,7 +185,9 @@ final class EditableOrderShippingUseCaseTests: XCTestCase {
         useCase.shippingLineRows.first?.editShippingLine()
 
         // Then
-        assertEqual(shippingLine.methodTitle, useCase.selectedShippingLine?.methodTitle)
+        let viewModel = try XCTUnwrap(useCase.shippingLineDetails)
+        XCTAssertTrue(viewModel.isExistingShippingLine)
+        assertEqual(shippingLine.methodTitle, viewModel.methodTitle)
     }
 
     func test_shipping_line_row_is_editable_for_new_order() throws {


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This is a small followup to https://github.com/woocommerce/woocommerce-ios/pull/12907, to simplify the view model for adding or editing shipping line details.

Instead of maintaining separate view models for adding or editing shipping line details, `EditableOrderShippingUseCase` now holds a single reference to a `ShippingLineSelectionDetailsViewModel`. It can be set with a view model appropriate for either adding a new shipping line or editing an existing one.

## Testing information
This is a refactor and should not affect the app behavior. Repeat the tests from https://github.com/woocommerce/woocommerce-ios/pull/12874 and confirm everything continues to work as expected.


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.