### PR TITLE
[Customers] Fetch customer data from storage

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Customers/CustomerDetailViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Customers/CustomerDetailViewModel.swift
@@ -1,9 +1,11 @@
 import Foundation
 import Yosemite
 import WooFoundation
+import protocol Storage.StorageManagerType
 
 final class CustomerDetailViewModel: ObservableObject {
     private let stores: StoresManager
+    private let storageManager: StorageManagerType
     private let siteID: Int64
     private let customerID: Int64
 
@@ -88,6 +90,14 @@ final class CustomerDetailViewModel: ObservableObject {
 
     @Published private var syncState: CustomerSyncState = .unsynced
 
+    // MARK: Storage
+
+    /// Results controller for stored customer details
+    private lazy var resultsController: ResultsController<StorageCustomer> = {
+        let predicate = NSPredicate(format: "siteID == %lld && customerID == %lld", siteID, customerID)
+        return ResultsController<StorageCustomer>(storageManager: storageManager, matching: predicate, sortedBy: [])
+    }()
+
     init(siteID: Int64,
          customerID: Int64,
          name: String?,
@@ -102,8 +112,10 @@ final class CustomerDetailViewModel: ObservableObject {
          region: String?,
          city: String?,
          postcode: String?,
-         stores: StoresManager = ServiceLocator.stores) {
+         stores: StoresManager = ServiceLocator.stores,
+         storageManager: StorageManagerType = ServiceLocator.storageManager) {
         self.stores = stores
+        self.storageManager = storageManager
         self.siteID = siteID
         self.customerID = customerID
         self.name = name ?? Localization.guestName
@@ -118,11 +130,14 @@ final class CustomerDetailViewModel: ObservableObject {
         self.region = region
         self.city = city
         self.postcode = postcode
+
+        configureResultsController()
     }
 
     convenience init(customer: WCAnalyticsCustomer,
                      currencySettings: CurrencySettings = ServiceLocator.currencySettings,
-                     stores: StoresManager = ServiceLocator.stores) {
+                     stores: StoresManager = ServiceLocator.stores,
+                     storageManager: StorageManagerType = ServiceLocator.storageManager) {
         let currencyFormatter = CurrencyFormatter(currencySettings: currencySettings)
         self.init(siteID: customer.siteID,
                   customerID: customer.userID,
@@ -138,7 +153,8 @@ final class CustomerDetailViewModel: ObservableObject {
                   region: customer.region.nullifyIfEmptyOrWhitespace(),
                   city: customer.city.nullifyIfEmptyOrWhitespace(),
                   postcode: customer.postcode.nullifyIfEmptyOrWhitespace(),
-                  stores: stores)
+                  stores: stores,
+                  storageManager: storageManager)
     }
 
     /// Whether a new order can be created for the customer.
@@ -270,7 +286,7 @@ extension CustomerDetailViewModel {
     }
 }
 
-// MARK: Syncing
+// MARK: Syncing & Storage
 extension CustomerDetailViewModel {
 
     /// Possible sync states for customer data
@@ -288,19 +304,45 @@ extension CustomerDetailViewModel {
             return
         }
 
-        syncState = .syncing
+        // Don't show loading state if we already have customer billing or shipping data to display
+        syncState = billing == nil && shipping == nil ? .syncing : .synced
         let action = CustomerAction.retrieveCustomer(siteID: siteID, customerID: customerID) { [weak self] result in
             guard let self else { return }
             switch result {
-            case let .success(customer):
-                billing = customer.billing
-                shipping = customer.shipping
+            case .success:
+                refreshStoredResults()
             case let .failure(error):
                 DDLogError("⛔️ Error fetching customer details: \(error)")
             }
             syncState = .synced
         }
         stores.dispatch(action)
+    }
+
+    /// Performs initial fetch from storage and updates results.
+    private func configureResultsController() {
+        resultsController.onDidChangeContent = { [weak self] in
+            self?.refreshStoredResults()
+        }
+        resultsController.onDidResetContent = { [weak self] in
+            self?.refreshStoredResults()
+        }
+
+        refreshStoredResults()
+    }
+
+    /// Refreshes locally stored customer data that was synced previously.
+    private func refreshStoredResults() {
+        do {
+            try resultsController.performFetch()
+            guard let customer = resultsController.fetchedObjects.first else {
+                return
+            }
+            billing = customer.billing
+            shipping = customer.shipping
+        } catch {
+            DDLogError("⛔️ Unable to fetch customer from storage: \(error)")
+        }
     }
 }
 


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This is a small performance improvement to the customer details in the Customers section. It adds fetching customer contact details (billing and shipping) from storage. That way, if the customer data is already in storage it will be displayed immediately instead of waiting for a fresh sync.

### How

* Adds and configures a `ResultsController` in `CustomerDetailsViewModel` to fetch the customer billing and shipping address from storage.
* Clarifies the possible loading states (since data could be loaded from storage or loaded/synced from remote) and transitions between states.
* When the remote sync is performed:
   * Only sets the `loading` state if there is no data to display yet.
   * Updates the results from storage after a successful sync.

## Testing steps
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->

1. Start logged out (to ensure there is no stored customer data).
2. Go to the More tab.
3. Open the Customers section.
4. Select a registered customer and confirm you see a loading indicator in the phone and address sections.
5. Confirm the customer phone and billing/shipping addresses are loaded.
6. Go back to the customer list.
7. Select the same customer again and confirm their phone and billing/shipping addresses appear immediately.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

https://github.com/woocommerce/woocommerce-ios/assets/8658164/c2c768f0-8075-4e70-b748-3bbaadabab9d



---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.