### PR TITLE
Google Ads: Integrate fetching ads campaign list

### DIFF
--- a/Fakes/Fakes/Networking.generated.swift
+++ b/Fakes/Fakes/Networking.generated.swift
@@ -571,6 +571,21 @@ extension Networking.GiftCardStatsTotals {
         )
     }
 }
+extension Networking.GoogleAdsCampaign {
+    /// Returns a "ready to use" type filled with fake values.
+    ///
+    public static func fake() -> Networking.GoogleAdsCampaign {
+        .init(
+            id: .fake(),
+            name: .fake(),
+            rawStatus: .fake(),
+            rawType: .fake(),
+            amount: .fake(),
+            country: .fake(),
+            targetedLocations: .fake()
+        )
+    }
+}
 extension Networking.GoogleAdsConnection {
     /// Returns a "ready to use" type filled with fake values.
     ///

--- a/Fakes/Fakes/Networking.generated.swift
+++ b/Fakes/Fakes/Networking.generated.swift
@@ -571,6 +571,21 @@ extension Networking.GiftCardStatsTotals {
         )
     }
 }
+extension Networking.GoogleAdsCampaign {
+    /// Returns a "ready to use" type filled with fake values.
+    ///
+    public static func fake() -> Networking.GoogleAdsCampaign {
+        .init(
+            id: .fake(),
+            name: .fake(),
+            rawStatus: .fake(),
+            rawType: .fake(),
+            amount: .fake(),
+            country: .fake(),
+            targetedLocations: .fake()
+        )
+    }
+}
 extension Networking.GoogleAdsCampaignStats {
     /// Returns a "ready to use" type filled with fake values.
     ///

--- a/Networking/Networking.xcodeproj/project.pbxproj
+++ b/Networking/Networking.xcodeproj/project.pbxproj
@@ -1031,6 +1031,8 @@
 		DEB387802C2AA05D0025256E /* GoogleListingsAndAdsRemoteTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEB3877F2C2AA05D0025256E /* GoogleListingsAndAdsRemoteTests.swift */; };
 		DEB3878A2C2D6E470025256E /* GoogleAdsCampaign.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEB387892C2D6E470025256E /* GoogleAdsCampaign.swift */; };
 		DEB3878C2C2D70EF0025256E /* GoogleAdsCampaignListMapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEB3878B2C2D70EF0025256E /* GoogleAdsCampaignListMapper.swift */; };
+		DEB3878F2C2D71A10025256E /* gla-campaign-list-without-data-envelope.json in Resources */ = {isa = PBXBuildFile; fileRef = DEB3878D2C2D71A10025256E /* gla-campaign-list-without-data-envelope.json */; };
+		DEB387902C2D71A10025256E /* gla-campaign-list-with-data-envelope.json in Resources */ = {isa = PBXBuildFile; fileRef = DEB3878E2C2D71A10025256E /* gla-campaign-list-with-data-envelope.json */; };
 		DEC2961C26BBE764005A056B /* ShippingLabelCustomsForm.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEC2961B26BBE764005A056B /* ShippingLabelCustomsForm.swift */; };
 		DEC2B08D297AA048003923FB /* reviews-all-without-data.json in Resources */ = {isa = PBXBuildFile; fileRef = DEC2B08C297AA048003923FB /* reviews-all-without-data.json */; };
 		DEC2B08F297AA123003923FB /* reviews-single-without-data.json in Resources */ = {isa = PBXBuildFile; fileRef = DEC2B08E297AA123003923FB /* reviews-single-without-data.json */; };
