### PR TITLE
[Woo POS] Add `Clear all` button to `CartView`

### DIFF
--- a/WooCommerce/Classes/POS/Presentation/CartView.swift
+++ b/WooCommerce/Classes/POS/Presentation/CartView.swift
@@ -16,6 +16,13 @@ struct CartView: View {
                 if let temsInCartLabel = viewModel.itemsInCartLabel {
                     Text(temsInCartLabel)
                         .foregroundColor(Color.posPrimaryTexti3)
+                    Button {
+                        viewModel.removeAllItemsFromCart()
+                    } label: {
+                        Text("Clear all")
+                            .foregroundColor(Color.init(uiColor: .wooCommercePurple(.shade60)))
+                    }
+                    .padding(.horizontal, 8)
                 }
             }
             .frame(maxWidth: .infinity, alignment: .leading)

--- a/WooCommerce/Classes/POS/ViewModels/PointOfSaleDashboardViewModel.swift
+++ b/WooCommerce/Classes/POS/ViewModels/PointOfSaleDashboardViewModel.swift
@@ -125,6 +125,10 @@ final class PointOfSaleDashboardViewModel: ObservableObject {
         }
     }
 
+    func removeAllItemsFromCart() {
+        itemsInCart.removeAll()
+    }
+
     var itemsInCartLabel: String? {
         switch itemsInCart.count {
         case 0:

--- a/WooCommerce/WooCommerceTests/POS/ViewModels/PointOfSaleDashboardViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/POS/ViewModels/PointOfSaleDashboardViewModelTests.swift
@@ -104,6 +104,29 @@ final class PointOfSaleDashboardViewModelTests: XCTestCase {
         // Then
         XCTAssertEqual(itemProvider.provideItemsInvocationCount, 1)
     }
+
+    func test_removeAllItemsFromCart_removes_all_items_from_cart() {
+        // Given
+        let numberOfItems = Int.random(in: 1...5)
+        for i in 1...numberOfItems {
+            let product = POSProduct(itemID: UUID(),
+                                     productID: Int64(i),
+                                     name: "Choco",
+                                     price: "2.00",
+                                     formattedPrice: "$2.00",
+                                     itemCategories: [],
+                                     productImageSource: nil,
+                                     productType: .simple)
+            sut.addItemToCart(product)
+        }
+        XCTAssertEqual(sut.itemsInCart.count, numberOfItems)
+
+        // When
+        sut.removeAllItemsFromCart()
+
+        // Then
+        XCTAssertEqual(sut.itemsInCart.count, 0)
+    }
 }
 
 private extension PointOfSaleDashboardViewModelTests {


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes #13150
https://github.com/woocommerce/woocommerce-ios/pull/13149 must be merged first

![Simulator Screen Recording - iPad Pro (12 9-inch) (6th generation) - 2024-06-26 at 11 08 12](https://github.com/woocommerce/woocommerce-ios/assets/3812076/fef263a4-4c22-400d-9ffa-7d66f39aa435)


## Description
This PR adds a `Clear all` button to the `CartView` as per latest designs on p1719373464939629/1718835247.409189-slack-C070SJRA8DP

## Testing
- In POS mode
- Add items to the cart
- Tap "Clear all"
- Observe the cart is emptied out and the cart view disappears