### PR TITLE
[Tooling] Allow `finalize_release` lane to be retried on CI

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -537,6 +537,7 @@ platform :ios do
       error_message = <<-MESSAGE
         Error removing branch protection or finalization of milestone `#{version}`: #{e.message}
         - If this is a retry of the lane, the milestone might have already been closed and this error is expected.
+          Just ensure the branch protection for `release/#{version}` is no more and that the milestone `#{version}` is indeed closed.
         - If this is the first run of the lane, please investigate the error.
       MESSAGE
 

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -533,7 +533,7 @@ platform :ios do
         repository: GITHUB_REPO,
         milestone: version
       )
-    rescue
+    rescue StandardError => e
       error_message = <<-MESSAGE
         Error removing branch protection or finalization of milestone `#{version}`: #{e.message}
         - If this is a retry of the lane, the milestone might have already been closed and this error is expected.

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -519,25 +519,30 @@ platform :ios do
 
     # Wrap up
     version = release_version_current
-    remove_branch_protection(
-      repository: GITHUB_REPO,
-      branch: "release/#{version}"
-    )
-    set_milestone_frozen_marker(
-      repository: GITHUB_REPO,
-      milestone: version,
-      freeze: false
-    )
-    create_new_milestone(
-      repository: GITHUB_REPO,
-      need_appstore_submission: true,
-      milestone_duration: 7,
-      number_of_days_from_code_freeze_to_release: 10
-    )
-    close_milestone(
-      repository: GITHUB_REPO,
-      milestone: version
-    )
+    begin
+      remove_branch_protection(
+        repository: GITHUB_REPO,
+        branch: "release/#{version}"
+      )
+      set_milestone_frozen_marker(
+        repository: GITHUB_REPO,
+        milestone: version,
+        freeze: false
+      )
+      close_milestone(
+        repository: GITHUB_REPO,
+        milestone: version
+      )
+    rescue
+      error_message = <<-MESSAGE
+        Error removing branch protection or finalization of milestone `#{version}`: #{e.message}
+        - If this is a retry of the lane, the milestone might have already been closed and this error is expected.
+        - If this is the first run of the lane, please investigate the error.
+      MESSAGE
+
+      UI.error(error_message)
+      buildkite_annotate(style: 'warning', context: 'finalize-release-error-milestone', message: error_message) if is_ci
+    end
 
     # Start the build
     UI.important('Pushing changes to remote and triggering the release build')


### PR DESCRIPTION
This allows the `finalize_release` lane to be retried (e.g. from MC's ReleaseV2) even if a previous run already removed the branch protection and/or closed the milestone.

_There are a lot of other refinements we could do on those lanes (replacing `|options|` with keywords, adding YARD doc, …) but I want to unblock today's release finalization ASAP so we can take care of those other refinements later._