### PR TITLE
Watch: Improve how dependencies are stored

### DIFF
--- a/Networking/Networking/Settings/Credentials.swift
+++ b/Networking/Networking/Settings/Credentials.swift
@@ -2,7 +2,7 @@ import Foundation
 
 /// Authenticated Requests Credentials
 ///
-public enum Credentials: Equatable {
+public enum Credentials: Codable, Equatable {
 
     // Keys
     private static let wpcomType = "AuthenticationType.wpcom"

--- a/WooCommerce/Classes/Extensions/UserDefaults+Woo.swift
+++ b/WooCommerce/Classes/Extensions/UserDefaults+Woo.swift
@@ -52,6 +52,9 @@ extension UserDefaults {
         // Store Creation
         case siteIDPendingStoreSwitch
         case expectedStoreNamePendingStoreSwitch
+
+        // Watch
+        case watchDependencies
     }
 }
 

--- a/WooCommerce/Classes/System/WatchDependencies.swift
+++ b/WooCommerce/Classes/System/WatchDependencies.swift
@@ -16,20 +16,7 @@ import class WooFoundationWatchOS.CurrencySettings
 
 /// WatchOS session dependencies.
 ///
-public struct WatchDependencies: Equatable {
-
-    // Dictionary Keys
-    private enum Keys {
-        static let credentials = "credentials"
-        static let store = "store"
-        static let type = "type"
-        static let username = "username"
-        static let secret = "secret"
-        static let address = "address"
-        static let id = "id"
-        static let name = "name"
-        static let currencySettings = "currency-settings"
-    }
+public struct WatchDependencies: Codable, Equatable {
 
     let storeID: Int64
     let storeName: String
@@ -41,75 +28,5 @@ public struct WatchDependencies: Equatable {
         self.storeName = storeName
         self.currencySettings = currencySettings
         self.credentials = credentials
-    }
-
-    /// Create Dependencies from a serialized dictionary.
-    public init?(dictionary: [String: Any]) {
-
-        guard let storeDic = dictionary[Keys.store] as? [String: Any] else {
-            return nil
-        }
-
-        let storeID = storeDic[Keys.id] as? Int64
-        let storeName = storeDic[Keys.name] as? String
-
-        // Read currency settings as a base64-string
-        let currencySettings: CurrencySettings = {
-            // If we could not find any setting, use a default one.
-            guard let base64Settings = storeDic[Keys.currencySettings] as? String,
-                  let currencyData = Data(base64Encoded: base64Settings),
-                  let settings = try? JSONDecoder().decode(CurrencySettings.self, from: currencyData) else {
-                return CurrencySettings()
-            }
-            return settings
-        }()
-
-
-        let credentials: Credentials? = {
-            guard let credentialsDic = dictionary[Keys.credentials] as? [String: String],
-                  let type = credentialsDic[Keys.type],
-                  let username = credentialsDic[Keys.username],
-                  let secret = credentialsDic[Keys.secret],
-                  let siteAddress = credentialsDic[Keys.address] else {
-                return nil
-            }
-
-            switch type {
-            case "AuthenticationType.wpcom":
-                return .wpcom(username: username, authToken: secret, siteAddress: siteAddress)
-            case "AuthenticationType.wporg":
-                return .wporg(username: username, password: secret, siteAddress: siteAddress)
-            case "AuthenticationType.applicationPassword":
-                return .applicationPassword(username: username, password: secret, siteAddress: siteAddress)
-            default:
-                return nil
-            }
-        }()
-
-        guard let storeID, let storeName, let credentials else {
-            return nil
-        }
-
-        self.init(storeID: storeID, storeName: storeName, currencySettings: currencySettings, credentials: credentials)
-    }
-
-    /// Dictionary to be transferred between sessions.
-    ///
-    public func toDictionary() -> [String: Any] {
-        // Send currency settings as a base64-string because a Data type can't be transferred to the watch.
-        let currencySettingJsonAsBase64 = (try? JSONEncoder().encode(currencySettings))?.base64EncodedString() ?? ""
-        return [
-            Keys.credentials: [
-                Keys.type: credentials.rawType,
-                Keys.username: credentials.username,
-                Keys.secret: credentials.secret,
-                Keys.address: credentials.siteAddress
-            ],
-            Keys.store: [
-                Keys.id: storeID,
-                Keys.name: storeName,
-                Keys.currencySettings: currencySettingJsonAsBase64
-            ]
-        ]
     }
 }

--- a/WooCommerce/Classes/System/WatchDependenciesSynchronizer.swift
+++ b/WooCommerce/Classes/System/WatchDependenciesSynchronizer.swift
@@ -72,8 +72,12 @@ final class WatchDependenciesSynchronizer: NSObject, WCSessionDelegate {
             .sink { [watchSession] dependencies, isSessionActive, _ in
                 guard isSessionActive else { return }
                 do {
-                    let dependenciesDic = dependencies?.toDictionary() ?? [:]
-                    try watchSession.updateApplicationContext(dependenciesDic)
+                    let data = try JSONEncoder().encode(dependencies)
+                    if let jsonObject = try JSONSerialization.jsonObject(with: data, options: .topLevelDictionaryAssumed) as? [String: Any] {
+                        try watchSession.updateApplicationContext(jsonObject)
+                    } else {
+                        DDLogError("⛔️ Unable to encode watch dependencies for synchronization. Resulting object is not a dictionary")
+                    }
                 } catch {
                     DDLogError("⛔️ Error synchronizing credentials into watch session: \(error)")
                 }

--- a/WooCommerce/Classes/System/WatchDependenciesSynchronizer.swift
+++ b/WooCommerce/Classes/System/WatchDependenciesSynchronizer.swift
@@ -72,6 +72,12 @@ final class WatchDependenciesSynchronizer: NSObject, WCSessionDelegate {
             .sink { [watchSession] dependencies, isSessionActive, _ in
                 guard isSessionActive else { return }
                 do {
+
+                    // If dependencies is nil, send an empty dictionary. This is most likely a logged out state
+                    guard let dependencies else {
+                        return try watchSession.updateApplicationContext([:])
+                    }
+
                     let data = try JSONEncoder().encode(dependencies)
                     if let jsonObject = try JSONSerialization.jsonObject(with: data, options: .topLevelDictionaryAssumed) as? [String: Any] {
                         try watchSession.updateApplicationContext(jsonObject)

--- a/WooCommerce/Woo Watch App/Dependencies/PhoneDependenciesSynchronizer.swift
+++ b/WooCommerce/Woo Watch App/Dependencies/PhoneDependenciesSynchronizer.swift
@@ -101,7 +101,14 @@ final class PhoneDependenciesSynchronizer: NSObject, ObservableObject, WCSession
     /// Receiving an empty dictionary will clear the store as it likely mean that the user has logged out of the app.
     ///
     private func storeDependencies(appContext: [String: Any]) {
-        let dependencies = WatchDependencies(dictionary: appContext)
+        let dependencies: WatchDependencies? = {
+            do {
+                let data = try JSONSerialization.data(withJSONObject: appContext)
+                return try JSONDecoder().decode(WatchDependencies.self, from: data)
+            } catch {
+                return nil
+            }
+        }()
 
         // Only store the dependencies if we get new values to store.
         guard self.dependencies != dependencies else {

--- a/WooCommerce/Woo Watch App/Dependencies/PhoneDependenciesSynchronizer.swift
+++ b/WooCommerce/Woo Watch App/Dependencies/PhoneDependenciesSynchronizer.swift
@@ -76,25 +76,13 @@ final class PhoneDependenciesSynchronizer: NSObject, ObservableObject, WCSession
     /// Load stored dependencies
     ///
     private func loadDependencies() -> WatchDependencies? {
-        guard let secret = keychain[WooConstants.authToken],
-              let username: String = userDefaults[.defaultUsername],
-              let type: String = userDefaults[.defaultCredentialsType],
-              let siteAddress: String = userDefaults[.defaultSiteAddress],
-              let storeID: Int64 = userDefaults[.defaultStoreID],
-              let storeName: String = userDefaults[.defaultStoreName],
-              let credentials = Credentials(rawType: type, username: username, secret: secret, siteAddress: siteAddress) else {
+        guard let dependenciesData = userDefaults[.watchDependencies] as? Data,
+              let secret = keychain[WooConstants.authToken] else {
             return nil
         }
 
-        let currencySettings: CurrencySettings = {
-            guard let currencySettingsData = userDefaults[.defaultStoreCurrencySettings] as? Data,
-                  let currencySettings = try? JSONDecoder().decode(CurrencySettings.self, from: currencySettingsData) else {
-                return CurrencySettings()
-            }
-            return currencySettings
-        }()
-
-        return WatchDependencies(storeID: storeID, storeName: storeName, currencySettings: currencySettings, credentials: credentials)
+        let safeDependencies = try? JSONDecoder().decode(WatchDependencies.self, from: dependenciesData)
+        return safeDependencies?.updatingSecret(secret: secret) // Inject stored secret
     }
 
     /// Store dependencies from the app context
@@ -106,6 +94,7 @@ final class PhoneDependenciesSynchronizer: NSObject, ObservableObject, WCSession
                 let data = try JSONSerialization.data(withJSONObject: appContext)
                 return try JSONDecoder().decode(WatchDependencies.self, from: data)
             } catch {
+                print ("Error decoding dependencies: \(error)")
                 return nil
             }
         }()
@@ -115,14 +104,47 @@ final class PhoneDependenciesSynchronizer: NSObject, ObservableObject, WCSession
             return
         }
 
-        userDefaults[.defaultStoreID] = dependencies?.storeID
-        userDefaults[.defaultStoreName] = dependencies?.storeName
-        userDefaults[.defaultUsername] = dependencies?.credentials.username
-        userDefaults[.defaultStoreCurrencySettings] = try? JSONEncoder().encode(dependencies?.currencySettings)
-        userDefaults[.defaultCredentialsType] = dependencies?.credentials.rawType
-        userDefaults[.defaultSiteAddress] = dependencies?.credentials.siteAddress
-        keychain[WooConstants.authToken] = dependencies?.credentials.secret
+        // Remove the secret from the dependencies object to not store the secret on a non-secure store.
+        // The secret should be stored in the keychain
+        let secret = dependencies?.credentials.secret
+        let safeDependencies = dependencies?.removingSecret()
+
+        userDefaults[.watchDependencies] = try? JSONEncoder().encode(safeDependencies)
+        keychain[WooConstants.authToken] = secret
 
         tracksProvider?.sendTracksEvent(.watchStoreDataSynced)
+    }
+}
+
+
+private extension WatchDependencies {
+    /// Removes the secret/auth token from the credential type.
+    ///
+    func removingSecret() -> WatchDependencies {
+        updatingSecret(secret: "")
+    }
+
+    /// Replaces the secret/auth token with the provided value.
+    ///
+    func updatingSecret(secret: String) -> WatchDependencies {
+        return WatchDependencies(storeID: storeID,
+                                 storeName: storeName,
+                                 currencySettings: currencySettings,
+                                 credentials: credentials.replacingSecret(secret))
+    }
+}
+
+private extension Credentials {
+    /// Replaces the secret/auth token with the provided value.
+    ///
+    func replacingSecret(_ secret: String) -> Credentials {
+        switch self {
+        case let .applicationPassword(username, _, siteAddress):
+            return .applicationPassword(username: username, password: secret, siteAddress: siteAddress)
+        case let .wpcom(username, _, siteAddress):
+            return .wpcom(username: username, authToken: secret, siteAddress: siteAddress)
+        case let .wporg(username, _, siteAddress):
+            return .wporg(username: username, password: secret, siteAddress: siteAddress)
+        }
     }
 }


### PR DESCRIPTION
Closes: #12950 

# Why

This PR refactors how the watch dependencies are stored for easier maintainability.

# How

- Make `WatchDependencies` conform to `Codable`, instead of creating our own dictionary manually
- Store `WatchDependencies` as a single value instead in the UserDefaults store
- Make sure the secret is not stored on user defaults.

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
