### PR TITLE
[Woo POS] Preparation before implementing payment message actions

### DIFF
--- a/WooCommerce/Classes/POS/Card Present Payments/CardPresentPaymentBluetoothReaderConnectionAlertsProvider.swift
+++ b/WooCommerce/Classes/POS/Card Present Payments/CardPresentPaymentBluetoothReaderConnectionAlertsProvider.swift
@@ -25,8 +25,8 @@ struct CardPresentPaymentBluetoothReaderConnectionAlertsProvider: BluetoothReade
 
     func connectingFailedNonRetryable(error: any Error,
                                       close: @escaping () -> Void) -> CardPresentPaymentEventDetails {
-        .errorNonRetryable(error: error,
-                           cancelPayment: close)
+        .connectingFailedNonRetryable(error: error,
+                                      endSearch: close)
     }
 
     func connectingFailedIncompleteAddress(wcSettingsAdminURL: URL?,
@@ -39,8 +39,8 @@ struct CardPresentPaymentBluetoothReaderConnectionAlertsProvider: BluetoothReade
                 endSearch: cancelSearch)
         }
         return .connectingFailedUpdateAddress(wcSettingsAdminURL: wcSettingsAdminURL,
-                                       retrySearch: retrySearch,
-                                       endSearch: cancelSearch)
+                                              retrySearch: retrySearch,
+                                              endSearch: cancelSearch)
     }
 
     func connectingFailedInvalidPostalCode(retrySearch: @escaping () -> Void,

--- a/WooCommerce/Classes/POS/Card Present Payments/CardPresentPaymentEventDetails.swift
+++ b/WooCommerce/Classes/POS/Card Present Payments/CardPresentPaymentEventDetails.swift
@@ -38,12 +38,12 @@ enum CardPresentPaymentEventDetails {
                                 cancelUpdate: () -> Void)
     case tapSwipeOrInsertCard(inputMethods: CardReaderInput,
                               cancelPayment: () -> Void)
-    case success(done: () -> Void)
-    case error(error: any Error,
-               tryAgain: () -> Void,
-               cancelPayment: () -> Void)
-    case errorNonRetryable(error: any Error,
-                           cancelPayment: () -> Void)
+    case paymentSuccess(done: () -> Void)
+    case paymentError(error: any Error,
+                      tryAgain: () -> Void,
+                      cancelPayment: () -> Void)
+    case paymentErrorNonRetryable(error: any Error,
+                                  cancelPayment: () -> Void)
     case processing
     case displayReaderMessage(message: String)
     case cancelledOnReader

--- a/WooCommerce/Classes/POS/Card Present Payments/CardPresentPaymentsTransactionAlertsProvider.swift
+++ b/WooCommerce/Classes/POS/Card Present Payments/CardPresentPaymentsTransactionAlertsProvider.swift
@@ -31,21 +31,21 @@ struct CardPresentPaymentsTransactionAlertsProvider: CardReaderTransactionAlerts
     func success(printReceipt: @escaping () -> Void,
                  emailReceipt: @escaping () -> Void,
                  noReceiptAction: @escaping () -> Void) -> CardPresentPaymentEventDetails {
-        .success(done: noReceiptAction)
+        .paymentSuccess(done: noReceiptAction)
     }
 
     func error(error: any Error,
                tryAgain: @escaping () -> Void,
                dismissCompletion: @escaping () -> Void) -> CardPresentPaymentEventDetails {
-        .error(error: error,
-               tryAgain: tryAgain,
-               cancelPayment: dismissCompletion)
+        .paymentError(error: error,
+                      tryAgain: tryAgain,
+                      cancelPayment: dismissCompletion)
     }
 
     func nonRetryableError(error: any Error,
                            dismissCompletion: @escaping () -> Void) -> CardPresentPaymentEventDetails {
-        .errorNonRetryable(error: error,
-                           cancelPayment: dismissCompletion)
+        .paymentErrorNonRetryable(error: error,
+                                  cancelPayment: dismissCompletion)
     }
 
     func cancelledOnReader() -> CardPresentPaymentEventDetails? {

--- a/WooCommerce/Classes/POS/Presentation/Card Present Payments/PointOfSaleCardPresentPaymentEventPresentationStyle.swift
+++ b/WooCommerce/Classes/POS/Presentation/Card Present Payments/PointOfSaleCardPresentPaymentEventPresentationStyle.swift
@@ -89,14 +89,14 @@ extension CardPresentPaymentEventDetails {
             return .message(.tapSwipeOrInsertCard(
                 viewModel: PointOfSaleCardPresentPaymentTapSwipeInsertCardMessageViewModel()))
 
-        case .success(done: let done):
-            return .message(.success(viewModel: PointOfSaleCardPresentPaymentSuccessMessageViewModel()))
+        case .paymentSuccess(done: let done):
+            return .message(.paymentSuccess(viewModel: PointOfSaleCardPresentPaymentSuccessMessageViewModel()))
 
-        case .error(error: let error, tryAgain: let tryAgain, cancelPayment: let cancelPayment):
-            return .message(.error(viewModel: PointOfSaleCardPresentPaymentErrorMessageViewModel()))
+        case .paymentError(error: let error, tryAgain: let tryAgain, cancelPayment: let cancelPayment):
+            return .message(.paymentError(viewModel: PointOfSaleCardPresentPaymentErrorMessageViewModel()))
 
-        case .errorNonRetryable(error: let error, cancelPayment: let cancelPayment):
-            return .message(.nonRetryableError(
+        case .paymentErrorNonRetryable(error: let error, cancelPayment: let cancelPayment):
+            return .message(.paymentErrorNonRetryable(
                 viewModel: PointOfSaleCardPresentPaymentNonRetryableErrorMessageViewModel()))
 
         case .processing:

--- a/WooCommerce/Classes/POS/Presentation/Card Present Payments/PointOfSaleCardPresentPaymentEventPresentationStyle.swift
+++ b/WooCommerce/Classes/POS/Presentation/Card Present Payments/PointOfSaleCardPresentPaymentEventPresentationStyle.swift
@@ -82,28 +82,33 @@ extension CardPresentPaymentEventDetails {
 
         /// Payment messages
         case .preparingForPayment(cancelPayment: let cancelPayment):
-            return .message(.preparingForPayment)
+            return .message(.preparingForPayment(
+                viewModel: PointOfSaleCardPresentPaymentPreparingForPaymentMessageViewModel()))
 
         case .tapSwipeOrInsertCard(inputMethods: let inputMethods, cancelPayment: let cancelPayment):
-            return .message(.tapSwipeOrInsertCard)
+            return .message(.tapSwipeOrInsertCard(
+                viewModel: PointOfSaleCardPresentPaymentTapSwipeInsertCardMessageViewModel()))
 
         case .success(done: let done):
-            return .message(.success)
+            return .message(.success(viewModel: PointOfSaleCardPresentPaymentSuccessMessageViewModel()))
 
         case .error(error: let error, tryAgain: let tryAgain, cancelPayment: let cancelPayment):
-            return .message(.error)
+            return .message(.error(viewModel: PointOfSaleCardPresentPaymentErrorMessageViewModel()))
 
         case .errorNonRetryable(error: let error, cancelPayment: let cancelPayment):
-            return .message(.nonRetryableError)
+            return .message(.nonRetryableError(
+                viewModel: PointOfSaleCardPresentPaymentNonRetryableErrorMessageViewModel()))
 
         case .processing:
-            return .message(.processing)
+            return .message(.processing(viewModel: PointOfSaleCardPresentPaymentProcessingMessageViewModel()))
 
         case .displayReaderMessage(message: let message):
-            return .message(.displayReaderMessage(message: message))
+            return .message(.displayReaderMessage(
+                viewModel: PointOfSaleCardPresentPaymentDisplayReaderMessageMessageViewModel(message: message)))
 
         case .cancelledOnReader:
-            return .message(.cancelledOnReader)
+            return .message(.cancelledOnReader(
+                viewModel: PointOfSaleCardPresentPaymentCancelledOnReaderMessageViewModel()))
 
         /// Not-yet supported types
         case .selectSearchType,

--- a/WooCommerce/Classes/POS/Presentation/Card Present Payments/Reader Messages/CardPresentPaymentDisplayReaderMessageAlertViewModel.swift
+++ b/WooCommerce/Classes/POS/Presentation/Card Present Payments/Reader Messages/CardPresentPaymentDisplayReaderMessageAlertViewModel.swift
@@ -1,5 +1,0 @@
-import Foundation
-
-struct CardPresentPaymentDisplayReaderMessageAlertViewModel {
-
-}

--- a/WooCommerce/Classes/POS/Presentation/Card Present Payments/Reader Messages/CardPresentPaymentErrorAlertViewModel.swift
+++ b/WooCommerce/Classes/POS/Presentation/Card Present Payments/Reader Messages/CardPresentPaymentErrorAlertViewModel.swift
@@ -1,5 +1,0 @@
-import Foundation
-
-struct CardPresentPaymentErrorAlertViewModel {
-
-}

--- a/WooCommerce/Classes/POS/Presentation/Card Present Payments/Reader Messages/CardPresentPaymentPreparingForPaymentAlertViewModel.swift
+++ b/WooCommerce/Classes/POS/Presentation/Card Present Payments/Reader Messages/CardPresentPaymentPreparingForPaymentAlertViewModel.swift
@@ -1,5 +1,0 @@
-import Foundation
-
-struct CardPresentPaymentPreparingForPaymentAlertViewModel {
-
-}

--- a/WooCommerce/Classes/POS/Presentation/Card Present Payments/Reader Messages/CardPresentPaymentProcessingPaymentAlertViewModel.swift
+++ b/WooCommerce/Classes/POS/Presentation/Card Present Payments/Reader Messages/CardPresentPaymentProcessingPaymentAlertViewModel.swift
@@ -1,5 +1,0 @@
-import Foundation
-
-struct CardPresentPaymentProcessingPaymentAlertViewModel {
-
-}

--- a/WooCommerce/Classes/POS/Presentation/Card Present Payments/Reader Messages/CardPresentPaymentSuccessAlertViewModel.swift
+++ b/WooCommerce/Classes/POS/Presentation/Card Present Payments/Reader Messages/CardPresentPaymentSuccessAlertViewModel.swift
@@ -1,5 +1,0 @@
-import Foundation
-
-struct CardPresentPaymentSuccessAlertViewModel {
-
-}

--- a/WooCommerce/Classes/POS/Presentation/Card Present Payments/Reader Messages/CardPresentPaymentTapSwipeInsertCardAlertViewModel.swift
+++ b/WooCommerce/Classes/POS/Presentation/Card Present Payments/Reader Messages/CardPresentPaymentTapSwipeInsertCardAlertViewModel.swift
@@ -1,5 +1,0 @@
-import Foundation
-
-struct CardPresentPaymentTapSwipeInsertCardAlertViewModel {
-
-}

--- a/WooCommerce/Classes/POS/Presentation/Card Present Payments/Reader Messages/PointOfSaleCardPresentPaymentCancelledOnReaderMessageViewModel.swift
+++ b/WooCommerce/Classes/POS/Presentation/Card Present Payments/Reader Messages/PointOfSaleCardPresentPaymentCancelledOnReaderMessageViewModel.swift
@@ -1,0 +1,5 @@
+import Foundation
+
+struct PointOfSaleCardPresentPaymentCancelledOnReaderMessageViewModel {
+
+}

--- a/WooCommerce/Classes/POS/Presentation/Card Present Payments/Reader Messages/PointOfSaleCardPresentPaymentDisplayReaderMessageMessageViewModel.swift
+++ b/WooCommerce/Classes/POS/Presentation/Card Present Payments/Reader Messages/PointOfSaleCardPresentPaymentDisplayReaderMessageMessageViewModel.swift
@@ -1,0 +1,5 @@
+import Foundation
+
+struct PointOfSaleCardPresentPaymentDisplayReaderMessageMessageViewModel {
+    let message: String
+}

--- a/WooCommerce/Classes/POS/Presentation/Card Present Payments/Reader Messages/PointOfSaleCardPresentPaymentErrorMessageViewModel.swift
+++ b/WooCommerce/Classes/POS/Presentation/Card Present Payments/Reader Messages/PointOfSaleCardPresentPaymentErrorMessageViewModel.swift
@@ -1,0 +1,5 @@
+import Foundation
+
+struct PointOfSaleCardPresentPaymentErrorMessageViewModel {
+
+}

--- a/WooCommerce/Classes/POS/Presentation/Card Present Payments/Reader Messages/PointOfSaleCardPresentPaymentMessageType.swift
+++ b/WooCommerce/Classes/POS/Presentation/Card Present Payments/Reader Messages/PointOfSaleCardPresentPaymentMessageType.swift
@@ -5,8 +5,8 @@ enum PointOfSaleCardPresentPaymentMessageType {
     case tapSwipeOrInsertCard(viewModel: PointOfSaleCardPresentPaymentTapSwipeInsertCardMessageViewModel)
     case processing(viewModel: PointOfSaleCardPresentPaymentProcessingMessageViewModel)
     case displayReaderMessage(viewModel: PointOfSaleCardPresentPaymentDisplayReaderMessageMessageViewModel)
-    case success(viewModel: PointOfSaleCardPresentPaymentSuccessMessageViewModel)
-    case error(viewModel: PointOfSaleCardPresentPaymentErrorMessageViewModel)
-    case nonRetryableError(viewModel: PointOfSaleCardPresentPaymentNonRetryableErrorMessageViewModel)
+    case paymentSuccess(viewModel: PointOfSaleCardPresentPaymentSuccessMessageViewModel)
+    case paymentError(viewModel: PointOfSaleCardPresentPaymentErrorMessageViewModel)
+    case paymentErrorNonRetryable(viewModel: PointOfSaleCardPresentPaymentNonRetryableErrorMessageViewModel)
     case cancelledOnReader(viewModel: PointOfSaleCardPresentPaymentCancelledOnReaderMessageViewModel)
 }

--- a/WooCommerce/Classes/POS/Presentation/Card Present Payments/Reader Messages/PointOfSaleCardPresentPaymentMessageType.swift
+++ b/WooCommerce/Classes/POS/Presentation/Card Present Payments/Reader Messages/PointOfSaleCardPresentPaymentMessageType.swift
@@ -1,12 +1,12 @@
 import Foundation
 
 enum PointOfSaleCardPresentPaymentMessageType {
-    case preparingForPayment
-    case tapSwipeOrInsertCard
-    case processing
-    case displayReaderMessage(message: String)
-    case success
-    case error
-    case nonRetryableError
-    case cancelledOnReader
+    case preparingForPayment(viewModel: PointOfSaleCardPresentPaymentPreparingForPaymentMessageViewModel)
+    case tapSwipeOrInsertCard(viewModel: PointOfSaleCardPresentPaymentTapSwipeInsertCardMessageViewModel)
+    case processing(viewModel: PointOfSaleCardPresentPaymentProcessingMessageViewModel)
+    case displayReaderMessage(viewModel: PointOfSaleCardPresentPaymentDisplayReaderMessageMessageViewModel)
+    case success(viewModel: PointOfSaleCardPresentPaymentSuccessMessageViewModel)
+    case error(viewModel: PointOfSaleCardPresentPaymentErrorMessageViewModel)
+    case nonRetryableError(viewModel: PointOfSaleCardPresentPaymentNonRetryableErrorMessageViewModel)
+    case cancelledOnReader(viewModel: PointOfSaleCardPresentPaymentCancelledOnReaderMessageViewModel)
 }

--- a/WooCommerce/Classes/POS/Presentation/Card Present Payments/Reader Messages/PointOfSaleCardPresentPaymentNonRetryableErrorMessageViewModel.swift
+++ b/WooCommerce/Classes/POS/Presentation/Card Present Payments/Reader Messages/PointOfSaleCardPresentPaymentNonRetryableErrorMessageViewModel.swift
@@ -1,0 +1,5 @@
+import Foundation
+
+struct PointOfSaleCardPresentPaymentNonRetryableErrorMessageViewModel {
+
+}

--- a/WooCommerce/Classes/POS/Presentation/Card Present Payments/Reader Messages/PointOfSaleCardPresentPaymentPreparingForPaymentMessageViewModel.swift
+++ b/WooCommerce/Classes/POS/Presentation/Card Present Payments/Reader Messages/PointOfSaleCardPresentPaymentPreparingForPaymentMessageViewModel.swift
@@ -1,0 +1,5 @@
+import Foundation
+
+struct PointOfSaleCardPresentPaymentPreparingForPaymentMessageViewModel {
+
+}

--- a/WooCommerce/Classes/POS/Presentation/Card Present Payments/Reader Messages/PointOfSaleCardPresentPaymentProcessingMessageViewModel.swift
+++ b/WooCommerce/Classes/POS/Presentation/Card Present Payments/Reader Messages/PointOfSaleCardPresentPaymentProcessingMessageViewModel.swift
@@ -1,0 +1,5 @@
+import Foundation
+
+struct PointOfSaleCardPresentPaymentProcessingMessageViewModel {
+
+}

--- a/WooCommerce/Classes/POS/Presentation/Card Present Payments/Reader Messages/PointOfSaleCardPresentPaymentSuccessMessageViewModel.swift
+++ b/WooCommerce/Classes/POS/Presentation/Card Present Payments/Reader Messages/PointOfSaleCardPresentPaymentSuccessMessageViewModel.swift
@@ -1,0 +1,5 @@
+import Foundation
+
+struct PointOfSaleCardPresentPaymentSuccessMessageViewModel {
+
+}

--- a/WooCommerce/Classes/POS/Presentation/Card Present Payments/Reader Messages/PointOfSaleCardPresentPaymentTapSwipeInsertCardMessageViewModel.swift
+++ b/WooCommerce/Classes/POS/Presentation/Card Present Payments/Reader Messages/PointOfSaleCardPresentPaymentTapSwipeInsertCardMessageViewModel.swift
@@ -1,0 +1,5 @@
+import Foundation
+
+struct PointOfSaleCardPresentPaymentTapSwipeInsertCardMessageViewModel {
+
+}

--- a/WooCommerce/Classes/POS/Presentation/PointOfSaleDashboardView.swift
+++ b/WooCommerce/Classes/POS/Presentation/PointOfSaleDashboardView.swift
@@ -35,8 +35,8 @@ struct PointOfSaleDashboardView: View {
                                 Text("tapSwipeOrInsertCard...")
                             case .processing:
                                 Text("processing...")
-                            case .displayReaderMessage(let message):
-                                Text("Reader message: \(message)")
+                            case .displayReaderMessage(let viewModel):
+                                Text("Reader message: \(viewModel.message)")
                             case .success:
                                 Text("Payment successful!")
                             case .error:

--- a/WooCommerce/Classes/POS/Presentation/PointOfSaleDashboardView.swift
+++ b/WooCommerce/Classes/POS/Presentation/PointOfSaleDashboardView.swift
@@ -37,11 +37,11 @@ struct PointOfSaleDashboardView: View {
                                 Text("processing...")
                             case .displayReaderMessage(let viewModel):
                                 Text("Reader message: \(viewModel.message)")
-                            case .success:
+                            case .paymentSuccess:
                                 Text("Payment successful!")
-                            case .error:
+                            case .paymentError:
                                 Text("Payment error")
-                            case .nonRetryableError:
+                            case .paymentErrorNonRetryable:
                                 Text("Payment error - non retryable")
                             case .cancelledOnReader:
                                 Text("Payment cancelled on reader")

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -795,14 +795,16 @@
 		205B7EC12C19FBEA00D14A36 /* CardPresentPaymentReaderUpdateFailedAlertViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 205B7EC02C19FBEA00D14A36 /* CardPresentPaymentReaderUpdateFailedAlertViewModel.swift */; };
 		205B7EC32C19FC3000D14A36 /* PointOfSaleCardPresentPaymentConnectingToReaderAlertViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 205B7EC22C19FC3000D14A36 /* PointOfSaleCardPresentPaymentConnectingToReaderAlertViewModel.swift */; };
 		205B7EC52C19FC4F00D14A36 /* PointOfSaleCardPresentPaymentConnectingFailedAlertViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 205B7EC42C19FC4F00D14A36 /* PointOfSaleCardPresentPaymentConnectingFailedAlertViewModel.swift */; };
-		205B7EC72C19FCA700D14A36 /* CardPresentPaymentPreparingForPaymentAlertViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 205B7EC62C19FCA700D14A36 /* CardPresentPaymentPreparingForPaymentAlertViewModel.swift */; };
-		205B7EC92C19FCDB00D14A36 /* CardPresentPaymentTapSwipeInsertCardAlertViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 205B7EC82C19FCDB00D14A36 /* CardPresentPaymentTapSwipeInsertCardAlertViewModel.swift */; };
-		205B7ECB2C19FCFC00D14A36 /* CardPresentPaymentProcessingPaymentAlertViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 205B7ECA2C19FCFC00D14A36 /* CardPresentPaymentProcessingPaymentAlertViewModel.swift */; };
-		205B7ECD2C19FD2F00D14A36 /* CardPresentPaymentDisplayReaderMessageAlertViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 205B7ECC2C19FD2F00D14A36 /* CardPresentPaymentDisplayReaderMessageAlertViewModel.swift */; };
-		205B7ECF2C19FD5200D14A36 /* CardPresentPaymentSuccessAlertViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 205B7ECE2C19FD5200D14A36 /* CardPresentPaymentSuccessAlertViewModel.swift */; };
-		205B7ED12C19FD8500D14A36 /* CardPresentPaymentErrorAlertViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 205B7ED02C19FD8500D14A36 /* CardPresentPaymentErrorAlertViewModel.swift */; };
+		205B7EC72C19FCA700D14A36 /* PointOfSaleCardPresentPaymentPreparingForPaymentMessageViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 205B7EC62C19FCA700D14A36 /* PointOfSaleCardPresentPaymentPreparingForPaymentMessageViewModel.swift */; };
+		205B7EC92C19FCDB00D14A36 /* PointOfSaleCardPresentPaymentTapSwipeInsertCardMessageViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 205B7EC82C19FCDB00D14A36 /* PointOfSaleCardPresentPaymentTapSwipeInsertCardMessageViewModel.swift */; };
+		205B7ECB2C19FCFC00D14A36 /* PointOfSaleCardPresentPaymentProcessingMessageViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 205B7ECA2C19FCFC00D14A36 /* PointOfSaleCardPresentPaymentProcessingMessageViewModel.swift */; };
+		205B7ECD2C19FD2F00D14A36 /* PointOfSaleCardPresentPaymentDisplayReaderMessageMessageViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 205B7ECC2C19FD2F00D14A36 /* PointOfSaleCardPresentPaymentDisplayReaderMessageMessageViewModel.swift */; };
+		205B7ECF2C19FD5200D14A36 /* PointOfSaleCardPresentPaymentSuccessMessageViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 205B7ECE2C19FD5200D14A36 /* PointOfSaleCardPresentPaymentSuccessMessageViewModel.swift */; };
+		205B7ED12C19FD8500D14A36 /* PointOfSaleCardPresentPaymentErrorMessageViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 205B7ED02C19FD8500D14A36 /* PointOfSaleCardPresentPaymentErrorMessageViewModel.swift */; };
 		205E79402C1CA213001BA266 /* PointOfSaleCardPresentPaymentMessageType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 205E793F2C1CA213001BA266 /* PointOfSaleCardPresentPaymentMessageType.swift */; };
 		205E79422C1CA6E3001BA266 /* PointOfSaleCardPresentPaymentEventPresentationStyle.swift in Sources */ = {isa = PBXBuildFile; fileRef = 205E79412C1CA6E3001BA266 /* PointOfSaleCardPresentPaymentEventPresentationStyle.swift */; };
