### PR TITLE
[Woo POS] use custom alert providers preparation

### DIFF
--- a/WooCommerce/Classes/POS/Card Present Payments/CardPresentPaymentCollectOrderPaymentUseCaseAdaptor.swift
+++ b/WooCommerce/Classes/POS/Card Present Payments/CardPresentPaymentCollectOrderPaymentUseCaseAdaptor.swift
@@ -24,14 +24,17 @@ struct CardPresentPaymentCollectOrderPaymentUseCaseAdaptor {
                 throw CardPresentPaymentServiceError.invalidAmount
             }
 
-            let orderPaymentUseCase = CollectOrderPaymentUseCase(siteID: siteID,
-                                                                 order: order,
-                                                                 formattedAmount: formattedAmount,
-                                                                 rootViewController: NullViewControllerPresenting(),
-                                                                 onboardingPresenter: onboardingPresenter,
-                                                                 configuration: configuration,
-                                                                 alertsPresenter: alertsPresenter,
-                                                                 preflightController: preflightController)
+            let orderPaymentUseCase = CollectOrderPaymentUseCase(
+                siteID: siteID,
+                order: order,
+                formattedAmount: formattedAmount,
+                rootViewController: NullViewControllerPresenting(),
+                onboardingPresenter: onboardingPresenter,
+                configuration: configuration,
+                alertsPresenter: alertsPresenter,
+                tapToPayAlertsProvider: BuiltInCardReaderPaymentAlertsProvider(),
+                bluetoothAlertsProvider: BluetoothCardReaderPaymentAlertsProvider(transactionType: .collectPayment),
+                preflightController: preflightController)
 
             return try await withTaskCancellationHandler {
                 return try await withCheckedThrowingContinuation { continuation in

--- a/WooCommerce/Classes/ViewRelated/Orders/Collect Payments/CollectOrderPaymentUseCase.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Collect Payments/CollectOrderPaymentUseCase.swift
@@ -220,10 +220,10 @@ private extension CollectOrderPaymentUseCase {
 
         guard orderTotalAmountCanBeConverted,
               let minimum = currencyFormatter.formatAmount(configuration.minimumAllowedChargeAmount, with: order.currency) else {
-            return NotValidAmountError.other
+            return CollectOrderPaymentUseCaseNotValidAmountError.other
         }
 
-        return NotValidAmountError.belowMinimumAmount(amount: minimum)
+        return CollectOrderPaymentUseCaseNotValidAmountError.belowMinimumAmount(amount: minimum)
     }
 
     func handleTotalAmountInvalidError(_ error: Error,
@@ -290,7 +290,7 @@ private extension CollectOrderPaymentUseCase {
                                                                onCompletion: onCompletion)
             case .success:
                 guard let orderTotal = self.orderTotal else {
-                    onCompletion(.failure(NotValidAmountError.other))
+                    onCompletion(.failure(CollectOrderPaymentUseCaseNotValidAmountError.other))
                     return
                 }
 
@@ -312,7 +312,8 @@ private extension CollectOrderPaymentUseCase {
                         guard let self = self else { return }
                         self.alertsPresenter.present(
                             viewModel: paymentAlerts.tapOrInsertCard(
-                                title: Localization.collectPaymentTitle(username: self.order.billingAddress?.firstName),
+                                title: CollectOrderPaymentUseCaseDefinitions.Localization.collectPaymentTitle(
+                                    username: self.order.billingAddress?.firstName),
                                 amount: self.formattedAmount,
                                 inputMethods: inputMethods,
                                 onCancel: { [weak self] in
@@ -326,7 +327,8 @@ private extension CollectOrderPaymentUseCase {
                         // Waiting message
                         self.alertsPresenter.present(
                             viewModel: paymentAlerts.processingTransaction(
-                                title: Localization.processingPaymentTitle(username: self.order.billingAddress?.firstName)))
+                                title: CollectOrderPaymentUseCaseDefinitions.Localization.processingPaymentTitle(
+                                    username: self.order.billingAddress?.firstName)))
                     }, onDisplayMessage: { [weak self] message in
                         guard let self = self else { return }
                         // Reader messages. EG: Remove Card
@@ -606,7 +608,7 @@ private extension CollectOrderPaymentUseCase {
         DDLogError("Failed to present receipt for order: \(order.orderID). Site \(order.siteID). Error: \(String(describing: error))")
 
         let noticePresenter = DefaultNoticePresenter()
-        let notice = Notice(title: Localization.failedReceiptPrintNoticeText,
+        let notice = Notice(title: CollectOrderPaymentUseCaseDefinitions.Localization.failedReceiptPrintNoticeText,
                                     feedbackType: .error)
         noticePresenter.presentingViewController = rootViewController
         noticePresenter.enqueue(notice: notice)
@@ -635,7 +637,7 @@ private extension CollectOrderPaymentUseCase {
 }
 
 // MARK: Definitions
-private extension CollectOrderPaymentUseCase {
+private enum CollectOrderPaymentUseCaseDefinitions {
     /// Mailing a receipt failed but the SDK didn't return a more specific error
     ///
     struct UnknownEmailError: Error {}
@@ -684,91 +686,89 @@ private extension CollectOrderPaymentUseCase {
     }
 }
 
-extension CollectOrderPaymentUseCase {
-    enum NotValidAmountError: Error, LocalizedError, Equatable {
-        case belowMinimumAmount(amount: String)
-        case other
+enum CollectOrderPaymentUseCaseNotValidAmountError: Error, LocalizedError, Equatable {
+    case belowMinimumAmount(amount: String)
+    case other
 
-        var errorDescription: String? {
-            switch self {
-            case .belowMinimumAmount(let amount):
-                return String.localizedStringWithFormat(Localization.belowMinimumAmount, amount)
-            case .other:
-                return Localization.defaultMessage
-            }
-        }
-
-        private enum Localization {
-            static let defaultMessage = NSLocalizedString(
-                "Unable to process payment. Order total amount is not valid.",
-                comment: "Error message when the order amount is not valid."
-            )
-
-            static let belowMinimumAmount = NSLocalizedString(
-                "Unable to process payment. Order total amount is below the minimum amount you can charge, which is %1$@",
-                comment: "Error message when the order amount is below the minimum amount allowed."
-            )
+    var errorDescription: String? {
+        switch self {
+        case .belowMinimumAmount(let amount):
+            return String.localizedStringWithFormat(Localization.belowMinimumAmount, amount)
+        case .other:
+            return Localization.defaultMessage
         }
     }
 
-    enum CollectOrderPaymentUseCaseError: LocalizedError {
-        case flowCanceledByUser
-        case paymentGatewayNotFound
-        case unknownErrorRefreshingOrder
-        case couldNotRefreshOrder(Error)
-        case orderAlreadyPaid
-        case alreadyRetried(Error)
+    private enum Localization {
+        static let defaultMessage = NSLocalizedString(
+            "Unable to process payment. Order total amount is not valid.",
+            comment: "Error message when the order amount is not valid."
+        )
 
-        var errorDescription: String? {
-            switch self {
-            case .flowCanceledByUser:
-                return Localization.paymentCancelledLocalizedDescription
-            case .paymentGatewayNotFound:
-                return Localization.paymentGatewayNotFoundLocalizedDescription
-            case .unknownErrorRefreshingOrder:
-                return Localization.unknownErrorWhileRefreshingOrderLocalizedDescription
-            case .couldNotRefreshOrder(let error as LocalizedError):
-                return error.errorDescription
-            case .couldNotRefreshOrder(let error):
-                return String.localizedStringWithFormat(Localization.couldNotRefreshOrderLocalizedDescription, error.localizedDescription)
-            case .orderAlreadyPaid:
-                return Localization.orderAlreadyPaidLocalizedDescription
-            case .alreadyRetried(let error as LocalizedError):
-                return error.errorDescription
-            case .alreadyRetried(let error):
-                return String.localizedStringWithFormat(Localization.couldNotRetryPaymentLocalizedDescription, error.localizedDescription)
-            }
+        static let belowMinimumAmount = NSLocalizedString(
+            "Unable to process payment. Order total amount is below the minimum amount you can charge, which is %1$@",
+            comment: "Error message when the order amount is below the minimum amount allowed."
+        )
+    }
+}
+
+enum CollectOrderPaymentUseCaseError: LocalizedError {
+    case flowCanceledByUser
+    case paymentGatewayNotFound
+    case unknownErrorRefreshingOrder
+    case couldNotRefreshOrder(Error)
+    case orderAlreadyPaid
+    case alreadyRetried(Error)
+
+    var errorDescription: String? {
+        switch self {
+        case .flowCanceledByUser:
+            return Localization.paymentCancelledLocalizedDescription
+        case .paymentGatewayNotFound:
+            return Localization.paymentGatewayNotFoundLocalizedDescription
+        case .unknownErrorRefreshingOrder:
+            return Localization.unknownErrorWhileRefreshingOrderLocalizedDescription
+        case .couldNotRefreshOrder(let error as LocalizedError):
+            return error.errorDescription
+        case .couldNotRefreshOrder(let error):
+            return String.localizedStringWithFormat(Localization.couldNotRefreshOrderLocalizedDescription, error.localizedDescription)
+        case .orderAlreadyPaid:
+            return Localization.orderAlreadyPaidLocalizedDescription
+        case .alreadyRetried(let error as LocalizedError):
+            return error.errorDescription
+        case .alreadyRetried(let error):
+            return String.localizedStringWithFormat(Localization.couldNotRetryPaymentLocalizedDescription, error.localizedDescription)
         }
+    }
 
-        private enum Localization {
-            static let couldNotRefreshOrderLocalizedDescription = NSLocalizedString(
-                "Unable to process payment. We could not fetch the latest order details. Please check your network " +
-                "connection and try again. Underlying error: %1$@",
-                comment: "Error message when collecting an In-Person Payment and unable to update the order. %!$@ will " +
-                "be replaced with further error details.")
+    private enum Localization {
+        static let couldNotRefreshOrderLocalizedDescription = NSLocalizedString(
+            "Unable to process payment. We could not fetch the latest order details. Please check your network " +
+            "connection and try again. Underlying error: %1$@",
+            comment: "Error message when collecting an In-Person Payment and unable to update the order. %!$@ will " +
+            "be replaced with further error details.")
 
-            static let unknownErrorWhileRefreshingOrderLocalizedDescription = NSLocalizedString(
-                "Unable to process payment. We could not fetch the latest order details. Please check your network " +
-                "connection and try again.",
-                comment: "Error message when collecting an In-Person Payment and unable to update the order.")
+        static let unknownErrorWhileRefreshingOrderLocalizedDescription = NSLocalizedString(
+            "Unable to process payment. We could not fetch the latest order details. Please check your network " +
+            "connection and try again.",
+            comment: "Error message when collecting an In-Person Payment and unable to update the order.")
 
-            static let orderAlreadyPaidLocalizedDescription = NSLocalizedString(
-                "Unable to process payment. This order is already paid, taking a further payment would result in the " +
-                "customer being charged twice for their order.",
-                comment: "Error message shown during In-Person Payments when the order is found to be paid after it's refreshed.")
+        static let orderAlreadyPaidLocalizedDescription = NSLocalizedString(
+            "Unable to process payment. This order is already paid, taking a further payment would result in the " +
+            "customer being charged twice for their order.",
+            comment: "Error message shown during In-Person Payments when the order is found to be paid after it's refreshed.")
 
-            static let paymentGatewayNotFoundLocalizedDescription = NSLocalizedString(
-                "Unable to process payment. We could not connect to the payment system. Please contact support if this " +
-                "error continues.",
-                comment: "Error message shown during In-Person Payments when the payment gateway is not available.")
+        static let paymentGatewayNotFoundLocalizedDescription = NSLocalizedString(
+            "Unable to process payment. We could not connect to the payment system. Please contact support if this " +
+            "error continues.",
+            comment: "Error message shown during In-Person Payments when the payment gateway is not available.")
 
-            static let paymentCancelledLocalizedDescription = NSLocalizedString(
-                "The payment was cancelled.", comment: "Message shown if a payment cancellation is shown as an error.")
+        static let paymentCancelledLocalizedDescription = NSLocalizedString(
+            "The payment was cancelled.", comment: "Message shown if a payment cancellation is shown as an error.")
 
-            static let couldNotRetryPaymentLocalizedDescription = NSLocalizedString(
-                "Unable to process payment. We could not complete this payment while retrying. Underlying error: %1$@",
-                comment: "Error message when retrying an In-Person Payment and an unknown error is received.")
-        }
+        static let couldNotRetryPaymentLocalizedDescription = NSLocalizedString(
+            "Unable to process payment. We could not complete this payment while retrying. Underlying error: %1$@",
+            comment: "Error message when retrying an In-Person Payment and an unknown error is received.")
     }
 }
 
@@ -814,7 +814,7 @@ extension CardReaderServiceError: CardPaymentErrorProtocol {
     }
 }
 
-extension CollectOrderPaymentUseCase.CollectOrderPaymentUseCaseError: CardPaymentErrorProtocol {
+extension CollectOrderPaymentUseCaseError: CardPaymentErrorProtocol {
     var retryApproach: CardPaymentRetryApproach {
         switch self {
         case .flowCanceledByUser, .orderAlreadyPaid, .alreadyRetried:

--- a/WooCommerce/Classes/ViewRelated/Orders/Collect Payments/CollectOrderPaymentUseCase.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Collect Payments/CollectOrderPaymentUseCase.swift
@@ -94,23 +94,21 @@ final class CollectOrderPaymentUseCase: NSObject, CollectOrderPaymentProtocol {
          stores: StoresManager = ServiceLocator.stores,
          paymentOrchestrator: PaymentCaptureOrchestrating = PaymentCaptureOrchestrator(),
          orderDurationRecorder: OrderDurationRecorderProtocol = OrderDurationRecorder.shared,
-         alertsPresenter: CardPresentPaymentAlertsPresenting? = nil,
-         preflightController: CardPresentPaymentPreflightControllerProtocol? = nil,
+         alertsPresenter: CardPresentPaymentAlertsPresenting,
+         tapToPayAlertsProvider: CardReaderTransactionAlertsProviding,
+         bluetoothAlertsProvider: CardReaderTransactionAlertsProviding,
+         preflightController: CardPresentPaymentPreflightControllerProtocol,
          analyticsTracker: CollectOrderPaymentAnalyticsTracking? = nil) {
         self.siteID = siteID
         self.order = order
         self.formattedAmount = formattedAmount
         self.rootViewController = rootViewController
         self.onboardingPresenter = onboardingPresenter
-        self.alertsPresenter = alertsPresenter ?? CardPresentPaymentAlertsPresenter(rootViewController: rootViewController)
+        self.alertsPresenter = alertsPresenter
         self.configuration = configuration
         self.stores = stores
         self.paymentOrchestrator = paymentOrchestrator
-        self.preflightController = preflightController ?? CardPresentPaymentPreflightController(siteID: siteID,
-                                                                                                configuration: configuration,
-                                                                                                rootViewController: rootViewController,
-                                                                                                alertsPresenter: self.alertsPresenter,
-                                                                                                onboardingPresenter: onboardingPresenter)
+        self.preflightController = preflightController
         self.analyticsTracker = analyticsTracker ?? CollectOrderPaymentAnalytics(siteID: siteID,
                                                                                  analytics: ServiceLocator.analytics,
                                                                                  configuration: configuration,

--- a/WooCommerce/Classes/ViewRelated/Orders/Payment Methods/PaymentMethodsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Payment Methods/PaymentMethodsViewModel.swift
@@ -205,6 +205,8 @@ final class PaymentMethodsViewModel: ObservableObject {
             DDLogError("⛔️ Order not found, can't collect payment.")
             return presentNoticeSubject.send(.error(Localization.genericCollectError))
         }
+        let alertsPresenter = CardPresentPaymentAlertsPresenter(rootViewController: rootViewController)
+        let configuration = CardPresentConfigurationLoader().configuration
 
         collectPaymentsUseCase = useCase ?? CollectOrderPaymentUseCase(
             siteID: self.siteID,
@@ -212,7 +214,15 @@ final class PaymentMethodsViewModel: ObservableObject {
             formattedAmount: self.formattedTotal,
             rootViewController: rootViewController,
             onboardingPresenter: self.cardPresentPaymentsOnboardingPresenter,
-            configuration: CardPresentConfigurationLoader().configuration)
+            configuration: CardPresentConfigurationLoader().configuration,
+            alertsPresenter: alertsPresenter,
+            tapToPayAlertsProvider: BuiltInCardReaderPaymentAlertsProvider(),
+            bluetoothAlertsProvider: BluetoothCardReaderPaymentAlertsProvider(transactionType: .collectPayment),
+            preflightController: CardPresentPaymentPreflightController(siteID: siteID,
+                                                                       configuration: configuration,
+                                                                       rootViewController: rootViewController,
+                                                                       alertsPresenter: alertsPresenter,
+                                                                       onboardingPresenter: self.cardPresentPaymentsOnboardingPresenter))
 
         collectPaymentsUseCase?.collectPayment(
             using: discoveryMethod,

--- a/WooCommerce/WooCommerceTests/ViewModels/CardPresentPayments/CollectOrderPaymentUseCaseTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewModels/CardPresentPayments/CollectOrderPaymentUseCaseTests.swift
@@ -47,6 +47,8 @@ final class CollectOrderPaymentUseCaseTests: XCTestCase {
                                              stores: stores,
                                              paymentOrchestrator: mockPaymentOrchestrator,
                                              alertsPresenter: alertsPresenter,
+                                             tapToPayAlertsProvider: BuiltInCardReaderPaymentAlertsProvider(),
+                                             bluetoothAlertsProvider: BluetoothCardReaderPaymentAlertsProvider(transactionType: .collectPayment),
                                              preflightController: mockPreflightController,
                                              analyticsTracker: mockAnalyticsTracker)
     }
@@ -101,6 +103,8 @@ final class CollectOrderPaymentUseCaseTests: XCTestCase {
                                                  stores: stores,
                                                  paymentOrchestrator: mockPaymentOrchestrator,
                                                  alertsPresenter: alertsPresenter,
+                                                 tapToPayAlertsProvider: BuiltInCardReaderPaymentAlertsProvider(),
+                                                 bluetoothAlertsProvider: BluetoothCardReaderPaymentAlertsProvider(transactionType: .collectPayment),
                                                  preflightController: mockPreflightController,
                                                  analyticsTracker: mockAnalyticsTracker)
 

--- a/WooCommerce/WooCommerceTests/ViewModels/CardPresentPayments/CollectOrderPaymentUseCaseTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewModels/CardPresentPayments/CollectOrderPaymentUseCaseTests.swift
@@ -139,8 +139,8 @@ final class CollectOrderPaymentUseCaseTests: XCTestCase {
 
         // Then
         XCTAssert(mockAnalyticsTracker.didCallTrackPaymentFailure)
-        let receivedError = try XCTUnwrap(mockAnalyticsTracker.spyTrackPaymentFailureError as? CollectOrderPaymentUseCase.NotValidAmountError)
-        assertEqual(CollectOrderPaymentUseCase.NotValidAmountError.belowMinimumAmount(amount: "$0.50"), receivedError)
+        let receivedError = try XCTUnwrap(mockAnalyticsTracker.spyTrackPaymentFailureError as? CollectOrderPaymentUseCaseNotValidAmountError)
+        assertEqual(CollectOrderPaymentUseCaseNotValidAmountError.belowMinimumAmount(amount: "$0.50"), receivedError)
     }
 
     func test_collectPayment_with_interac_dispatches_markOrderAsPaidLocally_after_successful_client_side_capture() throws {


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of: #12868
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

This PR forms part of a series, together making the alert providers and presenters used in card payments generic.

When complete, this will mean that the POS experience can use different alert view models from the existing app's CardPresentPaymentModalViewModel, specialised for the new design, while continuing to use all the existing payments logic.

This first PR prepares for the change by moving some static definitions out of classes which will rely on the new generics, as that's not permitted, and moves to passing the alert related dependencies in rather than building them in the `init`. That's so that we can give different concrete implementations from the different places we use the payments code.

## Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->

Check the existing payments work as expected in the main app, and that the POS reader connection works as well.

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.