### PR TITLE
[GLA Analytics] Add networking models for Google Listings & Ads campaign stats

### DIFF
--- a/Fakes/Fakes/Networking.generated.swift
+++ b/Fakes/Fakes/Networking.generated.swift
@@ -577,7 +577,20 @@ extension Networking.GoogleAdsCampaignStats {
     public static func fake() -> Networking.GoogleAdsCampaignStats {
         .init(
             siteID: .fake(),
-            totals: .fake()
+            totals: .fake(),
+            campaigns: .fake()
+        )
+    }
+}
+extension Networking.GoogleAdsCampaignStatsItem {
+    /// Returns a "ready to use" type filled with fake values.
+    ///
+    public static func fake() -> Networking.GoogleAdsCampaignStatsItem {
+        .init(
+            campaignID: .fake(),
+            campaignName: .fake(),
+            status: .fake(),
+            subtotals: .fake()
         )
     }
 }

--- a/Fakes/Fakes/Networking.generated.swift
+++ b/Fakes/Fakes/Networking.generated.swift
@@ -589,7 +589,7 @@ extension Networking.GoogleAdsCampaignStatsItem {
         .init(
             campaignID: .fake(),
             campaignName: .fake(),
-            status: .fake(),
+            rawStatus: .fake(),
             subtotals: .fake()
         )
     }

--- a/Fakes/Fakes/Networking.generated.swift
+++ b/Fakes/Fakes/Networking.generated.swift
@@ -571,6 +571,29 @@ extension Networking.GiftCardStatsTotals {
         )
     }
 }
+extension Networking.GoogleAdsCampaignStats {
+    /// Returns a "ready to use" type filled with fake values.
+    ///
+    public static func fake() -> Networking.GoogleAdsCampaignStats {
+        .init(
+            siteID: .fake(),
+            totals: .fake()
+        )
+    }
+}
+extension Networking.GoogleAdsCampaignStatsTotals {
+    /// Returns a "ready to use" type filled with fake values.
+    ///
+    public static func fake() -> Networking.GoogleAdsCampaignStatsTotals {
+        .init(
+            sales: .fake(),
+            spend: .fake(),
+            clicks: .fake(),
+            impressions: .fake(),
+            conversions: .fake()
+        )
+    }
+}
 extension Networking.GoogleAdsConnection {
     /// Returns a "ready to use" type filled with fake values.
     ///

--- a/Networking/Networking.xcodeproj/project.pbxproj
+++ b/Networking/Networking.xcodeproj/project.pbxproj
@@ -805,6 +805,7 @@
 		CE21FB142C2AC87000303832 /* google-ads-reports-programs-without-data.json in Resources */ = {isa = PBXBuildFile; fileRef = CE21FB132C2AC87000303832 /* google-ads-reports-programs-without-data.json */; };
 		CE21FB162C2AC90E00303832 /* GoogleAdsCampaignStats.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE21FB152C2AC90E00303832 /* GoogleAdsCampaignStats.swift */; };
 		CE21FB182C2AC97200303832 /* GoogleAdsCampaignStatsTotals.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE21FB172C2AC97200303832 /* GoogleAdsCampaignStatsTotals.swift */; };
+		CE21FB1C2C2AD7E200303832 /* GoogleAdsCampaignStatsItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE21FB1B2C2AD7E200303832 /* GoogleAdsCampaignStatsItem.swift */; };
 		CE21FB242C2C16DA00303832 /* google-ads-reports-programs.json in Resources */ = {isa = PBXBuildFile; fileRef = CE21FB232C2C16DA00303832 /* google-ads-reports-programs.json */; };
 		CE227093228DD44C00C0626C /* ProductStatus.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE227092228DD44C00C0626C /* ProductStatus.swift */; };
 		CE2678432A26102A00FD9AEB /* order-alternative-types.json in Resources */ = {isa = PBXBuildFile; fileRef = CE2678422A26102A00FD9AEB /* order-alternative-types.json */; };
