### PR TITLE
[Woo POS] Payment message actions

### DIFF
--- a/WooCommerce/Classes/POS/Presentation/Card Present Payments/PointOfSaleCardPresentPaymentEventPresentationStyle.swift
+++ b/WooCommerce/Classes/POS/Presentation/Card Present Payments/PointOfSaleCardPresentPaymentEventPresentationStyle.swift
@@ -88,7 +88,9 @@ extension CardPresentPaymentEventDetails {
 
         case .tapSwipeOrInsertCard(inputMethods: let inputMethods, cancelPayment: let cancelPayment):
             return .message(.tapSwipeOrInsertCard(
-                viewModel: PointOfSaleCardPresentPaymentTapSwipeInsertCardMessageViewModel()))
+                viewModel: PointOfSaleCardPresentPaymentTapSwipeInsertCardMessageViewModel(
+                    inputMethods: inputMethods,
+                    cancelAction: cancelPayment)))
 
         case .paymentSuccess(done: let done):
             return .message(.paymentSuccess(viewModel: PointOfSaleCardPresentPaymentSuccessMessageViewModel()))

--- a/WooCommerce/Classes/POS/Presentation/Card Present Payments/PointOfSaleCardPresentPaymentEventPresentationStyle.swift
+++ b/WooCommerce/Classes/POS/Presentation/Card Present Payments/PointOfSaleCardPresentPaymentEventPresentationStyle.swift
@@ -96,7 +96,11 @@ extension CardPresentPaymentEventDetails {
             return .message(.paymentSuccess(viewModel: PointOfSaleCardPresentPaymentSuccessMessageViewModel()))
 
         case .paymentError(error: let error, tryAgain: let tryAgain, cancelPayment: let cancelPayment):
-            return .message(.paymentError(viewModel: PointOfSaleCardPresentPaymentErrorMessageViewModel()))
+            return .message(.paymentError(
+                viewModel: PointOfSaleCardPresentPaymentErrorMessageViewModel(
+                    error: error,
+                    tryAgainButtonAction: tryAgain,
+                    cancelButtonAction: cancelPayment)))
 
         case .paymentErrorNonRetryable(error: let error, cancelPayment: let cancelPayment):
             return .message(.paymentErrorNonRetryable(

--- a/WooCommerce/Classes/POS/Presentation/Card Present Payments/PointOfSaleCardPresentPaymentEventPresentationStyle.swift
+++ b/WooCommerce/Classes/POS/Presentation/Card Present Payments/PointOfSaleCardPresentPaymentEventPresentationStyle.swift
@@ -83,7 +83,8 @@ extension CardPresentPaymentEventDetails {
         /// Payment messages
         case .preparingForPayment(cancelPayment: let cancelPayment):
             return .message(.preparingForPayment(
-                viewModel: PointOfSaleCardPresentPaymentPreparingForPaymentMessageViewModel()))
+                viewModel: PointOfSaleCardPresentPaymentPreparingForPaymentMessageViewModel(
+                    cancelAction: cancelPayment)))
 
         case .tapSwipeOrInsertCard(inputMethods: let inputMethods, cancelPayment: let cancelPayment):
             return .message(.tapSwipeOrInsertCard(

--- a/WooCommerce/Classes/POS/Presentation/Card Present Payments/PointOfSaleCardPresentPaymentEventPresentationStyle.swift
+++ b/WooCommerce/Classes/POS/Presentation/Card Present Payments/PointOfSaleCardPresentPaymentEventPresentationStyle.swift
@@ -104,7 +104,9 @@ extension CardPresentPaymentEventDetails {
 
         case .paymentErrorNonRetryable(error: let error, cancelPayment: let cancelPayment):
             return .message(.paymentErrorNonRetryable(
-                viewModel: PointOfSaleCardPresentPaymentNonRetryableErrorMessageViewModel()))
+                viewModel: PointOfSaleCardPresentPaymentNonRetryableErrorMessageViewModel(
+                    error: error,
+                    cancelButtonAction: cancelPayment)))
 
         case .processing:
             return .message(.processing(viewModel: PointOfSaleCardPresentPaymentProcessingMessageViewModel()))

--- a/WooCommerce/Classes/POS/Presentation/Card Present Payments/Reader Messages/PointOfSaleCardPresentPaymentErrorMessageViewModel.swift
+++ b/WooCommerce/Classes/POS/Presentation/Card Present Payments/Reader Messages/PointOfSaleCardPresentPaymentErrorMessageViewModel.swift
@@ -1,5 +1,51 @@
 import Foundation
+import enum Yosemite.CardReaderServiceError
 
 struct PointOfSaleCardPresentPaymentErrorMessageViewModel {
+    let title = Localization.title
+    let message: String
+    let tryAgainButtonViewModel: CardPresentPaymentsModalButtonViewModel
+    let cancelButtonViewModel: CardPresentPaymentsModalButtonViewModel
 
+    init(error: Error,
+         tryAgainButtonAction: @escaping () -> Void,
+         cancelButtonAction: @escaping () -> Void) {
+        self.message = Self.message(for: error)
+        self.tryAgainButtonViewModel = CardPresentPaymentsModalButtonViewModel(
+            title: Localization.tryAgain,
+            actionHandler: tryAgainButtonAction)
+        self.cancelButtonViewModel = CardPresentPaymentsModalButtonViewModel(
+            title: Localization.cancel,
+            actionHandler: cancelButtonAction)
+    }
+
+    private static func message(for error: Error) -> String {
+        if let error = error as? CardReaderServiceError {
+            return error.errorDescription ?? error.localizedDescription
+        } else {
+            return error.localizedDescription
+        }
+    }
+}
+
+private extension PointOfSaleCardPresentPaymentErrorMessageViewModel {
+    enum Localization {
+        static let title = NSLocalizedString(
+            "pointOfSale.cardPresent.paymentError.title",
+            value: "Payment failed",
+            comment: "Error message. Presented to users after collecting a payment fails on the Point of Sale Checkout"
+        )
+
+        static let tryAgain =  NSLocalizedString(
+            "pointOfSale.cardPresent.paymentError.tryAgain.button.title",
+            value: "Try Again",
+            comment: "Button to try to collect a payment again. Presented to users after collecting a payment fails on the Point of Sale Checkout"
+        )
+
+        static let cancel = NSLocalizedString(
+            "pointOfSale.cardPresent.paymentError.cancel.button.title",
+            value: "Cancel Payment",
+            comment: "Button to dismiss modal overlay. Presented to users after collecting a payment fails on the Point of Sale Checkout"
+        )
+    }
 }

--- a/WooCommerce/Classes/POS/Presentation/Card Present Payments/Reader Messages/PointOfSaleCardPresentPaymentNonRetryableErrorMessageViewModel.swift
+++ b/WooCommerce/Classes/POS/Presentation/Card Present Payments/Reader Messages/PointOfSaleCardPresentPaymentNonRetryableErrorMessageViewModel.swift
@@ -1,5 +1,40 @@
 import Foundation
+import enum Yosemite.CardReaderServiceError
 
 struct PointOfSaleCardPresentPaymentNonRetryableErrorMessageViewModel {
+    let title = Localization.title
+    let message: String
+    let cancelButtonViewModel: CardPresentPaymentsModalButtonViewModel
 
+    init(error: Error,
+         cancelButtonAction: @escaping () -> Void) {
+        self.message = Self.message(for: error)
+        self.cancelButtonViewModel = CardPresentPaymentsModalButtonViewModel(
+            title: Localization.cancel,
+            actionHandler: cancelButtonAction)
+    }
+
+    private static func message(for error: Error) -> String {
+        if let error = error as? CardReaderServiceError {
+            return error.errorDescription ?? error.localizedDescription
+        } else {
+            return error.localizedDescription
+        }
+    }
+}
+
+private extension PointOfSaleCardPresentPaymentNonRetryableErrorMessageViewModel {
+    enum Localization {
+        static let title = NSLocalizedString(
+            "pointOfSale.cardPresent.paymentErrorNonRetryable.title",
+            value: "Payment failed",
+            comment: "Error message. Presented to users after collecting a payment fails on the Point of Sale Checkout"
+        )
+
+        static let cancel = NSLocalizedString(
+            "pointOfSale.cardPresent.paymentErrorNonRetryable.cancel.button.title",
+            value: "Cancel Payment",
+            comment: "Button to dismiss modal overlay. Presented to users after collecting a payment fails on the Point of Sale Checkout"
+        )
+    }
 }

--- a/WooCommerce/Classes/POS/Presentation/Card Present Payments/Reader Messages/PointOfSaleCardPresentPaymentPreparingForPaymentMessageViewModel.swift
+++ b/WooCommerce/Classes/POS/Presentation/Card Present Payments/Reader Messages/PointOfSaleCardPresentPaymentPreparingForPaymentMessageViewModel.swift
@@ -1,5 +1,28 @@
 import Foundation
 
 struct PointOfSaleCardPresentPaymentPreparingForPaymentMessageViewModel {
+    let message: String = Localization.message
+    let cancelButtonViewModel: CardPresentPaymentsModalButtonViewModel
 
+    init(cancelAction: @escaping () -> Void) {
+        self.cancelButtonViewModel = CardPresentPaymentsModalButtonViewModel(
+            title: Localization.cancel,
+            actionHandler: cancelAction)
+    }
+}
+
+private extension PointOfSaleCardPresentPaymentPreparingForPaymentMessageViewModel {
+    enum Localization {
+        static let message = NSLocalizedString(
+            "pointOfSale.cardPresent.preparingCardReader.message",
+            value: "Preparing card reader",
+            comment: "Message shown on the Point of Sale checkout while the reader is being prepared."
+        )
+
+        static let cancel = NSLocalizedString(
+            "pointOfSale.cardPresent.preparingCardReader.cancel.button.title",
+            value: "Cancel",
+            comment: "Button to cancel preparation of the reader on the Point of Sale checkout."
+        )
+    }
 }

--- a/WooCommerce/Classes/POS/Presentation/Card Present Payments/Reader Messages/PointOfSaleCardPresentPaymentTapSwipeInsertCardMessageViewModel.swift
+++ b/WooCommerce/Classes/POS/Presentation/Card Present Payments/Reader Messages/PointOfSaleCardPresentPaymentTapSwipeInsertCardMessageViewModel.swift
@@ -1,5 +1,76 @@
 import Foundation
+import struct Yosemite.CardReaderInput
 
 struct PointOfSaleCardPresentPaymentTapSwipeInsertCardMessageViewModel {
+    let title = Localization.readerIsReady
+    let message: String
+    let cancelButtonViewModel: CardPresentPaymentsModalButtonViewModel
 
+    init(inputMethods: CardReaderInput,
+         cancelAction: @escaping () -> Void) {
+        self.message = Self.message(for: inputMethods)
+        self.cancelButtonViewModel = CardPresentPaymentsModalButtonViewModel(
+            title: Localization.cancel,
+            actionHandler: cancelAction)
+    }
+
+    private static func message(for inputMethods: CardReaderInput) -> String {
+        if inputMethods == [.swipe, .insert, .tap] {
+            return Localization.tapInsertOrSwipe
+        } else if inputMethods == [.tap, .insert] {
+            return Localization.tapOrInsert
+        } else if inputMethods.contains(.tap) {
+            return Localization.tap
+        } else if inputMethods.contains(.insert) {
+            return Localization.insert
+        } else {
+            return Localization.presentCard
+        }
+    }
+}
+
+private extension PointOfSaleCardPresentPaymentTapSwipeInsertCardMessageViewModel {
+    enum Localization {
+        static let readerIsReady = NSLocalizedString(
+            "pointOfSale.cardPresent.presentCard.title",
+            value: "Reader is ready",
+            comment: "Indicates the status of a card reader. Presented to users when payment collection starts"
+        )
+
+        static let tapInsertOrSwipe = NSLocalizedString(
+            "pointOfSale.cardPresent.presentCard.tapSwipeInsert",
+            value: "Tap, insert or swipe to pay",
+            comment: "Label asking users to present a card. Presented to users when a payment is going to be collected"
+        )
+
+        static let tapOrInsert = NSLocalizedString(
+            "pointOfSale.cardPresent.presentCard.tapInsert",
+            value: "Tap or insert card to pay",
+            comment: "Label asking users to present a card. Presented to users when a payment is going to be collected"
+        )
+
+        static let tap = NSLocalizedString(
+            "pointOfSale.cardPresent.presentCard.tap",
+            value: "Tap card to pay",
+            comment: "Label asking users to present a card. Presented to users when a payment is going to be collected"
+        )
+
+        static let insert = NSLocalizedString(
+            "pointOfSale.cardPresent.presentCard.insert",
+            value: "Insert card to pay",
+            comment: "Label asking users to present a card. Presented to users when a payment is going to be collected"
+        )
+
+        static let presentCard = NSLocalizedString(
+            "pointOfSale.cardPresent.presentCard.present",
+            value: "Present card to pay",
+            comment: "Label asking users to present a card. Presented to users when a payment is going to be collected"
+        )
+
+        static let cancel = NSLocalizedString(
+            "pointOfSale.cardPresent.presentCard.cancel.button.title",
+            value: "Cancel",
+            comment: "Button to cancel a payment"
+        )
+    }
 }

--- a/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/Reader Messages/PointOfSaleCardPresentPaymentDisplayReaderMessageMessageView.swift
+++ b/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/Reader Messages/PointOfSaleCardPresentPaymentDisplayReaderMessageMessageView.swift
@@ -1,0 +1,15 @@
+import SwiftUI
+
+struct PointOfSaleCardPresentPaymentDisplayReaderMessageMessageView: View {
+    let viewModel: PointOfSaleCardPresentPaymentDisplayReaderMessageMessageViewModel
+
+    var body: some View {
+        Text(viewModel.message)
+    }
+}
+
+#Preview {
+    PointOfSaleCardPresentPaymentDisplayReaderMessageMessageView(
+        viewModel: PointOfSaleCardPresentPaymentDisplayReaderMessageMessageViewModel(
+            message: "Please remove card"))
+}

--- a/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/Reader Messages/PointOfSaleCardPresentPaymentErrorMessageView.swift
+++ b/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/Reader Messages/PointOfSaleCardPresentPaymentErrorMessageView.swift
@@ -1,0 +1,30 @@
+import SwiftUI
+import enum Yosemite.CardReaderServiceError
+
+struct PointOfSaleCardPresentPaymentErrorMessageView: View {
+    let viewModel: PointOfSaleCardPresentPaymentErrorMessageViewModel
+
+    var body: some View {
+        HStack {
+            VStack {
+                Text(viewModel.title)
+                Text(viewModel.message)
+            }
+
+            Button(viewModel.tryAgainButtonViewModel.title,
+                   action: viewModel.tryAgainButtonViewModel.actionHandler)
+
+            Button(viewModel.cancelButtonViewModel.title,
+                   action: viewModel.cancelButtonViewModel.actionHandler)
+        }
+    }
+}
+
+#Preview {
+    PointOfSaleCardPresentPaymentErrorMessageView(
+        viewModel: PointOfSaleCardPresentPaymentErrorMessageViewModel(
+            error: CardReaderServiceError.paymentCapture(
+                underlyingError: .paymentDeclinedByCardReader),
+            tryAgainButtonAction: {},
+            cancelButtonAction: {}))
+}

--- a/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/Reader Messages/PointOfSaleCardPresentPaymentNonRetryableErrorMessageView.swift
+++ b/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/Reader Messages/PointOfSaleCardPresentPaymentNonRetryableErrorMessageView.swift
@@ -1,0 +1,26 @@
+import SwiftUI
+import enum Yosemite.CardReaderServiceError
+
+struct PointOfSaleCardPresentPaymentNonRetryableErrorMessageView: View {
+    let viewModel: PointOfSaleCardPresentPaymentNonRetryableErrorMessageViewModel
+
+    var body: some View {
+        HStack {
+            VStack {
+                Text(viewModel.title)
+                Text(viewModel.message)
+            }
+
+            Button(viewModel.cancelButtonViewModel.title,
+                   action: viewModel.cancelButtonViewModel.actionHandler)
+        }
+    }
+}
+
+#Preview {
+    PointOfSaleCardPresentPaymentNonRetryableErrorMessageView(
+        viewModel: PointOfSaleCardPresentPaymentNonRetryableErrorMessageViewModel(
+            error: CardReaderServiceError.paymentCapture(
+                underlyingError: .paymentDeclinedByCardReader),
+            cancelButtonAction: {}))
+}