@@ -2167,6 +2169,8 @@
 		DEB3877F2C2AA05D0025256E /* GoogleListingsAndAdsRemoteTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GoogleListingsAndAdsRemoteTests.swift; sourceTree = "<group>"; };
 		DEB387892C2D6E470025256E /* GoogleAdsCampaign.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GoogleAdsCampaign.swift; sourceTree = "<group>"; };
 		DEB3878B2C2D70EF0025256E /* GoogleAdsCampaignListMapper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GoogleAdsCampaignListMapper.swift; sourceTree = "<group>"; };
+		DEB3878D2C2D71A10025256E /* gla-campaign-list-without-data-envelope.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "gla-campaign-list-without-data-envelope.json"; sourceTree = "<group>"; };
+		DEB3878E2C2D71A10025256E /* gla-campaign-list-with-data-envelope.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "gla-campaign-list-with-data-envelope.json"; sourceTree = "<group>"; };
 		DEC2961B26BBE764005A056B /* ShippingLabelCustomsForm.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShippingLabelCustomsForm.swift; sourceTree = "<group>"; };
 		DEC2B08C297AA048003923FB /* reviews-all-without-data.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "reviews-all-without-data.json"; sourceTree = "<group>"; };
 		DEC2B08E297AA123003923FB /* reviews-single-without-data.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "reviews-single-without-data.json"; sourceTree = "<group>"; };
@@ -2965,6 +2969,8 @@
 		B559EBA820A0B5B100836CD4 /* Responses */ = {
 			isa = PBXGroup;
 			children = (
+				DEB3878E2C2D71A10025256E /* gla-campaign-list-with-data-envelope.json */,
+				DEB3878D2C2D71A10025256E /* gla-campaign-list-without-data-envelope.json */,
 				DEB387772C2A9ADC0025256E /* gla-connection-with-data-envelope.json */,
 				DEB387792C2A9B1E0025256E /* gla-connection-without-data-envelope.json */,
 				DE970D832C23E3F60019EF42 /* product-report-string-stock-quantity.json */,
@@ -4356,6 +4362,7 @@
 				31054724262E2FC600C5C02B /* wcpay-payment-intent-requires-capture.json in Resources */,
 				DE66C5692977D62700DAA978 /* plugins-without-data.json in Resources */,
 				EE9826902B17189B00A3F57E /* product-subscription-sync-renewals-day-month-format.json in Resources */,
+				DEB387902C2D71A10025256E /* gla-campaign-list-with-data-envelope.json in Resources */,
 				7492FAE3217FBDBC00ED2C69 /* settings-general-alt.json in Resources */,
 				93D8BBFF226BC1DA00AD2EB3 /* me-settings.json in Resources */,
 				74C947842193A6C70024CB60 /* comment-moderate-approved.json in Resources */,
@@ -4505,6 +4512,7 @@
 				3158FE7826129DF300E566B9 /* wcpay-account-restricted.json in Resources */,
 				EE065ACE2B8E51AD009848CB /* blaze-campaigns-list-success.json in Resources */,
 				45A4B85625D2E75300776FB4 /* shipping-label-address-validation-success.json in Resources */,
+				DEB3878F2C2D71A10025256E /* gla-campaign-list-without-data-envelope.json in Resources */,
 				457FC68C2382B2FD00B41B02 /* product-update.json in Resources */,
 				CE71E2292A4C35C900DB5376 /* reports-products.json in Resources */,
 				CE19CB11222486A600E8AF7A /* order-statuses.json in Resources */,

--- a/Networking/Networking.xcodeproj/project.pbxproj
+++ b/Networking/Networking.xcodeproj/project.pbxproj
@@ -1030,6 +1030,7 @@
 		DEB3877E2C2A9DE20025256E /* GoogleListingsAndAdsRemote.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEB3877D2C2A9DE20025256E /* GoogleListingsAndAdsRemote.swift */; };
 		DEB387802C2AA05D0025256E /* GoogleListingsAndAdsRemoteTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEB3877F2C2AA05D0025256E /* GoogleListingsAndAdsRemoteTests.swift */; };
 		DEB3878A2C2D6E470025256E /* GoogleAdsCampaign.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEB387892C2D6E470025256E /* GoogleAdsCampaign.swift */; };
+		DEB3878C2C2D70EF0025256E /* GoogleAdsCampaignListMapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEB3878B2C2D70EF0025256E /* GoogleAdsCampaignListMapper.swift */; };
 		DEC2961C26BBE764005A056B /* ShippingLabelCustomsForm.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEC2961B26BBE764005A056B /* ShippingLabelCustomsForm.swift */; };
 		DEC2B08D297AA048003923FB /* reviews-all-without-data.json in Resources */ = {isa = PBXBuildFile; fileRef = DEC2B08C297AA048003923FB /* reviews-all-without-data.json */; };
 		DEC2B08F297AA123003923FB /* reviews-single-without-data.json in Resources */ = {isa = PBXBuildFile; fileRef = DEC2B08E297AA123003923FB /* reviews-single-without-data.json */; };
@@ -2165,6 +2166,7 @@
 		DEB3877D2C2A9DE20025256E /* GoogleListingsAndAdsRemote.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GoogleListingsAndAdsRemote.swift; sourceTree = "<group>"; };
 		DEB3877F2C2AA05D0025256E /* GoogleListingsAndAdsRemoteTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GoogleListingsAndAdsRemoteTests.swift; sourceTree = "<group>"; };
 		DEB387892C2D6E470025256E /* GoogleAdsCampaign.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GoogleAdsCampaign.swift; sourceTree = "<group>"; };
+		DEB3878B2C2D70EF0025256E /* GoogleAdsCampaignListMapper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GoogleAdsCampaignListMapper.swift; sourceTree = "<group>"; };
 		DEC2961B26BBE764005A056B /* ShippingLabelCustomsForm.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShippingLabelCustomsForm.swift; sourceTree = "<group>"; };
 		DEC2B08C297AA048003923FB /* reviews-all-without-data.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "reviews-all-without-data.json"; sourceTree = "<group>"; };
 		DEC2B08E297AA123003923FB /* reviews-single-without-data.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "reviews-single-without-data.json"; sourceTree = "<group>"; };
@@ -3803,6 +3805,7 @@
 			isa = PBXGroup;
 			children = (
 				DEB387752C2A9A140025256E /* GoogleAdsConnectionMapper.swift */,
+				DEB3878B2C2D70EF0025256E /* GoogleAdsCampaignListMapper.swift */,
 			);
 			path = GoogleAds;
 			sourceTree = "<group>";
