### PR TITLE
Add missing track event for when dashboard is loaded

### DIFF
--- a/WooCommerce/Classes/Analytics/WooAnalyticsStat.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsStat.swift
@@ -147,6 +147,7 @@ enum WooAnalyticsStat: String {
 
     // MARK: Dashboard View Events
     //
+    case dashboardLoaded = "dashboard_loaded"
     case dashboardSelected = "main_tab_dashboard_selected"
     case dashboardReselected = "main_tab_dashboard_reselected"
     case dashboardPulledToRefresh = "dashboard_pulled_to_refresh"

--- a/WooCommerce/Classes/ViewRelated/Dashboard/DashboardViewHostingController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/DashboardViewHostingController.swift
@@ -60,6 +60,9 @@ final class DashboardViewHostingController: UIHostingController<DashboardView> {
 
     override func viewDidLoad() {
         super.viewDidLoad()
+
+        ServiceLocator.analytics.track(.dashboardLoaded)
+
         registerUserActivity()
         presentPrivacyBannerIfNeeded()
         observeModalJustInTimeMessages()


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #13089 
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This PR adds a missing event `dashboard_loaded` to track when the dashboard screen is loaded. This is necessary to start funnels to analyze the performance of the dynamic dashboard project.

## Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->
- Log out of the app and log in to a test store.
- After logging in successfully, confirm that the dashboard screen is displayed and event `dashboard_loaded` is tracked.
- Switch to another store and confirm that `dashboard_loaded` is tracked again.
- Relaunch the app and confirm that `dashboard_loaded` is tracked again.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->
N/A

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
