### PR TITLE
Dynamic Dashboard: Update new cards notice and "Share Your Store" card behaviors

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Dashboard/DashboardView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/DashboardView.swift
@@ -251,7 +251,7 @@ private extension DashboardView {
                 newCardsNoticeCard
             }
 
-            if !viewModel.hasOrders {
+            if !viewModel.hasOrders && !viewModel.isReloadingAllData {
                 shareStoreCard
             }
         }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/DashboardViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/DashboardViewModel.swift
@@ -60,7 +60,7 @@ final class DashboardViewModel: ObservableObject {
 
     @Published private(set) var jetpackBannerVisibleFromAppSettings = false
 
-    @Published private(set) var hasOrders = true
+    @Published private(set) var hasOrders = false
 
     @Published private(set) var isEligibleForInbox = false
 
@@ -595,9 +595,10 @@ private extension DashboardViewModel {
     }
 
     /// Determines whether to show the notice that new cards now exist and can be found in Customize screen.
-    /// Can optionally pass local cards in case they are recently loaded before calling this function.
     func configureNewCardsNotice() {
-        guard featureFlagService.isFeatureFlagEnabled(.dynamicDashboardM2) else {
+        // If the site has no orders, the app will display the "Share Your Store" card.
+        // In this situation, it should keep the notice (both card and badge) hidden.
+        guard featureFlagService.isFeatureFlagEnabled(.dynamicDashboardM2) && hasOrders else {
             return
         }
 

--- a/WooCommerce/Classes/ViewRelated/Dashboard/DashboardViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/DashboardViewModel.swift
@@ -163,13 +163,12 @@ final class DashboardViewModel: ObservableObject {
         await loadDashboardCardsFromStorage()
         updateDashboardCards(canShowOnboarding: storeOnboardingViewModel.canShowInDashboard,
                              canShowBlaze: blazeCampaignDashboardViewModel.canShowInDashboard,
-                             canShowAnalytics: hasOrders,
-                             canShowLastOrders: hasOrders,
-                             canShowInbox: isEligibleForInbox)
+                             canShowInbox: isEligibleForInbox,
+                             hasOrders: hasOrders)
     }
 
     func handleCustomizationDismissal() {
-        configureNewCardsNotice()
+        configureNewCardsNotice(hasOrders: hasOrders)
     }
 
     @MainActor
@@ -408,9 +407,8 @@ private extension DashboardViewModel {
                 guard let self else { return }
                 updateDashboardCards(canShowOnboarding: canShowOnboarding,
                                      canShowBlaze: canShowBlaze,
-                                     canShowAnalytics: hasOrders,
-                                     canShowLastOrders: hasOrders,
-                                     canShowInbox: isEligibleForInbox)
+                                     canShowInbox: isEligibleForInbox,
+                                     hasOrders: hasOrders)
             }
             .store(in: &subscriptions)
     }
@@ -546,9 +544,11 @@ private extension DashboardViewModel {
 
     func updateDashboardCards(canShowOnboarding: Bool,
                               canShowBlaze: Bool,
-                              canShowAnalytics: Bool,
-                              canShowLastOrders: Bool,
-                              canShowInbox: Bool) {
+                              canShowInbox: Bool,
+                              hasOrders: Bool) {
+
+        let canShowAnalytics = hasOrders
+        let canShowLastOrders = hasOrders
 
         // First, generate latest cards state based on current canShow states
         let initialCards = generateDefaultCards(canShowOnboarding: canShowOnboarding,
@@ -591,13 +591,13 @@ private extension DashboardViewModel {
             dashboardCards = reorderedCards + remainingCards
         }
 
-        configureNewCardsNotice()
+        configureNewCardsNotice(hasOrders: hasOrders)
     }
 
-    /// Determines whether to show the notice that new cards now exist and can be found in Customize screen.
-    func configureNewCardsNotice() {
-        // If the site has no orders, the app will display the "Share Your Store" card.
-        // In this situation, it should keep the notice (both card and badge) hidden.
+    /// Determines whether to show the notice that new cards are available and can be found in the Customize screen.
+    /// - Parameter hasOrders: A Boolean indicating whether the site has orders. If the site has no orders,
+    ///   the app will display the "Share Your Store" card, and the notice should remain hidden.
+    func configureNewCardsNotice(hasOrders: Bool) {
         guard featureFlagService.isFeatureFlagEnabled(.dynamicDashboardM2) && hasOrders else {
             return
         }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

Based on discussion in Slack: p1717560988330199-slack-C03L1NF1EA3

**tl;dr:** We want the app to not show the new card notices ("Add More Sections" card and Edit button badge), even if there are new cards, if currently the app is showing the "Share Your Store" card. The rationale is that if that card is shown, then the store has no orders yet, and the new cards aren't too useful yet in this situation.

Additionally, I also updated the behavior for "Share Your Store" to not be shown by default, and also when loading. Instead, it will be shown once loading is done. It looks more neat that way, previously it could show up first and then disappeared after orders checking was done and there were orders found.

## Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->

1. You will need two test sites: one with no order, and one with existing orders,
2. Start from logged out situation, then log in to the site with no order,
3. Once Dashboard is loaded, ensure that the "Share Your Store" card **is shown**, 
4. Ensure also that the Edit button **has no dot badge**, and the "Add More Sections" card **is not shown**,
5. Switch to the other test site with existing orders,
6. Once Dashboard is loaded, ensure that the "Share Your Store" card **is not shown**, 
7. Ensure also that the Edit button now **has a dot badge**, and the "Add More Sections" card **is shown**