@@ -5041,6 +5044,7 @@
 				CE583A0E2109154500D73C1C /* OrderNoteMapper.swift in Sources */,
 				D8FBFF0D22D3AF4A006E3336 /* StatsGranularityV4.swift in Sources */,
 				261870782540A252006522A1 /* ShippingLineTax.swift in Sources */,
+				DEB3878C2C2D70EF0025256E /* GoogleAdsCampaignListMapper.swift in Sources */,
 				EE998150295AACE10074AE68 /* RequestConverter.swift in Sources */,
 				74046E1B217A684D007DD7BF /* SiteSettingsRemote.swift in Sources */,
 				0359EA1D27AADE000048DE2D /* WCPayChargeMapper.swift in Sources */,

--- a/Networking/Networking.xcodeproj/project.pbxproj
+++ b/Networking/Networking.xcodeproj/project.pbxproj
@@ -1029,6 +1029,7 @@
 		DEB3877C2C2A9B600025256E /* GoogleAdsConnectionMapperTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEB3877B2C2A9B600025256E /* GoogleAdsConnectionMapperTests.swift */; };
 		DEB3877E2C2A9DE20025256E /* GoogleListingsAndAdsRemote.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEB3877D2C2A9DE20025256E /* GoogleListingsAndAdsRemote.swift */; };
 		DEB387802C2AA05D0025256E /* GoogleListingsAndAdsRemoteTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEB3877F2C2AA05D0025256E /* GoogleListingsAndAdsRemoteTests.swift */; };
+		DEB3878A2C2D6E470025256E /* GoogleAdsCampaign.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEB387892C2D6E470025256E /* GoogleAdsCampaign.swift */; };
 		DEC2961C26BBE764005A056B /* ShippingLabelCustomsForm.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEC2961B26BBE764005A056B /* ShippingLabelCustomsForm.swift */; };
 		DEC2B08D297AA048003923FB /* reviews-all-without-data.json in Resources */ = {isa = PBXBuildFile; fileRef = DEC2B08C297AA048003923FB /* reviews-all-without-data.json */; };
 		DEC2B08F297AA123003923FB /* reviews-single-without-data.json in Resources */ = {isa = PBXBuildFile; fileRef = DEC2B08E297AA123003923FB /* reviews-single-without-data.json */; };
@@ -2163,6 +2164,7 @@
 		DEB3877B2C2A9B600025256E /* GoogleAdsConnectionMapperTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GoogleAdsConnectionMapperTests.swift; sourceTree = "<group>"; };
 		DEB3877D2C2A9DE20025256E /* GoogleListingsAndAdsRemote.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GoogleListingsAndAdsRemote.swift; sourceTree = "<group>"; };
 		DEB3877F2C2AA05D0025256E /* GoogleListingsAndAdsRemoteTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GoogleListingsAndAdsRemoteTests.swift; sourceTree = "<group>"; };
+		DEB387892C2D6E470025256E /* GoogleAdsCampaign.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GoogleAdsCampaign.swift; sourceTree = "<group>"; };
 		DEC2961B26BBE764005A056B /* ShippingLabelCustomsForm.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShippingLabelCustomsForm.swift; sourceTree = "<group>"; };
 		DEC2B08C297AA048003923FB /* reviews-all-without-data.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "reviews-all-without-data.json"; sourceTree = "<group>"; };
 		DEC2B08E297AA123003923FB /* reviews-single-without-data.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "reviews-single-without-data.json"; sourceTree = "<group>"; };
@@ -3792,6 +3794,7 @@
 			isa = PBXGroup;
 			children = (
 				DEB387722C2A8F9A0025256E /* GoogleAdsConnection.swift */,
+				DEB387892C2D6E470025256E /* GoogleAdsCampaign.swift */,
 			);
 			path = GoogleAds;
 			sourceTree = "<group>";
@@ -4873,6 +4876,7 @@
 				EE2C09C829AF6357009396F9 /* StoreOnboardingTask.swift in Sources */,
 				D823D91022377B4F00C90817 /* ShipmentTrackingProviderGroup.swift in Sources */,
 				743E84EC22171F4600FAC9D7 /* ShipmentTracking.swift in Sources */,
+				DEB3878A2C2D6E470025256E /* GoogleAdsCampaign.swift in Sources */,
 				68F48B0B28E3B1CD0045C15B /* WCAnalyticsCustomerRemote.swift in Sources */,
 				DEC51AF327699ECE009F3DF4 /* SystemStatus+PostTypeCount.swift in Sources */,
 				B56C1EB820EA76F500D749F9 /* Site.swift in Sources */,

--- a/Networking/Networking.xcodeproj/project.pbxproj
+++ b/Networking/Networking.xcodeproj/project.pbxproj
@@ -1033,6 +1033,7 @@
 		DEB3878C2C2D70EF0025256E /* GoogleAdsCampaignListMapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEB3878B2C2D70EF0025256E /* GoogleAdsCampaignListMapper.swift */; };
 		DEB3878F2C2D71A10025256E /* gla-campaign-list-without-data-envelope.json in Resources */ = {isa = PBXBuildFile; fileRef = DEB3878D2C2D71A10025256E /* gla-campaign-list-without-data-envelope.json */; };
 		DEB387902C2D71A10025256E /* gla-campaign-list-with-data-envelope.json in Resources */ = {isa = PBXBuildFile; fileRef = DEB3878E2C2D71A10025256E /* gla-campaign-list-with-data-envelope.json */; };
