### PR TITLE
[Woo POS] Handle failures from `capture_terminal_payment` gracefully

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -5,7 +5,7 @@
 - [*] Blaze Campaigns: Added date range checks to ensure campaign start dates are within 60 days from today to avoid validation errors. [https://github.com/woocommerce/woocommerce-ios/pull/13124]
 - [*] Payments: fixed issue when connecting to a card reader after cancelling reader discovery [https://github.com/woocommerce/woocommerce-ios/issues/13125]
 - [*] Payments: fixed issue when connecting to a card reader after an error during reader connection [https://github.com/woocommerce/woocommerce-ios/pull/13126]
-
+- [*] Payments: improved collect payment error handling, by checking whether the payment was actually successful on some errors [https://github.com/woocommerce/woocommerce-ios/pull/13165]
 
 19.2
 -----

--- a/WooCommerce/Classes/ViewModels/CardPresentPayments/PaymentCaptureOrchestrator.swift
+++ b/WooCommerce/Classes/ViewModels/CardPresentPayments/PaymentCaptureOrchestrator.swift
@@ -8,7 +8,7 @@ struct CardPresentCapturedPaymentData {
     let paymentMethod: PaymentMethod
 
     /// Used for receipt generation for display in the app.
-    let receiptParameters: CardPresentReceiptParameters
+    let receiptParameters: CardPresentReceiptParameters?
 }
 
 protocol PaymentCaptureOrchestrating {

--- a/WooCommerce/Classes/ViewRelated/Orders/Collect Payments/CollectOrderPaymentUseCase.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Collect Payments/CollectOrderPaymentUseCase.swift
@@ -167,8 +167,8 @@ where BuiltInAlertProvider.AlertDetails == AlertPresenter.AlertDetails,
                                 self.presentBackendReceiptAlert(alertProvider: paymentAlertProvider, onCompleted: onCompleted)
                             case false:
                                 self.presentLocalReceiptAlert(receiptParameters: paymentData.receiptParameters,
-                                                         alertProvider: paymentAlertProvider,
-                                                         onCompleted: onCompleted)
+                                                              alertProvider: paymentAlertProvider,
+                                                              onCompleted: onCompleted)
                             }
                         }
                     }
@@ -612,7 +612,7 @@ private extension CollectOrderPaymentUseCase {
 
         let noticePresenter = DefaultNoticePresenter()
         let notice = Notice(title: CollectOrderPaymentUseCaseDefinitions.Localization.failedReceiptPrintNoticeText,
-                                    feedbackType: .error)
+                            feedbackType: .error)
         noticePresenter.presentingViewController = rootViewController
         noticePresenter.enqueue(notice: notice)
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Collect Payments/CollectOrderPaymentUseCase.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Collect Payments/CollectOrderPaymentUseCase.swift
@@ -285,10 +285,10 @@ private extension CollectOrderPaymentUseCase {
             guard let self = self else { return }
             switch result {
             case .failure(let error):
-                return self.handlePaymentFailureAndRetryPayment(error,
-                                                               alertProvider: paymentAlerts,
-                                                               paymentGatewayAccount: paymentGatewayAccount,
-                                                               onCompletion: onCompletion)
+                return self.checkThenHandlePaymentFailureAndRetryPayment(error,
+                                                                         alertProvider: paymentAlerts,
+                                                                         paymentGatewayAccount: paymentGatewayAccount,
+                                                                         onCompletion: onCompletion)
             case .success:
                 guard let orderTotal = self.orderTotal else {
                     onCompletion(.failure(CollectOrderPaymentUseCaseNotValidAmountError.other))
@@ -350,10 +350,10 @@ private extension CollectOrderPaymentUseCase {
                                 self?.handlePaymentCancellation(from: .other)
                             }
                         case .failure(let error):
-                            self?.handlePaymentFailureAndRetryPayment(error,
-                                                                      alertProvider: paymentAlerts,
-                                                                      paymentGatewayAccount: paymentGatewayAccount,
-                                                                      onCompletion: onCompletion)
+                            self?.checkThenHandlePaymentFailureAndRetryPayment(error,
+                                                                               alertProvider: paymentAlerts,
+                                                                               paymentGatewayAccount: paymentGatewayAccount,
+                                                                               onCompletion: onCompletion)
                         }
                     })
             }
@@ -379,7 +379,41 @@ private extension CollectOrderPaymentUseCase {
         alertsPresenter.present(viewModel: dismissedOnReaderAlert)
     }
 
