### PR TITLE
[Woo POS] Cart view: Dynamic item counter

### DIFF
--- a/WooCommerce/Classes/POS/Presentation/CartView.swift
+++ b/WooCommerce/Classes/POS/Presentation/CartView.swift
@@ -9,12 +9,18 @@ struct CartView: View {
 
     var body: some View {
         VStack {
-            Text("Cart")
-                .frame(maxWidth: .infinity, alignment: .leading)
-                .padding(.horizontal, 32)
-                .padding(.vertical, 8)
-                .font(.title)
-                .foregroundColor(Color.white)
+            HStack {
+                Text("Cart")
+                Spacer()
+                if let temsInCartLabel = viewModel.itemsInCartLabel {
+                    Text(temsInCartLabel)
+                }
+            }
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .padding(.horizontal, 32)
+            .padding(.vertical, 8)
+            .font(.title)
+            .foregroundColor(Color.white)
             ScrollView {
                 ForEach(viewModel.itemsInCart, id: \.id) { cartItem in
                     ItemRowView(cartItem: cartItem) {

--- a/WooCommerce/Classes/POS/ViewModels/PointOfSaleDashboardViewModel.swift
+++ b/WooCommerce/Classes/POS/ViewModels/PointOfSaleDashboardViewModel.swift
@@ -60,6 +60,17 @@ final class PointOfSaleDashboardViewModel: ObservableObject {
         checkIfCartEmpty()
     }
 
+    var itemsInCartLabel: String? {
+        switch itemsInCart.count {
+        case 0:
+            return nil
+        default:
+            return String.pluralize(itemsInCart.count,
+                                    singular: "%1$d item",
+                                    plural: "%1$d items")
+        }
+    }
+
     private func checkIfCartEmpty() {
         if itemsInCart.isEmpty {
             orderStage = .building


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes #12979
#12964 needs to be merged first.

## Description
This PR adds an item counter to the cart view with initial pluralization:
- If there are no items in cart, do not render the label
- When items in cart == 1, use singular
- When items in cart > 1, use plural

![Simulator Screen Recording - iPad Pro (12 9-inch) (6th generation) - 2024-06-07 at 12 02 10](https://github.com/woocommerce/woocommerce-ios/assets/3812076/f6d33a53-1208-43ef-8eaf-70949f44cadc)

A next good step could be to create a view model specifically for the Cart, since we're starting to pile up functions in the dashboard that perhaps it doesn't need to know about. Logged here: https://github.com/woocommerce/woocommerce-ios/issues/12998

## Testing information
- In POS mode
- Observe in the Cart view that there's no label to start with, adding products to the cart updates the label, removing them does the same until we have zero products and the label is back to be hidden.
