### PR TITLE
Google Ads: Integrate connection check endpoint on Networking layer

### DIFF
--- a/Fakes/Fakes/Networking.generated.swift
+++ b/Fakes/Fakes/Networking.generated.swift
@@ -571,6 +571,18 @@ extension Networking.GiftCardStatsTotals {
         )
     }
 }
+extension Networking.GoogleAdsConnection {
+    /// Returns a "ready to use" type filled with fake values.
+    ///
+    public static func fake() -> Networking.GoogleAdsConnection {
+        .init(
+            id: .fake(),
+            currency: .fake(),
+            symbol: .fake(),
+            rawStatus: .fake()
+        )
+    }
+}
 extension Networking.InboxAction {
     /// Returns a "ready to use" type filled with fake values.
     ///

--- a/Networking/Networking.xcodeproj/project.pbxproj
+++ b/Networking/Networking.xcodeproj/project.pbxproj
@@ -1023,6 +1023,8 @@
 		DEA6B1CA296D0E8B005AA5E9 /* systemStatus-without-data.json in Resources */ = {isa = PBXBuildFile; fileRef = DEA6B1C8296D0E8A005AA5E9 /* systemStatus-without-data.json */; };
 		DEB387732C2A8F9A0025256E /* GoogleAdsConnection.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEB387722C2A8F9A0025256E /* GoogleAdsConnection.swift */; };
 		DEB387762C2A9A140025256E /* GoogleAdsConnectionMapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEB387752C2A9A140025256E /* GoogleAdsConnectionMapper.swift */; };
+		DEB387782C2A9ADC0025256E /* gla-connection-with-data-envelope.json in Resources */ = {isa = PBXBuildFile; fileRef = DEB387772C2A9ADC0025256E /* gla-connection-with-data-envelope.json */; };
+		DEB3877A2C2A9B1E0025256E /* gla-connection-without-data-envelope.json in Resources */ = {isa = PBXBuildFile; fileRef = DEB387792C2A9B1E0025256E /* gla-connection-without-data-envelope.json */; };
 		DEC2961C26BBE764005A056B /* ShippingLabelCustomsForm.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEC2961B26BBE764005A056B /* ShippingLabelCustomsForm.swift */; };
 		DEC2B08D297AA048003923FB /* reviews-all-without-data.json in Resources */ = {isa = PBXBuildFile; fileRef = DEC2B08C297AA048003923FB /* reviews-all-without-data.json */; };
 		DEC2B08F297AA123003923FB /* reviews-single-without-data.json in Resources */ = {isa = PBXBuildFile; fileRef = DEC2B08E297AA123003923FB /* reviews-single-without-data.json */; };
