### PR TITLE
Customized payment flow POC: workaround approach mapping `CardPresentPaymentsModalViewModel` to new `CardPresentPaymentEvent` cases

### DIFF
--- a/WooCommerce/Classes/POS/Card Present Payments/CardPresentPaymentEvent.swift
+++ b/WooCommerce/Classes/POS/Card Present Payments/CardPresentPaymentEvent.swift
@@ -7,4 +7,5 @@ enum CardPresentPaymentEvent {
     case showAlert(_ alertViewModel: CardPresentPaymentAlertViewModel)
     case showReaderList(_ readerIDs: [String], selectionHandler: ((String?) -> Void))
     case showOnboarding(_ onboardingViewModel: CardPresentPaymentsOnboardingViewModel)
+    case showPaymentSuccess
 }

--- a/WooCommerce/Classes/POS/Card Present Payments/CardPresentPaymentEvent.swift
+++ b/WooCommerce/Classes/POS/Card Present Payments/CardPresentPaymentEvent.swift
@@ -4,8 +4,10 @@ typealias CardPresentPaymentAlertViewModel = CardPresentPaymentsModalViewModelCo
 
 enum CardPresentPaymentEvent {
     case idle
+    case readyForPayment
     case showAlert(_ alertViewModel: CardPresentPaymentAlertViewModel)
     case showReaderList(_ readerIDs: [String], selectionHandler: ((String?) -> Void))
     case showOnboarding(_ onboardingViewModel: CardPresentPaymentsOnboardingViewModel)
+    case showReaderMessage(_ message: String)
     case showPaymentSuccess
 }

--- a/WooCommerce/Classes/POS/Card Present Payments/CardPresentPaymentEvent.swift
+++ b/WooCommerce/Classes/POS/Card Present Payments/CardPresentPaymentEvent.swift
@@ -6,6 +6,7 @@ enum CardPresentPaymentEvent {
     case idle
     case readyForPayment
     case showAlert(_ alertViewModel: CardPresentPaymentAlertViewModel)
+    case showAlertWithDismiss(_ alertViewModel: CardPresentPaymentAlertViewModel)
     case showReaderList(_ readerIDs: [String], selectionHandler: ((String?) -> Void))
     case showOnboarding(_ onboardingViewModel: CardPresentPaymentsOnboardingViewModel)
     case showReaderMessage(_ message: String)

--- a/WooCommerce/Classes/POS/Card Present Payments/CardPresentPaymentsAlertPresenterAdaptor.swift
+++ b/WooCommerce/Classes/POS/Card Present Payments/CardPresentPaymentsAlertPresenterAdaptor.swift
@@ -20,9 +20,10 @@ final class CardPresentPaymentsAlertPresenterAdaptor: CardPresentPaymentAlertsPr
                 paymentAlertSubject.send(.showAlert(viewModel))
             case .hidden:
                 paymentAlertSubject.send(.idle)
-            case .inlineMessage(let message):
-                //TODO
-                paymentAlertSubject.send(.showAlert(viewModel))
+            case .readyForPayment:
+                paymentAlertSubject.send(.readyForPayment)
+            case .readerMessage(let message):
+                paymentAlertSubject.send(.showReaderMessage(message))
             case .success:
                 paymentAlertSubject.send(.showPaymentSuccess)
         }