+		205E79442C204368001BA266 /* PointOfSaleCardPresentPaymentNonRetryableErrorMessageViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 205E79432C204368001BA266 /* PointOfSaleCardPresentPaymentNonRetryableErrorMessageViewModel.swift */; };
+		205E79462C204387001BA266 /* PointOfSaleCardPresentPaymentCancelledOnReaderMessageViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 205E79452C204387001BA266 /* PointOfSaleCardPresentPaymentCancelledOnReaderMessageViewModel.swift */; };
 		20762BA12C18A66400758305 /* CardPresentPaymentBuiltInReaderConnectionAlertsProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 20762BA02C18A66400758305 /* CardPresentPaymentBuiltInReaderConnectionAlertsProvider.swift */; };
 		20762BA32C18A6A300758305 /* CardPresentPaymentEventDetails.swift in Sources */ = {isa = PBXBuildFile; fileRef = 20762BA22C18A6A300758305 /* CardPresentPaymentEventDetails.swift */; };
 		20762BA52C18B42C00758305 /* CardPresentPaymentBluetoothReaderConnectionAlertsProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 20762BA42C18B42C00758305 /* CardPresentPaymentBluetoothReaderConnectionAlertsProvider.swift */; };
@@ -3758,14 +3760,16 @@
 		205B7EC02C19FBEA00D14A36 /* CardPresentPaymentReaderUpdateFailedAlertViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardPresentPaymentReaderUpdateFailedAlertViewModel.swift; sourceTree = "<group>"; };
 		205B7EC22C19FC3000D14A36 /* PointOfSaleCardPresentPaymentConnectingToReaderAlertViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PointOfSaleCardPresentPaymentConnectingToReaderAlertViewModel.swift; sourceTree = "<group>"; };
 		205B7EC42C19FC4F00D14A36 /* PointOfSaleCardPresentPaymentConnectingFailedAlertViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PointOfSaleCardPresentPaymentConnectingFailedAlertViewModel.swift; sourceTree = "<group>"; };
-		205B7EC62C19FCA700D14A36 /* CardPresentPaymentPreparingForPaymentAlertViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardPresentPaymentPreparingForPaymentAlertViewModel.swift; sourceTree = "<group>"; };
-		205B7EC82C19FCDB00D14A36 /* CardPresentPaymentTapSwipeInsertCardAlertViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardPresentPaymentTapSwipeInsertCardAlertViewModel.swift; sourceTree = "<group>"; };
-		205B7ECA2C19FCFC00D14A36 /* CardPresentPaymentProcessingPaymentAlertViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardPresentPaymentProcessingPaymentAlertViewModel.swift; sourceTree = "<group>"; };
-		205B7ECC2C19FD2F00D14A36 /* CardPresentPaymentDisplayReaderMessageAlertViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardPresentPaymentDisplayReaderMessageAlertViewModel.swift; sourceTree = "<group>"; };
-		205B7ECE2C19FD5200D14A36 /* CardPresentPaymentSuccessAlertViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardPresentPaymentSuccessAlertViewModel.swift; sourceTree = "<group>"; };
-		205B7ED02C19FD8500D14A36 /* CardPresentPaymentErrorAlertViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardPresentPaymentErrorAlertViewModel.swift; sourceTree = "<group>"; };
+		205B7EC62C19FCA700D14A36 /* PointOfSaleCardPresentPaymentPreparingForPaymentMessageViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PointOfSaleCardPresentPaymentPreparingForPaymentMessageViewModel.swift; sourceTree = "<group>"; };
+		205B7EC82C19FCDB00D14A36 /* PointOfSaleCardPresentPaymentTapSwipeInsertCardMessageViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PointOfSaleCardPresentPaymentTapSwipeInsertCardMessageViewModel.swift; sourceTree = "<group>"; };
+		205B7ECA2C19FCFC00D14A36 /* PointOfSaleCardPresentPaymentProcessingMessageViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PointOfSaleCardPresentPaymentProcessingMessageViewModel.swift; sourceTree = "<group>"; };
+		205B7ECC2C19FD2F00D14A36 /* PointOfSaleCardPresentPaymentDisplayReaderMessageMessageViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PointOfSaleCardPresentPaymentDisplayReaderMessageMessageViewModel.swift; sourceTree = "<group>"; };
+		205B7ECE2C19FD5200D14A36 /* PointOfSaleCardPresentPaymentSuccessMessageViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PointOfSaleCardPresentPaymentSuccessMessageViewModel.swift; sourceTree = "<group>"; };
+		205B7ED02C19FD8500D14A36 /* PointOfSaleCardPresentPaymentErrorMessageViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PointOfSaleCardPresentPaymentErrorMessageViewModel.swift; sourceTree = "<group>"; };
 		205E793F2C1CA213001BA266 /* PointOfSaleCardPresentPaymentMessageType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PointOfSaleCardPresentPaymentMessageType.swift; sourceTree = "<group>"; };
 		205E79412C1CA6E3001BA266 /* PointOfSaleCardPresentPaymentEventPresentationStyle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PointOfSaleCardPresentPaymentEventPresentationStyle.swift; sourceTree = "<group>"; };
+		205E79432C204368001BA266 /* PointOfSaleCardPresentPaymentNonRetryableErrorMessageViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PointOfSaleCardPresentPaymentNonRetryableErrorMessageViewModel.swift; sourceTree = "<group>"; };
+		205E79452C204387001BA266 /* PointOfSaleCardPresentPaymentCancelledOnReaderMessageViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PointOfSaleCardPresentPaymentCancelledOnReaderMessageViewModel.swift; sourceTree = "<group>"; };
 		20762BA02C18A66400758305 /* CardPresentPaymentBuiltInReaderConnectionAlertsProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardPresentPaymentBuiltInReaderConnectionAlertsProvider.swift; sourceTree = "<group>"; };
 		20762BA22C18A6A300758305 /* CardPresentPaymentEventDetails.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardPresentPaymentEventDetails.swift; sourceTree = "<group>"; };
 		20762BA42C18B42C00758305 /* CardPresentPaymentBluetoothReaderConnectionAlertsProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardPresentPaymentBluetoothReaderConnectionAlertsProvider.swift; sourceTree = "<group>"; };
@@ -7598,12 +7602,14 @@
 			isa = PBXGroup;
 			children = (
 				205E793F2C1CA213001BA266 /* PointOfSaleCardPresentPaymentMessageType.swift */,
