### PR TITLE
[Woo POS] Merge `CardPresentPaymentEvent.showReaderList` event into `show` event

### DIFF
--- a/WooCommerce/Classes/POS/Card Present Payments/CardPresentPaymentCollectOrderPaymentUseCaseAdaptor.swift
+++ b/WooCommerce/Classes/POS/Card Present Payments/CardPresentPaymentCollectOrderPaymentUseCaseAdaptor.swift
@@ -95,8 +95,6 @@ final class CardPresentPaymentCollectOrderPaymentUseCaseAdaptor {
                 switch latestPaymentEvent {
                     case .show(let eventDetails):
                         onCancel(paymentEventDetails: eventDetails, paymentOrchestrator: invalidatablePaymentOrchestrator)
-                    case .showReaderList(_, let selectionHandler):
-                        selectionHandler(nil)
                     case .idle, .showOnboarding:
                         return
                 }
@@ -126,6 +124,8 @@ private extension CardPresentPaymentCollectOrderPaymentUseCaseAdaptor {
                 .connectingFailedUpdateAddress(_, _, let endSearch),
                 .foundReader(_, _, _, let endSearch):
             endSearch()
+        case .foundMultipleReaders(_, let selectionHandler):
+            selectionHandler(nil)
         case .updateProgress(_, _, let cancelUpdate):
             cancelUpdate?()
         case .updateFailed(_, let cancelUpdate),

--- a/WooCommerce/Classes/POS/Card Present Payments/CardPresentPaymentEvent.swift
+++ b/WooCommerce/Classes/POS/Card Present Payments/CardPresentPaymentEvent.swift
@@ -3,6 +3,5 @@ import Foundation
 enum CardPresentPaymentEvent {
     case idle
     case show(eventDetails: CardPresentPaymentEventDetails)
-    case showReaderList(_ readerIDs: [String], selectionHandler: ((String?) -> Void))
     case showOnboarding(_ onboardingViewModel: CardPresentPaymentsOnboardingViewModel)
 }

--- a/WooCommerce/Classes/POS/Card Present Payments/CardPresentPaymentEventDetails.swift
+++ b/WooCommerce/Classes/POS/Card Present Payments/CardPresentPaymentEventDetails.swift
@@ -28,6 +28,8 @@ enum CardPresentPaymentEventDetails {
                      connect: () -> Void,
                      continueSearch: () -> Void,
                      endSearch: () -> Void)
+    case foundMultipleReaders(readerIDs: [String],
+                              selectionHandler: (String?) -> Void)
     case updateProgress(requiredUpdate: Bool,
                         progress: Float,
                         cancelUpdate: (() -> Void)?)

--- a/WooCommerce/Classes/POS/Card Present Payments/CardPresentPaymentsAlertPresenterAdaptor.swift
+++ b/WooCommerce/Classes/POS/Card Present Payments/CardPresentPaymentsAlertPresenterAdaptor.swift
@@ -53,7 +53,7 @@ final class CardPresentPaymentsAlertPresenterAdaptor: CardPresentPaymentAlertsPr
             self?.latestReaderConnectionHandler = nil
         }
         self.latestReaderConnectionHandler = wrappedConnectionHandler
-        paymentEventSubject.send(.showReaderList(readerIDs, selectionHandler: wrappedConnectionHandler))
+        paymentEventSubject.send(.show(eventDetails: .foundMultipleReaders(readerIDs: readerIDs, selectionHandler: wrappedConnectionHandler)))
     }
 
     func updateSeveralReadersList(readerIDs: [String]) {
@@ -61,7 +61,7 @@ final class CardPresentPaymentsAlertPresenterAdaptor: CardPresentPaymentAlertsPr
             paymentEventSubject.send(.idle) // TODO: Consider more error handling here
             return
         }
