### PR TITLE
[Woo POS] Add SwiftUI-friendly action handlers

### DIFF
--- a/WooCommerce/Classes/POS/Card Present Payments/CardPresentPaymentEvent.swift
+++ b/WooCommerce/Classes/POS/Card Present Payments/CardPresentPaymentEvent.swift
@@ -1,8 +1,10 @@
 import Foundation
 
+typealias CardPresentPaymentAlertViewModel = CardPresentPaymentsModalViewModelContent & CardPresentPaymentsModalViewModelActions
+
 enum CardPresentPaymentEvent {
     case idle
-    case showAlert(_ alertViewModel: CardPresentPaymentsModalViewModel)
+    case showAlert(_ alertViewModel: CardPresentPaymentAlertViewModel)
     case showReaderList(_ readerIDs: [String], selectionHandler: ((String) -> Void))
     case showOnboarding(_ onboardingViewModel: CardPresentPaymentsOnboardingViewModel)
 }

--- a/WooCommerce/Classes/POS/Card Present Payments/CardPresentPaymentsModalButtonViewModel.swift
+++ b/WooCommerce/Classes/POS/Card Present Payments/CardPresentPaymentsModalButtonViewModel.swift
@@ -1,0 +1,18 @@
+import Foundation
+
+struct CardPresentPaymentsModalButtonViewModel {
+    var title: String
+    var actionHandler: () -> Void
+
+    init(title: String, actionHandler: @escaping (() -> Void)) {
+        self.title = title
+        self.actionHandler = actionHandler
+    }
+
+    init?(title: String?, actionHandler: @escaping (() -> Void)) {
+        guard let title else {
+            return nil
+        }
+        self.init(title: title, actionHandler: actionHandler)
+    }
+}