--- a/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/Reader Messages/PointOfSaleCardPresentPaymentPreparingForPaymentMessageView.swift
+++ b/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/Reader Messages/PointOfSaleCardPresentPaymentPreparingForPaymentMessageView.swift
@@ -1,0 +1,31 @@
+import SwiftUI
+
+struct PointOfSaleCardPresentPaymentPreparingForPaymentMessageView: View {
+    let viewModel: PointOfSaleCardPresentPaymentPreparingForPaymentMessageViewModel
+
+    var body: some View {
+        HStack {
+            ProgressView()
+                .progressViewStyle(IndefiniteCircularProgressViewStyle(
+                    size: Layout.progressViewSize,
+                    lineWidth: Layout.progressViewLineWidth))
+
+            Text(viewModel.message)
+
+            Button(viewModel.cancelButtonViewModel.title,
+                   action: viewModel.cancelButtonViewModel.actionHandler)
+        }
+    }
+}
+
+private extension PointOfSaleCardPresentPaymentPreparingForPaymentMessageView {
+    enum Layout {
+        static let progressViewSize: CGFloat = 24
+        static let progressViewLineWidth: CGFloat = 4
+    }
+}
+
+#Preview {
+    PointOfSaleCardPresentPaymentPreparingForPaymentMessageView(
+        viewModel: PointOfSaleCardPresentPaymentPreparingForPaymentMessageViewModel(cancelAction: {}))
+}