-        paymentEventSubject.send(.showReaderList(readerIDs, selectionHandler: latestReaderConnectionHandler))
+        paymentEventSubject.send(.show(eventDetails: .foundMultipleReaders(readerIDs: readerIDs, selectionHandler: latestReaderConnectionHandler)))
     }
 
     func dismiss() {

--- a/WooCommerce/Classes/POS/Presentation/Card Present Payments/Connection Alerts/PointOfSaleCardPresentPaymentAlertType.swift
+++ b/WooCommerce/Classes/POS/Presentation/Card Present Payments/Connection Alerts/PointOfSaleCardPresentPaymentAlertType.swift
@@ -7,6 +7,7 @@ enum PointOfSaleCardPresentPaymentAlertType {
     case scanningFailed(viewModel: PointOfSaleCardPresentPaymentScanningFailedAlertViewModel)
     case bluetoothRequired(viewModel: PointOfSaleCardPresentPaymentBluetoothRequiredAlertViewModel)
     case foundReader(viewModel: PointOfSaleCardPresentPaymentFoundReaderAlertViewModel)
+    case foundMultipleReaders(viewModel: PointOfSaleCardPresentPaymentFoundMultipleReadersAlertViewModel)
     case requiredReaderUpdateInProgress(viewModel: PointOfSaleCardPresentPaymentRequiredReaderUpdateInProgressAlertViewModel)
     case optionalReaderUpdateInProgress(viewModel: PointOfSaleCardPresentPaymentOptionalReaderUpdateInProgressAlertViewModel)
     case readerUpdateCompletion(viewModel: PointOfSaleCardPresentPaymentReaderUpdateCompletionAlertViewModel)

--- a/WooCommerce/Classes/POS/Presentation/Card Present Payments/Connection Alerts/PointOfSaleCardPresentPaymentFoundMultipleReadersAlertViewModel.swift
+++ b/WooCommerce/Classes/POS/Presentation/Card Present Payments/Connection Alerts/PointOfSaleCardPresentPaymentFoundMultipleReadersAlertViewModel.swift
@@ -16,31 +16,3 @@ struct PointOfSaleCardPresentPaymentFoundMultipleReadersAlertViewModel {
         }
     }
 }
-
-private extension PointOfSaleCardPresentPaymentFoundMultipleReadersAlertViewModel {
-    enum Localization {
-        static let title = NSLocalizedString(
-            "pointOfSale.cardPresentPayment.alert.foundReader.title",
-            value: "Do you want to connect to reader %1$@?",
-            comment: "Dialog title that displays the name of a found card reader"
-        )
-
-        static let connect = NSLocalizedString(
-            "pointOfSale.cardPresentPayment.alert.foundReader.connect.button.title",
-            value: "Connect to Reader",
-            comment: "Label for a button that when tapped, starts the process of connecting to a card reader"
-        )
-
-        static let continueSearching = NSLocalizedString(
-            "pointOfSale.cardPresentPayment.alert.foundReader.keepSearching.button.title",
-            value: "Keep Searching",
-            comment: "Label for a button that when tapped, continues searching for card readers"
-        )
-
-        static let cancel = NSLocalizedString(
-            "pointOfSale.cardPresentPayment.alert.foundReader.cancel.button.title",
-            value: "Cancel",
-            comment: "Label for a button that when tapped, cancels the process of connecting to a card reader "
-        )
-    }
-}

--- a/WooCommerce/Classes/POS/Presentation/Card Present Payments/Connection Alerts/PointOfSaleCardPresentPaymentFoundMultipleReadersAlertViewModel.swift
+++ b/WooCommerce/Classes/POS/Presentation/Card Present Payments/Connection Alerts/PointOfSaleCardPresentPaymentFoundMultipleReadersAlertViewModel.swift
@@ -1,5 +1,4 @@
 import Foundation
