### PR TITLE
[Customers] Create a new order with customer data pre-filled in order form

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -6,6 +6,7 @@
 - [*] Products: The creation sheet is now simplified and categorized better [https://github.com/woocommerce/woocommerce-ios/pull/12273]
 - [*] Restore a missing navigation bar on the privacy settings screen. [https://github.com/woocommerce/woocommerce-ios/pull/13018]
 - [**] Customers: The customers section (Menu > Customers) now includes registered customers' phone number and billing/shipping addresses, when available, with actions to copy their contact details or contact them via phone. [https://github.com/woocommerce/woocommerce-ios/pull/13034]
+- [**] Customers: You can now create a new order for registered customers in the Customers section (Menu > Customers). Tap the + button in a customer's details to create a new order with that customer pre-filled in the order form.
 
 
 19.0

--- a/WooCommerce/Classes/ViewRelated/Customers/CustomerDetailView.swift
+++ b/WooCommerce/Classes/ViewRelated/Customers/CustomerDetailView.swift
@@ -114,7 +114,7 @@ struct CustomerDetailView: View {
                 customerDetailRow(label: Localization.dateRegisteredLabel, value: viewModel.dateRegistered)
             }
 
-            if let billing = viewModel.billing, billing.isNotEmpty {
+            if let billing = viewModel.formattedBilling, billing.isNotEmpty {
                 Section(header: Text(Localization.billingSection)) {
                     Text(billing)
                         .swipeActions(edge: .leading) {
@@ -133,7 +133,7 @@ struct CustomerDetailView: View {
                         }
                 }
             }
-            if let shipping = viewModel.shipping, shipping.isNotEmpty {
+            if let shipping = viewModel.formattedShipping, shipping.isNotEmpty {
                 Section(header: Text(Localization.shippingSection)) {
                     Text(shipping)
                         .swipeActions(edge: .leading) {
@@ -308,7 +308,7 @@ private extension CustomerDetailView {
     }
 }
 
-#Preview("Unregistered Customer") {
+#Preview("Customer") {
     CustomerDetailView(viewModel: CustomerDetailViewModel(siteID: 1,
                                                           customerID: 0,
                                                           name: "Pat Smith",
@@ -322,28 +322,7 @@ private extension CustomerDetailView {
                                                           country: "United States",
                                                           region: "Oregon",
                                                           city: "Portland",
-                                                          postcode: "12345",
-                                                          billing: nil,
-                                                          shipping: nil))
-}
-
-#Preview("Registered Customer") {
-    CustomerDetailView(viewModel: CustomerDetailViewModel(siteID: 1,
-                                                          customerID: 0,
-                                                          name: "Pat Smith",
-                                                          dateLastActive: "Jan 1, 2024",
-                                                          email: "patsmith@example.com",
-                                                          ordersCount: "3",
-                                                          totalSpend: "$81.75",
-                                                          avgOrderValue: "$27.25",
-                                                          username: "patsmith",
-                                                          dateRegistered: "Jan 1, 2023",
-                                                          country: "United States",
-                                                          region: "Oregon",
-                                                          city: "Portland",
-                                                          postcode: "12345",
-                                                          billing: "Pat Smith\n1 Main Street\nPortland, Oregon 12345",
-                                                          shipping: "Pat Smith\n1 Main Street\nPortland, Oregon 12345"))
+                                                          postcode: "12345"))
 }
 
 #Preview("Customer with Placeholders") {
@@ -360,7 +339,5 @@ private extension CustomerDetailView {
                                                           country: nil,
                                                           region: nil,
                                                           city: nil,
-                                                          postcode: nil,
-                                                          billing: nil,
-                                                          shipping: nil))
+                                                          postcode: nil))
 }

--- a/WooCommerce/Classes/ViewRelated/Customers/CustomerDetailView.swift
+++ b/WooCommerce/Classes/ViewRelated/Customers/CustomerDetailView.swift
@@ -50,7 +50,7 @@ struct CustomerDetailView: View {
                                 .shimmering()
                         }
                     Spacer()
