### PR TITLE
[Woo POS] Extract totals logic to `TotalsViewModel`

### DIFF
--- a/WooCommerce/Classes/POS/Presentation/CartView.swift
+++ b/WooCommerce/Classes/POS/Presentation/CartView.swift
@@ -115,7 +115,8 @@ import Combine
     let orderStagePublisher = orderStageSubject.eraseToAnyPublisher()
     let dashboardViewModel = PointOfSaleDashboardViewModel(itemProvider: POSItemProviderPreview(),
                                                            cardPresentPaymentService: CardPresentPaymentPreviewService(),
-                                                           orderService: POSOrderPreviewService())
+                                                           orderService: POSOrderPreviewService(),
+                                                           currencyFormatter: .init(currencySettings: .init()))
     let cartViewModel = CartViewModel(orderStage: orderStagePublisher)
 
     return CartView(viewModel: dashboardViewModel, cartViewModel: cartViewModel)

--- a/WooCommerce/Classes/POS/Presentation/PointOfSaleDashboardView.swift
+++ b/WooCommerce/Classes/POS/Presentation/PointOfSaleDashboardView.swift
@@ -68,10 +68,11 @@ private extension PointOfSaleDashboardView {
     }
 
     var totalsView: some View {
-        TotalsView(viewModel: viewModel)
-            .background(Color(UIColor.systemBackground))
-            .frame(maxWidth: .infinity)
-            .cornerRadius(16)
+        TotalsView(viewModel: viewModel,
+                   totalsViewModel: viewModel.totalsViewModel)
+        .background(Color(UIColor.systemBackground))
+        .frame(maxWidth: .infinity)
+        .cornerRadius(16)
     }
 
     var productListView: some View {

--- a/WooCommerce/Classes/POS/Presentation/PointOfSaleDashboardView.swift
+++ b/WooCommerce/Classes/POS/Presentation/PointOfSaleDashboardView.swift
@@ -39,19 +39,6 @@ struct PointOfSaleDashboardView: View {
         }
         .toolbarBackground(Color.toolbarBackground, for: .bottomBar)
         .toolbarBackground(.visible, for: .bottomBar)
-        .sheet(isPresented: $viewModel.showsCardReaderSheet, content: {
-            // Might be the only way unless we make the type conform to `Identifiable`
-            if let alertType = viewModel.cardPresentPaymentAlertViewModel {
-                PointOfSaleCardPresentPaymentAlert(alertType: alertType)
-            } else {
-                switch viewModel.cardPresentPaymentEvent {
-                case .idle,
-                        .show, // handled above
-                        .showOnboarding:
-                    Text(viewModel.cardPresentPaymentEvent.temporaryEventDescription)
-                }
-            }
-        })
     }
 }
 
@@ -81,26 +68,14 @@ private extension PointOfSaleDashboardView {
     }
 }
 
-fileprivate extension CardPresentPaymentEvent {
-    var temporaryEventDescription: String {
-        switch self {
-        case .idle:
-            return "Idle"
-        case .show:
-            return "Event"
-        case .showOnboarding(let onboardingViewModel):
-            return "Onboarding: \(onboardingViewModel.state.reasonForAnalytics)" // This will only show the initial onboarding state
-        }
-    }
-}
-
 #if DEBUG
 #Preview {
     NavigationStack {
         PointOfSaleDashboardView(
             viewModel: PointOfSaleDashboardViewModel(itemProvider: POSItemProviderPreview(),
                                                      cardPresentPaymentService: CardPresentPaymentPreviewService(),
-                                                     orderService: POSOrderPreviewService()))
+                                                     orderService: POSOrderPreviewService(),
+                                                     currencyFormatter: .init(currencySettings: .init())))
     }
 }
 #endif

--- a/WooCommerce/Classes/POS/Presentation/PointOfSaleEntryPointView.swift
+++ b/WooCommerce/Classes/POS/Presentation/PointOfSaleEntryPointView.swift
@@ -1,4 +1,5 @@
 import SwiftUI
+import class WooFoundation.CurrencyFormatter
 import protocol Yosemite.POSItemProvider
 import protocol Yosemite.POSOrderServiceProtocol
 
@@ -10,13 +11,15 @@ struct PointOfSaleEntryPointView: View {
     init(itemProvider: POSItemProvider,
          hideAppTabBar: @escaping ((Bool) -> Void),
          cardPresentPaymentService: CardPresentPaymentFacade,
-         orderService: POSOrderServiceProtocol) {
+         orderService: POSOrderServiceProtocol,
+         currencyFormatter: CurrencyFormatter) {
         self.hideAppTabBar = hideAppTabBar
 
         _viewModel = StateObject(wrappedValue: PointOfSaleDashboardViewModel(
             itemProvider: itemProvider,
             cardPresentPaymentService: cardPresentPaymentService,
-            orderService: orderService)
+            orderService: orderService,
+            currencyFormatter: currencyFormatter)
         )
     }
 
@@ -36,6 +39,7 @@ struct PointOfSaleEntryPointView: View {
     PointOfSaleEntryPointView(itemProvider: POSItemProviderPreview(),
                               hideAppTabBar: { _ in },
                               cardPresentPaymentService: CardPresentPaymentPreviewService(),
-                              orderService: POSOrderPreviewService())
+                              orderService: POSOrderPreviewService(),
+                              currencyFormatter: .init(currencySettings: .init()))
 }
 #endif

