### PR TITLE
[Customers] Add phone and billing/shipping addresses to customer details view

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Customers/CustomerDetailView.swift
+++ b/WooCommerce/Classes/ViewRelated/Customers/CustomerDetailView.swift
@@ -1,10 +1,14 @@
 import SwiftUI
 
 struct CustomerDetailView: View {
-    @ObservedObject var viewModel: CustomerDetailViewModel
+    @StateObject private var viewModel: CustomerDetailViewModel
 
     @State private var isPresentingEmailDialog: Bool = false
     @State private var isShowingEmailView: Bool = false
+
+    init(viewModel: CustomerDetailViewModel) {
+        self._viewModel = StateObject(wrappedValue: viewModel)
+    }
 
     var body: some View {
         List {

--- a/WooCommerce/Classes/ViewRelated/Customers/CustomerDetailView.swift
+++ b/WooCommerce/Classes/ViewRelated/Customers/CustomerDetailView.swift
@@ -1,7 +1,7 @@
 import SwiftUI
 
 struct CustomerDetailView: View {
-    let viewModel: CustomerDetailViewModel
+    @ObservedObject var viewModel: CustomerDetailViewModel
 
     @State private var isPresentingEmailDialog: Bool = false
     @State private var isShowingEmailView: Bool = false
@@ -49,11 +49,23 @@ struct CustomerDetailView: View {
                 customerDetailRow(label: Localization.dateRegisteredLabel, value: viewModel.dateRegistered)
             }
 
-            Section(header: Text(Localization.locationSection)) {
-                customerDetailRow(label: Localization.countryLabel, value: viewModel.country)
-                customerDetailRow(label: Localization.regionLabel, value: viewModel.region)
-                customerDetailRow(label: Localization.cityLabel, value: viewModel.city)
-                customerDetailRow(label: Localization.postcodeLabel, value: viewModel.postcode)
+            if let billing = viewModel.billing, billing.isNotEmpty {
+                Section(header: Text(Localization.billingSection)) {
+                    Text(billing)
+                }
+            }
+            if let shipping = viewModel.shipping, shipping.isNotEmpty {
+                Section(header: Text(Localization.shippingSection)) {
+                    Text(shipping)
+                }
+            }
+            if viewModel.showLocation {
+                Section(header: Text(Localization.locationSection)) {
+                    customerDetailRow(label: Localization.countryLabel, value: viewModel.country)
+                    customerDetailRow(label: Localization.regionLabel, value: viewModel.region)
+                    customerDetailRow(label: Localization.cityLabel, value: viewModel.city)
+                    customerDetailRow(label: Localization.postcodeLabel, value: viewModel.postcode)
+                }
             }
         }
         .listStyle(.plain)
@@ -155,10 +167,16 @@ private extension CustomerDetailView {
         static let copyEmail = NSLocalizedString("customerDetailView.copyEmail",
                                                  value: "Copy email address",
                                                  comment: "Button to copy a customer's email address in the Customer Details screen.")
+        static let billingSection = NSLocalizedString("customerDetailView.billingSection",
+                                                       value: "BILLING ADDRESS",
+                                                       comment: "Heading for the section with customer billing address in the Customer Details screen.")
+        static let shippingSection = NSLocalizedString("customerDetailView.shippingSection",
+                                                       value: "SHIPPING ADDRESS",
+                                                       comment: "Heading for the section with customer shipping address in the Customer Details screen.")
     }
 }
 
-#Preview("Customer") {
+#Preview("Unregistered Customer") {
     CustomerDetailView(viewModel: CustomerDetailViewModel(name: "Pat Smith",
                                                           dateLastActive: "Jan 1, 2024",
                                                           email: "patsmith@example.com",
@@ -170,7 +188,26 @@ private extension CustomerDetailView {
                                                           country: "United States",
                                                           region: "Oregon",
                                                           city: "Portland",
-                                                          postcode: "12345"))
+                                                          postcode: "12345",
+                                                          billing: nil,
+                                                          shipping: nil))
+}
+
+#Preview("Registered Customer") {
+    CustomerDetailView(viewModel: CustomerDetailViewModel(name: "Pat Smith",
+                                                          dateLastActive: "Jan 1, 2024",
+                                                          email: "patsmith@example.com",
+                                                          ordersCount: "3",
+                                                          totalSpend: "$81.75",
+                                                          avgOrderValue: "$27.25",
+                                                          username: "patsmith",
+                                                          dateRegistered: "Jan 1, 2023",
+                                                          country: "United States",
+                                                          region: "Oregon",
+                                                          city: "Portland",
+                                                          postcode: "12345",
+                                                          billing: "Pat Smith\n1 Main Street\nPortland, Oregon 12345",
+                                                          shipping: "Pat Smith\n1 Main Street\nPortland, Oregon 12345"))
 }
 
 #Preview("Customer with Placeholders") {
