### PR TITLE
[Woo POS] Resolve POS currency injection and simplify `POSProduct`

### DIFF
--- a/WooCommerce/Classes/POS/Presentation/CartView.swift
+++ b/WooCommerce/Classes/POS/Presentation/CartView.swift
@@ -72,7 +72,6 @@ private extension CartView {
 #if DEBUG
 #Preview {
     CartView(viewModel: PointOfSaleDashboardViewModel(items: POSProductProvider.provideProductsForPreview(),
-                                                      currencySettings: .init(),
                                                       cardPresentPaymentService: CardPresentPaymentService(siteID: 0)))
 }
 #endif

--- a/WooCommerce/Classes/POS/Presentation/FilterView.swift
+++ b/WooCommerce/Classes/POS/Presentation/FilterView.swift
@@ -24,7 +24,6 @@ struct FilterView: View {
 #if DEBUG
 #Preview {
     FilterView(viewModel: PointOfSaleDashboardViewModel(items: [],
-                                                        currencySettings: .init(),
                                                         cardPresentPaymentService: CardPresentPaymentService(siteID: 0)))
 }
 #endif

--- a/WooCommerce/Classes/POS/Presentation/ItemGridView.swift
+++ b/WooCommerce/Classes/POS/Presentation/ItemGridView.swift
@@ -52,7 +52,6 @@ private extension ItemGridView {
     // TODO: https://github.com/woocommerce/woocommerce-ios/issues/12917
     // The Yosemite imports are only needed for previews
     ItemGridView(viewModel: PointOfSaleDashboardViewModel(items: POSProductProvider.provideProductsForPreview(),
-                                                             currencySettings: .init(),
                                                              cardPresentPaymentService: CardPresentPaymentService(siteID: 0)))
 }
 #endif

--- a/WooCommerce/Classes/POS/Presentation/PointOfSaleDashboardView.swift
+++ b/WooCommerce/Classes/POS/Presentation/PointOfSaleDashboardView.swift
@@ -95,7 +95,6 @@ fileprivate extension CardPresentPaymentEvent {
     // TODO: https://github.com/woocommerce/woocommerce-ios/issues/12917
     // The Yosemite imports are only needed for previews
     PointOfSaleDashboardView(viewModel: PointOfSaleDashboardViewModel(items: POSProductProvider.provideProductsForPreview(),
-                                                                      currencySettings: .init(),
                                                                       cardPresentPaymentService: CardPresentPaymentService(siteID: 0)))
 }
 #endif

