### PR TITLE
Dynamic Dashboard: Fix issue with missing Inbox card upon login

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Hub Menu/HubMenuViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Hub Menu/HubMenuViewModel.swift
@@ -69,6 +69,7 @@ final class HubMenuViewModel: ObservableObject {
     private let generalAppSettings: GeneralAppSettingsStorage
     private let cardPresentPaymentsOnboarding: CardPresentPaymentsOnboardingUseCaseProtocol
     private let posEligibilityChecker: POSEligibilityCheckerProtocol
+    private let inboxEligibilityChecker: InboxEligibilityChecker
 
     private(set) var productReviewFromNoteParcel: ProductReviewFromNoteParcel?
 
@@ -108,6 +109,7 @@ final class HubMenuViewModel: ObservableObject {
          featureFlagService: FeatureFlagService = ServiceLocator.featureFlagService,
          stores: StoresManager = ServiceLocator.stores,
          generalAppSettings: GeneralAppSettingsStorage = ServiceLocator.generalAppSettings,
+         inboxEligibilityChecker: InboxEligibilityChecker = InboxEligibilityUseCase(),
          blazeEligibilityChecker: BlazeEligibilityCheckerProtocol = BlazeEligibilityChecker()) {
         self.siteID = siteID
         self.tapToPayBadgePromotionChecker = tapToPayBadgePromotionChecker
@@ -115,6 +117,7 @@ final class HubMenuViewModel: ObservableObject {
         self.featureFlagService = featureFlagService
         self.generalAppSettings = generalAppSettings
         self.switchStoreEnabled = stores.isAuthenticatedWithoutWPCom == false
+        self.inboxEligibilityChecker = inboxEligibilityChecker
         self.blazeEligibilityChecker = blazeEligibilityChecker
         self.cardPresentPaymentsOnboarding = CardPresentPaymentsOnboardingUseCase()
         self.posEligibilityChecker = POSEligibilityChecker(cardPresentPaymentsOnboarding: cardPresentPaymentsOnboarding,
@@ -179,8 +182,7 @@ final class HubMenuViewModel: ObservableObject {
             generalElements.append(InAppPurchases())
         }
 
-        let inboxUseCase = InboxEligibilityUseCase(stores: stores, featureFlagService: featureFlagService)
-        inboxUseCase.isEligibleForInbox(siteID: siteID) { [weak self] isInboxMenuShown in
+        inboxEligibilityChecker.isEligibleForInbox(siteID: siteID) { [weak self] isInboxMenuShown in
             guard let self = self else { return }
             if let index = self.generalElements.firstIndex(where: { item in
                 type(of: item).id == Reviews.id

--- a/WooCommerce/Classes/ViewRelated/Inbox/InboxEligibilityUseCase.swift
+++ b/WooCommerce/Classes/ViewRelated/Inbox/InboxEligibilityUseCase.swift
@@ -1,6 +1,7 @@
 import Foundation
 import enum Yosemite.SystemStatusAction
 import protocol Yosemite.StoresManager
+import struct Yosemite.SystemPlugin
 import Experiments
 
 /// Checks whether a store is eligible for Inbox feature.
@@ -38,38 +39,60 @@ final class InboxEligibilityUseCase: InboxEligibilityChecker {
     ///   - siteID: the ID of the site to check for Inbox eligibility.
     ///   - completion: called when the Inbox eligibility is determined.
     func isEligibleForInbox(siteID: Int64, completion: @escaping (Bool) -> Void) {
-        guard featureFlagService.isFeatureFlagEnabled(.inbox) else {
-            return completion(false)
+        Task {
+            let result = await isEligibleForInbox(siteID: siteID)
+            completion(result)
         }
-
-        // Fetches WC plugin.
-        let action = SystemStatusAction.fetchSystemPlugin(siteID: siteID, systemPluginName: Constants.wcPluginName) { wcPlugin in
-            // WooCommerce plugin is expected to be active in order to use the app/inbox.
-            guard let wcPlugin = wcPlugin, wcPlugin.active else {
-                return completion(false)
-            }
-
-            let isInboxSupportedByWCPlugin = VersionHelpers.isVersionSupported(version: wcPlugin.version,
-                                                                               minimumRequired: Constants.wcPluginMinimumVersion)
-            completion(isInboxSupportedByWCPlugin)
-        }
-        stores.dispatch(action)
     }
 
     @MainActor
     func isEligibleForInbox(siteID: Int64) async -> Bool {
-        await withCheckedContinuation { [weak self] continuation in
-            guard let self else {
-                return continuation.resume(returning: false)
-            }
-            isEligibleForInbox(siteID: siteID) { isEligible in
-                continuation.resume(returning: isEligible)
-            }
+        guard featureFlagService.isFeatureFlagEnabled(.inbox) else {
+            return false
+        }
+
+        if let savedPlugin = await fetchWooPluginFromStorage(siteID: siteID) {
+            return checkIfInboxIsSupported(wcPlugin: savedPlugin)
+        } else {
+            let remotePlugin = await fetchWooPluginFromRemote(siteID: siteID)
+            return checkIfInboxIsSupported(wcPlugin: remotePlugin)
         }
     }
 }
 
 private extension InboxEligibilityUseCase {
+    @MainActor
+    func fetchWooPluginFromStorage(siteID: Int64) async -> SystemPlugin? {
+        await withCheckedContinuation { continuation in
+            stores.dispatch(SystemStatusAction.fetchSystemPlugin(siteID: siteID, systemPluginName: Constants.wcPluginName) { plugin in
+                continuation.resume(returning: plugin)
+            })
+        }
+    }
+
+    @MainActor
+    func fetchWooPluginFromRemote(siteID: Int64) async -> SystemPlugin? {
+        await withCheckedContinuation { continuation in
+            stores.dispatch(SystemStatusAction.synchronizeSystemInformation(siteID: siteID) { result in
+                switch result {
+                case .success(let info):
+                    let wcPlugin = info.systemPlugins.first(where: { $0.name == Constants.wcPluginName })
+                    continuation.resume(returning: wcPlugin)
+                case .failure:
+                    continuation.resume(returning: nil)
+                }
+            })
+        }
+    }
+
+    func checkIfInboxIsSupported(wcPlugin: SystemPlugin?) -> Bool {
+        guard let wcPlugin = wcPlugin, wcPlugin.active else {
+            return false
+        }
+        return VersionHelpers.isVersionSupported(version: wcPlugin.version,
+                                                 minimumRequired: Constants.wcPluginMinimumVersion)
+    }
+
     enum Constants {
         static let wcPluginName = "WooCommerce"
         // TODO: 6148 - Update the minimum WC version with inbox filtering.

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -2469,6 +2469,7 @@
 		DE78DE442B2846AF002E58DE /* ThemesCarouselViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE78DE432B2846AF002E58DE /* ThemesCarouselViewModelTests.swift */; };
 		DE792E1826EF35F40071200C /* ConnectivityObserver.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE792E1726EF35F40071200C /* ConnectivityObserver.swift */; };
 		DE792E1B26EF37ED0071200C /* DefaultConnectivityObserver.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE792E1A26EF37ED0071200C /* DefaultConnectivityObserver.swift */; };
+		DE7B17F52C0DF02800A6C7D8 /* InboxEligibilityUseCaseTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE7B17F42C0DF02800A6C7D8 /* InboxEligibilityUseCaseTests.swift */; };
 		DE7B479027A153C20018742E /* CouponSearchUICommand.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE7B478F27A153C20018742E /* CouponSearchUICommand.swift */; };
 		DE7B479327A38ADA0018742E /* CouponDetails.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE7B479227A38ADA0018742E /* CouponDetails.swift */; };
 		DE7B479527A38B8F0018742E /* CouponDetailsViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE7B479427A38B8F0018742E /* CouponDetailsViewModel.swift */; };
@@ -5372,6 +5373,7 @@
 		DE78DE432B2846AF002E58DE /* ThemesCarouselViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ThemesCarouselViewModelTests.swift; sourceTree = "<group>"; };
 		DE792E1726EF35F40071200C /* ConnectivityObserver.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConnectivityObserver.swift; sourceTree = "<group>"; };
 		DE792E1A26EF37ED0071200C /* DefaultConnectivityObserver.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefaultConnectivityObserver.swift; sourceTree = "<group>"; };
+		DE7B17F42C0DF02800A6C7D8 /* InboxEligibilityUseCaseTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InboxEligibilityUseCaseTests.swift; sourceTree = "<group>"; };
 		DE7B478F27A153C20018742E /* CouponSearchUICommand.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CouponSearchUICommand.swift; sourceTree = "<group>"; };
 		DE7B479227A38ADA0018742E /* CouponDetails.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CouponDetails.swift; sourceTree = "<group>"; };
 		DE7B479427A38B8F0018742E /* CouponDetailsViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CouponDetailsViewModel.swift; sourceTree = "<group>"; };
@@ -6485,6 +6487,7 @@
 			children = (
 				02645D8127BA20A30065DC68 /* InboxViewModelTests.swift */,
 				02645D8B27BA342D0065DC68 /* InboxNoteRowViewModelTests.swift */,
+				DE7B17F42C0DF02800A6C7D8 /* InboxEligibilityUseCaseTests.swift */,
 			);
 			path = Inbox;
 			sourceTree = "<group>";
@@ -15772,6 +15775,7 @@
 				03D7985C2A94EC7700809B0E /* MockCollectOrderPaymentAnalyticsTracker.swift in Sources */,
 				021E2A2023AA274700B1DE07 /* ProductBackordersSettingListSelectorCommandTests.swift in Sources */,
 				0235BFDB246E99A700778909 /* ProductFormActionsFactory+NonEmptyBottomSheetActionsTests.swift in Sources */,
+				DE7B17F52C0DF02800A6C7D8 /* InboxEligibilityUseCaseTests.swift in Sources */,
 				020BE76723B49FE9007FE54C /* AztecBoldFormatBarCommandTests.swift in Sources */,
 				57C9A8FE24C23335001E1C2F /* MockNoticePresenter.swift in Sources */,
 				02BAB01F24D0232800F8B06E /* MockProductVariation.swift in Sources */,

--- a/WooCommerce/WooCommerceTests/ViewRelated/HubMenu/HubMenuViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/HubMenu/HubMenuViewModelTests.swift
@@ -4,10 +4,10 @@ import XCTest
 @testable import WooCommerce
 @testable import Yosemite
 
-@MainActor
 final class HubMenuViewModelTests: XCTestCase {
     private let sampleSiteID: Int64 = 606
 
+    @MainActor
     func test_viewDidAppear_then_posts_notification() {
         // Given
         let viewModel = HubMenuViewModel(siteID: sampleSiteID, tapToPayBadgePromotionChecker: TapToPayBadgePromotionChecker())
@@ -20,6 +20,7 @@ final class HubMenuViewModelTests: XCTestCase {
         waitForExpectations(timeout: Constants.expectationTimeout)
     }
 
+    @MainActor
     func test_menuElements_do_not_include_inbox_when_feature_flag_is_off() {
         // Given
         let featureFlagService = MockFeatureFlagService(isInboxOn: false)
@@ -35,30 +36,16 @@ final class HubMenuViewModelTests: XCTestCase {
         }))
     }
 
+    @MainActor
     func test_menuElements_include_inbox_when_store_has_eligible_wc_version() {
-        // Given the store is eligible for inbox with only WC plugin
-        let featureFlagService = MockFeatureFlagService(isInboxOn: true)
+        let inboxEligibilityChecker = MockInboxEligibilityChecker()
+        inboxEligibilityChecker.isEligible = true
         let stores = MockStoresManager(sessionManager: .makeForTesting())
-
-        stores.whenReceivingAction(ofType: SystemStatusAction.self) { action in
-            switch action {
-            case let .fetchSystemPlugin(_, systemPluginName, onCompletion):
-                switch systemPluginName {
-                case PluginName.wooCommerce:
-                    onCompletion(Fixtures.wcPluginEligibleForInbox)
-                default:
-                    onCompletion(nil)
-                }
-            default:
-                break
-            }
-        }
 
         // When
         let viewModel = HubMenuViewModel(siteID: sampleSiteID,
                                          tapToPayBadgePromotionChecker: TapToPayBadgePromotionChecker(),
-                                         featureFlagService: featureFlagService,
-                                         stores: stores)
+                                         inboxEligibilityChecker: inboxEligibilityChecker)
         viewModel.setupMenuElements()
 
         // Then inbox is in the menu
@@ -67,6 +54,7 @@ final class HubMenuViewModelTests: XCTestCase {
         }))
     }
 
+    @MainActor
     func test_menuElements_do_not_include_inbox_when_store_has_ineligible_wc_version() {
         // Given the store is ineligible WC version for inbox and coupons feature is enabled in app settings
         let featureFlagService = MockFeatureFlagService(isInboxOn: true)
@@ -98,6 +86,7 @@ final class HubMenuViewModelTests: XCTestCase {
         }))
     }
 