@@ -1943,6 +1944,7 @@
 		CE21FB132C2AC87000303832 /* google-ads-reports-programs-without-data.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "google-ads-reports-programs-without-data.json"; sourceTree = "<group>"; };
 		CE21FB152C2AC90E00303832 /* GoogleAdsCampaignStats.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GoogleAdsCampaignStats.swift; sourceTree = "<group>"; };
 		CE21FB172C2AC97200303832 /* GoogleAdsCampaignStatsTotals.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GoogleAdsCampaignStatsTotals.swift; sourceTree = "<group>"; };
+		CE21FB1B2C2AD7E200303832 /* GoogleAdsCampaignStatsItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GoogleAdsCampaignStatsItem.swift; sourceTree = "<group>"; };
 		CE21FB232C2C16DA00303832 /* google-ads-reports-programs.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "google-ads-reports-programs.json"; sourceTree = "<group>"; };
 		CE227092228DD44C00C0626C /* ProductStatus.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductStatus.swift; sourceTree = "<group>"; };
 		CE2678422A26102A00FD9AEB /* order-alternative-types.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "order-alternative-types.json"; sourceTree = "<group>"; };
@@ -2559,6 +2561,7 @@
 				CE070A2D2BBC3C3500017578 /* GiftCardStatsTotals.swift */,
 				CE21FB152C2AC90E00303832 /* GoogleAdsCampaignStats.swift */,
 				CE21FB172C2AC97200303832 /* GoogleAdsCampaignStatsTotals.swift */,
+				CE21FB1B2C2AD7E200303832 /* GoogleAdsCampaignStatsItem.swift */,
 			);
 			path = Stats;
 			sourceTree = "<group>";
@@ -5075,6 +5078,7 @@
 				E18152BE28F85B5B0011A0EC /* InAppPurchasesRemote.swift in Sources */,
 				0329CF9B27A82E19008AFF91 /* WCPayCharge.swift in Sources */,
 				035BA3AA29113CBD0056F0AD /* DataBoolMapper.swift in Sources */,
+				CE21FB1C2C2AD7E200303832 /* GoogleAdsCampaignStatsItem.swift in Sources */,
 				74749B97224134FF005C4CF2 /* ProductMapper.swift in Sources */,
 				EE2C09C229AF26B2009396F9 /* StoreOnboardingTaskListMapper.swift in Sources */,
 				26455E2A25F669F0008A1D32 /* ProductAttributeTermMapper.swift in Sources */,

--- a/Networking/Networking.xcodeproj/project.pbxproj
+++ b/Networking/Networking.xcodeproj/project.pbxproj
@@ -802,6 +802,8 @@
 		CE19CB11222486A600E8AF7A /* order-statuses.json in Resources */ = {isa = PBXBuildFile; fileRef = CE19CB10222486A500E8AF7A /* order-statuses.json */; };
 		CE1BE7062A2A5E9A00C6B53B /* IdentifiableObject.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE1BE7052A2A5E9A00C6B53B /* IdentifiableObject.swift */; };
 		CE20179320E3EFA7005B4C18 /* broken-orders.json in Resources */ = {isa = PBXBuildFile; fileRef = CE20179220E3EFA7005B4C18 /* broken-orders.json */; };
+		CE21FB142C2AC87000303832 /* google-ads-reports-programs-without-data.json in Resources */ = {isa = PBXBuildFile; fileRef = CE21FB132C2AC87000303832 /* google-ads-reports-programs-without-data.json */; };
+		CE21FB242C2C16DA00303832 /* google-ads-reports-programs.json in Resources */ = {isa = PBXBuildFile; fileRef = CE21FB232C2C16DA00303832 /* google-ads-reports-programs.json */; };
 		CE227093228DD44C00C0626C /* ProductStatus.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE227092228DD44C00C0626C /* ProductStatus.swift */; };
 		CE2678432A26102A00FD9AEB /* order-alternative-types.json in Resources */ = {isa = PBXBuildFile; fileRef = CE2678422A26102A00FD9AEB /* order-alternative-types.json */; };
 		CE43066A23465F340073CBFF /* Refund.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE43066923465F340073CBFF /* Refund.swift */; };
