### PR TITLE
Fix SPM Repository URL Auto-Change on branch switch for swift-algorithms

### DIFF
--- a/WooCommerce.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/WooCommerce.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -75,7 +75,7 @@
       },
       {
         "package": "swift-algorithms",
-        "repositoryURL": "https://github.com/apple/swift-algorithms",
+        "repositoryURL": "https://github.com/apple/swift-algorithms.git",
         "state": {
           "branch": null,
           "revision": "f6919dfc309e7f1b56224378b11e28bab5bccc42",


### PR DESCRIPTION
Every time a branch switch occurs, Swift Package Manager (SPM) automatically updates the repository URL in the package manifest file. The URL changes from `"repositoryURL": "https://github.com/apple/swift-algorithms"` to `"repositoryURL": "https://github.com/apple/swift-algorithms.git"`. Making the change permanent so it should not happen again anymore.

<img width="1000" alt="Screenshot 2024-06-14 at 13 21 43" src="https://github.com/woocommerce/woocommerce-ios/assets/495617/3330ff80-4e1e-4727-b59b-031dea3813fc">



---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
