### PR TITLE
[GLA Analytics] Add Yosemite support for fetching Google Listings & Ads analytics

### DIFF
--- a/Yosemite/Yosemite/Actions/GoogleAdsAction.swift
+++ b/Yosemite/Yosemite/Actions/GoogleAdsAction.swift
@@ -24,4 +24,20 @@ public enum GoogleAdsAction: Action {
     ///
     case fetchAdsCampaigns(siteID: Int64,
                            onCompletion: (Result<[GoogleAdsCampaign], Error>) -> Void)
+
+    /// Retrieves the Google ads paid campaign stats for the provided siteID, and time range, without saving them to the Storage layer.
+    ///
+    /// - Parameters:
+    ///   - siteID: The site ID.
+    ///   - timeZone: The time zone to set the earliest/latest date strings in the API request.
+    ///   - earliestDateToInclude: The earliest date to include in the results.
+    ///   - latestDateToInclude: The latest date to include in the results.
+    ///   - onCompletion: Invoked when the request finishes.
+    ///     - `result.success(GoogleAdsCampaignStats)`: Successfully retrieved campaign stats.
+    ///     - `result.failure(Error)`: Error indicates issues retrieving campaign stats.
+    case retrieveCampaignStats(siteID: Int64,
+                               timeZone: TimeZone,
+                               earliestDateToInclude: Date,
+                               latestDateToInclude: Date,
+                               onCompletion: (Result<GoogleAdsCampaignStats, Error>) -> Void)
 }

--- a/Yosemite/Yosemite/Stores/GoogleAdsStore.swift
+++ b/Yosemite/Yosemite/Stores/GoogleAdsStore.swift
@@ -57,6 +57,12 @@ public final class GoogleAdsStore: Store {
             checkConnection(siteID: siteID, onCompletion: onCompletion)
         case let .fetchAdsCampaigns(siteID, onCompletion):
             fetchAdsCampaign(siteID: siteID, onCompletion: onCompletion)
+        case let .retrieveCampaignStats(siteID, timeZone, earliestDateToInclude, latestDateToInclude, onCompletion):
+            retrieveCampaignStats(siteID: siteID,
+                                  timeZone: timeZone,
+                                  earliestDateToInclude: earliestDateToInclude,
+                                  latestDateToInclude: latestDateToInclude,
+                                  onCompletion: onCompletion)
         }
     }
 }
