### PR TITLE
Dynamic Dashboard: Restore missing tracking events for stats cards

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Dashboard/DashboardView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/DashboardView.swift
@@ -132,10 +132,7 @@ struct DashboardView: View {
             connectivityStatus = status
         }
         .refreshable {
-            Task { @MainActor in
-                ServiceLocator.analytics.track(.dashboardPulledToRefresh)
-                await viewModel.reloadAllData()
-            }
+            viewModel.onPullToRefresh()
         }
         .safeAreaInset(edge: .bottom) {
             jetpackBenefitBanner

--- a/WooCommerce/Classes/ViewRelated/Dashboard/DashboardViewHostingController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/DashboardViewHostingController.swift
@@ -117,6 +117,7 @@ private extension DashboardViewHostingController {
 
         rootView.onViewAllAnalytics = { [weak self] siteID, siteTimeZone, timeRange in
             guard let self else { return }
+            ServiceLocator.analytics.track(event: .AnalyticsHub.seeMoreAnalyticsTapped())
             let analyticsHubVC = AnalyticsHubHostingViewController(siteID: siteID,
                                                                    timeZone: siteTimeZone,
                                                                    timeRange: timeRange,

--- a/WooCommerce/Classes/ViewRelated/Dashboard/StoreStats/StorePerformanceView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/StoreStats/StorePerformanceView.swift
@@ -82,6 +82,9 @@ struct StorePerformanceView: View {
         .sheet(isPresented: $showingSupportForm) {
             supportForm
         }
+        .onAppear {
+            viewModel.onViewAppear()
+        }
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Dashboard/StoreStats/StorePerformanceView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/StoreStats/StorePerformanceView.swift
@@ -119,8 +119,7 @@ private extension StorePerformanceView {
                     .subheadlineStyle()
                 if viewModel.timeRange.isCustomTimeRange {
                     Button {
-                        ServiceLocator.analytics.track(event: .DynamicDashboard.dashboardCardInteracted(type: .performance))
-
+                        viewModel.trackInteraction()
                         showingCustomRangePicker = true
                     } label: {
                         HStack {
@@ -137,7 +136,7 @@ private extension StorePerformanceView {
             }
             Spacer()
             StatsTimeRangePicker(currentTimeRange: viewModel.timeRange) { newTimeRange in
-                ServiceLocator.analytics.track(event: .DynamicDashboard.dashboardCardInteracted(type: .performance))
+                viewModel.trackInteraction()
 
                 if newTimeRange.isCustomTimeRange {
                     showingCustomRangePicker = true
@@ -216,8 +215,7 @@ private extension StorePerformanceView {
                 return
             }
 
-            ServiceLocator.analytics.track(event: .DynamicDashboard.dashboardCardInteracted(type: .performance))
-
+            viewModel.trackInteraction()
             onCustomRangeRedactedViewTap()
         }
     }
@@ -248,8 +246,7 @@ private extension StorePerformanceView {
         if let chartViewModel = viewModel.chartViewModel {
             VStack {
                 StoreStatsChart(viewModel: chartViewModel) { selectedIndex in
-                    ServiceLocator.analytics.track(event: .DynamicDashboard.dashboardCardInteracted(type: .performance))
-
+                    viewModel.trackInteraction()
                     viewModel.didSelectStatsInterval(at: selectedIndex)
                 }
                 .frame(height: Layout.chartViewHeight)
@@ -265,8 +262,7 @@ private extension StorePerformanceView {
 
     var viewAllAnalyticsButton: some View {
         Button {
-            ServiceLocator.analytics.track(event: .DynamicDashboard.dashboardCardInteracted(type: .performance))
-
+            viewModel.trackInteraction()
             onViewAllAnalytics(viewModel.siteID, viewModel.siteTimezone, viewModel.timeRange)
         } label: {
             HStack {

--- a/WooCommerce/Classes/ViewRelated/Dashboard/StoreStats/StorePerformanceViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/StoreStats/StorePerformanceViewModel.swift
@@ -104,7 +104,6 @@ final class StorePerformanceViewModel: ObservableObject {
         }
         saveLastTimeRange(timeRange)
         shouldHighlightStats = false
-        usageTracksEventEmitter.interacted()
         analytics.track(event: .Dashboard.dashboardMainStatsDate(timeRange: timeRange))
     }
 
@@ -162,6 +161,12 @@ final class StorePerformanceViewModel: ObservableObject {
     func hideStorePerformance() {
         analytics.track(event: .DynamicDashboard.hideCardTapped(type: .performance))
         onDismiss?()
+    }
+
+    /// Add necessary tracking for the interaction
+    func trackInteraction() {
+        usageTracksEventEmitter.interacted()
+        analytics.track(event: .DynamicDashboard.dashboardCardInteracted(type: .performance))
     }
 }
 
@@ -369,7 +374,7 @@ private extension StorePerformanceViewModel {
         if timeRange.isCustomTimeRange {
             analytics.track(event: .DashboardCustomRange.interacted())
         }
-        usageTracksEventEmitter.interacted()
+        trackInteraction()
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Dashboard/StoreStats/StorePerformanceViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/StoreStats/StorePerformanceViewModel.swift
@@ -226,7 +226,9 @@ private extension StorePerformanceViewModel {
         syncingDidFinishPublisher
             .receive(on: DispatchQueue.global(qos: .background))
             .sink { [weak self] in
-                self?.waitingTracker?.end()
+                guard let self else { return }
+                waitingTracker?.end()
+                analytics.track(event: .Dashboard.dashboardMainStatsLoaded(timeRange: timeRange))
             }
             .store(in: &subscriptions)
     }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/StoreStats/StorePerformanceViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/StoreStats/StorePerformanceViewModel.swift
@@ -163,10 +163,15 @@ final class StorePerformanceViewModel: ObservableObject {
         onDismiss?()
     }
 
-    /// Add necessary tracking for the interaction
+    /// Adds necessary tracking for the interaction
     func trackInteraction() {
         usageTracksEventEmitter.interacted()
         analytics.track(event: .DynamicDashboard.dashboardCardInteracted(type: .performance))
+    }
+
+    func onViewAppear() {
+        /// tracks `used_analytics`
+        usageTracksEventEmitter.interacted()
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Dashboard/TopPerformers/TopPerformersDashboardView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/TopPerformers/TopPerformersDashboardView.swift
@@ -104,8 +104,7 @@ private extension TopPerformersDashboardView {
 
                 if viewModel.timeRange.isCustomTimeRange {
                     Button {
-                        ServiceLocator.analytics.track(event: .DynamicDashboard.dashboardCardInteracted(type: .topPerformers))
-
+                        viewModel.trackInteraction()
                         showingCustomRangePicker = true
                     } label: {
                         HStack {
@@ -122,7 +121,7 @@ private extension TopPerformersDashboardView {
             }
             Spacer()
             StatsTimeRangePicker(currentTimeRange: viewModel.timeRange) { newTimeRange in
-                ServiceLocator.analytics.track(event: .DynamicDashboard.dashboardCardInteracted(type: .topPerformers))
+                viewModel.trackInteraction()
 
                 if newTimeRange.isCustomTimeRange {
                     showingCustomRangePicker = true
@@ -136,8 +135,7 @@ private extension TopPerformersDashboardView {
 
     var viewAllAnalyticsButton: some View {
         Button {
-            ServiceLocator.analytics.track(event: .DynamicDashboard.dashboardCardInteracted(type: .topPerformers))
-
+            viewModel.trackInteraction()
             onViewAllAnalytics(viewModel.siteID, viewModel.siteTimezone, viewModel.timeRange)
         } label: {
             HStack {

--- a/WooCommerce/Classes/ViewRelated/Dashboard/TopPerformers/TopPerformersDashboardView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/TopPerformers/TopPerformersDashboardView.swift
@@ -67,6 +67,9 @@ struct TopPerformersDashboardView: View {
         .sheet(item: $viewModel.selectedItem) { item in
             ViewControllerContainer(productDetailView(for: item))
         }
+        .onAppear {
+            viewModel.onViewAppear()
+        }
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Dashboard/TopPerformers/TopPerformersDashboardViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/TopPerformers/TopPerformersDashboardViewModel.swift
@@ -103,8 +103,14 @@ final class TopPerformersDashboardViewModel: ObservableObject {
         onDismiss?()
     }
 
+    /// Adds necessary tracking for the interaction
     func trackInteraction() {
         analytics.track(event: .DynamicDashboard.dashboardCardInteracted(type: .topPerformers))
+        usageTracksEventEmitter.interacted()
+    }
+
+    func onViewAppear() {
+        /// tracks `used_analytics`
         usageTracksEventEmitter.interacted()
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/TopPerformers/TopPerformersDashboardViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/TopPerformers/TopPerformersDashboardViewModel.swift
@@ -149,7 +149,7 @@ private extension TopPerformersDashboardViewModel {
             .receive(on: DispatchQueue.global(qos: .background))
             .sink { [weak self] error in
                 guard let self else { return }
-                if error != nil {
+                if error == nil {
                     analytics.track(event: .Dashboard.dashboardTopPerformersLoaded(timeRange: timeRange))
                 }
                 waitingTracker?.end()

--- a/WooCommerce/Classes/ViewRelated/Dashboard/TopPerformers/TopPerformersDashboardViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/TopPerformers/TopPerformersDashboardViewModel.swift
@@ -33,8 +33,7 @@ final class TopPerformersDashboardViewModel: ObservableObject {
     lazy var periodViewModel = TopPerformersPeriodViewModel(state: .loading) { [weak self] topPerformersItem in
         guard let self else { return }
 
-        analytics.track(event: .DynamicDashboard.dashboardCardInteracted(type: .topPerformers))
-        usageTracksEventEmitter.interacted()
+        trackInteraction()
         selectedItem = topPerformersItem
     }
 
@@ -74,8 +73,6 @@ final class TopPerformersDashboardViewModel: ObservableObject {
     func didSelectTimeRange(_ newTimeRange: StatsTimeRangeV4) {
         timeRange = newTimeRange
         saveLastTimeRange(timeRange)
-        usageTracksEventEmitter.interacted()
-        analytics.track(event: .Dashboard.dashboardMainStatsDate(timeRange: timeRange))
         updateResultsController()
 
         Task { [weak self] in
@@ -104,6 +101,11 @@ final class TopPerformersDashboardViewModel: ObservableObject {
     func dismissTopPerformers() {
         analytics.track(event: .DynamicDashboard.hideCardTapped(type: .topPerformers))
         onDismiss?()
+    }
+
+    func trackInteraction() {
+        analytics.track(event: .DynamicDashboard.dashboardCardInteracted(type: .topPerformers))
+        usageTracksEventEmitter.interacted()
     }
 }
 


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of #12988
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
When migrating the dashboard screen, we missed some tracking events for the Performance and Top Performers cards. This PR restores the following tracking events:
- `used_analytics`:
  - when pulling to refresh the My Store screen and either Performance or Top Performers card is enabled.
  - when interacting with Performance and Top Performers cards.
  - when navigating to the My Store tab.
- `dashboard_main_stats_loaded`
- `dashboard_top_performers_loaded`
- `dashboard_see_more_analytics_tapped`

Internal discussion: peaMlT-Gt-p2

## Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: https://woomobilep2.wordpress.com/2024/05/06/woocommerce-mobile-quality-report-march-april/#comment-12036 -->
- Log in to a test store with at least one existing order. 
- Enable Performance and Top Performers cards.
- After loading the Performance card, confirm that `dashboard_main_stats_loaded` is tracked.
- Tap on View all store analytics on the Performance card, and confirm that `dashboard_see_more_analytics_tapped` is tracked.
- After loading the Top Performers card, confirm that `dashboard_top_performers_loaded` is tracked.
- Tap on View all store analytics on the Top Performers card, and confirm that `dashboard_see_more_analytics_tapped` is tracked.
- Testing `used_analytics`: it's tricky to test this event because there's a buffer check in `StoreStatsUsageTracksEventEmitter`. Test the cases as listed in the Description section to confirm that this emitter is triggered using Xcode debugger if you cannot see the `used_analytics` events every often.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->
N/A

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
