### PR TITLE
[Woo POS] use custom alert providers connection prep

### DIFF
--- a/WooCommerce/Classes/POS/Card Present Payments/CardPresentPaymentService.swift
+++ b/WooCommerce/Classes/POS/Card Present Payments/CardPresentPaymentService.swift
@@ -149,6 +149,7 @@ private extension CardPresentPaymentService {
             onboardingPresenter: onboardingAdaptor,
             externalReaderConnectionController: connectionControllerManager.externalReaderConnectionController,
             tapToPayConnectionController: connectionControllerManager.tapToPayConnectionController,
+            tapToPayAlertProvider: BuiltInReaderConnectionAlertsProvider(),
             analyticsTracker: connectionControllerManager.analyticsTracker)
     }
 }

--- a/WooCommerce/Classes/POS/Card Present Payments/CardPresentPaymentService.swift
+++ b/WooCommerce/Classes/POS/Card Present Payments/CardPresentPaymentService.swift
@@ -148,7 +148,8 @@ private extension CardPresentPaymentService {
             alertsPresenter: paymentAlertsPresenterAdaptor,
             onboardingPresenter: onboardingAdaptor,
             externalReaderConnectionController: connectionControllerManager.externalReaderConnectionController,
-            tapToPayConnectionController: connectionControllerManager.tapToPayConnectionController)
+            tapToPayConnectionController: connectionControllerManager.tapToPayConnectionController,
+            analyticsTracker: connectionControllerManager.analyticsTracker)
     }
 }
 

--- a/WooCommerce/Classes/POS/Card Present Payments/CardPresentPaymentsConnectionControllerManager.swift
+++ b/WooCommerce/Classes/POS/Card Present Payments/CardPresentPaymentsConnectionControllerManager.swift
@@ -4,6 +4,7 @@ import struct Yosemite.CardPresentPaymentsConfiguration
 final class CardPresentPaymentsConnectionControllerManager {
     let externalReaderConnectionController: CardReaderConnectionController
     let tapToPayConnectionController: BuiltInCardReaderConnectionController
+    let analyticsTracker: CardReaderConnectionAnalyticsTracker
 
     init(siteID: Int64,
          configuration: CardPresentPaymentsConfiguration,
@@ -12,6 +13,7 @@ final class CardPresentPaymentsConnectionControllerManager {
             configuration: configuration,
             siteID: siteID,
             connectionType: .userInitiated)
+        self.analyticsTracker = analyticsTracker
         self.externalReaderConnectionController = CardReaderConnectionController(
             forSiteID: siteID,
             knownReaderProvider: CardReaderSettingsKnownReaderStorage(),

--- a/WooCommerce/Classes/ViewRelated/CardPresentPayments/CardPresentPaymentPreflightController.swift
+++ b/WooCommerce/Classes/ViewRelated/CardPresentPayments/CardPresentPaymentPreflightController.swift
@@ -80,9 +80,10 @@ final class CardPresentPaymentPreflightController: CardPresentPaymentPreflightCo
          rootViewController: ViewControllerPresenting,
          alertsPresenter: any CardPresentPaymentAlertsPresenting<CardPresentPaymentsModalViewModel>,
          onboardingPresenter: CardPresentPaymentsOnboardingPresenting,
-         externalReaderConnectionController: CardReaderConnectionController? = nil,
-         tapToPayConnectionController: BuiltInCardReaderConnectionController? = nil,
+         externalReaderConnectionController: CardReaderConnectionController,
+         tapToPayConnectionController: BuiltInCardReaderConnectionController,
          tapToPayReconnectionController: TapToPayReconnectionController = ServiceLocator.tapToPayReconnectionController,
+         analyticsTracker: CardReaderConnectionAnalyticsTracker,
          stores: StoresManager = ServiceLocator.stores,
          analytics: Analytics = ServiceLocator.analytics) {
         self.siteID = siteID
@@ -94,25 +95,9 @@ final class CardPresentPaymentPreflightController: CardPresentPaymentPreflightCo
         self.stores = stores
         self.analytics = analytics
         self.connectedReader = nil
-        self.analyticsTracker = CardReaderConnectionAnalyticsTracker(configuration: configuration,
-                                                                     siteID: siteID,
-                                                                     connectionType: .userInitiated,
-                                                                     stores: stores,
-                                                                     analytics: analytics)
-        self.connectionController = externalReaderConnectionController ?? CardReaderConnectionController(
-            forSiteID: siteID,
-            knownReaderProvider: CardReaderSettingsKnownReaderStorage(),
-            alertsPresenter: alertsPresenter,
-            alertsProvider: BluetoothReaderConnectionAlertsProvider(),
-            configuration: configuration,
-            analyticsTracker: analyticsTracker)
-
-        self.builtInConnectionController = tapToPayConnectionController ?? BuiltInCardReaderConnectionController(
-            forSiteID: siteID,
-            alertsPresenter: alertsPresenter,
-            alertsProvider: BuiltInReaderConnectionAlertsProvider(),
-            configuration: configuration,
-            analyticsTracker: analyticsTracker)
+        self.analyticsTracker = analyticsTracker
+        self.connectionController = externalReaderConnectionController
+        self.builtInConnectionController = tapToPayConnectionController
 
         self.supportDeterminer = CardReaderSupportDeterminer(siteID: siteID, configuration: configuration, stores: stores)
     }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/BluetoothReaderConnectionAlertsProvider.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/BluetoothReaderConnectionAlertsProvider.swift
@@ -54,6 +54,12 @@ struct BluetoothReaderConnectionAlertsProvider: BluetoothReaderConnnectionAlerts
         CardPresentModalUpdateProgress(requiredUpdate: requiredUpdate, progress: progress, cancel: cancel)
     }
 
+    func selectSearchType(tapToPay: @escaping () -> Void,
+                          bluetooth: @escaping () -> Void,
+                          cancel: @escaping () -> Void) -> CardPresentPaymentsModalViewModel {
+        CardPresentModalSelectSearchType(tapOnIPhoneAction: tapToPay, bluetoothAction: bluetooth, cancelAction: cancel)
+    }
+
     func foundReader(name: String,
                      connect: @escaping () -> Void,
                      continueSearch: @escaping () -> Void,

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/BuiltInReaderConnectionAlertsProvider.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/BuiltInReaderConnectionAlertsProvider.swift
@@ -61,4 +61,10 @@ struct BuiltInReaderConnectionAlertsProvider: CardReaderConnectionAlertsProvidin
                         cancel: (() -> Void)?) -> CardPresentPaymentsModalViewModel {
         CardPresentModalBuiltInConfigurationProgress(progress: progress, cancel: cancel)
     }
+
+    func selectSearchType(tapToPay: @escaping () -> Void,
+                          bluetooth: @escaping () -> Void,
+                          cancel: @escaping () -> Void) -> CardPresentPaymentsModalViewModel {
+        CardPresentModalSelectSearchType(tapOnIPhoneAction: tapToPay, bluetoothAction: bluetooth, cancelAction: cancel)
+    }
 }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/CardReaderConnectionAlertsProviding.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/CardReaderConnectionAlertsProviding.swift
