### PR TITLE
Fix Version Mismatch between app/appex targets

### DIFF
--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -16564,7 +16564,6 @@
 				CLANG_ENABLE_OBJC_WEAK = YES;
 				CODE_SIGN_ENTITLEMENTS = NotificationExtension/NotificationExtension.entitlements;
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = "$(VERSION_LONG)";
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = NotificationExtension/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = NotificationExtension;
@@ -16575,7 +16574,6 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = "$(VERSION_SHORT)";
 				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
 				MTL_FAST_MATH = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = com.automattic.woocommerce.notificationcontentextension;
@@ -16596,7 +16594,6 @@
 				CLANG_ENABLE_OBJC_WEAK = YES;
 				CODE_SIGN_ENTITLEMENTS = NotificationExtension/NotificationExtension.entitlements;
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = "$(VERSION_LONG)";
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = NotificationExtension/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = NotificationExtension;
@@ -16607,7 +16604,6 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = "$(VERSION_SHORT)";
 				MTL_FAST_MATH = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = com.automattic.woocommerce.notificationcontentextension;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -16627,7 +16623,6 @@
 				CLANG_ENABLE_OBJC_WEAK = YES;
 				CODE_SIGN_ENTITLEMENTS = NotificationExtension/NotificationExtension.entitlements;
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = "$(VERSION_LONG)";
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = NotificationExtension/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = NotificationExtension;
@@ -16638,7 +16633,6 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = "$(VERSION_SHORT)";
 				MTL_FAST_MATH = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = com.automattic.alpha.woocommerce.notificationcontentextension;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -16660,7 +16654,6 @@
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
 				CLANG_ENABLE_OBJC_WEAK = YES;
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 1;
 				ENABLE_USER_SCRIPT_SANDBOXING = YES;
 				GCC_C_LANGUAGE_STANDARD = gnu17;
 				GENERATE_INFOPLIST_FILE = YES;
@@ -16674,7 +16667,6 @@
 					"@executable_path/../../../../Frameworks",
 				);
 				LOCALIZATION_PREFERS_STRING_CATALOGS = YES;
-				MARKETING_VERSION = 1.0;
 				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
 				MTL_FAST_MATH = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = com.automattic.woocommerce.watchkitapp.widgets;
@@ -16701,7 +16693,6 @@
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
 				CLANG_ENABLE_OBJC_WEAK = YES;
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 1;
 				ENABLE_USER_SCRIPT_SANDBOXING = YES;
 				GCC_C_LANGUAGE_STANDARD = gnu17;
 				GENERATE_INFOPLIST_FILE = YES;
@@ -16715,7 +16706,6 @@
 					"@executable_path/../../../../Frameworks",
 				);
 				LOCALIZATION_PREFERS_STRING_CATALOGS = YES;
-				MARKETING_VERSION = 1.0;
 				MTL_FAST_MATH = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = com.automattic.woocommerce.watchkitapp.widgets;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -16740,7 +16730,6 @@
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
 				CLANG_ENABLE_OBJC_WEAK = YES;
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 1;
 				ENABLE_USER_SCRIPT_SANDBOXING = YES;
 				GCC_C_LANGUAGE_STANDARD = gnu17;
 				GENERATE_INFOPLIST_FILE = YES;
@@ -16754,7 +16743,6 @@
 					"@executable_path/../../../../Frameworks",
 				);
 				LOCALIZATION_PREFERS_STRING_CATALOGS = YES;
-				MARKETING_VERSION = 1.0;
 				MTL_FAST_MATH = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = com.automattic.alpha.woocommerce.watchkitapp.widgets;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -16781,7 +16769,6 @@
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
 				CLANG_ENABLE_OBJC_WEAK = YES;
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_ASSET_PATHS = "\"Woo Watch App/Preview Content\"";
 				ENABLE_PREVIEWS = YES;
 				ENABLE_USER_SCRIPT_SANDBOXING = NO;
@@ -16798,7 +16785,6 @@
 					"@loader_path/Frameworks",
 				);
 				LOCALIZATION_PREFERS_STRING_CATALOGS = YES;
-				MARKETING_VERSION = 1.0;
 				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
 				MTL_FAST_MATH = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = com.automattic.woocommerce.watchkitapp;
@@ -16828,7 +16814,6 @@
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
 				CLANG_ENABLE_OBJC_WEAK = YES;
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_ASSET_PATHS = "\"Woo Watch App/Preview Content\"";
 				ENABLE_PREVIEWS = YES;
 				ENABLE_USER_SCRIPT_SANDBOXING = NO;
@@ -16845,7 +16830,6 @@
 					"@loader_path/Frameworks",
 				);
 				LOCALIZATION_PREFERS_STRING_CATALOGS = YES;
