### PR TITLE
Google Ads: Update Yosemite to support checking GLA connection

### DIFF
--- a/WooCommerce/Classes/Yosemite/AuthenticatedState.swift
+++ b/WooCommerce/Classes/Yosemite/AuthenticatedState.swift
@@ -96,7 +96,8 @@ class AuthenticatedState: StoresManagerState {
                                network: network,
                                fileStorage: PListFileStorage()),
             WordPressSiteStore(network: network, dispatcher: dispatcher),
-            StoreOnboardingTasksStore(dispatcher: dispatcher, storageManager: storageManager, network: network)
+            StoreOnboardingTasksStore(dispatcher: dispatcher, storageManager: storageManager, network: network),
+            GoogleAdsStore(dispatcher: dispatcher, storageManager: storageManager, network: network)
         ]
 
 

--- a/Yosemite/Yosemite.xcodeproj/project.pbxproj
+++ b/Yosemite/Yosemite.xcodeproj/project.pbxproj
@@ -444,6 +444,8 @@
 		DEA493922B3BD49700EED015 /* BlazeTargetDevice+ReadOnlyConvertible.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEA493912B3BD49700EED015 /* BlazeTargetDevice+ReadOnlyConvertible.swift */; };
 		DEA493942B3D588500EED015 /* BlazeTargetLanguage+ReadonlyConvertible.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEA493932B3D588500EED015 /* BlazeTargetLanguage+ReadonlyConvertible.swift */; };
 		DEA493962B3D608B00EED015 /* BlazeTargetTopic+ReadonlyConvertible.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEA493952B3D608B00EED015 /* BlazeTargetTopic+ReadonlyConvertible.swift */; };
+		DEB387822C2AB4370025256E /* GoogleAdsStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEB387812C2AB4370025256E /* GoogleAdsStore.swift */; };
+		DEB387842C2AB50B0025256E /* GoogleAdsAction.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEB387832C2AB50B0025256E /* GoogleAdsAction.swift */; };
 		DED91DEE2AD673CF00CDCC53 /* BlazeAction.swift in Sources */ = {isa = PBXBuildFile; fileRef = DED91DED2AD673CF00CDCC53 /* BlazeAction.swift */; };
 		DED91DF02AD6756600CDCC53 /* BlazeStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = DED91DEF2AD6756600CDCC53 /* BlazeStore.swift */; };
 		DED91DF42AD67E9400CDCC53 /* BlazeStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DED91DF32AD67E9400CDCC53 /* BlazeStoreTests.swift */; };
@@ -945,6 +947,8 @@
 		DEA493912B3BD49700EED015 /* BlazeTargetDevice+ReadOnlyConvertible.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "BlazeTargetDevice+ReadOnlyConvertible.swift"; sourceTree = "<group>"; };
 		DEA493932B3D588500EED015 /* BlazeTargetLanguage+ReadonlyConvertible.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "BlazeTargetLanguage+ReadonlyConvertible.swift"; sourceTree = "<group>"; };
 		DEA493952B3D608B00EED015 /* BlazeTargetTopic+ReadonlyConvertible.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "BlazeTargetTopic+ReadonlyConvertible.swift"; sourceTree = "<group>"; };
+		DEB387812C2AB4370025256E /* GoogleAdsStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GoogleAdsStore.swift; sourceTree = "<group>"; };
+		DEB387832C2AB50B0025256E /* GoogleAdsAction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GoogleAdsAction.swift; sourceTree = "<group>"; };
 		DED91DED2AD673CF00CDCC53 /* BlazeAction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BlazeAction.swift; sourceTree = "<group>"; };
 		DED91DEF2AD6756600CDCC53 /* BlazeStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BlazeStore.swift; sourceTree = "<group>"; };
 		DED91DF32AD67E9400CDCC53 /* BlazeStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BlazeStoreTests.swift; sourceTree = "<group>"; };
@@ -1590,6 +1594,7 @@
 				570B05CD246B6A2F00C186AE /* ProductReview */,
 				0212AC5F242C680800C51F6C /* Enums */,
 				B5BC736420D1A98500B5B6FA /* AccountStore.swift */,
