### PR TITLE
[GLA Analytics] Add networking support for paginated campaign stats

### DIFF
--- a/Fakes/Fakes/Networking.generated.swift
+++ b/Fakes/Fakes/Networking.generated.swift
@@ -578,7 +578,8 @@ extension Networking.GoogleAdsCampaignStats {
         .init(
             siteID: .fake(),
             totals: .fake(),
-            campaigns: .fake()
+            campaigns: .fake(),
+            nextPageToken: .fake()
         )
     }
 }

--- a/Networking/Networking/Model/Copiable/Models+Copiable.generated.swift
+++ b/Networking/Networking/Model/Copiable/Models+Copiable.generated.swift
@@ -805,16 +805,19 @@ extension Networking.GoogleAdsCampaignStats {
     public func copy(
         siteID: CopiableProp<Int64> = .copy,
         totals: CopiableProp<GoogleAdsCampaignStatsTotals> = .copy,
-        campaigns: CopiableProp<[GoogleAdsCampaignStatsItem]> = .copy
+        campaigns: CopiableProp<[GoogleAdsCampaignStatsItem]> = .copy,
+        nextPageToken: NullableCopiableProp<String> = .copy
     ) -> Networking.GoogleAdsCampaignStats {
         let siteID = siteID ?? self.siteID
         let totals = totals ?? self.totals
         let campaigns = campaigns ?? self.campaigns
+        let nextPageToken = nextPageToken ?? self.nextPageToken
 
         return Networking.GoogleAdsCampaignStats(
             siteID: siteID,
             totals: totals,
-            campaigns: campaigns
+            campaigns: campaigns,
+            nextPageToken: nextPageToken
         )
     }
 }

--- a/Networking/Networking/Model/Stats/GoogleAdsCampaignStats.swift
+++ b/Networking/Networking/Model/Stats/GoogleAdsCampaignStats.swift
@@ -7,12 +7,22 @@ public struct GoogleAdsCampaignStats: Decodable, Equatable, GeneratedCopiable, G
     public let totals: GoogleAdsCampaignStatsTotals
     public let campaigns: [GoogleAdsCampaignStatsItem]
 
+    /// Token to request another page of stats data.
+    public let nextPageToken: String?
+
+    /// Whether there is another page of stats data.
+    public var hasNextPage: Bool {
+        nextPageToken != nil
+    }
+
     public init(siteID: Int64,
                 totals: GoogleAdsCampaignStatsTotals,
-                campaigns: [GoogleAdsCampaignStatsItem]) {
+                campaigns: [GoogleAdsCampaignStatsItem],
+                nextPageToken: String?) {
         self.siteID = siteID
         self.totals = totals
         self.campaigns = campaigns
+        self.nextPageToken = nextPageToken
     }
 
     public init(from decoder: Decoder) throws {
@@ -24,10 +34,12 @@ public struct GoogleAdsCampaignStats: Decodable, Equatable, GeneratedCopiable, G
         let totals = try container.decode(GoogleAdsCampaignStatsTotals.self, forKey: .totals)
         // Campaigns are `nil` if there are no campaigns; we convert this to an empty array.
         let campaigns = (try? container.decode([GoogleAdsCampaignStatsItem].self, forKey: .campaigns)) ?? []
+        let nextPageToken = try? container.decodeIfPresent(String.self, forKey: .nextPageToken)
 
         self.init(siteID: siteID,
                   totals: totals,
-                  campaigns: campaigns)
+                  campaigns: campaigns,
+                  nextPageToken: nextPageToken)
     }
 }
 
@@ -39,6 +51,7 @@ private extension GoogleAdsCampaignStats {
     enum CodingKeys: String, CodingKey {
         case totals
         case campaigns
+        case nextPageToken = "next_page"
     }
 }
 

--- a/Networking/Networking/Remote/GoogleListingsAndAdsRemote.swift
+++ b/Networking/Networking/Remote/GoogleListingsAndAdsRemote.swift
@@ -16,12 +16,14 @@ public protocol GoogleListingsAndAdsRemoteProtocol {
     ///   - latestDateToInclude: The latest date to include in the results.
     ///   - totals: Optionally limit the stats totals to fetch. Defaults to all stats totals.
     ///   - orderby: Define the stats total to use for ordering the list of campaigns in the response.
+    ///   - nextPageToken: Token to retrieve the next page of stats data.
     func loadCampaignStats(for siteID: Int64,
                            timeZone: TimeZone,
                            earliestDateToInclude: Date,
                            latestDateToInclude: Date,
                            totals: [GoogleListingsAndAdsRemote.StatsField],
-                           orderby: GoogleListingsAndAdsRemote.StatsField) async throws -> GoogleAdsCampaignStats
+                           orderby: GoogleListingsAndAdsRemote.StatsField,
+                           nextPageToken: String?) async throws -> GoogleAdsCampaignStats
 }
 
 /// Google Listings & Ads: Endpoints
@@ -44,7 +46,8 @@ public final class GoogleListingsAndAdsRemote: Remote, GoogleListingsAndAdsRemot
                                   earliestDateToInclude: Date,
                                   latestDateToInclude: Date,
                                   totals: [GoogleListingsAndAdsRemote.StatsField] = StatsField.allCases,