-				MARKETING_VERSION = 1.0;
 				MTL_FAST_MATH = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = com.automattic.woocommerce.watchkitapp;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -16873,7 +16857,6 @@
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
 				CLANG_ENABLE_OBJC_WEAK = YES;
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_ASSET_PATHS = "\"Woo Watch App/Preview Content\"";
 				ENABLE_PREVIEWS = YES;
 				ENABLE_USER_SCRIPT_SANDBOXING = NO;
@@ -16890,7 +16873,6 @@
 					"@loader_path/Frameworks",
 				);
 				LOCALIZATION_PREFERS_STRING_CATALOGS = YES;
-				MARKETING_VERSION = 1.0;
 				MTL_FAST_MATH = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = com.automattic.alpha.woocommerce.watchkitapp;
 				PRODUCT_NAME = "$(TARGET_NAME)";


### PR DESCRIPTION
## Why?

The `Woo Watch App` and `WatchWidgetsExtension` targets had a custom value for their `CURRENT_PROJECT_VERSION` and `MARKETING_VERSION` Build Settings.
This resulted in them using a different version string than the ones used by the main `WooCommerce` app target, and thus [making the app be rejected by App Store Connect during upload and validation of the binary](https://buildkite.com/automattic/woocommerce-ios/builds/22018#018fd333-224c-4ac5-9e29-3d4ea71749c4/823-4835):

```
[Application Loader Error Output]: ERROR: [ContentDelivery.Uploader] Asset validation failed (90379) CFBundleVersion Mismatch. The CFBundleVersion value ‘1’ of watch application ‘WooCommerce.app/Watch/Woo Watch App.app’ does not match the CFBundleVersion value ‘18.9.0.1’ of its containing iOS application ‘WooCommerce.app’. (ID: 5baea5ae-d445-4ce8-b7d1-8928e0fa6925)
[Application Loader Error Output]: ERROR: [ContentDelivery.Uploader] Asset validation failed (90379) CFBundleShortVersionString Mismatch. The CFBundleShortVersionString value ‘1.0’ of watch application ‘WooCommerce.app/Watch/Woo Watch App.app’ does not match the CFBundleShortVersionString value ‘18.9’ of its containing iOS application ‘WooCommerce.app’. (ID: d4aa223e-55ad-4e8d-8b7d-38812d63797f)
[Application Loader Error Output]: Error uploading ‘/var/folders/cv/v953tj997c95mt4pl1k9lqzw0000gn/T/b7bf028f-8767-4436-bedb-9d798e16f930.ipa’.
[Application Loader Error Output]: Asset validation failed CFBundleVersion Mismatch. The CFBundleVersion value ‘1’ of watch application ‘WooCommerce.app/Watch/Woo Watch App.app’ does not match the CFBundleVersion value ‘18.9.0.1’ of its containing iOS application ‘WooCommerce.app’. (ID: 5baea5ae-d445-4ce8-b7d1-8928e0fa6925) (90379)
[Application Loader Error Output]: Asset validation failed CFBundleShortVersionString Mismatch. The CFBundleShortVersionString value ‘1.0’ of watch application ‘WooCommerce.app/Watch/Woo Watch App.app’ does not match the CFBundleShortVersionString value ‘18.9’ of its containing iOS application ‘WooCommerce.app’. (ID: d4aa223e-55ad-4e8d-8b7d-38812d63797f) (90379)
[Application Loader Error Output]: The call to the altool completed with a non-zero exit status: 1. This indicates a failure.
```

## How?

Removing the custom value for those two Build Settings now makes all the targets use the values defined in the `xcconfig` file (especially the ones imported from the `config/Version.Public.xcconfig`) and thus the same as all other targets, thus avoiding the app being rejected by App Store Connect validation.

<img width="1356" alt="image" src="https://github.com/woocommerce/woocommerce-ios/assets/216089/b5e35200-5b8e-44c5-b062-0474ce947408">

```
12:40:04  📂 ~/Library/Developer/Xcode/Archives/2024-06-01/WooCommerce 01-06-2024, 12.39.xcarchive/ 
✓ $ find . -path '*.app/Info.plist' -o -path '*.appex/Info.plist' -print -exec /usr/libexec/PlistBuddy -c 'Print CFBundleVersion' -c 'Print CFBundleShortVersionString' {} \;
./Products/Applications/WooCommerce.app/PlugIns/NotificationExtension.appex/Info.plist
18.9.0.1
18.9
./Products/Applications/WooCommerce.app/PlugIns/StoreWidgetsExtension.appex/Info.plist
18.9.0.1
18.9
./Products/Applications/WooCommerce.app/Watch/Woo Watch App.app/PlugIns/WatchWidgetsExtension.appex/Info.plist
18.9.0.1
18.9
```