### PR TITLE
[Product Creation AI v2] Add Starting information screen

### DIFF
--- a/Experiments/Experiments/DefaultFeatureFlagService.swift
+++ b/Experiments/Experiments/DefaultFeatureFlagService.swift
@@ -62,8 +62,6 @@ public struct DefaultFeatureFlagService: FeatureFlagService {
             return true
         case .hazmatShipping:
             return true
-        case .productCreationAI:
-            return true
         case .giftCardInOrderForm:
             return true
         case .wooPaymentsDepositsOverviewInPaymentsMenu:

--- a/Experiments/Experiments/FeatureFlag.swift
+++ b/Experiments/Experiments/FeatureFlag.swift
@@ -140,10 +140,6 @@ public enum FeatureFlag: Int {
     ///
     case hazmatShipping
 
-    /// Enables product creation with AI.
-    ///
-    case productCreationAI
-
     /// Enables gift card support in order creation/editing
     ///
     case giftCardInOrderForm

--- a/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductWithAI/Container/AddProductWithAIContainerView.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductWithAI/Container/AddProductWithAIContainerView.swift
@@ -73,7 +73,9 @@ struct AddProductWithAIContainerView: View {
 
     var body: some View {
         VStack(alignment: .leading, spacing: 0) {
-            progressView
+            if viewModel.featureFlagService.isFeatureFlagEnabled(.productCreationAIv2M1) == false {
+                progressView
+            }
 
             switch viewModel.currentStep {
             case .productName:

--- a/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductWithAI/Container/AddProductWithAIContainerView.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductWithAI/Container/AddProductWithAIContainerView.swift
@@ -79,13 +79,23 @@ struct AddProductWithAIContainerView: View {
 
             switch viewModel.currentStep {
             case .productName:
-                AddProductNameWithAIView(viewModel: viewModel.addProductNameViewModel,
-                                         onUsePackagePhoto: onUsePackagePhoto,
-                                         onContinueWithProductName: { name in
-                    withAnimation {
-                        viewModel.onContinueWithProductName(name: name)
-                    }
-                })
+                if viewModel.featureFlagService.isFeatureFlagEnabled(.productCreationAIv2M1) {
+                    ProductCreationAIStartingInfoView(viewModel: viewModel.startingInfoViewModel,
+                                                      onUsePackagePhoto: onUsePackagePhoto,
+                                                      onContinueWithFeatures: { features in
+                        withAnimation {
+                            viewModel.onProductFeaturesAdded(features: features)
+                        }
+                    })
+                } else {
+                    AddProductNameWithAIView(viewModel: viewModel.addProductNameViewModel,
+                                             onUsePackagePhoto: onUsePackagePhoto,
+                                             onContinueWithProductName: { name in
+                        withAnimation {
+                            viewModel.onContinueWithProductName(name: name)
+                        }
+                    })
+                }
             case .aboutProduct:
                 AddProductFeaturesView(viewModel: .init(siteID: viewModel.siteID,
                                                         productName: viewModel.productName,

--- a/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductWithAI/Container/AddProductWithAIContainerViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductWithAI/Container/AddProductWithAIContainerViewModel.swift
@@ -100,13 +100,13 @@ final class AddProductWithAIContainerViewModel: ObservableObject {
     }
 
     func backtrackOrDismiss() {
+        if featureFlagService.isFeatureFlagEnabled(.productCreationAIv2M1),
+           currentStep == .preview {
+            return currentStep = .productName
+        }
+
         if let previousStep = currentStep.previousStep {
-            if previousStep == .aboutProduct,
-               featureFlagService.isFeatureFlagEnabled(.productCreationAIv2M1) {
-                currentStep = .productName
-            } else {
-                currentStep = previousStep
-            }
+            currentStep = previousStep
         } else {
             onCancel()
         }

--- a/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductWithAI/Container/AddProductWithAIContainerViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductWithAI/Container/AddProductWithAIContainerViewModel.swift
@@ -40,11 +40,11 @@ final class AddProductWithAIContainerViewModel: ObservableObject {
     private var isFirstAttemptGeneratingDetails: Bool
 
     private(set) lazy var startingInfoViewModel: ProductCreationAIStartingInfoViewModel = {
-        .init(siteID: siteID)
+        ProductCreationAIStartingInfoViewModel(siteID: siteID)
     }()
 
     private(set) lazy var addProductNameViewModel: AddProductNameWithAIViewModel = {
-        .init(siteID: siteID)
+        AddProductNameWithAIViewModel(siteID: siteID)
     }()
 
     @Published private(set) var currentStep: AddProductWithAIStep = .productName

--- a/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductWithAI/Container/AddProductWithAIContainerViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductWithAI/Container/AddProductWithAIContainerViewModel.swift
@@ -39,6 +39,10 @@ final class AddProductWithAIContainerViewModel: ObservableObject {
     private(set) var productDescription: String?
     private var isFirstAttemptGeneratingDetails: Bool
 
+    private(set) lazy var startingInfoViewModel: ProductCreationAIStartingInfoViewModel = {
+        .init(siteID: siteID)
+    }()
+
     private(set) lazy var addProductNameViewModel: AddProductNameWithAIViewModel = {
         .init(siteID: siteID)
     }()

--- a/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductWithAI/Container/AddProductWithAIContainerViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductWithAI/Container/AddProductWithAIContainerViewModel.swift
@@ -1,6 +1,7 @@
 import Foundation
 import Yosemite
 import protocol WooFoundation.Analytics
+import Experiments
 
 enum AddProductWithAIStep: Int, CaseIterable {
     case productName = 1
@@ -23,6 +24,7 @@ final class AddProductWithAIContainerViewModel: ObservableObject {
 
     let siteID: Int64
     let source: AddProductCoordinator.Source
+    let featureFlagService: FeatureFlagService
 
     var canBeDismissed: Bool {
         currentStep == .productName && addProductNameViewModel.productName == nil
@@ -47,12 +49,14 @@ final class AddProductWithAIContainerViewModel: ObservableObject {
          source: AddProductCoordinator.Source,
          analytics: Analytics = ServiceLocator.analytics,
          onCancel: @escaping () -> Void,
-         onCompletion: @escaping (Product) -> Void) {
+         onCompletion: @escaping (Product) -> Void,
+         featureFlagService: FeatureFlagService = ServiceLocator.featureFlagService) {
         self.siteID = siteID
         self.source = source
         self.analytics = analytics
         self.onCancel = onCancel
         self.completionHandler = onCompletion
+        self.featureFlagService = featureFlagService
         isFirstAttemptGeneratingDetails = true
     }
 

--- a/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductWithAI/Container/AddProductWithAIContainerViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductWithAI/Container/AddProductWithAIContainerViewModel.swift
@@ -97,7 +97,12 @@ final class AddProductWithAIContainerViewModel: ObservableObject {
 
     func backtrackOrDismiss() {
         if let previousStep = currentStep.previousStep {
-            currentStep = previousStep
+            if previousStep == .aboutProduct,
+               featureFlagService.isFeatureFlagEnabled(.productCreationAIv2M1) {
+                currentStep = .productName
+            } else {
+                currentStep = previousStep
+            }
         } else {
             onCancel()
         }

--- a/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductWithAI/Container/AddProductWithAIContainerViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductWithAI/Container/AddProductWithAIContainerViewModel.swift
@@ -27,7 +27,11 @@ final class AddProductWithAIContainerViewModel: ObservableObject {
     let featureFlagService: FeatureFlagService
 
     var canBeDismissed: Bool {
-        currentStep == .productName && addProductNameViewModel.productName == nil
+        if featureFlagService.isFeatureFlagEnabled(.productCreationAIv2M1) {
+            currentStep == .productName && startingInfoViewModel.productFeatures == nil
+        } else {
+            currentStep == .productName && addProductNameViewModel.productName == nil
+        }
     }
 
     private let analytics: Analytics

--- a/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductWithAI/ProductCreationAIEligibilityChecker.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductWithAI/ProductCreationAIEligibilityChecker.swift
@@ -1,6 +1,5 @@
 import Foundation
 import Yosemite
-import Experiments
 
 /// Protocol for checking "add product using AI" eligibility for easier unit testing.
 protocol ProductCreationAIEligibilityCheckerProtocol {
@@ -11,19 +10,12 @@ protocol ProductCreationAIEligibilityCheckerProtocol {
 /// Checks the eligibility for the "add product using AI" feature.
 final class ProductCreationAIEligibilityChecker: ProductCreationAIEligibilityCheckerProtocol {
     private let stores: StoresManager
-    private let featureFlagService: FeatureFlagService
 
-    init(stores: StoresManager = ServiceLocator.stores,
-         featureFlagService: FeatureFlagService = ServiceLocator.featureFlagService) {
+    init(stores: StoresManager = ServiceLocator.stores) {
         self.stores = stores
-        self.featureFlagService = featureFlagService
     }
 
     var isEligible: Bool {
-        guard featureFlagService.isFeatureFlagEnabled(.productCreationAI) else {
-            return false
-        }
-
         guard let site = stores.sessionManager.defaultSite else {
             return false
         }

--- a/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductWithAI/StartingInfo/ProductCreationAIStartingInfoView.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductWithAI/StartingInfo/ProductCreationAIStartingInfoView.swift
@@ -157,7 +157,7 @@ private extension ProductCreationAIStartingInfoView {
         )
         static let placeholder = NSLocalizedString(
             "For example: Black cotton t-shirt, soft fabric, durable stitching, unique design",
-            comment: "Placeholder text on the product name field"
+            comment: "Placeholder text on the product features field"
         )
         static let readTextFromPhoto = NSLocalizedString(
             "Read text from product photo",

--- a/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductWithAI/StartingInfo/ProductCreationAIStartingInfoView.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductWithAI/StartingInfo/ProductCreationAIStartingInfoView.swift
@@ -130,7 +130,6 @@ private extension ProductCreationAIStartingInfoView {
         static let titleBlockBottomPadding: CGFloat = 40
 
         static let titleBlockSpacing: CGFloat = 16
-        static let horizontalPadding: CGFloat = 16
 
         static let editorBlockSpacing: CGFloat = 8
         static let minimumEditorHeight: CGFloat = 70

--- a/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductWithAI/StartingInfo/ProductCreationAIStartingInfoView.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductWithAI/StartingInfo/ProductCreationAIStartingInfoView.swift
@@ -86,13 +86,13 @@ private extension ProductCreationAIStartingInfoView {
                     Image(systemName: Layout.UsePackagePhoto.cameraSFSymbol)
                         .renderingMode(.template)
                         .fontWeight(.semibold)
-                        .foregroundColor(Color(.brand))
+                        .foregroundColor(Color.accentColor)
                         .bodyStyle()
                         .padding(Layout.UsePackagePhoto.padding)
 
                     Text(Localization.readTextFromPhoto)
                         .fontWeight(.semibold)
-                        .foregroundColor(Color(.brand))
+                        .foregroundColor(Color.accentColor)
                         .bodyStyle()
                 }
             }

--- a/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductWithAI/StartingInfo/ProductCreationAIStartingInfoView.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductWithAI/StartingInfo/ProductCreationAIStartingInfoView.swift
@@ -148,23 +148,28 @@ private extension ProductCreationAIStartingInfoView {
 
     enum Localization {
         static let title = NSLocalizedString(
-            "Starting information",
+            "productCreationAIStartingInfoView.title",
+            value: "Starting information",
             comment: "Title on the starting info screen."
         )
         static let subtitle = NSLocalizedString(
-            "Tell us about your product, what it is and what makes it unique, then let the AI work its magic.",
+            "productCreationAIStartingInfoView.subtitle",
+            value: "Tell us about your product, what it is and what makes it unique, then let the AI work its magic.",
             comment: "Subtitle on the starting info screen."
         )
         static let placeholder = NSLocalizedString(
-            "For example: Black cotton t-shirt, soft fabric, durable stitching, unique design",
+            "productCreationAIStartingInfoView.placeholder",
+            value: "For example: Black cotton t-shirt, soft fabric, durable stitching, unique design",
             comment: "Placeholder text on the product features field"
         )
         static let readTextFromPhoto = NSLocalizedString(
-            "Read text from product photo",
+            "productCreationAIStartingInfoView.readTextFromPhoto",
+            value: "Read text from product photo",
             comment: "Upload package photo button on the text field"
         )
         static let continueText = NSLocalizedString(
-            "Continue",
+            "productCreationAIStartingInfoView.continueText",
+            value: "Continue",
             comment: "Continue button on the starting info screen."
         )
     }

--- a/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductWithAI/StartingInfo/ProductCreationAIStartingInfoView.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductWithAI/StartingInfo/ProductCreationAIStartingInfoView.swift
@@ -1,0 +1,178 @@
+import SwiftUI
+
+/// View for entering keywords or selecting package photo for creating a new product with AI.
+///
+struct ProductCreationAIStartingInfoView: View {
+    @ObservedObject private var viewModel: ProductCreationAIStartingInfoViewModel
+    @ScaledMetric private var scale: CGFloat = 1.0
+    @FocusState private var editorIsFocused: Bool
+
+    private let onUsePackagePhoto: (String?) -> Void
+    private let onContinueWithFeatures: (String) -> Void
+
+    init(viewModel: ProductCreationAIStartingInfoViewModel,
+         onUsePackagePhoto: @escaping (String?) -> Void,
+         onContinueWithFeatures: @escaping (String) -> Void) {
+        self.viewModel = viewModel
+        self.onUsePackagePhoto = onUsePackagePhoto
+        self.onContinueWithFeatures = onContinueWithFeatures
+    }
+
+    var body: some View {
+        ScrollView {
+            VStack(alignment: .leading, spacing: 0) {
+                VStack(alignment: .leading, spacing: Layout.titleBlockSpacing) {
+                    // Title label.
+                    Text(Localization.title)
+                        .fontWeight(.bold)
+                        .titleStyle()
+
+                    // Subtitle label.
+                    Text(Localization.subtitle)
+                        .foregroundColor(Color(.secondaryLabel))
+                        .bodyStyle()
+                }
+                .padding(.bottom, Layout.titleBlockBottomPadding)
+
+                VStack(alignment: .leading, spacing: Layout.titleBlockSpacing) {
+                    VStack(alignment: .leading, spacing: Layout.editorBlockSpacing) {
+                        VStack(spacing: 0) {
+                            ZStack(alignment: .topLeading) {
+                                TextEditor(text: $viewModel.features)
+                                    .bodyStyle()
+                                    .foregroundColor(.secondary)
+                                    .padding(insets: Layout.messageContentInsets)
+                                    .frame(minHeight: Layout.minimumEditorHeight, maxHeight: .infinity)
+                                    .focused($editorIsFocused)
+
+                                // Placeholder text
+                                placeholderText
+                            }
+
+                            Divider()
+                                .frame(height: Layout.dividerHeight)
+                                .foregroundColor(Color(.separator))
+
+                            readTextFromPhotoButton
+                                .padding(insets: Layout.readTextFromPhotoButtonInsets)
+                        }
+                        .overlay(
+                            RoundedRectangle(cornerRadius: Layout.cornerRadius).stroke(editorIsFocused ? Color(.brand) : Color(.separator))
+                        )
+                    }
+                }
+            }
+            .padding(insets: Layout.insets)
+        }
+        .safeAreaInset(edge: .bottom) {
+            VStack {
+                // CTA to continue to next screen.
+                continueButton
+                    .padding()
+            }
+            .background(Color(uiColor: .systemBackground))
+        }
+    }
+}
+
+private extension ProductCreationAIStartingInfoView {
+    var readTextFromPhotoButton: some View {
+        HStack {
+            Button {
+                viewModel.didTapReadTextFromPhoto()
+                // TODO: Launch photo selection flow
+            } label: {
+                HStack(alignment: .center, spacing: Layout.UsePackagePhoto.spacing) {
+                    Image(systemName: Layout.UsePackagePhoto.cameraSFSymbol)
+                        .renderingMode(.template)
+                        .fontWeight(.semibold)
+                        .foregroundColor(Color(.brand))
+                        .bodyStyle()
+                        .padding(Layout.UsePackagePhoto.padding)
+
+                    Text(Localization.readTextFromPhoto)
+                        .fontWeight(.semibold)
+                        .foregroundColor(Color(.brand))
+                        .bodyStyle()
+                }
+            }
+            Spacer()
+        }
+    }
+
+    var placeholderText: some View {
+        Text(Localization.placeholder)
+            .foregroundColor(Color(.placeholderText))
+            .bodyStyle()
+            .padding(insets: Layout.placeholderInsets)
+            // Allows gestures to pass through to the `TextEditor`.
+            .allowsHitTesting(false)
+            .renderedIf(viewModel.features.isEmpty)
+    }
+
+    var continueButton: some View {
+        Button {
+            // continue
+            editorIsFocused = false
+            viewModel.didTapContinue()
+            onContinueWithFeatures(viewModel.features)
+        } label: {
+            Text(Localization.continueText)
+        }
+        .buttonStyle(PrimaryButtonStyle())
+        .disabled(viewModel.features.isEmpty)
+    }
+}
+private extension ProductCreationAIStartingInfoView {
+    enum Layout {
+        static let insets: EdgeInsets = .init(top: 24, leading: 16, bottom: 16, trailing: 16)
+
+        static let titleBlockBottomPadding: CGFloat = 40
+
+        static let titleBlockSpacing: CGFloat = 16
+        static let horizontalPadding: CGFloat = 16
+
+        static let editorBlockSpacing: CGFloat = 8
+        static let minimumEditorHeight: CGFloat = 70
+        static let cornerRadius: CGFloat = 8
+        static let messageContentInsets: EdgeInsets = .init(top: 10, leading: 10, bottom: 10, trailing: 10)
+        static let placeholderInsets: EdgeInsets = .init(top: 16, leading: 16, bottom: 16, trailing: 16)
+        static let dividerHeight: CGFloat = 1
+        static let readTextFromPhotoButtonInsets: EdgeInsets = .init(top: 11, leading: 16, bottom: 11, trailing: 16)
+
+        enum UsePackagePhoto {
+            static let padding: CGFloat = 4
+            static let spacing: CGFloat = 4
+            static let cameraSFSymbol = "camera"
+        }
+    }
+
+    enum Localization {
+        static let title = NSLocalizedString(
+            "Starting information",
+            comment: "Title on the starting info screen."
+        )
+        static let subtitle = NSLocalizedString(
+            "Tell us about your product, what it is and what makes it unique, then let the AI work its magic.",
+            comment: "Subtitle on the starting info screen."
+        )
+        static let placeholder = NSLocalizedString(
+            "For example: Black cotton t-shirt, soft fabric, durable stitching, unique design",
+            comment: "Placeholder text on the product name field"
+        )
+        static let readTextFromPhoto = NSLocalizedString(
+            "Read text from product photo",
+            comment: "Upload package photo button on the text field"
+        )
+        static let continueText = NSLocalizedString(
+            "Continue",
+            comment: "Continue button on the starting info screen."
+        )
+    }
+}
+
+struct ProductCreationAIStartingInfoView_Previews: PreviewProvider {
+    static var previews: some View {
+        ProductCreationAIStartingInfoView(viewModel: .init(siteID: 123), onUsePackagePhoto: { _ in }, onContinueWithFeatures: { _ in })
+    }
+}

--- a/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductWithAI/StartingInfo/ProductCreationAIStartingInfoViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductWithAI/StartingInfo/ProductCreationAIStartingInfoViewModel.swift
@@ -1,0 +1,25 @@
+import Foundation
+import protocol WooFoundation.Analytics
+
+/// View model for `ProductCreationAIStartingInfoView`.
+///
+final class ProductCreationAIStartingInfoViewModel: ObservableObject {
+    @Published var features: String
+
+    let siteID: Int64
+    private let analytics: Analytics
+
+    init(siteID: Int64, analytics: Analytics = ServiceLocator.analytics) {
+        self.siteID = siteID
+        self.features = ""
+        self.analytics = analytics
+    }
+
+    func didTapReadTextFromPhoto() {
+        // TODO: 13103 - Add tracking
+    }
+
+    func didTapContinue() {
+        // TODO: 13103 - Add tracking
+    }
+}

--- a/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductWithAI/StartingInfo/ProductCreationAIStartingInfoViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductWithAI/StartingInfo/ProductCreationAIStartingInfoViewModel.swift
@@ -9,6 +9,13 @@ final class ProductCreationAIStartingInfoViewModel: ObservableObject {
     let siteID: Int64
     private let analytics: Analytics
 
+    var productFeatures: String? {
+        guard features.isNotEmpty else {
+            return nil
+        }
+        return features
+    }
+
     init(siteID: Int64, analytics: Analytics = ServiceLocator.analytics) {
         self.siteID = siteID
         self.features = ""

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -2693,6 +2693,8 @@
 		E1E649EB28461EDF0070B194 /* BetaFeaturesConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1E649EA28461EDF0070B194 /* BetaFeaturesConfiguration.swift */; };
 		E1ED16E4266E10A10037B8DB /* ApplicationLogViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1ED16E3266E10A10037B8DB /* ApplicationLogViewModel.swift */; };
 		E1F52DC62668E03B00349D75 /* CardPresentModalBluetoothRequired.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1F52DC52668E03B00349D75 /* CardPresentModalBluetoothRequired.swift */; };
+		EE09DE062C2C0C9600A32680 /* ProductCreationAIStartingInfoView.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE09DE052C2C0C9600A32680 /* ProductCreationAIStartingInfoView.swift */; };
+		EE09DE082C2C0CA100A32680 /* ProductCreationAIStartingInfoViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE09DE072C2C0CA100A32680 /* ProductCreationAIStartingInfoViewModel.swift */; };
 		EE0EE7A628B7415200F6061E /* CustomHelpCenterContent.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE0EE7A528B7415200F6061E /* CustomHelpCenterContent.swift */; };
 		EE0EE7A828B74EF300F6061E /* CustomHelpCenterContentTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE0EE7A728B74EF300F6061E /* CustomHelpCenterContentTests.swift */; };
 		EE1905822B50289100617C53 /* BlazeCampaignCreationFormViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE1905812B50289100617C53 /* BlazeCampaignCreationFormViewModelTests.swift */; };
@@ -5651,6 +5653,8 @@
 		E1E649EA28461EDF0070B194 /* BetaFeaturesConfiguration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BetaFeaturesConfiguration.swift; sourceTree = "<group>"; };
 		E1ED16E3266E10A10037B8DB /* ApplicationLogViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ApplicationLogViewModel.swift; sourceTree = "<group>"; };
 		E1F52DC52668E03B00349D75 /* CardPresentModalBluetoothRequired.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardPresentModalBluetoothRequired.swift; sourceTree = "<group>"; };
+		EE09DE052C2C0C9600A32680 /* ProductCreationAIStartingInfoView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductCreationAIStartingInfoView.swift; sourceTree = "<group>"; };
+		EE09DE072C2C0CA100A32680 /* ProductCreationAIStartingInfoViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductCreationAIStartingInfoViewModel.swift; sourceTree = "<group>"; };
 		EE0EE7A528B7415200F6061E /* CustomHelpCenterContent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomHelpCenterContent.swift; sourceTree = "<group>"; };
 		EE0EE7A728B74EF300F6061E /* CustomHelpCenterContentTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomHelpCenterContentTests.swift; sourceTree = "<group>"; };
 		EE1905812B50289100617C53 /* BlazeCampaignCreationFormViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BlazeCampaignCreationFormViewModelTests.swift; sourceTree = "<group>"; };
@@ -12773,6 +12777,15 @@
 			path = "In-Person Payments";
 			sourceTree = "<group>";
 		};
+		EE09DE042C2C0C7600A32680 /* StartingInfo */ = {
+			isa = PBXGroup;
+			children = (
+				EE09DE052C2C0C9600A32680 /* ProductCreationAIStartingInfoView.swift */,
+				EE09DE072C2C0CA100A32680 /* ProductCreationAIStartingInfoViewModel.swift */,
+			);
+			path = StartingInfo;
+			sourceTree = "<group>";
+		};
 		EE3272A229A88F670015F8D0 /* Onboarding */ = {
 			isa = PBXGroup;
 			children = (
@@ -12882,6 +12895,7 @@
 		EE5B5BB12AB30BF9009BCBD6 /* AddProductWithAI */ = {
 			isa = PBXGroup;
 			children = (
+				EE09DE042C2C0C7600A32680 /* StartingInfo */,
 				EEA6935A2B231A3100BAECA6 /* Survey */,
 				EE7707C62ABBF473009FD564 /* AIToneVoice */,
 				DE8BEB942ABC195C00F5E56C /* Preview */,
@@ -15748,6 +15762,7 @@
 				0313651728ACE9F400EEE571 /* InPersonPaymentsCashOnDeliveryPaymentGatewayNotSetUpViewModel.swift in Sources */,
 				571CDD5A250ACC470076B8CC /* UITableViewDiffableDataSource+Helpers.swift in Sources */,
 				DE7E5E7D2B4BB617002E28D2 /* BlazeTargetLanguagePickerView.swift in Sources */,
+				EE09DE082C2C0CA100A32680 /* ProductCreationAIStartingInfoViewModel.swift in Sources */,
 				02B1AA6529A4705A00D54FCB /* TabbedViewController.swift in Sources */,
 				4580BA7423F192D400B5F764 /* ProductSettingsViewController.swift in Sources */,
 				02A723282AB2E1C2003AEC7E /* GiftCardInputViewModel.swift in Sources */,
@@ -15780,6 +15795,7 @@
 				FE28F7182684EE6A004465C7 /* RoleErrorViewModel.swift in Sources */,
 				02C0CD2C23B5BC9600F880B1 /* DefaultImageService.swift in Sources */,
 				B9D19A442AE7B66B00D944D8 /* CustomAmountRowView.swift in Sources */,
+				EE09DE062C2C0C9600A32680 /* ProductCreationAIStartingInfoView.swift in Sources */,
 				03E471C8293A3076001A58AD /* CardPresentModalBuiltInConnectingToReader.swift in Sources */,
 				EEC259462B4556B6004D703C /* BlazeEditAdHostingController.swift in Sources */,
 				EE5B5BC72AB8379C009BCBD6 /* AddProductWithAIContainerViewModel.swift in Sources */,

--- a/WooCommerce/WooCommerceTests/Mocks/MockFeatureFlagService.swift
+++ b/WooCommerce/WooCommerceTests/Mocks/MockFeatureFlagService.swift
@@ -14,7 +14,6 @@ struct MockFeatureFlagService: FeatureFlagService {
     private let isBlazeEnabled: Bool
     private let isShareProductAIEnabled: Bool
     private let betterCustomerSelectionInOrder: Bool
-    private let productCreationAI: Bool
     private let productBundles: Bool
     private let productBundlesInOrderForm: Bool
     private let isScanToUpdateInventoryEnabled: Bool
@@ -38,7 +37,6 @@ struct MockFeatureFlagService: FeatureFlagService {
          isBlazeEnabled: Bool = false,
          isShareProductAIEnabled: Bool = false,
          betterCustomerSelectionInOrder: Bool = false,
-         productCreationAI: Bool = false,
          productBundles: Bool = false,
          productBundlesInOrderForm: Bool = false,
          isScanToUpdateInventoryEnabled: Bool = false,
@@ -61,7 +59,6 @@ struct MockFeatureFlagService: FeatureFlagService {
         self.isBlazeEnabled = isBlazeEnabled
         self.isShareProductAIEnabled = isShareProductAIEnabled
         self.betterCustomerSelectionInOrder = betterCustomerSelectionInOrder
-        self.productCreationAI = productCreationAI
         self.productBundles = productBundles
         self.productBundlesInOrderForm = productBundlesInOrderForm
         self.isScanToUpdateInventoryEnabled = isScanToUpdateInventoryEnabled
@@ -98,8 +95,6 @@ struct MockFeatureFlagService: FeatureFlagService {
             return isShareProductAIEnabled
         case .betterCustomerSelectionInOrder:
             return betterCustomerSelectionInOrder
-        case .productCreationAI:
-            return productCreationAI
         case .productBundles:
             return productBundles
         case .productBundlesInOrderForm:

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/Add Product/AddProductWithAI/AddProductWithAIContainerViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/Add Product/AddProductWithAI/AddProductWithAIContainerViewModelTests.swift
@@ -30,7 +30,11 @@ final class AddProductWithAIContainerViewModelTests: XCTestCase {
 
     func test_canBeDismissed_returns_false_if_current_step_is_productName_and_the_name_field_is_not_empty() {
         // Given
-        let viewModel = AddProductWithAIContainerViewModel(siteID: 123, source: .productsTab, onCancel: {}, onCompletion: { _ in })
+        let viewModel = AddProductWithAIContainerViewModel(siteID: 123,
+                                                           source: .productsTab,
+                                                           onCancel: {},
+                                                           onCompletion: { _ in },
+                                                           featureFlagService: MockFeatureFlagService(isProductCreationAIv2M1Enabled: false))
 
         // When
         viewModel.addProductNameViewModel.productNameContent = "iPhone 15"

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/Add Product/AddProductWithAI/ProductCreationAIEligibilityCheckerTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/Add Product/AddProductWithAI/ProductCreationAIEligibilityCheckerTests.swift
@@ -19,8 +19,7 @@ final class ProductCreationAIEligibilityCheckerTests: XCTestCase {
     func test_isEligible_is_true_for_wpcom_store() throws {
         // Given
         updateDefaultStore(isWPCOMStore: true)
-        let checker = ProductCreationAIEligibilityChecker(stores: stores,
-                                                          featureFlagService: MockFeatureFlagService(productCreationAI: true))
+        let checker = ProductCreationAIEligibilityChecker(stores: stores)
 
         // When
         let isEligible = checker.isEligible
@@ -32,8 +31,7 @@ final class ProductCreationAIEligibilityCheckerTests: XCTestCase {
     func test_isEligible_is_false_for_non_wpcom_store() throws {
         // Given
         updateDefaultStore(isWPCOMStore: false)
-        let checker = ProductCreationAIEligibilityChecker(stores: stores,
-                                                          featureFlagService: MockFeatureFlagService(productCreationAI: true))
+        let checker = ProductCreationAIEligibilityChecker(stores: stores)
         // When
         let isEligible = checker.isEligible
 
@@ -44,25 +42,12 @@ final class ProductCreationAIEligibilityCheckerTests: XCTestCase {
     func test_isEligible_is_true_for_non_wpcom_store_when_ai_assistant_feature_is_active() throws {
         // Given
         updateDefaultStore(isWPCOMStore: false, isAIAssistantActive: true)
-        let checker = ProductCreationAIEligibilityChecker(stores: stores,
-                                                          featureFlagService: MockFeatureFlagService(productCreationAI: true))
+        let checker = ProductCreationAIEligibilityChecker(stores: stores)
         // When
         let isEligible = checker.isEligible
 
         // Then
         XCTAssertTrue(isEligible)
-    }
-
-    func test_isEligible_is_false_when_feature_flag_is_false() throws {
-        // Given
-        updateDefaultStore(isWPCOMStore: true)
-        let checker = ProductCreationAIEligibilityChecker(stores: stores,
-                                                          featureFlagService: MockFeatureFlagService(productCreationAI: false))
-        // When
-        let isEligible = checker.isEligible
-
-        // Then
-        XCTAssertFalse(isEligible)
     }
 }
 


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of: #13104
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

As part of the Product Creation AI v2 work this PR Adds initial version for "Starting information" screen. 

Changes
- Remove the previous feature flag using for Product Creation AI v1. 
- View and ViewModel for Starting information" screen. 
- Show "Starting information" screen after checking feature flag.
- Hide the progress bar after checking feature flag.
- Navigate to product preview screen from "Starting information" screen. 

## Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->

1. Create a JN site with Jetpack AI plugin
2. Turn on `productCreationAIv2M1` feature flag
3. Build and run the app
4. Navigate to the products tab
5. Tap `+` button on top right
6. Tap "Create a product with AI"
7.  Validate that the new "Starting information" screen is displayed. 
8. Stop the app.
9. Disable the `productCreationAIv2M1` feature flag and build and run the app. 
10. Repeat steps 4 to 6.
11.  Validate that the previous "Add product name" screen is displayed. 


## Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->
Test the product creation with AI flow works as before when `productCreationAIv2M1` feature flag turned off. 

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->
| `productCreationAIv2M1` false | `productCreationAIv2M1` true |
|--------|--------|
| ![Simulator Screenshot - iPhone 15 Pro Max - 2024-06-26 at 21 20 10](https://github.com/woocommerce/woocommerce-ios/assets/524475/0f68618e-bf12-4829-b53e-df2a4c97b46d) | ![Simulator Screenshot - iPhone 15 Pro Max - 2024-06-26 at 21 21 12](https://github.com/woocommerce/woocommerce-ios/assets/524475/dae2f48d-7e97-4c17-8b58-fed8c4a558e6) | 

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.