### PR TITLE
[WOO POS] Fixing checkout button color

### DIFF
--- a/WooCommerce/Classes/POS/Presentation/CartView.swift
+++ b/WooCommerce/Classes/POS/Presentation/CartView.swift
@@ -49,7 +49,7 @@ struct CartView: View {
 ///
 private extension CartView {
     private var checkoutButtonForegroundColor: Color {
-        return viewModel.checkoutButtonDisabled ? Color.gray : Color.primaryBackground
+        return viewModel.checkoutButtonDisabled ? Color.gray : Color.primaryText
     }
 
     private var checkoutButtonBackgroundColor: Color {


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

Small change in foreground color for checkout button. This is just a temporary change since we will update the colors for the final design anyway.

<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->

## Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: https://woomobilep2.wordpress.com/2024/05/06/woocommerce-mobile-quality-report-march-april/#comment-12036 -->

- enter POS
- add item to cart
- check that checkout button text color is correct

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

| Before      | After |
| ----------- | ----------- |
| ![Simulator Screenshot - iPad Pro (11-inch) (4th generation) 17 2 - 2024-06-12 at 19 30 16](https://github.com/woocommerce/woocommerce-ios/assets/6242034/85a5bc7d-3211-4610-85f8-b30ec3afcdbd)      | ![Simulator Screenshot - iPad Pro (11-inch) (4th generation) 17 2 - 2024-06-12 at 19 31 21](https://github.com/woocommerce/woocommerce-ios/assets/6242034/4dd11960-a7e3-4e5e-af68-e1ef74468a76)       |

---
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
