### PR TITLE
[GLA Analytics] Add networking mapper and remote endpoint for Google Listings & Ads campaign stats

### DIFF
--- a/Networking/Networking.xcodeproj/project.pbxproj
+++ b/Networking/Networking.xcodeproj/project.pbxproj
@@ -806,6 +806,8 @@
 		CE21FB162C2AC90E00303832 /* GoogleAdsCampaignStats.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE21FB152C2AC90E00303832 /* GoogleAdsCampaignStats.swift */; };
 		CE21FB182C2AC97200303832 /* GoogleAdsCampaignStatsTotals.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE21FB172C2AC97200303832 /* GoogleAdsCampaignStatsTotals.swift */; };
 		CE21FB1C2C2AD7E200303832 /* GoogleAdsCampaignStatsItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE21FB1B2C2AD7E200303832 /* GoogleAdsCampaignStatsItem.swift */; };
+		CE21FB1E2C2ADA4300303832 /* GoogleAdsCampaignStatsMapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE21FB1D2C2ADA4300303832 /* GoogleAdsCampaignStatsMapper.swift */; };
+		CE21FB202C2ADAC500303832 /* GoogleAdsCampaignStatsMapperTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE21FB1F2C2ADAC500303832 /* GoogleAdsCampaignStatsMapperTests.swift */; };
 		CE21FB242C2C16DA00303832 /* google-ads-reports-programs.json in Resources */ = {isa = PBXBuildFile; fileRef = CE21FB232C2C16DA00303832 /* google-ads-reports-programs.json */; };
 		CE227093228DD44C00C0626C /* ProductStatus.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE227092228DD44C00C0626C /* ProductStatus.swift */; };
 		CE2678432A26102A00FD9AEB /* order-alternative-types.json in Resources */ = {isa = PBXBuildFile; fileRef = CE2678422A26102A00FD9AEB /* order-alternative-types.json */; };
@@ -1945,6 +1947,8 @@
 		CE21FB152C2AC90E00303832 /* GoogleAdsCampaignStats.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GoogleAdsCampaignStats.swift; sourceTree = "<group>"; };
 		CE21FB172C2AC97200303832 /* GoogleAdsCampaignStatsTotals.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GoogleAdsCampaignStatsTotals.swift; sourceTree = "<group>"; };
 		CE21FB1B2C2AD7E200303832 /* GoogleAdsCampaignStatsItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GoogleAdsCampaignStatsItem.swift; sourceTree = "<group>"; };
+		CE21FB1D2C2ADA4300303832 /* GoogleAdsCampaignStatsMapper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GoogleAdsCampaignStatsMapper.swift; sourceTree = "<group>"; };
+		CE21FB1F2C2ADAC500303832 /* GoogleAdsCampaignStatsMapperTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GoogleAdsCampaignStatsMapperTests.swift; sourceTree = "<group>"; };
 		CE21FB232C2C16DA00303832 /* google-ads-reports-programs.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "google-ads-reports-programs.json"; sourceTree = "<group>"; };
 		CE227092228DD44C00C0626C /* ProductStatus.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductStatus.swift; sourceTree = "<group>"; };
 		CE2678422A26102A00FD9AEB /* order-alternative-types.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "order-alternative-types.json"; sourceTree = "<group>"; };
@@ -3437,6 +3441,7 @@
 				CE865A9C2A41E1480049B03C /* EntityDateModifiedMapper.swift */,
 				2676F4CD290AE6BB00C7A15B /* EntityIDMapper.swift */,
 				CE070A352BBC53D100017578 /* GiftCardStatsMapper.swift */,
+				CE21FB1D2C2ADA4300303832 /* GoogleAdsCampaignStatsMapper.swift */,
 				DE50295C28C6068B00551736 /* JetpackUserMapper.swift */,
 				AEF9458A27297FF6001DCCFB /* IgnoringResponseMapper.swift */,
 				E18152BF28F85D4A0011A0EC /* InAppPurchasesProductMapper.swift */,