+				DEB387812C2AB4370025256E /* GoogleAdsStore.swift */,
 				D87F614B22657B150031A13B /* AppSettingsStore.swift */,
 				2685C116263C98CF00D9EE97 /* AddOnGroupStore.swift */,
 				DED91DEF2AD6756600CDCC53 /* BlazeStore.swift */,
@@ -1860,6 +1865,7 @@
 			isa = PBXGroup;
 			children = (
 				B5DC3CB020D1B8720063AC41 /* AccountAction.swift */,
+				DEB387832C2AB50B0025256E /* GoogleAdsAction.swift */,
 				D87F614922657A690031A13B /* AppSettingsAction.swift */,
 				D4CBAE6326D4464500BBE6D1 /* AnnouncementsAction.swift */,
 				2685C110263C97A800D9EE97 /* AddOnGroupAction.swift */,
@@ -2418,6 +2424,7 @@
 				247CE8442582F3BB00F9D9D1 /* MockSettingActionHandler.swift in Sources */,
 				B52E002E211A3F5500700FDE /* ReadOnlyType.swift in Sources */,
 				5726456F250BD4E4005BBD7C /* OrdersUpsertUseCase.swift in Sources */,
+				DEB387822C2AB4370025256E /* GoogleAdsStore.swift in Sources */,
 				3147030C2670333200EF253A /* WCPayAccount+PaymentGatewayAccount.swift in Sources */,
 				02EF1668292DB68C00D90AD6 /* PaymentAction.swift in Sources */,
 				B5C9DE162087FF0E006B910A /* Store.swift in Sources */,
@@ -2435,6 +2442,7 @@
 				B9AECD3E2850F41100E78584 /* OrderCardPresentPaymentEligibilityAction.swift in Sources */,
 				025CA2CE238F53CB00B05C81 /* ProductShippingClass+ReadOnlyConvertible.swift in Sources */,
 				247CE86225832B1600F9D9D1 /* MockRefundActionHandler.swift in Sources */,
+				DEB387842C2AB50B0025256E /* GoogleAdsAction.swift in Sources */,
 				26E5A07625A626CA000DF8F6 /* ProductAttributeTerm+ReadOnlyConvertible.swift in Sources */,
 				FEEB2F5D268A15730075A6E0 /* User+Roles.swift in Sources */,
 				261CF1C9255B2C7B0090D8D3 /* PaymentGateway+ReadOnlyConvertible.swift in Sources */,

--- a/Yosemite/Yosemite.xcodeproj/project.pbxproj
+++ b/Yosemite/Yosemite.xcodeproj/project.pbxproj
@@ -446,6 +446,8 @@
 		DEA493962B3D608B00EED015 /* BlazeTargetTopic+ReadonlyConvertible.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEA493952B3D608B00EED015 /* BlazeTargetTopic+ReadonlyConvertible.swift */; };
 		DEB387822C2AB4370025256E /* GoogleAdsStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEB387812C2AB4370025256E /* GoogleAdsStore.swift */; };
 		DEB387842C2AB50B0025256E /* GoogleAdsAction.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEB387832C2AB50B0025256E /* GoogleAdsAction.swift */; };
+		DEB387862C2C09A70025256E /* GoogleAdsStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEB387852C2C09A70025256E /* GoogleAdsStoreTests.swift */; };
+		DEB387882C2C09FC0025256E /* MockGoogleListingsAndAdsRemote.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEB387872C2C09FC0025256E /* MockGoogleListingsAndAdsRemote.swift */; };
 		DED91DEE2AD673CF00CDCC53 /* BlazeAction.swift in Sources */ = {isa = PBXBuildFile; fileRef = DED91DED2AD673CF00CDCC53 /* BlazeAction.swift */; };
 		DED91DF02AD6756600CDCC53 /* BlazeStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = DED91DEF2AD6756600CDCC53 /* BlazeStore.swift */; };
 		DED91DF42AD67E9400CDCC53 /* BlazeStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DED91DF32AD67E9400CDCC53 /* BlazeStoreTests.swift */; };
