### PR TITLE
[Order Form] Design updates for Order Total bottom sheet

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/OrderForm.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/OrderForm.swift
@@ -381,14 +381,14 @@ struct OrderForm: View {
                 FeedbackBannerPopover(isPresented: $viewModel.shippingUseCase.isSurveyPromptPresented, config: viewModel.shippingUseCase.feedbackBannerConfig)
 
                 ExpandableBottomSheet(onChangeOfExpansion: viewModel.orderTotalsExpansionChanged) {
-                    VStack {
+                    VStack(spacing: .zero) {
                         HStack {
                             Text(Localization.orderTotal)
                             Spacer()
                             Text(viewModel.orderTotal)
                         }
                         .font(.headline)
-                        .padding()
+                        .padding([.bottom, .horizontal])
 
                         Divider()
                             .padding([.leading], Layout.dividerLeadingPadding)

--- a/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/ExpandableBottomSheet.swift
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/ExpandableBottomSheet.swift
@@ -71,7 +71,7 @@ struct ExpandableBottomSheet<AlwaysVisibleContent, ExpandableContent>: View wher
                 // but it's here as it wants to be outside the scrollview.
                 Divider()
                     .renderedIf(isExpanded || revealContentDuringDrag)
-                    .padding([.leading], Layout.dividerLeadingPadding)
+                    .padding([.bottom, .leading], Layout.dividerPadding)
             }
             .frame(maxWidth: .infinity)
             .clipped()
@@ -154,7 +154,7 @@ struct ExpandableBottomSheet<AlwaysVisibleContent, ExpandableContent>: View wher
         let collapsedHeight = fixedContentSize.height + chevronSize.height + Layout.chevronPadding
         let screenHeight = UIScreen.main.bounds.height
         let maxExpandedHeight = screenHeight * 0.8
-        let fullHeight = min(collapsedHeight + expandingContentSize.height, maxExpandedHeight)
+        let fullHeight = min(collapsedHeight + expandingContentSize.height + Layout.dividerPadding, maxExpandedHeight)
         let currentHeight = isExpanded ? fullHeight : collapsedHeight
         let dragAdjustedHeight = currentHeight - dragAmount
 
@@ -168,7 +168,7 @@ fileprivate enum Layout {
     static let chevronPadding: CGFloat = 8
     static let sheetCornerRadius: CGFloat = 10
     static let shadowRadius: CGFloat = 5
-    static let dividerLeadingPadding: CGFloat = 16
+    static let dividerPadding: CGFloat = 16
 }
 
 fileprivate enum Localization {

--- a/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/ExpandableBottomSheet.swift
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/ExpandableBottomSheet.swift
@@ -84,6 +84,12 @@ struct ExpandableBottomSheet<AlwaysVisibleContent, ExpandableContent>: View wher
                         panelHeight = calculateHeight()
                     }
                 })
+                .contentShape(Rectangle())
+                .onTapGesture {
+                    withAnimation {
+                        isExpanded.toggle()
+                    }
+                }
         }
         .padding(.horizontal, insets: safeAreaInsets)
         .background(GeometryReader { geometryProxy in


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #12934
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This makes two design updates to the Order Total section in the order form:

* Removes extra spacing and padding, to make the bottom sheet more compact when collapsed.
* Makes the entire "Order total" section tappable, to expand and collapse the bottom sheet.

## Testing steps
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->

1. Build and run the app.
2. Create a new order and add items to the order.
3. Confirm you can tap the "Order total" section or the chevron to expand/collapse the totals.
4. Confirm you can drag the bottom sheet up/down to expand/collapse the totals.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->
Before|After
-|-
![Simulator Screenshot - iPhone 15 Plus - 2024-06-04 at 13 03 31](https://github.com/woocommerce/woocommerce-ios/assets/8658164/18c527f2-b020-40f7-9557-9cc02803e075)|![Simulator Screenshot - iPhone 15 Plus - 2024-06-04 at 16 13 01](https://github.com/woocommerce/woocommerce-ios/assets/8658164/85fbc809-7ae7-49a9-b476-9a5ef8d9eacc)
![Simulator Screenshot - iPhone 15 Plus - 2024-06-04 at 13 03 40](https://github.com/woocommerce/woocommerce-ios/assets/8658164/8b3510a3-acbd-4b7a-a7eb-ed9a54679cca)|![Simulator Screenshot - iPhone 15 Plus - 2024-06-04 at 16 13 12](https://github.com/woocommerce/woocommerce-ios/assets/8658164/456db14e-b26c-4b27-bc46-b2be522be72d)
![Simulator Screenshot - iPhone 15 Plus - 2024-06-04 at 13 03 42](https://github.com/woocommerce/woocommerce-ios/assets/8658164/700fc148-3ff8-4d1e-9707-c0f656887456)|![Simulator Screenshot - iPhone 15 Plus - 2024-06-04 at 16 13 15](https://github.com/woocommerce/woocommerce-ios/assets/8658164/98fc3df0-c9a5-43a7-bfd5-fbeeed41cef0)


https://github.com/woocommerce/woocommerce-ios/assets/8658164/ee2cde95-84c3-4c2a-92ff-dc2d78e20122



---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.