### PR TITLE
[Woo POS] Remove unused code in webview presenting

### DIFF
--- a/WooCommerce/Classes/POS/Card Present Payments/CardPresentPaymentsAlertPresenterAdaptor.swift
+++ b/WooCommerce/Classes/POS/Card Present Payments/CardPresentPaymentsAlertPresenterAdaptor.swift
@@ -18,7 +18,7 @@ final class CardPresentPaymentsAlertPresenterAdaptor: CardPresentPaymentAlertsPr
     }
 
     func presentWCSettingsWebView(adminURL: URL, completion: @escaping () -> Void) {
-        // Web view support in SwiftUI is in the alert's implementation of `CardPresentPaymentsModalViewModelWCSettingsWebViewPresenting`
+        assertionFailure("Web view should be presented within `CardPresentPaymentEventDetails`")
     }
 
     func foundSeveralReaders(readerIDs: [String], connect: @escaping (String) -> Void, cancelSearch: @escaping () -> Void) {

--- a/WooCommerce/Classes/ViewModels/CardPresentPayments/CardPresentModalConnectionFailedUpdateAddress.swift
+++ b/WooCommerce/Classes/ViewModels/CardPresentPayments/CardPresentModalConnectionFailedUpdateAddress.swift
@@ -85,12 +85,6 @@ extension CardPresentModalConnectingFailedUpdateAddress {
     }
 }
 
-extension CardPresentModalConnectingFailedUpdateAddress: CardPresentPaymentsModalViewModelWCSettingsWebViewPresenting {
-    var webViewModel: AnyPublisher<WCSettingsWebViewModel?, Never> {
-        $wcSettingsWebViewModel.eraseToAnyPublisher()
-    }
-}
-
 private extension CardPresentModalConnectingFailedUpdateAddress {
     enum Localization {
         static let title = NSLocalizedString(

--- a/WooCommerce/Classes/ViewModels/CardPresentPayments/CardPresentPaymentsModalViewModelWCSettingsWebViewPresenting.swift
+++ b/WooCommerce/Classes/ViewModels/CardPresentPayments/CardPresentPaymentsModalViewModelWCSettingsWebViewPresenting.swift
@@ -9,7 +9,3 @@ struct WCSettingsWebViewModel: Identifiable {
     let webViewURL: URL
     let onCompletion: () -> Void
 }
-
-protocol CardPresentPaymentsModalViewModelWCSettingsWebViewPresenting {
-    var webViewModel: AnyPublisher<WCSettingsWebViewModel?, Never> { get }
-}


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #12864 
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

While looking at extracting `UIApplication.shared.open(adminUrl)` and after discussing with Josh, we're just going to show the WC settings URL in a webview regardless of the store type (self-hosted/WPCOM) while the URL is presented differently in the [existing app](https://github.com/woocommerce/woocommerce-ios/blob/28e3126911d9cbd6bc821dfee8527fd48dcaa5cb/WooCommerce/Classes/ViewRelated/CardPresentPayments/CardReaderConnectionController.swift#L675-L683) when tapping on the `Edit Address` CTA. Since we're already doing that from https://github.com/woocommerce/woocommerce-ios/issues/12868, we can remove the previous `CardPresentPaymentsModalViewModelWCSettingsWebViewPresenting` protocol now.

## Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->

## Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->

For easier testing, feel free to mock the error by replacing `CardReaderConnectionController.onInitialization` with

```swift
        let url = URL(string: "{{site_url}}/wp-admin/admin.php?page=wc-settings&tab=tax") // just an example
        showConnectionFailed(error: CardReaderServiceError.connection(underlyingError: .incompleteStoreAddress(adminUrl: url)))
```

And then:

Prerequisite: having a self-hosted store eligible for POS

- Switch to a store in the prerequisite if needed
- Turn on the feature switch in Menu > Settings > Experimental Features > POS, if needed
- Go to the Menu tab --> the POS row should appear shortly
- Tap to enter POS
- Tap `Connect now` in the bottom bar --> the error modal should be shown
- Tap `Enter Address` --> it should open the webview modally (make sure the proxy is disabled)
- Tap `Done` --> it should restart reader search

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

Examples are for a self-hosted store.

Existing app:


https://github.com/woocommerce/woocommerce-ios/assets/1945542/186b6ca8-2768-4cd0-80af-14d437e60c67

POS:


https://github.com/woocommerce/woocommerce-ios/assets/1945542/1aeb7435-490a-4606-b741-e4d2c674e7d8


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.