@@ -3632,6 +3637,7 @@
 				B524194221AC622500D6FC0A /* DotcomDeviceMapperTests.swift */,
 				CE865AA42A4209A70049B03C /* EntityDateModifiedMapperTests.swift */,
 				CE070A372BBC543200017578 /* GiftCardStatsMapperTests.swift */,
+				CE21FB1F2C2ADAC500303832 /* GoogleAdsCampaignStatsMapperTests.swift */,
 				AED8AEBB272A997500663FCC /* IgnoringResponseMapperTests.swift */,
 				E18152C328F85E5C0011A0EC /* InAppPurchasesProductsMapperTests.swift */,
 				E1A5C27128F93ED900081046 /* InAppPurchaseOrderResultMapperTests.swift */,
@@ -5061,6 +5067,7 @@
 				B5C6FCCF20A3592900A4F8E4 /* OrderItem.swift in Sources */,
 				CE070A2E2BBC3C3500017578 /* GiftCardStatsTotals.swift in Sources */,
 				CEE9187D29F7D636004B23FF /* OrderGiftCard.swift in Sources */,
+				CE21FB1E2C2ADA4300303832 /* GoogleAdsCampaignStatsMapper.swift in Sources */,
 				020EF5E92A8BC957009D2169 /* ProductsTotalMapper.swift in Sources */,
 				02C254A025636F6900A04423 /* ShippingLabelRefund.swift in Sources */,
 				CCF48B24262890BB0034EA83 /* ShippingLabelPaymentCardType.swift in Sources */,
@@ -5213,6 +5220,7 @@
 				CEE02EEB2B34811400162F63 /* DecodingError+CodingPathTests.swift in Sources */,
 				EE3F89862C2ACF12003DEC07 /* JetpackAIQueryResponseMapperTests.swift in Sources */,
 				45551F142523E7FF007EF104 /* UserAgentTests.swift in Sources */,
+				CE21FB202C2ADAC500303832 /* GoogleAdsCampaignStatsMapperTests.swift in Sources */,
 				03EB998A2906AB0C00F06A39 /* JustInTimeMessagesRemoteTests.swift in Sources */,
 				CCE5F39129F000AC00087332 /* SubscriptionListMapperTests.swift in Sources */,
 				DEDA8D9B2B05BEF80076BF0F /* CreateProductVariationTests.swift in Sources */,

--- a/Networking/Networking/Mapper/GoogleAdsCampaignStatsMapper.swift
+++ b/Networking/Networking/Mapper/GoogleAdsCampaignStatsMapper.swift
@@ -1,0 +1,33 @@
+import Foundation
+
+/// Mapper: GoogleAdsCampaignStats
+///
+struct GoogleAdsCampaignStatsMapper: Mapper {
+    /// Site Identifier associated with the stats that will be parsed.
+    ///
+    let siteID: Int64
+
+    /// (Attempts) to convert a dictionary into a StatsReport entity.
+    ///
+    func map(response: Data) throws -> GoogleAdsCampaignStats {
+        let decoder = JSONDecoder()
+        decoder.userInfo = [
+            .siteID: siteID
+        ]
+        if hasDataEnvelope(in: response) {
+            return try decoder.decode(GoogleAdsCampaignStatsEnvelope.self, from: response).data
+        } else {
+            return try decoder.decode(GoogleAdsCampaignStats.self, from: response)
+        }
+    }
+}
+
+
+/// GoogleAdsCampaignStatsEnvelope Disposable Entity
+///
+/// Stats endpoint returns the requested stats in the `data` key. This entity
+/// allows us to parse all the things with JSONDecoder.
+///
+private struct GoogleAdsCampaignStatsEnvelope: Decodable {
+    let data: GoogleAdsCampaignStats
+}

