### PR TITLE
[Woo POS] Update reader list UI with CTAs to connect to a reader and cancel search

### DIFF
--- a/WooCommerce/Classes/POS/Card Present Payments/CardPresentPaymentEvent.swift
+++ b/WooCommerce/Classes/POS/Card Present Payments/CardPresentPaymentEvent.swift
@@ -5,6 +5,6 @@ typealias CardPresentPaymentAlertViewModel = CardPresentPaymentsModalViewModelCo
 enum CardPresentPaymentEvent {
     case idle
     case showAlert(_ alertViewModel: CardPresentPaymentAlertViewModel)
-    case showReaderList(_ readerIDs: [String], selectionHandler: ((String) -> Void))
+    case showReaderList(_ readerIDs: [String], selectionHandler: ((String?) -> Void))
     case showOnboarding(_ onboardingViewModel: CardPresentPaymentsOnboardingViewModel)
 }

--- a/WooCommerce/Classes/POS/Card Present Payments/CardPresentPaymentsAlertPresenterAdaptor.swift
+++ b/WooCommerce/Classes/POS/Card Present Payments/CardPresentPaymentsAlertPresenterAdaptor.swift
@@ -6,7 +6,7 @@ final class CardPresentPaymentsAlertPresenterAdaptor: CardPresentPaymentAlertsPr
 
     private let paymentAlertSubject: PassthroughSubject<CardPresentPaymentEvent, Never> = PassthroughSubject()
 
