### PR TITLE
[Customers] Tracks events for new customer contact actions

### DIFF
--- a/WooCommerce/Classes/Analytics/WooAnalyticsEvent.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsEvent.swift
@@ -3077,6 +3077,26 @@ extension WooAnalyticsEvent {
             static let registered = "registered"
             static let hasEmail = "has_email_address"
         }
+
+        /// Possible actions to take in customer details
+        enum Action: String {
+            fileprivate static let key = "action"
+
+            case call = "phone_call"
+            case message = "text_message"
+            case copyPhone = "copy_phone_number"
+            case whatsapp = "whatsapp"
+            case telegram = "telegram"
+        }
+
+        /// Possible addresses in customer details
+        enum Address: String {
+            fileprivate static let key = "address"
+
+            case shipping = "shipping_address"
+            case billing = "billing_address"
+        }
+
         static func customerListLoaded() -> WooAnalyticsEvent {
             WooAnalyticsEvent(statName: .customerHubLoaded, properties: [:])
         }
@@ -3104,6 +3124,18 @@ extension WooAnalyticsEvent {
 
         static func customerDetailCopyEmailOptionTapped() -> WooAnalyticsEvent {
             WooAnalyticsEvent(statName: .customersHubDetailCopyEmailOptionTapped, properties: [:])
+        }
+
+        static func customerDetailPhoneMenuTapped() -> WooAnalyticsEvent {
+            WooAnalyticsEvent(statName: .customersHubDetailPhoneMenuTapped, properties: [:])
+        }
+
+        static func customerDetailActionTapped(_ action: Action) -> WooAnalyticsEvent {
+            WooAnalyticsEvent(statName: .customersHubDetailPhoneActionTapped, properties: [Action.key: action.rawValue])
+        }
+
+        static func customerDetailAddressCopied(_ address: Address) -> WooAnalyticsEvent {
+            WooAnalyticsEvent(statName: .customersHubDetailAddressCopied, properties: [Address.key: address.rawValue])
         }
     }
 }

