### PR TITLE
[Woo POS] implement connection views

### DIFF
--- a/WooCommerce/Classes/POS/Card Present Payments/CardPresentPaymentAlertDetails.swift
+++ b/WooCommerce/Classes/POS/Card Present Payments/CardPresentPaymentAlertDetails.swift
@@ -17,7 +17,7 @@ enum CardPresentPaymentAlertDetails {
                                           endSearch: () -> Void)
     case connectingFailedChargeReader(retrySearch: () -> Void,
                                       endSearch: () -> Void)
-    case connectingFailedUpdateAddress(wcSettingsAdminURL: URL?,
+    case connectingFailedUpdateAddress(wcSettingsAdminURL: URL,
                                        retrySearch: () -> Void,
                                        endSearch: () -> Void)
     case preparingForPayment(cancelPayment: () -> Void)

--- a/WooCommerce/Classes/POS/Card Present Payments/CardPresentPaymentAlertDetails.swift
+++ b/WooCommerce/Classes/POS/Card Present Payments/CardPresentPaymentAlertDetails.swift
@@ -5,7 +5,8 @@ enum CardPresentPaymentAlertDetails {
     case scanningForReaders(endSearch: () -> Void)
     case scanningFailed(error: Error,
                         endSearch: () -> Void)
-    case bluetoothRequired
+    case bluetoothRequired(error: Error,
+                           endSearch: () -> Void)
     case connectingToReader
     case connectingFailed(error: Error,
                           retrySearch: () -> Void,

--- a/WooCommerce/Classes/POS/Card Present Payments/CardPresentPaymentBluetoothReaderConnectionAlertsProvider.swift
+++ b/WooCommerce/Classes/POS/Card Present Payments/CardPresentPaymentBluetoothReaderConnectionAlertsProvider.swift
@@ -33,7 +33,12 @@ struct CardPresentPaymentBluetoothReaderConnectionAlertsProvider: BluetoothReade
                                            openWCSettings: (() -> Void)?,
                                            retrySearch: @escaping () -> Void,
                                            cancelSearch: @escaping () -> Void) -> CardPresentPaymentAlertDetails {
-        .connectingFailedUpdateAddress(wcSettingsAdminURL: wcSettingsAdminURL,
+        guard let wcSettingsAdminURL else {
+            return .connectingFailedNonRetryable(
+                error: CardPresentPaymentServiceError.incompleteAddressConnectionError,
+                endSearch: cancelSearch)
+        }
+        return .connectingFailedUpdateAddress(wcSettingsAdminURL: wcSettingsAdminURL,
                                        retrySearch: retrySearch,
                                        endSearch: cancelSearch)
     }

--- a/WooCommerce/Classes/POS/Card Present Payments/CardPresentPaymentBuiltInReaderConnectionAlertsProvider.swift
+++ b/WooCommerce/Classes/POS/Card Present Payments/CardPresentPaymentBuiltInReaderConnectionAlertsProvider.swift
@@ -34,7 +34,12 @@ struct CardPresentPaymentBuiltInReaderConnectionAlertsProvider: CardReaderConnec
                                            openWCSettings: (() -> Void)?,
                                            retrySearch: @escaping () -> Void,
                                            cancelSearch: @escaping () -> Void) -> CardPresentPaymentAlertDetails {
-        .connectingFailedUpdateAddress(wcSettingsAdminURL: wcSettingsAdminURL,
+        guard let wcSettingsAdminURL else {
+            return .connectingFailedNonRetryable(
+                error: CardPresentPaymentServiceError.incompleteAddressConnectionError,
+                endSearch: cancelSearch)
+        }
+        return .connectingFailedUpdateAddress(wcSettingsAdminURL: wcSettingsAdminURL,
                                        retrySearch: retrySearch,
                                        endSearch: cancelSearch)
     }

--- a/WooCommerce/Classes/POS/Card Present Payments/CardPresentPaymentEvent.swift
+++ b/WooCommerce/Classes/POS/Card Present Payments/CardPresentPaymentEvent.swift
@@ -9,6 +9,10 @@ enum CardPresentPaymentAlertType {
     case updateFailed(viewModel: CardPresentPaymentReaderUpdateFailedAlertViewModel)
     case connectingToReader(viewModel: CardPresentPaymentConnectingToReaderAlertViewModel)
     case connectingFailed(viewModel: CardPresentPaymentConnectingFailedAlertViewModel)
+    case connectingFailedNonRetryable(viewModel: CardPresentPaymentConnectingFailedNonRetryableAlertViewModel)
+    case connectingFailedChargeReader(viewModel: CardPresentPaymentConnectingFailedChargeReaderAlertViewModel)
+    case connectingFailedUpdateAddress(viewModel: CardPresentPaymentConnectingFailedUpdateAddressAlertViewModel)
+    case connectingFailedUpdatePostalCode(viewModel: CardPresentPaymentConnectingFailedUpdatePostalCodeAlertViewModel)
 }
 
 enum CardPresentPaymentMessageType {

--- a/WooCommerce/Classes/POS/Card Present Payments/CardPresentPaymentEvent.swift
+++ b/WooCommerce/Classes/POS/Card Present Payments/CardPresentPaymentEvent.swift
@@ -3,6 +3,7 @@ import Foundation
 enum CardPresentPaymentAlertType {
     case scanningForReaders(viewModel: CardPresentPaymentScanningForReadersAlertViewModel)
     case scanningFailed(viewModel: CardPresentPaymentScanningFailedAlertViewModel)
+    case bluetoothRequired(viewModel: CardPresentPaymentBluetoothRequiredAlertViewModel)
     case foundReader(viewModel: CardPresentPaymentFoundReaderAlertViewModel)
     case updatingReader(viewModel: CardPresentPaymentUpdatingReaderAlertViewModel)
     case updateFailed(viewModel: CardPresentPaymentReaderUpdateFailedAlertViewModel)

--- a/WooCommerce/Classes/POS/Card Present Payments/CardPresentPaymentService.swift
+++ b/WooCommerce/Classes/POS/Card Present Payments/CardPresentPaymentService.swift
@@ -164,4 +164,5 @@ private extension CardPresentPaymentService {
 enum CardPresentPaymentServiceError: Error {
     case invalidAmount
     case unknownPaymentError(underlyingError: Error)
+    case incompleteAddressConnectionError
 }

--- a/WooCommerce/Classes/POS/Card Present Payments/CardPresentPaymentsAlertPresenterAdaptor.swift
+++ b/WooCommerce/Classes/POS/Card Present Payments/CardPresentPaymentsAlertPresenterAdaptor.swift
@@ -28,7 +28,7 @@ final class CardPresentPaymentsAlertPresenterAdaptor: CardPresentPaymentAlertsPr
             case .connectingFailed(let error, let retrySearch, let endSearch):
             paymentAlertSubject.send(.showAlert(.connectingFailed(viewModel: .init(error: error, retryButtonAction: retrySearch, cancelButtonAction: endSearch))))
             case .connectingFailedNonRetryable(let error, let endSearch):
-                paymentAlertSubject.send(.showAlert(.connectingFailedNonRetryable(viewModel: .init())))
+            paymentAlertSubject.send(.showAlert(.connectingFailedNonRetryable(viewModel: .init(error: error, cancelAction: endSearch))))
             case .connectingFailedUpdatePostalCode(let retrySearch, let endSearch):
                 paymentAlertSubject.send(.showAlert(.connectingFailedUpdatePostalCode(viewModel: .init())))
             case .connectingFailedChargeReader(let retrySearch, let endSearch):

--- a/WooCommerce/Classes/POS/Card Present Payments/CardPresentPaymentsAlertPresenterAdaptor.swift
+++ b/WooCommerce/Classes/POS/Card Present Payments/CardPresentPaymentsAlertPresenterAdaptor.swift
@@ -19,9 +19,9 @@ final class CardPresentPaymentsAlertPresenterAdaptor: CardPresentPaymentAlertsPr
                 // TODO: hide it in collectPayment flow
                 paymentAlertSubject.send(.showAlert(.scanningForReaders(viewModel: .init(endSearchAction: endSearch))))
             case .scanningFailed(let error, let endSearch):
-                paymentAlertSubject.send(.showAlert(.scanningFailed(viewModel: .init())))
-            case .bluetoothRequired:
-                paymentAlertSubject.send(.showAlert(.scanningFailed(viewModel: .init())))
+            paymentAlertSubject.send(.showAlert(.scanningFailed(viewModel: .init(error: error, endSearchAction: endSearch))))
+            case .bluetoothRequired(let error, let endSearch):
+            paymentAlertSubject.send(.showAlert(.bluetoothRequired(viewModel: .init(error: error, endSearch: endSearch))))
             case .connectingToReader:
                 // TODO: hide it in collectPayment flow
                 paymentAlertSubject.send(.showAlert(.connectingToReader(viewModel: .init())))

--- a/WooCommerce/Classes/POS/Card Present Payments/CardPresentPaymentsAlertPresenterAdaptor.swift
+++ b/WooCommerce/Classes/POS/Card Present Payments/CardPresentPaymentsAlertPresenterAdaptor.swift
@@ -30,7 +30,8 @@ final class CardPresentPaymentsAlertPresenterAdaptor: CardPresentPaymentAlertsPr
             case .connectingFailedNonRetryable(let error, let endSearch):
             paymentAlertSubject.send(.showAlert(.connectingFailedNonRetryable(viewModel: .init(error: error, cancelAction: endSearch))))
             case .connectingFailedUpdatePostalCode(let retrySearch, let endSearch):
-            paymentAlertSubject.send(.showAlert(.connectingFailedUpdatePostalCode(viewModel: .init(retryButtonAction: retrySearch, cancelButtonAction: endSearch))))
+            paymentAlertSubject.send(.showAlert(.connectingFailedUpdatePostalCode(
+                viewModel: .init(retryButtonAction: retrySearch, cancelButtonAction: endSearch))))
             case .connectingFailedChargeReader(let retrySearch, let endSearch):
             paymentAlertSubject.send(.showAlert(.connectingFailedChargeReader(viewModel: .init(
                 retryButtonAction: retrySearch,

--- a/WooCommerce/Classes/POS/Card Present Payments/CardPresentPaymentsAlertPresenterAdaptor.swift
+++ b/WooCommerce/Classes/POS/Card Present Payments/CardPresentPaymentsAlertPresenterAdaptor.swift
@@ -30,7 +30,7 @@ final class CardPresentPaymentsAlertPresenterAdaptor: CardPresentPaymentAlertsPr
             case .connectingFailedNonRetryable(let error, let endSearch):
             paymentAlertSubject.send(.showAlert(.connectingFailedNonRetryable(viewModel: .init(error: error, cancelAction: endSearch))))
             case .connectingFailedUpdatePostalCode(let retrySearch, let endSearch):
-                paymentAlertSubject.send(.showAlert(.connectingFailedUpdatePostalCode(viewModel: .init())))
+            paymentAlertSubject.send(.showAlert(.connectingFailedUpdatePostalCode(viewModel: .init(retryButtonAction: retrySearch, cancelButtonAction: endSearch))))
             case .connectingFailedChargeReader(let retrySearch, let endSearch):
             paymentAlertSubject.send(.showAlert(.connectingFailedChargeReader(viewModel: .init(
                 retryButtonAction: retrySearch,

--- a/WooCommerce/Classes/POS/Card Present Payments/CardPresentPaymentsAlertPresenterAdaptor.swift
+++ b/WooCommerce/Classes/POS/Card Present Payments/CardPresentPaymentsAlertPresenterAdaptor.swift
@@ -26,14 +26,15 @@ final class CardPresentPaymentsAlertPresenterAdaptor: CardPresentPaymentAlertsPr
                 // TODO: hide it in collectPayment flow
                 paymentAlertSubject.send(.showAlert(.connectingToReader(viewModel: .init())))
             case .connectingFailed(let error, let retrySearch, let endSearch):
-                paymentAlertSubject.send(.showAlert(.connectingFailed(viewModel: .init())))
+            paymentAlertSubject.send(.showAlert(.connectingFailed(viewModel: .init(error: error, retryButtonAction: retrySearch, cancelButtonAction: endSearch))))
             case .connectingFailedNonRetryable(let error, let endSearch):
-                paymentAlertSubject.send(.showAlert(.connectingFailed(viewModel: .init())))
-            case .connectingFailedUpdatePostalCode(let retrySearch, let endSearch),
-                    .connectingFailedChargeReader(let retrySearch, let endSearch):
-                paymentAlertSubject.send(.showAlert(.connectingFailed(viewModel: .init())))
+                paymentAlertSubject.send(.showAlert(.connectingFailedNonRetryable(viewModel: .init())))
+            case .connectingFailedUpdatePostalCode(let retrySearch, let endSearch):
+                paymentAlertSubject.send(.showAlert(.connectingFailedUpdatePostalCode(viewModel: .init())))
+            case .connectingFailedChargeReader(let retrySearch, let endSearch):
+                paymentAlertSubject.send(.showAlert(.connectingFailedChargeReader(viewModel: .init())))
             case .connectingFailedUpdateAddress(let wcSettingsAdminURL, let retrySearch, let endSearch):
-                paymentAlertSubject.send(.showAlert(.connectingFailed(viewModel: .init())))
+                paymentAlertSubject.send(.showAlert(.connectingFailedUpdateAddress(viewModel: .init())))
             case .preparingForPayment(let cancelPayment):
                 paymentAlertSubject.send(.showPaymentMessage(.preparingForPayment))
             // TODO: support this case

--- a/WooCommerce/Classes/POS/Card Present Payments/CardPresentPaymentsAlertPresenterAdaptor.swift
+++ b/WooCommerce/Classes/POS/Card Present Payments/CardPresentPaymentsAlertPresenterAdaptor.swift
@@ -36,7 +36,11 @@ final class CardPresentPaymentsAlertPresenterAdaptor: CardPresentPaymentAlertsPr
                 retryButtonAction: retrySearch,
                 cancelButtonAction: endSearch))))
             case .connectingFailedUpdateAddress(let wcSettingsAdminURL, let retrySearch, let endSearch):
-                paymentAlertSubject.send(.showAlert(.connectingFailedUpdateAddress(viewModel: .init())))
+                paymentAlertSubject.send(.showAlert(.connectingFailedUpdateAddress(
+                    viewModel: CardPresentPaymentConnectingFailedUpdateAddressAlertViewModel(
+                        settingsAdminUrl: wcSettingsAdminURL,
+                        retrySearchAction: retrySearch,
+                        cancelSearchAction: endSearch))))
             case .preparingForPayment(let cancelPayment):
                 paymentAlertSubject.send(.showPaymentMessage(.preparingForPayment))
             // TODO: support this case

--- a/WooCommerce/Classes/POS/Card Present Payments/CardPresentPaymentsAlertPresenterAdaptor.swift
+++ b/WooCommerce/Classes/POS/Card Present Payments/CardPresentPaymentsAlertPresenterAdaptor.swift
@@ -32,7 +32,9 @@ final class CardPresentPaymentsAlertPresenterAdaptor: CardPresentPaymentAlertsPr
             case .connectingFailedUpdatePostalCode(let retrySearch, let endSearch):
                 paymentAlertSubject.send(.showAlert(.connectingFailedUpdatePostalCode(viewModel: .init())))
             case .connectingFailedChargeReader(let retrySearch, let endSearch):
-                paymentAlertSubject.send(.showAlert(.connectingFailedChargeReader(viewModel: .init())))
+            paymentAlertSubject.send(.showAlert(.connectingFailedChargeReader(viewModel: .init(
+                retryButtonAction: retrySearch,
+                cancelButtonAction: endSearch))))
             case .connectingFailedUpdateAddress(let wcSettingsAdminURL, let retrySearch, let endSearch):
                 paymentAlertSubject.send(.showAlert(.connectingFailedUpdateAddress(viewModel: .init())))
             case .preparingForPayment(let cancelPayment):

--- a/WooCommerce/Classes/POS/Presentation/Card Present Payments/Payment Alerts/CardPresentPaymentAlertViewModel.swift
+++ b/WooCommerce/Classes/POS/Presentation/Card Present Payments/Payment Alerts/CardPresentPaymentAlertViewModel.swift
@@ -64,7 +64,10 @@ extension CardPresentPaymentAlertDetails {
                 cancelButtonAction: endSearch))
 
         case .connectingFailedUpdateAddress(let wcSettingsAdminURL, let retrySearch, let endSearch):
-            .connectingFailedUpdateAddress(CardPresentPaymentConnectingFailedUpdateAddressAlertViewModel())
+                .connectingFailedUpdateAddress(CardPresentPaymentConnectingFailedUpdateAddressAlertViewModel(
+                    settingsAdminUrl: wcSettingsAdminURL,
+                    retrySearchAction: retrySearch,
+                    cancelSearchAction: endSearch))
 
         case .preparingForPayment(let cancelPayment):
                 .preparingForPayment(CardPresentPaymentPreparingForPaymentAlertViewModel())

--- a/WooCommerce/Classes/POS/Presentation/Card Present Payments/Payment Alerts/CardPresentPaymentAlertViewModel.swift
+++ b/WooCommerce/Classes/POS/Presentation/Card Present Payments/Payment Alerts/CardPresentPaymentAlertViewModel.swift
@@ -59,7 +59,9 @@ extension CardPresentPaymentAlertDetails {
                 .connectingFailedUpdatePostalCode(CardPresentPaymentConnectingFailedUpdatePostalCodeAlertViewModel())
 
         case .connectingFailedChargeReader(let retrySearch, let endSearch):
-            .connectingFailedChargeReader(CardPresentPaymentConnectingFailedChargeReaderAlertViewModel())
+            .connectingFailedChargeReader(CardPresentPaymentConnectingFailedChargeReaderAlertViewModel(
+                retryButtonAction: retrySearch,
+                cancelButtonAction: endSearch))
 
         case .connectingFailedUpdateAddress(let wcSettingsAdminURL, let retrySearch, let endSearch):
             .connectingFailedUpdateAddress(CardPresentPaymentConnectingFailedUpdateAddressAlertViewModel())

--- a/WooCommerce/Classes/POS/Presentation/Card Present Payments/Payment Alerts/CardPresentPaymentAlertViewModel.swift
+++ b/WooCommerce/Classes/POS/Presentation/Card Present Payments/Payment Alerts/CardPresentPaymentAlertViewModel.swift
@@ -3,6 +3,7 @@ import Foundation
 enum CardPresentPaymentAlertViewModel {
     case scanningForReaders(CardPresentPaymentScanningForReadersAlertViewModel)
     case scanningFailed(CardPresentPaymentScanningFailedAlertViewModel)
+    case bluetoothRequired(CardPresentPaymentBluetoothRequiredAlertViewModel)
 
     case foundReader(CardPresentPaymentFoundReaderAlertViewModel)
 
@@ -35,8 +36,8 @@ extension CardPresentPaymentAlertDetails {
                     error: error,
                     endSearchAction: endSearch))
 
-        case .bluetoothRequired:
-                .scanningFailed(CardPresentPaymentScanningFailedAlertViewModel())
+        case .bluetoothRequired(let error, let endSearch):
+                .bluetoothRequired(CardPresentPaymentBluetoothRequiredAlertViewModel(error: error, endSearch: endSearch))
 
         case .connectingToReader:
                 .connectingToReader(CardPresentPaymentConnectingToReaderAlertViewModel())

--- a/WooCommerce/Classes/POS/Presentation/Card Present Payments/Payment Alerts/CardPresentPaymentAlertViewModel.swift
+++ b/WooCommerce/Classes/POS/Presentation/Card Present Payments/Payment Alerts/CardPresentPaymentAlertViewModel.swift
@@ -53,7 +53,7 @@ extension CardPresentPaymentAlertDetails {
                     cancelButtonAction: endSearch))
 
         case .connectingFailedNonRetryable(let error, let endSearch):
-            .connectingFailedNonRetryable(CardPresentPaymentConnectingFailedNonRetryableAlertViewModel())
+                .connectingFailedNonRetryable(CardPresentPaymentConnectingFailedNonRetryableAlertViewModel(error: error, cancelAction: endSearch))
 
         case .connectingFailedUpdatePostalCode(let retrySearch, let endSearch):
                 .connectingFailedUpdatePostalCode(CardPresentPaymentConnectingFailedUpdatePostalCodeAlertViewModel())

--- a/WooCommerce/Classes/POS/Presentation/Card Present Payments/Payment Alerts/CardPresentPaymentAlertViewModel.swift
+++ b/WooCommerce/Classes/POS/Presentation/Card Present Payments/Payment Alerts/CardPresentPaymentAlertViewModel.swift
@@ -31,7 +31,9 @@ extension CardPresentPaymentAlertDetails {
                 .scanningForReaders(CardPresentPaymentScanningForReadersAlertViewModel(endSearchAction: endSearch))
 
         case .scanningFailed(let error, let endSearch):
-                .scanningFailed(CardPresentPaymentScanningFailedAlertViewModel())
+                .scanningFailed(CardPresentPaymentScanningFailedAlertViewModel(
+                    error: error,
+                    endSearchAction: endSearch))
 
         case .bluetoothRequired:
                 .scanningFailed(CardPresentPaymentScanningFailedAlertViewModel())

--- a/WooCommerce/Classes/POS/Presentation/Card Present Payments/Payment Alerts/CardPresentPaymentAlertViewModel.swift
+++ b/WooCommerce/Classes/POS/Presentation/Card Present Payments/Payment Alerts/CardPresentPaymentAlertViewModel.swift
@@ -12,6 +12,10 @@ enum CardPresentPaymentAlertViewModel {
 
     case connectingToReader(CardPresentPaymentConnectingToReaderAlertViewModel)
     case connectingFailed(CardPresentPaymentConnectingFailedAlertViewModel)
+    case connectingFailedNonRetryable(CardPresentPaymentConnectingFailedNonRetryableAlertViewModel)
+    case connectingFailedChargeReader(CardPresentPaymentConnectingFailedChargeReaderAlertViewModel)
+    case connectingFailedUpdateAddress(CardPresentPaymentConnectingFailedUpdateAddressAlertViewModel)
+    case connectingFailedUpdatePostalCode(CardPresentPaymentConnectingFailedUpdatePostalCodeAlertViewModel)
 
     case preparingForPayment(CardPresentPaymentPreparingForPaymentAlertViewModel)
 
@@ -43,17 +47,22 @@ extension CardPresentPaymentAlertDetails {
                 .connectingToReader(CardPresentPaymentConnectingToReaderAlertViewModel())
 
         case .connectingFailed(let error, let retrySearch, let endSearch):
-            .connectingFailed(CardPresentPaymentConnectingFailedAlertViewModel())
+                .connectingFailed(CardPresentPaymentConnectingFailedAlertViewModel(
+                    error: error,
+                    retryButtonAction: retrySearch,
+                    cancelButtonAction: endSearch))
 
         case .connectingFailedNonRetryable(let error, let endSearch):
-            .connectingFailed(CardPresentPaymentConnectingFailedAlertViewModel())
+            .connectingFailedNonRetryable(CardPresentPaymentConnectingFailedNonRetryableAlertViewModel())
 
-        case .connectingFailedUpdatePostalCode(let retrySearch, let endSearch),
-                .connectingFailedChargeReader(let retrySearch, let endSearch):
-            .connectingFailed(CardPresentPaymentConnectingFailedAlertViewModel())
+        case .connectingFailedUpdatePostalCode(let retrySearch, let endSearch):
+                .connectingFailedUpdatePostalCode(CardPresentPaymentConnectingFailedUpdatePostalCodeAlertViewModel())
+
+        case .connectingFailedChargeReader(let retrySearch, let endSearch):
+            .connectingFailedChargeReader(CardPresentPaymentConnectingFailedChargeReaderAlertViewModel())
 
         case .connectingFailedUpdateAddress(let wcSettingsAdminURL, let retrySearch, let endSearch):
-            .connectingFailed(CardPresentPaymentConnectingFailedAlertViewModel())
+            .connectingFailedUpdateAddress(CardPresentPaymentConnectingFailedUpdateAddressAlertViewModel())
 
         case .preparingForPayment(let cancelPayment):
                 .preparingForPayment(CardPresentPaymentPreparingForPaymentAlertViewModel())

--- a/WooCommerce/Classes/POS/Presentation/Card Present Payments/Payment Alerts/CardPresentPaymentAlertViewModel.swift
+++ b/WooCommerce/Classes/POS/Presentation/Card Present Payments/Payment Alerts/CardPresentPaymentAlertViewModel.swift
@@ -56,7 +56,9 @@ extension CardPresentPaymentAlertDetails {
                 .connectingFailedNonRetryable(CardPresentPaymentConnectingFailedNonRetryableAlertViewModel(error: error, cancelAction: endSearch))
 
         case .connectingFailedUpdatePostalCode(let retrySearch, let endSearch):
-                .connectingFailedUpdatePostalCode(CardPresentPaymentConnectingFailedUpdatePostalCodeAlertViewModel())
+                .connectingFailedUpdatePostalCode(CardPresentPaymentConnectingFailedUpdatePostalCodeAlertViewModel(
+                    retryButtonAction: retrySearch,
+                    cancelButtonAction: endSearch))
 
         case .connectingFailedChargeReader(let retrySearch, let endSearch):
             .connectingFailedChargeReader(CardPresentPaymentConnectingFailedChargeReaderAlertViewModel(

--- a/WooCommerce/Classes/POS/Presentation/Card Present Payments/Payment Alerts/CardPresentPaymentConnectingFailedAlertViewModel.swift
+++ b/WooCommerce/Classes/POS/Presentation/Card Present Payments/Payment Alerts/CardPresentPaymentConnectingFailedAlertViewModel.swift
@@ -1,5 +1,53 @@
 import Foundation
+import SwiftUI
+import enum Yosemite.CardReaderServiceError
 
 struct CardPresentPaymentConnectingFailedAlertViewModel {
+    let title = Localization.title
+    let image = Image(uiImage: .paymentErrorImage)
+    let errorDetails: String?
 
+    let retryButtonViewModel: CardPresentPaymentsModalButtonViewModel
+
+    let cancelButtonViewModel: CardPresentPaymentsModalButtonViewModel
+
+    init(error: Error,
+         retryButtonAction: @escaping () -> Void,
+         cancelButtonAction: @escaping () -> Void) {
+        switch error {
+        case CardReaderServiceError.connection(let underlyingError):
+            errorDetails = underlyingError.localizedDescription
+        default:
+            errorDetails = nil
+        }
+
+        retryButtonViewModel = CardPresentPaymentsModalButtonViewModel(
+            title: Localization.tryAgain,
+            actionHandler: retryButtonAction)
+        cancelButtonViewModel = CardPresentPaymentsModalButtonViewModel(
+            title: Localization.cancel,
+            actionHandler: cancelButtonAction)
+    }
+}
+
+private extension CardPresentPaymentConnectingFailedAlertViewModel {
+    enum Localization {
+        static let title = NSLocalizedString(
+            "cardPresentPayment.alert.connectingFailed.title",
+            value: "We couldn't connect your reader",
+            comment: "Title of the alert presented when the user tries to connect to a specific card reader and it fails"
+        )
+
+        static let tryAgain = NSLocalizedString(
+            "cardPresentPayment.alert.connectingFailed.tryAgain.button.title",
+            value: "Try again",
+            comment: "Button to dismiss the alert presented when connecting to a specific reader fails. This allows the search to continue."
+        )
+
+        static let cancel = NSLocalizedString(
+            "cardPresentPayment.alert.connectingFailed.cancel.button.title",
+            value: "Cancel",
+            comment: "Button to dismiss the alert presented when connecting to a specific reader fails. This also cancels searching."
+        )
+    }
 }

--- a/WooCommerce/Classes/POS/Presentation/Card Present Payments/Payment Alerts/CardPresentPaymentConnectingFailedChargeReaderAlertViewModel.swift
+++ b/WooCommerce/Classes/POS/Presentation/Card Present Payments/Payment Alerts/CardPresentPaymentConnectingFailedChargeReaderAlertViewModel.swift
@@ -1,0 +1,5 @@
+import Foundation
+
+struct CardPresentPaymentConnectingFailedChargeReaderAlertViewModel {
+
+}

--- a/WooCommerce/Classes/POS/Presentation/Card Present Payments/Payment Alerts/CardPresentPaymentConnectingFailedChargeReaderAlertViewModel.swift
+++ b/WooCommerce/Classes/POS/Presentation/Card Present Payments/Payment Alerts/CardPresentPaymentConnectingFailedChargeReaderAlertViewModel.swift
@@ -1,5 +1,51 @@
 import Foundation
+import SwiftUI
 
 struct CardPresentPaymentConnectingFailedChargeReaderAlertViewModel {
+    let title = Localization.title
+    let errorDetails = Localization.errorDetails
+    let image = Image(uiImage: .paymentErrorImage)
+    let retryButtonViewModel: CardPresentPaymentsModalButtonViewModel
+    let cancelButtonViewModel: CardPresentPaymentsModalButtonViewModel
 
+    init(retryButtonAction: @escaping () -> Void,
+         cancelButtonAction: @escaping () -> Void) {
+        self.retryButtonViewModel = CardPresentPaymentsModalButtonViewModel(
+            title: Localization.retry,
+            actionHandler: retryButtonAction)
+        self.cancelButtonViewModel = CardPresentPaymentsModalButtonViewModel(
+            title: Localization.cancel,
+            actionHandler: cancelButtonAction)
+    }
+}
+
+private extension CardPresentPaymentConnectingFailedChargeReaderAlertViewModel {
+    enum Localization {
+        static let title = NSLocalizedString(
+            "cardPresentPayment.alert.connectingFailedChargeReader.title",
+            value: "We couldn't connect your reader",
+            comment: "Title of the alert presented when the user tries to connect to a specific card reader and it fails " +
+            "due to it having a critically low battery"
+        )
+
+        static let errorDetails = NSLocalizedString(
+            "cardPresentPayment.alert.connectingFailedChargeReader.error.details",
+            value: "The reader has a critically low battery. Please charge the reader or try a different reader.",
+            comment: "Subtitle of the alert presented when the user tries to connect to a specific card reader and it fails " +
+            "due to it having a critically low battery"
+        )
+
+        static let retry = NSLocalizedString(
+            "cardPresentPayment.alert.connectingFailedChargeReader.retry.button.title",
+            value: "Try Again",
+            comment: "Button to try again after connecting to a specific reader fails due to a critically low battery."
+        )
+
+        static let cancel = NSLocalizedString(
+            "cardPresentPayment.alert.connectingFailedChargeReader.cancel.button.title",
+            value: "Cancel",
+            comment: "Button to dismiss the alert presented when connecting to a specific reader fails due to a critically low " +
+            "battery. This also cancels searching."
+        )
+    }
 }

--- a/WooCommerce/Classes/POS/Presentation/Card Present Payments/Payment Alerts/CardPresentPaymentConnectingFailedNonRetryableAlertViewModel.swift
+++ b/WooCommerce/Classes/POS/Presentation/Card Present Payments/Payment Alerts/CardPresentPaymentConnectingFailedNonRetryableAlertViewModel.swift
@@ -1,0 +1,5 @@
+import Foundation
+
+struct CardPresentPaymentConnectingFailedNonRetryableAlertViewModel {
+
+}

--- a/WooCommerce/Classes/POS/Presentation/Card Present Payments/Payment Alerts/CardPresentPaymentConnectingFailedNonRetryableAlertViewModel.swift
+++ b/WooCommerce/Classes/POS/Presentation/Card Present Payments/Payment Alerts/CardPresentPaymentConnectingFailedNonRetryableAlertViewModel.swift
@@ -1,5 +1,33 @@
 import Foundation
+import SwiftUI
 
 struct CardPresentPaymentConnectingFailedNonRetryableAlertViewModel {
+    let title = Localization.title
+    let errorDetails: String
+    let image = Image(uiImage: .paymentErrorImage)
+    let cancelButtonViewModel: CardPresentPaymentsModalButtonViewModel
 
+    init(error: Error,
+         cancelAction: @escaping () -> Void) {
+        self.errorDetails = error.localizedDescription
+        self.cancelButtonViewModel = CardPresentPaymentsModalButtonViewModel(
+            title: Localization.dismiss,
+            actionHandler: cancelAction)
+    }
+}
+
+private extension CardPresentPaymentConnectingFailedNonRetryableAlertViewModel {
+    enum Localization {
+        static let title = NSLocalizedString(
+            "cardPresentPayment.alert.connectingFailedNonRetryable.title",
+            value: "Connection failed",
+            comment: "Error message. Presented to users after collecting a payment fails"
+        )
+
+        static let dismiss = NSLocalizedString(
+            "cardPresentPayment.alert.connectingFailedNonRetryable.dismiss.button.title",
+            value: "Dismiss",
+            comment: "Button to dismiss. Presented to users after collecting a payment fails"
+        )
+    }
 }

--- a/WooCommerce/Classes/POS/Presentation/Card Present Payments/Payment Alerts/CardPresentPaymentConnectingFailedUpdateAddressAlertViewModel.swift
+++ b/WooCommerce/Classes/POS/Presentation/Card Present Payments/Payment Alerts/CardPresentPaymentConnectingFailedUpdateAddressAlertViewModel.swift
@@ -8,7 +8,7 @@ final class CardPresentPaymentConnectingFailedUpdateAddressAlertViewModel: Obser
 
     @Published var shouldShowSettingsWebView: Bool = false
 
-    @Published var primaryButtonViewModel: CardPresentPaymentsModalButtonViewModel? = nil
+    @Published private(set) var primaryButtonViewModel: CardPresentPaymentsModalButtonViewModel? = nil
     let cancelButtonViewModel: CardPresentPaymentsModalButtonViewModel
 
     private let retrySearchAction: () -> Void

--- a/WooCommerce/Classes/POS/Presentation/Card Present Payments/Payment Alerts/CardPresentPaymentConnectingFailedUpdateAddressAlertViewModel.swift
+++ b/WooCommerce/Classes/POS/Presentation/Card Present Payments/Payment Alerts/CardPresentPaymentConnectingFailedUpdateAddressAlertViewModel.swift
@@ -1,0 +1,5 @@
+import Foundation
+
+struct CardPresentPaymentConnectingFailedUpdateAddressAlertViewModel {
+
+}

--- a/WooCommerce/Classes/POS/Presentation/Card Present Payments/Payment Alerts/CardPresentPaymentConnectingFailedUpdateAddressAlertViewModel.swift
+++ b/WooCommerce/Classes/POS/Presentation/Card Present Payments/Payment Alerts/CardPresentPaymentConnectingFailedUpdateAddressAlertViewModel.swift
@@ -1,5 +1,77 @@
 import Foundation
+import SwiftUI
 
-struct CardPresentPaymentConnectingFailedUpdateAddressAlertViewModel {
+final class CardPresentPaymentConnectingFailedUpdateAddressAlertViewModel: ObservableObject {
+    let title = Localization.title
+    let image = Image(uiImage: .paymentErrorImage)
+    let settingsAdminUrl: URL
 
+    @Published var shouldShowSettingsWebView: Bool = false
+
+    @Published var primaryButtonViewModel: CardPresentPaymentsModalButtonViewModel? = nil
+    let cancelButtonViewModel: CardPresentPaymentsModalButtonViewModel
+
+    private let retrySearchAction: () -> Void
+
+    private var openSettingsButtonViewModel: CardPresentPaymentsModalButtonViewModel {
+        CardPresentPaymentsModalButtonViewModel(
+            title: Localization.openAdmin,
+            actionHandler: { [weak self] in
+                guard let self else { return }
+                shouldShowSettingsWebView = true
+                primaryButtonViewModel = retryButtonViewModel
+            })
+    }
+
+    private var retryButtonViewModel: CardPresentPaymentsModalButtonViewModel
+
+    init(settingsAdminUrl: URL,
+         retrySearchAction: @escaping () -> Void,
+         cancelSearchAction: @escaping () -> Void) {
+        self.settingsAdminUrl = settingsAdminUrl
+        self.retrySearchAction = retrySearchAction
+        self.retryButtonViewModel = CardPresentPaymentsModalButtonViewModel(
+            title: Localization.retry,
+            actionHandler: retrySearchAction)
+        self.cancelButtonViewModel = CardPresentPaymentsModalButtonViewModel(
+            title: Localization.cancel,
+            actionHandler: cancelSearchAction)
+        self.primaryButtonViewModel = openSettingsButtonViewModel
+    }
+
+    func settingsWebViewWasDismissed() {
+        retrySearchAction()
+    }
+}
+
+private extension CardPresentPaymentConnectingFailedUpdateAddressAlertViewModel {
+    enum Localization {
+        static let title = NSLocalizedString(
+            "cardPresentPayment.alert.connectingFailedUpdateAddress.title",
+            value: "Please correct your store address to proceed",
+            comment: "Title of the alert presented when the user tries to connect to a specific card reader and it fails " +
+            "due to address problems"
+        )
+
+        static let openAdmin = NSLocalizedString(
+            "cardPresentPayment.alert.connectingFailedUpdateAddress.openSettings.button.title",
+            value: "Enter Address",
+            comment: "Button to open a webview at the admin pages, so that the merchant can update their store address " +
+            "to continue setting up In Person Payments"
+        )
+
+        static let retry = NSLocalizedString(
+            "cardPresentPayment.alert.connectingFailedUpdateAddress.retry.button.title",
+            value: "Retry After Updating",
+            comment: "Button to try again after connecting to a specific reader fails due to address problems. " +
+            "Intended for use after the merchant corrects the address in the store admin pages."
+        )
+
+        static let cancel = NSLocalizedString(
+            "cardPresentPayment.alert.connectingFailedUpdateAddress.cancel.button.title",
+            value: "Cancel",
+            comment: "Button to dismiss the alert presented when connecting to a specific reader fails due to address " +
+            "problems. This also cancels searching."
+        )
+    }
 }

--- a/WooCommerce/Classes/POS/Presentation/Card Present Payments/Payment Alerts/CardPresentPaymentConnectingFailedUpdatePostalCodeAlertViewModel.swift
+++ b/WooCommerce/Classes/POS/Presentation/Card Present Payments/Payment Alerts/CardPresentPaymentConnectingFailedUpdatePostalCodeAlertViewModel.swift
@@ -1,0 +1,5 @@
+import Foundation
+
+struct CardPresentPaymentConnectingFailedUpdatePostalCodeAlertViewModel {
+
+}

--- a/WooCommerce/Classes/POS/Presentation/Card Present Payments/Payment Alerts/CardPresentPaymentConnectingFailedUpdatePostalCodeAlertViewModel.swift
+++ b/WooCommerce/Classes/POS/Presentation/Card Present Payments/Payment Alerts/CardPresentPaymentConnectingFailedUpdatePostalCodeAlertViewModel.swift
@@ -1,5 +1,52 @@
 import Foundation
+import SwiftUI
 
 struct CardPresentPaymentConnectingFailedUpdatePostalCodeAlertViewModel {
+    let title = Localization.title
+    let image = Image(uiImage: .paymentErrorImage)
+    let errorDetails = Localization.errorDetails
+    let retryButtonViewModel: CardPresentPaymentsModalButtonViewModel
+    let cancelButtonViewModel: CardPresentPaymentsModalButtonViewModel
 
+    init(retryButtonAction: @escaping () -> Void,
+         cancelButtonAction: @escaping () -> Void) {
+        self.retryButtonViewModel = CardPresentPaymentsModalButtonViewModel(
+            title: Localization.retry,
+            actionHandler: retryButtonAction)
+        self.cancelButtonViewModel = CardPresentPaymentsModalButtonViewModel(
+            title: Localization.cancel,
+            actionHandler: cancelButtonAction)
+    }
+}
+
+private extension CardPresentPaymentConnectingFailedUpdatePostalCodeAlertViewModel {
+    enum Localization {
+        static let title = NSLocalizedString(
+            "cardPresentPayment.alert.connectingFailedUpdatePostCode.title",
+            value: "Please correct your store's postcode/ZIP",
+            comment: "Title of the alert presented when the user tries to connect to a specific card reader and it fails " +
+            "due to postal code problems"
+        )
+
+        static let errorDetails = NSLocalizedString(
+            "cardPresentPayment.alert.connectingFailedUpdatePostCode.errorDetails",
+            value: "You can set your store's postcode/ZIP in wp-admin > WooCommerce > Settings (General)",
+            comment: "Subtitle of the alert presented when the user tries to connect to a specific card reader and it fails " +
+            "due to postal code problems"
+        )
+
+        static let retry = NSLocalizedString(
+            "cardPresentPayment.alert.connectingFailedUpdatePostCode.retry.button.title",
+            value: "Retry After Updating",
+            comment: "Button to try again after connecting to a specific reader fails due to postal code problems. " +
+            "Intended for use after the merchant corrects the postal code in the store admin pages."
+        )
+
+        static let cancel = NSLocalizedString(
+            "cardPresentPayment.alert.connectingFailedUpdatePostCode.cancel.button.title",
+            value: "Cancel",
+            comment: "Button to dismiss the alert presented when connecting to a specific reader fails due to postal code " +
+            "problems. This also cancels searching."
+        )
+    }
 }

--- a/WooCommerce/Classes/POS/Presentation/Card Present Payments/Payment Alerts/CardPresentPaymentConnectingToReaderAlertViewModel.swift
+++ b/WooCommerce/Classes/POS/Presentation/Card Present Payments/Payment Alerts/CardPresentPaymentConnectingToReaderAlertViewModel.swift
@@ -1,5 +1,24 @@
 import Foundation
+import SwiftUI
 
 struct CardPresentPaymentConnectingToReaderAlertViewModel {
+    let title = Localization.title
+    let image = Image(uiImage: .cardReaderConnecting)
+    let instruction = Localization.instruction
+}
 
+private extension CardPresentPaymentConnectingToReaderAlertViewModel {
+    enum Localization {
+        static let title = NSLocalizedString(
+            "cardPresentPayment.alert.connectingToReader.title",
+            value: "Connecting to reader",
+            comment: "Title label for modal dialog that appears when connecting to a card reader"
+        )
+
+        static let instruction = NSLocalizedString(
+            "cardPresentPayment.alert.connectingToReader.instruction",
+            value: "Please wait...",
+            comment: "Label within the modal dialog that appears when connecting to a card reader"
+        )
+    }
 }

--- a/WooCommerce/Classes/POS/Presentation/Card Present Payments/Payment Alerts/CardPresentPaymentScanningFailedAlertViewModel.swift
+++ b/WooCommerce/Classes/POS/Presentation/Card Present Payments/Payment Alerts/CardPresentPaymentScanningFailedAlertViewModel.swift
@@ -1,5 +1,30 @@
 import Foundation
+import SwiftUI
 
 struct CardPresentPaymentScanningFailedAlertViewModel {
+    let title = Localization.title
+    let image = Image(uiImage: .paymentErrorImage)
+    let buttonViewModel: CardPresentPaymentsModalButtonViewModel
+    let errorDetails: String
 
+    init(error: Error, endSearchAction: @escaping () -> Void) {
+        self.buttonViewModel = CardPresentPaymentsModalButtonViewModel(
+            title: Localization.dismiss,
+            actionHandler: endSearchAction)
+        self.errorDetails = error.localizedDescription
+    }
+}
+
+private extension CardPresentPaymentScanningFailedAlertViewModel {
+    enum Localization {
+        static let title = NSLocalizedString(
+            "Connecting reader failed",
+            comment: "Title of the alert presented when the user tries to connect a Bluetooth card reader and it fails"
+        )
+
+        static let dismiss = NSLocalizedString(
+            "Dismiss",
+            comment: "Button to dismiss the alert presented when finding a reader to connect to fails"
+        )
+    }
 }

--- a/WooCommerce/Classes/POS/Presentation/Card Present Payments/Payment Alerts/CardPresentPaymentScanningFailedBluetoothRequiredAlertViewModel.swift
+++ b/WooCommerce/Classes/POS/Presentation/Card Present Payments/Payment Alerts/CardPresentPaymentScanningFailedBluetoothRequiredAlertViewModel.swift
@@ -1,0 +1,46 @@
+import Foundation
+import SwiftUI
+
+struct CardPresentPaymentBluetoothRequiredAlertViewModel {
+    let title = Localization.bluetoothRequired
+    let image = Image(uiImage: .paymentErrorImage)
+    let openSettingsButtonViewModel: CardPresentPaymentsModalButtonViewModel
+    let dismissButtonViewModel: CardPresentPaymentsModalButtonViewModel
+    let errorDetails: String
+
+    init(error: Error, endSearch: @escaping () -> Void) {
+        self.openSettingsButtonViewModel = CardPresentPaymentsModalButtonViewModel(
+            title: Localization.openDeviceSettings,
+            actionHandler: Self.openDeviceSettings)
+        self.dismissButtonViewModel = CardPresentPaymentsModalButtonViewModel(
+            title: Localization.dismiss,
+            actionHandler: endSearch)
+        self.errorDetails = error.localizedDescription
+    }
+
+    private static func openDeviceSettings() {
+        guard let targetURL = URL(string: UIApplication.openSettingsURLString) else {
+            return
+        }
+        UIApplication.shared.open(targetURL)
+    }
+}
+
+private extension CardPresentPaymentBluetoothRequiredAlertViewModel {
+    enum Localization {
+        static let bluetoothRequired = NSLocalizedString(
+            "Bluetooth permission required",
+            comment: "Title of the alert presented when the user tries to connect a Bluetooth card reader with insufficient permissions"
+        )
+
+        static let openDeviceSettings = NSLocalizedString(
+            "Open Device Settings",
+            comment: "Opens iOS's Device Settings for the app"
+        )
+
+        static let dismiss = NSLocalizedString(
+            "Dismiss",
+            comment: "Button to dismiss the alert presented when finding a reader to connect to fails"
+        )
+    }
+}

--- a/WooCommerce/Classes/POS/Presentation/CardPresentPaymentAlert.swift
+++ b/WooCommerce/Classes/POS/Presentation/CardPresentPaymentAlert.swift
@@ -13,6 +13,8 @@ struct CardPresentPaymentAlert: View {
             CardPresentPaymentScanningForReadersView(viewModel: alertViewModel)
         case .scanningFailed(let alertViewModel):
             CardPresentPaymentScanningForReadersFailedView(viewModel: alertViewModel)
+        case .bluetoothRequired(let alertViewModel):
+            CardPresentPaymentBluetoothRequiredAlertView(viewModel: alertViewModel)
         case .foundReader(let alertViewModel):
             CardPresentPaymentFoundReadersView(viewModel: alertViewModel)
         case .updatingReader(let alertViewModel):

--- a/WooCommerce/Classes/POS/Presentation/CardPresentPaymentAlert.swift
+++ b/WooCommerce/Classes/POS/Presentation/CardPresentPaymentAlert.swift
@@ -25,6 +25,14 @@ struct CardPresentPaymentAlert: View {
             CardPresentPaymentConnectingToReaderView(viewModel: alertViewModel)
         case .connectingFailed(let alertViewModel):
             CardPresentPaymentConnectingFailedView(viewModel: alertViewModel)
+        case .connectingFailedNonRetryable(let alertViewModel):
+            CardPresentPaymentConnectingFailedNonRetryableView(viewModel: alertViewModel)
+        case .connectingFailedChargeReader(let alertViewModel):
+            CardPresentPaymentConnectingFailedChargeReaderView(viewModel: alertViewModel)
+        case .connectingFailedUpdateAddress(let alertViewModel):
+            CardPresentPaymentConnectingFailedUpdateAddressView(viewModel: alertViewModel)
+        case .connectingFailedUpdatePostalCode(let alertViewModel):
+            CardPresentPaymentConnectingFailedUpdatePostalCodeView(viewModel: alertViewModel)
         }
     }
 }

--- a/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/CardPresentPaymentBluetoothRequiredAlertView.swift
+++ b/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/CardPresentPaymentBluetoothRequiredAlertView.swift
@@ -31,3 +31,4 @@ struct CardPresentPaymentBluetoothRequiredAlertView: View {
 
 #Preview {
     CardPresentPaymentBluetoothRequiredAlertView(viewModel: .init(error: NSError(domain: "", code: 1), endSearch: {}))
+}

--- a/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/CardPresentPaymentBluetoothRequiredAlertView.swift
+++ b/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/CardPresentPaymentBluetoothRequiredAlertView.swift
@@ -2,7 +2,7 @@ import SwiftUI
 
 struct CardPresentPaymentBluetoothRequiredAlertView: View {
     private let viewModel: CardPresentPaymentBluetoothRequiredAlertViewModel
-    @Environment(\.dismiss) var dismiss
+    @Environment(\.dismiss) private var dismiss
 
     init(viewModel: CardPresentPaymentBluetoothRequiredAlertViewModel) {
         self.viewModel = viewModel

--- a/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/CardPresentPaymentBluetoothRequiredAlertView.swift
+++ b/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/CardPresentPaymentBluetoothRequiredAlertView.swift
@@ -11,7 +11,7 @@ struct CardPresentPaymentBluetoothRequiredAlertView: View {
     var body: some View {
         VStack {
             Text(viewModel.title)
-            
+
             viewModel.image
 
             Text(viewModel.errorDetails)

--- a/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/CardPresentPaymentBluetoothRequiredAlertView.swift
+++ b/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/CardPresentPaymentBluetoothRequiredAlertView.swift
@@ -28,3 +28,6 @@ struct CardPresentPaymentBluetoothRequiredAlertView: View {
         }
     }
 }
+
+#Preview {
+    CardPresentPaymentBluetoothRequiredAlertView(viewModel: .init(error: NSError(domain: "", code: 1), endSearch: {}))

--- a/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/CardPresentPaymentBluetoothRequiredAlertView.swift
+++ b/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/CardPresentPaymentBluetoothRequiredAlertView.swift
@@ -1,0 +1,30 @@
+import SwiftUI
+
+struct CardPresentPaymentBluetoothRequiredAlertView: View {
+    private let viewModel: CardPresentPaymentBluetoothRequiredAlertViewModel
+    @Environment(\.dismiss) var dismiss
+
+    init(viewModel: CardPresentPaymentBluetoothRequiredAlertViewModel) {
+        self.viewModel = viewModel
+    }
+
+    var body: some View {
+        VStack {
+            Text(viewModel.title)
+            
+            viewModel.image
+
+            Text(viewModel.errorDetails)
+
+            Button(viewModel.openSettingsButtonViewModel.title,
+                   action: viewModel.openSettingsButtonViewModel.actionHandler)
+            .buttonStyle(PrimaryButtonStyle())
+
+            Button(viewModel.dismissButtonViewModel.title) {
+                dismiss()
+                viewModel.dismissButtonViewModel.actionHandler()
+            }
+            .buttonStyle(SecondaryButtonStyle())
+        }
+    }
+}

--- a/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/CardPresentPaymentConnectingFailedChargeReaderView.swift
+++ b/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/CardPresentPaymentConnectingFailedChargeReaderView.swift
@@ -3,11 +3,26 @@ import SwiftUI
 struct CardPresentPaymentConnectingFailedChargeReaderView: View {
     let viewModel: CardPresentPaymentConnectingFailedChargeReaderAlertViewModel
     var body: some View {
-        Text("Connecting failed – charge reader")
+        VStack {
+            Text(viewModel.title)
+
+            viewModel.image
+
+            Text(viewModel.errorDetails)
+
+            Button(viewModel.retryButtonViewModel.title,
+                   action: viewModel.retryButtonViewModel.actionHandler)
+
+            Button(viewModel.cancelButtonViewModel.title,
+                   action: viewModel.cancelButtonViewModel.actionHandler)
+            .buttonStyle(SecondaryButtonStyle())
+        }
     }
 }
 
 #Preview {
     CardPresentPaymentConnectingFailedChargeReaderView(
-        viewModel: CardPresentPaymentConnectingFailedChargeReaderAlertViewModel())
+        viewModel: CardPresentPaymentConnectingFailedChargeReaderAlertViewModel(
+            retryButtonAction: {},
+            cancelButtonAction: {}))
 }

--- a/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/CardPresentPaymentConnectingFailedChargeReaderView.swift
+++ b/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/CardPresentPaymentConnectingFailedChargeReaderView.swift
@@ -1,0 +1,13 @@
+import SwiftUI
+
+struct CardPresentPaymentConnectingFailedChargeReaderView: View {
+    let viewModel: CardPresentPaymentConnectingFailedChargeReaderAlertViewModel
+    var body: some View {
+        Text("Connecting failed – charge reader")
+    }
+}
+
+#Preview {
+    CardPresentPaymentConnectingFailedChargeReaderView(
+        viewModel: CardPresentPaymentConnectingFailedChargeReaderAlertViewModel())
+}

--- a/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/CardPresentPaymentConnectingFailedNonRetryableView.swift
+++ b/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/CardPresentPaymentConnectingFailedNonRetryableView.swift
@@ -3,11 +3,23 @@ import SwiftUI
 struct CardPresentPaymentConnectingFailedNonRetryableView: View {
     let viewModel: CardPresentPaymentConnectingFailedNonRetryableAlertViewModel
     var body: some View {
-        Text("Connecting failed – non retryable")
+        VStack {
+            Text(viewModel.title)
+
+            viewModel.image
+
+            Text(viewModel.errorDetails)
+
+            Button(viewModel.cancelButtonViewModel.title,
+                   action: viewModel.cancelButtonViewModel.actionHandler)
+            .buttonStyle(SecondaryButtonStyle())
+        }
     }
 }
 
 #Preview {
     CardPresentPaymentConnectingFailedNonRetryableView(
-        viewModel: CardPresentPaymentConnectingFailedNonRetryableAlertViewModel())
+        viewModel: CardPresentPaymentConnectingFailedNonRetryableAlertViewModel(
+            error: NSError(domain: "payments error", code: 1),
+            cancelAction: {}))
 }

--- a/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/CardPresentPaymentConnectingFailedNonRetryableView.swift
+++ b/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/CardPresentPaymentConnectingFailedNonRetryableView.swift
@@ -1,0 +1,13 @@
+import SwiftUI
+
+struct CardPresentPaymentConnectingFailedNonRetryableView: View {
+    let viewModel: CardPresentPaymentConnectingFailedNonRetryableAlertViewModel
+    var body: some View {
+        Text("Connecting failed – non retryable")
+    }
+}
+
+#Preview {
+    CardPresentPaymentConnectingFailedNonRetryableView(
+        viewModel: CardPresentPaymentConnectingFailedNonRetryableAlertViewModel())
+}

--- a/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/CardPresentPaymentConnectingFailedUpdateAddressView.swift
+++ b/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/CardPresentPaymentConnectingFailedUpdateAddressView.swift
@@ -1,0 +1,13 @@
+import SwiftUI
+
+struct CardPresentPaymentConnectingFailedUpdateAddressView: View {
+    let viewModel: CardPresentPaymentConnectingFailedUpdateAddressAlertViewModel
+    var body: some View {
+        Text("Connecting failed - update address")
+    }
+}
+
+#Preview {
+    CardPresentPaymentConnectingFailedUpdateAddressView(
+        viewModel: CardPresentPaymentConnectingFailedUpdateAddressAlertViewModel())
+}

--- a/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/CardPresentPaymentConnectingFailedUpdateAddressView.swift
+++ b/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/CardPresentPaymentConnectingFailedUpdateAddressView.swift
@@ -1,13 +1,33 @@
 import SwiftUI
 
 struct CardPresentPaymentConnectingFailedUpdateAddressView: View {
-    let viewModel: CardPresentPaymentConnectingFailedUpdateAddressAlertViewModel
+    @StateObject var viewModel: CardPresentPaymentConnectingFailedUpdateAddressAlertViewModel
     var body: some View {
-        Text("Connecting failed - update address")
+        VStack {
+            Text(viewModel.title)
+
+            viewModel.image
+
+            if let primaryButtonViewModel = viewModel.primaryButtonViewModel {
+                Button(primaryButtonViewModel.title,
+                       action: primaryButtonViewModel.actionHandler)
+            }
+
+            Button(viewModel.cancelButtonViewModel.title,
+                   action: viewModel.cancelButtonViewModel.actionHandler)
+            .buttonStyle(SecondaryButtonStyle())
+        }
+        .sheet(isPresented: $viewModel.shouldShowSettingsWebView) {
+            WCSettingsWebView(adminUrl: viewModel.settingsAdminUrl,
+                              completion: viewModel.settingsWebViewWasDismissed)
+        }
     }
 }
 
 #Preview {
     CardPresentPaymentConnectingFailedUpdateAddressView(
-        viewModel: CardPresentPaymentConnectingFailedUpdateAddressAlertViewModel())
+        viewModel: CardPresentPaymentConnectingFailedUpdateAddressAlertViewModel(
+            settingsAdminUrl: URL(string: "http://example.com")!,
+            retrySearchAction: {},
+            cancelSearchAction: {}))
 }

--- a/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/CardPresentPaymentConnectingFailedUpdatePostalCodeView.swift
+++ b/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/CardPresentPaymentConnectingFailedUpdatePostalCodeView.swift
@@ -4,11 +4,27 @@ struct CardPresentPaymentConnectingFailedUpdatePostalCodeView: View {
     let viewModel: CardPresentPaymentConnectingFailedUpdatePostalCodeAlertViewModel
 
     var body: some View {
-        Text("Connecting failed – update postal code")
+        VStack {
+            Text(viewModel.title)
+
+            viewModel.image
+
+            Text(viewModel.errorDetails)
+
+            Button(viewModel.retryButtonViewModel.title,
+                   action: viewModel.retryButtonViewModel.actionHandler)
+            .buttonStyle(PrimaryButtonStyle())
+
+            Button(viewModel.cancelButtonViewModel.title,
+                   action: viewModel.cancelButtonViewModel.actionHandler)
+            .buttonStyle(SecondaryButtonStyle())
+        }
     }
 }
 
 #Preview {
     CardPresentPaymentConnectingFailedUpdatePostalCodeView(
-        viewModel: CardPresentPaymentConnectingFailedUpdatePostalCodeAlertViewModel())
+        viewModel: CardPresentPaymentConnectingFailedUpdatePostalCodeAlertViewModel(
+            retryButtonAction: {},
+            cancelButtonAction: {}))
 }

--- a/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/CardPresentPaymentConnectingFailedUpdatePostalCodeView.swift
+++ b/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/CardPresentPaymentConnectingFailedUpdatePostalCodeView.swift
@@ -1,0 +1,14 @@
+import SwiftUI
+
+struct CardPresentPaymentConnectingFailedUpdatePostalCodeView: View {
+    let viewModel: CardPresentPaymentConnectingFailedUpdatePostalCodeAlertViewModel
+
+    var body: some View {
+        Text("Connecting failed – update postal code")
+    }
+}
+
+#Preview {
+    CardPresentPaymentConnectingFailedUpdatePostalCodeView(
+        viewModel: CardPresentPaymentConnectingFailedUpdatePostalCodeAlertViewModel())
+}

--- a/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/CardPresentPaymentConnectingFailedView.swift
+++ b/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/CardPresentPaymentConnectingFailedView.swift
@@ -8,10 +8,30 @@ struct CardPresentPaymentConnectingFailedView: View {
     }
 
     var body: some View {
-        Text("Connection to reader failed")
+        VStack {
+            Text(viewModel.title)
+
+            viewModel.image
+
+            if let errorDetails = viewModel.errorDetails {
+                Text(errorDetails)
+            }
+
+            Button(viewModel.retryButtonViewModel.title,
+                   action: viewModel.retryButtonViewModel.actionHandler)
+            .buttonStyle(PrimaryButtonStyle())
+
+            Button(viewModel.cancelButtonViewModel.title,
+                   action: viewModel.cancelButtonViewModel.actionHandler)
+            .buttonStyle(SecondaryButtonStyle())
+        }
     }
 }
 
 #Preview {
-    CardPresentPaymentConnectingFailedView(viewModel: CardPresentPaymentConnectingFailedAlertViewModel())
+    CardPresentPaymentConnectingFailedView(
+        viewModel: CardPresentPaymentConnectingFailedAlertViewModel(
+            error: NSError(domain: "preview.error", code: 1),
+            retryButtonAction: {},
+            cancelButtonAction: {}))
 }

--- a/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/CardPresentPaymentConnectingToReaderView.swift
+++ b/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/CardPresentPaymentConnectingToReaderView.swift
@@ -10,9 +10,9 @@ struct CardPresentPaymentConnectingToReaderView: View {
     var body: some View {
         VStack {
             Text(viewModel.title)
-            
+
             viewModel.image
-            
+
             Text(viewModel.instruction)
         }
     }

--- a/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/CardPresentPaymentConnectingToReaderView.swift
+++ b/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/CardPresentPaymentConnectingToReaderView.swift
@@ -8,7 +8,13 @@ struct CardPresentPaymentConnectingToReaderView: View {
     }
 
     var body: some View {
-        Text("Connecting to reader...")
+        VStack {
+            Text(viewModel.title)
+            
+            viewModel.image
+            
+            Text(viewModel.instruction)
+        }
     }
 }
 

--- a/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/CardPresentPaymentScanningForReadersFailedView.swift
+++ b/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/CardPresentPaymentScanningForReadersFailedView.swift
@@ -8,10 +8,23 @@ struct CardPresentPaymentScanningForReadersFailedView: View {
     }
 
     var body: some View {
-        Text("Reader scanning failed")
+        VStack {
+            Text(viewModel.title)
+
+            viewModel.image
+
+            Text(viewModel.errorDetails)
+
+            Button(viewModel.buttonViewModel.title,
+                   action: viewModel.buttonViewModel.actionHandler)
+            .buttonStyle(SecondaryButtonStyle())
+        }
     }
 }
 
 #Preview {
-    CardPresentPaymentScanningForReadersFailedView(viewModel: CardPresentPaymentScanningFailedAlertViewModel())
+    CardPresentPaymentScanningForReadersFailedView(
+        viewModel:CardPresentPaymentScanningFailedAlertViewModel(
+            error: NSError(domain: "", code: 1, userInfo: nil),
+            endSearchAction: {}))
 }

--- a/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/CardPresentPaymentScanningForReadersFailedView.swift
+++ b/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/CardPresentPaymentScanningForReadersFailedView.swift
@@ -24,7 +24,7 @@ struct CardPresentPaymentScanningForReadersFailedView: View {
 
 #Preview {
     CardPresentPaymentScanningForReadersFailedView(
-        viewModel:CardPresentPaymentScanningFailedAlertViewModel(
+        viewModel: CardPresentPaymentScanningFailedAlertViewModel(
             error: NSError(domain: "", code: 1, userInfo: nil),
             endSearchAction: {}))
 }

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -774,6 +774,8 @@
 		202496642B0B9E0D00EE527D /* ScrollViewSectionKit in Frameworks */ = {isa = PBXBuildFile; productRef = 202496632B0B9E0D00EE527D /* ScrollViewSectionKit */; };
 		2024966A2B0CC97100EE527D /* MockWooPaymentsDepositService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 202496692B0CC97100EE527D /* MockWooPaymentsDepositService.swift */; };
 		202D2A5A2AC5933100E4ABC0 /* TopTabView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 202D2A592AC5933100E4ABC0 /* TopTabView.swift */; };
+		203163A92C1B5AA7001C96DA /* CardPresentPaymentScanningFailedBluetoothRequiredAlertViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 203163A82C1B5AA7001C96DA /* CardPresentPaymentScanningFailedBluetoothRequiredAlertViewModel.swift */; };
+		203163AB2C1B5DEE001C96DA /* CardPresentPaymentBluetoothRequiredAlertView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 203163AA2C1B5DEE001C96DA /* CardPresentPaymentBluetoothRequiredAlertView.swift */; };
 		203A5C312AC5ADD700BF29A1 /* WooPaymentsDepositsOverviewView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 203A5C302AC5ADD700BF29A1 /* WooPaymentsDepositsOverviewView.swift */; };
 		204C9C742B6BDFFB007A94E0 /* UIUserInterfaceSizeClass+Helpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 204C9C732B6BDFFB007A94E0 /* UIUserInterfaceSizeClass+Helpers.swift */; };
 		204CB80E2C0F8A5E000C9773 /* MockViewControllerPresenting.swift in Sources */ = {isa = PBXBuildFile; fileRef = 204CB80D2C0F8A5E000C9773 /* MockViewControllerPresenting.swift */; };
