### PR TITLE
[Mobile Payments] Fix connecting reader after error

### DIFF
--- a/Hardware/Hardware/CardReader/StripeCardReader/StripeCardReaderService.swift
+++ b/Hardware/Hardware/CardReader/StripeCardReader/StripeCardReaderService.swift
@@ -543,6 +543,8 @@ extension StripeCardReaderService: CardReaderService {
                     let serviceError: CardReaderServiceError = underlyingError.isSoftwareUpdateError ?
                         .softwareUpdate(underlyingError: underlyingError, batteryLevel: batteryLevel) :
                         .connection(underlyingError: underlyingError)
+
+                    self.switchStatusToFault(error: serviceError)
                     promise(.failure(serviceError))
                 }
 

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -3,6 +3,7 @@
 19.3
 -----
 - [*] Payments: fixed issue when connecting to a card reader after cancelling reader discovery [https://github.com/woocommerce/woocommerce-ios/issues/13125]
+- [*] Payments: fixed issue when connecting to a card reader after an error during reader connection [https://github.com/woocommerce/woocommerce-ios/pull/13126]
 
 19.2
 -----


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #13123
Merge after: #13125 
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

This PR fixes an issue when trying a second connection after an error during reader connection, which made it impossible to connect to another reader.

On the second connection attempt, the last found reader would be immediately presented as an option for the user to connect to.

Unfortunately, this was a stale representation of the reader and would be sent even if the reader in question was turned off.

This was due to the state not being reset after a connection error

Discovery errors already cleared the state of the CardReaderService, but errors during connection do not.

This PR fixes that issue by switching the service to a fault state when the user acknowledges the error.

## Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->

1. Launch the app
2. Navigate to `Menu > Payments > Manage Card Reader`
3. Tap `Connect Card Reader`
4. Tap `Connect to reader` to start the connection to a reader, then immediately turn the reader off
5. When you're shown the error, tap `Cancel`
6. Tap `Connect to reader` again, leaving your reader off
7. Observe that the "Scanning for reader" alert is shown while it does a proper search for readers
8. Turn your reader on
9. Tap `Connect` on the found alert that shows up
10. Observe that after a few seconds, the reader connects correctly.

## Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->

Consider testing #13125 at the same time as this PR.

This changes the handling of connection errors, and software update errors for required updates. We should make sure that it works correctly with both types.

The only software update error we can trigger using the simulator is `lowBattery` – that does display some strange behaviour before the fix, which is improved with this.

Note that the `Try again` button will never find the reader which triggered the error. This seems deliberate, and I don't intend to change that behaviour here, though for this error it would _arguably_ be better if previously-found readers are available to choose from.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->


https://github.com/woocommerce/woocommerce-ios/assets/2472348/9a54012a-4bfa-47b9-b387-3af8bf9a03aa


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.