### PR TITLE
[Order Creation] Ensure customer list loads if `date_last_active_gmt` is `null`

### DIFF
--- a/Networking/Networking/Model/Copiable/Models+Copiable.generated.swift
+++ b/Networking/Networking/Model/Copiable/Models+Copiable.generated.swift
@@ -3462,7 +3462,7 @@ extension Networking.WCAnalyticsCustomer {
         email: NullableCopiableProp<String> = .copy,
         username: NullableCopiableProp<String> = .copy,
         dateRegistered: NullableCopiableProp<Date> = .copy,
-        dateLastActive: CopiableProp<Date> = .copy,
+        dateLastActive: NullableCopiableProp<Date> = .copy,
         ordersCount: CopiableProp<Int> = .copy,
         totalSpend: CopiableProp<Decimal> = .copy,
         averageOrderValue: CopiableProp<Decimal> = .copy,

--- a/Networking/Networking/Model/WCAnalyticsCustomer.swift
+++ b/Networking/Networking/Model/WCAnalyticsCustomer.swift
@@ -24,7 +24,7 @@ public struct WCAnalyticsCustomer: Decodable, GeneratedCopiable, GeneratedFakeab
     public let dateRegistered: Date?
 
     /// Date customer was last active, in GMT
-    public let dateLastActive: Date
+    public let dateLastActive: Date?
 
     /// Number of orders for the customer
     public let ordersCount: Int
@@ -56,7 +56,7 @@ public struct WCAnalyticsCustomer: Decodable, GeneratedCopiable, GeneratedFakeab
                 email: String?,
                 username: String?,
                 dateRegistered: Date?,
-                dateLastActive: Date,
+                dateLastActive: Date?,
                 ordersCount: Int,
                 totalSpend: Decimal,
                 averageOrderValue: Decimal,
@@ -96,7 +96,7 @@ public struct WCAnalyticsCustomer: Decodable, GeneratedCopiable, GeneratedFakeab
         let email = try container.decode(String.self, forKey: .email)
         let username = try container.decode(String.self, forKey: .username)
         let dateRegistered = try? container.decode(Date.self, forKey: .dateRegisteredGMT)
-        let dateLastActive = try container.decode(Date.self, forKey: .dateLastActiveGMT)
+        let dateLastActive = try? container.decode(Date.self, forKey: .dateLastActiveGMT)
         let ordersCount = try container.decode(Int.self, forKey: .ordersCount)
         let totalSpend = try container.decode(Decimal.self, forKey: .totalSpend)
         let averageOrderValue = try container.decode(Decimal.self, forKey: .avgOrderValue)

--- a/Networking/NetworkingTests/Responses/wc-analytics-customers-without-data.json
+++ b/Networking/NetworkingTests/Responses/wc-analytics-customers-without-data.json
@@ -29,12 +29,12 @@
         "state":"CA",
         "postcode":"94103",
         "date_registered":null,
-        "date_last_active":"2022-07-12T08:36:54",
+        "date_last_active":null,
         "date_last_order":"2022-07-12 08:36:54",
         "orders_count":1,
         "total_spend":10,
         "avg_order_value":10,
         "date_registered_gmt":null,
-        "date_last_active_gmt":"2022-07-12T08:36:54"
+        "date_last_active_gmt":null
     }
 ]

--- a/Networking/NetworkingTests/Responses/wc-analytics-customers.json
+++ b/Networking/NetworkingTests/Responses/wc-analytics-customers.json
@@ -68,13 +68,13 @@
             "state":"CA",
             "postcode":"94103",
             "date_registered":null,
-            "date_last_active":"2022-07-12T08:36:54",
+            "date_last_active":null,
             "date_last_order":"2022-07-12 08:36:54",
             "orders_count":1,
             "total_spend":10,
             "avg_order_value":10,
             "date_registered_gmt":null,
