### PR TITLE
Dynamic Dashboard: Enable the feature flag for M2 again

### DIFF
--- a/Experiments/Experiments/DefaultFeatureFlagService.swift
+++ b/Experiments/Experiments/DefaultFeatureFlagService.swift
@@ -89,7 +89,7 @@ public struct DefaultFeatureFlagService: FeatureFlagService {
         case .displayPointOfSaleToggle:
             return buildConfig == .localDeveloper || buildConfig == .alpha
         case .dynamicDashboardM2:
-            return buildConfig == .localDeveloper || buildConfig == .alpha
+            return true
         default:
             return true
         }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of #12655 
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
The changes made in #12890 seem to have been lost during a forced push. This PR enable the feature flag for Dynamic Dashboard M2 again to make this feature accessible in production.

## Steps to reproduce
Ensure that the new cards in dynamic dashboard M2 are now available.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->
N/A

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
