### PR TITLE
[Woo POS] Refactor card connection WC settings webview presentation to allow custom UI

### DIFF
--- a/WooCommerce/Classes/POS/Card Present Payments/CardPresentPaymentEvent.swift
+++ b/WooCommerce/Classes/POS/Card Present Payments/CardPresentPaymentEvent.swift
@@ -7,4 +7,5 @@ enum CardPresentPaymentEvent {
     case showAlert(_ alertViewModel: CardPresentPaymentAlertViewModel)
     case showReaderList(_ readerIDs: [String], selectionHandler: ((String) -> Void))
     case showOnboarding(_ onboardingViewModel: CardPresentPaymentsOnboardingViewModel)
+    case showWCSettingsWebView(adminURL: URL, completion: () -> Void)
 }

--- a/WooCommerce/Classes/POS/Card Present Payments/CardPresentPaymentService.swift
+++ b/WooCommerce/Classes/POS/Card Present Payments/CardPresentPaymentService.swift
@@ -4,8 +4,6 @@ import struct Yosemite.Order
 import struct Yosemite.CardPresentPaymentsConfiguration
 import struct Yosemite.CardReader
 
-import UIKit // TODO: remove after update to `ViewControllerPresenting` when #12864 is done
-
 final class CardPresentPaymentService: CardPresentPaymentFacade {
     let paymentEventPublisher: AnyPublisher<CardPresentPaymentEvent, Never>
 
@@ -90,7 +88,7 @@ private extension CardPresentPaymentService {
         CardPresentPaymentPreflightController(
             siteID: siteID,
             configuration: cardPresentPaymentsConfiguration,
-            rootViewController: UIViewController(), // TODO: update to `ViewControllerPresenting` when #12864 is done
+            rootViewController: NullViewControllerPresenting(),
             alertsPresenter: paymentAlertsPresenterAdaptor,
             onboardingPresenter: onboardingAdaptor,
             externalReaderConnectionController: connectionControllerManager.externalReaderConnectionController,

--- a/WooCommerce/Classes/POS/Card Present Payments/CardPresentPaymentsAlertPresenterAdaptor.swift
+++ b/WooCommerce/Classes/POS/Card Present Payments/CardPresentPaymentsAlertPresenterAdaptor.swift
@@ -16,6 +16,10 @@ final class CardPresentPaymentsAlertPresenterAdaptor: CardPresentPaymentAlertsPr
         paymentAlertSubject.send(.showAlert(viewModel))
     }
 
+    func presentWCSettingsWebView(adminURL: URL, completion: @escaping () -> Void) {
+        paymentAlertSubject.send(.showWCSettingsWebView(adminURL: adminURL, completion: completion))
+    }
+
     func foundSeveralReaders(readerIDs: [String], connect: @escaping (String) -> Void, cancelSearch: @escaping () -> Void) {
         let wrappedConnectionHandler = { [weak self] readerID in
             connect(readerID)

--- a/WooCommerce/Classes/POS/Presentation/PointOfSaleDashboardView.swift
+++ b/WooCommerce/Classes/POS/Presentation/PointOfSaleDashboardView.swift
@@ -49,6 +49,8 @@ struct PointOfSaleDashboardView: View {
             switch viewModel.cardPresentPaymentEvent {
             case .showAlert(let alertViewModel):
                 CardPresentPaymentAlert(alertViewModel: alertViewModel)
+            case let .showWCSettingsWebView(adminURL, completion):
+                WCSettingsWebView(adminUrl: adminURL, completion: completion)
             case .idle,
                     .showReaderList,
                     .showOnboarding:
@@ -93,6 +95,8 @@ fileprivate extension CardPresentPaymentEvent {
             return "Reader List: \(readerIDs.joined())"
         case .showOnboarding(let onboardingViewModel):
             return "Onboarding: \(onboardingViewModel.state.reasonForAnalytics)" // This will only show the initial onboarding state
+        case .showWCSettingsWebView(let adminURL, _):
+            return "WC Settings: \(adminURL.absoluteString)"
         }
     }
 }

--- a/WooCommerce/Classes/POS/ViewModels/PointOfSaleDashboardViewModel.swift
+++ b/WooCommerce/Classes/POS/ViewModels/PointOfSaleDashboardViewModel.swift
@@ -110,7 +110,8 @@ private extension PointOfSaleDashboardViewModel {
                 return false
             case .showAlert,
                     .showReaderList,
-                    .showOnboarding:
+                    .showOnboarding,
+                    .showWCSettingsWebView:
                 return true
             }
         }.assign(to: &$showsCardReaderSheet)

--- a/WooCommerce/Classes/POS/ViewModels/PointOfSaleDashboardViewModel.swift
+++ b/WooCommerce/Classes/POS/ViewModels/PointOfSaleDashboardViewModel.swift
@@ -17,7 +17,7 @@ final class PointOfSaleDashboardViewModel: ObservableObject {
 
     @Published var showsCardReaderSheet: Bool = false
     @Published private(set) var cardPresentPaymentEvent: CardPresentPaymentEvent = .idle
-    @ObservedObject private(set) var cardReaderConnectionViewModel: CardReaderConnectionViewModel
+    let cardReaderConnectionViewModel: CardReaderConnectionViewModel
 
     @Published var showsFilterSheet: Bool = false
 

--- a/WooCommerce/Classes/ViewModels/CardPresentPayments/CardPresentModalConnectionFailedUpdateAddress.swift
+++ b/WooCommerce/Classes/ViewModels/CardPresentPayments/CardPresentModalConnectionFailedUpdateAddress.swift
@@ -4,7 +4,7 @@ import Yosemite
 /// Modal presented when an error occurs while connecting to a reader due to problems with the address
 ///
 final class CardPresentModalConnectingFailedUpdateAddress: CardPresentPaymentsModalViewModel {
-    private let openWCSettingsAction: ((UIViewController) -> Void)?
+    private let openWCSettingsAction: (() -> Void)?
     private let retrySearchAction: () -> Void
     private let cancelSearchAction: () -> Void
 
@@ -37,7 +37,7 @@ final class CardPresentModalConnectingFailedUpdateAddress: CardPresentPaymentsMo
     }
 
     init(image: UIImage = .paymentErrorImage,
-         openWCSettings: ((UIViewController) -> Void)?,
+         openWCSettings: (() -> Void)?,
          retrySearch: @escaping () -> Void,
          cancelSearch: @escaping () -> Void) {
         self.image = image
@@ -47,11 +47,10 @@ final class CardPresentModalConnectingFailedUpdateAddress: CardPresentPaymentsMo
     }
 
     func didTapPrimaryButton(in viewController: UIViewController?) {
-        guard let openWCSettingsAction = openWCSettingsAction,
-              let viewController = viewController else {
+        guard let openWCSettingsAction else {
             return retrySearchAction()
         }
-        openWCSettingsAction(viewController)
+        openWCSettingsAction()
     }
 
     func didTapSecondaryButton(in viewController: UIViewController?) {

--- a/WooCommerce/Classes/ViewRelated/CardPresentPayments/BuiltInCardReaderConnectionController.swift
+++ b/WooCommerce/Classes/ViewRelated/CardPresentPayments/BuiltInCardReaderConnectionController.swift
@@ -495,32 +495,21 @@ private extension BuiltInCardReaderConnectionController {
     }
 
     private func openWCSettingsAction(adminUrl: URL?,
-                                      retrySearch: @escaping () -> Void) -> ((UIViewController) -> Void)? {
+                                      retrySearch: @escaping () -> Void) -> (() -> Void)? {
         if let adminUrl = adminUrl {
             if let site = stores.sessionManager.defaultSite,
                site.isWordPressComStore {
-                return { [weak self] viewController in
-                    self?.openWCSettingsInWebview(url: adminUrl, from: viewController, retrySearch: retrySearch)
+                return { [weak self] in
+                    self?.alertsPresenter.presentWCSettingsWebView(adminURL: adminUrl, completion: retrySearch)
                 }
             } else {
-                return { [weak self] _ in
+                return { [weak self] in
                     UIApplication.shared.open(adminUrl)
                     self?.showIncompleteAddressErrorWithRefreshButton()
                 }
             }
         }
         return nil
-    }
-    private func openWCSettingsInWebview(url adminUrl: URL,
-                                         from viewController: UIViewController,
-                                         retrySearch: @escaping () -> Void) {
-        let nav = WCSettingsWebView(adminUrl: adminUrl) {
-            viewController.dismiss(animated: true) {
-                retrySearch()
-            }
-        }
-        let hostingController = UIHostingController(rootView: nav)
-        viewController.present(hostingController, animated: true, completion: nil)
     }
 
     private func showIncompleteAddressErrorWithRefreshButton() {

--- a/WooCommerce/Classes/ViewRelated/CardPresentPayments/BuiltInCardReaderConnectionController.swift
+++ b/WooCommerce/Classes/ViewRelated/CardPresentPayments/BuiltInCardReaderConnectionController.swift
@@ -514,26 +514,11 @@ private extension BuiltInCardReaderConnectionController {
     private func openWCSettingsInWebview(url adminUrl: URL,
                                          from viewController: UIViewController,
                                          retrySearch: @escaping () -> Void) {
-        let nav = NavigationView {
-            AuthenticatedWebView(isPresented: .constant(true),
-                                 url: adminUrl,
-                                 urlToTriggerExit: nil,
-                                 exitTrigger: nil)
-                                 .navigationTitle(Localization.adminWebviewTitle)
-                                 .navigationBarTitleDisplayMode(.inline)
-                                 .toolbar {
-                                     ToolbarItem(placement: .confirmationAction) {
-                                         Button(action: {
-                                             viewController.dismiss(animated: true) {
-                                                 retrySearch()
-                                             }
-                                         }, label: {
-                                             Text(Localization.doneButtonUpdateAddress)
-                                         })
-                                     }
-                                 }
+        let nav = WCSettingsWebView(adminUrl: adminUrl) {
+            viewController.dismiss(animated: true) {
+                retrySearch()
+            }
         }
-        .wooNavigationBarStyle()
         let hostingController = UIHostingController(rootView: nav)
         viewController.present(hostingController, animated: true, completion: nil)
     }
@@ -564,21 +549,6 @@ private extension BuiltInCardReaderConnectionController {
     private func returnFailure(error: Error) {
         onCompletion?(.failure(error))
         state = .idle
-    }
-}
-
-private extension BuiltInCardReaderConnectionController {
-    enum Localization {
-        static let adminWebviewTitle = NSLocalizedString(
-            "WooCommerce Settings",
-            comment: "Navigation title of the webview which used by the merchant to update their store address"
-        )
-
-        static let doneButtonUpdateAddress = NSLocalizedString(
-            "Done",
-            comment: "The button title to indicate that the user has finished updating their store's address and is" +
-            "ready to close the webview. This also tries to connect to the reader again."
-        )
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/CardPresentPayments/CardPresentPaymentPreflightController.swift
+++ b/WooCommerce/Classes/ViewRelated/CardPresentPayments/CardPresentPaymentPreflightController.swift
@@ -44,7 +44,7 @@ final class CardPresentPaymentPreflightController: CardPresentPaymentPreflightCo
 
     /// Root View Controller
     /// Used for showing onboarding alerts
-    private let rootViewController: UIViewController
+    private let rootViewController: ViewControllerPresenting
 
     /// Onboarding presenter.
     /// Shows messages to help a merchant get correctly set up for card payments, prior to taking a payment.
@@ -77,7 +77,7 @@ final class CardPresentPaymentPreflightController: CardPresentPaymentPreflightCo
 
     init(siteID: Int64,
          configuration: CardPresentPaymentsConfiguration,
-         rootViewController: UIViewController,
+         rootViewController: ViewControllerPresenting,
          alertsPresenter: CardPresentPaymentAlertsPresenting,
          onboardingPresenter: CardPresentPaymentsOnboardingPresenting,
          externalReaderConnectionController: CardReaderConnectionController? = nil,

--- a/WooCommerce/Classes/ViewRelated/CardPresentPayments/CardReaderConnectionController.swift
+++ b/WooCommerce/Classes/ViewRelated/CardPresentPayments/CardReaderConnectionController.swift
@@ -666,32 +666,21 @@ private extension CardReaderConnectionController {
     }
 
     private func openWCSettingsAction(adminUrl: URL?,
-                                      retrySearch: @escaping () -> Void) -> ((UIViewController) -> Void)? {
+                                      retrySearch: @escaping () -> Void) -> (() -> Void)? {
         if let adminUrl = adminUrl {
             if let site = stores.sessionManager.defaultSite,
                site.isWordPressComStore {
-                return { [weak self] viewController in
-                    self?.openWCSettingsInWebview(url: adminUrl, from: viewController, retrySearch: retrySearch)
+                return { [weak self] in
+                    self?.alertsPresenter.presentWCSettingsWebView(adminURL: adminUrl, completion: retrySearch)
                 }
             } else {
-                return { [weak self] _ in
+                return { [weak self] in
                     UIApplication.shared.open(adminUrl)
                     self?.showIncompleteAddressErrorWithRefreshButton()
                 }
             }
         }
         return nil
-    }
-    private func openWCSettingsInWebview(url adminUrl: URL,
-                                         from viewController: UIViewController,
-                                         retrySearch: @escaping () -> Void) {
-        let nav = WCSettingsWebView(adminUrl: adminUrl) {
-            viewController.dismiss(animated: true) {
-                retrySearch()
-            }
-        }
-        let hostingController = UIHostingController(rootView: nav)
-        viewController.present(hostingController, animated: true, completion: nil)
     }
 
     private func showIncompleteAddressErrorWithRefreshButton() {

--- a/WooCommerce/Classes/ViewRelated/CardPresentPayments/CardReaderConnectionController.swift
+++ b/WooCommerce/Classes/ViewRelated/CardPresentPayments/CardReaderConnectionController.swift
@@ -685,26 +685,11 @@ private extension CardReaderConnectionController {
     private func openWCSettingsInWebview(url adminUrl: URL,
                                          from viewController: UIViewController,
                                          retrySearch: @escaping () -> Void) {
-        let nav = NavigationView {
-            AuthenticatedWebView(isPresented: .constant(true),
-                                 url: adminUrl,
-                                 urlToTriggerExit: nil,
-                                 exitTrigger: nil)
-                                 .navigationTitle(Localization.adminWebviewTitle)
-                                 .navigationBarTitleDisplayMode(.inline)
-                                 .toolbar {
-                                     ToolbarItem(placement: .confirmationAction) {
-                                         Button(action: {
-                                             viewController.dismiss(animated: true) {
-                                                 retrySearch()
-                                             }
-                                         }, label: {
-                                             Text(Localization.doneButtonUpdateAddress)
-                                         })
-                                     }
-                                 }
+        let nav = WCSettingsWebView(adminUrl: adminUrl) {
+            viewController.dismiss(animated: true) {
+                retrySearch()
+            }
         }
-        .wooNavigationBarStyle()
         let hostingController = UIHostingController(rootView: nav)
         viewController.present(hostingController, animated: true, completion: nil)
     }
@@ -735,20 +720,5 @@ private extension CardReaderConnectionController {
     private func returnFailure(error: Error) {
         onCompletion?(.failure(error))
         state = .idle
-    }
-}
-
-private extension CardReaderConnectionController {
-    enum Localization {
-        static let adminWebviewTitle = NSLocalizedString(
-            "WooCommerce Settings",
-            comment: "Navigation title of the webview which used by the merchant to update their store address"
-        )
-
-        static let doneButtonUpdateAddress = NSLocalizedString(
-            "Done",
-            comment: "The button title to indicate that the user has finished updating their store's address and is" +
-            "ready to close the webview. This also tries to connect to the reader again."
-        )
     }
 }

--- a/WooCommerce/Classes/ViewRelated/CardPresentPayments/WCSettingsWebView.swift
+++ b/WooCommerce/Classes/ViewRelated/CardPresentPayments/WCSettingsWebView.swift
@@ -17,10 +17,6 @@ struct WCSettingsWebView: View {
                                      ToolbarItem(placement: .confirmationAction) {
                                          Button(action: {
                                              completion()
-                                             // TODO: implement the completion logic
-//                                             viewController.dismiss(animated: true) {
-//                                                 retrySearch()
-//                                             }
                                          }, label: {
                                              Text(Localization.doneButtonUpdateAddress)
                                          })
@@ -28,6 +24,7 @@ struct WCSettingsWebView: View {
                                  }
         }
         .wooNavigationBarStyle()
+        .navigationViewStyle(.stack)
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/CardPresentPayments/WCSettingsWebView.swift
+++ b/WooCommerce/Classes/ViewRelated/CardPresentPayments/WCSettingsWebView.swift
@@ -1,0 +1,51 @@
+import SwiftUI
+
+/// Displays WooCommerce settings in a webview within a navigation view.
+struct WCSettingsWebView: View {
+    let adminUrl: URL
+    let completion: () -> Void
+
+    var body: some View {
+        NavigationView {
+            AuthenticatedWebView(isPresented: .constant(true),
+                                 url: adminUrl,
+                                 urlToTriggerExit: nil,
+                                 exitTrigger: nil)
+                                 .navigationTitle(Localization.adminWebviewTitle)
+                                 .navigationBarTitleDisplayMode(.inline)
+                                 .toolbar {
+                                     ToolbarItem(placement: .confirmationAction) {
+                                         Button(action: {
+                                             completion()
+                                             // TODO: implement the completion logic
+//                                             viewController.dismiss(animated: true) {
+//                                                 retrySearch()
+//                                             }
+                                         }, label: {
+                                             Text(Localization.doneButtonUpdateAddress)
+                                         })
+                                     }
+                                 }
+        }
+        .wooNavigationBarStyle()
+    }
+}
+
+private extension WCSettingsWebView {
+    enum Localization {
+        static let adminWebviewTitle = NSLocalizedString(
+            "WooCommerce Settings",
+            comment: "Navigation title of the webview which used by the merchant to update their store address"
+        )
+
+        static let doneButtonUpdateAddress = NSLocalizedString(
+            "Done",
+            comment: "The button title to indicate that the user has finished updating their store's address and is" +
+            "ready to close the webview. This also tries to connect to the reader again."
+        )
+    }
+}
+
+#Preview {
+    WCSettingsWebView(adminUrl: WooConstants.URLs.wooPaymentsStartupGuide.asURL(), completion: {})
+}

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/BluetoothReaderConnectionAlertsProvider.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/BluetoothReaderConnectionAlertsProvider.swift
@@ -25,7 +25,7 @@ struct BluetoothReaderConnectionAlertsProvider: BluetoothReaderConnnectionAlerts
         CardPresentModalNonRetryableError(amount: "", error: error, onDismiss: close)
     }
 
-    func connectingFailedIncompleteAddress(openWCSettings: ((UIViewController) -> Void)?,
+    func connectingFailedIncompleteAddress(openWCSettings: (() -> Void)?,
                                            retrySearch: @escaping () -> Void,
                                            cancelSearch: @escaping () -> Void) -> CardPresentPaymentsModalViewModel {
         CardPresentModalConnectingFailedUpdateAddress(openWCSettings: openWCSettings, retrySearch: retrySearch, cancelSearch: cancelSearch)

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/BuiltInReaderConnectionAlertsProvider.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/BuiltInReaderConnectionAlertsProvider.swift
@@ -29,7 +29,7 @@ struct BuiltInReaderConnectionAlertsProvider: CardReaderConnectionAlertsProvidin
     }
 
 
-    func connectingFailedIncompleteAddress(openWCSettings: ((UIViewController) -> Void)?,
+    func connectingFailedIncompleteAddress(openWCSettings: (() -> Void)?,
                                            retrySearch: @escaping () -> Void,
                                            cancelSearch: @escaping () -> Void) -> CardPresentPaymentsModalViewModel {
         CardPresentModalConnectingFailedUpdateAddress(image: .builtInReaderError,

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/CardReaderConnectionAlertsProviding.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/CardReaderConnectionAlertsProviding.swift
@@ -35,7 +35,7 @@ protocol CardReaderConnectionAlertsProviding {
     /// Defines an alert indicating connecting failed because their address needs updating.
     /// The user may try again or cancel
     ///
-    func connectingFailedIncompleteAddress(openWCSettings: ((UIViewController) -> Void)?,
+    func connectingFailedIncompleteAddress(openWCSettings: (() -> Void)?,
                                            retrySearch: @escaping () -> Void,
                                            cancelSearch: @escaping () -> Void) -> CardPresentPaymentsModalViewModel
 

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/CardReaderSettingsAlerts.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/CardReaderSettingsAlerts.swift
@@ -29,7 +29,7 @@ final class CardReaderSettingsAlerts: CardReaderSettingsAlertsProvider {
     }
 
     func connectingFailedIncompleteAddress(from: UIViewController,
-                                        openWCSettings: ((UIViewController) -> Void)?,
+                                        openWCSettings: (() -> Void)?,
                                         retrySearch: @escaping () -> Void,
                                         cancelSearch: @escaping () -> Void) {
         setViewModelAndPresent(from: from,
@@ -193,7 +193,7 @@ private extension CardReaderSettingsAlerts {
         CardPresentModalConnectingFailed(error: error, retrySearch: continueSearch, cancelSearch: cancelSearch)
     }
 
-    func connectingFailedUpdateAddress(openWCSettings: ((UIViewController) -> Void)?,
+    func connectingFailedUpdateAddress(openWCSettings: (() -> Void)?,
                                        retrySearch: @escaping () -> Void,
                                        cancelSearch: @escaping () -> Void) -> CardPresentPaymentsModalViewModel {
         return CardPresentModalConnectingFailedUpdateAddress(openWCSettings: openWCSettings,

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/CardReaderSettingsAlertsProvider.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/CardReaderSettingsAlertsProvider.swift
@@ -52,7 +52,7 @@ protocol CardReaderSettingsAlertsProvider {
     /// The user may try again or cancel
     ///
     func connectingFailedIncompleteAddress(from: UIViewController,
-                                           openWCSettings: ((UIViewController) -> Void)?,
+                                           openWCSettings: (() -> Void)?,
                                            retrySearch: @escaping () -> Void,
                                            cancelSearch: @escaping () -> Void)
 

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/SilenceablePassthroughCardPresentPaymentAlertsPresenter.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/SilenceablePassthroughCardPresentPaymentAlertsPresenter.swift
@@ -11,6 +11,10 @@ final class SilenceablePassthroughCardPresentPaymentAlertsPresenter: CardPresent
         alertSubject.send(viewModel)
     }
 
+    func presentWCSettingsWebView(adminURL: URL, completion: @escaping () -> Void) {
+        // TODO: confirm if this is needed
+    }
+
     func foundSeveralReaders(readerIDs: [String], connect: @escaping (String) -> Void, cancelSearch: @escaping () -> Void) {
         // no-op – currently this only supports Built In readers, which don't require this
     }

--- a/WooCommerce/Classes/ViewRelated/Orders/Collect Payments/CardPresentPaymentAlertsPresenter.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Collect Payments/CardPresentPaymentAlertsPresenter.swift
@@ -1,8 +1,10 @@
 import Foundation
+import SwiftUI
 import UIKit
 
 protocol CardPresentPaymentAlertsPresenting {
     func present(viewModel: CardPresentPaymentsModalViewModel)
+    func presentWCSettingsWebView(adminURL: URL, completion: @escaping () -> Void)
     func foundSeveralReaders(readerIDs: [String],
                              connect: @escaping (String) -> Void,
                              cancelSearch: @escaping () -> Void)
@@ -67,6 +69,19 @@ final class CardPresentPaymentAlertsPresenter: CardPresentPaymentAlertsPresentin
             return
         }
         from.present(present, animated: animated)
+    }
+
+    func presentWCSettingsWebView(adminURL: URL, completion: @escaping () -> Void) {
+        guard let modalController else {
+            return
+        }
+        let nav = WCSettingsWebView(adminUrl: adminURL) {
+            modalController.dismiss(animated: true) {
+                completion()
+            }
+        }
+        let hostingController = UIHostingController(rootView: nav)
+        modalController.present(hostingController, animated: true, completion: nil)
     }
 
     /// Dismisses the `SeveralReadersFoundViewController`, then presents any

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -254,6 +254,7 @@
 		025A1248247CE793008EA761 /* ProductFormViewModel+ObservablesTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 025A1247247CE793008EA761 /* ProductFormViewModel+ObservablesTests.swift */; };
 		025B1748237A92D800C780B4 /* ProductFormSection+ReusableTableRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 025B1747237A92D800C780B4 /* ProductFormSection+ReusableTableRow.swift */; };
 		025B174A237AA49D00C780B4 /* Product+ProductForm.swift in Sources */ = {isa = PBXBuildFile; fileRef = 025B1749237AA49D00C780B4 /* Product+ProductForm.swift */; };
+		025B3C9A2C0EE5BA0013F036 /* WCSettingsWebView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 025B3C992C0EE5BA0013F036 /* WCSettingsWebView.swift */; };
 		025C00682550DE4700FAC222 /* ProductSKUInputScannerViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 025C00642550DE4600FAC222 /* ProductSKUInputScannerViewController.swift */; };
 		025C00692550DE4700FAC222 /* CodeScannerViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = 025C00652550DE4700FAC222 /* CodeScannerViewController.xib */; };
 		025C006A2550DE4700FAC222 /* ProductSKUInputScannerViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = 025C00662550DE4700FAC222 /* ProductSKUInputScannerViewController.xib */; };
@@ -3172,6 +3173,7 @@
 		025A1247247CE793008EA761 /* ProductFormViewModel+ObservablesTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ProductFormViewModel+ObservablesTests.swift"; sourceTree = "<group>"; };
 		025B1747237A92D800C780B4 /* ProductFormSection+ReusableTableRow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ProductFormSection+ReusableTableRow.swift"; sourceTree = "<group>"; };
 		025B1749237AA49D00C780B4 /* Product+ProductForm.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Product+ProductForm.swift"; sourceTree = "<group>"; };
+		025B3C992C0EE5BA0013F036 /* WCSettingsWebView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WCSettingsWebView.swift; sourceTree = "<group>"; };
 		025C00642550DE4600FAC222 /* ProductSKUInputScannerViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ProductSKUInputScannerViewController.swift; sourceTree = "<group>"; };
 		025C00652550DE4700FAC222 /* CodeScannerViewController.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = CodeScannerViewController.xib; sourceTree = "<group>"; };
 		025C00662550DE4700FAC222 /* ProductSKUInputScannerViewController.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = ProductSKUInputScannerViewController.xib; sourceTree = "<group>"; };
@@ -11785,6 +11787,7 @@
 				31C21FA526D994B700916E2E /* SeveralReadersFoundViewController.xib */,
 				0379C51627BFCE9800A7E284 /* WCPayCardBrand+icons.swift */,
 				020A55F027F6C605007843F0 /* CardReaderConnectionAnalyticsTracker.swift */,
+				025B3C992C0EE5BA0013F036 /* WCSettingsWebView.swift */,
 			);
 			path = CardPresentPayments;
 			sourceTree = "<group>";
@@ -14176,6 +14179,7 @@
 				02B21C5729C9EEF900C5623B /* WooAnalyticsEvent+StoreOnboarding.swift in Sources */,
 				0216271E2375044D000208D2 /* AztecFormatBar+Update.swift in Sources */,
 				CC254F3626C437AB005F3C82 /* ShippingLabelCustomPackageForm.swift in Sources */,
+				025B3C9A2C0EE5BA0013F036 /* WCSettingsWebView.swift in Sources */,
 				DE86E9292A4C213A00A89A5B /* WooAnalyticsEvent+AIFeedback.swift in Sources */,
 				026826932BF59D830036F959 /* PointOfSaleDashboardViewModel.swift in Sources */,
 				026CF63A237E9ABE009563D4 /* ProductVariationsViewController.swift in Sources */,

--- a/WooCommerce/WooCommerceTests/Mocks/MockCardPresentPaymentAlertsPresenter.swift
+++ b/WooCommerce/WooCommerceTests/Mocks/MockCardPresentPaymentAlertsPresenter.swift
@@ -15,6 +15,10 @@ final class MockCardPresentPaymentAlertsPresenter: CardPresentPaymentAlertsPrese
         onPresentCalled?(viewModel)
     }
 
+    func presentWCSettingsWebView(adminURL: URL, completion: @escaping () -> Void) {
+        // no-op
+    }
+
     func foundSeveralReaders(readerIDs: [String],
                              connect: @escaping (String) -> Void,
                              cancelSearch: @escaping () -> Void) {

--- a/WooCommerce/WooCommerceTests/Mocks/MockCardReaderSettingsAlerts.swift
+++ b/WooCommerce/WooCommerceTests/Mocks/MockCardReaderSettingsAlerts.swift
@@ -97,7 +97,7 @@ extension MockCardReaderSettingsAlerts: BluetoothReaderConnnectionAlertsProvidin
         return MockCardPresentPaymentsModalViewModel()
     }
 
-    func connectingFailedIncompleteAddress(openWCSettings: ((UIViewController) -> Void)?,
+    func connectingFailedIncompleteAddress(openWCSettings: (() -> Void)?,
                                            retrySearch: @escaping () -> Void,
                                            cancelSearch: @escaping () -> Void) -> CardPresentPaymentsModalViewModel {
         if mode == .continueSearchingAfterConnectionFailure {


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Parts of #12864 
<!-- Id number of the GitHub issue this PR addresses. -->

## Why

This PR addresses two parts of #12864:
- Replace `CardPresentPaymentPreflightController`'s direct `UIViewController` dependency with `ViewControllerPresenting` to allow passing a null implementation
- Refactor the WC settings webview presentation logic in `CardReaderConnectionController` and `BuiltInCardReaderConnectionController`

## How

- For the first part:

`CardPresentPaymentPreflightController`'s `UIViewController` dependency can already be replaced with `ViewControllerPresenting` as it's only used in the onboarding `CardPresentPaymentsOnboardingPresenting`. This was done in https://github.com/woocommerce/woocommerce-ios/pull/12932/commits/3d9ad35d3eac5b12500cba231ca0d8cd1bdfe236.

- For the second part:

Instead of the CardReaderConnectionController` and `BuiltInCardReaderConnectionController` presenting the webview themselves (with the same implementation detail), I went with adding a new `presentWCSettingsWebView` method to `CardPresentPaymentAlertsPresenting` protocol. This way, each alerts presenter can choose how to present the WC Settings webview. My main concern is that this method doesn't sound directly related to "alerts" as in the protocol name. I'm open to other approaches as well!

This way, `UIViewController` parameter can be removed from `openWCSettings`, and the presentation of the webview is now invoked by `alertsPresenter.presentWCSettingsWebView` and implemented in `CardPresentPaymentAlertsPresenter` for UIKit (existing app) and `CardPresentPaymentsAlertPresenterAdaptor` which emits the equivalent new `CardPresentPaymentEvent.showWCSettingsWebView` for SwiftUI (POS).


## Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->

For easier testing, feel free to mock the error by replacing `CardReaderConnectionController.onInitialization` with

```swift
        let url = URL(string: "{{site_url}}/wp-admin/admin.php?page=wc-settings&tab=tax") // just an example
        showConnectionFailed(error: CardReaderServiceError.connection(underlyingError: .incompleteStoreAddress(adminUrl: url)))
```

And then:

Prerequisite: having a store eligible for POS

### POS

- Switch to a store in the prerequisite if needed
- Turn on the feature switch in Menu > Settings > Experimental Features > POS, if needed
- Go to the Menu tab --> the POS row should appear shortly
- Tap to enter POS
- Tap `Reader disconnected` --> the error modal should be shown
- Tap `Enter Address` --> it should open the webview (make sure the proxy is disabled)

### Payments menu

- Go to the Menu tab > Payments > Manage Card Reader
- Tap to connect reader --> the error modal should be shown
- Tap `Enter Address` --> it should open the webview (make sure the proxy is disabled)

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->


https://github.com/woocommerce/woocommerce-ios/assets/1945542/4eccb6e0-cb56-4f9b-aca8-bf47c59c600a


https://github.com/woocommerce/woocommerce-ios/assets/1945542/ec885823-4aed-4f37-bb77-fcaa35f582ff





---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.