### PR TITLE
[Woo POS] Remove cash payment

### DIFF
--- a/WooCommerce/Classes/POS/Presentation/TotalsView.swift
+++ b/WooCommerce/Classes/POS/Presentation/TotalsView.swift
@@ -44,10 +44,6 @@ private extension TotalsView {
         Text("Tap or insert card to pay")
     }
 
-    private var takeCashView: some View {
-        Text("Take cash payment")
-    }
-
     private var paymentSuccessfulView: some View {
         Text("Payment successful")
     }
@@ -61,10 +57,6 @@ private extension TotalsView {
             tapInsertCardView
         case .cardPaymentSuccessful:
             paymentSuccessfulView
-        case .acceptingCash:
-            takeCashView
-        case .cashPaymentSuccessful:
-            paymentSuccessfulView
         }
     }
 
@@ -77,10 +69,6 @@ private extension TotalsView {
             EmptyView()
         case .cardPaymentSuccessful:
             EmptyView()
-        case .acceptingCash:
-            EmptyView()
-        case .cashPaymentSuccessful:
-            EmptyView()
         }
     }
 
@@ -91,47 +79,6 @@ private extension TotalsView {
                 .font(.title)
             paymentsIconView
         }
-    }
-
-    private var cashPaymentButton: some View {
-        Button("Cash payment") {
-            paymentState = .acceptingCash
-        }
-        .padding(30)
-        .font(.title)
-        .foregroundColor(Color.primaryText)
-        .overlay(
-            RoundedRectangle(cornerRadius: 16)
-                .stroke(Color.primaryText, lineWidth: 2)
-        )
-    }
-
-    private var confirmCashPaymentButton: some View {
-        Button("Confirm") {
-            paymentState = .cashPaymentSuccessful
-        }
-        .padding(30)
-        .font(.title)
-        .foregroundColor(Color.primaryText)
-        .background(Color.secondaryBackground)
-        .cornerRadius(16)
-        .overlay(
-            RoundedRectangle(cornerRadius: 16)
-                .stroke(Color.primaryText, lineWidth: 2)
-        )
-    }
-
-    private var cancelCashPaymentButton: some View {
-        Button("Cancel") {
-            paymentState = .acceptingCard
-        }
-        .padding(30)
-        .font(.title)
-        .foregroundColor(Color.primaryText)
-        .overlay(
-            RoundedRectangle(cornerRadius: 16)
-                .stroke(Color.primaryText, lineWidth: 2)
-        )
     }
 
     private var provideReceiptButton: some View {
@@ -165,21 +112,14 @@ private extension TotalsView {
         VStack {
             switch paymentState {
             case .acceptingCard:
-                HStack {
-                    cashPaymentButton
-                }
+                EmptyView()
             case .processingCard:
                 EmptyView()
-            case .cardPaymentSuccessful, .cashPaymentSuccessful:
+            case .cardPaymentSuccessful:
                 HStack {
                     provideReceiptButton
                     Spacer()
                     newTransactionButton
-                }
-            case .acceptingCash:
-                HStack {
-                    confirmCashPaymentButton
-                    cancelCashPaymentButton
                 }
             }
         }

--- a/WooCommerce/Classes/POS/ViewModels/PointOfSaleDashboardViewModel.swift
+++ b/WooCommerce/Classes/POS/ViewModels/PointOfSaleDashboardViewModel.swift
@@ -8,8 +8,6 @@ final class PointOfSaleDashboardViewModel: ObservableObject {
         case acceptingCard
         case processingCard
         case cardPaymentSuccessful
-        case acceptingCash
-        case cashPaymentSuccessful
     }
 
     @Published private(set) var items: [POSItem]


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #13031 
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

As confirmed in p91TBi-bot-p2#comment-12344, cash payment is out of the M1 scope. This PR removes the CTA and related states accordingly to make it easier for card payment UI updates later.

## Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->

Prerequisite: the store is eligible for POS and the feature switch is enabled in Menu > Settings > Experimental Features > POS
* Launch app
* Go to Menu > Point of Sale
* Add some item(s) to the cart
* Tap to check out --> the `Cash payment` CTA shouldn't be shown anymore

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->


<img src="https://github.com/woocommerce/woocommerce-ios/assets/1945542/9d3db909-13bf-4732-b3fe-48919ab26d59" width="300" />

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.