### PR TITLE
[Woo POS] Iteration: Update UI colors

### DIFF
--- a/WooCommerce/Classes/POS/Presentation/CartView.swift
+++ b/WooCommerce/Classes/POS/Presentation/CartView.swift
@@ -11,9 +11,11 @@ struct CartView: View {
         VStack {
             HStack {
                 Text("Cart")
+                    .foregroundColor(Color.posPrimaryTexti3)
                 Spacer()
                 if let temsInCartLabel = viewModel.itemsInCartLabel {
                     Text(temsInCartLabel)
+                        .foregroundColor(Color.posPrimaryTexti3)
                 }
             }
             .frame(maxWidth: .infinity, alignment: .leading)
@@ -28,7 +30,7 @@ struct CartView: View {
                             viewModel.removeItemFromCart(cartItem)
                         }
                         .id(cartItem.id)
-                        .background(Color.tertiaryBackground)
+                        .background(Color.posBackgroundGreyi3)
                         .padding(.horizontal, 32)
                     }
                 }
@@ -52,7 +54,7 @@ struct CartView: View {
             }
         }
         .frame(maxWidth: .infinity)
-        .background(Color.secondaryBackground)
+        .background(Color.posBackgroundWhitei3)
     }
 }
 

--- a/WooCommerce/Classes/POS/Presentation/CartView.swift
+++ b/WooCommerce/Classes/POS/Presentation/CartView.swift
@@ -66,7 +66,7 @@ private extension CartView {
     }
 
     private var checkoutButtonBackgroundColor: Color {
-        return viewModel.checkoutButtonDisabled ? Color.white.opacity(0.5) : Color.white
+        return viewModel.checkoutButtonDisabled ? Color.white.opacity(0.5) : Color.init(uiColor: .wooCommercePurple(.shade60))
     }
 
     var checkoutButton: some View {

--- a/WooCommerce/Classes/POS/Presentation/CartView.swift
+++ b/WooCommerce/Classes/POS/Presentation/CartView.swift
@@ -61,14 +61,6 @@ struct CartView: View {
 /// View sub-components
 ///
 private extension CartView {
-    private var checkoutButtonForegroundColor: Color {
-        return viewModel.checkoutButtonDisabled ? Color.gray : Color.primaryBackground
-    }
-
-    private var checkoutButtonBackgroundColor: Color {
-        return viewModel.checkoutButtonDisabled ? Color.white.opacity(0.5) : Color.init(uiColor: .wooCommercePurple(.shade60))
-    }
-
     var checkoutButton: some View {
         Button {
             viewModel.submitCart()
@@ -79,12 +71,11 @@ private extension CartView {
                 Spacer()
             }
         }
-        .disabled(viewModel.checkoutButtonDisabled)
         .padding(.all, 20)
         .frame(maxWidth: .infinity, idealHeight: 120)
         .font(.title)
-        .foregroundColor(checkoutButtonForegroundColor)
-        .background(checkoutButtonBackgroundColor)
+        .foregroundColor(Color.primaryBackground)
+        .background(Color.init(uiColor: .wooCommercePurple(.shade60)))
         .cornerRadius(10)
     }
 

--- a/WooCommerce/Classes/POS/Presentation/ItemCardView.swift
+++ b/WooCommerce/Classes/POS/Presentation/ItemCardView.swift
@@ -39,14 +39,16 @@ struct ItemCardView: View {
             Spacer()
             Text(item.price)
                 .foregroundStyle(Color.posPrimaryTexti3)
+                .padding()
         }
-        .frame(maxWidth: .infinity)
+        .frame(maxWidth: .infinity, idealHeight: Constants.productCardHeight)
         .background(Color.posBackgroundWhitei3)
     }
 }
 
 private extension ItemCardView {
     enum Constants {
+        static let productCardHeight: CGFloat = 120
         static let productImageWidth: CGFloat = 60
         static let productImageCornerRadius: CGFloat = 0
         static let maxNumberOfCategories = 3

--- a/WooCommerce/Classes/POS/Presentation/ItemCardView.swift
+++ b/WooCommerce/Classes/POS/Presentation/ItemCardView.swift
@@ -32,16 +32,16 @@ struct ItemCardView: View {
             }
             VStack(alignment: .leading) {
                 Text(item.name)
-                    .foregroundStyle(Color.primaryBackground)
+                    .foregroundStyle(Color.posPrimaryTexti3)
                 Text(commaSeparatedItemCategories)
-                    .foregroundStyle(Color.primaryBackground)
+                    .foregroundStyle(Color.posPrimaryTexti3)
             }
             Spacer()
             Text(item.price)
-                .foregroundStyle(Color.primaryBackground)
+                .foregroundStyle(Color.posPrimaryTexti3)
         }
         .frame(maxWidth: .infinity)
-        .background(Color.tertiaryBackground)
+        .background(Color.posBackgroundWhitei3)
     }
 }
 

