### PR TITLE
Watch: Improve refresh strategy

### DIFF
--- a/WooCommerce/Woo Watch App/App/AppBindings.swift
+++ b/WooCommerce/Woo Watch App/App/AppBindings.swift
@@ -1,4 +1,5 @@
 import Foundation
+import Combine
 
 /// Keeps track of all the bindings that are needed through the app lifecycle.
 /// This type is meant to be passed as an environment variable
@@ -8,4 +9,8 @@ class AppBindings: NSObject, ObservableObject {
     /// Determines when an order notification arrives and should be presented.
     ///
     @Published var orderNotification: PushNotification?
+
+    /// Trigger to refresh data.
+    ///
+    let refreshData = PassthroughSubject<Void, Never>()
 }

--- a/WooCommerce/Woo Watch App/App/AppDelegate.swift
+++ b/WooCommerce/Woo Watch App/App/AppDelegate.swift
@@ -26,6 +26,12 @@ class AppDelegate: NSObject, ObservableObject, WKApplicationDelegate {
         UNUserNotificationCenter.current().delegate = self
     }
 
+    /// Setup code when the app transitions from background to foreground.
+    ///
+    func applicationWillEnterForeground() {
+        appBindings.refreshData.send()
+    }
+
     /// Sets up CocoaLumberjack logging.
     ///
     func setupCocoaLumberjack() {

--- a/WooCommerce/Woo Watch App/App/WooApp.swift
+++ b/WooCommerce/Woo Watch App/App/WooApp.swift
@@ -32,6 +32,7 @@ struct Woo_Watch_AppApp: App {
                     })
                     .compatibleVerticalStyle()
                     .environment(\.dependencies, dependencies)