@@ -949,6 +951,8 @@
 		DEA493952B3D608B00EED015 /* BlazeTargetTopic+ReadonlyConvertible.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "BlazeTargetTopic+ReadonlyConvertible.swift"; sourceTree = "<group>"; };
 		DEB387812C2AB4370025256E /* GoogleAdsStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GoogleAdsStore.swift; sourceTree = "<group>"; };
 		DEB387832C2AB50B0025256E /* GoogleAdsAction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GoogleAdsAction.swift; sourceTree = "<group>"; };
+		DEB387852C2C09A70025256E /* GoogleAdsStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GoogleAdsStoreTests.swift; sourceTree = "<group>"; };
+		DEB387872C2C09FC0025256E /* MockGoogleListingsAndAdsRemote.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockGoogleListingsAndAdsRemote.swift; sourceTree = "<group>"; };
 		DED91DED2AD673CF00CDCC53 /* BlazeAction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BlazeAction.swift; sourceTree = "<group>"; };
 		DED91DEF2AD6756600CDCC53 /* BlazeStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BlazeStore.swift; sourceTree = "<group>"; };
 		DED91DF32AD67E9400CDCC53 /* BlazeStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BlazeStoreTests.swift; sourceTree = "<group>"; };
@@ -1384,6 +1388,7 @@
 				0286A1BD2A0CC4810099EF94 /* MockFeatureFlagRemote.swift */,
 				02DF98082A136BFB0009E2EA /* MockSitePluginsRemote.swift */,
 				EE4D51B72ACD3C9800783D77 /* MockProductCategoriesRemote.swift */,
+				DEB387872C2C09FC0025256E /* MockGoogleListingsAndAdsRemote.swift */,
 			);
 			path = Remote;
 			sourceTree = "<group>";
@@ -1718,6 +1723,7 @@
 				0391C13C29CC5E14008A3E86 /* OrderCardPresentPaymentEligibilityStoreTests.swift */,
 				0286A1BB2A0CC4120099EF94 /* FeatureFlagStoreTests.swift */,
 				DEDA8DB22B184B950076BF0F /* WordPressThemeStoreTests.swift */,
+				DEB387852C2C09A70025256E /* GoogleAdsStoreTests.swift */,
 			);
 			path = Stores;
 			sourceTree = "<group>";
@@ -2587,6 +2593,7 @@
 				B5A01CA120D19C4700E3207E /* MockStorageManager.swift in Sources */,
 				578CE7922475EC9200492EBF /* MockProductsRemote.swift in Sources */,
 				7455263022305F88003F8932 /* OrderStatusStoreTests.swift in Sources */,
+				DEB387862C2C09A70025256E /* GoogleAdsStoreTests.swift in Sources */,
 				B5C9DE242087FF20006B910A /* StoreTests.swift in Sources */,
 				455A931D2747C19300259C7F /* AppSettingsStoreTests+OrdersSettings.swift in Sources */,
 				D88303E925E459DC00C877F9 /* CardPresentPaymentStoreTests.swift in Sources */,
@@ -2621,6 +2628,7 @@
 				741F34842195F752005F5BD9 /* CommentStoreTests.swift in Sources */,
 				B5C9DE282087FF20006B910A /* MockSiteStore.swift in Sources */,
 				FEEB2F5F268A1C5E0075A6E0 /* User+RolesTests.swift in Sources */,
+				DEB387882C2C09FC0025256E /* MockGoogleListingsAndAdsRemote.swift in Sources */,
 				B5BC736820D1AA8F00B5B6FA /* AccountStoreTests.swift in Sources */,
 				68BD37B928DB323D00C2A517 /* CustomerStoreTests.swift in Sources */,
 				DE50296728C7114800551736 /* JetpackConnectionStoreTests.swift in Sources */,