--- a/WooCommerce/Classes/POS/Presentation/ItemListView.swift
+++ b/WooCommerce/Classes/POS/Presentation/ItemListView.swift
@@ -13,7 +13,7 @@ struct ItemListView: View {
                 .frame(maxWidth: .infinity, alignment: .leading)
                 .padding(.vertical, 8)
                 .font(.title)
-                .foregroundColor(Color.white)
+                .foregroundColor(Color.posPrimaryTexti3)
             ScrollView {
                 ForEach(viewModel.items, id: \.productID) { item in
                     Button(action: {
@@ -25,7 +25,7 @@ struct ItemListView: View {
             }
         }
         .padding(.horizontal, 32)
-        .background(Color.secondaryBackground)
+        .background(Color.posBackgroundGreyi3)
     }
 }
 

--- a/WooCommerce/Classes/POS/Presentation/ItemRowView.swift
+++ b/WooCommerce/Classes/POS/Presentation/ItemRowView.swift
@@ -26,9 +26,12 @@ struct ItemRowView: View {
                     .frame(width: 60 * scale, height: 60 * scale)
                     .foregroundColor(.gray)
             }
-            Text(cartItem.item.name)
-                .padding(.horizontal, 32)
-                .foregroundColor(Color.primaryBackground)
+            VStack(alignment: .leading) {
+                Text(cartItem.item.name)
+                    .foregroundColor(Color.posPrimaryTexti3)
+                Text(cartItem.item.price)
+                    .foregroundColor(Color.posPrimaryTexti3)
+            }
             Spacer()
             Button(action: {
                 onItemRemoveTapped?()
@@ -37,11 +40,9 @@ struct ItemRowView: View {
             })
             .frame(width: 56, height: 56, alignment: .trailing)
             .padding(.horizontal, 32)
-            .foregroundColor(Color.lightBlue)
-            .background(Color(.clear))
+            .foregroundColor(Color.posIconGrayi3)
         }
         .frame(maxWidth: .infinity, idealHeight: 120)
-        .foregroundColor(Color.tertiaryBackground)
     }
 }
 

--- a/WooCommerce/Classes/POS/Presentation/PointOfSaleDashboardView.swift
+++ b/WooCommerce/Classes/POS/Presentation/PointOfSaleDashboardView.swift
@@ -54,7 +54,7 @@ struct PointOfSaleDashboardView: View {
             }
             .padding()
         }
