### PR TITLE
[Woo POS] Update progress indicator with `IndefiniteCircularProgressViewStyle` to match the existing payment alert design

### DIFF
--- a/WooCommerce/Classes/POS/Presentation/CardPresentPaymentAlert.swift
+++ b/WooCommerce/Classes/POS/Presentation/CardPresentPaymentAlert.swift
@@ -34,8 +34,8 @@ struct BasicCardPresentPaymentAlert: View {
 
             if viewModel.showLoadingIndicator {
                 ProgressView()
-                    .progressViewStyle(CircularProgressViewStyle(tint: .gray))
-                    .scaleEffect(1.5, anchor: .center)
+                    .progressViewStyle(IndefiniteCircularProgressViewStyle(size: Layout.circularProgressIndicatorSize))
+                    .padding()
             } else {
                 Image(uiImage: viewModel.image)
                     .padding()
@@ -97,6 +97,7 @@ private extension BasicCardPresentPaymentAlert {
         static let padding: EdgeInsets = .init(top: 40, leading: 96, bottom: 56, trailing: 96)
         static let stackViewVerticalSpacing: CGFloat = 32
         static let defaultVerticalSpacing: CGFloat = 16
+        static let circularProgressIndicatorSize: CGFloat = 96
     }
 }
 


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #13016 
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

To match the existing alert design in the app, this PR updates the progress indicator UI to use what's in the existing design, `IndefiniteCircularProgressViewStyle`.

## Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->

Prerequisite: the store is eligible for POS and the feature switch is enabled in Menu > Settings > Experimental Features > POS
* Launch app
* Go to Menu > Point of Sale
* Add some item(s) to cart, check out, and tap `Collect payment` --> the "Getting ready to collect payment" modal should show a spinner animating like in the existing app

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

light | dark
-- | --
<img width="590" alt="Screenshot 2024-06-12 at 4 45 51 PM" src="https://github.com/woocommerce/woocommerce-ios/assets/1945542/b354f8f3-f4da-4b56-8c43-f0dbb276b03b"> | <img width="591" alt="Screenshot 2024-06-12 at 4 46 06 PM" src="https://github.com/woocommerce/woocommerce-ios/assets/1945542/5dfac053-4631-4f3e-822f-189439294c38">


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.