-            "date_last_active_gmt":"2022-07-12T08:36:54"
+            "date_last_active_gmt":null
         }
     ]
 }

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -5,6 +5,7 @@
 - [*] Product Form: Support picking videos from local library for downloadable files. [https://github.com/woocommerce/woocommerce-ios/pull/13051]
 - [*] Disable bookable products from the order creation form. [https://github.com/woocommerce/woocommerce-ios/pull/13022]
 - [internal] Update: ZendeskSupportSDK from v6.0 to v.8.0.3 [https://github.com/woocommerce/woocommerce-ios/pull/12984]
+- [*] Order Creation: Fixes a bug where the customer list would not load when adding a customer to an order, if the store had a customer with no previous activity. [https://github.com/woocommerce/woocommerce-ios/pull/13094]
 
 19.1
 -----

--- a/WooCommerce/Classes/ViewRelated/Customers/CustomerDetailViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Customers/CustomerDetailViewModel.swift
@@ -11,7 +11,7 @@ final class CustomerDetailViewModel: ObservableObject {
     let name: String
 
     /// Date the customer was last active
-    let dateLastActive: String
+    let dateLastActive: String?
 
     /// Customer email
     let email: String?
@@ -91,7 +91,7 @@ final class CustomerDetailViewModel: ObservableObject {
     init(siteID: Int64,
          customerID: Int64,
          name: String?,
-         dateLastActive: String,
+         dateLastActive: String?,
          email: String?,
          ordersCount: String,
          totalSpend: String,
@@ -127,7 +127,7 @@ final class CustomerDetailViewModel: ObservableObject {
         self.init(siteID: customer.siteID,
                   customerID: customer.userID,
                   name: customer.name?.nullifyIfEmptyOrWhitespace(),
-                  dateLastActive: DateFormatter.mediumLengthLocalizedDateFormatter.string(from: customer.dateLastActive),
+                  dateLastActive: customer.dateLastActive.map { DateFormatter.mediumLengthLocalizedDateFormatter.string(from: $0) },
                   email: customer.email?.nullifyIfEmptyOrWhitespace(),
                   ordersCount: customer.ordersCount.description,
                   totalSpend: currencyFormatter.formatAmount(customer.totalSpend) ?? customer.totalSpend.description,

--- a/WooCommerce/WooCommerceTests/ViewRelated/Customers/CustomerDetailViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Customers/CustomerDetailViewModelTests.swift
@@ -18,7 +18,7 @@ final class CustomerDetailViewModelTests: XCTestCase {
         assertEqual(customer.name, vm.name)
         assertEqual(customer.email, vm.email)
         assertEqual(dateFormatter.string(from: try XCTUnwrap(customer.dateRegistered)), vm.dateRegistered)
-        assertEqual(dateFormatter.string(from: customer.dateLastActive), vm.dateLastActive)
+        assertEqual(dateFormatter.string(from: try XCTUnwrap(customer.dateLastActive)), vm.dateLastActive)
         assertEqual(customer.ordersCount.description, vm.ordersCount)
         assertEqual("$10.00", vm.totalSpend)
         assertEqual("$5.00", vm.avgOrderValue)
@@ -35,7 +35,7 @@ final class CustomerDetailViewModelTests: XCTestCase {
                                                        email: "",
                                                        username: "",
                                                        dateRegistered: .some(nil),
-                                                       dateLastActive: Date(),
+                                                       dateLastActive: .some(nil),
                                                        ordersCount: 0,
                                                        totalSpend: 0,
                                                        averageOrderValue: 0,
@@ -49,12 +49,12 @@ final class CustomerDetailViewModelTests: XCTestCase {
 
         // Then
         assertEqual("Guest", vm.name)
-        assertEqual(dateFormatter.string(from: customer.dateLastActive), vm.dateLastActive)
         assertEqual(customer.ordersCount.description, vm.ordersCount)
         assertEqual("$0.00", vm.totalSpend)
         assertEqual("$0.00", vm.avgOrderValue)
         XCTAssertNil(vm.email)
         XCTAssertNil(vm.dateRegistered)
+        XCTAssertNil(vm.dateLastActive)
         XCTAssertNil(vm.country)
         XCTAssertNil(vm.region)
         XCTAssertNil(vm.city)

--- a/Yosemite/Yosemite/Model/Storage/WCAnalyticsCustomer+ReadOnlyConvertible.swift
+++ b/Yosemite/Yosemite/Model/Storage/WCAnalyticsCustomer+ReadOnlyConvertible.swift
@@ -37,7 +37,7 @@ extension Storage.WCAnalyticsCustomer: ReadOnlyConvertible {
                                    email: email,
                                    username: username,
                                    dateRegistered: dateRegistered,
-                                   dateLastActive: dateLastActive ?? Date(),
+                                   dateLastActive: dateLastActive,
                                    ordersCount: Int(ordersCount),
                                    totalSpend: totalSpend?.decimalValue ?? 0,
                                    averageOrderValue: averageOrderValue?.decimalValue ?? 0,


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #13092
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This fixes a bug where the customer list (e.g. in order creation) failed to load if the API returned `null` for a customer's `date_last_active_gmt` field.

We now handle decoding the `WCAnalyticsCustomer` entity when that field is `null`, and handle the `null` value in the UI (in the Customers section).

## Testing steps
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->

1. Add a new customer to your test store (in wp-admin).
2. In the app, go to the Orders tab.
3. Tap the + button to create a new order.
4. Add an existing customer to the order; confirm the customer list loads and you can select the newly added customer.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

Before|After
-|-
![Simulator Screenshot - iPhone 15 Plus - 2024-06-19 at 15 20 29](https://github.com/woocommerce/woocommerce-ios/assets/8658164/205567f7-5468-48e3-8449-517974b96f71)|![Simulator Screenshot - iPhone 15 Plus - 2024-06-19 at 15 21 41](https://github.com/woocommerce/woocommerce-ios/assets/8658164/d208f01b-69f1-4da6-964f-db7544fe28a8)

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.