### PR TITLE
[Woo POS] Update POS entry point accessory icon

### DIFF
--- a/WooCommerce/Classes/Extensions/UIImage+Woo.swift
+++ b/WooCommerce/Classes/Extensions/UIImage+Woo.swift
@@ -1063,10 +1063,10 @@ extension UIImage {
             .imageFlippedForRightToLeftLayoutDirection()
     }
 
-    /// Play square image
+    /// Switching mode image
     ///
-    static var playSquareImage: UIImage {
-        UIImage(systemName: "play.square")!
+    static var switchingModeImage: UIImage {
+        UIImage(systemName: "arrow.left.arrow.right")!
     }
 
     /// Plus Icon

--- a/WooCommerce/Classes/ViewRelated/Hub Menu/HubMenu.swift
+++ b/WooCommerce/Classes/ViewRelated/Hub Menu/HubMenu.swift
@@ -252,7 +252,7 @@ private extension HubMenu {
                 case .leading:
                     return .chevronImage
                 case .enteringMode:
-                    return .playSquareImage
+                    return .switchingModeImage
                         .withTintColor(.secondaryLabel, renderingMode: .alwaysTemplate)
                 }
             }

--- a/WooCommerce/WooCommerceTests/Extensions/IconsTests.swift
+++ b/WooCommerce/WooCommerceTests/Extensions/IconsTests.swift
@@ -494,8 +494,8 @@ final class IconsTests: XCTestCase {
         XCTAssertNotNil(UIImage.print)
     }
 
-    func test_playSquareImage_is_not_nil() {
-        XCTAssertNotNil(UIImage.playSquareImage)
+    func test_switchingModeImage_is_not_nil() {
+        XCTAssertNotNil(UIImage.switchingModeImage)
     }
 
     func testPlusImageIconIsNotNil() {


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #12779 
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

This accessory icon was updated after the main dev work was done from a p2 suggestion, and this PR updates it to match the final design.

## Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->

Prerequisite: the store is eligible for POS and the feature switch is enabled in Menu > Settings > Experimental Features > POS
* Launch app
* Go to Menu --> the Point of Sale row should have the "mode switching" icon as in the design (not sure why design shorthand stopped working for me TfaZ4LUkEwEGrxfnEFzvJj/WooCommerce-POS?node-id=207-7690&t=adlqGSVP1I5CpBV7-0)

## Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

- [x] @jaclync tests in both light and dark modes

before | after
-- | --
![Simulator Screenshot - iPad (10th generation) - 2024-06-21 at 09 23 09](https://github.com/woocommerce/woocommerce-ios/assets/1945542/662be55f-a199-48fd-bd15-14269d0306ae) | ![Simulator Screenshot - iPad (10th generation) - 2024-06-21 at 09 25 37](https://github.com/woocommerce/woocommerce-ios/assets/1945542/8064be3c-54b2-4e8f-a620-8dd4d3b9336d)


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.