--- a/WooCommerce/Classes/POS/Card Present Payments/CardPresentPaymentsModalButtonViewModel.swift
+++ b/WooCommerce/Classes/POS/Card Present Payments/CardPresentPaymentsModalButtonViewModel.swift
@@ -1,8 +1,8 @@
 import Foundation
 
 struct CardPresentPaymentsModalButtonViewModel {
-    var title: String
-    var actionHandler: () -> Void
+    let title: String
+    let actionHandler: () -> Void
 
     init(title: String, actionHandler: @escaping (() -> Void)) {
         self.title = title

--- a/WooCommerce/Classes/POS/Presentation/CardPresentPaymentAlert.swift
+++ b/WooCommerce/Classes/POS/Presentation/CardPresentPaymentAlert.swift
@@ -1,0 +1,25 @@
+import SwiftUI
+
+struct CardPresentPaymentAlert: View {
+    let alertViewModel: CardPresentPaymentAlertViewModel
+
+    var body: some View {
+        Text(alertViewModel.topTitle)
+        if let primaryButton = alertViewModel.primaryButtonViewModel {
+            Button(primaryButton.title, action: primaryButton.actionHandler)
+        }
+
+        if let secondaryButton = alertViewModel.secondaryButtonViewModel {
+            Button(secondaryButton.title, action: secondaryButton.actionHandler)
+        }
+
+        if let auxiliaryButton = alertViewModel.auxiliaryButtonViewModel {
+            Button(auxiliaryButton.title, action: auxiliaryButton.actionHandler)
+        }
+    }
+}
+
+#Preview {
+    let alertViewModel = CardPresentModalFoundReader(name: "Stripe M2", connect: {}, continueSearch: {}, cancel: {})
+    return CardPresentPaymentAlert(alertViewModel: alertViewModel)
+}

--- a/WooCommerce/Classes/POS/Presentation/CardPresentPaymentAlert.swift
+++ b/WooCommerce/Classes/POS/Presentation/CardPresentPaymentAlert.swift
@@ -4,17 +4,24 @@ struct CardPresentPaymentAlert: View {
     let alertViewModel: CardPresentPaymentAlertViewModel
 
     var body: some View {
-        Text(alertViewModel.topTitle)
-        if let primaryButton = alertViewModel.primaryButtonViewModel {
-            Button(primaryButton.title, action: primaryButton.actionHandler)
-        }
+        VStack {
+            Text(alertViewModel.topTitle)
 
-        if let secondaryButton = alertViewModel.secondaryButtonViewModel {
-            Button(secondaryButton.title, action: secondaryButton.actionHandler)
-        }
+            if let bottomTitle = alertViewModel.bottomTitle {
+                Text(bottomTitle)
+            }
 
-        if let auxiliaryButton = alertViewModel.auxiliaryButtonViewModel {
-            Button(auxiliaryButton.title, action: auxiliaryButton.actionHandler)
+            if let primaryButton = alertViewModel.primaryButtonViewModel {
+                Button(primaryButton.title, action: primaryButton.actionHandler)
+            }
+
+            if let secondaryButton = alertViewModel.secondaryButtonViewModel {
+                Button(secondaryButton.title, action: secondaryButton.actionHandler)
+            }
+
+            if let auxiliaryButton = alertViewModel.auxiliaryButtonViewModel {
+                Button(auxiliaryButton.title, action: auxiliaryButton.actionHandler)
+            }
         }
     }
 }

--- a/WooCommerce/Classes/POS/Presentation/PointOfSaleDashboardView.swift
+++ b/WooCommerce/Classes/POS/Presentation/PointOfSaleDashboardView.swift
@@ -46,7 +46,14 @@ struct PointOfSaleDashboardView: View {
             })
         }
         .sheet(isPresented: $viewModel.showsCardReaderSheet, content: {
-            Text(viewModel.cardPresentPaymentEvent.temporaryEventDescription)
+            switch viewModel.cardPresentPaymentEvent {
+            case .showAlert(let alertViewModel):
+                CardPresentPaymentAlert(alertViewModel: alertViewModel)
+            case .idle,
+                    .showReaderList,
+                    .showOnboarding:
+                Text(viewModel.cardPresentPaymentEvent.temporaryEventDescription)
+            }
         })
         .sheet(isPresented: $viewModel.showsFilterSheet, content: {
             FilterView(viewModel: viewModel)

--- a/WooCommerce/Classes/ViewModels/CardPresentPayments/CardPresentPaymentsModalViewModel.swift
+++ b/WooCommerce/Classes/ViewModels/CardPresentPayments/CardPresentPaymentsModalViewModel.swift
@@ -1,6 +1,8 @@
 import UIKit
 
-typealias CardPresentPaymentsModalViewModel = CardPresentPaymentsModalViewModelContent & CardPresentPaymentsModalViewModelUIKitActions
+typealias CardPresentPaymentsModalViewModel = CardPresentPaymentsModalViewModelContent
+    & CardPresentPaymentsModalViewModelUIKitActions
+    & CardPresentPaymentsModalViewModelActions
 
 /// Abstracts configuration and contents of the modal screens presented
 /// during operations related to Card Present Payments
@@ -57,6 +59,35 @@ protocol CardPresentPaymentsModalViewModelUIKitActions {
     /// Executes action associated to a tap in the view controller auxiliary button
     /// - Parameter viewController: usually the view controller sending the tap
     func didTapAuxiliaryButton(in viewController: UIViewController?)
+}
+
+protocol CardPresentPaymentsModalViewModelActions {
+    var primaryButtonViewModel: CardPresentPaymentsModalButtonViewModel? { get }
+    var secondaryButtonViewModel: CardPresentPaymentsModalButtonViewModel? { get }
+    var auxiliaryButtonViewModel: CardPresentPaymentsModalButtonViewModel? { get }
+}
+
+/// This is an initial, naive adapting of the existing view models to call the handlers without passing a view controller
+/// That's not really good enough, but unblocks us to be able to use the buttons.
+/// We should replace this with specific SwiftUI handlers.
+extension CardPresentPaymentsModalViewModelUIKitActions where Self: CardPresentPaymentsModalViewModelActions {
+    var primaryButtonViewModel: CardPresentPaymentsModalButtonViewModel? {
+        CardPresentPaymentsModalButtonViewModel(title: primaryButtonTitle) {
+            didTapPrimaryButton(in: nil)
+        }
+    }
+
+    var secondaryButtonViewModel: CardPresentPaymentsModalButtonViewModel? {
+        CardPresentPaymentsModalButtonViewModel(title: secondaryButtonTitle) {
+            didTapAuxiliaryButton(in: nil)
+        }
+    }
+
+    var auxiliaryButtonViewModel: CardPresentPaymentsModalButtonViewModel? {
+        CardPresentPaymentsModalButtonViewModel(title: auxiliaryButtonTitle) {
+            didTapAuxiliaryButton(in: nil)
+        }
+    }
 }
 
 /// The type of card-present transaction.

--- a/WooCommerce/Classes/ViewModels/CardPresentPayments/CardPresentPaymentsModalViewModel.swift
+++ b/WooCommerce/Classes/ViewModels/CardPresentPayments/CardPresentPaymentsModalViewModel.swift
@@ -79,7 +79,7 @@ extension CardPresentPaymentsModalViewModelUIKitActions where Self: CardPresentP
 
     var secondaryButtonViewModel: CardPresentPaymentsModalButtonViewModel? {
         CardPresentPaymentsModalButtonViewModel(title: secondaryButtonTitle) {
-            didTapAuxiliaryButton(in: nil)
+            didTapSecondaryButton(in: nil)
         }
     }
 

--- a/WooCommerce/Classes/ViewModels/CardPresentPayments/CardPresentPaymentsModalViewModel.swift
+++ b/WooCommerce/Classes/ViewModels/CardPresentPayments/CardPresentPaymentsModalViewModel.swift
@@ -1,13 +1,12 @@
 import UIKit
 
+typealias CardPresentPaymentsModalViewModel = CardPresentPaymentsModalViewModelContent & CardPresentPaymentsModalViewModelUIKitActions
+
 /// Abstracts configuration and contents of the modal screens presented
 /// during operations related to Card Present Payments
-protocol CardPresentPaymentsModalViewModel {
+protocol CardPresentPaymentsModalViewModelContent {
     /// The number and distribution of text labels
     var textMode: PaymentsModalTextMode { get }
-
-    /// The number and distribution of action buttons
-    var actionsMode: PaymentsModalActionsMode { get }
 
     /// The title at the top of the modal view.
     var topTitle: String { get }
@@ -18,7 +17,22 @@ protocol CardPresentPaymentsModalViewModel {
     /// An illustration accompanying the modal
     var image: UIImage { get }
 
+    /// Large loading indicator which may be shown in place of the image
     var showLoadingIndicator: Bool { get }
+
+    /// The title in the bottom section of the modal. Right below the image
+    var bottomTitle: String? { get }
+
+    /// The subtitle in the bottom section of the modal. Right below the image
+    var bottomSubtitle: String? { get }
+
+    /// The accessibilityLabel to be provided to VoiceOver
+    var accessibilityLabel: String? { get }
+}
+
+protocol CardPresentPaymentsModalViewModelUIKitActions {
+    /// The number and distribution of action buttons
+    var actionsMode: PaymentsModalActionsMode { get }
 
     /// Provides a title for a primary action button
     var primaryButtonTitle: String? { get }
@@ -31,15 +45,6 @@ protocol CardPresentPaymentsModalViewModel {
 
     /// Provides a title as a NSAttributedString for an auxiliary button
     var auxiliaryAttributedButtonTitle: NSAttributedString? { get }
-
-    /// The title in the bottom section of the modal. Right below the image
-    var bottomTitle: String? { get }
-
-    /// The subtitle in the bottom section of the modal. Right below the image
-    var bottomSubtitle: String? { get }
-
-    /// The accessibilityLabel to be provided to VoiceOver
-    var accessibilityLabel: String? { get }
 
     /// Executes action associated to a tap in the view controller primary button
     /// - Parameter viewController: usually the view controller sending the tap
@@ -99,13 +104,17 @@ enum PaymentsModalActionsMode {
 
 }
 
-extension CardPresentPaymentsModalViewModel {
+extension CardPresentPaymentsModalViewModelUIKitActions {
     /// Default implementation for NSAttributedString auxiliary button title.
     /// If is not set directly by each Modal's ViewModel, it will default to nil
     var auxiliaryAttributedButtonTitle: NSAttributedString? {
         get { return nil }
     }
+}
 
+extension CardPresentPaymentsModalViewModelContent {
+    /// Default implementation for the large loading indicator used in place of an image.
+    /// If is not set directly by each Modal's ViewModel, it will default to false
     var showLoadingIndicator: Bool {
         get { return false }
     }

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -762,6 +762,7 @@
 		2004E2E32C0A128400D62521 /* CardPresentPaymentsConnectionControllerManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2004E2E22C0A128400D62521 /* CardPresentPaymentsConnectionControllerManager.swift */; };
 		2004E2E52C0A206800D62521 /* CardPresentPaymentsAlertPresenterAdaptor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2004E2E42C0A206800D62521 /* CardPresentPaymentsAlertPresenterAdaptor.swift */; };
 		2004E2E72C0DFB9E00D62521 /* CardPresentPaymentsModalButtonViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2004E2E62C0DFB9E00D62521 /* CardPresentPaymentsModalButtonViewModel.swift */; };
+		2004E2E92C0DFE2B00D62521 /* CardPresentPaymentAlert.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2004E2E82C0DFE2B00D62521 /* CardPresentPaymentAlert.swift */; };
 		201F5AC52AD4061800EF6C55 /* AboutTapToPayViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 201F5AC42AD4061800EF6C55 /* AboutTapToPayViewModel.swift */; };
 		20203AB22B31EEF1009D0C11 /* ExpandableBottomSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 20203AB12B31EEF1009D0C11 /* ExpandableBottomSheet.swift */; };
 		202496642B0B9E0D00EE527D /* ScrollViewSectionKit in Frameworks */ = {isa = PBXBuildFile; productRef = 202496632B0B9E0D00EE527D /* ScrollViewSectionKit */; };
@@ -3682,6 +3683,7 @@
 		2004E2E22C0A128400D62521 /* CardPresentPaymentsConnectionControllerManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardPresentPaymentsConnectionControllerManager.swift; sourceTree = "<group>"; };
 		2004E2E42C0A206800D62521 /* CardPresentPaymentsAlertPresenterAdaptor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardPresentPaymentsAlertPresenterAdaptor.swift; sourceTree = "<group>"; };
 		2004E2E62C0DFB9E00D62521 /* CardPresentPaymentsModalButtonViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardPresentPaymentsModalButtonViewModel.swift; sourceTree = "<group>"; };
+		2004E2E82C0DFE2B00D62521 /* CardPresentPaymentAlert.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardPresentPaymentAlert.swift; sourceTree = "<group>"; };
 		200B84AD2BEB99AC00EAAB23 /* WooCommercePOS.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = WooCommercePOS.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		201F5AC42AD4061800EF6C55 /* AboutTapToPayViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AboutTapToPayViewModel.swift; sourceTree = "<group>"; };
 		20203AB12B31EEF1009D0C11 /* ExpandableBottomSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExpandableBottomSheet.swift; sourceTree = "<group>"; };
@@ -6517,6 +6519,7 @@
 				026826B02BF59E170036F959 /* CardReaderConnection */,
 				026826A72BF59DF70036F959 /* PointOfSaleEntryPointView.swift */,
 				026826A52BF59DF60036F959 /* PointOfSaleDashboardView.swift */,
+				2004E2E82C0DFE2B00D62521 /* CardPresentPaymentAlert.swift */,
 				026826A82BF59DF70036F959 /* ItemGridView.swift */,
 				026826A32BF59DF60036F959 /* CartView.swift */,
 				026826A22BF59DF60036F959 /* ItemRowView.swift */,
@@ -15373,6 +15376,7 @@
 				020BE74D23B1F5EB007FE54C /* TitleAndTextFieldTableViewCell.swift in Sources */,
 				023D692E2588BF0900F7DA72 /* ShippingLabelPaperSizeListSelectorCommand.swift in Sources */,
 				CC3B35DD28E5A6EA0036B097 /* ReviewReplyViewModel.swift in Sources */,
+				2004E2E92C0DFE2B00D62521 /* CardPresentPaymentAlert.swift in Sources */,
 				DE86E9272A4BEA2500A89A5B /* FeedbackView.swift in Sources */,
 				CC72BB6427BD842500837876 /* DisclosureIndicator.swift in Sources */,
 				77E53EC52510C193003D385F /* ProductDownloadListViewController+Droppable.swift in Sources */,

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -761,6 +761,7 @@
 		2004E2E12C08ED3200D62521 /* ViewControllerPresenting.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2004E2DB2C08E95B00D62521 /* ViewControllerPresenting.swift */; };
 		2004E2E32C0A128400D62521 /* CardPresentPaymentsConnectionControllerManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2004E2E22C0A128400D62521 /* CardPresentPaymentsConnectionControllerManager.swift */; };
 		2004E2E52C0A206800D62521 /* CardPresentPaymentsAlertPresenterAdaptor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2004E2E42C0A206800D62521 /* CardPresentPaymentsAlertPresenterAdaptor.swift */; };
