### PR TITLE
Google Ads: Add eligibility check for campaign creation

### DIFF
--- a/Experiments/Experiments/DefaultFeatureFlagService.swift
+++ b/Experiments/Experiments/DefaultFeatureFlagService.swift
@@ -90,6 +90,8 @@ public struct DefaultFeatureFlagService: FeatureFlagService {
             return true
         case .productCreationAIv2M1:
             return buildConfig == .localDeveloper || buildConfig == .alpha
+        case .googleAdsCampaignCreationOnWebView:
+            return buildConfig == .localDeveloper || buildConfig == .alpha
         default:
             return true
         }

--- a/Experiments/Experiments/FeatureFlag.swift
+++ b/Experiments/Experiments/FeatureFlag.swift
@@ -199,4 +199,8 @@ public enum FeatureFlag: Int {
     /// Enables M1 updates of product creation AI version 2
     ///
     case productCreationAIv2M1
+
+    /// Enables Google ads campaign creation on web view
+    ///
+    case googleAdsCampaignCreationOnWebView
 }

--- a/WooCommerce/Classes/GoogleAds/GoogleAdsEligibilityChecker.swift
+++ b/WooCommerce/Classes/GoogleAds/GoogleAdsEligibilityChecker.swift
@@ -14,7 +14,8 @@ final class DefaultGoogleAdsEligibilityChecker: GoogleAdsEligibilityChecker {
     private let stores: StoresManager
     private let featureFlagService: FeatureFlagService
 
-    init(stores: StoresManager = ServiceLocator.stores, featureFlagService: FeatureFlagService = ServiceLocator.featureFlagService) {
+    init(stores: StoresManager = ServiceLocator.stores,
+         featureFlagService: FeatureFlagService = ServiceLocator.featureFlagService) {
         self.stores = stores
         self.featureFlagService = featureFlagService
     }

--- a/WooCommerce/Classes/GoogleAds/GoogleAdsEligibilityChecker.swift
+++ b/WooCommerce/Classes/GoogleAds/GoogleAdsEligibilityChecker.swift
@@ -93,6 +93,10 @@ private extension DefaultGoogleAdsEligibilityChecker {
 
     enum Constants {
         static let pluginSlug = "google-listings-and-ads/google-listings-and-ads"
+
+        /// Version 2.7.5 is required to check for campaign creation success on the web.
+        /// Ref: https://github.com/woocommerce/google-listings-and-ads/releases/tag/2.7.5.
+        /// We can remove this limit once we support native experience.
         static let pluginMinimumVersion = "2.7.5"
     }
 }

--- a/WooCommerce/Classes/GoogleAds/GoogleAdsEligibilityChecker.swift
+++ b/WooCommerce/Classes/GoogleAds/GoogleAdsEligibilityChecker.swift
@@ -25,16 +25,8 @@ final class DefaultGoogleAdsEligibilityChecker: GoogleAdsEligibilityChecker {
             return false
         }
 
-        let isPluginSatisfied: Bool = await {
-            if let savedPlugin = await fetchPluginFromStorage(siteID: siteID) {
-                return checkIfGoogleAdsIsSupported(plugin: savedPlugin)
-            } else {
-                let remotePlugin = await fetchPluginFromRemote(siteID: siteID)
-                return checkIfGoogleAdsIsSupported(plugin: remotePlugin)
-            }
-        }()
-
-        guard isPluginSatisfied else {
+        let remotePlugin = await fetchPluginFromRemote(siteID: siteID)
+        guard checkIfGoogleAdsIsSupported(plugin: remotePlugin) else {
             return false
         }
 
@@ -65,8 +57,8 @@ private extension DefaultGoogleAdsEligibilityChecker {
             stores.dispatch(SystemStatusAction.synchronizeSystemInformation(siteID: siteID) { result in
                 switch result {
                 case .success(let info):
-                    let wcPlugin = info.systemPlugins.first(where: { $0.plugin == Constants.pluginSlug })
-                    continuation.resume(returning: wcPlugin)
+                    let plugin = info.systemPlugins.first(where: { $0.plugin == Constants.pluginSlug })
+                    continuation.resume(returning: plugin)
                 case .failure:
                     continuation.resume(returning: nil)
                 }

--- a/WooCommerce/Classes/GoogleAds/GoogleAdsEligibilityChecker.swift
+++ b/WooCommerce/Classes/GoogleAds/GoogleAdsEligibilityChecker.swift
@@ -92,7 +92,7 @@ private extension DefaultGoogleAdsEligibilityChecker {
     }
 
     enum Constants {
-        static let pluginSlug = "google-listings-and-ads/google-listings-and-ads"
+        static let pluginSlug = "google-listings-and-ads/google-listings-and-ads.php"
 
         /// Version 2.7.5 is required to check for campaign creation success on the web.
         /// Ref: https://github.com/woocommerce/google-listings-and-ads/releases/tag/2.7.5.

--- a/WooCommerce/Classes/GoogleAds/GoogleAdsEligibilityChecker.swift
+++ b/WooCommerce/Classes/GoogleAds/GoogleAdsEligibilityChecker.swift
@@ -43,15 +43,6 @@ final class DefaultGoogleAdsEligibilityChecker: GoogleAdsEligibilityChecker {
 
 private extension DefaultGoogleAdsEligibilityChecker {
     @MainActor
-    func fetchPluginFromStorage(siteID: Int64) async -> SystemPlugin? {
-        await withCheckedContinuation { continuation in
-            stores.dispatch(SystemStatusAction.fetchSystemPluginWithPath(siteID: siteID, pluginPath: Constants.pluginSlug) { plugin in
-                continuation.resume(returning: plugin)
-            })
-        }
-    }
-
-    @MainActor
     func fetchPluginFromRemote(siteID: Int64) async -> SystemPlugin? {
         await withCheckedContinuation { continuation in
             stores.dispatch(SystemStatusAction.synchronizeSystemInformation(siteID: siteID) { result in

--- a/WooCommerce/Classes/GoogleAds/GoogleAdsEligibilityChecker.swift
+++ b/WooCommerce/Classes/GoogleAds/GoogleAdsEligibilityChecker.swift
@@ -1,0 +1,78 @@
+import Foundation
+import Experiments
+import Yosemite
+
+/// Interface for checking if a site is eligible for creating Google ads campaigns from the app.
+///
+protocol GoogleAdsEligibilityChecker {
+    @MainActor
+    func isSiteEligible(siteID: Int64) async -> Bool
+}
+
+final class DefaultGoogleAdsEligibilityChecker: GoogleAdsEligibilityChecker {
+
+    private let stores: StoresManager
+    private let featureFlagService: FeatureFlagService
+
+    init(stores: StoresManager = ServiceLocator.stores, featureFlagService: FeatureFlagService = ServiceLocator.featureFlagService) {
+        self.stores = stores
+        self.featureFlagService = featureFlagService
+    }
+
+    func isSiteEligible(siteID: Int64) async -> Bool {
+        guard featureFlagService.isFeatureFlagEnabled(.googleAdsCampaignCreationOnWebView) else {
+            return false
+        }
+
+        let isPluginSatisfied: Bool = await {
+            if let savedPlugin = await fetchPluginFromStorage(siteID: siteID) {
+                return checkIfGoogleAdsIsSupported(plugin: savedPlugin)
+            } else {
+                let remotePlugin = await fetchPluginFromRemote(siteID: siteID)
+                return checkIfGoogleAdsIsSupported(plugin: remotePlugin)
+            }
+        }()
+
+        return isPluginSatisfied
+    }
+
+}
+
+private extension DefaultGoogleAdsEligibilityChecker {
+    @MainActor
+    func fetchPluginFromStorage(siteID: Int64) async -> SystemPlugin? {
+        await withCheckedContinuation { continuation in
+            stores.dispatch(SystemStatusAction.fetchSystemPluginWithPath(siteID: siteID, pluginPath: Constants.pluginSlug) { plugin in
+                continuation.resume(returning: plugin)
+            })
+        }
+    }
+
+    @MainActor
+    func fetchPluginFromRemote(siteID: Int64) async -> SystemPlugin? {
+        await withCheckedContinuation { continuation in
+            stores.dispatch(SystemStatusAction.synchronizeSystemInformation(siteID: siteID) { result in
+                switch result {
+                case .success(let info):
+                    let wcPlugin = info.systemPlugins.first(where: { $0.plugin == Constants.pluginSlug })
+                    continuation.resume(returning: wcPlugin)
+                case .failure:
+                    continuation.resume(returning: nil)
+                }
+            })
+        }
+    }
+
+    func checkIfGoogleAdsIsSupported(plugin: SystemPlugin?) -> Bool {
+        guard let plugin = plugin, plugin.active else {
+            return false
+        }
+        return VersionHelpers.isVersionSupported(version: plugin.version,
+                                                 minimumRequired: Constants.pluginMinimumVersion)
+    }
+
+    enum Constants {
+        static let pluginSlug = "google-listings-and-ads/google-listings-and-ads"
+        static let pluginMinimumVersion = "2.7.5"
+    }
+}

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -2575,6 +2575,7 @@
 		DEACB8852A64F74A00253F0F /* MediaPickingCoordinatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEACB8842A64F74A00253F0F /* MediaPickingCoordinatorTests.swift */; };
 		DEACB8872A65020A00253F0F /* WooAnalyticsEvent+AddProductFromImage.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEACB8862A65020A00253F0F /* WooAnalyticsEvent+AddProductFromImage.swift */; };
 		DEB387952C2E7A7C0025256E /* GoogleAdsEligibilityChecker.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEB387942C2E7A7C0025256E /* GoogleAdsEligibilityChecker.swift */; };
+		DEB387982C2E803A0025256E /* DefaultGoogleAdsEligibilityCheckTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEB387972C2E803A0025256E /* DefaultGoogleAdsEligibilityCheckTests.swift */; };
 		DEBAB70B2A7A3FE000743185 /* StorePlanBannerPresenterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEBAB70A2A7A3FE000743185 /* StorePlanBannerPresenterTests.swift */; };
 		DEBAB70D2A7A6F1100743185 /* MockStorePlanSynchronizer.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEBAB70C2A7A6F1100743185 /* MockStorePlanSynchronizer.swift */; };
 		DEBAB70F2A7A6F3800743185 /* MockConnectivityObserver.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEBAB70E2A7A6F3800743185 /* MockConnectivityObserver.swift */; };
@@ -5537,6 +5538,7 @@
 		DEACB8842A64F74A00253F0F /* MediaPickingCoordinatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MediaPickingCoordinatorTests.swift; sourceTree = "<group>"; };
 		DEACB8862A65020A00253F0F /* WooAnalyticsEvent+AddProductFromImage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "WooAnalyticsEvent+AddProductFromImage.swift"; sourceTree = "<group>"; };
 		DEB387942C2E7A7C0025256E /* GoogleAdsEligibilityChecker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GoogleAdsEligibilityChecker.swift; sourceTree = "<group>"; };
+		DEB387972C2E803A0025256E /* DefaultGoogleAdsEligibilityCheckTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefaultGoogleAdsEligibilityCheckTests.swift; sourceTree = "<group>"; };
 		DEBAB70A2A7A3FE000743185 /* StorePlanBannerPresenterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StorePlanBannerPresenterTests.swift; sourceTree = "<group>"; };
 		DEBAB70C2A7A6F1100743185 /* MockStorePlanSynchronizer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockStorePlanSynchronizer.swift; sourceTree = "<group>"; };
 		DEBAB70E2A7A6F3800743185 /* MockConnectivityObserver.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockConnectivityObserver.swift; sourceTree = "<group>"; };
@@ -9940,6 +9942,7 @@
 		B56DB3E02049BFAA00D4AA8E /* WooCommerceTests */ = {
 			isa = PBXGroup;
 			children = (
+				DEB387962C2E80060025256E /* GoogleAds */,
 				DABF35242C11B40C006AF826 /* POS */,
 				B958A7CF28B527FB00823EEF /* Universal Links */,
 				D8F01DD125DEDC0100CE70BE /* Stripe Integration Tests */,
@@ -12520,6 +12523,14 @@
 			isa = PBXGroup;
 			children = (
 				DEB387942C2E7A7C0025256E /* GoogleAdsEligibilityChecker.swift */,
+			);
+			path = GoogleAds;
+			sourceTree = "<group>";
+		};
+		DEB387962C2E80060025256E /* GoogleAds */ = {
+			isa = PBXGroup;
+			children = (
+				DEB387972C2E803A0025256E /* DefaultGoogleAdsEligibilityCheckTests.swift */,
 			);
 			path = GoogleAds;
 			sourceTree = "<group>";
@@ -16410,6 +16421,7 @@
 				029700EF24FE38F000D242F8 /* ScrollWatcherTests.swift in Sources */,
 				0236BCA425087B660043EB43 /* ProductFormRemoteActionUseCaseTests.swift in Sources */,
 				CC13C0CD278E086D00C0B5B5 /* ProductVariationSelectorViewModelTests.swift in Sources */,
+				DEB387982C2E803A0025256E /* DefaultGoogleAdsEligibilityCheckTests.swift in Sources */,
 				0371C36A2876DBCA00277E2C /* FeatureAnnouncementCardViewModelTests.swift in Sources */,
 				DE26B5292775C76C00A2EA0A /* MockSyncingCoordinator.swift in Sources */,
 				0968B80C27CFB2EF0021210A /* BulkUpdateOptionsModelTests.swift in Sources */,

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -2574,6 +2574,7 @@
 		DEA88F522AAAC1180037273B /* AddEditProductCategoryViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEA88F512AAAC1180037273B /* AddEditProductCategoryViewModelTests.swift */; };
 		DEACB8852A64F74A00253F0F /* MediaPickingCoordinatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEACB8842A64F74A00253F0F /* MediaPickingCoordinatorTests.swift */; };
 		DEACB8872A65020A00253F0F /* WooAnalyticsEvent+AddProductFromImage.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEACB8862A65020A00253F0F /* WooAnalyticsEvent+AddProductFromImage.swift */; };
+		DEB387952C2E7A7C0025256E /* GoogleAdsEligibilityChecker.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEB387942C2E7A7C0025256E /* GoogleAdsEligibilityChecker.swift */; };
 		DEBAB70B2A7A3FE000743185 /* StorePlanBannerPresenterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEBAB70A2A7A3FE000743185 /* StorePlanBannerPresenterTests.swift */; };
 		DEBAB70D2A7A6F1100743185 /* MockStorePlanSynchronizer.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEBAB70C2A7A6F1100743185 /* MockStorePlanSynchronizer.swift */; };
 		DEBAB70F2A7A6F3800743185 /* MockConnectivityObserver.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEBAB70E2A7A6F3800743185 /* MockConnectivityObserver.swift */; };
@@ -5535,6 +5536,7 @@
 		DEA88F512AAAC1180037273B /* AddEditProductCategoryViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddEditProductCategoryViewModelTests.swift; sourceTree = "<group>"; };
 		DEACB8842A64F74A00253F0F /* MediaPickingCoordinatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MediaPickingCoordinatorTests.swift; sourceTree = "<group>"; };
 		DEACB8862A65020A00253F0F /* WooAnalyticsEvent+AddProductFromImage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "WooAnalyticsEvent+AddProductFromImage.swift"; sourceTree = "<group>"; };
+		DEB387942C2E7A7C0025256E /* GoogleAdsEligibilityChecker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GoogleAdsEligibilityChecker.swift; sourceTree = "<group>"; };
 		DEBAB70A2A7A3FE000743185 /* StorePlanBannerPresenterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StorePlanBannerPresenterTests.swift; sourceTree = "<group>"; };
 		DEBAB70C2A7A6F1100743185 /* MockStorePlanSynchronizer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockStorePlanSynchronizer.swift; sourceTree = "<group>"; };
 		DEBAB70E2A7A6F3800743185 /* MockConnectivityObserver.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockConnectivityObserver.swift; sourceTree = "<group>"; };
@@ -10014,6 +10016,7 @@
 		B56DB3F12049C0B800D4AA8E /* Classes */ = {
 			isa = PBXGroup;
 			children = (
+				DEB387932C2E7A540025256E /* GoogleAds */,
 				20AE33C32B0510AD00527B60 /* Destinations */,
 				02D7E7BF2A4CA8E50003049A /* LocalAnnouncements */,
 				B9F3DAAB29BB714900DDD545 /* App Intents */,
@@ -12513,6 +12516,14 @@
 			path = StoreStats;
 			sourceTree = "<group>";
 		};
+		DEB387932C2E7A540025256E /* GoogleAds */ = {
+			isa = PBXGroup;
+			children = (
+				DEB387942C2E7A7C0025256E /* GoogleAdsEligibilityChecker.swift */,
+			);
+			path = GoogleAds;
+			sourceTree = "<group>";
+		};
 		DEC0293829C419F500FD0E2F /* Application Password */ = {
 			isa = PBXGroup;
 			children = (
@@ -14431,6 +14442,7 @@
 				025B3C9A2C0EE5BA0013F036 /* WCSettingsWebView.swift in Sources */,
 				DE86E9292A4C213A00A89A5B /* WooAnalyticsEvent+AIFeedback.swift in Sources */,
 				026826932BF59D830036F959 /* PointOfSaleDashboardViewModel.swift in Sources */,
+				DEB387952C2E7A7C0025256E /* GoogleAdsEligibilityChecker.swift in Sources */,
 				026CF63A237E9ABE009563D4 /* ProductVariationsViewController.swift in Sources */,
 				45D685FE23D0FB25005F87D0 /* Throttler.swift in Sources */,
 				203163AB2C1B5DEE001C96DA /* PointOfSaleCardPresentPaymentBluetoothRequiredAlertView.swift in Sources */,

--- a/WooCommerce/WooCommerceTests/GoogleAds/DefaultGoogleAdsEligibilityCheckTests.swift
+++ b/WooCommerce/WooCommerceTests/GoogleAds/DefaultGoogleAdsEligibilityCheckTests.swift
@@ -1,0 +1,44 @@
+import XCTest
+import Yosemite
+@testable import WooCommerce
+
+final class DefaultGoogleAdsEligibilityCheckerTests: XCTestCase {
+
+    @MainActor
+    func test_isSiteEligible_returns_false_if_feature_flag_is_disabled() async {
+        // Given
+        let featureFlagService = MockFeatureFlagService(googleAdsCampaignCreationOnWebView: false)
+        let checker = DefaultGoogleAdsEligibilityChecker(featureFlagService: featureFlagService)
+
+        // When
+        let result = await checker.isSiteEligible(siteID: 123)
+
+        // Then
+        XCTAssertFalse(result)
+    }
+
+    @MainActor
+    func test_isSiteEligible_returns_false_if_plugin_is_not_installed() async {
+        // Given
+        let featureFlagService = MockFeatureFlagService(googleAdsCampaignCreationOnWebView: false)
+        let stores = MockStoresManager(sessionManager: .makeForTesting())
+        let checker = DefaultGoogleAdsEligibilityChecker(featureFlagService: featureFlagService)
+
+        // When
+        stores.whenReceivingAction(ofType: SystemStatusAction.self) { action in
+            switch action {
+            case let .synchronizeSystemInformation(_, onCompletion):
+                let systemInfo = SystemInformation.fake().copy(systemPlugins: [])
+                onCompletion(.success(systemInfo))
+            case let .fetchSystemPluginWithPath(_, _, onCompletion):
+                onCompletion(nil)
+            default:
+                break
+            }
+        }
+        let result = await checker.isSiteEligible(siteID: 123)
+
+        // Then
+        XCTAssertFalse(result)
+    }
+}

--- a/WooCommerce/WooCommerceTests/GoogleAds/DefaultGoogleAdsEligibilityCheckTests.swift
+++ b/WooCommerce/WooCommerceTests/GoogleAds/DefaultGoogleAdsEligibilityCheckTests.swift
@@ -4,7 +4,7 @@ import Yosemite
 
 final class DefaultGoogleAdsEligibilityCheckerTests: XCTestCase {
     private let sampleSite: Int64 = 325
-    private let pluginSlug = "google-listings-and-ads/google-listings-and-ads"
+    private let pluginSlug = "google-listings-and-ads/google-listings-and-ads.php"
 
     private var stores: MockStoresManager!
 
@@ -36,7 +36,7 @@ final class DefaultGoogleAdsEligibilityCheckerTests: XCTestCase {
         // Given
         let featureFlagService = MockFeatureFlagService(googleAdsCampaignCreationOnWebView: true)
         let checker = DefaultGoogleAdsEligibilityChecker(stores: stores, featureFlagService: featureFlagService)
-        mockRequests(syncedPlugins: [], fetchedPluginWithPath: nil)
+        mockRequests(syncedPlugins: [])
 
         // When
         let result = await checker.isSiteEligible(siteID: sampleSite)
@@ -71,7 +71,7 @@ final class DefaultGoogleAdsEligibilityCheckerTests: XCTestCase {
                                               plugin: pluginSlug,
                                               version: "2.7.4",
                                               active: true)
-        mockRequests(fetchedPluginWithPath: plugin)
+        mockRequests(syncedPlugins: [plugin])
 
         // When
         let result = await checker.isSiteEligible(siteID: sampleSite)
@@ -90,7 +90,7 @@ final class DefaultGoogleAdsEligibilityCheckerTests: XCTestCase {
                                               version: "2.7.5",
                                               active: true)
         let connection = GoogleAdsConnection.fake().copy(rawStatus: "incomplete")
-        mockRequests(fetchedPluginWithPath: plugin, adsConnection: connection)
+        mockRequests(syncedPlugins: [plugin], adsConnection: connection)
 
         // When
         let result = await checker.isSiteEligible(siteID: sampleSite)
@@ -109,7 +109,7 @@ final class DefaultGoogleAdsEligibilityCheckerTests: XCTestCase {
                                               version: "2.7.5",
                                               active: true)
         let connection = GoogleAdsConnection.fake().copy(rawStatus: "connected")
-        mockRequests(fetchedPluginWithPath: plugin, adsConnection: connection)
+        mockRequests(syncedPlugins: [plugin], adsConnection: connection)
 
         // When
         let result = await checker.isSiteEligible(siteID: sampleSite)
@@ -122,15 +122,12 @@ final class DefaultGoogleAdsEligibilityCheckerTests: XCTestCase {
 // MARK: - Helpers
 private extension DefaultGoogleAdsEligibilityCheckerTests {
     func mockRequests(syncedPlugins: [SystemPlugin] = [],
-                      fetchedPluginWithPath: SystemPlugin? = nil,
                       adsConnection: GoogleAdsConnection? = nil) {
         stores.whenReceivingAction(ofType: SystemStatusAction.self) { action in
             switch action {
             case let .synchronizeSystemInformation(_, onCompletion):
                 let systemInfo = SystemInformation.fake().copy(systemPlugins: syncedPlugins)
                 onCompletion(.success(systemInfo))
-            case let .fetchSystemPluginWithPath(_, _, onCompletion):
-                onCompletion(fetchedPluginWithPath)
             default:
                 break
             }

--- a/WooCommerce/WooCommerceTests/GoogleAds/DefaultGoogleAdsEligibilityCheckTests.swift
+++ b/WooCommerce/WooCommerceTests/GoogleAds/DefaultGoogleAdsEligibilityCheckTests.swift
@@ -3,6 +3,20 @@ import Yosemite
 @testable import WooCommerce
 
 final class DefaultGoogleAdsEligibilityCheckerTests: XCTestCase {
+    private let sampleSite: Int64 = 325
+    private let pluginSlug = "google-listings-and-ads/google-listings-and-ads"
+
+    private var stores: MockStoresManager!
+
+    override func setUp() {
+        stores = MockStoresManager(sessionManager: .makeForTesting())
+        super.setUp()
+    }
+
+    override func tearDown() {
+        stores = nil
+        super.tearDown()
+    }
 
     @MainActor
     func test_isSiteEligible_returns_false_if_feature_flag_is_disabled() async {
@@ -11,7 +25,7 @@ final class DefaultGoogleAdsEligibilityCheckerTests: XCTestCase {
         let checker = DefaultGoogleAdsEligibilityChecker(featureFlagService: featureFlagService)
 
         // When
-        let result = await checker.isSiteEligible(siteID: 123)
+        let result = await checker.isSiteEligible(siteID: sampleSite)
 
         // Then
         XCTAssertFalse(result)
@@ -20,25 +34,118 @@ final class DefaultGoogleAdsEligibilityCheckerTests: XCTestCase {
     @MainActor
     func test_isSiteEligible_returns_false_if_plugin_is_not_installed() async {
         // Given
-        let featureFlagService = MockFeatureFlagService(googleAdsCampaignCreationOnWebView: false)
-        let stores = MockStoresManager(sessionManager: .makeForTesting())
-        let checker = DefaultGoogleAdsEligibilityChecker(featureFlagService: featureFlagService)
+        let featureFlagService = MockFeatureFlagService(googleAdsCampaignCreationOnWebView: true)
+        let checker = DefaultGoogleAdsEligibilityChecker(stores: stores, featureFlagService: featureFlagService)
+        mockRequests(syncedPlugins: [], fetchedPluginWithPath: nil)
 
         // When
+        let result = await checker.isSiteEligible(siteID: sampleSite)
+
+        // Then
+        XCTAssertFalse(result)
+    }
+
+    @MainActor
+    func test_isSiteEligible_returns_false_if_plugin_is_not_active() async {
+        // Given
+        let featureFlagService = MockFeatureFlagService(googleAdsCampaignCreationOnWebView: true)
+        let checker = DefaultGoogleAdsEligibilityChecker(stores: stores, featureFlagService: featureFlagService)
+        let plugin = SystemPlugin.fake().copy(siteID: sampleSite,
+                                              plugin: pluginSlug,
+                                              active: false)
+        mockRequests(syncedPlugins: [plugin])
+
+        // When
+        let result = await checker.isSiteEligible(siteID: sampleSite)
+
+        // Then
+        XCTAssertFalse(result)
+    }
+
+    @MainActor
+    func test_isSiteEligible_returns_false_if_plugin_is_active_but_has_older_version() async {
+        // Given
+        let featureFlagService = MockFeatureFlagService(googleAdsCampaignCreationOnWebView: true)
+        let checker = DefaultGoogleAdsEligibilityChecker(stores: stores, featureFlagService: featureFlagService)
+        let plugin = SystemPlugin.fake().copy(siteID: sampleSite,
+                                              plugin: pluginSlug,
+                                              version: "2.7.4",
+                                              active: true)
+        mockRequests(fetchedPluginWithPath: plugin)
+
+        // When
+        let result = await checker.isSiteEligible(siteID: sampleSite)
+
+        // Then
+        XCTAssertFalse(result)
+    }
+
+    @MainActor
+    func test_isSiteEligible_returns_false_if_plugin_is_satisfied_but_connection_is_not() async {
+        // Given
+        let featureFlagService = MockFeatureFlagService(googleAdsCampaignCreationOnWebView: true)
+        let checker = DefaultGoogleAdsEligibilityChecker(stores: stores, featureFlagService: featureFlagService)
+        let plugin = SystemPlugin.fake().copy(siteID: sampleSite,
+                                              plugin: pluginSlug,
+                                              version: "2.7.5",
+                                              active: true)
+        let connection = GoogleAdsConnection.fake().copy(rawStatus: "incomplete")
+        mockRequests(fetchedPluginWithPath: plugin, adsConnection: connection)
+
+        // When
+        let result = await checker.isSiteEligible(siteID: sampleSite)
+
+        // Then
+        XCTAssertFalse(result)
+    }
+
+    @MainActor
+    func test_isSiteEligible_returns_true_if_plugin_is_satisfied_and_ads_account_is_connected() async {
+        // Given
+        let featureFlagService = MockFeatureFlagService(googleAdsCampaignCreationOnWebView: true)
+        let checker = DefaultGoogleAdsEligibilityChecker(stores: stores, featureFlagService: featureFlagService)
+        let plugin = SystemPlugin.fake().copy(siteID: sampleSite,
+                                              plugin: pluginSlug,
+                                              version: "2.7.5",
+                                              active: true)
+        let connection = GoogleAdsConnection.fake().copy(rawStatus: "connected")
+        mockRequests(fetchedPluginWithPath: plugin, adsConnection: connection)
+
+        // When
+        let result = await checker.isSiteEligible(siteID: sampleSite)
+
+        // Then
+        XCTAssertTrue(result)
+    }
+}
+
+// MARK: - Helpers
+private extension DefaultGoogleAdsEligibilityCheckerTests {
+    func mockRequests(syncedPlugins: [SystemPlugin] = [],
+                      fetchedPluginWithPath: SystemPlugin? = nil,
+                      adsConnection: GoogleAdsConnection? = nil) {
         stores.whenReceivingAction(ofType: SystemStatusAction.self) { action in
             switch action {
             case let .synchronizeSystemInformation(_, onCompletion):
-                let systemInfo = SystemInformation.fake().copy(systemPlugins: [])
+                let systemInfo = SystemInformation.fake().copy(systemPlugins: syncedPlugins)
                 onCompletion(.success(systemInfo))
             case let .fetchSystemPluginWithPath(_, _, onCompletion):
-                onCompletion(nil)
+                onCompletion(fetchedPluginWithPath)
             default:
                 break
             }
         }
-        let result = await checker.isSiteEligible(siteID: 123)
-
-        // Then
-        XCTAssertFalse(result)
+        stores.whenReceivingAction(ofType: GoogleAdsAction.self) { action in
+            switch action {
+            case let .checkConnection(_, onCompletion):
+                if let adsConnection {
+                    onCompletion(.success(adsConnection))
+                } else {
+                    onCompletion(.failure(NSError(domain: "Test", code: 404)))
+                }
+            default:
+                break
+            }
+        }
     }
 }

--- a/WooCommerce/WooCommerceTests/Mocks/MockFeatureFlagService.swift
+++ b/WooCommerce/WooCommerceTests/Mocks/MockFeatureFlagService.swift
@@ -24,6 +24,7 @@ struct MockFeatureFlagService: FeatureFlagService {
     private let isDisplayPointOfSaleToggleEnabled: Bool
     private let isDynamicDashboardM2Enabled: Bool
     private let isProductCreationAIv2M1Enabled: Bool
+    private let googleAdsCampaignCreationOnWebView: Bool
 
     init(isInboxOn: Bool = false,
          isUpdateOrderOptimisticallyOn: Bool = false,
@@ -46,7 +47,8 @@ struct MockFeatureFlagService: FeatureFlagService {
          isSubscriptionsInOrderCreationCustomersEnabled: Bool = false,
          isDisplayPointOfSaleToggleEnabled: Bool = false,
          isDynamicDashboardM2Enabled: Bool = false,
-         isProductCreationAIv2M1Enabled: Bool = false) {
+         isProductCreationAIv2M1Enabled: Bool = false,
+         googleAdsCampaignCreationOnWebView: Bool = false) {
         self.isInboxOn = isInboxOn
         self.isUpdateOrderOptimisticallyOn = isUpdateOrderOptimisticallyOn
         self.shippingLabelsOnboardingM1 = shippingLabelsOnboardingM1
@@ -69,6 +71,7 @@ struct MockFeatureFlagService: FeatureFlagService {
         self.isDisplayPointOfSaleToggleEnabled = isDisplayPointOfSaleToggleEnabled
         self.isDynamicDashboardM2Enabled = isDynamicDashboardM2Enabled
         self.isProductCreationAIv2M1Enabled = isProductCreationAIv2M1Enabled
+        self.googleAdsCampaignCreationOnWebView = googleAdsCampaignCreationOnWebView
     }
 
     func isFeatureFlagEnabled(_ featureFlag: FeatureFlag) -> Bool {
@@ -115,6 +118,8 @@ struct MockFeatureFlagService: FeatureFlagService {
             return isDynamicDashboardM2Enabled
         case .productCreationAIv2M1:
             return isProductCreationAIv2M1Enabled
+        case .googleAdsCampaignCreationOnWebView:
+            return googleAdsCampaignCreationOnWebView
         default:
             return false
         }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #13190
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This PR adds an eligibility checker to decide whether to display the entry point to Google ads campaign creation on the app. The logic includes:
- Check the new feature flag `googleAdsCampaignCreationOnWebView` to ensure that it's enabled.
- Check the cached system plugin for GLA plugin. If not, fetch from remote the plugin by GLA's slug.
- If found, the plugin should be active and has version 2.7.5 or above.
- If the plugin is satisfied, check to ensure that Google ads account is connected for the plugin.

## Testing steps
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->
The eligibility check has not been used anywhere, so just unit tests passing is sufficient.


## Screenshots
<!-- Include before and after images or gifs when appropriate. -->
N/A

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
