### PR TITLE
[WOO POS] Move refreshable modifier to product list view

### DIFF
--- a/WooCommerce/Classes/POS/Presentation/PointOfSaleDashboardView.swift
+++ b/WooCommerce/Classes/POS/Presentation/PointOfSaleDashboardView.swift
@@ -32,9 +32,6 @@ struct PointOfSaleDashboardView: View {
         .task {
             await viewModel.populatePointOfSaleItems()
         }
-        .refreshable {
-            await viewModel.reload()
-        }
         .background(Color.posBackgroundGreyi3)
         .navigationBarBackButtonHidden(true)
         .toolbar {
@@ -82,6 +79,9 @@ private extension PointOfSaleDashboardView {
     var productGridView: some View {
         ItemListView(viewModel: viewModel)
             .frame(maxWidth: .infinity)
+            .refreshable {
+                await viewModel.reload()
+            }
     }
 }
 


### PR DESCRIPTION
## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

- Moved pull to refresh modifer directly to products list view to have pull to refresh only on that view instead of whole view.

## Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: https://woomobilep2.wordpress.com/2024/05/06/woocommerce-mobile-quality-report-march-april/#comment-12036 -->

- Enter POS
- Pull to refresh product list and check that it works
- Add few items in cart
- Pull cart and check that it does not have pull to refresh control
- Check that products list still had pull to refresh control

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

![Simulator Screen Recording - iPad Pro (11-inch) (4th generation) 17 2 - 2024-06-26 at 17 25 06](https://github.com/woocommerce/woocommerce-ios/assets/6242034/0ae028cc-23e0-48b3-9d6b-ee2d9f83e57b)

---
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
