### PR TITLE
Settings: Fix missing navigation bar for privacy settings screen

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -2,6 +2,7 @@
 
 19.1
 -----
+- [*] Restore a missing navigation bar on the privacy settings screen. [https://github.com/woocommerce/woocommerce-ios/pull/13018]
 
 
 19.0

--- a/WooCommerce/Classes/ViewRelated/Hub Menu/HubMenuViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Hub Menu/HubMenuViewController.swift
@@ -59,6 +59,7 @@ final class HubMenuViewController: UIHostingController<HubMenu> {
 
         let settings = SettingsViewController()
         navigationController.setViewControllers(navigationController.viewControllers + [settings, privacy], animated: true)
+        navigationController.setNavigationBarHidden(false, animated: false)
     }
 
     override func viewWillAppear(_ animated: Bool) {

--- a/WooCommerce/Classes/ViewRelated/Inbox/InboxEligibilityUseCase.swift
+++ b/WooCommerce/Classes/ViewRelated/Inbox/InboxEligibilityUseCase.swift
@@ -39,7 +39,7 @@ final class InboxEligibilityUseCase: InboxEligibilityChecker {
     ///   - siteID: the ID of the site to check for Inbox eligibility.
     ///   - completion: called when the Inbox eligibility is determined.
     func isEligibleForInbox(siteID: Int64, completion: @escaping (Bool) -> Void) {
-        Task {
+        Task { @MainActor in
             let result = await isEligibleForInbox(siteID: siteID)
             completion(result)
         }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #12784 
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
Previously when opening the privacy settings screen from the privacy settings banner, the navigation bar is missing making it tricky to navigate away from the screen.

This PR fixes this bug to restore the navigation bar for the privacy settings screen. Also, a minor update was added to fix a warning for the eligibility check of Inbox in Hub Menu

## Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: https://woomobilep2.wordpress.com/2024/05/06/woocommerce-mobile-quality-report-march-april/#comment-12036 -->

- In `PrivacyBannerPresentationUseCase`, update `shouldShowPrivacyBanner` to return `true`.
- Build the app and tap on Go to Settings.
- Confirm that the privacy settings screen now has a navigation bar. You can tap the Back button to dismiss the screen.
- Confirm that Xcode doesn't show warning about publishing changes from a background thread on the Hub menu.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

https://github.com/woocommerce/woocommerce-ios/assets/5533851/892250ec-76a1-410b-adaa-5b0e567ced6f



---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
