### PR TITLE
Revert "Update release notes and CHANGELOG based on 19.0 changes"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,6 @@
 <!--
 Contains editorialized release notes. Raw release notes should go into `RELEASE-NOTES.txt`.
 -->
-## 19.0
-Our latest version enriches your My Store screen, now featuring details on your most recent orders, low stock products, active coupons, customer reviews, and more. Dive deeper into your store’s performance with these new additions!
-
 ## 18.9
 Stay ahead with our latest WooCommerce update! Explore our new Watch App for instant store data and order updates at a glance. We've fixed the issue with shipping methods, plus you can now have multiple shipping lines on orders, so you can handle complex shipping needs for your orders seamlessly.
 

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -6,7 +6,9 @@
 
 19.0
 -----
-Our latest version enriches your My Store screen, now featuring details on your most recent orders, low stock products, active coupons, customer reviews, and more. Dive deeper into your store’s performance with these new additions!
+- [***] Now you can add more sections to the My Store screen including contents for the last orders, top products with low stock, top active coupons and more! [https://github.com/woocommerce/woocommerce-ios/pull/12890]
+- [internal] Resolved an issue where users were unable to upload product images when the store is set to private on WP.com. [https://github.com/woocommerce/woocommerce-ios/issues/12646]
+- [internal] Bump Tracks iOS library to v.3.4.1, that fix a deadlock while getting device info. [https://github.com/woocommerce/woocommerce-ios/pull/12939]
 
 18.9
 -----


### PR DESCRIPTION
Reverting as I added the release notes to `RELEASE-NOTES.txt ` file https://github.com/woocommerce/woocommerce-ios/blob/6265f2be3a034e5d58d7a4c6f6d7288dcd83aa3b/RELEASE-NOTES.txt instead of `release_notes.txt` https://github.com/woocommerce/woocommerce-ios/blob/release/19.0/WooCommerce/Resources/release_notes.txt