-    private var latestReaderConnectionHandler: ((String) -> Void)?
+    private var latestReaderConnectionHandler: ((String?) -> Void)?
 
     init() {
         paymentAlertPublisher = paymentAlertSubject.eraseToAnyPublisher()
@@ -21,8 +21,12 @@ final class CardPresentPaymentsAlertPresenterAdaptor: CardPresentPaymentAlertsPr
     }
 
     func foundSeveralReaders(readerIDs: [String], connect: @escaping (String) -> Void, cancelSearch: @escaping () -> Void) {
-        let wrappedConnectionHandler = { [weak self] readerID in
-            connect(readerID)
+        let wrappedConnectionHandler = { [weak self] (readerID: String?) in
+            if let readerID {
+                connect(readerID)
+            } else {
+                cancelSearch()
+            }
             self?.latestReaderConnectionHandler = nil
         }
         self.latestReaderConnectionHandler = wrappedConnectionHandler

--- a/WooCommerce/Classes/POS/Presentation/Card Present Payments/FoundCardReaderListView.swift
+++ b/WooCommerce/Classes/POS/Presentation/Card Present Payments/FoundCardReaderListView.swift
@@ -20,24 +20,17 @@ struct FoundCardReaderListView: View {
                 .font(.headline)
                 .padding(Layout.headerPadding)
 
-            List(readerIDs, id: \.self) { reader in
-                HStack {
-                    Text(reader)
-                    Spacer()
-                    Button(SeveralReadersFoundViewController.Localization.connect) {
-                        connect(reader)
+            List(readerIDs, id: \.self) { readerID in
+                VStack {
+                    readerRow(readerID: readerID)
+
+                    if readerID == readerIDs.last {
+                        scanningText()
                     }
-                    .buttonStyle(TextButtonStyle())
                 }
                 .listRowSeparator(.hidden)
             }
             .listStyle(.plain)
-
-            HStack(spacing: Layout.horizontalSpacing) {
-                ActivityIndicator(isAnimating: .constant(true), style: .large)
-                Text(SeveralReadersFoundViewController.Localization.scanningLabel)
-                Spacer()
-            }
 
             Button(action: {
                 cancelSearch()
@@ -48,6 +41,28 @@ struct FoundCardReaderListView: View {
             .padding(Layout.buttonPadding)
         }
         .padding(Layout.padding)
+    }
+}
+
+private extension FoundCardReaderListView {
+    @ViewBuilder func readerRow(readerID: String) -> some View {
+        HStack {
+            Text(readerID)
+            Spacer()
+            Button(SeveralReadersFoundViewController.Localization.connect) {
+                connect(readerID)
+            }
+            .buttonStyle(TextButtonStyle())
+        }
+    }
+
+    @ViewBuilder func scanningText() -> some View {
+        HStack(spacing: Layout.horizontalSpacing) {
+            ActivityIndicator(isAnimating: .constant(true), style: .medium)
+            Text(SeveralReadersFoundViewController.Localization.scanningLabel)
+                .font(.footnote)
+            Spacer()
+        }
     }
 }
 

--- a/WooCommerce/Classes/POS/Presentation/Card Present Payments/FoundCardReaderListView.swift
+++ b/WooCommerce/Classes/POS/Presentation/Card Present Payments/FoundCardReaderListView.swift
@@ -1,0 +1,67 @@
+import SwiftUI
+
+/// Displays a list of card readers that are found, with a CTA to connect to a reader and a CTA to cancel reader search.
+struct FoundCardReaderListView: View {
+    private let readerIDs: [String]
+    private let connect: (String) -> Void
+    private let cancelSearch: () -> Void
+
+    init(readerIDs: [String],
+         connect: @escaping ((String) -> Void),
+         cancelSearch: @escaping (() -> Void)) {
+        self.readerIDs = readerIDs
+        self.connect = connect
+        self.cancelSearch = cancelSearch
+    }
+
+    var body: some View {
+        VStack(spacing: 0) {
+            Text(SeveralReadersFoundViewController.Localization.headline)
+                .font(.headline)
+                .padding(Layout.headerPadding)
+
+            List(readerIDs, id: \.self) { reader in
+                HStack {
+                    Text(reader)
+                    Spacer()
+                    Button(SeveralReadersFoundViewController.Localization.connect) {
+                        connect(reader)
+                    }
+                    .buttonStyle(TextButtonStyle())
+                }
+                .listRowSeparator(.hidden)
+            }
+            .listStyle(.plain)
+
+            HStack(spacing: Layout.horizontalSpacing) {
+                ActivityIndicator(isAnimating: .constant(true), style: .large)
+                Text(SeveralReadersFoundViewController.Localization.scanningLabel)
+                Spacer()
+            }
+
+            Button(action: {
+                cancelSearch()
+            }) {
+                Text(SeveralReadersFoundViewController.Localization.cancel)
+            }
+            .buttonStyle(SecondaryButtonStyle())
+            .padding(Layout.buttonPadding)
+        }
+        .padding(Layout.padding)
+    }
+}
+
+private extension FoundCardReaderListView {
+    enum Layout {
+        static let padding: EdgeInsets = .init(top: 0, leading: 16, bottom: 0, trailing: 16)
+        static let headerPadding: EdgeInsets = .init(top: 20, leading: 4, bottom: 20, trailing: 4)
+        static let buttonPadding: EdgeInsets = .init(top: 16, leading: 0, bottom: 16, trailing: 0)
+        static let horizontalSpacing: CGFloat = 16
+    }
+}
+
+#Preview {
+    FoundCardReaderListView(readerIDs: ["Reader 1", "Reader 2"],
+                            connect: { _ in },
+                            cancelSearch: {})
+}

--- a/WooCommerce/Classes/POS/Presentation/PointOfSaleDashboardView.swift
+++ b/WooCommerce/Classes/POS/Presentation/PointOfSaleDashboardView.swift
@@ -36,8 +36,13 @@ struct PointOfSaleDashboardView: View {
             switch viewModel.cardPresentPaymentEvent {
             case .showAlert(let alertViewModel):
                 CardPresentPaymentAlert(alertViewModel: alertViewModel)
+            case let .showReaderList(readerIDs, selectionHandler):
+                FoundCardReaderListView(readerIDs: readerIDs, connect: { readerID in
+                    selectionHandler(readerID)
+                }, cancelSearch: {
+                    selectionHandler(nil)
+                })
             case .idle,
-                    .showReaderList,
                     .showOnboarding:
                 Text(viewModel.cardPresentPaymentEvent.temporaryEventDescription)
             }

--- a/WooCommerce/Classes/ViewRelated/CardPresentPayments/SeveralReadersFoundViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/CardPresentPayments/SeveralReadersFoundViewController.swift
@@ -269,7 +269,7 @@ private enum Row {
 
 // MARK: - Localization
 //
-private extension SeveralReadersFoundViewController {
+extension SeveralReadersFoundViewController {
     enum Localization {
         static let headline = NSLocalizedString(
             "Several readers found",

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -119,6 +119,7 @@
 		021EBB362A3054BE003634CA /* BlazeEligibilityChecker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 021EBB352A3054BE003634CA /* BlazeEligibilityChecker.swift */; };
 		021EBB382A3076F4003634CA /* BlazeEligibilityCheckerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 021EBB372A3076F4003634CA /* BlazeEligibilityCheckerTests.swift */; };
 		021FB44C24A5E3B00090E144 /* ProductListMultiSelectorSearchUICommand.swift in Sources */ = {isa = PBXBuildFile; fileRef = 021FB44B24A5E3B00090E144 /* ProductListMultiSelectorSearchUICommand.swift */; };
+		0220F4952C16DC98003723C2 /* FoundCardReaderListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0220F4942C16DC98003723C2 /* FoundCardReaderListView.swift */; };
 		0221121E288973C20028F0AF /* LocalNotification.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0221121D288973C20028F0AF /* LocalNotification.swift */; };
 		022266BA2AE76E0E00614F34 /* ProductBundleItem+SwiftUIPreviewHelpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 022266B92AE76E0E00614F34 /* ProductBundleItem+SwiftUIPreviewHelpers.swift */; };
 		022266BC2AE7707000614F34 /* ConfigurableBundleItemViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 022266BB2AE7707000614F34 /* ConfigurableBundleItemViewModel.swift */; };
@@ -3044,6 +3045,7 @@
 		021EBB352A3054BE003634CA /* BlazeEligibilityChecker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BlazeEligibilityChecker.swift; sourceTree = "<group>"; };
 		021EBB372A3076F4003634CA /* BlazeEligibilityCheckerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BlazeEligibilityCheckerTests.swift; sourceTree = "<group>"; };
 		021FB44B24A5E3B00090E144 /* ProductListMultiSelectorSearchUICommand.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductListMultiSelectorSearchUICommand.swift; sourceTree = "<group>"; };
+		0220F4942C16DC98003723C2 /* FoundCardReaderListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FoundCardReaderListView.swift; sourceTree = "<group>"; };
 		0221121D288973C20028F0AF /* LocalNotification.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocalNotification.swift; sourceTree = "<group>"; };
 		022266B92AE76E0E00614F34 /* ProductBundleItem+SwiftUIPreviewHelpers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ProductBundleItem+SwiftUIPreviewHelpers.swift"; sourceTree = "<group>"; };
 		022266BB2AE7707000614F34 /* ConfigurableBundleItemViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConfigurableBundleItemViewModel.swift; sourceTree = "<group>"; };
@@ -7195,6 +7197,7 @@
 			isa = PBXGroup;
 			children = (
 				02E71DB52C118C640036C2FD /* CardPresentPaymentAlertSwiftUIViewModel.swift */,
+				0220F4942C16DC98003723C2 /* FoundCardReaderListView.swift */,
 			);
 			path = "Card Present Payments";
 			sourceTree = "<group>";
@@ -15635,6 +15638,7 @@
 				CC4D1D8625E6CDDE00B6E4E7 /* RenameAttributesViewModel.swift in Sources */,
 				DEFA3D932897D8930076FAE1 /* NoWooErrorViewModel.swift in Sources */,
 				209B15672AD85F070094152A /* OperatingSystemVersion+Localization.swift in Sources */,
+				0220F4952C16DC98003723C2 /* FoundCardReaderListView.swift in Sources */,
 				020A55F127F6C605007843F0 /* CardReaderConnectionAnalyticsTracker.swift in Sources */,
 				6850C5F12B69E74D0026A93B /* ReceiptViewController.swift in Sources */,
 				DEC2962126BD1627005A056B /* ShippingLabelCustomsFormList.swift in Sources */,


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of #13016 
<!-- Id number of the GitHub issue this PR addresses. -->

## Why

As we're showing payment UI the same as the existing app for M1 at least, this PR handles the design updates when there are multiple readers found. Before this PR, a plain Text was shown. In this PR, the view should look mostly the same as the existing app (`app`).

## How

First, to handle the cancel action, `CardPresentPaymentsAlertPresenterAdaptor.latestReaderConnectionHandler` was updated to take in an optional reader ID to support cancelation when the ID is nil. We could also add another handler closure separately from the connect action, but I thought it's easier to keep just one handler. Happy to change this if having a separate handler would make the code clearer.

The new view for the reader list is `FoundCardReaderListView`, which mimics the styles in `SeveralReadersFoundViewController` and its xib (including the two cells the table view shows). I chose to reuse the strings from `SeveralReadersFoundViewController.Localization` to avoid duplication, feel free to share any concerns we can also use non-localizable strings for now.

Finally, the reader list view is integrated into the UI in `PointOfSaleDashboardView`.

## Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->

## Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->

Prerequisite: the store is eligible for POS and the feature switch is enabled in Menu > Settings > Experimental Features > POS. There should be multiple readers available, it's easier testing this state with a simulated Stripe reader in the WooCommerce scheme to have multiple readers

- Launch app
- Enter POS mode in Menu > Point of Sale
- Tap `Reader Disconnected` --> when an alert appears with `Keep Searching` CTA, tap `Keep Searching`. If it doesn't show up, try relaunching the app. The reader list should look like the `app`
- Tap `Connect` on a reader
- After the connection completes, verify that the connected reader name is the same as the one in Menu > Payments > Manage Card Reader
- In Menu > Payments > Manage Card Reader, disconnect the reader
- Enter POS mode in Menu > Point of Sale
- Tap `Reader Disconnected` --> when an alert appears with `Keep Searching` CTA, tap `Keep Searching`. If it doesn't show up, try relaunching the app. The reader list should look like the `app`
- Tap `Cancel` at the bottom --> the flow should be canceled shortly

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

light | dark
-- | --
<img src="https://github.com/woocommerce/woocommerce-ios/assets/1945542/160bd8df-7cc0-420a-a896-3bfb29b74c53" width="500" /> | <img src="https://github.com/woocommerce/woocommerce-ios/assets/1945542/68f49d02-1339-4e35-8490-f3171049e488" width="500" />


https://github.com/woocommerce/woocommerce-ios/assets/1945542/544deec6-d578-419e-9066-40a7b5e9b8ff



---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary. 