@@ -3726,6 +3728,8 @@
 		20203AB12B31EEF1009D0C11 /* ExpandableBottomSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExpandableBottomSheet.swift; sourceTree = "<group>"; };
 		202496692B0CC97100EE527D /* MockWooPaymentsDepositService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockWooPaymentsDepositService.swift; sourceTree = "<group>"; };
 		202D2A592AC5933100E4ABC0 /* TopTabView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TopTabView.swift; sourceTree = "<group>"; };
+		203163A82C1B5AA7001C96DA /* CardPresentPaymentScanningFailedBluetoothRequiredAlertViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardPresentPaymentScanningFailedBluetoothRequiredAlertViewModel.swift; sourceTree = "<group>"; };
+		203163AA2C1B5DEE001C96DA /* CardPresentPaymentBluetoothRequiredAlertView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardPresentPaymentBluetoothRequiredAlertView.swift; sourceTree = "<group>"; };
 		203A5C302AC5ADD700BF29A1 /* WooPaymentsDepositsOverviewView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WooPaymentsDepositsOverviewView.swift; sourceTree = "<group>"; };
 		204C9C732B6BDFFB007A94E0 /* UIUserInterfaceSizeClass+Helpers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIUserInterfaceSizeClass+Helpers.swift"; sourceTree = "<group>"; };
 		204CB80D2C0F8A5E000C9773 /* MockViewControllerPresenting.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockViewControllerPresenting.swift; sourceTree = "<group>"; };
@@ -6613,6 +6617,7 @@
 			children = (
 				026826BE2BF59E410036F959 /* CardPresentPaymentScanningForReadersView.swift */,
 				026826B62BF59E400036F959 /* CardPresentPaymentScanningForReadersFailedView.swift */,
