### PR TITLE
[Product Creation AI v2] Detect texts from image

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductWithAI/StartingInfo/ProductCreationAIStartingInfoView.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductWithAI/StartingInfo/ProductCreationAIStartingInfoView.swift
@@ -77,7 +77,6 @@ struct ProductCreationAIStartingInfoView: View {
                             .font(.footnote)
                             .fontWeight(.semibold)
                             .foregroundStyle(Color(uiColor: .secondaryLabel))
-                            .padding(insets: Layout.messageContentInsets)
                     }
                 }
             }

--- a/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductWithAI/StartingInfo/ProductCreationAIStartingInfoView.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductWithAI/StartingInfo/ProductCreationAIStartingInfoView.swift
@@ -71,6 +71,14 @@ struct ProductCreationAIStartingInfoView: View {
                             RoundedRectangle(cornerRadius: Layout.cornerRadius).stroke(editorIsFocused ? Color(.brand) : Color(.separator))
                         )
                     }
+
+                    if let message = viewModel.textDetectionErrorMessage {
+                        Text(message)
+                            .font(.footnote)
+                            .fontWeight(.semibold)
+                            .foregroundStyle(Color(uiColor: .secondaryLabel))
+                            .padding(insets: Layout.messageContentInsets)
+                    }
                 }
             }
             .padding(insets: Layout.insets)

