### PR TITLE
fix: Inject documentation URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ Please, remember to not add this information on your commits and PRs.
     - [In-app Feedback](docs/in-app-feedback.md)
     - [Card Present Payments](docs/card-present-payments.md)
 - Other
-    - [Enable hot reload with Inject](docs/inject-hot-reload)
+    - [Enable hot reload with Inject](docs/inject-hot-reload.md)
 
 ## 👏 Contributing
 


### PR DESCRIPTION
I just discovered that the URL in `trunk` of [Enable hot reload with Inject](https://github.com/woocommerce/woocommerce-ios/blob/trunk/docs/inject-hot-reload.md) was not working properly. Fixed it.

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
