### PR TITLE
Fix Apple Watch Previews

### DIFF
--- a/WooCommerce/Woo Watch App/ConnectView.swift
+++ b/WooCommerce/Woo Watch App/ConnectView.swift
@@ -45,4 +45,5 @@ extension ConnectView {
 
 #Preview {
     ConnectView()
+        .environmentObject(WatchTracksProvider())
 }

--- a/WooCommerce/WooCommerce.xcodeproj/xcshareddata/xcschemes/Woo Watch App.xcscheme
+++ b/WooCommerce/WooCommerce.xcodeproj/xcshareddata/xcschemes/Woo Watch App.xcscheme
@@ -1,0 +1,91 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1500"
+   version = "1.7">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "26F81B142BE433A2009EC58E"
+               BuildableName = "Woo Watch App.app"
+               BlueprintName = "Woo Watch App"
+               ReferencedContainer = "container:WooCommerce.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "NO"
+            buildForRunning = "NO"
+            buildForProfiling = "NO"
+            buildForArchiving = "NO"
+            buildForAnalyzing = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "B56DB3C52049BFAA00D4AA8E"
+               BuildableName = "WooCommerce.app"
+               BlueprintName = "WooCommerce"
+               ReferencedContainer = "container:WooCommerce.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      shouldAutocreateTestPlan = "YES">
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "26F81B142BE433A2009EC58E"
+            BuildableName = "Woo Watch App.app"
+            BlueprintName = "Woo Watch App"
+            ReferencedContainer = "container:WooCommerce.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "26F81B142BE433A2009EC58E"
+            BuildableName = "Woo Watch App.app"
+            BlueprintName = "Woo Watch App"
+            ReferencedContainer = "container:WooCommerce.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>


### PR DESCRIPTION
Based on #12961
closes #12957
 
# Why

This PR fixes the Apple Watch previews

# How

Removes the main app from the watch app scheme as [suggested here](https://forums.developer.apple.com/forums/thread/743957)


<img width="935" alt="Screenshot 2024-06-06 at 10 12 48 AM" src="https://github.com/woocommerce/woocommerce-ios/assets/562080/66d3eada-3ca1-4159-9460-daa90e1e90f1">

# Demo

iOS Preview | Watch Preview
---- | ----
<img width="528" alt="ios" src="https://github.com/woocommerce/woocommerce-ios/assets/562080/a3467cf6-dab1-4a99-bb71-b2e21bfe08bf"> | <img width="283" alt="watch" src="https://github.com/woocommerce/woocommerce-ios/assets/562080/fd044577-635e-415f-b9cb-98d638c0640d">

# Help

@crazytonyli Would you mind checking this PR and ensuring the Watch App scheme change does not hurt? 

I'm especially concerned about breaking the release process. As in the past, we had problems when validating the build on Itunes.   p1717199829153529-slack-thread_ts=1717136995.187409 


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
