### PR TITLE
[Woo POS] Disable navigation during payment

### DIFF
--- a/WooCommerce/Classes/POS/Presentation/CartView.swift
+++ b/WooCommerce/Classes/POS/Presentation/CartView.swift
@@ -51,6 +51,7 @@ struct CartView: View {
             case .finalizing:
                 addMoreButton
                     .padding(32)
+                    .disabled(viewModel.isAddMoreDisabled)
             }
         }
         .frame(maxWidth: .infinity)

--- a/WooCommerce/Classes/POS/Presentation/CartView.swift
+++ b/WooCommerce/Classes/POS/Presentation/CartView.swift
@@ -69,15 +69,13 @@ private extension CartView {
             HStack {
                 Spacer()
                 Text("Checkout")
+                    .font(.title)
+                    .padding(20)
                 Spacer()
             }
         }
-        .padding(.all, 20)
-        .frame(maxWidth: .infinity, idealHeight: 120)
-        .font(.title)
-        .foregroundColor(Color.primaryBackground)
-        .background(Color.init(uiColor: .wooCommercePurple(.shade60)))
-        .cornerRadius(10)
+        .buttonStyle(.borderedProminent)
+        .tint(Color.primaryTint)
     }
 
     var addMoreButton: some View {
@@ -86,17 +84,12 @@ private extension CartView {
         } label: {
             Spacer()
             Text("Add More")
+                .font(.title)
+                .padding(20)
             Spacer()
         }
-        .padding(20)
-        .frame(maxWidth: .infinity, idealHeight: 120)
-        .font(.title)
-        .foregroundColor(Color.white)
-        .background(Color.secondaryBackground)
-        .overlay(
-            RoundedRectangle(cornerRadius: 10)
-                .stroke(.white, lineWidth: 2)
-        )
+        .buttonStyle(.borderedProminent)
+        .tint(Color.secondaryBackground)
     }
 }
 