--- a/Networking/Networking/Model/Copiable/Models+Copiable.generated.swift
+++ b/Networking/Networking/Model/Copiable/Models+Copiable.generated.swift
@@ -842,11 +842,11 @@ extension Networking.GoogleAdsCampaignStatsItem {
 
 extension Networking.GoogleAdsCampaignStatsTotals {
     public func copy(
-        sales: CopiableProp<Decimal> = .copy,
-        spend: CopiableProp<Decimal> = .copy,
-        clicks: CopiableProp<Int> = .copy,
-        impressions: CopiableProp<Int> = .copy,
-        conversions: CopiableProp<Decimal> = .copy
+        sales: NullableCopiableProp<Decimal> = .copy,
+        spend: NullableCopiableProp<Decimal> = .copy,
+        clicks: NullableCopiableProp<Int> = .copy,
+        impressions: NullableCopiableProp<Int> = .copy,
+        conversions: NullableCopiableProp<Decimal> = .copy
     ) -> Networking.GoogleAdsCampaignStatsTotals {
         let sales = sales ?? self.sales
         let spend = spend ?? self.spend

--- a/Networking/Networking/Model/Stats/GoogleAdsCampaignStatsTotals.swift
+++ b/Networking/Networking/Model/Stats/GoogleAdsCampaignStatsTotals.swift
@@ -3,25 +3,25 @@ import Codegen
 /// Represents the data associated with Google Listings & Ads paid campaign stats over a specific period.
 public struct GoogleAdsCampaignStatsTotals: Decodable, Equatable, GeneratedCopiable, GeneratedFakeable, WCAnalyticsStatsTotals {
     /// Amount in sales attributed to ads campaign
-    public let sales: Decimal
+    public let sales: Decimal?
 
     /// Amount spent on ads campaign
-    public let spend: Decimal
+    public let spend: Decimal?
 
     /// Number of clicks on ads campaign
-    public let clicks: Int
+    public let clicks: Int?
 
     /// Number of impressions of ads campaign
-    public let impressions: Int
+    public let impressions: Int?
 
     /// Number of conversions from ads campaign
-    public let conversions: Decimal
+    public let conversions: Decimal?
 
-    public init(sales: Decimal,
-                spend: Decimal,
-                clicks: Int,
-                impressions: Int,
-                conversions: Decimal) {
+    public init(sales: Decimal?,
+                spend: Decimal?,
+                clicks: Int?,
+                impressions: Int?,
+                conversions: Decimal?) {
         self.sales = sales
         self.spend = spend
         self.clicks = clicks
@@ -31,11 +31,11 @@ public struct GoogleAdsCampaignStatsTotals: Decodable, Equatable, GeneratedCopia
 
     public init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
-        let sales = try container.decode(Decimal.self, forKey: .sales)
-        let spend = try container.decode(Decimal.self, forKey: .spend)
-        let clicks = try container.decode(Int.self, forKey: .clicks)
-        let impressions = try container.decode(Int.self, forKey: .impressions)
-        let conversions = try container.decode(Decimal.self, forKey: .conversions)
+        let sales = try container.decodeIfPresent(Decimal.self, forKey: .sales)
+        let spend = try container.decodeIfPresent(Decimal.self, forKey: .spend)
+        let clicks = try container.decodeIfPresent(Int.self, forKey: .clicks)
+        let impressions = try container.decodeIfPresent(Int.self, forKey: .impressions)
+        let conversions = try container.decodeIfPresent(Decimal.self, forKey: .conversions)
 
         self.init(sales: sales,
                   spend: spend,

--- a/Networking/Networking/Remote/GoogleListingsAndAdsRemote.swift
+++ b/Networking/Networking/Remote/GoogleListingsAndAdsRemote.swift
@@ -6,6 +6,22 @@ public protocol GoogleListingsAndAdsRemoteProtocol {
     /// Check Google ads connection for the given site.
     ///
     func checkConnection(for siteID: Int64) async throws -> GoogleAdsConnection
+
+    /// Fetch the paid campaign stats for the given site.
+    ///
+    /// - Parameters:
+    ///   - siteID: The site ID.
+    ///   - timeZone: The time zone to set the earliest/latest date strings in the API request.
+    ///   - earliestDateToInclude: The earliest date to include in the results.
+    ///   - latestDateToInclude: The latest date to include in the results.
+    ///   - totals: Optionally limit the stats totals to fetch. Defaults to all stats totals.
+    ///   - orderby: Optionally define the stats total to use for ordering the list of campaigns in the response.
+    func loadCampaignStats(for siteID: Int64,
+                           timeZone: TimeZone,
+                           earliestDateToInclude: Date,
+                           latestDateToInclude: Date,
+                           totals: [GoogleListingsAndAdsRemote.StatsField]?,
+                           orderby: GoogleListingsAndAdsRemote.StatsField?) async throws -> GoogleAdsCampaignStats
 }
 
 /// Google Listings & Ads: Endpoints
@@ -22,10 +38,57 @@ public final class GoogleListingsAndAdsRemote: Remote, GoogleListingsAndAdsRemot
         let mapper = GoogleAdsConnectionMapper()
         return try await enqueue(request, mapper: mapper)
     }
+
+    public func loadCampaignStats(for siteID: Int64,
+                                  timeZone: TimeZone,
+                                  earliestDateToInclude: Date,
+                                  latestDateToInclude: Date,
+                                  totals: [GoogleListingsAndAdsRemote.StatsField]?,
+                                  orderby: GoogleListingsAndAdsRemote.StatsField?) async throws -> GoogleAdsCampaignStats {
+        let dateFormatter = DateFormatter.Defaults.iso8601WithoutTimeZone
+        dateFormatter.timeZone = timeZone
+
+        var parameters: [String: Any] = [
+            ParameterKeys.after: dateFormatter.string(from: earliestDateToInclude),
+            ParameterKeys.before: dateFormatter.string(from: latestDateToInclude)
+        ]
+        // Only include these parameters if not `nil`
+        parameters[ParameterKeys.totals] = totals?.map { $0.rawValue }.joined(separator: ",")
+        parameters[ParameterKeys.orderby] = orderby?.rawValue
+
+        let request = JetpackRequest(wooApiVersion: .none,
+                                     method: .get,
+                                     siteID: siteID,
+                                     path: Paths.campaignsReport,
+                                     parameters: parameters,
+                                     availableAsRESTRequest: true)
+        let mapper = GoogleAdsCampaignStatsMapper(siteID: siteID)
+        return try await enqueue(request, mapper: mapper)
+    }
+}
+
+public extension GoogleListingsAndAdsRemote {
+    /// Stats total fields for Google analytics reports
+    ///
+    enum StatsField: String {
+        case sales
+        case spend
+        case clicks
+        case impressions
+        case conversions
+    }
 }
 
 private extension GoogleListingsAndAdsRemote {
     enum Paths {
         static let connection = "wc/gla/ads/connection"
+        static let campaignsReport = "wc/gla/ads/reports/programs"
+    }
+
+    enum ParameterKeys {
+        static let after    = "after"
+        static let before   = "before"
+        static let totals   = "fields"
+        static let orderby  = "orderby"
     }
 }

--- a/Networking/NetworkingTests/Mapper/GoogleAdsCampaignStatsMapperTests.swift
+++ b/Networking/NetworkingTests/Mapper/GoogleAdsCampaignStatsMapperTests.swift
@@ -1,0 +1,84 @@
+import XCTest
+@testable import Networking
+
+
+/// GoogleAdsCampaignStatsMapper Unit Tests
+///
+final class GoogleAdsCampaignStatsMapperTests: XCTestCase {
+    private struct Constants {
+        static let siteID: Int64 = 1234
+    }
+
+    /// Verifies that all of the GoogleAdsCampaignStats fields are parsed correctly.
+    ///
+    func test_goodle_ads_campaign_stat_fields_are_properly_parsed() throws {
+        // Given
+        let granularity = StatsGranularityV4.daily
+
+        // When
+        guard let adsCampaignStats = mapStatItems(from: "google-ads-reports-programs", granularity: granularity) else {
+            XCTFail()
+            return
+        }
+
+        // Then
+        XCTAssertEqual(adsCampaignStats.siteID, Constants.siteID)
+
+        // Stats report totals are parsed
+        XCTAssertEqual(adsCampaignStats.totals.sales, 0)
+        XCTAssertEqual(adsCampaignStats.totals.spend, 0)
+        XCTAssertEqual(adsCampaignStats.totals.clicks, 0)
+        XCTAssertEqual(adsCampaignStats.totals.impressions, 0)
+        XCTAssertEqual(adsCampaignStats.totals.conversions, 0)
+
+        // Stats report campaigns are parsed
+        XCTAssertTrue(adsCampaignStats.campaigns.isEmpty)
+    }
+
+    /// Verifies that all of the GoogleAdsCampaignStats fields are parsed correctly.
+    ///
+    func test_google_ads_campaign_stat_fields_without_data_are_properly_parsed() throws {
+        // Given
+        let granularity = StatsGranularityV4.daily
+
+        // When
+        guard let adsCampaignStats = mapStatItems(from: "google-ads-reports-programs-without-data", granularity: granularity) else {
+            XCTFail()
+            return
+        }
+
+        // Then
+        XCTAssertEqual(adsCampaignStats.siteID, Constants.siteID)
+
+        // Stats report totals are parsed
+        XCTAssertEqual(adsCampaignStats.totals.sales, 11)
+        XCTAssertEqual(adsCampaignStats.totals.spend, 73.01)
+        XCTAssertEqual(adsCampaignStats.totals.clicks, 154)
+        XCTAssertEqual(adsCampaignStats.totals.impressions, 16938)
+        XCTAssertEqual(adsCampaignStats.totals.conversions, 3)
+
+        // Stats report campaigns are parsed
+        XCTAssertEqual(adsCampaignStats.campaigns.count, 2)
+        let firstCampaign = try XCTUnwrap(adsCampaignStats.campaigns.first)
+        XCTAssertEqual(firstCampaign.campaignID, 123)
+        XCTAssertEqual(firstCampaign.campaignName, "One")
+        XCTAssertEqual(firstCampaign.status, .enabled)
+        XCTAssertEqual(firstCampaign.subtotals.sales, 11)
+        XCTAssertEqual(firstCampaign.subtotals.spend, 63.14)
+        XCTAssertEqual(firstCampaign.subtotals.clicks, 139)
+        XCTAssertEqual(firstCampaign.subtotals.impressions, 16037)
+        XCTAssertEqual(firstCampaign.subtotals.conversions, 3)
+    }
+}
+
+private extension GoogleAdsCampaignStatsMapperTests {
+    /// Returns the GoogleAdsCampaignStatsMapper output upon receiving `filename` (Data Encoded)
+    ///
+    func mapStatItems(from filename: String, granularity: StatsGranularityV4) -> GoogleAdsCampaignStats? {
+        guard let response = Loader.contentsOf(filename) else {
+            return nil
+        }
+
+        return try! GoogleAdsCampaignStatsMapper(siteID: Constants.siteID).map(response: response)
+    }
+}

--- a/Networking/NetworkingTests/Mapper/GoogleAdsCampaignStatsMapperTests.swift
+++ b/Networking/NetworkingTests/Mapper/GoogleAdsCampaignStatsMapperTests.swift
@@ -27,9 +27,9 @@ final class GoogleAdsCampaignStatsMapperTests: XCTestCase {
         // Stats report totals are parsed
         XCTAssertEqual(adsCampaignStats.totals.sales, 0)
         XCTAssertEqual(adsCampaignStats.totals.spend, 0)
-        XCTAssertEqual(adsCampaignStats.totals.clicks, 0)
-        XCTAssertEqual(adsCampaignStats.totals.impressions, 0)
-        XCTAssertEqual(adsCampaignStats.totals.conversions, 0)
+        XCTAssertNil(adsCampaignStats.totals.clicks)
+        XCTAssertNil(adsCampaignStats.totals.impressions)
+        XCTAssertNil(adsCampaignStats.totals.conversions)
 
         // Stats report campaigns are parsed
         XCTAssertTrue(adsCampaignStats.campaigns.isEmpty)

--- a/Networking/NetworkingTests/Remote/GoogleListingsAndAdsRemoteTests.swift
+++ b/Networking/NetworkingTests/Remote/GoogleListingsAndAdsRemoteTests.swift
@@ -57,4 +57,52 @@ final class GoogleListingsAndAdsRemoteTests: XCTestCase {
         }
     }
 
+    // MARK: - Load campaign stats
+
+    func test_loadCampaignStats_returns_parsed_stats() async throws {
+        // Given
+        let remote = GoogleListingsAndAdsRemote(network: network)
+
+        let suffix = "wc/gla/ads/reports/programs"
+        network.simulateResponse(requestUrlSuffix: suffix, filename: "google-ads-reports-programs-without-data")
+
+        // When
+        let results = try await remote.loadCampaignStats(for: sampleSiteID,
+                                                         timeZone: .current,
+                                                         earliestDateToInclude: Date(),
+                                                         latestDateToInclude: Date(),
+                                                         totals: nil,
+                                                         orderby: nil)
+
+        // Then
+        XCTAssertEqual(results.siteID, sampleSiteID)
+        XCTAssertEqual(results.totals, GoogleAdsCampaignStatsTotals(sales: 11, spend: 73.01, clicks: 154, impressions: 16938, conversions: 3))
+        XCTAssertEqual(results.campaigns.count, 2)
+    }
+
+    func test_loadCampaignStats_properly_relays_networking_errors() async {
+        // Given
+        let remote = GoogleListingsAndAdsRemote(network: network)
+
+        let expectedError = NetworkError.unacceptableStatusCode(statusCode: 403)
+        let suffix = "wc/gla/ads/reports/programs"
+        network.simulateError(requestUrlSuffix: suffix, error: expectedError)
+
+        do {
+            // When
+            _ = try await remote.loadCampaignStats(for: sampleSiteID,
+                                                   timeZone: .current,
+                                                   earliestDateToInclude: Date(),
+                                                   latestDateToInclude: Date(),
+                                                   totals: nil,
+                                                   orderby: nil)
+
+            // Then
+            XCTFail("Request should fail")
+        } catch {
+            // Then
+            XCTAssertEqual(error as? NetworkError, expectedError)
+        }
+    }
+
 }

--- a/Networking/NetworkingTests/Remote/GoogleListingsAndAdsRemoteTests.swift
+++ b/Networking/NetworkingTests/Remote/GoogleListingsAndAdsRemoteTests.swift
@@ -71,8 +71,7 @@ final class GoogleListingsAndAdsRemoteTests: XCTestCase {
                                                          timeZone: .current,
                                                          earliestDateToInclude: Date(),
                                                          latestDateToInclude: Date(),
-                                                         totals: nil,
-                                                         orderby: nil)
+                                                         orderby: .sales)
 
         // Then
         XCTAssertEqual(results.siteID, sampleSiteID)
@@ -94,8 +93,7 @@ final class GoogleListingsAndAdsRemoteTests: XCTestCase {
                                                    timeZone: .current,
                                                    earliestDateToInclude: Date(),
                                                    latestDateToInclude: Date(),
-                                                   totals: nil,
-                                                   orderby: nil)
+                                                   orderby: .sales)
 
             // Then
             XCTFail("Request should fail")

--- a/Networking/NetworkingTests/Responses/google-ads-reports-programs.json
+++ b/Networking/NetworkingTests/Responses/google-ads-reports-programs.json
@@ -5,10 +5,7 @@
         "intervals": null,
         "totals": {
             "sales": 0,
-            "spend": 0,
-            "clicks": 0,
-            "impressions": 0,
-            "conversions": 0
+            "spend": 0
         },
         "next_page": null
     }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #13163
<!-- Id number of the GitHub issue this PR addresses. -->

## Why
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This adds the rest of the networking support to fetch paid campaign report stats for the Google Listings & Ads extension.

## How

* Updates the `GoogleAdsCampaignStatsTotals` model to support `nil` values for all totals properties. This allows us to limit the totals we request from the API, in which case only some of the fields will be included in the response. (We shouldn't default to `0` values because we don't want to accidentally store or display the wrong value in cases where we just haven't requested it from remote yet.)
* Adds `GoogleAdsCampaignStatsMapper` to map the API response to the networking models.
* Adds the `loadCampaignStats` request method to `GoogleListingsAndAdsRemote`.
* Adds unit tests for the mapper and remote endpoint.

## Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->

This new endpoint isn't yet used in the app. For now, confirm unit tests pass.


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.