### PR TITLE
Enable Inbox Notes and manage CTAs with a new feature flag

### DIFF
--- a/Experiments/Experiments/DefaultFeatureFlagService.swift
+++ b/Experiments/Experiments/DefaultFeatureFlagService.swift
@@ -12,9 +12,9 @@ public struct DefaultFeatureFlagService: FeatureFlagService {
 
         switch featureFlag {
         case .inbox:
-            return buildConfig == .localDeveloper || buildConfig == .alpha
+            return true
         case .showInboxCTA:
-            return buildConfig == .localDeveloper || buildConfig == .alpha
+            return true
         case .sideBySideViewForOrderForm:
             return true
         case .updateOrderOptimistically:

--- a/Experiments/Experiments/DefaultFeatureFlagService.swift
+++ b/Experiments/Experiments/DefaultFeatureFlagService.swift
@@ -13,6 +13,8 @@ public struct DefaultFeatureFlagService: FeatureFlagService {
         switch featureFlag {
         case .inbox:
             return buildConfig == .localDeveloper || buildConfig == .alpha
+        case .showInboxCTA:
+            return buildConfig == .localDeveloper || buildConfig == .alpha
         case .sideBySideViewForOrderForm:
             return true
         case .updateOrderOptimistically:

--- a/Experiments/Experiments/FeatureFlag.swift
+++ b/Experiments/Experiments/FeatureFlag.swift
@@ -14,9 +14,13 @@ public enum FeatureFlag: Int {
     ///
     case reviews
 
-    /// Displays the Inbox option under the Hub Menu.
+    /// Displays the Inbox option under the Hub Menu and the Dynamic Dashboard
     ///
     case inbox
+    
+    /// Displays the call to actions in the Inbox Notes under the Hub Menu and the Dynamic Dashboard
+    ///
+    case showInboxCTA
 
     /// Displays the OrderForm side by side with the Product Selector
     ///

--- a/Experiments/Experiments/FeatureFlag.swift
+++ b/Experiments/Experiments/FeatureFlag.swift
@@ -17,7 +17,7 @@ public enum FeatureFlag: Int {
     /// Displays the Inbox option under the Hub Menu and the Dynamic Dashboard
     ///
     case inbox
-    
+
     /// Displays the call to actions in the Inbox Notes under the Hub Menu and the Dynamic Dashboard
     ///
     case showInboxCTA

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -2,7 +2,7 @@
 
 19.4
 -----
-
+- [***] Inbox Notes have been enabled in both the Dynamic Dashboard and the Hub Menu, offering users a centralized and non-intrusive method for receiving important updates, feature announcements, and pertinent information. [https://github.com/woocommerce/woocommerce-ios/pull/13214]
 
 19.3
 -----

--- a/WooCommerce/Classes/ViewRelated/Inbox/InboxNoteRow.swift
+++ b/WooCommerce/Classes/ViewRelated/Inbox/InboxNoteRow.swift
@@ -68,7 +68,7 @@ struct InboxNoteRow: View {
                                 Text(action.title)
                                     .font(Font(contentFont))
                             }
-                        }
+                        }.renderedIf(viewModel.showInboxCTA)
 
                         Text(Localization.surveyCompleted)
                             .secondaryBodyStyle()

--- a/WooCommerce/Classes/ViewRelated/Inbox/InboxNoteRow.swift
+++ b/WooCommerce/Classes/ViewRelated/Inbox/InboxNoteRow.swift
@@ -68,7 +68,8 @@ struct InboxNoteRow: View {
                                 Text(action.title)
                                     .font(Font(contentFont))
                             }
-                        }.renderedIf(viewModel.showInboxCTA)
+                        }
+                        .renderedIf(viewModel.showInboxCTA)
 
                         Text(Localization.surveyCompleted)
                             .secondaryBodyStyle()

--- a/WooCommerce/Classes/ViewRelated/Inbox/InboxNoteRowViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Inbox/InboxNoteRowViewModel.swift
@@ -41,7 +41,7 @@ struct InboxNoteRowViewModel: Identifiable, Equatable {
 
     /// Indicate if the call to actions of the Inbox Note Row should be hidden
     var showInboxCTA: Bool {
-        return featureFlagService.isFeatureFlagEnabled(.showInboxCTA)
+        featureFlagService.isFeatureFlagEnabled(.showInboxCTA)
     }
 
     init(note: InboxNote,

--- a/WooCommerce/Classes/ViewRelated/Inbox/InboxNoteRowViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Inbox/InboxNoteRowViewModel.swift
@@ -1,4 +1,5 @@
 import SwiftUI
+import Experiments
 import Yosemite
 
 /// View model for `InboxNoteRow`.
@@ -23,6 +24,9 @@ struct InboxNoteRowViewModel: Identifiable, Equatable {
     /// Stores to handle note actions.
     private let stores: StoresManager
 
+    /// Feature Flag Service.
+    private let featureFlagService: FeatureFlagService
+
     /// Whether the row is shown in placeholder state.
     let isPlaceholder: Bool
 
@@ -35,11 +39,17 @@ struct InboxNoteRowViewModel: Identifiable, Equatable {
     /// Indicate if the note is actioned or not.
     let isActioned: Bool
 
+    /// Indicate if the call to actions of the Inbox Note Row should be hidden
+    var showInboxCTA: Bool {
+        return featureFlagService.isFeatureFlagEnabled(.showInboxCTA)
+    }
+
     init(note: InboxNote,
          today: Date = .init(),
          locale: Locale = .current,
          calendar: Calendar = .current,
-         stores: StoresManager = ServiceLocator.stores) {
+         stores: StoresManager = ServiceLocator.stores,
+         featureFlagService: FeatureFlagService = ServiceLocator.featureFlagService) {
         let attributedContent = note.content.htmlToAttributedString
             .addingAttributes([
                 .foregroundColor: UIColor.secondaryLabel
@@ -60,6 +70,7 @@ struct InboxNoteRowViewModel: Identifiable, Equatable {
                   actions: actions,
                   siteID: note.siteID,
                   stores: stores,
+                  featureFlagService: featureFlagService,
                   isPlaceholder: false,
                   isRead: note.isRead,
                   isSurvey: note.type == "survey",
@@ -74,6 +85,7 @@ struct InboxNoteRowViewModel: Identifiable, Equatable {
          actions: [InboxNoteRowActionViewModel],
          siteID: Int64,
          stores: StoresManager = ServiceLocator.stores,
+         featureFlagService: FeatureFlagService = ServiceLocator.featureFlagService,
          isPlaceholder: Bool,
          isRead: Bool,
          isSurvey: Bool,
@@ -85,6 +97,7 @@ struct InboxNoteRowViewModel: Identifiable, Equatable {
         self.actions = actions
         self.siteID = siteID
         self.stores = stores
+        self.featureFlagService = featureFlagService
         self.isPlaceholder = isPlaceholder
         self.isRead = isRead
         self.isSurvey = isSurvey

--- a/WooCommerce/WooCommerceTests/Mocks/MockFeatureFlagService.swift
+++ b/WooCommerce/WooCommerceTests/Mocks/MockFeatureFlagService.swift
@@ -3,6 +3,7 @@ import Experiments
 
 struct MockFeatureFlagService: FeatureFlagService {
     private let isInboxOn: Bool
+    private let isShowInboxCTAEnabled: Bool
     private let isUpdateOrderOptimisticallyOn: Bool
     private let shippingLabelsOnboardingM1: Bool
     private let isDomainSettingsEnabled: Bool
@@ -27,6 +28,7 @@ struct MockFeatureFlagService: FeatureFlagService {
     private let googleAdsCampaignCreationOnWebView: Bool
 
     init(isInboxOn: Bool = false,
+         isShowInboxCTAEnabled: Bool = false,
          isUpdateOrderOptimisticallyOn: Bool = false,
          shippingLabelsOnboardingM1: Bool = false,
          isDomainSettingsEnabled: Bool = false,
@@ -50,6 +52,7 @@ struct MockFeatureFlagService: FeatureFlagService {
          isProductCreationAIv2M1Enabled: Bool = false,
          googleAdsCampaignCreationOnWebView: Bool = false) {
         self.isInboxOn = isInboxOn
+        self.isShowInboxCTAEnabled = isShowInboxCTAEnabled
         self.isUpdateOrderOptimisticallyOn = isUpdateOrderOptimisticallyOn
         self.shippingLabelsOnboardingM1 = shippingLabelsOnboardingM1
         self.isDomainSettingsEnabled = isDomainSettingsEnabled
@@ -78,6 +81,8 @@ struct MockFeatureFlagService: FeatureFlagService {
         switch featureFlag {
         case .inbox:
             return isInboxOn
+        case .showInboxCTA:
+            return isShowInboxCTAEnabled
         case .updateOrderOptimistically:
             return isUpdateOrderOptimisticallyOn
         case .shippingLabelsOnboardingM1:

--- a/WooCommerce/WooCommerceTests/ViewRelated/Inbox/InboxNoteRowViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Inbox/InboxNoteRowViewModelTests.swift
@@ -102,4 +102,28 @@ final class InboxNoteRowViewModelTests: XCTestCase {
         XCTAssertEqual(actionViewModel.title, "Accept Apple Pay")
         XCTAssertEqual(actionViewModel.url?.absoluteString, "https://woocommerce.com")
     }
+
+    func test_showInboxCTA_property_is_correctly_enabled() throws {
+        // Given
+        let featureFlagService = MockFeatureFlagService(isShowInboxCTAEnabled: true)
+        let note = InboxNote.fake()
+
+        // When
+        let viewModel = InboxNoteRowViewModel(note: note, featureFlagService: featureFlagService)
+
+        // Then
+        XCTAssertTrue(viewModel.showInboxCTA)
+    }
+
+    func test_showInboxCTA_property_is_correctly_disabled() throws {
+        // Given
+        let featureFlagService = MockFeatureFlagService(isShowInboxCTAEnabled: false)
+        let note = InboxNote.fake()
+
+        // When
+        let viewModel = InboxNoteRowViewModel(note: note, featureFlagService: featureFlagService)
+
+        // Then
+        XCTAssertFalse(viewModel.showInboxCTA)
+    }
 }


### PR DESCRIPTION
Closes: #13196

## Description
This PR addresses issue #13196, aiming to enable Inbox Notes and provide a way to control the display of the Call to Action (CTA) display within the Inbox Notes Cards. The changes introduced in this PR should work consistently across both the Dynamic Dashboard and the Inbox menu.

## Changes
1. **Inbox Notes Activation**: The Inbox Notes, previously hidden behind a local feature flag, have now been enabled. This change allows users to view Inbox Notes within the Dynamic Dashboard and in the Hub Menu.

2. **New Feature Flag - showInboxCTA**: A new local feature flag named `showInboxCTA` has been introduced. This flag is set to `true` by default, allowing the CTA to be displayed in the Inbox Notes Cards. When the flag is set to `false`, the CTA will be hidden, and users will only see the note content with just the dismiss button (or some actions if the card contains a survey).

3. **Compatibility with Dynamic Dashboard and Inbox Menu**: The implementation ensures that the feature flag controls the CTA visibility on both the Dynamic Dashboard and the Inbox menu.

## Testing information
1. Verify that Inbox Notes are visible on the WooCommerce dashboard.
2. Toggle the `showInboxCTA` feature flag to `false` and confirm that the CTA in the Inbox Notes Cards is hidden accordingly.
3. Check compatibility by navigating between the Dynamic Dashboard and the Inbox menu to ensure consistent behavior regarding the CTA visibility based on the feature flag.

## Screenshots
| `showInboxCTA = false` in Dynamic Dashboard             |  `showInboxCTA = false` in Inbox Notes under Hub Menu |
:-------------------------:|:-------------------------:
![Simulator Screenshot - iPhone 15 Pro Max - 2024-07-01 at 17 09 42](https://github.com/woocommerce/woocommerce-ios/assets/495617/26becef6-617f-43ba-a6c6-21e6e4f34056) | ![Simulator Screenshot - iPhone 15 Pro Max - 2024-07-01 at 17 09 31](https://github.com/woocommerce/woocommerce-ios/assets/495617/e939be31-c7e2-4718-9429-9016ac8bbe2d)



| `showInboxCTA = true` in Dynamic Dashboard            |  `showInboxCTA = true` in Inbox Notes under Hub Menu |
:-------------------------:|:-------------------------:
![Simulator Screenshot - iPhone 15 Pro Max - 2024-07-01 at 17 19 05](https://github.com/woocommerce/woocommerce-ios/assets/495617/75e99adf-d19d-4e09-98c2-5e7b3ca2b984) | ![Simulator Screenshot - iPhone 15 Pro Max - 2024-07-01 at 17 19 14](https://github.com/woocommerce/woocommerce-ios/assets/495617/a7c475f2-7a3f-4fde-9654-0ab84e464dc6)



---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
