### PR TITLE
[Order Form] Update naming for shipping lines logic for editable orders

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/AddOrderComponentsSection/AddOrderComponentsSection.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/AddOrderComponentsSection/AddOrderComponentsSection.swift
@@ -4,8 +4,8 @@ struct AddOrderComponentsSection: View {
     /// View model to drive the view content
     let viewModel: EditableOrderViewModel.PaymentDataViewModel
 
-    /// Use case for shipping lines on an order
-    @ObservedObject private var shippingUseCase: EditableOrderShippingUseCase
+    /// View model for shipping lines on an order
+    @ObservedObject private var shippingLineViewModel: EditableOrderShippingLineViewModel
 
     /// Indicates if the coupon line details screen should be shown or not.
     ///
@@ -30,11 +30,11 @@ struct AddOrderComponentsSection: View {
     @ScaledMetric private var scale: CGFloat = 1.0
 
     init(viewModel: EditableOrderViewModel.PaymentDataViewModel,
-         shippingUseCase: EditableOrderShippingUseCase,
+         shippingLineViewModel: EditableOrderShippingLineViewModel,
          shouldShowCouponsInfoTooltip: Binding<Bool>,
          shouldShowGiftCardForm: Binding<Bool>) {
         self.viewModel = viewModel
-        self.shippingUseCase = shippingUseCase
+        self.shippingLineViewModel = shippingLineViewModel
         self._shouldShowCouponsInfoTooltip = shouldShowCouponsInfoTooltip
         self._shouldShowGiftCardForm = shouldShowGiftCardForm
     }
@@ -122,14 +122,14 @@ private extension AddOrderComponentsSection {
 
     @ViewBuilder var addShippingRow: some View {
         Button(Localization.addShipping) {
-            shippingUseCase.addShippingLine()
+            shippingLineViewModel.addShippingLine()
         }
         .buttonStyle(PlusButtonStyle())
         .padding()
         .accessibilityIdentifier("add-shipping-button")
         .disabled(viewModel.orderIsEmpty)
-        .renderedIf(!shippingUseCase.paymentData.shouldShowShippingTotal)
-        .sheet(item: $shippingUseCase.shippingLineDetails, content: { viewModel in
+        .renderedIf(!shippingLineViewModel.paymentData.shouldShowShippingTotal)
+        .sheet(item: $shippingLineViewModel.shippingLineDetails, content: { viewModel in
             ShippingLineSelectionDetails(viewModel: viewModel)
         })
     }
@@ -234,10 +234,12 @@ private extension AddOrderComponentsSection {
 struct AddOrderComponentsSection_Previews: PreviewProvider {
     static var previews: some View {
         let viewModel = EditableOrderViewModel.PaymentDataViewModel(itemsTotal: "20.00")
-        let shippingUseCase = EditableOrderShippingUseCase(siteID: 1, flow: .creation, orderSynchronizer: RemoteOrderSynchronizer(siteID: 1, flow: .creation))
+        let shippingLineViewModel = EditableOrderShippingLineViewModel(siteID: 1,
+                                                                       flow: .creation,
+                                                                       orderSynchronizer: RemoteOrderSynchronizer(siteID: 1, flow: .creation))
 
         AddOrderComponentsSection(viewModel: viewModel,
-                                  shippingUseCase: shippingUseCase,
+                                  shippingLineViewModel: shippingLineViewModel,
                                   shouldShowCouponsInfoTooltip: .constant(true),
                                   shouldShowGiftCardForm: .constant(false))
             .previewLayout(.sizeThatFits)

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/EditableOrderViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/EditableOrderViewModel.swift
@@ -365,9 +365,9 @@ final class EditableOrderViewModel: ObservableObject {
 
     // MARK: Shipping line properties
 
-    /// Use case to display, add, edit, or remove shipping lines.
+    /// View model to display, add, edit, or remove shipping lines.
     ///
-    @Published var shippingUseCase: EditableOrderShippingUseCase
+    @Published var shippingLineViewModel: EditableOrderShippingLineViewModel
 
     // MARK: Customer data properties
 
@@ -504,7 +504,7 @@ final class EditableOrderViewModel: ObservableObject {
             resetAddressForm: {}
         )
 
-        self.shippingUseCase = EditableOrderShippingUseCase(siteID: siteID, flow: flow, orderSynchronizer: orderSynchronizer)
+        self.shippingLineViewModel = EditableOrderShippingLineViewModel(siteID: siteID, flow: flow, orderSynchronizer: orderSynchronizer)
 
         configureDisabledState()
         configureCollectPaymentDisabledState()

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/OrderForm.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/OrderForm.swift
@@ -294,15 +294,15 @@ struct OrderForm: View {
                             Spacer(minLength: Layout.sectionSpacing)
 
                             Group {
-                                OrderShippingSection(useCase: viewModel.shippingUseCase)
+                                OrderShippingSection(viewModel: viewModel.shippingLineViewModel)
                                     .disabled(viewModel.shouldShowNonEditableIndicators)
                                 Spacer(minLength: Layout.sectionSpacing)
                             }
-                            .renderedIf(viewModel.shippingUseCase.shippingLineRows.isNotEmpty)
+                            .renderedIf(viewModel.shippingLineViewModel.shippingLineRows.isNotEmpty)
 
                             AddOrderComponentsSection(
                                 viewModel: viewModel.paymentDataViewModel,
-                                shippingUseCase: viewModel.shippingUseCase,
+                                shippingLineViewModel: viewModel.shippingLineViewModel,
                                 shouldShowCouponsInfoTooltip: $shouldShowInformationalCouponTooltip,
                                 shouldShowGiftCardForm: $shouldShowGiftCardForm)
                             .addingTopAndBottomDividers()
@@ -378,7 +378,8 @@ struct OrderForm: View {
         }
         .safeAreaInset(edge: .bottom) {
             VStack {
-                FeedbackBannerPopover(isPresented: $viewModel.shippingUseCase.isSurveyPromptPresented, config: viewModel.shippingUseCase.feedbackBannerConfig)
+                FeedbackBannerPopover(isPresented: $viewModel.shippingLineViewModel.isSurveyPromptPresented,
+                                      config: viewModel.shippingLineViewModel.feedbackBannerConfig)
 
                 ExpandableBottomSheet(onChangeOfExpansion: viewModel.orderTotalsExpansionChanged) {
                     VStack {
@@ -399,7 +400,7 @@ struct OrderForm: View {
                 } expandableContent: {
                     OrderPaymentSection(
                         viewModel: viewModel.paymentDataViewModel,
-                        shippingUseCase: viewModel.shippingUseCase,
+                        shippingLineViewModel: viewModel.shippingLineViewModel,
                         shouldShowGiftCardForm: $shouldShowGiftCardForm)
                     .disabled(viewModel.shouldShowNonEditableIndicators)
                 }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/PaymentSection/OrderPaymentSection.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/PaymentSection/OrderPaymentSection.swift
@@ -7,8 +7,8 @@ struct OrderPaymentSection: View {
     /// View model to drive the view content
     let viewModel: EditableOrderViewModel.PaymentDataViewModel
 
-    /// Use case for shipping lines on an order
-    let shippingUseCase: EditableOrderShippingUseCase
+    /// View model for shipping lines on an order
+    let shippingLineViewModel: EditableOrderShippingLineViewModel
 
     /// Indicates if the gift card code input sheet should be shown or not.
     ///
@@ -36,10 +36,10 @@ struct OrderPaymentSection: View {
     }
 
     init(viewModel: EditableOrderViewModel.PaymentDataViewModel,
-         shippingUseCase: EditableOrderShippingUseCase,
+         shippingLineViewModel: EditableOrderShippingLineViewModel,
          shouldShowGiftCardForm: Binding<Bool>) {
         self.viewModel = viewModel
-        self.shippingUseCase = shippingUseCase
+        self.shippingLineViewModel = shippingLineViewModel
         self._shouldShowGiftCardForm = shouldShowGiftCardForm
     }
 
@@ -94,8 +94,8 @@ private extension OrderPaymentSection {
 
     @ViewBuilder var existingShippingRow: some View {
         TitleAndValueRow(title: Localization.shippingTotal,
-                         value: .content(shippingUseCase.paymentData.shippingTotal))
-        .renderedIf(shippingUseCase.paymentData.shouldShowShippingTotal)
+                         value: .content(shippingLineViewModel.paymentData.shippingTotal))
+        .renderedIf(shippingLineViewModel.paymentData.shouldShowShippingTotal)
     }
 
     @ViewBuilder var productsRow: some View {
@@ -157,7 +157,7 @@ private extension OrderPaymentSection {
             taxSectionTitle
             taxLines
             shippingTax
-                .renderedIf(shippingUseCase.paymentData.shouldShowShippingTax)
+                .renderedIf(shippingLineViewModel.paymentData.shouldShowShippingTax)
             taxBasedOnLine
                 .onTapGesture {
                     shouldShowTaxEducationalDialog = true
@@ -215,7 +215,7 @@ private extension OrderPaymentSection {
                     .foregroundColor(Color(uiColor: .secondaryLabel))
                     .multilineTextAlignment(.leading)
                     .frame(maxWidth: .infinity, alignment: .leading)
-                Text(shippingUseCase.paymentData.shippingTax)
+                Text(shippingLineViewModel.paymentData.shippingTax)
                     .footnoteStyle()
                     .multilineTextAlignment(.trailing)
                     .frame(width: nil, alignment: .trailing)
@@ -324,10 +324,12 @@ private extension OrderPaymentSection {
 struct OrderPaymentSection_Previews: PreviewProvider {
     static var previews: some View {
         let viewModel = EditableOrderViewModel.PaymentDataViewModel(itemsTotal: "20.00")
-        let shippingUseCase = EditableOrderShippingUseCase(siteID: 1, flow: .creation, orderSynchronizer: RemoteOrderSynchronizer(siteID: 1, flow: .creation))
+        let shippingLineViewModel = EditableOrderShippingLineViewModel(siteID: 1,
+                                                                       flow: .creation,
+                                                                       orderSynchronizer: RemoteOrderSynchronizer(siteID: 1, flow: .creation))
 
         OrderPaymentSection(viewModel: viewModel,
-                            shippingUseCase: shippingUseCase,
+                            shippingLineViewModel: shippingLineViewModel,
                             shouldShowGiftCardForm: .constant(false))
             .previewLayout(.sizeThatFits)
     }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/Shipping/EditableOrderShippingLineViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/Shipping/EditableOrderShippingLineViewModel.swift
@@ -5,9 +5,11 @@ import protocol Storage.StorageManagerType
 import struct Storage.FeedbackSettings
 import Combine
 
-/// Use case to add, edit, or remove shipping lines on an order.
+/// View model used for order shipping lines in order creation and editing flows.
 ///
-final class EditableOrderShippingUseCase: ObservableObject {
+/// Encapsulates logic for displaying and editing (adding, updating, or removing) shipping lines on an order.
+///
+final class EditableOrderShippingLineViewModel: ObservableObject {
     private var siteID: Int64
     private var analytics: Analytics
     private var storageManager: StorageManagerType
@@ -147,7 +149,7 @@ final class EditableOrderShippingUseCase: ObservableObject {
 
 // MARK: Configuration
 
-private extension EditableOrderShippingUseCase {
+private extension EditableOrderShippingLineViewModel {
     /// Binds the order state to the `shouldShowNonEditableIndicators` property.
     ///
     func configureNonEditableIndicators() {
@@ -262,16 +264,16 @@ private extension EditableOrderShippingUseCase {
     }
 }
 
-private extension EditableOrderShippingUseCase {
+private extension EditableOrderShippingLineViewModel {
     enum Localization {
         enum FeedbackBanner {
-            static let title = NSLocalizedString("editableOrderShippingUseCase.feedbackSurvey.title",
+            static let title = NSLocalizedString("editableOrderShippingLineViewModel.feedbackSurvey.title",
                                                  value: "Shipping added!",
                                                  comment: "Title for the feedback survey about adding shipping to an order")
-            static let message = NSLocalizedString("editableOrderShippingUseCase.feedbackSurvey.message",
+            static let message = NSLocalizedString("editableOrderShippingLineViewModel.feedbackSurvey.message",
                                                    value: "Does Woo make shipping easy?",
                                                    comment: "Message for the feedback survey about adding shipping to an order")
-            static let buttonTitle = NSLocalizedString("editableOrderShippingUseCase.feedbackSurvey.buttonTitle",
+            static let buttonTitle = NSLocalizedString("editableOrderShippingLineViewModel.feedbackSurvey.buttonTitle",
                                                        value: "Share your feedback",
                                                        comment: "Title for button to view the feedback survey about adding shipping to an order")
         }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/Shipping/OrderShippingSection.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/Shipping/OrderShippingSection.swift
@@ -1,8 +1,8 @@
 import SwiftUI
 
 struct OrderShippingSection: View {
-    /// Use case to add, edit, or remove shipping lines
-    @ObservedObject var useCase: EditableOrderShippingUseCase
+    /// View model to add, edit, or remove shipping lines
+    @ObservedObject var viewModel: EditableOrderShippingLineViewModel
 
     @Environment(\.safeAreaInsets) private var safeAreaInsets: EdgeInsets
 
@@ -17,18 +17,18 @@ struct OrderShippingSection: View {
 
                 Image(uiImage: .lockImage)
                     .foregroundColor(Color(.primary))
-                    .renderedIf(useCase.shouldShowNonEditableIndicators)
+                    .renderedIf(viewModel.shouldShowNonEditableIndicators)
 
                 Button(action: {
-                    useCase.addShippingLine()
+                    viewModel.addShippingLine()
                 }) {
                     Image(uiImage: .plusImage)
                 }
                 .scaledToFit()
-                .renderedIf(!useCase.shouldShowNonEditableIndicators)
+                .renderedIf(!viewModel.shouldShowNonEditableIndicators)
             }
 
-            ForEach(useCase.shippingLineRows) { shippingLineRow in
+            ForEach(viewModel.shippingLineRows) { shippingLineRow in
                 ShippingLineRowView(viewModel: shippingLineRow)
             }
         }
@@ -36,7 +36,7 @@ struct OrderShippingSection: View {
         .padding()
         .background(Color(.listForeground(modal: true)))
         .addingTopAndBottomDividers()
-        .sheet(item: $useCase.shippingLineDetails, content: { viewModel in
+        .sheet(item: $viewModel.shippingLineDetails, content: { viewModel in
             ShippingLineSelectionDetails(viewModel: viewModel)
         })
     }

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -2149,8 +2149,8 @@
 		CE6A8FB42B724D7C0063564D /* AnalyticsReportLink.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE6A8FB32B724D7C0063564D /* AnalyticsReportLink.swift */; };
 		CE6A8FB62B725A690063564D /* AnalyticsReportLinkViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE6A8FB52B725A690063564D /* AnalyticsReportLinkViewModel.swift */; };
 		CE6A8FB82B7291760063564D /* AnalyticsReportLinkViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE6A8FB72B7291760063564D /* AnalyticsReportLinkViewModelTests.swift */; };
-		CE7F778B2C074D2500C89F4E /* EditableOrderShippingUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE7F778A2C074D2500C89F4E /* EditableOrderShippingUseCase.swift */; };
-		CE7F778D2C0770FF00C89F4E /* EditableOrderShippingUseCaseTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE7F778C2C0770FF00C89F4E /* EditableOrderShippingUseCaseTests.swift */; };
+		CE7F778B2C074D2500C89F4E /* EditableOrderShippingLineViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE7F778A2C074D2500C89F4E /* EditableOrderShippingLineViewModel.swift */; };
+		CE7F778D2C0770FF00C89F4E /* EditableOrderShippingLineViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE7F778C2C0770FF00C89F4E /* EditableOrderShippingLineViewModelTests.swift */; };
 		CE85535D209B5BB700938BDC /* OrderDetailsViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE85535C209B5BB700938BDC /* OrderDetailsViewModel.swift */; };
 		CE855365209BA6A700938BDC /* CustomerInfoTableViewCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = CE855361209BA6A700938BDC /* CustomerInfoTableViewCell.xib */; };
 		CE855366209BA6A700938BDC /* CustomerInfoTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE855362209BA6A700938BDC /* CustomerInfoTableViewCell.swift */; };
@@ -5047,8 +5047,8 @@
 		CE6A8FB32B724D7C0063564D /* AnalyticsReportLink.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnalyticsReportLink.swift; sourceTree = "<group>"; };
 		CE6A8FB52B725A690063564D /* AnalyticsReportLinkViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnalyticsReportLinkViewModel.swift; sourceTree = "<group>"; };
 		CE6A8FB72B7291760063564D /* AnalyticsReportLinkViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnalyticsReportLinkViewModelTests.swift; sourceTree = "<group>"; };
-		CE7F778A2C074D2500C89F4E /* EditableOrderShippingUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditableOrderShippingUseCase.swift; sourceTree = "<group>"; };
-		CE7F778C2C0770FF00C89F4E /* EditableOrderShippingUseCaseTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditableOrderShippingUseCaseTests.swift; sourceTree = "<group>"; };
+		CE7F778A2C074D2500C89F4E /* EditableOrderShippingLineViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditableOrderShippingLineViewModel.swift; sourceTree = "<group>"; };
+		CE7F778C2C0770FF00C89F4E /* EditableOrderShippingLineViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditableOrderShippingLineViewModelTests.swift; sourceTree = "<group>"; };
 		CE85535C209B5BB700938BDC /* OrderDetailsViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OrderDetailsViewModel.swift; sourceTree = "<group>"; };
 		CE855361209BA6A700938BDC /* CustomerInfoTableViewCell.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = CustomerInfoTableViewCell.xib; sourceTree = "<group>"; };
 		CE855362209BA6A700938BDC /* CustomerInfoTableViewCell.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CustomerInfoTableViewCell.swift; sourceTree = "<group>"; };
@@ -11122,7 +11122,7 @@
 		CE29FEEB2BFF7706007679C2 /* Shipping */ = {
 			isa = PBXGroup;
 			children = (
-				CE7F778A2C074D2500C89F4E /* EditableOrderShippingUseCase.swift */,
+				CE7F778A2C074D2500C89F4E /* EditableOrderShippingLineViewModel.swift */,
 				CE29FEEC2BFF771F007679C2 /* ShippingLineRowView.swift */,
 				CE29FEF32C009D7C007679C2 /* ShippingLineRowViewModel.swift */,
 				CE29FEF12C009867007679C2 /* OrderShippingSection.swift */,
@@ -11134,7 +11134,7 @@
 			isa = PBXGroup;
 			children = (
 				CE29FEF52C009F5F007679C2 /* ShippingLineRowViewModelTests.swift */,
-				CE7F778C2C0770FF00C89F4E /* EditableOrderShippingUseCaseTests.swift */,
+				CE7F778C2C0770FF00C89F4E /* EditableOrderShippingLineViewModelTests.swift */,
 			);
 			path = Shipping;
 			sourceTree = "<group>";
@@ -14211,7 +14211,7 @@
 				026826AD2BF59DF70036F959 /* PointOfSaleDashboardView.swift in Sources */,
 				DE2FE595292737330018040A /* JetpackSetupView.swift in Sources */,
 				B59D1EEA2190AE96009D1978 /* StorageNote+Woo.swift in Sources */,
-				CE7F778B2C074D2500C89F4E /* EditableOrderShippingUseCase.swift in Sources */,
+				CE7F778B2C074D2500C89F4E /* EditableOrderShippingLineViewModel.swift in Sources */,
 				B95A45E92A77AE2C0073A91F /* CustomerSelectorViewModel.swift in Sources */,
 				024DF3072372C18D006658FE /* AztecUIConfigurator.swift in Sources */,
 				DE02ABBE2B578D0E008E0AC4 /* CreditCardType.swift in Sources */,
@@ -15892,7 +15892,7 @@
 				B9DC770729F2D4910013B191 /* MockProductSelectorTopProductsProvider.swift in Sources */,
 				02BAB02924D13AA500F8B06E /* ProductVariationFormActionsFactoryTests.swift in Sources */,
 				B53A569B21123E8E000776C9 /* MockTableView.swift in Sources */,
-				CE7F778D2C0770FF00C89F4E /* EditableOrderShippingUseCaseTests.swift in Sources */,
+				CE7F778D2C0770FF00C89F4E /* EditableOrderShippingLineViewModelTests.swift in Sources */,
 				2667BFE3252FA695008099D4 /* RefundItemQuantityListSelectorCommandTests.swift in Sources */,
 				DEBAB70F2A7A6F3800743185 /* MockConnectivityObserver.swift in Sources */,
 				EEEA41F22869A5F400AEFC4B /* MockProductImagesProductIDUpdater.swift in Sources */,

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/EditableOrderViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/EditableOrderViewModelTests.swift
@@ -83,7 +83,7 @@ final class EditableOrderViewModelTests: XCTestCase {
             }
 
             // Trigger remote sync
-            viewModel.shippingUseCase.saveShippingLine(.fake())
+            viewModel.shippingLineViewModel.saveShippingLine(.fake())
         }
 
         // Then
@@ -191,7 +191,7 @@ final class EditableOrderViewModelTests: XCTestCase {
             }
 
             // When remote sync is triggered
-            viewModel.shippingUseCase.saveShippingLine(.fake())
+            viewModel.shippingLineViewModel.saveShippingLine(.fake())
         }
 
         // Then
@@ -215,7 +215,7 @@ final class EditableOrderViewModelTests: XCTestCase {
             }
 
             // When remote sync is triggered
-            viewModel.shippingUseCase.saveShippingLine(.fake())
+            viewModel.shippingLineViewModel.saveShippingLine(.fake())
         }
 
         // Then
@@ -240,7 +240,7 @@ final class EditableOrderViewModelTests: XCTestCase {
                 }
             }
             // Remote sync is triggered
-            viewModel.shippingUseCase.saveShippingLine(.fake())
+            viewModel.shippingLineViewModel.saveShippingLine(.fake())
         }
 
         // Then
@@ -966,7 +966,7 @@ final class EditableOrderViewModelTests: XCTestCase {
                 }
             }
             // Trigger remote sync
-            self.viewModel.shippingUseCase.saveShippingLine(.fake())
+            self.viewModel.shippingLineViewModel.saveShippingLine(.fake())
         }
 
         // Then
@@ -990,7 +990,7 @@ final class EditableOrderViewModelTests: XCTestCase {
                 }
             }
             // Trigger remote sync
-            viewModel.shippingUseCase.saveShippingLine(.fake())
+            viewModel.shippingLineViewModel.saveShippingLine(.fake())
         }
 
         // Then
@@ -1015,7 +1015,7 @@ final class EditableOrderViewModelTests: XCTestCase {
             }
         }
         // Trigger remote sync
-        viewModel.shippingUseCase.saveShippingLine(.fake())
+        viewModel.shippingLineViewModel.saveShippingLine(.fake())
 
         // Then
         waitForExpectations(timeout: Constants.expectationTimeout, handler: nil)
@@ -1080,7 +1080,7 @@ final class EditableOrderViewModelTests: XCTestCase {
         let shippingLine = ShippingLine.fake()
 
         // When
-        viewModel.shippingUseCase.saveShippingLine(shippingLine)
+        viewModel.shippingLineViewModel.saveShippingLine(shippingLine)
 
         // Then
         XCTAssertTrue(viewModel.hasChanges)
@@ -1352,7 +1352,7 @@ final class EditableOrderViewModelTests: XCTestCase {
             }
 
             // When remote sync is triggered
-            viewModel.shippingUseCase.saveShippingLine(.fake())
+            viewModel.shippingLineViewModel.saveShippingLine(.fake())
         }
 
         // Then
@@ -1427,7 +1427,7 @@ final class EditableOrderViewModelTests: XCTestCase {
                 }
             }
             // Trigger remote sync
-            viewModel.shippingUseCase.saveShippingLine(.fake())
+            viewModel.shippingLineViewModel.saveShippingLine(.fake())
         }
 
         // When
@@ -3142,10 +3142,10 @@ final class EditableOrderViewModelTests: XCTestCase {
                                                storageManager: storageManager)
 
         // When
-        viewModel.shippingUseCase.shippingLineRows.first?.editShippingLine()
+        viewModel.shippingLineViewModel.shippingLineRows.first?.editShippingLine()
 
         // Then
-        let editShippingLineViewModel = try XCTUnwrap(viewModel.shippingUseCase.shippingLineDetails)
+        let editShippingLineViewModel = try XCTUnwrap(viewModel.shippingLineViewModel.shippingLineDetails)
         assertEqual(shippingLine.methodTitle, editShippingLineViewModel.methodTitle)
     }
 }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/Shipping/EditableOrderShippingLineViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/Shipping/EditableOrderShippingLineViewModelTests.swift
@@ -4,8 +4,8 @@ import Yosemite
 import Storage
 @testable import WooCommerce
 
-final class EditableOrderShippingUseCaseTests: XCTestCase {
-    var useCase: EditableOrderShippingUseCase!
+final class EditableOrderShippingLineViewModelTests: XCTestCase {
+    var viewModel: EditableOrderShippingLineViewModel!
     var stores: MockStoresManager!
     var storageManager: MockStorageManager!
     var analytics: MockAnalyticsProvider!
@@ -22,7 +22,7 @@ final class EditableOrderShippingUseCaseTests: XCTestCase {
         storageManager = MockStorageManager()
         analytics = MockAnalyticsProvider()
         orderSynchronizer = RemoteOrderSynchronizer(siteID: sampleSiteID, flow: .creation, stores: stores, currencySettings: currencySettings)
-        useCase = EditableOrderShippingUseCase(siteID: sampleSiteID,
+        viewModel = EditableOrderShippingLineViewModel(siteID: sampleSiteID,
                                                    flow: .creation,
                                                    orderSynchronizer: orderSynchronizer,
                                                    analytics: WooAnalytics(analyticsProvider: analytics),
@@ -45,7 +45,7 @@ final class EditableOrderShippingUseCaseTests: XCTestCase {
         }
 
         // When
-        _ = EditableOrderShippingUseCase(siteID: sampleSiteID,
+        _ = EditableOrderShippingLineViewModel(siteID: sampleSiteID,
                                              flow: .creation,
                                              orderSynchronizer: orderSynchronizer,
                                              stores: stores)
@@ -62,7 +62,7 @@ final class EditableOrderShippingUseCaseTests: XCTestCase {
         let order = Order.fake().copy(siteID: sampleSiteID, shippingLines: [shippingLine])
 
         // When
-        let useCase = EditableOrderShippingUseCase(siteID: sampleSiteID,
+        let viewModel = EditableOrderShippingLineViewModel(siteID: sampleSiteID,
                                                        flow: .editing(initialOrder: order),
                                                        orderSynchronizer: RemoteOrderSynchronizer(siteID: sampleSiteID,
                                                                                                   flow: .editing(initialOrder: order),
@@ -70,8 +70,8 @@ final class EditableOrderShippingUseCaseTests: XCTestCase {
                                                        storageManager: storageManager)
 
         // Then
-        assertEqual(1, useCase.shippingLineRows.count)
-        let shippingLineRow = try XCTUnwrap(useCase.shippingLineRows.first)
+        assertEqual(1, viewModel.shippingLineRows.count)
+        let shippingLineRow = try XCTUnwrap(viewModel.shippingLineRows.first)
         assertEqual(shippingLine.methodTitle, shippingLineRow.shippingTitle)
         assertEqual(shippingMethod.title, shippingLineRow.shippingMethod)
     }
@@ -83,7 +83,7 @@ final class EditableOrderShippingUseCaseTests: XCTestCase {
         let currencySettings = CurrencySettings(currencyCode: .GBP, currencyPosition: .left, thousandSeparator: "", decimalSeparator: ".", numberOfDecimals: 2)
 
         // When
-        let paymentData = EditableOrderShippingUseCase.ShippingPaymentData(shippingTotal: "3.00",
+        let paymentData = EditableOrderShippingLineViewModel.ShippingPaymentData(shippingTotal: "3.00",
                                                                                shippingTax: "0.30",
                                                                                currencyFormatter: CurrencyFormatter(currencySettings: currencySettings))
 
@@ -95,7 +95,7 @@ final class EditableOrderShippingUseCaseTests: XCTestCase {
 
     func test_payment_data_is_initialized_with_expected_default_values_for_new_order() {
         // Given
-        let paymentData = useCase.paymentData
+        let paymentData = viewModel.paymentData
 
         // Then
         XCTAssertEqual(paymentData.shippingTotal, "$0.00")
@@ -111,18 +111,18 @@ final class EditableOrderShippingUseCaseTests: XCTestCase {
                                         total: "10",
                                         totalTax: "",
                                         taxes: [])
-        useCase.saveShippingLine(shippingLine)
+        viewModel.saveShippingLine(shippingLine)
 
         // Then
-        XCTAssertTrue(useCase.paymentData.shouldShowShippingTotal)
-        XCTAssertEqual(useCase.paymentData.shippingTotal, "$10.00")
+        XCTAssertTrue(viewModel.paymentData.shouldShowShippingTotal)
+        XCTAssertEqual(viewModel.paymentData.shippingTotal, "$10.00")
 
         // When
-        useCase.removeShippingLine(shippingLine)
+        viewModel.removeShippingLine(shippingLine)
 
         // Then
-        XCTAssertFalse(useCase.paymentData.shouldShowShippingTotal)
-        XCTAssertEqual(useCase.paymentData.shippingTotal, "$0.00")
+        XCTAssertFalse(viewModel.paymentData.shouldShowShippingTotal)
+        XCTAssertEqual(viewModel.paymentData.shippingTotal, "$0.00")
     }
 
     func test_payment_data_values_correct_when_shipping_line_is_negative() throws {
@@ -133,29 +133,29 @@ final class EditableOrderShippingUseCaseTests: XCTestCase {
                                         total: "-5",
                                         totalTax: "",
                                         taxes: [])
-        useCase.saveShippingLine(shippingLine)
+        viewModel.saveShippingLine(shippingLine)
 
         // Then
-        XCTAssertTrue(useCase.paymentData.shouldShowShippingTotal)
-        XCTAssertEqual(useCase.paymentData.shippingTotal, "-$5.00")
+        XCTAssertTrue(viewModel.paymentData.shouldShowShippingTotal)
+        XCTAssertEqual(viewModel.paymentData.shippingTotal, "-$5.00")
 
         // When
-        useCase.removeShippingLine(shippingLine)
+        viewModel.removeShippingLine(shippingLine)
 
         // Then
-        XCTAssertFalse(useCase.paymentData.shouldShowShippingTotal)
-        XCTAssertEqual(useCase.paymentData.shippingTotal, "$0.00")
+        XCTAssertFalse(viewModel.paymentData.shouldShowShippingTotal)
+        XCTAssertEqual(viewModel.paymentData.shippingTotal, "$0.00")
     }
 
     // MARK: Add shipping line
 
     func test_addShippingLine_sets_view_model_for_new_shipping_line() throws {
         // When
-        useCase.addShippingLine()
+        viewModel.addShippingLine()
 
         // Then
-        let viewModel = try XCTUnwrap(useCase.shippingLineDetails)
-        XCTAssertFalse(viewModel.isExistingShippingLine)
+        let detailsViewModel = try XCTUnwrap(viewModel.shippingLineDetails)
+        XCTAssertFalse(detailsViewModel.isExistingShippingLine)
     }
 
     // MARK: Shipping line rows
@@ -165,42 +165,42 @@ final class EditableOrderShippingUseCaseTests: XCTestCase {
         let shippingLine = ShippingLine.fake().copy(methodTitle: "Flat Rate")
 
         // When
-        useCase.saveShippingLine(shippingLine)
+        viewModel.saveShippingLine(shippingLine)
 
         // Then
-        assertEqual(1, useCase.shippingLineRows.count)
-        assertEqual(shippingLine.methodTitle, useCase.shippingLineRows.first?.shippingTitle)
+        assertEqual(1, viewModel.shippingLineRows.count)
+        assertEqual(shippingLine.methodTitle, viewModel.shippingLineRows.first?.shippingTitle)
     }
 
     func test_expected_view_model_set_when_shipping_line_row_is_edited() throws {
         // Given
         let shippingLine = ShippingLine.fake().copy(methodTitle: "Flat Rate")
         let order = Order.fake().copy(siteID: sampleSiteID, shippingLines: [shippingLine])
-        let useCase = EditableOrderShippingUseCase(siteID: sampleSiteID,
+        let viewModel = EditableOrderShippingLineViewModel(siteID: sampleSiteID,
                                                        flow: .editing(initialOrder: order),
                                                        orderSynchronizer: RemoteOrderSynchronizer(siteID: sampleSiteID,
                                                                                                   flow: .editing(initialOrder: order),
                                                                                                   stores: stores))
 
         // When
-        useCase.shippingLineRows.first?.editShippingLine()
+        viewModel.shippingLineRows.first?.editShippingLine()
 
         // Then
-        let viewModel = try XCTUnwrap(useCase.shippingLineDetails)
-        XCTAssertTrue(viewModel.isExistingShippingLine)
-        assertEqual(shippingLine.methodTitle, viewModel.methodTitle)
+        let detailsViewModel = try XCTUnwrap(viewModel.shippingLineDetails)
+        XCTAssertTrue(detailsViewModel.isExistingShippingLine)
+        assertEqual(shippingLine.methodTitle, detailsViewModel.methodTitle)
     }
 
     func test_shipping_line_row_is_editable_for_new_order() throws {
         // Given
-        XCTAssertFalse(useCase.shouldShowNonEditableIndicators)
+        XCTAssertFalse(viewModel.shouldShowNonEditableIndicators)
         let shippingLine = ShippingLine.fake().copy(methodTitle: "Flat Rate")
 
         // When
-        useCase.saveShippingLine(shippingLine)
+        viewModel.saveShippingLine(shippingLine)
 
         // Then
-        let shippingLineRow = try XCTUnwrap(useCase.shippingLineRows.first)
+        let shippingLineRow = try XCTUnwrap(viewModel.shippingLineRows.first)
         XCTAssertTrue(shippingLineRow.editable)
     }
 
@@ -210,14 +210,14 @@ final class EditableOrderShippingUseCaseTests: XCTestCase {
         let order = Order.fake().copy(siteID: sampleSiteID, isEditable: false, shippingLines: [shippingLine])
 
         // When
-        let useCase = EditableOrderShippingUseCase(siteID: sampleSiteID,
+        let viewModel = EditableOrderShippingLineViewModel(siteID: sampleSiteID,
                                                        flow: .editing(initialOrder: order),
                                                        orderSynchronizer: RemoteOrderSynchronizer(siteID: sampleSiteID,
                                                                                                   flow: .editing(initialOrder: order),
                                                                                                   stores: stores))
 
         // Then
-        let shippingLineRow = try XCTUnwrap(useCase.shippingLineRows.first)
+        let shippingLineRow = try XCTUnwrap(viewModel.shippingLineRows.first)
         XCTAssertFalse(shippingLineRow.editable)
     }
 
@@ -227,27 +227,27 @@ final class EditableOrderShippingUseCaseTests: XCTestCase {
         let order = Order.fake().copy(siteID: sampleSiteID, isEditable: true, shippingLines: [shippingLine])
 
         // When
-        let useCase = EditableOrderShippingUseCase(siteID: sampleSiteID,
+        let viewModel = EditableOrderShippingLineViewModel(siteID: sampleSiteID,
                                                        flow: .editing(initialOrder: order),
                                                        orderSynchronizer: RemoteOrderSynchronizer(siteID: sampleSiteID,
                                                                                                   flow: .editing(initialOrder: order),
                                                                                                   stores: stores))
 
         // Then
-        let shippingLineRow = try XCTUnwrap(useCase.shippingLineRows.first)
+        let shippingLineRow = try XCTUnwrap(viewModel.shippingLineRows.first)
         XCTAssertTrue(shippingLineRow.editable)
     }
 
     func test_shipping_line_row_is_not_editable_for_order() throws {
         // Given
-        XCTAssertFalse(useCase.shouldShowNonEditableIndicators)
+        XCTAssertFalse(viewModel.shouldShowNonEditableIndicators)
         let shippingLine = ShippingLine.fake().copy(methodTitle: "Flat Rate")
 
         // When
-        useCase.saveShippingLine(shippingLine)
+        viewModel.saveShippingLine(shippingLine)
 
         // Then
-        let shippingLineRow = try XCTUnwrap(useCase.shippingLineRows.first)
+        let shippingLineRow = try XCTUnwrap(viewModel.shippingLineRows.first)
         XCTAssertTrue(shippingLineRow.editable)
     }
 
@@ -255,7 +255,7 @@ final class EditableOrderShippingUseCaseTests: XCTestCase {
 
     func test_addShippingLine_tracks_expected_event() {
         // When
-        useCase.addShippingLine()
+        viewModel.addShippingLine()
 
         // Then
         XCTAssertEqual(analytics.receivedEvents, [WooAnalyticsStat.orderAddShippingTapped.rawValue])
@@ -266,7 +266,7 @@ final class EditableOrderShippingUseCaseTests: XCTestCase {
         let shippingLine = ShippingLine.fake().copy(methodID: "flat_rate")
 
         // When
-        useCase.saveShippingLine(shippingLine)
+        viewModel.saveShippingLine(shippingLine)
 
         // Then
         XCTAssertEqual(analytics.receivedEvents, [WooAnalyticsStat.orderShippingMethodAdd.rawValue])
@@ -277,7 +277,7 @@ final class EditableOrderShippingUseCaseTests: XCTestCase {
 
     func test_removeShippingLine_tracks_expected_event() throws {
         // When
-        useCase.removeShippingLine(ShippingLine.fake())
+        viewModel.removeShippingLine(ShippingLine.fake())
 
         // Then
         XCTAssertEqual(analytics.receivedEvents, [WooAnalyticsStat.orderShippingMethodRemove.rawValue])
@@ -293,7 +293,7 @@ final class EditableOrderShippingUseCaseTests: XCTestCase {
         let expectedFeedbackType: SurveyViewController.Source = .orderFormShippingLines
 
         // When & Then
-        assertEqual(expectedFeedbackType, useCase.feedbackBannerConfig.feedbackType)
+        assertEqual(expectedFeedbackType, viewModel.feedbackBannerConfig.feedbackType)
     }
 
     func test_feedback_survey_config_onSurveyButtonTapped_updates_feedback_visibility() throws {
@@ -312,7 +312,7 @@ final class EditableOrderShippingUseCaseTests: XCTestCase {
         }
 
         // When
-        useCase.feedbackBannerConfig.onSurveyButtonTapped()
+        viewModel.feedbackBannerConfig.onSurveyButtonTapped()
 
         // Then
         assertEqual(.orderFormShippingLines, updatedType)
@@ -326,7 +326,7 @@ final class EditableOrderShippingUseCaseTests: XCTestCase {
 
     func test_feedback_survey_config_onSurveyButtonTapped_tracks_expected_event() throws {
         // When
-        useCase.feedbackBannerConfig.onSurveyButtonTapped()
+        viewModel.feedbackBannerConfig.onSurveyButtonTapped()
 
         // Then
         assertEqual([WooAnalyticsStat.featureFeedbackBanner.rawValue], analytics.receivedEvents)
@@ -350,7 +350,7 @@ final class EditableOrderShippingUseCaseTests: XCTestCase {
         }
 
         // When
-        useCase.feedbackBannerConfig.onCloseButtonTapped()
+        viewModel.feedbackBannerConfig.onCloseButtonTapped()
 
         // Then
         assertEqual(.orderFormShippingLines, updatedType)
@@ -359,7 +359,7 @@ final class EditableOrderShippingUseCaseTests: XCTestCase {
 
     func test_feedback_survey_config_onCloseButtonTapped_tracks_expected_event() throws {
         // When
-        useCase.feedbackBannerConfig.onCloseButtonTapped()
+        viewModel.feedbackBannerConfig.onCloseButtonTapped()
 
         // Then
         assertEqual([WooAnalyticsStat.featureFeedbackBanner.rawValue], analytics.receivedEvents)


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
As discussed in our team's PR review sync, the shipping lines logic extracted in https://github.com/woocommerce/woocommerce-ios/pull/12907 was more of a sub-view model (encapsulating view data and state, as well as actions) than a use case. This PR renames `EditableOrderShippingUseCase` to `EditableOrderShippingLineViewModel` (and related properties) for more clarity.

## Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->
This doesn't change any app behavior; confirm tests pass and optionally test:

1. Build and run the app.
2. Create a new order and add a product.
3. Add shipping to the order and confirm the shipping line and shipping total are reflected in the order form.
4. Create the order and confirm the shipping details are saved.


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.