--- a/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/Reader Messages/PointOfSaleCardPresentPaymentTapSwipeInsertCardMessageView.swift
+++ b/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/Reader Messages/PointOfSaleCardPresentPaymentTapSwipeInsertCardMessageView.swift
@@ -1,0 +1,25 @@
+import SwiftUI
+
+struct PointOfSaleCardPresentPaymentTapSwipeInsertCardMessageView: View {
+    let viewModel: PointOfSaleCardPresentPaymentTapSwipeInsertCardMessageViewModel
+
+    var body: some View {
+        HStack {
+            VStack {
+                Text(viewModel.title)
+                Text(viewModel.message)
+            }
+
+            Button(viewModel.cancelButtonViewModel.title,
+                   action: viewModel.cancelButtonViewModel.actionHandler)
+        }
+    }
+}
+
+#Preview {
+    PointOfSaleCardPresentPaymentTapSwipeInsertCardMessageView(
+        viewModel: PointOfSaleCardPresentPaymentTapSwipeInsertCardMessageViewModel(
+            inputMethods: [.tap, .insert],
+            cancelAction: {}
+        ))
+}

--- a/WooCommerce/Classes/POS/Presentation/PointOfSaleDashboardView.swift
+++ b/WooCommerce/Classes/POS/Presentation/PointOfSaleDashboardView.swift
@@ -36,7 +36,7 @@ struct PointOfSaleDashboardView: View {
                             case .processing:
                                 Text("processing...")
                             case .displayReaderMessage(let viewModel):
-                                Text("Reader message: \(viewModel.message)")
+                                PointOfSaleCardPresentPaymentDisplayReaderMessageMessageView(viewModel: viewModel)
                             case .paymentSuccess:
                                 Text("Payment successful!")
                             case .paymentError(let viewModel):

--- a/WooCommerce/Classes/POS/Presentation/PointOfSaleDashboardView.swift
+++ b/WooCommerce/Classes/POS/Presentation/PointOfSaleDashboardView.swift
@@ -29,8 +29,8 @@ struct PointOfSaleDashboardView: View {
                         // TODO: replace temporary inline message UI based on design
                         if let inlinePaymentMessage = viewModel.cardPresentPaymentInlineMessage {
                             switch inlinePaymentMessage {
-                            case .preparingForPayment:
-                                Text("Preparing for payment...")
+                            case .preparingForPayment(let viewModel):
+                                PointOfSaleCardPresentPaymentPreparingForPaymentMessageView(viewModel: viewModel)
                             case .tapSwipeOrInsertCard:
                                 Text("tapSwipeOrInsertCard...")
                             case .processing:

--- a/WooCommerce/Classes/POS/Presentation/PointOfSaleDashboardView.swift
+++ b/WooCommerce/Classes/POS/Presentation/PointOfSaleDashboardView.swift
@@ -41,8 +41,8 @@ struct PointOfSaleDashboardView: View {
                                 Text("Payment successful!")
                             case .paymentError(let viewModel):
                                 PointOfSaleCardPresentPaymentErrorMessageView(viewModel: viewModel)
-                            case .paymentErrorNonRetryable:
-                                Text("Payment error - non retryable")
+                            case .paymentErrorNonRetryable(let viewModel):
+                                PointOfSaleCardPresentPaymentNonRetryableErrorMessageView(viewModel: viewModel)
                             case .cancelledOnReader:
                                 Text("Payment cancelled on reader")
                             }

--- a/WooCommerce/Classes/POS/Presentation/PointOfSaleDashboardView.swift
+++ b/WooCommerce/Classes/POS/Presentation/PointOfSaleDashboardView.swift
@@ -39,8 +39,8 @@ struct PointOfSaleDashboardView: View {
                                 Text("Reader message: \(viewModel.message)")
                             case .paymentSuccess:
                                 Text("Payment successful!")
-                            case .paymentError:
-                                Text("Payment error")
+                            case .paymentError(let viewModel):
+                                PointOfSaleCardPresentPaymentErrorMessageView(viewModel: viewModel)
                             case .paymentErrorNonRetryable:
                                 Text("Payment error - non retryable")
                             case .cancelledOnReader:

--- a/WooCommerce/Classes/POS/Presentation/PointOfSaleDashboardView.swift
+++ b/WooCommerce/Classes/POS/Presentation/PointOfSaleDashboardView.swift
@@ -31,8 +31,8 @@ struct PointOfSaleDashboardView: View {
                             switch inlinePaymentMessage {
                             case .preparingForPayment(let viewModel):
                                 PointOfSaleCardPresentPaymentPreparingForPaymentMessageView(viewModel: viewModel)
-                            case .tapSwipeOrInsertCard:
-                                Text("tapSwipeOrInsertCard...")
+                            case .tapSwipeOrInsertCard(let viewModel):
+                                PointOfSaleCardPresentPaymentTapSwipeInsertCardMessageView(viewModel: viewModel)
                             case .processing:
                                 Text("processing...")
                             case .displayReaderMessage(let viewModel):

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -806,6 +806,7 @@
 		205E79442C204368001BA266 /* PointOfSaleCardPresentPaymentNonRetryableErrorMessageViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 205E79432C204368001BA266 /* PointOfSaleCardPresentPaymentNonRetryableErrorMessageViewModel.swift */; };
 		205E79462C204387001BA266 /* PointOfSaleCardPresentPaymentCancelledOnReaderMessageViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 205E79452C204387001BA266 /* PointOfSaleCardPresentPaymentCancelledOnReaderMessageViewModel.swift */; };
 		205E79482C204B21001BA266 /* PointOfSaleCardPresentPaymentPreparingForPaymentMessageView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 205E79472C204B21001BA266 /* PointOfSaleCardPresentPaymentPreparingForPaymentMessageView.swift */; };
+		205E794B2C2051B5001BA266 /* PointOfSaleCardPresentPaymentTapSwipeInsertCardMessageView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 205E794A2C2051B5001BA266 /* PointOfSaleCardPresentPaymentTapSwipeInsertCardMessageView.swift */; };
 		20762BA12C18A66400758305 /* CardPresentPaymentBuiltInReaderConnectionAlertsProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 20762BA02C18A66400758305 /* CardPresentPaymentBuiltInReaderConnectionAlertsProvider.swift */; };
 		20762BA32C18A6A300758305 /* CardPresentPaymentEventDetails.swift in Sources */ = {isa = PBXBuildFile; fileRef = 20762BA22C18A6A300758305 /* CardPresentPaymentEventDetails.swift */; };
 		20762BA52C18B42C00758305 /* CardPresentPaymentBluetoothReaderConnectionAlertsProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 20762BA42C18B42C00758305 /* CardPresentPaymentBluetoothReaderConnectionAlertsProvider.swift */; };
@@ -3772,6 +3773,7 @@
 		205E79432C204368001BA266 /* PointOfSaleCardPresentPaymentNonRetryableErrorMessageViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PointOfSaleCardPresentPaymentNonRetryableErrorMessageViewModel.swift; sourceTree = "<group>"; };
 		205E79452C204387001BA266 /* PointOfSaleCardPresentPaymentCancelledOnReaderMessageViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PointOfSaleCardPresentPaymentCancelledOnReaderMessageViewModel.swift; sourceTree = "<group>"; };
 		205E79472C204B21001BA266 /* PointOfSaleCardPresentPaymentPreparingForPaymentMessageView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PointOfSaleCardPresentPaymentPreparingForPaymentMessageView.swift; sourceTree = "<group>"; };
+		205E794A2C2051B5001BA266 /* PointOfSaleCardPresentPaymentTapSwipeInsertCardMessageView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PointOfSaleCardPresentPaymentTapSwipeInsertCardMessageView.swift; sourceTree = "<group>"; };
 		20762BA02C18A66400758305 /* CardPresentPaymentBuiltInReaderConnectionAlertsProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardPresentPaymentBuiltInReaderConnectionAlertsProvider.swift; sourceTree = "<group>"; };
 		20762BA22C18A6A300758305 /* CardPresentPaymentEventDetails.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardPresentPaymentEventDetails.swift; sourceTree = "<group>"; };
 		20762BA42C18B42C00758305 /* CardPresentPaymentBluetoothReaderConnectionAlertsProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardPresentPaymentBluetoothReaderConnectionAlertsProvider.swift; sourceTree = "<group>"; };
@@ -7621,6 +7623,7 @@
 			isa = PBXGroup;
 			children = (
 				205E79472C204B21001BA266 /* PointOfSaleCardPresentPaymentPreparingForPaymentMessageView.swift */,
+				205E794A2C2051B5001BA266 /* PointOfSaleCardPresentPaymentTapSwipeInsertCardMessageView.swift */,
 			);
 			path = "Reader Messages";
 			sourceTree = "<group>";