@@ -80,6 +86,27 @@ private extension GoogleAdsStore {
             do {
                 let campaigns = try await remote.fetchAdsCampaigns(for: siteID)
                 onCompletion(.success(campaigns))
+            } catch {
+                onCompletion(.failure(error))
+            }
+        }
+    }
+
+    func retrieveCampaignStats(siteID: Int64,
+                               timeZone: TimeZone,
+                               earliestDateToInclude: Date,
+                               latestDateToInclude: Date,
+                               onCompletion: @escaping (Result<GoogleAdsCampaignStats, Error>) -> Void) {
+        Task { @MainActor in
+            do {
+                let campaignStats = try await remote.loadCampaignStats(for: siteID,
+                                                                       timeZone: timeZone,
+                                                                       earliestDateToInclude: earliestDateToInclude,
+                                                                       latestDateToInclude: latestDateToInclude,
+                                                                       totals: GoogleListingsAndAdsRemote.StatsField.allCases,
+                                                                       orderby: .sales,
+                                                                       nextPageToken: nil)
+                onCompletion(.success(campaignStats))
             } catch {
                 onCompletion(.failure(error))
             }

--- a/Yosemite/YosemiteTests/Mocks/Networking/Remote/MockGoogleListingsAndAdsRemote.swift
+++ b/Yosemite/YosemiteTests/Mocks/Networking/Remote/MockGoogleListingsAndAdsRemote.swift
@@ -7,6 +7,8 @@ final class MockGoogleListingsAndAdsRemote {
     private var fetchingAdsCampaignsResult: Result<[GoogleAdsCampaign], Error>?
     private var loadingCampaignStatsResults: Result<GoogleAdsCampaignStats, Error>?
 
+    private var invocationCountOfLoadingCampaignStats: Int = 0
+
     func whenCheckingConnection(thenReturn result: Result<GoogleAdsConnection, Error>) {
         checkingConnectionResult = result
     }
@@ -34,6 +36,9 @@ extension MockGoogleListingsAndAdsRemote: GoogleListingsAndAdsRemoteProtocol {
         }
         switch result {
         case .success(let stats):
+            // If we have already returned a page of stats, make this the final page.
+            let stats = invocationCountOfLoadingCampaignStats > 0 ? stats.copy(nextPageToken: .some(nil)) : stats
+            invocationCountOfLoadingCampaignStats += 1
             return stats
         case .failure(let error):
             throw error

--- a/Yosemite/YosemiteTests/Stores/GoogleAdsStoreTests.swift
+++ b/Yosemite/YosemiteTests/Stores/GoogleAdsStoreTests.swift
@@ -152,7 +152,7 @@ final class GoogleAdsStoreTests: XCTestCase {
                                    network: network,
                                    remote: remote)
         let campaignStats = GoogleAdsCampaignStats.fake().copy(siteID: sampleSiteID,
-                                                               totals: .fake().copy(sales: 12345),
+                                                               totals: .fake().copy(sales: 12345, spend: nil),
                                                                campaigns: [.fake().copy(campaignName: "Spring Ads Campaign")],
                                                                nextPageToken: "next")
         remote.whenLoadingCampaignStatsResults(thenReturn: .success(campaignStats))
@@ -171,6 +171,7 @@ final class GoogleAdsStoreTests: XCTestCase {
         // Then
         let receivedCampaignStats = try result.get()
         assertEqual(24690, receivedCampaignStats.totals.sales)
+        XCTAssertNil(receivedCampaignStats.totals.spend)
         assertEqual(2, receivedCampaignStats.campaigns.count)
     }
 

--- a/Yosemite/YosemiteTests/Stores/GoogleAdsStoreTests.swift
+++ b/Yosemite/YosemiteTests/Stores/GoogleAdsStoreTests.swift
@@ -117,4 +117,55 @@ final class GoogleAdsStoreTests: XCTestCase {
         XCTAssertTrue(result.isFailure)
         XCTAssertEqual(result.failure as? NetworkError, .timeout())
     }
+
+    // MARK: - Retrieve campaign stats
+
+    func test_retrieveCampaignStats_returns_campaign_stats_on_success() throws {
+        // Given
+        let store = GoogleAdsStore(dispatcher: Dispatcher(),
+                                   storageManager: storageManager,
+                                   network: network,
+                                   remote: remote)
+        let campaignStats = GoogleAdsCampaignStats.fake().copy(totals: .fake().copy(sales: 12345), campaigns: [.fake().copy(campaignName: "Spring Ads Campaign")])
+        remote.whenLoadingCampaignStatsResults(thenReturn: .success(campaignStats))
+
+        // When
+        let result = waitFor { promise in
+            store.onAction(GoogleAdsAction.retrieveCampaignStats(siteID: self.sampleSiteID,
+                                                                 timeZone: .current,
+                                                                 earliestDateToInclude: Date(),
+                                                                 latestDateToInclude: Date(),
+                                                                 onCompletion: { result in
+                promise(result)
+            }))
+        }
+
+        // Then
+        let receivedCampaignStats = try result.get()
+        assertEqual(campaignStats, receivedCampaignStats)
+    }
+
+    func test_retrieveCampaignStats_returns_error_on_failure() throws {
+        // Given
+        let store = GoogleAdsStore(dispatcher: Dispatcher(),
+                                   storageManager: storageManager,
+                                   network: network,
+                                   remote: remote)
+        remote.whenLoadingCampaignStatsResults(thenReturn: .failure(NetworkError.timeout()))
+
+        // When
+        let result = waitFor { promise in
+            store.onAction(GoogleAdsAction.retrieveCampaignStats(siteID: self.sampleSiteID,
+                                                                 timeZone: .current,
+                                                                 earliestDateToInclude: Date(),
+                                                                 latestDateToInclude: Date(),
+                                                                 onCompletion: { result in
+                promise(result)
+            }))
+        }
+
+        // Then
+        XCTAssertTrue(result.isFailure)
+        XCTAssertEqual(result.failure as? NetworkError, .timeout())
+    }
 }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #13203
<!-- Id number of the GitHub issue this PR addresses. -->

## Why
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This adds support in the Yosemite layer for fetching Google Listings & Ads analytics from remote.

## How

* Adds a new `retrieveCampaignStats` action to `GoogleAdsAction`.
* Adds a new `retrieveCampaignStats` method to `GoogleAdsStore`:
   * Requests a new page of stats repeatedly until all pages of stats are retrieved.
   * Compiles all of the retrieved stats by summing the totals and combining the campaign list.

We need to do this because each page of stats is incomplete, only returning the totals for the campaigns returned on that page. To have accurate totals, we need to request all campaigns and then combine them and their totals.

Note: This means the UI will be blocked for this action until all campaigns are retrieved. I believe this is worth it, to avoid dispatching this action inappropriately (we shouldn't ever request only partial stats in the UI layer) and because any partial data could be very confusing if we display it to merchants. We also expect it to be rare that a merchant will have more than one page of campaigns to request. However, we should watch for any performance issues (in our stats or user reports) in case we want to revisit this.

## Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->

This new action is not yet used in the app. Confirm unit tests pass.


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.