-                    if let phone = viewModel.phone {
+                    if viewModel.phone != nil {
                         Button {
                             isPresentingPhoneDialog.toggle()
                             viewModel.trackPhoneMenuTapped()

--- a/WooCommerce/Classes/ViewRelated/Customers/CustomerDetailView.swift
+++ b/WooCommerce/Classes/ViewRelated/Customers/CustomerDetailView.swift
@@ -90,10 +90,23 @@ struct CustomerDetailView: View {
                 customerDetailRow(label: Localization.dateLastActiveLabel, value: viewModel.dateLastActive)
             }
 
-            Section(header: Text(Localization.ordersSection)) {
+            Section {
                 customerDetailRow(label: Localization.ordersCountLabel, value: viewModel.ordersCount)
                 customerDetailRow(label: Localization.totalSpendLabel, value: viewModel.totalSpend)
                 customerDetailRow(label: Localization.avgOrderValueLabel, value: viewModel.avgOrderValue)
+            } header: {
+                HStack {
+                    Text(Localization.ordersSection)
+                    Spacer()
+                    Button {
+                        viewModel.createNewOrder()
+                    } label: {
+                        Image(uiImage: .plusImage)
+                    }
+                    .accessibilityLabel(Localization.newOrder)
+                    .renderedIf(viewModel.canCreateNewOrder)
+
+                }
             }
 
             Section(header: Text(Localization.registrationSection)) {
@@ -207,6 +220,9 @@ private extension CustomerDetailView {
         static let ordersSection = NSLocalizedString("customerDetailView.ordersSection",
                                                        value: "ORDERS",
                                                        comment: "Heading for the section with customer order stats in the Customer Details screen.")
+        static let newOrder = NSLocalizedString("customerDetailsView.newOrderButton",
+                                                value: "Create a new order",
+                                                comment: "Label for button to create a new order for the customer in the Customer Details screen.")
         static let ordersCountLabel = NSLocalizedString("customerDetailView.ordersCountLabel",
                                                         value: "Orders",
                                                         comment: "Label for the number of orders in the Customer Details screen.")

--- a/WooCommerce/Classes/ViewRelated/Customers/CustomerDetailViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Customers/CustomerDetailViewModel.swift
@@ -151,7 +151,7 @@ final class CustomerDetailViewModel: ObservableObject {
         guard canCreateNewOrder else {
             return
         }
-        MainTabBarController.presentOrderCreationFlow(for: customerID)
+        MainTabBarController.presentOrderCreationFlow(for: customerID, billing: billing, shipping: shipping)
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Customers/CustomerDetailViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Customers/CustomerDetailViewModel.swift
@@ -23,7 +23,7 @@ final class CustomerDetailViewModel: ObservableObject {
 
     /// Customer phone
     var phone: String? {
-        phoneSource?.phone
+        phoneSource?.phone?.nullifyIfEmptyOrWhitespace()
     }
 
     // MARK: Orders

--- a/WooCommerce/Classes/ViewRelated/Customers/CustomerDetailViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Customers/CustomerDetailViewModel.swift
@@ -136,6 +136,19 @@ final class CustomerDetailViewModel: ObservableObject {
                   shipping: nil,
                   stores: stores)
     }
+
+    /// Whether a new order can be created for the customer.
+    var canCreateNewOrder: Bool {
+        customerID != 0
+    }
+
+    /// Navigates to the Orders tab and opens a new order with this customer pre-filled in the order form.
+    func createNewOrder() {
+        guard canCreateNewOrder else {
+            return
+        }
+        MainTabBarController.presentOrderCreationFlow(for: customerID)
+    }
 }
 
 // MARK: Contact actions

--- a/WooCommerce/Classes/ViewRelated/MainTabBarController.swift
+++ b/WooCommerce/Classes/ViewRelated/MainTabBarController.swift
@@ -449,7 +449,7 @@ extension MainTabBarController {
         }
     }
 
-    static func presentOrderCreationFlow(for customerID: Int64) {
+    static func presentOrderCreationFlow(for customerID: Int64, billing: Address?, shipping: Address?) {
         switchToOrdersTab {
             let tabBar = AppDelegate.shared.tabBarController
             let ordersContainerController = tabBar?.ordersContainerController
@@ -458,7 +458,7 @@ extension MainTabBarController {
                 return
             }
 
-            ordersSplitViewWrapperController.presentOrderCreationFlow(for: customerID)
+            ordersSplitViewWrapperController.presentOrderCreationFlow(for: customerID, billing: billing, shipping: shipping)
         }
     }
 

--- a/WooCommerce/Classes/ViewRelated/MainTabBarController.swift
+++ b/WooCommerce/Classes/ViewRelated/MainTabBarController.swift
@@ -449,6 +449,19 @@ extension MainTabBarController {
         }
     }
 
+    static func presentOrderCreationFlow(for customerID: Int64) {
+        switchToOrdersTab {
+            let tabBar = AppDelegate.shared.tabBarController
+            let ordersContainerController = tabBar?.ordersContainerController
+
+            guard let ordersSplitViewWrapperController = ordersContainerController?.wrappedController as? OrdersSplitViewWrapperController else {
+                return
+            }
+
+            ordersSplitViewWrapperController.presentOrderCreationFlow(for: customerID)
+        }
+    }
+
     private static func presentDetails(for orderID: Int64, siteID: Int64) {
         ordersTabSplitViewWrapper()?.presentDetails(for: orderID, siteID: siteID)
     }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/EditableOrderViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/EditableOrderViewModel.swift
@@ -467,6 +467,7 @@ final class EditableOrderViewModel: ObservableObject {
          orderDurationRecorder: OrderDurationRecorderProtocol = OrderDurationRecorder.shared,
          permissionChecker: CaptureDevicePermissionChecker = AVCaptureDevicePermissionChecker(),
          initialItem: OrderBaseItem? = nil,
+         initialCustomerID: Int64? = nil,
          quantityDebounceDuration: Double = Constants.quantityDebounceDuration) {
         self.siteID = siteID
         self.flow = flow
@@ -528,6 +529,7 @@ final class EditableOrderViewModel: ObservableObject {
         forwardSyncApproachToSynchronizer()
         observeChangesFromProductSelectorButtonTapSelectionSync()
         observeChangesInCustomerDetails()
+        configureOrderWithinitialCustomer(initialCustomerID)
     }
 
     /// Observes and keeps track of changes within the Customer Details
@@ -1652,6 +1654,16 @@ private extension EditableOrderViewModel {
         // Increase quantity if exists
         let match = productRows.first(where: { $0.productRow.productOrVariationID == item.itemID })
         match?.productRow.stepperViewModel.incrementQuantity()
+    }
+
+    /// If given an initial customer ID on initialization, updates the Order with the customer
+    ///
+    func configureOrderWithinitialCustomer(_ customerID: Int64?) {
+        guard let customerID else {
+            return
+        }
+        orderSynchronizer.setCustomerID.send(customerID)
+        orderSynchronizer.retryTrigger.send() // Trigger a remote sync to retrieve the customer details on the order.
     }
 
     /// Updates customer data viewmodel based on order addresses.

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/EditableOrderViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/EditableOrderViewModel.swift
@@ -451,6 +451,10 @@ final class EditableOrderViewModel: ObservableObject {
     ///
     private let initialItem: OrderBaseItem?
 
+    /// Initial customer data given to the order when it is created, if any
+    ///
+    private let initialCustomer: (id: Int64, billing: Address?, shipping: Address?)?
+
     private let orderDurationRecorder: OrderDurationRecorderProtocol
 
     private let barcodeSKUScannerItemFinder: BarcodeSKUScannerItemFinder
@@ -467,7 +471,7 @@ final class EditableOrderViewModel: ObservableObject {
          orderDurationRecorder: OrderDurationRecorderProtocol = OrderDurationRecorder.shared,
          permissionChecker: CaptureDevicePermissionChecker = AVCaptureDevicePermissionChecker(),
          initialItem: OrderBaseItem? = nil,
-         initialCustomerID: Int64? = nil,
+         initialCustomer: (id: Int64, billing: Address?, shipping: Address?)? = nil,
          quantityDebounceDuration: Double = Constants.quantityDebounceDuration) {
         self.siteID = siteID
         self.flow = flow
@@ -480,6 +484,7 @@ final class EditableOrderViewModel: ObservableObject {
         self.orderDurationRecorder = orderDurationRecorder
         self.permissionChecker = permissionChecker
         self.initialItem = initialItem
+        self.initialCustomer = initialCustomer
         self.barcodeSKUScannerItemFinder = BarcodeSKUScannerItemFinder(stores: stores)
         self.quantityDebounceDuration = quantityDebounceDuration
 
@@ -529,7 +534,6 @@ final class EditableOrderViewModel: ObservableObject {
         forwardSyncApproachToSynchronizer()
         observeChangesFromProductSelectorButtonTapSelectionSync()
         observeChangesInCustomerDetails()
-        configureOrderWithinitialCustomer(initialCustomerID)
     }
 
     /// Observes and keeps track of changes within the Customer Details
@@ -1656,14 +1660,15 @@ private extension EditableOrderViewModel {
         match?.productRow.stepperViewModel.incrementQuantity()
     }
 
-    /// If given an initial customer ID on initialization, updates the Order with the customer
+    /// If given initial customer data on initialization, updates the Order with the customer data.
     ///
-    func configureOrderWithinitialCustomer(_ customerID: Int64?) {
+    func configureOrderWithInitialCustomerIfNeeded(_ customerID: Int64?, billing: Address?, shipping: Address?) {
         guard let customerID else {
             return
         }
         orderSynchronizer.setCustomerID.send(customerID)
-        orderSynchronizer.retryTrigger.send() // Trigger a remote sync to retrieve the customer details on the order.
+        orderSynchronizer.setAddresses.send(Self.createAddressesInputIfPossible(billingAddress: billing, shippingAddress: shipping))
+        resetAddressForm()
     }
 
     /// Updates customer data viewmodel based on order addresses.
@@ -1676,6 +1681,7 @@ private extension EditableOrderViewModel {
                     CustomerDataViewModel(billingAddress: $0.billingAddress, shippingAddress: $0.shippingAddress)
                 }
                 .assign(to: &$customerDataViewModel)
+            configureOrderWithInitialCustomerIfNeeded(initialCustomer?.id, billing: initialCustomer?.billing, shipping: initialCustomer?.shipping)
             return
         }
 
@@ -1713,6 +1719,8 @@ private extension EditableOrderViewModel {
                 )
             }
             .assign(to: &customerSectionViewModel.$customerData)
+
+        configureOrderWithInitialCustomerIfNeeded(initialCustomer?.id, billing: initialCustomer?.billing, shipping: initialCustomer?.shipping)
     }
 
     /// Updates notes data viewmodel based on order customer notes.

--- a/WooCommerce/Classes/ViewRelated/Orders/OrdersRootViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrdersRootViewController.swift
@@ -193,8 +193,8 @@ final class OrdersRootViewController: UIViewController {
 
     /// Presents the Order Creation flow with the given customer pre-filled.
     ///
-    func presentOrderCreationFlowWithCustomer(_ customerID: Int64) {
-        let viewModel = EditableOrderViewModel(siteID: siteID, initialCustomerID: customerID)
+    func presentOrderCreationFlowWithCustomer(id customerID: Int64, billing: Address?, shipping: Address?) {
+        let viewModel = EditableOrderViewModel(siteID: siteID, initialCustomer: (customerID, billing, shipping))
         setupNavigation(viewModel: viewModel)
     }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/OrdersRootViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrdersRootViewController.swift
@@ -191,6 +191,13 @@ final class OrdersRootViewController: UIViewController {
         setupNavigation(viewModel: viewModel)
     }
 
+    /// Presents the Order Creation flow with the given customer pre-filled.
+    ///
+    func presentOrderCreationFlowWithCustomer(_ customerID: Int64) {
+        let viewModel = EditableOrderViewModel(siteID: siteID, initialCustomerID: customerID)
+        setupNavigation(viewModel: viewModel)
+    }
+
     /// Coordinates the navigation between the different views involved in Order Creation, Editing, and Details
     ///
     private func setupNavigation(viewModel: EditableOrderViewModel) {

--- a/WooCommerce/Classes/ViewRelated/Orders/OrdersSplitViewWrapperController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrdersSplitViewWrapperController.swift
@@ -64,8 +64,8 @@ final class OrdersSplitViewWrapperController: UIViewController {
         ordersViewController.presentOrderCreationFlow()
     }
 
-    func presentOrderCreationFlow(for customerID: Int64) {
-        ordersViewController.presentOrderCreationFlowWithCustomer(customerID)
+    func presentOrderCreationFlow(for customerID: Int64, billing: Address?, shipping: Address?) {
+        ordersViewController.presentOrderCreationFlowWithCustomer(id: customerID, billing: billing, shipping: shipping)
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/OrdersSplitViewWrapperController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrdersSplitViewWrapperController.swift
@@ -63,6 +63,10 @@ final class OrdersSplitViewWrapperController: UIViewController {
     func presentOrderCreationFlow() {
         ordersViewController.presentOrderCreationFlow()
     }
+
+    func presentOrderCreationFlow(for customerID: Int64) {
+        ordersViewController.presentOrderCreationFlowWithCustomer(customerID)
+    }
 }
 
 private extension OrdersSplitViewWrapperController {

--- a/WooCommerce/WooCommerceTests/ViewRelated/Customers/CustomerDetailViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Customers/CustomerDetailViewModelTests.swift
@@ -87,8 +87,8 @@ final class CustomerDetailViewModelTests: XCTestCase {
         // Then
         let viewModel = try XCTUnwrap(vm)
         XCTAssertFalse(viewModel.showLocation)
-        assertEqual(billing.fullNameWithCompanyAndAddress, viewModel.billing)
-        assertEqual(shipping.fullNameWithCompanyAndAddress, viewModel.shipping)
+        assertEqual(billing.fullNameWithCompanyAndAddress, viewModel.formattedBilling)
+        assertEqual(shipping.fullNameWithCompanyAndAddress, viewModel.formattedShipping)
         assertEqual(billing.phone, viewModel.phone)
     }
 


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of: #13023
<!-- Id number of the GitHub issue this PR addresses. -->

## Why
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This adds support for creating a new order from the Customers section in the Hub menu. In customer details for a registered customer, a new order can be created with that customer pre-filled in the order form.

## How
In Customers:
* Adds a plus button to the Orders section in `CustomerDetailView`, to start the order creation flow. This button is visible for registered customers.
* Updates `CustomerDetailViewModel`:
   * Saves the billing and shipping `Address` entities (which are synced for registered customers), so they can be sent to the order form for order creation.
   * Adds the `createNewOrder()` method to trigger the order creation flow.

In `EditableOrderViewModel`:
* Adds an `initialCustomer` property and init parameter that takes a customer ID, billing address, and shipping address. This is `nil` by default.
* Adds the `configureOrderWithInitialCustomerIfNeeded(_:billing:shipping:)` method that sends the customer data to the order synchronizer if `initialCustomer` has data. This method is called in `configureCustomerDataViewModel()`.
* Adds unit tests to ensure the customer data is set as expected in both the feature flagged and legacy flows.

Connecting bits:
* Adds a method to `OrdersRootViewController` to start the order creation flow with the initial customer data.
* Adds a method to `OrdersSplitViewWrapperController` to call the method in `OrdersRootViewController`.
* Adds a method to `MainTabBarController` to switch to the Orders tab and call the method in `OrdersSplitViewWrapperController`.

## Testing steps
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->

1. Open the Menu tab.
2. Open the Customers section.
3. Select a registered customer.
4. Tap the + button in the Orders section.
5. Confirm the order form is opened with the customer data prefilled.
6. Finish creating the order and confirm the order details show the correct customer data.

## Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->

Scenarios considered:
* Creating a new order from the Orders tab works as before (empty order form).
* Create a new order from customer details prefills the customer data, and the order is recorded as an order for that customer.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

### New order with customer prefilled


https://github.com/woocommerce/woocommerce-ios/assets/8658164/51dfedbb-412b-4277-90c0-29748a576f21

Legacy flow:


https://github.com/woocommerce/woocommerce-ios/assets/8658164/add3a5df-c4f7-4380-9eb9-afb7ce8a64b4



### New order (no customer prefilled)

Feature flagged flow|Legacy flow
-|-
![NewOrder-NoCustomer](https://github.com/woocommerce/woocommerce-ios/assets/8658164/d4b355f7-72b6-4205-b6c1-b4815dd0b1e8)|![NewOrder-NoCustomer-LegacyFlow](https://github.com/woocommerce/woocommerce-ios/assets/8658164/0d738343-afd4-4923-a742-0712e5cc3ec3)


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary. 