### PR TITLE
Dynamic Dashboard: Parse product reports' stock quantity using Decimal instead of Int

### DIFF
--- a/Networking/Networking.xcodeproj/project.pbxproj
+++ b/Networking/Networking.xcodeproj/project.pbxproj
@@ -1007,6 +1007,7 @@
 		DE78DE4A2B2AEC7F002E58DE /* wp-page-list-success.json in Resources */ = {isa = PBXBuildFile; fileRef = DE78DE492B2AEC7F002E58DE /* wp-page-list-success.json */; };
 		DE78DE4C2B2AED4C002E58DE /* WordPressPageMapperTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE78DE4B2B2AED4C002E58DE /* WordPressPageMapperTests.swift */; };
 		DE78DE4E2B2BF0EA002E58DE /* product-subscription-alternative-types.json in Resources */ = {isa = PBXBuildFile; fileRef = DE78DE4D2B2BF0EA002E58DE /* product-subscription-alternative-types.json */; };
+		DE970D842C23E3F60019EF42 /* product-report-string-stock-quantity.json in Resources */ = {isa = PBXBuildFile; fileRef = DE970D832C23E3F60019EF42 /* product-report-string-stock-quantity.json */; };
 		DE97C3922861B8E20042E973 /* CouponEncoderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE97C3912861B8E20042E973 /* CouponEncoderTests.swift */; };
 		DE9D6BCC270D769C00BA6562 /* shipping-label-address-without-name-validation-success.json in Resources */ = {isa = PBXBuildFile; fileRef = DE9D6BCB270D769B00BA6562 /* shipping-label-address-without-name-validation-success.json */; };
 		DE9DEEF5291CF1B40070AD7C /* site-plugin-without-envelope.json in Resources */ = {isa = PBXBuildFile; fileRef = DE9DEEF4291CF1B40070AD7C /* site-plugin-without-envelope.json */; };