--- a/WooCommerce/Classes/Analytics/WooAnalyticsStat.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsStat.swift
@@ -1086,6 +1086,9 @@ enum WooAnalyticsStat: String {
     case customersHubDetailEmailMenuTapped = "customers_hub_customer_detail_email_menu_tapped"
     case customersHubDetailEmailOptionTapped = "customers_hub_customer_detail_email_option_tapped"
     case customersHubDetailCopyEmailOptionTapped = "customers_hub_customer_detail_email_copy_option_tapped"
+    case customersHubDetailPhoneMenuTapped = "customers_hub_customer_detail_phone_menu_tapped"
+    case customersHubDetailPhoneActionTapped = "customers_hub_customer_detail_phone_action_tapped"
+    case customersHubDetailAddressCopied = "customers_hub_customer_detail_address_copied"
 
     // MARK: Close Account
     case closeAccountTapped = "close_account_tapped"

--- a/WooCommerce/Classes/ViewRelated/Customers/CustomerDetailView.swift
+++ b/WooCommerce/Classes/ViewRelated/Customers/CustomerDetailView.swift
@@ -53,6 +53,7 @@ struct CustomerDetailView: View {
                     if let phone = viewModel.phone {
                         Button {
                             isPresentingPhoneDialog.toggle()
+                            viewModel.trackPhoneMenuTapped()
                         } label: {
                             Image(uiImage: .ellipsisImage)
                                 .foregroundColor(Color(.primary))
@@ -66,11 +67,12 @@ struct CustomerDetailView: View {
 
                             Button(Localization.ContactAction.message) {
                                 isShowingMessageView.toggle()
+                                viewModel.trackMessageActionTapped()
                             }
                             .renderedIf(MessageComposeView.canSendMessage())
 
                             Button(Localization.ContactAction.copyPhoneNumber) {
-                                phone.sendToPasteboard(includeTrailingNewline: false)
+                                viewModel.copyPhone()
                             }
 
                             Button(Localization.ContactAction.whatsapp) {
@@ -104,14 +106,14 @@ struct CustomerDetailView: View {
                     Text(billing)
                         .swipeActions(edge: .leading) {
                             Button {
-                                billing.sendToPasteboard()
+                                viewModel.copyBillingAddress()
                             } label: {
                                 Text(Localization.ContactAction.copy)
                             }
                         }
                         .contextMenu {
                             Button {
-                                billing.sendToPasteboard()
+                                viewModel.copyBillingAddress()
                             } label: {
                                 Label(Localization.ContactAction.copy, systemImage: "doc.on.doc")
                             }
@@ -123,14 +125,14 @@ struct CustomerDetailView: View {
                     Text(shipping)
                         .swipeActions(edge: .leading) {
                             Button {
-                                shipping.sendToPasteboard()
+                                viewModel.copyShippingAddress()
                             } label: {
                                 Text(Localization.ContactAction.copy)
                             }
                         }
                         .contextMenu {
                             Button {
-                                shipping.sendToPasteboard()
+                                viewModel.copyShippingAddress()
                             } label: {
                                 Label(Localization.ContactAction.copy, systemImage: "doc.on.doc")
                             }

--- a/WooCommerce/Classes/ViewRelated/Customers/CustomerDetailViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Customers/CustomerDetailViewModel.swift
@@ -156,6 +156,22 @@ extension CustomerDetailViewModel {
         ServiceLocator.analytics.track(event: .CustomersHub.customerDetailEmailOptionTapped())
     }
 
+    /// Tracks when the phone menu is opened.
+    func trackPhoneMenuTapped() {
+        ServiceLocator.analytics.track(event: .CustomersHub.customerDetailPhoneMenuTapped())
+    }
+
+    /// Tracks when the option to send a text message is tapped.
+    func trackMessageActionTapped() {
+        ServiceLocator.analytics.track(event: .CustomersHub.customerDetailActionTapped(.message))
+    }
+
+    /// Copies the customer phone to the pasteboard.
+    func copyPhone() {
+        phone?.sendToPasteboard(includeTrailingNewline: false)
+        ServiceLocator.analytics.track(event: .CustomersHub.customerDetailActionTapped(.copyPhone))
+    }
+
     /// Whether the device can perform a phone call
     var isPhoneCallAvailable: Bool {
         guard let phoneURL else {
@@ -170,6 +186,7 @@ extension CustomerDetailViewModel {
             return
         }
         UIApplication.shared.open(phoneURL, options: [:], completionHandler: nil)
+        ServiceLocator.analytics.track(event: .CustomersHub.customerDetailActionTapped(.call))
     }
 
     /// Whatsapp deeplink to contact someone through their phone number
@@ -194,6 +211,7 @@ extension CustomerDetailViewModel {
             return
         }
         UIApplication.shared.open(whatsappDeeplink)
+        ServiceLocator.analytics.track(event: .CustomersHub.customerDetailActionTapped(.whatsapp))
     }
 
     /// Telegram deeplink to contact someone through their phone number
@@ -218,6 +236,19 @@ extension CustomerDetailViewModel {
             return
         }
         UIApplication.shared.open(telegramDeeplink)
+        ServiceLocator.analytics.track(event: .CustomersHub.customerDetailActionTapped(.telegram))
+    }
+
+    /// Copies the billing address to the pasteboard.
+    func copyBillingAddress() {
+        billing?.sendToPasteboard()
+        ServiceLocator.analytics.track(event: .CustomersHub.customerDetailAddressCopied(.billing))
+    }
+
+    /// Copies the shipping address to the pasteboard.
+    func copyShippingAddress() {
+        shipping?.sendToPasteboard()
+        ServiceLocator.analytics.track(event: .CustomersHub.customerDetailAddressCopied(.shipping))
     }
 }
 


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of: #13023
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

Adds the following new events:

* `customers_hub_customer_detail_phone_menu_tapped` - triggered in customer details when the ellipsis menu next to the phone number is tapped. (Registration: https://github.com/Automattic/tracks-events-registration/pull/2494)
* `customers_hub_customer_detail_phone_action_tapped` with custom prop `action` - triggered in customer details when a phone action is tapped, e.g. call, message, copy. Custom prop records which action was selected. (Registration: https://github.com/Automattic/tracks-events-registration/pull/2495)
* `customers_hub_customer_detail_address_copied` with custom prop `address` - triggered in customer details when the billing or shipping address is copied. Custom prop records which address was copied. (Registration: https://github.com/Automattic/tracks-events-registration/pull/2496)

## Testing steps
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->

1. Build and run the app (building on device will offer more phone actions).
2. Go to the Menu tab.
3. Select Customers.
4. Select a registered customer with a phone number and address.
5. Tap the ellipsis menu next to the customer's phone number and confirm `customers_hub_customer_detail_phone_menu_tapped` is tracked.
6. Select an option in the menu and confirm `customers_hub_customer_detail_phone_action_tapped` is tracked with the corresponding `action` property.
7. Copy the billing or shipping address and confirm `customers_hub_customer_detail_address_copied` is tracked with the corresponding `address` property.


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.