### PR TITLE
Dynamic Dashboard: Track first card saved

### DIFF
--- a/WooCommerce/Classes/Analytics/WooAnalyticsEvent+DynamicDashboard.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsEvent+DynamicDashboard.swift
@@ -7,6 +7,7 @@ extension WooAnalyticsEvent {
             case type
             case cards
             case newCardAvailable = "new_card_available"
+            case firstCardType = "first_card_type"
         }
 
         /// When the user taps the button to edit the dashboard layout.
@@ -24,8 +25,13 @@ extension WooAnalyticsEvent {
         /// When the user taps the Save button to in the layout editor.
         static func editorSaveTapped(types: [DashboardCard.CardType]) -> WooAnalyticsEvent {
             let typeNames = types.map { $0.analyticName }.sorted().joined(separator: ",")
-            return WooAnalyticsEvent(statName: .dynamicDashboardEditorSaveTapped,
-                                     properties: [Keys.cards.rawValue: typeNames])
+            return WooAnalyticsEvent(
+                statName: .dynamicDashboardEditorSaveTapped,
+                properties: [
+                    Keys.cards.rawValue: typeNames,
+                    Keys.firstCardType.rawValue: types.first?.analyticName
+                ].compactMapValues { $0 }
+            )
         }
 
         /// When the user taps the Retry button on the error state view of any dashboard card.

--- a/WooCommerce/Classes/ViewRelated/Dashboard/DashboardCustomization/DashboardCustomizationViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/DashboardCustomization/DashboardCustomizationViewModel.swift
@@ -1,9 +1,6 @@
 import Yosemite
-import protocol WooFoundation.Analytics
 
 final class DashboardCustomizationViewModel: ObservableObject {
-
-    private let analytics: Analytics
 
     /// Ordered array of all available dashboard cards.
     ///
@@ -41,7 +38,6 @@ final class DashboardCustomizationViewModel: ObservableObject {
     ///   - onSave: Optional closure to perform when the changes are saved.
     init(allCards: [DashboardCard],
          inactiveCards: [DashboardCard] = [],
-         analytics: Analytics = ServiceLocator.analytics,
          onSave: (([DashboardCard]) -> Void)? = nil) {
         self.inactiveCards = inactiveCards
 
@@ -55,7 +51,6 @@ final class DashboardCustomizationViewModel: ObservableObject {
         self.originalSelection = selectedCards
 
         self.onSave = onSave
-        self.analytics = analytics
     }
 
     /// Assembles the new selections and order into an updated set of cards.
@@ -65,8 +60,6 @@ final class DashboardCustomizationViewModel: ObservableObject {
         var updatedCards = allCards.map { card in
             card.copy(enabled: selectedCards.contains(card))
         }
-
-        // TODO: add tracking
 
         // Add back any inactive cards
         updatedCards.append(contentsOf: inactiveCards)

--- a/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/DashboardViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/DashboardViewModelTests.swift
@@ -345,6 +345,7 @@ final class DashboardViewModelTests: XCTestCase {
         let index = try XCTUnwrap(analyticsProvider.receivedEvents.firstIndex(where: { $0 == "dynamic_dashboard_editor_save_tapped" }))
         let properties = analyticsProvider.receivedProperties[index] as? [String: AnyHashable]
         XCTAssertEqual(properties?["cards"], "blaze,performance")
+        XCTAssertEqual(properties?["first_card_type"], "performance")
     }
 
     // MARK: Install theme


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of #12877 
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
As raised by Hicham in [p1714021289626249-slack-C03L1NF1EA3], we may benefit from knowing which cards are most commonly saved on the top of the dashboard.

This PR adds a new property `first_card_type` to track the first card saved to the dashboard in the event `_dynamic_dashboard_editor_save_tapped`.

## Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: https://woomobilep2.wordpress.com/2024/05/06/woocommerce-mobile-quality-report-march-april/#comment-12036 -->
- Log in to a store.
- Tap Edit on the top right of the My Store screen.
- Select/deselect and reorder items as you like.
- Tap Save and confirm that `dynamic_dashboard_editor_save_tapped` is tracked with correct values for both `cards` and `first_card_type`.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->
N/A

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