+				203163AA2C1B5DEE001C96DA /* CardPresentPaymentBluetoothRequiredAlertView.swift */,
 				026826B82BF59E400036F959 /* CardPresentPaymentConnectingToReaderView.swift */,
 				026826B72BF59E400036F959 /* CardPresentPaymentConnectingFailedView.swift */,
 				026826BB2BF59E410036F959 /* CardPresentPaymentFoundReadersView.swift */,
@@ -7553,6 +7558,7 @@
 				205B7EC82C19FCDB00D14A36 /* CardPresentPaymentTapSwipeInsertCardAlertViewModel.swift */,
 				205B7EB82C19FAF700D14A36 /* CardPresentPaymentScanningForReadersAlertViewModel.swift */,
 				205B7EBA2C19FB1200D14A36 /* CardPresentPaymentScanningFailedAlertViewModel.swift */,
+				203163A82C1B5AA7001C96DA /* CardPresentPaymentScanningFailedBluetoothRequiredAlertViewModel.swift */,
 				205B7EBC2C19FB6600D14A36 /* CardPresentPaymentFoundReaderAlertViewModel.swift */,
 				205B7EBE2C19FBCA00D14A36 /* CardPresentPaymentUpdatingReaderAlertViewModel.swift */,
 				205B7ED02C19FD8500D14A36 /* CardPresentPaymentErrorAlertViewModel.swift */,