@@ -1936,6 +1938,8 @@
 		CE19CB10222486A500E8AF7A /* order-statuses.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "order-statuses.json"; sourceTree = "<group>"; };
 		CE1BE7052A2A5E9A00C6B53B /* IdentifiableObject.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IdentifiableObject.swift; sourceTree = "<group>"; };
 		CE20179220E3EFA7005B4C18 /* broken-orders.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "broken-orders.json"; sourceTree = "<group>"; };
+		CE21FB132C2AC87000303832 /* google-ads-reports-programs-without-data.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "google-ads-reports-programs-without-data.json"; sourceTree = "<group>"; };
+		CE21FB232C2C16DA00303832 /* google-ads-reports-programs.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "google-ads-reports-programs.json"; sourceTree = "<group>"; };
 		CE227092228DD44C00C0626C /* ProductStatus.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductStatus.swift; sourceTree = "<group>"; };
 		CE2678422A26102A00FD9AEB /* order-alternative-types.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "order-alternative-types.json"; sourceTree = "<group>"; };
 		CE43066923465F340073CBFF /* Refund.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Refund.swift; sourceTree = "<group>"; };
@@ -3397,6 +3401,8 @@
 				CE070A2F2BBC527900017578 /* gift-card-stats.json */,
 				CE070A332BBC52B200017578 /* gift-card-stats-without-data.json */,
 				68FBA53B2C290A5F0067B377 /* products-load-all-type-simple.json */,
+				CE21FB132C2AC87000303832 /* google-ads-reports-programs-without-data.json */,
+				CE21FB232C2C16DA00303832 /* google-ads-reports-programs.json */,
 			);
 			path = Responses;
 			sourceTree = "<group>";
@@ -4202,6 +4208,7 @@
 				DE5CA111288A3E080077BEF9 /* product-malformed-variations-and-image-alt.json in Resources */,
 				02DD6492248A3EC00082523E /* product-external.json in Resources */,
 				03DCB7522624B3BE00C8953D /* coupons-all.json in Resources */,
+				CE21FB142C2AC87000303832 /* google-ads-reports-programs-without-data.json in Resources */,
 				02B41A94296C04BC00FE3311 /* load-site-plans-no-current-plan.json in Resources */,
 				DE66C5612977CB5F00DAA978 /* shipping-label-eligibility-success-without-data.json in Resources */,
 				028CB716290223CB00331C09 /* create-account-success.json in Resources */,
@@ -4439,6 +4446,7 @@
 				02B41A90296BC85800FE3311 /* site-domains.json in Resources */,
 				DE2004702BFB535500660A72 /* product-report.json in Resources */,
 				EE57C13E297FBEE200BC31E7 /* product-tags-created-without-data.json in Resources */,
+				CE21FB242C2C16DA00303832 /* google-ads-reports-programs.json in Resources */,
 				EEA658462966C67C00112DF0 /* products-ids-only-without-data.json in Resources */,
 				DE2004762C001F7500660A72 /* variation-report.json in Resources */,
 				DE2095C127966EC800171F1C /* coupon-reports.json in Resources */,

--- a/Networking/Networking.xcodeproj/project.pbxproj
+++ b/Networking/Networking.xcodeproj/project.pbxproj
@@ -803,6 +803,8 @@
 		CE1BE7062A2A5E9A00C6B53B /* IdentifiableObject.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE1BE7052A2A5E9A00C6B53B /* IdentifiableObject.swift */; };
 		CE20179320E3EFA7005B4C18 /* broken-orders.json in Resources */ = {isa = PBXBuildFile; fileRef = CE20179220E3EFA7005B4C18 /* broken-orders.json */; };
 		CE21FB142C2AC87000303832 /* google-ads-reports-programs-without-data.json in Resources */ = {isa = PBXBuildFile; fileRef = CE21FB132C2AC87000303832 /* google-ads-reports-programs-without-data.json */; };