--- a/Yosemite/Yosemite/Actions/GoogleAdsAction.swift
+++ b/Yosemite/Yosemite/Actions/GoogleAdsAction.swift
@@ -1,0 +1,17 @@
+import Foundation
+import Networking
+
+// MARK: - GoogleAdsAction: Defines all of the Actions supported by the GoogleAdsStore.
+//
+public enum GoogleAdsAction: Action {
+
+    /// Checks for connection of the given site with the Google Listings & Ads plugin.
+    ///
+    /// - `siteID`: the site to check the connection for.
+    /// - `onCompletion`: invoked when the check request finishes.
+    ///     - `result.success(GoogleAdsConnection)`: Successfully fetched the connection details.
+    ///     - `result.failure(Error)`: error indicates issues fetching the connection details.
+    ///
+    case checkConnection(siteID: Int64,
+                         onCompletion: (Result<GoogleAdsConnection, Error>) -> Void)
+}

--- a/Yosemite/Yosemite/Model/Model.swift
+++ b/Yosemite/Yosemite/Model/Model.swift
@@ -43,6 +43,7 @@ public typealias DotcomDevice = Networking.DotcomDevice
 public typealias DotcomUser = Networking.DotcomUser
 public typealias Feature = Networking.Feature
 public typealias FreeDomainSuggestion = Networking.FreeDomainSuggestion
+public typealias GoogleAdsConnection = Networking.GoogleAdsConnection
 public typealias GiftCardStats = Networking.GiftCardStats
 public typealias GiftCardStatsInterval = Networking.GiftCardStatsInterval
 public typealias GiftCardStatsTotals = Networking.GiftCardStatsTotals

--- a/Yosemite/Yosemite/Stores/GoogleAdsStore.swift
+++ b/Yosemite/Yosemite/Stores/GoogleAdsStore.swift
@@ -1,0 +1,74 @@
+import Foundation
+import Networking
+import Storage
+
+// MARK: - GoogleAdsStore
+//
+public final class GoogleAdsStore: Store {
+    private let remote: GoogleListingsAndAdsRemoteProtocol
+
+    private lazy var sharedDerivedStorage: StorageType = {
+        return storageManager.writerDerivedStorage
+    }()
+
+    init(dispatcher: Dispatcher,
+         storageManager: StorageManagerType,
+         network: Network,
+         remote: GoogleListingsAndAdsRemoteProtocol) {
+        self.remote = remote
+        super.init(dispatcher: dispatcher, storageManager: storageManager, network: network)
+    }
+
+    /// Initializes a new GoogleAdsStore.
+    /// - Parameters:
+    ///   - dispatcher: The dispatcher used to subscribe to `GoogleAdsAction`.
+    ///   - storageManager: The storage layer used to store and retrieve persisted data.
+    ///   - network: The network layer used to fetch data from the remote
+    ///
+    public override convenience init(dispatcher: Dispatcher,
+                                     storageManager: StorageManagerType,
+                                     network: Network) {
+        self.init(dispatcher: dispatcher,
+                  storageManager: storageManager,
+                  network: network,
+                  remote: GoogleListingsAndAdsRemote(network: network))
+    }
+
+    // MARK: - Actions
+
+    /// Registers for supported Actions.
+    ///
+    override public func registerSupportedActions(in dispatcher: Dispatcher) {
+        dispatcher.register(processor: self, for: GoogleAdsAction.self)
+    }
+
+    /// Receives and executes Actions.
+    /// - Parameters:
+    ///   - action: An action to handle. Must be a `GoogleAdsAction`
+    ///
+    override public func onAction(_ action: Action) {
+        guard let action = action as? GoogleAdsAction else {
+            assertionFailure("GoogleAdsStore received an unsupported action")
+            return
+        }
+
+        switch action {
+        case let .checkConnection(siteID, onCompletion):
+            checkConnection(siteID: siteID, onCompletion: onCompletion)
+        }
+    }
+}
+
+private extension GoogleAdsStore {
+    func checkConnection(siteID: Int64,
+                         onCompletion: @escaping (Result<GoogleAdsConnection, Error>) -> Void) {
+        Task { @MainActor in
+            do {
+                let connection = try await remote.checkConnection(for: siteID)
+                onCompletion(.success(connection))
+            } catch {
+                onCompletion(.failure(error))
+            }
+        }
+    }
+}

