### PR TITLE
Dynamic Dashboard: Add tracking for dashboard card data loading

### DIFF
--- a/WooCommerce/Classes/Analytics/TracksProvider.swift
+++ b/WooCommerce/Classes/Analytics/TracksProvider.swift
@@ -32,7 +32,14 @@ public extension TracksProvider {
             guard Self.tracksService.trackEventName(eventName, withCustomProperties: properties) else {
                 return DDLogError("🔴 Error tracking \(eventName) with properties: \(properties)")
             }
-            DDLogInfo("🔵 Tracked \(eventName), properties: \(properties)")
+
+            let keyValuePairs = properties
+                .map { key, value in
+                    "\(key): \(value)"
+                }
+                .joined(separator: ", ")
+
+            DDLogInfo("🔵 Tracked \(eventName), properties: [\(keyValuePairs)]")
         } else {
             Self.tracksService.trackEventName(eventName)
             DDLogInfo("🔵 Tracked \(eventName)")

--- a/WooCommerce/Classes/Analytics/WooAnalytics.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalytics.swift
@@ -221,13 +221,25 @@ private extension Analytics {
         let err = error as NSError
         let errorCode: String = {
             if let networkError = error as? AFError {
-                return "\(networkError.responseCode ?? 0)"
+                if let responseCode = networkError.responseCode {
+                    return "\(responseCode)"
+                } else if let underlyingError = networkError.underlyingError as? NSError {
+                    return "\(underlyingError.code)"
+                }
             } else if let loginError = error as? SiteCredentialLoginError {
                 return "\(loginError.underlyingError.code)"
             }
             return "\(err.code)"
         }()
-        let errorDomain = err.domain
+
+        let errorDomain: String = {
+            if let networkError = error as? AFError,
+               let underlyingError = networkError.underlyingError as? NSError {
+                return underlyingError.domain
+            }
+            return err.domain
+        }()
+
         let errorDescription = err.description
 
         return [

--- a/WooCommerce/Classes/Analytics/WooAnalyticsEvent+DynamicDashboard.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsEvent+DynamicDashboard.swift
@@ -51,6 +51,25 @@ extension WooAnalyticsEvent {
         static func dashboardCardAddNewSectionsTapped() -> WooAnalyticsEvent {
             WooAnalyticsEvent(statName: .dynamicDashboardAddNewSectionsTapped, properties: [:])
         }
+
+        /// When a dashboard card starts loading data.
+        static func cardLoadingStarted(type: DashboardCard.CardType) -> WooAnalyticsEvent {
+            WooAnalyticsEvent(statName: .dynamicDashboardCardDataLoadingStarted,
+                              properties: [Keys.type.rawValue: type.analyticName])
+        }
+
+        /// When a dashboard card completes loading data without error
+        static func cardLoadingCompleted(type: DashboardCard.CardType) -> WooAnalyticsEvent {
+            WooAnalyticsEvent(statName: .dynamicDashboardCardDataLoadingCompleted,
+                              properties: [Keys.type.rawValue: type.analyticName])
+        }
+
+        /// When a dashboard card fails to load data
+        static func cardLoadingFailed(type: DashboardCard.CardType, error: Error) -> WooAnalyticsEvent {
+            WooAnalyticsEvent(statName: .dynamicDashboardCardDataLoadingFailed,
+                              properties: [Keys.type.rawValue: type.analyticName],
+                              error: error)
+        }
     }
 }
 

--- a/WooCommerce/Classes/Analytics/WooAnalyticsStat.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsStat.swift
@@ -188,6 +188,9 @@ enum WooAnalyticsStat: String {
     case dynamicDashboardCardRetryTapped = "dynamic_dashboard_card_retry_tapped"
     case dynamicDashboardCardInteracted = "dynamic_dashboard_card_interacted"
     case dynamicDashboardAddNewSectionsTapped = "dynamic_dashboard_add_new_sections_tapped"
+    case dynamicDashboardCardDataLoadingStarted = "dynamic_dashboard_card_data_loading_started"
+    case dynamicDashboardCardDataLoadingCompleted = "dynamic_dashboard_card_data_loading_completed"
+    case dynamicDashboardCardDataLoadingFailed = "dynamic_dashboard_card_data_loading_failed"
 
     // MARK: Analytics Hub Events
     //

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Blaze/BlazeCampaignDashboardViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Blaze/BlazeCampaignDashboardViewModel.swift
@@ -152,7 +152,7 @@ final class BlazeCampaignDashboardViewModel: ObservableObject {
             syncingError = error
         }
 
-        trackingSyncingResult()
+        trackSyncingResult()
         updateResults()
     }
 
@@ -316,7 +316,8 @@ private extension BlazeCampaignDashboardViewModel {
             }
             .store(in: &subscriptions)
     }
-    func trackingSyncingResult() {
+
+    func trackSyncingResult() {
         if let syncingError {
             analytics.track(event: .DynamicDashboard.cardLoadingFailed(type: .blaze, error: syncingError))
         } else {

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Blaze/BlazeCampaignDashboardViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Blaze/BlazeCampaignDashboardViewModel.swift
@@ -131,7 +131,7 @@ final class BlazeCampaignDashboardViewModel: ObservableObject {
     func reload() async {
         syncingError = nil
         update(state: .loading)
-        
+
         analytics.track(event: .DynamicDashboard.cardLoadingStarted(type: .blaze))
 
         guard isSiteEligibleForBlaze else {

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Blaze/BlazeCampaignDashboardViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Blaze/BlazeCampaignDashboardViewModel.swift
@@ -134,6 +134,8 @@ final class BlazeCampaignDashboardViewModel: ObservableObject {
 
         analytics.track(event: .DynamicDashboard.cardLoadingStarted(type: .blaze))
 
+        isSiteEligibleForBlaze = await blazeEligibilityChecker.isSiteEligible()
+
         guard isSiteEligibleForBlaze else {
             update(state: .empty)
             return

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Coupons/MostActiveCouponsCardViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Coupons/MostActiveCouponsCardViewModel.swift
@@ -64,6 +64,7 @@ final class MostActiveCouponsCardViewModel: ObservableObject {
 
     @MainActor
     func reloadData() async {
+        analytics.track(event: .DynamicDashboard.cardLoadingStarted(type: .coupons))
         syncingData = true
         syncingError = nil
         rows = []
@@ -87,9 +88,12 @@ final class MostActiveCouponsCardViewModel: ObservableObject {
                     }
                 }
             }
+
+            analytics.track(event: .DynamicDashboard.cardLoadingCompleted(type: .coupons))
         } catch {
             syncingError = error
             DDLogError("⛔️ Dashboard (Most active coupons) — Error loading most active coupons: \(error)")
+            analytics.track(event: .DynamicDashboard.cardLoadingFailed(type: .coupons, error: error))
         }
         syncingData = false
     }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/DashboardViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/DashboardViewModel.swift
@@ -290,7 +290,7 @@ private extension DashboardViewModel {
                 await self.syncAnnouncements(for: self.siteID)
             }
             group.addTask { [weak self] in
-                await self?.reloadBlazeCampaignView()
+                await self?.blazeCampaignDashboardViewModel.checkAvailability()
             }
             group.addTask { [weak self] in
                 await self?.updateJetpackBannerVisibilityFromAppSettings()

--- a/WooCommerce/Classes/ViewRelated/Dashboard/DashboardViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/DashboardViewModel.swift
@@ -148,8 +148,6 @@ final class DashboardViewModel: ObservableObject {
         configureOrdersResultController()
         setupDashboardCards()
         installPendingThemeIfNeeded()
-        observeValuesForDashboardCards()
-        observeDashboardCardsAndReload()
     }
 
     /// Must be called by the `View` during the `onAppear()` event. This will
@@ -269,6 +267,8 @@ private extension DashboardViewModel {
             }))
         }
         savedCards = storageCards ?? []
+        observeValuesForDashboardCards()
+        observeDashboardCardsAndReload()
     }
 
     func saveDashboardCards(cards: [DashboardCard]) {

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Inbox/InboxDashboardCardViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Inbox/InboxDashboardCardViewModel.swift
@@ -47,13 +47,16 @@ final class InboxDashboardCardViewModel: ObservableObject {
 
     @MainActor
     func reloadData() async {
+        analytics.track(event: .DynamicDashboard.cardLoadingStarted(type: .inbox))
         syncingData = true
         syncingError = nil
         do {
             // Ignoring the result from remote as we're using storage as the single source of truth
             _ = try await loadInboxMessages()
+            analytics.track(event: .DynamicDashboard.cardLoadingCompleted(type: .inbox))
         } catch {
             syncingError = error
+            analytics.track(event: .DynamicDashboard.cardLoadingFailed(type: .inbox, error: error))
         }
         syncingData = false
     }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Onboarding/StoreOnboardingViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Onboarding/StoreOnboardingViewModel.swift
@@ -109,11 +109,12 @@ class StoreOnboardingViewModel: ObservableObject {
         analytics.track(event: .DynamicDashboard.cardLoadingStarted(type: .onboarding))
         await update(state: .loading)
 
-        var tasks: [StoreOnboardingTaskViewModel] = []
+        let tasks: [StoreOnboardingTaskViewModel]
         var syncingError: Error?
         do {
             tasks = try await loadTasks()
         } catch {
+            tasks = []
             syncingError = error
         }
 

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Orders/LastOrdersDashboardCardViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Orders/LastOrdersDashboardCardViewModel.swift
@@ -122,6 +122,7 @@ final class LastOrdersDashboardCardViewModel: ObservableObject {
 
     @MainActor
     func reloadData() async {
+        analytics.track(event: .DynamicDashboard.cardLoadingStarted(type: .lastOrders))
         syncingData = true
         syncingError = nil
         rows = []
@@ -131,9 +132,11 @@ final class LastOrdersDashboardCardViewModel: ObservableObject {
             try? await loadOrderStatuses()
             rows = try await orders
                 .map { LastOrderDashboardRowViewModel(order: $0) }
+            analytics.track(event: .DynamicDashboard.cardLoadingCompleted(type: .lastOrders))
         } catch {
             syncingError = error
             DDLogError("⛔️ Dashboard (Last orders) — Error loading orders: \(error)")
+            analytics.track(event: .DynamicDashboard.cardLoadingFailed(type: .lastOrders, error: error))
         }
         syncingData = false
     }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/ProductStock/ProductStockDashboardCardViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/ProductStock/ProductStockDashboardCardViewModel.swift
@@ -164,11 +164,10 @@ private extension ProductStockDashboardCardViewModel {
                 }
             }
 
-            while !group.isEmpty {
-                // gather the results and re-throw any failure.
-                if let items = try await group.next() {
-                    allReports.append(contentsOf: items)
-                }
+            // rethrow any failure.
+            for try await items in group {
+                // gather the results
+                allReports.append(contentsOf: items)
             }
 
             return allReports

--- a/WooCommerce/Classes/ViewRelated/Dashboard/ProductStock/ProductStockDashboardCardViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/ProductStock/ProductStockDashboardCardViewModel.swift
@@ -34,6 +34,7 @@ final class ProductStockDashboardCardViewModel: ObservableObject {
 
     @MainActor
     func reloadData() async {
+        analytics.track(event: .DynamicDashboard.cardLoadingStarted(type: .stock))
         syncingData = true
         syncingError = nil
         do {
@@ -43,8 +44,10 @@ final class ProductStockDashboardCardViewModel: ObservableObject {
                 savedReports[item.productID]
             }
             .sorted { ($0.stockQuantity ?? 0) < ($1.stockQuantity ?? 0) }
+            analytics.track(event: .DynamicDashboard.cardLoadingCompleted(type: .stock))
         } catch {
             syncingError = error
+            analytics.track(event: .DynamicDashboard.cardLoadingFailed(type: .stock, error: error))
         }
         syncingData = false
     }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Reviews/ReviewsDashboardCardViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Reviews/ReviewsDashboardCardViewModel.swift
@@ -109,13 +109,16 @@ final class ReviewsDashboardCardViewModel: ObservableObject {
 
     @MainActor
     func reloadData() async {
+        analytics.track(event: .DynamicDashboard.cardLoadingStarted(type: .reviews))
         syncingData = true
         syncingError = nil
         do {
             try await synchronizeReviews(filter: currentFilter)
+            analytics.track(event: .DynamicDashboard.cardLoadingCompleted(type: .reviews))
         } catch {
             syncingError = error
             DDLogError("⛔️ Dashboard (Reviews) — Error synchronizing reviews: \(error)")
+            analytics.track(event: .DynamicDashboard.cardLoadingFailed(type: .reviews, error: error))
         }
         syncingData = false
     }
@@ -245,24 +248,18 @@ private extension ReviewsDashboardCardViewModel {
             updateProductsResultsController(for: productIDs)
 
             // Get product names and, optionally, read status from notifications.
-            await withTaskGroup(of: Void.self) { group in
+            try await withThrowingTaskGroup(of: Void.self) { group in
                 group.addTask { [weak self] in
-                    do {
-                        try await self?.retrieveProducts(for: productIDs)
-                    } catch {
-                        self?.syncingError = error
-                        DDLogError("⛔️ Dashboard (Reviews) — Error retrieving products: \(error)")
-                    }
+                    try await self?.retrieveProducts(for: productIDs)
                 }
                 if stores.isAuthenticatedWithoutWPCom == false {
                     group.addTask { [weak self] in
-                        do {
-                            try await self?.synchronizeNotifications()
-                        } catch {
-                            self?.syncingError = error
-                            DDLogError("⛔️ Dashboard (Reviews) — Error synchronizing notifications: \(error)")
-                        }
+                        try await self?.synchronizeNotifications()
                     }
+                }
+                // rethrow any failure.
+                for try await result in group {
+                    // no-op if result doesn't throw any error
                 }
             }
         }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/StoreStats/StorePerformanceViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/StoreStats/StorePerformanceViewModel.swift
@@ -412,9 +412,9 @@ private extension StorePerformanceViewModel {
                 try await self?.syncSiteSummaryStats(latestDateToInclude: latestDateToInclude)
             }
 
-            while !group.isEmpty {
-                // rethrow any failure.
-                try await group.next()
+            // rethrow any failure.
+            for try await result in group {
+                // no-op if result doesn't throw any error
             }
         }
     }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/StoreStats/StorePerformanceViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/StoreStats/StorePerformanceViewModel.swift
@@ -56,7 +56,7 @@ final class StorePerformanceViewModel: ObservableObject {
     private let chartValueSelectedEventsSubject = PassthroughSubject<Int?, Never>()
 
     private var waitingTracker: WaitingTimeTracker?
-    private let syncingDidFinishPublisher = PassthroughSubject<Void, Never>()
+    private let syncingDidFinishPublisher = PassthroughSubject<Error?, Never>()
 
     // To check whether the tab is showing the visitors and conversion views as redacted for custom range.
     // This redaction is only shown on Custom Range tab with WordPress.com or Jetpack connected sites,
@@ -133,6 +133,7 @@ final class StorePerformanceViewModel: ObservableObject {
         syncingData = true
         loadingError = nil
         waitingTracker = WaitingTimeTracker(trackScenario: .dashboardMainStats)
+        analytics.track(event: .DynamicDashboard.cardLoadingStarted(type: .performance))
         do {
             try await syncAllStats()
             trackDashboardStatsSyncComplete()
@@ -147,15 +148,17 @@ final class StorePerformanceViewModel: ObservableObject {
             case .thisWeek, .thisMonth, .thisYear:
                 siteVisitStatMode = .default
             }
+            syncingDidFinishPublisher.send(nil)
         } catch DotcomError.noRestRoute {
             statsVersion = .v3
+            syncingDidFinishPublisher.send(DotcomError.noRestRoute)
         } catch {
             statsVersion = .v4
             DDLogError("⛔️ Error loading store stats: \(error)")
             handleSyncError(error: error)
+            syncingDidFinishPublisher.send(error)
         }
         syncingData = false
-        syncingDidFinishPublisher.send()
     }
 
     func hideStorePerformance() {
@@ -235,10 +238,15 @@ private extension StorePerformanceViewModel {
     func observeSyncingCompletion() {
         syncingDidFinishPublisher
             .receive(on: DispatchQueue.global(qos: .background))
-            .sink { [weak self] in
+            .sink { [weak self] error in
                 guard let self else { return }
                 waitingTracker?.end()
                 analytics.track(event: .Dashboard.dashboardMainStatsLoaded(timeRange: timeRange))
+                if let error {
+                    analytics.track(event: .DynamicDashboard.cardLoadingFailed(type: .performance, error: error))
+                } else {
+                    analytics.track(event: .DynamicDashboard.cardLoadingCompleted(type: .performance))
+                }
             }
             .store(in: &subscriptions)
     }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Blaze/BlazeCampaignDashboardViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Blaze/BlazeCampaignDashboardViewModelTests.swift
@@ -60,7 +60,7 @@ final class BlazeCampaignDashboardViewModelTests: XCTestCase {
         mockSynchronizeCampaignsList()
 
         // When
-        await sut.reload()
+        await sut.checkAvailability()
 
         // Then
         XCTAssertTrue(sut.canShowInDashboard)
@@ -81,7 +81,7 @@ final class BlazeCampaignDashboardViewModelTests: XCTestCase {
         mockSynchronizeCampaignsList()
 
         // When
-        await sut.reload()
+        await sut.checkAvailability()
 
         // Then
         XCTAssertFalse(sut.canShowInDashboard)
@@ -102,7 +102,7 @@ final class BlazeCampaignDashboardViewModelTests: XCTestCase {
         mockSynchronizeCampaignsList()
 
         // When
-        await sut.reload()
+        await sut.checkAvailability()
 
         // Then
         XCTAssertFalse(sut.canShowInDashboard)
@@ -132,6 +132,7 @@ final class BlazeCampaignDashboardViewModelTests: XCTestCase {
         mockSynchronizeCampaignsList()
 
         // When
+        await sut.checkAvailability()
         await sut.reload()
 
         // Then
@@ -201,6 +202,7 @@ final class BlazeCampaignDashboardViewModelTests: XCTestCase {
         mockSynchronizeProducts()
 
         // When
+        await sut.checkAvailability()
         await sut.reload()
 
         // Then
@@ -228,6 +230,7 @@ final class BlazeCampaignDashboardViewModelTests: XCTestCase {
         mockSynchronizeProducts(insertProductToStorage: fakeProduct)
 
         // When
+        await sut.checkAvailability()
         await sut.reload()
 
         // Then
@@ -254,6 +257,7 @@ final class BlazeCampaignDashboardViewModelTests: XCTestCase {
         mockSynchronizeProducts(insertProductToStorage: fakeProduct)
 
         // When
+        await sut.checkAvailability()
         await sut.reload()
 
         // Then
@@ -277,6 +281,7 @@ final class BlazeCampaignDashboardViewModelTests: XCTestCase {
         mockSynchronizeProducts()
 
         // When
+        await sut.checkAvailability()
         await sut.reload()
 
         // Then
@@ -321,6 +326,7 @@ final class BlazeCampaignDashboardViewModelTests: XCTestCase {
         }
 
         // When
+        await sut.checkAvailability()
         await sut.reload()
     }
 
@@ -338,6 +344,7 @@ final class BlazeCampaignDashboardViewModelTests: XCTestCase {
         mockSynchronizeProducts()
 
         // When
+        await sut.checkAvailability()
         await sut.reload()
 
         // Then
@@ -361,6 +368,7 @@ final class BlazeCampaignDashboardViewModelTests: XCTestCase {
         mockSynchronizeProducts(insertProductToStorage: fakeProduct)
 
         // When
+        await sut.checkAvailability()
         await sut.reload()
 
         // Then
@@ -380,6 +388,7 @@ final class BlazeCampaignDashboardViewModelTests: XCTestCase {
         mockSynchronizeProducts()
 
         // When
+        await sut.checkAvailability()
         await sut.reload()
 
         // Then
@@ -420,6 +429,7 @@ final class BlazeCampaignDashboardViewModelTests: XCTestCase {
         }
 
         // When
+        await sut.checkAvailability()
         await sut.reload()
     }
 
@@ -435,7 +445,9 @@ final class BlazeCampaignDashboardViewModelTests: XCTestCase {
 
         mockSynchronizeCampaignsList(insertCampaignToStorage: fakeBlazeCampaign)
         mockSynchronizeProducts()
+
         // When
+        await sut.checkAvailability()
         await sut.reload()
 
         // Then
@@ -458,6 +470,7 @@ final class BlazeCampaignDashboardViewModelTests: XCTestCase {
         mockSynchronizeProducts(insertProductToStorage: fakeProduct)
 
         // When
+        await sut.checkAvailability()
         await sut.reload()
 
         // Then
@@ -477,6 +490,7 @@ final class BlazeCampaignDashboardViewModelTests: XCTestCase {
         mockSynchronizeProducts()
 
         // When
+        await sut.checkAvailability()
         await sut.reload()
 
         // Then
@@ -498,6 +512,7 @@ final class BlazeCampaignDashboardViewModelTests: XCTestCase {
         mockSynchronizeCampaignsList()
         mockSynchronizeProducts()
 
+        await sut.checkAvailability()
         await sut.reload()
 
         if case .empty = sut.state {
@@ -531,6 +546,7 @@ final class BlazeCampaignDashboardViewModelTests: XCTestCase {
         mockSynchronizeCampaignsList()
         mockSynchronizeProducts()
 
+        await sut.checkAvailability()
         await sut.reload()
 
         if case .empty = sut.state {
@@ -565,6 +581,7 @@ final class BlazeCampaignDashboardViewModelTests: XCTestCase {
         mockSynchronizeCampaignsList()
         mockSynchronizeProducts()
 
+        await sut.checkAvailability()
         await sut.reload()
 
         if case .empty = sut.state {
@@ -742,6 +759,7 @@ final class BlazeCampaignDashboardViewModelTests: XCTestCase {
         mockSynchronizeProducts()
 
         // When
+        await sut.checkAvailability()
         await sut.reload()
 
         // Then
@@ -769,6 +787,7 @@ final class BlazeCampaignDashboardViewModelTests: XCTestCase {
         mockSynchronizeProducts(insertProductToStorage: fakeProduct)
 
         // When
+        await sut.checkAvailability()
         await sut.reload()
 
         // Then
@@ -836,12 +855,14 @@ final class BlazeCampaignDashboardViewModelTests: XCTestCase {
         mockSynchronizeProducts()
 
         // When
+        await sut.checkAvailability()
         await sut.reload()
 
         // Then
         XCTAssertTrue(analyticsProvider.receivedEvents.filter { $0 == "blaze_entry_point_displayed" }.count == 1)
 
         // When
+        await sut.checkAvailability()
         await sut.reload()
 
         // Then


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #13156 
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This PR adds more tracking for dashboard cards data loading. Changes include:
- New events for when card loading starts, completes or fails.
- Updated tracking for all card types: performance, top performers, blaze, onboarding, last orders, most active coupons, stock, reviews, inbox.
- Some improvements:
  - Updated logs to not show type `AnyHashable` for property keys to make it more readable.
  - Track the correct error type and domain if the error is AFError with NSError as the underlying error.
  - Dashboard: fixed redundant requests for default cards by observing dashboard cards after fetching saved cards from storage. Otherwise, the default cards' data will always be loaded when the dashboard first loads.
  - Blaze card: separate logic to check card availability and reload data. This fixes duplicated requests on the dashboard.
  - Fixed rethrow error logic for performance, stock, and review cards to avoid mutating the task group in an async context.
  - Updated the review card to rethrow any errors while retrieving products. This also fixes #13152.

## Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->
- Test each card on the dashboard by disabling all the other cards to make it easier to read the logs.
- Confirm that for each card:
  - `dynamic_dashboard_card_data_loading_started` is tracked with the correct card type when it first loads. No other card type should be loaded.
  - After loading completes, `dynamic_dashboard_card_data_loading_completed` is tracked with the correct card type.
  - Disable the internet connection and reload the dashboard. Confirm that `dynamic_dashboard_card_data_loading_failed` is tracked with the correct card type and error properties.
- Also confirm that all cards still load correctly. 

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->
N/A

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