@@ -2149,6 +2151,8 @@
 		DEA6B1C8296D0E8A005AA5E9 /* systemStatus-without-data.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "systemStatus-without-data.json"; sourceTree = "<group>"; };
 		DEB387722C2A8F9A0025256E /* GoogleAdsConnection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GoogleAdsConnection.swift; sourceTree = "<group>"; };
 		DEB387752C2A9A140025256E /* GoogleAdsConnectionMapper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GoogleAdsConnectionMapper.swift; sourceTree = "<group>"; };
+		DEB387772C2A9ADC0025256E /* gla-connection-with-data-envelope.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "gla-connection-with-data-envelope.json"; sourceTree = "<group>"; };
+		DEB387792C2A9B1E0025256E /* gla-connection-without-data-envelope.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "gla-connection-without-data-envelope.json"; sourceTree = "<group>"; };
 		DEC2961B26BBE764005A056B /* ShippingLabelCustomsForm.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShippingLabelCustomsForm.swift; sourceTree = "<group>"; };
 		DEC2B08C297AA048003923FB /* reviews-all-without-data.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "reviews-all-without-data.json"; sourceTree = "<group>"; };
 		DEC2B08E297AA123003923FB /* reviews-single-without-data.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "reviews-single-without-data.json"; sourceTree = "<group>"; };
@@ -2943,6 +2947,8 @@
 		B559EBA820A0B5B100836CD4 /* Responses */ = {
 			isa = PBXGroup;
 			children = (
+				DEB387772C2A9ADC0025256E /* gla-connection-with-data-envelope.json */,
+				DEB387792C2A9B1E0025256E /* gla-connection-without-data-envelope.json */,
 				DE970D832C23E3F60019EF42 /* product-report-string-stock-quantity.json */,
 				DE2004752C001F7500660A72 /* variation-report.json */,
 				DE20046F2BFB535500660A72 /* product-report.json */,
@@ -4243,6 +4249,7 @@
 				2683D70E24456DB8002A1589 /* categories-empty.json in Resources */,
 				D865CE67278CA225002C8520 /* stripe-payment-intent-succeeded.json in Resources */,
 				02EFF81E2ABC3D0E0015ABB2 /* order-gift-card-cannot-apply-error.json in Resources */,
+				DEB3877A2C2A9B1E0025256E /* gla-connection-without-data-envelope.json in Resources */,
 				20D210C32B1780CE0099E517 /* deposits-overview-all.json in Resources */,
 				DE66C5652977CC4300DAA978 /* shipping-label-purchase-success-without-data.json in Resources */,
 				DE74F2A027E3137F0002FE59 /* setting-analytics.json in Resources */,
@@ -4404,6 +4411,7 @@
 				EE57C125297EB4E300BC31E7 /* product-attributes-all-without-data.json in Resources */,
 				DE2004592BF6142200660A72 /* product-stock.json in Resources */,
 				31054714262E2F3B00C5C02B /* wcpay-payment-intent-requires-payment-method.json in Resources */,
+				DEB387782C2A9ADC0025256E /* gla-connection-with-data-envelope.json in Resources */,
 				EE57C134297F985A00BC31E7 /* product-variations-bulk-update-without-data.json in Resources */,
 				CE865A9F2A41E42F0049B03C /* date-modified-gmt.json in Resources */,
 				2683D71024456EE4002A1589 /* categories-extra.json in Resources */,

--- a/Networking/Networking.xcodeproj/project.pbxproj
+++ b/Networking/Networking.xcodeproj/project.pbxproj
@@ -1021,6 +1021,7 @@
 		DEA6B1C6296C13FB005AA5E9 /* payment-gateway-list-without-data.json in Resources */ = {isa = PBXBuildFile; fileRef = DEA6B1C5296C13FB005AA5E9 /* payment-gateway-list-without-data.json */; };
 		DEA6B1C9296D0E8B005AA5E9 /* systemStatusWithPluginsOnly-without-data.json in Resources */ = {isa = PBXBuildFile; fileRef = DEA6B1C7296D0E8A005AA5E9 /* systemStatusWithPluginsOnly-without-data.json */; };
 		DEA6B1CA296D0E8B005AA5E9 /* systemStatus-without-data.json in Resources */ = {isa = PBXBuildFile; fileRef = DEA6B1C8296D0E8A005AA5E9 /* systemStatus-without-data.json */; };
+		DEB387732C2A8F9A0025256E /* GoogleAdsConnection.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEB387722C2A8F9A0025256E /* GoogleAdsConnection.swift */; };
 		DEC2961C26BBE764005A056B /* ShippingLabelCustomsForm.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEC2961B26BBE764005A056B /* ShippingLabelCustomsForm.swift */; };
 		DEC2B08D297AA048003923FB /* reviews-all-without-data.json in Resources */ = {isa = PBXBuildFile; fileRef = DEC2B08C297AA048003923FB /* reviews-all-without-data.json */; };
 		DEC2B08F297AA123003923FB /* reviews-single-without-data.json in Resources */ = {isa = PBXBuildFile; fileRef = DEC2B08E297AA123003923FB /* reviews-single-without-data.json */; };
