### PR TITLE
[WOO POS] Scroll to added item in cart

### DIFF
--- a/WooCommerce/Classes/POS/Presentation/CartView.swift
+++ b/WooCommerce/Classes/POS/Presentation/CartView.swift
@@ -21,13 +21,24 @@ struct CartView: View {
             .padding(.vertical, 8)
             .font(.title)
             .foregroundColor(Color.white)
-            ScrollView {
-                ForEach(viewModel.itemsInCart, id: \.id) { cartItem in
-                    ItemRowView(cartItem: cartItem) {
-                        viewModel.removeItemFromCart(cartItem)
+            ScrollViewReader { proxy in
+                ScrollView {
+                    ForEach(viewModel.itemsInCart, id: \.id) { cartItem in
+                        ItemRowView(cartItem: cartItem) {
+                            viewModel.removeItemFromCart(cartItem)
+                        }
+                        .id(cartItem.id)
+                        .background(Color.tertiaryBackground)
+                        .padding(.horizontal, 32)
                     }
-                    .background(Color.tertiaryBackground)
-                    .padding(.horizontal, 32)
+                }
+                .onChange(of: viewModel.itemToScrollToWhenCartUpdated?.id) { _ in
+                    if viewModel.orderStage == .building,
+                       let last = viewModel.itemToScrollToWhenCartUpdated?.id {
+                        withAnimation {
+                            proxy.scrollTo(last.id)
+                        }
+                    }
                 }
             }
             Spacer()

--- a/WooCommerce/Classes/POS/Presentation/CartView.swift
+++ b/WooCommerce/Classes/POS/Presentation/CartView.swift
@@ -36,7 +36,7 @@ struct CartView: View {
                     if viewModel.orderStage == .building,
                        let last = viewModel.itemToScrollToWhenCartUpdated?.id {
                         withAnimation {
-                            proxy.scrollTo(last.id)
+                            proxy.scrollTo(last)
                         }
                     }
                 }

--- a/WooCommerce/Classes/POS/ViewModels/PointOfSaleDashboardViewModel.swift
+++ b/WooCommerce/Classes/POS/ViewModels/PointOfSaleDashboardViewModel.swift
@@ -49,6 +49,10 @@ final class PointOfSaleDashboardViewModel: ObservableObject {
         observeCardPresentPaymentEvents()
         observeItemsInCartForCartTotal()
     }
+    
+    var itemToScrollToWhenCartUpdated: CartItem? {
+        return itemsInCart.last
+    }
 
     func addItemToCart(_ item: POSItem) {
         let cartItem = CartItem(id: UUID(), item: item, quantity: 1)

--- a/WooCommerce/Classes/POS/ViewModels/PointOfSaleDashboardViewModel.swift
+++ b/WooCommerce/Classes/POS/ViewModels/PointOfSaleDashboardViewModel.swift
@@ -49,7 +49,7 @@ final class PointOfSaleDashboardViewModel: ObservableObject {
         observeCardPresentPaymentEvents()
         observeItemsInCartForCartTotal()
     }
-    
+
     var itemToScrollToWhenCartUpdated: CartItem? {
         return itemsInCart.last
     }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

When we add new item to the cart we will scroll to that item so we do not "lose" the item in the list.

<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->

## Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: https://woomobilep2.wordpress.com/2024/05/06/woocommerce-mobile-quality-report-march-april/#comment-12036 -->

- enter POS
- keep adding items in the cart until they fill up the cart scroll view
- add few more and see that the scroll view scrolls to the newly added item and makes it visible

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

![Simulator Screen Recording - iPad Pro (11-inch) (4th generation) - 2024-06-11 at 15 57 49](https://github.com/woocommerce/woocommerce-ios/assets/6242034/efd1fc1d-ee08-42c8-9f4a-c7c8f151a7e1)

---
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