-                                  orderby: GoogleListingsAndAdsRemote.StatsField) async throws -> GoogleAdsCampaignStats {
+                                  orderby: GoogleListingsAndAdsRemote.StatsField,
+                                  nextPageToken: String? = nil) async throws -> GoogleAdsCampaignStats {
         let dateFormatter = DateFormatter.Defaults.iso8601WithoutTimeZone
         dateFormatter.timeZone = timeZone
 
@@ -54,6 +57,8 @@ public final class GoogleListingsAndAdsRemote: Remote, GoogleListingsAndAdsRemot
             ParameterKeys.totals: totals.map { $0.rawValue }.joined(separator: ","),
             ParameterKeys.orderby: orderby.rawValue
         ]
+        // Only include this parameter if the value is non-nil.
+        parameters[ParameterKeys.nextPageToken] = nextPageToken
 
         let request = JetpackRequest(wooApiVersion: .none,
                                      method: .get,
@@ -85,9 +90,10 @@ private extension GoogleListingsAndAdsRemote {
     }
 
     enum ParameterKeys {
-        static let after    = "after"
-        static let before   = "before"
-        static let totals   = "fields"
-        static let orderby  = "orderby"
+        static let after            = "after"
+        static let before           = "before"
+        static let totals           = "fields"
+        static let orderby          = "orderby"
+        static let nextPageToken    = "next_page"
     }
 }

--- a/Networking/NetworkingTests/Mapper/GoogleAdsCampaignStatsMapperTests.swift
+++ b/Networking/NetworkingTests/Mapper/GoogleAdsCampaignStatsMapperTests.swift
@@ -23,6 +23,7 @@ final class GoogleAdsCampaignStatsMapperTests: XCTestCase {
 
         // Then
         XCTAssertEqual(adsCampaignStats.siteID, Constants.siteID)
+        XCTAssertFalse(adsCampaignStats.hasNextPage)
 
         // Stats report totals are parsed
         XCTAssertEqual(adsCampaignStats.totals.sales, 0)
@@ -49,6 +50,7 @@ final class GoogleAdsCampaignStatsMapperTests: XCTestCase {
 
         // Then
         XCTAssertEqual(adsCampaignStats.siteID, Constants.siteID)
+        XCTAssertTrue(adsCampaignStats.hasNextPage)
 
         // Stats report totals are parsed
         XCTAssertEqual(adsCampaignStats.totals.sales, 11)

--- a/Networking/NetworkingTests/Remote/GoogleListingsAndAdsRemoteTests.swift
+++ b/Networking/NetworkingTests/Remote/GoogleListingsAndAdsRemoteTests.swift
@@ -79,6 +79,48 @@ final class GoogleListingsAndAdsRemoteTests: XCTestCase {
         XCTAssertEqual(results.campaigns.count, 2)
     }
 
+    func test_loadCampaignStats_excludes_next_page_parameter_when_not_provided() async throws {
+        // Given
+        let remote = GoogleListingsAndAdsRemote(network: network)
+
+        let suffix = "wc/gla/ads/reports/programs"
+        network.simulateResponse(requestUrlSuffix: suffix, filename: "google-ads-reports-programs-without-data")
+
+        // When
+        _ = try await remote.loadCampaignStats(for: sampleSiteID,
+                                               timeZone: .current,
+                                               earliestDateToInclude: Date(),
+                                               latestDateToInclude: Date(),
+                                               orderby: .sales)
+
+        // Then
+        let excludedParam = "next_page"
+        let queryParameters = try XCTUnwrap(network.queryParameters)
+        XCTAssertFalse(queryParameters.contains(where: { $0.contains(excludedParam) }), "Query parameters contain unexpected param: \(excludedParam)")
+    }
+
+    func test_loadCampaignStats_includes_next_page_parameter_when_provided() async throws {
+        // Given
+        let remote = GoogleListingsAndAdsRemote(network: network)
+
+        let suffix = "wc/gla/ads/reports/programs"
+        network.simulateResponse(requestUrlSuffix: suffix, filename: "google-ads-reports-programs-without-data")
+        let nextPageToken = "abcdefg"
+
+        // When
+        _ = try await remote.loadCampaignStats(for: sampleSiteID,
+                                               timeZone: .current,
+                                               earliestDateToInclude: Date(),
+                                               latestDateToInclude: Date(),
+                                               orderby: .sales,
+                                               nextPageToken: nextPageToken)
+
+        // Then
+        let expectedParam = "next_page=\(nextPageToken)"
+        let queryParameters = try XCTUnwrap(network.queryParameters)
+        XCTAssertTrue(queryParameters.contains(expectedParam), "Query parameters missing expected param: \(expectedParam)")
+    }
+
     func test_loadCampaignStats_properly_relays_networking_errors() async {
         // Given
         let remote = GoogleListingsAndAdsRemote(network: network)

--- a/Networking/NetworkingTests/Responses/google-ads-reports-programs-without-data.json
+++ b/Networking/NetworkingTests/Responses/google-ads-reports-programs-without-data.json
@@ -53,5 +53,6 @@
         "clicks": 154,
         "impressions": 16938,
         "conversions": 3
-    }
+    },
+    "next_page": "abcdefg"
 }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #13163
<!-- Id number of the GitHub issue this PR addresses. -->

## Why
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
The Google Ads campaign report data returned by the API can be paginated. When there is another page of data available, the response includes a `next_page` field with a token to request the next page of data. This PR adds support for decoding that token and including it in a remote request.

## How

* Adds an optional `nextPageToken` property to `GoogleAdsCampaignStatsTotals`. There is also a computed property `hasNextPage` for convenience when checking if we should make another request.
* Updates the remote request method in `GoogleListingsAndAdsRemote` to accept a `nextPageToken` argument and include it in the request parameters.
* Updates mocks and unit tests.

## Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->
This new endpoint isn't yet used in the app. For now, confirm unit tests pass.

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.