-import SwiftUI
 
 struct PointOfSaleCardPresentPaymentFoundMultipleReadersAlertViewModel {
     let readerIDs: [String]

--- a/WooCommerce/Classes/POS/Presentation/Card Present Payments/Connection Alerts/PointOfSaleCardPresentPaymentFoundMultipleReadersAlertViewModel.swift
+++ b/WooCommerce/Classes/POS/Presentation/Card Present Payments/Connection Alerts/PointOfSaleCardPresentPaymentFoundMultipleReadersAlertViewModel.swift
@@ -1,0 +1,46 @@
+import Foundation
+import SwiftUI
+
+struct PointOfSaleCardPresentPaymentFoundMultipleReadersAlertViewModel {
+    let readerIDs: [String]
+    let connect: (String) -> Void
+    let cancelSearch: () -> Void
+
+    init(readerIDs: [String], selectionHandler: @escaping (String?) -> Void) {
+        self.readerIDs = readerIDs
+        self.connect = { readerID in
+            selectionHandler(readerID)
+        }
+        self.cancelSearch = {
+            selectionHandler(nil)
+        }
+    }
+}
+
+private extension PointOfSaleCardPresentPaymentFoundMultipleReadersAlertViewModel {
+    enum Localization {
+        static let title = NSLocalizedString(
+            "pointOfSale.cardPresentPayment.alert.foundReader.title",
+            value: "Do you want to connect to reader %1$@?",
+            comment: "Dialog title that displays the name of a found card reader"
+        )
+
+        static let connect = NSLocalizedString(
+            "pointOfSale.cardPresentPayment.alert.foundReader.connect.button.title",
+            value: "Connect to Reader",
+            comment: "Label for a button that when tapped, starts the process of connecting to a card reader"
+        )
+
+        static let continueSearching = NSLocalizedString(
+            "pointOfSale.cardPresentPayment.alert.foundReader.keepSearching.button.title",
+            value: "Keep Searching",
+            comment: "Label for a button that when tapped, continues searching for card readers"
+        )
+
+        static let cancel = NSLocalizedString(
+            "pointOfSale.cardPresentPayment.alert.foundReader.cancel.button.title",
+            value: "Cancel",
+            comment: "Label for a button that when tapped, cancels the process of connecting to a card reader "
+        )
+    }
+}

--- a/WooCommerce/Classes/POS/Presentation/Card Present Payments/Connection Alerts/PointOfSaleCardPresentPaymentFoundMultipleReadersView.swift
+++ b/WooCommerce/Classes/POS/Presentation/Card Present Payments/Connection Alerts/PointOfSaleCardPresentPaymentFoundMultipleReadersView.swift
@@ -1,7 +1,7 @@
 import SwiftUI
 
 /// Displays a list of card readers that are found, with a CTA to connect to a reader and a CTA to cancel reader search.
-struct FoundCardReaderListView: View {
+struct PointOfSaleCardPresentPaymentFoundMultipleReadersView: View {
     private let readerIDs: [String]
     private let connect: (String) -> Void
     private let cancelSearch: () -> Void
@@ -42,7 +42,7 @@ struct FoundCardReaderListView: View {
     }
 }
 
-private extension FoundCardReaderListView {
+private extension PointOfSaleCardPresentPaymentFoundMultipleReadersView {
     @ViewBuilder func readerRow(readerID: String) -> some View {
         HStack {
             Text(readerID)
@@ -64,7 +64,7 @@ private extension FoundCardReaderListView {
     }
 }
 
-private extension FoundCardReaderListView {
+private extension PointOfSaleCardPresentPaymentFoundMultipleReadersView {
     enum Layout {
         static let padding: EdgeInsets = .init(top: 0, leading: 16, bottom: 0, trailing: 16)
         static let headerPadding: EdgeInsets = .init(top: 20, leading: 4, bottom: 20, trailing: 4)
@@ -74,6 +74,6 @@ private extension FoundCardReaderListView {
 }
 
 #Preview {
-    FoundCardReaderListView(viewModel: .init(readerIDs: ["Reader 1", "Reader 2"],
-                                             selectionHandler: { _ in }))
+    PointOfSaleCardPresentPaymentFoundMultipleReadersView(viewModel: .init(readerIDs: ["Reader 1", "Reader 2"],
+                                                                           selectionHandler: { _ in }))
 }

--- a/WooCommerce/Classes/POS/Presentation/Card Present Payments/FoundCardReaderListView.swift
+++ b/WooCommerce/Classes/POS/Presentation/Card Present Payments/FoundCardReaderListView.swift
@@ -6,12 +6,10 @@ struct FoundCardReaderListView: View {
     private let connect: (String) -> Void
     private let cancelSearch: () -> Void
 
-    init(readerIDs: [String],
-         connect: @escaping ((String) -> Void),
-         cancelSearch: @escaping (() -> Void)) {
-        self.readerIDs = readerIDs
-        self.connect = connect
-        self.cancelSearch = cancelSearch
+    init(viewModel: PointOfSaleCardPresentPaymentFoundMultipleReadersAlertViewModel) {
+        self.readerIDs = viewModel.readerIDs
+        self.connect = viewModel.connect
+        self.cancelSearch = viewModel.cancelSearch
     }
 
     var body: some View {
@@ -76,7 +74,6 @@ private extension FoundCardReaderListView {
 }
 
 #Preview {
-    FoundCardReaderListView(readerIDs: ["Reader 1", "Reader 2"],
-                            connect: { _ in },
-                            cancelSearch: {})
+    FoundCardReaderListView(viewModel: .init(readerIDs: ["Reader 1", "Reader 2"],
+                                             selectionHandler: { _ in }))
 }

--- a/WooCommerce/Classes/POS/Presentation/Card Present Payments/PointOfSaleCardPresentPaymentEventPresentationStyle.swift
+++ b/WooCommerce/Classes/POS/Presentation/Card Present Payments/PointOfSaleCardPresentPaymentEventPresentationStyle.swift
@@ -68,6 +68,12 @@ extension CardPresentPaymentEventDetails {
                     continueSearchAction: continueSearch,
                     endSearchAction: endSearch)))
 
+        case .foundMultipleReaders(let readerIDs, let selectionHandler):
+            return .alert(.foundMultipleReaders(
+                viewModel: PointOfSaleCardPresentPaymentFoundMultipleReadersAlertViewModel(
+                    readerIDs: readerIDs,
+                    selectionHandler: selectionHandler)))
+
         case .updateProgress(let requiredUpdate, let progress, let cancelUpdate):
                 if progress == 1.0 {
                     return .alert(.readerUpdateCompletion(viewModel: .init()))

--- a/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/Connection Alerts/PointOfSaleCardPresentPaymentFoundMultipleReadersView.swift
+++ b/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/Connection Alerts/PointOfSaleCardPresentPaymentFoundMultipleReadersView.swift
@@ -14,7 +14,7 @@ struct PointOfSaleCardPresentPaymentFoundMultipleReadersView: View {
 
     var body: some View {
         VStack(spacing: 0) {
-            Text(SeveralReadersFoundViewController.Localization.headline)
+            Text(Localization.headline)
                 .font(.headline)
                 .padding(Layout.headerPadding)
 
@@ -33,7 +33,7 @@ struct PointOfSaleCardPresentPaymentFoundMultipleReadersView: View {
             Button(action: {
                 cancelSearch()
             }) {
-                Text(SeveralReadersFoundViewController.Localization.cancel)
+                Text(Localization.cancel)
             }
             .buttonStyle(SecondaryButtonStyle())
             .padding(Layout.buttonPadding)
@@ -47,7 +47,7 @@ private extension PointOfSaleCardPresentPaymentFoundMultipleReadersView {
         HStack {
             Text(readerID)
             Spacer()
-            Button(SeveralReadersFoundViewController.Localization.connect) {
+            Button(Localization.connect) {
                 connect(readerID)
             }
             .buttonStyle(TextButtonStyle())
@@ -57,10 +57,38 @@ private extension PointOfSaleCardPresentPaymentFoundMultipleReadersView {
     @ViewBuilder func scanningText() -> some View {
         HStack(spacing: Layout.horizontalSpacing) {
             ActivityIndicator(isAnimating: .constant(true), style: .medium)
-            Text(SeveralReadersFoundViewController.Localization.scanningLabel)
+            Text(Localization.scanningLabel)
                 .font(.footnote)
             Spacer()
         }
+    }
+}
+
+private extension PointOfSaleCardPresentPaymentFoundMultipleReadersView {
+    enum Localization {
+        static let headline = NSLocalizedString(
+            "pointOfSale.cardPresentPayment.alert.foundMultipleReaders.headline",
+            value: "Several readers found",
+            comment: "Title of a modal presenting a list of readers to choose from."
+        )
+
+        static let connect = NSLocalizedString(
+            "pointOfSale.cardPresentPayment.alert.foundMultipleReaders.connect.button.title",
+            value: "Connect",
+            comment: "Button in a cell to allow the user to connect to that reader for that cell"
+        )
+
+        static let scanningLabel = NSLocalizedString(
+            "pointOfSale.cardPresentPayment.alert.foundMultipleReaders.scanning.label",
+            value: "Scanning for readers",
+            comment: "Label for a cell informing the user that reader scanning is ongoing."
+        )
+
+        static let cancel = NSLocalizedString(
+            "pointOfSale.cardPresentPayment.alert.foundMultipleReaders.cancel.button.title",
+            value: "Cancel",
+            comment: "Button to allow the user to close the modal without connecting."
+        )
     }
 }
 

--- a/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/PointOfSaleCardPresentPaymentAlert.swift
+++ b/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/PointOfSaleCardPresentPaymentAlert.swift
@@ -18,7 +18,7 @@ struct PointOfSaleCardPresentPaymentAlert: View {
         case .foundReader(let alertViewModel):
             PointOfSaleCardPresentPaymentFoundReadersView(viewModel: alertViewModel)
         case .foundMultipleReaders(let alertViewModel):
-            FoundCardReaderListView(viewModel: alertViewModel)
+            PointOfSaleCardPresentPaymentFoundMultipleReadersView(viewModel: alertViewModel)
         case .requiredReaderUpdateInProgress(let alertViewModel):
             PointOfSaleCardPresentPaymentRequiredReaderUpdateInProgressView(viewModel: alertViewModel)
         case .optionalReaderUpdateInProgress(let alertViewModel):

--- a/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/PointOfSaleCardPresentPaymentAlert.swift
+++ b/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/PointOfSaleCardPresentPaymentAlert.swift
@@ -17,6 +17,8 @@ struct PointOfSaleCardPresentPaymentAlert: View {
             PointOfSaleCardPresentPaymentBluetoothRequiredAlertView(viewModel: alertViewModel)
         case .foundReader(let alertViewModel):
             PointOfSaleCardPresentPaymentFoundReadersView(viewModel: alertViewModel)
+        case .foundMultipleReaders(let alertViewModel):
+            FoundCardReaderListView(viewModel: alertViewModel)
         case .requiredReaderUpdateInProgress(let alertViewModel):
             PointOfSaleCardPresentPaymentRequiredReaderUpdateInProgressView(viewModel: alertViewModel)
         case .optionalReaderUpdateInProgress(let alertViewModel):

--- a/WooCommerce/Classes/POS/Presentation/PointOfSaleDashboardView.swift
+++ b/WooCommerce/Classes/POS/Presentation/PointOfSaleDashboardView.swift
@@ -48,13 +48,6 @@ struct PointOfSaleDashboardView: View {
                 PointOfSaleCardPresentPaymentAlert(alertType: alertType)
             } else {
                 switch viewModel.cardPresentPaymentEvent {
-                case let .showReaderList(readerIDs, selectionHandler):
-                    // TODO: make this an instance of `showAlert` so we can handle it above too.
-                    FoundCardReaderListView(readerIDs: readerIDs, connect: { readerID in
-                        selectionHandler(readerID)
-                    }, cancelSearch: {
-                        selectionHandler(nil)
-                    })
                 case .idle,
                         .show, // handled above
                         .showOnboarding:
@@ -96,8 +89,6 @@ fileprivate extension CardPresentPaymentEvent {
             return "Idle"
         case .show:
             return "Event"
-        case .showReaderList(let readerIDs, _):
-            return "Reader List: \(readerIDs.joined())"
         case .showOnboarding(let onboardingViewModel):
             return "Onboarding: \(onboardingViewModel.state.reasonForAnalytics)" // This will only show the initial onboarding state
         }

--- a/WooCommerce/Classes/POS/ViewModels/PointOfSaleDashboardViewModel.swift
+++ b/WooCommerce/Classes/POS/ViewModels/PointOfSaleDashboardViewModel.swift
@@ -282,8 +282,7 @@ private extension PointOfSaleDashboardViewModel {
                 case .message, .none:
                     return false
                 }
-            case .showReaderList,
-                    .showOnboarding:
+            case .showOnboarding:
                 return true
             }
         }.assign(to: &$showsCardReaderSheet)

--- a/WooCommerce/Classes/ViewRelated/CardPresentPayments/SeveralReadersFoundViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/CardPresentPayments/SeveralReadersFoundViewController.swift
@@ -269,7 +269,7 @@ private enum Row {
 
 // MARK: - Localization
 //
-extension SeveralReadersFoundViewController {
+private extension SeveralReadersFoundViewController {
     enum Localization {
         static let headline = NSLocalizedString(
             "Several readers found",

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -7588,6 +7588,7 @@
 				203163BA2C1C5F72001C96DA /* PointOfSaleCardPresentPaymentConnectingFailedUpdatePostalCodeView.swift */,
 				203163B62C1C5EDF001C96DA /* PointOfSaleCardPresentPaymentConnectingFailedChargeReaderView.swift */,
 				026826BB2BF59E410036F959 /* PointOfSaleCardPresentPaymentFoundReadersView.swift */,
+				0220F4942C16DC98003723C2 /* PointOfSaleCardPresentPaymentFoundMultipleReadersView.swift */,
 				203163B82C1C5F42001C96DA /* PointOfSaleCardPresentPaymentConnectingFailedUpdateAddressView.swift */,
 				026826B92BF59E400036F959 /* PointOfSaleCardPresentPaymentRequiredReaderUpdateInProgressView.swift */,
 				029D025D2C231F2A00CB1E75 /* PointOfSaleCardPresentPaymentOptionalReaderUpdateInProgressView.swift */,
@@ -7632,7 +7633,6 @@
 				026225202C21F01F00700977 /* PointOfSaleCardPresentPaymentReaderUpdateFailedNonRetryableAlertViewModel.swift */,
 				02B9243E2C2200D600DC75F2 /* PointOfSaleCardPresentPaymentReaderUpdateFailedLowBatteryAlertViewModel.swift */,
 				029048282C2B5825009B77F9 /* PointOfSaleCardPresentPaymentFoundMultipleReadersAlertViewModel.swift */,
-				0220F4942C16DC98003723C2 /* PointOfSaleCardPresentPaymentFoundMultipleReadersView.swift */,
 			);
 			path = "Connection Alerts";
 			sourceTree = "<group>";

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -401,6 +401,7 @@
 		028FA466257E021100F88A48 /* RefundShippingLabelViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 028FA465257E021100F88A48 /* RefundShippingLabelViewModel.swift */; };
 		028FA46C257E0D9F00F88A48 /* PlainTextSectionHeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 028FA46B257E0D9F00F88A48 /* PlainTextSectionHeaderView.swift */; };
 		028FF8E32AA1E1C60038964F /* ProductDetailsCellViewModel+AddOns.swift in Sources */ = {isa = PBXBuildFile; fileRef = 028FF8E22AA1E1C60038964F /* ProductDetailsCellViewModel+AddOns.swift */; };
+		029048292C2B5825009B77F9 /* PointOfSaleCardPresentPaymentFoundMultipleReadersAlertViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 029048282C2B5825009B77F9 /* PointOfSaleCardPresentPaymentFoundMultipleReadersAlertViewModel.swift */; };
 		0290E26F238E3CE400B5C466 /* ListSelectorViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0290E26D238E3CE400B5C466 /* ListSelectorViewController.swift */; };
 		0290E275238E4F8100B5C466 /* PaginatedListSelectorViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0290E273238E4F8100B5C466 /* PaginatedListSelectorViewController.swift */; };
 		0290E27E238E5B5C00B5C466 /* ProductStockStatusListSelectorCommandTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0290E27D238E5B5C00B5C466 /* ProductStockStatusListSelectorCommandTests.swift */; };
@@ -3377,6 +3378,7 @@
 		028FA465257E021100F88A48 /* RefundShippingLabelViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RefundShippingLabelViewModel.swift; sourceTree = "<group>"; };
 		028FA46B257E0D9F00F88A48 /* PlainTextSectionHeaderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlainTextSectionHeaderView.swift; sourceTree = "<group>"; };
 		028FF8E22AA1E1C60038964F /* ProductDetailsCellViewModel+AddOns.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ProductDetailsCellViewModel+AddOns.swift"; sourceTree = "<group>"; };
+		029048282C2B5825009B77F9 /* PointOfSaleCardPresentPaymentFoundMultipleReadersAlertViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PointOfSaleCardPresentPaymentFoundMultipleReadersAlertViewModel.swift; sourceTree = "<group>"; };
 		0290E26D238E3CE400B5C466 /* ListSelectorViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ListSelectorViewController.swift; sourceTree = "<group>"; };
 		0290E273238E4F8100B5C466 /* PaginatedListSelectorViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaginatedListSelectorViewController.swift; sourceTree = "<group>"; };
 		0290E27D238E5B5C00B5C466 /* ProductStockStatusListSelectorCommandTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductStockStatusListSelectorCommandTests.swift; sourceTree = "<group>"; };
@@ -7630,6 +7632,7 @@
 				02ED3D202C2330F400ED6F3E /* PointOfSaleCardPresentPaymentReaderUpdateFailedAlertViewModel.swift */,
 				026225202C21F01F00700977 /* PointOfSaleCardPresentPaymentReaderUpdateFailedNonRetryableAlertViewModel.swift */,
 				02B9243E2C2200D600DC75F2 /* PointOfSaleCardPresentPaymentReaderUpdateFailedLowBatteryAlertViewModel.swift */,
+				029048282C2B5825009B77F9 /* PointOfSaleCardPresentPaymentFoundMultipleReadersAlertViewModel.swift */,
 			);
 			path = "Connection Alerts";
 			sourceTree = "<group>";
@@ -14804,6 +14807,7 @@
 				023D69BC2589BF5900F7DA72 /* PrintShippingLabelCoordinator.swift in Sources */,
 				45F627B8253603AE00894B86 /* ProductDownloadSettingsViewController.swift in Sources */,
 				D843D5D322485009001BFA55 /* ShipmentProvidersViewController.swift in Sources */,
+				029048292C2B5825009B77F9 /* PointOfSaleCardPresentPaymentFoundMultipleReadersAlertViewModel.swift in Sources */,
 				02482A8E237BEAE9007E73ED /* AztecLinkFormatBarCommand.swift in Sources */,
 				02162729237965E8000208D2 /* ProductFormTableViewModel.swift in Sources */,
 				68E6749F2A4DA01C0034BA1E /* WooWPComPlan.swift in Sources */,

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -119,7 +119,7 @@
 		021EBB362A3054BE003634CA /* BlazeEligibilityChecker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 021EBB352A3054BE003634CA /* BlazeEligibilityChecker.swift */; };
 		021EBB382A3076F4003634CA /* BlazeEligibilityCheckerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 021EBB372A3076F4003634CA /* BlazeEligibilityCheckerTests.swift */; };
 		021FB44C24A5E3B00090E144 /* ProductListMultiSelectorSearchUICommand.swift in Sources */ = {isa = PBXBuildFile; fileRef = 021FB44B24A5E3B00090E144 /* ProductListMultiSelectorSearchUICommand.swift */; };
-		0220F4952C16DC98003723C2 /* FoundCardReaderListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0220F4942C16DC98003723C2 /* FoundCardReaderListView.swift */; };
+		0220F4952C16DC98003723C2 /* PointOfSaleCardPresentPaymentFoundMultipleReadersView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0220F4942C16DC98003723C2 /* PointOfSaleCardPresentPaymentFoundMultipleReadersView.swift */; };
 		0221121E288973C20028F0AF /* LocalNotification.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0221121D288973C20028F0AF /* LocalNotification.swift */; };
 		022266BA2AE76E0E00614F34 /* ProductBundleItem+SwiftUIPreviewHelpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 022266B92AE76E0E00614F34 /* ProductBundleItem+SwiftUIPreviewHelpers.swift */; };
 		022266BC2AE7707000614F34 /* ConfigurableBundleItemViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 022266BB2AE7707000614F34 /* ConfigurableBundleItemViewModel.swift */; };
@@ -3094,7 +3094,7 @@
 		021EBB352A3054BE003634CA /* BlazeEligibilityChecker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BlazeEligibilityChecker.swift; sourceTree = "<group>"; };
 		021EBB372A3076F4003634CA /* BlazeEligibilityCheckerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BlazeEligibilityCheckerTests.swift; sourceTree = "<group>"; };
 		021FB44B24A5E3B00090E144 /* ProductListMultiSelectorSearchUICommand.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductListMultiSelectorSearchUICommand.swift; sourceTree = "<group>"; };
-		0220F4942C16DC98003723C2 /* FoundCardReaderListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FoundCardReaderListView.swift; sourceTree = "<group>"; };
+		0220F4942C16DC98003723C2 /* PointOfSaleCardPresentPaymentFoundMultipleReadersView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PointOfSaleCardPresentPaymentFoundMultipleReadersView.swift; sourceTree = "<group>"; };
 		0221121D288973C20028F0AF /* LocalNotification.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocalNotification.swift; sourceTree = "<group>"; };
 		022266B92AE76E0E00614F34 /* ProductBundleItem+SwiftUIPreviewHelpers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ProductBundleItem+SwiftUIPreviewHelpers.swift"; sourceTree = "<group>"; };
 		022266BB2AE7707000614F34 /* ConfigurableBundleItemViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConfigurableBundleItemViewModel.swift; sourceTree = "<group>"; };
@@ -7284,7 +7284,6 @@
 				205E79412C1CA6E3001BA266 /* PointOfSaleCardPresentPaymentEventPresentationStyle.swift */,
 				205E793E2C1CA1EF001BA266 /* Reader Messages */,
 				205B7EB52C19F89B00D14A36 /* Connection Alerts */,
-				0220F4942C16DC98003723C2 /* FoundCardReaderListView.swift */,
 			);
 			path = "Card Present Payments";
 			sourceTree = "<group>";
@@ -7633,6 +7632,7 @@
 				026225202C21F01F00700977 /* PointOfSaleCardPresentPaymentReaderUpdateFailedNonRetryableAlertViewModel.swift */,
 				02B9243E2C2200D600DC75F2 /* PointOfSaleCardPresentPaymentReaderUpdateFailedLowBatteryAlertViewModel.swift */,
 				029048282C2B5825009B77F9 /* PointOfSaleCardPresentPaymentFoundMultipleReadersAlertViewModel.swift */,
+				0220F4942C16DC98003723C2 /* PointOfSaleCardPresentPaymentFoundMultipleReadersView.swift */,
 			);
 			path = "Connection Alerts";
 			sourceTree = "<group>";
@@ -15879,7 +15879,7 @@
 				CC4D1D8625E6CDDE00B6E4E7 /* RenameAttributesViewModel.swift in Sources */,
 				DEFA3D932897D8930076FAE1 /* NoWooErrorViewModel.swift in Sources */,
 				209B15672AD85F070094152A /* OperatingSystemVersion+Localization.swift in Sources */,
-				0220F4952C16DC98003723C2 /* FoundCardReaderListView.swift in Sources */,
+				0220F4952C16DC98003723C2 /* PointOfSaleCardPresentPaymentFoundMultipleReadersView.swift in Sources */,
 				020A55F127F6C605007843F0 /* CardReaderConnectionAnalyticsTracker.swift in Sources */,
 				6850C5F12B69E74D0026A93B /* ReceiptViewController.swift in Sources */,
 				DEC2962126BD1627005A056B /* ShippingLabelCustomsFormList.swift in Sources */,


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #13072 
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

More details about why we're doing this at https://github.com/woocommerce/woocommerce-ios/issues/13072.

Now that we have an adaptor for the alert provider and alert presenter, this PR moves `CardPresentPaymentEvent.showReaderList` to `CardPresentPaymentEventDetails.foundMultipleReaders` then to be presented as an alert like other connection event cases.

`FoundCardReaderListView` was renamed to `PointOfSaleCardPresentPaymentFoundMultipleReadersView` (though GitHub didn't group the diffs in one place) to be consistent with other views. `PointOfSaleCardPresentPaymentFoundMultipleReadersAlertViewModel` was created to provide what the view needs. I decided to keep the localizable strings within the view for simplicity even though other views generally have the strings provided by the view model, but I'm happy to change it.

## Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->


Prerequisite: the store is eligible for POS and the feature switch is enabled in Menu > Settings > Experimental Features > POS. Testing with a simulated card reader is recommended, unless you have multiple card readers at hand

* Launch app
* Go to Menu > Point of Sale
* Tap `Connect now` --> the reader found modal should be shown with 3 CTAs (if it just auto-connects, try disconnecting in Menu > Payments > Manage Card Reader and/or switching stores to clear the selected reader state)
* Tap `Keep Searching` --> the reader list should be shown as before
* Tap `Cancel` --> the modal should be dismissed and no reader should be connected
* Tap `Connect now` again
* Tap `Keep Searching`
* Tap `Connect` on a reader --> the reader should be connected, and matches the ID as in Menu > Payments > Manage Card Reader

## Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->


https://github.com/woocommerce/woocommerce-ios/assets/1945542/3c61fee1-c71e-45c4-a58e-ddfad1cc83ba



---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.