-				205B7EC82C19FCDB00D14A36 /* CardPresentPaymentTapSwipeInsertCardAlertViewModel.swift */,
-				205B7ED02C19FD8500D14A36 /* CardPresentPaymentErrorAlertViewModel.swift */,
-				205B7EC62C19FCA700D14A36 /* CardPresentPaymentPreparingForPaymentAlertViewModel.swift */,
-				205B7ECA2C19FCFC00D14A36 /* CardPresentPaymentProcessingPaymentAlertViewModel.swift */,
-				205B7ECE2C19FD5200D14A36 /* CardPresentPaymentSuccessAlertViewModel.swift */,
-				205B7ECC2C19FD2F00D14A36 /* CardPresentPaymentDisplayReaderMessageAlertViewModel.swift */,
+				205E79452C204387001BA266 /* PointOfSaleCardPresentPaymentCancelledOnReaderMessageViewModel.swift */,
+				205B7EC82C19FCDB00D14A36 /* PointOfSaleCardPresentPaymentTapSwipeInsertCardMessageViewModel.swift */,
+				205B7ED02C19FD8500D14A36 /* PointOfSaleCardPresentPaymentErrorMessageViewModel.swift */,
+				205E79432C204368001BA266 /* PointOfSaleCardPresentPaymentNonRetryableErrorMessageViewModel.swift */,
+				205B7EC62C19FCA700D14A36 /* PointOfSaleCardPresentPaymentPreparingForPaymentMessageViewModel.swift */,
+				205B7ECA2C19FCFC00D14A36 /* PointOfSaleCardPresentPaymentProcessingMessageViewModel.swift */,
+				205B7ECE2C19FD5200D14A36 /* PointOfSaleCardPresentPaymentSuccessMessageViewModel.swift */,
+				205B7ECC2C19FD2F00D14A36 /* PointOfSaleCardPresentPaymentDisplayReaderMessageMessageViewModel.swift */,
 			);
 			path = "Reader Messages";
 			sourceTree = "<group>";