+		CE21FB162C2AC90E00303832 /* GoogleAdsCampaignStats.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE21FB152C2AC90E00303832 /* GoogleAdsCampaignStats.swift */; };
+		CE21FB182C2AC97200303832 /* GoogleAdsCampaignStatsTotals.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE21FB172C2AC97200303832 /* GoogleAdsCampaignStatsTotals.swift */; };
 		CE21FB242C2C16DA00303832 /* google-ads-reports-programs.json in Resources */ = {isa = PBXBuildFile; fileRef = CE21FB232C2C16DA00303832 /* google-ads-reports-programs.json */; };
 		CE227093228DD44C00C0626C /* ProductStatus.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE227092228DD44C00C0626C /* ProductStatus.swift */; };
 		CE2678432A26102A00FD9AEB /* order-alternative-types.json in Resources */ = {isa = PBXBuildFile; fileRef = CE2678422A26102A00FD9AEB /* order-alternative-types.json */; };
@@ -1939,6 +1941,8 @@
 		CE1BE7052A2A5E9A00C6B53B /* IdentifiableObject.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IdentifiableObject.swift; sourceTree = "<group>"; };
 		CE20179220E3EFA7005B4C18 /* broken-orders.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "broken-orders.json"; sourceTree = "<group>"; };
 		CE21FB132C2AC87000303832 /* google-ads-reports-programs-without-data.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "google-ads-reports-programs-without-data.json"; sourceTree = "<group>"; };
+		CE21FB152C2AC90E00303832 /* GoogleAdsCampaignStats.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GoogleAdsCampaignStats.swift; sourceTree = "<group>"; };
+		CE21FB172C2AC97200303832 /* GoogleAdsCampaignStatsTotals.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GoogleAdsCampaignStatsTotals.swift; sourceTree = "<group>"; };
 		CE21FB232C2C16DA00303832 /* google-ads-reports-programs.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "google-ads-reports-programs.json"; sourceTree = "<group>"; };
 		CE227092228DD44C00C0626C /* ProductStatus.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductStatus.swift; sourceTree = "<group>"; };
 		CE2678422A26102A00FD9AEB /* order-alternative-types.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "order-alternative-types.json"; sourceTree = "<group>"; };
@@ -2553,6 +2557,8 @@
 				CE070A292BBC3C0A00017578 /* GiftCardStats.swift */,
 				CE070A2B2BBC3C2B00017578 /* GiftCardStatsInterval.swift */,
 				CE070A2D2BBC3C3500017578 /* GiftCardStatsTotals.swift */,
+				CE21FB152C2AC90E00303832 /* GoogleAdsCampaignStats.swift */,
+				CE21FB172C2AC97200303832 /* GoogleAdsCampaignStatsTotals.swift */,
 			);
 			path = Stats;
 			sourceTree = "<group>";
@@ -4818,6 +4824,7 @@
 				0359EA1B27AAC7CC0048DE2D /* WCPayCardPresentReceiptDetails.swift in Sources */,
 				74ABA1D3213F25AE00FFAD30 /* TopEarnerStatsMapper.swift in Sources */,
 				020D07B823D852BB00FD9580 /* Media.swift in Sources */,
+				CE21FB182C2AC97200303832 /* GoogleAdsCampaignStatsTotals.swift in Sources */,
 				B5BB1D0C20A2050300112D92 /* DateFormatter+Woo.swift in Sources */,
 				743E84EE2217244C00FAC9D7 /* ShipmentTrackingListMapper.swift in Sources */,
 				DEFBA7542949CE6600C35BA9 /* RequestProcessor.swift in Sources */,
@@ -5149,6 +5156,7 @@
 				E1BAB2C52913FB1800C3982B /* WordPressApiValidator.swift in Sources */,
 				CE6BFEEA2236E191005C79FB /* ProductType.swift in Sources */,
 				CE6D666C2379E19D007835A1 /* Array+Woo.swift in Sources */,
+				CE21FB162C2AC90E00303832 /* GoogleAdsCampaignStats.swift in Sources */,
 				CCF48B1E26288FEC0034EA83 /* ShippingLabelPaymentMethod.swift in Sources */,
 				DE2E8E9D29530EEF002E4B14 /* WordPressSite.swift in Sources */,
 				DEC51AE927687AAF009F3DF4 /* SystemPluginMapper.swift in Sources */,