+		2004E2E72C0DFB9E00D62521 /* CardPresentPaymentsModalButtonViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2004E2E62C0DFB9E00D62521 /* CardPresentPaymentsModalButtonViewModel.swift */; };
 		201F5AC52AD4061800EF6C55 /* AboutTapToPayViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 201F5AC42AD4061800EF6C55 /* AboutTapToPayViewModel.swift */; };
 		20203AB22B31EEF1009D0C11 /* ExpandableBottomSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 20203AB12B31EEF1009D0C11 /* ExpandableBottomSheet.swift */; };
 		202496642B0B9E0D00EE527D /* ScrollViewSectionKit in Frameworks */ = {isa = PBXBuildFile; productRef = 202496632B0B9E0D00EE527D /* ScrollViewSectionKit */; };
@@ -3680,6 +3681,7 @@
 		2004E2DB2C08E95B00D62521 /* ViewControllerPresenting.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ViewControllerPresenting.swift; sourceTree = "<group>"; };
 		2004E2E22C0A128400D62521 /* CardPresentPaymentsConnectionControllerManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardPresentPaymentsConnectionControllerManager.swift; sourceTree = "<group>"; };
 		2004E2E42C0A206800D62521 /* CardPresentPaymentsAlertPresenterAdaptor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardPresentPaymentsAlertPresenterAdaptor.swift; sourceTree = "<group>"; };
+		2004E2E62C0DFB9E00D62521 /* CardPresentPaymentsModalButtonViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardPresentPaymentsModalButtonViewModel.swift; sourceTree = "<group>"; };
 		200B84AD2BEB99AC00EAAB23 /* WooCommercePOS.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = WooCommercePOS.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		201F5AC42AD4061800EF6C55 /* AboutTapToPayViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AboutTapToPayViewModel.swift; sourceTree = "<group>"; };
 		20203AB12B31EEF1009D0C11 /* ExpandableBottomSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExpandableBottomSheet.swift; sourceTree = "<group>"; };
@@ -4319,8 +4321,8 @@
 		68E952CF287587BF0095A23D /* CardReaderManualRowView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardReaderManualRowView.swift; sourceTree = "<group>"; };
 		68E952D12875A44B0095A23D /* CardReaderType+Manual.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "CardReaderType+Manual.swift"; sourceTree = "<group>"; };
 		68ED2BD52ADD2C8C00ECA88D /* LineDetailView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LineDetailView.swift; sourceTree = "<group>"; };
-		6A58DEEBCA91CDE69F439754 /* Pods_Woo_Watch_App.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_Woo_Watch_App.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		68F151E02C0DA7910082AEC8 /* CartItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CartItem.swift; sourceTree = "<group>"; };
+		6A58DEEBCA91CDE69F439754 /* Pods_Woo_Watch_App.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_Woo_Watch_App.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		6DC4526F9A7357761197EBF0 /* Pods_WooCommerceTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_WooCommerceTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		72E1A3B02BE650CC82F2DA14 /* Pods-NotificationExtension.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-NotificationExtension.release.xcconfig"; path = "../Pods/Target Support Files/Pods-NotificationExtension/Pods-NotificationExtension.release.xcconfig"; sourceTree = "<group>"; };
 		740382D92267D94100A627F4 /* LargeImageTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LargeImageTableViewCell.swift; sourceTree = "<group>"; };
@@ -7433,6 +7435,7 @@
 				027179E12C08817F0049F0BD /* CardPresentPaymentService.swift */,
 				2004E2E42C0A206800D62521 /* CardPresentPaymentsAlertPresenterAdaptor.swift */,
 				2004E2E22C0A128400D62521 /* CardPresentPaymentsConnectionControllerManager.swift */,