@@ -14451,7 +14457,7 @@
 				DEC51B00276AEE91009F3DF4 /* SystemStatusReportViewModel.swift in Sources */,
 				B66D6CEC29396A3E0075D4AF /* AnalyticsHubTimeRangeData.swift in Sources */,
 				CC4A4E962655273D00B75DCD /* ShippingLabelPaymentMethods.swift in Sources */,
-				205B7ECB2C19FCFC00D14A36 /* CardPresentPaymentProcessingPaymentAlertViewModel.swift in Sources */,
+				205B7ECB2C19FCFC00D14A36 /* PointOfSaleCardPresentPaymentProcessingMessageViewModel.swift in Sources */,
 				45DB6D972632CF9300E83C1A /* ActivityIndicator.swift in Sources */,
 				2647F7B529280A7F00D59FDF /* AnalyticsHubView.swift in Sources */,
 				863012A72B288F60004EC9DC /* ThemesPreviewView.swift in Sources */,
@@ -14467,7 +14473,7 @@
 				205B7EB92C19FAF700D14A36 /* PointOfSaleCardPresentPaymentScanningForReadersAlertViewModel.swift in Sources */,
 				31C21FA426D9949000916E2E /* SeveralReadersFoundViewController.swift in Sources */,
 				45E1482527736D1E0099CF23 /* SettingsView.swift in Sources */,