--- a/Networking/Networking/Model/Copiable/Models+Copiable.generated.swift
+++ b/Networking/Networking/Model/Copiable/Models+Copiable.generated.swift
@@ -804,14 +804,38 @@ extension Networking.GiftCardStatsTotals {
 extension Networking.GoogleAdsCampaignStats {
     public func copy(
         siteID: CopiableProp<Int64> = .copy,
-        totals: CopiableProp<GoogleAdsCampaignStatsTotals> = .copy
+        totals: CopiableProp<GoogleAdsCampaignStatsTotals> = .copy,
+        campaigns: CopiableProp<[GoogleAdsCampaignStatsItem]> = .copy
     ) -> Networking.GoogleAdsCampaignStats {
         let siteID = siteID ?? self.siteID
         let totals = totals ?? self.totals
+        let campaigns = campaigns ?? self.campaigns
 
         return Networking.GoogleAdsCampaignStats(
             siteID: siteID,
-            totals: totals
+            totals: totals,
+            campaigns: campaigns
+        )
+    }
+}
+
+extension Networking.GoogleAdsCampaignStatsItem {
+    public func copy(
+        campaignID: CopiableProp<Int64> = .copy,
+        campaignName: NullableCopiableProp<String> = .copy,
+        status: CopiableProp<String> = .copy,
+        subtotals: CopiableProp<GoogleAdsCampaignStatsTotals> = .copy
+    ) -> Networking.GoogleAdsCampaignStatsItem {
+        let campaignID = campaignID ?? self.campaignID
+        let campaignName = campaignName ?? self.campaignName
+        let status = status ?? self.status
+        let subtotals = subtotals ?? self.subtotals
+
+        return Networking.GoogleAdsCampaignStatsItem(
+            campaignID: campaignID,
+            campaignName: campaignName,
+            status: status,
+            subtotals: subtotals
         )
     }
 }

--- a/Networking/Networking/Model/Copiable/Models+Copiable.generated.swift
+++ b/Networking/Networking/Model/Copiable/Models+Copiable.generated.swift
@@ -801,6 +801,45 @@ extension Networking.GiftCardStatsTotals {
     }
 }
 