+		DEB387922C2D72160025256E /* GoogleAdsCampaignListMapperTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEB387912C2D72160025256E /* GoogleAdsCampaignListMapperTests.swift */; };
 		DEC2961C26BBE764005A056B /* ShippingLabelCustomsForm.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEC2961B26BBE764005A056B /* ShippingLabelCustomsForm.swift */; };
 		DEC2B08D297AA048003923FB /* reviews-all-without-data.json in Resources */ = {isa = PBXBuildFile; fileRef = DEC2B08C297AA048003923FB /* reviews-all-without-data.json */; };
 		DEC2B08F297AA123003923FB /* reviews-single-without-data.json in Resources */ = {isa = PBXBuildFile; fileRef = DEC2B08E297AA123003923FB /* reviews-single-without-data.json */; };
@@ -2171,6 +2172,7 @@
 		DEB3878B2C2D70EF0025256E /* GoogleAdsCampaignListMapper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GoogleAdsCampaignListMapper.swift; sourceTree = "<group>"; };
 		DEB3878D2C2D71A10025256E /* gla-campaign-list-without-data-envelope.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "gla-campaign-list-without-data-envelope.json"; sourceTree = "<group>"; };
 		DEB3878E2C2D71A10025256E /* gla-campaign-list-with-data-envelope.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "gla-campaign-list-with-data-envelope.json"; sourceTree = "<group>"; };
+		DEB387912C2D72160025256E /* GoogleAdsCampaignListMapperTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GoogleAdsCampaignListMapperTests.swift; sourceTree = "<group>"; };
 		DEC2961B26BBE764005A056B /* ShippingLabelCustomsForm.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShippingLabelCustomsForm.swift; sourceTree = "<group>"; };
 		DEC2B08C297AA048003923FB /* reviews-all-without-data.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "reviews-all-without-data.json"; sourceTree = "<group>"; };
 		DEC2B08E297AA123003923FB /* reviews-single-without-data.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "reviews-single-without-data.json"; sourceTree = "<group>"; };
@@ -3714,6 +3716,7 @@
 				DE2004732BFB53DD00660A72 /* ProductReportListMapperTests.swift */,
 				EE3F89852C2ACF12003DEC07 /* JetpackAIQueryResponseMapperTests.swift */,
 				DEB3877B2C2A9B600025256E /* GoogleAdsConnectionMapperTests.swift */,
+				DEB387912C2D72160025256E /* GoogleAdsCampaignListMapperTests.swift */,
 			);
 			path = Mapper;
 			sourceTree = "<group>";
@@ -5260,6 +5263,7 @@
 				5726F7342460A8F00031CAAC /* CopiableTests.swift in Sources */,
 				0313651D28AE625300EEE571 /* PaymentGatewayMapperTests.swift in Sources */,
 				26615479242DA54D00A31661 /* ProductCategoyListMapperTests.swift in Sources */,
+				DEB387922C2D72160025256E /* GoogleAdsCampaignListMapperTests.swift in Sources */,
 				B5C6FCC820A32E4800A4F8E4 /* DateFormatterWooTests.swift in Sources */,
 				74C8F06A20EEBC8C00B6EDC9 /* OrderMapperTests.swift in Sources */,
 				45152835257A8F490076B03C /* ProductAttributeListMapperTests.swift in Sources */,

--- a/Networking/Networking/Mapper/GoogleAds/GoogleAdsCampaignListMapper.swift
+++ b/Networking/Networking/Mapper/GoogleAds/GoogleAdsCampaignListMapper.swift
@@ -1,0 +1,26 @@
+import Foundation
+
+/// Mapper: `[GoogleAdsCampaign]`
+///
+struct GoogleAdsCampaignListMapper: Mapper {
+
+    /// (Attempts) to convert a dictionary into `[GoogleAdsCampaign]`.
+    ///
+    func map(response: Data) throws -> [GoogleAdsCampaign] {
+        let decoder = JSONDecoder()
+        if hasDataEnvelope(in: response) {
+            return try decoder.decode(GoogleAdsCampaignListEnvelope.self, from: response).data
+        } else {
+            return try decoder.decode([GoogleAdsCampaign].self, from: response)
+        }
+    }
+}
+
+
+/// GoogleAdsCampaignListEnvelope Disposable Entity:
+/// Load Google Ads campaign list endpoint returns the result in the `data` key.
+/// This entity allows us to parse all the things with JSONDecoder.
+///
+private struct GoogleAdsCampaignListEnvelope: Decodable {
+    let data: [GoogleAdsCampaign]
+}

--- a/Networking/Networking/Model/Copiable/Models+Copiable.generated.swift
+++ b/Networking/Networking/Model/Copiable/Models+Copiable.generated.swift
@@ -801,6 +801,36 @@ extension Networking.GiftCardStatsTotals {
     }
 }
 
