### PR TITLE
Dynamic Dashboard: Various design updates

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Dashboard/DashboardView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/DashboardView.swift
@@ -307,7 +307,7 @@ private extension DashboardView {
                 .multilineTextAlignment(.center)
                 .padding(.horizontal, Layout.elementPadding)
 
-            Button(Localization.NewCardsNoticeCard.addSectionsButtonLabel) {
+            Button(Localization.NewCardsNoticeCard.addSectionsButtonText) {
                 ServiceLocator.analytics.track(event: .DynamicDashboard.dashboardCardAddNewSectionsTapped())
 
                 viewModel.showCustomizationScreen()
@@ -439,9 +439,9 @@ private extension DashboardView {
                 comment: "Subtitle of the New Cards Notice card"
             )
 
-            static let addSectionsButtonLabel = NSLocalizedString(
-                "dashboardView.newCardsNoticeCard.addSectionsButtonLabel",
-                value: "Add new sections",
+            static let addSectionsButtonText = NSLocalizedString(
+                "dashboardView.newCardsNoticeCard.addSectionsButtonText",
+                value: "Add New Sections",
                 comment: "Label of the button to add sections"
             )
         }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/DashboardView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/DashboardView.swift
@@ -314,7 +314,7 @@ private extension DashboardView {
             }
             .buttonStyle(PrimaryButtonStyle())
             .padding(.horizontal, Layout.elementPadding)
-            .padding(.bottom, Layout.padding)
+            .padding(.bottom, Layout.elementPadding)
         }
         .background(Color(.listForeground(modal: false)))
         .clipShape(RoundedRectangle(cornerSize: Layout.cornerSize))

--- a/WooCommerce/Classes/ViewRelated/InAppFeedback/InAppFeedbackCardView.swift
+++ b/WooCommerce/Classes/ViewRelated/InAppFeedback/InAppFeedbackCardView.swift
@@ -9,21 +9,21 @@ struct InAppFeedbackCardView: View {
 
     var body: some View {
         VStack(spacing: Layout.padding) {
-            Text(Localization.title)
+            Text(Localization.feedbackTitle)
                 .headlineStyle()
                 .multilineTextAlignment(.center)
                 .padding(.top, Layout.padding)
 
-            HStack(spacing: Layout.padding) {
-                Button(Localization.couldBeBetter) {
-                    viewModel.didTapCouldBeBetter()
-                }
-                .buttonStyle(SecondaryButtonStyle())
-
+            AdaptiveStack(spacing: Layout.padding) {
                 Button(Localization.iLikeIt) {
                     viewModel.didTapILikeIt()
                 }
                 .buttonStyle(PrimaryButtonStyle())
+
+                Button(Localization.couldBeBetter) {
+                    viewModel.didTapCouldBeBetter()
+                }
+                .buttonStyle(SecondaryButtonStyle())
             }
             .padding(Layout.padding)
         }
@@ -41,9 +41,9 @@ private extension InAppFeedbackCardView {
     }
 
     enum Localization {
-        static let title = NSLocalizedString(
-            "inAppFeedbackCardView.title",
-            value: "Enjoying the WooCommerce app?",
+        static let feedbackTitle = NSLocalizedString(
+            "inAppFeedbackCardView.feedbackTitle",
+            value: "Are you enjoying the app?",
             comment: "The title used when asking the user for feedback for the app."
         )
         static let couldBeBetter = NSLocalizedString(

--- a/WooCommerce/Classes/ViewRelated/InAppFeedback/InAppFeedbackCardView.swift
+++ b/WooCommerce/Classes/ViewRelated/InAppFeedback/InAppFeedbackCardView.swift
@@ -14,16 +14,9 @@ struct InAppFeedbackCardView: View {
                 .multilineTextAlignment(.center)
                 .padding(.top, Layout.padding)
 
-            AdaptiveStack(spacing: Layout.padding) {
-                Button(Localization.iLikeIt) {
-                    viewModel.didTapILikeIt()
-                }
-                .buttonStyle(PrimaryButtonStyle())
-
-                Button(Localization.couldBeBetter) {
-                    viewModel.didTapCouldBeBetter()
-                }
-                .buttonStyle(SecondaryButtonStyle())
+            ViewThatFits(in: .horizontal) {
+                horizontalButtonGroup
+                verticalButtonGroup
             }
             .padding(Layout.padding)
         }
@@ -31,6 +24,44 @@ struct InAppFeedbackCardView: View {
             RoundedRectangle(cornerRadius: Layout.cornerRadius)
                 .stroke(Color(.border), lineWidth: 1)
         )
+    }
+}
+
+private extension InAppFeedbackCardView {
+    var verticalButtonGroup: some View {
+        VStack(spacing: Layout.padding) {
+            Button(Localization.iLikeIt) {
+                viewModel.didTapILikeIt()
+            }
+            .buttonStyle(PrimaryButtonStyle())
+
+            Button(Localization.couldBeBetter) {
+                viewModel.didTapCouldBeBetter()
+            }
+            .buttonStyle(SecondaryButtonStyle())
+        }
+    }
+
+    var horizontalButtonGroup: some View {
+        HStack(spacing: Layout.padding) {
+            Button {
+                viewModel.didTapILikeIt()
+            } label: {
+                Text(Localization.iLikeIt)
+                    .fixedSize(horizontal: true, vertical: false)
+                    .frame(maxWidth: .infinity)
+            }
+            .buttonStyle(PrimaryButtonStyle())
+
+            Button {
+                viewModel.didTapCouldBeBetter()
+            } label: {
+                Text(Localization.couldBeBetter)
+                    .fixedSize(horizontal: true, vertical: false)
+                    .frame(maxWidth: .infinity)
+            }
+            .buttonStyle(SecondaryButtonStyle())
+        }
     }
 }
 


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part: #12974
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

This PR does three things:
1. "Add New Sections" card: Capitalizes the button text for the "Add New Sections" card.
2. "Add New Sections" card: Updates the spacing below the button to match the "Share your store" card.
3. "In-app Feedback" card: Update wording, ordering of the button, and wraps the button inside `AdaptiveStack`.

**More on point 3:**
The original issue was with the "Could be better" button, where it wraps into two lines:
<img width="344" alt="Screenshot 2024-06-06 at 16 22 45" src="https://github.com/woocommerce/woocommerce-ios/assets/266376/4f91011d-b1a1-4bbd-b5a0-96efc1138307">
The expected solution is to detect if the button label will go more than one line, and if so, make the button go full-width instead (and the other button will also be full-width and be pushed downward).

The solution here with `AdaptiveStack` partially provides that:

| Font size Setting | Result |
|-|-|
| ![Simulator Screenshot - iPhone 15 iOS 17 4 - 2024-06-06 at 16 27 05](https://github.com/woocommerce/woocommerce-ios/assets/266376/546473b6-061a-4af0-8972-59b9132669ad) | ![Simulator Screenshot - iPhone 15 iOS 17 4 - 2024-06-06 at 16 27 21](https://github.com/woocommerce/woocommerce-ios/assets/266376/cf0a1a4c-8792-4858-90d5-8d58e7404385) |

However, this is only partial because on smaller font setting, the button is still having two-line of text:

| Font size Setting | Result |
|-|-|
| ![Simulator Screenshot - iPhone 15 iOS 17 4 - 2024-06-06 at 16 26 40](https://github.com/woocommerce/woocommerce-ios/assets/266376/c1f283c3-e56b-4351-b685-1063207d8036) | ![Simulator Screenshot - iPhone 15 iOS 17 4 - 2024-06-06 at 16 26 28](https://github.com/woocommerce/woocommerce-ios/assets/266376/5645c2b7-9833-4736-bfee-79da57ba1faf) | 

I spent a couple hours trying to figure out how to detect if the button is on two lines, and then force it to be full-width instead, and could not figure out. This partial solution I think is still an improvement.

## Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->

1. To check the design, I recommend locally editing `DashboardView`, to always show Add New Sections (`newCardsNoticeCard`) and Feedback (`feedbackCard`) card. Also show `shareStoreCard` always.
2. Build app,
3. Ensure the button on "Add New Sections" are capitalized.
4. Compare the button on "Add New Sections" card with "Share Your Store" card and ensure the bottom paddings are similar for both.
5. Check the feedback card and ensure the wording is updated to "Are you enjoying the app?"
6. Check the feedback card and ensure the "I like it" button is now shown first.
7. Play around with the font size setting like in the screenshots above. Ensure that on a large enough text, the button becomes vertically stacked.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->
