### PR TITLE
Fix SwiftUI Preview

### DIFF
--- a/Networking/Networking.xcodeproj/project.pbxproj
+++ b/Networking/Networking.xcodeproj/project.pbxproj
@@ -5463,7 +5463,6 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 8409BB32277EE720D63713D4 /* Pods-NetworkingWatchOS.debug.xcconfig */;
 			buildSettings = {
-				ARCHS = "$(ARCHS_STANDARD)";
 				ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = YES;
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
 				CODE_SIGN_STYLE = Automatic;
@@ -5487,10 +5486,9 @@
 				MODULE_VERIFIER_SUPPORTED_LANGUAGE_STANDARDS = "gnu17 gnu++20";
 				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
 				MTL_FAST_MATH = YES;
-				ONLY_ACTIVE_ARCH = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = com.automattomatic.NetworkingWatchOS;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
-				SDKROOT = auto;
+				SDKROOT = watchos;
 				SKIP_INSTALL = YES;
 				SUPPORTED_PLATFORMS = "watchos watchsimulator";
 				SUPPORTS_MACCATALYST = NO;
@@ -5507,7 +5505,6 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 14CE248C7246705417A41DE1 /* Pods-NetworkingWatchOS.release.xcconfig */;
 			buildSettings = {
-				ARCHS = "$(ARCHS_STANDARD)";
 				ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = YES;
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
 				CODE_SIGN_STYLE = Automatic;
@@ -5532,7 +5529,7 @@
 				MTL_FAST_MATH = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = com.automattomatic.NetworkingWatchOS;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
-				SDKROOT = auto;
+				SDKROOT = watchos;
 				SKIP_INSTALL = YES;
 				SUPPORTED_PLATFORMS = "watchos watchsimulator";
 				SUPPORTS_MACCATALYST = NO;
@@ -5548,7 +5545,6 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 61A45743E761BA40FF08B27D /* Pods-NetworkingWatchOS.release-alpha.xcconfig */;
 			buildSettings = {
-				ARCHS = "$(ARCHS_STANDARD)";
 				ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = YES;
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
 				CODE_SIGN_STYLE = Automatic;
@@ -5573,7 +5569,7 @@
 				MTL_FAST_MATH = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = com.automattomatic.NetworkingWatchOS;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
-				SDKROOT = auto;
+				SDKROOT = watchos;
 				SKIP_INSTALL = YES;
 				SUPPORTED_PLATFORMS = "watchos watchsimulator";
 				SUPPORTS_MACCATALYST = NO;

--- a/WooFoundation/WooFoundation.xcodeproj/project.pbxproj
+++ b/WooFoundation/WooFoundation.xcodeproj/project.pbxproj
@@ -772,7 +772,7 @@
 				MODULE_VERIFIER_SUPPORTED_LANGUAGE_STANDARDS = "gnu17 gnu++20";
 				PRODUCT_BUNDLE_IDENTIFIER = com.automattomatic.WooFoundationWatchOS;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
-				SDKROOT = iphoneos;
+				SDKROOT = watchos;
 				SKIP_INSTALL = YES;
 				SUPPORTED_PLATFORMS = "watchos watchsimulator";
 				SUPPORTS_MACCATALYST = NO;
@@ -817,7 +817,7 @@
 				MODULE_VERIFIER_SUPPORTED_LANGUAGE_STANDARDS = "gnu17 gnu++20";
 				PRODUCT_BUNDLE_IDENTIFIER = com.automattomatic.WooFoundationWatchOS;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
-				SDKROOT = iphoneos;
+				SDKROOT = watchos;
 				SKIP_INSTALL = YES;
 				SUPPORTED_PLATFORMS = "watchos watchsimulator";
 				SUPPORTS_MACCATALYST = NO;
@@ -862,7 +862,7 @@
 				MODULE_VERIFIER_SUPPORTED_LANGUAGE_STANDARDS = "gnu17 gnu++20";
 				PRODUCT_BUNDLE_IDENTIFIER = com.automattomatic.WooFoundationWatchOS;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
-				SDKROOT = iphoneos;
+				SDKROOT = watchos;
 				SKIP_INSTALL = YES;
 				SUPPORTED_PLATFORMS = "watchos watchsimulator";
 				SUPPORTS_MACCATALYST = NO;


### PR DESCRIPTION
SwiftUI Preview starts to work after changing the NetworkingWatchOS target's 'Base SDK' build setting from 'Automatic' to 'watchOS'.

Very strangely, the 'Build Active Architecture Only' settings, whose value(`YES`) is the same as its inherited value, needs to be deleted. Otherwise, the app deosn't compile.

Here is a summary of all the changed build settings.

In the 'NetworkingWatchOS' target
* Architecture: Removed (Because it's the same as the inherited setting)
* Build Active Architecture Only: Removed (Because it's the same as the inherited setting)
* Base SDK: 'Automatic' -> 'watchOS'

In the 'WooFoundationWatchOS' target
* Base SDK: 'iOS' -> 'watchOS'

----

With the changes above, I'm able to see the preview content in `WPComEmailLoginView.swift` on both iPhone and iPad.

<img width="2032" alt="Screenshot 2024-06-05 at 10 37 34 AM" src="https://github.com/woocommerce/woocommerce-ios/assets/1101828/6affcdc2-53af-4abb-a721-e4088207cc7e">