+				2004E2E62C0DFB9E00D62521 /* CardPresentPaymentsModalButtonViewModel.swift */,
 			);
 			path = "Card Present Payments";
 			sourceTree = "<group>";
@@ -14560,6 +14563,7 @@
 				B5A56BF0219F2CE90065A902 /* VerticalButton.swift in Sources */,
 				D831E2DC230E0558000037D0 /* Authentication.swift in Sources */,
 				26DB7E3528636D2200506173 /* NonEditableOrderBanner.swift in Sources */,
+				2004E2E72C0DFB9E00D62521 /* CardPresentPaymentsModalButtonViewModel.swift in Sources */,
 				204C9C742B6BDFFB007A94E0 /* UIUserInterfaceSizeClass+Helpers.swift in Sources */,
 				028A4657295B2CF4001CF6CE /* StoreCreationSellingPlatformsQuestionView.swift in Sources */,
 				314DC4BF268D183600444C9E /* CardReaderSettingsKnownReaderStorage.swift in Sources */,


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of: #12868 
Closes: #12893 
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

This PR adds buttons to the temporary payment alerts, with a naive implementation for tapping them. It allows us to try our connection work more within the app, but not all buttons work yet.

1. Split the `CardPresentPaymentsModalViewModel` into its constituent parts: `Content`, `UIKitActions`, and `Actions` – `Actions` are intended to be the future of this approach, but both may live on long term.
2. The Facade only vends `Content & Actions` with the events it publishes – swiftUI code doesn't directly know about the `UIKitActions` any more
3. The buttons are now rendered on the temporary view.
4. The bottom title was added as well, to provide more context especially around software updates.

Any action handler which requires a UIViewController to complete its work will fail at the moment.

To move on from the naive implementation, the next step is to add specific action handlers to each view model, rather than wrapping the UIKit ones as we do in the extension right now.

## Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->

Using a US-based WooPayments store which has passed IPP onboarding on the device you're using

1. Launch the app
2. Having enabled it in experimental features, navigate to `Menu > Point of Sale Mode`
3. Tap `Reader disconnected`
4. Observe that the modals which show have buttons and two lines of text (in some cases.)

## Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->

As noted above, not all buttons will work. I've not exhaustively tested it as this is still a partial implementation – mostly just checking that it does show the buttons and builds correctly will be enough here, IMO. We can do fuller testing when the buttons all actually work.

Also note that on successful connection, the modal is not yet dismissed, so it looks like it's just connecting forever.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

https://github.com/woocommerce/woocommerce-ios/assets/2472348/e0ffc6e9-6259-4cd1-9ffc-f5facf17c1f6



---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.