### PR TITLE
[Woo POS] UI updates to titles and product cards

### DIFF
--- a/WooCommerce/Classes/POS/Presentation/CartView.swift
+++ b/WooCommerce/Classes/POS/Presentation/CartView.swift
@@ -15,19 +15,21 @@ struct CartView: View {
             HStack {
                 Image(uiImage: .shoppingCartIcon)
                     .resizable()
-                    .frame(width: Constants.fontSize, height: Constants.fontSize)
+                    .frame(width: Constants.primaryFontSize, height: Constants.primaryFontSize)
                     .foregroundColor(.black)
                 Text("Cart")
-                    .font(.system(size: Constants.fontSize, weight: .bold, design: .default))
+                    .font(.system(size: Constants.primaryFontSize, weight: .bold, design: .default))
                     .foregroundColor(Color.posPrimaryTexti3)
                 Spacer()
                 if let temsInCartLabel = cartViewModel.itemsInCartLabel {
                     Text(temsInCartLabel)
+                        .font(.system(size: Constants.secondaryFontSize, weight: .semibold, design: .default))
                         .foregroundColor(Color.posSecondaryTexti3)
                     Button {
                         cartViewModel.removeAllItemsFromCart()
                     } label: {
                         Text("Clear all")
+                            .font(.system(size: Constants.secondaryFontSize, weight: .semibold, design: .default))
                             .foregroundColor(Color.init(uiColor: .wooCommercePurple(.shade60)))
                     }
                     .padding(.horizontal, 8)
@@ -76,7 +78,8 @@ struct CartView: View {
 
 private extension CartView {
     enum Constants {
-        static let fontSize: CGFloat = 40
+        static let primaryFontSize: CGFloat = 40
+        static let secondaryFontSize: CGFloat = 20
     }
 }
 

--- a/WooCommerce/Classes/POS/Presentation/CartView.swift
+++ b/WooCommerce/Classes/POS/Presentation/CartView.swift
@@ -18,7 +18,7 @@ struct CartView: View {
                 Spacer()
                 if let temsInCartLabel = cartViewModel.itemsInCartLabel {
                     Text(temsInCartLabel)
-                        .foregroundColor(Color.posPrimaryTexti3)
+                        .foregroundColor(Color.posSecondaryTexti3)
                     Button {
                         cartViewModel.removeAllItemsFromCart()
                     } label: {

--- a/WooCommerce/Classes/POS/Presentation/CartView.swift
+++ b/WooCommerce/Classes/POS/Presentation/CartView.swift
@@ -15,21 +15,21 @@ struct CartView: View {
             HStack {
                 Image(uiImage: .shoppingCartIcon)
                     .resizable()
-                    .frame(width: Constants.primaryFontSize, height: Constants.primaryFontSize)
+                    .frame(width: Constants.iconSize, height: Constants.iconSize)
                     .foregroundColor(.black)
                 Text("Cart")
-                    .font(.system(size: Constants.primaryFontSize, weight: .bold, design: .default))
+                    .font(Constants.primaryFont)
                     .foregroundColor(Color.posPrimaryTexti3)
                 Spacer()
                 if let temsInCartLabel = cartViewModel.itemsInCartLabel {
                     Text(temsInCartLabel)
-                        .font(.system(size: Constants.secondaryFontSize, weight: .semibold, design: .default))
+                        .font(Constants.secondaryFont)
                         .foregroundColor(Color.posSecondaryTexti3)
                     Button {
                         cartViewModel.removeAllItemsFromCart()
                     } label: {
                         Text("Clear all")
-                            .font(.system(size: Constants.secondaryFontSize, weight: .semibold, design: .default))
+                            .font(Constants.secondaryFont)
                             .foregroundColor(Color.init(uiColor: .wooCommercePurple(.shade60)))
                     }
                     .padding(.horizontal, 8)
@@ -78,8 +78,9 @@ struct CartView: View {
 
 private extension CartView {
     enum Constants {
-        static let primaryFontSize: CGFloat = 40
-        static let secondaryFontSize: CGFloat = 20
+        static let iconSize: CGFloat = 40
+        static let primaryFont: Font = .system(size: 40, weight: .bold, design: .default)
+        static let secondaryFont: Font = .system(size: 20, weight: .semibold, design: .default)
     }
 }
 

--- a/WooCommerce/Classes/POS/Presentation/CartView.swift
+++ b/WooCommerce/Classes/POS/Presentation/CartView.swift
@@ -42,8 +42,6 @@ struct CartView: View {
                             cartViewModel.removeItemFromCart(cartItem)
                         } : nil)
                         .id(cartItem.id)
-                        .background(Color.posBackgroundGreyi3)
-                        .padding(.horizontal, 32)
                     }
                 }
                 .onChange(of: cartViewModel.itemToScrollToWhenCartUpdated?.id) { _ in

--- a/WooCommerce/Classes/POS/Presentation/CartView.swift
+++ b/WooCommerce/Classes/POS/Presentation/CartView.swift
@@ -13,7 +13,12 @@ struct CartView: View {
     var body: some View {
         VStack {
             HStack {
+                Image(uiImage: .shoppingCartIcon)
+                    .resizable()
+                    .frame(width: Constants.fontSize, height: Constants.fontSize)
+                    .foregroundColor(.black)
                 Text("Cart")
+                    .font(.system(size: Constants.fontSize, weight: .bold, design: .default))
                     .foregroundColor(Color.posPrimaryTexti3)
                 Spacer()
                 if let temsInCartLabel = cartViewModel.itemsInCartLabel {
@@ -66,6 +71,12 @@ struct CartView: View {
         }
         .frame(maxWidth: .infinity)
         .background(Color.posBackgroundWhitei3)
+    }
+}
+
+private extension CartView {
+    enum Constants {
+        static let fontSize: CGFloat = 40
     }
 }
 

--- a/WooCommerce/Classes/POS/Presentation/ItemCardView.swift
+++ b/WooCommerce/Classes/POS/Presentation/ItemCardView.swift
@@ -11,14 +11,15 @@ struct ItemCardView: View {
     }
 
     private var commaSeparatedItemCategories: String {
+        // TODO: Delete
         item.itemCategories.prefix(Constants.maxNumberOfCategories).joined(separator: ", ")
     }
 
     var body: some View {
-        HStack {
+        HStack(spacing: 0) {
             if let imageSource = item.productImageSource {
                 ProductImageThumbnail(productImageURL: URL(string: imageSource),
-                                      productImageSize: Constants.productImageWidth,
+                                      productImageSize: Constants.productCardHeight,
                                       scale: scale,
                                       productImageCornerRadius: Constants.productImageCornerRadius,
                                       foregroundColor: .clear)
@@ -26,8 +27,8 @@ struct ItemCardView: View {
                 // TODO:
                 // Handle what we'll show when there's lack of images:
                 Rectangle()
-                    .frame(width: Constants.productImageWidth * scale,
-                           height: Constants.productImageWidth * scale)
+                    .frame(width: Constants.productCardHeight * scale,
+                           height: Constants.productCardHeight * scale)
                     .foregroundColor(.gray)
             }
             VStack(alignment: .leading) {
@@ -43,15 +44,23 @@ struct ItemCardView: View {
         }
         .frame(maxWidth: .infinity, idealHeight: Constants.productCardHeight)
         .background(Color.posBackgroundWhitei3)
+        .overlay {
+            RoundedRectangle(cornerRadius: Constants.productCardCornerRadius)
+                .stroke(Color.black, lineWidth: Constants.nilOutline)
+        }
+        .clipShape(RoundedRectangle(cornerRadius: Constants.productCardCornerRadius))
     }
 }
 
 private extension ItemCardView {
     enum Constants {
         static let productCardHeight: CGFloat = 120
-        static let productImageWidth: CGFloat = 60
+        static let productCardCornerRadius: CGFloat = 20
         static let productImageCornerRadius: CGFloat = 0
         static let maxNumberOfCategories = 3
+        // The use of stroke means the shape is rendered as an outline (border) rather than a filled shape,
+        // since we still have to give it a value, we use 0 so it renders no border but it's shaped as one.
+        static let nilOutline: CGFloat = 0
     }
 }
 

--- a/WooCommerce/Classes/POS/Presentation/ItemCardView.swift
+++ b/WooCommerce/Classes/POS/Presentation/ItemCardView.swift
@@ -28,12 +28,12 @@ struct ItemCardView: View {
             }
             Text(item.name)
                 .foregroundStyle(Color.posPrimaryTexti3)
-                .font(.system(size: Constants.fontSize, weight: .medium, design: .default))
+                .font(Constants.itemNameFont)
                 .padding(.horizontal, Constants.horizontalElementSpacing)
             Spacer()
             Text(item.formattedPrice)
                 .foregroundStyle(Color.posPrimaryTexti3)
-                .font(.system(size: Constants.fontSize, weight: .light, design: .default))
+                .font(Constants.itemPriceFont)
                 .padding()
         }
         .frame(maxWidth: .infinity, idealHeight: Constants.productCardHeight)
@@ -56,7 +56,8 @@ private extension ItemCardView {
         static let nilOutline: CGFloat = 0
         static let horizontalCardSpacing: CGFloat = 0
         static let horizontalElementSpacing: CGFloat = 16
-        static let fontSize: CGFloat = 24
+        static let itemNameFont: Font = .system(size: 24, weight: .medium, design: .default)
+        static let itemPriceFont: Font = .system(size: 24, weight: .light, design: .default)
     }
 }
 

--- a/WooCommerce/Classes/POS/Presentation/ItemCardView.swift
+++ b/WooCommerce/Classes/POS/Presentation/ItemCardView.swift
@@ -11,7 +11,7 @@ struct ItemCardView: View {
     }
 
     var body: some View {
-        HStack(spacing: 0) {
+        HStack(spacing: Constants.horizontalCardSpacing) {
             if let imageSource = item.productImageSource {
                 ProductImageThumbnail(productImageURL: URL(string: imageSource),
                                       productImageSize: Constants.productCardHeight,
@@ -26,13 +26,14 @@ struct ItemCardView: View {
                            height: Constants.productCardHeight * scale)
                     .foregroundColor(.gray)
             }
-            VStack(alignment: .leading) {
-                Text(item.name)
-                    .foregroundStyle(Color.posPrimaryTexti3)
-            }
+            Text(item.name)
+                .foregroundStyle(Color.posPrimaryTexti3)
+                .font(.system(size: Constants.fontSize, weight: .medium, design: .default))
+                .padding(.horizontal, Constants.horizontalElementSpacing)
             Spacer()
             Text(item.formattedPrice)
                 .foregroundStyle(Color.posPrimaryTexti3)
+                .font(.system(size: Constants.fontSize, weight: .light, design: .default))
                 .padding()
         }
         .frame(maxWidth: .infinity, idealHeight: Constants.productCardHeight)
@@ -53,6 +54,9 @@ private extension ItemCardView {
         // The use of stroke means the shape is rendered as an outline (border) rather than a filled shape,
         // since we still have to give it a value, we use 0 so it renders no border but it's shaped as one.
         static let nilOutline: CGFloat = 0
+        static let horizontalCardSpacing: CGFloat = 0
+        static let horizontalElementSpacing: CGFloat = 16
+        static let fontSize: CGFloat = 24
     }
 }
 

--- a/WooCommerce/Classes/POS/Presentation/ItemCardView.swift
+++ b/WooCommerce/Classes/POS/Presentation/ItemCardView.swift
@@ -49,7 +49,7 @@ struct ItemCardView: View {
 private extension ItemCardView {
     enum Constants {
         static let productCardHeight: CGFloat = 120
-        static let productCardCornerRadius: CGFloat = 20
+        static let productCardCornerRadius: CGFloat = 8
         static let productImageCornerRadius: CGFloat = 0
         // The use of stroke means the shape is rendered as an outline (border) rather than a filled shape,
         // since we still have to give it a value, we use 0 so it renders no border but it's shaped as one.

--- a/WooCommerce/Classes/POS/Presentation/ItemCardView.swift
+++ b/WooCommerce/Classes/POS/Presentation/ItemCardView.swift
@@ -10,11 +10,6 @@ struct ItemCardView: View {
         self.item = item
     }
 
-    private var commaSeparatedItemCategories: String {
-        // TODO: Delete
-        item.itemCategories.prefix(Constants.maxNumberOfCategories).joined(separator: ", ")
-    }
-
     var body: some View {
         HStack(spacing: 0) {
             if let imageSource = item.productImageSource {
@@ -33,8 +28,6 @@ struct ItemCardView: View {
             }
             VStack(alignment: .leading) {
                 Text(item.name)
-                    .foregroundStyle(Color.posPrimaryTexti3)
-                Text(commaSeparatedItemCategories)
                     .foregroundStyle(Color.posPrimaryTexti3)
             }
             Spacer()
@@ -57,7 +50,6 @@ private extension ItemCardView {
         static let productCardHeight: CGFloat = 120
         static let productCardCornerRadius: CGFloat = 20
         static let productImageCornerRadius: CGFloat = 0
-        static let maxNumberOfCategories = 3
         // The use of stroke means the shape is rendered as an outline (border) rather than a filled shape,
         // since we still have to give it a value, we use 0 so it renders no border but it's shaped as one.
         static let nilOutline: CGFloat = 0

--- a/WooCommerce/Classes/POS/Presentation/ItemListView.swift
+++ b/WooCommerce/Classes/POS/Presentation/ItemListView.swift
@@ -13,7 +13,7 @@ struct ItemListView: View {
             Text("Products")
                 .frame(maxWidth: .infinity, alignment: .leading)
                 .padding(.vertical, 8)
-                .font(.title)
+                .font(.system(size: Constants.fontSize, weight: .bold, design: .default))
                 .foregroundColor(Color.posPrimaryTexti3)
             if viewModel.isSyncingItems {
                 Spacer()
@@ -39,6 +39,12 @@ struct ItemListView: View {
         }
         .padding(.horizontal, 32)
         .background(Color.posBackgroundGreyi3)
+    }
+}
+
+private extension ItemListView {
+    enum Constants {
+        static let fontSize: CGFloat = 40
     }
 }
 

--- a/WooCommerce/Classes/POS/Presentation/ItemListView.swift
+++ b/WooCommerce/Classes/POS/Presentation/ItemListView.swift
@@ -13,7 +13,7 @@ struct ItemListView: View {
             Text("Products")
                 .frame(maxWidth: .infinity, alignment: .leading)
                 .padding(.vertical, 8)
-                .font(.system(size: Constants.fontSize, weight: .bold, design: .default))
+                .font(Constants.titleFont)
                 .foregroundColor(Color.posPrimaryTexti3)
             if viewModel.isSyncingItems {
                 Spacer()
@@ -44,7 +44,7 @@ struct ItemListView: View {
 
 private extension ItemListView {
     enum Constants {
-        static let fontSize: CGFloat = 40
+        static let titleFont: Font = .system(size: 40, weight: .bold, design: .default)
     }
 }
 

--- a/WooCommerce/Classes/POS/Presentation/ItemRowView.swift
+++ b/WooCommerce/Classes/POS/Presentation/ItemRowView.swift
@@ -12,18 +12,19 @@ struct ItemRowView: View {
     }
 
     var body: some View {
-        HStack {
+        HStack(spacing: 0) {
             if let imageSource = cartItem.item.productImageSource {
                 ProductImageThumbnail(productImageURL: URL(string: imageSource),
-                                      productImageSize: 60,
+                                      productImageSize: Constants.productCardHeight,
                                       scale: scale,
-                                      productImageCornerRadius: 1,
+                                      productImageCornerRadius: Constants.productCardCornerRadius,
                                       foregroundColor: .clear)
             } else {
                 // TODO:
                 // Handle what we'll show when there's lack of images:
                 Rectangle()
-                    .frame(width: 60 * scale, height: 60 * scale)
+                    .frame(width: Constants.productCardHeight * scale,
+                           height: Constants.productCardHeight * scale)
                     .foregroundColor(.gray)
             }
             VStack(alignment: .leading) {
@@ -44,7 +45,22 @@ struct ItemRowView: View {
                 .foregroundColor(Color.posIconGrayi3)
             }
         }
-        .frame(maxWidth: .infinity, idealHeight: 120)
+        .frame(maxWidth: .infinity, idealHeight: Constants.productCardHeight)
+        .overlay {
+            RoundedRectangle(cornerRadius: Constants.productCardCornerRadius)
+                .stroke(Color.black, lineWidth: Constants.nilOutline)
+        }
+        .clipShape(RoundedRectangle(cornerRadius: Constants.productCardCornerRadius))
+    }
+}
+
+private extension ItemRowView {
+    enum Constants {
+        static let productCardHeight: CGFloat = 64
+        static let productCardCornerRadius: CGFloat = 20
+        // The use of stroke means the shape is rendered as an outline (border) rather than a filled shape,
+        // since we still have to give it a value, we use 0 so it renders no border but it's shaped as one.
+        static let nilOutline: CGFloat = 0
     }
 }
 

--- a/WooCommerce/Classes/POS/Presentation/ItemRowView.swift
+++ b/WooCommerce/Classes/POS/Presentation/ItemRowView.swift
@@ -46,11 +46,13 @@ struct ItemRowView: View {
             }
         }
         .frame(maxWidth: .infinity, idealHeight: Constants.productCardHeight)
+        .background(Color.posBackgroundGreyi3)
         .overlay {
             RoundedRectangle(cornerRadius: Constants.productCardCornerRadius)
                 .stroke(Color.black, lineWidth: Constants.nilOutline)
         }
         .clipShape(RoundedRectangle(cornerRadius: Constants.productCardCornerRadius))
+        .padding(.horizontal, Constants.horizontalPadding)
     }
 }
 
@@ -61,6 +63,7 @@ private extension ItemRowView {
         // The use of stroke means the shape is rendered as an outline (border) rather than a filled shape,
         // since we still have to give it a value, we use 0 so it renders no border but it's shaped as one.
         static let nilOutline: CGFloat = 0
+        static let horizontalPadding: CGFloat = 32
     }
 }
 

--- a/WooCommerce/Classes/POS/Presentation/ItemRowView.swift
+++ b/WooCommerce/Classes/POS/Presentation/ItemRowView.swift
@@ -30,11 +30,11 @@ struct ItemRowView: View {
             VStack(alignment: .leading) {
                 Text(cartItem.item.name)
                     .foregroundColor(Color.posPrimaryTexti3)
-                    .font(.system(size: Constants.fontSize, weight: .medium, design: .default))
+                    .font(Constants.itemNameFont)
                     .padding(.horizontal, Constants.horizontalElementSpacing)
                 Text(cartItem.item.formattedPrice)
                     .foregroundColor(Color.posPrimaryTexti3)
-                    .font(.system(size: Constants.fontSize, weight: .light, design: .default))
+                    .font(Constants.itemPriceFont)
                     .padding(.horizontal, Constants.horizontalElementSpacing)
             }
             Spacer()
@@ -72,8 +72,9 @@ private extension ItemRowView {
         static let horizontalPadding: CGFloat = 32
         static let horizontalCardSpacing: CGFloat = 0
         static let horizontalElementSpacing: CGFloat = 16
-        static let fontSize: CGFloat = 16
         static let buttonWidth: CGFloat = 56
+        static let itemNameFont: Font = .system(size: 16, weight: .medium, design: .default)
+        static let itemPriceFont: Font = .system(size: 16, weight: .light, design: .default)
     }
 }
 

--- a/WooCommerce/Classes/POS/Presentation/ItemRowView.swift
+++ b/WooCommerce/Classes/POS/Presentation/ItemRowView.swift
@@ -12,7 +12,7 @@ struct ItemRowView: View {
     }
 
     var body: some View {
-        HStack(spacing: 0) {
+        HStack(spacing: Constants.horizontalCardSpacing) {
             if let imageSource = cartItem.item.productImageSource {
                 ProductImageThumbnail(productImageURL: URL(string: imageSource),
                                       productImageSize: Constants.productCardHeight,
@@ -30,8 +30,12 @@ struct ItemRowView: View {
             VStack(alignment: .leading) {
                 Text(cartItem.item.name)
                     .foregroundColor(Color.posPrimaryTexti3)
+                    .font(.system(size: Constants.fontSize, weight: .medium, design: .default))
+                    .padding(.horizontal, Constants.horizontalElementSpacing)
                 Text(cartItem.item.formattedPrice)
                     .foregroundColor(Color.posPrimaryTexti3)
+                    .font(.system(size: Constants.fontSize, weight: .light, design: .default))
+                    .padding(.horizontal, Constants.horizontalElementSpacing)
             }
             Spacer()
             if let onItemRemoveTapped {
@@ -40,8 +44,10 @@ struct ItemRowView: View {
                 }, label: {
                     Image(systemName: "x.circle")
                 })
-                .frame(width: 56, height: 56, alignment: .trailing)
-                .padding(.horizontal, 32)
+                .frame(width: Constants.buttonWidth,
+                       height: Constants.buttonWidth,
+                       alignment: .trailing)
+                .padding(.horizontal, Constants.horizontalPadding)
                 .foregroundColor(Color.posIconGrayi3)
             }
         }
@@ -59,11 +65,15 @@ struct ItemRowView: View {
 private extension ItemRowView {
     enum Constants {
         static let productCardHeight: CGFloat = 64
-        static let productCardCornerRadius: CGFloat = 20
+        static let productCardCornerRadius: CGFloat = 8
         // The use of stroke means the shape is rendered as an outline (border) rather than a filled shape,
         // since we still have to give it a value, we use 0 so it renders no border but it's shaped as one.
         static let nilOutline: CGFloat = 0
         static let horizontalPadding: CGFloat = 32
+        static let horizontalCardSpacing: CGFloat = 0
+        static let horizontalElementSpacing: CGFloat = 16
+        static let fontSize: CGFloat = 16
+        static let buttonWidth: CGFloat = 56
     }
 }
 

--- a/WooCommerce/Classes/POS/Utils/Color+WooCommercePOS.swift
+++ b/WooCommerce/Classes/POS/Utils/Color+WooCommercePOS.swift
@@ -42,6 +42,10 @@ extension Color {
         Color(red: 39.0 / 255.0, green: 27.0 / 255.0, blue: 61.0 / 255.0)
     }
 
+    static var posSecondaryTexti3: Color {
+        Color(red: 60.0 / 255.0, green: 60.0 / 255.0, blue: 67.0 / 255.0, opacity: 0.6)
+    }
+
     static var posIconGrayi3: Color {
         return Color.gray
     }


### PR DESCRIPTION
## Description

This PR updates the product cards within Product List and Cart Views, as well as the title of the sections ("Products", "Cart"), to make them closer to the latest high-fidelity designs:

| Proposed design |
|--------|
| <img width="737" alt="Screenshot 2024-07-02 at 18 15 54" src="https://github.com/woocommerce/woocommerce-ios/assets/3812076/80ffd067-7e04-442b-b556-f0dc40b620e1"> | 

| Implemented so far |
|--------|
| <img width="750" alt="Screenshot 2024-07-02 at 18 25 08" src="https://github.com/woocommerce/woocommerce-ios/assets/3812076/e2af8ce1-3c6a-45b3-b6e8-77cb9f06ebf8">| 

## Changes
* Updates size and font for titles
* Added "cart icon" to cart view
* Updated  `ItemCardView`'s (left side) to be closer to the proposed design
* Updated `ItemRowView`'s (right side) to be closer to the proposed design

What's still missing? (Future PRs)
* Product list vs Cart space distribution. Right now they take 50% of the space, but should be more like 70/30.
* Move all previous constants and strings to a private extension
* Handle what we'll show when there's lack of images, product name, or price. This will be part of M2 and handling non-happy paths.
* Loading screen when entering POS mode. To be provided by design.

## Testing
Run the POS, and observe that the design is closer to the designs, for example:
* Rounded borders for the product cards
* The cart icon it's displayed bigger when we add products to cart, and smaller when there's no products
* The item counter uses a "grey" colour
* Fonts for text and price in different weights

