### PR TITLE
[GLA Analytics] Refactor analytics UI helpers in preparation for Google Campaigns card

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/AnalyticsHubView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/AnalyticsHubView.swift
@@ -126,11 +126,11 @@ private extension AnalyticsHubView {
         case .orders:
             AnalyticsReportCard(viewModel: viewModel.ordersCard)
         case .products:
-            AnalyticsItemsSoldCard(statsViewModel: viewModel.productsStatsCard, itemsViewModel: viewModel.itemsSoldCard)
+            AnalyticsTopPerformersCard(statsViewModel: viewModel.productsStatsCard, itemsViewModel: viewModel.itemsSoldCard)
         case .sessions:
             AnalyticsSessionsReportCard(viewModel: viewModel.sessionsCard)
         case .bundles:
-            AnalyticsItemsSoldCard(bundlesViewModel: viewModel.bundlesCard)
+            AnalyticsTopPerformersCard(bundlesViewModel: viewModel.bundlesCard)
         case .giftCards:
             AnalyticsReportCard(viewModel: viewModel.giftCardsCard)
         }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/Report Cards/AnalyticsTopPerformersCard.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/Report Cards/AnalyticsTopPerformersCard.swift
@@ -1,20 +1,20 @@
 import SwiftUI
 
-/// Card to display items sold on the Analytics Hub
+/// Card to display a stat and a list of top performers for that stat on the Analytics Hub
 ///
