### PR TITLE
Watch: Small Screen / Accessibility Adjustments

### DIFF
--- a/WooCommerce/Woo Watch App/ConnectView.swift
+++ b/WooCommerce/Woo Watch App/ConnectView.swift
@@ -13,6 +13,7 @@ struct ConnectView: View {
         VStack(spacing: Layout.mainSpacing) {
             Text(message)
                 .multilineTextAlignment(.center)
+                .fixedSize(horizontal: false, vertical: true)
 
             Image(systemName: "bolt.fill")
                 .renderingMode(.original)
@@ -20,7 +21,7 @@ struct ConnectView: View {
                 .frame(width: Layout.boltSize.width, height: Layout.boltSize.height)
                 .foregroundStyle(Layout.ambarColor)
         }
-        .padding()
+        .padding(.vertical)
         .task {
             tracksProvider.sendTracksEvent(.watchConnectingOpened)
         }

--- a/WooCommerce/Woo Watch App/MyStore/MyStoreView.swift
+++ b/WooCommerce/Woo Watch App/MyStore/MyStoreView.swift
@@ -36,7 +36,7 @@ struct MyStoreView: View {
                 dataView(revenue: revenue, orders: totalOrders, visitors: totalVisitors, conversion: conversion, time: time)
             }
         }
-        .padding()
+        .padding(.horizontal)
         .background(
             LinearGradient(gradient: Gradient(colors: [Colors.wooPurpleBackground, .black]), startPoint: .top, endPoint: .bottom)
         )
@@ -66,77 +66,81 @@ struct MyStoreView: View {
     /// My Store Stats data view.
     ///
     @ViewBuilder func dataView(revenue: String, orders: String, visitors: String, conversion: String, time: String) -> some View {
-        VStack {
-            Text(dependencies.storeName)
-                .font(.body)
-                .foregroundStyle(Colors.wooPurple5)
-                .padding(.bottom, Layout.storeNamePadding)
+        ScrollView {
+            VStack {
+                Text(dependencies.storeName)
+                    .font(.body)
+                    .foregroundStyle(Colors.wooPurple5)
+                    .lineLimit(2)
+                    .fixedSize(horizontal: false, vertical: true)
+                    .padding(.bottom, Layout.storeNamePadding)
 
-            Text(Localization.revenue)
-                .font(.caption2)
-                .foregroundStyle(Colors.wooPurple5)
+                Text(Localization.revenue)
+                    .font(.caption2)
+                    .foregroundStyle(Colors.wooPurple5)
                 .padding(.bottom, Layout.revenueTitlePadding)
 
-            Text(revenue)
-                .font(.title2)
-                .bold()
+                Text(revenue)
+                    .font(.title2)
+                    .bold()
                 .padding(.bottom, Layout.revenueValuePadding)
 
-            Divider()
+                Divider()
                 .padding(.bottom, Layout.dividerPadding)
 
-            HStack {
-                Text(Localization.today)
-                Spacer()
-                Text(Localization.time(time))
-            }
-            .font(.footnote)
-            .foregroundStyle(.secondary)
-            .padding(.bottom, Layout.datePadding)
-
-            HStack {
-
-                Button(action: {
-                    self.watchTab = .ordersList
-                }) {
-                    HStack {
-                        Images.document
-                            .renderingMode(.original)
-                            .foregroundStyle(Colors.wooPurple10)
-
-                        Text(orders)
-                            .font(.caption)
-                            .bold()
-                    }
-                    .padding(Layout.orderButtonPadding)
+                HStack {
+                    Text(Localization.today)
+                    Spacer()
+                    Text(Localization.time(time))
                 }
-                .buttonStyle(.plain)
-                .background(Colors.wooPurple80)
-                .cornerRadius(Layout.orderButtonCornerRadius)
+                .font(.footnote)
+                .foregroundStyle(.secondary)
+                .padding(.bottom, Layout.datePadding)
 
-                Spacer()
+                HStack {
 
-                VStack(spacing: Layout.iconsSpacing) {
-                    HStack(spacing: Layout.iconsSpacing) {
+                    Button(action: {
+                        self.watchTab = .ordersList
+                    }) {
+                        HStack {
+                            Images.document
+                                .renderingMode(.original)
+                                .foregroundStyle(Colors.wooPurple10)
 
-                        Text(visitors)
-                            .font(.caption)
-                            .bold()
-
-                        Images.person
-                            .renderingMode(.original)
-                            .foregroundStyle(Colors.wooPurple10)
+                            Text(orders)
+                                .font(.caption)
+                                .bold()
+                        }
+                        .padding(Layout.orderButtonPadding)
                     }
+                    .buttonStyle(.plain)
+                    .background(Colors.wooPurple80)
+                    .cornerRadius(Layout.orderButtonCornerRadius)
 
-                    HStack(spacing: Layout.iconsSpacing) {
+                    Spacer()
 
-                        Text(conversion)
-                            .font(.caption2)
-                            .bold()
+                    VStack(spacing: Layout.iconsSpacing) {
+                        HStack(spacing: Layout.iconsSpacing) {
 
-                        Images.zigzag
-                            .renderingMode(.original)
-                            .foregroundStyle(Colors.wooPurple10)
+                            Text(visitors)
+                                .font(.caption)
+                                .bold()
+
+                            Images.person
+                                .renderingMode(.original)
+                                .foregroundStyle(Colors.wooPurple10)
+                        }
+
+                        HStack(spacing: Layout.iconsSpacing) {
+
+                            Text(conversion)
+                                .font(.caption2)
+                                .bold()
+
+                            Images.zigzag
+                                .renderingMode(.original)
+                                .foregroundStyle(Colors.wooPurple10)
+                        }
                     }
                 }
             }

--- a/WooCommerce/Woo Watch App/Orders/OrderDetailView.swift
+++ b/WooCommerce/Woo Watch App/Orders/OrderDetailView.swift
@@ -50,47 +50,49 @@ struct OrderDetailView: View {
     /// First View: Summary
     ///
     @ViewBuilder private var summaryView: some View {
-        VStack(alignment: .leading) {
+        ScrollView {
+            VStack(alignment: .leading) {
 
-            // Date & Time
-            HStack {
-                Text(order.date)
-                Spacer()
-                Text(order.time)
-            }
-            .font(.caption2)
-            .foregroundStyle(.secondary)
-
-            Divider()
-
-            // Name, total, status
-            VStack(alignment: .leading, spacing: Layout.nameSectionSpacing) {
-                Text(order.name)
-                    .font(.body)
-                    .fixedSize(horizontal: false, vertical: true)
-
-                Text(order.total)
-                    .font(.title2)
-                    .bold()
-
-                Text(order.status)
-                    .font(.footnote)
-                    .foregroundStyle(Colors.gray5)
-            }
-            .padding(.bottom, Layout.mainSectionsPadding)
-
-            // Products button
-            Button(Localization.products(order.itemCount).lowercased()) {
-                if order.itemCount > 0 {
-                    self.selectedTab = .products
+                // Date & Time
+                HStack {
+                    Text(order.date)
+                    Spacer()
+                    Text(order.time)
                 }
+                .font(.caption2)
+                .foregroundStyle(.secondary)
+
+                Divider()
+
+                // Name, total, status
+                VStack(alignment: .leading, spacing: Layout.nameSectionSpacing) {
+                    Text(order.name)
+                        .font(.body)
+                        .fixedSize(horizontal: false, vertical: true)
+
+                    Text(order.total)
+                        .font(.title2)
+                        .bold()
+
+                    Text(order.status)
+                        .font(.footnote)
+                        .foregroundStyle(Colors.gray5)
+                }
+                .padding(.bottom, Layout.mainSectionsPadding)
+
+                // Products button
+                Button(Localization.products(order.itemCount).lowercased()) {
+                    if order.itemCount > 0 {
+                        self.selectedTab = .products
+                    }
+                }
+                .font(.caption2)
+                .buttonStyle(.borderless)
+                .frame(maxWidth: .greatestFiniteMagnitude, alignment: .leading)
+                .padding()
+                .background(Colors.whiteTransparent)
+                .cornerRadius(Layout.buttonCornerRadius)
             }
-            .font(.caption2)
-            .buttonStyle(.borderless)
-            .frame(maxWidth: .greatestFiniteMagnitude, alignment: .leading)
-            .padding()
-            .background(Colors.whiteTransparent)
-            .cornerRadius(Layout.buttonCornerRadius)
         }
     }
 


### PR DESCRIPTION
closes #12992 #12948 

# Why

This PR makes sure that all content is visible when using smaller screens or when using accessibility fonts

# How

- Make sure labels grow as intended.
- Add scroll views when content can overflow the screen.

# Screenshots

### Connecting

<img width="271" alt="Screenshot 2024-06-07 at 4 26 15 PM" src="https://github.com/woocommerce/woocommerce-ios/assets/562080/f9510e5f-3c5c-4413-8c61-de8d7c30ece4">


### My Store

| Top | Scrolled |
|--------|--------|
|  ![Simulator Screenshot - Apple Watch SE (40mm) (2nd generation) - 2024-06-11 at 11 06 58](https://github.com/woocommerce/woocommerce-ios/assets/562080/7ab45e5d-750f-455a-b82e-8a31a7cde14e) | ![Simulator Screenshot - Apple Watch SE (40mm) (2nd generation) - 2024-06-11 at 11 07 34](https://github.com/woocommerce/woocommerce-ios/assets/562080/1b11b277-78d4-4ca4-af17-835d73eddfb0) |

### Order Detail Summary

| Top | Scrolled |
|--------|--------|
| ![Simulator Screenshot - Apple Watch SE (40mm) (2nd generation) - 2024-06-11 at 11 33 34](https://github.com/woocommerce/woocommerce-ios/assets/562080/432f4ced-30ec-44ea-a01d-0162f7a6051d) |  ![Simulator Screenshot - Apple Watch SE (40mm) (2nd generation) - 2024-06-11 at 11 33 36](https://github.com/woocommerce/woocommerce-ios/assets/562080/ae6e54c0-d345-4bbc-9b5f-c742400def2b) |

### Order Detail Customer

| Top | Scrolled |
|--------|--------|
| ![Simulator Screenshot - Apple Watch SE (40mm) (2nd generation) - 2024-06-11 at 11 33 49](https://github.com/woocommerce/woocommerce-ios/assets/562080/a8a7ab7f-e486-4bf8-9d0e-0a8ced154e95) | ![Simulator Screenshot - Apple Watch SE (40mm) (2nd generation) - 2024-06-11 at 11 33 51](https://github.com/woocommerce/woocommerce-ios/assets/562080/da2fc0c4-6b9c-42b8-b4ee-86e3c9779c2a)
 |

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