-				205B7ED12C19FD8500D14A36 /* CardPresentPaymentErrorAlertViewModel.swift in Sources */,
+				205B7ED12C19FD8500D14A36 /* PointOfSaleCardPresentPaymentErrorMessageViewModel.swift in Sources */,
 				02E3B62829026C8F007E0F13 /* AccountCreationForm.swift in Sources */,
 				CC078531266E706300BA9AC1 /* ErrorTopBannerFactory.swift in Sources */,
 				EE9D03122B89DF760077CED1 /* WooAnalyticsEvent+OrdersListFilter.swift in Sources */,
@@ -14942,6 +14948,7 @@
 				26C6E8E626E6B5F500C7BB0F /* StateSelectorViewModel.swift in Sources */,
 				B99B30CD2A85200D0066743D /* AddressFormViewModel.swift in Sources */,
 				020B2F9423BDDBDC00BD79AD /* ProductUpdateError+UI.swift in Sources */,
+				205E79462C204387001BA266 /* PointOfSaleCardPresentPaymentCancelledOnReaderMessageViewModel.swift in Sources */,
 				021125A52578E5730075AD2A /* BoldableTextView.swift in Sources */,
 				CE85FD5A20F7A7640080B73E /* TableFooterView.swift in Sources */,
 				CC254F2D26C17AB5005F3C82 /* BottomButtonView.swift in Sources */,
