### PR TITLE
[Woo POS] Retrieve order remotely in payment collection instead of relying on existing order in storage

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Hub Menu/HubMenu.swift
+++ b/WooCommerce/Classes/ViewRelated/Hub Menu/HubMenu.swift
@@ -164,8 +164,7 @@ private extension HubMenu {
             case HubMenuViewModel.PointOfSaleEntryPoint.id:
                 if let cardPresentPaymentService = viewModel.cardPresentPaymentService,
                    let orderService = POSOrderService(siteID: viewModel.siteID,
-                                                      credentials: viewModel.credentials,
-                                                      storageManager: ServiceLocator.storageManager) {
+                                                      credentials: viewModel.credentials) {
                     PointOfSaleEntryPointView(
                         itemProvider: viewModel.posItemProvider,
                         hideAppTabBar: { isHidden in

--- a/WooCommerce/Classes/ViewRelated/Orders/Collect Payments/CollectOrderPaymentUseCase.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Collect Payments/CollectOrderPaymentUseCase.swift
@@ -753,7 +753,8 @@ enum CollectOrderPaymentUseCaseError: LocalizedError {
 
         static let orderTotalChangedLocalizedDescription = NSLocalizedString(
             "collectOrderPaymentUseCase.error.message.orderTotalChanged",
-            value: "Unable to process payment. Order total has changed since the beginning of payment.",
+            value: "Order total has changed since the beginning of payment. Please go back and check the order is " +
+            "correct, then try the payment again.",
             comment: "Error message when collecting an In-Person Payment and the order total has changed remotely.")
 
         static let orderAlreadyPaidLocalizedDescription = NSLocalizedString(

--- a/WooCommerce/Classes/ViewRelated/Orders/Collect Payments/CollectOrderPaymentUseCase.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Collect Payments/CollectOrderPaymentUseCase.swift
@@ -752,8 +752,9 @@ enum CollectOrderPaymentUseCaseError: LocalizedError {
             "be replaced with further error details.")
 
         static let orderTotalChangedLocalizedDescription = NSLocalizedString(
-            "Unable to process payment. Order total has changed since the beginning of payment.",
-            comment: "Error message when collecting an In-Person Payment and unable to update the order.")
+            "collectOrderPaymentUseCase.error.message.orderTotalChanged",
+            value: "Unable to process payment. Order total has changed since the beginning of payment.",
+            comment: "Error message when collecting an In-Person Payment and the order total has changed remotely.")
 
         static let orderAlreadyPaidLocalizedDescription = NSLocalizedString(
             "Unable to process payment. This order is already paid, taking a further payment would result in the " +

--- a/WooCommerce/Classes/ViewRelated/Orders/Collect Payments/CollectOrderPaymentUseCase.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Collect Payments/CollectOrderPaymentUseCase.swift
@@ -247,18 +247,20 @@ private extension CollectOrderPaymentUseCase {
             }
         }))
 
-        let action = OrderAction.retrieveOrder(siteID: order.siteID, orderID: order.orderID) { [weak self] (order, error) in
+        let action = OrderAction.retrieveOrderRemotely(siteID: order.siteID, orderID: order.orderID) { [weak self] result in
             guard let self = self else { return }
-            guard let order = order else {
-                DDLogError("⛔️ Error synchronizing Order: \(error.debugDescription)")
-                if let error = error {
-                    return onCheckCompletion(.failure(CollectOrderPaymentUseCaseError.couldNotRefreshOrder(error)))
-                } else {
-                    return onCheckCompletion(.failure(CollectOrderPaymentUseCaseError.unknownErrorRefreshingOrder))
-                }
-            }
 
-            self.order = order
+            switch result {
+                case .success(let order):
+                    guard order.total == self.order.total else {
+                        return onCheckCompletion(.failure(CollectOrderPaymentUseCaseError.orderTotalChanged))
+                    }
+
+                    self.order = order
+                case .failure(let error):
+                    DDLogError("⛔️ Error synchronizing Order: \(error.localizedDescription)")
+                    return onCheckCompletion(.failure(CollectOrderPaymentUseCaseError.couldNotRefreshOrder(error)))
+            }
 
             guard self.isTotalAmountValid() else {
                 return onCheckCompletion(.failure(self.totalAmountInvalidError()))
@@ -716,7 +718,7 @@ enum CollectOrderPaymentUseCaseNotValidAmountError: Error, LocalizedError, Equat
 enum CollectOrderPaymentUseCaseError: LocalizedError {
     case flowCanceledByUser
     case paymentGatewayNotFound
-    case unknownErrorRefreshingOrder
+    case orderTotalChanged
     case couldNotRefreshOrder(Error)
     case orderAlreadyPaid
     case alreadyRetried(Error)
@@ -727,8 +729,8 @@ enum CollectOrderPaymentUseCaseError: LocalizedError {
             return Localization.paymentCancelledLocalizedDescription
         case .paymentGatewayNotFound:
             return Localization.paymentGatewayNotFoundLocalizedDescription
-        case .unknownErrorRefreshingOrder:
-            return Localization.unknownErrorWhileRefreshingOrderLocalizedDescription
+        case .orderTotalChanged:
+            return Localization.orderTotalChangedLocalizedDescription
         case .couldNotRefreshOrder(let error as LocalizedError):
             return error.errorDescription
         case .couldNotRefreshOrder(let error):
@@ -749,9 +751,8 @@ enum CollectOrderPaymentUseCaseError: LocalizedError {
             comment: "Error message when collecting an In-Person Payment and unable to update the order. %!$@ will " +
             "be replaced with further error details.")
 
-        static let unknownErrorWhileRefreshingOrderLocalizedDescription = NSLocalizedString(
-            "Unable to process payment. We could not fetch the latest order details. Please check your network " +
-            "connection and try again.",
+        static let orderTotalChangedLocalizedDescription = NSLocalizedString(
+            "Unable to process payment. Order total has changed since the beginning of payment.",
             comment: "Error message when collecting an In-Person Payment and unable to update the order.")
 
         static let orderAlreadyPaidLocalizedDescription = NSLocalizedString(
@@ -822,7 +823,7 @@ extension CollectOrderPaymentUseCaseError: CardPaymentErrorProtocol {
             return .dontRetry
         case .paymentGatewayNotFound:
             return .restart
-        case .unknownErrorRefreshingOrder, .couldNotRefreshOrder:
+        case .couldNotRefreshOrder, .orderTotalChanged:
             return .reuseIntent
         }
     }

--- a/WooCommerce/Classes/ViewRelated/Orders/Collect Payments/CollectOrderPaymentUseCase.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Collect Payments/CollectOrderPaymentUseCase.swift
@@ -820,11 +820,11 @@ extension CardReaderServiceError: CardPaymentErrorProtocol {
 extension CollectOrderPaymentUseCaseError: CardPaymentErrorProtocol {
     var retryApproach: CardPaymentRetryApproach {
         switch self {
-        case .flowCanceledByUser, .orderAlreadyPaid, .alreadyRetried:
+        case .flowCanceledByUser, .orderAlreadyPaid, .alreadyRetried, .orderTotalChanged:
             return .dontRetry
         case .paymentGatewayNotFound:
             return .restart
-        case .couldNotRefreshOrder, .orderTotalChanged:
+        case .couldNotRefreshOrder:
             return .reuseIntent
         }
     }

--- a/WooCommerce/WooCommerceTests/ViewModels/CardPresentPayments/CollectOrderPaymentUseCaseTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewModels/CardPresentPayments/CollectOrderPaymentUseCaseTests.swift
@@ -31,8 +31,8 @@ final class CollectOrderPaymentUseCaseTests: XCTestCase {
         let order = Order.fake().copy(siteID: defaultSiteID, orderID: defaultOrderID, total: "1.5")
         stores.whenReceivingAction(ofType: OrderAction.self) { action in
             switch action {
-            case .retrieveOrder(_, _, let completion):
-                completion(order, nil)
+            case .retrieveOrderRemotely(_, _, let completion):
+                completion(.success(order))
             default:
                 break
             }
@@ -111,8 +111,8 @@ final class CollectOrderPaymentUseCaseTests: XCTestCase {
 
         stores.whenReceivingAction(ofType: OrderAction.self) { action in
             switch action {
-            case .retrieveOrder(_, _, let completion):
-                completion(order, nil)
+            case .retrieveOrderRemotely(_, _, let completion):
+                completion(.success(order))
             default:
                 break
             }
@@ -154,8 +154,8 @@ final class CollectOrderPaymentUseCaseTests: XCTestCase {
         var markOrderAsPaidLocallyAction: (siteID: Int64, orderID: Int64)?
         stores.whenReceivingAction(ofType: OrderAction.self) { action in
             switch action {
-            case .retrieveOrder(_, _, let completion):
-                completion(Order.fake().copy(siteID: self.defaultSiteID, orderID: self.defaultOrderID, total: "1.5"), nil)
+            case .retrieveOrderRemotely(_, _, let completion):
+                completion(.success(Order.fake().copy(siteID: self.defaultSiteID, orderID: self.defaultOrderID, total: "1.5")))
             case .markOrderAsPaidLocally(let siteID, let orderID, _, _):
                 markOrderAsPaidLocallyAction = (siteID: siteID, orderID: orderID)
             default:
@@ -187,8 +187,8 @@ final class CollectOrderPaymentUseCaseTests: XCTestCase {
         var markOrderAsPaidLocallyAction: (siteID: Int64, orderID: Int64)?
         stores.whenReceivingAction(ofType: OrderAction.self) { action in
             switch action {
-            case .retrieveOrder(_, _, let completion):
-                completion(Order.fake().copy(siteID: self.defaultSiteID, orderID: self.defaultOrderID, total: "1.5"), nil)
+            case .retrieveOrderRemotely(_, _, let completion):
+                completion(.success(Order.fake().copy(siteID: self.defaultSiteID, orderID: self.defaultOrderID, total: "1.5")))
             case .markOrderAsPaidLocally(let siteID, let orderID, _, _):
                 markOrderAsPaidLocallyAction = (siteID: siteID, orderID: orderID)
             default:

--- a/Yosemite/Yosemite/Actions/OrderAction.swift
+++ b/Yosemite/Yosemite/Actions/OrderAction.swift
@@ -75,8 +75,14 @@ public enum OrderAction: Action {
     case resetStoredOrders(onCompletion: () -> Void)
 
     /// Retrieves the specified OrderID.
+    /// If the order exists in storage, it syncs the order's last modified date and if it is different, it syncs the order remotely.
+    /// Otherwise, the order in storage is returned.
     ///
     case retrieveOrder(siteID: Int64, orderID: Int64, onCompletion: (Order?, Error?) -> Void)
+
+    /// Retrieves the specified OrderID remotely.
+    ///
+    case retrieveOrderRemotely(siteID: Int64, orderID: Int64, onCompletion: (Result<Order, Error>) -> Void)
 
     /// Updates a given Order's Status.
     ///

--- a/Yosemite/Yosemite/Stores/OrderStore.swift
+++ b/Yosemite/Yosemite/Stores/OrderStore.swift
@@ -39,6 +39,8 @@ public class OrderStore: Store {
             resetStoredOrders(onCompletion: onCompletion)
         case .retrieveOrder(let siteID, let orderID, let onCompletion):
             retrieveOrder(siteID: siteID, orderID: orderID, onCompletion: onCompletion)
+        case .retrieveOrderRemotely(let siteID, let orderID, let onCompletion):
+            retrieveOrderRemotely(siteID: siteID, orderID: orderID, onCompletion: onCompletion)
         case .searchOrders(let siteID, let keyword, let pageNumber, let pageSize, let onCompletion):
             searchOrders(siteID: siteID, keyword: keyword, pageNumber: pageNumber, pageSize: pageSize, onCompletion: onCompletion)
         case let .fetchFilteredOrders(siteID, statuses, after, before, modifiedAfter, customerID, productID, writeStrategy, pageSize, onCompletion):
@@ -332,6 +334,18 @@ private extension OrderStore {
                     return loadOrderFromRemote(siteID: siteID, orderID: orderID, onCompletion: onCompletion)
                 }
                 onCompletion(storedOrder, nil)
+            }
+        }
+    }
+
+    func retrieveOrderRemotely(siteID: Int64, orderID: Int64, onCompletion: @escaping (Result<Order, Error>) -> Void) {
+        loadOrderFromRemote(siteID: siteID, orderID: orderID) { order, error in
+            if let error {
+                onCompletion(.failure(error))
+            } else if let order {
+                onCompletion(.success(order))
+            } else {
+                onCompletion(.failure(RetrieveOrderError.noErrorAndOrderFromRemote))
             }
         }
     }
@@ -755,6 +769,10 @@ private extension OrderStore {
 extension OrderStore {
     enum MarkOrderAsPaidLocallyError: Error {
         case orderNotFoundInStorage
+    }
+
+    enum RetrieveOrderError: Error {
+        case noErrorAndOrderFromRemote
     }
 
     public enum GiftCardError: Error, Equatable {

--- a/Yosemite/Yosemite/Tools/POS/POSOrderService.swift
+++ b/Yosemite/Yosemite/Tools/POS/POSOrderService.swift
@@ -1,6 +1,5 @@
 import Foundation
 import Networking
-import Storage
 
 /// POSCartItem is different from the CartItem in the POS app layer.
 /// - The POS cart UI might show the cart items differently from how they appear in an order in wp-admin.
@@ -99,23 +98,19 @@ public final class POSOrderService: POSOrderServiceProtocol {
 
     private let siteID: Int64
     private let ordersRemote: OrdersRemote
-    private let storageManager: StorageManagerType
-
-    private lazy var sharedDerivedStorage: StorageType = storageManager.writerDerivedStorage
 
     // MARK: - Initialization
 
-    public convenience init?(siteID: Int64, credentials: Credentials?, storageManager: StorageManagerType) {
+    public convenience init?(siteID: Int64, credentials: Credentials?) {
         guard let credentials else {
             DDLogError("⛔️ Could not create POSOrderService due to not finding credentials")
             return nil
         }
-        self.init(siteID: siteID, network: AlamofireNetwork(credentials: credentials), storageManager: storageManager)
+        self.init(siteID: siteID, network: AlamofireNetwork(credentials: credentials))
     }
 
-    public init(siteID: Int64, network: Network, storageManager: StorageManagerType) {
+    public init(siteID: Int64, network: Network) {
         self.siteID = siteID
-        self.storageManager = storageManager
         self.ordersRemote = OrdersRemote(network: network)
     }
 

--- a/Yosemite/YosemiteTests/Stores/OrderStoreTests.swift
+++ b/Yosemite/YosemiteTests/Stores/OrderStoreTests.swift
@@ -448,6 +448,86 @@ final class OrderStoreTests: XCTestCase {
         assertEqual(expectedOrder, fetchedOrder)
     }
 
+    // MARK: - OrderAction.retrieveOrderRemotely
+
+    /// Verifies that OrderAction.retrieveOrderRemotely returns the expected Order.
+    ///
+    func test_retrieveOrderRemotely_returns_expected_fields() {
+        // Given
+        let orderStore = OrderStore(dispatcher: dispatcher, storageManager: storageManager, network: network)
+        let remoteOrder = sampleOrder()
+        network.simulateResponse(requestUrlSuffix: "orders/963", filename: "order")
+
+        // When
+        let result = waitFor { promise in
+            orderStore.onAction(OrderAction.retrieveOrderRemotely(siteID: self.sampleSiteID, orderID: self.sampleOrderID) { result in
+                promise(result)
+            })
+        }
+
+        // Then
+        XCTAssertEqual(try? result.get(), remoteOrder)
+    }
+
+    /// Verifies that `OrderAction.retrieveOrderRemotely` effectively persists all of the remote order fields
+    /// correctly across all of the related `Order` objects (items, coupons, etc).
+    ///
+    func test_retrieveOrderRemotely_effectively_persists_order_fields_and_related_objects() {
+        // Given
+        let orderStore = OrderStore(dispatcher: dispatcher, storageManager: storageManager, network: network)
+        let remoteOrder = sampleOrder()
+        network.simulateResponse(requestUrlSuffix: "orders/963", filename: "order")
+
+        XCTAssertEqual(viewStorage.countObjects(ofType: Storage.Order.self), 0)
+
+        // When
+        let result = waitFor { promise in
+            orderStore.onAction(OrderAction.retrieveOrderRemotely(siteID: self.sampleSiteID, orderID: self.sampleOrderID) { result in
+                promise(result)
+            })
+        }
+
+        // Then
+        XCTAssertTrue(result.isSuccess)
+
+        let predicate = NSPredicate(format: "orderID = %ld", remoteOrder.orderID)
+        let storedOrder = viewStorage.firstObject(ofType: Storage.Order.self, matching: predicate)
+        XCTAssertEqual(storedOrder?.toReadOnly(), remoteOrder)
+    }
+
+    func test_retrieveOrderRemotely_does_not_return_existing_order_in_storage_and_replaces_order_in_storage() throws {
+        // Given
+        let orderStore = OrderStore(dispatcher: dispatcher, storageManager: storageManager, network: network)
+        network.simulateResponse(requestUrlSuffix: "orders/963", filename: "order")
+
+        // Inserting an order without related objects for simpler testing.
+        // The status is different from the remote order in the simulated response.
+        let existingOrder = sampleOrder().copy(status: .autoDraft)
+        storageManager.insertSampleOrder(readOnlyOrder: existingOrder)
+        viewStorage.saveIfNeeded()
+
+        let predicate = NSPredicate(format: "orderID = %ld", existingOrder.orderID)
+        let existingOrderFromStorage = viewStorage.firstObject(ofType: Storage.Order.self, matching: predicate)?.toReadOnly()
+        assertEqual(existingOrder.status, existingOrderFromStorage?.status)
+
+        XCTAssertEqual(viewStorage.countObjects(ofType: Storage.Order.self), 1)
+
+        // When
+        let result = waitFor { promise in
+            orderStore.onAction(OrderAction.retrieveOrderRemotely(siteID: self.sampleSiteID, orderID: self.sampleOrderID) { result in
+                promise(result)
+            })
+        }
+
+        // Then
+        let retrievedOrder = try XCTUnwrap(result.get())
+        XCTAssertFalse(retrievedOrder == existingOrder)
+        XCTAssertFalse(retrievedOrder.status == existingOrder.status)
+
+        XCTAssertEqual(viewStorage.countObjects(ofType: Storage.Order.self), 1)
+        let orderFromStorage = viewStorage.firstObject(ofType: Storage.Order.self, matching: predicate)?.toReadOnly()
+        assertEqual(retrievedOrder, orderFromStorage)
+    }
 
     // MARK: - OrderStore.upsertStoredOrder
 


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #12869 

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

### Why

Previously, we encountered a bug where the order amount in payment collection became outdated after the first checkout p1718989636432309/1718983933.798199-slack-C070SJRA8DP. The reason was that CollectOrderPaymentUseCase dispatches `OrderAction.retrieveOrder` which uses the existing order in storage if its modified date field hasn't changed remotely (which is the case for edited auto-draft orders at least).

To fix this, originally I upserted the synced order to storage in POSOrderService. But it has a side effect of auto-draft orders appearing in the orders tab until the next sync. After @joshheald's clarification, using the order from storage was not the intended behavior and we should always load the order remotely for payment validation.

### How

A new action `OrderAction.retrieveOrderRemotely` was added with some test cases (and I got stuck in the last test case from not saving the context before dispatching the action 😅 ).

Then, `CollectOrderPaymentUseCase` replaces `OrderAction.retrieveOrder` with `OrderAction.retrieveOrderRemotely` to always load the error from the network. A new error `CollectOrderPaymentUseCaseError.orderTotalChanged` is now thrown if the order total from the remote is different from the original order in the use case. The merchant is able to retry, and  `OrderAction.retrieveOrder` will be triggered again in case the merchant can fix this in some way. Please feel free to suggest handling the error in a better way.

Because of the change to use the order from a remote sync, the storage code in `POSOrderService` was removed completely.

## Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->

Ensure that the previous issue p1718989636432309/1718983933.798199-slack-C070SJRA8DP that requires upserting the order does not occur anymore.

Prerequisite: the store is eligible for POS and the feature switch is enabled in Menu > Settings > Experimental Features > POS
- Launch app
- Go to Menu > Point of Sale
- Connect the reader
- Add something to the cart
- Go to checkout
- Wait for it to be ready to tap
- Go back to Add More
- Add another item
- Go to checkout
- Tap card when it's ready --> the payment should succeed in the end, and the corresponding order in the orders tab should have the same amount as in the order total

## Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->

@jaclync also tested going through several transactions and going back and forth before the final payment.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

The error case looks like this:

<img src="https://github.com/woocommerce/woocommerce-ios/assets/1945542/d48e7402-b315-454f-852b-67904c6a76cd" width="300" />

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.