### PR TITLE
[Woo POS] Add pull-to-refresh to product list

### DIFF
--- a/WooCommerce/Classes/POS/Presentation/ItemListView.swift
+++ b/WooCommerce/Classes/POS/Presentation/ItemListView.swift
@@ -8,19 +8,17 @@ struct ItemListView: View {
     }
 
     var body: some View {
-        if viewModel.isSyncingItems {
-            VStack {
+        VStack {
+            Text("Products")
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .padding(.vertical, 8)
+                .font(.title)
+                .foregroundColor(Color.posPrimaryTexti3)
+            if viewModel.isSyncingItems {
                 Spacer()
                 Text("Loading...")
                 Spacer()
-            }
-        } else {
-            VStack {
-                Text("Products")
-                    .frame(maxWidth: .infinity, alignment: .leading)
-                    .padding(.vertical, 8)
-                    .font(.title)
-                    .foregroundColor(Color.posPrimaryTexti3)
+            } else {
                 ScrollView {
                     ForEach(viewModel.items, id: \.productID) { item in
                         Button(action: {
@@ -31,9 +29,9 @@ struct ItemListView: View {
                     }
                 }
             }
-            .padding(.horizontal, 32)
-            .background(Color.posBackgroundGreyi3)
         }
+        .padding(.horizontal, 32)
+        .background(Color.posBackgroundGreyi3)
     }
 }
 

--- a/WooCommerce/Classes/POS/Presentation/PointOfSaleDashboardView.swift
+++ b/WooCommerce/Classes/POS/Presentation/PointOfSaleDashboardView.swift
@@ -32,6 +32,9 @@ struct PointOfSaleDashboardView: View {
         .task {
             await viewModel.populatePointOfSaleItems()
         }
+        .refreshable {
+            await viewModel.reload()
+        }
         .background(Color.posBackgroundGreyi3)
         .navigationBarBackButtonHidden(true)
         .toolbar {

--- a/WooCommerce/Classes/POS/ViewModels/PointOfSaleDashboardViewModel.swift
+++ b/WooCommerce/Classes/POS/ViewModels/PointOfSaleDashboardViewModel.swift
@@ -76,12 +76,27 @@ final class PointOfSaleDashboardViewModel: ObservableObject {
 
     @MainActor
     func populatePointOfSaleItems() async {
+        isSyncingItems = true
         do {
             items = try await itemProvider.providePointOfSaleItems()
-            isSyncingItems = false
         } catch {
-            debugPrint("\(error)")
+            DDLogError("Error on load while fetching product data: \(error)")
         }
+        isSyncingItems = false
+    }
+
+    @MainActor
+    func reload() async {
+        isSyncingItems = true
+        do {
+            let newItems = try await itemProvider.providePointOfSaleItems()
+            // Only clears in-memory items if the `do` block continues, otherwise we keep them in memory.
+            items.removeAll()
+            items = newItems
+        } catch {
+            DDLogError("Error on reload while updating product data: \(error)")
+        }
+        isSyncingItems = false
     }
 
     var isCartCollapsed: Bool {

--- a/WooCommerce/WooCommerceTests/POS/ViewModels/PointOfSaleDashboardViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/POS/ViewModels/PointOfSaleDashboardViewModelTests.swift
@@ -95,6 +95,15 @@ final class PointOfSaleDashboardViewModelTests: XCTestCase {
         // Then
         XCTAssertEqual(sut.isSyncingItems, false)
     }
+
+    func test_reload_invokes_providePointOfSaleItems() async {
+        // Given/When
+        XCTAssertEqual(itemProvider.provideItemsInvocationCount, 0)
+        await sut.reload()
+
+        // Then
+        XCTAssertEqual(itemProvider.provideItemsInvocationCount, 1)
+    }
 }
 
 private extension PointOfSaleDashboardViewModelTests {
@@ -105,8 +114,10 @@ private extension PointOfSaleDashboardViewModelTests {
     final class MockPOSItemProvider: POSItemProvider {
         var items: [POSItem] = []
         var shouldThrowError: Bool = false
+        var provideItemsInvocationCount = 0
 
         func providePointOfSaleItems() async throws -> [Yosemite.POSItem] {
+            provideItemsInvocationCount += 1
             if shouldThrowError {
                 throw POSError.forcedError
             }

--- a/WooCommerce/WooCommerceTests/POS/ViewModels/PointOfSaleDashboardViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/POS/ViewModels/PointOfSaleDashboardViewModelTests.swift
@@ -5,25 +5,29 @@ import XCTest
 @testable import enum Yosemite.Credentials
 @testable import protocol Yosemite.POSItemProvider
 @testable import protocol Yosemite.POSItem
+@testable import protocol Yosemite.POSOrderServiceProtocol
 
 final class PointOfSaleDashboardViewModelTests: XCTestCase {
 
     private var sut: PointOfSaleDashboardViewModel!
     private var cardPresentPaymentService: CardPresentPaymentPreviewService!
     private var itemProvider: MockPOSItemProvider!
+    private var orderService: POSOrderServiceProtocol!
 
     override func setUp() {
         super.setUp()
         cardPresentPaymentService = CardPresentPaymentPreviewService()
         itemProvider = MockPOSItemProvider()
+        orderService = POSOrderPreviewService()
         sut = PointOfSaleDashboardViewModel(itemProvider: itemProvider,
                                             cardPresentPaymentService: cardPresentPaymentService,
-                                            orderService: POSOrderPreviewService())
+                                            orderService: orderService)
     }
 
     override func tearDown() {
         cardPresentPaymentService = nil
         itemProvider = nil
+        orderService = nil
         sut = nil
         super.tearDown()
     }
@@ -64,13 +68,48 @@ final class PointOfSaleDashboardViewModelTests: XCTestCase {
         // Then
         XCTAssertEqual(sut.isSyncingItems, false)
     }
+
+    func test_isSyncingItems_is_true_when_reload_is_invoked_then_toggled_to_false_when_completed() async throws {
+        XCTAssertEqual(sut.isSyncingItems, true, "Precondition")
+
+        // Given/When
+        await sut.reload()
+
+        // Then
+        XCTAssertEqual(sut.isSyncingItems, false)
+    }
+
+    func test_isSyncingItems_is_true_when_reload_is_invoked_then_toggled_to_false_when_error() async throws {
+        // Given
+        let itemProvider = MockPOSItemProvider()
+        itemProvider.shouldThrowError = true
+
+        let sut = PointOfSaleDashboardViewModel(itemProvider: itemProvider,
+                                                cardPresentPaymentService: cardPresentPaymentService,
+                                                orderService: orderService)
+        XCTAssertEqual(sut.isSyncingItems, true, "Precondition")
+
+        // Given/When
+        await sut.reload()
+
+        // Then
+        XCTAssertEqual(sut.isSyncingItems, false)
+    }
 }
 
 private extension PointOfSaleDashboardViewModelTests {
+    enum POSError: Error {
+        case forcedError
+    }
+
     final class MockPOSItemProvider: POSItemProvider {
         var items: [POSItem] = []
+        var shouldThrowError: Bool = false
 
         func providePointOfSaleItems() async throws -> [Yosemite.POSItem] {
+            if shouldThrowError {
+                throw POSError.forcedError
+            }
             return items
         }
 


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of #12837

## Description
This PR adds pull-to-refresh functionality to the POS product list via the `.refreshable` async handler
![Simulator Screen Recording - iPad Pro (12 9-inch) (6th generation) - 2024-06-26 at 09 17 07](https://github.com/woocommerce/woocommerce-ios/assets/3812076/cfc96777-6fbe-484a-985b-7b19d324ae82)

## Testing
- In POS
- Load the product list
- In your site, create a new simple product, publish it
- Pull-to-refresh in the product list, you'll see a "loading..." screen
- Observe that the new product appears in the product list
- Observe that also works when the cart already has products added to it

Note that the network request data sorting is set to `"orderby":"title","order":"asc"` so depending on the product's name this will appear further down in the list.

Additionally you can add a print statement after the await, and observe the console before and after adding a product via the web:
```diff
let newItems = try await itemProvider.providePointOfSaleItems()
+ debugPrint("🍍 Items in array: \(newItems.count)")
```
