### PR TITLE
Blaze: Fix incorrect order for campaigns

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Blaze/BlazeCampaignList/BlazeCampaignListViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Blaze/BlazeCampaignList/BlazeCampaignListViewModel.swift
@@ -46,7 +46,9 @@ final class BlazeCampaignListViewModel: ObservableObject {
     /// Blaze campaign ResultsController.
     private lazy var resultsController: ResultsController<StorageBlazeCampaignListItem> = {
         let predicate = NSPredicate(format: "siteID == %lld", siteID)
-        let sortDescriptorByID = NSSortDescriptor(keyPath: \StorageBlazeCampaignListItem.campaignID, ascending: false)
+        let sortDescriptorByID = NSSortDescriptor(key: "campaignID",
+                                                  ascending: false,
+                                                  selector: #selector(NSString.localizedStandardCompare))
         let resultsController = ResultsController<StorageBlazeCampaignListItem>(storageManager: storageManager,
                                                                         matching: predicate,
                                                                         sortedBy: [sortDescriptorByID])

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Blaze/BlazeCampaignDashboardViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Blaze/BlazeCampaignDashboardViewModel.swift
@@ -77,7 +77,9 @@ final class BlazeCampaignDashboardViewModel: ObservableObject {
     /// Blaze campaign ResultsController.
     private lazy var blazeCampaignResultsController: ResultsController<StorageBlazeCampaignListItem> = {
         let predicate = NSPredicate(format: "siteID == %lld", siteID)
-        let sortDescriptorByID = NSSortDescriptor(keyPath: \StorageBlazeCampaignListItem.campaignID, ascending: false)
+        let sortDescriptorByID = NSSortDescriptor(key: "campaignID",
+                                                  ascending: false,
+                                                  selector: #selector(NSString.localizedStandardCompare))
         let resultsController = ResultsController<StorageBlazeCampaignListItem>(storageManager: storageManager,
                                                                                 matching: predicate,
                                                                                 fetchLimit: 1,

--- a/WooCommerce/WooCommerceTests/ViewRelated/Blaze/BlazeCampaignListViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Blaze/BlazeCampaignListViewModelTests.swift
@@ -194,12 +194,13 @@ final class BlazeCampaignListViewModelTests: XCTestCase {
     func test_campaignModels_match_loaded_campaigns() {
         // Given
         let stores = MockStoresManager(sessionManager: .testingInstance)
-        let campaign = BlazeCampaignListItem.fake().copy(siteID: sampleSiteID, budgetCurrency: "USD")
+        let campaign1 = BlazeCampaignListItem.fake().copy(siteID: sampleSiteID, campaignID: "9", budgetCurrency: "USD")
+        let campaign2 = BlazeCampaignListItem.fake().copy(siteID: sampleSiteID, campaignID: "10", budgetCurrency: "USD")
         stores.whenReceivingAction(ofType: BlazeAction.self) { action in
             guard case let .synchronizeCampaignsList(_, _, _, onCompletion) = action else {
                 return
             }
-            self.insertCampaigns([campaign])
+            self.insertCampaigns([campaign1, campaign2])
             onCompletion(.success(true))
         }
         let viewModel = BlazeCampaignListViewModel(siteID: sampleSiteID, stores: stores, storageManager: storageManager)
@@ -208,7 +209,8 @@ final class BlazeCampaignListViewModelTests: XCTestCase {
         viewModel.loadCampaigns()
 
         // Then
-        XCTAssertEqual(viewModel.campaigns.first, campaign)
+        // ensure that the items are sorted correctly by IDs
+        XCTAssertEqual(viewModel.campaigns, [campaign2, campaign1])
     }
 
     func test_campaignModels_are_empty_when_loaded_campaigns_are_empty() {

--- a/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Blaze/BlazeCampaignDashboardViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Blaze/BlazeCampaignDashboardViewModelTests.swift
@@ -518,6 +518,39 @@ final class BlazeCampaignDashboardViewModelTests: XCTestCase {
     }
 
     @MainActor
+    func test_latest_campaign_is_displayed() async {
+        // Given
+        let checker = MockBlazeEligibilityChecker(isSiteEligible: true)
+        let campaign1 = BlazeCampaignListItem.fake().copy(siteID: sampleSiteID, campaignID: "9", budgetCurrency: "USD")
+        let campaign2 = BlazeCampaignListItem.fake().copy(siteID: sampleSiteID, campaignID: "10", budgetCurrency: "USD")
+        let sut = BlazeCampaignDashboardViewModel(siteID: sampleSiteID,
+                                                  stores: stores,
+                                                  storageManager: storageManager,
+                                                  blazeEligibilityChecker: checker)
+
+        mockSynchronizeCampaignsList()
+        mockSynchronizeProducts()
+
+        await sut.reload()
+
+        if case .empty = sut.state {
+            // Expected empty state when no Blaze campaign or published product
+        } else {
+            XCTFail("Wrong state")
+        }
+
+        // When
+        insertCampaigns([campaign1, campaign2])
+
+        // Then
+        if case .showCampaign(let campaign) = sut.state {
+            XCTAssertEqual(campaign, campaign2)
+        } else {
+            XCTFail("Wrong state")
+        }
+    }
+
+    @MainActor
     func test_state_is_showProduct_if_published_product_is_added_to_storage() async {
         // Given
         let checker = MockBlazeEligibilityChecker(isSiteEligible: true)


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #12975 
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
Previously, when a store has campaign IDs from 9999 to 10000, the campaign list displays the item with ID 9999 first even though it's older. The reason is that the IDs are string, and by default, strings starting with "9" go before those starting with "1" descendingly.

This PR fixes this logic by using `NSString.localizedStandardCompare` to order numeric strings as expected.

## Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: https://woomobilep2.wordpress.com/2024/05/06/woocommerce-mobile-quality-report-march-april/#comment-12036 -->
- Log in to a store with 9 campaigns.
- Create a new campaign.
- On the My Store screen, confirm that the latest campaign is displayed.
- Switch to the Menu tab > Blaze.
- Confirm that the latest campaign with ID "10" should be on the top of the list and go before the campaign with ID "9".

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->
Dashboard card | Campaign list
--- | ---
<img src="https://github.com/woocommerce/woocommerce-ios/assets/5533851/458558b6-31a1-467e-bf9e-4a8b1256394a" width=320 /> | <img src="https://github.com/woocommerce/woocommerce-ios/assets/5533851/0d820e42-f6c8-475d-94ee-0e42ed4d90f7" width=320 />


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