+extension Networking.GoogleAdsCampaign {
+    public func copy(
+        id: CopiableProp<Int64> = .copy,
+        name: CopiableProp<String> = .copy,
+        rawStatus: CopiableProp<String> = .copy,
+        rawType: CopiableProp<String> = .copy,
+        amount: CopiableProp<Double> = .copy,
+        country: CopiableProp<String> = .copy,
+        targetedLocations: CopiableProp<[String]> = .copy
+    ) -> Networking.GoogleAdsCampaign {
+        let id = id ?? self.id
+        let name = name ?? self.name
+        let rawStatus = rawStatus ?? self.rawStatus
+        let rawType = rawType ?? self.rawType
+        let amount = amount ?? self.amount
+        let country = country ?? self.country
+        let targetedLocations = targetedLocations ?? self.targetedLocations
+
+        return Networking.GoogleAdsCampaign(
+            id: id,
+            name: name,
+            rawStatus: rawStatus,
+            rawType: rawType,
+            amount: amount,
+            country: country,
+            targetedLocations: targetedLocations
+        )
+    }
+}
+
 extension Networking.GoogleAdsCampaignStats {
     public func copy(
         siteID: CopiableProp<Int64> = .copy,

--- a/Networking/Networking/Model/Copiable/Models+Copiable.generated.swift
+++ b/Networking/Networking/Model/Copiable/Models+Copiable.generated.swift
@@ -801,6 +801,36 @@ extension Networking.GiftCardStatsTotals {
     }
 }
 
+extension Networking.GoogleAdsCampaign {
+    public func copy(
+        id: CopiableProp<Int64> = .copy,
+        name: CopiableProp<String> = .copy,
+        rawStatus: CopiableProp<String> = .copy,
+        rawType: CopiableProp<String> = .copy,
+        amount: CopiableProp<Double> = .copy,
+        country: CopiableProp<String> = .copy,
+        targetedLocations: CopiableProp<[String]> = .copy
+    ) -> Networking.GoogleAdsCampaign {
+        let id = id ?? self.id
+        let name = name ?? self.name
+        let rawStatus = rawStatus ?? self.rawStatus
+        let rawType = rawType ?? self.rawType
+        let amount = amount ?? self.amount
+        let country = country ?? self.country
+        let targetedLocations = targetedLocations ?? self.targetedLocations
+
+        return Networking.GoogleAdsCampaign(
+            id: id,
+            name: name,
+            rawStatus: rawStatus,
+            rawType: rawType,
+            amount: amount,
+            country: country,
+            targetedLocations: targetedLocations
+        )
+    }
+}
+
 extension Networking.GoogleAdsConnection {
     public func copy(
         id: CopiableProp<Int64> = .copy,

--- a/Networking/Networking/Model/GoogleAds/GoogleAdsCampaign.swift
+++ b/Networking/Networking/Model/GoogleAds/GoogleAdsCampaign.swift
@@ -1,0 +1,61 @@
+import Codegen
+import Foundation
+
+/// Details for a Google ads campaign.
+///
+public struct GoogleAdsCampaign: Decodable, Equatable, GeneratedFakeable, GeneratedCopiable {
+
+    public let id: Int64
+
+    public let name: String
+
+    public let rawStatus: String
+
+    public let rawType: String
+
+    public let amount: Double
+
+    public let country: String
+
+    public let targetedLocations: [String]
+
+    public var status: Status {
+        Status(rawValue: rawStatus) ?? .disabled
+    }
+
+    public init(id: Int64,
+                name: String,
+                rawStatus: String,
+                rawType: String,
+                amount: Double,
+                country: String,
+                targetedLocations: [String]) {
+        self.id = id
+        self.name = name
+        self.rawStatus = rawStatus
+        self.rawType = rawType
+        self.amount = amount
+        self.country = country
+        self.targetedLocations = targetedLocations
+    }
+}
+
+public extension GoogleAdsCampaign {
+    enum Status: String {
+        case enabled
+        case disabled
+        case removed
+    }
+}
+
+private extension GoogleAdsCampaign {
+    enum CodingKeys: String, CodingKey {
+        case id
+        case name
+        case rawStatus = "status"
+        case rawType = "type"
+        case amount
+        case country
+        case targetedLocations = "targeted_locations"
+    }
+}

--- a/Networking/Networking/Remote/GoogleListingsAndAdsRemote.swift
+++ b/Networking/Networking/Remote/GoogleListingsAndAdsRemote.swift
@@ -9,7 +9,7 @@ public protocol GoogleListingsAndAdsRemoteProtocol {
 
     /// Fetch ads campaigns for the given site
     ///
-    func fetchAdsCampaign(for siteID: Int64) async throws -> [GoogleAdsCampaign]
+    func fetchAdsCampaigns(for siteID: Int64) async throws -> [GoogleAdsCampaign]
 }
 
 /// Google Listings & Ads: Endpoints
@@ -27,7 +27,7 @@ public final class GoogleListingsAndAdsRemote: Remote, GoogleListingsAndAdsRemot
         return try await enqueue(request, mapper: mapper)
     }
 
-    public func fetchAdsCampaign(for siteID: Int64) async throws -> [GoogleAdsCampaign] {
+    public func fetchAdsCampaigns(for siteID: Int64) async throws -> [GoogleAdsCampaign] {
         let path = Paths.adsCampaigns
         let request = JetpackRequest(wooApiVersion: .none,
                                      method: .get,

--- a/Networking/Networking/Remote/GoogleListingsAndAdsRemote.swift
+++ b/Networking/Networking/Remote/GoogleListingsAndAdsRemote.swift
@@ -6,6 +6,10 @@ public protocol GoogleListingsAndAdsRemoteProtocol {
     /// Check Google ads connection for the given site.
     ///
     func checkConnection(for siteID: Int64) async throws -> GoogleAdsConnection
+
+    /// Fetch ads campaigns for the given site
+    ///
+    func fetchAdsCampaign(for siteID: Int64) async throws -> [GoogleAdsCampaign]
 }
 
 /// Google Listings & Ads: Endpoints
@@ -22,10 +26,22 @@ public final class GoogleListingsAndAdsRemote: Remote, GoogleListingsAndAdsRemot
         let mapper = GoogleAdsConnectionMapper()
         return try await enqueue(request, mapper: mapper)
     }
+
+    public func fetchAdsCampaign(for siteID: Int64) async throws -> [GoogleAdsCampaign] {
+        let path = Paths.adsCampaigns
+        let request = JetpackRequest(wooApiVersion: .none,
+                                     method: .get,
+                                     siteID: siteID,
+                                     path: path,
+                                     availableAsRESTRequest: true)
+        let mapper = GoogleAdsCampaignListMapper()
+        return try await enqueue(request, mapper: mapper)
+    }
 }
 
 private extension GoogleListingsAndAdsRemote {
     enum Paths {
         static let connection = "wc/gla/ads/connection"
+        static let adsCampaigns = "wc/gla/ads/campaigns"
     }
 }

--- a/Networking/NetworkingTests/Mapper/GoogleAdsCampaignListMapperTests.swift
+++ b/Networking/NetworkingTests/Mapper/GoogleAdsCampaignListMapperTests.swift
@@ -1,0 +1,71 @@
+import XCTest
+@testable import Networking
+
+final class GoogleAdsCampaignListMapperTests: XCTestCase {
+
+    func test_google_ads_campaign_list_is_properly_parsed_with_data_envelope() throws {
+        // When
+        let campaigns = try mapGoogleAdsCampaignList(from: "gla-campaign-list-with-data-envelope")
+
+        // Then
+        XCTAssertEqual(campaigns.count, 2)
+        let firstItem = try XCTUnwrap(campaigns.first)
+        XCTAssertEqual(firstItem.id, 21401695859)
+        XCTAssertEqual(firstItem.name, "Campaign 2024-06-21 04:26:32")
+        XCTAssertEqual(firstItem.rawStatus, "enabled")
+        XCTAssertEqual(firstItem.rawType, "performance_max")
+        XCTAssertEqual(firstItem.amount, 10)
+        XCTAssertEqual(firstItem.country, "US")
+        XCTAssertEqual(firstItem.targetedLocations, ["US"])
+        XCTAssertEqual(firstItem.status, .enabled)
+
+        let secondItem = try XCTUnwrap(campaigns.last)
+        XCTAssertEqual(secondItem.id, 21402492606)
+        XCTAssertEqual(secondItem.name, "Campaign 2024-06-24 05:08:41")
+        XCTAssertEqual(secondItem.rawStatus, "disabled")
+        XCTAssertEqual(secondItem.rawType, "performance_max")
+        XCTAssertEqual(secondItem.amount, 30)
+        XCTAssertEqual(secondItem.country, "US")
+        XCTAssertEqual(secondItem.targetedLocations, ["US"])
+        XCTAssertEqual(secondItem.status, .disabled)
+    }
+
+    func test_google_ads_campaign_list_is_properly_parsed_without_data_envelope() throws {
+        // When
+        let campaigns = try mapGoogleAdsCampaignList(from: "gla-campaign-list-without-data-envelope")
+
+        // Then
+        XCTAssertEqual(campaigns.count, 2)
+        let firstItem = try XCTUnwrap(campaigns.first)
+        XCTAssertEqual(firstItem.id, 21401695859)
+        XCTAssertEqual(firstItem.name, "Campaign 2024-06-21 04:26:32")
+        XCTAssertEqual(firstItem.rawStatus, "enabled")
+        XCTAssertEqual(firstItem.rawType, "performance_max")
+        XCTAssertEqual(firstItem.amount, 10)
+        XCTAssertEqual(firstItem.country, "US")
+        XCTAssertEqual(firstItem.targetedLocations, ["US"])
+        XCTAssertEqual(firstItem.status, .enabled)
+
+        let secondItem = try XCTUnwrap(campaigns.last)
+        XCTAssertEqual(secondItem.id, 21402492606)
+        XCTAssertEqual(secondItem.name, "Campaign 2024-06-24 05:08:41")
+        XCTAssertEqual(secondItem.rawStatus, "disabled")
+        XCTAssertEqual(secondItem.rawType, "performance_max")
+        XCTAssertEqual(secondItem.amount, 30)
+        XCTAssertEqual(secondItem.country, "US")
+        XCTAssertEqual(secondItem.targetedLocations, ["US"])
+        XCTAssertEqual(secondItem.status, .disabled)
+    }
+}
+
+private extension GoogleAdsCampaignListMapperTests {
+    /// Returns the [GoogleAdsCampaign] output upon receiving `filename` (Data Encoded)
+    ///
+    func mapGoogleAdsCampaignList(from filename: String) throws -> [GoogleAdsCampaign] {
+        guard let response = Loader.contentsOf(filename) else {
+            return []
+        }
+
+        return try GoogleAdsCampaignListMapper().map(response: response)
+    }
+}

--- a/Networking/NetworkingTests/Remote/GoogleListingsAndAdsRemoteTests.swift
+++ b/Networking/NetworkingTests/Remote/GoogleListingsAndAdsRemoteTests.swift
@@ -57,4 +57,55 @@ final class GoogleListingsAndAdsRemoteTests: XCTestCase {
         }
     }
 
+    // MARK: - Fetch ads campaigns
+
+    func test_fetchAdsCampaigns_returns_parsed_connection() async throws {
+        // Given
+        let remote = GoogleListingsAndAdsRemote(network: network)
+
+        let suffix = "wc/gla/ads/campaigns"
+        network.simulateResponse(requestUrlSuffix: suffix, filename: "gla-campaign-list-with-data-envelope")
+
+        // When
+        let results = try await remote.fetchAdsCampaigns(for: sampleSiteID)
+
+        // Then
+        let expectedCampaigns = [
+            GoogleAdsCampaign(id: 21401695859,
+                              name: "Campaign 2024-06-21 04:26:32",
+                              rawStatus: "enabled",
+                              rawType: "performance_max",
+                              amount: 10,
+                              country: "US",
+                              targetedLocations: ["US"]),
+            GoogleAdsCampaign(id: 21402492606,
+                              name: "Campaign 2024-06-24 05:08:41",
+                              rawStatus: "disabled",
+                              rawType: "performance_max",
+                              amount: 30,
+                              country: "US",
+                              targetedLocations: ["US"])
+        ]
+        XCTAssertEqual(results, expectedCampaigns)
+    }
+
+    func test_fetchAdsCampaigns_properly_relays_networking_errors() async {
+        // Given
+        let remote = GoogleListingsAndAdsRemote(network: network)
+
+        let expectedError = NetworkError.unacceptableStatusCode(statusCode: 403)
+        let suffix = "wc/gla/ads/campaigns"
+        network.simulateError(requestUrlSuffix: suffix, error: expectedError)
+
+        do {
+            // When
+            _ = try await remote.fetchAdsCampaigns(for: sampleSiteID)
+
+            // Then
+            XCTFail("Request should fail")
+        } catch {
+            // Then
+            XCTAssertEqual(error as? NetworkError, expectedError)
+        }
+    }
 }

--- a/Networking/NetworkingTests/Responses/gla-campaign-list-with-data-envelope.json
+++ b/Networking/NetworkingTests/Responses/gla-campaign-list-with-data-envelope.json
@@ -1,0 +1,26 @@
+{
+    "data": [
+        {
+            "id": 21401695859,
+            "name": "Campaign 2024-06-21 04:26:32",
+            "status": "enabled",
+            "type": "performance_max",
+            "amount": 10,
+            "country": "US",
+            "targeted_locations": [
+                "US"
+            ]
+        },
+        {
+            "id": 21402492606,
+            "name": "Campaign 2024-06-24 05:08:41",
+            "status": "disabled",
+            "type": "performance_max",
+            "amount": 30,
+            "country": "US",
+            "targeted_locations": [
+                "US"
+            ]
+        }
+    ]
+}

--- a/Networking/NetworkingTests/Responses/gla-campaign-list-without-data-envelope.json
+++ b/Networking/NetworkingTests/Responses/gla-campaign-list-without-data-envelope.json
@@ -1,0 +1,24 @@
+[
+    {
+        "id": 21401695859,
+        "name": "Campaign 2024-06-21 04:26:32",
+        "status": "enabled",
+        "type": "performance_max",
+        "amount": 10,
+        "country": "US",
+        "targeted_locations": [
+            "US"
+        ]
+    },
+    {
+        "id": 21402492606,
+        "name": "Campaign 2024-06-24 05:08:41",
+        "status": "disabled",
+        "type": "performance_max",
+        "amount": 30,
+        "country": "US",
+        "targeted_locations": [
+            "US"
+        ]
+    }
+]

--- a/Yosemite/YosemiteTests/Mocks/Networking/Remote/MockGoogleListingsAndAdsRemote.swift
+++ b/Yosemite/YosemiteTests/Mocks/Networking/Remote/MockGoogleListingsAndAdsRemote.swift
@@ -39,7 +39,7 @@ extension MockGoogleListingsAndAdsRemote: GoogleListingsAndAdsRemoteProtocol {
             throw error
         }
     }