@@ -14955,6 +14958,7 @@
 				02667A1A2ABDD44200C77B56 /* GiftCardCodeScannerViewController.swift in Sources */,
 				57A25C7C25ACFAEC00A54A62 /* OrderFulfillmentNoticePresenter.swift in Sources */,
 				B9E4364C287587D300883CFA /* FeatureAnnouncementCardView.swift in Sources */,
+				205E794B2C2051B5001BA266 /* PointOfSaleCardPresentPaymentTapSwipeInsertCardMessageView.swift in Sources */,
 				267F60132A0C24D700CD1E4E /* PrivacyBannerViewController.swift in Sources */,
 				D8610BD2256F291000A5DF27 /* JetpackErrorViewModel.swift in Sources */,
 				26C6E8E626E6B5F500C7BB0F /* StateSelectorViewModel.swift in Sources */,

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -808,6 +808,7 @@
 		205E79482C204B21001BA266 /* PointOfSaleCardPresentPaymentPreparingForPaymentMessageView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 205E79472C204B21001BA266 /* PointOfSaleCardPresentPaymentPreparingForPaymentMessageView.swift */; };
 		205E794B2C2051B5001BA266 /* PointOfSaleCardPresentPaymentTapSwipeInsertCardMessageView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 205E794A2C2051B5001BA266 /* PointOfSaleCardPresentPaymentTapSwipeInsertCardMessageView.swift */; };
 		205E794D2C2057B9001BA266 /* PointOfSaleCardPresentPaymentErrorMessageView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 205E794C2C2057B9001BA266 /* PointOfSaleCardPresentPaymentErrorMessageView.swift */; };
