### PR TITLE
Update Localization guidelines according to the latest reverse-DNS keys requirements

### DIFF
--- a/docs/localization.md
+++ b/docs/localization.md
@@ -4,19 +4,42 @@ During development, using [`NSLocalizedString()`](https://developer.apple.com/do
 
 During the release process, `NSLocalizedString` statements are scanned and stored in the `Localizable.strings` file. The file is then uploaded to [GlotPress](https://translate.wordpress.com/projects/woocommerce/woocommerce-ios/) for translation. Before the release build is finalized, all the translations are grabbed from GlotPress and saved back to the `Localizable.strings` files.
 
+## Use Unique Reverse-DNS Naming Style Keys
+
+Use a unique reverse-DNS naming style for keys of localized strings (instead of using the English copy as key). This allows to avoid issues where the same word in English could need different translations based on context, or very long keys causing issues with some translation services.
+
+```swift
+// Do
+let postBtnTitle = NSLocalizedString("editor.post.buttonTitle", value: "Post", comment: "Verb. Action to publish a post")
+let postType = NSLocalizedString("reader.post.title", value: "Post", comment: "Noun. Describes when an entry is a blog post (and not story or page)"
+```
+
+```swift
+// Don't
+let postBtnTitle = NSLocalizedString("Post", comment: "Verb. Action to publish a post")
+let postType = NSLocalizedString("Post", comment: "Noun. Describes when an entry is a blog post (and not story or page)"
+```
+
 ## Always Add Comments
 
 Always add a meaningful comment. If possible, describe where and how the string will be used. If there are placeholders, describe what each placeholder is. 
 
 ```swift
 // Do
-let title = NSLocalizedString("Following %1$@",
-                              comment: "Title for a notice informing the user that they've successfully followed a site. %1$@ is a placeholder for the name of the site.")
+let title = String(format: NSLocalizedString(
+    "reader.post.follow.successTitle",
+    value: "Following %1$@",
+    comment: "Notice title when following a site succeeds. %1$@ is a placeholder for the site name."
+), siteName)
 ```
 
 ```swift
-// Avoid
-let title = NSLocalizedString("Following %@", comment: "")
+// Don't
+let title = String(format: NSLocalizedString(
+    "reader.post.follow.successTitle",
+    value: "Following %1$@",
+    comment: ""
+), siteName)
 ```
 
 Comments help give more context to translators.
@@ -28,35 +51,43 @@ Always include the positional index of parameters, even if you only have one pla
 ```swift
 // Do
 let title = NSLocalizedString(
-    "%1$@ left a review on %2$@",
+    "notifications.review.description",
+    value: "%1$@ left a review on %2$@",
     comment: "Title for a product review in Notifications." +
         " The %1$@ is a placeholder for the author's name." +
-        " The %2$@ is a placeholder for the product name.")
+        " The %2$@ is a placeholder for the product name."
+)
 ```
 
 ```swift
 // Don't
 let title = NSLocalizedString(
-    "%@ left a review on %@",
+    "notifications.review.description",
+    value: "%@ left a review on %@",
     comment: "Title for a product review in Notifications." +
         " The first placeholder is the author's name." +
-        " The second placeholder is the product name.")
+        " The second placeholder is the product name."
+)
 ```
 
 ## Do Not Use Variables
 
-Do not use variables as the argument of `NSLocalizedString()`. The string value will not be automatically picked up. 
+Do not use variables as the argument of `NSLocalizedString()` (neither for the key, the value or the comment). The string key, value and comment will not be automatically picked up by the `genstrings` tool which expects string literals.
 
 ```swift
 // Do
-let myText = NSLocalizedString("This is the text I want to translate.", comment: "Put a meaningful comment here.")
+let myText = NSLocalizedString("some.place.title", value: "This is the text I want to translate.", comment: "Put a meaningful comment here.")
 myTextLabel?.text = myText
 ```
 
 ```swift
 // Don't
 let myText = "This is the text I want to translate."
-myTextLabel?.text = NSLocalizedString(myText, comment: "Put a meaningful comment here.")
+myTextLabel?.text = NSLocalizedString("some.place.title", value: myText, comment: "Put a meaningful comment here.")
+let myKey = "some.place.title"
+myTextLabel?.text = NSLocalizedString(myKey, value: "This is the text I want to translate.", comment: "Put a meaningful comment here.")
+let comment = "Put a meaningful comment here."
+myTextLabel?.text = NSLocalizedString("some.place.title", value: "This is the text I want to translate.", comment: comment)
 ```
 
 ## Do Not Use Interpolated Strings
@@ -68,14 +99,14 @@ Use [`String.localizedStringWithFormat`](https://developer.apple.com/documentati
 ```swift
 // Do
 let year = 2019
-let template = NSLocalizedString("© %1$d Acme, Inc.", comment: "Copyright Notice")
+let template = NSLocalizedString("mysite.copyrightNotice.title", value: "© %1$d Acme, Inc.", comment: "Copyright Notice")
 let str = String.localizeStringWithFormat(template, year)
 ```
 
 ```swift
 // Don't
 let year = 2019
-let str = NSLocalizedString("© \(year) Acme, Inc.", comment: "Copyright Notice")
+let str = NSLocalizedString("mysite.copyrightNotice.title", value: "© \(year) Acme, Inc.", comment: "Copyright Notice")
 ```
 
 ## Multiline Strings
@@ -85,7 +116,8 @@ For readability, you can split the string and concatenate the parts using the pl
 ```swift
 // Okay
 NSLocalizedString(
-    "Take some long text here " +
+    "some.place.concatenatedDescription",
+    value: "Take some long text here " +
     "and then concatenate it using the '+' symbol."
     comment: "You can even use this form of concatenation " +
         "for extra-long comments that take the time to explain " +
@@ -98,7 +130,8 @@ Do not use extended delimiters (e.g. triple quotes). They are not automatically 
 ```swift
 // Don't
 NSLocalizedString(
-    """Triple-quoted text, when used in NSLocalizedString, is Not OK. Our scripts break when you use this."""
+    "some.place.tripleQuotedDescription",
+    value: """Triple-quoted text, when used in NSLocalizedString, is Not OK. Our scripts break when you use this."""
     comment: """Triple-quoted text, when used in NSLocalizedString, is Not OK."""
 )
 ```
@@ -109,8 +142,8 @@ GlotPress currently does not support pluralization using the [`.stringsdict` fil
 
 ```swift
 struct PostCountLabels {
-    static let singular = NSLocalizedString("%1$d Post", comment: "Number of posts displayed in Posting Activity when a day is selected. %1$d will contain the actual number (singular).")
-    static let plural = NSLocalizedString("%1$d Posts", comment: "Number of posts displayed in Posting Activity when a day is selected. %1$d will contain the actual number (plural).")
+    static let singular = NSLocalizedString("activity.post.title", value: "%1$d Post", comment: "Number of posts displayed in Posting Activity when a day is selected. %1$d will contain the actual number (singular).")
+    static let plural = NSLocalizedString("activity.postList.title", value: "%1$d Posts", comment: "Number of posts displayed in Posting Activity when a day is selected. %1$d will contain the actual number (plural).")
 }
 
 let postCountText = (count == 1 ? PostCountLabels.singular : PostCountLabels.plural)


### PR DESCRIPTION
## Description

iOS localized strings should use reverse-DNS keys. More context: p91TBi-aJl-p2. There are already places in the app that use reverse-DNS keys:

https://github.com/woocommerce/woocommerce-ios/blob/437cb762a2b44c9dbdb97e292b4c4e38db59f44a/WooCommerce/Classes/Blaze/BlazeCampaignCreationCoordinator.swift#L345

However, the documentation is outdated and doesn't mention this requirement.

## Solution

Update the documentation, using [WordPress iOS localization.md](https://github.com/wordpress-mobile/WordPress-iOS/blob/trunk/docs/localization.md) as an example.