### PR TITLE
[Woo POS] Incomplete address connection error handling: show admin URL externally instead of authenticated webview for self-hosted stores

### DIFF
--- a/WooCommerce/Classes/POS/Card Present Payments/CardPresentPaymentBluetoothReaderConnectionAlertsProvider.swift
+++ b/WooCommerce/Classes/POS/Card Present Payments/CardPresentPaymentBluetoothReaderConnectionAlertsProvider.swift
@@ -30,6 +30,7 @@ struct CardPresentPaymentBluetoothReaderConnectionAlertsProvider: BluetoothReade
     }
 
     func connectingFailedIncompleteAddress(wcSettingsAdminURL: URL?,
+                                           showsInAuthenticatedWebView: Bool,
                                            openWCSettings: (() -> Void)?,
                                            retrySearch: @escaping () -> Void,
                                            cancelSearch: @escaping () -> Void) -> CardPresentPaymentEventDetails {
@@ -39,6 +40,7 @@ struct CardPresentPaymentBluetoothReaderConnectionAlertsProvider: BluetoothReade
                 endSearch: cancelSearch)
         }
         return .connectingFailedUpdateAddress(wcSettingsAdminURL: wcSettingsAdminURL,
+                                              showsInAuthenticatedWebView: showsInAuthenticatedWebView,
                                               retrySearch: retrySearch,
                                               endSearch: cancelSearch)
     }