@@ -2145,6 +2146,7 @@
 		DEA6B1C5296C13FB005AA5E9 /* payment-gateway-list-without-data.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "payment-gateway-list-without-data.json"; sourceTree = "<group>"; };
 		DEA6B1C7296D0E8A005AA5E9 /* systemStatusWithPluginsOnly-without-data.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "systemStatusWithPluginsOnly-without-data.json"; sourceTree = "<group>"; };
 		DEA6B1C8296D0E8A005AA5E9 /* systemStatus-without-data.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "systemStatus-without-data.json"; sourceTree = "<group>"; };
+		DEB387722C2A8F9A0025256E /* GoogleAdsConnection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GoogleAdsConnection.swift; sourceTree = "<group>"; };
 		DEC2961B26BBE764005A056B /* ShippingLabelCustomsForm.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShippingLabelCustomsForm.swift; sourceTree = "<group>"; };
 		DEC2B08C297AA048003923FB /* reviews-all-without-data.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "reviews-all-without-data.json"; sourceTree = "<group>"; };
 		DEC2B08E297AA123003923FB /* reviews-single-without-data.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "reviews-single-without-data.json"; sourceTree = "<group>"; };
@@ -2831,6 +2833,7 @@
 		B557DA1B20979E6D005962F4 /* Model */ = {
 			isa = PBXGroup;
 			children = (
+				DEB387712C2A8F400025256E /* GoogleAds */,
 				EE1CB8F22B4BC7F300AD24D5 /* Blaze */,
 				EE57C10A297926E800BC31E7 /* ApplicationPassword */,
 				5726F72F2460A83D0031CAAC /* Copiable */,
@@ -3756,6 +3759,14 @@
 				8646A9B62B4522E7001F606C /* BlazeForecastedImpressionsInputEncoderTests.swift */,
 			);
 			path = Encoder;
+			sourceTree = "<group>";
+		};
+		DEB387712C2A8F400025256E /* GoogleAds */ = {
+			isa = PBXGroup;
+			children = (
+				DEB387722C2A8F9A0025256E /* GoogleAdsConnection.swift */,
+			);
+			path = GoogleAds;
 			sourceTree = "<group>";
 		};
 		DEC51AE527684717009F3DF4 /* SystemStatusDetails */ = {
@@ -5098,6 +5109,7 @@
 				CE6BFEE82236D133005C79FB /* ProductDimensions.swift in Sources */,
 				077F39D426A58DE700ABEADC /* SystemStatusMapper.swift in Sources */,
 				45152811257A81730076B03C /* ProductAttributeMapper.swift in Sources */,
+				DEB387732C2A8F9A0025256E /* GoogleAdsConnection.swift in Sources */,
 				CE865A9D2A41E1480049B03C /* EntityDateModifiedMapper.swift in Sources */,
 				B505F6D120BEE39600BB1B69 /* AccountRemote.swift in Sources */,
 				B567AF2B20A0FA4200AB6C62 /* OrderListMapper.swift in Sources */,

--- a/Networking/Networking.xcodeproj/project.pbxproj
+++ b/Networking/Networking.xcodeproj/project.pbxproj
@@ -1026,6 +1026,7 @@
 		DEB387782C2A9ADC0025256E /* gla-connection-with-data-envelope.json in Resources */ = {isa = PBXBuildFile; fileRef = DEB387772C2A9ADC0025256E /* gla-connection-with-data-envelope.json */; };
 		DEB3877A2C2A9B1E0025256E /* gla-connection-without-data-envelope.json in Resources */ = {isa = PBXBuildFile; fileRef = DEB387792C2A9B1E0025256E /* gla-connection-without-data-envelope.json */; };
 		DEB3877C2C2A9B600025256E /* GoogleAdsConnectionMapperTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEB3877B2C2A9B600025256E /* GoogleAdsConnectionMapperTests.swift */; };
+		DEB3877E2C2A9DE20025256E /* GoogleListingsAndAdsRemote.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEB3877D2C2A9DE20025256E /* GoogleListingsAndAdsRemote.swift */; };
 		DEC2961C26BBE764005A056B /* ShippingLabelCustomsForm.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEC2961B26BBE764005A056B /* ShippingLabelCustomsForm.swift */; };
 		DEC2B08D297AA048003923FB /* reviews-all-without-data.json in Resources */ = {isa = PBXBuildFile; fileRef = DEC2B08C297AA048003923FB /* reviews-all-without-data.json */; };
 		DEC2B08F297AA123003923FB /* reviews-single-without-data.json in Resources */ = {isa = PBXBuildFile; fileRef = DEC2B08E297AA123003923FB /* reviews-single-without-data.json */; };
@@ -2155,6 +2156,7 @@
 		DEB387772C2A9ADC0025256E /* gla-connection-with-data-envelope.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "gla-connection-with-data-envelope.json"; sourceTree = "<group>"; };
 		DEB387792C2A9B1E0025256E /* gla-connection-without-data-envelope.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "gla-connection-without-data-envelope.json"; sourceTree = "<group>"; };
 		DEB3877B2C2A9B600025256E /* GoogleAdsConnectionMapperTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GoogleAdsConnectionMapperTests.swift; sourceTree = "<group>"; };
+		DEB3877D2C2A9DE20025256E /* GoogleListingsAndAdsRemote.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GoogleListingsAndAdsRemote.swift; sourceTree = "<group>"; };
 		DEC2961B26BBE764005A056B /* ShippingLabelCustomsForm.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShippingLabelCustomsForm.swift; sourceTree = "<group>"; };
 		DEC2B08C297AA048003923FB /* reviews-all-without-data.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "reviews-all-without-data.json"; sourceTree = "<group>"; };
 		DEC2B08E297AA123003923FB /* reviews-single-without-data.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "reviews-single-without-data.json"; sourceTree = "<group>"; };
@@ -2805,6 +2807,7 @@
 				0286981329ED2D6400853B88 /* GenerativeContentRemote.swift */,
 				DED91DE42AD64B2900CDCC53 /* BlazeRemote.swift */,
 				DEDA8DA82B183D5D0076BF0F /* WordPressThemeRemote.swift */,
+				DEB3877D2C2A9DE20025256E /* GoogleListingsAndAdsRemote.swift */,
 			);
 			path = Remote;
 			sourceTree = "<group>";
@@ -4942,6 +4945,7 @@
 				B554FA912180BCFC00C54DFF /* NoteHash.swift in Sources */,
 				68F48B0D28E3B2E80045C15B /* WCAnalyticsCustomerMapper.swift in Sources */,
 				CE0A0F19223987DF0075ED8D /* ProductListMapper.swift in Sources */,