--- a/WooCommerce/Classes/POS/Card Present Payments/CardPresentPaymentsAlertPresenterAdaptor.swift
+++ b/WooCommerce/Classes/POS/Card Present Payments/CardPresentPaymentsAlertPresenterAdaptor.swift
@@ -18,6 +18,8 @@ final class CardPresentPaymentsAlertPresenterAdaptor: CardPresentPaymentAlertsPr
         switch presentation {
             case .alert(let viewModel):
                 paymentAlertSubject.send(.showAlert(viewModel))
+            case .alertWithDismiss(let viewModel):
+                paymentAlertSubject.send(.showAlertWithDismiss(viewModel))
             case .hidden:
                 paymentAlertSubject.send(.idle)
             case .readyForPayment:

--- a/WooCommerce/Classes/POS/Card Present Payments/CardPresentPaymentsAlertPresenterAdaptor.swift
+++ b/WooCommerce/Classes/POS/Card Present Payments/CardPresentPaymentsAlertPresenterAdaptor.swift
@@ -13,7 +13,19 @@ final class CardPresentPaymentsAlertPresenterAdaptor: CardPresentPaymentAlertsPr
     }
 
     func present(viewModel: CardPresentPaymentsModalViewModel) {
-        paymentAlertSubject.send(.showAlert(viewModel))
+        let presentation = POSCardPresentPaymentsModalViewModel(modalViewModel: viewModel).presentation
+
+        switch presentation {
+            case .alert(let viewModel):
+                paymentAlertSubject.send(.showAlert(viewModel))
+            case .hidden:
+                paymentAlertSubject.send(.idle)
+            case .inlineMessage(let message):
+                //TODO
+                paymentAlertSubject.send(.showAlert(viewModel))
+            case .success:
+                paymentAlertSubject.send(.showPaymentSuccess)
+        }
     }
 
     func presentWCSettingsWebView(adminURL: URL, completion: @escaping () -> Void) {

--- a/WooCommerce/Classes/POS/Card Present Payments/CardPresentPaymentsAlertPresenterAdaptor.swift
+++ b/WooCommerce/Classes/POS/Card Present Payments/CardPresentPaymentsAlertPresenterAdaptor.swift
@@ -22,7 +22,7 @@ final class CardPresentPaymentsAlertPresenterAdaptor: CardPresentPaymentAlertsPr
                 paymentAlertSubject.send(.idle)
             case .readyForPayment:
                 paymentAlertSubject.send(.readyForPayment)
-            case .readerMessage(let message):
+            case .inlineMessage(let message):
                 paymentAlertSubject.send(.showReaderMessage(message))
             case .success:
                 paymentAlertSubject.send(.showPaymentSuccess)

--- a/WooCommerce/Classes/POS/Presentation/CardPresentPaymentAlert.swift
+++ b/WooCommerce/Classes/POS/Presentation/CardPresentPaymentAlert.swift
@@ -6,7 +6,7 @@ struct CardPresentPaymentAlert: View {
     // alertViewModel changed – possibly we needed to invalidate the view's id.
     @ObservedObject private var viewModel: CardPresentPaymentAlertSwiftUIViewModel
 
-    init(alertViewModel: CardPresentPaymentAlertViewModel) {
+     init(alertViewModel: CardPresentPaymentAlertViewModel) {
         self.viewModel = .init(alertViewModel: alertViewModel)
     }
 
@@ -93,6 +93,95 @@ private extension BasicCardPresentPaymentAlert {
 }
 
 private extension BasicCardPresentPaymentAlert {
+    enum Layout {
+        static let padding: EdgeInsets = .init(top: 40, leading: 96, bottom: 56, trailing: 96)
+        static let stackViewVerticalSpacing: CGFloat = 32
+        static let defaultVerticalSpacing: CGFloat = 16
+    }
+}
+
+struct DismissableCardPresentPaymentAlert: View {
+    let viewModel: CardPresentPaymentAlertViewModel
+    @Environment(\.dismiss) private var dismiss
+
+    var body: some View {
+        VStack(spacing: Layout.stackViewVerticalSpacing) {
+            VStack(alignment: .center, spacing: Layout.defaultVerticalSpacing) {
+                Text(viewModel.topTitle)
+                    .font(.body)
+                if let topSubtitle = viewModel.topSubtitle, shouldShowTopSubtitle() {
+                    Text(topSubtitle)
+                        .font(.title)
+                }
+            }
+
+            if viewModel.showLoadingIndicator {
+                ProgressView()
+                    .progressViewStyle(CircularProgressViewStyle(tint: .gray))
+                    .scaleEffect(1.5, anchor: .center)
+            } else {
+                Image(uiImage: viewModel.image)
+                    .padding()
+            }
+
+            if let bottomTitle = viewModel.bottomTitle, shouldShowBottomLabels() {
+                VStack(alignment: .center, spacing: Layout.defaultVerticalSpacing) {
+                    Text(bottomTitle)
+                        .font(.subheadline)
+
+                    if let bottomSubtitle = viewModel.bottomSubtitle, shouldShowBottomSubtitle() {
+                        Text(bottomSubtitle)
+                            .foregroundStyle(Color(uiColor: .systemColor(.secondaryLabel)))
+                            .font(.footnote)
+                    }
+                }
+            }
+
+            VStack(spacing: Layout.defaultVerticalSpacing) {
+                if let primaryButton = viewModel.primaryButtonViewModel {
+                    Button(primaryButton.title, action: primaryButton.actionHandler)
+                        .buttonStyle(PrimaryButtonStyle())
+                }
+
+                if let secondaryButton = viewModel.secondaryButtonViewModel {
+                    Button(secondaryButton.title, action: secondaryButton.actionHandler)
+                        .buttonStyle(SecondaryButtonStyle())
+                }
+
+                if let auxiliaryButton = viewModel.auxiliaryButtonViewModel {
+                    Button(auxiliaryButton.title, action: auxiliaryButton.actionHandler)
+                        .buttonStyle(LinkButtonStyle())
+                }
+
+                Button(action: {
+                    dismiss()
+                }) {
+                    Text("Close")
+                }
+            }
+        }
+        .multilineTextAlignment(.center)
+        .padding(Layout.padding)
+    }
+}
+
+private extension DismissableCardPresentPaymentAlert {
+    func shouldShowTopSubtitle() -> Bool {
+        viewModel.textMode != .reducedTopInfo
+    }
+
+    func shouldShowBottomLabels() -> Bool {
+        viewModel.textMode != .noBottomInfo
+    }
+
+    func shouldShowBottomSubtitle() -> Bool {
+        let textMode = viewModel.textMode
+        return textMode == .fullInfo ||
+            textMode == .reducedTopInfo
+    }
+}
+
+private extension DismissableCardPresentPaymentAlert {
     enum Layout {
         static let padding: EdgeInsets = .init(top: 40, leading: 96, bottom: 56, trailing: 96)
         static let stackViewVerticalSpacing: CGFloat = 32

--- a/WooCommerce/Classes/POS/Presentation/PointOfSaleDashboardView.swift
+++ b/WooCommerce/Classes/POS/Presentation/PointOfSaleDashboardView.swift
@@ -43,7 +43,9 @@ struct PointOfSaleDashboardView: View {
                     selectionHandler(nil)
                 })
             case .idle,
+                    .readyForPayment,
                     .showOnboarding,
+                    .showReaderMessage,
                     .showPaymentSuccess:
                 Text(viewModel.cardPresentPaymentEvent.temporaryEventDescription)
             }
@@ -86,6 +88,10 @@ fileprivate extension CardPresentPaymentEvent {
             return "Reader List: \(readerIDs.joined())"
         case .showOnboarding(let onboardingViewModel):
             return "Onboarding: \(onboardingViewModel.state.reasonForAnalytics)" // This will only show the initial onboarding state
+        case .showReaderMessage(let message):
+            return "Reader message: \(message)"
+        case .readyForPayment:
+            return "Ready for payment"
         case .showPaymentSuccess:
             return "Payment successful"
         }

--- a/WooCommerce/Classes/POS/Presentation/PointOfSaleDashboardView.swift
+++ b/WooCommerce/Classes/POS/Presentation/PointOfSaleDashboardView.swift
@@ -43,7 +43,8 @@ struct PointOfSaleDashboardView: View {
                     selectionHandler(nil)
                 })
             case .idle,
-                    .showOnboarding:
+                    .showOnboarding,
+                    .showPaymentSuccess:
                 Text(viewModel.cardPresentPaymentEvent.temporaryEventDescription)
             }
         })