-struct AnalyticsItemsSoldCard: View {
+struct AnalyticsTopPerformersCard: View {
 
-    /// Title for the items sold card.
+    /// Title for the top performers card.
     ///
     let title: String
 
-    /// Title for the items sold metric.
+    /// Title for the top performers stat.
     ///
-    let itemsSoldTitle: String
+    let statTitle: String
 
-    /// Items sold quantity. Needs to be formatted.
+    /// Value for the top performers stat. Needs to be formatted.
     ///
-    let itemsSold: String
+    let statValue: String
 
     /// Delta Tag Value. Needs to be formatted
     let delta: String
@@ -37,21 +37,21 @@ struct AnalyticsItemsSoldCard: View {
     ///
     let statsErrorMessage: String
 
-    /// Items Solds data to render.
+    /// Top performers data to render.
     ///
-    let itemsSoldData: [TopPerformersRow.Data]
+    let topPerformersData: [TopPerformersRow.Data]
 
     /// Indicates if the values should be hidden (for loading state)
     ///
-    let isItemsSoldRedacted: Bool
+    let isTopPerformersRedacted: Bool
 
-    /// Indicates if there was an error loading items sold part of the card.
+    /// Indicates if there was an error loading top performers part of the card.
     ///
-    let showItemsSoldError: Bool
+    let showTopPerformersError: Bool
 
-    /// Error message to display if there was an error loading items sold part of the card.
+    /// Error message to display if there was an error loading top performers part of the card.
     ///
-    let itemsSoldErrorMessage: String
+    let topPerformersErrorMessage: String
 
     /// URL for the products analytics web report
     ///
@@ -65,13 +65,13 @@ struct AnalyticsItemsSoldCard: View {
                 .foregroundColor(Color(.text))
                 .footnoteStyle()
 
-            Text(itemsSoldTitle)
+            Text(statTitle)
                 .headlineStyle()
                 .padding(.top, Layout.titleSpacing)
                 .padding(.bottom, Layout.columnSpacing)
 
             HStack {
-                Text(itemsSold)
+                Text(statValue)
                     .titleStyle()
                     .frame(maxWidth: .infinity, alignment: .leading)
                     .redacted(reason: isStatsRedacted ? .placeholder : [])
@@ -91,13 +91,13 @@ struct AnalyticsItemsSoldCard: View {
             }
 
             TopPerformersView(itemTitle: title.localizedCapitalized,
-                              valueTitle: itemsSoldTitle,
-                              rows: itemsSoldData,
-                              isRedacted: isItemsSoldRedacted)
+                              valueTitle: statTitle,
+                              rows: topPerformersData,
+                              isRedacted: isTopPerformersRedacted)
                 .padding(.vertical, Layout.columnSpacing)
 
-            if showItemsSoldError {
-                Text(itemsSoldErrorMessage)
+            if showTopPerformersError {
+                Text(topPerformersErrorMessage)
                     .foregroundColor(Color(.text))
                     .subheadlineStyle()
                     .frame(maxWidth: .infinity, alignment: .leading)
@@ -113,7 +113,7 @@ struct AnalyticsItemsSoldCard: View {
 }
 
 // MARK: Constants
-private extension AnalyticsItemsSoldCard {
+private extension AnalyticsTopPerformersCard {
     enum Layout {
         static let titleSpacing: CGFloat = 24
         static let cardPadding: CGFloat = 16
@@ -126,24 +126,24 @@ private extension AnalyticsItemsSoldCard {
 struct AnalyticsItemsSoldCardPreviews: PreviewProvider {
     static var previews: some View {
         let imageURL = URL(string: "https://s0.wordpress.com/i/store/mobile/plans-premium.png")
-        AnalyticsItemsSoldCard(title: "Products",
-                               itemsSoldTitle: "Items Sold",
-                               itemsSold: "2,234",
+        AnalyticsTopPerformersCard(title: "Products",
+                               statTitle: "Items Sold",
+                               statValue: "2,234",
                                delta: "+23%",
                                deltaBackgroundColor: .withColorStudio(.green, shade: .shade50),
                                deltaTextColor: .textInverted,
                                isStatsRedacted: false,
                                showStatsError: false,
                                statsErrorMessage: "Unable to load product analytics",
-                               itemsSoldData: [
+                               topPerformersData: [
                                 .init(imageURL: imageURL, name: "Tabletop Photos", details: "Net Sales: $1,232", value: "32"),
                                 .init(imageURL: imageURL, name: "Kentya Palm", details: "Net Sales: $800", value: "10"),
                                 .init(imageURL: imageURL, name: "Love Ficus", details: "Net Sales: $599", value: "5"),
                                 .init(imageURL: imageURL, name: "Bird Of Paradise", details: "Net Sales: $23.50", value: "2"),
                                ],
-                               isItemsSoldRedacted: false,
-                               showItemsSoldError: false,
-                               itemsSoldErrorMessage: "Unable to load product items sold analytics",
+                               isTopPerformersRedacted: false,
+                               showTopPerformersError: false,
+                               topPerformersErrorMessage: "Unable to load product items sold analytics",
                                reportViewModel: .init(reportType: .products,
                                                       period: .today,
                                                       webViewTitle: "Products Report",
@@ -151,19 +151,19 @@ struct AnalyticsItemsSoldCardPreviews: PreviewProvider {
                                                       usageTracksEventEmitter: StoreStatsUsageTracksEventEmitter()))
             .previewLayout(.sizeThatFits)
 
-        AnalyticsItemsSoldCard(title: "Products",
-                               itemsSoldTitle: "Items Sold",
-                               itemsSold: "-",
+        AnalyticsTopPerformersCard(title: "Products",
+                               statTitle: "Items Sold",
+                               statValue: "-",
                                delta: "0%",
                                deltaBackgroundColor: .withColorStudio(.gray, shade: .shade0),
                                deltaTextColor: .text,
                                isStatsRedacted: false,
                                showStatsError: true,
                                statsErrorMessage: "Unable to load product analytics",
-                               itemsSoldData: [],
-                               isItemsSoldRedacted: false,
-                               showItemsSoldError: true,
-                               itemsSoldErrorMessage: "Unable to load product items sold analytics",
+                               topPerformersData: [],
+                               isTopPerformersRedacted: false,
+                               showTopPerformersError: true,
+                               topPerformersErrorMessage: "Unable to load product items sold analytics",
                                reportViewModel: .init(reportType: .products,
                                                       period: .today,
                                                       webViewTitle: "Products Report",

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/Report Cards/BundlesReportCardViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/Report Cards/BundlesReportCardViewModel.swift
@@ -143,12 +143,12 @@ extension AnalyticsBundlesReportCardViewModel {
 
 /// Convenience extension to create an `AnalyticsItemsSoldCard` from a view model.
 ///
-extension AnalyticsItemsSoldCard {
+extension AnalyticsTopPerformersCard {
     init(bundlesViewModel: AnalyticsBundlesReportCardViewModel) {
         // Header with stats
         self.title = bundlesViewModel.title
-        self.itemsSoldTitle = bundlesViewModel.bundlesSoldTitle
-        self.itemsSold = bundlesViewModel.bundlesSold
+        self.statTitle = bundlesViewModel.bundlesSoldTitle
+        self.statValue = bundlesViewModel.bundlesSold
         self.delta = bundlesViewModel.delta.string
         self.deltaBackgroundColor = bundlesViewModel.delta.direction.deltaBackgroundColor
         self.deltaTextColor = bundlesViewModel.delta.direction.deltaTextColor
@@ -158,10 +158,10 @@ extension AnalyticsItemsSoldCard {
         self.reportViewModel = bundlesViewModel.reportViewModel
 
         // Top performers list
-        self.itemsSoldData = bundlesViewModel.bundlesSoldData
-        self.isItemsSoldRedacted = bundlesViewModel.isRedacted
-        self.showItemsSoldError = bundlesViewModel.showBundlesSoldError
-        self.itemsSoldErrorMessage = bundlesViewModel.bundlesSoldErrorMessage
+        self.topPerformersData = bundlesViewModel.bundlesSoldData
+        self.isTopPerformersRedacted = bundlesViewModel.isRedacted
+        self.showTopPerformersError = bundlesViewModel.showBundlesSoldError
+        self.topPerformersErrorMessage = bundlesViewModel.bundlesSoldErrorMessage
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/Report Cards/ProductsReportCardViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/Report Cards/ProductsReportCardViewModel.swift
@@ -156,12 +156,12 @@ extension AnalyticsItemsSoldViewModel {
 
 /// Convenience extension to create an `AnalyticsItemsSoldCard` from a view model.
 ///
-extension AnalyticsItemsSoldCard {
+extension AnalyticsTopPerformersCard {
     init(statsViewModel: AnalyticsProductsStatsCardViewModel, itemsViewModel: AnalyticsItemsSoldViewModel) {
         // Header with stats
         self.title = statsViewModel.title
-        self.itemsSoldTitle = statsViewModel.itemsSoldTitle
-        self.itemsSold = statsViewModel.itemsSold
+        self.statTitle = statsViewModel.itemsSoldTitle
+        self.statValue = statsViewModel.itemsSold
         self.delta = statsViewModel.delta.string
         self.deltaBackgroundColor = statsViewModel.delta.direction.deltaBackgroundColor
         self.deltaTextColor = statsViewModel.delta.direction.deltaTextColor
@@ -171,10 +171,10 @@ extension AnalyticsItemsSoldCard {
         self.reportViewModel = statsViewModel.reportViewModel
 
         // Top performers list
-        self.itemsSoldData = itemsViewModel.itemsSoldData
-        self.isItemsSoldRedacted = itemsViewModel.isRedacted
-        self.showItemsSoldError = itemsViewModel.showItemsSoldError
-        self.itemsSoldErrorMessage = itemsViewModel.itemsSoldErrorMessage
+        self.topPerformersData = itemsViewModel.itemsSoldData
+        self.isTopPerformersRedacted = itemsViewModel.isRedacted
+        self.showTopPerformersError = itemsViewModel.showItemsSoldError
+        self.topPerformersErrorMessage = itemsViewModel.itemsSoldErrorMessage
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Factories/StatsDataTextFormatter.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Factories/StatsDataTextFormatter.swift
@@ -15,13 +15,10 @@ struct StatsDataTextFormatter {
                                        currencyFormatter: CurrencyFormatter = CurrencyFormatter(currencySettings: ServiceLocator.currencySettings),
                                        currencyCode: String = ServiceLocator.currencySettings.currencyCode.rawValue,
                                        numberOfFractionDigits: Int = ServiceLocator.currencySettings.fractionDigits) -> String {
-        if let revenue = totalRevenue(at: selectedIntervalIndex, orderStats: orderStats) {
-            // If revenue is an integer, no decimal points are shown.
-            let numberOfDecimals: Int? = revenue.rounded(.plain, scale: numberOfFractionDigits).isInteger ? 0 : nil
-            return currencyFormatter.formatAmount(revenue, with: currencyCode, numberOfDecimals: numberOfDecimals) ?? String()
-        } else {
-            return Constants.placeholderText
-        }
+        return formatAmount(totalRevenue(at: selectedIntervalIndex, orderStats: orderStats),
+                            currencyFormatter: currencyFormatter,
+                            currencyCode: currencyCode,
+                            numberOfFractionDigits: numberOfFractionDigits)
     }
 
     /// Creates the text to display for the net revenue.
@@ -30,13 +27,10 @@ struct StatsDataTextFormatter {
                                      currencyFormatter: CurrencyFormatter = CurrencyFormatter(currencySettings: ServiceLocator.currencySettings),
                                      currencyCode: String = ServiceLocator.currencySettings.currencyCode.rawValue,
                                      numberOfFractionDigits: Int = ServiceLocator.currencySettings.fractionDigits) -> String {
-        guard let revenue = orderStats?.totals.netRevenue else {
-            return Constants.placeholderText
-        }
-
-        // If revenue is an integer, no decimal points are shown.
-        let numberOfDecimals: Int? = revenue.rounded(.plain, scale: numberOfFractionDigits).isInteger ? 0 : nil
-        return currencyFormatter.formatAmount(revenue, with: currencyCode, numberOfDecimals: numberOfDecimals) ?? String()
+        return formatAmount(orderStats?.totals.netRevenue,
+                            currencyFormatter: currencyFormatter,
+                            currencyCode: currencyCode,
+                            numberOfFractionDigits: numberOfFractionDigits)
     }
 
     // MARK: Orders Stats
@@ -57,13 +51,10 @@ struct StatsDataTextFormatter {
                                             currencyFormatter: CurrencyFormatter = CurrencyFormatter(currencySettings: ServiceLocator.currencySettings),
                                             currencyCode: String = ServiceLocator.currencySettings.currencyCode.rawValue,
                                             numberOfFractionDigits: Int = ServiceLocator.currencySettings.fractionDigits) -> String {
-        if let value = averageOrderValue(orderStats: orderStats) {
-            // If order value is an integer, no decimal points are shown.
-            let numberOfDecimals: Int? = value.rounded(.plain, scale: numberOfFractionDigits).isInteger ? 0 : nil
-            return currencyFormatter.formatAmount(value, with: currencyCode, numberOfDecimals: numberOfDecimals) ?? String()
-        } else {
-            return Constants.placeholderText
-        }
+        return formatAmount(averageOrderValue(orderStats: orderStats),
+                            currencyFormatter: currencyFormatter,
+                            currencyCode: currencyCode,
+                            numberOfFractionDigits: numberOfFractionDigits)
     }
 
     // MARK: Views and Visitors Stats
@@ -160,14 +151,29 @@ struct StatsDataTextFormatter {
                                              currencyFormatter: CurrencyFormatter = CurrencyFormatter(currencySettings: ServiceLocator.currencySettings),
                                              currencyCode: String = ServiceLocator.currencySettings.currencyCode.rawValue,
                                              numberOfFractionDigits: Int = ServiceLocator.currencySettings.fractionDigits) -> String {
-        guard let giftCardStats else {
-            return Constants.placeholderText
-        }
-        // If net amount is an integer, no decimal points are shown.
-        let netAmount = giftCardStats.totals.netAmount
-        let numberOfDecimals: Int? = netAmount.rounded(.plain, scale: numberOfFractionDigits).isInteger ? 0 : nil
-        return currencyFormatter.formatAmount(netAmount, with: currencyCode, numberOfDecimals: numberOfDecimals) ?? String()
+        return formatAmount(giftCardStats?.totals.netAmount,
+                            currencyFormatter: currencyFormatter,
+                            currencyCode: currencyCode,
+                            numberOfFractionDigits: numberOfFractionDigits)
     }
+
+    // MARK: Generic helpers
+
+    /// Creates the text to display for an amount with currency settings.
+    ///
+    /// If the amount is an integer, no decimal points are shown, e.g. `$12.34` or `$12` (not `$12.00`).
+    ///
+    static func formatAmount(_ amount: Decimal?,
+                             currencyFormatter: CurrencyFormatter = CurrencyFormatter(currencySettings: ServiceLocator.currencySettings),
+                             currencyCode: String = ServiceLocator.currencySettings.currencyCode.rawValue,
+                             numberOfFractionDigits: Int = ServiceLocator.currencySettings.fractionDigits) -> String {
+      guard let amount else {
+          return Constants.placeholderText
+      }
+      // If amount is an integer, no decimal points are shown.
+      let numberOfDecimals: Int? = amount.rounded(.plain, scale: numberOfFractionDigits).isInteger ? 0 : nil
+      return currencyFormatter.formatAmount(amount, with: currencyCode, numberOfDecimals: numberOfDecimals) ?? String()
+  }
 }
 
 extension StatsDataTextFormatter {

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -1081,7 +1081,7 @@
 		26E1BECC251BE5570096D0A1 /* RefundItemTableViewCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = 26E1BECB251BE5570096D0A1 /* RefundItemTableViewCell.xib */; };
 		26E1BECE251CD9F80096D0A1 /* RefundItemViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26E1BECD251CD9F80096D0A1 /* RefundItemViewModel.swift */; };
 		26E7EE6A292D688900793045 /* AnalyticsHubViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26E7EE69292D688900793045 /* AnalyticsHubViewModel.swift */; };
-		26E7EE6E29300E8100793045 /* AnalyticsItemsSoldCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26E7EE6D29300E8100793045 /* AnalyticsItemsSoldCard.swift */; };
+		26E7EE6E29300E8100793045 /* AnalyticsTopPerformersCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26E7EE6D29300E8100793045 /* AnalyticsTopPerformersCard.swift */; };
 		26E7EE7029300F6200793045 /* DeltaTag.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26E7EE6F29300F6200793045 /* DeltaTag.swift */; };
 		26E7EE7229301EBC00793045 /* ProductsReportCardViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26E7EE7129301EBC00793045 /* ProductsReportCardViewModel.swift */; };
 		26E7EE7429365F0700793045 /* TopPerformersView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26E7EE7329365F0700793045 /* TopPerformersView.swift */; };
@@ -4018,7 +4018,7 @@
 		26E1BECB251BE5570096D0A1 /* RefundItemTableViewCell.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = RefundItemTableViewCell.xib; sourceTree = "<group>"; };
 		26E1BECD251CD9F80096D0A1 /* RefundItemViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RefundItemViewModel.swift; sourceTree = "<group>"; };
 		26E7EE69292D688900793045 /* AnalyticsHubViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnalyticsHubViewModel.swift; sourceTree = "<group>"; };
-		26E7EE6D29300E8100793045 /* AnalyticsItemsSoldCard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnalyticsItemsSoldCard.swift; sourceTree = "<group>"; };
+		26E7EE6D29300E8100793045 /* AnalyticsTopPerformersCard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnalyticsTopPerformersCard.swift; sourceTree = "<group>"; };
 		26E7EE6F29300F6200793045 /* DeltaTag.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeltaTag.swift; sourceTree = "<group>"; };
 		26E7EE7129301EBC00793045 /* ProductsReportCardViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductsReportCardViewModel.swift; sourceTree = "<group>"; };
 		26E7EE7329365F0700793045 /* TopPerformersView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TopPerformersView.swift; sourceTree = "<group>"; };
@@ -11798,7 +11798,7 @@
 			children = (
 				CEA455BF2BB340C100D932CF /* Components */,
 				2647F7B9292BE2F900D59FDF /* AnalyticsReportCard.swift */,
-				26E7EE6D29300E8100793045 /* AnalyticsItemsSoldCard.swift */,
+				26E7EE6D29300E8100793045 /* AnalyticsTopPerformersCard.swift */,
 				CEF2DD852B558E3E00A3DD0B /* AnalyticsCTACard.swift */,
 				CEA455C62BB5CA5E00D932CF /* AnalyticsSessionsUnavailableCard.swift */,
 				CEA455C82BB5DA4C00D932CF /* AnalyticsSessionsReportCard.swift */,
@@ -14297,7 +14297,7 @@
 				03EF24FC28BF996F006A033E /* InPersonPaymentsCashOnDeliveryPaymentGatewayHelpers.swift in Sources */,
 				57896D6625362B0C000E8C4D /* TitleAndEditableValueTableViewCellViewModel.swift in Sources */,
 				0205021E27C8B6C600FB1C6B /* InboxEligibilityUseCase.swift in Sources */,
-				26E7EE6E29300E8100793045 /* AnalyticsItemsSoldCard.swift in Sources */,
+				26E7EE6E29300E8100793045 /* AnalyticsTopPerformersCard.swift in Sources */,
 				03E471DA29424E82001A58AD /* CardPresentModalBuiltInSuccess.swift in Sources */,
 				26E1BECE251CD9F80096D0A1 /* RefundItemViewModel.swift in Sources */,
 				DE7B479027A153C20018742E /* CouponSearchUICommand.swift in Sources */,

--- a/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Factories/StatsDataTextFormatterTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Factories/StatsDataTextFormatterTests.swift
@@ -9,6 +9,7 @@ final class StatsDataTextFormatterTests: XCTestCase {
 
     private let currencyFormatter = CurrencyFormatter(currencySettings: CurrencySettings()) // Default is US
     private let currencyCode = CurrencySettings().currencyCode
+    private let fractionDigits = CurrencySettings().fractionDigits
 
     // MARK: Revenue Stats
 
@@ -695,5 +696,66 @@ final class StatsDataTextFormatterTests: XCTestCase {
         // Then
         XCTAssertEqual(delta.string, "-23%")
         XCTAssertEqual(delta.direction, .negative)
+    }
+
+    // MARK: formatAmount helper
+
+    func test_formatAmount_does_not_return_decimal_points_for_integer_value() {
+        // Given
+        let amount: Decimal = 62
+
+        // When
+        let formattedAmount = StatsDataTextFormatter.formatAmount(amount,
+                                                                  currencyFormatter: currencyFormatter,
+                                                                  currencyCode: currencyCode.rawValue,
+                                                                  numberOfFractionDigits: fractionDigits)
+
+        // Then
+        XCTAssertEqual(formattedAmount, "$62")
+    }
+
+    func test_formatAmount_does_not_return_decimal_points_for_rounded_integer_value() {
+        // Given
+        let amount: Decimal = 62.0000000000002
+
+        // When
+        let formattedAmount = StatsDataTextFormatter.formatAmount(amount,
+                                                                  currencyFormatter: currencyFormatter,
+                                                                  currencyCode: currencyCode.rawValue,
+                                                                  numberOfFractionDigits: fractionDigits)
+
+        // Then
+        XCTAssertEqual(formattedAmount, "$62")
+    }
+
+    func test_formatAmount_returns_expected_number_of_fractional_digits() {
+        // Given
+        let amount: Decimal = 62.0023
+        let customCurrencySettings = CurrencySettings()
+        customCurrencySettings.fractionDigits = 3
+        let currencyFormatter = CurrencyFormatter(currencySettings: customCurrencySettings)
+
+        // When
+        let formattedAmount = StatsDataTextFormatter.formatAmount(amount,
+                                                                  currencyFormatter: currencyFormatter,
+                                                                  currencyCode: currencyCode.rawValue,
+                                                                  numberOfFractionDigits: customCurrencySettings.fractionDigits)
+
+        // Then
+        XCTAssertEqual(formattedAmount, "$62.002")
+    }
+
+    func test_formatAmount_returns_decimal_points_from_currency_settings_for_noninteger_value() {
+        // Given
+        let amount: Decimal = 62.856
+
+        // When
+        let formattedAmount = StatsDataTextFormatter.formatAmount(amount,
+                                                                  currencyFormatter: currencyFormatter,
+                                                                  currencyCode: currencyCode.rawValue,
+                                                                  numberOfFractionDigits: fractionDigits)
+
+        // Then
+        XCTAssertEqual(formattedAmount, "$62.86")
     }
 }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of: #13186
<!-- Id number of the GitHub issue this PR addresses. -->

## Why
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This refactors some of the analytics UI layer in preparation for adding a Google Campaigns analytics card.

## How

* We want to reuse the `AnalyticsItemsSoldCard` for Google Campaigns. This renames the `AnalyticsItemsSoldCard` to `AnalyticsTopPerformersCard` (and renames some of its properties accordingly) to make it clearer that the card can be used to display any metric and list of top performers for that metric, not just items sold.
* Adds a generic helper to `StatsDataTextFormatter` to format amounts with currency:
   * This reduces some of the repetition for existing stats data that formats an amount.
   * It also means we can reuse that helper for any amounts we want to format that way, e.g. the upcoming Google Campaigns card (without having to add a separate method for each metric on the card).

## Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->
These changes refactor but should not change the existing behavior. To test:

1. Build and run the app.
2. Select "View all store analytics" on a dashboard card to open the Analytics Hub.
3. Confirm all cards load with the expected content (no change from before).

## Screenshots

Before|After
-|-
![Before](https://github.com/woocommerce/woocommerce-ios/assets/8658164/96f1939b-9307-4a2e-bf98-313b949a461c)|![After](https://github.com/woocommerce/woocommerce-ios/assets/8658164/180ff7b0-077f-48d3-a53b-59483678525d)

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.