### PR TITLE
[Customers] Add phone and address contact actions to customer details view

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -4,6 +4,7 @@
 -----
 - [*] Products: The creation sheet is now simplified and categorized better [https://github.com/woocommerce/woocommerce-ios/pull/12273]
 - [*] Restore a missing navigation bar on the privacy settings screen. [https://github.com/woocommerce/woocommerce-ios/pull/13018]
+- [**] Customers: The customers section (Menu > Customers) now includes registered customers' phone number and billing/shipping addresses, when available, with actions to copy their contact details or contact them via phone. [https://github.com/woocommerce/woocommerce-ios/pull/13034]
 
 
 19.0

--- a/WooCommerce/Classes/ViewRelated/Customers/CustomerDetailView.swift
+++ b/WooCommerce/Classes/ViewRelated/Customers/CustomerDetailView.swift
@@ -28,13 +28,13 @@ struct CustomerDetailView: View {
                     .accessibilityLabel(Localization.emailAction)
                     .renderedIf(viewModel.email != nil)
                     .confirmationDialog(Localization.emailAction, isPresented: $isPresentingEmailDialog) {
-                        Button(Localization.sendEmail) {
+                        Button(Localization.ContactAction.sendEmail) {
                             isShowingEmailView.toggle()
                             viewModel.trackEmailOptionTapped()
                         }
                         .renderedIf(EmailView.canSendEmail())
 
-                        Button(Localization.copyEmail) {
+                        Button(Localization.ContactAction.copyEmail) {
                             viewModel.copyEmail()
                         }
                     }
@@ -66,11 +66,39 @@ struct CustomerDetailView: View {
             if let billing = viewModel.billing, billing.isNotEmpty {
                 Section(header: Text(Localization.billingSection)) {
                     Text(billing)
+                        .swipeActions(edge: .leading) {
+                            Button {
+                                billing.sendToPasteboard()
+                            } label: {
+                                Text(Localization.ContactAction.copy)
+                            }
+                        }
+                        .contextMenu {
+                            Button {
+                                billing.sendToPasteboard()
+                            } label: {
+                                Label(Localization.ContactAction.copy, systemImage: "doc.on.doc")
+                            }
+                        }
                 }
             }
             if let shipping = viewModel.shipping, shipping.isNotEmpty {
                 Section(header: Text(Localization.shippingSection)) {
                     Text(shipping)
+                        .swipeActions(edge: .leading) {
+                            Button {
+                                shipping.sendToPasteboard()
+                            } label: {
+                                Text(Localization.ContactAction.copy)
+                            }
+                        }
+                        .contextMenu {
+                            Button {
+                                shipping.sendToPasteboard()
+                            } label: {
+                                Label(Localization.ContactAction.copy, systemImage: "doc.on.doc")
+                            }
+                        }
                 }
             }
             if viewModel.showLocation {
@@ -183,12 +211,6 @@ private extension CustomerDetailView {
         static let emailAction = NSLocalizedString("customerDetailView.emailActionLabel",
                                                    value: "Contact customer via email",
                                                    comment: "Title for action to contact a customer via email.")
-        static let sendEmail = NSLocalizedString("customerDetailView.sendEmail",
-                                                 value: "Email",
-                                                 comment: "Button to email a customer in the Customer Details screen.")
-        static let copyEmail = NSLocalizedString("customerDetailView.copyEmail",
-                                                 value: "Copy email address",
-                                                 comment: "Button to copy a customer's email address in the Customer Details screen.")
         static let billingSection = NSLocalizedString("customerDetailView.billingSection",
                                                        value: "BILLING ADDRESS",
                                                        comment: "Heading for the section with customer billing address in the Customer Details screen.")
@@ -198,6 +220,18 @@ private extension CustomerDetailView {
         static let phonePlaceholder = NSLocalizedString("customerDetailView.phonePlaceholder",
                                                         value: "No phone number",
                                                         comment: "Placeholder if a customer's phone number is not available in the Customer Details screen.")
+
+        enum ContactAction {
+            static let sendEmail = NSLocalizedString("customerDetailView.sendEmail",
+                                                     value: "Email",
+                                                     comment: "Button to email a customer in the Customer Details screen.")
+            static let copyEmail = NSLocalizedString("customerDetailView.copyEmail",
+                                                     value: "Copy email address",
+                                                     comment: "Button to copy a customer's email address in the Customer Details screen.")
+            static let copy = NSLocalizedString("customerDetailView.copyButton.label",
+                                                value: "Copy",
+                                                comment: "Copy address text button title — should be one word and as short as possible.")
+        }
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/MessageComposeView.swift
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/MessageComposeView.swift
@@ -1,0 +1,47 @@
+import SwiftUI
+import UIKit
+import MessageUI
+
+/// SwiftUI wrapper of `MFMessageComposeViewController`.
+/// Its interface lets the user compose and send text messages.
+struct MessageComposeView: UIViewControllerRepresentable {
+
+    /// Phone number to set as recipient
+    let phone: String?
+
+    class Coordinator: NSObject, MFMessageComposeViewControllerDelegate {
+        func messageComposeViewController(_ controller: MFMessageComposeViewController,
+                                          didFinishWith result: MessageComposeResult) {
+            controller.dismiss(animated: true, completion: nil)
+        }
+    }
+
+    func makeCoordinator() -> Coordinator {
+        return Coordinator()
+    }
+
+    func makeUIViewController(context: UIViewControllerRepresentableContext<MessageComposeView>) -> MFMessageComposeViewController {
+        let message = MFMessageComposeViewController()
+        message.messageComposeDelegate = context.coordinator
+
+        if let phone {
+            message.recipients = [phone]
+        }
+
+        return message
+    }
+
+    func updateUIViewController(_ uiViewController: MFMessageComposeViewController,
+                                context: UIViewControllerRepresentableContext<MessageComposeView>) {
+
+    }
+
+    /// Returns a Boolean that indicates whether the current device is able to send a text.
+    ///
+    /// You should call this method before attempting to display the message composition interface.
+    /// If it returns false, you must not display the message composition interface.
+    ///
+    static func canSendMessage() -> Bool {
+        MFMessageComposeViewController.canSendText()
+    }
+}

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -2185,6 +2185,7 @@
 		CEE006052077D1280079161F /* SummaryTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEE006032077D1280079161F /* SummaryTableViewCell.swift */; };
 		CEE006062077D1280079161F /* SummaryTableViewCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = CEE006042077D1280079161F /* SummaryTableViewCell.xib */; };
 		CEE006082077D14C0079161F /* OrderDetailsViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEE006072077D14C0079161F /* OrderDetailsViewController.swift */; };
+		CEE02AF82C1859B400B0B6AB /* MessageComposeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEE02AF72C1859B400B0B6AB /* MessageComposeView.swift */; };
 		CEE482D52B83A9A300FAC8C5 /* AnalyticsCard+UI.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEE482D42B83A9A300FAC8C5 /* AnalyticsCard+UI.swift */; };
 		CEEC9B6021E79CAA0055EEF0 /* FeatureFlagTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEEC9B5F21E79CAA0055EEF0 /* FeatureFlagTests.swift */; };
 		CEEC9B6421E7AB850055EEF0 /* AppRatingManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEEC9B6221E79EE00055EEF0 /* AppRatingManager.swift */; };
@@ -5092,6 +5093,7 @@
 		CEE006032077D1280079161F /* SummaryTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SummaryTableViewCell.swift; sourceTree = "<group>"; };
 		CEE006042077D1280079161F /* SummaryTableViewCell.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = SummaryTableViewCell.xib; sourceTree = "<group>"; };
 		CEE006072077D14C0079161F /* OrderDetailsViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OrderDetailsViewController.swift; sourceTree = "<group>"; };
+		CEE02AF72C1859B400B0B6AB /* MessageComposeView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MessageComposeView.swift; sourceTree = "<group>"; };
 		CEE482D42B83A9A300FAC8C5 /* AnalyticsCard+UI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AnalyticsCard+UI.swift"; sourceTree = "<group>"; };
 		CEEC9B5F21E79CAA0055EEF0 /* FeatureFlagTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeatureFlagTests.swift; sourceTree = "<group>"; };
 		CEEC9B6221E79EE00055EEF0 /* AppRatingManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppRatingManager.swift; sourceTree = "<group>"; };
@@ -8696,6 +8698,7 @@
 				20203AB12B31EEF1009D0C11 /* ExpandableBottomSheet.swift */,
 				20DA6DDA2B681175002AA0FB /* AdaptiveModalContainer.swift */,
 				CE63024D2BAC664900E3325C /* EmailView.swift */,
+				CEE02AF72C1859B400B0B6AB /* MessageComposeView.swift */,
 				DE8AA0B42BBEBE590084D2CC /* ViewControllerContainer.swift */,
 				CE9F60112C09D53500652E0A /* FeedbackBannerPopover.swift */,
 			);
@@ -15410,6 +15413,7 @@
 				039B7E6329F136F200E21EF4 /* SetUpTapToPayOnboardingViewController.swift in Sources */,
 				450C2CBA24D3127500D570DD /* ProductReviewsTableViewCell.swift in Sources */,
 				B991D3952A4EC0F800D886ED /* CouponLineViewModel.swift in Sources */,
+				CEE02AF82C1859B400B0B6AB /* MessageComposeView.swift in Sources */,
 				D8C2A28F231BD00500F503E9 /* ReviewsViewModel.swift in Sources */,
 				EE8B42162BFC33670077C4E7 /* LastOrdersDashboardEmptyView.swift in Sources */,
 				20E188842AD059A50053E945 /* AboutTapToPayView.swift in Sources */,


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of: #13023
<!-- Id number of the GitHub issue this PR addresses. -->

## Why
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This adds contact actions for customers with a phone number and billing and/or shipping addresses:

* Phone number actions (when supported on the device): call, message, copy, whatsapp, telegram.
* Billing and shipping address can be copied (swipe or long tap).

## How
* Adds `MessageComposeView`, a SwiftUI wrapper of `MFMessageComposeViewController` (for composing text messages).
* When the customer details are synced in `CustomerDetailViewModel`, we save a cleaned version of the phone number and an actionable URL version of the phone number, for use in the phone contact actions. The view model also adds helpers for these actions.
* `CustomerDetailView`:
   * Adds an ellipsis button in the phone row that opens a dialog with the phone actions available on the device.
   * Adds swipe and long-tap gestures to the billing and shipping addresses.
   * Adds `MessageComposeView` in a sheet, which is opened when the "Message" contact action is selected for a phone number.

## Testing steps
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->

1. Go to the Menu tab.
2. Open the Customers section.
3. Select a registered customer.
4. Next to the customer's phone number, tap the ellipsis menu to open the contact dialog.
5. Select each action and confirm it works as expected.
6. Long tap the billing or shipping address and confirm you can copy the address.
7. Swipe the billing or shipping address and confirm you can copy the address.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->
Phone actions|Message composer|Long tap to copy|Swipe to copy
-|-|-|-
![IMG_3628](https://github.com/woocommerce/woocommerce-ios/assets/8658164/da4eecce-52f1-4b08-8ee3-f544b966f8c1)|![IMG_3629](https://github.com/woocommerce/woocommerce-ios/assets/8658164/a216ad69-a10d-4e73-aed5-75e46a918b25)|![IMG_3630](https://github.com/woocommerce/woocommerce-ios/assets/8658164/8f8ab0de-ad1a-4425-b413-5d81877654cd)|![IMG_3631](https://github.com/woocommerce/woocommerce-ios/assets/8658164/672d6de7-3218-4396-8644-3e474e25e2e0)

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.