### PR TITLE
[Woo POS] Update toolbar to be at the bottom

### DIFF
--- a/WooCommerce/Classes/POS/Presentation/CardReaderConnection/CardReaderConnectionStatusView.swift
+++ b/WooCommerce/Classes/POS/Presentation/CardReaderConnection/CardReaderConnectionStatusView.swift
@@ -16,15 +16,26 @@ struct CardReaderConnectionStatusView: View {
         Group {
             switch connectionViewModel.connectionStatus {
                 case .connected:
-                    Text("Reader connected")
+                    HStack(spacing: Layout.buttonImageAndTextSpacing) {
+                        Image(systemName: "wave.3.forward.circle")
+                        Text("Reader Connected")
+                    }
+                    .foregroundColor(.init(uiColor: .withColorStudio(.wooCommercePurple, shade: .shade10)))
                 case .disconnected:
                     Button {
                         connectionViewModel.connectReader()
                     } label: {
-                        Text("Reader disconnected")
+                        Text("Reader Disconnected")
+                            .foregroundColor(.init(uiColor: .withColorStudio(.wooCommercePurple, shade: .shade10)))
                     }
             }
         }
+    }
+}
+
+private extension CardReaderConnectionStatusView {
+    enum Layout {
+        static let buttonImageAndTextSpacing: CGFloat = 12
     }
 }
 