+				DEB3877E2C2A9DE20025256E /* GoogleListingsAndAdsRemote.swift in Sources */,
 				26BD9FCF2965EE71004E0D15 /* ProductVariationsBulkCreateMapper.swift in Sources */,
 				DE4D23BC29B5FC0D003A4B5D /* AnnouncementListMapper.swift in Sources */,
 				021C7BF723863D1800A3BCBD /* Encodable+Serialization.swift in Sources */,

--- a/Networking/Networking.xcodeproj/project.pbxproj
+++ b/Networking/Networking.xcodeproj/project.pbxproj
@@ -1027,6 +1027,7 @@
 		DEB3877A2C2A9B1E0025256E /* gla-connection-without-data-envelope.json in Resources */ = {isa = PBXBuildFile; fileRef = DEB387792C2A9B1E0025256E /* gla-connection-without-data-envelope.json */; };
 		DEB3877C2C2A9B600025256E /* GoogleAdsConnectionMapperTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEB3877B2C2A9B600025256E /* GoogleAdsConnectionMapperTests.swift */; };
 		DEB3877E2C2A9DE20025256E /* GoogleListingsAndAdsRemote.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEB3877D2C2A9DE20025256E /* GoogleListingsAndAdsRemote.swift */; };
+		DEB387802C2AA05D0025256E /* GoogleListingsAndAdsRemoteTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEB3877F2C2AA05D0025256E /* GoogleListingsAndAdsRemoteTests.swift */; };
 		DEC2961C26BBE764005A056B /* ShippingLabelCustomsForm.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEC2961B26BBE764005A056B /* ShippingLabelCustomsForm.swift */; };
 		DEC2B08D297AA048003923FB /* reviews-all-without-data.json in Resources */ = {isa = PBXBuildFile; fileRef = DEC2B08C297AA048003923FB /* reviews-all-without-data.json */; };
 		DEC2B08F297AA123003923FB /* reviews-single-without-data.json in Resources */ = {isa = PBXBuildFile; fileRef = DEC2B08E297AA123003923FB /* reviews-single-without-data.json */; };
@@ -2157,6 +2158,7 @@
 		DEB387792C2A9B1E0025256E /* gla-connection-without-data-envelope.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "gla-connection-without-data-envelope.json"; sourceTree = "<group>"; };
 		DEB3877B2C2A9B600025256E /* GoogleAdsConnectionMapperTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GoogleAdsConnectionMapperTests.swift; sourceTree = "<group>"; };
 		DEB3877D2C2A9DE20025256E /* GoogleListingsAndAdsRemote.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GoogleListingsAndAdsRemote.swift; sourceTree = "<group>"; };
+		DEB3877F2C2AA05D0025256E /* GoogleListingsAndAdsRemoteTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GoogleListingsAndAdsRemoteTests.swift; sourceTree = "<group>"; };
 		DEC2961B26BBE764005A056B /* ShippingLabelCustomsForm.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShippingLabelCustomsForm.swift; sourceTree = "<group>"; };
 		DEC2B08C297AA048003923FB /* reviews-all-without-data.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "reviews-all-without-data.json"; sourceTree = "<group>"; };
 		DEC2B08E297AA123003923FB /* reviews-single-without-data.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "reviews-single-without-data.json"; sourceTree = "<group>"; };
@@ -2585,6 +2587,7 @@
 			children = (
 				B5969E1420A47F99005E9DF1 /* RemoteTests.swift */,
 				DED91DE62AD64ED500CDCC53 /* BlazeRemoteTests.swift */,
+				DEB3877F2C2AA05D0025256E /* GoogleListingsAndAdsRemoteTests.swift */,
 				DEDA8DAA2B18407D0076BF0F /* WordPressThemeRemoteTests.swift */,
 				B505F6D620BEE58800BB1B69 /* AccountRemoteTests.swift */,
 				93D8BC00226BC20600AD2EB3 /* AccountSettingsRemoteTests.swift */,
@@ -5372,6 +5375,7 @@
 				E18152C428F85E5C0011A0EC /* InAppPurchasesProductsMapperTests.swift in Sources */,
 				68BFF9022B677F1D00B15FF2 /* ReceiptRemoteTests.swift in Sources */,
 				DE2004742BFB53DD00660A72 /* ProductReportListMapperTests.swift in Sources */,
+				DEB387802C2AA05D0025256E /* GoogleListingsAndAdsRemoteTests.swift in Sources */,
 				CCE5F39729F00B5200087332 /* SubscriptionsRemoteTests.swift in Sources */,
 				DED91DE72AD64ED500CDCC53 /* BlazeRemoteTests.swift in Sources */,
 				D8A2849A25FBB2E70019A84B /* ProductAttributeTermListMapperTests.swift in Sources */,