@@ -85,6 +86,8 @@ fileprivate extension CardPresentPaymentEvent {
             return "Reader List: \(readerIDs.joined())"
         case .showOnboarding(let onboardingViewModel):
             return "Onboarding: \(onboardingViewModel.state.reasonForAnalytics)" // This will only show the initial onboarding state
+        case .showPaymentSuccess:
+            return "Payment successful"
         }
     }
 }

--- a/WooCommerce/Classes/POS/Presentation/PointOfSaleDashboardView.swift
+++ b/WooCommerce/Classes/POS/Presentation/PointOfSaleDashboardView.swift
@@ -36,6 +36,8 @@ struct PointOfSaleDashboardView: View {
             switch viewModel.cardPresentPaymentEvent {
             case .showAlert(let alertViewModel):
                 CardPresentPaymentAlert(alertViewModel: alertViewModel)
+            case .showAlertWithDismiss(let alertViewModel):
+                DismissableCardPresentPaymentAlert(viewModel: alertViewModel)
             case let .showReaderList(readerIDs, selectionHandler):
                 FoundCardReaderListView(readerIDs: readerIDs, connect: { readerID in
                     selectionHandler(readerID)
@@ -94,6 +96,8 @@ fileprivate extension CardPresentPaymentEvent {
             return "Ready for payment"
         case .showPaymentSuccess:
             return "Payment successful"
+        case .showAlertWithDismiss(let alertViewModel):
+            return "Alert: \(alertViewModel.topTitle)"
         }
     }
 }

--- a/WooCommerce/Classes/POS/Presentation/TotalsView.swift
+++ b/WooCommerce/Classes/POS/Presentation/TotalsView.swift
@@ -46,9 +46,13 @@ final class TotalsViewModel: ObservableObject {
                 }
 
                 // TODO: update to acceptingCard when reader is ready for payment
-//                if case = cardPresentPaymentEvent
-//            case acceptingCard
-//            case processingCard
+                if case .readyForPayment = cardPresentPaymentEvent {
+                    return .acceptingCard
+                }
+
+                if case let .showReaderMessage(message) = cardPresentPaymentEvent {
+                    return .processingCard(readerMessage: message)
+                }
 
                 if cashPaymentState == .inProgress {
                     return .acceptingCash
@@ -100,8 +104,15 @@ struct TotalsView: View {
 }
 
 private extension TotalsView {
-    private var tapInsertCardView: some View {
-        Text("Tap or insert card to pay")
+    @ViewBuilder func tapInsertCardView(readerMessage: String?) -> some View {
+        VStack {
+            // TODO: update image based on M1 design
+            Image(uiImage: .cardPresentImage)
+            if let readerMessage {
+                Text(readerMessage)
+                    .font(.footnote)
+            }
+        }
     }
 
     private var takeCashView: some View {
@@ -116,9 +127,9 @@ private extension TotalsView {
     private var paymentsTextView: some View {
         switch totalsViewModel.paymentState {
         case .acceptingCard:
-            tapInsertCardView
-        case .processingCard:
-            tapInsertCardView
+            tapInsertCardView(readerMessage: nil)
+        case let .processingCard(readerMessage):
+            tapInsertCardView(readerMessage: readerMessage)
         case .cardPaymentSuccessful:
             paymentSuccessfulView
         case .acceptingCash:

--- a/WooCommerce/Classes/POS/ViewModels/PointOfSaleDashboardViewModel.swift
+++ b/WooCommerce/Classes/POS/ViewModels/PointOfSaleDashboardViewModel.swift
@@ -6,7 +6,7 @@ import class WooFoundation.CurrencySettings
 final class PointOfSaleDashboardViewModel: ObservableObject {
     enum PaymentState {
         case acceptingCard
-        case processingCard
+        case processingCard(readerMessage: String?)
         case cardPaymentSuccessful
         case acceptingCash
         case cashPaymentSuccessful
@@ -138,12 +138,14 @@ private extension PointOfSaleDashboardViewModel {
         cardPresentPaymentService.paymentEventPublisher.assign(to: &$cardPresentPaymentEvent)
         cardPresentPaymentService.paymentEventPublisher.map { event in
             switch event {
-            case .idle:
+            case .idle,
+                    .readyForPayment,
+                    .showReaderMessage,
+                    .showPaymentSuccess:
                 return false
             case .showAlert,
                     .showReaderList,
-                    .showOnboarding,
-                    .showPaymentSuccess:
+                    .showOnboarding:
                 return true
             }
         }.assign(to: &$showsCardReaderSheet)

--- a/WooCommerce/Classes/POS/ViewModels/PointOfSaleDashboardViewModel.swift
+++ b/WooCommerce/Classes/POS/ViewModels/PointOfSaleDashboardViewModel.swift
@@ -144,6 +144,7 @@ private extension PointOfSaleDashboardViewModel {
                     .showPaymentSuccess:
                 return false
             case .showAlert,
+                    .showAlertWithDismiss,
                     .showReaderList,
                     .showOnboarding:
                 return true

--- a/WooCommerce/Classes/POS/ViewModels/PointOfSaleDashboardViewModel.swift
+++ b/WooCommerce/Classes/POS/ViewModels/PointOfSaleDashboardViewModel.swift
@@ -142,7 +142,8 @@ private extension PointOfSaleDashboardViewModel {
                 return false
             case .showAlert,
                     .showReaderList,
-                    .showOnboarding:
+                    .showOnboarding,
+                    .showPaymentSuccess:
                 return true
             }
         }.assign(to: &$showsCardReaderSheet)

--- a/WooCommerce/Classes/ViewModels/CardPresentPayments/CardPresentModalDisplayMessage.swift
+++ b/WooCommerce/Classes/ViewModels/CardPresentPayments/CardPresentModalDisplayMessage.swift
@@ -12,7 +12,8 @@ final class CardPresentModalDisplayMessage: CardPresentPaymentsModalViewModel {
     private let amount: String
 
     /// Message from reader to display
-    private let message: String
+    /// Consider refactoring the `POSCardPresentPaymentsModalViewModel` use case to make this property private again.
+    let message: String
 
     let textMode: PaymentsModalTextMode = .reducedBottomInfo
     let actionsMode: PaymentsModalActionsMode = .none

--- a/WooCommerce/Classes/ViewModels/CardPresentPayments/CardPresentModalDisplayMessage.swift
+++ b/WooCommerce/Classes/ViewModels/CardPresentPayments/CardPresentModalDisplayMessage.swift
@@ -1,6 +1,7 @@
 import UIKit
 import Yosemite
 
+// TODO: rename to `CardPresentModalDisplayReaderMessage`
 /// Modal presented when a (headless) card reader requests we display a message to the customer
 final class CardPresentModalDisplayMessage: CardPresentPaymentsModalViewModel {
 

--- a/WooCommerce/Classes/ViewModels/CardPresentPayments/CardPresentPaymentsModalViewModel.swift
+++ b/WooCommerce/Classes/ViewModels/CardPresentPayments/CardPresentPaymentsModalViewModel.swift
@@ -69,6 +69,7 @@ protocol CardPresentPaymentsModalViewModelActions {
 
 enum POSCardPresentPaymentsModalPresentation {
     case alert(viewModel: CardPresentPaymentAlertViewModel)
+    case alertWithDismiss(viewModel: CardPresentPaymentAlertViewModel)
     case hidden
     case readyForPayment
     case inlineMessage(message: String)
@@ -92,6 +93,15 @@ private extension POSCardPresentPaymentsModalViewModel {
                 return .inlineMessage(message: "Connecting to reader...")
             case is CardPresentModalPreparingForPayment:
                 return .hidden
+            case is CardPresentModalError:
+                guard let actionHandler = modalViewModel.primaryButtonViewModel?.actionHandler else {
+                    return .hidden
+                }
+                return .alertWithDismiss(viewModel: CardPresentModalError(
+                    errorDescription: modalViewModel.bottomTitle,
+                    transactionType: .collectPayment,
+                    primaryAction: actionHandler,
+                    dismissCompletion: {}))
             case is CardPresentModalTapCard:
                 return .readyForPayment
             case is CardPresentModalProcessing:

--- a/WooCommerce/Classes/ViewModels/CardPresentPayments/CardPresentPaymentsModalViewModel.swift
+++ b/WooCommerce/Classes/ViewModels/CardPresentPayments/CardPresentPaymentsModalViewModel.swift
@@ -71,7 +71,7 @@ enum POSCardPresentPaymentsModalPresentation {
     case alert(viewModel: CardPresentPaymentAlertViewModel)
     case hidden
     case readyForPayment
-    case readerMessage(message: String)
+    case inlineMessage(message: String)
     case success
 }
 
@@ -87,18 +87,18 @@ private extension POSCardPresentPaymentsModalViewModel {
     static func presentation(from modalViewModel: CardPresentPaymentsModalViewModel) -> POSCardPresentPaymentsModalPresentation {
         switch modalViewModel {
             case is CardPresentModalScanningForReader:
-                return .readerMessage(message: "Scanning for reader...")
+                return .inlineMessage(message: "Scanning for reader...")
             case is CardPresentModalConnectingToReader:
-                return .readerMessage(message: "Connecting to reader...")
+                return .inlineMessage(message: "Connecting to reader...")
             case is CardPresentModalPreparingForPayment:
                 return .hidden
             case is CardPresentModalTapCard:
                 return .readyForPayment
             case is CardPresentModalProcessing:
-                return .readerMessage(message: "Processing payment...")
+                return .inlineMessage(message: "Processing payment...")
             case let viewModel as CardPresentModalDisplayMessage:
                 // This is really just a workaround from making `CardPresentModalDisplayMessage.message` public that we should consider refactoring/changing.
-                return .readerMessage(message: viewModel.message)
+                return .inlineMessage(message: viewModel.message)
             case is CardPresentModalSuccess:
                 return .success
             case is CardPresentModalSuccessWithoutEmail:


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

Requirements:
- Hide certain alerts
- Show certain messages not in the alert (e.g. reader message, success state)

Based on two ideas from our DM discussion:
- Adding another protocol similar to `CardPresentPaymentsModalViewModelActions` to provide additional info for customized UX
- Map CardPresentPaymentModalViewModel to another VM for customized UX

I ended up with a mix of these two ideas, as implemented in this POC PR.

### Next steps

- [ ] Separate connection & payment events so that connection events are shown from `connectReader` and payment events are shown from `collectPayment`
  - I tried adding a new `connectionAlertPublisher` to `CardPresentPaymentsAlertPresenterAdaptor`, but a new state `connectReader/collectPayment` might be necessary in `CardPresentPaymentsAlertPresenterAdaptor` to determine which publisher to emit to avoid duplicate events

## Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->

## Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->

Prerequisite: the store is eligible for POS and the feature switch is enabled in Menu > Settings > Experimental Features > POS
* Launch app
* Enter Menu > POS
* Add at least one item to cart
* Tap `Collect payment` --> in the happy path, no alert should be shown and some status messages might be shown inline. Upon a successful payment, `Payment successful` text should be shown

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->


https://github.com/woocommerce/woocommerce-ios/assets/1945542/1a67e8d9-1102-4d3c-9659-881bc818021b



---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.