+extension Networking.GoogleAdsCampaignStats {
+    public func copy(
+        siteID: CopiableProp<Int64> = .copy,
+        totals: CopiableProp<GoogleAdsCampaignStatsTotals> = .copy
+    ) -> Networking.GoogleAdsCampaignStats {
+        let siteID = siteID ?? self.siteID
+        let totals = totals ?? self.totals
+
+        return Networking.GoogleAdsCampaignStats(
+            siteID: siteID,
+            totals: totals
+        )
+    }
+}
+
+extension Networking.GoogleAdsCampaignStatsTotals {
+    public func copy(
+        sales: CopiableProp<Decimal> = .copy,
+        spend: CopiableProp<Decimal> = .copy,
+        clicks: CopiableProp<Int> = .copy,
+        impressions: CopiableProp<Int> = .copy,
+        conversions: CopiableProp<Decimal> = .copy
+    ) -> Networking.GoogleAdsCampaignStatsTotals {
+        let sales = sales ?? self.sales
+        let spend = spend ?? self.spend
+        let clicks = clicks ?? self.clicks
+        let impressions = impressions ?? self.impressions
+        let conversions = conversions ?? self.conversions
+
+        return Networking.GoogleAdsCampaignStatsTotals(
+            sales: sales,
+            spend: spend,
+            clicks: clicks,
+            impressions: impressions,
+            conversions: conversions
+        )
+    }
+}
+
 extension Networking.GoogleAdsConnection {
     public func copy(
         id: CopiableProp<Int64> = .copy,

--- a/Networking/Networking/Model/Copiable/Models+Copiable.generated.swift
+++ b/Networking/Networking/Model/Copiable/Models+Copiable.generated.swift
@@ -823,18 +823,18 @@ extension Networking.GoogleAdsCampaignStatsItem {
     public func copy(
         campaignID: CopiableProp<Int64> = .copy,
         campaignName: NullableCopiableProp<String> = .copy,
-        status: CopiableProp<String> = .copy,
+        rawStatus: CopiableProp<String> = .copy,
         subtotals: CopiableProp<GoogleAdsCampaignStatsTotals> = .copy
     ) -> Networking.GoogleAdsCampaignStatsItem {
         let campaignID = campaignID ?? self.campaignID
         let campaignName = campaignName ?? self.campaignName
-        let status = status ?? self.status
+        let rawStatus = rawStatus ?? self.rawStatus
         let subtotals = subtotals ?? self.subtotals
 
         return Networking.GoogleAdsCampaignStatsItem(
             campaignID: campaignID,
             campaignName: campaignName,
-            status: status,
+            rawStatus: rawStatus,
             subtotals: subtotals
         )
     }

--- a/Networking/Networking/Model/Stats/GoogleAdsCampaignStats.swift
+++ b/Networking/Networking/Model/Stats/GoogleAdsCampaignStats.swift
@@ -1,0 +1,42 @@
+import Foundation
+import Codegen
+
+/// Represents Google Listings & Ads paid campaign stats over a specific period.
+public struct GoogleAdsCampaignStats: Decodable, Equatable, GeneratedCopiable, GeneratedFakeable {
+    public let siteID: Int64
+    public let totals: GoogleAdsCampaignStatsTotals
+
+    public init(siteID: Int64,
+                totals: GoogleAdsCampaignStatsTotals) {
+        self.siteID = siteID
+        self.totals = totals
+    }
+
+    public init(from decoder: Decoder) throws {
+        guard let siteID = decoder.userInfo[.siteID] as? Int64 else {
+            throw GoogleAdsCampaignStatsAPIError.missingSiteID
+        }
+
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        let totals = try container.decode(GoogleAdsCampaignStatsTotals.self, forKey: .totals)
+
+        self.init(siteID: siteID,
+                  totals: totals)
+    }
+}
+
+
+// MARK: - Constants!
+//
+private extension GoogleAdsCampaignStats {
+
+    enum CodingKeys: String, CodingKey {
+        case totals = "totals"
+    }
+}
+
+// MARK: - Decoding Errors
+//
+enum GoogleAdsCampaignStatsAPIError: Error {
+    case missingSiteID
+}

--- a/Networking/Networking/Model/Stats/GoogleAdsCampaignStats.swift
+++ b/Networking/Networking/Model/Stats/GoogleAdsCampaignStats.swift
@@ -5,11 +5,14 @@ import Codegen
 public struct GoogleAdsCampaignStats: Decodable, Equatable, GeneratedCopiable, GeneratedFakeable {
     public let siteID: Int64
     public let totals: GoogleAdsCampaignStatsTotals
+    public let campaigns: [GoogleAdsCampaignStatsItem]
 
     public init(siteID: Int64,
-                totals: GoogleAdsCampaignStatsTotals) {
+                totals: GoogleAdsCampaignStatsTotals,
+                campaigns: [GoogleAdsCampaignStatsItem]) {
         self.siteID = siteID
         self.totals = totals
+        self.campaigns = campaigns
     }
 
     public init(from decoder: Decoder) throws {
@@ -19,9 +22,12 @@ public struct GoogleAdsCampaignStats: Decodable, Equatable, GeneratedCopiable, G
 
         let container = try decoder.container(keyedBy: CodingKeys.self)
         let totals = try container.decode(GoogleAdsCampaignStatsTotals.self, forKey: .totals)
+        // Campaigns are `nil` if there are no campaigns; we convert this to an empty array.
+        let campaigns = (try? container.decode([GoogleAdsCampaignStatsItem].self, forKey: .campaigns)) ?? []
 
         self.init(siteID: siteID,
-                  totals: totals)
+                  totals: totals,
+                  campaigns: campaigns)
     }
 }
 
@@ -31,7 +37,8 @@ public struct GoogleAdsCampaignStats: Decodable, Equatable, GeneratedCopiable, G
 private extension GoogleAdsCampaignStats {
 
     enum CodingKeys: String, CodingKey {
-        case totals = "totals"
+        case totals
+        case campaigns
     }
 }
 

--- a/Networking/Networking/Model/Stats/GoogleAdsCampaignStatsItem.swift
+++ b/Networking/Networking/Model/Stats/GoogleAdsCampaignStatsItem.swift
@@ -13,9 +13,15 @@ public struct GoogleAdsCampaignStatsItem: Decodable, Equatable, GeneratedCopiabl
     ///
     public let campaignName: String?
 
+    /// Campaign status (raw value)
+    ///
+    public let rawStatus: String
+
     /// Campaign status
     ///
-    public let status: String
+    public var status: Status {
+        Status(rawValue: rawStatus) ?? .removed
+    }
 
     /// Subtotal stats
     ///
@@ -24,11 +30,19 @@ public struct GoogleAdsCampaignStatsItem: Decodable, Equatable, GeneratedCopiabl
 
     /// Designated Initializer.
     ///
-    public init(campaignID: Int64, campaignName: String?, status: String, subtotals: GoogleAdsCampaignStatsTotals) {
+    public init(campaignID: Int64, campaignName: String?, rawStatus: String, subtotals: GoogleAdsCampaignStatsTotals) {
         self.campaignID = campaignID
         self.campaignName = campaignName ?? ""
-        self.status = status
+        self.rawStatus = rawStatus
         self.subtotals = subtotals
+    }
+}
+
+public extension GoogleAdsCampaignStatsItem {
+    enum Status: String {
+        case enabled
+        case paused
+        case removed
     }
 }
 
@@ -39,7 +53,7 @@ private extension GoogleAdsCampaignStatsItem {
     enum CodingKeys: String, CodingKey {
         case campaignID     = "id"
         case campaignName   = "name"
-        case status
+        case rawStatus      = "status"
         case subtotals
     }
 }

--- a/Networking/Networking/Model/Stats/GoogleAdsCampaignStatsItem.swift
+++ b/Networking/Networking/Model/Stats/GoogleAdsCampaignStatsItem.swift
@@ -1,0 +1,53 @@
+import Foundation
+import Codegen
+
+/// Represents a single campaign stat for a specific period.
+///
+public struct GoogleAdsCampaignStatsItem: Decodable, Equatable, GeneratedCopiable, GeneratedFakeable {
+
+    /// Campaign ID
+    ///
+    public let campaignID: Int64
+
+    /// Campaign name
+    ///
+    public let campaignName: String?
+
+    /// Campaign status
+    ///
+    public let status: String
+
+    /// Subtotal stats
+    ///
+    public let subtotals: GoogleAdsCampaignStatsTotals
+
+
+    /// Designated Initializer.
+    ///
+    public init(campaignID: Int64, campaignName: String?, status: String, subtotals: GoogleAdsCampaignStatsTotals) {
+        self.campaignID = campaignID
+        self.campaignName = campaignName ?? ""
+        self.status = status
+        self.subtotals = subtotals
+    }
+}
+
+
+// MARK: - Constants!
+//
+private extension GoogleAdsCampaignStatsItem {
+    enum CodingKeys: String, CodingKey {
+        case campaignID     = "id"
+        case campaignName   = "name"
+        case status
+        case subtotals
+    }
+}
+
+// MARK: - Identifiable Conformance
+//
+extension GoogleAdsCampaignStatsItem: Identifiable {
+    public var id: Int64 {
+        campaignID
+    }
+}

--- a/Networking/Networking/Model/Stats/GoogleAdsCampaignStatsTotals.swift
+++ b/Networking/Networking/Model/Stats/GoogleAdsCampaignStatsTotals.swift
@@ -1,0 +1,59 @@
+import Codegen
+
+/// Represents the data associated with Google Listings & Ads paid campaign stats over a specific period.
+public struct GoogleAdsCampaignStatsTotals: Decodable, Equatable, GeneratedCopiable, GeneratedFakeable, WCAnalyticsStatsTotals {
+    /// Amount in sales attributed to ads campaign
+    public let sales: Decimal
+
+    /// Amount spent on ads campaign
+    public let spend: Decimal
+
+    /// Number of clicks on ads campaign
+    public let clicks: Int
+
+    /// Number of impressions of ads campaign
+    public let impressions: Int
+
+    /// Number of conversions from ads campaign
+    public let conversions: Decimal
+
+    public init(sales: Decimal,
+                spend: Decimal,
+                clicks: Int,
+                impressions: Int,
+                conversions: Decimal) {
+        self.sales = sales
+        self.spend = spend
+        self.clicks = clicks
+        self.impressions = impressions
+        self.conversions = conversions
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        let sales = try container.decode(Decimal.self, forKey: .sales)
+        let spend = try container.decode(Decimal.self, forKey: .spend)
+        let clicks = try container.decode(Int.self, forKey: .clicks)
+        let impressions = try container.decode(Int.self, forKey: .impressions)
+        let conversions = try container.decode(Decimal.self, forKey: .conversions)
+
+        self.init(sales: sales,
+                  spend: spend,
+                  clicks: clicks,
+                  impressions: impressions,
+                  conversions: conversions)
+    }
+}
+
+
+// MARK: - Constants!
+//
+private extension GoogleAdsCampaignStatsTotals {
+    enum CodingKeys: String, CodingKey {
+        case sales
+        case spend
+        case clicks
+        case impressions
+        case conversions
+    }
+}

--- a/Networking/NetworkingTests/Responses/google-ads-reports-programs-without-data.json
+++ b/Networking/NetworkingTests/Responses/google-ads-reports-programs-without-data.json
@@ -1,0 +1,57 @@
+{
+    "campaigns": [
+        {
+            "id": 123,
+            "name": "One",
+            "status": "enabled",
+            "subtotals": {
+                "sales": 11,
+                "spend": 63.14,
+                "clicks": 139,
+                "impressions": 16037,
+                "conversions": 3
+            }
+        },
+        {
+            "id": 234,
+            "name": "Two",
+            "status": "enabled",
+            "subtotals": {
+                "sales": 0,
+                "spend": 9.87,
+                "clicks": 15,
+                "impressions": 901,
+                "conversions": 0
+            }
+        }
+    ],
+    "intervals": [
+        {
+            "interval": "2021-09",
+            "subtotals": {
+                "sales": 0,
+                "spend": 38,
+                "clicks": 90,
+                "impressions": 9941,
+                "conversions": 0
+            }
+        },
+        {
+            "interval": "2021-10",
+            "subtotals": {
+                "sales": 11,
+                "spend": 35.01,
+                "clicks": 64,
+                "impressions": 6997,
+                "conversions": 3
+            }
+        }
+    ],
+    "totals": {
+        "sales": 11,
+        "spend": 73.01,
+        "clicks": 154,
+        "impressions": 16938,
+        "conversions": 3
+    }
+}

--- a/Networking/NetworkingTests/Responses/google-ads-reports-programs.json
+++ b/Networking/NetworkingTests/Responses/google-ads-reports-programs.json
@@ -1,0 +1,15 @@
+{
+    "data": {
+        "products": null,
+        "campaigns": null,
+        "intervals": null,
+        "totals": {
+            "sales": 0,
+            "spend": 0,
+            "clicks": 0,
+            "impressions": 0,
+            "conversions": 0
+        },
+        "next_page": null
+    }
+}


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of: #13163
<!-- Id number of the GitHub issue this PR addresses. -->

## Why
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This adds the networking models to represent the paid campaign report stats for the Google Listings & Ads extension.

## How
There are three new networking models:

* `GoogleAdsCampaignStats` - Top-level model that contains the site ID, the stats totals, and a list of campaigns. This model doesn't include the intervals in the API response because we currently don't plan to use that interval data in the analytics hub.
* `GoogleAdsCampaignStatsTotals` - Represents the five possible stats totals in a campaign report (sales, spend, clicks, impressions, conversions). These are all 0 values if there are no campaigns or stats to display.
* `GoogleAdsCampaignStatsItem` - This represents a campaign in the report. It includes the campaign ID, a campaign name, the campaign status, and the campaign's stats subtotals.

This PR also adds mock API responses and generated fake and copiable methods for the new models.

## Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->

These models aren't yet used in the app; unit tests will be added in the PRs that add a mapper and remote endpoint using these models.


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.