-    
+
     func checkConnection(for siteID: Int64) async throws -> Networking.GoogleAdsConnection {
         guard let result = checkingConnectionResult else {
             XCTFail("Could not find result for checking GLA connection.")

--- a/Yosemite/YosemiteTests/Mocks/Networking/Remote/MockGoogleListingsAndAdsRemote.swift
+++ b/Yosemite/YosemiteTests/Mocks/Networking/Remote/MockGoogleListingsAndAdsRemote.swift
@@ -5,6 +5,7 @@ final class MockGoogleListingsAndAdsRemote {
 
     private var checkingConnectionResult: Result<GoogleAdsConnection, Error>?
     private var fetchingAdsCampaignsResult: Result<[GoogleAdsCampaign], Error>?
+    private var loadingCampaignStatsResults: Result<GoogleAdsCampaignStats, Error>?
 
     func whenCheckingConnection(thenReturn result: Result<GoogleAdsConnection, Error>) {
         checkingConnectionResult = result
@@ -13,9 +14,32 @@ final class MockGoogleListingsAndAdsRemote {
     func whenFetchingAdsCampaigns(thenReturn result: Result<[GoogleAdsCampaign], Error>) {
         fetchingAdsCampaignsResult = result
     }
+
+    func whenLoadingCampaignStatsResults(thenReturn result: Result<GoogleAdsCampaignStats, Error>) {
+        loadingCampaignStatsResults = result
+    }
 }
 
 extension MockGoogleListingsAndAdsRemote: GoogleListingsAndAdsRemoteProtocol {
+    func loadCampaignStats(for siteID: Int64,
+                           timeZone: TimeZone,
+                           earliestDateToInclude: Date,
+                           latestDateToInclude: Date,
+                           totals: [Networking.GoogleListingsAndAdsRemote.StatsField],
+                           orderby: Networking.GoogleListingsAndAdsRemote.StatsField,
+                           nextPageToken: String?) async throws -> GoogleAdsCampaignStats {
+        guard let result = loadingCampaignStatsResults else {
+            XCTFail("Could not find result for loading GLA campaign stats.")
+            throw NetworkError.notFound()
+        }
+        switch result {
+        case .success(let stats):
+            return stats
+        case .failure(let error):
+            throw error
+        }
+    }
+    
     func checkConnection(for siteID: Int64) async throws -> Networking.GoogleAdsConnection {
         guard let result = checkingConnectionResult else {
             XCTFail("Could not find result for checking GLA connection.")

--- a/Yosemite/YosemiteTests/Mocks/Networking/Remote/MockGoogleListingsAndAdsRemote.swift
+++ b/Yosemite/YosemiteTests/Mocks/Networking/Remote/MockGoogleListingsAndAdsRemote.swift
@@ -4,9 +4,14 @@ import Networking
 final class MockGoogleListingsAndAdsRemote {
 
     private var checkingConnectionResult: Result<GoogleAdsConnection, Error>?
+    private var fetchingAdsCampaignsResult: Result<[GoogleAdsCampaign], Error>?
 
     func whenCheckingConnection(thenReturn result: Result<GoogleAdsConnection, Error>) {
         checkingConnectionResult = result
+    }
+
+    func whenFetchingAdsCampaigns(thenReturn result: Result<[GoogleAdsCampaign], Error>) {
+        fetchingAdsCampaignsResult = result
     }
 }
 
@@ -19,6 +24,19 @@ extension MockGoogleListingsAndAdsRemote: GoogleListingsAndAdsRemoteProtocol {
         switch result {
         case .success(let connection):
             return connection
+        case .failure(let error):
+            throw error
+        }
+    }
+
+    func fetchAdsCampaign(for siteID: Int64) async throws -> [GoogleAdsCampaign] {
+        guard let result = fetchingAdsCampaignsResult else {
+            XCTFail("Could not find result for fetching GLA campaigns.")
+            throw NetworkError.notFound()
+        }
+        switch result {
+        case .success(let campaigns):
+            return campaigns
         case .failure(let error):
             throw error
         }

--- a/Yosemite/YosemiteTests/Mocks/Networking/Remote/MockGoogleListingsAndAdsRemote.swift
+++ b/Yosemite/YosemiteTests/Mocks/Networking/Remote/MockGoogleListingsAndAdsRemote.swift
@@ -29,7 +29,7 @@ extension MockGoogleListingsAndAdsRemote: GoogleListingsAndAdsRemoteProtocol {
         }
     }
 
-    func fetchAdsCampaign(for siteID: Int64) async throws -> [GoogleAdsCampaign] {
+    func fetchAdsCampaigns(for siteID: Int64) async throws -> [GoogleAdsCampaign] {
         guard let result = fetchingAdsCampaignsResult else {
             XCTFail("Could not find result for fetching GLA campaigns.")
             throw NetworkError.notFound()


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of #13182 
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This PR updates the Networking layer to support fetching Google ads campaign list for a given site. Due to the large change, Yosemite update will be added in a separate PR.

Changes include:
- New model for Google ads campaign.
- New mapper for parsing Google ads campaign list.
- New method in `GoogleListingsAndAdsRemote` to support fetching campaign list for a given site.

## Tesing steps
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->
Just CI passing is sufficient.


## Screenshots
<!-- Include before and after images or gifs when appropriate. -->
N/A

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