@@ -14315,6 +14321,7 @@
 				026826932BF59D830036F959 /* PointOfSaleDashboardViewModel.swift in Sources */,
 				026CF63A237E9ABE009563D4 /* ProductVariationsViewController.swift in Sources */,
 				45D685FE23D0FB25005F87D0 /* Throttler.swift in Sources */,
+				203163AB2C1B5DEE001C96DA /* CardPresentPaymentBluetoothRequiredAlertView.swift in Sources */,
 				DE5C19C92AC42E7E0064600A /* WooAnalyticsEvent+ProductNameAI.swift in Sources */,
 				0250192E2BDF81F3009493A5 /* OrderCustomerSection.swift in Sources */,
 				459097F823CDE47F00DEA9E0 /* UIAlertController+Helpers.swift in Sources */,
@@ -15470,6 +15477,7 @@
 				03191AE628E1DF0600670723 /* PluginDetailsViewModel.swift in Sources */,
 				CE22709F2293052700C0626C /* WebviewHelper.swift in Sources */,
 				02BA12852461674B008D8325 /* Optional+String.swift in Sources */,
+				203163A92C1B5AA7001C96DA /* CardPresentPaymentScanningFailedBluetoothRequiredAlertViewModel.swift in Sources */,
 				DEEDA239298A11FB0088256B /* SiteCredentialLoginUseCase.swift in Sources */,
 				744F00D221B582A9007EFA93 /* StarRatingView.swift in Sources */,
 				45F627B9253603AE00894B86 /* ProductDownloadSettingsViewModel.swift in Sources */,

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -776,6 +776,14 @@
 		202D2A5A2AC5933100E4ABC0 /* TopTabView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 202D2A592AC5933100E4ABC0 /* TopTabView.swift */; };
 		203163A92C1B5AA7001C96DA /* CardPresentPaymentScanningFailedBluetoothRequiredAlertViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 203163A82C1B5AA7001C96DA /* CardPresentPaymentScanningFailedBluetoothRequiredAlertViewModel.swift */; };
 		203163AB2C1B5DEE001C96DA /* CardPresentPaymentBluetoothRequiredAlertView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 203163AA2C1B5DEE001C96DA /* CardPresentPaymentBluetoothRequiredAlertView.swift */; };