-    /// Log the failure reason, cancel the current payment and retry it if possible.
+    /// Check whether payment was actually successful (for some errors which may hide success) – return success if it was.
+    /// If it wasn't, log the failure reason, inform the user, and offer them the chance to retry it if possible.
+    ///
+    func checkThenHandlePaymentFailureAndRetryPayment(_ error: Error,
+                                                      alertProvider paymentAlerts: any CardReaderTransactionAlertsProviding<AlertPresenter.AlertDetails>,
+                                                      paymentGatewayAccount: PaymentGatewayAccount,
+                                                      onCompletion: @escaping (Result<CardPresentCapturedPaymentData, Error>) -> ()) {
+        guard case ServerSidePaymentCaptureError.paymentGateway(.otherError) = error else {
+            return handlePaymentFailureAndRetryPayment(error,
+                                                       alertProvider: paymentAlerts,
+                                                       paymentGatewayAccount: paymentGatewayAccount,
+                                                       onCompletion: onCompletion)
+        }
+
+        // This is an unknown error during payment capture.
+        // The first time this happens, we check if the order's actually paid, and return success if it is.
+        let action = OrderAction.retrieveOrderRemotely(siteID: siteID, orderID: order.orderID) { [weak self] result in
+            guard let self else { return }
+            guard let refreshedOrder = try? result.get(),
+                  refreshedOrder.datePaid != nil else {
+                return handlePaymentFailureAndRetryPayment(error,
+                                                           alertProvider: paymentAlerts,
+                                                           paymentGatewayAccount: paymentGatewayAccount,
+                                                           onCompletion: onCompletion)
+            }
+
+            // Since the order's paid, we can return success
+            onCompletion(.success(CardPresentCapturedPaymentData(
+                paymentMethod: .unknown,
+                receiptParameters: nil)))
+        }
+        stores.dispatch(action)
+    }
+
+    /// Log the failure reason, inform the user, and offer them the chance to retry it if possible.
     ///
     func handlePaymentFailureAndRetryPayment(_ error: Error,
                                              alertProvider paymentAlerts: any CardReaderTransactionAlertsProviding<AlertPresenter.AlertDetails>,
@@ -455,10 +489,10 @@ private extension CollectOrderPaymentUseCase {
                     self.checkOrderIsStillEligibleForPayment(alertProvider: paymentAlerts, onPaymentCompletion: onCompletion) { result in
                         switch result {
                         case .failure(let error):
-                            return self.handlePaymentFailureAndRetryPayment(error,
-                                                                            alertProvider: paymentAlerts,
-                                                                            paymentGatewayAccount: paymentGatewayAccount,
-                                                                            onCompletion: onCompletion)
+                            return self.checkThenHandlePaymentFailureAndRetryPayment(error,
+                                                                                     alertProvider: paymentAlerts,
+                                                                                     paymentGatewayAccount: paymentGatewayAccount,
+                                                                                     onCompletion: onCompletion)
                         case .success:
                             self.paymentOrchestrator.retryPayment(for: self.order) { [weak self] result in
                                 guard let self = self else { return }
@@ -475,10 +509,10 @@ private extension CollectOrderPaymentUseCase {
                                     }
                                 case .failure(let error):
                                     let retryError = CollectOrderPaymentUseCaseError.alreadyRetried(error)
-                                    self.handlePaymentFailureAndRetryPayment(retryError,
-                                                                             alertProvider: paymentAlerts,
-                                                                             paymentGatewayAccount: paymentGatewayAccount,
-                                                                             onCompletion: onCompletion)
+                                    self.checkThenHandlePaymentFailureAndRetryPayment(retryError,
+                                                                                      alertProvider: paymentAlerts,
+                                                                                      paymentGatewayAccount: paymentGatewayAccount,
+                                                                                      onCompletion: onCompletion)
                                 }
                             }
                         }
@@ -523,7 +557,7 @@ private extension CollectOrderPaymentUseCase {
                 case let .success(receipt):
                     self.presentBackendReceiptModally(receipt: receipt, onCompleted: onCompleted)
                 case let .failure(error):
-                    self.presentBackedReceiptFailedNotice(with: error, onCompleted: onCompleted)
+                    self.presentReceiptFailedNotice(with: error, onCompleted: onCompleted)
                 }
             })
         }