+		205E794F2C207D38001BA266 /* PointOfSaleCardPresentPaymentNonRetryableErrorMessageView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 205E794E2C207D38001BA266 /* PointOfSaleCardPresentPaymentNonRetryableErrorMessageView.swift */; };
 		20762BA12C18A66400758305 /* CardPresentPaymentBuiltInReaderConnectionAlertsProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 20762BA02C18A66400758305 /* CardPresentPaymentBuiltInReaderConnectionAlertsProvider.swift */; };
 		20762BA32C18A6A300758305 /* CardPresentPaymentEventDetails.swift in Sources */ = {isa = PBXBuildFile; fileRef = 20762BA22C18A6A300758305 /* CardPresentPaymentEventDetails.swift */; };
 		20762BA52C18B42C00758305 /* CardPresentPaymentBluetoothReaderConnectionAlertsProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 20762BA42C18B42C00758305 /* CardPresentPaymentBluetoothReaderConnectionAlertsProvider.swift */; };
@@ -3776,6 +3777,7 @@
 		205E79472C204B21001BA266 /* PointOfSaleCardPresentPaymentPreparingForPaymentMessageView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PointOfSaleCardPresentPaymentPreparingForPaymentMessageView.swift; sourceTree = "<group>"; };
 		205E794A2C2051B5001BA266 /* PointOfSaleCardPresentPaymentTapSwipeInsertCardMessageView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PointOfSaleCardPresentPaymentTapSwipeInsertCardMessageView.swift; sourceTree = "<group>"; };
 		205E794C2C2057B9001BA266 /* PointOfSaleCardPresentPaymentErrorMessageView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PointOfSaleCardPresentPaymentErrorMessageView.swift; sourceTree = "<group>"; };
+		205E794E2C207D38001BA266 /* PointOfSaleCardPresentPaymentNonRetryableErrorMessageView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PointOfSaleCardPresentPaymentNonRetryableErrorMessageView.swift; sourceTree = "<group>"; };
 		20762BA02C18A66400758305 /* CardPresentPaymentBuiltInReaderConnectionAlertsProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardPresentPaymentBuiltInReaderConnectionAlertsProvider.swift; sourceTree = "<group>"; };
 		20762BA22C18A6A300758305 /* CardPresentPaymentEventDetails.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardPresentPaymentEventDetails.swift; sourceTree = "<group>"; };
 		20762BA42C18B42C00758305 /* CardPresentPaymentBluetoothReaderConnectionAlertsProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardPresentPaymentBluetoothReaderConnectionAlertsProvider.swift; sourceTree = "<group>"; };
@@ -7627,6 +7629,7 @@
 				205E79472C204B21001BA266 /* PointOfSaleCardPresentPaymentPreparingForPaymentMessageView.swift */,
 				205E794A2C2051B5001BA266 /* PointOfSaleCardPresentPaymentTapSwipeInsertCardMessageView.swift */,
 				205E794C2C2057B9001BA266 /* PointOfSaleCardPresentPaymentErrorMessageView.swift */,