+                    .environment(\.appBindings, appBindings)
                     .id(dependencies.storeID) // Forces a redraw when the store id changes
 
                 } else {

--- a/WooCommerce/Woo Watch App/Dependencies/Environment+AppBindings.swift
+++ b/WooCommerce/Woo Watch App/Dependencies/Environment+AppBindings.swift
@@ -1,0 +1,18 @@
+import SwiftUI
+
+/// Environment AppBindings setup
+///
+private enum AppBindingsKey: EnvironmentKey {
+    static let defaultValue: AppBindings = AppBindings()
+}
+
+extension EnvironmentValues {
+    var appBindings: AppBindings {
+        get {
+            self[AppBindingsKey.self]
+        }
+        set {
+            self[AppBindingsKey.self] = newValue
+        }
+    }
+}

--- a/WooCommerce/Woo Watch App/MyStore/MyStoreViewModel.swift
+++ b/WooCommerce/Woo Watch App/MyStore/MyStoreViewModel.swift
@@ -28,9 +28,9 @@ final class MyStoreViewModel: ObservableObject {
         self.dependencies = dependencies
     }
 
-    @MainActor
     /// Perform the initial fetch and binds the refresh trigger for further refreshes.
     ///
+    @MainActor
     func fetchAndBindRefreshTrigger(trigger: AnyPublisher<Void, Never>) async {
         trigger
             .sink { [weak self] _ in

--- a/WooCommerce/Woo Watch App/MyStore/MyStoreViewModel.swift
+++ b/WooCommerce/Woo Watch App/MyStore/MyStoreViewModel.swift
@@ -1,4 +1,5 @@
 import Foundation
+import Combine
 import NetworkingWatchOS
 import WooFoundationWatchOS
 
@@ -8,7 +9,7 @@ final class MyStoreViewModel: ObservableObject {
 
     /// Enum that tracks the state of the view.
     ///
-    enum ViewState {
+    enum ViewState: Equatable {
         case idle
         case loading
         case error
@@ -17,17 +18,43 @@ final class MyStoreViewModel: ObservableObject {
 
     private let dependencies: WatchDependencies
 
+    /// Combine subs store.
+    ///
+    private var subscriptions: Set<AnyCancellable> = []
+
     @Published private(set) var viewState: ViewState = .idle
 
     init(dependencies: WatchDependencies) {
         self.dependencies = dependencies
     }
 
+    @MainActor
+    /// Perform the initial fetch and binds the refresh trigger for further refreshes.
+    ///
+    func fetchAndBindRefreshTrigger(trigger: AnyPublisher<Void, Never>) async {
+        trigger
+            .sink { [weak self] _ in
+                // Do not refresh data if we are already loading it.
+                guard let self, self.viewState != .loading else { return }
+
+                Task {
+                    await self.fetchStats()
+                }
+            }
+            .store(in: &subscriptions)
+
+        await fetchStats()
+    }
+
     /// Fetch stats and update the view state based on the result.
     ///
     @MainActor
-    func fetchStats() async {
-        self.viewState = .loading
+    private func fetchStats() async {
+
+        if Self.shouldTransitionToLoading(state: viewState) {
+            self.viewState = .loading
+        }
+
         let service = StoreInfoDataService(credentials: dependencies.credentials)
         do {
             let stats = try await service.fetchTodayStats(for: dependencies.storeID)
@@ -54,6 +81,17 @@ final class MyStoreViewModel: ObservableObject {
         } catch {
             DDLogError("⛔️ Error fetching watch today stats: \(error)")
             self.viewState = .error
+        }
+    }
+
+    /// Determines when we should transition to a loading state.
+    ///
+    static private func shouldTransitionToLoading(state: ViewState) -> Bool {
+        switch state {
+        case .idle, .error:
+            return true
+        case .loading, .loaded: // If we have already loaded the data don't transition to a loading state.
+            return false
         }
     }
 }

--- a/WooCommerce/Woo Watch App/Orders/OrdersListView.swift
+++ b/WooCommerce/Woo Watch App/Orders/OrdersListView.swift
@@ -4,6 +4,8 @@ import SwiftUI
 ///
 struct OrdersListView: View {
 
+    @Environment(\.appBindings) private var appBindings
+
     @EnvironmentObject private var tracksProvider: WatchTracksProvider
 
     // Used to changed the tab programmatically
@@ -23,7 +25,7 @@ struct OrdersListView: View {
             case .idle:
                 Rectangle().hidden()
                     .task {
-                        await viewModel.fetchOrders()
+                        await viewModel.fetchAndBindRefreshTrigger(trigger: appBindings.refreshData.eraseToAnyPublisher())
                     }
             case .loading:
                 loadingView
@@ -87,7 +89,7 @@ struct OrdersListView: View {
 
             Button(Localization.retry) {
                 Task {
-                    await viewModel.fetchOrders()
+                    appBindings.refreshData.send()
                 }
             }
             .padding(.bottom, -16)

--- a/WooCommerce/Woo Watch App/Orders/OrdersListViewModel.swift
+++ b/WooCommerce/Woo Watch App/Orders/OrdersListViewModel.swift
@@ -1,4 +1,5 @@
 import Foundation
+import Combine
 import NetworkingWatchOS
 import WooFoundationWatchOS
 
@@ -10,17 +11,43 @@ final class OrdersListViewModel: ObservableObject {
     ///
     @Published private(set) var viewState = OrdersListView.State.idle
 
+    /// Combine subs store.
+    ///
+    private var subscriptions: Set<AnyCancellable> = []
+
     private let dependencies: WatchDependencies
 
     init(dependencies: WatchDependencies) {
         self.dependencies = dependencies
     }
 
+    /// Perform the initial fetch and binds the refresh trigger for further refreshes.
+    ///
+    @MainActor
+    func fetchAndBindRefreshTrigger(trigger: AnyPublisher<Void, Never>) async {
+        trigger
+            .sink { [weak self] _ in
+                // Do not refresh data if we are already loading it.
+                guard let self, self.viewState != .loading else { return }
+
+                Task {
+                    await self.fetchOrders()
+                }
+            }
+            .store(in: &subscriptions)
+
+        await fetchOrders()
+    }
+
     /// Fetch orders from a the remote source and updates the view state accordingly.
     ///
     @MainActor
-    func fetchOrders() async {
-        self.viewState = .loading
+    private func fetchOrders() async {
+
+        if Self.shouldTransitionToLoading(state: viewState) {
+            self.viewState = .loading
+        }
+
         let service = OrdersDataService(credentials: dependencies.credentials)
         do {
             let orders = try await service.loadAllOrders(for: dependencies.storeID, pageNumber: 1, pageSize: 50)
@@ -57,6 +84,17 @@ final class OrdersListViewModel: ObservableObject {
                                         items: items)
         }
     }
+
+    /// Determines when we should transition to a loading state.
+    ///
+    static private func shouldTransitionToLoading(state: OrdersListView.State) -> Bool {
+        switch state {
+        case .idle, .error:
+            return true
+        case .loading, .loaded: // If we have already loaded the data don't transition to a loading state.
+            return false
+        }
+    }
 }
 
 /// Data types that feed the OrdersListView
@@ -65,7 +103,7 @@ extension OrdersListView {
 
     /// Represents the possible view states
     ///
-    enum State {
+    enum State: Equatable {
         case idle
         case loading
         case loaded(orders: [Order])

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -851,6 +851,7 @@
 		262A0999262908A60033AD20 /* OrderAddOnListI1Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 262A0998262908A60033AD20 /* OrderAddOnListI1Tests.swift */; };
 		262A09A5262F65690033AD20 /* OrderAddOnTopBanner.swift in Sources */ = {isa = PBXBuildFile; fileRef = 262A09A4262F65690033AD20 /* OrderAddOnTopBanner.swift */; };
 		262A2C2B2537A3330086C1BE /* MockRefunds.swift in Sources */ = {isa = PBXBuildFile; fileRef = 262A2C2A2537A3330086C1BE /* MockRefunds.swift */; };
+		262C25362C1B4EB800E525E4 /* Environment+AppBindings.swift in Sources */ = {isa = PBXBuildFile; fileRef = 262C25352C1B4EB800E525E4 /* Environment+AppBindings.swift */; };
 		262C921F26EEF8B100011F92 /* Binding.swift in Sources */ = {isa = PBXBuildFile; fileRef = 262C921E26EEF8B100011F92 /* Binding.swift */; };
 		262C922126F1370000011F92 /* StorePickerError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 262C922026F1370000011F92 /* StorePickerError.swift */; };
 		262EB5AE298C70EF009DCC36 /* SupportFormViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 262EB5AD298C70EF009DCC36 /* SupportFormViewModel.swift */; };
@@ -3783,6 +3784,7 @@
 		262A0998262908A60033AD20 /* OrderAddOnListI1Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OrderAddOnListI1Tests.swift; sourceTree = "<group>"; };
 		262A09A4262F65690033AD20 /* OrderAddOnTopBanner.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OrderAddOnTopBanner.swift; sourceTree = "<group>"; };
 		262A2C2A2537A3330086C1BE /* MockRefunds.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockRefunds.swift; sourceTree = "<group>"; };
+		262C25352C1B4EB800E525E4 /* Environment+AppBindings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Environment+AppBindings.swift"; sourceTree = "<group>"; };
 		262C921E26EEF8B100011F92 /* Binding.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Binding.swift; sourceTree = "<group>"; };
 		262C922026F1370000011F92 /* StorePickerError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StorePickerError.swift; sourceTree = "<group>"; };
 		262EB5AD298C70EF009DCC36 /* SupportFormViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SupportFormViewModel.swift; sourceTree = "<group>"; };
@@ -7899,6 +7901,7 @@
 			children = (
 				2604C3B92BE977F000250465 /* PhoneDependenciesSynchronizer.swift */,
 				26B984D32BEECC610052658C /* Environment+Dependencies.swift */,
+				262C25352C1B4EB800E525E4 /* Environment+AppBindings.swift */,
 			);
 			path = Dependencies;
 			sourceTree = "<group>";
@@ -14002,6 +14005,7 @@
 				26B984D62BEECF260052658C /* ConnectView.swift in Sources */,
 				26DD32D62BEBCE3900F2C69C /* UserDefaults+Woo.swift in Sources */,
 				26CA471D2BFD805900E54348 /* CNContact+Helpers.swift in Sources */,
+				262C25362C1B4EB800E525E4 /* Environment+AppBindings.swift in Sources */,
 				269FFA482BF516BA004E6B86 /* Logging.swift in Sources */,
 				26F81B182BE433A2009EC58E /* WooApp.swift in Sources */,
 				26CA47212BFD82AE00E54348 /* DateFormatter+Helpers.swift in Sources */,


### PR DESCRIPTION
Closes: #12953 

# Why

This PR improves the watch refresh strategy to update the data when the app comes from the background instead of everytime the user navigates to that screen.

# How

- Expose a new `refreshData` trigger instead in `AppBindings`
- Update view models to refresh its data when the trigger emits an event.
- Make sure the redacted/loading UI is only shown the first time.

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