--- a/Networking/Networking.xcodeproj/project.pbxproj
+++ b/Networking/Networking.xcodeproj/project.pbxproj
@@ -1025,6 +1025,7 @@
 		DEB387762C2A9A140025256E /* GoogleAdsConnectionMapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEB387752C2A9A140025256E /* GoogleAdsConnectionMapper.swift */; };
 		DEB387782C2A9ADC0025256E /* gla-connection-with-data-envelope.json in Resources */ = {isa = PBXBuildFile; fileRef = DEB387772C2A9ADC0025256E /* gla-connection-with-data-envelope.json */; };
 		DEB3877A2C2A9B1E0025256E /* gla-connection-without-data-envelope.json in Resources */ = {isa = PBXBuildFile; fileRef = DEB387792C2A9B1E0025256E /* gla-connection-without-data-envelope.json */; };
+		DEB3877C2C2A9B600025256E /* GoogleAdsConnectionMapperTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEB3877B2C2A9B600025256E /* GoogleAdsConnectionMapperTests.swift */; };
 		DEC2961C26BBE764005A056B /* ShippingLabelCustomsForm.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEC2961B26BBE764005A056B /* ShippingLabelCustomsForm.swift */; };
 		DEC2B08D297AA048003923FB /* reviews-all-without-data.json in Resources */ = {isa = PBXBuildFile; fileRef = DEC2B08C297AA048003923FB /* reviews-all-without-data.json */; };
 		DEC2B08F297AA123003923FB /* reviews-single-without-data.json in Resources */ = {isa = PBXBuildFile; fileRef = DEC2B08E297AA123003923FB /* reviews-single-without-data.json */; };
@@ -2153,6 +2154,7 @@
 		DEB387752C2A9A140025256E /* GoogleAdsConnectionMapper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GoogleAdsConnectionMapper.swift; sourceTree = "<group>"; };
 		DEB387772C2A9ADC0025256E /* gla-connection-with-data-envelope.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "gla-connection-with-data-envelope.json"; sourceTree = "<group>"; };
 		DEB387792C2A9B1E0025256E /* gla-connection-without-data-envelope.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "gla-connection-without-data-envelope.json"; sourceTree = "<group>"; };
+		DEB3877B2C2A9B600025256E /* GoogleAdsConnectionMapperTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GoogleAdsConnectionMapperTests.swift; sourceTree = "<group>"; };
 		DEC2961B26BBE764005A056B /* ShippingLabelCustomsForm.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShippingLabelCustomsForm.swift; sourceTree = "<group>"; };
 		DEC2B08C297AA048003923FB /* reviews-all-without-data.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "reviews-all-without-data.json"; sourceTree = "<group>"; };
 		DEC2B08E297AA123003923FB /* reviews-single-without-data.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "reviews-single-without-data.json"; sourceTree = "<group>"; };
@@ -3686,6 +3688,7 @@
 				CEB9BF442BB19EDE0007978A /* ProductBundleStatsMapperTests.swift */,
 				DE20045C2BF614A300660A72 /* ProductStockListMapperTests.swift */,
 				DE2004732BFB53DD00660A72 /* ProductReportListMapperTests.swift */,
+				DEB3877B2C2A9B600025256E /* GoogleAdsConnectionMapperTests.swift */,
 			);
 			path = Mapper;
 			sourceTree = "<group>";
@@ -5202,6 +5205,7 @@
 				DE02ABB72B563F3A008E0AC4 /* BlazePaymentInfoMapperTests.swift in Sources */,
 				2661547B242DAC1C00A31661 /* ProductCategoriesRemoteTests.swift in Sources */,
 				4513382227A8409000AE5E78 /* InboxNotesRemoteTests.swift in Sources */,
+				DEB3877C2C2A9B600025256E /* GoogleAdsConnectionMapperTests.swift in Sources */,
 				025F9A252B020F1900B91F1D /* MockURLProtocol.swift in Sources */,
 				45E461BE26837DB900011BF2 /* DataRemoteTests.swift in Sources */,
 				DEDA8DB92B187EC90076BF0F /* WordPressThemeMapperTests.swift in Sources */,

--- a/Networking/Networking.xcodeproj/project.pbxproj
+++ b/Networking/Networking.xcodeproj/project.pbxproj
@@ -1022,6 +1022,7 @@
 		DEA6B1C9296D0E8B005AA5E9 /* systemStatusWithPluginsOnly-without-data.json in Resources */ = {isa = PBXBuildFile; fileRef = DEA6B1C7296D0E8A005AA5E9 /* systemStatusWithPluginsOnly-without-data.json */; };
 		DEA6B1CA296D0E8B005AA5E9 /* systemStatus-without-data.json in Resources */ = {isa = PBXBuildFile; fileRef = DEA6B1C8296D0E8A005AA5E9 /* systemStatus-without-data.json */; };
 		DEB387732C2A8F9A0025256E /* GoogleAdsConnection.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEB387722C2A8F9A0025256E /* GoogleAdsConnection.swift */; };