+    @MainActor
     func test_generalElements_does_not_include_blaze_when_default_site_is_not_set() {
         // When
         let viewModel = HubMenuViewModel(siteID: sampleSiteID,
@@ -108,6 +97,7 @@ final class HubMenuViewModelTests: XCTestCase {
         XCTAssertNil(viewModel.generalElements.firstIndex(where: { $0.id == HubMenuViewModel.Blaze.id }))
     }
 
+    @MainActor
     func test_generalElements_does_not_include_blaze_when_site_is_not_eligible_for_blaze() throws {
         // Given
         let stores = MockStoresManager(sessionManager: .makeForTesting())
@@ -128,6 +118,7 @@ final class HubMenuViewModelTests: XCTestCase {
         XCTAssertNil(viewModel.generalElements.firstIndex(where: { $0.id == HubMenuViewModel.Blaze.id }))
     }
 
+    @MainActor
     func test_generalElements_includes_blaze_after_payments_when_site_is_eligible_for_blaze() throws {
         // Given
         let stores = MockStoresManager(sessionManager: .makeForTesting())
@@ -152,6 +143,7 @@ final class HubMenuViewModelTests: XCTestCase {
         XCTAssertEqual(viewModel.generalElements[blazeIndex - 1].id, HubMenuViewModel.Payments.id)
     }
 
+    @MainActor
     func test_storeURL_when_site_has_storeURL_then_returns_storeURL() {
         // Given
         let sampleStoreURL = "https://testshop.com/"
@@ -168,6 +160,8 @@ final class HubMenuViewModelTests: XCTestCase {
         // Then
         XCTAssertEqual(viewModel.storeURL, try sampleStoreURL.asURL())
     }
+
+    @MainActor
     func test_woocommerceAdminURL_when_site_has_adminURL_then_returns_adminURL() {
         // Given
         let sampleAdminURL = "https://testshop.com/wp-admin/"
@@ -184,6 +178,8 @@ final class HubMenuViewModelTests: XCTestCase {
         // Then
         XCTAssertEqual(viewModel.woocommerceAdminURL, try sampleAdminURL.asURL())
     }
+
+    @MainActor
     func test_storeURL_when_storeURL_is_nil_then_returns_woocommerce_fallback_url() {
         // Given
         let sampleStoreURL: String? = nil
@@ -200,6 +196,8 @@ final class HubMenuViewModelTests: XCTestCase {
         XCTAssertNotNil(viewModel.storeURL)
         XCTAssertEqual(viewModel.storeURL, WooConstants.URLs.blog.asURL())
     }
+
+    @MainActor
     func test_woocommerceAdminURL_when_adminURL_is_nil_then_returns_adminURL() {
         // Given
         let sampleStoreURL = "https://testshop.com"
@@ -218,6 +216,8 @@ final class HubMenuViewModelTests: XCTestCase {
         XCTAssertNotNil(viewModel.woocommerceAdminURL)
         XCTAssertEqual(viewModel.woocommerceAdminURL, try URL(string: expectedAdminURL)?.asURL())
     }
+
+    @MainActor
     func test_woocommerceAdminURL_when_adminURL_is_empty_then_returns_adminURL() {
         // Given
         let sampleStoreURL = "https://testshop.com"
@@ -237,6 +237,7 @@ final class HubMenuViewModelTests: XCTestCase {
         XCTAssertEqual(viewModel.woocommerceAdminURL, try URL(string: expectedAdminURL)?.asURL())
     }
 
+    @MainActor
     func test_switchStoreEnabled_returns_true_when_logged_in_with_wpcom() {
         // Given
         let sampleStoreURL = "https://testshop.com"
@@ -255,6 +256,7 @@ final class HubMenuViewModelTests: XCTestCase {
         XCTAssertTrue(viewModel.switchStoreEnabled)
     }
 
+    @MainActor
     func test_switchStoreEnabled_returns_false_when_logged_in_without_wpcom() {
         // Given
         let sampleStoreURL = "https://testshop.com"
@@ -273,6 +275,7 @@ final class HubMenuViewModelTests: XCTestCase {
         XCTAssertFalse(viewModel.switchStoreEnabled)
     }
 
+    @MainActor
     func test_shouldAuthenticateAdminPage_returns_true_when_logged_in_with_wpcom_to_wpcom_site() {
         // Given
         let sampleStoreURL = "https://testshop.com"
@@ -291,6 +294,7 @@ final class HubMenuViewModelTests: XCTestCase {
         XCTAssertTrue(viewModel.shouldAuthenticateAdminPage)
     }
 
+    @MainActor
     func test_shouldAuthenticateAdminPage_returns_true_when_logged_in_without_wpcom_to_self_hosted_site() {
         // Given
         let sampleStoreURL = "https://testshop.com"
@@ -309,6 +313,7 @@ final class HubMenuViewModelTests: XCTestCase {
         XCTAssertTrue(viewModel.shouldAuthenticateAdminPage)
     }
 
+    @MainActor
     func test_shouldAuthenticateAdminPage_returns_false_when_logged_in_with_wpcom_to_self_hosted_site() {
         // Given
         let sampleStoreURL = "https://testshop.com"
@@ -327,6 +332,7 @@ final class HubMenuViewModelTests: XCTestCase {
         XCTAssertFalse(viewModel.shouldAuthenticateAdminPage)
     }
 
+    @MainActor
     func test_menuElements_include_subscriptions_on_wp_com_sites_if_not_free_trial() {
         // Given
         let sessionManager = SessionManager.testingInstance
@@ -344,6 +350,7 @@ final class HubMenuViewModelTests: XCTestCase {
         }))
     }
 
+    @MainActor
     func test_menuElements_does_not_include_subscriptions_on_wp_com_free_trial_sites() {
         // Given
         let freeTrialPlanSlug = "ecommerce-trial-bundle-monthly"
@@ -362,6 +369,7 @@ final class HubMenuViewModelTests: XCTestCase {
         }))
     }
 
+    @MainActor
     func test_menuElements_does_not_include_subscriptions_on_self_hosted_sites() {
         // Given
         let sessionManager = SessionManager.testingInstance
@@ -379,6 +387,7 @@ final class HubMenuViewModelTests: XCTestCase {
         }))
     }
 
+    @MainActor
     func test_menuElements_include_customers() {
         // Given
         let viewModel = HubMenuViewModel(siteID: sampleSiteID,
@@ -393,6 +402,7 @@ final class HubMenuViewModelTests: XCTestCase {
         }))
     }
 
+    @MainActor
     func test_showPayments_replaces_navigationPath_with_payments() {
         // Given
         var navigationPath = NavigationPath(["testPath1", "testPath2"])

--- a/WooCommerce/WooCommerceTests/ViewRelated/Inbox/InboxEligibilityUseCaseTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Inbox/InboxEligibilityUseCaseTests.swift
@@ -1,0 +1,121 @@
+import XCTest
+@testable import WooCommerce
+import Yosemite
+
+final class InboxEligibilityUseCaseTests: XCTestCase {
+
+    @MainActor
+    func test_async_isEligibleForInbox_returns_true_if_stored_woo_plugin_is_found_and_version_is_eligible_and_feature_flag_is_on() async {
+        // Given
+        let siteID: Int64 = 132
+        let featureFlagService = MockFeatureFlagService(isInboxOn: true)
+        let stores = MockStoresManager(sessionManager: .makeForTesting())
+        let useCase = InboxEligibilityUseCase(stores: stores, featureFlagService: featureFlagService)
+
+        var triggeredSyncingSystemInformation = false
+
+        // When
+        stores.whenReceivingAction(ofType: SystemStatusAction.self) { action in
+            switch action {
+            case let .fetchSystemPlugin(_, _, onCompletion):
+                onCompletion(SystemPlugin.fake().copy(siteID: siteID, name: "WooCommerce", version: "6.0.0", active: true))
+            case .synchronizeSystemInformation:
+                triggeredSyncingSystemInformation = true
+            default:
+                break
+            }
+        }
+        let result = await useCase.isEligibleForInbox(siteID: siteID)
+
+        // Then
+        XCTAssertTrue(result)
+        XCTAssertFalse(triggeredSyncingSystemInformation)
+    }
+
+    @MainActor
+    func test_async_isEligibleForInbox_returns_true_if_remote_woo_plugin_is_found_and_version_is_eligible_and_feature_flag_is_on() async {
+        // Given
+        let siteID: Int64 = 132
+        let featureFlagService = MockFeatureFlagService(isInboxOn: true)
+        let stores = MockStoresManager(sessionManager: .makeForTesting())
+        let useCase = InboxEligibilityUseCase(stores: stores, featureFlagService: featureFlagService)
+
+        var triggeredSyncingSystemInformation = false
+
+        // When
+        stores.whenReceivingAction(ofType: SystemStatusAction.self) { action in
+            switch action {
+            case let .fetchSystemPlugin(_, _, onCompletion):
+                onCompletion(nil)
+            case let .synchronizeSystemInformation(_, onCompletion):
+                let wooPlugin = SystemPlugin.fake().copy(siteID: siteID, name: "WooCommerce", version: "6.0.0", active: true)
+                let systemInfo = SystemInformation.fake().copy(systemPlugins: [wooPlugin])
+                triggeredSyncingSystemInformation = true
+                onCompletion(.success(systemInfo))
+            default:
+                break
+            }
+        }
+        let result = await useCase.isEligibleForInbox(siteID: siteID)
+
+        // Then
+        XCTAssertTrue(result)
+        XCTAssertTrue(triggeredSyncingSystemInformation)
+    }
+
+    @MainActor
+    func test_async_isEligibleForInbox_returns_false_if_stored_woo_plugin_is_found_and_version_is_eligible_and_feature_flag_is_off() async {
+        // Given
+        let siteID: Int64 = 132
+        let featureFlagService = MockFeatureFlagService(isInboxOn: false)
+        let stores = MockStoresManager(sessionManager: .makeForTesting())
+        let useCase = InboxEligibilityUseCase(stores: stores, featureFlagService: featureFlagService)
+
+        var triggeredSyncingSystemInformation = false
+
+        // When
+        stores.whenReceivingAction(ofType: SystemStatusAction.self) { action in
+            switch action {
+            case let .fetchSystemPlugin(_, _, onCompletion):
+                onCompletion(SystemPlugin.fake().copy(siteID: siteID, name: "WooCommerce", version: "6.0.0"))
+            case .synchronizeSystemInformation:
+                triggeredSyncingSystemInformation = true
+            default:
+                break
+            }
+        }
+        let result = await useCase.isEligibleForInbox(siteID: siteID)
+
+        // Then
+        XCTAssertFalse(result)
+        XCTAssertFalse(triggeredSyncingSystemInformation)
+    }
+
+    @MainActor
+    func test_async_isEligibleForInbox_returns_false_if_stored_woo_plugin_is_found_and_version_is_ineligible_and_feature_flag_is_on() async {
+        // Given
+        let siteID: Int64 = 132
+        let featureFlagService = MockFeatureFlagService(isInboxOn: true)
+        let stores = MockStoresManager(sessionManager: .makeForTesting())
+        let useCase = InboxEligibilityUseCase(stores: stores, featureFlagService: featureFlagService)
+
+        var triggeredSyncingSystemInformation = false
+
+        // When
+        stores.whenReceivingAction(ofType: SystemStatusAction.self) { action in
+            switch action {
+            case let .fetchSystemPlugin(_, _, onCompletion):
+                onCompletion(SystemPlugin.fake().copy(siteID: siteID, name: "WooCommerce", version: "4.5.0"))
+            case .synchronizeSystemInformation:
+                triggeredSyncingSystemInformation = true
+            default:
+                break
+            }
+        }
+        let result = await useCase.isEligibleForInbox(siteID: siteID)
+
+        // Then
+        XCTAssertFalse(result)
+        XCTAssertFalse(triggeredSyncingSystemInformation)
+    }
+}


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of #12843 
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
The eligibility check for inbox is currently checking for the Woo plugin in storage only. After the user first logs in or switches to a new store, the syncing for system information may take longer than the check for the system plugin in storage, so the eligibility check for inbox can fail with a nil plugin.

This PR fixes this by updating the eligibility check:
- Check for the woo plugin in storage by default.
- If the woo plugin cannot be found, sync system information and check for the woo plugin in the result.

This makes sure that we'll always have the most up-to-date details about the woo plugin when checking if the store is eligible for inbox feature.


## Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: https://woomobilep2.wordpress.com/2024/05/06/woocommerce-mobile-quality-report-march-april/#comment-12036 -->
- Enable the feature flag for dynamic dashboard M2 and inbox.
- Log out of the app and log in again to a test store version larger than 5.0.0.
- On the dashboard screen, tap the Edit button.
- Confirm that the Inbox option is available.
- Switch to the Hub menu, confirm that the inbox row is available. Tapping on it should display the inbox list.

Disable the feature flag for inbox and confirm that the Inbox option is not available on both the dashboard screen and hub menu.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->
Dashboard Customize | Hub menu
--- | ---
<img src="https://github.com/woocommerce/woocommerce-ios/assets/5533851/591d1191-8b25-47d7-a19a-d4783d1815a9" width=320 /> | <img src="https://github.com/woocommerce/woocommerce-ios/assets/5533851/d58bca21-7cfe-4b52-80e7-79ab732892e0" width=320 />


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