--- a/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductWithAI/StartingInfo/ProductCreationAIStartingInfoViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductWithAI/StartingInfo/ProductCreationAIStartingInfoViewModel.swift
@@ -86,6 +86,16 @@ final class ProductCreationAIStartingInfoViewModel: ObservableObject {
 
 private extension ProductCreationAIStartingInfoViewModel {
     enum Localization {
+        static let noTextDetected = NSLocalizedString(
+            "productCreationAIStartingInfoViewModel.noTextDetected",
+            value: "No text detected. Please select another packaging photo or enter product details manually.",
+            comment: "No text detected message while adding package photo in the starting information screen."
+        )
+        static let textDetectionFailed = NSLocalizedString(
+            "productCreationAIStartingInfoViewModel.textDetectionFailed",
+            value: "An error occurred while scanning the photo. Please select another packaging photo or enter product details manually.",
+            comment: "Text detection failed error message on the starting information screen."
+        )
         enum PhotoRemovedNotice {
             static let title = NSLocalizedString(
                 "productCreationAIStartingInfoViewModel.photoRemovedNotice.title",

--- a/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductWithAI/StartingInfo/ProductCreationAIStartingInfoViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductWithAI/StartingInfo/ProductCreationAIStartingInfoViewModel.swift
@@ -156,3 +156,7 @@ extension ProductCreationAIStartingInfoViewModel {
         }
     }
 }
+
+private enum ScanError: Error {
+    case noTextDetected
+}

--- a/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductWithAI/StartingInfo/ProductCreationAIStartingInfoViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductWithAI/StartingInfo/ProductCreationAIStartingInfoViewModel.swift
@@ -19,6 +19,7 @@ final class ProductCreationAIStartingInfoViewModel: ObservableObject {
 
     let siteID: Int64
     private let analytics: Analytics
+    private let imageTextScanner: ImageTextScannerProtocol
 
     var productFeatures: String? {
         guard features.isNotEmpty else {
@@ -27,9 +28,12 @@ final class ProductCreationAIStartingInfoViewModel: ObservableObject {
         return features
     }
 
-    init(siteID: Int64, analytics: Analytics = ServiceLocator.analytics) {
+    init(siteID: Int64,
+         imageTextScanner: ImageTextScannerProtocol = ImageTextScanner(),
+         analytics: Analytics = ServiceLocator.analytics) {
         self.siteID = siteID
         self.features = ""
+        self.imageTextScanner = imageTextScanner
         self.analytics = analytics
         imageState = .empty
     }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/Add Product/AddProductWithAI/ProductCreationAIStartingInfoViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/Add Product/AddProductWithAI/ProductCreationAIStartingInfoViewModelTests.swift
@@ -95,4 +95,100 @@ final class ProductCreationAIStartingInfoViewModelTests: XCTestCase {
         // Then
         XCTAssertEqual(sut.imageState, .empty)
     }
+
+    func test_it_populates_detected_texts() async {
+        // Given
+        let imageTextScanner = MockImageTextScanner(result: .success(["test", "product", "package"]))
+        let sut = ProductCreationAIStartingInfoViewModel(siteID: siteID,
+                                                         imageTextScanner: imageTextScanner)
+
+        sut.onPickPackagePhoto = { _ in
+            self.sampleImage
+        }
+
+        // When
+        await sut.selectImage(from: .siteMediaLibrary)
+
+        // Then
+        XCTAssertEqual(sut.features, "test product package")
+    }
+
+    func test_it_preserves_previously_detected_text_when_text_detection_fails() async {
+        // Given
+        let imageTextScanner = MockImageTextScanner(result: .success(["test", "product", "package"]))
+        let sut = ProductCreationAIStartingInfoViewModel(siteID: siteID,
+                                                         imageTextScanner: imageTextScanner)
+
+        sut.onPickPackagePhoto = { _ in
+            self.sampleImage
+        }
+        await sut.selectImage(from: .siteMediaLibrary)
+        XCTAssertEqual(sut.features, "test product package")
+
+        // When
+        let error = NSError(domain: "test", code: 10000)
+        imageTextScanner.result = .failure(error)
+        await sut.selectImage(from: .siteMediaLibrary)
+
+        // Then
+        XCTAssertEqual(sut.features, "test product package")
+    }
+
+    func test_it_shows_text_detection_error_when_text_detection_fails() async {
+        // Given
+        let error = NSError(domain: "test", code: 10000)
+        let imageTextScanner = MockImageTextScanner(result: .failure(error))
+        let sut = ProductCreationAIStartingInfoViewModel(siteID: siteID,
+                                                         imageTextScanner: imageTextScanner)
+
+        sut.onPickPackagePhoto = { _ in
+            self.sampleImage
+        }
+
+        // When
+        await sut.selectImage(from: .siteMediaLibrary)
+
+        // Then
+        XCTAssertEqual(sut.textDetectionErrorMessage,
+                       ProductCreationAIStartingInfoViewModel.Localization.textDetectionFailed)
+    }
+
+    func test_it_shows_text_detection_error_when_no_text_detected() async {
+        // Given
+        let imageTextScanner = MockImageTextScanner(result: .success([]))
+        let sut = ProductCreationAIStartingInfoViewModel(siteID: siteID,
+                                                         imageTextScanner: imageTextScanner)
+
+        sut.onPickPackagePhoto = { _ in
+            self.sampleImage
+        }
+
+        // When
+        await sut.selectImage(from: .siteMediaLibrary)
+
+        // Then
+        XCTAssertEqual(sut.textDetectionErrorMessage,
+                       ProductCreationAIStartingInfoViewModel.Localization.noTextDetected)
+    }
+
+    func test_it_resets_text_detection_error_when_new_image_with_text_is_loaded_again() async {
+        // Given
+        let imageTextScanner = MockImageTextScanner(result: .success([]))
+        let sut = ProductCreationAIStartingInfoViewModel(siteID: siteID,
+                                                         imageTextScanner: imageTextScanner)
+
+        sut.onPickPackagePhoto = { _ in
+            self.sampleImage
+        }
+        await sut.selectImage(from: .siteMediaLibrary)
+        XCTAssertEqual(sut.textDetectionErrorMessage,
+                       ProductCreationAIStartingInfoViewModel.Localization.noTextDetected)
+
+        // When
+        imageTextScanner.result = .success(["test"])
+        await sut.selectImage(from: .siteMediaLibrary)
+
+        // Then
+        XCTAssertNil(sut.textDetectionErrorMessage)
+    }
 }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #13105
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

Detects text from selected package photo and populates the detected texts in the text field. 

Changes
- Use ImageScanner to detect texts.
- Populate detect texts in the text field. 
- Show an error message when text detection fails.
- Unit tests.

## Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->

1. Create a JN site with Jetpack AI plugin
2. Turn on `productCreationAIv2M1` feature flag
3. Build and run the app
4. Navigate to the products tab
5. Tap `+` button on top right
6. Tap "Create a product with AI"
7.  Tap "Read text from product photo" button below the text field
8. Select a package photo with text
9. Validate that texts are detected from the image and populated in the text field.
10. Select a different package image with no text.
11. Validate that an error message is displayed below the text field.

## Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->
- Test with package images with no text.
- Test with package image with text in a language different than English. 

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->
| Texts detected | No text detected |
|--------|--------|
| ![Simulator Screenshot - iPhone 15 Pro Max - 2024-07-02 at 18 00 20](https://github.com/woocommerce/woocommerce-ios/assets/524475/3842f0b7-aae9-43fd-b4f7-be3a0db6e0a6) | ![Simulator Screenshot - iPhone 15 Pro Max - 2024-07-02 at 18 00 39](https://github.com/woocommerce/woocommerce-ios/assets/524475/e9811ce5-4a23-48e4-91c3-5b77516a1452) | 

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.