+		DEB387762C2A9A140025256E /* GoogleAdsConnectionMapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEB387752C2A9A140025256E /* GoogleAdsConnectionMapper.swift */; };
 		DEC2961C26BBE764005A056B /* ShippingLabelCustomsForm.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEC2961B26BBE764005A056B /* ShippingLabelCustomsForm.swift */; };
 		DEC2B08D297AA048003923FB /* reviews-all-without-data.json in Resources */ = {isa = PBXBuildFile; fileRef = DEC2B08C297AA048003923FB /* reviews-all-without-data.json */; };
 		DEC2B08F297AA123003923FB /* reviews-single-without-data.json in Resources */ = {isa = PBXBuildFile; fileRef = DEC2B08E297AA123003923FB /* reviews-single-without-data.json */; };
@@ -2147,6 +2148,7 @@
 		DEA6B1C7296D0E8A005AA5E9 /* systemStatusWithPluginsOnly-without-data.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "systemStatusWithPluginsOnly-without-data.json"; sourceTree = "<group>"; };
 		DEA6B1C8296D0E8A005AA5E9 /* systemStatus-without-data.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "systemStatus-without-data.json"; sourceTree = "<group>"; };
 		DEB387722C2A8F9A0025256E /* GoogleAdsConnection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GoogleAdsConnection.swift; sourceTree = "<group>"; };
+		DEB387752C2A9A140025256E /* GoogleAdsConnectionMapper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GoogleAdsConnectionMapper.swift; sourceTree = "<group>"; };
 		DEC2961B26BBE764005A056B /* ShippingLabelCustomsForm.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShippingLabelCustomsForm.swift; sourceTree = "<group>"; };
 		DEC2B08C297AA048003923FB /* reviews-all-without-data.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "reviews-all-without-data.json"; sourceTree = "<group>"; };
 		DEC2B08E297AA123003923FB /* reviews-single-without-data.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "reviews-single-without-data.json"; sourceTree = "<group>"; };
@@ -3381,6 +3383,7 @@
 		B567AF2720A0FA0A00AB6C62 /* Mapper */ = {
 			isa = PBXGroup;
 			children = (
+				DEB387742C2A9A040025256E /* GoogleAds */,
 				EE1CB9032B4BC88700AD24D5 /* Blaze */,
 				EE57C10F297927A000BC31E7 /* ApplicationPassword */,
 				B567AF2820A0FA1E00AB6C62 /* Mapper.swift */,
@@ -3765,6 +3768,14 @@
 			isa = PBXGroup;
 			children = (
 				DEB387722C2A8F9A0025256E /* GoogleAdsConnection.swift */,
+			);
+			path = GoogleAds;
+			sourceTree = "<group>";
+		};
+		DEB387742C2A9A040025256E /* GoogleAds */ = {
+			isa = PBXGroup;
+			children = (
+				DEB387752C2A9A140025256E /* GoogleAdsConnectionMapper.swift */,
 			);
 			path = GoogleAds;
 			sourceTree = "<group>";
@@ -4968,6 +4979,7 @@
 				D8FBFF2222D5266E006E3336 /* OrderStatsV4Interval.swift in Sources */,
 				4568E2222459ADC60007E478 /* SitePostsRemote.swift in Sources */,
 				02C11276274285FF00F4F0B4 /* WooCommerceAvailabilityMapper.swift in Sources */,
+				DEB387762C2A9A140025256E /* GoogleAdsConnectionMapper.swift in Sources */,
 				CC0786C5267BAF0F00BA9AC1 /* ShippingLabelStatusMapper.swift in Sources */,
 				4515280D257A7EEC0076B03C /* ProductAttributeListMapper.swift in Sources */,
 				93D8BBFD226BBEE800AD2EB3 /* AccountSettingsMapper.swift in Sources */,

--- a/Networking/Networking/Mapper/GoogleAds/GoogleAdsConnectionMapper.swift
+++ b/Networking/Networking/Mapper/GoogleAds/GoogleAdsConnectionMapper.swift
@@ -1,0 +1,26 @@
+import Foundation
+
+/// Mapper: `GoogleAdsConnection`
+///
+struct GoogleAdsConnectionMapper: Mapper {
+
+    /// (Attempts) to convert a dictionary into `GoogleAdsConnection`.
+    ///
+    func map(response: Data) throws -> GoogleAdsConnection {
+        let decoder = JSONDecoder()
+        if hasDataEnvelope(in: response) {
+            return try decoder.decode(GoogleAdsConnectionEnvelope.self, from: response).data
+        } else {
+            return try decoder.decode(GoogleAdsConnection.self, from: response)
+        }
+    }
+}
+
+
+/// GoogleAdsConnectionEnvelope Disposable Entity:
+/// Load Google Ads connection endpoint returns the result in the `data` key.
+/// This entity allows us to parse all the things with JSONDecoder.
+///
+private struct GoogleAdsConnectionEnvelope: Decodable {
+    let data: GoogleAdsConnection
+}

--- a/Networking/Networking/Model/Copiable/Models+Copiable.generated.swift
+++ b/Networking/Networking/Model/Copiable/Models+Copiable.generated.swift
@@ -801,6 +801,27 @@ extension Networking.GiftCardStatsTotals {
     }
 }
 
+extension Networking.GoogleAdsConnection {
+    public func copy(
+        id: CopiableProp<Int64> = .copy,
+        currency: CopiableProp<String> = .copy,
+        symbol: CopiableProp<String> = .copy,
+        rawStatus: CopiableProp<String> = .copy
+    ) -> Networking.GoogleAdsConnection {
+        let id = id ?? self.id
+        let currency = currency ?? self.currency
+        let symbol = symbol ?? self.symbol
+        let rawStatus = rawStatus ?? self.rawStatus
+
+        return Networking.GoogleAdsConnection(
+            id: id,
+            currency: currency,
+            symbol: symbol,
+            rawStatus: rawStatus
+        )
+    }
+}
+
 extension Networking.InboxAction {
     public func copy(
         id: CopiableProp<Int64> = .copy,

--- a/Networking/Networking/Model/GoogleAds/GoogleAdsConnection.swift
+++ b/Networking/Networking/Model/GoogleAds/GoogleAdsConnection.swift
@@ -1,0 +1,43 @@
+import Codegen
+import Foundation
+
+/// Connection details for Google Listings & Ads extension.
+///
+public struct GoogleAdsConnection: Equatable, Decodable, GeneratedFakeable, GeneratedCopiable {
+
+    public let id: Int64
+
+    public let currency: String
+
+    public let symbol: String
+
+    public let rawStatus: String
+
+    public var status: Status {
+        Status(rawValue: rawStatus) ?? .disconnected
+    }
+
+    public init(id: Int64, currency: String, symbol: String, rawStatus: String) {
+        self.id = id
+        self.currency = currency
+        self.symbol = symbol
+        self.rawStatus = rawStatus
+    }
+}
+
+public extension GoogleAdsConnection {
+    enum Status: String {
+        case disconnected
+        case incomplete
+        case connected
+    }
+}
+
+private extension GoogleAdsConnection {
+    enum CodingKeys: String, CodingKey {
+        case id
+        case currency
+        case symbol
+        case rawStatus = "status"
+    }
+}

--- a/Networking/Networking/Remote/GoogleListingsAndAdsRemote.swift
+++ b/Networking/Networking/Remote/GoogleListingsAndAdsRemote.swift
@@ -1,0 +1,27 @@
+import Foundation
+
+/// Interface for remote requests to Google Listings & Ads plugin.
+///
+public protocol GoogleListingsAndAdsRemoteProtocol {
+    /// Check Google ads connection for the given site.
+    ///
+    func checkConnection(for siteID: Int64) async throws -> GoogleAdsConnection
+}
+
+/// Google Listings & Ads: Endpoints
+///
+public final class GoogleListingsAndAdsRemote: Remote, GoogleListingsAndAdsRemoteProtocol {
+
+    public func checkConnection(for siteID: Int64) async throws -> GoogleAdsConnection {
+        let path = Paths.connection
+        let request = JetpackRequest(wooApiVersion: .none, method: .get, siteID: siteID, path: path)
+        let mapper = GoogleAdsConnectionMapper()
+        return try await enqueue(request, mapper: mapper)
+    }
+}
+
+private extension GoogleListingsAndAdsRemote {
+    enum Paths {
+        static let connection = "wc/gla/ads/connection"
+    }
+}

--- a/Networking/Networking/Remote/GoogleListingsAndAdsRemote.swift
+++ b/Networking/Networking/Remote/GoogleListingsAndAdsRemote.swift
@@ -14,7 +14,11 @@ public final class GoogleListingsAndAdsRemote: Remote, GoogleListingsAndAdsRemot
 
     public func checkConnection(for siteID: Int64) async throws -> GoogleAdsConnection {
         let path = Paths.connection
-        let request = JetpackRequest(wooApiVersion: .none, method: .get, siteID: siteID, path: path)
+        let request = JetpackRequest(wooApiVersion: .none,
+                                     method: .get,
+                                     siteID: siteID,
+                                     path: path,
+                                     availableAsRESTRequest: true)
         let mapper = GoogleAdsConnectionMapper()
         return try await enqueue(request, mapper: mapper)
     }

--- a/Networking/NetworkingTests/Mapper/GoogleAdsConnectionMapperTests.swift
+++ b/Networking/NetworkingTests/Mapper/GoogleAdsConnectionMapperTests.swift
@@ -1,0 +1,41 @@
+import XCTest
+@testable import Networking
+
+final class GoogleAdsConnectionMapperTests: XCTestCase {
+
+    func test_google_ads_connection_is_properly_parsed_with_data_envelope() throws {
+        // When
+        let connection = try mapGoogleAdsConnection(from: "gla-connection-with-data-envelope")
+
+        // Then
+        XCTAssertEqual(connection?.id, 3904318964)
+        XCTAssertEqual(connection?.currency, "USD")
+        XCTAssertEqual(connection?.symbol, "$")
+        XCTAssertEqual(connection?.rawStatus, "incomplete")
+        XCTAssertEqual(connection?.status, .incomplete)
+    }
+
+    func test_google_ads_connection_is_properly_parsed_without_data_envelope() throws {
+        // When
+        let connection = try mapGoogleAdsConnection(from: "gla-connection-without-data-envelope")
+
+        // Then
+        XCTAssertEqual(connection?.id, 1234567890)
+        XCTAssertEqual(connection?.currency, "USD")
+        XCTAssertEqual(connection?.symbol, "$")
+        XCTAssertEqual(connection?.rawStatus, "connected")
+        XCTAssertEqual(connection?.status, .connected)
+    }
+}
+
+private extension GoogleAdsConnectionMapperTests {
+    /// Returns the GoogleAdsConnection output upon receiving `filename` (Data Encoded)
+    ///
+    func mapGoogleAdsConnection(from filename: String) throws -> GoogleAdsConnection? {
+        guard let response = Loader.contentsOf(filename) else {
+            return nil
+        }
+
+        return try GoogleAdsConnectionMapper().map(response: response)
+    }
+}

--- a/Networking/NetworkingTests/Remote/GoogleListingsAndAdsRemoteTests.swift
+++ b/Networking/NetworkingTests/Remote/GoogleListingsAndAdsRemoteTests.swift
@@ -1,0 +1,60 @@
+import XCTest
+@testable import Networking
+
+final class GoogleListingsAndAdsRemoteTests: XCTestCase {
+
+    /// Dummy Network Wrapper
+    ///
+    private var network: MockNetwork!
+
+    /// Dummy Site ID
+    ///
+    private let sampleSiteID: Int64 = 1234
+
+    override func setUp() {
+        super.setUp()
+        network = MockNetwork()
+    }
+
+    override func tearDown() {
+        network = nil
+        super.tearDown()
+    }
+
+    // MARK: - Check connection
+
+    func test_checkConnection_returns_parsed_connection() async throws {
+        // Given
+        let remote = GoogleListingsAndAdsRemote(network: network)
+
+        let suffix = "wc/gla/ads/connection"
+        network.simulateResponse(requestUrlSuffix: suffix, filename: "gla-connection-with-data-envelope")
+
+        // When
+        let results = try await remote.checkConnection(for: sampleSiteID)
+
+        // Then
+        XCTAssertEqual(results, GoogleAdsConnection(id: 3904318964, currency: "USD", symbol: "$", rawStatus: "incomplete"))
+    }
+
+    func test_checkConnection_properly_relays_networking_errors() async {
+        // Given
+        let remote = GoogleListingsAndAdsRemote(network: network)
+
+        let expectedError = NetworkError.unacceptableStatusCode(statusCode: 403)
+        let suffix = "wc/gla/ads/connection"
+        network.simulateError(requestUrlSuffix: suffix, error: expectedError)
+
+        do {
+            // When
+            _ = try await remote.checkConnection(for: sampleSiteID)
+
+            // Then
+            XCTFail("Request should fail")
+        } catch {
+            // Then
+            XCTAssertEqual(error as? NetworkError, expectedError)
+        }
+    }
+
+}

--- a/Networking/NetworkingTests/Responses/gla-connection-with-data-envelope.json
+++ b/Networking/NetworkingTests/Responses/gla-connection-with-data-envelope.json
@@ -1,0 +1,11 @@
+{
+    "data": {
+        "id": 3904318964,
+        "currency": "USD",
+        "symbol": "$",
+        "status": "incomplete",
+        "step": "account_access",
+        "sub_account": true,
+        "created_timestamp": 1718811662
+    }
+}

--- a/Networking/NetworkingTests/Responses/gla-connection-without-data-envelope.json
+++ b/Networking/NetworkingTests/Responses/gla-connection-without-data-envelope.json
@@ -1,0 +1,6 @@
+{
+    "id": 1234567890,
+    "currency": "USD",
+    "symbol": "$",
+    "status": "connected"
+}


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of #13139 
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This PR updates the Networking layer to integrate the endpoint to check the connection of a given site with Google Ads plugin. Changes include:
- New model and mapper for Google ads connection
- New remote for Google ads endpoints.
- Integration of the connection check at path `GET wc/gla/ads/connection`.

Yosemite update will be done in a separate PR.

## Testing steps
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->
Just CI passing should be sufficient.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->
N/A

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