-        .background(Color.primaryBackground)
+        .background(Color.posBackgroundGreyi3)
         .navigationBarBackButtonHidden(true)
         .toolbar {
             ToolbarItem(placement: .bottomBar) {
@@ -94,7 +94,6 @@ private extension PointOfSaleDashboardView {
 
     var cartView: some View {
         CartView(viewModel: viewModel)
-            .background(Color.secondaryBackground)
             .frame(maxWidth: .infinity)
     }
 
@@ -106,7 +105,6 @@ private extension PointOfSaleDashboardView {
 
     var productGridView: some View {
         ItemListView(viewModel: viewModel)
-            .background(Color.secondaryBackground)
             .frame(maxWidth: .infinity)
     }
 }

--- a/WooCommerce/Classes/POS/Utils/Color+WooCommercePOS.swift
+++ b/WooCommerce/Classes/POS/Utils/Color+WooCommercePOS.swift
@@ -14,18 +14,6 @@ extension Color {
         return Color(red: 89.0 / 255.0, green: 181.0 / 255.0, blue: 227.0 / 255.0)
     }
 
-    /// Tertiary POS background color
-    ///
-    static var tertiaryBackground: Color {
-        return Color(red: 142.0 / 255.0, green: 208.0 / 255.0, blue: 240.0 / 255.0)
-    }
-
-    /// POS color: Light Blue
-    ///
-    static var lightBlue: Color {
-        return Color(red: 202.0 / 255.0, green: 237.0 / 255.0, blue: 255.0 / 255.0)
-    }
-
     /// Default POS text color
     ///
     static var primaryText: Color {

--- a/WooCommerce/Classes/POS/Utils/Color+WooCommercePOS.swift
+++ b/WooCommerce/Classes/POS/Utils/Color+WooCommercePOS.swift
@@ -43,4 +43,22 @@ extension Color {
     static var wooAmberShade80: Color {
         Color(red: 123.0 / 255.0, green: 7.0 / 255.0, blue: 0.0 / 255.0)
     }
+
+    /// Colors from hi-fi m: p91TBi-bot-p2
+    /// 
+    static var posPrimaryTexti3: Color {
+        Color(red: 39.0 / 255.0, green: 27.0 / 255.0, blue: 61.0 / 255.0)
+    }
+
+    static var posIconGrayi3: Color {
+        return Color.gray
+    }
+
+    static var posBackgroundGreyi3: Color {
+        Color(red: 246.0 / 255.0, green: 247.0 / 255.0, blue: 247.0 / 255.0)
+    }
+    
+    static var posBackgroundWhitei3: Color {
+        Color.white
+    }
 }

--- a/WooCommerce/Classes/POS/Utils/Color+WooCommercePOS.swift
+++ b/WooCommerce/Classes/POS/Utils/Color+WooCommercePOS.swift
@@ -45,7 +45,7 @@ extension Color {
     }
 
     /// Colors from hi-fi m: p91TBi-bot-p2
-    /// 
+    ///
     static var posPrimaryTexti3: Color {
         Color(red: 39.0 / 255.0, green: 27.0 / 255.0, blue: 61.0 / 255.0)
     }
@@ -57,7 +57,7 @@ extension Color {
     static var posBackgroundGreyi3: Color {
         Color(red: 246.0 / 255.0, green: 247.0 / 255.0, blue: 247.0 / 255.0)
     }
-    
+
     static var posBackgroundWhitei3: Color {
         Color.white
     }

--- a/WooCommerce/Classes/POS/ViewModels/PointOfSaleDashboardViewModel.swift
+++ b/WooCommerce/Classes/POS/ViewModels/PointOfSaleDashboardViewModel.swift
@@ -103,10 +103,6 @@ final class PointOfSaleDashboardViewModel: ObservableObject {
         }
     }
 
-    var checkoutButtonDisabled: Bool {
-        return itemsInCart.isEmpty
-    }
-
     func cardPaymentTapped() {
         Task { @MainActor in
             showsCreatingOrderSheet = true


### PR DESCRIPTION
## Description
This PR updates the colors from i1 (blueish) to i3 (greyish) for Product Selector and Cart. Designs are still not final, this is just an iteration to get closer to the latest update.

## Testing:
* In POS, observe that:
  * The blue-based colors from the initial wireframes are no longer visible
  * The product list items (left) are bigger (~120 height)
  * The cart items (right) show the price as well

❓ Question: @bozidarsevo  I think I can also remove the logic for the checkout button to be disabled, right? Since the Cart view is now hidden if there are no products in the cart, the checkout disabled style will never be shown.

## Screenshots
![simulator_screenshot_8D813300-1A8B-4DC9-A0FA-3C7E896C5F2B](https://github.com/woocommerce/woocommerce-ios/assets/3812076/b2d8403e-cf14-4ce9-b825-1616ec2f55bf)