+				205E794E2C207D38001BA266 /* PointOfSaleCardPresentPaymentNonRetryableErrorMessageView.swift */,
 			);
 			path = "Reader Messages";
 			sourceTree = "<group>";
@@ -14699,6 +14702,7 @@
 				DEC75CC42BC4E55A00763801 /* DashboardCustomizationViewModel.swift in Sources */,
 				02490D1A284DE664002096EF /* ProductImagesSaver.swift in Sources */,
 				8646A9BA2B46C7CA001F606C /* BlazeAdDestinationSettingView.swift in Sources */,
+				205E794F2C207D38001BA266 /* PointOfSaleCardPresentPaymentNonRetryableErrorMessageView.swift in Sources */,
 				0215320B24231D5A003F2BBD /* UIStackView+Subviews.swift in Sources */,
 				02F4F50B237AEB8A00E13A9C /* ProductFormTableViewDataSource.swift in Sources */,
 				2004E2CC2C07795E00D62521 /* CardPresentPaymentError.swift in Sources */,

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -805,6 +805,7 @@
 		205E79422C1CA6E3001BA266 /* PointOfSaleCardPresentPaymentEventPresentationStyle.swift in Sources */ = {isa = PBXBuildFile; fileRef = 205E79412C1CA6E3001BA266 /* PointOfSaleCardPresentPaymentEventPresentationStyle.swift */; };
 		205E79442C204368001BA266 /* PointOfSaleCardPresentPaymentNonRetryableErrorMessageViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 205E79432C204368001BA266 /* PointOfSaleCardPresentPaymentNonRetryableErrorMessageViewModel.swift */; };
 		205E79462C204387001BA266 /* PointOfSaleCardPresentPaymentCancelledOnReaderMessageViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 205E79452C204387001BA266 /* PointOfSaleCardPresentPaymentCancelledOnReaderMessageViewModel.swift */; };
+		205E79482C204B21001BA266 /* PointOfSaleCardPresentPaymentPreparingForPaymentMessageView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 205E79472C204B21001BA266 /* PointOfSaleCardPresentPaymentPreparingForPaymentMessageView.swift */; };
 		20762BA12C18A66400758305 /* CardPresentPaymentBuiltInReaderConnectionAlertsProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 20762BA02C18A66400758305 /* CardPresentPaymentBuiltInReaderConnectionAlertsProvider.swift */; };
 		20762BA32C18A6A300758305 /* CardPresentPaymentEventDetails.swift in Sources */ = {isa = PBXBuildFile; fileRef = 20762BA22C18A6A300758305 /* CardPresentPaymentEventDetails.swift */; };
 		20762BA52C18B42C00758305 /* CardPresentPaymentBluetoothReaderConnectionAlertsProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 20762BA42C18B42C00758305 /* CardPresentPaymentBluetoothReaderConnectionAlertsProvider.swift */; };
@@ -3770,6 +3771,7 @@
 		205E79412C1CA6E3001BA266 /* PointOfSaleCardPresentPaymentEventPresentationStyle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PointOfSaleCardPresentPaymentEventPresentationStyle.swift; sourceTree = "<group>"; };
 		205E79432C204368001BA266 /* PointOfSaleCardPresentPaymentNonRetryableErrorMessageViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PointOfSaleCardPresentPaymentNonRetryableErrorMessageViewModel.swift; sourceTree = "<group>"; };
 		205E79452C204387001BA266 /* PointOfSaleCardPresentPaymentCancelledOnReaderMessageViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PointOfSaleCardPresentPaymentCancelledOnReaderMessageViewModel.swift; sourceTree = "<group>"; };
+		205E79472C204B21001BA266 /* PointOfSaleCardPresentPaymentPreparingForPaymentMessageView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PointOfSaleCardPresentPaymentPreparingForPaymentMessageView.swift; sourceTree = "<group>"; };
 		20762BA02C18A66400758305 /* CardPresentPaymentBuiltInReaderConnectionAlertsProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardPresentPaymentBuiltInReaderConnectionAlertsProvider.swift; sourceTree = "<group>"; };
 		20762BA22C18A6A300758305 /* CardPresentPaymentEventDetails.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardPresentPaymentEventDetails.swift; sourceTree = "<group>"; };
 		20762BA42C18B42C00758305 /* CardPresentPaymentBluetoothReaderConnectionAlertsProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardPresentPaymentBluetoothReaderConnectionAlertsProvider.swift; sourceTree = "<group>"; };
@@ -6637,6 +6639,7 @@
 		026826B12BF59E1F0036F959 /* UI States */ = {
 			isa = PBXGroup;
 			children = (
+				205E79492C204B2D001BA266 /* Reader Messages */,
 				026826BE2BF59E410036F959 /* PointOfSaleCardPresentPaymentScanningForReadersView.swift */,
 				026826B62BF59E400036F959 /* PointOfSaleCardPresentPaymentScanningForReadersFailedView.swift */,
 				203163AA2C1B5DEE001C96DA /* PointOfSaleCardPresentPaymentBluetoothRequiredAlertView.swift */,
@@ -7610,6 +7613,14 @@
 				205B7ECA2C19FCFC00D14A36 /* PointOfSaleCardPresentPaymentProcessingMessageViewModel.swift */,
 				205B7ECE2C19FD5200D14A36 /* PointOfSaleCardPresentPaymentSuccessMessageViewModel.swift */,
 				205B7ECC2C19FD2F00D14A36 /* PointOfSaleCardPresentPaymentDisplayReaderMessageMessageViewModel.swift */,
+			);
+			path = "Reader Messages";
+			sourceTree = "<group>";
+		};
+		205E79492C204B2D001BA266 /* Reader Messages */ = {
+			isa = PBXGroup;
+			children = (
+				205E79472C204B21001BA266 /* PointOfSaleCardPresentPaymentPreparingForPaymentMessageView.swift */,
 			);
 			path = "Reader Messages";
 			sourceTree = "<group>";
@@ -14637,6 +14648,7 @@
 				CE22E3F72170E23C005A6BEF /* PrivacySettingsViewController.swift in Sources */,
 				021125482577CC650075AD2A /* ShippingLabelDetailsViewModel.swift in Sources */,
 				2004E2D82C08E56300D62521 /* CardPresentPaymentOnboardingPresentationEvent.swift in Sources */,
+				205E79482C204B21001BA266 /* PointOfSaleCardPresentPaymentPreparingForPaymentMessageView.swift in Sources */,
 				68D1BEDD2900E4180074A29E /* CustomerSearchUICommand.swift in Sources */,
 				316837DA25CCA90C00E36B2F /* OrderStatusListDataSource.swift in Sources */,
 				FE28F6F4268477C1004465C7 /* RoleEligibilityUseCase.swift in Sources */,

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -809,6 +809,7 @@
 		205E794B2C2051B5001BA266 /* PointOfSaleCardPresentPaymentTapSwipeInsertCardMessageView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 205E794A2C2051B5001BA266 /* PointOfSaleCardPresentPaymentTapSwipeInsertCardMessageView.swift */; };
 		205E794D2C2057B9001BA266 /* PointOfSaleCardPresentPaymentErrorMessageView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 205E794C2C2057B9001BA266 /* PointOfSaleCardPresentPaymentErrorMessageView.swift */; };
 		205E794F2C207D38001BA266 /* PointOfSaleCardPresentPaymentNonRetryableErrorMessageView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 205E794E2C207D38001BA266 /* PointOfSaleCardPresentPaymentNonRetryableErrorMessageView.swift */; };