--- a/WooCommerce/Classes/POS/Card Present Payments/CardPresentPaymentBuiltInReaderConnectionAlertsProvider.swift
+++ b/WooCommerce/Classes/POS/Card Present Payments/CardPresentPaymentBuiltInReaderConnectionAlertsProvider.swift
@@ -31,6 +31,7 @@ struct CardPresentPaymentBuiltInReaderConnectionAlertsProvider: CardReaderConnec
     }
 
     func connectingFailedIncompleteAddress(wcSettingsAdminURL: URL?,
+                                           showsInAuthenticatedWebView: Bool,
                                            openWCSettings: (() -> Void)?,
                                            retrySearch: @escaping () -> Void,
                                            cancelSearch: @escaping () -> Void) -> CardPresentPaymentEventDetails {
@@ -40,8 +41,9 @@ struct CardPresentPaymentBuiltInReaderConnectionAlertsProvider: CardReaderConnec
                 endSearch: cancelSearch)
         }
         return .connectingFailedUpdateAddress(wcSettingsAdminURL: wcSettingsAdminURL,
-                                       retrySearch: retrySearch,
-                                       endSearch: cancelSearch)
+                                              showsInAuthenticatedWebView: showsInAuthenticatedWebView,
+                                              retrySearch: retrySearch,
+                                              endSearch: cancelSearch)
     }
 
     func connectingFailedInvalidPostalCode(retrySearch: @escaping () -> Void,

--- a/WooCommerce/Classes/POS/Card Present Payments/CardPresentPaymentCollectOrderPaymentUseCaseAdaptor.swift
+++ b/WooCommerce/Classes/POS/Card Present Payments/CardPresentPaymentCollectOrderPaymentUseCaseAdaptor.swift
@@ -121,7 +121,7 @@ private extension CardPresentPaymentCollectOrderPaymentUseCaseAdaptor {
                 .connectingFailedNonRetryable(_, let endSearch),
                 .connectingFailedUpdatePostalCode(_, let endSearch),
                 .connectingFailedChargeReader(_, let endSearch),
-                .connectingFailedUpdateAddress(_, _, let endSearch),
+                .connectingFailedUpdateAddress(_, _, _, let endSearch),
                 .foundReader(_, _, _, let endSearch):
             endSearch()
         case .foundMultipleReaders(_, let selectionHandler):

--- a/WooCommerce/Classes/POS/Card Present Payments/CardPresentPaymentEventDetails.swift
+++ b/WooCommerce/Classes/POS/Card Present Payments/CardPresentPaymentEventDetails.swift
@@ -18,6 +18,7 @@ enum CardPresentPaymentEventDetails {
     case connectingFailedChargeReader(retrySearch: () -> Void,
                                       endSearch: () -> Void)
     case connectingFailedUpdateAddress(wcSettingsAdminURL: URL,
+                                       showsInAuthenticatedWebView: Bool,
                                        retrySearch: () -> Void,
                                        endSearch: () -> Void)
     case preparingForPayment(cancelPayment: () -> Void)

--- a/WooCommerce/Classes/POS/Presentation/Card Present Payments/Connection Alerts/PointOfSaleCardPresentPaymentConnectingFailedUpdateAddressAlertViewModel.swift
+++ b/WooCommerce/Classes/POS/Presentation/Card Present Payments/Connection Alerts/PointOfSaleCardPresentPaymentConnectingFailedUpdateAddressAlertViewModel.swift
@@ -11,6 +11,7 @@ final class PointOfSaleCardPresentPaymentConnectingFailedUpdateAddressAlertViewM
     @Published private(set) var primaryButtonViewModel: CardPresentPaymentsModalButtonViewModel? = nil
     let cancelButtonViewModel: CardPresentPaymentsModalButtonViewModel
 
+    private let showsInAuthenticatedWebView: Bool
     private let retrySearchAction: () -> Void
 
     private var openSettingsButtonViewModel: CardPresentPaymentsModalButtonViewModel {
@@ -18,7 +19,11 @@ final class PointOfSaleCardPresentPaymentConnectingFailedUpdateAddressAlertViewM
             title: Localization.openAdmin,
             actionHandler: { [weak self] in
                 guard let self else { return }
-                shouldShowSettingsWebView = true
+                if showsInAuthenticatedWebView {
+                    shouldShowSettingsWebView = true
+                } else {
+                    UIApplication.shared.open(settingsAdminUrl)
+                }
                 primaryButtonViewModel = retryButtonViewModel
             })
     }
@@ -26,9 +31,11 @@ final class PointOfSaleCardPresentPaymentConnectingFailedUpdateAddressAlertViewM
     private var retryButtonViewModel: CardPresentPaymentsModalButtonViewModel
 
     init(settingsAdminUrl: URL,
+         showsInAuthenticatedWebView: Bool,
          retrySearchAction: @escaping () -> Void,
          cancelSearchAction: @escaping () -> Void) {
         self.settingsAdminUrl = settingsAdminUrl
+        self.showsInAuthenticatedWebView = showsInAuthenticatedWebView
         self.retrySearchAction = retrySearchAction
         self.retryButtonViewModel = CardPresentPaymentsModalButtonViewModel(
             title: Localization.retry,

--- a/WooCommerce/Classes/POS/Presentation/Card Present Payments/PointOfSaleCardPresentPaymentEventPresentationStyle.swift
+++ b/WooCommerce/Classes/POS/Presentation/Card Present Payments/PointOfSaleCardPresentPaymentEventPresentationStyle.swift
@@ -53,10 +53,11 @@ extension CardPresentPaymentEventDetails {
                     retryButtonAction: retrySearch,
                     cancelButtonAction: endSearch)))
 
-        case .connectingFailedUpdateAddress(let wcSettingsAdminURL, let retrySearch, let endSearch):
+        case .connectingFailedUpdateAddress(let wcSettingsAdminURL, let showsInAuthenticatedWebView, let retrySearch, let endSearch):
             return .alert(.connectingFailedUpdateAddress(
                 viewModel: PointOfSaleCardPresentPaymentConnectingFailedUpdateAddressAlertViewModel(
                     settingsAdminUrl: wcSettingsAdminURL,
+                    showsInAuthenticatedWebView: showsInAuthenticatedWebView,
                     retrySearchAction: retrySearch,
                     cancelSearchAction: endSearch)))
 

--- a/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/Connection Alerts/PointOfSaleCardPresentPaymentConnectingFailedUpdateAddressView.swift
+++ b/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/Connection Alerts/PointOfSaleCardPresentPaymentConnectingFailedUpdateAddressView.swift
@@ -28,6 +28,7 @@ struct PointOfSaleCardPresentPaymentConnectingFailedUpdateAddressView: View {
     PointOfSaleCardPresentPaymentConnectingFailedUpdateAddressView(
         viewModel: PointOfSaleCardPresentPaymentConnectingFailedUpdateAddressAlertViewModel(
             settingsAdminUrl: URL(string: "http://example.com")!,
+            showsInAuthenticatedWebView: true,
             retrySearchAction: {},
             cancelSearchAction: {}))
 }

--- a/WooCommerce/Classes/ViewRelated/CardPresentPayments/BuiltInCardReaderConnectionController.swift
+++ b/WooCommerce/Classes/ViewRelated/CardPresentPayments/BuiltInCardReaderConnectionController.swift
@@ -474,6 +474,7 @@ private extension BuiltInCardReaderConnectionController {
             alertsPresenter.present(
                 viewModel: alertsProvider.connectingFailedIncompleteAddress(
                     wcSettingsAdminURL: adminUrl,
+                    showsInAuthenticatedWebView: isWPCOMStore(),
                     openWCSettings: openWCSettingsAction(adminUrl: adminUrl,
                                                          retrySearch: retrySearch),
                     retrySearch: retrySearch,
@@ -501,8 +502,7 @@ private extension BuiltInCardReaderConnectionController {
     private func openWCSettingsAction(adminUrl: URL?,
                                       retrySearch: @escaping () -> Void) -> (() -> Void)? {
         if let adminUrl = adminUrl {
-            if let site = stores.sessionManager.defaultSite,
-               site.isWordPressComStore {
+            if isWPCOMStore() {
                 return { [weak self] in
                     self?.alertsPresenter.presentWCSettingsWebView(adminURL: adminUrl, completion: retrySearch)
                 }
@@ -514,6 +514,10 @@ private extension BuiltInCardReaderConnectionController {
             }
         }
         return nil
+    }
+
+    private func isWPCOMStore() -> Bool {
+        stores.sessionManager.defaultSite?.isWordPressComStore == true
     }
 
     private func showIncompleteAddressErrorWithRefreshButton() {

--- a/WooCommerce/Classes/ViewRelated/CardPresentPayments/CardReaderConnectionController.swift
+++ b/WooCommerce/Classes/ViewRelated/CardPresentPayments/CardReaderConnectionController.swift
@@ -644,6 +644,7 @@ private extension CardReaderConnectionController {
             alertsPresenter.present(
                 viewModel: alertsProvider.connectingFailedIncompleteAddress(
                     wcSettingsAdminURL: adminUrl,
+                    showsInAuthenticatedWebView: isWPCOMStore(),
                     openWCSettings: openWCSettingsAction(adminUrl: adminUrl,
                                                          retrySearch: retrySearch),
                     retrySearch: retrySearch,
@@ -672,8 +673,7 @@ private extension CardReaderConnectionController {
     private func openWCSettingsAction(adminUrl: URL?,
                                       retrySearch: @escaping () -> Void) -> (() -> Void)? {
         if let adminUrl = adminUrl {
-            if let site = stores.sessionManager.defaultSite,
-               site.isWordPressComStore {
+            if isWPCOMStore() {
                 return { [weak self] in
                     self?.alertsPresenter.presentWCSettingsWebView(adminURL: adminUrl, completion: retrySearch)
                 }
@@ -685,6 +685,10 @@ private extension CardReaderConnectionController {
             }
         }
         return nil
+    }
+
+    private func isWPCOMStore() -> Bool {
+        stores.sessionManager.defaultSite?.isWordPressComStore == true
     }
 
     private func showIncompleteAddressErrorWithRefreshButton() {

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/BluetoothReaderConnectionAlertsProvider.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/BluetoothReaderConnectionAlertsProvider.swift
@@ -27,6 +27,7 @@ struct BluetoothReaderConnectionAlertsProvider: BluetoothReaderConnnectionAlerts
     }
 
     func connectingFailedIncompleteAddress(wcSettingsAdminURL: URL?,
+                                           showsInAuthenticatedWebView: Bool,
                                            openWCSettings: (() -> Void)?,
                                            retrySearch: @escaping () -> Void,
                                            cancelSearch: @escaping () -> Void) -> CardPresentPaymentsModalViewModel {

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/BuiltInReaderConnectionAlertsProvider.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/BuiltInReaderConnectionAlertsProvider.swift
@@ -30,6 +30,7 @@ struct BuiltInReaderConnectionAlertsProvider: CardReaderConnectionAlertsProvidin
 
 
     func connectingFailedIncompleteAddress(wcSettingsAdminURL: URL?,
+                                           showsInAuthenticatedWebView: Bool,
                                            openWCSettings: (() -> Void)?,
                                            retrySearch: @escaping () -> Void,
                                            cancelSearch: @escaping () -> Void) -> CardPresentPaymentsModalViewModel {

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/CardReaderConnectionAlertsProviding.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/CardReadersV2/CardReaderConnectionAlertsProviding.swift
@@ -37,6 +37,7 @@ protocol CardReaderConnectionAlertsProviding<AlertDetails> {
     /// The user may try again or cancel
     ///
     func connectingFailedIncompleteAddress(wcSettingsAdminURL: URL?,
+                                           showsInAuthenticatedWebView: Bool,
                                            openWCSettings: (() -> Void)?,
                                            retrySearch: @escaping () -> Void,
                                            cancelSearch: @escaping () -> Void) -> AlertDetails

--- a/WooCommerce/WooCommerceTests/Mocks/MockCardReaderSettingsAlerts.swift
+++ b/WooCommerce/WooCommerceTests/Mocks/MockCardReaderSettingsAlerts.swift
@@ -100,6 +100,7 @@ extension MockCardReaderSettingsAlerts: BluetoothReaderConnnectionAlertsProvidin
     }
 
     func connectingFailedIncompleteAddress(wcSettingsAdminURL: URL?,
+                                           showsInAuthenticatedWebView: Bool,
                                            openWCSettings: (() -> Void)?,
                                            retrySearch: @escaping () -> Void,
                                            cancelSearch: @escaping () -> Void) -> CardPresentPaymentsModalViewModel {


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #12864 
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

As shared in https://github.com/woocommerce/woocommerce-ios/pull/13081, for self-hosted stores encountering incomplete address error during the reader connection flow, opening the admin URL in a WPCOM authenticated webview to update the address does not work. The WPCOM authenticated webview redirects to a page that doesn't present the address settings form and it's not easy to navigate to that form either. This PR aims to fix this issue since this error is easily reproducible.

I tried not to overspend time on this edge case, and this is a relatively simple approach I could think of. Please feel free to suggest other ways or improvements! The main change is to add a parameter `showsInAuthenticatedWebView: Bool` to `connectingFailedIncompleteAddress` alert to indicate whether the admin URL should be shown in an authenticated webview or not. In both `CardReaderConnectionController` and `BuiltInCardReaderConnectionController`, they pass `isWPCOMStore` to the parameter value so that it's only true for WPCOM stores. Then, in `PointOfSaleCardPresentPaymentConnectingFailedUpdateAddressAlertViewModel`, it triggers `UIApplication.shared.open` if `showsInAuthenticatedWebView` is `false`. I tried searching for a way to conditionally open the link in SwiftUI instead of the view model triggering `UIApplication.shared.open`, but it seems that `@Environment(\.openURL)` and [`Link`](https://developer.apple.com/documentation/swiftui/link) are meant to be triggered within the SwiftUI view.

## Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->

Prerequisite: the store is **self-hosted** and eligible for POS, the feature switch is enabled in Menu > Settings > Experimental Features > POS. Before testing, in wp-admin > WooCommerce > Settings (or Settings > WooCommerce in WPCOM eCommerce plan stores), delete the first line of the address.

* Launch app
* Go to Menu > Point of Sale
* Tap `Connect now` --> after connecting to a reader, an error alert should be shown about an incomplete address with a CTA to update the address
* Tap `Enter Address` --> it should open the WooCommerce settings form in an external webview like in Safari
* Add back the first line of the address
* Go back to the app, and tap `Retry after Updating` --> the connection flow should continue and then succeed eventually

## Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->

- [x] @jaclync tests the flow for a WPCOM store
- [x] @jaclync tests the flow in the existing app for a WPCOM store
- [x] @jaclync tests the flow in the existing app for a self-hosted store

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->


https://github.com/woocommerce/woocommerce-ios/assets/1945542/5b0a8e30-f5aa-43ac-805c-2a4b6dd20979


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.