+		203163AD2C1C5C54001C96DA /* CardPresentPaymentConnectingFailedNonRetryableAlertViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 203163AC2C1C5C54001C96DA /* CardPresentPaymentConnectingFailedNonRetryableAlertViewModel.swift */; };
+		203163AF2C1C5C6B001C96DA /* CardPresentPaymentConnectingFailedUpdateAddressAlertViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 203163AE2C1C5C6B001C96DA /* CardPresentPaymentConnectingFailedUpdateAddressAlertViewModel.swift */; };
+		203163B12C1C5C87001C96DA /* CardPresentPaymentConnectingFailedUpdatePostalCodeAlertViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 203163B02C1C5C87001C96DA /* CardPresentPaymentConnectingFailedUpdatePostalCodeAlertViewModel.swift */; };
+		203163B32C1C5DAC001C96DA /* CardPresentPaymentConnectingFailedChargeReaderAlertViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 203163B22C1C5DAC001C96DA /* CardPresentPaymentConnectingFailedChargeReaderAlertViewModel.swift */; };
+		203163B52C1C5EB2001C96DA /* CardPresentPaymentConnectingFailedNonRetryableView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 203163B42C1C5EB2001C96DA /* CardPresentPaymentConnectingFailedNonRetryableView.swift */; };
+		203163B72C1C5EDF001C96DA /* CardPresentPaymentConnectingFailedChargeReaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 203163B62C1C5EDF001C96DA /* CardPresentPaymentConnectingFailedChargeReaderView.swift */; };
+		203163B92C1C5F42001C96DA /* CardPresentPaymentConnectingFailedUpdateAddressView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 203163B82C1C5F42001C96DA /* CardPresentPaymentConnectingFailedUpdateAddressView.swift */; };
+		203163BB2C1C5F72001C96DA /* CardPresentPaymentConnectingFailedUpdatePostalCodeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 203163BA2C1C5F72001C96DA /* CardPresentPaymentConnectingFailedUpdatePostalCodeView.swift */; };
 		203A5C312AC5ADD700BF29A1 /* WooPaymentsDepositsOverviewView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 203A5C302AC5ADD700BF29A1 /* WooPaymentsDepositsOverviewView.swift */; };
 		204C9C742B6BDFFB007A94E0 /* UIUserInterfaceSizeClass+Helpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 204C9C732B6BDFFB007A94E0 /* UIUserInterfaceSizeClass+Helpers.swift */; };
 		204CB80E2C0F8A5E000C9773 /* MockViewControllerPresenting.swift in Sources */ = {isa = PBXBuildFile; fileRef = 204CB80D2C0F8A5E000C9773 /* MockViewControllerPresenting.swift */; };
@@ -3730,6 +3738,14 @@
 		202D2A592AC5933100E4ABC0 /* TopTabView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TopTabView.swift; sourceTree = "<group>"; };
 		203163A82C1B5AA7001C96DA /* CardPresentPaymentScanningFailedBluetoothRequiredAlertViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardPresentPaymentScanningFailedBluetoothRequiredAlertViewModel.swift; sourceTree = "<group>"; };
 		203163AA2C1B5DEE001C96DA /* CardPresentPaymentBluetoothRequiredAlertView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardPresentPaymentBluetoothRequiredAlertView.swift; sourceTree = "<group>"; };
+		203163AC2C1C5C54001C96DA /* CardPresentPaymentConnectingFailedNonRetryableAlertViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardPresentPaymentConnectingFailedNonRetryableAlertViewModel.swift; sourceTree = "<group>"; };
+		203163AE2C1C5C6B001C96DA /* CardPresentPaymentConnectingFailedUpdateAddressAlertViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardPresentPaymentConnectingFailedUpdateAddressAlertViewModel.swift; sourceTree = "<group>"; };
+		203163B02C1C5C87001C96DA /* CardPresentPaymentConnectingFailedUpdatePostalCodeAlertViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardPresentPaymentConnectingFailedUpdatePostalCodeAlertViewModel.swift; sourceTree = "<group>"; };
+		203163B22C1C5DAC001C96DA /* CardPresentPaymentConnectingFailedChargeReaderAlertViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardPresentPaymentConnectingFailedChargeReaderAlertViewModel.swift; sourceTree = "<group>"; };
+		203163B42C1C5EB2001C96DA /* CardPresentPaymentConnectingFailedNonRetryableView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardPresentPaymentConnectingFailedNonRetryableView.swift; sourceTree = "<group>"; };
+		203163B62C1C5EDF001C96DA /* CardPresentPaymentConnectingFailedChargeReaderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardPresentPaymentConnectingFailedChargeReaderView.swift; sourceTree = "<group>"; };
+		203163B82C1C5F42001C96DA /* CardPresentPaymentConnectingFailedUpdateAddressView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardPresentPaymentConnectingFailedUpdateAddressView.swift; sourceTree = "<group>"; };
+		203163BA2C1C5F72001C96DA /* CardPresentPaymentConnectingFailedUpdatePostalCodeView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardPresentPaymentConnectingFailedUpdatePostalCodeView.swift; sourceTree = "<group>"; };
 		203A5C302AC5ADD700BF29A1 /* WooPaymentsDepositsOverviewView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WooPaymentsDepositsOverviewView.swift; sourceTree = "<group>"; };
 		204C9C732B6BDFFB007A94E0 /* UIUserInterfaceSizeClass+Helpers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIUserInterfaceSizeClass+Helpers.swift"; sourceTree = "<group>"; };
 		204CB80D2C0F8A5E000C9773 /* MockViewControllerPresenting.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockViewControllerPresenting.swift; sourceTree = "<group>"; };
@@ -6620,7 +6636,11 @@
 				203163AA2C1B5DEE001C96DA /* CardPresentPaymentBluetoothRequiredAlertView.swift */,
 				026826B82BF59E400036F959 /* CardPresentPaymentConnectingToReaderView.swift */,
 				026826B72BF59E400036F959 /* CardPresentPaymentConnectingFailedView.swift */,
+				203163B42C1C5EB2001C96DA /* CardPresentPaymentConnectingFailedNonRetryableView.swift */,
+				203163BA2C1C5F72001C96DA /* CardPresentPaymentConnectingFailedUpdatePostalCodeView.swift */,
+				203163B62C1C5EDF001C96DA /* CardPresentPaymentConnectingFailedChargeReaderView.swift */,
 				026826BB2BF59E410036F959 /* CardPresentPaymentFoundReadersView.swift */,
+				203163B82C1C5F42001C96DA /* CardPresentPaymentConnectingFailedUpdateAddressView.swift */,
 				026826B92BF59E400036F959 /* CardPresentPaymentReaderUpdateInProgressView.swift */,
 				026826BC2BF59E410036F959 /* CardPresentPaymentReaderUpdateFailedView.swift */,
 				026826BA2BF59E400036F959 /* ReaderConnectedView.swift */,
@@ -7565,6 +7585,10 @@
 				205B7EC02C19FBEA00D14A36 /* CardPresentPaymentReaderUpdateFailedAlertViewModel.swift */,
 				205B7EC22C19FC3000D14A36 /* CardPresentPaymentConnectingToReaderAlertViewModel.swift */,
 				205B7EC42C19FC4F00D14A36 /* CardPresentPaymentConnectingFailedAlertViewModel.swift */,