@@ -15074,6 +15081,7 @@
 				03E471C0293A158D001A58AD /* CardReaderConnectionAlertsProviding.swift in Sources */,
 				D8C2A291231BD0FD00F503E9 /* ReviewsDataSource.swift in Sources */,
 				CE855366209BA6A700938BDC /* CustomerInfoTableViewCell.swift in Sources */,
+				205E79442C204368001BA266 /* PointOfSaleCardPresentPaymentNonRetryableErrorMessageViewModel.swift in Sources */,
 				02DAE7FC291B7B8B009342B7 /* DomainSelectorViewModel.swift in Sources */,
 				26838356296F702B00CCF60A /* GenerateAllVariationsPresenter.swift in Sources */,
 				4521396E27FEE55200964ED3 /* FullScreenTextView.swift in Sources */,
@@ -15203,7 +15211,7 @@
 				AEB73C0C25CD734200A8454A /* AttributePickerViewModel.swift in Sources */,
 				D8752EF7265E60F4008ACC80 /* PaymentCaptureCelebration.swift in Sources */,
 				B98BA12D2AE90023006F1E4A /* OrderCustomAmountsSection.swift in Sources */,
-				205B7EC72C19FCA700D14A36 /* CardPresentPaymentPreparingForPaymentAlertViewModel.swift in Sources */,
+				205B7EC72C19FCA700D14A36 /* PointOfSaleCardPresentPaymentPreparingForPaymentMessageViewModel.swift in Sources */,
 				DE7E5E882B4D16EB002E28D2 /* BlazeTargetDevicePickerView.swift in Sources */,
 				EE6B2AD129DC522300048A8F /* StoreCreationProgressView.swift in Sources */,
 				B58B4AB62108F11C00076FDD /* Notice.swift in Sources */,
