### PR TITLE
[Mobile Payents] Prevent use of stale readers after cancelling discovery

### DIFF
--- a/Hardware/Hardware/CardReader/StripeCardReader/StripeCardReaderService.swift
+++ b/Hardware/Hardware/CardReader/StripeCardReader/StripeCardReaderService.swift
@@ -1023,6 +1023,7 @@ private extension StripeCardReaderService {
     func switchStatusToIdle() {
         updateDiscoveryStatus(to: .idle)
         resetDiscoveredReadersSubject()
+        discoveredStripeReadersCache.clear()
     }
 
     func switchStatusToDiscovering() {
@@ -1032,6 +1033,7 @@ private extension StripeCardReaderService {
     func switchStatusToFault(error: Error) {
         updateDiscoveryStatus(to: .fault)
         resetDiscoveredReadersSubject(error: error)
+        discoveredStripeReadersCache.clear()
     }
 
     func updateDiscoveryStatus(to newStatus: CardReaderServiceDiscoveryStatus) {

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -2,7 +2,7 @@
 
 19.3
 -----
-
+- [*] Payments: fixed issue when connecting to a card reader after cancelling reader discovery [https://github.com/woocommerce/woocommerce-ios/issues/13125]
 
 19.2
 -----


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #13122 
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

This PR fixes an issue where it became impossible, or at least difficult, to connect to a reader after cancelling a previous connection attempt.

We cache readers found in the StripeCardReaderService. Stripe warn us not to reuse these, and after a successful connection we do discard them.

However, after cancelling a discovery, or facing an error, we _don’t_. This leads to us trying to connect to stale reader objects, which results in a never-ending connection attempt.

This PR clears the cache when we cancel or error in the discovery process.

## Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->

1. Go to Menu > Payments > Manage Card Reader
2. Tap `Connect card reader`
3. Tap `Cancel` on the alert asking if you want to connect a particular reader
4. Tap `Connect card reader` again
5. Tap `Connect` on the reader connection alert
6. Observe that the reader connects successfully (previously, it would have stayed stuck on the "connecting" screen)

## Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->

Consider testing this under #13126 

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->


https://github.com/woocommerce/woocommerce-ios/assets/2472348/5a6a39f9-42a8-4d1e-8b0a-1c54d6d79896


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.