### PR TITLE
[WOO POS] show remove item only when building the cart

### DIFF
--- a/WooCommerce/Classes/POS/Presentation/CartView.swift
+++ b/WooCommerce/Classes/POS/Presentation/CartView.swift
@@ -26,9 +26,10 @@ struct CartView: View {
             ScrollViewReader { proxy in
                 ScrollView {
                     ForEach(viewModel.itemsInCart, id: \.id) { cartItem in
-                        ItemRowView(cartItem: cartItem) {
+                        ItemRowView(cartItem: cartItem,
+                                    onItemRemoveTapped: viewModel.canDeleteItemsFromCart ? {
                             viewModel.removeItemFromCart(cartItem)
-                        }
+                        } : nil)
                         .id(cartItem.id)
                         .background(Color.posBackgroundGreyi3)
                         .padding(.horizontal, 32)

--- a/WooCommerce/Classes/POS/Presentation/ItemRowView.swift
+++ b/WooCommerce/Classes/POS/Presentation/ItemRowView.swift
@@ -33,14 +33,16 @@ struct ItemRowView: View {
                     .foregroundColor(Color.posPrimaryTexti3)
             }
             Spacer()
-            Button(action: {
-                onItemRemoveTapped?()
-            }, label: {
-                Image(systemName: "x.circle")
-            })
-            .frame(width: 56, height: 56, alignment: .trailing)
-            .padding(.horizontal, 32)
-            .foregroundColor(Color.posIconGrayi3)
+            if let onItemRemoveTapped {
+                Button(action: {
+                    onItemRemoveTapped()
+                }, label: {
+                    Image(systemName: "x.circle")
+                })
+                .frame(width: 56, height: 56, alignment: .trailing)
+                .padding(.horizontal, 32)
+                .foregroundColor(Color.posIconGrayi3)
+            }
         }
         .frame(maxWidth: .infinity, idealHeight: 120)
     }

--- a/WooCommerce/Classes/POS/ViewModels/PointOfSaleDashboardViewModel.swift
+++ b/WooCommerce/Classes/POS/ViewModels/PointOfSaleDashboardViewModel.swift
@@ -84,6 +84,10 @@ final class PointOfSaleDashboardViewModel: ObservableObject {
         }
     }
 
+    var canDeleteItemsFromCart: Bool {
+        return orderStage != .finalizing
+    }
+
     var isCartCollapsed: Bool {
         itemsInCart.isEmpty
     }
@@ -95,19 +99,11 @@ final class PointOfSaleDashboardViewModel: ObservableObject {
     func addItemToCart(_ item: POSItem) {
         let cartItem = CartItem(id: UUID(), item: item, quantity: 1)
         itemsInCart.append(cartItem)
-
-        if orderStage == .finalizing {
-            startSyncingOrder()
-        }
     }
 
     func removeItemFromCart(_ cartItem: CartItem) {
         itemsInCart.removeAll(where: { $0.id == cartItem.id })
         checkIfCartEmpty()
-
-        if orderStage == .finalizing {
-            startSyncingOrder()
-        }
     }
 
     var itemsInCartLabel: String? {


### PR DESCRIPTION
## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

After doing some code cleanup I needed to also remove the button in cart item that removes the item from the cart. We are only able to edit the cart while we are in cart building phase.

## Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: https://woomobilep2.wordpress.com/2024/05/06/woocommerce-mobile-quality-report-march-april/#comment-12036 -->

- Enter POS
- Add few products in the cart
- Check that there is X button on the cart items, tap one of them and check that that item is removed from the cart
- Tap "Checkout"
- Check that there are no X buttons on the cart items

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

![Simulator Screen Recording - iPad Pro (11-inch) (4th generation) 17 2 - 2024-06-25 at 17 06 22](https://github.com/woocommerce/woocommerce-ios/assets/6242034/246e3625-9bc4-4bc7-b358-3db364e944ba)

---
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