--- a/WooCommerce/Classes/POS/Presentation/PointOfSaleEntryPointView.swift
+++ b/WooCommerce/Classes/POS/Presentation/PointOfSaleEntryPointView.swift
@@ -5,12 +5,10 @@ import class WooFoundation.CurrencySettings
 
 struct PointOfSaleEntryPointView: View {
     @StateObject private var viewModel: PointOfSaleDashboardViewModel
-    private var itemProvider: POSItemProvider
 
     private let hideAppTabBar: ((Bool) -> Void)
 
     init(itemProvider: POSItemProvider, currencySettings: CurrencySettings, hideAppTabBar: @escaping ((Bool) -> Void), siteID: Int64) {
-        self.itemProvider = itemProvider
         self.hideAppTabBar = hideAppTabBar
 
         _viewModel = StateObject(wrappedValue: PointOfSaleDashboardViewModel(

--- a/WooCommerce/Classes/POS/Presentation/PointOfSaleEntryPointView.swift
+++ b/WooCommerce/Classes/POS/Presentation/PointOfSaleEntryPointView.swift
@@ -1,19 +1,17 @@
 import SwiftUI
 import protocol Yosemite.POSItemProvider
 import class Yosemite.NullPOSProductProvider
-import class WooFoundation.CurrencySettings
 
 struct PointOfSaleEntryPointView: View {
     @StateObject private var viewModel: PointOfSaleDashboardViewModel
 
     private let hideAppTabBar: ((Bool) -> Void)
 
-    init(itemProvider: POSItemProvider, currencySettings: CurrencySettings, hideAppTabBar: @escaping ((Bool) -> Void), siteID: Int64) {
+    init(itemProvider: POSItemProvider, hideAppTabBar: @escaping ((Bool) -> Void), siteID: Int64) {
         self.hideAppTabBar = hideAppTabBar
 
         _viewModel = StateObject(wrappedValue: PointOfSaleDashboardViewModel(
             items: itemProvider.providePointOfSaleItems(),
-            currencySettings: .init(),
             cardPresentPaymentService: CardPresentPaymentService(siteID: siteID))
         )
     }
@@ -33,6 +31,6 @@ struct PointOfSaleEntryPointView: View {
 #Preview {
     // TODO: https://github.com/woocommerce/woocommerce-ios/issues/12917
     // Some Yosemite imports are only needed for previews
-    PointOfSaleEntryPointView(itemProvider: NullPOSProductProvider(), currencySettings: ServiceLocator.currencySettings, hideAppTabBar: { _ in }, siteID: 0)
+    PointOfSaleEntryPointView(itemProvider: NullPOSProductProvider(), hideAppTabBar: { _ in }, siteID: 0)
 }
 #endif

--- a/WooCommerce/Classes/POS/Presentation/TotalsView.swift
+++ b/WooCommerce/Classes/POS/Presentation/TotalsView.swift
@@ -62,7 +62,6 @@ private extension TotalsView {
 #if DEBUG
 #Preview {
     TotalsView(viewModel: .init(items: [],
-                                currencySettings: .init(),
                                 cardPresentPaymentService: CardPresentPaymentService(siteID: 0)))
 }
 #endif

--- a/WooCommerce/Classes/POS/ViewModels/PointOfSaleDashboardViewModel.swift
+++ b/WooCommerce/Classes/POS/ViewModels/PointOfSaleDashboardViewModel.swift
@@ -28,15 +28,13 @@ final class PointOfSaleDashboardViewModel: ObservableObject {
 
     @Published private(set) var orderStage: OrderStage = .building
 
-    private let currencyFormatter: CurrencyFormatter
-
     private let cardPresentPaymentService: CardPresentPaymentFacade
 
+    private let currencyFormatter = CurrencyFormatter(currencySettings: ServiceLocator.currencySettings)
+
     init(items: [POSItem],
-         currencySettings: CurrencySettings,
          cardPresentPaymentService: CardPresentPaymentFacade) {
         self.items = items
-        self.currencyFormatter = CurrencyFormatter(currencySettings: currencySettings)
         self.cardPresentPaymentService = cardPresentPaymentService
         self.cardReaderConnectionViewModel = CardReaderConnectionViewModel(cardPresentPayment: cardPresentPaymentService)
         observeCardPresentPaymentEvents()
@@ -81,7 +79,6 @@ extension PointOfSaleDashboardViewModel {
     // Helper function to populate SwifUI previews
     static func defaultPreview() -> PointOfSaleDashboardViewModel {
         PointOfSaleDashboardViewModel(items: [],
-                                      currencySettings: .init(),
                                       cardPresentPaymentService: CardPresentPaymentService(siteID: 0))
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Hub Menu/HubMenu.swift
+++ b/WooCommerce/Classes/ViewRelated/Hub Menu/HubMenu.swift
@@ -165,7 +165,6 @@ private extension HubMenu {
                 // TODO:
                 // PointOfSaleEntryPointView does not need currencySettings, since these are passed through POSItemProvider
                 PointOfSaleEntryPointView(itemProvider: viewModel.posItemProvider,
-                                          currencySettings: ServiceLocator.currencySettings,
                                           hideAppTabBar: { isHidden in
                     AppDelegate.shared.setShouldHideTabBar(isHidden)
                 }, siteID: viewModel.siteID)

--- a/Yosemite/Yosemite.xcodeproj/project.pbxproj
+++ b/Yosemite/Yosemite.xcodeproj/project.pbxproj
@@ -248,6 +248,7 @@
 		578CE7972475FD8200492EBF /* MockProductReview.swift in Sources */ = {isa = PBXBuildFile; fileRef = 578CE7962475FD8200492EBF /* MockProductReview.swift */; };
 		57DFCC7925003C4000251E0C /* FetchResultSnapshotsProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57DFCC7825003C4000251E0C /* FetchResultSnapshotsProvider.swift */; };
 		681D952B28E0F62B00C4039E /* CustomerAction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 681D952A28E0F62B00C4039E /* CustomerAction.swift */; };
+		687F83722C0EBF8900460AB3 /* POSProductProviderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 687F83712C0EBF8900460AB3 /* POSProductProviderTests.swift */; };
 		6889089F28F7B8540081A07E /* Customer+ReadOnlyConvertible.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6889089E28F7B8540081A07E /* Customer+ReadOnlyConvertible.swift */; };
 		6898F3742C0842150039F10A /* POSItemProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6898F3732C0842150039F10A /* POSItemProvider.swift */; };
 		689D11D52891B9A400F6A83F /* WooFoundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 689D11D42891B9A400F6A83F /* WooFoundation.framework */; };
@@ -735,6 +736,7 @@
 		57DFCC7825003C4000251E0C /* FetchResultSnapshotsProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FetchResultSnapshotsProvider.swift; sourceTree = "<group>"; };
 		585B973F61632665297738A3 /* Pods-Yosemite.release-alpha.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Yosemite.release-alpha.xcconfig"; path = "../Pods/Target Support Files/Pods-Yosemite/Pods-Yosemite.release-alpha.xcconfig"; sourceTree = "<group>"; };
 		681D952A28E0F62B00C4039E /* CustomerAction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomerAction.swift; sourceTree = "<group>"; };
+		687F83712C0EBF8900460AB3 /* POSProductProviderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = POSProductProviderTests.swift; sourceTree = "<group>"; };
 		6889089E28F7B8540081A07E /* Customer+ReadOnlyConvertible.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Customer+ReadOnlyConvertible.swift"; sourceTree = "<group>"; };
 		6898F3732C0842150039F10A /* POSItemProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = POSItemProvider.swift; sourceTree = "<group>"; };
 		689D11D42891B9A400F6A83F /* WooFoundation.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = WooFoundation.framework; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -1388,6 +1390,14 @@
 			path = SnapshotsProvider;
 			sourceTree = "<group>";
 		};
+		687F83702C0EBF3E00460AB3 /* PointOfSale */ = {
+			isa = PBXGroup;
+			children = (
+				687F83712C0EBF8900460AB3 /* POSProductProviderTests.swift */,
+			);
+			path = PointOfSale;
+			sourceTree = "<group>";
+		};
 		6898F3722C0840FE0039F10A /* PointOfSale */ = {
 			isa = PBXGroup;
 			children = (
@@ -1758,6 +1768,7 @@
 		B5C9DE022087FEC0006B910A /* YosemiteTests */ = {
 			isa = PBXGroup;
 			children = (
+				687F83702C0EBF3E00460AB3 /* PointOfSale */,
 				5779A0CB2500429700E35AF2 /* SnapshotsProvider */,
 				022F00C324728AFB008CD97F /* PListStorage */,
 				B5BC71DA21139CF2005CF5AA /* Responses */,
@@ -2512,6 +2523,7 @@
 				B5C9DE272087FF20006B910A /* MockAcountStore.swift in Sources */,
 				312DB64D268BD22B00AA0EE9 /* AppSettingsStoreTests+CardReaderSettings.swift in Sources */,
 				EEB4E2CF29B04D7900371C3C /* StoreOnboardingTasksStoreTests.swift in Sources */,
+				687F83722C0EBF8900460AB3 /* POSProductProviderTests.swift in Sources */,
 				03EB99922907EBB300F06A39 /* JustInTimeMessageStoreTests.swift in Sources */,
 				026D52C0238235930092AE05 /* ProductVariationStoreTests.swift in Sources */,
 				7492FAE1217FB87100ED2C69 /* SettingStoreTests.swift in Sources */,

--- a/Yosemite/Yosemite/PointOfSale/POSProduct.swift
+++ b/Yosemite/Yosemite/PointOfSale/POSProduct.swift
@@ -4,13 +4,11 @@ public struct POSProduct: POSItem {
     public let productID: Int64
     public let name: String
     public let price: String
-    public let formattedPrice: String
 
-    public init(itemID: UUID, productID: Int64, name: String, price: String, formattedPrice: String) {
+    public init(itemID: UUID, productID: Int64, name: String, price: String) {
         self.itemID = itemID
         self.productID = productID
         self.name = name
         self.price = price
-        self.formattedPrice = formattedPrice
     }
 }

--- a/Yosemite/Yosemite/PointOfSale/POSProductProvider.swift
+++ b/Yosemite/Yosemite/PointOfSale/POSProductProvider.swift
@@ -72,15 +72,15 @@ extension POSProductProvider {
         POSProduct(itemID: UUID(),
                    productID: 1,
                    name: "Product 1",
-                   price: "1.00")
+                   price: "$1.00")
     }
 
     public static func provideProductsForPreview() -> [POSProduct] {
         return [
-            POSProduct(itemID: UUID(), productID: 1, name: "Product 1", price: "1.00"),
-            POSProduct(itemID: UUID(), productID: 2, name: "Product 2", price: "2.00"),
-            POSProduct(itemID: UUID(), productID: 3, name: "Product 3", price: "3.00"),
-            POSProduct(itemID: UUID(), productID: 4, name: "Product 4", price: "4.00")
+            POSProduct(itemID: UUID(), productID: 1, name: "Product 1", price: "$1.00"),
+            POSProduct(itemID: UUID(), productID: 2, name: "Product 2", price: "$2.00"),
+            POSProduct(itemID: UUID(), productID: 3, name: "Product 3", price: "$3.00"),
+            POSProduct(itemID: UUID(), productID: 4, name: "Product 4", price: "$4.00")
         ]
     }
 }

--- a/Yosemite/Yosemite/PointOfSale/POSProductProvider.swift
+++ b/Yosemite/Yosemite/PointOfSale/POSProductProvider.swift
@@ -1,5 +1,6 @@
 import Foundation
 import protocol Storage.StorageManagerType
+import class WooFoundation.CurrencyFormatter
 import class WooFoundation.CurrencySettings
 
 /// Product provider for the Point of Sale feature
@@ -48,14 +49,15 @@ public final class POSProductProvider: POSItemProvider {
             DDLogError("Error fetching products from storage")
         }
 
-        // 2. Map result to POSProduct and populate the output
+        // 2. Map result to POSProduct, and populate the output already formatted with any applicable store settings
+        let currencyFormatter = CurrencyFormatter(currencySettings: currencySettings)
         return loadedProducts.map { product in
-            // TODO: Decorate the price with currency formatting
-            POSProduct(itemID: UUID(),
-                       productID: product.productID,
-                       name: product.name,
-                       price: product.price,
-                       formattedPrice: "$\(product.price)")
+            let formattedPrice = currencyFormatter.formatAmount(product.price, with: currencySettings.currencyCode.rawValue) ?? "-"
+
+            return POSProduct(itemID: UUID(),
+                              productID: product.productID,
+                              name: product.name,
+                              price: formattedPrice)
         }
     }
 
@@ -70,16 +72,15 @@ extension POSProductProvider {
         POSProduct(itemID: UUID(),
                    productID: 1,
                    name: "Product 1",
-                   price: "1.00",
-                   formattedPrice: "$1.00")
+                   price: "1.00")
     }
 
     public static func provideProductsForPreview() -> [POSProduct] {
         return [
-            POSProduct(itemID: UUID(), productID: 1, name: "Product 1", price: "1.00", formattedPrice: "$1.00"),
-            POSProduct(itemID: UUID(), productID: 2, name: "Product 2", price: "2.00", formattedPrice: "$2.00"),
-            POSProduct(itemID: UUID(), productID: 3, name: "Product 3", price: "3.00", formattedPrice: "$3.00"),
-            POSProduct(itemID: UUID(), productID: 4, name: "Product 4", price: "4.00", formattedPrice: "$4.00"),
+            POSProduct(itemID: UUID(), productID: 1, name: "Product 1", price: "1.00"),
+            POSProduct(itemID: UUID(), productID: 2, name: "Product 2", price: "2.00"),
+            POSProduct(itemID: UUID(), productID: 3, name: "Product 3", price: "3.00"),
+            POSProduct(itemID: UUID(), productID: 4, name: "Product 4", price: "4.00")
         ]
     }
 }

--- a/Yosemite/YosemiteTests/PointOfSale/POSProductProviderTests.swift
+++ b/Yosemite/YosemiteTests/PointOfSale/POSProductProviderTests.swift
@@ -24,7 +24,7 @@ final class POSProductProviderTests: XCTestCase {
         let currencySettings = CurrencySettings()
 
         let sampleProduct = Product.fake().copy(siteID: 123,
-                                                productID: 789, 
+                                                productID: 789,
                                                 name: "Choco",
                                                 productTypeKey: "simple",
                                                 price: "2",

--- a/Yosemite/YosemiteTests/PointOfSale/POSProductProviderTests.swift
+++ b/Yosemite/YosemiteTests/PointOfSale/POSProductProviderTests.swift
@@ -1,0 +1,47 @@
+import XCTest
+import WooFoundation
+@testable import Yosemite
+
+final class POSProductProviderTests: XCTestCase {
+
+    func test_POSProductProvider_returns_no_products_when_store_has_no_products() {
+        let storageManager = MockStorageManager()
+        let siteID: Int64 = 123
+        let currencySettings = CurrencySettings()
+
+        let sut = POSProductProvider(storageManager: storageManager,
+                                     siteID: siteID,
+                                     currencySettings: currencySettings)
+
+        let products = sut.providePointOfSaleItems()
+
+        XCTAssertTrue(products.isEmpty)
+    }
+
+    func test_POSProductProvider_returns_correctly_formatted_product_when_store_has_eligible_products() {
+        let storageManager = MockStorageManager()
+        let siteID: Int64 = 123
+        let currencySettings = CurrencySettings()
+
+        let sampleProduct = Product.fake().copy(siteID: 123,
+                                                productID: 789, 
+                                                name: "Choco",
+                                                productTypeKey: "simple",
+                                                price: "2",
+                                                purchasable: true)
+        storageManager.insertSampleProduct(readOnlyProduct: sampleProduct)
+
+        let sut = POSProductProvider(storageManager: storageManager,
+                                     siteID: siteID,
+                                     currencySettings: currencySettings)
+
+        let products = sut.providePointOfSaleItems()
+
+        guard let product = products.first else {
+            return XCTFail("No eligible products")
+        }
+        XCTAssertEqual(product.name, "Choco")
+        XCTAssertEqual(product.productID, 789)
+        XCTAssertEqual(product.price, "$2.00")
+    }
+}


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #12918

## Description
This PR simplifies the usage of currency settings in the `pos` by removing duplicated `CurrencySettings` dependencies from the entry point (view and view model) and moving it to the `POSProductProvider` instead. We also simplify the `POSProduct` model and format the price internally, so we only need to expose a `price` to the views, which is already formatted.

<img width="360" alt="Screenshot 2024-06-04 at 11 41 08" src="https://github.com/woocommerce/woocommerce-ios/assets/3812076/33ed8844-2419-44a9-a068-6a8bfe08c4cb">


Since also seems we have a more or less stable foundation of what the initial models and item provider looks like, this PR also introduces some initial unit tests to assure that `POSProduct` price is correctly formatted. More tests will be added as we go.

## Changes: 
- Removes `CurrencySettings` dependency from `PointOfSaleEntryPointView`
- Removes `CurrencySettings` dependency from `PointOfSaleDashboardViewModel`
- Removes `CurrencySettings` dependency from previews
- Removes `formattedPrice` property from `POSProduct`
- Adds `CurrencySettings` usage to `POSProductProvider`
- Adds `POSProductProviderTests`

## Testing information
- In POS mode
- Observe that store products still display the price and currency 
- Tap on checkout, observe that the temporary totals calculation also shows prices and currencies