### PR TITLE
[Woo POS] Use generic models for payment alerts

### DIFF
--- a/WooCommerce/Classes/POS/Card Present Payments/CardPresentPaymentCollectOrderPaymentUseCaseAdaptor.swift
+++ b/WooCommerce/Classes/POS/Card Present Payments/CardPresentPaymentCollectOrderPaymentUseCaseAdaptor.swift
@@ -17,14 +17,16 @@ struct CardPresentPaymentCollectOrderPaymentUseCaseAdaptor {
                             preflightController: CardPresentPaymentPreflightController,
                             onboardingPresenter: CardPresentPaymentsOnboardingPresenting,
                             configuration: CardPresentPaymentsConfiguration,
-                            alertsPresenter: CardPresentPaymentAlertsPresenting,
+                            alertsPresenter: CardPresentPaymentsAlertPresenterAdaptor,
                             paymentEventSubject: any Subject<CardPresentPaymentEvent, Never>) -> Task<CardPresentPaymentAdaptedCollectOrderPaymentResult, Error> {
         return Task {
             guard let formattedAmount = currencyFormatter.formatAmount(order.total, with: order.currency) else {
                 throw CardPresentPaymentServiceError.invalidAmount
             }
 
-            let orderPaymentUseCase = CollectOrderPaymentUseCase(
+            let orderPaymentUseCase = CollectOrderPaymentUseCase<BuiltInCardReaderPaymentAlertsProvider,
+                                                                 BluetoothCardReaderPaymentAlertsProvider,
+                                                                    CardPresentPaymentsAlertPresenterAdaptor>(
                 siteID: siteID,
                 order: order,
                 formattedAmount: formattedAmount,

--- a/WooCommerce/Classes/POS/Card Present Payments/CardPresentPaymentService.swift
+++ b/WooCommerce/Classes/POS/Card Present Payments/CardPresentPaymentService.swift
@@ -15,7 +15,7 @@ final class CardPresentPaymentService: CardPresentPaymentFacade {
 
     private let onboardingAdaptor: CardPresentPaymentsOnboardingPresenterAdaptor
 
-    private let paymentAlertsPresenterAdaptor: CardPresentPaymentAlertsPresenting
+    private let paymentAlertsPresenterAdaptor: CardPresentPaymentsAlertPresenterAdaptor
     private let connectionControllerManager: CardPresentPaymentsConnectionControllerManager
 
     private let siteID: Int64

--- a/WooCommerce/Classes/POS/Card Present Payments/CardPresentPaymentsAlertPresenterAdaptor.swift
+++ b/WooCommerce/Classes/POS/Card Present Payments/CardPresentPaymentsAlertPresenterAdaptor.swift
@@ -2,6 +2,7 @@ import Foundation
 import Combine
 
 final class CardPresentPaymentsAlertPresenterAdaptor: CardPresentPaymentAlertsPresenting {
+    typealias AlertDetails = CardPresentPaymentsModalViewModel
     let paymentAlertPublisher: AnyPublisher<CardPresentPaymentEvent, Never>
 
     private let paymentAlertSubject: PassthroughSubject<CardPresentPaymentEvent, Never> = PassthroughSubject()

--- a/WooCommerce/Classes/POS/Card Present Payments/CardPresentPaymentsConnectionControllerManager.swift
+++ b/WooCommerce/Classes/POS/Card Present Payments/CardPresentPaymentsConnectionControllerManager.swift
@@ -7,7 +7,7 @@ final class CardPresentPaymentsConnectionControllerManager {
 
     init(siteID: Int64,
          configuration: CardPresentPaymentsConfiguration,
-         alertsPresenter: CardPresentPaymentAlertsPresenting) {
+         alertsPresenter: any CardPresentPaymentAlertsPresenting<CardPresentPaymentsModalViewModel>) {
         let analyticsTracker = CardReaderConnectionAnalyticsTracker(
             configuration: configuration,
             siteID: siteID,

--- a/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsPaymentAlerts.swift
+++ b/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsPaymentAlerts.swift
@@ -29,7 +29,7 @@ final class OrderDetailsPaymentAlerts: OrderDetailsPaymentAlertsProtocol {
 
     private let transactionType: CardPresentTransactionType
 
-    private let alertsProvider: CardReaderTransactionAlertsProviding
+    private let alertsProvider: BluetoothCardReaderPaymentAlertsProvider
 
     init(transactionType: CardPresentTransactionType,
          presentingController: UIViewController) {

--- a/WooCommerce/Classes/ViewRelated/CardPresentPayments/BuiltInCardReaderConnectionController.swift
+++ b/WooCommerce/Classes/ViewRelated/CardPresentPayments/BuiltInCardReaderConnectionController.swift
@@ -76,7 +76,7 @@ final class BuiltInCardReaderConnectionController: BuiltInCardReaderConnectionCo
     }
 
     private let siteID: Int64
-    private let alertsPresenter: CardPresentPaymentAlertsPresenting
+    private let alertsPresenter: any CardPresentPaymentAlertsPresenting<CardPresentPaymentsModalViewModel>
     private let configuration: CardPresentPaymentsConfiguration
 
     private let alertsProvider: CardReaderConnectionAlertsProviding
@@ -113,7 +113,7 @@ final class BuiltInCardReaderConnectionController: BuiltInCardReaderConnectionCo
         forSiteID: Int64,
         storageManager: StorageManagerType = ServiceLocator.storageManager,
         stores: StoresManager = ServiceLocator.stores,
-        alertsPresenter: CardPresentPaymentAlertsPresenting,
+        alertsPresenter: any CardPresentPaymentAlertsPresenting<CardPresentPaymentsModalViewModel>,
         alertsProvider: CardReaderConnectionAlertsProviding,
         configuration: CardPresentPaymentsConfiguration,
         analyticsTracker: CardReaderConnectionAnalyticsTracker,

--- a/WooCommerce/Classes/ViewRelated/CardPresentPayments/CardPresentPaymentPreflightController.swift
+++ b/WooCommerce/Classes/ViewRelated/CardPresentPayments/CardPresentPaymentPreflightController.swift
@@ -32,7 +32,7 @@ final class CardPresentPaymentPreflightController: CardPresentPaymentPreflightCo
 
     /// Alerts presenter to send alert view models
     ///
-    private var alertsPresenter: CardPresentPaymentAlertsPresenting
+    private var alertsPresenter: any CardPresentPaymentAlertsPresenting<CardPresentPaymentsModalViewModel>
 
     /// Stores manager.
     ///
@@ -78,7 +78,7 @@ final class CardPresentPaymentPreflightController: CardPresentPaymentPreflightCo
     init(siteID: Int64,
          configuration: CardPresentPaymentsConfiguration,
          rootViewController: ViewControllerPresenting,
-         alertsPresenter: CardPresentPaymentAlertsPresenting,
+         alertsPresenter: any CardPresentPaymentAlertsPresenting<CardPresentPaymentsModalViewModel>,
          onboardingPresenter: CardPresentPaymentsOnboardingPresenting,
          externalReaderConnectionController: CardReaderConnectionController? = nil,
          tapToPayConnectionController: BuiltInCardReaderConnectionController? = nil,

--- a/WooCommerce/Classes/ViewRelated/CardPresentPayments/CardReaderConnectionController.swift
+++ b/WooCommerce/Classes/ViewRelated/CardPresentPayments/CardReaderConnectionController.swift
@@ -80,7 +80,7 @@ final class CardReaderConnectionController {
 
     private let siteID: Int64
     private let knownCardReaderProvider: CardReaderSettingsKnownReaderProvider
-    private let alertsPresenter: CardPresentPaymentAlertsPresenting
+    private let alertsPresenter: any CardPresentPaymentAlertsPresenting<CardPresentPaymentsModalViewModel>
     private let configuration: CardPresentPaymentsConfiguration
 
     private let alertsProvider: BluetoothReaderConnnectionAlertsProviding
@@ -135,7 +135,7 @@ final class CardReaderConnectionController {
         storageManager: StorageManagerType = ServiceLocator.storageManager,
         stores: StoresManager = ServiceLocator.stores,
         knownReaderProvider: CardReaderSettingsKnownReaderProvider,
-        alertsPresenter: CardPresentPaymentAlertsPresenting,
+        alertsPresenter: any CardPresentPaymentAlertsPresenting<CardPresentPaymentsModalViewModel>,
         alertsProvider: BluetoothReaderConnnectionAlertsProviding,
         configuration: CardPresentPaymentsConfiguration,
         analyticsTracker: CardReaderConnectionAnalyticsTracker

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/CardReaderSettingsSearchingViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/CardReaderSettingsSearchingViewController.swift
@@ -10,7 +10,7 @@ final class CardReaderSettingsSearchingViewController: UIHostingController<CardR
 
     private var viewModel: CardReaderSettingsSearchingViewModel
 
-    private lazy var alertsPresenter: CardPresentPaymentAlertsPresenting = CardPresentPaymentAlertsPresenter(rootViewController: self)
+    private lazy var alertsPresenter: CardPresentPaymentAlertsPresenter = CardPresentPaymentAlertsPresenter(rootViewController: self)
 
     private let alertsProvider: BluetoothReaderConnnectionAlertsProviding = BluetoothReaderConnectionAlertsProvider()
 

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/CardReaderTransactionAlertsProviding.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/CardReaderTransactionAlertsProviding.swift
@@ -5,48 +5,49 @@ import Yosemite
 /// alert viewModels such a provider is expected to provide over the course of performind
 /// a card present transaction (payment or refund.)
 ///
-protocol CardReaderTransactionAlertsProviding {
+protocol CardReaderTransactionAlertsProviding<AlertDetails> {
+    associatedtype AlertDetails
     /// A cancellable alert indicating that we are checking the order at the start of a payment flow
     ///
-    func validatingOrder(onCancel: @escaping () -> Void) -> CardPresentPaymentsModalViewModel
+    func validatingOrder(onCancel: @escaping () -> Void) -> AlertDetails
 
     /// A cancellable alert indicating we are preparing a reader to collect card details
     ///
-    func preparingReader(onCancel: @escaping () -> Void) -> CardPresentPaymentsModalViewModel
+    func preparingReader(onCancel: @escaping () -> Void) -> AlertDetails
 
     /// A cancellable alert indicating the reader is ready to collect card details
     ///
     func tapOrInsertCard(title: String,
                          amount: String,
                          inputMethods: CardReaderInput,
-                         onCancel: @escaping () -> Void) -> CardPresentPaymentsModalViewModel
+                         onCancel: @escaping () -> Void) -> AlertDetails
 
     /// An alert to display a message from a reader
     ///
-    func displayReaderMessage(message: String) -> CardPresentPaymentsModalViewModel
+    func displayReaderMessage(message: String) -> AlertDetails
 
     /// An alert to show that the transaction is being processed
     ///
-    func processingTransaction(title: String) -> CardPresentPaymentsModalViewModel
+    func processingTransaction(title: String) -> AlertDetails
 
     /// An alert to display successful transaction and provide options related to receipts
     ///
     func success(printReceipt: @escaping () -> Void,
                  emailReceipt: @escaping () -> Void,
-                 noReceiptAction: @escaping () -> Void) -> CardPresentPaymentsModalViewModel
+                 noReceiptAction: @escaping () -> Void) -> AlertDetails
 
     /// An alert to display a retriable and cancellable error
     ///
     func error(error: Error,
                tryAgain: @escaping () -> Void,
-               dismissCompletion: @escaping () -> Void) -> CardPresentPaymentsModalViewModel
+               dismissCompletion: @escaping () -> Void) -> AlertDetails
 
     /// An alert to display a non-retriable and cancellable error
     ///
     func nonRetryableError(error: Error,
-                           dismissCompletion: @escaping () -> Void) -> CardPresentPaymentsModalViewModel
+                           dismissCompletion: @escaping () -> Void) -> AlertDetails
 
     /// An alert to notify the merchant that the transaction was cancelled using a button on the reader
     ///
-    func cancelledOnReader() -> CardPresentPaymentsModalViewModel?
+    func cancelledOnReader() -> AlertDetails?
 }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/SetUpTapToPayInformationViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/SetUpTapToPayInformationViewModel.swift
@@ -24,7 +24,7 @@ final class SetUpTapToPayInformationViewModel: PaymentSettingsFlowPresentedViewM
     private let analytics: Analytics = ServiceLocator.analytics
 
     var connectionController: BuiltInCardReaderConnectionController? = nil
-    var alertsPresenter: CardPresentPaymentAlertsPresenting? = nil
+    var alertsPresenter: (any CardPresentPaymentAlertsPresenting)? = nil
 
     private(set) var noConnectedReader: CardReaderSettingsTriState = .isUnknown {
         didSet {

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/SilenceablePassthroughCardPresentPaymentAlertsPresenter.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/SilenceablePassthroughCardPresentPaymentAlertsPresenter.swift
@@ -3,7 +3,7 @@ import Combine
 
 final class SilenceablePassthroughCardPresentPaymentAlertsPresenter: CardPresentPaymentAlertsPresenting {
     private var alertSubject: CurrentValueSubject<CardPresentPaymentsModalViewModel?, Never> = CurrentValueSubject(nil)
-    private var alertsPresenter: CardPresentPaymentAlertsPresenting?
+    private var alertsPresenter: (any CardPresentPaymentAlertsPresenting<CardPresentPaymentsModalViewModel>)?
 
     private var alertSubscription: AnyCancellable? = nil
 
@@ -28,7 +28,7 @@ final class SilenceablePassthroughCardPresentPaymentAlertsPresenter: CardPresent
         alertsPresenter?.dismiss()
     }
 
-    func startPresentingAlerts(from alertsPresenter: CardPresentPaymentAlertsPresenting) {
+    func startPresentingAlerts(from alertsPresenter: any CardPresentPaymentAlertsPresenting<CardPresentPaymentsModalViewModel>) {
         self.alertsPresenter = alertsPresenter
         alertSubscription = alertSubject.share().sink { viewModel in
             DispatchQueue.main.async {

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/TapToPayReconnectionController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/TapToPayReconnectionController.swift
@@ -3,7 +3,7 @@ import Yosemite
 
 protocol BuiltInCardReaderConnectionControllerBuilding {
     func createConnectionController(forSiteID: Int64,
-                                    alertsPresenter: CardPresentPaymentAlertsPresenting,
+                                    alertsPresenter: any CardPresentPaymentAlertsPresenting<CardPresentPaymentsModalViewModel>,
                                     configuration: CardPresentPaymentsConfiguration,
                                     analyticsTracker: CardReaderConnectionAnalyticsTracker,
                                     allowTermsOfServiceAcceptance: Bool) -> BuiltInCardReaderConnectionControlling
@@ -11,7 +11,7 @@ protocol BuiltInCardReaderConnectionControllerBuilding {
 
 fileprivate class BuiltInCardReaderConnectionControllerFactory: BuiltInCardReaderConnectionControllerBuilding {
     func createConnectionController(forSiteID siteID: Int64,
-                                    alertsPresenter: CardPresentPaymentAlertsPresenting,
+                                    alertsPresenter: any CardPresentPaymentAlertsPresenting<CardPresentPaymentsModalViewModel>,
                                     configuration: CardPresentPaymentsConfiguration,
                                     analyticsTracker: CardReaderConnectionAnalyticsTracker,
                                     allowTermsOfServiceAcceptance: Bool) -> BuiltInCardReaderConnectionControlling {
@@ -91,7 +91,7 @@ final class TapToPayReconnectionController {
     ///   - alertsPresenter: The alerts presenter which can show the connection alerts.
     ///   It will be immediately called with the most recent alert
     ///   - onCompletion: A completion handler for the automatic reconnection, with success or an error.
-    func showAlertsForReconnection(from alertsPresenter: CardPresentPaymentAlertsPresenting,
+    func showAlertsForReconnection(from alertsPresenter: any CardPresentPaymentAlertsPresenting<CardPresentPaymentsModalViewModel>,
                                    onCompletion: @escaping (Result<CardReaderConnectionResult, Error>) -> Void) {
         guard isReconnecting else {
             return onCompletion(.failure(TapToPayReconnectionError.noReconnectionInProgress))

--- a/WooCommerce/Classes/ViewRelated/Orders/Collect Payments/CardPresentPaymentAlertsPresenter.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Collect Payments/CardPresentPaymentAlertsPresenter.swift
@@ -2,8 +2,9 @@ import Foundation
 import SwiftUI
 import UIKit
 
-protocol CardPresentPaymentAlertsPresenting {
-    func present(viewModel: CardPresentPaymentsModalViewModel)
+protocol CardPresentPaymentAlertsPresenting<AlertDetails> {
+    associatedtype AlertDetails
+    func present(viewModel: AlertDetails)
     func presentWCSettingsWebView(adminURL: URL, completion: @escaping () -> Void)
     func foundSeveralReaders(readerIDs: [String],
                              connect: @escaping (String) -> Void,

--- a/WooCommerce/Classes/ViewRelated/Orders/Collect Payments/CollectOrderPaymentUseCase.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Collect Payments/CollectOrderPaymentUseCase.swift
@@ -29,7 +29,9 @@ protocol CollectOrderPaymentProtocol {
 /// Use case to collect payments from an order.
 /// Orchestrates reader connection, payment, UI alerts, receipt handling and analytics.
 ///
-final class CollectOrderPaymentUseCase<BuiltInAlertProvider: CardReaderTransactionAlertsProviding, BluetoothAlertProvider: CardReaderTransactionAlertsProviding, AlertPresenter: CardPresentPaymentAlertsPresenting>:
+final class CollectOrderPaymentUseCase<BuiltInAlertProvider: CardReaderTransactionAlertsProviding, 
+                                        BluetoothAlertProvider: CardReaderTransactionAlertsProviding,
+                                        AlertPresenter: CardPresentPaymentAlertsPresenting>:
     NSObject, CollectOrderPaymentProtocol where BuiltInAlertProvider.AlertDetails == AlertPresenter.AlertDetails,
                                                 BluetoothAlertProvider.AlertDetails == AlertPresenter.AlertDetails {
     /// Currency Formatter
@@ -512,7 +514,8 @@ private extension CollectOrderPaymentUseCase {
     /// Allow merchants to print or email backend-generated receipts.
     /// The alerts presenter can be simplified once we remove legacy receipts: https://github.com/woocommerce/woocommerce-ios/issues/11897
     ///
-    func presentBackendReceiptAlert(alertProvider paymentAlerts: any CardReaderTransactionAlertsProviding<AlertPresenter.AlertDetails>, onCompleted: @escaping () -> ()) {
+    func presentBackendReceiptAlert(alertProvider paymentAlerts: any CardReaderTransactionAlertsProviding<AlertPresenter.AlertDetails>, 
+                                    onCompleted: @escaping () -> ()) {
         // Handles receipt presentation for both print and email actions
         let receiptPresentationCompletionAction: () -> Void = { [weak self] in
             guard let self else { return }

--- a/WooCommerce/Classes/ViewRelated/Orders/Collect Payments/CollectOrderPaymentUseCase.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Collect Payments/CollectOrderPaymentUseCase.swift
@@ -29,7 +29,7 @@ protocol CollectOrderPaymentProtocol {
 /// Use case to collect payments from an order.
 /// Orchestrates reader connection, payment, UI alerts, receipt handling and analytics.
 ///
-final class CollectOrderPaymentUseCase<BuiltInAlertProvider: CardReaderTransactionAlertsProviding, 
+final class CollectOrderPaymentUseCase<BuiltInAlertProvider: CardReaderTransactionAlertsProviding,
                                         BluetoothAlertProvider: CardReaderTransactionAlertsProviding,
                                         AlertPresenter: CardPresentPaymentAlertsPresenting>:
     NSObject, CollectOrderPaymentProtocol where BuiltInAlertProvider.AlertDetails == AlertPresenter.AlertDetails,
@@ -514,7 +514,7 @@ private extension CollectOrderPaymentUseCase {
     /// Allow merchants to print or email backend-generated receipts.
     /// The alerts presenter can be simplified once we remove legacy receipts: https://github.com/woocommerce/woocommerce-ios/issues/11897
     ///
-    func presentBackendReceiptAlert(alertProvider paymentAlerts: any CardReaderTransactionAlertsProviding<AlertPresenter.AlertDetails>, 
+    func presentBackendReceiptAlert(alertProvider paymentAlerts: any CardReaderTransactionAlertsProviding<AlertPresenter.AlertDetails>,
                                     onCompleted: @escaping () -> ()) {
         // Handles receipt presentation for both print and email actions
         let receiptPresentationCompletionAction: () -> Void = { [weak self] in

--- a/WooCommerce/Classes/ViewRelated/Orders/Payment Methods/PaymentMethodsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Payment Methods/PaymentMethodsViewModel.swift
@@ -208,7 +208,9 @@ final class PaymentMethodsViewModel: ObservableObject {
         let alertsPresenter = CardPresentPaymentAlertsPresenter(rootViewController: rootViewController)
         let configuration = CardPresentConfigurationLoader().configuration
 
-        collectPaymentsUseCase = useCase ?? CollectOrderPaymentUseCase(
+        collectPaymentsUseCase = useCase ?? CollectOrderPaymentUseCase<BuiltInCardReaderPaymentAlertsProvider,
+                                                                        BluetoothCardReaderPaymentAlertsProvider,
+                                                                        CardPresentPaymentAlertsPresenter>(
             siteID: self.siteID,
             order: order,
             formattedAmount: self.formattedTotal,

--- a/WooCommerce/WooCommerceTests/Mocks/MockBuiltInCardReaderConnectionControllerFactory.swift
+++ b/WooCommerce/WooCommerceTests/Mocks/MockBuiltInCardReaderConnectionControllerFactory.swift
@@ -4,7 +4,7 @@ import Yosemite
 
 class MockBuiltInCardReaderConnectionControllerFactory: BuiltInCardReaderConnectionControllerBuilding {
     var spyCreateConnectionControllerSiteID: Int64? = nil
-    var spyCreateConnectionControllerAlertsPresenter: CardPresentPaymentAlertsPresenting? = nil
+    var spyCreateConnectionControllerAlertsPresenter: (any CardPresentPaymentAlertsPresenting)? = nil
     var spyCreateConnectionControllerConfiguration: CardPresentPaymentsConfiguration? = nil
     var spyCreateConnectionControllerAnalyticsTracker: CardReaderConnectionAnalyticsTracker? = nil
     var spyCreateConnectionControllerAllowTermsOfServiceAcceptance: Bool? = nil
@@ -14,7 +14,7 @@ class MockBuiltInCardReaderConnectionControllerFactory: BuiltInCardReaderConnect
     var mockConnectionController: MockBuiltInCardReaderConnectionController? = nil
 
     func createConnectionController(forSiteID siteID: Int64,
-                                    alertsPresenter: CardPresentPaymentAlertsPresenting,
+                                    alertsPresenter: any CardPresentPaymentAlertsPresenting<CardPresentPaymentsModalViewModel>,
                                     configuration: CardPresentPaymentsConfiguration,
                                     analyticsTracker: CardReaderConnectionAnalyticsTracker,
                                     allowTermsOfServiceAcceptance: Bool) -> BuiltInCardReaderConnectionControlling {

--- a/WooCommerce/WooCommerceTests/ViewModels/CardPresentPayments/CollectOrderPaymentUseCaseTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewModels/CardPresentPayments/CollectOrderPaymentUseCaseTests.swift
@@ -16,7 +16,9 @@ final class CollectOrderPaymentUseCaseTests: XCTestCase {
     private var mockPreflightController: MockCardPresentPaymentPreflightController!
     private var mockAnalyticsTracker: MockCollectOrderPaymentAnalyticsTracker!
     private var mockPaymentOrchestrator: MockPaymentCaptureOrchestrator!
-    private var useCase: CollectOrderPaymentUseCase!
+    private var useCase: CollectOrderPaymentUseCase<BuiltInCardReaderPaymentAlertsProvider,
+                                                        BluetoothCardReaderPaymentAlertsProvider,
+                                                        MockCardPresentPaymentAlertsPresenter>!
 
     override func setUp() {
         super.setUp()
@@ -94,19 +96,22 @@ final class CollectOrderPaymentUseCaseTests: XCTestCase {
     func test_collectPayment_with_below_minimum_amount_results_in_failure_and_tracks_collectPaymentFailed_event() throws {
         // Given
         let order = Order.fake().copy(total: "0.49")
-        let useCase = CollectOrderPaymentUseCase(siteID: 122,
-                                                 order: order,
-                                                 formattedAmount: "0.49",
-                                                 rootViewController: MockViewControllerPresenting(),
-                                                 onboardingPresenter: onboardingPresenter,
-                                                 configuration: Mocks.configuration,
-                                                 stores: stores,
-                                                 paymentOrchestrator: mockPaymentOrchestrator,
-                                                 alertsPresenter: alertsPresenter,
-                                                 tapToPayAlertsProvider: BuiltInCardReaderPaymentAlertsProvider(),
-                                                 bluetoothAlertsProvider: BluetoothCardReaderPaymentAlertsProvider(transactionType: .collectPayment),
-                                                 preflightController: mockPreflightController,
-                                                 analyticsTracker: mockAnalyticsTracker)
+        let useCase = CollectOrderPaymentUseCase<BuiltInCardReaderPaymentAlertsProvider,
+                                                    BluetoothCardReaderPaymentAlertsProvider,
+                                                    MockCardPresentPaymentAlertsPresenter>(
+            siteID: 122,
+            order: order,
+            formattedAmount: "0.49",
+            rootViewController: MockViewControllerPresenting(),
+            onboardingPresenter: onboardingPresenter,
+            configuration: Mocks.configuration,
+            stores: stores,
+            paymentOrchestrator: mockPaymentOrchestrator,
+            alertsPresenter: alertsPresenter,
+            tapToPayAlertsProvider: BuiltInCardReaderPaymentAlertsProvider(),
+            bluetoothAlertsProvider: BluetoothCardReaderPaymentAlertsProvider(transactionType: .collectPayment),
+            preflightController: mockPreflightController,
+            analyticsTracker: mockAnalyticsTracker)
 
         stores.whenReceivingAction(ofType: OrderAction.self) { action in
             switch action {


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of: #12868
Merge after #13036
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

This PR forms part of a series, together making the alert providers and presenters used in card payments generic.

When complete, this will mean that the POS experience can use different alert view models from the existing app's CardPresentPaymentModalViewModel, specialised for the new design, while continuing to use all the existing payments logic.

This second PR updates the payment alerts to have generics in their definitions, but all callers still use the concrete implementation `CardPresentPaymentsModalViewModel` because the connection controllers also use the same alert presenters, and those aren't able to use generics yet. This means that with this PR, we're still constrained to using the same view model in all uses.

## Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->

Check the existing payments work as expected in the main app, and that the POS reader connection works as well.

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary