### PR TITLE
[Tablet Orders] Add unit test coverage for `OrderSearchUICommand`

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Search/Order/OrderSearchUICommand.swift
+++ b/WooCommerce/Classes/ViewRelated/Search/Order/OrderSearchUICommand.swift
@@ -1,6 +1,7 @@
 import Yosemite
 import Networking
 import protocol Storage.StorageManagerType
+import protocol WooFoundation.Analytics
 
 /// Implementation of `SearchUICommand` for Order search.
 final class OrderSearchUICommand: SearchUICommand {
@@ -27,17 +28,22 @@ final class OrderSearchUICommand: SearchUICommand {
     }()
 
     private let siteID: Int64
-
     private let storageManager: StorageManagerType
+    private let analytics: Analytics
+    private let stores: StoresManager
 
     private let onSelectSearchResult: ((Order, UIViewController) -> Void)
 
     init(siteID: Int64,
          onSelectSearchResult: @escaping ((Order, UIViewController) -> Void),
-         storageManager: StorageManagerType = ServiceLocator.storageManager) {
+         storageManager: StorageManagerType = ServiceLocator.storageManager,
+         analytics: Analytics = ServiceLocator.analytics,
+         stores: StoresManager = ServiceLocator.stores) {
         self.siteID = siteID
         self.onSelectSearchResult = onSelectSearchResult
         self.storageManager = storageManager
+        self.analytics = analytics
+        self.stores = stores
         configureResultsController()
     }
 
@@ -80,8 +86,8 @@ final class OrderSearchUICommand: SearchUICommand {
             onCompletion?(error == nil)
         }
 
-        ServiceLocator.stores.dispatch(action)
-        ServiceLocator.analytics.track(.ordersListSearch, withProperties: ["search": "\(keyword)"])
+        stores.dispatch(action)
+        analytics.track(.ordersListSearch, withProperties: ["search": "\(keyword)"])
     }
 
     func didSelectSearchResult(model: Order, from viewController: UIViewController, reloadData: () -> Void, updateActionButton: () -> Void) {

--- a/WooCommerce/Classes/ViewRelated/Search/Order/OrderSearchUICommand.swift
+++ b/WooCommerce/Classes/ViewRelated/Search/Order/OrderSearchUICommand.swift
@@ -115,18 +115,10 @@ private extension OrderSearchUICommand {
     }
 
     func lookUpOrderStatus(for order: Order) -> OrderStatus? {
-        if let mockLookUpOrderStatus = OrderSearchUICommand._lookUpOrderStatus {
-            return mockLookUpOrderStatus(order)
-        }
         let listAll = statusResultsController.fetchedObjects
         for orderStatus in listAll where orderStatus.status == order.status {
             return orderStatus
         }
         return nil
     }
-}
-
-// Add an extension to OrderSearchUICommand to inject the lookUpOrderStatus method for testing
-extension OrderSearchUICommand {
-    static var _lookUpOrderStatus: ((Networking.Order) -> Networking.OrderStatus?)?
 }

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -1972,6 +1972,7 @@
 		C064EE2B2783480000D54B0D /* OrderDataStructs.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0115DFC277CC19E007293B8 /* OrderDataStructs.swift */; };
 		C0A37CB8282957EB00E0826D /* orders_3337_add_customer_details.json in Resources */ = {isa = PBXBuildFile; fileRef = C0A37CB7282957EB00E0826D /* orders_3337_add_customer_details.json */; };
 		C0CE1F84282AB1590019138E /* countries.json in Resources */ = {isa = PBXBuildFile; fileRef = C0CE1F83282AB1590019138E /* countries.json */; };
+		C7533D1E2C1E38E0002EBAE7 /* OrderSearchUICommandTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7533D1D2C1E38E0002EBAE7 /* OrderSearchUICommandTests.swift */; };
 		CC0324A3263AD9F40056C6B7 /* MockShippingLabelAccountSettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC0324A2263AD9F40056C6B7 /* MockShippingLabelAccountSettings.swift */; };
 		CC04918D292BB74500F719D8 /* StatsDataTextFormatter.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC04918C292BB74500F719D8 /* StatsDataTextFormatter.swift */; };
 		CC04918F292BD6AC00F719D8 /* StatsDataTextFormatterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC04918E292BD6AC00F719D8 /* StatsDataTextFormatterTests.swift */; };
@@ -4894,6 +4895,7 @@
 		C0A37CB7282957EB00E0826D /* orders_3337_add_customer_details.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = orders_3337_add_customer_details.json; sourceTree = "<group>"; };
 		C0CE1F83282AB1590019138E /* countries.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = countries.json; sourceTree = "<group>"; };
 		C5EFBA3D6E428FD34F5A4171 /* Pods_NotificationExtension.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_NotificationExtension.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		C7533D1D2C1E38E0002EBAE7 /* OrderSearchUICommandTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OrderSearchUICommandTests.swift; sourceTree = "<group>"; };
 		CB4839361AA061340BE98DA9 /* Pods-StoreWidgetsExtension.release-alpha.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-StoreWidgetsExtension.release-alpha.xcconfig"; path = "../Pods/Target Support Files/Pods-StoreWidgetsExtension/Pods-StoreWidgetsExtension.release-alpha.xcconfig"; sourceTree = "<group>"; };
 		CC0324A2263AD9F40056C6B7 /* MockShippingLabelAccountSettings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockShippingLabelAccountSettings.swift; sourceTree = "<group>"; };
 		CC04918C292BB74500F719D8 /* StatsDataTextFormatter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StatsDataTextFormatter.swift; sourceTree = "<group>"; };
@@ -8841,6 +8843,7 @@
 		573D0ACC2458665C004DE614 /* Search */ = {
 			isa = PBXGroup;
 			children = (
+				C7533D1C2C1E387D002EBAE7 /* Order */,
 				682210EB2909664800814E14 /* Customer */,
 				020C908224C84638001E2BEB /* Product */,
 			);
@@ -10571,6 +10574,14 @@
 				C0CE1F83282AB1590019138E /* countries.json */,
 			);
 			path = data;
+			sourceTree = "<group>";
+		};
+		C7533D1C2C1E387D002EBAE7 /* Order */ = {
+			isa = PBXGroup;
+			children = (
+				C7533D1D2C1E38E0002EBAE7 /* OrderSearchUICommandTests.swift */,
+			);
+			path = Order;
 			sourceTree = "<group>";
 		};
 		CC01CE5B29B2342E004FF537 /* Bundled Products */ = {
@@ -16307,6 +16318,7 @@
 				B935D3632A9F57600067B927 /* NewTaxRateSelectorViewModelTests.swift in Sources */,
 				0258B66D2518778300EB5CF2 /* ProductFormViewModelTests.swift in Sources */,
 				45AF9DAA265CEAA3001EB794 /* ShippingLabelCarrierRowViewModelTests.swift in Sources */,
+				C7533D1E2C1E38E0002EBAE7 /* OrderSearchUICommandTests.swift in Sources */,
 				748C7784211E2D8400814F2C /* DoubleWooTests.swift in Sources */,
 				03F8D87D2A7A76DE00DD6D2F /* MockCardPresentPaymentPreflightController.swift in Sources */,
 				02524A5D252ED5C60033E7BD /* ProductVariationLoadUseCaseTests.swift in Sources */,

--- a/WooCommerce/WooCommerceTests/ViewRelated/Search/Order/OrderSearchUICommandTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Search/Order/OrderSearchUICommandTests.swift
@@ -117,7 +117,7 @@ final class OrderSearchUICommandTests: XCTestCase {
         let selectedOrder = waitFor { promise in
             let command = OrderSearchUICommand(siteID: self.siteID, onSelectSearchResult: { order, _ in
                 promise(order)
-            }, storageManager: storageManager)
+            }, storageManager: self.storageManager)
             command.didSelectSearchResult(model: order, from: .init(), reloadData: {}, updateActionButton: {})
         }
 
@@ -131,17 +131,6 @@ final class OrderSearchUICommandTests: XCTestCase {
             storageManager.insertOrderStatus(name: status.rawValue)
         }
         storageManager.viewStorage.saveIfNeeded()
-    }
-
-    private func waitFor<T>(timeout: TimeInterval = 1, _ completion: (_ promise: @escaping (T) -> Void) -> Void) -> T? {
-        var result: T?
-        let expectation = self.expectation(description: "Waiting for completion")
-        completion {
-            result = $0
-            expectation.fulfill()
-        }
-        waitForExpectations(timeout: timeout, handler: nil)
-        return result
     }
 }
 

--- a/WooCommerce/WooCommerceTests/ViewRelated/Search/Order/OrderSearchUICommandTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Search/Order/OrderSearchUICommandTests.swift
@@ -51,7 +51,7 @@ final class OrderSearchUICommandTests: XCTestCase {
 
     func test_CreateCellViewModel() {
         // Given
-        let mockOrder = MockOrders().makeOrder(status: .onHold, items: [], shippingLines: [], refunds: [], fees: [], taxes: [], customFields: [], giftCards: [])
+        let mockOrder = MockOrders().makeOrder(status: .onHold)
 
         let command = OrderSearchUICommand(siteID: siteID, onSelectSearchResult: { _, _ in }, storageManager: storageManager)
 

--- a/WooCommerce/WooCommerceTests/ViewRelated/Search/Order/OrderSearchUICommandTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Search/Order/OrderSearchUICommandTests.swift
@@ -1,22 +1,27 @@
 import XCTest
 
 @testable import WooCommerce
+import Storage
 import Yosemite
+import Networking
 
 final class OrderSearchUICommandTests: XCTestCase {
     let siteID: Int64 = 12345
+    private var storageManager: MockStorageManager!
 
     override func setUpWithError() throws {
         super.setUp()
+        storageManager = MockStorageManager()
     }
 
     override func tearDownWithError() throws {
+        storageManager = nil
         super.tearDown()
     }
 
     func testCreateStarterViewControllerReturnsNil() throws {
         // Given
-        let command = OrderSearchUICommand(siteID: siteID, onSelectSearchResult: { _, _ in })
+        let command = OrderSearchUICommand(siteID: siteID, onSelectSearchResult: { _, _ in }, storageManager: storageManager)
 
         // When
         let starterViewController = command.createStarterViewController()
@@ -27,8 +32,7 @@ final class OrderSearchUICommandTests: XCTestCase {
 
     func testCreateResultsController() {
         // Given
-
-        let command = OrderSearchUICommand(siteID: siteID, onSelectSearchResult: { _, _ in })
+        let command = OrderSearchUICommand(siteID: siteID, onSelectSearchResult: { _, _ in }, storageManager: storageManager)
 
         // When
         let resultsController = command.createResultsController()
@@ -42,16 +46,28 @@ final class OrderSearchUICommandTests: XCTestCase {
 
     func testCreateCellViewModel() {
         // Given
-        let order = MockOrders().makeOrder()
+        let mockOrders = MockOrders()
+        let mockOrder = mockOrders.sampleOrder() as Networking.Order
 
-        let command = OrderSearchUICommand(siteID: siteID, onSelectSearchResult: { _, _ in })
+        // Create a local mock order status
+        let mockOrderStatus = OrderStatus(
+            name: "Processing",
+            siteID: mockOrder.siteID,
+            slug: "processing",
+            total: 0
+        )
+        let command = OrderSearchUICommand(siteID: siteID, onSelectSearchResult: { _, _ in }, storageManager: storageManager)
+
+        // Override the lookUpOrderStatus method to return the mock order status
+        OrderSearchUICommand._lookUpOrderStatus = { (order: Networking.Order) in
+            return mockOrderStatus
+        }
 
         // When
-        let cellViewModel = command.createCellViewModel(model: order)
+        let cellViewModel = command.createCellViewModel(model: mockOrder)
 
         // Then
         XCTAssertNotNil(cellViewModel, "Expected createCellViewModel to return an OrderListCellViewModel instance")
-        XCTAssertEqual(cellViewModel.status, OrderStatusEnum.processing, "Expected order status to match")
+        XCTAssertEqual(cellViewModel.statusString, mockOrderStatus.name, "Expected order status name to match")
     }
-
 }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Search/Order/OrderSearchUICommandTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Search/Order/OrderSearchUICommandTests.swift
@@ -4,6 +4,7 @@ import XCTest
 import Yosemite
 
 final class OrderSearchUICommandTests: XCTestCase {
+    let siteID: Int64 = 12345
 
     override func setUpWithError() throws {
         super.setUp()
@@ -15,13 +16,42 @@ final class OrderSearchUICommandTests: XCTestCase {
 
     func testCreateStarterViewControllerReturnsNil() throws {
         // Given
-        let command = OrderSearchUICommand(siteID: 12345, onSelectSearchResult: { _, _ in })
+        let command = OrderSearchUICommand(siteID: siteID, onSelectSearchResult: { _, _ in })
 
         // When
         let starterViewController = command.createStarterViewController()
 
         // Then
         XCTAssertNil(starterViewController, "Expected createStarterViewController to return nil")
+    }
+
+    func testCreateResultsController() {
+        // Given
+
+        let command = OrderSearchUICommand(siteID: siteID, onSelectSearchResult: { _, _ in })
+
+        // When
+        let resultsController = command.createResultsController()
+
+        // Then
+        XCTAssertNotNil(resultsController, "Expected createResultsController to return a ResultsController instance")
+        XCTAssertEqual(resultsController.predicate?.predicateFormat, "siteID == \(siteID)", "Predicate format did not match")
+        XCTAssertEqual(resultsController.sortDescriptors?.first?.key, "dateCreated", "First sort descriptor key did not match")
+        XCTAssertEqual(resultsController.sortDescriptors?.first?.ascending, false, "First sort descriptor ascending did not match")
+    }
+
+    func testCreateCellViewModel() {
+        // Given
+        let order = MockOrders().makeOrder()
+
+        let command = OrderSearchUICommand(siteID: siteID, onSelectSearchResult: { _, _ in })
+
+        // When
+        let cellViewModel = command.createCellViewModel(model: order)
+
+        // Then
+        XCTAssertNotNil(cellViewModel, "Expected createCellViewModel to return an OrderListCellViewModel instance")
+        XCTAssertEqual(cellViewModel.status, OrderStatusEnum.processing, "Expected order status to match")
     }
 
 }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Search/Order/OrderSearchUICommandTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Search/Order/OrderSearchUICommandTests.swift
@@ -24,7 +24,7 @@ final class OrderSearchUICommandTests: XCTestCase {
         super.tearDown()
     }
 
-    func testCreateStarterViewControllerReturnsNil() {
+    func test_createStarterViewController_returns_nil_so_empty_results_table_shown_before_search() {
         // Given
         let command = OrderSearchUICommand(siteID: siteID, onSelectSearchResult: { _, _ in }, storageManager: storageManager)
 
@@ -32,10 +32,10 @@ final class OrderSearchUICommandTests: XCTestCase {
         let starterViewController = command.createStarterViewController()
 
         // Then
-        XCTAssertNil(starterViewController, "Expected createStarterViewController to return nil")
+        XCTAssertNil(starterViewController, "Expected createStarterViewController to return nil so that the empty results table will be shown before the search.")
     }
 
-    func testCreateResultsController() {
+    func test_createResultsController_returns_results_controller_with_correct_predicate_and_sort_options() {
         // Given
         let command = OrderSearchUICommand(siteID: siteID, onSelectSearchResult: { _, _ in }, storageManager: storageManager)
 
@@ -49,7 +49,7 @@ final class OrderSearchUICommandTests: XCTestCase {
         XCTAssertEqual(resultsController.sortDescriptors?.first?.ascending, false, "First sort descriptor ascending did not match")
     }
 
-    func testCreateCellViewModel() {
+    func test_CreateCellViewModel() {
         // Given
         let mockOrder = MockOrders().makeOrder(status: .onHold, items: [], shippingLines: [], refunds: [], fees: [], taxes: [], customFields: [], giftCards: [])
 
@@ -67,7 +67,7 @@ final class OrderSearchUICommandTests: XCTestCase {
         XCTAssertEqual(cellViewModel.status, .onHold, "Expected createCellViewModel to return on hold status")
     }
 
-    func testSanitizeKeyword() {
+    func test_SanitizeKeyword_removing_leading_pound_symbol() {
         // Given
         let command = OrderSearchUICommand(siteID: siteID, onSelectSearchResult: { _, _ in }, storageManager: storageManager)
 
@@ -80,7 +80,7 @@ final class OrderSearchUICommandTests: XCTestCase {
         XCTAssertEqual(sanitizedKeywordWithoutHash, "123", "Expected sanitizeKeyword to return the keyword unchanged if there's no leading '#'")
     }
 
-    func testSynchronizeModelsTracksAnalytics() throws {
+    func test_SynchronizeModels_tracks_orders_list_search_analytics() throws {
         // Given
         let stores = MockStoresManager(sessionManager: .testingInstance)
         let command = OrderSearchUICommand(siteID: siteID, onSelectSearchResult: { _, _ in }, storageManager: storageManager, analytics: analytics, stores: stores)
@@ -116,7 +116,7 @@ final class OrderSearchUICommandTests: XCTestCase {
         XCTAssertEqual(eventProperties["search"] as? String, keyword)
     }
 
-    func testDidSelectSearchResult() throws {
+    func test_DidSelectSearchResult_selects_correct_order() throws {
         // Given
         let order = Order.fake()
 

--- a/WooCommerce/WooCommerceTests/ViewRelated/Search/Order/OrderSearchUICommandTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Search/Order/OrderSearchUICommandTests.swift
@@ -165,6 +165,7 @@ private final class MockOrderStatusesStoresManager: MockStorageManager {
         orderStatus.name = name
         orderStatus.slug = name
         orderStatus.siteID = MockOrderStatusesStoresManager.siteID
+        viewStorage.saveIfNeeded()
         return orderStatus
     }
 }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Search/Order/OrderSearchUICommandTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Search/Order/OrderSearchUICommandTests.swift
@@ -10,21 +10,21 @@ final class OrderSearchUICommandTests: XCTestCase {
     private var analyticsProvider: MockAnalyticsProvider!
     private var analytics: WooAnalytics!
 
-    override func setUpWithError() throws {
+    override func setUp() {
         super.setUp()
         storageManager = MockOrderStatusesStoresManager()
         analyticsProvider = MockAnalyticsProvider()
         analytics = WooAnalytics(analyticsProvider: analyticsProvider)
     }
 
-    override func tearDownWithError() throws {
+    override func tearDown() {
         storageManager = nil
         analyticsProvider = nil
         analytics = nil
         super.tearDown()
     }
 
-    func testCreateStarterViewControllerReturnsNil() throws {
+    func testCreateStarterViewControllerReturnsNil() {
         // Given
         let command = OrderSearchUICommand(siteID: siteID, onSelectSearchResult: { _, _ in }, storageManager: storageManager)
 

--- a/WooCommerce/WooCommerceTests/ViewRelated/Search/Order/OrderSearchUICommandTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Search/Order/OrderSearchUICommandTests.swift
@@ -2,7 +2,6 @@ import XCTest
 import Yosemite
 @testable import WooCommerce
 import Storage
-import Networking
 import protocol WooFoundation.Analytics
 
 final class OrderSearchUICommandTests: XCTestCase {
@@ -119,7 +118,7 @@ final class OrderSearchUICommandTests: XCTestCase {
 
     func testDidSelectSearchResult() throws {
         // Given
-        let order = Networking.Order.fake().copy()
+        let order = Order.fake()
 
         // When
         let selectedOrder = waitFor { promise in

--- a/WooCommerce/WooCommerceTests/ViewRelated/Search/Order/OrderSearchUICommandTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Search/Order/OrderSearchUICommandTests.swift
@@ -1,0 +1,27 @@
+import XCTest
+
+@testable import WooCommerce
+import Yosemite
+
+final class OrderSearchUICommandTests: XCTestCase {
+
+    override func setUpWithError() throws {
+        super.setUp()
+    }
+
+    override func tearDownWithError() throws {
+        super.tearDown()
+    }
+
+    func testCreateStarterViewControllerReturnsNil() throws {
+        // Given
+        let command = OrderSearchUICommand(siteID: 12345, onSelectSearchResult: { _, _ in })
+
+        // When
+        let starterViewController = command.createStarterViewController()
+
+        // Then
+        XCTAssertNil(starterViewController, "Expected createStarterViewController to return nil")
+    }
+
+}

--- a/WooCommerce/WooCommerceTests/ViewRelated/Search/Order/OrderSearchUICommandTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Search/Order/OrderSearchUICommandTests.swift
@@ -60,6 +60,19 @@ final class OrderSearchUICommandTests: XCTestCase {
         XCTAssertEqual(cellViewModel.status, .onHold, "Expected createCellViewModel to return on hold status")
     }
 
+    func testSanitizeKeyword() {
+        // Given
+        let command = OrderSearchUICommand(siteID: siteID, onSelectSearchResult: { _, _ in }, storageManager: storageManager)
+
+        // When
+        let sanitizedKeywordWithHash = command.sanitizeKeyword("#123")
+        let sanitizedKeywordWithoutHash = command.sanitizeKeyword("123")
+
+        // Then
+        XCTAssertEqual(sanitizedKeywordWithHash, "123", "Expected sanitizeKeyword to remove the leading '#'")
+        XCTAssertEqual(sanitizedKeywordWithoutHash, "123", "Expected sanitizeKeyword to return the keyword unchanged if there's no leading '#'")
+    }
+
     private func insertOrderStatuses() {
         let statuses: [OrderStatusEnum] = [.pending, .processing, .onHold, .completed, .cancelled, .failed, .custom("aCustomStatus")]
         statuses.forEach { status in


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: https://github.com/woocommerce/woocommerce-ios/issues/12204

## Description
This PR adds unit tests for `OrderSearchUICommand` which is used for for Order search.


## Steps to reproduce
N/A. The type currently has no unit test coverage. This PR adds coverage by introducing `OrderSearchUICommandTests`.

## Testing information
Run the UnitTests test plan in Xcode. Verify all tests pass.

Check the added coverage by modifying the class under test, `OrderSearchUICommand` and rerunning the tests.

For example, comment out:

`onSelectSearchResult(model, viewController)`

Rerun the tests and and you should see the associated test fail: `testDidSelectSearchResult`.

Try the same thing by commenting out:
`analytics.track(.ordersListSearch, withProperties: ["search": "\(keyword)"])`

Rerun the tests and and you should see the associated test fail: `testSynchronizeModelsTracksAnalytics`


## Screenshots
N/A. This change only involves unit tests.

---
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
