### PR TITLE
Watch: Improve sync connection

### DIFF
--- a/WooCommerce/Classes/System/WatchDependenciesSynchronizer.swift
+++ b/WooCommerce/Classes/System/WatchDependenciesSynchronizer.swift
@@ -108,3 +108,19 @@ extension WatchDependenciesSynchronizer {
         ServiceLocator.analytics.track(analyticEvent)
     }
 }
+
+// MARK: Sync Delegate
+extension WatchDependenciesSynchronizer {
+    /// The `didReceiveMessage` only supports sync requests events for now.
+    /// When one is identified we should try to re-sync credentials.
+    ///
+    func session(_ session: WCSession, didReceiveMessage message: [String : Any]) {
+        guard message[WooConstants.watchTracksKey] as? Bool == true else {
+            return DDLogError("⛔️ Unsupported sync request message: \(message)")
+        }
+
+        // Reset storeID to trigger a `re-sync`.
+        // This could be improved by having a custom re-sync trigger(publisher).
+        self.storeID = self.storeID
+    }
+}

--- a/WooCommerce/Classes/System/WooConstants.swift
+++ b/WooCommerce/Classes/System/WooConstants.swift
@@ -83,6 +83,10 @@ public enum WooConstants {
     /// Key used to identify track events sent between the phone and the watch.
     ///
     static let watchTracksKey = "watch-tracks-event"
+
+    /// Key used to identify sync request attempt from the watch.
+    ///
+    static let watchSyncKey = "watch-tracks-event"
 }
 
 // MARK: URLs

--- a/WooCommerce/Classes/System/WooConstants.swift
+++ b/WooCommerce/Classes/System/WooConstants.swift
@@ -86,7 +86,7 @@ public enum WooConstants {
 
     /// Key used to identify sync request attempt from the watch.
     ///
-    static let watchSyncKey = "watch-tracks-event"
+    static let watchSyncKey = "watch-sync-event"
 }
 
 // MARK: URLs

--- a/WooCommerce/Woo Watch App/App/WooApp.swift
+++ b/WooCommerce/Woo Watch App/App/WooApp.swift
@@ -36,7 +36,7 @@ struct Woo_Watch_AppApp: App {
 
                 } else {
 
-                    ConnectView()
+                    ConnectView(synchronizer: phoneDependencySynchronizer)
 
                 }
             }

--- a/WooCommerce/Woo Watch App/ConnectView.swift
+++ b/WooCommerce/Woo Watch App/ConnectView.swift
@@ -7,23 +7,33 @@ struct ConnectView: View {
 
     @EnvironmentObject private var tracksProvider: WatchTracksProvider
 
+    let synchronizer: PhoneDependenciesSynchronizer
+
     let message: String = Localization.connectMessage
 
     var body: some View {
-        VStack(spacing: Layout.mainSpacing) {
-            Text(message)
-                .multilineTextAlignment(.center)
-                .fixedSize(horizontal: false, vertical: true)
+        ScrollView {
+            VStack(spacing: Layout.mainSpacing) {
+                Text(message)
+                    .multilineTextAlignment(.center)
+                    .fixedSize(horizontal: false, vertical: true)
 
-            Image(systemName: "bolt.fill")
-                .renderingMode(.original)
-                .resizable()
-                .frame(width: Layout.boltSize.width, height: Layout.boltSize.height)
-                .foregroundStyle(Layout.ambarColor)
+                Image(systemName: "bolt.fill")
+                    .renderingMode(.original)
+                    .resizable()
+                    .frame(width: Layout.boltSize.width, height: Layout.boltSize.height)
+                    .foregroundStyle(Layout.ambarColor)
+
+                Button(Localization.itsNotWorking) {
+                    synchronizer.requestCredentialSync()
+                }
+            }
         }
-        .padding(.vertical)
         .task {
             tracksProvider.sendTracksEvent(.watchConnectingOpened)
+        }
+        .onAppear {
+            synchronizer.requestCredentialSync()
         }
     }
 }
@@ -41,10 +51,15 @@ extension ConnectView {
             value: "Open Woo on your iPhone, connect your store, and hold your Watch nearby",
             comment: "Info message when connecting your watch to the phone for the first time."
         )
+        static let itsNotWorking = AppLocalizedString(
+            "watch.connect.notworking.title",
+            value: "It's not working",
+            comment: "Button title for when connecting the watch does not work on the connecting screen."
+        )
     }
 }
 
 #Preview {
-    ConnectView()
+    ConnectView(synchronizer: PhoneDependenciesSynchronizer())
         .environmentObject(WatchTracksProvider())
 }

--- a/WooCommerce/Woo Watch App/ConnectView.swift
+++ b/WooCommerce/Woo Watch App/ConnectView.swift
@@ -32,9 +32,6 @@ struct ConnectView: View {
         .task {
             tracksProvider.sendTracksEvent(.watchConnectingOpened)
         }
-        .onAppear {
-            synchronizer.requestCredentialSync()
-        }
     }
 }
 

--- a/WooCommerce/Woo Watch App/Dependencies/PhoneDependenciesSynchronizer.swift
+++ b/WooCommerce/Woo Watch App/Dependencies/PhoneDependenciesSynchronizer.swift
@@ -47,6 +47,14 @@ final class PhoneDependenciesSynchronizer: NSObject, ObservableObject, WCSession
             self.reloadDependencies()
 
             self.tracksProvider?.flushQueuedEvents()
+
+            // If we could not find dependencies after the session is activated try a credential sync.
+            // Give it 1 second so the watch can successfully reach the counterpart.
+            if self.dependencies == nil {
+                DispatchQueue.main.asyncAfter(deadline: .now() + 1) {
+                    self.requestCredentialSync()
+                }
+            }
         }
     }
 

--- a/WooCommerce/Woo Watch App/Dependencies/PhoneDependenciesSynchronizer.swift
+++ b/WooCommerce/Woo Watch App/Dependencies/PhoneDependenciesSynchronizer.swift
@@ -32,6 +32,13 @@ final class PhoneDependenciesSynchronizer: NSObject, ObservableObject, WCSession
         }
     }
 
+    /// Sends a message to the paired counterpart to attempt a credential sync.
+    /// This should be received in `WatchDependenciesSynchronizer.didReceiveMessage` method.
+    ///
+    func requestCredentialSync() {
+        WCSession.default.sendMessage([WooConstants.watchSyncKey: true], replyHandler: nil)
+    }
+
     /// Get the latest application context when the session activates
     ///
     func session(_ session: WCSession, activationDidCompleteWith activationState: WCSessionActivationState, error: Error?) {


### PR DESCRIPTION
closes #12993 

# Why

This PR does two main things:

- Try a credential sync when the connect view is presented
- Add a button to manually retry a credential sync.

# How

In this PR the watch is sending a custom message to the phone with key `watch-sync-event`. When this message is received the phone tries to update with application context with the credentials information

# Demo

Normal | Big Fonts | Big Font Scrolled
--- | --- | ---
![normal](https://github.com/woocommerce/woocommerce-ios/assets/562080/030bb169-aeca-44b5-ad0c-3624288d90ec) | ![scrolled](https://github.com/woocommerce/woocommerce-ios/assets/562080/a203f7c1-a7cb-48ef-9477-ea27b3f12448) | ![big-font](https://github.com/woocommerce/woocommerce-ios/assets/562080/96964252-2f9b-4517-873e-711c263c6ae2)


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
