### PR TITLE
Bump Tracks iOS library to v.3.4.1

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -30,7 +30,7 @@ def aztec
 end
 
 def tracks
-  pod 'Automattic-Tracks-iOS', '~> 3.0'
+  pod 'Automattic-Tracks-iOS', '~> 3.4.1'
   # pod 'Automattic-Tracks-iOS', :git => 'https://github.com/Automattic/Automattic-Tracks-iOS.git', :branch => 'trunk'
   # pod 'Automattic-Tracks-iOS', :git => 'https://github.com/Automattic/Automattic-Tracks-iOS.git', :commit => ''
   # pod 'Automattic-Tracks-iOS', :path => '../Automattic-Tracks-iOS'

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -1,7 +1,7 @@
 PODS:
   - Alamofire (5.8.1)
-  - Automattic-Tracks-iOS (3.0.0):
-    - Sentry (~> 8.0)
+  - Automattic-Tracks-iOS (3.4.1):
+    - Sentry (~> 8.26)
     - Sodium (>= 0.9.1)
     - UIDeviceIdentifier (~> 2.0)
   - CocoaLumberjack/Core (3.8.5)
@@ -12,12 +12,9 @@ PODS:
   - Kingfisher (7.6.2)
   - NSObject-SafeExpectations (0.0.6)
   - "NSURL+IDN (0.4)"
-  - Sentry (8.15.2):
-    - Sentry/Core (= 8.15.2)
-    - SentryPrivate (= 8.15.2)
-  - Sentry/Core (8.15.2):
-    - SentryPrivate (= 8.15.2)
-  - SentryPrivate (8.15.2)
+  - Sentry (8.26.0):
+    - Sentry/Core (= 8.26.0)
+  - Sentry/Core (8.26.0)
   - Sodium (0.9.1)
   - Sourcery (1.0.3)
   - StripeTerminal (3.3.1)
@@ -60,7 +57,7 @@ PODS:
 
 DEPENDENCIES:
   - Alamofire (~> 5.0)
-  - Automattic-Tracks-iOS (~> 3.0)
+  - Automattic-Tracks-iOS (~> 3.4.1)
   - CocoaLumberjack/Swift (~> 3.8.5)
   - Gridicons (~> 1.2.0)
   - KeychainAccess (~> 4.2.2)
@@ -89,7 +86,6 @@ SPEC REPOS:
     - NSObject-SafeExpectations
     - "NSURL+IDN"
     - Sentry
-    - SentryPrivate
     - Sodium
     - Sourcery
     - StripeTerminal
@@ -114,15 +110,14 @@ SPEC REPOS:
 
 SPEC CHECKSUMS:
   Alamofire: 3ca42e259043ee0dc5c0cdd76c4bc568b8e42af7
-  Automattic-Tracks-iOS: f30bf3362a77010ccb9fe9aded453645089f6ccb
+  Automattic-Tracks-iOS: 2d4bee68ff9db4d51f2f6c9fc85857dc69a008a4
   CocoaLumberjack: 6a459bc897d6d80bd1b8c78482ec7ad05dffc3f0
   Gridicons: 4455b9f366960121430e45997e32112ae49ffe1d
   KeychainAccess: c0c4f7f38f6fc7bbe58f5702e25f7bd2f65abf51
   Kingfisher: 6c5449c6450c5239166510ba04afe374a98afc4f
   NSObject-SafeExpectations: c01c8881cbd97efad6f668286b913cd0b7d62ab5
   "NSURL+IDN": afc873e639c18138a1589697c3add197fe8679ca
-  Sentry: 6f5742b4c47c17c9adcf265f6f328cf4a0ed1923
-  SentryPrivate: b2f7996f37781080f04a946eb4e377ff63c64195
+  Sentry: 74a073c71c998117edb08f56f443c83570a31bed
   Sodium: 23d11554ecd556196d313cf6130d406dfe7ac6da
   Sourcery: 70a6048014bd4f37ea80e6bd4354d47bf3b760e1
   StripeTerminal: 369ef0cf0b90d838f42be1a0b371475986f4b79f
@@ -146,6 +141,6 @@ SPEC CHECKSUMS:
   ZendeskSupportProvidersSDK: 685b5d185af47ced0ec40564ec46355c838bbd06
   ZendeskSupportSDK: 92e6f9d334e81e9186f8a17583862350460a5393
 
-PODFILE CHECKSUM: b7524097126a1fa85798f3d6352edd9b658ce91f
+PODFILE CHECKSUM: 1f66349fc0f65a2b05ac6ee9a7c58ee2e95f60f1
 
 COCOAPODS: 1.14.0

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -3,6 +3,7 @@
 19.0
 -----
 - [internal] Resolved an issue where users were unable to upload product images when the store is set to private on WP.com. [https://github.com/woocommerce/woocommerce-ios/issues/12646]
+- [internal] Bump Tracks iOS library to v.3.4.1, that fix a deadlock while getting device info. [https://github.com/woocommerce/woocommerce-ios/pull/12939]
 
 18.9
 -----


### PR DESCRIPTION
Super small PR to update Tracks iOS library from v.3.0 to 3.4.1.

I have noticed that there are some old crashes related to Tracks, so I wonder if an update would solve them.

From v.3.0 to v.3.4.1 these are the changes in the library:
- CrashLoggingDataProvider now allows to specify the events sampling rate https://github.com/Automattic/Automattic-Tracks-iOS/pull/271
- CrashLogging new API that supports logging Errors with Tag/Value [https://github.com/Automattic/Automattic-Tracks-iOS/pull/274]
- Add function to log JavaScript exceptions in CrashLogging [https://github.com/Automattic/Automattic-Tracks-iOS/pull/278]
- Fix a deadlock while getting device info. [https://github.com/Automattic/Automattic-Tracks-iOS/pull/282] **(this could generate one of the crashes)**
- The device_info_status_bar_height event property value now will always be zero. [https://github.com/Automattic/Automattic-Tracks-iOS/pull/281]
- Calculate device_info_orientation event property value based on "device orientation" rather than "interface orientation". [https://github.com/Automattic/Automattic-Tracks-iOS/pull/281]
- Fix Xcode 15.4 compatibility by using Sentry 8.26.0 [https://github.com/Automattic/Automattic-Tracks-iOS/pull/286]


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
