### PR TITLE
Google Ads: Update Yosemite to support fetching ads campaigns

### DIFF
--- a/Yosemite/Yosemite/Actions/GoogleAdsAction.swift
+++ b/Yosemite/Yosemite/Actions/GoogleAdsAction.swift
@@ -14,4 +14,14 @@ public enum GoogleAdsAction: Action {
     ///
     case checkConnection(siteID: Int64,
                          onCompletion: (Result<GoogleAdsConnection, Error>) -> Void)
+
+    /// Fetches Google ads campaigns for a given site.
+    ///
+    /// - `siteID`: the site to fetch campaigns for.
+    /// - `onCompletion`: invoked when the fetch request finishes.
+    ///     - `result.success([GoogleAdsCampaign])`: Successfully fetched campaigns.
+    ///     - `result.failure(Error)`: error indicates issues fetching campaigns.
+    ///
+    case fetchAdsCampaigns(siteID: Int64,
+                           onCompletion: (Result<[GoogleAdsCampaign], Error>) -> Void)
 }

--- a/Yosemite/Yosemite/Model/Model.swift
+++ b/Yosemite/Yosemite/Model/Model.swift
@@ -43,6 +43,7 @@ public typealias DotcomDevice = Networking.DotcomDevice
 public typealias DotcomUser = Networking.DotcomUser
 public typealias Feature = Networking.Feature
 public typealias FreeDomainSuggestion = Networking.FreeDomainSuggestion
+public typealias GoogleAdsCampaign = Networking.GoogleAdsCampaign
 public typealias GoogleAdsConnection = Networking.GoogleAdsConnection
 public typealias GiftCardStats = Networking.GiftCardStats
 public typealias GiftCardStatsInterval = Networking.GiftCardStatsInterval

--- a/Yosemite/Yosemite/Stores/GoogleAdsStore.swift
+++ b/Yosemite/Yosemite/Stores/GoogleAdsStore.swift
@@ -55,6 +55,8 @@ public final class GoogleAdsStore: Store {
         switch action {
         case let .checkConnection(siteID, onCompletion):
             checkConnection(siteID: siteID, onCompletion: onCompletion)
+        case let .fetchAdsCampaigns(siteID, onCompletion):
+            fetchAdsCampaign(siteID: siteID, onCompletion: onCompletion)
         }
     }
 }
@@ -66,6 +68,18 @@ private extension GoogleAdsStore {
             do {
                 let connection = try await remote.checkConnection(for: siteID)
                 onCompletion(.success(connection))
+            } catch {
+                onCompletion(.failure(error))
+            }
+        }
+    }
+
+    func fetchAdsCampaign(siteID: Int64,
+                          onCompletion: @escaping (Result<[GoogleAdsCampaign], Error>) -> Void) {
+        Task { @MainActor in
+            do {
+                let campaigns = try await remote.fetchAdsCampaigns(for: siteID)
+                onCompletion(.success(campaigns))
             } catch {
                 onCompletion(.failure(error))
             }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #13182
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This PR updates `GoogleAdsStore` and `GoogleAdsAction` to support fetching ads campaigns.

## Testing
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->
- Just CI passing is sufficent.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->
N/A

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