--- a/WooCommerce/Classes/POS/Presentation/PointOfSaleDashboardView.swift
+++ b/WooCommerce/Classes/POS/Presentation/PointOfSaleDashboardView.swift
@@ -33,7 +33,8 @@ struct PointOfSaleDashboardView: View {
         .navigationBarBackButtonHidden(true)
         .toolbar {
             ToolbarItem(placement: .bottomBar) {
-                POSToolbarView(readerConnectionViewModel: viewModel.cardReaderConnectionViewModel)
+                POSToolbarView(readerConnectionViewModel: viewModel.cardReaderConnectionViewModel,
+                               isExitPOSDisabled: $viewModel.isExitPOSDisabled)
             }
         }
         .toolbarBackground(Color.toolbarBackground, for: .bottomBar)

--- a/WooCommerce/Classes/POS/Presentation/Toolbar/POSToolbarView.swift
+++ b/WooCommerce/Classes/POS/Presentation/Toolbar/POSToolbarView.swift
@@ -3,9 +3,12 @@ import SwiftUI
 struct POSToolbarView: View {
     @Environment(\.presentationMode) private var presentationMode
     private let readerConnectionViewModel: CardReaderConnectionViewModel
+    @Binding private var isExitPOSDisabled: Bool
 
-    init(readerConnectionViewModel: CardReaderConnectionViewModel) {
+    init(readerConnectionViewModel: CardReaderConnectionViewModel,
+         isExitPOSDisabled: Binding<Bool>) {
         self.readerConnectionViewModel = readerConnectionViewModel
+        self._isExitPOSDisabled = isExitPOSDisabled
     }
 
     var body: some View {
@@ -17,8 +20,9 @@ struct POSToolbarView: View {
                     Image(uiImage: .swapHorizontal)
                     Text("Exit POS")
                 }
-                .foregroundColor(Color(uiColor: .gray(.shade60)))
             }
+            .tint(Color(uiColor: .gray(.shade60)))
+            .disabled(isExitPOSDisabled)
 
             Spacer()
 
@@ -36,7 +40,8 @@ private extension POSToolbarView {
 #if DEBUG
 
 #Preview {
-    POSToolbarView(readerConnectionViewModel: .init(cardPresentPayment: CardPresentPaymentPreviewService()))
+    POSToolbarView(readerConnectionViewModel: .init(cardPresentPayment: CardPresentPaymentPreviewService()),
+                   isExitPOSDisabled: .constant(false))
 }
 
 #endif

--- a/WooCommerce/Classes/POS/Presentation/Toolbar/POSToolbarView.swift
+++ b/WooCommerce/Classes/POS/Presentation/Toolbar/POSToolbarView.swift
@@ -11,7 +11,6 @@ struct POSToolbarView: View {
     var body: some View {
         HStack {
             Button {
-                // TODO: we need to cancel any prepared reader payment before we exit, or the reader can't be disconnected.
                 presentationMode.wrappedValue.dismiss()
             } label: {
                 HStack(spacing: Layout.buttonImageAndTextSpacing) {

--- a/WooCommerce/Classes/POS/Presentation/TotalsView.swift
+++ b/WooCommerce/Classes/POS/Presentation/TotalsView.swift
@@ -14,9 +14,6 @@ struct TotalsView: View {
                     cardReaderView
                         .font(.title)
                         .padding()
-                    // Temporarily removed because the CardReaderView is doing this job right now.
-    //                paymentsView
-    //                    .padding()
                     Spacer()
                     VStack(alignment: .leading, spacing: 32) {
                         HStack {
@@ -88,34 +85,6 @@ struct TotalsView: View {
 }
 
 private extension TotalsView {
-    private var tapInsertCardView: some View {
-        Text("Tap or insert card to pay")
-    }
-
-    private var paymentSuccessfulView: some View {
-        Text("Payment successful")
-    }
-
-    @ViewBuilder
-    private var paymentsTextView: some View {
-        switch viewModel.paymentState {
-        case .acceptingCard:
-            tapInsertCardView
-        case .processingCard:
-            tapInsertCardView
-        case .cardPaymentSuccessful:
-            paymentSuccessfulView
-        }
-    }
-
-    @ViewBuilder
-    private var paymentsView: some View {
-        VStack {
-            paymentsTextView
-                .font(.title)
-        }
-    }
-
     private var newTransactionButton: some View {
         Button(action: {
             viewModel.startNewTransaction()

--- a/WooCommerce/Classes/POS/Utils/Color+WooCommercePOS.swift
+++ b/WooCommerce/Classes/POS/Utils/Color+WooCommercePOS.swift
@@ -24,6 +24,10 @@ extension Color {
         Color(uiColor: .systemBackground)
     }
 
+    static var primaryTint: Color {
+        Color(uiColor: .wooCommercePurple(.shade60))
+    }
+
     static var wooAmberShade40: Color {
         Color(red: 255.0 / 255.0, green: 166.0 / 255.0, blue: 14.0 / 255.0)
     }

--- a/WooCommerce/Classes/POS/ViewModels/PointOfSaleDashboardViewModel.swift
+++ b/WooCommerce/Classes/POS/ViewModels/PointOfSaleDashboardViewModel.swift
@@ -12,7 +12,7 @@ import struct Yosemite.Order
 final class PointOfSaleDashboardViewModel: ObservableObject {
     enum PaymentState {
         case acceptingCard
-        case processingCard
+        case preparingReader
         case cardPaymentSuccessful
     }
 
@@ -153,7 +153,7 @@ final class PointOfSaleDashboardViewModel: ObservableObject {
 
     @MainActor
     private func collectPayment(for order: Order) async throws {
-        paymentState = .processingCard
+        paymentState = .preparingReader
 
         let paymentResult = try await cardPresentPaymentService.collectPayment(for: order, using: .bluetooth)
 

--- a/WooCommerce/Classes/POS/ViewModels/PointOfSaleDashboardViewModel.swift
+++ b/WooCommerce/Classes/POS/ViewModels/PointOfSaleDashboardViewModel.swift
@@ -68,6 +68,7 @@ final class PointOfSaleDashboardViewModel: ObservableObject {
     @Published private(set) var orderStage: OrderStage = .building
     @Published private(set) var paymentState: PointOfSaleDashboardViewModel.PaymentState = .acceptingCard
     @Published private(set) var isAddMoreDisabled: Bool = false
+    @Published var isExitPOSDisabled: Bool = false
 
     /// Order created the first time the checkout is shown for a given transaction.
     /// If the merchant goes back to the product selection screen and makes changes, this should be updated when they return to the checkout.
@@ -291,6 +292,20 @@ private extension PointOfSaleDashboardViewModel {
                 }
             }
             .assign(to: &$isAddMoreDisabled)
+
+        $paymentState
+            .map { paymentState in
+                switch paymentState {
+                case .processingPayment:
+                    return true
+                case .idle,
+                        .acceptingCard,
+                        .preparingReader,
+                        .cardPaymentSuccessful:
+                    return false
+                }
+            }
+            .assign(to: &$isExitPOSDisabled)
     }
 
     @MainActor

--- a/WooCommerce/Classes/POS/ViewModels/PointOfSaleDashboardViewModel.swift
+++ b/WooCommerce/Classes/POS/ViewModels/PointOfSaleDashboardViewModel.swift
@@ -67,6 +67,7 @@ final class PointOfSaleDashboardViewModel: ObservableObject {
 
     @Published private(set) var orderStage: OrderStage = .building
     @Published private(set) var paymentState: PointOfSaleDashboardViewModel.PaymentState = .acceptingCard
+    @Published private(set) var isAddMoreDisabled: Bool = false
 
     /// Order created the first time the checkout is shown for a given transaction.
     /// If the merchant goes back to the product selection screen and makes changes, this should be updated when they return to the checkout.
@@ -87,6 +88,7 @@ final class PointOfSaleDashboardViewModel: ObservableObject {
         self.orderService = orderService
         observeCardPresentPaymentEvents()
         observeItemsInCartForCartTotal()
+        observePaymentStateForButtonDisabledProperties()
     }
 
     var isCartCollapsed: Bool {
@@ -273,6 +275,22 @@ private extension PointOfSaleDashboardViewModel {
         cardPresentPaymentService.paymentEventPublisher
             .compactMap({ PaymentState(from: $0) })
             .assign(to: &$paymentState)
+    }
+
+    func observePaymentStateForButtonDisabledProperties() {
+        $paymentState
+            .map { paymentState in
+                switch paymentState {
+                case .processingPayment,
+                        .cardPaymentSuccessful:
+                    return true
+                case .idle,
+                        .acceptingCard,
+                        .preparingReader:
+                    return false
+                }
+            }
+            .assign(to: &$isAddMoreDisabled)
     }
 
     @MainActor


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #13115 
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

Payments in POS are shown inline, so they don't block the UI modally as in the main app experience. That means merchants can continue to interact with the app while the reader is preparing, and during some payment actions.

If they go back to the cart, or exit the POS, while there's a payment action ongoing, we handle that by cancelling the in-progress payment.

However, during payment processing, we can't (reliably) cancel the payment.

This PR disables the `Add More` and `Exit POS` buttons while there's a payment in progress. The buttons are both disabled when the payment enters the `processing` state – a few moments after they tap their card.

`Add More` is re-enabled when the payment is cancelled (e.g. from an error) or after it's successful, when they tap `New transaction`.

`Exit POS` is re-enabled when the payment is cancelled, or as soon as the payment is successful (no need to tap `New transaction`.

## Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->

1. Launch the app and select a POS-eligible store
2. Navigate to `Menu > Point of Sale mode`
3. Tap `Exit POS` – observe that it works as expected
4. Go back in to the POS mode
5. Connect a card reader
6. Add a product to your cart, and tap Checkout
7. Observe that you can tap `Add More` or `Exit POS` at any time, even when the reader is ready for you to tap your card
8. If you exited, get back to the same state
9. Tap your card – observe that both buttons are disabled and grey out.
10. Wait for success – observe that the `Add More` button remains disabled, but the `Exit POS` button is re-enabled
11. Tap `New transaction` – observe that next time you go to the checkout, the `Add More` button is enabled again.

Repeat the above with a payment error – e.g. by tapping a live card, or [using an error amount](https://docs.stripe.com/terminal/references/testing#physical-test-cards)

- Observe that the buttons remain disabled until you tap `Try Again` or `Cancel Payment` on the error.
## Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->

Connecting a reader should never disable the buttons, as it only happens during payment.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->


https://github.com/woocommerce/woocommerce-ios/assets/2472348/c7a7940e-72bb-47c4-880f-619f9dd11acb


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.