@@ -15231,7 +15239,7 @@
 				CE63024E2BAC664900E3325C /* EmailView.swift in Sources */,
 				DE4B3B5826A7041800EEF2D8 /* EdgeInsets+Woo.swift in Sources */,
 				02CE4304276993DA0006EAEF /* CaptureDevicePermissionChecker.swift in Sources */,
-				205B7ECD2C19FD2F00D14A36 /* CardPresentPaymentDisplayReaderMessageAlertViewModel.swift in Sources */,
+				205B7ECD2C19FD2F00D14A36 /* PointOfSaleCardPresentPaymentDisplayReaderMessageMessageViewModel.swift in Sources */,
 				DEF8CF1F29AC870A00800A60 /* WPComEmailLoginViewModel.swift in Sources */,
 				74A33D8021C3F234009E25DE /* LicensesViewController.swift in Sources */,
 				02EEA9282923338100D05F47 /* StoreCreationPlanView.swift in Sources */,
@@ -15399,7 +15407,7 @@
 				4574745D24EA84D800CF49BC /* ProductTypeBottomSheetListSelectorCommand.swift in Sources */,
 				26578C4126277AFF00A15097 /* OrderAddOnsListViewController.swift in Sources */,
 				02F67FEE25805F9C00C3BAD2 /* ShippingLabelTrackingURLGenerator.swift in Sources */,