@@ -53,6 +53,10 @@ protocol CardReaderConnectionAlertsProviding {
     /// Shows progress when a software update is being installed
     ///
     func updateProgress(requiredUpdate: Bool, progress: Float, cancel: (() -> Void)?) -> CardPresentPaymentsModalViewModel
+
+    func selectSearchType(tapToPay: @escaping () -> Void,
+                          bluetooth: @escaping () -> Void,
+                          cancel: @escaping () -> Void) -> CardPresentPaymentsModalViewModel
 }
 
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Issue Refunds/RefundConfirmationViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Issue Refunds/RefundConfirmationViewModel.swift
@@ -98,6 +98,8 @@ final class RefundConfirmationViewModel {
             alerts: OrderDetailsPaymentAlerts(transactionType: .refund,
                                               presentingController: rootViewController),
             cardPresentConfiguration: CardPresentConfigurationLoader(stores: actionProcessor).configuration,
+            cardReaderConnectionAlerts: BluetoothReaderConnectionAlertsProvider(),
+            alertPresenter: CardPresentPaymentAlertsPresenter(rootViewController: rootViewController),
             dependencies: RefundSubmissionUseCase.Dependencies(
                 currencyFormatter: currencyFormatter,
                 cardPresentPaymentsOnboardingPresenter: cardPresentPaymentsOnboardingPresenter,

--- a/WooCommerce/Classes/ViewRelated/Orders/Payment Methods/PaymentMethodsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Payment Methods/PaymentMethodsViewModel.swift
@@ -207,6 +207,25 @@ final class PaymentMethodsViewModel: ObservableObject {
         }
         let alertsPresenter = CardPresentPaymentAlertsPresenter(rootViewController: rootViewController)
         let configuration = CardPresentConfigurationLoader().configuration
+        let analyticsTracker = CardReaderConnectionAnalyticsTracker(
+            configuration: configuration,
+            siteID: siteID,
+            connectionType: .userInitiated,
+            stores: stores,
+            analytics: analytics)
+        let externalReaderConnectionController = CardReaderConnectionController(
+            forSiteID: siteID,
+            knownReaderProvider: CardReaderSettingsKnownReaderStorage(),
+            alertsPresenter: alertsPresenter,
+            alertsProvider: BluetoothReaderConnectionAlertsProvider(),
+            configuration: configuration,
+            analyticsTracker: analyticsTracker)
+        let tapToPayConnectionController = BuiltInCardReaderConnectionController(
+            forSiteID: siteID,
+            alertsPresenter: alertsPresenter,
+            alertsProvider: BuiltInReaderConnectionAlertsProvider(),
+            configuration: configuration,
+            analyticsTracker: analyticsTracker)
 
         collectPaymentsUseCase = useCase ?? CollectOrderPaymentUseCase<BuiltInCardReaderPaymentAlertsProvider,
                                                                         BluetoothCardReaderPaymentAlertsProvider,
@@ -224,7 +243,10 @@ final class PaymentMethodsViewModel: ObservableObject {
                                                                        configuration: configuration,
                                                                        rootViewController: rootViewController,
                                                                        alertsPresenter: alertsPresenter,
-                                                                       onboardingPresenter: self.cardPresentPaymentsOnboardingPresenter))
+                                                                       onboardingPresenter: self.cardPresentPaymentsOnboardingPresenter,
+                                                                       externalReaderConnectionController: externalReaderConnectionController,
+                                                                       tapToPayConnectionController: tapToPayConnectionController,
+                                                                       analyticsTracker: analyticsTracker))
 
         collectPaymentsUseCase?.collectPayment(
             using: discoveryMethod,

--- a/WooCommerce/Classes/ViewRelated/Orders/Payment Methods/PaymentMethodsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Payment Methods/PaymentMethodsViewModel.swift
@@ -220,10 +220,11 @@ final class PaymentMethodsViewModel: ObservableObject {
             alertsProvider: BluetoothReaderConnectionAlertsProvider(),
             configuration: configuration,
             analyticsTracker: analyticsTracker)
+        let tapToPayAlertsProvider = BuiltInReaderConnectionAlertsProvider()
         let tapToPayConnectionController = BuiltInCardReaderConnectionController(
             forSiteID: siteID,
             alertsPresenter: alertsPresenter,
-            alertsProvider: BuiltInReaderConnectionAlertsProvider(),
+            alertsProvider: tapToPayAlertsProvider,
             configuration: configuration,
             analyticsTracker: analyticsTracker)
 
@@ -246,6 +247,7 @@ final class PaymentMethodsViewModel: ObservableObject {
                                                                        onboardingPresenter: self.cardPresentPaymentsOnboardingPresenter,
                                                                        externalReaderConnectionController: externalReaderConnectionController,
                                                                        tapToPayConnectionController: tapToPayConnectionController,
+                                                                       tapToPayAlertProvider: tapToPayAlertsProvider,
                                                                        analyticsTracker: analyticsTracker))
 
         collectPaymentsUseCase?.collectPayment(

--- a/WooCommerce/Classes/ViewRelated/Orders/Refund/RefundSubmissionUseCase.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Refund/RefundSubmissionUseCase.swift
@@ -320,7 +320,9 @@ private extension RefundSubmissionUseCase {
             })
         }, onProcessingMessage: { [weak self] in
             // Shows waiting message.
-            self?.alerts.processingPayment(title: RefundSubmissionUseCaseDefinitions.Localization.refundPaymentTitle(username: self?.order.billingAddress?.firstName))
+            self?.alerts.processingPayment(
+                title: RefundSubmissionUseCaseDefinitions.Localization.refundPaymentTitle(
+                    username: self?.order.billingAddress?.firstName))
         }, onDisplayMessage: { [weak self] message in
             // Shows reader messages (e.g. Remove Card).
             self?.alerts.displayReaderMessage(message: message)

--- a/WooCommerce/Classes/ViewRelated/Orders/Refund/RefundSubmissionUseCase.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Refund/RefundSubmissionUseCase.swift
@@ -63,6 +63,8 @@ final class RefundSubmissionUseCase: NSObject, RefundSubmissionProtocol {
     /// Alert manager to inform merchants about card reader connection actions used in `CardReaderConnectionController`.
     private let cardReaderConnectionAlerts: BluetoothReaderConnnectionAlertsProviding
 
+    private let alertPresenter: any CardPresentPaymentAlertsPresenting<CardPresentPaymentsModalViewModel>
+
     /// Provides any known card reader to be used in `CardReaderConnectionController`.
     private let knownReaderProvider: CardReaderSettingsKnownReaderProvider
 
@@ -76,7 +78,7 @@ final class RefundSubmissionUseCase: NSObject, RefundSubmissionProtocol {
                                    storageManager: storageManager,
                                    stores: stores,
                                    knownReaderProvider: knownReaderProvider,
-                                   alertsPresenter: CardPresentPaymentAlertsPresenter(rootViewController: rootViewController),
+                                   alertsPresenter: alertPresenter,
                                    alertsProvider: cardReaderConnectionAlerts,
                                    configuration: cardPresentConfiguration,
                                    analyticsTracker: .init(configuration: cardPresentConfiguration,
@@ -89,7 +91,6 @@ final class RefundSubmissionUseCase: NSObject, RefundSubmissionProtocol {
     private let cardPresentConfiguration: CardPresentPaymentsConfiguration
 
     struct Dependencies {
-        let cardReaderConnectionAlerts: BluetoothReaderConnnectionAlertsProviding
         let currencyFormatter: CurrencyFormatter
         let currencySettings: CurrencySettings
         let knownReaderProvider: CardReaderSettingsKnownReaderProvider
@@ -98,15 +99,13 @@ final class RefundSubmissionUseCase: NSObject, RefundSubmissionProtocol {
         let storageManager: StorageManagerType
         let analytics: Analytics
 
-        init(cardReaderConnectionAlerts: BluetoothReaderConnnectionAlertsProviding = BluetoothReaderConnectionAlertsProvider(),
-             currencyFormatter: CurrencyFormatter = CurrencyFormatter(currencySettings: ServiceLocator.currencySettings),
+        init(currencyFormatter: CurrencyFormatter = CurrencyFormatter(currencySettings: ServiceLocator.currencySettings),
              currencySettings: CurrencySettings = ServiceLocator.currencySettings,
              knownReaderProvider: CardReaderSettingsKnownReaderProvider = CardReaderSettingsKnownReaderStorage(),
              cardPresentPaymentsOnboardingPresenter: CardPresentPaymentsOnboardingPresenting = CardPresentPaymentsOnboardingPresenter(),
              stores: StoresManager = ServiceLocator.stores,
              storageManager: StorageManagerType = ServiceLocator.storageManager,
              analytics: Analytics = ServiceLocator.analytics) {
-            self.cardReaderConnectionAlerts = cardReaderConnectionAlerts
             self.currencyFormatter = currencyFormatter
             self.currencySettings = currencySettings
             self.knownReaderProvider = knownReaderProvider
@@ -121,6 +120,8 @@ final class RefundSubmissionUseCase: NSObject, RefundSubmissionProtocol {
          rootViewController: UIViewController,
          alerts: OrderDetailsPaymentAlertsProtocol,
          cardPresentConfiguration: CardPresentPaymentsConfiguration,
+         cardReaderConnectionAlerts: any BluetoothReaderConnnectionAlertsProviding,
+         alertPresenter: any CardPresentPaymentAlertsPresenting<CardPresentPaymentsModalViewModel>,
          dependencies: Dependencies = Dependencies()) {
         self.details = details
         self.formattedAmount = {
@@ -130,7 +131,8 @@ final class RefundSubmissionUseCase: NSObject, RefundSubmissionProtocol {
         }()
         self.rootViewController = rootViewController
         self.alerts = alerts
-        self.cardReaderConnectionAlerts = dependencies.cardReaderConnectionAlerts
+        self.cardReaderConnectionAlerts = cardReaderConnectionAlerts
+        self.alertPresenter = alertPresenter
         self.currencyFormatter = dependencies.currencyFormatter
         self.cardPresentConfiguration = cardPresentConfiguration
         self.knownReaderProvider = dependencies.knownReaderProvider

--- a/WooCommerce/WooCommerceTests/Mocks/MockCardReaderSettingsAlerts.swift
+++ b/WooCommerce/WooCommerceTests/Mocks/MockCardReaderSettingsAlerts.swift
@@ -157,6 +157,10 @@ extension MockCardReaderSettingsAlerts: BluetoothReaderConnnectionAlertsProvidin
     func dismiss() {
         // GNDN
     }
+
+    func selectSearchType(tapToPay: @escaping () -> Void, bluetooth: @escaping () -> Void, cancel: @escaping () -> Void) -> CardPresentPaymentsModalViewModel {
+        return MockCardPresentPaymentsModalViewModel()
+    }
 }
 
 

--- a/WooCommerce/WooCommerceTests/ViewModels/CardPresentPayments/RefundSubmissionUseCaseTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewModels/CardPresentPayments/RefundSubmissionUseCaseTests.swift
@@ -156,7 +156,7 @@ final class RefundSubmissionUseCaseTests: XCTestCase {
         }
 
         // Then
-        XCTAssertEqual(result.failure as? RefundSubmissionUseCase.RefundSubmissionError, .unknownPaymentGatewayAccount)
+        XCTAssertEqual(result.failure as? RefundSubmissionUseCaseSubmissionError, .unknownPaymentGatewayAccount)
     }
 
     func test_submitRefund_successfully_tracks_interacRefundSuccess_event_when_payment_method_is_interac() throws {
@@ -226,7 +226,7 @@ final class RefundSubmissionUseCaseTests: XCTestCase {
                                                    amount: "2.28",
                                                    paymentGatewayAccount: createPaymentGatewayAccount(siteID: Mocks.siteID)))
         mockCardPresentPaymentActions(clientSideRefundResult: .success(()))
-        mockServerSideRefund(result: .failure(RefundSubmissionUseCase.RefundSubmissionError.cardReaderDisconnected))
+        mockServerSideRefund(result: .failure(RefundSubmissionUseCaseSubmissionError.cardReaderDisconnected))
 
         // When
         let result = waitFor { promise in
@@ -237,7 +237,7 @@ final class RefundSubmissionUseCaseTests: XCTestCase {
 
         // Then
         XCTAssertTrue(result.isFailure)
-        XCTAssertEqual(result.failure as? RefundSubmissionUseCase.RefundSubmissionError, .cardReaderDisconnected)
+        XCTAssertEqual(result.failure as? RefundSubmissionUseCaseSubmissionError, .cardReaderDisconnected)
 
         let indexOfEvent = try XCTUnwrap(analyticsProvider.receivedEvents.firstIndex(where: { $0 == "interac_refund_success"}))
         let eventProperties = try XCTUnwrap(analyticsProvider.receivedProperties[indexOfEvent])
@@ -258,7 +258,7 @@ final class RefundSubmissionUseCaseTests: XCTestCase {
                                                                                   dedicatedFileName: "A000000003101001")))),
                                                    amount: "2.28",
                                                    paymentGatewayAccount: createPaymentGatewayAccount(siteID: Mocks.siteID)))
-        mockCardPresentPaymentActions(clientSideRefundResult: .failure(RefundSubmissionUseCase.RefundSubmissionError.cardReaderDisconnected))
+        mockCardPresentPaymentActions(clientSideRefundResult: .failure(RefundSubmissionUseCaseSubmissionError.cardReaderDisconnected))
 
         // When
         let result: Result<Void, Error> = waitFor { promise in
@@ -270,7 +270,7 @@ final class RefundSubmissionUseCaseTests: XCTestCase {
 
         // Then
         XCTAssertTrue(result.isFailure)
-        XCTAssertEqual(result.failure as? RefundSubmissionUseCase.RefundSubmissionError, .cardReaderDisconnected)
+        XCTAssertEqual(result.failure as? RefundSubmissionUseCaseSubmissionError, .cardReaderDisconnected)
 
         let indexOfEvent = try XCTUnwrap(analyticsProvider.receivedEvents.firstIndex(where: { $0 == "interac_refund_failed"}))
         let eventProperties = try XCTUnwrap(analyticsProvider.receivedProperties[indexOfEvent])
@@ -347,7 +347,7 @@ final class RefundSubmissionUseCaseTests: XCTestCase {
 
         // Then
         XCTAssertTrue(result.isFailure)
-        XCTAssertEqual(result.failure as? RefundSubmissionUseCase.RefundSubmissionError, .cardReaderDisconnected)
+        XCTAssertEqual(result.failure as? RefundSubmissionUseCaseSubmissionError, .cardReaderDisconnected)
 
         let indexOfEvent = try XCTUnwrap(analyticsProvider.receivedEvents.firstIndex(where: { $0 == "interac_refund_cancelled"}))
         let eventProperties = try XCTUnwrap(analyticsProvider.receivedProperties[indexOfEvent])
@@ -368,7 +368,7 @@ final class RefundSubmissionUseCaseTests: XCTestCase {
                                                                                   dedicatedFileName: "A000000003101001")))),
                                                    amount: "2.28",
                                                    paymentGatewayAccount: createPaymentGatewayAccount(siteID: Mocks.siteID)))
-        mockCardPresentPaymentActions(clientSideRefundResult: .failure(RefundSubmissionUseCase.RefundSubmissionError.cardReaderDisconnected),
+        mockCardPresentPaymentActions(clientSideRefundResult: .failure(RefundSubmissionUseCaseSubmissionError.cardReaderDisconnected),
                                       cancelRefundResult: .success(()))
 
         // When
@@ -381,7 +381,7 @@ final class RefundSubmissionUseCaseTests: XCTestCase {
 
         // Then
         XCTAssertTrue(result.isFailure)
-        XCTAssertEqual(result.failure as? RefundSubmissionUseCase.RefundSubmissionError, .canceledByUser)
+        XCTAssertEqual(result.failure as? RefundSubmissionUseCaseSubmissionError, .canceledByUser)
 
         let indexOfEvent = try XCTUnwrap(analyticsProvider.receivedEvents.firstIndex(where: { $0 == "interac_refund_cancelled"}))
         let eventProperties = try XCTUnwrap(analyticsProvider.receivedProperties[indexOfEvent])

--- a/WooCommerce/WooCommerceTests/ViewModels/CardPresentPayments/RefundSubmissionUseCaseTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewModels/CardPresentPayments/RefundSubmissionUseCaseTests.swift
@@ -448,7 +448,6 @@ private extension RefundSubmissionUseCaseTests {
 
     func createUseCase(details: RefundSubmissionUseCase.Details) -> RefundSubmissionUseCase {
         let dependencies = Dependencies(
-            cardReaderConnectionAlerts: cardReaderConnectionAlerts,
             currencyFormatter: CurrencyFormatter(currencySettings: .init()),
             currencySettings: .init(),
             knownReaderProvider: knownCardReaderProvider,
@@ -463,6 +462,8 @@ private extension RefundSubmissionUseCaseTests {
             rootViewController: .init(),
             alerts: alerts,
             cardPresentConfiguration: Mocks.configuration,
+            cardReaderConnectionAlerts: cardReaderConnectionAlerts,
+            alertPresenter: MockCardPresentPaymentAlertsPresenter(),
             dependencies: dependencies)
     }
 

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Payment Methods/PaymentMethodsViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Payment Methods/PaymentMethodsViewModelTests.swift
@@ -806,7 +806,7 @@ final class PaymentMethodsViewModelTests: XCTestCase {
             switch action {
             case let .selectedPaymentGatewayAccount(onCompletion):
                 onCompletion(PaymentGatewayAccount.fake())
-            case .checkDeviceSupport:
+            case .checkDeviceSupport, .observeConnectedReaders:
                 break
             default:
                 XCTFail("Unexpected action: \(action)")


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of: #12868
Merge after: #13037
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
This PR forms part of a series, together making the alert providers and presenters used in card payments generic.

When complete, this will mean that the POS experience can use different alert view models from the existing app's CardPresentPaymentModalViewModel, specialised for the new design, while continuing to use all the existing payments logic.

This third PR prepares for the changes to the connection controllers. Currently, we are tied to using the same view model for all cases because of the shared alert presenter needing to have the same type as both the transaction alert provider and the connection alert presenters.

The preparation is to move some static definitions out of classes which will rely on the new generics, as that's not permitted, and moves to passing the alert related dependencies in rather than building them in the `init`. That's so that we can give different concrete implementations from the different places we use the payments code.

## Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->

Check the existing payments work as expected in the main app, and that the POS reader connection works as well.

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.