### PR TITLE
Support opening inventory settings for product with non-integer stock quantity

### DIFF
--- a/Networking/Networking/Model/Product/Product.swift
+++ b/Networking/Networking/Model/Product/Product.swift
@@ -166,7 +166,7 @@ public struct Product: Codable, GeneratedCopiable, Equatable, GeneratedFakeable 
     /// Whether the product has an integer (or nil) stock quantity.
     /// Decimal (non-integer) stock quantities currently aren't accepted by the Core API.
     /// Related issue: https://github.com/woocommerce/woocommerce-ios/issues/3494
-    public var hasIntegerStockQuantity: Bool {
+    private var hasIntegerStockQuantity: Bool {
         guard let stockQuantity = stockQuantity else {
             return true
         }

--- a/Networking/Networking/Model/Product/ProductVariation.swift
+++ b/Networking/Networking/Model/Product/ProductVariation.swift
@@ -78,7 +78,7 @@ public struct ProductVariation: Codable, GeneratedCopiable, Equatable, Generated
     /// Whether the product variation has an integer (or nil) stock quantity.
     /// Decimal (non-integer) stock quantities currently aren't accepted by the Core API.
     /// Related issue: https://github.com/woocommerce/woocommerce-ios/issues/3494
-    public var hasIntegerStockQuantity: Bool {
+    private var hasIntegerStockQuantity: Bool {
         guard let stockQuantity = stockQuantity else {
             return true
         }

--- a/WooCommerce/Classes/Extensions/UITextField+Helpers.swift
+++ b/WooCommerce/Classes/Extensions/UITextField+Helpers.swift
@@ -7,6 +7,12 @@ extension UITextField {
         textColor = .text
     }
 
+    func applySecondaryBodyStyle() {
+        adjustsFontForContentSizeCategory = true
+        font = .body
+        textColor = .textSubtle
+    }
+
     func applyHeadlineStyle() {
         adjustsFontForContentSizeCategory = true
         font = .headline

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/EditableProductModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/EditableProductModel.swift
@@ -119,10 +119,6 @@ extension EditableProductModel: ProductFormDataModel, TaxClassRequestable {
         product.stockQuantity
     }
 
-    var hasIntegerStockQuantity: Bool {
-        product.hasIntegerStockQuantity
-    }
-
     var backordersKey: String {
         product.backordersKey
     }

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/EditableProductVariationModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/EditableProductVariationModel.swift
@@ -150,10 +150,6 @@ extension EditableProductVariationModel: ProductFormDataModel, TaxClassRequestab
         productVariation.stockQuantity
     }
 
-    var hasIntegerStockQuantity: Bool {
-        productVariation.hasIntegerStockQuantity
-    }
-
     var backordersKey: String {
         productVariation.backordersKey
     }

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Inventory Settings/Product+InventorySettingsViewModels.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Inventory Settings/Product+InventorySettingsViewModels.swift
@@ -14,7 +14,8 @@ extension Product {
 
     static func createStockQuantityViewModel(stockQuantity: Decimal?, onInputChange: @escaping (_ input: String?) -> Void) -> UnitInputViewModel {
         let title = NSLocalizedString("Quantity", comment: "Title of the cell in Product Inventory Settings > Quantity")
-        let value = NumberFormatter.localizedString(from: (stockQuantity ?? 0) as NSDecimalNumber, number: .decimal)
+        let stockQuantity = stockQuantity ?? 0
+        let value = NumberFormatter.localizedString(from: stockQuantity as NSDecimalNumber, number: .decimal)
         let accessibilityHint = NSLocalizedString(
             "The stock quantity for this product. Editable.",
             comment: "VoiceOver accessibility hint, informing the user that the cell shows the stock quantity information for this product.")
@@ -27,6 +28,7 @@ extension Product {
                                   keyboardType: .numberPad,
                                   inputFormatter: IntegerInputFormatter(),
                                   style: .primary,
+                                  isInputEnabled: stockQuantity.isInteger,
                                   onInputChange: onInputChange)
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Inventory Settings/Product+InventorySettingsViewModels.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Inventory Settings/Product+InventorySettingsViewModels.swift
@@ -14,7 +14,7 @@ extension Product {
 
     static func createStockQuantityViewModel(stockQuantity: Decimal?, onInputChange: @escaping (_ input: String?) -> Void) -> UnitInputViewModel {
         let title = NSLocalizedString("Quantity", comment: "Title of the cell in Product Inventory Settings > Quantity")
-        let value = "\(stockQuantity ?? 0)"
+        let value = NumberFormatter.localizedString(from: (stockQuantity ?? 0) as NSDecimalNumber, number: .decimal)
         let accessibilityHint = NSLocalizedString(
             "The stock quantity for this product. Editable.",
             comment: "VoiceOver accessibility hint, informing the user that the cell shows the stock quantity information for this product.")

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormActionsFactory.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormActionsFactory.swift
@@ -171,7 +171,7 @@ private extension ProductFormActionsFactory {
         let shouldShowReviewsRow = product.reviewsAllowed
         let canEditProductType = editable
         let shouldShowShippingSettingsRow = product.isShippingEnabled()
-        let canEditInventorySettingsRow = editable && product.hasIntegerStockQuantity
+        let canEditInventorySettingsRow = editable
         let shouldShowQuantityRulesRow = isMinMaxQuantitiesEnabled && product.canEditQuantityRules
 
         let actions: [ProductFormEditAction?] = [
@@ -238,7 +238,7 @@ private extension ProductFormActionsFactory {
     func allSettingsSectionActionsForVariableProduct() -> [ProductFormEditAction] {
         let shouldShowReviewsRow = product.reviewsAllowed
         let canEditProductType = editable
-        let canEditInventorySettingsRow = editable && product.hasIntegerStockQuantity
+        let canEditInventorySettingsRow = editable
         let shouldShowAttributesRow = product.product.attributesForVariations.isNotEmpty
         let shouldShowNoPriceWarningRow: Bool = {
             let variationsHaveNoPriceSet = variationsPrice == .notSet
@@ -314,7 +314,7 @@ private extension ProductFormActionsFactory {
     func allSettingsSectionActionsForSubscriptionProduct() -> [ProductFormEditAction] {
         let shouldShowReviewsRow = product.reviewsAllowed
         let shouldShowQuantityRulesRow = isMinMaxQuantitiesEnabled && product.canEditQuantityRules
-        let canEditInventorySettingsRow = editable && product.hasIntegerStockQuantity
+        let canEditInventorySettingsRow = editable
         let canEditProductType = editable
         let shouldShowShippingSettingsRow = product.isShippingEnabled()
 
@@ -344,7 +344,7 @@ private extension ProductFormActionsFactory {
 
         let actions: [ProductFormEditAction?] = {
             let canEditProductType = editable
-            let canEditInventorySettingsRow = editable && product.hasIntegerStockQuantity
+            let canEditInventorySettingsRow = editable
             let shouldShowNoPriceWarningRow: Bool = {
                 let variationsHaveNoPriceSet = variationsPrice == .notSet
                 let productHasNoPriceSet = variationsPrice == .unknown && product.product.variations.isNotEmpty && product.product.price.isEmpty

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormDataModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormDataModel.swift
@@ -50,7 +50,6 @@ protocol ProductFormDataModel {
     var manageStock: Bool { get }
     var stockStatus: ProductStockStatus { get }
     var stockQuantity: Decimal? { get }
-    var hasIntegerStockQuantity: Bool { get }
     var backordersKey: String { get }
     var soldIndividually: Bool? { get }
     // Whether stock status is available for the product.

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductVariationFormActionsFactory.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductVariationFormActionsFactory.swift
@@ -60,7 +60,7 @@ private extension ProductVariationFormActionsFactory {
         let shouldShowPriceSettingsRow = editable || productVariation.regularPrice?.isNotEmpty == true
         let shouldShowNoPriceWarningRow = productVariation.isEnabledAndMissingPrice
         let shouldShowShippingSettingsRow = productVariation.isShippingEnabled()
-        let canEditInventorySettingsRow = editable && productVariation.hasIntegerStockQuantity
+        let canEditInventorySettingsRow = editable
         let subscriptionOrPriceRow: ProductFormEditAction? = {
             if shouldShowPriceSettingsRow {
                 return .priceSettings(editable: editable, hideSeparator: shouldShowNoPriceWarningRow)

--- a/WooCommerce/Classes/ViewRelated/ReusableViews/UnitInputTableViewCell.swift
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/UnitInputTableViewCell.swift
@@ -26,6 +26,7 @@ struct UnitInputViewModel {
     let keyboardType: UIKeyboardType
     let inputFormatter: UnitInputFormatter
     let style: Style
+    var isInputEnabled: Bool = true
     let onInputChange: ((_ input: String?) -> Void)?
 }
 
@@ -70,6 +71,7 @@ final class UnitInputTableViewCell: UITableViewCell {
         onInputChange = viewModel.onInputChange
 
         configureStyle(viewModel.style)
+        configureInputTextFieldState(enabled: viewModel.isInputEnabled)
 
         rearrangeInputAndUnitStackViewSubviews(using: viewModel.unitPosition)
     }
@@ -137,6 +139,11 @@ private extension UnitInputTableViewCell {
 
         // If auto font size adjustment is enabled, the text field does not know the appropriate width and the font size shrinks even though space is available.
         inputTextField.adjustsFontSizeToFitWidth = false
+    }
+
+    func configureInputTextFieldState(enabled: Bool) {
+        inputTextField.isEnabled = enabled
+        enabled ? inputTextField.applyBodyStyle() : inputTextField.applySecondaryBodyStyle()
     }
 
     private func configureStyle(_ style: UnitInputViewModel.Style) {

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/Actions Factory/ProductFormActionsFactory+ReadonlyProductTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/Actions Factory/ProductFormActionsFactory+ReadonlyProductTests.swift
@@ -46,7 +46,7 @@ final class ProductFormActionsFactory_ReadonlyProductTests: XCTestCase {
         XCTAssertEqual(factory.bottomSheetActions(), expectedBottomSheetActions)
     }
 
-    func test_readonly_simple_product_with_decimal_stock_quantities_has_readonly_inventory_settings() {
+    func test_readonly_simple_product_with_decimal_stock_quantities_has_editable_inventory_settings() {
         // Arrange
         let product = Product.fake().copy(productTypeKey: ProductType.simple.rawValue, stockQuantity: 1.5)
         let model = EditableProductModel(product: product)
@@ -55,7 +55,7 @@ final class ProductFormActionsFactory_ReadonlyProductTests: XCTestCase {
         let factory = ProductFormActionsFactory(product: model, formType: .edit)
 
         // Assert
-        XCTAssert(factory.settingsSectionActions().contains(.inventorySettings(editable: false)))
+        XCTAssert(factory.settingsSectionActions().contains(.inventorySettings(editable: true)))
     }
 
     // MARK: - Affiliate products
@@ -204,7 +204,7 @@ final class ProductFormActionsFactory_ReadonlyProductTests: XCTestCase {
         XCTAssertEqual(factory.bottomSheetActions(), expectedBottomSheetActions)
     }
 
-    func test_readonly_variable_product_with_decimal_stock_quantities_has_readonly_inventory_settings() {
+    func test_readonly_variable_product_with_decimal_stock_quantities_has_editable_inventory_settings() {
         // Arrange
         let product = Product.fake().copy(productTypeKey: ProductType.variable.rawValue, stockQuantity: 1.5)
         let model = EditableProductModel(product: product)
@@ -213,7 +213,7 @@ final class ProductFormActionsFactory_ReadonlyProductTests: XCTestCase {
         let factory = ProductFormActionsFactory(product: model, formType: .edit)
 
         // Assert
-        XCTAssert(factory.settingsSectionActions().contains(.inventorySettings(editable: false)))
+        XCTAssert(factory.settingsSectionActions().contains(.inventorySettings(editable: true)))
     }
 }
 

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/Actions Factory/ProductVariationFormActionsFactory+ReadonlyVariationTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/Actions Factory/ProductVariationFormActionsFactory+ReadonlyVariationTests.swift
@@ -55,7 +55,7 @@ final class ProductVariationFormActionsFactory_ReadonlyVariationTests: XCTestCas
         XCTAssertEqual(factory.bottomSheetActions(), expectedBottomSheetActions)
     }
 
-    func test_variation_with_decimal_stock_quantities_has_read_only_inventory() {
+    func test_variation_with_decimal_stock_quantities_has_editable_inventory() {
         // Arrange
         let productVariation = Fixtures.variationWithDecimalStockQuantity
         let model = EditableProductVariationModel(productVariation: productVariation)
@@ -67,7 +67,7 @@ final class ProductVariationFormActionsFactory_ReadonlyVariationTests: XCTestCas
         let expectedSettingsSectionActions: [ProductFormEditAction] = [.priceSettings(editable: true, hideSeparator: false),
                                                                        .attributes(editable: true),
                                                                        .status(editable: true),
-                                                                       .inventorySettings(editable: false)]
+                                                                       .inventorySettings(editable: true)]
         XCTAssertEqual(factory.settingsSectionActions(), expectedSettingsSectionActions)
     }
 }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #13184
More context: peaMlT-HN-p2 and pdfdoF-58c-p2
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

iOS app doesn't allow opening product inventory settings if non-integer stock quantity is used. It's done due to limited non-integer stock quantity support. Android is more permissive and only forbids editing stock quantity while allowing to open and change all the other inventory settings.

This change emulates Android behavior on iOS and allows opening inventory settings for products with non-integer stock quantity while forbidding editing stock quantity to avoid API issues.

### Technical details

Up until version 9.1.0, the REST API did not support setting non-integer stock_quantity values. Changes introduced in version 9.1.0 (https://github.com/woocommerce/woocommerce/pull/48541) enable saving of non-integer stock quantity values via the REST API **but only when the default** `woocommerce_stock_amount filters` are unhooked. Plugins such as [Smart Product Quantity](https://href.li/?https://woocommerce.com/products/smart-product-quantity/) are used to allow merchants to use decimal stock amounts on the web by unhooking the default `woocommerce_stock_amount` filter that sets the `stock_quantity` to an integer.

We need to limit usage of non-integer on the app side to avoid errors when saving products, unless we can ensure that the conditions for saving non-integer amounts are met. 

## Testing information

Consider testing the changes with simple products, variable products, subscription products, and subscription variable products. Use both positive and negative stock values.

1. Add a plugin such as [Smart Product Quantity](https://href.li/?https://woocommerce.com/products/smart-product-quantity/) to the WooCommerce store
2. Add a product, enable inventory, and set the value to a decimal amount (e.g 1.5)
3. Open this store on the Woo app
4. Select the Product tab and the product
5. Confirm inventory settings can be opened
6. Confirm that the stock quantity input field is disabled
7. Change any other product attribute in the app
8. Confirm the changes are saved successfully

## Solution

1. Remove integer stock quantity checks for Inventory Settings actions
2. Disable the inventory text field in `UnitInputTableViewCell` if the stock quantity is a non-integer
3. Update tests

## Screenshots

https://github.com/woocommerce/woocommerce-ios/assets/4062343/986f9596-3d26-4650-972d-94526ecbb5ab

### ⚠️ Issues

There is a corner case with editing variable products that also exists on Android. 

**Pre-conditions:**
- Parent product has a non-integer stock quantity
- Variable products have stock disabled

If we enable stock for a variable product on the app, it's stock quantity automatically gets set to a parent product quantity. However, when we save, the value is set to 0 since we currently don't send non-integer stock quantity values to the API. I think this case needs to be handled once we decide to add proper non-integer stock quantity support in the apps. However, let me know what you think.

https://github.com/woocommerce/woocommerce-ios/assets/4062343/0415bb9a-b2de-4457-bbe5-cf38130743b5

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.