### PR TITLE
[Woo POS] Remove Yosemite dependencies from SwiftUI previews

### DIFF
--- a/WooCommerce/Classes/POS/Presentation/CartView.swift
+++ b/WooCommerce/Classes/POS/Presentation/CartView.swift
@@ -1,4 +1,3 @@
-import class Yosemite.POSProductProvider
 import SwiftUI
 
 struct CartView: View {
@@ -71,7 +70,7 @@ private extension CartView {
 
 #if DEBUG
 #Preview {
-    CartView(viewModel: PointOfSaleDashboardViewModel(items: POSProductProvider.provideProductsForPreview(),
+    CartView(viewModel: PointOfSaleDashboardViewModel(items: POSItemProviderPreview().providePointOfSaleItems(),
                                                       cardPresentPaymentService: CardPresentPaymentService(siteID: 0)))
 }
 #endif

--- a/WooCommerce/Classes/POS/Presentation/ItemCardView.swift
+++ b/WooCommerce/Classes/POS/Presentation/ItemCardView.swift
@@ -1,4 +1,3 @@
-import class Yosemite.POSProductProvider
 import protocol Yosemite.POSItem
 import SwiftUI
 
@@ -33,8 +32,7 @@ struct ItemCardView: View {
 
 #if DEBUG
 #Preview {
-    // TODO: https://github.com/woocommerce/woocommerce-ios/issues/12917
-    // Some Yosemite imports are only needed for previews
-    ItemCardView(item: POSProductProvider.provideProductForPreview(), onItemCardTapped: { })
+    ItemCardView(item: POSItemProviderPreview().providePointOfSaleItem(),
+                 onItemCardTapped: { })
 }
 #endif

--- a/WooCommerce/Classes/POS/Presentation/ItemGridView.swift
+++ b/WooCommerce/Classes/POS/Presentation/ItemGridView.swift
@@ -1,4 +1,3 @@
-import class Yosemite.POSProductProvider
 import SwiftUI
 
 struct ItemGridView: View {
@@ -49,9 +48,7 @@ private extension ItemGridView {
 
 #if DEBUG
 #Preview {
-    // TODO: https://github.com/woocommerce/woocommerce-ios/issues/12917
-    // The Yosemite imports are only needed for previews
-    ItemGridView(viewModel: PointOfSaleDashboardViewModel(items: POSProductProvider.provideProductsForPreview(),
-                                                             cardPresentPaymentService: CardPresentPaymentService(siteID: 0)))
+    ItemGridView(viewModel: PointOfSaleDashboardViewModel(items: POSItemProviderPreview().providePointOfSaleItems(),
+                                                          cardPresentPaymentService: CardPresentPaymentService(siteID: 0)))
 }
 #endif

--- a/WooCommerce/Classes/POS/Presentation/ItemRowView.swift
+++ b/WooCommerce/Classes/POS/Presentation/ItemRowView.swift
@@ -1,4 +1,3 @@
-import class Yosemite.POSProductProvider
 import SwiftUI
 
 struct ItemRowView: View {
@@ -33,11 +32,9 @@ struct ItemRowView: View {
 
 #if DEBUG
 #Preview {
-    // TODO: https://github.com/woocommerce/woocommerce-ios/issues/12917
-    // The Yosemite imports are only needed for previews
     ItemRowView(cartItem: CartItem(id: UUID(),
-                                      item: POSProductProvider.provideProductForPreview(),
-                                      quantity: 2),
+                                   item: POSItemProviderPreview().providePointOfSaleItem(),
+                                   quantity: 2),
                 onItemRemoveTapped: { })
 }
 #endif

--- a/WooCommerce/Classes/POS/Presentation/PointOfSaleDashboardView.swift
+++ b/WooCommerce/Classes/POS/Presentation/PointOfSaleDashboardView.swift
@@ -1,4 +1,3 @@
-import class Yosemite.POSProductProvider
 import SwiftUI
 
 struct PointOfSaleDashboardView: View {
@@ -92,9 +91,8 @@ fileprivate extension CardPresentPaymentEvent {
 
 #if DEBUG
 #Preview {
-    // TODO: https://github.com/woocommerce/woocommerce-ios/issues/12917
-    // The Yosemite imports are only needed for previews
-    PointOfSaleDashboardView(viewModel: PointOfSaleDashboardViewModel(items: POSProductProvider.provideProductsForPreview(),
-                                                                      cardPresentPaymentService: CardPresentPaymentService(siteID: 0)))
+    PointOfSaleDashboardView(
+        viewModel: PointOfSaleDashboardViewModel(items: POSItemProviderPreview().providePointOfSaleItems(),
+                                                 cardPresentPaymentService: CardPresentPaymentService(siteID: 0)))
 }
 #endif

--- a/WooCommerce/Classes/POS/Presentation/PointOfSaleEntryPointView.swift
+++ b/WooCommerce/Classes/POS/Presentation/PointOfSaleEntryPointView.swift
@@ -1,6 +1,5 @@
 import SwiftUI
 import protocol Yosemite.POSItemProvider
-import class Yosemite.NullPOSProductProvider
 
 struct PointOfSaleEntryPointView: View {
     @StateObject private var viewModel: PointOfSaleDashboardViewModel
@@ -29,8 +28,6 @@ struct PointOfSaleEntryPointView: View {
 
 #if DEBUG
 #Preview {
-    // TODO: https://github.com/woocommerce/woocommerce-ios/issues/12917
-    // Some Yosemite imports are only needed for previews
-    PointOfSaleEntryPointView(itemProvider: NullPOSProductProvider(), hideAppTabBar: { _ in }, siteID: 0)
+    PointOfSaleEntryPointView(itemProvider: POSItemProviderPreview(), hideAppTabBar: { _ in }, siteID: 0)
 }
 #endif

--- a/WooCommerce/Classes/POS/Utils/PreviewHelpers.swift
+++ b/WooCommerce/Classes/POS/Utils/PreviewHelpers.swift
@@ -1,24 +1,29 @@
 import Foundation
-import class Yosemite.POSProductProvider
 import protocol Yosemite.POSItemProvider
 import protocol Yosemite.POSItem
-import struct Yosemite.POSProduct
 
 #if DEBUG
 // MARK: - PreviewProvider helpers
 //
+struct POSProductPreview: POSItem {
+    var itemID: UUID
+    var productID: Int64
+    var name: String
+    var price: String
+}
+
 final class POSItemProviderPreview: POSItemProvider {
     public func providePointOfSaleItems() -> [POSItem] {
         return [
-            POSProduct(itemID: UUID(), productID: 1, name: "Product 1", price: "$1.00"),
-            POSProduct(itemID: UUID(), productID: 2, name: "Product 2", price: "$2.00"),
-            POSProduct(itemID: UUID(), productID: 3, name: "Product 3", price: "$3.00"),
-            POSProduct(itemID: UUID(), productID: 4, name: "Product 4", price: "$4.00")
+            POSProductPreview(itemID: UUID(), productID: 1, name: "Product 1", price: "$1.00"),
+            POSProductPreview(itemID: UUID(), productID: 2, name: "Product 2", price: "$2.00"),
+            POSProductPreview(itemID: UUID(), productID: 3, name: "Product 3", price: "$3.00"),
+            POSProductPreview(itemID: UUID(), productID: 4, name: "Product 4", price: "$4.00")
         ]
     }
 
     public func providePointOfSaleItem() -> POSItem {
-        POSProduct(itemID: UUID(),
+        POSProductPreview(itemID: UUID(),
                    productID: 1,
                    name: "Product 1",
                    price: "$1.00")

--- a/WooCommerce/Classes/POS/Utils/PreviewHelpers.swift
+++ b/WooCommerce/Classes/POS/Utils/PreviewHelpers.swift
@@ -1,0 +1,27 @@
+import Foundation
+import class Yosemite.POSProductProvider
+import protocol Yosemite.POSItemProvider
+import protocol Yosemite.POSItem
+import struct Yosemite.POSProduct
+
+#if DEBUG
+// MARK: - PreviewProvider helpers
+//
+final class POSItemProviderPreview: POSItemProvider {
+    public func providePointOfSaleItems() -> [POSItem] {
+        return [
+            POSProduct(itemID: UUID(), productID: 1, name: "Product 1", price: "$1.00"),
+            POSProduct(itemID: UUID(), productID: 2, name: "Product 2", price: "$2.00"),
+            POSProduct(itemID: UUID(), productID: 3, name: "Product 3", price: "$3.00"),
+            POSProduct(itemID: UUID(), productID: 4, name: "Product 4", price: "$4.00")
+        ]
+    }
+
+    public func providePointOfSaleItem() -> POSItem {
+        POSProduct(itemID: UUID(),
+                   productID: 1,
+                   name: "Product 1",
+                   price: "$1.00")
+    }
+}
+#endif

--- a/WooCommerce/Classes/POS/Utils/PreviewHelpers.swift
+++ b/WooCommerce/Classes/POS/Utils/PreviewHelpers.swift
@@ -6,10 +6,10 @@ import protocol Yosemite.POSItem
 // MARK: - PreviewProvider helpers
 //
 struct POSProductPreview: POSItem {
-    var itemID: UUID
-    var productID: Int64
-    var name: String
-    var price: String
+    let itemID: UUID
+    let productID: Int64
+    let name: String
+    let price: String
 }
 
 final class POSItemProviderPreview: POSItemProvider {

--- a/WooCommerce/Classes/POS/Utils/PreviewHelpers.swift
+++ b/WooCommerce/Classes/POS/Utils/PreviewHelpers.swift
@@ -13,7 +13,7 @@ struct POSProductPreview: POSItem {
 }
 
 final class POSItemProviderPreview: POSItemProvider {
-    public func providePointOfSaleItems() -> [POSItem] {
+    func providePointOfSaleItems() -> [POSItem] {
         return [
             POSProductPreview(itemID: UUID(), productID: 1, name: "Product 1", price: "$1.00"),
             POSProductPreview(itemID: UUID(), productID: 2, name: "Product 2", price: "$2.00"),
@@ -22,7 +22,7 @@ final class POSItemProviderPreview: POSItemProvider {
         ]
     }
 
-    public func providePointOfSaleItem() -> POSItem {
+    func providePointOfSaleItem() -> POSItem {
         POSProductPreview(itemID: UUID(),
                    productID: 1,
                    name: "Product 1",

--- a/WooCommerce/Classes/POS/ViewModels/PointOfSaleDashboardViewModel.swift
+++ b/WooCommerce/Classes/POS/ViewModels/PointOfSaleDashboardViewModel.swift
@@ -1,6 +1,5 @@
 import SwiftUI
 import protocol Yosemite.POSItem
-import struct Yosemite.POSProduct
 import class WooFoundation.CurrencyFormatter
 import class WooFoundation.CurrencySettings
 

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -1449,6 +1449,7 @@
 		68D1BEDD2900E4180074A29E /* CustomerSearchUICommand.swift in Sources */ = {isa = PBXBuildFile; fileRef = 68D1BEDC2900E4180074A29E /* CustomerSearchUICommand.swift */; };
 		68D5094E2AD39BC900B6FFD5 /* DiscountLineDetailsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 68D5094D2AD39BC900B6FFD5 /* DiscountLineDetailsView.swift */; };
 		68D8FBD12BFEF9C700477C42 /* TotalsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 68D8FBD02BFEF9C700477C42 /* TotalsView.swift */; };
+		68E4E8B52C0EF39D00CFA0C3 /* PreviewHelpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 68E4E8B42C0EF39D00CFA0C3 /* PreviewHelpers.swift */; };
 		68E6749F2A4DA01C0034BA1E /* WooWPComPlan.swift in Sources */ = {isa = PBXBuildFile; fileRef = 68E6749E2A4DA01C0034BA1E /* WooWPComPlan.swift */; };
 		68E674A12A4DA0B30034BA1E /* InAppPurchasesError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 68E674A02A4DA0B30034BA1E /* InAppPurchasesError.swift */; };
 		68E674A32A4DA7990034BA1E /* PrePurchaseUpgradesErrorView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 68E674A22A4DA7990034BA1E /* PrePurchaseUpgradesErrorView.swift */; };
@@ -4306,6 +4307,7 @@
 		68D1BEDC2900E4180074A29E /* CustomerSearchUICommand.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomerSearchUICommand.swift; sourceTree = "<group>"; };
 		68D5094D2AD39BC900B6FFD5 /* DiscountLineDetailsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiscountLineDetailsView.swift; sourceTree = "<group>"; };
 		68D8FBD02BFEF9C700477C42 /* TotalsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TotalsView.swift; sourceTree = "<group>"; };
+		68E4E8B42C0EF39D00CFA0C3 /* PreviewHelpers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PreviewHelpers.swift; sourceTree = "<group>"; };
 		68E6749E2A4DA01C0034BA1E /* WooWPComPlan.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WooWPComPlan.swift; sourceTree = "<group>"; };
 		68E674A02A4DA0B30034BA1E /* InAppPurchasesError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InAppPurchasesError.swift; sourceTree = "<group>"; };
 		68E674A22A4DA7990034BA1E /* PrePurchaseUpgradesErrorView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PrePurchaseUpgradesErrorView.swift; sourceTree = "<group>"; };
@@ -6505,6 +6507,7 @@
 			isa = PBXGroup;
 			children = (
 				026826982BF59DA80036F959 /* Color+WooCommercePOS.swift */,
+				68E4E8B42C0EF39D00CFA0C3 /* PreviewHelpers.swift */,
 			);
 			path = Utils;
 			sourceTree = "<group>";
@@ -15228,6 +15231,7 @@
 				B554E1792152F20000F31188 /* UINavigationBar+Appearance.swift in Sources */,
 				26AE31B0251E602D004B1BCE /* RefundShippingDetailsTableViewCell.swift in Sources */,
 				020732062988AC4D000A53C2 /* DomainContactInfoFormViewModel.swift in Sources */,
+				68E4E8B52C0EF39D00CFA0C3 /* PreviewHelpers.swift in Sources */,
 				EE8B42092BF668540077C4E7 /* MostActiveCouponRow.swift in Sources */,
 				022266BA2AE76E0E00614F34 /* ProductBundleItem+SwiftUIPreviewHelpers.swift in Sources */,
 				262A09A5262F65690033AD20 /* OrderAddOnTopBanner.swift in Sources */,

--- a/Yosemite/Yosemite/PointOfSale/POSProduct.swift
+++ b/Yosemite/Yosemite/PointOfSale/POSProduct.swift
@@ -1,9 +1,9 @@
 
 struct POSProduct: POSItem {
-    public let itemID: UUID
-    public let productID: Int64
-    public let name: String
-    public let price: String
+    let itemID: UUID
+    let productID: Int64
+    let name: String
+    let price: String
 
     init(itemID: UUID, productID: Int64, name: String, price: String) {
         self.itemID = itemID

--- a/Yosemite/Yosemite/PointOfSale/POSProduct.swift
+++ b/Yosemite/Yosemite/PointOfSale/POSProduct.swift
@@ -1,11 +1,11 @@
 
-public struct POSProduct: POSItem {
+struct POSProduct: POSItem {
     public let itemID: UUID
     public let productID: Int64
     public let name: String
     public let price: String
 
-    public init(itemID: UUID, productID: Int64, name: String, price: String) {
+    init(itemID: UUID, productID: Int64, name: String, price: String) {
         self.itemID = itemID
         self.productID = productID
         self.name = name

--- a/Yosemite/Yosemite/PointOfSale/POSProductProvider.swift
+++ b/Yosemite/Yosemite/PointOfSale/POSProductProvider.swift
@@ -64,34 +64,3 @@ public final class POSProductProvider: POSItemProvider {
     // TODO: Mechanism to reload/sync product data.
     // https://github.com/woocommerce/woocommerce-ios/issues/12837
 }
-
-// MARK: - PreviewProvider helpers
-//
-extension POSProductProvider {
-    public static func provideProductForPreview() -> POSProduct {
-        POSProduct(itemID: UUID(),
-                   productID: 1,
-                   name: "Product 1",
-                   price: "$1.00")
-    }
-
-    public static func provideProductsForPreview() -> [POSProduct] {
-        return [
-            POSProduct(itemID: UUID(), productID: 1, name: "Product 1", price: "$1.00"),
-            POSProduct(itemID: UUID(), productID: 2, name: "Product 2", price: "$2.00"),
-            POSProduct(itemID: UUID(), productID: 3, name: "Product 3", price: "$3.00"),
-            POSProduct(itemID: UUID(), productID: 4, name: "Product 4", price: "$4.00")
-        ]
-    }
-}
-
-/// Null product provider that acts as preview helper for the Point of Sale feature
-///
-public final class NullPOSProductProvider: POSItemProvider {
-
-    public init() {}
-
-    public func providePointOfSaleItems() -> [POSItem] {
-        []
-    }
-}


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #12917
#12918 needs to be merged first.

## Description
This PR removes direct Yosemite dependencies from SwiftUI previews. For this, we create a new `POSItemProviderPreview` and `POSProductPreview` implementations in the app layer, for debug builds only.

This also allows us to make both `POSProduct` internal to Yosemite, and previews providers internal to `WooCommerce`.

## Testing information
- CI should pass.
- Previews should render.
