### PR TITLE
[Woo POS] Remove unused swiftui modal actions

### DIFF
--- a/WooCommerce/Classes/ViewModels/CardPresentPayments/CardPresentModalBluetoothRequired.swift
+++ b/WooCommerce/Classes/ViewModels/CardPresentPayments/CardPresentModalBluetoothRequired.swift
@@ -56,15 +56,6 @@ final class CardPresentModalBluetoothRequired: CardPresentPaymentsModalViewModel
     func didTapAuxiliaryButton(in viewController: UIViewController?) { }
 }
 
-// CardPresentPaymentsModalViewModelActions
-extension CardPresentModalBluetoothRequired {
-    var secondaryButtonViewModel: CardPresentPaymentsModalButtonViewModel? {
-        CardPresentPaymentsModalButtonViewModel(
-            title: Localization.dismiss,
-            actionHandler: primaryAction)
-    }
-}
-
 private extension CardPresentModalBluetoothRequired {
     enum Localization {
         static let bluetoothRequired = NSLocalizedString(

--- a/WooCommerce/Classes/ViewModels/CardPresentPayments/CardPresentModalBuiltInSuccess.swift
+++ b/WooCommerce/Classes/ViewModels/CardPresentPayments/CardPresentModalBuiltInSuccess.swift
@@ -63,26 +63,6 @@ final class CardPresentModalBuiltInSuccess: CardPresentPaymentsModalViewModel {
     }
 }
 
-// CardPresentPaymentsModalViewModelActions
-/// In the adapted version of the card reader, receipt presentation can be separated from the payment alerts.
-/// The existing print/email handlers won't work directly, as they rely on being able to present a receipt view controller
-/// As a step towards this, we'll only provide the "Save and continue" button here.
-// TODO: Consider changing the text of this button
-extension CardPresentModalBuiltInSuccess {
-    var primaryButtonViewModel: CardPresentPaymentsModalButtonViewModel? {
-        CardPresentPaymentsModalButtonViewModel(title: Localization.saveReceiptAndContinue,
-                                                actionHandler: noReceiptAction)
-    }
-
-    var secondaryButtonViewModel: CardPresentPaymentsModalButtonViewModel? {
-        nil
-    }
-
-    var auxiliaryButtonViewModel: CardPresentPaymentsModalButtonViewModel? {
-        nil
-    }
-}
-
 private extension CardPresentModalBuiltInSuccess {
     enum Localization {
         static let paymentSuccessful = NSLocalizedString(

--- a/WooCommerce/Classes/ViewModels/CardPresentPayments/CardPresentModalBuiltInSuccessWithoutEmail.swift
+++ b/WooCommerce/Classes/ViewModels/CardPresentPayments/CardPresentModalBuiltInSuccessWithoutEmail.swift
@@ -53,26 +53,6 @@ final class CardPresentModalBuiltInSuccessWithoutEmail: CardPresentPaymentsModal
     func didTapAuxiliaryButton(in viewController: UIViewController?) {}
 }
 
-// CardPresentPaymentsModalViewModelActions
-/// In the adapted version of the card reader, receipt presentation can be separated from the payment alerts.
-/// The existing print/email handlers won't work directly, as they rely on being able to present a receipt view controller
-/// As a step towards this, we'll only provide the "Save and continue" button here.
-// TODO: Consider changing the text of this button
-extension CardPresentModalBuiltInSuccessWithoutEmail {
-    var primaryButtonViewModel: CardPresentPaymentsModalButtonViewModel? {
-        CardPresentPaymentsModalButtonViewModel(title: Localization.saveReceiptAndContinue,
-                                                actionHandler: noReceiptAction)
-    }
-
-    var secondaryButtonViewModel: CardPresentPaymentsModalButtonViewModel? {
-        nil
-    }
-
-    var auxiliaryButtonViewModel: CardPresentPaymentsModalButtonViewModel? {
-        nil
-    }
-}
-
 private extension CardPresentModalBuiltInSuccessWithoutEmail {
     enum Localization {
         static let paymentSuccessful = NSLocalizedString(

--- a/WooCommerce/Classes/ViewModels/CardPresentPayments/CardPresentModalConnectionFailedUpdateAddress.swift
+++ b/WooCommerce/Classes/ViewModels/CardPresentPayments/CardPresentModalConnectionFailedUpdateAddress.swift
@@ -67,24 +67,6 @@ final class CardPresentModalConnectingFailedUpdateAddress: CardPresentPaymentsMo
     func didTapAuxiliaryButton(in viewController: UIViewController?) { }
 }
 
-// CardPresentPaymentsModalViewModelActions
-extension CardPresentModalConnectingFailedUpdateAddress {
-    var primaryButtonViewModel: CardPresentPaymentsModalButtonViewModel? {
-        CardPresentPaymentsModalButtonViewModel(
-            title: primaryButtonTitle,
-            actionHandler: { [weak self] in
-                guard let self else { return }
-                if let adminURL = wcSettingsAdminURL {
-                    wcSettingsWebViewModel = .init(webViewURL: adminURL, onCompletion: { [weak self] in
-                        guard let self else { return }
-                        wcSettingsWebViewModel = nil
-                        retrySearchAction()
-                    })
-                }
-            })
-    }
-}
-
 extension CardPresentModalConnectingFailedUpdateAddress: CardPresentPaymentsModalViewModelWCSettingsWebViewPresenting {
     var webViewModel: AnyPublisher<WCSettingsWebViewModel?, Never> {
         $wcSettingsWebViewModel.eraseToAnyPublisher()

--- a/WooCommerce/Classes/ViewModels/CardPresentPayments/CardPresentModalError.swift
+++ b/WooCommerce/Classes/ViewModels/CardPresentPayments/CardPresentModalError.swift
@@ -61,23 +61,6 @@ final class CardPresentModalError: CardPresentPaymentsModalViewModel {
     func didTapAuxiliaryButton(in viewController: UIViewController?) { }
 }
 
-// CardPresentPaymentsModalViewModelActions
-extension CardPresentModalError {
-    var primaryButtonViewModel: CardPresentPaymentsModalButtonViewModel? {
-        CardPresentPaymentsModalButtonViewModel(
-            title: primaryButtonTitle,
-            actionHandler: primaryAction)
-    }
-
-    var secondaryButtonViewModel: CardPresentPaymentsModalButtonViewModel? {
-        // TODO: dismissCompletion is not enough for dismissal.
-        // Find another way to dismiss the alert here. We may need a specialised alert provider to fix this one.
-        CardPresentPaymentsModalButtonViewModel(
-            title: secondaryButtonTitle,
-            actionHandler: dismissCompletion)
-    }
-}
-
 private extension CardPresentModalError {
     enum Localization {
         static func paymentFailed(transactionType: CardPresentTransactionType) -> String {

--- a/WooCommerce/Classes/ViewModels/CardPresentPayments/CardPresentModalNonRetryableError.swift
+++ b/WooCommerce/Classes/ViewModels/CardPresentPayments/CardPresentModalNonRetryableError.swift
@@ -66,17 +66,6 @@ final class CardPresentModalNonRetryableError: CardPresentPaymentsModalViewModel
     func didTapAuxiliaryButton(in viewController: UIViewController?) { }
 }
 
-// CardPresentPaymentsModalViewModelActions
-extension CardPresentModalNonRetryableError {
-    // TODO: onDismiss is not enough for dismissal.
-    // Find another way to dismiss the alert here. We may need a specialised alert provider to fix this one.
-    var primaryButtonViewModel: CardPresentPaymentsModalButtonViewModel? {
-        CardPresentPaymentsModalButtonViewModel(
-            title: Localization.dismiss,
-            actionHandler: onDismiss)
-    }
-}
-
 private extension CardPresentModalNonRetryableError {
     enum Localization {
         static let paymentFailed = NSLocalizedString(

--- a/WooCommerce/Classes/ViewModels/CardPresentPayments/CardPresentModalScanningFailed.swift
+++ b/WooCommerce/Classes/ViewModels/CardPresentPayments/CardPresentModalScanningFailed.swift
@@ -52,15 +52,6 @@ final class CardPresentModalScanningFailed: CardPresentPaymentsModalViewModel {
     func didTapAuxiliaryButton(in viewController: UIViewController?) { }
 }
 
-// CardPresentPaymentsModalViewModelActions
-extension CardPresentModalScanningFailed {
-    var primaryButtonViewModel: CardPresentPaymentsModalButtonViewModel? {
-        CardPresentPaymentsModalButtonViewModel(
-            title: Localization.dismiss,
-            actionHandler: primaryAction)
-    }
-}
-
 private extension CardPresentModalScanningFailed {
     enum Localization {
         static let title = NSLocalizedString(

--- a/WooCommerce/Classes/ViewModels/CardPresentPayments/CardPresentModalSuccess.swift
+++ b/WooCommerce/Classes/ViewModels/CardPresentPayments/CardPresentModalSuccess.swift
@@ -63,26 +63,6 @@ final class CardPresentModalSuccess: CardPresentPaymentsModalViewModel {
     }
 }
 
-// CardPresentPaymentsModalViewModelActions
-/// In the adapted version of the card reader, receipt presentation can be separated from the payment alerts.
-/// The existing print/email handlers won't work directly, as they rely on being able to present a receipt view controller
-/// As a step towards this, we'll only provide the "Save and continue" button here.
-// TODO: Consider changing the text of this button
-extension CardPresentModalSuccess {
-    var primaryButtonViewModel: CardPresentPaymentsModalButtonViewModel? {
-        CardPresentPaymentsModalButtonViewModel(title: Localization.saveReceiptAndContinue,
-                                                actionHandler: noReceiptAction)
-    }
-
-    var secondaryButtonViewModel: CardPresentPaymentsModalButtonViewModel? {
-        nil
-    }
-
-    var auxiliaryButtonViewModel: CardPresentPaymentsModalButtonViewModel? {
-        nil
-    }
-}
-
 private extension CardPresentModalSuccess {
     enum Localization {
         static let paymentSuccessful = NSLocalizedString(

--- a/WooCommerce/Classes/ViewModels/CardPresentPayments/CardPresentModalSuccessWithoutEmail.swift
+++ b/WooCommerce/Classes/ViewModels/CardPresentPayments/CardPresentModalSuccessWithoutEmail.swift
@@ -53,26 +53,6 @@ final class CardPresentModalSuccessWithoutEmail: CardPresentPaymentsModalViewMod
     func didTapAuxiliaryButton(in viewController: UIViewController?) {}
 }
 
-// CardPresentPaymentsModalViewModelActions
-/// In the adapted version of the card reader, receipt presentation can be separated from the payment alerts.
-/// The existing print/email handlers won't work directly, as they rely on being able to present a receipt view controller
-/// As a step towards this, we'll only provide the "Save and continue" button here.
-// TODO: Consider changing the text of this button
-extension CardPresentModalSuccessWithoutEmail {
-    var primaryButtonViewModel: CardPresentPaymentsModalButtonViewModel? {
-        CardPresentPaymentsModalButtonViewModel(title: Localization.saveReceiptAndContinue,
-                                                actionHandler: noReceiptAction)
-    }
-
-    var secondaryButtonViewModel: CardPresentPaymentsModalButtonViewModel? {
-        nil
-    }
-
-    var auxiliaryButtonViewModel: CardPresentPaymentsModalButtonViewModel? {
-        nil
-    }
-}
-
 private extension CardPresentModalSuccessWithoutEmail {
     enum Localization {
         static let paymentSuccessful = NSLocalizedString(

--- a/WooCommerce/Classes/ViewModels/CardPresentPayments/CardPresentModalTapCard.swift
+++ b/WooCommerce/Classes/ViewModels/CardPresentPayments/CardPresentModalTapCard.swift
@@ -77,15 +77,6 @@ final class CardPresentModalTapCard: CardPresentPaymentsModalViewModel {
     }
 }
 
-// CardPresentPaymentsModalViewModelActions
-extension CardPresentModalTapCard {
-    var secondaryButtonViewModel: CardPresentPaymentsModalButtonViewModel? {
-        CardPresentPaymentsModalButtonViewModel(
-            title: Localization.cancel,
-            actionHandler: onCancel)
-    }
-}
-
 private extension CardPresentModalTapCard {
     enum Localization {
         static let readerIsReady = NSLocalizedString(

--- a/WooCommerce/Classes/ViewModels/CardPresentPayments/CardPresentPaymentsModalViewModel.swift
+++ b/WooCommerce/Classes/ViewModels/CardPresentPayments/CardPresentPaymentsModalViewModel.swift
@@ -2,7 +2,6 @@ import UIKit
 
 typealias CardPresentPaymentsModalViewModel = CardPresentPaymentsModalViewModelContent
     & CardPresentPaymentsModalViewModelUIKitActions
-    & CardPresentPaymentsModalViewModelActions
 
 /// Abstracts configuration and contents of the modal screens presented
 /// during operations related to Card Present Payments
@@ -59,34 +58,6 @@ protocol CardPresentPaymentsModalViewModelUIKitActions {
     /// Executes action associated to a tap in the view controller auxiliary button
     /// - Parameter viewController: usually the view controller sending the tap
     func didTapAuxiliaryButton(in viewController: UIViewController?)
-}
-
-protocol CardPresentPaymentsModalViewModelActions {
-    var primaryButtonViewModel: CardPresentPaymentsModalButtonViewModel? { get }
-    var secondaryButtonViewModel: CardPresentPaymentsModalButtonViewModel? { get }
-    var auxiliaryButtonViewModel: CardPresentPaymentsModalButtonViewModel? { get }
-}
-
-/// This is a naive fallback use of the existing UIKit handlers, without passing a view controller.
-/// In general, we should have specific SwiftUI handlers for each view model, but this helps us move forward quickly.
-extension CardPresentPaymentsModalViewModelUIKitActions where Self: CardPresentPaymentsModalViewModelActions {
-    var primaryButtonViewModel: CardPresentPaymentsModalButtonViewModel? {
-        CardPresentPaymentsModalButtonViewModel(title: primaryButtonTitle) {
-            didTapPrimaryButton(in: nil)
-        }
-    }
-
-    var secondaryButtonViewModel: CardPresentPaymentsModalButtonViewModel? {
-        CardPresentPaymentsModalButtonViewModel(title: secondaryButtonTitle) {
-            didTapSecondaryButton(in: nil)
-        }
-    }
-
-    var auxiliaryButtonViewModel: CardPresentPaymentsModalButtonViewModel? {
-        CardPresentPaymentsModalButtonViewModel(title: auxiliaryButtonTitle) {
-            didTapAuxiliaryButton(in: nil)
-        }
-    }
 }
 
 /// The type of card-present transaction.


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #12868
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

This PR removes the initial approach we took to adapting the UIKit card payment modal view models for use in SwiftUI.

We now have a specialised AlertProvider, so these are never used in SwiftUI, and the additional code can be removed.

## Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->

Launch the app on a store eligible for Woo POS

Try a payment using the old experience, and the POS experience.

Check that the buttons in both still work correctly.

## Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

https://github.com/woocommerce/woocommerce-ios/assets/2472348/957cc45a-c47e-47a8-8e91-1506ad3904c5



---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.