--- a/WooCommerce/Classes/POS/Presentation/PointOfSaleDashboardView.swift
+++ b/WooCommerce/Classes/POS/Presentation/PointOfSaleDashboardView.swift
@@ -11,8 +11,6 @@ struct PointOfSaleDashboardView: View {
 
     var body: some View {
         VStack {
-            Text("WooCommerce Point Of Sale")
-                .foregroundColor(Color.white)
             HStack {
                 switch viewModel.orderStage {
                 case .building:
@@ -30,19 +28,9 @@ struct PointOfSaleDashboardView: View {
         .background(Color.primaryBackground)
         .navigationBarBackButtonHidden(true)
         .toolbar {
-            ToolbarItem(placement: .topBarLeading, content: {
-                Button("Exit POS") {
-                    presentationMode.wrappedValue.dismiss()
-                }
-            })
-            ToolbarItem(placement: .principal, content: {
-                CardReaderConnectionStatusView(connectionViewModel: viewModel.cardReaderConnectionViewModel)
-            })
-            ToolbarItem(placement: .primaryAction, content: {
-                Button("History") {
-                    debugPrint("Not implemented")
-                }
-            })
+            ToolbarItem(placement: .bottomBar) {
+                POSToolbarView(readerConnectionViewModel: viewModel.cardReaderConnectionViewModel)
+            }
         }
         .sheet(isPresented: $viewModel.showsCardReaderSheet, content: {
             switch viewModel.cardPresentPaymentEvent {

--- a/WooCommerce/Classes/POS/Presentation/Toolbar/POSToolbarView.swift
+++ b/WooCommerce/Classes/POS/Presentation/Toolbar/POSToolbarView.swift
@@ -1,7 +1,7 @@
 import SwiftUI
 
 struct POSToolbarView: View {
-    @Environment(\.presentationMode) var presentationMode
+    @Environment(\.presentationMode) private var presentationMode
     private let readerConnectionViewModel: CardReaderConnectionViewModel
 
     init(readerConnectionViewModel: CardReaderConnectionViewModel) {

--- a/WooCommerce/Classes/POS/Presentation/Toolbar/POSToolbarView.swift
+++ b/WooCommerce/Classes/POS/Presentation/Toolbar/POSToolbarView.swift
@@ -33,6 +33,10 @@ private extension POSToolbarView {
     }
 }
 
+#if DEBUG
+
 #Preview {
     POSToolbarView(readerConnectionViewModel: .init(cardPresentPayment: CardPresentPaymentPreviewService()))
 }
+
+#endif

--- a/WooCommerce/Classes/POS/Presentation/Toolbar/POSToolbarView.swift
+++ b/WooCommerce/Classes/POS/Presentation/Toolbar/POSToolbarView.swift
@@ -1,0 +1,38 @@
+import SwiftUI
+
+struct POSToolbarView: View {
+    @Environment(\.presentationMode) var presentationMode
+    private let readerConnectionViewModel: CardReaderConnectionViewModel
+
+    init(readerConnectionViewModel: CardReaderConnectionViewModel) {
+        self.readerConnectionViewModel = readerConnectionViewModel
+    }
+
+    var body: some View {
+        HStack {
+            Button {
+                presentationMode.wrappedValue.dismiss()
+            } label: {
+                HStack(spacing: Layout.buttonImageAndTextSpacing) {
+                    Image(systemName: "arrow.left.arrow.right")
+                    Text("Exit POS")
+                }
+                .foregroundColor(Color.white)
+            }
+
+            Spacer()
+
+            CardReaderConnectionStatusView(connectionViewModel: readerConnectionViewModel)
+        }
+    }
+}
+
+private extension POSToolbarView {
+    enum Layout {
+        static let buttonImageAndTextSpacing: CGFloat = 12
+    }
+}
+
+#Preview {
+    POSToolbarView(readerConnectionViewModel: .init(cardPresentPayment: CardPresentPaymentPreviewService()))
+}

--- a/WooCommerce/Classes/POS/Utils/Color+WooCommercePOS.swift
+++ b/WooCommerce/Classes/POS/Utils/Color+WooCommercePOS.swift
@@ -5,7 +5,7 @@ extension Color {
     /// Primary POS background color
     ///
     static var primaryBackground: Color {
-        return Color(red: 11.0 / 255.0, green: 146.0 / 255.0, blue: 213.0 / 255.0)
+        return Color(red: 24.0 / 255.0, green: 24.0 / 255.0, blue: 24.0 / 255.0)
     }
 
     /// Secondary POS background color

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -592,6 +592,7 @@
 		02EEB5C52424AFAA00B8A701 /* TextFieldTableViewCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = 02EEB5C32424AFAA00B8A701 /* TextFieldTableViewCell.xib */; };
 		02EF166C292DFE9A00D90AD6 /* WebCheckoutViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02EF166B292DFE9A00D90AD6 /* WebCheckoutViewModel.swift */; };
 		02EFDAD52C11967500131820 /* CardPresentPaymentsModalViewModelWCSettingsWebViewPresenting.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02EFDAD42C11967500131820 /* CardPresentPaymentsModalViewModelWCSettingsWebViewPresenting.swift */; };
+		02EFDADA2C12D38300131820 /* POSToolbarView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02EFDAD92C12D38300131820 /* POSToolbarView.swift */; };
 		02EFF8172ABBEBED0015ABB2 /* GiftCardError+Description.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02EFF8162ABBEBED0015ABB2 /* GiftCardError+Description.swift */; };
 		02EFF81A2ABC28BA0015ABB2 /* GiftCardInputViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02EFF8192ABC28BA0015ABB2 /* GiftCardInputViewModelTests.swift */; };
 		02F1E6BD2A39805C00C3E4C7 /* ProductDescriptionAICoordinatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02F1E6BC2A39805C00C3E4C7 /* ProductDescriptionAICoordinatorTests.swift */; };
@@ -3517,6 +3518,7 @@
 		02EEB5C32424AFAA00B8A701 /* TextFieldTableViewCell.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = TextFieldTableViewCell.xib; sourceTree = "<group>"; };
 		02EF166B292DFE9A00D90AD6 /* WebCheckoutViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebCheckoutViewModel.swift; sourceTree = "<group>"; };
 		02EFDAD42C11967500131820 /* CardPresentPaymentsModalViewModelWCSettingsWebViewPresenting.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardPresentPaymentsModalViewModelWCSettingsWebViewPresenting.swift; sourceTree = "<group>"; };
+		02EFDAD92C12D38300131820 /* POSToolbarView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = POSToolbarView.swift; sourceTree = "<group>"; };
 		02EFF8162ABBEBED0015ABB2 /* GiftCardError+Description.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "GiftCardError+Description.swift"; sourceTree = "<group>"; };
 		02EFF8192ABC28BA0015ABB2 /* GiftCardInputViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GiftCardInputViewModelTests.swift; sourceTree = "<group>"; };
 		02F1E6BC2A39805C00C3E4C7 /* ProductDescriptionAICoordinatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductDescriptionAICoordinatorTests.swift; sourceTree = "<group>"; };
@@ -6532,6 +6534,7 @@
 		026826A12BF59DED0036F959 /* Presentation */ = {
 			isa = PBXGroup;
 			children = (
+				02EFDAD62C12D32700131820 /* Toolbar */,
 				02E71DB42C118C470036C2FD /* Card Present Payments */,
 				026826B02BF59E170036F959 /* CardReaderConnection */,
 				026826A72BF59DF70036F959 /* PointOfSaleEntryPointView.swift */,
@@ -7242,6 +7245,14 @@
 				02EF166B292DFE9A00D90AD6 /* WebCheckoutViewModel.swift */,
 			);
 			path = Plan;
+			sourceTree = "<group>";
+		};
+		02EFDAD62C12D32700131820 /* Toolbar */ = {
+			isa = PBXGroup;
+			children = (
+				02EFDAD92C12D38300131820 /* POSToolbarView.swift */,
+			);
+			path = Toolbar;
 			sourceTree = "<group>";
 		};
 		02EFF8182ABC28A50015ABB2 /* GiftCards */ = {
@@ -14311,6 +14322,7 @@
 				2688643D25D470C000821BA5 /* EditAttributesViewModel.swift in Sources */,
 				03A9F3B22A03E70700385673 /* AdaptiveAsyncImage.swift in Sources */,
 				DE2004602BF7092900660A72 /* ProductStockDashboardCard.swift in Sources */,
+				02EFDADA2C12D38300131820 /* POSToolbarView.swift in Sources */,
 				31C21FA426D9949000916E2E /* SeveralReadersFoundViewController.swift in Sources */,
 				45E1482527736D1E0099CF23 /* SettingsView.swift in Sources */,
 				02E3B62829026C8F007E0F13 /* AccountCreationForm.swift in Sources */,


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #12971
<!-- Id number of the GitHub issue this PR addresses. -->

## Why

Now that we've decided to have the menu navigation in a static bottom bar p91TBi-bls-p2, and since it includes the reader connection CTA that we've implemented, I did a check to make sure that the bottom toolbar is feasible in SwiftUI (turned out it is) with quick design updates.

## How

In order to implement the bottom toolbar, there's only one placement type `ToolbarItem(placement: .bottomBar)` to provide a view for the bottom bar. Therefore, the toolbar was moved to a separate view, `POSToolbarView` as an HStack with the Exit CTA on the leading edge and Connection CTA on the trailing edge.

## Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->

Prerequisite: having a store eligible for POS

- Switch to a store in the prerequisite if needed
- Turn on the feature switch in Menu > Settings > Experimental Features > POS, if needed
- Go to the Menu tab --> the POS row should appear shortly
- Tap on the POS row --> the toolbar should be at the bottom
- If the reader is disconnected, tap `Reader Disconnected` and proceed to connect to a reader --> after a reader is connected, the UI should show `Reader Connected`

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

<img src="https://github.com/woocommerce/woocommerce-ios/assets/1945542/dd21c349-33bd-492d-aedb-ffb8ed8bcfdd" width="300" />

https://github.com/woocommerce/woocommerce-ios/assets/1945542/87d1b37c-b94a-4f5a-beba-66aa5625013c



---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.