### PR TITLE
[WOO POS] Go back to cart building if cart is emptied from checkout

### DIFF
--- a/WooCommerce/Classes/POS/ViewModels/PointOfSaleDashboardViewModel.swift
+++ b/WooCommerce/Classes/POS/ViewModels/PointOfSaleDashboardViewModel.swift
@@ -205,7 +205,7 @@ final class PointOfSaleDashboardViewModel: ObservableObject {
 
     @MainActor
     private func collectPayment(for order: Order) async throws {
-        let paymentResult = try await cardPresentPaymentService.collectPayment(for: order, using: .bluetooth)
+        _ = try await cardPresentPaymentService.collectPayment(for: order, using: .bluetooth)
     }
 
     @MainActor

--- a/WooCommerce/Classes/POS/ViewModels/PointOfSaleDashboardViewModel.swift
+++ b/WooCommerce/Classes/POS/ViewModels/PointOfSaleDashboardViewModel.swift
@@ -37,7 +37,11 @@ final class PointOfSaleDashboardViewModel: ObservableObject {
     }
 
     @Published private(set) var items: [POSItem] = []
-    @Published private(set) var itemsInCart: [CartItem] = []
+    @Published private(set) var itemsInCart: [CartItem] = [] {
+        didSet {
+            checkIfCartEmpty()
+        }
+    }
 
     // Total amounts
     @Published private(set) var formattedCartTotalPrice: String?
@@ -140,12 +144,10 @@ final class PointOfSaleDashboardViewModel: ObservableObject {
 
     func removeItemFromCart(_ cartItem: CartItem) {
         itemsInCart.removeAll(where: { $0.id == cartItem.id })
-        checkIfCartEmpty()
     }
 
     func removeAllItemsFromCart() {
         itemsInCart.removeAll()
-        checkIfCartEmpty()
     }
 
     var itemsInCartLabel: String? {

--- a/WooCommerce/Classes/POS/ViewModels/PointOfSaleDashboardViewModel.swift
+++ b/WooCommerce/Classes/POS/ViewModels/PointOfSaleDashboardViewModel.swift
@@ -145,6 +145,7 @@ final class PointOfSaleDashboardViewModel: ObservableObject {
 
     func removeAllItemsFromCart() {
         itemsInCart.removeAll()
+        checkIfCartEmpty()
     }
 
     var itemsInCartLabel: String? {


### PR DESCRIPTION
## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

Just a minor tweak that returns to cart building if the cart is emptied.

## Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: https://woomobilep2.wordpress.com/2024/05/06/woocommerce-mobile-quality-report-march-april/#comment-12036 -->

- Enter POS
- Add few items in the cart
- Tap Checkout
- Tap Clear all button
- Check that you are back in the cart building stage

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

![Simulator Screen Recording - iPad Pro (11-inch) (4th generation) 17 2 - 2024-06-26 at 14 36 25](https://github.com/woocommerce/woocommerce-ios/assets/6242034/cc7c08d0-2213-4c06-8f50-900fa584f3e5)

---
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