--- a/Yosemite/YosemiteTests/Mocks/Networking/Remote/MockGoogleListingsAndAdsRemote.swift
+++ b/Yosemite/YosemiteTests/Mocks/Networking/Remote/MockGoogleListingsAndAdsRemote.swift
@@ -1,0 +1,26 @@
+import XCTest
+import Networking
+
+final class MockGoogleListingsAndAdsRemote {
+
+    private var checkingConnectionResult: Result<GoogleAdsConnection, Error>?
+
+    func whenCheckingConnection(thenReturn result: Result<GoogleAdsConnection, Error>) {
+        checkingConnectionResult = result
+    }
+}
+
+extension MockGoogleListingsAndAdsRemote: GoogleListingsAndAdsRemoteProtocol {
+    func checkConnection(for siteID: Int64) async throws -> Networking.GoogleAdsConnection {
+        guard let result = checkingConnectionResult else {
+            XCTFail("Could not find result for checking GLA connection.")
+            throw NetworkError.notFound()
+        }
+        switch result {
+        case .success(let connection):
+            return connection
+        case .failure(let error):
+            throw error
+        }
+    }
+}

--- a/Yosemite/YosemiteTests/Stores/GoogleAdsStoreTests.swift
+++ b/Yosemite/YosemiteTests/Stores/GoogleAdsStoreTests.swift
@@ -1,0 +1,77 @@
+import XCTest
+@testable import Networking
+@testable import Yosemite
+
+final class GoogleAdsStoreTests: XCTestCase {
+
+    /// Mock network to inject responses
+    ///
+    private var network: MockNetwork!
+
+    /// Spy remote to check request parameter use
+    ///
+    private var remote: MockGoogleListingsAndAdsRemote!
+
+    /// Mock Storage: InMemory
+    ///
+    private var storageManager: MockStorageManager!
+
+    private let sampleSiteID: Int64 = 120934
+
+    override func setUp() {
+        super.setUp()
+        network = MockNetwork()
+        remote = MockGoogleListingsAndAdsRemote()
+        storageManager = MockStorageManager()
+    }
+
+    override func tearDown() {
+        network = nil
+        remote = nil
+        storageManager = nil
+        super.tearDown()
+    }
+
+    // MARK: - Check connection
+
+    func test_checkConnection_returns_connection_on_success() throws {
+        // Given
+        let store = GoogleAdsStore(dispatcher: Dispatcher(),
+                                   storageManager: storageManager,
+                                   network: network,
+                                   remote: remote)
+        let connection = GoogleAdsConnection.fake().copy(id: 234, rawStatus: "incomplete")
+        remote.whenCheckingConnection(thenReturn: .success(connection))
+
+        // When
+        let result = waitFor { promise in
+            store.onAction(GoogleAdsAction.checkConnection(siteID: self.sampleSiteID, onCompletion: { result in
+                promise(result)
+            }))
+        }
+
+        // Then
+        let receivedConnection = try result.get()
+        assertEqual(connection, receivedConnection)
+    }
+
+    func test_checkConnection_returns_error_on_failure() throws {
+        // Given
+        let store = GoogleAdsStore(dispatcher: Dispatcher(),
+                                   storageManager: storageManager,
+                                   network: network,
+                                   remote: remote)
+        remote.whenCheckingConnection(thenReturn: .failure(NetworkError.timeout()))
+
+        // When
+        let result = waitFor { promise in
+            store.onAction(GoogleAdsAction.checkConnection(siteID: self.sampleSiteID, onCompletion: { result in
+                promise(result)
+            }))
+        }
+
+        // Then
+        XCTAssertTrue(result.isFailure)
+        XCTAssertEqual(result.failure as? NetworkError, .timeout())
+    }
+}


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #13139 
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This PR continues the work from #13140 to add a new store and action for GLA to enable checking site connection with the plugin.

## Testing
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->
Just CI passing is sufficient.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->
N/A

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
