### PR TITLE
[Woo POS] Use generic alert details for connection

### DIFF
--- a/WooCommerce/Classes/POS/Card Present Payments/CardPresentPaymentCollectOrderPaymentUseCaseAdaptor.swift
+++ b/WooCommerce/Classes/POS/Card Present Payments/CardPresentPaymentCollectOrderPaymentUseCaseAdaptor.swift
@@ -14,7 +14,10 @@ struct CardPresentPaymentCollectOrderPaymentUseCaseAdaptor {
     func collectPaymentTask(for order: Order,
                             using connectionMethod: CardReaderConnectionMethod,
                             siteID: Int64,
-                            preflightController: CardPresentPaymentPreflightController,
+                            preflightController: CardPresentPaymentPreflightController<
+                            BluetoothReaderConnectionAlertsProvider,
+                            BuiltInReaderConnectionAlertsProvider,
+                            CardPresentPaymentsAlertPresenterAdaptor>,
                             onboardingPresenter: CardPresentPaymentsOnboardingPresenting,
                             configuration: CardPresentPaymentsConfiguration,
                             alertsPresenter: CardPresentPaymentsAlertPresenterAdaptor,

--- a/WooCommerce/Classes/POS/Card Present Payments/CardPresentPaymentPreflightAdaptor.swift
+++ b/WooCommerce/Classes/POS/Card Present Payments/CardPresentPaymentPreflightAdaptor.swift
@@ -7,9 +7,13 @@ protocol CardPresentPaymentPreflightControllerFacade {
 }
 
 final class CardPresentPaymentPreflightAdaptor: CardPresentPaymentPreflightControllerFacade {
-    private let preflightController: CardPresentPaymentPreflightController
+    private let preflightController: CardPresentPaymentPreflightController<BluetoothReaderConnectionAlertsProvider,
+                                                                            BuiltInReaderConnectionAlertsProvider,
+                                                                            CardPresentPaymentsAlertPresenterAdaptor>
 
-    init(preflightController: CardPresentPaymentPreflightController) {
+    init(preflightController: CardPresentPaymentPreflightController<BluetoothReaderConnectionAlertsProvider,
+         BuiltInReaderConnectionAlertsProvider,
+         CardPresentPaymentsAlertPresenterAdaptor>) {
         self.preflightController = preflightController
     }
 

--- a/WooCommerce/Classes/POS/Card Present Payments/CardPresentPaymentService.swift
+++ b/WooCommerce/Classes/POS/Card Present Payments/CardPresentPaymentService.swift
@@ -140,18 +140,25 @@ private extension CardPresentPaymentService {
         }
     }
 
-    func createPreflightController() -> CardPresentPaymentPreflightController {
-        return CardPresentPaymentPreflightController(
-            siteID: siteID,
-            configuration: cardPresentPaymentsConfiguration,
-            rootViewController: NullViewControllerPresenting(),
-            alertsPresenter: paymentAlertsPresenterAdaptor,
-            onboardingPresenter: onboardingAdaptor,
-            externalReaderConnectionController: connectionControllerManager.externalReaderConnectionController,
-            tapToPayConnectionController: connectionControllerManager.tapToPayConnectionController,
-            tapToPayAlertProvider: BuiltInReaderConnectionAlertsProvider(),
-            analyticsTracker: connectionControllerManager.analyticsTracker)
-    }
+    func createPreflightController() -> CardPresentPaymentPreflightController<
+        BluetoothReaderConnectionAlertsProvider,
+        BuiltInReaderConnectionAlertsProvider,
+        CardPresentPaymentsAlertPresenterAdaptor> {
+            let alertProvider = BuiltInReaderConnectionAlertsProvider()
+            return CardPresentPaymentPreflightController(
+                siteID: siteID,
+                configuration: cardPresentPaymentsConfiguration,
+                rootViewController: NullViewControllerPresenting(),
+                alertsPresenter: paymentAlertsPresenterAdaptor,
+                onboardingPresenter: onboardingAdaptor,
+                tapToPayAlertProvider: alertProvider,
+                externalReaderConnectionController: connectionControllerManager.externalReaderConnectionController,
+                tapToPayConnectionController: connectionControllerManager.tapToPayConnectionController,
+                tapToPayReconnectionController: TapToPayReconnectionController(
+                    connectionControllerFactory: BuiltInCardReaderConnectionControllerFactory(
+                        alertProvider: alertProvider)),
+                analyticsTracker: connectionControllerManager.analyticsTracker)
+        }
 }
 
 enum CardPresentPaymentServiceError: Error {

--- a/WooCommerce/Classes/POS/Card Present Payments/CardPresentPaymentsConnectionControllerManager.swift
+++ b/WooCommerce/Classes/POS/Card Present Payments/CardPresentPaymentsConnectionControllerManager.swift
@@ -2,13 +2,13 @@ import Foundation
 import struct Yosemite.CardPresentPaymentsConfiguration
 
 final class CardPresentPaymentsConnectionControllerManager {
-    let externalReaderConnectionController: CardReaderConnectionController
-    let tapToPayConnectionController: BuiltInCardReaderConnectionController
+    let externalReaderConnectionController: CardReaderConnectionController<BluetoothReaderConnectionAlertsProvider, CardPresentPaymentsAlertPresenterAdaptor>
+    let tapToPayConnectionController: BuiltInCardReaderConnectionController<BuiltInReaderConnectionAlertsProvider, CardPresentPaymentsAlertPresenterAdaptor>
     let analyticsTracker: CardReaderConnectionAnalyticsTracker
 
     init(siteID: Int64,
          configuration: CardPresentPaymentsConfiguration,
-         alertsPresenter: any CardPresentPaymentAlertsPresenting<CardPresentPaymentsModalViewModel>) {
+         alertsPresenter: CardPresentPaymentsAlertPresenterAdaptor) {
         let analyticsTracker = CardReaderConnectionAnalyticsTracker(
             configuration: configuration,
             siteID: siteID,

--- a/WooCommerce/Classes/ServiceLocator/ServiceLocator.swift
+++ b/WooCommerce/Classes/ServiceLocator/ServiceLocator.swift
@@ -100,7 +100,9 @@ final class ServiceLocator {
     private static var _cardPresentPaymentsOnboardingIPPUsersRefresher: CardPresentPaymentsOnboardingIPPUsersRefresher =
     CardPresentPaymentsOnboardingIPPUsersRefresher()
 
-    private static var _tapToPayReconnectionController: TapToPayReconnectionController = TapToPayReconnectionController()
+    private static var _tapToPayReconnectionController = TapToPayReconnectionController<BuiltInReaderConnectionAlertsProvider, CardPresentPaymentAlertsPresenter>(
+            connectionControllerFactory: BuiltInCardReaderConnectionControllerFactory(
+                alertProvider: BuiltInReaderConnectionAlertsProvider()))
 
     /// Tracker for app startup waiting time
     ///
@@ -254,7 +256,8 @@ final class ServiceLocator {
         _cardPresentPaymentsOnboardingIPPUsersRefresher
     }
 
-    static var tapToPayReconnectionController: TapToPayReconnectionController {
+    static var tapToPayReconnectionController: TapToPayReconnectionController<BuiltInReaderConnectionAlertsProvider,
+                                                                                CardPresentPaymentAlertsPresenter> {
         _tapToPayReconnectionController
     }
 

--- a/WooCommerce/Classes/ViewRelated/CardPresentPayments/BuiltInCardReaderConnectionController.swift
+++ b/WooCommerce/Classes/ViewRelated/CardPresentPayments/BuiltInCardReaderConnectionController.swift
@@ -12,7 +12,10 @@ protocol BuiltInCardReaderConnectionControlling {
     func searchAndConnect(onCompletion: @escaping (Result<CardReaderConnectionResult, Error>) -> Void)
 }
 
-final class BuiltInCardReaderConnectionController: BuiltInCardReaderConnectionControlling {
+final class BuiltInCardReaderConnectionController<AlertProvider: CardReaderConnectionAlertsProviding,
+                                                  AlertPresenter: CardPresentPaymentAlertsPresenting>:
+                                                    BuiltInCardReaderConnectionControlling
+where AlertProvider.AlertDetails == AlertPresenter.AlertDetails {
     private enum ControllerState {
         /// Initial state of the controller
         ///
@@ -76,10 +79,10 @@ final class BuiltInCardReaderConnectionController: BuiltInCardReaderConnectionCo
     }
 
     private let siteID: Int64
-    private let alertsPresenter: any CardPresentPaymentAlertsPresenting<CardPresentPaymentsModalViewModel>
+    private let alertsPresenter: AlertPresenter
     private let configuration: CardPresentPaymentsConfiguration
 
-    private let alertsProvider: CardReaderConnectionAlertsProviding
+    private let alertsProvider: AlertProvider
 
     /// The reader we want the user to consider connecting to
     ///
@@ -113,8 +116,8 @@ final class BuiltInCardReaderConnectionController: BuiltInCardReaderConnectionCo
         forSiteID: Int64,
         storageManager: StorageManagerType = ServiceLocator.storageManager,
         stores: StoresManager = ServiceLocator.stores,
-        alertsPresenter: any CardPresentPaymentAlertsPresenting<CardPresentPaymentsModalViewModel>,
-        alertsProvider: CardReaderConnectionAlertsProviding,
+        alertsPresenter: AlertPresenter,
+        alertsProvider: AlertProvider,
         configuration: CardPresentPaymentsConfiguration,
         analyticsTracker: CardReaderConnectionAnalyticsTracker,
         allowTermsOfServiceAcceptance: Bool = true

--- a/WooCommerce/Classes/ViewRelated/CardPresentPayments/CardReaderConnectionController.swift
+++ b/WooCommerce/Classes/ViewRelated/CardPresentPayments/CardReaderConnectionController.swift
@@ -7,7 +7,9 @@ import Yosemite
 
 /// Facilitates connecting to a card reader
 ///
-final class CardReaderConnectionController {
+final class CardReaderConnectionController<AlertProvider: BluetoothReaderConnnectionAlertsProviding,
+                                          AlertPresenter: CardPresentPaymentAlertsPresenting>
+where AlertProvider.AlertDetails == AlertPresenter.AlertDetails {
     private enum ControllerState {
         /// Initial state of the controller
         ///
@@ -80,10 +82,10 @@ final class CardReaderConnectionController {
 
     private let siteID: Int64
     private let knownCardReaderProvider: CardReaderSettingsKnownReaderProvider
-    private let alertsPresenter: any CardPresentPaymentAlertsPresenting<CardPresentPaymentsModalViewModel>
+    private let alertsPresenter: AlertPresenter
     private let configuration: CardPresentPaymentsConfiguration
 
-    private let alertsProvider: BluetoothReaderConnnectionAlertsProviding
+    private let alertsProvider: AlertProvider
 
     /// Reader(s) discovered by the card reader service
     ///
@@ -135,8 +137,8 @@ final class CardReaderConnectionController {
         storageManager: StorageManagerType = ServiceLocator.storageManager,
         stores: StoresManager = ServiceLocator.stores,
         knownReaderProvider: CardReaderSettingsKnownReaderProvider,
-        alertsPresenter: any CardPresentPaymentAlertsPresenting<CardPresentPaymentsModalViewModel>,
-        alertsProvider: BluetoothReaderConnnectionAlertsProviding,
+        alertsPresenter: AlertPresenter,
+        alertsProvider: AlertProvider,
         configuration: CardPresentPaymentsConfiguration,
         analyticsTracker: CardReaderConnectionAnalyticsTracker
     ) {

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/BluetoothReaderConnectionAlertsProvider.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/BluetoothReaderConnectionAlertsProvider.swift
@@ -2,6 +2,7 @@ import Foundation
 import UIKit
 
 struct BluetoothReaderConnectionAlertsProvider: BluetoothReaderConnnectionAlertsProviding {
+    typealias AlertDetails = CardPresentPaymentsModalViewModel
     func scanningForReader(cancel: @escaping () -> Void) -> CardPresentPaymentsModalViewModel {
         CardPresentModalScanningForReader(cancel: cancel)
     }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/CardReaderConnectionAlertsProviding.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/CardReaderConnectionAlertsProviding.swift
@@ -6,31 +6,32 @@ import Yosemite
 /// alert viewModels such a provider is expected to provide over the course of searching for
 /// and connecting to a reader
 ///
-protocol CardReaderConnectionAlertsProviding {
+protocol CardReaderConnectionAlertsProviding<AlertDetails> {
+    associatedtype AlertDetails
     /// Defines a cancellable alert indicating we are searching for a reader
     ///
-    func scanningForReader(cancel: @escaping () -> Void) -> CardPresentPaymentsModalViewModel
+    func scanningForReader(cancel: @escaping () -> Void) -> AlertDetails
 
     /// Defines a cancellable (closeable) alert indicating the search failed
     ///
-    func scanningFailed(error: Error, close: @escaping () -> Void) -> CardPresentPaymentsModalViewModel
+    func scanningFailed(error: Error, close: @escaping () -> Void) -> AlertDetails
 
     /// Defines a non-interactive alert indicating a connection is in progress to a particular reader
     ///
-    func connectingToReader() -> CardPresentPaymentsModalViewModel
+    func connectingToReader() -> AlertDetails
 
     /// Defines an alert indicating connecting failed. The user may continue the search
     /// or cancel
     ///
     func connectingFailed(error: Error,
                           retrySearch: @escaping () -> Void,
-                          cancelSearch: @escaping () -> Void) -> CardPresentPaymentsModalViewModel
+                          cancelSearch: @escaping () -> Void) -> AlertDetails
 
     /// Defines an alert indicating connecting failed, in a way which must be resolved outside
     /// the connection flow. The user can close the alert.
     ///
     func connectingFailedNonRetryable(error: Error,
-                                      close: @escaping () -> Void) -> CardPresentPaymentsModalViewModel
+                                      close: @escaping () -> Void) -> AlertDetails
 
     /// Defines an alert indicating connecting failed because their address needs updating.
     /// The user may try again or cancel
@@ -38,25 +39,25 @@ protocol CardReaderConnectionAlertsProviding {
     func connectingFailedIncompleteAddress(wcSettingsAdminURL: URL?,
                                            openWCSettings: (() -> Void)?,
                                            retrySearch: @escaping () -> Void,
-                                           cancelSearch: @escaping () -> Void) -> CardPresentPaymentsModalViewModel
+                                           cancelSearch: @escaping () -> Void) -> AlertDetails
 
     /// Defines an alert indicating connecting failed because their postal code needs updating.
     /// The user may try again or cancel
     ///
     func connectingFailedInvalidPostalCode(retrySearch: @escaping () -> Void,
-                                           cancelSearch: @escaping () -> Void) -> CardPresentPaymentsModalViewModel
+                                           cancelSearch: @escaping () -> Void) -> AlertDetails
 
     /// Defines an alert indicating an update couldn't be installed.
     ///
-    func updatingFailed(tryAgain: (() -> Void)?, close: @escaping () -> Void) -> CardPresentPaymentsModalViewModel
+    func updatingFailed(tryAgain: (() -> Void)?, close: @escaping () -> Void) -> AlertDetails
 
     /// Shows progress when a software update is being installed
     ///
-    func updateProgress(requiredUpdate: Bool, progress: Float, cancel: (() -> Void)?) -> CardPresentPaymentsModalViewModel
+    func updateProgress(requiredUpdate: Bool, progress: Float, cancel: (() -> Void)?) -> AlertDetails
 
     func selectSearchType(tapToPay: @escaping () -> Void,
                           bluetooth: @escaping () -> Void,
-                          cancel: @escaping () -> Void) -> CardPresentPaymentsModalViewModel
+                          cancel: @escaping () -> Void) -> AlertDetails
 }
 
 
@@ -64,14 +65,15 @@ protocol CardReaderConnectionAlertsProviding {
 /// between several readers - defining what alert viewModels such a provider is expected to provide over
 /// the course of searching for and connecting to a reader.
 ///
-protocol MultipleCardReaderConnectionAlertsProviding {
+protocol MultipleCardReaderConnectionAlertsProviding<AlertDetails> {
+    associatedtype AlertDetails
     /// Defines an interactive alert indicating a reader has been found. The user must
     /// choose to connect to that reader or continue searching
     ///
     func foundReader(name: String,
                      connect: @escaping () -> Void,
                      continueSearch: @escaping () -> Void,
-                     cancelSearch: @escaping () -> Void) -> CardPresentPaymentsModalViewModel
+                     cancelSearch: @escaping () -> Void) -> AlertDetails
 
     // TODO: implement this approach, allowing us to remove the several readers logic from CardPresentPaymentAlertsPresenter
     // https://github.com/woocommerce/woocommerce-ios/issues/8296
@@ -91,19 +93,22 @@ protocol MultipleCardReaderConnectionAlertsProviding {
 /// powered readers - defining what alert viewModels such a provider is expected to provide over
 /// the course of searching for and connecting to a reader.
 ///
-protocol BatteryPoweredCardReaderConnectionAlertsProviding {
+protocol BatteryPoweredCardReaderConnectionAlertsProviding<AlertDetails> {
+    associatedtype AlertDetails
     /// Defines an alert indicating connecting failed because the reader battery is critically low.
     /// The user may try searching again (i.e. for a different reader) or cancel
     ///
     func connectingFailedCriticallyLowBattery(retrySearch: @escaping () -> Void,
-                                              cancelSearch: @escaping () -> Void) -> CardPresentPaymentsModalViewModel
+                                              cancelSearch: @escaping () -> Void) -> AlertDetails
 
     /// Defines an alert indicating an update couldn't be installed because the reader is low on battery.
     ///
     func updatingFailedLowBattery(batteryLevel: Double?,
-                                  close: @escaping () -> Void) -> CardPresentPaymentsModalViewModel
+                                  close: @escaping () -> Void) -> AlertDetails
 }
 
-typealias BluetoothReaderConnnectionAlertsProviding = CardReaderConnectionAlertsProviding &
-                                                      MultipleCardReaderConnectionAlertsProviding &
-                                                      BatteryPoweredCardReaderConnectionAlertsProviding
+protocol BluetoothReaderConnnectionAlertsProviding<AlertDetails>: CardReaderConnectionAlertsProviding,
+                                                                  MultipleCardReaderConnectionAlertsProviding,
+                                                                  BatteryPoweredCardReaderConnectionAlertsProviding {
+    associatedtype AlertDetails
+}

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/CardReaderSettingsSearchingViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/CardReaderSettingsSearchingViewController.swift
@@ -12,11 +12,11 @@ final class CardReaderSettingsSearchingViewController: UIHostingController<CardR
 
     private lazy var alertsPresenter: CardPresentPaymentAlertsPresenter = CardPresentPaymentAlertsPresenter(rootViewController: self)
 
-    private let alertsProvider: BluetoothReaderConnnectionAlertsProviding = BluetoothReaderConnectionAlertsProvider()
+    private let alertsProvider: BluetoothReaderConnectionAlertsProvider = BluetoothReaderConnectionAlertsProvider()
 
     /// Connection Controller (helps connect readers)
     ///
-    private lazy var connectionController: CardReaderConnectionController? = {
+    private lazy var connectionController: CardReaderConnectionController<BluetoothReaderConnectionAlertsProvider, CardPresentPaymentAlertsPresenter>? = {
         guard let knownReaderProvider = viewModel.knownReaderProvider else {
             return nil
         }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/SetUpTapToPayInformationViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/SetUpTapToPayInformationViewModel.swift
@@ -23,8 +23,8 @@ final class SetUpTapToPayInformationViewModel: PaymentSettingsFlowPresentedViewM
     private let onboardingStatePublisher: Published<CardPresentPaymentOnboardingState>.Publisher
     private let analytics: Analytics = ServiceLocator.analytics
 
-    var connectionController: BuiltInCardReaderConnectionController? = nil
-    var alertsPresenter: (any CardPresentPaymentAlertsPresenting)? = nil
+    var connectionController: BuiltInCardReaderConnectionController<BuiltInReaderConnectionAlertsProvider, CardPresentPaymentAlertsPresenter>? = nil
+    var alertsPresenter: CardPresentPaymentAlertsPresenter? = nil
 
     private(set) var noConnectedReader: CardReaderSettingsTriState = .isUnknown {
         didSet {

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/SilenceablePassthroughCardPresentPaymentAlertsPresenter.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/SilenceablePassthroughCardPresentPaymentAlertsPresenter.swift
@@ -1,13 +1,13 @@
 import Foundation
 import Combine
 
-final class SilenceablePassthroughCardPresentPaymentAlertsPresenter: CardPresentPaymentAlertsPresenting {
-    private var alertSubject: CurrentValueSubject<CardPresentPaymentsModalViewModel?, Never> = CurrentValueSubject(nil)
-    private var alertsPresenter: (any CardPresentPaymentAlertsPresenting<CardPresentPaymentsModalViewModel>)?
+final class SilenceablePassthroughCardPresentPaymentAlertsPresenter<AlertPresenter: CardPresentPaymentAlertsPresenting>: CardPresentPaymentAlertsPresenting {
+    private var alertSubject: CurrentValueSubject<AlertPresenter.AlertDetails?, Never> = CurrentValueSubject(nil)
+    private var alertsPresenter: (any CardPresentPaymentAlertsPresenting<AlertPresenter.AlertDetails>)?
 
     private var alertSubscription: AnyCancellable? = nil
 
-    func present(viewModel: CardPresentPaymentsModalViewModel) {
+    func present(viewModel: AlertPresenter.AlertDetails) {
         alertSubject.send(viewModel)
     }
 
@@ -28,7 +28,7 @@ final class SilenceablePassthroughCardPresentPaymentAlertsPresenter: CardPresent
         alertsPresenter?.dismiss()
     }
 
-    func startPresentingAlerts(from alertsPresenter: any CardPresentPaymentAlertsPresenting<CardPresentPaymentsModalViewModel>) {
+    func startPresentingAlerts(from alertsPresenter: AlertPresenter) {
         self.alertsPresenter = alertsPresenter
         alertSubscription = alertSubject.share().sink { viewModel in
             DispatchQueue.main.async {

--- a/WooCommerce/Classes/ViewRelated/Orders/Collect Payments/CardPresentPaymentAlertsPresenter.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Collect Payments/CardPresentPaymentAlertsPresenter.swift
@@ -14,6 +14,7 @@ protocol CardPresentPaymentAlertsPresenting<AlertDetails> {
 }
 
 final class CardPresentPaymentAlertsPresenter: CardPresentPaymentAlertsPresenting {
+    typealias AlertDetails = CardPresentPaymentsModalViewModel
     private var modalController: CardPresentPaymentsModalViewController?
     private var severalFoundController: SeveralReadersFoundViewController?
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Collect Payments/CollectOrderPaymentUseCase.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Collect Payments/CollectOrderPaymentUseCase.swift
@@ -32,8 +32,9 @@ protocol CollectOrderPaymentProtocol {
 final class CollectOrderPaymentUseCase<BuiltInAlertProvider: CardReaderTransactionAlertsProviding,
                                         BluetoothAlertProvider: CardReaderTransactionAlertsProviding,
                                         AlertPresenter: CardPresentPaymentAlertsPresenting>:
-    NSObject, CollectOrderPaymentProtocol where BuiltInAlertProvider.AlertDetails == AlertPresenter.AlertDetails,
-                                                BluetoothAlertProvider.AlertDetails == AlertPresenter.AlertDetails {
+    NSObject, CollectOrderPaymentProtocol 
+where BuiltInAlertProvider.AlertDetails == AlertPresenter.AlertDetails,
+      BluetoothAlertProvider.AlertDetails == AlertPresenter.AlertDetails {
     /// Currency Formatter
     ///
     private let currencyFormatter = CurrencyFormatter(currencySettings: ServiceLocator.currencySettings)
@@ -514,8 +515,9 @@ private extension CollectOrderPaymentUseCase {
     /// Allow merchants to print or email backend-generated receipts.
     /// The alerts presenter can be simplified once we remove legacy receipts: https://github.com/woocommerce/woocommerce-ios/issues/11897
     ///
-    func presentBackendReceiptAlert(alertProvider paymentAlerts: any CardReaderTransactionAlertsProviding<AlertPresenter.AlertDetails>,
-                                    onCompleted: @escaping () -> ()) {
+    func presentBackendReceiptAlert(
+        alertProvider paymentAlerts: any CardReaderTransactionAlertsProviding<AlertPresenter.AlertDetails>,
+        onCompleted: @escaping () -> ()) {
         // Handles receipt presentation for both print and email actions
         let receiptPresentationCompletionAction: () -> Void = { [weak self] in
             guard let self else { return }

--- a/WooCommerce/Classes/ViewRelated/Orders/Collect Payments/CollectOrderPaymentUseCase.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Collect Payments/CollectOrderPaymentUseCase.swift
@@ -32,7 +32,7 @@ protocol CollectOrderPaymentProtocol {
 final class CollectOrderPaymentUseCase<BuiltInAlertProvider: CardReaderTransactionAlertsProviding,
                                         BluetoothAlertProvider: CardReaderTransactionAlertsProviding,
                                         AlertPresenter: CardPresentPaymentAlertsPresenting>:
-    NSObject, CollectOrderPaymentProtocol 
+    NSObject, CollectOrderPaymentProtocol
 where BuiltInAlertProvider.AlertDetails == AlertPresenter.AlertDetails,
       BluetoothAlertProvider.AlertDetails == AlertPresenter.AlertDetails {
     /// Currency Formatter

--- a/WooCommerce/Classes/ViewRelated/Orders/Payment Methods/PaymentMethodsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Payment Methods/PaymentMethodsViewModel.swift
@@ -245,9 +245,10 @@ final class PaymentMethodsViewModel: ObservableObject {
                                                                        rootViewController: rootViewController,
                                                                        alertsPresenter: alertsPresenter,
                                                                        onboardingPresenter: self.cardPresentPaymentsOnboardingPresenter,
+                                                                       tapToPayAlertProvider: BuiltInReaderConnectionAlertsProvider(),
                                                                        externalReaderConnectionController: externalReaderConnectionController,
                                                                        tapToPayConnectionController: tapToPayConnectionController,
-                                                                       tapToPayAlertProvider: tapToPayAlertsProvider,
+                                                                       tapToPayReconnectionController: ServiceLocator.tapToPayReconnectionController,
                                                                        analyticsTracker: analyticsTracker))
 
         collectPaymentsUseCase?.collectPayment(

--- a/WooCommerce/Classes/ViewRelated/Orders/Refund/RefundSubmissionUseCase.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Refund/RefundSubmissionUseCase.swift
@@ -22,7 +22,9 @@ protocol RefundSubmissionProtocol {
 /// If in-person refund is required for the payment method (e.g. Interac in Canada), orchestrates reader connection, refund, UI alerts,
 /// submit refund to the site, and analytics.
 /// Otherwise, it submits the refund to the site directly with analytics.
-final class RefundSubmissionUseCase: NSObject, RefundSubmissionProtocol {
+final class RefundSubmissionUseCase<AlertProvider: BluetoothReaderConnnectionAlertsProviding,
+                                        AlertPresenter: CardPresentPaymentAlertsPresenting>: NSObject, RefundSubmissionProtocol
+where AlertProvider.AlertDetails == AlertPresenter.AlertDetails {
     /// Refund details.
     private let details: Details
 
@@ -61,9 +63,9 @@ final class RefundSubmissionUseCase: NSObject, RefundSubmissionProtocol {
     private lazy var cardPresentRefundOrchestrator = CardPresentRefundOrchestrator(stores: stores)
 
     /// Alert manager to inform merchants about card reader connection actions used in `CardReaderConnectionController`.
-    private let cardReaderConnectionAlerts: BluetoothReaderConnnectionAlertsProviding
+    private let cardReaderConnectionAlerts: AlertProvider
 
-    private let alertPresenter: any CardPresentPaymentAlertsPresenting<CardPresentPaymentsModalViewModel>
+    private let alertPresenter: AlertPresenter
 
     /// Provides any known card reader to be used in `CardReaderConnectionController`.
     private let knownReaderProvider: CardReaderSettingsKnownReaderProvider
@@ -120,8 +122,8 @@ final class RefundSubmissionUseCase: NSObject, RefundSubmissionProtocol {
          rootViewController: UIViewController,
          alerts: OrderDetailsPaymentAlertsProtocol,
          cardPresentConfiguration: CardPresentPaymentsConfiguration,
-         cardReaderConnectionAlerts: any BluetoothReaderConnnectionAlertsProviding,
-         alertPresenter: any CardPresentPaymentAlertsPresenting<CardPresentPaymentsModalViewModel>,
+         cardReaderConnectionAlerts: AlertProvider,
+         alertPresenter: AlertPresenter,
          dependencies: Dependencies = Dependencies()) {
         self.details = details
         self.formattedAmount = {

--- a/WooCommerce/WooCommerceTests/Mocks/MockBuiltInCardReaderConnectionControllerFactory.swift
+++ b/WooCommerce/WooCommerceTests/Mocks/MockBuiltInCardReaderConnectionControllerFactory.swift
@@ -3,8 +3,11 @@ import Foundation
 import Yosemite
 
 class MockBuiltInCardReaderConnectionControllerFactory: BuiltInCardReaderConnectionControllerBuilding {
+    typealias AlertProvider = BuiltInReaderConnectionAlertsProvider
+    typealias AlertPresenter = SilenceablePassthroughCardPresentPaymentAlertsPresenter<CardPresentPaymentAlertsPresenter>
+
     var spyCreateConnectionControllerSiteID: Int64? = nil
-    var spyCreateConnectionControllerAlertsPresenter: (any CardPresentPaymentAlertsPresenting)? = nil
+    var spyCreateConnectionControllerAlertsPresenter: AlertPresenter? = nil
     var spyCreateConnectionControllerConfiguration: CardPresentPaymentsConfiguration? = nil
     var spyCreateConnectionControllerAnalyticsTracker: CardReaderConnectionAnalyticsTracker? = nil
     var spyCreateConnectionControllerAllowTermsOfServiceAcceptance: Bool? = nil
@@ -14,12 +17,12 @@ class MockBuiltInCardReaderConnectionControllerFactory: BuiltInCardReaderConnect
     var mockConnectionController: MockBuiltInCardReaderConnectionController? = nil
 
     func createConnectionController(forSiteID siteID: Int64,
-                                    alertsPresenter: any CardPresentPaymentAlertsPresenting<CardPresentPaymentsModalViewModel>,
+                                    alertPresenter: AlertPresenter,
                                     configuration: CardPresentPaymentsConfiguration,
                                     analyticsTracker: CardReaderConnectionAnalyticsTracker,
                                     allowTermsOfServiceAcceptance: Bool) -> BuiltInCardReaderConnectionControlling {
         spyCreateConnectionControllerSiteID = siteID
-        spyCreateConnectionControllerAlertsPresenter = alertsPresenter
+        spyCreateConnectionControllerAlertsPresenter = alertPresenter
         spyCreateConnectionControllerConfiguration = configuration
         spyCreateConnectionControllerAnalyticsTracker = analyticsTracker
         spyCreateConnectionControllerAllowTermsOfServiceAcceptance = allowTermsOfServiceAcceptance

--- a/WooCommerce/WooCommerceTests/Mocks/MockCardReaderSettingsAlerts.swift
+++ b/WooCommerce/WooCommerceTests/Mocks/MockCardReaderSettingsAlerts.swift
@@ -28,6 +28,8 @@ final class MockCardReaderSettingsAlerts {
 }
 
 extension MockCardReaderSettingsAlerts: BluetoothReaderConnnectionAlertsProviding {
+    typealias AlertDetails = CardPresentPaymentsModalViewModel
+
     func scanningForReader(cancel: @escaping () -> Void) -> CardPresentPaymentsModalViewModel {
         if mode == .cancelScanning {
             cancel()

--- a/WooCommerce/WooCommerceTests/ViewModels/CardPresentPayments/RefundSubmissionUseCaseTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewModels/CardPresentPayments/RefundSubmissionUseCaseTests.swift
@@ -7,7 +7,7 @@ import WooFoundation
 import protocol Storage.StorageManagerType
 import protocol Storage.StorageType
 
-private typealias Dependencies = RefundSubmissionUseCase.Dependencies
+private typealias Dependencies = RefundSubmissionUseCase<MockCardReaderSettingsAlerts, MockCardPresentPaymentAlertsPresenter>.Dependencies
 
 final class RefundSubmissionUseCaseTests: XCTestCase {
     private var stores: MockStoresManager!
@@ -446,7 +446,8 @@ private extension RefundSubmissionUseCaseTests {
         }
     }
 
-    func createUseCase(details: RefundSubmissionUseCase.Details) -> RefundSubmissionUseCase {
+    func createUseCase(details: RefundSubmissionUseCase<MockCardReaderSettingsAlerts, MockCardPresentPaymentAlertsPresenter>.Details) ->
+    RefundSubmissionUseCase<MockCardReaderSettingsAlerts, MockCardPresentPaymentAlertsPresenter> {
         let dependencies = Dependencies(
             currencyFormatter: CurrencyFormatter(currencySettings: .init()),
             currencySettings: .init(),

--- a/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Settings/In-Person Payments/TapToPayReconnectionControllerTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Settings/In-Person Payments/TapToPayReconnectionControllerTests.swift
@@ -10,7 +10,7 @@ final class TapToPayReconnectionControllerTests: XCTestCase {
     private var storageManager: MockStorageManager!
     private var connectionControllerFactory: MockBuiltInCardReaderConnectionControllerFactory!
     private var onboardingCache: CardPresentPaymentOnboardingStateCache!
-    private var sut: TapToPayReconnectionController!
+    private var sut: TapToPayReconnectionController<BuiltInReaderConnectionAlertsProvider, CardPresentPaymentAlertsPresenter>!
     private let sampleSiteID: Int64 = 12891
     private let sampleConfiguration: CardPresentPaymentsConfiguration = CardPresentPaymentsConfiguration(country: .US)
 


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of: #12868
Merge after #13038
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This PR forms part of a series, together making the alert providers and presenters used in card payments generic.

When complete, this will mean that the POS experience can use different alert view models from the existing app's CardPresentPaymentModalViewModel, specialised for the new design, while continuing to use all the existing payments logic.

This fourth PR converts the connection controllers to use generic alert view models, but doesn't take advantage of that with a new type yet. We _could_ do that now, but to keep the PRs a sensible size, I've opted to do that in the next PR.

## Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->

Check the existing payments work as expected in the main app, and that the POS reader connection works as well.

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.