+				203163AE2C1C5C6B001C96DA /* CardPresentPaymentConnectingFailedUpdateAddressAlertViewModel.swift */,
+				203163B02C1C5C87001C96DA /* CardPresentPaymentConnectingFailedUpdatePostalCodeAlertViewModel.swift */,
+				203163AC2C1C5C54001C96DA /* CardPresentPaymentConnectingFailedNonRetryableAlertViewModel.swift */,
+				203163B22C1C5DAC001C96DA /* CardPresentPaymentConnectingFailedChargeReaderAlertViewModel.swift */,
 				205B7EC62C19FCA700D14A36 /* CardPresentPaymentPreparingForPaymentAlertViewModel.swift */,
 				205B7ECA2C19FCFC00D14A36 /* CardPresentPaymentProcessingPaymentAlertViewModel.swift */,
 				205B7ECC2C19FD2F00D14A36 /* CardPresentPaymentDisplayReaderMessageAlertViewModel.swift */,
@@ -14649,6 +14673,7 @@
 				860476E82B6CA0FC00AF0AEB /* BottomSheetProductType.swift in Sources */,
 				028296EC237D28B600E84012 /* TextViewViewController.swift in Sources */,
 				02B8650F24A9E2D800265779 /* Product+SwiftUIPreviewHelpers.swift in Sources */,
+				203163B92C1C5F42001C96DA /* CardPresentPaymentConnectingFailedUpdateAddressView.swift in Sources */,
 				454B28BE23BF63C600CD2091 /* DateIntervalFormatter+Helpers.swift in Sources */,
 				AE6DBE3B2732CAAD00957E7A /* AdaptiveStack.swift in Sources */,
 				03A6C18628B8CC7F00AADF23 /* InPersonPaymentsOnboardingErrorButtonViewModel.swift in Sources */,
@@ -14862,6 +14887,7 @@
 				E1F52DC62668E03B00349D75 /* CardPresentModalBluetoothRequired.swift in Sources */,
 				CE29A63029F2DACC003D2A00 /* OrderSubscriptionTableViewCell.swift in Sources */,
 				DE1B030D268DD01A00804330 /* ReviewOrderViewController.swift in Sources */,
+				203163AF2C1C5C6B001C96DA /* CardPresentPaymentConnectingFailedUpdateAddressAlertViewModel.swift in Sources */,
 				EE45E2BF2A409E250085F227 /* UIColor+Tooltip.swift in Sources */,
 				B5FD111621D3F13700560344 /* BordersView.swift in Sources */,
 				68E674AF2A4DACD50034BA1E /* UpgradeTopBarView.swift in Sources */,
@@ -15111,6 +15137,7 @@
 				02ECD1E624FFB4E900735BE5 /* ProductFactory.swift in Sources */,
 				260520F42B87BA23005D5D59 /* WooAnalyticsEvent+ConnectivityTool.swift in Sources */,
 				579CDEFF274D7E7900E8903D /* StoreStatsUsageTracksEventEmitter.swift in Sources */,
+				203163AD2C1C5C54001C96DA /* CardPresentPaymentConnectingFailedNonRetryableAlertViewModel.swift in Sources */,
 				CEDBDA472B6BEF2E002047D4 /* AnalyticsWebReport.swift in Sources */,
 				314DC4BD268D158F00444C9E /* CardReaderSettingsKnownReadersProvider.swift in Sources */,
 				264957A329C520860095AA4C /* SubscriptionsView.swift in Sources */,
@@ -15488,6 +15515,7 @@
 				CE29FEED2BFF771F007679C2 /* ShippingLineRowView.swift in Sources */,
 				B932847429A8D6E600B01251 /* CardPresentPaymentsOnboardingIPPUsersRefresher.swift in Sources */,
 				AE3AA889290C303B00BE422D /* WebKitViewController.swift in Sources */,
+				203163B52C1C5EB2001C96DA /* CardPresentPaymentConnectingFailedNonRetryableView.swift in Sources */,
 				4535EE7A281ADD56004212B4 /* CouponCodeInputFormatter.swift in Sources */,
 				0373A1312A1E3FD700731236 /* TapToPayBadgePromotionChecker.swift in Sources */,
 				DEDB2D262845D31900CE7D35 /* CouponAllowedEmailsViewModel.swift in Sources */,
@@ -15507,6 +15535,7 @@
 				CEE02AF82C1859B400B0B6AB /* MessageComposeView.swift in Sources */,
 				D8C2A28F231BD00500F503E9 /* ReviewsViewModel.swift in Sources */,
 				EE8B42162BFC33670077C4E7 /* LastOrdersDashboardEmptyView.swift in Sources */,
+				203163B32C1C5DAC001C96DA /* CardPresentPaymentConnectingFailedChargeReaderAlertViewModel.swift in Sources */,
 				20E188842AD059A50053E945 /* AboutTapToPayView.swift in Sources */,
 				EE8A30452B74948C001D7C66 /* OrderAttributionInfo+Origin.swift in Sources */,
 				205B7ECF2C19FD5200D14A36 /* CardPresentPaymentSuccessAlertViewModel.swift in Sources */,
@@ -15525,6 +15554,7 @@
 				EE45E2B72A409BA40085F227 /* Tooltip.swift in Sources */,
 				B65496342A0B291A003D29E1 /* EUShippingNoticeBanner.swift in Sources */,
 				B946881029B8DD01000646B0 /* InPersonPaymentsMenuViewController+Activity.swift in Sources */,
+				203163B12C1C5C87001C96DA /* CardPresentPaymentConnectingFailedUpdatePostalCodeAlertViewModel.swift in Sources */,
 				027EB56C29C05F4B003CE551 /* StoreOnboardingLaunchStoreView.swift in Sources */,
 				DEC75CC62BC4ED2100763801 /* DashboardCard+UI.swift in Sources */,
 				09EA565527C8ACEE00407D40 /* BulkUpdateViewController.swift in Sources */,
@@ -15569,8 +15599,10 @@
 				DE19BB1A26C3B5DC00AB70D9 /* ShippingLabelCustomsFormItemDetailsViewModel.swift in Sources */,
 				B6F3796C293794A000718561 /* AnalyticsHubYearToDateRangeData.swift in Sources */,
 				2667BFE52530DCF4008099D4 /* RefundItemsValuesCalculationUseCase.swift in Sources */,
+				203163BB2C1C5F72001C96DA /* CardPresentPaymentConnectingFailedUpdatePostalCodeView.swift in Sources */,
 				AEE9A880293A3E5500227C92 /* RefreshablePlainList.swift in Sources */,
 				02D4472C2A4D29930040D72D /* WooAnalyticsEvent+LocalAnnouncement.swift in Sources */,
+				203163B72C1C5EDF001C96DA /* CardPresentPaymentConnectingFailedChargeReaderView.swift in Sources */,
 				2004E2ED2C0F5DD800D62521 /* CardPresentPaymentCollectOrderPaymentUseCaseAdaptor.swift in Sources */,
 				868029532C184E6C00CB64A1 /* BottomSheetProductCategory.swift in Sources */,
 				B55BC1F121A878A30011A0C0 /* String+HTML.swift in Sources */,


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of: #12868
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

This PR reimplements all the connection alerts in SwiftUI, using our new event details and view models. Update alerts usually happen during connection, but they aren't implemented yet here.

The translation/creation of the viewmodels from the event details is improved in the next PR, here it's a little clunky and the naming isn't perfect... but putting them together would be huge.

Apologies that it's quite long. They're all pretty similar so it made sense to group them together, but I think we can test them all together, possibly at the end once we're done styling them fully.

## Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->

## Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if 