### PR TITLE
Google Ads: Navigation from Hub menu entry point

### DIFF
--- a/WooCommerce/Classes/GoogleAds/GoogleAdsCampaignCoordinator.swift
+++ b/WooCommerce/Classes/GoogleAds/GoogleAdsCampaignCoordinator.swift
@@ -1,0 +1,108 @@
+import Foundation
+import Yosemite
+
+/// Reusable coordinator to handle Google Ads campaigns.
+///
+final class GoogleAdsCampaignCoordinator: Coordinator {
+    let navigationController: UINavigationController
+
+    private let siteID: Int64
+    private let siteAdminURL: String
+
+    private let hasGoogleAdsCampaigns: Bool
+    private let shouldAuthenticateAdminPage: Bool
+
+    init(siteID: Int64,
+         siteAdminURL: String,
+         hasGoogleAdsCampaigns: Bool,
+         shouldAuthenticateAdminPage: Bool,
+         navigationController: UINavigationController) {
+        self.siteID = siteID
+        self.siteAdminURL = siteAdminURL
+        self.shouldAuthenticateAdminPage = shouldAuthenticateAdminPage
+        self.hasGoogleAdsCampaigns = hasGoogleAdsCampaigns
+        self.navigationController = navigationController
+    }
+
+    func start() {
+        guard let url = createGoogleAdsCampaignURL() else {
+            return
+        }
+        let controller = createCampaignViewController(with: url)
+        controller.navigationItem.leftBarButtonItem = UIBarButtonItem(barButtonSystemItem: .cancel, target: self, action: #selector(dismissCampaignView))
+        navigationController.present(UINavigationController(rootViewController: controller), animated: true)
+    }
+}
+
+// MARK: - Private helpers
+//
+private extension GoogleAdsCampaignCoordinator {
+    @objc func dismissCampaignView() {
+        navigationController.dismiss(animated: true)
+    }
+
+    func createCampaignViewController(with url: URL) -> UIViewController {
+        let exitTriggerClosure: (URL?) -> Void = { [weak self] newURL in
+            if let newURL, newURL != url {
+                self?.checkIfCampaignCreationSucceeded(url: newURL)
+            }
+        }
+        if shouldAuthenticateAdminPage {
+            let viewModel = DefaultAuthenticatedWebViewModel(
+                title: Localization.googleForWooCommerce,
+                initialURL: url,
+                exitTrigger: exitTriggerClosure
+            )
+            return AuthenticatedWebViewController(viewModel: viewModel)
+        } else {
+            let controller = WebViewHostingController(url: url, exitTrigger: exitTriggerClosure)
+            controller.title = Localization.googleForWooCommerce
+            return controller
+        }
+    }
+
+    func checkIfCampaignCreationSucceeded(url: URL) {
+        let components = URLComponents(url: url, resolvingAgainstBaseURL: true)
+        let queryItems = components?.queryItems
+        let creationSucceeded = queryItems?.first(where: {
+            $0.name == Constants.campaignParam &&
+            $0.value == Constants.savedValue
+        }) != nil
+        if creationSucceeded {
+            // dismisses the web view
+            navigationController.dismiss(animated: true)
+
+            // TODO: show success bottom sheet
+            DDLogDebug("🎉 Campaign creation success")
+        }
+    }
+
+    func createGoogleAdsCampaignURL() -> URL? {
+        let path: String = {
+            if hasGoogleAdsCampaigns {
+                Constants.campaignDashboardPath
+            } else {
+                Constants.campaignCreationPath
+            }
+        }()
+        return URL(string: siteAdminURL.appending(path))
+    }
+}
+
+
+private extension GoogleAdsCampaignCoordinator {
+    enum Constants {
+        static let campaignDashboardPath = "admin.php?page=wc-admin&path=%2Fgoogle%2Fdashboard"
+        static let campaignCreationPath = "admin.php?page=wc-admin&path=%2Fgoogle%2Fdashboard&subpath=%2Fcampaigns%2Fcreate"
+        static let campaignParam = "campaign"
+        static let savedValue = "saved"
+    }
+
+    enum Localization {
+        static let googleForWooCommerce = NSLocalizedString(
+            "googleAdsCampaignCoordinator.googleForWooCommerce",
+            value: "Google for WooCommerce",
+            comment: "Title of the Google Ads campaign view"
+        )
+    }
+}

--- a/WooCommerce/Classes/GoogleAds/GoogleAdsCampaignCoordinator.swift
+++ b/WooCommerce/Classes/GoogleAds/GoogleAdsCampaignCoordinator.swift
@@ -42,8 +42,8 @@ private extension GoogleAdsCampaignCoordinator {
     }
 
     func createCampaignViewController(with url: URL) -> UIViewController {
-        let exitTriggerClosure: (URL?) -> Void = { [weak self] newURL in
-            if let newURL, newURL != url {
+        let redirectHandler: (URL) -> Void = { [weak self] newURL in
+            if newURL != url {
                 self?.checkIfCampaignCreationSucceeded(url: newURL)
             }
         }
@@ -51,11 +51,11 @@ private extension GoogleAdsCampaignCoordinator {
             let viewModel = DefaultAuthenticatedWebViewModel(
                 title: Localization.googleForWooCommerce,
                 initialURL: url,
-                exitTrigger: exitTriggerClosure
+                redirectHandler: redirectHandler
             )
             return AuthenticatedWebViewController(viewModel: viewModel)
         } else {
-            let controller = WebViewHostingController(url: url, exitTrigger: exitTriggerClosure)
+            let controller = WebViewHostingController(url: url, redirectHandler: redirectHandler)
             controller.title = Localization.googleForWooCommerce
             return controller
         }
@@ -73,7 +73,7 @@ private extension GoogleAdsCampaignCoordinator {
             navigationController.dismiss(animated: true)
 
             // TODO: show success bottom sheet
-            DDLogDebug("🎉 Campaign creation success")
+            DDLogDebug("🎉 Google Ads campaign creation success")
         }
     }
 

--- a/WooCommerce/Classes/GoogleAds/GoogleAdsEligibilityChecker.swift
+++ b/WooCommerce/Classes/GoogleAds/GoogleAdsEligibilityChecker.swift
@@ -25,18 +25,18 @@ final class DefaultGoogleAdsEligibilityChecker: GoogleAdsEligibilityChecker {
             return false
         }
 
-        let remotePlugin = await fetchPluginFromRemote(siteID: siteID)
-        guard checkIfGoogleAdsIsSupported(plugin: remotePlugin) else {
-            return false
-        }
-
         do {
             let connection = try await checkGoogleAdsConnection(siteID: siteID)
-            return connection.status == .connected
+            guard connection.status == .connected else {
+                return false
+            }
         } catch {
             DDLogError("⛔️ Error checking Google ads connection: \(error)")
-            return false
         }
+
+        /// Ensures that the plugin is running the correct version.
+        let remotePlugin = await fetchPluginFromRemote(siteID: siteID)
+        return checkIfGoogleAdsIsSupported(plugin: remotePlugin)
     }
 
 }

--- a/WooCommerce/Classes/ViewRelated/CardPresentPayments/WCSettingsWebView.swift
+++ b/WooCommerce/Classes/ViewRelated/CardPresentPayments/WCSettingsWebView.swift
@@ -1,6 +1,6 @@
 import SwiftUI
 
-/// Displays WooCommerce settings in a webview within a navigation view.
+/// Displays WooCommerce settings in a web view within a navigation view.
 struct WCSettingsWebView: View {
     let adminUrl: URL
     let completion: () -> Void
@@ -8,9 +8,7 @@ struct WCSettingsWebView: View {
     var body: some View {
         NavigationView {
             AuthenticatedWebView(isPresented: .constant(true),
-                                 url: adminUrl,
-                                 urlToTriggerExit: nil,
-                                 exitTrigger: nil)
+                                 url: adminUrl)
                                  .navigationTitle(Localization.adminWebviewTitle)
                                  .navigationBarTitleDisplayMode(.inline)
                                  .toolbar {

--- a/WooCommerce/Classes/ViewRelated/Hub Menu/HubMenu.swift
+++ b/WooCommerce/Classes/ViewRelated/Hub Menu/HubMenu.swift
@@ -394,10 +394,9 @@ private extension HubMenu {
         static let avatarSize: CGFloat = 40
         static let chevronSize: CGFloat = 20
         static let iconSize: CGFloat = 20
+        static let trackingOptionKey = "option"
         static let dotBadgePadding = EdgeInsets(top: 6, leading: 0, bottom: 0, trailing: 2)
         static let dotBadgeSize: CGFloat = 6
-
-        static let trackingOptionKey = "option"
 
         /// Spacing for the badge view in the avatar row.
         ///

--- a/WooCommerce/Classes/ViewRelated/Hub Menu/HubMenu.swift
+++ b/WooCommerce/Classes/ViewRelated/Hub Menu/HubMenu.swift
@@ -176,6 +176,13 @@ private extension HubMenu {
                     // TODO: When we have a singleton for the card payment service, this should not be required.
                     Text("Error creating card payment service")
                 }
+            case HubMenuViewModel.GoogleAds.id:
+                webView(url: viewModel.googleAdsCampaignURL,
+                        title: "Google for WooCommerce",
+                        shouldAuthenticate: viewModel.shouldAuthenticateAdminPage,
+                        exitTrigger: { url in
+                    viewModel.checkIfCampaignCreationSucceeded(url: url)
+                })
             default:
                 fatalError("🚨 Unsupported menu item")
             }
@@ -195,14 +202,22 @@ private extension HubMenu {
     }
 
     @ViewBuilder
-    func webView(url: URL, title: String, shouldAuthenticate: Bool) -> some View {
+    func webView(url: URL,
+                 title: String,
+                 shouldAuthenticate: Bool,
+                 urlToTriggerExit: String? = nil,
+                 exitTrigger: ((URL?) -> Void)? = nil) -> some View {
         Group {
             if shouldAuthenticate {
                 AuthenticatedWebView(isPresented: .constant(true),
-                                     url: url)
+                                     url: url,
+                                     urlToTriggerExit: urlToTriggerExit,
+                                     exitTrigger: exitTrigger)
             } else {
                 WebView(isPresented: .constant(true),
-                        url: url)
+                        url: url,
+                        urlToTriggerExit: urlToTriggerExit,
+                        exitTrigger: exitTrigger)
             }
         }
         .navigationTitle(title)

--- a/WooCommerce/Classes/ViewRelated/Hub Menu/HubMenu.swift
+++ b/WooCommerce/Classes/ViewRelated/Hub Menu/HubMenu.swift
@@ -208,18 +208,18 @@ private extension HubMenu {
                  title: String,
                  shouldAuthenticate: Bool,
                  urlToTriggerExit: String? = nil,
-                 exitTrigger: ((URL?) -> Void)? = nil) -> some View {
+                 redirectHandler: ((URL) -> Void)? = nil) -> some View {
         Group {
             if shouldAuthenticate {
                 AuthenticatedWebView(isPresented: .constant(true),
                                      url: url,
                                      urlToTriggerExit: urlToTriggerExit,
-                                     exitTrigger: exitTrigger)
+                                     redirectHandler: redirectHandler)
             } else {
                 WebView(isPresented: .constant(true),
                         url: url,
                         urlToTriggerExit: urlToTriggerExit,
-                        exitTrigger: exitTrigger)
+                        redirectHandler: redirectHandler)
             }
         }
         .navigationTitle(title)

--- a/WooCommerce/Classes/ViewRelated/Hub Menu/HubMenu.swift
+++ b/WooCommerce/Classes/ViewRelated/Hub Menu/HubMenu.swift
@@ -178,7 +178,7 @@ private extension HubMenu {
                 }
             case HubMenuViewModel.GoogleAds.id:
                 webView(url: viewModel.googleAdsCampaignURL,
-                        title: "Google for WooCommerce",
+                        title: Localization.googleForWooCommerce,
                         shouldAuthenticate: viewModel.shouldAuthenticateAdminPage,
                         exitTrigger: { url in
                     viewModel.checkIfCampaignCreationSucceeded(url: url)
@@ -410,6 +410,11 @@ private extension HubMenu {
             "hubMenu.productReview",
             value: "Product Review",
             comment: "Title of the view containing a single Product Review"
+        )
+        static let googleForWooCommerce = NSLocalizedString(
+            "hubMenu.googleForWooCommerce",
+            value: "Google for WooCommerce",
+            comment: "Title of the Google Ads campaign view"
         )
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Hub Menu/HubMenuViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Hub Menu/HubMenuViewController.swift
@@ -8,6 +8,7 @@ final class HubMenuViewController: UIHostingController<HubMenu> {
     private let tapToPayBadgePromotionChecker: TapToPayBadgePromotionChecker
 
     private var storePickerCoordinator: StorePickerCoordinator?
+    private var googleAdsCampaignCoordinator: GoogleAdsCampaignCoordinator?
 
     init(siteID: Int64,
          navigationController: UINavigationController?,
@@ -18,8 +19,13 @@ final class HubMenuViewController: UIHostingController<HubMenu> {
         self.tapToPayBadgePromotionChecker = tapToPayBadgePromotionChecker
         super.init(rootView: HubMenu(viewModel: viewModel))
         configureTabBarItem()
+
         rootView.switchStoreHandler = { [weak self] in
             self?.presentSwitchStore()
+        }
+
+        rootView.googleAdsCampaignHandler = { [weak self] in
+            self?.presentGoogleAds()
         }
     }
 
@@ -80,6 +86,20 @@ private extension HubMenuViewController {
             storePickerCoordinator = StorePickerCoordinator(navigationController, config: .switchingStores)
             storePickerCoordinator?.start()
         }
+    }
+
+    func presentGoogleAds() {
+        guard let navigationController else {
+            return
+        }
+        googleAdsCampaignCoordinator = GoogleAdsCampaignCoordinator(
+            siteID: viewModel.siteID,
+            siteAdminURL: viewModel.woocommerceAdminURL.absoluteString,
+            hasGoogleAdsCampaigns: viewModel.hasGoogleAdsCampaigns,
+            shouldAuthenticateAdminPage: viewModel.shouldAuthenticateAdminPage,
+            navigationController: navigationController
+        )
+        googleAdsCampaignCoordinator?.start()
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Hub Menu/HubMenuViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Hub Menu/HubMenuViewModel.swift
@@ -204,6 +204,11 @@ final class HubMenuViewModel: ObservableObject {
             // dismisses the web view
             displayingGoogleAdsCampaigns = false
 
+            // updates the check for campaigns
+            Task { @MainActor in
+                hasGoogleAdsCampaigns = await checkIfSiteHasGoogleAdsCampaigns()
+            }
+
             // TODO: show success bottom sheet
             DDLogDebug("🎉 Campaign creation success")
         }

--- a/WooCommerce/Classes/ViewRelated/Hub Menu/HubMenuViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Hub Menu/HubMenuViewModel.swift
@@ -67,7 +67,7 @@ final class HubMenuViewModel: ObservableObject {
     @Published private(set) var shouldAuthenticateAdminPage = false
 
     @Published private(set) var hasGoogleAdsCampaigns = false
-    @Published private(set) var currentSite: Yosemite.Site?
+    @Published private var currentSite: Yosemite.Site?
 
     private let stores: StoresManager
     private let featureFlagService: FeatureFlagService

--- a/WooCommerce/Classes/ViewRelated/Hub Menu/HubMenuViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Hub Menu/HubMenuViewModel.swift
@@ -67,7 +67,7 @@ final class HubMenuViewModel: ObservableObject {
 
     @Published private(set) var shouldAuthenticateAdminPage = false
 
-    @Published private(set) var hasGoogleAdsCampaigns = false
+    @Published private var hasGoogleAdsCampaigns = false
     @Published var displayingGoogleAdsCampaigns = false
 
     var googleAdsCampaignURL: URL {

--- a/WooCommerce/Classes/ViewRelated/Hub Menu/HubMenuViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Hub Menu/HubMenuViewModel.swift
@@ -5,7 +5,6 @@ import Combine
 import Experiments
 import Yosemite
 import struct Storage.GeneralAppSettingsStorage
-import protocol WooFoundation.Analytics
 
 extension NSNotification.Name {
     /// Posted whenever the hub menu view did appear.
@@ -78,7 +77,6 @@ final class HubMenuViewModel: ObservableObject {
     private let inboxEligibilityChecker: InboxEligibilityChecker
     private let blazeEligibilityChecker: BlazeEligibilityCheckerProtocol
     private let googleAdsEligibilityChecker: GoogleAdsEligibilityChecker
-    private let analytics: Analytics
 
     private(set) lazy var posItemProvider: POSItemProvider = {
         let currencySettings = ServiceLocator.currencySettings
@@ -130,8 +128,7 @@ final class HubMenuViewModel: ObservableObject {
          generalAppSettings: GeneralAppSettingsStorage = ServiceLocator.generalAppSettings,
          inboxEligibilityChecker: InboxEligibilityChecker = InboxEligibilityUseCase(),
          blazeEligibilityChecker: BlazeEligibilityCheckerProtocol = BlazeEligibilityChecker(),
-         googleAdsEligibilityChecker: GoogleAdsEligibilityChecker = DefaultGoogleAdsEligibilityChecker(),
-         analytics: Analytics = ServiceLocator.analytics) {
+         googleAdsEligibilityChecker: GoogleAdsEligibilityChecker = DefaultGoogleAdsEligibilityChecker()) {
         self.siteID = siteID
         self.credentials = stores.sessionManager.defaultCredentials
         self.tapToPayBadgePromotionChecker = tapToPayBadgePromotionChecker
@@ -147,7 +144,6 @@ final class HubMenuViewModel: ObservableObject {
                                                            siteSettings: ServiceLocator.selectedSiteSettings,
                                                            currencySettings: ServiceLocator.currencySettings,
                                                            featureFlagService: featureFlagService)
-        self.analytics = analytics
         observeSiteForUIUpdates()
         observePlanName()
         tapToPayBadgePromotionChecker.$shouldShowTapToPayBadges.share().assign(to: &$shouldShowNewFeatureBadgeOnPayments)

--- a/WooCommerce/Classes/ViewRelated/Hub Menu/HubMenuViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Hub Menu/HubMenuViewModel.swift
@@ -66,7 +66,7 @@ final class HubMenuViewModel: ObservableObject {
 
     @Published private(set) var shouldAuthenticateAdminPage = false
 
-    @Published private var hasGoogleAdsCampaigns = false
+    @Published private(set) var hasGoogleAdsCampaigns = false
 
     var googleAdsCampaignURL: URL {
         let path: String = {

--- a/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/AuthenticatedWebView.swift
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/AuthenticatedWebView.swift
@@ -24,9 +24,13 @@ final class DefaultAuthenticatedWebViewModel: AuthenticatedWebViewModel {
     }
 
     func handleRedirect(for url: URL?) {
+        guard let url else {
+            return
+        }
         if let urlToTriggerExit,
-            let url,
             url.absoluteString.contains(urlToTriggerExit) {
+            exitTrigger?(url)
+        } else {
             exitTrigger?(url)
         }
     }
@@ -57,9 +61,9 @@ struct AuthenticatedWebView: UIViewControllerRepresentable {
         }
 
     init(isPresented: Binding<Bool>,
-             url: URL,
-             urlToTriggerExit: String? = nil,
-             exitTrigger: ((URL?) -> Void)? = nil) {
+         url: URL,
+         urlToTriggerExit: String? = nil,
+         exitTrigger: ((URL?) -> Void)? = nil) {
             self._isPresented = isPresented
             viewModel = DefaultAuthenticatedWebViewModel(initialURL: url,
                                                          urlToTriggerExit: urlToTriggerExit,

--- a/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/AuthenticatedWebView.swift
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/AuthenticatedWebView.swift
@@ -6,17 +6,24 @@ import WebKit
 final class DefaultAuthenticatedWebViewModel: AuthenticatedWebViewModel {
     let title: String
     let initialURL: URL?
+
+    /// A url to trigger dismissing of the web view.
     let urlToTriggerExit: String?
-    let exitTrigger: ((URL?) -> Void)?
+
+    /// Closure to determine the action given the redirect URL.
+    /// If `urlToTriggerExit` is provided, this closure is triggered only when
+    /// a redirect URL matches `urlToTriggerExit`.
+    /// Otherwise, the closure is triggered whenever the web view redirects to a new URL.
+    let redirectHandler: ((URL) -> Void)?
 
     init(title: String = "",
          initialURL: URL,
          urlToTriggerExit: String? = nil,
-         exitTrigger: ((URL?) -> Void)? = nil) {
+         redirectHandler: ((URL) -> Void)? = nil) {
         self.title = title
         self.initialURL = initialURL
         self.urlToTriggerExit = urlToTriggerExit
-        self.exitTrigger = exitTrigger
+        self.redirectHandler = redirectHandler
     }
 
     func handleDismissal() {
@@ -27,11 +34,13 @@ final class DefaultAuthenticatedWebViewModel: AuthenticatedWebViewModel {
         guard let url else {
             return
         }
-        if let urlToTriggerExit,
-            url.absoluteString.contains(urlToTriggerExit) {
-            exitTrigger?(url)
-        } else {
-            exitTrigger?(url)
+        guard let urlToTriggerExit else {
+            // always trigger `redirectHandler` if `urlToTriggerExit` is not specified.
+            redirectHandler?(url)
+            return
+        }
+        if url.absoluteString.contains(urlToTriggerExit) {
+            redirectHandler?(url)
         }
     }
 
@@ -55,19 +64,19 @@ struct AuthenticatedWebView: UIViewControllerRepresentable {
     let viewModel: AuthenticatedWebViewModel
 
     init(isPresented: Binding<Bool>,
-             viewModel: AuthenticatedWebViewModel) {
-            self._isPresented = isPresented
-            self.viewModel = viewModel
-        }
+         viewModel: AuthenticatedWebViewModel) {
+        self._isPresented = isPresented
+        self.viewModel = viewModel
+    }
 
     init(isPresented: Binding<Bool>,
          url: URL,
          urlToTriggerExit: String? = nil,
-         exitTrigger: ((URL?) -> Void)? = nil) {
+         redirectHandler: ((URL) -> Void)? = nil) {
             self._isPresented = isPresented
             viewModel = DefaultAuthenticatedWebViewModel(initialURL: url,
                                                          urlToTriggerExit: urlToTriggerExit,
-                                                         exitTrigger: exitTrigger)
+                                                         redirectHandler: redirectHandler)
         }
 
     func makeUIViewController(context: Context) -> AuthenticatedWebViewController {

--- a/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/WebView.swift
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/WebView.swift
@@ -4,6 +4,27 @@ import WebKit
 import Alamofire
 import class Networking.UserAgent
 
+/// Hosting controller for WebView
+///
+final class WebViewHostingController: UIHostingController<WebView> {
+    init(url: URL,
+         disableLinkClicking: Bool = false,
+         onCommit: ((WKWebView)->Void)? = nil,
+         urlToTriggerExit: String? = nil,
+         exitTrigger: ((URL?) -> Void)? = nil) {
+        super.init(rootView: WebView(isPresented: .constant(true),
+                                     url: url,
+                                     disableLinkClicking: disableLinkClicking,
+                                     onCommit: onCommit,
+                                     urlToTriggerExit: urlToTriggerExit,
+                                     exitTrigger: exitTrigger))
+    }
+    
+    @MainActor required dynamic init?(coder aDecoder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+}
+
 /// Mirror of AuthenticatedWebView, for equivalent display of URLs in `WKWebView` that do not need authentication on WPCom.
 struct WebView: UIViewRepresentable {
     @Environment(\.presentationMode) var presentation

--- a/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/WebView.swift
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/WebView.swift
@@ -19,7 +19,7 @@ final class WebViewHostingController: UIHostingController<WebView> {
                                      urlToTriggerExit: urlToTriggerExit,
                                      exitTrigger: exitTrigger))
     }
-    
+
     @MainActor required dynamic init?(coder aDecoder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -2583,6 +2583,7 @@
 		DEB387952C2E7A7C0025256E /* GoogleAdsEligibilityChecker.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEB387942C2E7A7C0025256E /* GoogleAdsEligibilityChecker.swift */; };
 		DEB387982C2E803A0025256E /* DefaultGoogleAdsEligibilityCheckTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEB387972C2E803A0025256E /* DefaultGoogleAdsEligibilityCheckTests.swift */; };
 		DEB3879A2C32A6400025256E /* MockGoogleAdsEligibilityChecker.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEB387992C32A6400025256E /* MockGoogleAdsEligibilityChecker.swift */; };
+		DEB3879E2C34FE620025256E /* GoogleAdsCampaignCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEB3879D2C34FE620025256E /* GoogleAdsCampaignCoordinator.swift */; };
 		DEBAB70B2A7A3FE000743185 /* StorePlanBannerPresenterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEBAB70A2A7A3FE000743185 /* StorePlanBannerPresenterTests.swift */; };
 		DEBAB70D2A7A6F1100743185 /* MockStorePlanSynchronizer.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEBAB70C2A7A6F1100743185 /* MockStorePlanSynchronizer.swift */; };
 		DEBAB70F2A7A6F3800743185 /* MockConnectivityObserver.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEBAB70E2A7A6F3800743185 /* MockConnectivityObserver.swift */; };
@@ -5554,6 +5555,7 @@
 		DEB387942C2E7A7C0025256E /* GoogleAdsEligibilityChecker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GoogleAdsEligibilityChecker.swift; sourceTree = "<group>"; };
 		DEB387972C2E803A0025256E /* DefaultGoogleAdsEligibilityCheckTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefaultGoogleAdsEligibilityCheckTests.swift; sourceTree = "<group>"; };
 		DEB387992C32A6400025256E /* MockGoogleAdsEligibilityChecker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockGoogleAdsEligibilityChecker.swift; sourceTree = "<group>"; };
+		DEB3879D2C34FE620025256E /* GoogleAdsCampaignCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GoogleAdsCampaignCoordinator.swift; sourceTree = "<group>"; };
 		DEBAB70A2A7A3FE000743185 /* StorePlanBannerPresenterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StorePlanBannerPresenterTests.swift; sourceTree = "<group>"; };
 		DEBAB70C2A7A6F1100743185 /* MockStorePlanSynchronizer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockStorePlanSynchronizer.swift; sourceTree = "<group>"; };
 		DEBAB70E2A7A6F3800743185 /* MockConnectivityObserver.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockConnectivityObserver.swift; sourceTree = "<group>"; };
@@ -12546,6 +12548,7 @@
 			isa = PBXGroup;
 			children = (
 				DEB387942C2E7A7C0025256E /* GoogleAdsEligibilityChecker.swift */,
+				DEB3879D2C34FE620025256E /* GoogleAdsCampaignCoordinator.swift */,
 			);
 			path = GoogleAds;
 			sourceTree = "<group>";
@@ -14874,6 +14877,7 @@
 				DE4D23A629B0AF88003A4B5D /* WPComPasswordLoginViewModel.swift in Sources */,
 				E1E636BB26FB467A00C9D0D7 /* Comparable+Woo.swift in Sources */,
 				450C2CB024CF006A00D570DD /* ProductTagsDataSource.swift in Sources */,
+				DEB3879E2C34FE620025256E /* GoogleAdsCampaignCoordinator.swift in Sources */,
 				EE45E2BA2A409BA40085F227 /* TooltipPresenter.swift in Sources */,
 				023D69BC2589BF5900F7DA72 /* PrintShippingLabelCoordinator.swift in Sources */,
 				45F627B8253603AE00894B86 /* ProductDownloadSettingsViewController.swift in Sources */,

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -2584,6 +2584,7 @@
 		DEB387982C2E803A0025256E /* DefaultGoogleAdsEligibilityCheckTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEB387972C2E803A0025256E /* DefaultGoogleAdsEligibilityCheckTests.swift */; };
 		DEB3879A2C32A6400025256E /* MockGoogleAdsEligibilityChecker.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEB387992C32A6400025256E /* MockGoogleAdsEligibilityChecker.swift */; };
 		DEB3879E2C34FE620025256E /* GoogleAdsCampaignCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEB3879D2C34FE620025256E /* GoogleAdsCampaignCoordinator.swift */; };
+		DEB387A02C35109E0025256E /* GoogleAdsCampaignCoordinatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEB3879F2C35109E0025256E /* GoogleAdsCampaignCoordinatorTests.swift */; };
 		DEBAB70B2A7A3FE000743185 /* StorePlanBannerPresenterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEBAB70A2A7A3FE000743185 /* StorePlanBannerPresenterTests.swift */; };
 		DEBAB70D2A7A6F1100743185 /* MockStorePlanSynchronizer.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEBAB70C2A7A6F1100743185 /* MockStorePlanSynchronizer.swift */; };
 		DEBAB70F2A7A6F3800743185 /* MockConnectivityObserver.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEBAB70E2A7A6F3800743185 /* MockConnectivityObserver.swift */; };
@@ -5556,6 +5557,7 @@
 		DEB387972C2E803A0025256E /* DefaultGoogleAdsEligibilityCheckTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefaultGoogleAdsEligibilityCheckTests.swift; sourceTree = "<group>"; };
 		DEB387992C32A6400025256E /* MockGoogleAdsEligibilityChecker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockGoogleAdsEligibilityChecker.swift; sourceTree = "<group>"; };
 		DEB3879D2C34FE620025256E /* GoogleAdsCampaignCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GoogleAdsCampaignCoordinator.swift; sourceTree = "<group>"; };
+		DEB3879F2C35109E0025256E /* GoogleAdsCampaignCoordinatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GoogleAdsCampaignCoordinatorTests.swift; sourceTree = "<group>"; };
 		DEBAB70A2A7A3FE000743185 /* StorePlanBannerPresenterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StorePlanBannerPresenterTests.swift; sourceTree = "<group>"; };
 		DEBAB70C2A7A6F1100743185 /* MockStorePlanSynchronizer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockStorePlanSynchronizer.swift; sourceTree = "<group>"; };
 		DEBAB70E2A7A6F3800743185 /* MockConnectivityObserver.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockConnectivityObserver.swift; sourceTree = "<group>"; };
@@ -12557,6 +12559,7 @@
 			isa = PBXGroup;
 			children = (
 				DEB387972C2E803A0025256E /* DefaultGoogleAdsEligibilityCheckTests.swift */,
+				DEB3879F2C35109E0025256E /* GoogleAdsCampaignCoordinatorTests.swift */,
 			);
 			path = GoogleAds;
 			sourceTree = "<group>";
@@ -16561,6 +16564,7 @@
 				20B0D65E2AD45BDE0059735A /* AboutTapToPayContactlessLimitViewModelTests.swift in Sources */,
 				453770D12431FF4700AC718D /* ProductSettingsViewModelTests.swift in Sources */,
 				2619FA2C25C897930006DAFF /* AddAttributeOptionsViewModelTests.swift in Sources */,
+				DEB387A02C35109E0025256E /* GoogleAdsCampaignCoordinatorTests.swift in Sources */,
 				020BE77523B4A7EC007FE54C /* AztecSourceCodeFormatBarCommandTests.swift in Sources */,
 				DE4D23B429B58C5A003A4B5D /* MockWordPressComAccountService.swift in Sources */,
 				57A5D8D92534FEBB00AA54D6 /* TotalRefundedCalculationUseCaseTests.swift in Sources */,

--- a/WooCommerce/WooCommerceTests/GoogleAds/DefaultGoogleAdsEligibilityCheckTests.swift
+++ b/WooCommerce/WooCommerceTests/GoogleAds/DefaultGoogleAdsEligibilityCheckTests.swift
@@ -32,11 +32,12 @@ final class DefaultGoogleAdsEligibilityCheckerTests: XCTestCase {
     }
 
     @MainActor
-    func test_isSiteEligible_returns_false_if_plugin_is_not_installed() async {
+    func test_isSiteEligible_returns_false_if_google_ads_account_is_not_connected() async {
         // Given
         let featureFlagService = MockFeatureFlagService(googleAdsCampaignCreationOnWebView: true)
         let checker = DefaultGoogleAdsEligibilityChecker(stores: stores, featureFlagService: featureFlagService)
-        mockRequests(syncedPlugins: [])
+        let connection = GoogleAdsConnection.fake().copy(rawStatus: "incomplete")
+        mockRequests(adsConnection: connection)
 
         // When
         let result = await checker.isSiteEligible(siteID: sampleSite)
@@ -46,24 +47,7 @@ final class DefaultGoogleAdsEligibilityCheckerTests: XCTestCase {
     }
 
     @MainActor
-    func test_isSiteEligible_returns_false_if_plugin_is_not_active() async {
-        // Given
-        let featureFlagService = MockFeatureFlagService(googleAdsCampaignCreationOnWebView: true)
-        let checker = DefaultGoogleAdsEligibilityChecker(stores: stores, featureFlagService: featureFlagService)
-        let plugin = SystemPlugin.fake().copy(siteID: sampleSite,
-                                              plugin: pluginSlug,
-                                              active: false)
-        mockRequests(syncedPlugins: [plugin])
-
-        // When
-        let result = await checker.isSiteEligible(siteID: sampleSite)
-
-        // Then
-        XCTAssertFalse(result)
-    }
-
-    @MainActor
-    func test_isSiteEligible_returns_false_if_plugin_is_active_but_has_older_version() async {
+    func test_isSiteEligible_returns_false_if_plugin_version_is_not_satisfied() async {
         // Given
         let featureFlagService = MockFeatureFlagService(googleAdsCampaignCreationOnWebView: true)
         let checker = DefaultGoogleAdsEligibilityChecker(stores: stores, featureFlagService: featureFlagService)
@@ -71,25 +55,7 @@ final class DefaultGoogleAdsEligibilityCheckerTests: XCTestCase {
                                               plugin: pluginSlug,
                                               version: "2.7.4",
                                               active: true)
-        mockRequests(syncedPlugins: [plugin])
-
-        // When
-        let result = await checker.isSiteEligible(siteID: sampleSite)
-
-        // Then
-        XCTAssertFalse(result)
-    }
-
-    @MainActor
-    func test_isSiteEligible_returns_false_if_plugin_is_satisfied_but_connection_is_not() async {
-        // Given
-        let featureFlagService = MockFeatureFlagService(googleAdsCampaignCreationOnWebView: true)
-        let checker = DefaultGoogleAdsEligibilityChecker(stores: stores, featureFlagService: featureFlagService)
-        let plugin = SystemPlugin.fake().copy(siteID: sampleSite,
-                                              plugin: pluginSlug,
-                                              version: "2.7.5",
-                                              active: true)
-        let connection = GoogleAdsConnection.fake().copy(rawStatus: "incomplete")
+        let connection = GoogleAdsConnection.fake().copy(rawStatus: "connected")
         mockRequests(syncedPlugins: [plugin], adsConnection: connection)
 
         // When

--- a/WooCommerce/WooCommerceTests/GoogleAds/GoogleAdsCampaignCoordinatorTests.swift
+++ b/WooCommerce/WooCommerceTests/GoogleAds/GoogleAdsCampaignCoordinatorTests.swift
@@ -1,0 +1,58 @@
+import XCTest
+@testable import WooCommerce
+
+final class GoogleAdsCampaignCoordinatorTests: XCTestCase {
+
+    private var navigationController: UINavigationController!
+    private let siteAdminURL = "https://example.com/wp-admin/"
+
+    override func setUp() {
+        super.setUp()
+        navigationController = UINavigationController()
+        let window = UIWindow(frame: UIScreen.main.bounds)
+        window.rootViewController = UIViewController()
+        window.makeKeyAndVisible()
+        window.rootViewController = navigationController
+     }
+
+     override func tearDown() {
+         super.tearDown()
+         navigationController = nil
+     }
+
+    func test_web_view_is_presented_if_authentication_is_not_needed() throws {
+        // Given
+        let coordinator = GoogleAdsCampaignCoordinator(
+            siteID: 123,
+            siteAdminURL: siteAdminURL,
+            hasGoogleAdsCampaigns: true,
+            shouldAuthenticateAdminPage: false,
+            navigationController: navigationController
+        )
+
+        // When
+        coordinator.start()
+
+        // Then
+        let presentedController = try XCTUnwrap((coordinator.navigationController.presentedViewController as? UINavigationController)?.viewControllers.last)
+        XCTAssertTrue(presentedController is WebViewHostingController)
+    }
+
+    func test_authenticated_web_view_is_presented_if_authentication_is_needed() throws {
+        // Given
+        let coordinator = GoogleAdsCampaignCoordinator(
+            siteID: 123,
+            siteAdminURL: siteAdminURL,
+            hasGoogleAdsCampaigns: true,
+            shouldAuthenticateAdminPage: true,
+            navigationController: navigationController
+        )
+
+        // When
+        coordinator.start()
+
+        // Then
+        let presentedController = try XCTUnwrap((coordinator.navigationController.presentedViewController as? UINavigationController)?.viewControllers.last)
+        XCTAssertTrue(presentedController is AuthenticatedWebViewController)
+    }
+}

--- a/WooCommerce/WooCommerceTests/ViewRelated/HubMenu/HubMenuViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/HubMenu/HubMenuViewModelTests.swift
@@ -490,7 +490,7 @@ final class HubMenuViewModelTests: XCTestCase {
     }
 
     @MainActor
-    func test_hasGoogleAdsCampaigns_returns_false_if_site_has_no_campaigns() {
+    func test_googleAdsCampaignURL_is_correct_when_site_has_no_campaigns() {
         // Given
         let stores = MockStoresManager(sessionManager: .makeForTesting())
         // Setting site ID is required before setting `Site`.
@@ -517,11 +517,12 @@ final class HubMenuViewModelTests: XCTestCase {
         }
 
         // Then
-        XCTAssertFalse(viewModel.hasGoogleAdsCampaigns)
+        let campaignCreationPath = HubMenuViewModel.Constants.GoogleAds.campaignCreationPath
+        XCTAssertTrue(viewModel.googleAdsCampaignURL.absoluteString.hasSuffix(campaignCreationPath))
     }
 
     @MainActor
-    func test_hasGoogleAdsCampaigns_returns_false_if_site_has_campaigns() {
+    func test_googleAdsCampaignURL_is_correct_when_site_has_campaigns() {
         // Given
         let stores = MockStoresManager(sessionManager: .makeForTesting())
         // Setting site ID is required before setting `Site`.
@@ -549,7 +550,70 @@ final class HubMenuViewModelTests: XCTestCase {
         }
 
         // Then
-        XCTAssertTrue(viewModel.hasGoogleAdsCampaigns)
+        let campaignCreationPath = HubMenuViewModel.Constants.GoogleAds.campaignDashboardPath
+        XCTAssertTrue(viewModel.googleAdsCampaignURL.absoluteString.hasSuffix(campaignCreationPath))
+    }
+
+    @MainActor
+    func test_checkIfCampaignCreationSucceeded_sets_displayingGoogleAdsCampaigns_to_false_if_creation_succeeds() {
+        // Given
+        let viewModel = HubMenuViewModel(siteID: sampleSiteID,
+                                         tapToPayBadgePromotionChecker: TapToPayBadgePromotionChecker())
+        viewModel.displayingGoogleAdsCampaigns = true
+
+        // When
+        let path = "https://example.com/wp-admin/admin.php?page=wc-admin&campaign=saved"
+        viewModel.checkIfCampaignCreationSucceeded(url: URL(string: path))
+
+        // Then
+        XCTAssertFalse(viewModel.displayingGoogleAdsCampaigns)
+    }
+
+    @MainActor
+    func test_checkIfCampaignCreationSucceeded_does_not_set_displayingGoogleAdsCampaigns_to_false_if_creation_does_not_complete() {
+        // Given
+        let viewModel = HubMenuViewModel(siteID: sampleSiteID,
+                                         tapToPayBadgePromotionChecker: TapToPayBadgePromotionChecker())
+        viewModel.displayingGoogleAdsCampaigns = true
+
+        // When
+        let path = "https://example.com/wp-admin/admin.php?page=wc-admin&path=%2Fgoogle%2Fdashboard"
+        viewModel.checkIfCampaignCreationSucceeded(url: URL(string: path))
+
+        // Then
+        XCTAssertTrue(viewModel.displayingGoogleAdsCampaigns)
+    }
+
+    @MainActor
+    func test_handleTap_sets_displayingGoogleAdsCampaigns_to_true_if_menu_item_is_googleAds() {
+        // Given
+        let viewModel = HubMenuViewModel(siteID: sampleSiteID,
+                                         tapToPayBadgePromotionChecker: TapToPayBadgePromotionChecker())
+        XCTAssertFalse(viewModel.displayingGoogleAdsCampaigns)
+        XCTAssertNil(viewModel.selectedMenuID)
+
+        // When
+        viewModel.handleTap(menu: HubMenuViewModel.GoogleAds())
+
+        // Then
+        XCTAssertTrue(viewModel.displayingGoogleAdsCampaigns)
+        XCTAssertNil(viewModel.selectedMenuID)
+    }
+
+    @MainActor
+    func test_handleTap_does_not_set_displayingGoogleAdsCampaigns_to_true_if_menu_item_is_not_googleAds() {
+        // Given
+        let viewModel = HubMenuViewModel(siteID: sampleSiteID,
+                                         tapToPayBadgePromotionChecker: TapToPayBadgePromotionChecker())
+        XCTAssertFalse(viewModel.displayingGoogleAdsCampaigns)
+        XCTAssertNil(viewModel.selectedMenuID)
+
+        // When
+        viewModel.handleTap(menu: HubMenuViewModel.Blaze())
+
+        // Then
+        XCTAssertFalse(viewModel.displayingGoogleAdsCampaigns)
+        assertEqual(HubMenuViewModel.Blaze.id, viewModel.selectedMenuID)
     }
 }
 

--- a/WooCommerce/WooCommerceTests/ViewRelated/HubMenu/HubMenuViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/HubMenu/HubMenuViewModelTests.swift
@@ -488,6 +488,69 @@ final class HubMenuViewModelTests: XCTestCase {
         XCTAssertEqual(viewModel.navigationPath.count, 1)
         XCTAssertEqual(viewModel.navigationPath, NavigationPath([HubMenuNavigationDestination.payments]))
     }
+
+    @MainActor
+    func test_hasGoogleAdsCampaigns_returns_false_if_site_has_no_campaigns() {
+        // Given
+        let stores = MockStoresManager(sessionManager: .makeForTesting())
+        // Setting site ID is required before setting `Site`.
+        stores.updateDefaultStore(storeID: sampleSiteID)
+        stores.updateDefaultStore(.fake().copy(siteID: sampleSiteID))
+
+        var fetchAdsCampaignsTriggered = false
+        stores.whenReceivingAction(ofType: GoogleAdsAction.self) { action in
+            switch action {
+            case let .fetchAdsCampaigns(siteID, onCompletion):
+                onCompletion(.success([]))
+                fetchAdsCampaignsTriggered = true
+            default:
+                break
+            }
+        }
+
+        // When
+        let viewModel = HubMenuViewModel(siteID: sampleSiteID,
+                                         tapToPayBadgePromotionChecker: TapToPayBadgePromotionChecker(),
+                                         stores: stores)
+        waitUntil {
+            fetchAdsCampaignsTriggered
+        }
+
+        // Then
+        XCTAssertFalse(viewModel.hasGoogleAdsCampaigns)
+    }
+
+    @MainActor
+    func test_hasGoogleAdsCampaigns_returns_false_if_site_has_campaigns() {
+        // Given
+        let stores = MockStoresManager(sessionManager: .makeForTesting())
+        // Setting site ID is required before setting `Site`.
+        stores.updateDefaultStore(storeID: sampleSiteID)
+        stores.updateDefaultStore(.fake().copy(siteID: sampleSiteID))
+
+        var fetchAdsCampaignsTriggered = false
+        stores.whenReceivingAction(ofType: GoogleAdsAction.self) { action in
+            switch action {
+            case let .fetchAdsCampaigns(siteID, onCompletion):
+                let campaign = GoogleAdsCampaign.fake().copy(id: 134254)
+                onCompletion(.success([campaign]))
+                fetchAdsCampaignsTriggered = true
+            default:
+                break
+            }
+        }
+
+        // When
+        let viewModel = HubMenuViewModel(siteID: sampleSiteID,
+                                         tapToPayBadgePromotionChecker: TapToPayBadgePromotionChecker(),
+                                         stores: stores)
+        waitUntil {
+            fetchAdsCampaignsTriggered
+        }
+
+        // Then
+        XCTAssertTrue(viewModel.hasGoogleAdsCampaigns)
+    }
 }
 
 private extension HubMenuViewModelTests {

--- a/WooCommerce/WooCommerceTests/ViewRelated/HubMenu/HubMenuViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/HubMenu/HubMenuViewModelTests.swift
@@ -490,7 +490,7 @@ final class HubMenuViewModelTests: XCTestCase {
     }
 
     @MainActor
-    func test_googleAdsCampaignURL_is_correct_when_site_has_no_campaigns() {
+    func test_hasGoogleAdsCampaigns_is_false_when_site_has_no_campaigns() {
         // Given
         let stores = MockStoresManager(sessionManager: .makeForTesting())
         // Setting site ID is required before setting `Site`.
@@ -517,12 +517,11 @@ final class HubMenuViewModelTests: XCTestCase {
         }
 
         // Then
-        let campaignCreationPath = HubMenuViewModel.Constants.GoogleAds.campaignCreationPath
-        XCTAssertTrue(viewModel.googleAdsCampaignURL.absoluteString.hasSuffix(campaignCreationPath))
+        XCTAssertFalse(viewModel.hasGoogleAdsCampaigns)
     }
 
     @MainActor
-    func test_googleAdsCampaignURL_is_correct_when_site_has_campaigns() {
+    func test_hasGoogleAdsCampaigns_is_true_when_site_has_campaigns() {
         // Given
         let stores = MockStoresManager(sessionManager: .makeForTesting())
         // Setting site ID is required before setting `Site`.
@@ -550,70 +549,7 @@ final class HubMenuViewModelTests: XCTestCase {
         }
 
         // Then
-        let campaignCreationPath = HubMenuViewModel.Constants.GoogleAds.campaignDashboardPath
-        XCTAssertTrue(viewModel.googleAdsCampaignURL.absoluteString.hasSuffix(campaignCreationPath))
-    }
-
-    @MainActor
-    func test_checkIfCampaignCreationSucceeded_sets_displayingGoogleAdsCampaigns_to_false_if_creation_succeeds() {
-        // Given
-        let viewModel = HubMenuViewModel(siteID: sampleSiteID,
-                                         tapToPayBadgePromotionChecker: TapToPayBadgePromotionChecker())
-        viewModel.displayingGoogleAdsCampaigns = true
-
-        // When
-        let path = "https://example.com/wp-admin/admin.php?page=wc-admin&campaign=saved"
-        viewModel.checkIfCampaignCreationSucceeded(url: URL(string: path))
-
-        // Then
-        XCTAssertFalse(viewModel.displayingGoogleAdsCampaigns)
-    }
-
-    @MainActor
-    func test_checkIfCampaignCreationSucceeded_does_not_set_displayingGoogleAdsCampaigns_to_false_if_creation_does_not_complete() {
-        // Given
-        let viewModel = HubMenuViewModel(siteID: sampleSiteID,
-                                         tapToPayBadgePromotionChecker: TapToPayBadgePromotionChecker())
-        viewModel.displayingGoogleAdsCampaigns = true
-
-        // When
-        let path = "https://example.com/wp-admin/admin.php?page=wc-admin&path=%2Fgoogle%2Fdashboard"
-        viewModel.checkIfCampaignCreationSucceeded(url: URL(string: path))
-
-        // Then
-        XCTAssertTrue(viewModel.displayingGoogleAdsCampaigns)
-    }
-
-    @MainActor
-    func test_handleTap_sets_displayingGoogleAdsCampaigns_to_true_if_menu_item_is_googleAds() {
-        // Given
-        let viewModel = HubMenuViewModel(siteID: sampleSiteID,
-                                         tapToPayBadgePromotionChecker: TapToPayBadgePromotionChecker())
-        XCTAssertFalse(viewModel.displayingGoogleAdsCampaigns)
-        XCTAssertNil(viewModel.selectedMenuID)
-
-        // When
-        viewModel.handleTap(menu: HubMenuViewModel.GoogleAds())
-
-        // Then
-        XCTAssertTrue(viewModel.displayingGoogleAdsCampaigns)
-        XCTAssertNil(viewModel.selectedMenuID)
-    }
-
-    @MainActor
-    func test_handleTap_does_not_set_displayingGoogleAdsCampaigns_to_true_if_menu_item_is_not_googleAds() {
-        // Given
-        let viewModel = HubMenuViewModel(siteID: sampleSiteID,
-                                         tapToPayBadgePromotionChecker: TapToPayBadgePromotionChecker())
-        XCTAssertFalse(viewModel.displayingGoogleAdsCampaigns)
-        XCTAssertNil(viewModel.selectedMenuID)
-
-        // When
-        viewModel.handleTap(menu: HubMenuViewModel.Blaze())
-
-        // Then
-        XCTAssertFalse(viewModel.displayingGoogleAdsCampaigns)
-        assertEqual(HubMenuViewModel.Blaze.id, viewModel.selectedMenuID)
+        XCTAssertTrue(viewModel.hasGoogleAdsCampaigns)
     }
 }
 


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #13218 
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This PR handles the navigation for GLA from the Hub menu entry point. Changes include:
- Updated `DefaultGoogleAdsEligibilityChecker` to optimize the check following the technical post pe5sF9-2O6-p2.
- Updated `HubMenuViewModel` to check if the site has campaigns to determine the web page to display:
  - If the site has existing campaigns, display the dashboard page.
  - Otherwise, display the campaign creation page.
- Updated `WebView` and `AuthenticatedWebView` to support `exitTrigger` without `urlToTriggerExit`.
- Added `GoogleAdsCampaignCoordinator` to handle navigation to Google ads campaigns.
- Updated `HubMenu` and `HubMenuHostingController` to start the coordinator when tapping the Google ads entry point.

## Testing steps
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->
- Pre-requisite: Install, activate, and set up the Google Ads plugin to a test site following pe5sF9-2Qo-p2. Ensure that you're using the plugin version 2.7.5 or above.
- Log in to your test store and navigate to the Menu tab.
- Select Google for WooCommerce. Confirm that a web view is presented for campaign management.
  - If the store is a self-hosted store authenticated with WPCom credentials, you'd be asked to log in with WPOrg credentials. 
  - If the store is a WPCom store or self-hosted store authenticated with WPOrg credentials, you'd be authenticated automatically.
- Assuming your site has no paid campaign created yet, tapping the entry point should display the creation flow. Proceed to create a test campaign.
- When the campaign is created successfully, the web view should be dismissed.
- Tap on the entry point again, this time you should see the campaign dashboard page.


## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

https://github.com/woocommerce/woocommerce-ios/assets/5533851/209da385-6a52-4c53-a56d-1dbb4bba8927



---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
