### PR TITLE
[Woo POS] Reset `foundReaders` to fix connection issue after the first time

### DIFF
--- a/WooCommerce/Classes/POS/Card Present Payments/CardPresentPaymentService.swift
+++ b/WooCommerce/Classes/POS/Card Present Payments/CardPresentPaymentService.swift
@@ -141,7 +141,6 @@ private extension CardPresentPaymentService {
     }
 
     func createPreflightController() -> CardPresentPaymentPreflightController {
-        connectionControllerManager.externalReaderConnectionController.resetFoundReaders()
         return CardPresentPaymentPreflightController(
             siteID: siteID,
             configuration: cardPresentPaymentsConfiguration,

--- a/WooCommerce/Classes/POS/Card Present Payments/CardPresentPaymentService.swift
+++ b/WooCommerce/Classes/POS/Card Present Payments/CardPresentPaymentService.swift
@@ -141,7 +141,8 @@ private extension CardPresentPaymentService {
     }
 
     func createPreflightController() -> CardPresentPaymentPreflightController {
-        CardPresentPaymentPreflightController(
+        connectionControllerManager.externalReaderConnectionController.resetFoundReaders()
+        return CardPresentPaymentPreflightController(
             siteID: siteID,
             configuration: cardPresentPaymentsConfiguration,
             rootViewController: NullViewControllerPresenting(),

--- a/WooCommerce/Classes/ViewRelated/CardPresentPayments/CardReaderConnectionController.swift
+++ b/WooCommerce/Classes/ViewRelated/CardPresentPayments/CardReaderConnectionController.swift
@@ -166,12 +166,6 @@ final class CardReaderConnectionController {
             self?.state = .initializing
         }
     }
-
-    /// If reader can be disconnected externally during the lifetime of a `CardReaderConnectionController`, found readers need to be reset so as
-    /// not to result in potential connection failure due to outdated found readers.
-    func resetFoundReaders() {
-        foundReaders = []
-    }
 }
 
 private extension CardReaderConnectionController {
@@ -284,6 +278,7 @@ private extension CardReaderConnectionController {
     func onPreparingForSearch() {
         /// Always start fresh - i.e. we haven't skipped connecting to any reader yet
         ///
+        foundReaders = []
         skippedReaderIDs = []
         candidateReader = nil
         showSeveralFoundReaders = false

--- a/WooCommerce/Classes/ViewRelated/CardPresentPayments/CardReaderConnectionController.swift
+++ b/WooCommerce/Classes/ViewRelated/CardPresentPayments/CardReaderConnectionController.swift
@@ -166,6 +166,12 @@ final class CardReaderConnectionController {
             self?.state = .initializing
         }
     }
+
+    /// If reader can be disconnected externally during the lifetime of a `CardReaderConnectionController`, found readers need to be reset so as
+    /// not to result in potential connection failure due to outdated found readers.
+    func resetFoundReaders() {
+        foundReaders = []
+    }
 }
 
 private extension CardReaderConnectionController {


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #13004

## Why

During testing, an issue was discovered where reader connection stops working after a successful connection iOS, then the reader is disconnected in Menu > Payments > Manage Card Reader. After some debugging, this is due to `CardReaderConnectionController`'s internal `foundReaders` being non-empty from the first connection. On the second connection attempt in POS where the same `CardReaderConnectionController` is used, the controller tries connecting to the previously found readers and fails (Stripe returns `Hardware.UnderlyingError.alreadyConnectedToReader`). Because the reader connection state can be changed outside of the POS, `foundReaders` can be outdated. When I was looking into why this issue doesn't happen outside of POS like in order payment collection or payment settings, it's because a new `CardReaderConnectionController` is created for each connection in these use cases, and `foundReaders` is empty by default.

## How

I was hoping not to affect the existing app, so I added a new function to clear `CardReaderConnectionController.foundReaders` that's only called from `CardPresentPaymentService` currently only used in POS. This seems to fix the issue.

Other things I also tried were to make `CardPresentPaymentService` or `CardReaderConnectionController` a singleton in `ServiceLocator` so that `CardReaderConnectionController`'s state can be consistent throughout use cases in the app. However, it wasn't trivial to handle the reinitialization after store switches and replace existing `CardReaderConnectionController` usage - I think it requires a technical design review for this move. After `CardPresentPaymentService` is fully implemented, we can consider making this a singleton instead of `CardReaderConnectionController` as in our chat before, if we're okay with the changes to the existing app use cases.

## Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->

Prerequisite: the store is eligible for POS and the feature switch is enabled in Menu > Settings > Experimental Features > POS

- Launch app
- Collect payment or connect reader in POS successfully
- Disconnect reader in Menu > Payments > Manage Card Reader
- Connect reader in POS again --> reader should be connected; before the PR, the second connection doesn't work consistently

## Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->


https://github.com/woocommerce/woocommerce-ios/assets/1945542/5ebb88d6-a2b5-4c9f-a12d-d8c5d28a56ed



---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.