@@ -185,5 +222,7 @@ private extension CustomerDetailView {
                                                           country: nil,
                                                           region: nil,
                                                           city: nil,
-                                                          postcode: nil))
+                                                          postcode: nil,
+                                                          billing: nil,
+                                                          shipping: nil))
 }

--- a/WooCommerce/Classes/ViewRelated/Customers/CustomerDetailView.swift
+++ b/WooCommerce/Classes/ViewRelated/Customers/CustomerDetailView.swift
@@ -96,6 +96,9 @@ struct CustomerDetailView: View {
             EmailView(emailAddress: viewModel.email)
                 .ignoresSafeArea(edges: .bottom)
         }
+        .onAppear {
+            viewModel.syncCustomerAddressData()
+        }
     }
 }
 
@@ -199,7 +202,9 @@ private extension CustomerDetailView {
 }
 
 #Preview("Unregistered Customer") {
-    CustomerDetailView(viewModel: CustomerDetailViewModel(name: "Pat Smith",
+    CustomerDetailView(viewModel: CustomerDetailViewModel(siteID: 1,
+                                                          customerID: 0,
+                                                          name: "Pat Smith",
                                                           dateLastActive: "Jan 1, 2024",
                                                           email: "patsmith@example.com",
                                                           ordersCount: "3",
@@ -216,7 +221,9 @@ private extension CustomerDetailView {
 }
 
 #Preview("Registered Customer") {
-    CustomerDetailView(viewModel: CustomerDetailViewModel(name: "Pat Smith",
+    CustomerDetailView(viewModel: CustomerDetailViewModel(siteID: 1,
+                                                          customerID: 0,
+                                                          name: "Pat Smith",
                                                           dateLastActive: "Jan 1, 2024",
                                                           email: "patsmith@example.com",
                                                           ordersCount: "3",
@@ -233,7 +240,9 @@ private extension CustomerDetailView {
 }
 
 #Preview("Customer with Placeholders") {
-    CustomerDetailView(viewModel: CustomerDetailViewModel(name: "Guest",
+    CustomerDetailView(viewModel: CustomerDetailViewModel(siteID: 1,
+                                                          customerID: 0,
+                                                          name: "Guest",
                                                           dateLastActive: "Jan 1, 2024",
                                                           email: nil,
                                                           ordersCount: "0",

--- a/WooCommerce/Classes/ViewRelated/Customers/CustomerDetailView.swift
+++ b/WooCommerce/Classes/ViewRelated/Customers/CustomerDetailView.swift
@@ -35,6 +35,11 @@ struct CustomerDetailView: View {
                         }
                     }
                 }
+                HStack {
+                    Text(viewModel.phone ?? Localization.phonePlaceholder)
+                        .style(for: viewModel.phone)
+                    Spacer()
+                }
                 customerDetailRow(label: Localization.dateLastActiveLabel, value: viewModel.dateLastActive)
             }
 
@@ -173,6 +178,9 @@ private extension CustomerDetailView {
         static let shippingSection = NSLocalizedString("customerDetailView.shippingSection",
                                                        value: "SHIPPING ADDRESS",
                                                        comment: "Heading for the section with customer shipping address in the Customer Details screen.")
+        static let phonePlaceholder = NSLocalizedString("customerDetailView.phonePlaceholder",
+                                                        value: "No phone number",
+                                                        comment: "Placeholder if a customer's phone number is not available in the Customer Details screen.")
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Customers/CustomerDetailView.swift
+++ b/WooCommerce/Classes/ViewRelated/Customers/CustomerDetailView.swift
@@ -38,6 +38,11 @@ struct CustomerDetailView: View {
                 HStack {
                     Text(viewModel.phone ?? Localization.phonePlaceholder)
                         .style(for: viewModel.phone)
+                        .if(viewModel.isSyncing) { phone in
+                            phone
+                                .redacted(reason: .placeholder)
+                                .shimmering()
+                        }
                     Spacer()
                 }
                 customerDetailRow(label: Localization.dateLastActiveLabel, value: viewModel.dateLastActive)
@@ -70,6 +75,11 @@ struct CustomerDetailView: View {
                     customerDetailRow(label: Localization.regionLabel, value: viewModel.region)
                     customerDetailRow(label: Localization.cityLabel, value: viewModel.city)
                     customerDetailRow(label: Localization.postcodeLabel, value: viewModel.postcode)
+                }
+                .if(viewModel.isSyncing) { location in
+                    location
+                        .redacted(reason: .placeholder)
+                        .shimmering()
                 }
             }
         }

--- a/WooCommerce/Classes/ViewRelated/Customers/CustomerDetailViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Customers/CustomerDetailViewModel.swift
@@ -14,6 +14,9 @@ final class CustomerDetailViewModel: ObservableObject {
     /// Customer email
     let email: String?
 
+    /// Customer phone
+    var phone: String?
+
     // MARK: Orders
 
     /// Number of orders from the customer
@@ -131,7 +134,7 @@ final class CustomerDetailViewModel: ObservableObject {
 }
 
 private extension CustomerDetailViewModel {
-    /// Retrieves and sets the customer billing and shipping address from remote, for registered customers.
+    /// Retrieves the customer billing and shipping details from remote and sets the corresponding addresses and phone number, for registered customers.
     ///
     func syncCustomerAddressData(siteID: Int64, userID: Int64) {
         // Only try to sync the address data for registered customers
@@ -145,6 +148,11 @@ private extension CustomerDetailViewModel {
             case let .success(customer):
                 billing = customer.billing?.fullNameWithCompanyAndAddress
                 shipping = customer.shipping?.fullNameWithCompanyAndAddress
+                if customer.billing?.hasPhoneNumber == true {
+                    phone = customer.billing?.phone
+                } else if customer.shipping?.hasPhoneNumber == true {
+                    phone = customer.shipping?.phone
+                }
             case let .failure(error):
                 DDLogError("⛔️ Error fetching customer details: \(error)")
             }

--- a/WooCommerce/Classes/ViewRelated/Customers/CustomerDetailViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Customers/CustomerDetailViewModel.swift
@@ -63,6 +63,15 @@ final class CustomerDetailViewModel: ObservableObject {
     /// Formatted shipping name and address
     @Published private(set) var shipping: String?
 
+    // MARK: Sync
+
+    /// Whether the view model is currently syncing customer data
+    var isSyncing: Bool {
+        syncState == .syncing
+    }
+
+    private var syncState: CustomerSyncState = .syncing
+
     init(name: String?,
          dateLastActive: String,
          email: String?,
@@ -133,12 +142,22 @@ final class CustomerDetailViewModel: ObservableObject {
     }
 }
 
+// MARK: Syncing
 private extension CustomerDetailViewModel {
+
+    /// Possible sync states for customer data
+    enum CustomerSyncState {
+        case unsynced
+        case syncing
+        case synced
+    }
+
     /// Retrieves the customer billing and shipping details from remote and sets the corresponding addresses and phone number, for registered customers.
     ///
     func syncCustomerAddressData(siteID: Int64, userID: Int64) {
         // Only try to sync the address data for registered customers
         guard userID != 0 else {
+            syncState = .unsynced
             return
         }
 
@@ -156,6 +175,7 @@ private extension CustomerDetailViewModel {
             case let .failure(error):
                 DDLogError("⛔️ Error fetching customer details: \(error)")
             }
+            syncState = .synced
         }
         stores.dispatch(action)
     }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Customers/CustomerDetailViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Customers/CustomerDetailViewModelTests.swift
@@ -9,18 +9,7 @@ final class CustomerDetailViewModelTests: XCTestCase {
 
     func test_it_inits_with_expected_values_from_customer() throws {
         // Given
-        let customer = WCAnalyticsCustomer.fake().copy(name: "Pat Smith",
-                                                       email: "pat.smith@example.com",
-                                                       username: "psmith",
-                                                       dateRegistered: Date(),
-                                                       dateLastActive: Date(),
-                                                       ordersCount: 2,
-                                                       totalSpend: 10,
-                                                       averageOrderValue: 5,
-                                                       country: "US",
-                                                       region: "CA",
-                                                       city: "San Francisco",
-                                                       postcode: "94103")
+        let customer = sampleCustomer()
 
         // When
         let vm = CustomerDetailViewModel(customer: customer, currencySettings: CurrencySettings())
@@ -73,24 +62,11 @@ final class CustomerDetailViewModelTests: XCTestCase {
         XCTAssertTrue(vm.showLocation)
     }
 
-    func test_it_updates_billing_and_shipping_from_remote() throws {
+    func test_it_updates_billing_and_shipping_and_phone_from_remote() throws {
         // Given
         let stores = MockStoresManager(sessionManager: .testingInstance)
         let billing = sampleAddress()
         let shipping = Address.fake().copy(company: "Widget Shop", address1: "1 Main Street")
-        let customer = WCAnalyticsCustomer.fake().copy(userID: 123,
-                                                       name: "Pat Smith",
-                                                       email: "pat.smith@example.com",
-                                                       username: "psmith",
-                                                       dateRegistered: Date(),
-                                                       dateLastActive: Date(),
-                                                       ordersCount: 2,
-                                                       totalSpend: 10,
-                                                       averageOrderValue: 5,
-                                                       country: "US",
-                                                       region: "CA",
-                                                       city: "San Francisco",
-                                                       postcode: "94103")
 
         // When
         var vm: CustomerDetailViewModel?
@@ -106,7 +82,7 @@ final class CustomerDetailViewModelTests: XCTestCase {
                 }
             }
 
-            vm = CustomerDetailViewModel(customer: customer, stores: stores)
+            vm = CustomerDetailViewModel(customer: self.sampleCustomer(), stores: stores)
         }
 
         // Then
@@ -114,6 +90,7 @@ final class CustomerDetailViewModelTests: XCTestCase {
         XCTAssertFalse(viewModel.showLocation)
         assertEqual(billing.fullNameWithCompanyAndAddress, viewModel.billing)
         assertEqual(shipping.fullNameWithCompanyAndAddress, viewModel.shipping)
+        assertEqual(billing.phone, viewModel.phone)
     }
 
 }
@@ -131,5 +108,21 @@ private extension CustomerDetailViewModelTests {
                        country: "US",
                        phone: "333-333-3333",
                        email: "scrambled@scrambled.com")
+    }
+
+    func sampleCustomer() -> WCAnalyticsCustomer {
+        WCAnalyticsCustomer.fake().copy(userID: 123,
+                                        name: "Pat Smith",
+                                        email: "pat.smith@example.com",
+                                        username: "psmith",
+                                        dateRegistered: Date(),
+                                        dateLastActive: Date(),
+                                        ordersCount: 2,
+                                        totalSpend: 10,
+                                        averageOrderValue: 5,
+                                        country: "US",
+                                        region: "CA",
+                                        city: "San Francisco",
+                                        postcode: "94103")
     }
 }


### PR DESCRIPTION
Part of: #13023

## Why
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
For registered customers, we now fetch their billing and shipping details and insert them into the customer details view.

## How

`CustomerDetailViewModel` now supports syncing the customer's billing and shipping data (address and phone) from remote, based on the customer's user ID. When the sync is performed:
   * We track the sync state and can use the property `isSyncing` to determine if the data is currently syncing.
   * We save the billing and shipping address, if available.
   * We save a phone number (billing or shipping), if available.

In `CustomerDetailView`:
* We start syncing the customer data before the view appears (in a task) and show a loading animation (in the phone and address rows) while the sync is happening.
* If the customer is not registered or does not have any details, we show:
   * A placeholder ("No phone number") in the phone number row.
   * The location section with data from `WCAnalyticsCustomer`.
* If the registered customer details are available, we show:
   * The phone number from their billing address (or, if no billing phone is available, from their shipping address).
   * "Billing address" and "Shipping address" sections with the respective addresses.

## Testing steps
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->

Registered customer:

1. Go to the Menu tab.
2. Open the Customers section.
3. Select a registered customer.
4. Confirm the customer's phone number and billing/shipping addresses load and are displayed as expected.

Unregistered customer:

1. Go to the Menu tab.
2. Open the Customers section.
3. Select an unregistered customer.
4. Confirm you see a row in the customer details with a "No phone number" placeholder.
5. Confirm you see a Location section with the customer's location details, and no billing/shipping sections.

## Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->

Scenarios considered:
* Registered customer
  * With complete billing and shipping details
  * With either billing or shipping details
  * With no available details
* Unregistered customer
* Sync failure

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

https://github.com/woocommerce/woocommerce-ios/assets/8658164/5aa6d0f5-c239-4ed3-9e30-9626222c99b1



---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
_Release notes will be added in a followup PR that adds contact actions for the phone and addresses._