@@ -2130,6 +2131,7 @@
 		DE78DE492B2AEC7F002E58DE /* wp-page-list-success.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "wp-page-list-success.json"; sourceTree = "<group>"; };
 		DE78DE4B2B2AED4C002E58DE /* WordPressPageMapperTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WordPressPageMapperTests.swift; sourceTree = "<group>"; };
 		DE78DE4D2B2BF0EA002E58DE /* product-subscription-alternative-types.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "product-subscription-alternative-types.json"; sourceTree = "<group>"; };
+		DE970D832C23E3F60019EF42 /* product-report-string-stock-quantity.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "product-report-string-stock-quantity.json"; sourceTree = "<group>"; };
 		DE97C3912861B8E20042E973 /* CouponEncoderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CouponEncoderTests.swift; sourceTree = "<group>"; };
 		DE9D6BCB270D769B00BA6562 /* shipping-label-address-without-name-validation-success.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "shipping-label-address-without-name-validation-success.json"; sourceTree = "<group>"; };
 		DE9DEEF4291CF1B40070AD7C /* site-plugin-without-envelope.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "site-plugin-without-envelope.json"; sourceTree = "<group>"; };
@@ -2936,6 +2938,7 @@
 		B559EBA820A0B5B100836CD4 /* Responses */ = {
 			isa = PBXGroup;
 			children = (
+				DE970D832C23E3F60019EF42 /* product-report-string-stock-quantity.json */,
 				DE2004752C001F7500660A72 /* variation-report.json */,
 				DE20046F2BFB535500660A72 /* product-report.json */,
 				DE2004712BFB536900660A72 /* product-report-without-data-envelope.json */,
@@ -4411,6 +4414,7 @@
 				CC0786632678F79500BA9AC1 /* shipping-label-purchase-success.json in Resources */,
 				DE4F2A3F29750EF400B0701C /* inbox-note-list-without-data.json in Resources */,
 				7497376A2141F2BE0008C490 /* top-performers-week-alt.json in Resources */,
+				DE970D842C23E3F60019EF42 /* product-report-string-stock-quantity.json in Resources */,
 				DEEDA4442975003800F845AB /* settings-general-without-data.json in Resources */,
 				EE66BB042B28975B00518DAF /* theme-install-already-installed.json in Resources */,
 				D865CE61278CA1AE002C8520 /* stripe-payment-intent-processing.json in Resources */,

--- a/Networking/Networking/Model/Copiable/Models+Copiable.generated.swift
+++ b/Networking/Networking/Model/Copiable/Models+Copiable.generated.swift
@@ -2287,7 +2287,7 @@ extension Networking.ProductReport {
         name: CopiableProp<String> = .copy,
         imageURL: NullableCopiableProp<URL> = .copy,
         itemsSold: CopiableProp<Int> = .copy,
-        stockQuantity: CopiableProp<Int> = .copy
+        stockQuantity: NullableCopiableProp<Decimal> = .copy
     ) -> Networking.ProductReport {
         let productID = productID ?? self.productID
         let variationID = variationID ?? self.variationID
@@ -2311,7 +2311,7 @@ extension Networking.ProductReport.ExtendedInfo {
     public func copy(
         name: CopiableProp<String> = .copy,
         image: NullableCopiableProp<String> = .copy,
-        stockQuantity: CopiableProp<Int> = .copy
+        stockQuantity: NullableCopiableProp<Decimal> = .copy
     ) -> Networking.ProductReport.ExtendedInfo {
         let name = name ?? self.name
         let image = image ?? self.image

--- a/Networking/Networking/Model/Product/ProductReport.swift
+++ b/Networking/Networking/Model/Product/ProductReport.swift
@@ -9,14 +9,14 @@ public struct ProductReport: Decodable, Equatable, GeneratedCopiable, GeneratedF
     public let name: String
     public let imageURL: URL?
     public let itemsSold: Int
-    public let stockQuantity: Int
+    public let stockQuantity: Decimal?
 
     public init(productID: Int64,
                 variationID: Int64?,
                 name: String,
                 imageURL: URL? = nil,
                 itemsSold: Int,
-                stockQuantity: Int) {
+                stockQuantity: Decimal?) {
         self.productID = productID
         self.variationID = variationID
         self.itemsSold = itemsSold
@@ -55,14 +55,27 @@ public extension ProductReport {
     struct ExtendedInfo: Decodable, Equatable, GeneratedCopiable, GeneratedFakeable {
         public let name: String
         public let image: String?
-        public let stockQuantity: Int
+        public let stockQuantity: Decimal?
 
         public init(name: String,
                     image: String?,
-                    stockQuantity: Int) {
+                    stockQuantity: Decimal?) {
             self.name = name
             self.image = image
             self.stockQuantity = stockQuantity
+        }
+
+        public init(from decoder: Decoder) throws {
+            let container = try decoder.container(keyedBy: CodingKeys.self)
+            let name = try container.decode(String.self, forKey: .name)
+            let image = try container.decodeIfPresent(String.self, forKey: .image)
+
+            // Even though WooCommerce Core returns Int or null values,
+            // some plugins alter the field value from Int to Decimal or String.
+            // We handle this as an optional Decimal value.
+            let stockQuantity = container.failsafeDecodeIfPresent(decimalForKey: .stockQuantity)
+
+            self.init(name: name, image: image, stockQuantity: stockQuantity)
         }
 
         private enum CodingKeys: String, CodingKey {

--- a/Networking/NetworkingTests/Mapper/ProductReportListMapperTests.swift
+++ b/Networking/NetworkingTests/Mapper/ProductReportListMapperTests.swift
@@ -31,6 +31,20 @@ final class ProductReportListMapperTests: XCTestCase {
         XCTAssertEqual(firstItem.imageURL?.absoluteString, "https://test.ninja/wp-content/uploads/2024/05/img-laboriosam-300x300.png")
     }
 
+    func test_product_reports_with_string_stock_quantity_are_properly_parsed() throws {
+        // When
+        let list = mapProductReports(from: "product-report-string-stock-quantity")
+
+        // Then
+        XCTAssertEqual(list.count, 1)
+        let firstItem = try XCTUnwrap(list.first)
+        XCTAssertEqual(firstItem.productID, 248)
+        XCTAssertEqual(firstItem.name, "Fantastic Concrete Shirt")
+        XCTAssertEqual(firstItem.itemsSold, 8)
+        XCTAssertEqual(firstItem.stockQuantity, 55)
+        XCTAssertEqual(firstItem.imageURL?.absoluteString, "https://test.ninja/wp-content/uploads/2024/05/img-laboriosam-300x300.png")
+    }
+
     func test_variation_reports_are_properly_parsed() throws {
         // When
         let list = mapProductReports(from: "variation-report")

--- a/Networking/NetworkingTests/Mapper/ProductReportListMapperTests.swift
+++ b/Networking/NetworkingTests/Mapper/ProductReportListMapperTests.swift
@@ -41,7 +41,7 @@ final class ProductReportListMapperTests: XCTestCase {
         XCTAssertEqual(firstItem.productID, 248)
         XCTAssertEqual(firstItem.name, "Fantastic Concrete Shirt")
         XCTAssertEqual(firstItem.itemsSold, 8)
-        XCTAssertEqual(firstItem.stockQuantity, 55)
+        XCTAssertEqual(firstItem.stockQuantity, 55.4)
         XCTAssertEqual(firstItem.imageURL?.absoluteString, "https://test.ninja/wp-content/uploads/2024/05/img-laboriosam-300x300.png")
     }
 

--- a/Networking/NetworkingTests/Responses/product-report-string-stock-quantity.json
+++ b/Networking/NetworkingTests/Responses/product-report-string-stock-quantity.json
@@ -1,0 +1,27 @@
+{
+    "data": [
+        {
+          "product_id": 248,
+          "items_sold": 8,
+          "net_revenue": 6235.52,
+          "orders_count": 1,
+          "extended_info": {
+            "name": "Fantastic Concrete Shirt",
+            "price": 779.44,
+            "image": "<img width=\"300\" height=\"300\" src=\"https://test.ninja/wp-content/uploads/2024/05/img-laboriosam-300x300.png\" class=\"attachment-woocommerce_thumbnail size-woocommerce_thumbnail\" alt=\"\" decoding=\"async\" loading=\"lazy\" srcset=\"https://test.ninja/wp-content/uploads/2024/05/img-laboriosam-300x300.png 300w, https://test.ninja/wp-content/uploads/2024/05/img-laboriosam-150x150.png 150w, https://test.ninja/wp-content/uploads/2024/05/img-laboriosam-600x600.png 600w, https://test.ninja/wp-content/uploads/2024/05/img-laboriosam-100x100.png 100w, https://test.ninja/wp-content/uploads/2024/05/img-laboriosam.png 700w\" sizes=\"(max-width: 300px) 100vw, 300px\" />",
+            "permalink": "https://test.ninja/product/fantastic-concrete-shirt/?attribute_omnis-beatae-quaerat=ex&attribute_pa_numeric-size=7&attribute_pa_color=pink",
+            "stock_status": "instock",
+            "stock_quantity": "55",
+            "low_stock_amount": 2,
+            "sku": "fantastic-concrete-shirt-64346342"
+          },
+          "_links": {
+            "product": [
+              {
+                "href": "https://test.ninja/wp-json/wc-analytics/products/248"
+              }
+            ]
+          }
+        }
+      ]
+}

--- a/Networking/NetworkingTests/Responses/product-report-string-stock-quantity.json
+++ b/Networking/NetworkingTests/Responses/product-report-string-stock-quantity.json
@@ -11,7 +11,7 @@
             "image": "<img width=\"300\" height=\"300\" src=\"https://test.ninja/wp-content/uploads/2024/05/img-laboriosam-300x300.png\" class=\"attachment-woocommerce_thumbnail size-woocommerce_thumbnail\" alt=\"\" decoding=\"async\" loading=\"lazy\" srcset=\"https://test.ninja/wp-content/uploads/2024/05/img-laboriosam-300x300.png 300w, https://test.ninja/wp-content/uploads/2024/05/img-laboriosam-150x150.png 150w, https://test.ninja/wp-content/uploads/2024/05/img-laboriosam-600x600.png 600w, https://test.ninja/wp-content/uploads/2024/05/img-laboriosam-100x100.png 100w, https://test.ninja/wp-content/uploads/2024/05/img-laboriosam.png 700w\" sizes=\"(max-width: 300px) 100vw, 300px\" />",
             "permalink": "https://test.ninja/product/fantastic-concrete-shirt/?attribute_omnis-beatae-quaerat=ex&attribute_pa_numeric-size=7&attribute_pa_color=pink",
             "stock_status": "instock",
-            "stock_quantity": "55",
+            "stock_quantity": "55.4",
             "low_stock_amount": 2,
             "sku": "fantastic-concrete-shirt-64346342"
           },

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -8,6 +8,7 @@
 - [*] Disable bookable products from the order creation form. [https://github.com/woocommerce/woocommerce-ios/pull/13022]
 - [internal] Update: ZendeskSupportSDK from v6.0 to v.8.0.3 [https://github.com/woocommerce/woocommerce-ios/pull/12984]
 - [*] Order Creation: Fixes a bug where the customer list would not load when adding a customer to an order, if the store had a customer with no previous activity. [https://github.com/woocommerce/woocommerce-ios/pull/13094]
+- [*] Dynamic dashboard: Fix potential issue rendering Stock card when stock quantity is non-integer. [https://github.com/woocommerce/woocommerce-ios/pull/13098]
 
 19.1
 -----

--- a/WooCommerce/Classes/ViewRelated/Dashboard/ProductStock/ProductStockDashboardCard.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/ProductStock/ProductStockDashboardCard.swift
@@ -162,7 +162,7 @@ private extension ProductStockDashboardCard {
                                     .multilineTextAlignment(.leading)
                                 }
                                 Spacer()
-                                Text("\(element.stockQuantity)")
+                                Text("\(element.stockQuantity ?? 0)")
                                     .foregroundStyle(Color(.error))
                                     .bodyStyle()
                                     .fontWeight(.semibold)

--- a/WooCommerce/Classes/ViewRelated/Dashboard/ProductStock/ProductStockDashboardCard.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/ProductStock/ProductStockDashboardCard.swift
@@ -162,7 +162,7 @@ private extension ProductStockDashboardCard {
                                     .multilineTextAlignment(.leading)
                                 }
                                 Spacer()
-                                Text("\(element.stockQuantity ?? 0)")
+                                Text("\(Decimal(4.6))")
                                     .foregroundStyle(Color(.error))
                                     .bodyStyle()
                                     .fontWeight(.semibold)

--- a/WooCommerce/Classes/ViewRelated/Dashboard/ProductStock/ProductStockDashboardCard.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/ProductStock/ProductStockDashboardCard.swift
@@ -162,7 +162,7 @@ private extension ProductStockDashboardCard {
                                     .multilineTextAlignment(.leading)
                                 }
                                 Spacer()
-                                Text("\(Decimal(4.6))")
+                                Text("\(element.stockQuantity ?? 0)")
                                     .foregroundStyle(Color(.error))
                                     .bodyStyle()
                                     .fontWeight(.semibold)

--- a/WooCommerce/Classes/ViewRelated/Dashboard/ProductStock/ProductStockDashboardCardViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/ProductStock/ProductStockDashboardCardViewModel.swift
@@ -42,7 +42,7 @@ final class ProductStockDashboardCardViewModel: ObservableObject {
             reports = stock.compactMap { item in
                 savedReports[item.productID]
             }
-            .sorted { $0.stockQuantity < $1.stockQuantity }
+            .sorted { ($0.stockQuantity ?? 0) < ($1.stockQuantity ?? 0) }
         } catch {
             syncingError = error
         }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #13097 
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
We are currently parsing `stockQuantity` in `ProductReport` as Int, but some plugins like [Smart Product Quantity](https://woocommerce.com/products/smart-product-quantity/) can alter the type to double.

This PR updates the type of `stockQuantity` to `Decimal` to ensure that the stock card are rendered properly in this edge case.

## Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->
- Since Smart Product Quantity is a paid extension, we might not want to add it to our test store just for testing. A simpler way to check is to set the [value](https://github.com/woocommerce/woocommerce-ios/blob/6007cc806f4df1705ac555ada24c5f095aa00528/WooCommerce/Classes/ViewRelated/Dashboard/ProductStock/ProductStockDashboardCard.swift#L165) in `ProductStockDashboardCard` to `Decimal("7.6")` to ensure the value is displayed correctly.
- Unit tests have been added to ensure that parsing non-int quantity works as expected.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->
<img src="https://github.com/woocommerce/woocommerce-ios/assets/5533851/64fe3efd-0cd5-456e-94bd-fc3c2ce78b8e" width=320 />


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
