### PR TITLE
Dynamic Dashboard: Tracking events Blaze card

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Dashboard/Blaze/BlazeCampaignDashboardViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Blaze/BlazeCampaignDashboardViewModel.swift
@@ -146,7 +146,6 @@ final class BlazeCampaignDashboardViewModel: ObservableObject {
     }
 
     func didSelectCampaignList() {
-        analytics.track(event: .DynamicDashboard.dashboardCardInteracted(type: .blaze))
         analytics.track(event: .Blaze.blazeCampaignListEntryPointSelected(source: .myStoreSection))
     }
 
@@ -162,7 +161,6 @@ final class BlazeCampaignDashboardViewModel: ObservableObject {
     }
 
     func didSelectCreateCampaign(source: BlazeSource) {
-        analytics.track(event: .DynamicDashboard.dashboardCardInteracted(type: .blaze))
         analytics.track(event: .Blaze.blazeEntryPointTapped(source: source))
     }
 


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #12877 
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

Stops tracking duplicate `dynamic_dashboard_card_interacted` event for Blaze card. 

Changes
- Stop tracking from `BlazeCampaignDashboardViewModel` because those events are tracked from `DashboardViewHostingController` `configureBlazeSection` callbacks. 

## Steps to reproduce
- Create a JN site
- Create products and orders
- Login into the app using the JN store
- Add "Blaze campaigns" card to the dashboard
- Interact with the Blaze campaign card. Tap on the product or tap on the "Create Campaign" button.
- Confirm that `dynamic_dashboard_card_interacted` event is tracked with `type` as `blaze`. 
- Create a Blaze campaign.
- Interact with the Blaze campaign card (tap on a product or campaign)
- Confirm that `dynamic_dashboard_card_interacted` event is tracked with `type` as `blaze`. 
- Tap "View all campaigns" button 
- Confirm that `dynamic_dashboard_card_interacted` event is tracked with `type` as `blaze`. 

## Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->

The Blaze card has the following states based on the store.
- No Blaze campaigns created.
- Blaze campaign submitted.

We should test both states of the Blaze card.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

| No campaigns | Campaigns available |
|--------|--------|
| <img width="354" alt="image" src="https://github.com/woocommerce/woocommerce-ios/assets/524475/28f24c36-3ba5-441d-9976-a8eee9c8d300"> | <img width="343" alt="image" src="https://github.com/woocommerce/woocommerce-ios/assets/524475/848f0f5b-14e7-4503-8751-3c3cec2b6835"> | 

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.