+		205E79512C207FAE001BA266 /* PointOfSaleCardPresentPaymentDisplayReaderMessageMessageView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 205E79502C207FAE001BA266 /* PointOfSaleCardPresentPaymentDisplayReaderMessageMessageView.swift */; };
 		20762BA12C18A66400758305 /* CardPresentPaymentBuiltInReaderConnectionAlertsProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 20762BA02C18A66400758305 /* CardPresentPaymentBuiltInReaderConnectionAlertsProvider.swift */; };
 		20762BA32C18A6A300758305 /* CardPresentPaymentEventDetails.swift in Sources */ = {isa = PBXBuildFile; fileRef = 20762BA22C18A6A300758305 /* CardPresentPaymentEventDetails.swift */; };
 		20762BA52C18B42C00758305 /* CardPresentPaymentBluetoothReaderConnectionAlertsProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 20762BA42C18B42C00758305 /* CardPresentPaymentBluetoothReaderConnectionAlertsProvider.swift */; };
@@ -3778,6 +3779,7 @@
 		205E794A2C2051B5001BA266 /* PointOfSaleCardPresentPaymentTapSwipeInsertCardMessageView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PointOfSaleCardPresentPaymentTapSwipeInsertCardMessageView.swift; sourceTree = "<group>"; };
 		205E794C2C2057B9001BA266 /* PointOfSaleCardPresentPaymentErrorMessageView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PointOfSaleCardPresentPaymentErrorMessageView.swift; sourceTree = "<group>"; };
 		205E794E2C207D38001BA266 /* PointOfSaleCardPresentPaymentNonRetryableErrorMessageView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PointOfSaleCardPresentPaymentNonRetryableErrorMessageView.swift; sourceTree = "<group>"; };
+		205E79502C207FAE001BA266 /* PointOfSaleCardPresentPaymentDisplayReaderMessageMessageView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PointOfSaleCardPresentPaymentDisplayReaderMessageMessageView.swift; sourceTree = "<group>"; };
 		20762BA02C18A66400758305 /* CardPresentPaymentBuiltInReaderConnectionAlertsProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardPresentPaymentBuiltInReaderConnectionAlertsProvider.swift; sourceTree = "<group>"; };
 		20762BA22C18A6A300758305 /* CardPresentPaymentEventDetails.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardPresentPaymentEventDetails.swift; sourceTree = "<group>"; };
 		20762BA42C18B42C00758305 /* CardPresentPaymentBluetoothReaderConnectionAlertsProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardPresentPaymentBluetoothReaderConnectionAlertsProvider.swift; sourceTree = "<group>"; };
@@ -7630,6 +7632,7 @@
 				205E794A2C2051B5001BA266 /* PointOfSaleCardPresentPaymentTapSwipeInsertCardMessageView.swift */,
 				205E794C2C2057B9001BA266 /* PointOfSaleCardPresentPaymentErrorMessageView.swift */,
 				205E794E2C207D38001BA266 /* PointOfSaleCardPresentPaymentNonRetryableErrorMessageView.swift */,
+				205E79502C207FAE001BA266 /* PointOfSaleCardPresentPaymentDisplayReaderMessageMessageView.swift */,
 			);
 			path = "Reader Messages";
 			sourceTree = "<group>";
@@ -14674,6 +14677,7 @@
 				204CB8102C10BB88000C9773 /* CardPresentPaymentPreviewService.swift in Sources */,
 				B57B678A2107546E00AF8905 /* Address+Woo.swift in Sources */,
 				035F2308275690970019E1B0 /* CardPresentModalConnectingFailedUpdatePostalCode.swift in Sources */,
+				205E79512C207FAE001BA266 /* PointOfSaleCardPresentPaymentDisplayReaderMessageMessageView.swift in Sources */,
 				EEB4E2DC29B600B800371C3C /* CouponLineDetails.swift in Sources */,
 				03F5CB012A0BA3D40026877A /* ModalOverlay.swift in Sources */,
 				02C37B7D2967B72A00F0CF9E /* FreeStagingDomainView.swift in Sources */,

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -807,6 +807,7 @@
 		205E79462C204387001BA266 /* PointOfSaleCardPresentPaymentCancelledOnReaderMessageViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 205E79452C204387001BA266 /* PointOfSaleCardPresentPaymentCancelledOnReaderMessageViewModel.swift */; };
 		205E79482C204B21001BA266 /* PointOfSaleCardPresentPaymentPreparingForPaymentMessageView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 205E79472C204B21001BA266 /* PointOfSaleCardPresentPaymentPreparingForPaymentMessageView.swift */; };
 		205E794B2C2051B5001BA266 /* PointOfSaleCardPresentPaymentTapSwipeInsertCardMessageView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 205E794A2C2051B5001BA266 /* PointOfSaleCardPresentPaymentTapSwipeInsertCardMessageView.swift */; };