@@ -535,12 +569,18 @@ private extension CollectOrderPaymentUseCase {
 
     /// Allow merchants to print or email locally-generated receipts.
     ///
-    func presentLocalReceiptAlert(receiptParameters: CardPresentReceiptParameters,
+    func presentLocalReceiptAlert(receiptParameters: CardPresentReceiptParameters?,
                              alertProvider paymentAlerts: any CardReaderTransactionAlertsProviding<AlertPresenter.AlertDetails>,
                              onCompleted: @escaping () -> ()) {
         // Present receipt alert
         alertsPresenter.present(viewModel: paymentAlerts.success(printReceipt: { [order, configuration, weak self] in
             guard let self = self else { return }
+
+            guard let receiptParameters = receiptParameters else {
+                return self.presentReceiptFailedNotice(
+                    with: CollectOrderPaymentReceiptError.noReceiptDataBecauseSuccessInferred,
+                    onCompleted: onCompleted)
+            }
 
             // Delegate print action
             Task { @MainActor in
@@ -557,6 +597,12 @@ private extension CollectOrderPaymentUseCase {
             guard let self = self else { return }
 
             analyticsTracker.trackEmailTapped()
+
+            guard let receiptParameters = receiptParameters else {
+                return self.presentReceiptFailedNotice(
+                    with: CollectOrderPaymentReceiptError.noReceiptDataBecauseSuccessInferred,
+                    onCompleted: onCompleted)
+            }
 
             // Request & present email
             paymentOrchestrator.emailReceipt(for: order, params: receiptParameters) { [weak self] emailContent in
@@ -602,7 +648,7 @@ private extension CollectOrderPaymentUseCase {
         rootViewController.present(navigationController, animated: true)
     }
 
-    func presentBackedReceiptFailedNotice(with error: Error?, onCompleted: @escaping (() -> Void)) {
+    func presentReceiptFailedNotice(with error: Error?, onCompleted: @escaping (() -> Void)) {
         // TODO: consider removing this under #12864, when we have some other way to handle notices.
         guard let rootViewController = rootViewController as? UIViewController else {
             return
@@ -829,4 +875,8 @@ extension CollectOrderPaymentUseCaseError: CardPaymentErrorProtocol {
             return .reuseIntent
         }
     }
+}
+
+enum CollectOrderPaymentReceiptError: Error {
+    case noReceiptDataBecauseSuccessInferred
 }

--- a/WooCommerce/Classes/ViewRelated/Orders/Collect Payments/CollectOrderPaymentUseCase.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Collect Payments/CollectOrderPaymentUseCase.swift
@@ -576,7 +576,7 @@ private extension CollectOrderPaymentUseCase {
         alertsPresenter.present(viewModel: paymentAlerts.success(printReceipt: { [order, configuration, weak self] in
             guard let self = self else { return }
 
-            guard let receiptParameters = receiptParameters else {
+            guard let receiptParameters else {
                 return self.presentReceiptFailedNotice(
                     with: CollectOrderPaymentReceiptError.noReceiptDataBecauseSuccessInferred,
                     onCompleted: onCompleted)
@@ -598,7 +598,7 @@ private extension CollectOrderPaymentUseCase {
 
             analyticsTracker.trackEmailTapped()
 
-            guard let receiptParameters = receiptParameters else {
+            guard let receiptParameters else {
                 return self.presentReceiptFailedNotice(
                     with: CollectOrderPaymentReceiptError.noReceiptDataBecauseSuccessInferred,
                     onCompleted: onCompleted)


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #13162
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

Sometimes, we can get an error or non-response when there’s an error capturing the payment on the server.

This can happen when there are poor network conditions. It’s possible for the payment request to be successful and handled by WooPayments, but then the response can be lost.

Previously, this was shown as an error, leading merchants to believe the order wasn’t paid.

This PR improves that by adding a check for whether the order is paid, when it receives one of these errors. If the order is paid, it shows the payment success screen.

If it’s not paid, or we can’t refresh the order, the original error is shown.

## Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->

### Existing IPP experience

1. Set up Proxyman or Charles to intercept traffic for your test device
2. Launch the app using a store eligible for IPP
3. Navigate to `Orders > +`
4. Add a new order, and tap `Collect Payment`
5. Select `Card reader` and connect to the reader if needed
6. Enable breakpoints in your proxy for the response of `POST` requests to `https://public-api.wordpress.com/rest/v1.1/jetpack-blogs/*/rest-api/`
7. Tap your card on the reader
8. Abort the `capture_terminal_payment` response when the breakpoint is hit (equivalent to poor network conditions meaning it was lost.)
9. Observe that the payment success alert is shown. Note that the receipt actions will not work on older stores which require local receipts.

### New POS experience

1. Set up Proxyman or Charles to intercept traffic for your test device
2. Launch the app using a store eligible for IPP
3. Navigate to `Menu > Point of Sale mode`
4. Add an item to your basket and tap `Checkout`
5. Enable breakpoints in your proxy for the response of `POST` requests to `https://public-api.wordpress.com/rest/v1.1/jetpack-blogs/*/rest-api/`
6. Tap your card on the reader
7. Abort the `capture_terminal_payment` response when the breakpoint is hit (equivalent to poor network conditions meaning it was lost.)
8. Observe that the payment shows as successful.

## Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->

To test other scenarios, also enable breakpoints for `GET` requests to `https://public-api.wordpress.com/rest/v1.1/jetpack-blogs/*/rest-api/?json=true&path=/wc/v3/orders/*` when you're about to tap the card.

After aborting the `capture_terminal_payment` response, abort the three Order requests as well. You'll see that the payment is shown as failed. Retrying after this without aborting requests should show the error that the order is already paid

If you abort the _request_, instead of the response, for `capture_terminal_payment`, you'll see the original (not very good) `Yosemite.ServerSidePaymentCapture error (error 0)` error, and trying again should be successful.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->


https://github.com/woocommerce/woocommerce-ios/assets/2472348/b639f926-7a60-4cc0-ad39-d92ccd3819a3


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.