-				205B7EC92C19FCDB00D14A36 /* CardPresentPaymentTapSwipeInsertCardAlertViewModel.swift in Sources */,
+				205B7EC92C19FCDB00D14A36 /* PointOfSaleCardPresentPaymentTapSwipeInsertCardMessageViewModel.swift in Sources */,
 				0269A63C2581D26C007B49ED /* ShippingLabelPrintingStepListView.swift in Sources */,
 				3188533C2639FE5800F66A9C /* PaymentSettingsFlowPresentedViewModel.swift in Sources */,
 				CE55F2D42B238C04005D53D7 /* CollapsibleProductCardPriceSummaryViewModel.swift in Sources */,
@@ -15550,7 +15558,7 @@
 				203163B32C1C5DAC001C96DA /* PointOfSaleCardPresentPaymentConnectingFailedChargeReaderAlertViewModel.swift in Sources */,
 				20E188842AD059A50053E945 /* AboutTapToPayView.swift in Sources */,
 				EE8A30452B74948C001D7C66 /* OrderAttributionInfo+Origin.swift in Sources */,
-				205B7ECF2C19FD5200D14A36 /* CardPresentPaymentSuccessAlertViewModel.swift in Sources */,
+				205B7ECF2C19FD5200D14A36 /* PointOfSaleCardPresentPaymentSuccessMessageViewModel.swift in Sources */,
 				026D4652295D763B0037F59A /* CountryCode+FlagEmoji.swift in Sources */,
 				B9F3DAAD29BB71B100DDD545 /* CollectPaymentAppIntent.swift in Sources */,
 				EEBDF7DF2A2F674100EFEF47 /* ShareProductAIEligibilityChecker.swift in Sources */,


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of : #12868 
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

This PR adds/renames empty view models for the various payment messages that should be handled from the CardPresentPaymentService.

Additionally, it makes some improvements from the last PR (renaming unclear events like `error`, `success` to be more specific to the payment flow) and fixes a mistake where a payment error was sent instead of a connection error.

## Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->

Launch the app and try the payment flows in the POS and existing experiences. You should not see any functional changes.

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.