--- a/WooCommerce/Classes/POS/Presentation/TotalsView.swift
+++ b/WooCommerce/Classes/POS/Presentation/TotalsView.swift
@@ -36,7 +36,7 @@ struct TotalsView: View {
                         HStack {
                             VStack(spacing: Constants.totalsVerticalSpacing) {
                                 priceFieldView(title: "Subtotal",
-                                               formattedPrice: viewModel.formattedCartTotalPrice,
+                                               formattedPrice: totalsViewModel.formattedCartTotalPrice,
                                                shimmeringActive: false,
                                                redacted: false)
                                 Divider()
@@ -61,7 +61,9 @@ struct TotalsView: View {
                         )
                         if totalsViewModel.showRecalculateButton {
                             Button("Calculate amounts") {
-                                viewModel.calculateAmountsTapped()
+                                totalsViewModel.calculateAmountsTapped(
+                                    with: viewModel.cartViewModel.itemsInCart,
+                                    allItems: viewModel.itemSelectorViewModel.items)
                             }
                         }
                     }

--- a/WooCommerce/Classes/POS/Presentation/TotalsView.swift
+++ b/WooCommerce/Classes/POS/Presentation/TotalsView.swift
@@ -2,9 +2,23 @@ import SwiftUI
 
 struct TotalsView: View {
     @ObservedObject private var viewModel: PointOfSaleDashboardViewModel
+    @ObservedObject private var totalsViewModel: TotalsViewModel
 
-    init(viewModel: PointOfSaleDashboardViewModel) {
+    init(viewModel: PointOfSaleDashboardViewModel, totalsViewModel: TotalsViewModel) {
         self.viewModel = viewModel
+        self.totalsViewModel = totalsViewModel
+    }
+
+    var isShimmering: Bool {
+        totalsViewModel.isSyncingOrder
+    }
+
+    var isPriceFieldRedacted: Bool {
+        viewModel.formattedOrderTotalTaxPrice == nil || totalsViewModel.isSyncingOrder
+    }
+
+    var isTotalPriceFieldRedacted: Bool {
+        viewModel.formattedOrderTotalPrice == nil || totalsViewModel.isSyncingOrder
     }
 
     var body: some View {
@@ -27,13 +41,13 @@ struct TotalsView: View {
                                 priceFieldView(title: "Taxes",
                                                formattedPrice:
                                                 viewModel.formattedOrderTotalTaxPrice,
-                                               shimmeringActive: viewModel.isSyncingOrder,
-                                               redacted: viewModel.formattedOrderTotalTaxPrice == nil || viewModel.isSyncingOrder)
+                                               shimmeringActive: isShimmering,
+                                               redacted: isPriceFieldRedacted)
                                 Divider()
                                     .overlay(Color.posTotalsSeparator)
                                 totalPriceView(formattedPrice: viewModel.formattedOrderTotalPrice,
-                                               shimmeringActive: viewModel.isSyncingOrder,
-                                               redacted: viewModel.formattedOrderTotalPrice == nil || viewModel.isSyncingOrder)
+                                               shimmeringActive: isShimmering,
+                                               redacted: isTotalPriceFieldRedacted)
                             }
                             .padding()
                             .frame(idealWidth: Constants.pricesIdealWidth)
@@ -181,10 +195,10 @@ private extension TotalsView {
     }
 }
 
-#if DEBUG
-#Preview {
-    TotalsView(viewModel: .init(itemProvider: POSItemProviderPreview(),
-                                cardPresentPaymentService: CardPresentPaymentPreviewService(),
-                                orderService: POSOrderPreviewService()))
-}
-#endif
+//#if DEBUG
+//#Preview {
+//    TotalsView(viewModel: .init(itemProvider: POSItemProviderPreview(),
+//                                cardPresentPaymentService: CardPresentPaymentPreviewService(),
+//                                orderService: POSOrderPreviewService()))
+//}
+//#endif

--- a/WooCommerce/Classes/POS/Presentation/TotalsView.swift
+++ b/WooCommerce/Classes/POS/Presentation/TotalsView.swift
@@ -10,15 +10,18 @@ struct TotalsView: View {
     }
 
     var isShimmering: Bool {
+        // TODO: Move to VM
         totalsViewModel.isSyncingOrder
     }
 
     var isPriceFieldRedacted: Bool {
-        viewModel.formattedOrderTotalTaxPrice == nil || totalsViewModel.isSyncingOrder
+        // TODO: Move to VM
+        totalsViewModel.formattedOrderTotalTaxPrice == nil || totalsViewModel.isSyncingOrder
     }
 
     var isTotalPriceFieldRedacted: Bool {
-        viewModel.formattedOrderTotalPrice == nil || totalsViewModel.isSyncingOrder
+        // TODO: Move to VM
+        totalsViewModel.formattedOrderTotalPrice == nil || totalsViewModel.isSyncingOrder
     }
 
     var body: some View {
@@ -40,12 +43,12 @@ struct TotalsView: View {
                                     .overlay(Color.posTotalsSeparator)
                                 priceFieldView(title: "Taxes",
                                                formattedPrice:
-                                                viewModel.formattedOrderTotalTaxPrice,
+                                                totalsViewModel.formattedOrderTotalTaxPrice,
                                                shimmeringActive: isShimmering,
                                                redacted: isPriceFieldRedacted)
                                 Divider()
                                     .overlay(Color.posTotalsSeparator)
-                                totalPriceView(formattedPrice: viewModel.formattedOrderTotalPrice,
+                                totalPriceView(formattedPrice: totalsViewModel.formattedOrderTotalPrice,
                                                shimmeringActive: isShimmering,
                                                redacted: isTotalPriceFieldRedacted)
                             }
@@ -56,7 +59,7 @@ struct TotalsView: View {
                             RoundedRectangle(cornerRadius: Constants.defaultBorderLineCornerRadius)
                                 .stroke(Color.posTotalsSeparator, lineWidth: Constants.defaultBorderLineWidth)
                         )
-                        if viewModel.showRecalculateButton {
+                        if totalsViewModel.showRecalculateButton {
                             Button("Calculate amounts") {
                                 viewModel.calculateAmountsTapped()
                             }
@@ -91,10 +94,6 @@ struct TotalsView: View {
                 Gradient.Stop(color: Color.posTotalsGradientPurple, location: 1.0)
             ]
         }
-    }
-
-    private var paymentButtonsDisabled: Bool {
-        return !viewModel.areAmountsFullyCalculated
     }
 }
 

--- a/WooCommerce/Classes/POS/Presentation/TotalsView.swift
+++ b/WooCommerce/Classes/POS/Presentation/TotalsView.swift
@@ -129,7 +129,7 @@ private extension TotalsView {
     }
 
     @ViewBuilder private var cardReaderView: some View {
-        switch viewModel.cardReaderConnectionViewModel.connectionStatus {
+        switch totalsViewModel.connectionStatus {
         case .connected:
             if let inlinePaymentMessage = totalsViewModel.cardPresentPaymentInlineMessage {
                 PointOfSaleCardPresentPaymentInLineMessage(messageType: inlinePaymentMessage)

--- a/WooCommerce/Classes/POS/Presentation/TotalsView.swift
+++ b/WooCommerce/Classes/POS/Presentation/TotalsView.swift
@@ -9,21 +9,6 @@ struct TotalsView: View {
         self.totalsViewModel = totalsViewModel
     }
 
-    var isShimmering: Bool {
-        // TODO: Move to VM
-        totalsViewModel.isSyncingOrder
-    }
-
-    var isPriceFieldRedacted: Bool {
-        // TODO: Move to VM
-        totalsViewModel.formattedOrderTotalTaxPrice == nil || totalsViewModel.isSyncingOrder
-    }
-
-    var isTotalPriceFieldRedacted: Bool {
-        // TODO: Move to VM
-        totalsViewModel.formattedOrderTotalPrice == nil || totalsViewModel.isSyncingOrder
-    }
-
     var body: some View {
         HStack {
             VStack(alignment: .leading) {
@@ -44,13 +29,13 @@ struct TotalsView: View {
                                 priceFieldView(title: "Taxes",
                                                formattedPrice:
                                                 totalsViewModel.formattedOrderTotalTaxPrice,
-                                               shimmeringActive: isShimmering,
-                                               redacted: isPriceFieldRedacted)
+                                               shimmeringActive: totalsViewModel.isShimmering,
+                                               redacted: totalsViewModel.isPriceFieldRedacted)
                                 Divider()
                                     .overlay(Color.posTotalsSeparator)
                                 totalPriceView(formattedPrice: totalsViewModel.formattedOrderTotalPrice,
-                                               shimmeringActive: isShimmering,
-                                               redacted: isTotalPriceFieldRedacted)
+                                               shimmeringActive: totalsViewModel.isShimmering,
+                                               redacted: totalsViewModel.isTotalPriceFieldRedacted)
                             }
                             .padding()
                             .frame(idealWidth: Constants.pricesIdealWidth)

--- a/WooCommerce/Classes/POS/ViewModels/TotalsViewModel.swift
+++ b/WooCommerce/Classes/POS/ViewModels/TotalsViewModel.swift
@@ -33,7 +33,19 @@ final class TotalsViewModel: ObservableObject {
         formattedOrderTotalTaxPrice != nil &&
         formattedOrderTotalPrice != nil
     }
-    
+
+    var isShimmering: Bool {
+        isSyncingOrder
+    }
+
+    var isPriceFieldRedacted: Bool {
+        formattedOrderTotalTaxPrice == nil || isSyncingOrder
+    }
+
+    var isTotalPriceFieldRedacted: Bool {
+        formattedOrderTotalPrice == nil || isSyncingOrder
+    }
+
     init(orderService: POSOrderServiceProtocol) {
         self.orderService = orderService
         // TODO:

--- a/WooCommerce/Classes/POS/ViewModels/TotalsViewModel.swift
+++ b/WooCommerce/Classes/POS/ViewModels/TotalsViewModel.swift
@@ -1,8 +1,37 @@
 import SwiftUI
+import struct Yosemite.POSOrder
+import class WooFoundation.CurrencyFormatter
+import class WooFoundation.CurrencySettings
 
 final class TotalsViewModel: ObservableObject {
 
     @Published private(set) var isSyncingOrder: Bool = false
+
+    /// Order created the first time the checkout is shown for a given transaction.
+    /// If the merchant goes back to the product selection screen and makes changes, this should be updated when they return to the checkout.
+    @Published private(set) var order: POSOrder?
+
+    func formattedPrice(_ price: String?, currency: String?) -> String? {
+        guard let price, let currency else {
+            return nil
+        }
+        // TODO:
+        // Remove ServiceLocator dependency
+        return CurrencyFormatter(currencySettings: ServiceLocator.currencySettings).formatAmount(price, with: currency)
+    }
+
+    var formattedOrderTotalPrice: String? {
+        formattedPrice(order?.total, currency: order?.currency)
+    }
+
+    var formattedOrderTotalTaxPrice: String? {
+        formattedPrice(order?.totalTax, currency: order?.currency)
+    }
+
+    var showRecalculateButton: Bool {
+        !areAmountsFullyCalculated &&
+        isSyncingOrder == false
+    }
 
     func startSyncOrder() {
         isSyncingOrder = true
@@ -10,6 +39,20 @@ final class TotalsViewModel: ObservableObject {
 
     func stopSyncOrder() {
         isSyncingOrder = false
+    }
+
+    func clearOrder() {
+        order = nil
+    }
+
+    func setOrder(updatedOrder: POSOrder) {
+        order = updatedOrder
+    }
+
+    var areAmountsFullyCalculated: Bool {
+        isSyncingOrder == false &&
+        formattedOrderTotalTaxPrice != nil &&
+        formattedOrderTotalPrice != nil
     }
 
 }

--- a/WooCommerce/Classes/POS/ViewModels/TotalsViewModel.swift
+++ b/WooCommerce/Classes/POS/ViewModels/TotalsViewModel.swift
@@ -1,24 +1,19 @@
 import SwiftUI
+import protocol Yosemite.POSOrderServiceProtocol
+import protocol Yosemite.POSItem
+import struct Yosemite.POSCartItem
 import struct Yosemite.POSOrder
 import class WooFoundation.CurrencyFormatter
 import class WooFoundation.CurrencySettings
 
 final class TotalsViewModel: ObservableObject {
-
-    @Published private(set) var isSyncingOrder: Bool = false
-
     /// Order created the first time the checkout is shown for a given transaction.
     /// If the merchant goes back to the product selection screen and makes changes, this should be updated when they return to the checkout.
     @Published private(set) var order: POSOrder?
+    @Published private(set) var isSyncingOrder: Bool = false
+    @Published private(set) var formattedCartTotalPrice: String?
 
-    func formattedPrice(_ price: String?, currency: String?) -> String? {
-        guard let price, let currency else {
-            return nil
-        }
-        // TODO:
-        // Remove ServiceLocator dependency
-        return CurrencyFormatter(currencySettings: ServiceLocator.currencySettings).formatAmount(price, with: currency)
-    }
+    private let orderService: POSOrderServiceProtocol
 
     var formattedOrderTotalPrice: String? {
         formattedPrice(order?.total, currency: order?.currency)
@@ -33,7 +28,34 @@ final class TotalsViewModel: ObservableObject {
         isSyncingOrder == false
     }
 
+    var areAmountsFullyCalculated: Bool {
+        isSyncingOrder == false &&
+        formattedOrderTotalTaxPrice != nil &&
+        formattedOrderTotalPrice != nil
+    }
+    
+    init(orderService: POSOrderServiceProtocol) {
+        self.orderService = orderService
+        // TODO:
+        // - Inject cardPresentPaymentService
+        // - Inject currencyFormatted
+        // TODO:
+        // - observe ConnectedReaderForStatus
+        // - observe CardPresentPaymentEvents
+    }
+
+    func formattedPrice(_ price: String?, currency: String?) -> String? {
+        guard let price, let currency else {
+            return nil
+        }
+        // TODO:
+        // Remove ServiceLocator dependency. Inject from the app through point of entry
+        return CurrencyFormatter(currencySettings: ServiceLocator.currencySettings).formatAmount(price, with: currency)
+    }
+
     func startSyncOrder() {
+        // TODO: 
+        // Start & stop methods may no longer be needed, since sync state it's only internal
         isSyncingOrder = true
     }
 
@@ -49,10 +71,58 @@ final class TotalsViewModel: ObservableObject {
         order = updatedOrder
     }
 
-    var areAmountsFullyCalculated: Bool {
-        isSyncingOrder == false &&
-        formattedOrderTotalTaxPrice != nil &&
-        formattedOrderTotalPrice != nil
+    func calculateAmountsTapped(with cartItems: [CartItem], allItems: [POSItem]) {
+        startSyncingOrder(with: cartItems, allItems: allItems)
     }
 
+    func startSyncingOrder(with cartItems: [CartItem], allItems: [POSItem]) {
+        Task { @MainActor in
+            calculateCartTotal(cartItems: cartItems)
+            await syncOrder(for: cartItems, allItems: allItems)
+        }
+    }
+
+    @MainActor
+    private func syncOrder(for cartProducts: [CartItem], allItems: [POSItem]) async {
+        guard isSyncingOrder == false else {
+            return
+        }
+        startSyncOrder()
+        let cart = cartProducts
+            .map {
+                POSCartItem(itemID: nil,
+                            product: $0.item,
+                            quantity: Decimal($0.quantity))
+            }
+        defer {
+            stopSyncOrder()
+        }
+        
+        do {
+            startSyncOrder()
+            let order = try await orderService.syncOrder(cart: cart,
+                                                         order: order,
+                                                         allProducts: allItems)
+            setOrder(updatedOrder: order)
+            stopSyncOrder()
+            // TODO: this is temporary solution
+            // TODO: Move card present here as well.
+            // await prepareConnectedReaderForPayment()
+            DDLogInfo("🟢 [POS] Synced order: \(order)")
+        } catch {
+            DDLogError("🔴 [POS] Error syncing order: \(error)")
+        }
+    }
+
+    private func calculateCartTotal(cartItems: [CartItem]) {
+        formattedCartTotalPrice = { cartItems in
+            let totalValue: Decimal = cartItems.reduce(0) { partialResult, cartItem in
+                let itemPrice = CurrencyFormatter(currencySettings: ServiceLocator.currencySettings).convertToDecimal(cartItem.item.price) ?? 0
+                let quantity = cartItem.quantity
+                let total = itemPrice.multiplying(by: NSDecimalNumber(value: quantity)) as Decimal
+                return partialResult + total
+            }
+            return CurrencyFormatter(currencySettings: ServiceLocator.currencySettings).formatAmount(totalValue)
+        }(cartItems)
+    }
 }

--- a/WooCommerce/Classes/POS/ViewModels/TotalsViewModel.swift
+++ b/WooCommerce/Classes/POS/ViewModels/TotalsViewModel.swift
@@ -1,0 +1,15 @@
+import SwiftUI
+
+final class TotalsViewModel: ObservableObject {
+
+    @Published private(set) var isSyncingOrder: Bool = false
+
+    func startSyncOrder() {
+        isSyncingOrder = true
+    }
+
+    func stopSyncOrder() {
+        isSyncingOrder = false
+    }
+
+}

--- a/WooCommerce/Classes/POS/ViewModels/TotalsViewModel.swift
+++ b/WooCommerce/Classes/POS/ViewModels/TotalsViewModel.swift
@@ -1,19 +1,39 @@
 import SwiftUI
 import protocol Yosemite.POSOrderServiceProtocol
 import protocol Yosemite.POSItem
+import struct Yosemite.Order
 import struct Yosemite.POSCartItem
 import struct Yosemite.POSOrder
 import class WooFoundation.CurrencyFormatter
 import class WooFoundation.CurrencySettings
 
 final class TotalsViewModel: ObservableObject {
+    enum PaymentState {
+        case idle
+        case acceptingCard
+        case preparingReader
+        case processingPayment
+        case cardPaymentSuccessful
+    }
+
+    @Published var showsCardReaderSheet: Bool = false
+    @Published private(set) var cardPresentPaymentEvent: CardPresentPaymentEvent = .idle
+    @Published private(set) var cardPresentPaymentAlertViewModel: PointOfSaleCardPresentPaymentAlertType?
+    @Published private(set) var cardPresentPaymentInlineMessage: PointOfSaleCardPresentPaymentMessageType?
+
     /// Order created the first time the checkout is shown for a given transaction.
     /// If the merchant goes back to the product selection screen and makes changes, this should be updated when they return to the checkout.
     @Published private(set) var order: POSOrder?
     @Published private(set) var isSyncingOrder: Bool = false
     @Published private(set) var formattedCartTotalPrice: String?
 
+    @Published private(set) var paymentState: PaymentState = .acceptingCard
+
+    @Published private var connectionStatus: CardReaderConnectionStatus = .disconnected
+
     private let orderService: POSOrderServiceProtocol
+    private let cardPresentPaymentService: CardPresentPaymentFacade
+    private let currencyFormatter: CurrencyFormatter
 
     var formattedOrderTotalPrice: String? {
         formattedPrice(order?.total, currency: order?.currency)
@@ -46,14 +66,15 @@ final class TotalsViewModel: ObservableObject {
         formattedOrderTotalPrice == nil || isSyncingOrder
     }
 
-    init(orderService: POSOrderServiceProtocol) {
+    init(orderService: POSOrderServiceProtocol,
+         cardPresentPaymentService: CardPresentPaymentFacade,
+         currencyFormatter: CurrencyFormatter) {
         self.orderService = orderService
-        // TODO:
-        // - Inject cardPresentPaymentService
-        // - Inject currencyFormatted
-        // TODO:
-        // - observe ConnectedReaderForStatus
-        // - observe CardPresentPaymentEvents
+        self.cardPresentPaymentService = cardPresentPaymentService
+        self.currencyFormatter = currencyFormatter
+
+        observeConnectedReaderForStatus()
+        observeCardPresentPaymentEvents()
     }
 
     func formattedPrice(_ price: String?, currency: String?) -> String? {
@@ -94,8 +115,36 @@ final class TotalsViewModel: ObservableObject {
         }
     }
 
+    func cardPaymentTapped() {
+        Task { @MainActor in
+            await collectPayment()
+        }
+    }
+
+    // TODO: remove because it is unused
+//    @MainActor
+//    func updateOrderStatus(_ status: OrderStatusEnum) async throws -> POSOrder? {
+//        guard let order = totalsViewModel.order else {
+//            return nil
+//        }
+//        let updatedOrder = try await self.orderService.updateOrderStatus(posOrder: order, status: status)
+//        return updatedOrder
+//    }
+
+    func startNewTransaction() {
+        paymentState = .acceptingCard
+        clearOrder()
+    }
+
     @MainActor
-    private func syncOrder(for cartProducts: [CartItem], allItems: [POSItem]) async {
+    func onTotalsViewDisappearance() {
+        cardPresentPaymentService.cancelPayment()
+    }
+}
+
+private extension TotalsViewModel {
+    @MainActor
+    func syncOrder(for cartProducts: [CartItem], allItems: [POSItem]) async {
         guard isSyncingOrder == false else {
             return
         }
@@ -126,7 +175,7 @@ final class TotalsViewModel: ObservableObject {
         }
     }
 
-    private func calculateCartTotal(cartItems: [CartItem]) {
+    func calculateCartTotal(cartItems: [CartItem]) {
         formattedCartTotalPrice = { cartItems in
             let totalValue: Decimal = cartItems.reduce(0) { partialResult, cartItem in
                 let itemPrice = CurrencyFormatter(currencySettings: ServiceLocator.currencySettings).convertToDecimal(cartItem.item.price) ?? 0
@@ -136,5 +185,102 @@ final class TotalsViewModel: ObservableObject {
             }
             return CurrencyFormatter(currencySettings: ServiceLocator.currencySettings).formatAmount(totalValue)
         }(cartItems)
+    }
+}
+
+private extension TotalsViewModel {
+    @MainActor
+    func collectPayment() async {
+        guard let order else {
+            return
+        }
+        do {
+            let finalOrder = orderService.order(from: order)
+            try await collectPayment(for: finalOrder)
+        } catch {
+            DDLogError("Error taking payment: \(error)")
+        }
+    }
+
+    @MainActor
+    func collectPayment(for order: Order) async throws {
+        _ = try await cardPresentPaymentService.collectPayment(for: order, using: .bluetooth)
+    }
+
+    @MainActor
+    func prepareConnectedReaderForPayment() async {
+        guard connectionStatus == .connected else {
+            return
+        }
+        await collectPayment()
+    }
+}
+
+private extension TotalsViewModel {
+    func observeConnectedReaderForStatus() {
+        cardPresentPaymentService.connectedReaderPublisher
+            .map { connectedReader in
+                connectedReader == nil ? .disconnected: .connected
+            }
+            .assign(to: &$connectionStatus)
+    }
+
+    func observeCardPresentPaymentEvents() {
+        cardPresentPaymentService.paymentEventPublisher.assign(to: &$cardPresentPaymentEvent)
+        cardPresentPaymentService.paymentEventPublisher
+            .map { event -> PointOfSaleCardPresentPaymentAlertType? in
+                guard case let .show(eventDetails) = event,
+                      case let .alert(alertType) = eventDetails.pointOfSalePresentationStyle else {
+                    return nil
+                }
+                return alertType
+            }
+            .assign(to: &$cardPresentPaymentAlertViewModel)
+        cardPresentPaymentService.paymentEventPublisher
+            .map { event -> PointOfSaleCardPresentPaymentMessageType? in
+                guard case let .show(eventDetails) = event,
+                      case let .message(messageType) = eventDetails.pointOfSalePresentationStyle else {
+                    return nil
+                }
+                return messageType
+            }
+            .assign(to: &$cardPresentPaymentInlineMessage)
+        cardPresentPaymentService.paymentEventPublisher.map { event in
+            switch event {
+            case .idle:
+                return false
+            case .show(let eventDetails):
+                switch eventDetails.pointOfSalePresentationStyle {
+                case .alert:
+                    return true
+                case .message, .none:
+                    return false
+                }
+            case .showOnboarding:
+                return true
+            }
+        }.assign(to: &$showsCardReaderSheet)
+        cardPresentPaymentService.paymentEventPublisher
+            .compactMap({ PaymentState(from: $0) })
+            .assign(to: &$paymentState)
+    }
+}
+
+private extension TotalsViewModel.PaymentState {
+    init?(from cardPaymentEvent: CardPresentPaymentEvent) {
+        switch cardPaymentEvent {
+        case .idle:
+            self = .idle
+        case .show(.validatingOrder):
+            self = .preparingReader
+        case .show(.tapSwipeOrInsertCard):
+            self = .acceptingCard
+        case .show(.processing):
+            self = .processingPayment
+        case .show(.paymentSuccess):
+            self = .cardPaymentSuccessful
+        default:
+            return nil
+        }
     }
 }

--- a/WooCommerce/Classes/POS/ViewModels/TotalsViewModel.swift
+++ b/WooCommerce/Classes/POS/ViewModels/TotalsViewModel.swift
@@ -121,16 +121,6 @@ final class TotalsViewModel: ObservableObject {
         }
     }
 
-    // TODO: remove because it is unused
-//    @MainActor
-//    func updateOrderStatus(_ status: OrderStatusEnum) async throws -> POSOrder? {
-//        guard let order = totalsViewModel.order else {
-//            return nil
-//        }
-//        let updatedOrder = try await self.orderService.updateOrderStatus(posOrder: order, status: status)
-//        return updatedOrder
-//    }
-
     func startNewTransaction() {
         paymentState = .acceptingCard
         clearOrder()

--- a/WooCommerce/Classes/ViewRelated/Hub Menu/HubMenu.swift
+++ b/WooCommerce/Classes/ViewRelated/Hub Menu/HubMenu.swift
@@ -171,7 +171,8 @@ private extension HubMenu {
                             AppDelegate.shared.setShouldHideTabBar(isHidden)
                         },
                         cardPresentPaymentService: cardPresentPaymentService,
-                        orderService: orderService)
+                        orderService: orderService,
+                        currencyFormatter: .init(currencySettings: ServiceLocator.currencySettings))
                 } else {
                     // TODO: When we have a singleton for the card payment service, this should not be required.
                     Text("Error creating card payment service")

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -1491,6 +1491,8 @@
 		68709D402A2EE2DC00A7FA6C /* UpgradesViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 68709D3F2A2EE2DC00A7FA6C /* UpgradesViewModel.swift */; };
 		6879B8DB287AFFA100A0F9A8 /* CardReaderManualsViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6879B8DA287AFFA100A0F9A8 /* CardReaderManualsViewModelTests.swift */; };
 		6881CCC42A5EE6BF00AEDE36 /* WooPlanCardView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6881CCC32A5EE6BF00AEDE36 /* WooPlanCardView.swift */; };
+		6885E2CC2C32B14B004C8D70 /* TotalsViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6885E2CB2C32B14B004C8D70 /* TotalsViewModel.swift */; };
+		6885E2CE2C32B2E2004C8D70 /* TotalsViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6885E2CD2C32B2E2004C8D70 /* TotalsViewModelTests.swift */; };
 		6888A2C82A668D650026F5C0 /* FullFeatureListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6888A2C72A668D650026F5C0 /* FullFeatureListView.swift */; };
 		6888A2CA2A66C42C0026F5C0 /* FullFeatureListViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6888A2C92A66C42C0026F5C0 /* FullFeatureListViewModel.swift */; };
 		68A38DF52B293B030090C263 /* MockProductListViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 68A38DF42B293B030090C263 /* MockProductListViewModel.swift */; };
@@ -4416,6 +4418,8 @@
 		68709D3F2A2EE2DC00A7FA6C /* UpgradesViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UpgradesViewModel.swift; sourceTree = "<group>"; };
 		6879B8DA287AFFA100A0F9A8 /* CardReaderManualsViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardReaderManualsViewModelTests.swift; sourceTree = "<group>"; };
 		6881CCC32A5EE6BF00AEDE36 /* WooPlanCardView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WooPlanCardView.swift; sourceTree = "<group>"; };
+		6885E2CB2C32B14B004C8D70 /* TotalsViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TotalsViewModel.swift; sourceTree = "<group>"; };
+		6885E2CD2C32B2E2004C8D70 /* TotalsViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TotalsViewModelTests.swift; sourceTree = "<group>"; };
 		6888A2C72A668D650026F5C0 /* FullFeatureListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FullFeatureListView.swift; sourceTree = "<group>"; };
 		6888A2C92A66C42C0026F5C0 /* FullFeatureListViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FullFeatureListViewModel.swift; sourceTree = "<group>"; };
 		68A38DF42B293B030090C263 /* MockProductListViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockProductListViewModel.swift; sourceTree = "<group>"; };
@@ -6629,6 +6633,7 @@
 				026826922BF59D830036F959 /* PointOfSaleDashboardViewModel.swift */,
 				683763152C2E44B800AD51D0 /* ItemSelectorViewModel.swift */,
 				6837631B2C2E847D00AD51D0 /* CartViewModel.swift */,
+				6885E2CB2C32B14B004C8D70 /* TotalsViewModel.swift */,
 			);
 			path = ViewModels;
 			sourceTree = "<group>";
@@ -12143,6 +12148,7 @@
 				DABF35262C11B426006AF826 /* PointOfSaleDashboardViewModelTests.swift */,
 				683763172C2E497000AD51D0 /* ItemSelectorViewModelTests.swift */,
 				683763192C2E6F5900AD51D0 /* CartViewModelTests.swift */,
+				6885E2CD2C32B2E2004C8D70 /* TotalsViewModelTests.swift */,
 			);
 			path = ViewModels;
 			sourceTree = "<group>";
@@ -15906,6 +15912,7 @@
 				26B9875D273C6A830090E8CA /* SimplePaymentsNoteViewModel.swift in Sources */,
 				CE6302482BAB60AE00E3325C /* CustomerDetailViewModel.swift in Sources */,
 				DEF36DEA2898D3CF00178AC2 /* AuthenticatedWebViewModel.swift in Sources */,
+				6885E2CC2C32B14B004C8D70 /* TotalsViewModel.swift in Sources */,
 				45A0E4CB2566B56000D4E8C3 /* NumberOfLinkedProductsTableViewCell.swift in Sources */,
 				038BC37F29C37B0E00EAF565 /* SetUpTapToPayCompleteViewController.swift in Sources */,
 				E16715CB26663B0B00326230 /* CardPresentModalSuccessWithoutEmail.swift in Sources */,
@@ -16566,6 +16573,7 @@
 				B90DACC22A31BBC800365897 /* BarcodeSKUScannerProductFinderTests.swift in Sources */,
 				D88D5A3B230B5D63007B6E01 /* MockAnalyticsProvider.swift in Sources */,
 				CE5757AF2B7E7F7400AEEB6D /* AnalyticsHubCustomizeViewModelTests.swift in Sources */,
+				6885E2CE2C32B2E2004C8D70 /* TotalsViewModelTests.swift in Sources */,
 				EE1905822B50289100617C53 /* BlazeCampaignCreationFormViewModelTests.swift in Sources */,
 				B9C4AB29280031AB007008B8 /* PaymentReceiptEmailParameterDeterminerTests.swift in Sources */,
 				029A9C672535873000BECEC5 /* AppCoordinatorTests.swift in Sources */,

--- a/WooCommerce/WooCommerceTests/POS/ViewModels/PointOfSaleDashboardViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/POS/ViewModels/PointOfSaleDashboardViewModelTests.swift
@@ -21,7 +21,8 @@ final class PointOfSaleDashboardViewModelTests: XCTestCase {
         orderService = POSOrderPreviewService()
         sut = PointOfSaleDashboardViewModel(itemProvider: itemProvider,
                                             cardPresentPaymentService: cardPresentPaymentService,
-                                            orderService: orderService)
+                                            orderService: orderService,
+                                            currencyFormatter: .init(currencySettings: .init()))
     }
 
     override func tearDown() {

--- a/WooCommerce/WooCommerceTests/POS/ViewModels/TotalsViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/POS/ViewModels/TotalsViewModelTests.swift
@@ -1,0 +1,7 @@
+import XCTest
+
+final class TotalsViewModelTests: XCTestCase {
+
+    func test_isSyncingOrder() {}
+
+}

--- a/WooCommerce/WooCommerceTests/POS/ViewModels/TotalsViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/POS/ViewModels/TotalsViewModelTests.swift
@@ -9,6 +9,7 @@ final class TotalsViewModelTests: XCTestCase {
     func test_formattedPrice() {}
     func test_formattedOrderTotalPrice() {}
     func test_formattedOrderTotalTaxPrice() {}
+    func test_areAmountsFullyCalculated() {}
     func test_clearOrder() {}
     func test_setOrder() {}
 }

--- a/WooCommerce/WooCommerceTests/POS/ViewModels/TotalsViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/POS/ViewModels/TotalsViewModelTests.swift
@@ -3,5 +3,12 @@ import XCTest
 final class TotalsViewModelTests: XCTestCase {
 
     func test_isSyncingOrder() {}
-
+    func test_startSyncOrder() {}
+    func test_stopSyncOrder() {}
+    func test_order() {}
+    func test_formattedPrice() {}
+    func test_formattedOrderTotalPrice() {}
+    func test_formattedOrderTotalTaxPrice() {}
+    func test_clearOrder() {}
+    func test_setOrder() {}
 }

--- a/Yosemite/Yosemite/Tools/POS/POSOrderService.swift
+++ b/Yosemite/Yosemite/Tools/POS/POSOrderService.swift
@@ -79,13 +79,6 @@ public protocol POSOrderServiceProtocol {
     /// - Returns: Order from the remote sync.
     func syncOrder(cart: [POSCartItem], order: POSOrder?, allProducts: [POSItem]) async throws -> POSOrder
 
-    /// Updates status of an order and syncs it
-    /// - Parameters:
-    ///   - posOrder: POS order.
-    ///   - status: New order status.
-    /// - Returns: Updated and synced POS order.
-    func updateOrderStatus(posOrder: POSOrder, status: OrderStatusEnum) async throws -> POSOrder
-
     /// Creates WOO Order from POS Order.
     /// - Parameters:
     ///   - posOrder: POS order.
@@ -126,14 +119,6 @@ public final class POSOrderService: POSOrderServiceProtocol {
         } else {
             syncedOrder = try await ordersRemote.createPOSOrder(siteID: siteID, order: order, fields: [.items, .status])
         }
-
-        return POSOrder(order: syncedOrder)
-    }
-
-    public func updateOrderStatus(posOrder: POSOrder, status: OrderStatusEnum) async throws -> POSOrder {
-        let order: Order = order(from: posOrder)
-
-        let syncedOrder: Order = try await ordersRemote.updatePOSOrder(siteID: siteID, order: order, fields: [.status])
 
         return POSOrder(order: syncedOrder)
     }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of https://github.com/woocommerce/woocommerce-ios/issues/12998


## Description

This PR is part 3 (and last) of splitting `PointOfSaleDashboardViewModel` responsibilities based on the 3 main views in POS: 
* Item selector 
* Cart view
* Totals view (this PR)

As order syncing and payment collection work hand in hand, the move of both parts is in the same PR to also unblock other work affected by the view models like Bozidar's UI updates https://github.com/woocommerce/woocommerce-ios/pull/13166. 

Most of the diffs move code from `PointOfSaleDashboardViewModel` to `TotalsViewModel` with minimum changes and reorganization in the file to privatize the methods as much as possible. 

`TotalsView` still depends on `PointOfSaleDashboardViewModel` for starting a new transaction and to provide the cart items & POS items for calculating the total amount manually after an order sync failure, we can consider refactoring in the future.

## Changes
- Created `TotalsViewModel`, which encapsulates most of totals and payments logic
- CurrencyFormatter is injected from the app to the pos through the entry point
- Cleanup of unused code
- Added empty preliminary list of unit test, that will be tackled on a separate PR

## Testing
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->

Prerequisite: the store is eligible for POS and the feature switch is enabled in Menu > Settings > Experimental Features > POS
* Launch app
* Go to Menu > Point of Sale
* Add an item (with a non-zero price and ideally with tax applied on checkout) to cart
* Tap `Checkout` --> the order total should be updated to a correct, non-zero value
* Tap `Collect Payment` and proceed to tap a card to pay --> the transaction should succeed
* Tap `New transaction` and repeat the above steps --> the second transaction should succeed
* Tap `Exit POS` and go to the orders tab --> the two orders should be shown as completed

