### PR TITLE
[Shipping Lines] Present shipping lines survey in order form

### DIFF
--- a/Storage/Storage/Model/FeedbackType.swift
+++ b/Storage/Storage/Model/FeedbackType.swift
@@ -12,4 +12,8 @@ public enum FeedbackType: String, Codable {
     /// Identifier for the coupon management feedback survey
     ///
     case couponManagement
+
+    /// Identifier for the order form shipping lines feedback survey
+    ///
+    case orderFormShippingLines
 }

--- a/WooCommerce/Classes/Analytics/WooAnalyticsEvent.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsEvent.swift
@@ -82,6 +82,8 @@ extension WooAnalyticsEvent {
         case tapToPayFirstPaymentPaymentsMenu
         /// Shown in Product details form for a AI generated product
         case productCreationAI = "product_creation_ai"
+        /// Shown in the order form after adding a shipping line
+        case orderFormShippingLines = "order_form_shipping_lines"
     }
 
     /// The action performed on the survey screen.

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/OrderForm.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/OrderForm.swift
@@ -378,7 +378,7 @@ struct OrderForm: View {
         }
         .safeAreaInset(edge: .bottom) {
             VStack {
-                BannerPopover(isPresented: $viewModel.shippingUseCase.shouldShowFeedbackSurvey, config: viewModel.shippingUseCase.feedbackSurveyConfig)
+                FeedbackBannerPopover(isPresented: $viewModel.shippingUseCase.isSurveyPromptPresented, config: viewModel.shippingUseCase.feedbackBannerConfig)
 
                 ExpandableBottomSheet(onChangeOfExpansion: viewModel.orderTotalsExpansionChanged) {
                     VStack {

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/Shipping/EditableOrderShippingUseCase.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/Shipping/EditableOrderShippingUseCase.swift
@@ -2,6 +2,7 @@ import WooFoundation
 import Yosemite
 import protocol Experiments.FeatureFlagService
 import protocol Storage.StorageManagerType
+import struct Storage.FeedbackSettings
 import Combine
 
 /// Use case to add, edit, or remove shipping lines on an order.
@@ -86,10 +87,12 @@ final class EditableOrderShippingUseCase: ObservableObject {
                                             onSurveyButtonTapped: { [weak self] in
             guard let self else { return }
             analytics.track(event: .featureFeedbackBanner(context: .orderFormShippingLines, action: .gaveFeedback))
+            updateFeedbackSurveyVisibility(.given(Date()))
         },
                                             onCloseButtonTapped: { [weak self] in
             guard let self else { return }
             analytics.track(event: .featureFeedbackBanner(context: .orderFormShippingLines, action: .dismissed))
+            updateFeedbackSurveyVisibility(.dismissed)
         })
     }()
 
@@ -117,7 +120,7 @@ final class EditableOrderShippingUseCase: ObservableObject {
     /// - Parameter shippingLine: New or updated shipping line object to save.
     func saveShippingLine(_ shippingLine: ShippingLine) {
         orderSynchronizer.setShipping.send(shippingLine)
-        isSurveyPromptPresented = true // TODO-12586: Limit when this is shown
+        refreshFeedbackSurveyVisibility()
         analytics.track(event: WooAnalyticsEvent.Orders.orderShippingMethodAdd(flow: flow.analyticsFlow,
                                                                                methodID: shippingLine.methodID ?? "",
                                                                                shippingLinesCount: Int64(orderSynchronizer.order.shippingLines.count)))
@@ -227,6 +230,32 @@ private extension EditableOrderShippingUseCase {
                 self?.updateShippingMethodsResultsController()
             case let .failure(error):
                 DDLogError("⛔️ Error retrieving available shipping methods: \(error)")
+            }
+        }
+        stores.dispatch(action)
+    }
+
+    /// Checks whether the feedback survey prompt should be visible.
+    ///
+    func refreshFeedbackSurveyVisibility() {
+        let action = AppSettingsAction.loadFeedbackVisibility(type: .orderFormShippingLines) { [weak self] result in
+            switch result {
+            case .success(let visible):
+                self?.isSurveyPromptPresented = visible
+            case.failure(let error):
+                self?.isSurveyPromptPresented = false
+                DDLogError("⛔️ Error loading feedback visibility for shipping lines: \(error)")
+            }
+        }
+        stores.dispatch(action)
+    }
+
+    /// Saves when the feedback survey prompt has been interacted with.
+    ///
+    func updateFeedbackSurveyVisibility(_ status: FeedbackSettings.Status) {
+        let action = AppSettingsAction.updateFeedbackStatus(type: .orderFormShippingLines, status: status) { result in
+            if let error = result.failure {
+                DDLogError("⛔️ Error updating feedback visibility for shipping lines: \(error)")
             }
         }
         stores.dispatch(action)

--- a/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/FeedbackBannerPopover.swift
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/FeedbackBannerPopover.swift
@@ -30,6 +30,7 @@ struct FeedbackBannerPopover: View {
                         .frame(width: Layout.buttonSize, height: Layout.buttonSize)
                         .foregroundStyle(Color(.invertedSecondaryLabel))
                 }
+                .accessibilityIdentifier("feedback-banner-popover-close-button")
             }
 
             Text(config.message)

--- a/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/FeedbackBannerPopover.swift
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/FeedbackBannerPopover.swift
@@ -1,19 +1,16 @@
 import SwiftUI
 
-struct BannerPopover: View {
+/// View for displaying a popover with a prompt to share feedback.
+///
+struct FeedbackBannerPopover: View {
     /// Whether the popover is presented.
-    ///
     @Binding var isPresented: Bool
 
-    /// Configuration for the popover.
-    ///
+    /// Configuration for the banner.
     var config: Configuration
 
-    /// View model for the link webview.
-    ///
-    /// Setting this view model displays the webview in a sheet.
-    ///
-    @State private var webviewViewModel: WebViewSheetViewModel?
+    /// Defines whether the feedback survey is presented.
+    @State private var isSurveyPresented: Bool = false
 
     var body: some View {
         VStack(alignment: .leading, spacing: Layout.spacing) {
@@ -25,6 +22,7 @@ struct BannerPopover: View {
                 Spacer()
 
                 Button {
+                    config.onCloseButtonTapped()
                     isPresented = false
                 } label: {
                     Image(uiImage: .closeButton)
@@ -38,7 +36,8 @@ struct BannerPopover: View {
                 .foregroundStyle(Color(.textInverted))
 
             Button {
-                webviewViewModel = WebViewSheetViewModel(url: config.buttonURL, navigationTitle: config.buttonTitle, authenticated: false)
+                isSurveyPresented = true
+                config.onSurveyButtonTapped()
             } label: {
                 Text(config.buttonTitle)
                     .foregroundStyle(Color(.wooCommercePurple(.shade20)))
@@ -55,13 +54,10 @@ struct BannerPopover: View {
         .padding()
         .frame(maxWidth: .infinity)
         .transition(.opacity.animation(.easeInOut))
-        .renderedIf(isPresented)
-        .sheet(item: $webviewViewModel) { viewModel in
-            WebViewSheet(viewModel: viewModel) {
-                isPresented = false // Close the banner when the webview is dismissed
-                webviewViewModel = nil
-            }
+        .sheet(isPresented: $isSurveyPresented) {
+            Survey(source: config.feedbackType)
         }
+        .renderedIf(isPresented)
     }
 
     struct Configuration {
@@ -71,15 +67,21 @@ struct BannerPopover: View {
         /// Banner message.
         let message: String
 
-        /// Title for banner button.
+        /// Title for button that opens the survey.
         let buttonTitle: String
 
-        /// URL for banner button.
-        let buttonURL: URL
+        /// Feedback survey type.
+        let feedbackType: SurveyViewController.Source
+
+        /// Closure triggered when survey button is tapped.
+        let onSurveyButtonTapped: () -> Void
+
+        /// Closure triggered when close button is tapped.
+        let onCloseButtonTapped: () -> Void
     }
 }
 
-private extension BannerPopover {
+private extension FeedbackBannerPopover {
     enum Layout {
         static let spacing: CGFloat = 8
         static let cornerRadius: CGFloat = 8
@@ -90,8 +92,10 @@ private extension BannerPopover {
 }
 
 #Preview {
-    BannerPopover(isPresented: .constant(true), config: .init(title: "Take a survey!",
-                                                              message: "What do you think?",
-                                                              buttonTitle: "Share your feedback",
-                                                              buttonURL: WooConstants.URLs.blog.asURL()))
+    FeedbackBannerPopover(isPresented: .constant(true), config: .init(title: "Take a survey!",
+                                                                      message: "What do you think of the app?",
+                                                                      buttonTitle: "Share your feedback",
+                                                                      feedbackType: .inAppFeedback,
+                                                                      onSurveyButtonTapped: {},
+                                                                      onCloseButtonTapped: {}))
 }

--- a/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/FeedbackBannerPopover.swift
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/FeedbackBannerPopover.swift
@@ -55,7 +55,9 @@ struct FeedbackBannerPopover: View {
         .frame(maxWidth: .infinity)
         .transition(.opacity.animation(.easeInOut))
         .sheet(isPresented: $isSurveyPresented) {
-            Survey(source: config.feedbackType)
+            Survey(source: config.feedbackType, onDismiss: {
+                isPresented = false
+            })
         }
         .renderedIf(isPresented)
     }

--- a/WooCommerce/Classes/ViewRelated/Survey/Survey.swift
+++ b/WooCommerce/Classes/ViewRelated/Survey/Survey.swift
@@ -8,8 +8,18 @@ struct Survey: UIViewControllerRepresentable {
     ///
     let source: SurveyViewController.Source
 
+    /// Optional closure when survey is dismissed
+    ///
+    let onDismiss: (() -> Void)?
+
+    init(source: SurveyViewController.Source,
+         onDismiss: (() -> Void)? = nil) {
+        self.source = source
+        self.onDismiss = onDismiss
+    }
+
     func makeUIViewController(context: Context) -> SurveyCoordinatingController {
-        return SurveyCoordinatingController(survey: source)
+        return SurveyCoordinatingController(survey: source, onDismiss: onDismiss)
 
     }
 

--- a/WooCommerce/Classes/ViewRelated/Survey/SurveyCoordinatingController.swift
+++ b/WooCommerce/Classes/ViewRelated/Survey/SurveyCoordinatingController.swift
@@ -19,14 +19,18 @@ final class SurveyCoordinatingController: WooNavigationController {
     /// What kind of survey to present.
     private let survey: SurveyViewController.Source
 
+    private let onDismiss: (() -> Void)?
+
     init(survey: SurveyViewController.Source,
          zendeskManager: ZendeskManagerProtocol = ZendeskProvider.shared,
          viewControllersFactory: SurveyViewControllersFactoryProtocol = SurveyViewControllersFactory(),
-         analytics: Analytics = ServiceLocator.analytics) {
+         analytics: Analytics = ServiceLocator.analytics,
+         onDismiss: (() -> Void)? = nil) {
         self.survey = survey
         self.zendeskManager = zendeskManager
         self.viewControllersFactory = viewControllersFactory
         self.analytics = analytics
+        self.onDismiss = onDismiss
         super.init(nibName: nil, bundle: nil)
         startSurveyNavigation()
     }
@@ -41,6 +45,8 @@ final class SurveyCoordinatingController: WooNavigationController {
         if isBeingDismissed && !receivedSurveyFinishedEvent {
             analytics.track(event: .surveyScreen(context: survey.feedbackContextForEvents, action: .canceled))
         }
+
+        onDismiss?()
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Survey/SurveyViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Survey/SurveyViewController.swift
@@ -71,6 +71,7 @@ extension SurveyViewController {
         case storeSetup
         case tapToPayFirstPayment
         case productCreationAI
+        case orderFormShippingLines
 
         fileprivate var url: URL {
             switch self {
@@ -120,6 +121,11 @@ extension SurveyViewController {
                     .asURL()
                     .tagPlatform("ios")
                     .tagAppVersion(Bundle.main.bundleVersion())
+            case .orderFormShippingLines:
+                return WooConstants.URLs.orderCreationShippingFeedback
+                    .asURL()
+                    .tagPlatform("ios")
+                    .tagAppVersion(Bundle.main.bundleVersion())
             }
         }
 
@@ -134,7 +140,8 @@ extension SurveyViewController {
                     .couponManagement,
                     .storeSetup,
                     .tapToPayFirstPayment,
-                    .productCreationAI:
+                    .productCreationAI,
+                    .orderFormShippingLines:
                 return Localization.giveFeedback
             }
         }
@@ -160,6 +167,8 @@ extension SurveyViewController {
                 return .tapToPayFirstPaymentPaymentsMenu
             case .productCreationAI:
                 return .productCreationAI
+            case .orderFormShippingLines:
+                return .orderFormShippingLines
             }
         }
     }

--- a/WooCommerce/UITestsFoundation/Screens/Orders/UnifiedOrderScreen.swift
+++ b/WooCommerce/UITestsFoundation/Screens/Orders/UnifiedOrderScreen.swift
@@ -53,6 +53,10 @@ public final class UnifiedOrderScreen: ScreenObject {
         $0.buttons["custom-amount-percentage-button"]
     }
 
+    private let feedbackBannerCloseButtonGetter: (XCUIApplication) -> XCUIElement = {
+        $0.buttons["feedback-banner-popover-close-button"]
+    }
+
     private var createButton: XCUIElement { createButtonGetter(app) }
 
     private var recalculateButton: XCUIElement { recalculateButtonGetter(app) }
@@ -96,6 +100,10 @@ public final class UnifiedOrderScreen: ScreenObject {
     /// Percentage of Order Total Button in Custom Amount ssheet.
     ///
     private var percentageOfTotalButton: XCUIElement { percentageOfTotalButtonGetter(app) }
+
+    /// Close button for Feedback Banner popover.
+    ///
+    private var feedbackBannerCloseButton: XCUIElement { feedbackBannerCloseButtonGetter(app) }
 
     public enum Flow {
         case creation
@@ -182,6 +190,16 @@ public final class UnifiedOrderScreen: ScreenObject {
         return try CustomerNoteScreen()
     }
 
+    /// Closes the feedback banner popover, if needed.
+    /// - Returns: Unified Order screen object.
+    @discardableResult
+    func closeFeedbackBannerPopoverIfNeeded() -> UnifiedOrderScreen {
+        if feedbackBannerCloseButton.exists {
+            feedbackBannerCloseButton.tap()
+        }
+        return self
+    }
+
 // MARK: - High-level Order Creation actions
 
     /// Creates a remote order with all of the entered order data.
@@ -238,6 +256,7 @@ public final class UnifiedOrderScreen: ScreenObject {
             .enterShippingAmount(amount)
             .enterShippingName(name)
             .confirmShippingDetails()
+            .closeFeedbackBannerPopoverIfNeeded()
     }
 
     /// Adds a fee on the Custom Amount screen.

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -2157,7 +2157,7 @@
 		CE8CCD43239AC06E009DBD22 /* RefundDetailsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE8CCD41239AC06E009DBD22 /* RefundDetailsViewController.swift */; };
 		CE8CCD44239AC06E009DBD22 /* RefundDetailsViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = CE8CCD42239AC06E009DBD22 /* RefundDetailsViewController.xib */; };
 		CE91BEA029FBE9E100B6E1AF /* QuantityRulesViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE91BE9F29FBE9E100B6E1AF /* QuantityRulesViewModelTests.swift */; };
-		CE9F60122C09D53500652E0A /* BannerPopover.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE9F60112C09D53500652E0A /* BannerPopover.swift */; };
+		CE9F60122C09D53500652E0A /* FeedbackBannerPopover.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE9F60112C09D53500652E0A /* FeedbackBannerPopover.swift */; };
 		CEA16F3A20FD0C8C0061B4E1 /* WooAnalytics.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEA16F3920FD0C8C0061B4E1 /* WooAnalytics.swift */; };
 		CEA455C12BB3446D00D932CF /* BundlesReportCardViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEA455C02BB3446D00D932CF /* BundlesReportCardViewModel.swift */; };
 		CEA455C52BB44F9E00D932CF /* ProductsReportItem+Woo.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEA455C42BB44F9E00D932CF /* ProductsReportItem+Woo.swift */; };
@@ -5052,7 +5052,7 @@
 		CE8CCD41239AC06E009DBD22 /* RefundDetailsViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RefundDetailsViewController.swift; sourceTree = "<group>"; };
 		CE8CCD42239AC06E009DBD22 /* RefundDetailsViewController.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = RefundDetailsViewController.xib; sourceTree = "<group>"; };
 		CE91BE9F29FBE9E100B6E1AF /* QuantityRulesViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QuantityRulesViewModelTests.swift; sourceTree = "<group>"; };
-		CE9F60112C09D53500652E0A /* BannerPopover.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BannerPopover.swift; sourceTree = "<group>"; };
+		CE9F60112C09D53500652E0A /* FeedbackBannerPopover.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedbackBannerPopover.swift; sourceTree = "<group>"; };
 		CEA16F3920FD0C8C0061B4E1 /* WooAnalytics.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WooAnalytics.swift; sourceTree = "<group>"; };
 		CEA455C02BB3446D00D932CF /* BundlesReportCardViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BundlesReportCardViewModel.swift; sourceTree = "<group>"; };
 		CEA455C42BB44F9E00D932CF /* ProductsReportItem+Woo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ProductsReportItem+Woo.swift"; sourceTree = "<group>"; };
@@ -8658,7 +8658,7 @@
 				20DA6DDA2B681175002AA0FB /* AdaptiveModalContainer.swift */,
 				CE63024D2BAC664900E3325C /* EmailView.swift */,
 				DE8AA0B42BBEBE590084D2CC /* ViewControllerContainer.swift */,
-				CE9F60112C09D53500652E0A /* BannerPopover.swift */,
+				CE9F60112C09D53500652E0A /* FeedbackBannerPopover.swift */,
 			);
 			path = "SwiftUI Components";
 			sourceTree = "<group>";
@@ -15463,7 +15463,7 @@
 				45977EBA2603F632006CDFB8 /* MapsHelper.swift in Sources */,
 				86023FAA2B15CAD800A28F07 /* ThemesEligibilityUseCase.swift in Sources */,
 				DE792E1826EF35F40071200C /* ConnectivityObserver.swift in Sources */,
-				CE9F60122C09D53500652E0A /* BannerPopover.swift in Sources */,
+				CE9F60122C09D53500652E0A /* FeedbackBannerPopover.swift in Sources */,
 				B9B0391628A6824200DC1C83 /* PermanentNoticePresenter.swift in Sources */,
 				45693189265403A1009ED69D /* ShippingLabelCarriersViewModel.swift in Sources */,
 				0211254125778BDF0075AD2A /* ShippingLabelDetailsViewController.swift in Sources */,

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/Shipping/EditableOrderShippingUseCaseTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/Shipping/EditableOrderShippingUseCaseTests.swift
@@ -284,6 +284,36 @@ final class EditableOrderShippingUseCaseTests: XCTestCase {
         let properties = try XCTUnwrap(analytics.receivedProperties.first?["flow"] as? String)
         XCTAssertEqual(properties, "creation")
     }
+
+    // MARK: Feedback survey
+
+    func test_feedback_survey_config_has_expected_feedback_type() throws {
+        // Given
+        let expectedFeedbackType: SurveyViewController.Source = .orderFormShippingLines
+
+        // When & Then
+        assertEqual(expectedFeedbackType, useCase.feedbackBannerConfig.feedbackType)
+    }
+
+    func test_feedback_survey_config_onSurveyButtonTapped_tracks_expected_event() throws {
+        // When
+        useCase.feedbackBannerConfig.onSurveyButtonTapped()
+
+        // Then
+        assertEqual([WooAnalyticsStat.featureFeedbackBanner.rawValue], analytics.receivedEvents)
+        assertEqual("order_form_shipping_lines", analytics.receivedProperties.first?["context"] as? String)
+        assertEqual("gave_feedback", analytics.receivedProperties.first?["action"] as? String)
+    }
+
+    func test_feedback_survey_config_onCloseButtonTapped_tracks_expected_event() throws {
+        // When
+        useCase.feedbackBannerConfig.onCloseButtonTapped()
+
+        // Then
+        assertEqual([WooAnalyticsStat.featureFeedbackBanner.rawValue], analytics.receivedEvents)
+        assertEqual("order_form_shipping_lines", analytics.receivedProperties.first?["context"] as? String)
+        assertEqual("dismissed", analytics.receivedProperties.first?["action"] as? String)
+    }
 }
 
 private extension MockStorageManager {

--- a/Yosemite/Yosemite/Stores/AppSettings/InAppFeedbackCardVisibilityUseCase.swift
+++ b/Yosemite/Yosemite/Stores/AppSettings/InAppFeedbackCardVisibilityUseCase.swift
@@ -39,6 +39,8 @@ struct InAppFeedbackCardVisibilityUseCase {
             return try shouldGeneralFeedbackBeVisible(currentDate: currentDate)
         case .shippingLabelsRelease3, .couponManagement:
             return settings.feedbackStatus(of: feedbackType) == .pending
+        case .orderFormShippingLines:
+            return try shouldFeedbackPopoverBeVisible(currentDate: currentDate)
         }
     }
 
@@ -62,6 +64,22 @@ struct InAppFeedbackCardVisibilityUseCase {
         }
 
         return true
+    }
+
+    /// Returns whether a feedback popover should be displayed.
+    ///
+    private func shouldFeedbackPopoverBeVisible(currentDate: Date) throws -> Bool {
+        switch settings.feedbackStatus(of: feedbackType) {
+        case .pending:
+            return true
+        case .dismissed:
+            return false
+        case .given(let lastFeedbackDate):
+            if try numberOfDays(from: lastFeedbackDate, to: currentDate) < Constants.feedbackPopoverFrequencyInDays {
+                return false
+            }
+            return true
+        }
     }
 
     /// Returns the total number of days between `from` and `to`.
@@ -121,5 +139,8 @@ private extension InAppFeedbackCardVisibilityUseCase {
         /// The minimum number of days after the user's last feedback before we should ask
         /// for another feedback.
         static let feedbackFrequencyInDays = 6 * 30
+        /// The minimum number of days after the user's last interaction with a feature
+        /// feedback popover before we should ask for another feedback.
+        static let feedbackPopoverFrequencyInDays = 7
     }
 }

--- a/Yosemite/YosemiteTests/Stores/AppSettings/InAppFeedbackCardVisibilityUseCaseTests.swift
+++ b/Yosemite/YosemiteTests/Stores/AppSettings/InAppFeedbackCardVisibilityUseCaseTests.swift
@@ -154,6 +154,74 @@ final class InAppFeedbackCardVisibilityUseCaseTests: XCTestCase {
         // Then
         XCTAssertEqual(error as? InferenceError, .failedToInferInstallationDate)
     }
+
+    func test_orderFormShippingLines_shouldBeVisible_is_true_if_feedback_status_is_pending() throws {
+        // Given
+        let lastFeedbackDate = try date(from: "2020-11-06T00:00:00Z")
+        let currentDate = try date(from: "2020-11-12T23:59:59Z")
+
+        fileManager.whenRetrievingAttributesOfItem(atPath: try documentDirectoryURL().path, thenReturn: [:])
+
+        let settings = createAppSetting(installationDate: nil, feedbackType: .orderFormShippingLines, feedbackStatus: .pending)
+        let useCase = InAppFeedbackCardVisibilityUseCase(settings: settings, feedbackType: .orderFormShippingLines, fileManager: fileManager, calendar: calendar)
+
+        // When
+        let shouldBeVisible = try useCase.shouldBeVisible(currentDate: currentDate)
+
+        // Then
+        XCTAssertTrue(shouldBeVisible)
+    }
+
+    func test_orderFormShippingLines_shouldBeVisible_is_false_if_feedback_status_is_dismissed() throws {
+        // Given
+        let lastFeedbackDate = try date(from: "2020-11-06T00:00:00Z")
+        let currentDate = try date(from: "2020-11-12T23:59:59Z")
+
+        fileManager.whenRetrievingAttributesOfItem(atPath: try documentDirectoryURL().path, thenReturn: [:])
+
+        let settings = createAppSetting(installationDate: nil, feedbackType: .orderFormShippingLines, feedbackStatus: .dismissed)
+        let useCase = InAppFeedbackCardVisibilityUseCase(settings: settings, feedbackType: .orderFormShippingLines, fileManager: fileManager, calendar: calendar)
+
+        // When
+        let shouldBeVisible = try useCase.shouldBeVisible(currentDate: currentDate)
+
+        // Then
+        XCTAssertFalse(shouldBeVisible)
+    }
+
+    func test_orderFormShippingLines_shouldBeVisible_is_false_if_lastFeedback_is_less_than_7_days_ago() throws {
+        // Given
+        let lastFeedbackDate = try date(from: "2020-11-06T00:00:00Z")
+        let currentDate = try date(from: "2020-11-12T23:59:59Z")
+
+        fileManager.whenRetrievingAttributesOfItem(atPath: try documentDirectoryURL().path, thenReturn: [:])
+
+        let settings = createAppSetting(installationDate: nil, feedbackType: .orderFormShippingLines, feedbackStatus: .given(lastFeedbackDate))
+        let useCase = InAppFeedbackCardVisibilityUseCase(settings: settings, feedbackType: .orderFormShippingLines, fileManager: fileManager, calendar: calendar)
+
+        // When
+        let shouldBeVisible = try useCase.shouldBeVisible(currentDate: currentDate)
+
+        // Then
+        XCTAssertFalse(shouldBeVisible)
+    }
+
+    func test_orderFormShippingLines_shouldBeVisible_is_true_if_lastFeedback_is_more_than_or_equal_to_7_days_ago() throws {
+        // Given
+        let lastFeedbackDate = try date(from: "2020-11-06T00:00:00Z")
+        let currentDate = try date(from: "2020-11-13T00:00:00Z")
+
+        fileManager.whenRetrievingAttributesOfItem(atPath: try documentDirectoryURL().path, thenReturn: [:])
+
+        let settings = createAppSetting(installationDate: nil, feedbackType: .orderFormShippingLines, feedbackStatus: .given(lastFeedbackDate))
+        let useCase = InAppFeedbackCardVisibilityUseCase(settings: settings, feedbackType: .orderFormShippingLines, fileManager: fileManager, calendar: calendar)
+
+        // When
+        let shouldBeVisible = try useCase.shouldBeVisible(currentDate: currentDate)
+
+        // Then
+        XCTAssertTrue(shouldBeVisible)
+    }
 }
 
 // MARK: - Utils


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #12586
<!-- Id number of the GitHub issue this PR addresses. -->

## Why
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
We want to prompt the merchant to share feedback about shipping after adding shipping lines to an order. One week after sharing feedback, the merchant is eligible to share feedback again.

## How

* The popover component is now `FeedbackBannerPopover` and it presents the sheet with the corresponding `Survey`. (For now, this simplifies handling whether the sheet is presented. If we end up wanting to use this popover for other purposes, we can always extract the feedback logic into a separate view.)
* Adds an optional `onDismiss` method to `SurveyCoordinatingController`; this allows `FeedbackBannerPopover` to dismiss itself when the survey is dismissed.
* Adds the `orderFormShippingLines` case to `SurveyViewController.Source`, to present the correct survey for shipping lines in the `Survey` view.
* Adds the `orderFormShippingLines` case to `FeedbackType` and `InAppFeedbackCardVisibilityUseCase`, to handle storing and loading the feedback popover's visibility, based on when and how the merchant last interacted with it.
* Adds the `orderFormShippingLines` case to `WooAnalyticsEvent` to handle tracking interactions with the feedback popover.
* Updates `EditableOrderShippingUseCase`:
   * Tracks the expected events and saves the popover visibility status when the merchant shares feedback or dismisses the popover.
   * Displays the popover based on the previously saved visibility status.
* Updates the UI tests to close the feedback popover if it appears.

## Testing steps

1. Build and run the app.
2. Open the Orders tab.
3. Create a new order and add a product, or edit an existing order.
4. Add a new shipping line to the order and confirm the feedback prompt appears.
5. Tap on "Share your feedback" and confirm the survey appears.
6. Complete the survey and, when you finish, confirm the feedback prompt is dismissed when you dismiss the survey.
7. Add another new shipping line and confirm no feedback prompt appears.

## Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->

Additional scenarios (requires re-installing the app if you have interacted with the feedback prompt already):

* Close the survey without finishing it and confirm the prompt is dismissed. Confirm you aren't prompted again after adding a new shipping line.
* Close the prompt. Confirm you aren't prompted again after adding a new shipping line.
* Relaunch the app without reinstalling and confirm you aren't prompted again after adding a new shipping line.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

https://github.com/woocommerce/woocommerce-ios/assets/8658164/15be9d4b-a7ad-464b-aa31-5deba8e93c49



---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.