### PR TITLE
[Woo POS] Fix order sync from passing empty items for the products

### DIFF
--- a/WooCommerce/Classes/POS/ViewModels/PointOfSaleDashboardViewModel.swift
+++ b/WooCommerce/Classes/POS/ViewModels/PointOfSaleDashboardViewModel.swift
@@ -38,7 +38,6 @@ final class PointOfSaleDashboardViewModel: ObservableObject {
 
     let itemSelectorViewModel: ItemSelectorViewModel
 
-    @Published private(set) var items: [POSItem] = []
     @Published private(set) var itemsInCart: [CartItem] = [] {
         didSet {
             checkIfCartEmpty()
@@ -345,8 +344,8 @@ private extension PointOfSaleDashboardViewModel {
         do {
             isSyncingOrder = true
             let order = try await orderService.syncOrder(cart: cart,
-                                                              order: order,
-                                                              allProducts: items)
+                                                         order: order,
+                                                         allProducts: itemSelectorViewModel.items)
             self.order = order
             isSyncingOrder = false
             // TODO: this is temporary solution


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of #12998 
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

After merging https://github.com/woocommerce/woocommerce-ios/pull/13188 and testing the WIP https://github.com/woocommerce/woocommerce-ios/pull/13191, I realized that the order sync stopped working because the dashboard VM is still using the `items: [POSItem]` internal variable that isn't set anymore after extracting the item selector logic in https://github.com/woocommerce/woocommerce-ios/pull/13188. Without the item list, order sync cannot properly set the order line items in the API request and it results in 0 order total and an empty order in core. This PR fixes it by removing the `items` variable and replacing its usage in order sync with `itemSelectorViewModel.items`.

## Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->

Prerequisite: the store is eligible for POS and the feature switch is enabled in Menu > Settings > Experimental Features > POS
* Launch app
* Go to Menu > Point of Sale
* Add an item (with a non-zero price) to cart
* Tap `Checkout` --> the order total should be updated to a correct, non-zero value (before this PR in trunk, the order total is always 0 after the sync)

## Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->


https://github.com/woocommerce/woocommerce-ios/assets/1945542/b52965d8-0c1a-48a1-a33f-44ff57e3fa81



---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.