### PR TITLE
[Customers] Track when a new order is created from customer details

### DIFF
--- a/WooCommerce/Classes/Analytics/WooAnalyticsEvent.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsEvent.swift
@@ -3137,6 +3137,10 @@ extension WooAnalyticsEvent {
         static func customerDetailAddressCopied(_ address: Address) -> WooAnalyticsEvent {
             WooAnalyticsEvent(statName: .customersHubDetailAddressCopied, properties: [Address.key: address.rawValue])
         }
+
+        static func customerDetailNewOrder() -> WooAnalyticsEvent {
+            WooAnalyticsEvent(statName: .customersHubDetailNewOrderTapped, properties: [:])
+        }
     }
 }
 

--- a/WooCommerce/Classes/Analytics/WooAnalyticsStat.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsStat.swift
@@ -1089,6 +1089,7 @@ enum WooAnalyticsStat: String {
     case customersHubDetailPhoneMenuTapped = "customers_hub_customer_detail_phone_menu_tapped"
     case customersHubDetailPhoneActionTapped = "customers_hub_customer_detail_phone_action_tapped"
     case customersHubDetailAddressCopied = "customers_hub_customer_detail_address_copied"
+    case customersHubDetailNewOrderTapped = "customers_hub_customer_detail_new_order_tapped"
 
     // MARK: Close Account
     case closeAccountTapped = "close_account_tapped"

--- a/WooCommerce/Classes/ViewRelated/Customers/CustomerDetailViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Customers/CustomerDetailViewModel.swift
@@ -152,6 +152,7 @@ final class CustomerDetailViewModel: ObservableObject {
             return
         }
         MainTabBarController.presentOrderCreationFlow(for: customerID, billing: billing, shipping: shipping)
+        ServiceLocator.analytics.track(event: .CustomersHub.customerDetailNewOrder())
     }
 }
 


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of: #13023
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

Adds the following new event:

* `customers_hub_customer_detail_new_order_tapped` - triggered when a new order is started from customer details in the Hub menu Customers section (Registration: https://github.com/Automattic/tracks-events-registration/pull/2497)

## Testing steps
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->

1. Build and run the app (building on device will offer more phone actions).
2. Go to the Menu tab.
3. Select Customers.
4. Select a registered customer.
5. Tap the + button at the top of the Orders section to create a new order for the customer.
6. Confirm the new event is tracked.

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.