+		205E794D2C2057B9001BA266 /* PointOfSaleCardPresentPaymentErrorMessageView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 205E794C2C2057B9001BA266 /* PointOfSaleCardPresentPaymentErrorMessageView.swift */; };
 		20762BA12C18A66400758305 /* CardPresentPaymentBuiltInReaderConnectionAlertsProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 20762BA02C18A66400758305 /* CardPresentPaymentBuiltInReaderConnectionAlertsProvider.swift */; };
 		20762BA32C18A6A300758305 /* CardPresentPaymentEventDetails.swift in Sources */ = {isa = PBXBuildFile; fileRef = 20762BA22C18A6A300758305 /* CardPresentPaymentEventDetails.swift */; };
 		20762BA52C18B42C00758305 /* CardPresentPaymentBluetoothReaderConnectionAlertsProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 20762BA42C18B42C00758305 /* CardPresentPaymentBluetoothReaderConnectionAlertsProvider.swift */; };
@@ -3774,6 +3775,7 @@
 		205E79452C204387001BA266 /* PointOfSaleCardPresentPaymentCancelledOnReaderMessageViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PointOfSaleCardPresentPaymentCancelledOnReaderMessageViewModel.swift; sourceTree = "<group>"; };
 		205E79472C204B21001BA266 /* PointOfSaleCardPresentPaymentPreparingForPaymentMessageView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PointOfSaleCardPresentPaymentPreparingForPaymentMessageView.swift; sourceTree = "<group>"; };
 		205E794A2C2051B5001BA266 /* PointOfSaleCardPresentPaymentTapSwipeInsertCardMessageView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PointOfSaleCardPresentPaymentTapSwipeInsertCardMessageView.swift; sourceTree = "<group>"; };
+		205E794C2C2057B9001BA266 /* PointOfSaleCardPresentPaymentErrorMessageView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PointOfSaleCardPresentPaymentErrorMessageView.swift; sourceTree = "<group>"; };
 		20762BA02C18A66400758305 /* CardPresentPaymentBuiltInReaderConnectionAlertsProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardPresentPaymentBuiltInReaderConnectionAlertsProvider.swift; sourceTree = "<group>"; };
 		20762BA22C18A6A300758305 /* CardPresentPaymentEventDetails.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardPresentPaymentEventDetails.swift; sourceTree = "<group>"; };
 		20762BA42C18B42C00758305 /* CardPresentPaymentBluetoothReaderConnectionAlertsProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardPresentPaymentBluetoothReaderConnectionAlertsProvider.swift; sourceTree = "<group>"; };
@@ -7624,6 +7626,7 @@
 			children = (
 				205E79472C204B21001BA266 /* PointOfSaleCardPresentPaymentPreparingForPaymentMessageView.swift */,
 				205E794A2C2051B5001BA266 /* PointOfSaleCardPresentPaymentTapSwipeInsertCardMessageView.swift */,
+				205E794C2C2057B9001BA266 /* PointOfSaleCardPresentPaymentErrorMessageView.swift */,
 			);
 			path = "Reader Messages";
 			sourceTree = "<group>";
@@ -14795,6 +14798,7 @@
 				0235595024496853004BE2B8 /* BottomSheetListSelectorViewController.swift in Sources */,
 				57A49128250A7EB2000FEF21 /* OrderListViewController.swift in Sources */,
 				203163BD2C1C9602001C96DA /* PointOfSaleCardPresentPaymentAlertType.swift in Sources */,
+				205E794D2C2057B9001BA266 /* PointOfSaleCardPresentPaymentErrorMessageView.swift in Sources */,
 				DE34771327F174C8009CA300 /* StatusView.swift in Sources */,
 				45DB704A26121F3C0064A6CF /* TitleAndValueRow.swift in Sources */,
 				039298C82A45EE3900F393D5 /* MyStoreRoute.swift in Sources */,


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of: #12868 
Merge after: #13073
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

This PR (primarily) allows the actions associated with payment messages to be used. We show buttons on relevant alerts to cancel or retry the payment in progress.

Additionally, this implements a basic view for some of the payment messages, beyond the simple `Text` that was used as a placeholder up to now.

With this change, it's possible to do full payment flows, including reacting to errors.

These messages are implemented:

- Preparing for payment
- Tap/swipe/insert card
- Payment error
- Payment error (non-retryable)
- Display reader message

Each was implemented in its own commit.

The following messages still need views to be implemented:

- Processing
- Success
- Cancelled on reader
- Validating order

The UI is (obviously) not final yet.

## Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->

1. Launch the app using a US-based store eligible for the new POS experience
2. Navigate to `Menu > Point of Sale`
3. Add something to your cart
4. Tap checkout
5. Tap `Collect payment`
6. Wait for connection to complete
7. Go through the payment process, using a live card (it will error) – observe that the messages are presented as expected.
8. Tap "try again" on the error
9. Use the test card
10. Observe that the payment is successful

Repeat the test only using a test card
Observe that the second error is non-retryable, and only has a cancel button.

## Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->

Note that I needed to add an `.idle` event when cancel is tapped on an error alert. This was sent via the PaymentAlertPresenterAdapter. It would be a bit better if we actually called cancel on the service in this case, but to keep this PR a little simpler I've not done that yet. Broadly, this matches the existing implementation which dismisses the error when cancel is tapped, without cancelling the payment intent.

I've tested this on an iPad air running iOS 16, using an M2 card reader.

Note that "Remove card" is a `displayReaderMessage` instance. The other messages are self-explanatory.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

https://github.com/woocommerce/woocommerce-ios/assets/2472348/a52906cc-3438-4bbe-9197-f333097788d3



---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.