### PR TITLE
[Woo POS] Update entry point eligibility condition to use Woo 6.6+

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/POS/POSEligibilityChecker.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/POS/POSEligibilityChecker.swift
@@ -71,7 +71,12 @@ private extension POSEligibilityChecker {
                 return
             }
 
-            let siteID = stores.sessionManager.defaultStoreID ?? 0
+            guard let siteID = stores.sessionManager.defaultStoreID else {
+                DDLogError("⛔️ Default store ID value is nil")
+                promise(.success(false))
+                return
+            }
+
             let action = SystemStatusAction.fetchSystemPlugin(siteID: siteID, systemPluginName: Constants.wcPluginName) { wcPlugin in
                 guard let wcPlugin = wcPlugin, wcPlugin.active else {
                     promise(.success(false))

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/POS/POSEligibilityChecker.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/POS/POSEligibilityChecker.swift
@@ -24,7 +24,7 @@ final class POSEligibilityChecker: POSEligibilityCheckerProtocol {
                 .eraseToAnyPublisher()
         }
 
-        return Publishers.CombineLatest(isOnboardingComplete(), isWooCommerceVersionSupported())
+        return Publishers.CombineLatest(isOnboardingComplete, isWooCommerceVersionSupported)
             .map { $0 && $1 }
             .eraseToAnyPublisher()
     }
@@ -52,10 +52,10 @@ final class POSEligibilityChecker: POSEligibilityCheckerProtocol {
 }
 
 private extension POSEligibilityChecker {
-    func isOnboardingComplete() -> AnyPublisher<Bool, Never> {
+    var isOnboardingComplete: AnyPublisher<Bool, Never> {
         return cardPresentPaymentsOnboarding.statePublisher
             .filter { [weak self] _ in
-                self?.isEligibleFromSiteChecks() ?? false
+                self?.isEligibleFromSiteChecks ?? false
             }
             .map { onboardingState in
                 // Woo Payments plugin enabled and user setup complete
@@ -64,8 +64,8 @@ private extension POSEligibilityChecker {
             .eraseToAnyPublisher()
     }
 
-    func isWooCommerceVersionSupported() -> AnyPublisher<Bool, Never> {
-        return Future<Bool, Never> { [weak self] promise in
+    var isWooCommerceVersionSupported: AnyPublisher<Bool, Never> {
+        Future<Bool, Never> { [weak self] promise in
             guard let self else {
                 promise(.success(false))
                 return
@@ -87,7 +87,7 @@ private extension POSEligibilityChecker {
         .eraseToAnyPublisher()
     }
 
-    func isEligibleFromSiteChecks() -> Bool {
+    var isEligibleFromSiteChecks: Bool {
         // Conditions that can change if site settings are synced during the lifetime.
         let isCountryCodeUS = SiteAddress(siteSettings: siteSettings.siteSettings).countryCode == .US
         let isCurrencyUSD = currencySettings.currencyCode == .USD

--- a/WooCommerce/WooCommerceTests/ViewRelated/Settings/POS/POSEligibilityCheckerTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Settings/POS/POSEligibilityCheckerTests.swift
@@ -31,7 +31,7 @@ final class POSEligibilityCheckerTests: XCTestCase {
         super.tearDown()
     }
 
-    func test_site_with_all_conditions_is_eligible() throws {
+    func test_is_eligible_when_all_conditions_satisfied_then_returns_true() throws {
         // Given
         let featureFlagService = MockFeatureFlagService(isDisplayPointOfSaleToggleEnabled: true)
         setupCountry(country: .us)
@@ -47,7 +47,7 @@ final class POSEligibilityCheckerTests: XCTestCase {
         XCTAssertTrue(isEligible)
     }
 
-    func test_non_iPad_devices_are_not_eligible() throws {
+    func test_is_eligible_when_non_iPad_device_then_returns_false() throws {
         // Given
         let featureFlagService = MockFeatureFlagService(isDisplayPointOfSaleToggleEnabled: true)
         setupCountry(country: .us)
@@ -66,7 +66,7 @@ final class POSEligibilityCheckerTests: XCTestCase {
             }
     }
 
-    func test_non_us_site_is_not_eligible() throws {
+    func test_is_eligible_when_non_us_site_then_returns_false() throws {
         // Given
         let featureFlagService = MockFeatureFlagService(isDisplayPointOfSaleToggleEnabled: true)
         [Country.ca, Country.es, Country.gb].forEach { country in
@@ -85,7 +85,7 @@ final class POSEligibilityCheckerTests: XCTestCase {
         }
     }
 
-    func test_non_usd_site_is_not_eligible() throws {
+    func test_is_eligible_when_non_usd_currency_then_returns_false() throws {
         // Given
         let featureFlagService = MockFeatureFlagService(isDisplayPointOfSaleToggleEnabled: true)
         setupCountry(country: .us)
@@ -101,7 +101,7 @@ final class POSEligibilityCheckerTests: XCTestCase {
         XCTAssertFalse(isEligible)
     }
 
-    func test_is_not_eligible_when_feature_flag_is_disabled() throws {
+    func test_is_eligible_when_feature_flag_is_disabled_then_returns_false() throws {
         // Given
         let featureFlagService = MockFeatureFlagService(isDisplayPointOfSaleToggleEnabled: false)
         setupCountry(country: .us)
@@ -117,7 +117,7 @@ final class POSEligibilityCheckerTests: XCTestCase {
         XCTAssertFalse(isEligible)
     }
 
-    func test_is_not_eligible_when_onboarding_state_is_not_completed_wcpay() throws {
+    func test_is_eligible_when_onboarding_state_is_not_completed_wcpay_then_returns_false() throws {
         // Given
         let featureFlagService = MockFeatureFlagService(isDisplayPointOfSaleToggleEnabled: true)
         setupCountry(country: .us)
@@ -156,7 +156,7 @@ final class POSEligibilityCheckerTests: XCTestCase {
         XCTAssertFalse(isEligible)
     }
 
-    func test_is_not_eligible_when_woo_commerce_version_low() throws {
+    func test_is_eligible_when_WooCommerce_version_is_below_6_6_then_returns_false() throws {
         // Given
         let featureFlagService = MockFeatureFlagService(isDisplayPointOfSaleToggleEnabled: true)
         setupCountry(country: .us)
@@ -177,13 +177,13 @@ final class POSEligibilityCheckerTests: XCTestCase {
         XCTAssertFalse(isEligible)
     }
 
-    func test_is_eligible_when_woo_commerce_version_supported() throws {
+    func test_is_eligible_when_WooCommerce_version_is_above_6_6_then_returns_true() throws {
         // Given
         let featureFlagService = MockFeatureFlagService(isDisplayPointOfSaleToggleEnabled: true)
         setupCountry(country: .us)
 
         // Supported WooCommerce version
-        setupWooCommerceVersion("6.8.0")
+        setupWooCommerceVersion("6.6.0")
 
         // When
         let checker = POSEligibilityChecker(userInterfaceIdiom: .pad,


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #12878
<!-- Id number of the GitHub issue this PR addresses. -->

## Description

Check the WooCommerce version to determine POS menu option eligibility. Changes:

1. Introduce `SystemStatusAction.fetchSystemPlugin` into `POSEligibilityChecker` to check supported `WooCommerce` version
2. Refactor the code to combine onboarding criteria and WooCommerce version support criteria with Combine
3. Always return a fresh `isEligible` value when it's requested.  When we called `observeEligibility()` on init, the version checks ended up being called only when the app was launched. It's safer to call this every time the menu is presented to ensure the most up-to-date Woo version state. Both `cardPresentPaymentsOnboarding` and `fetchSystemPlugin` return locally cached results so there's no additional delay because of that.

**Note**

I noticed that both on this branch and on trunk, sometimes the POS option appears with a delay. It happens because `cardPresentPaymentsOnboarding.statePublisher` doesn't return a cached result. I don't know if it's intended or not, I asked a question in an old PR https://github.com/woocommerce/woocommerce-ios/pull/9002/files#r1662527153 . Maybe it can be improved.

## Testing information

Note: The easiest way to test is to change the hardcoded `wcPluginMinimumVersion` in `POSEligibilityChecker` to a higher version than currently installed on the site.

1. Launch a site with Woo Payments configured and a WooCommerce version higher than 6.6
5. Enable POS Experimental Feature in Settings
6. Confirm POS option appears in the menu
7. Kill & Relaunch the app
8. Confirm POS option appears in the menu
9. Use the site with lower WooCommerce version (or hardcode higher WooCommerce version)
10. Relaunch the app
11. Confirm POS option doesn't appear in the menu

## Screenshots

Note: Video is made while testing POS eligibility from WooCommerce 9.0.0

https://github.com/woocommerce/woocommerce-ios/assets/4062343/b6f79cf0-03eb-4443-8eb9-dda28910de1c

- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.