### PR TITLE
[Woo POS] Fix reader connection alerts not showing up when connecting reader from the bottom bar

### DIFF
--- a/WooCommerce/Classes/POS/Presentation/PointOfSaleDashboardView.swift
+++ b/WooCommerce/Classes/POS/Presentation/PointOfSaleDashboardView.swift
@@ -4,9 +4,11 @@ struct PointOfSaleDashboardView: View {
     @Environment(\.presentationMode) var presentationMode
 
     @ObservedObject private var viewModel: PointOfSaleDashboardViewModel
+    @ObservedObject private var totalsViewModel: TotalsViewModel
 
     init(viewModel: PointOfSaleDashboardViewModel) {
         self.viewModel = viewModel
+        self.totalsViewModel = viewModel.totalsViewModel
     }
 
     var body: some View {
@@ -39,6 +41,19 @@ struct PointOfSaleDashboardView: View {
         }
         .toolbarBackground(Color.toolbarBackground, for: .bottomBar)
         .toolbarBackground(.visible, for: .bottomBar)
+        .sheet(isPresented: $totalsViewModel.showsCardReaderSheet, content: {
+            // Might be the only way unless we make the type conform to `Identifiable`
+            if let alertType = totalsViewModel.cardPresentPaymentAlertViewModel {
+                PointOfSaleCardPresentPaymentAlert(alertType: alertType)
+            } else {
+                switch totalsViewModel.cardPresentPaymentEvent {
+                case .idle,
+                        .show, // handled above
+                        .showOnboarding:
+                    Text(viewModel.totalsViewModel.cardPresentPaymentEvent.temporaryEventDescription)
+                }
+            }
+        })
     }
 }
 
@@ -65,6 +80,19 @@ private extension PointOfSaleDashboardView {
     var productListView: some View {
         ItemListView(viewModel: viewModel.itemSelectorViewModel)
             .frame(maxWidth: .infinity)
+    }
+}
+
+fileprivate extension CardPresentPaymentEvent {
+    var temporaryEventDescription: String {
+        switch self {
+        case .idle:
+            return "Idle"
+        case .show:
+            return "Event"
+        case .showOnboarding(let onboardingViewModel):
+            return "Onboarding: \(onboardingViewModel.state.reasonForAnalytics)" // This will only show the initial onboarding state
+        }
     }
 }
 

--- a/WooCommerce/Classes/POS/Presentation/TotalsView.swift
+++ b/WooCommerce/Classes/POS/Presentation/TotalsView.swift
@@ -66,19 +66,6 @@ struct TotalsView: View {
         .onDisappear {
             totalsViewModel.onTotalsViewDisappearance()
         }
-        .sheet(isPresented: $totalsViewModel.showsCardReaderSheet, content: {
-            // Might be the only way unless we make the type conform to `Identifiable`
-            if let alertType = totalsViewModel.cardPresentPaymentAlertViewModel {
-                PointOfSaleCardPresentPaymentAlert(alertType: alertType)
-            } else {
-                switch totalsViewModel.cardPresentPaymentEvent {
-                case .idle,
-                        .show, // handled above
-                        .showOnboarding:
-                    Text(totalsViewModel.cardPresentPaymentEvent.temporaryEventDescription)
-                }
-            }
-        })
     }
 
     private var gradientStops: [Gradient.Stop] {
@@ -191,19 +178,6 @@ private extension TotalsView {
         static let newTransactionButtonSpacing: CGFloat = 20
         static let newTransactionButtonPadding: CGFloat = 16
         static let newTransactionButtonFont: Font = Font.system(size: 32, weight: .medium)
-    }
-}
-
-fileprivate extension CardPresentPaymentEvent {
-    var temporaryEventDescription: String {
-        switch self {
-        case .idle:
-            return "Idle"
-        case .show:
-            return "Event"
-        case .showOnboarding(let onboardingViewModel):
-            return "Onboarding: \(onboardingViewModel.state.reasonForAnalytics)" // This will only show the initial onboarding state
-        }
     }
 }
 


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of #12998 
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

When the reader/payment alert `sheet` was moved from `PointOfSaleDashboardView` to `TotalsView` in https://github.com/woocommerce/woocommerce-ios/pull/13211, if the reader connection is initiated from the bottom bar then no alerts are shown anymore (thanks to @bozidarsevo for discovering this issue https://github.com/woocommerce/woocommerce-ios/pull/13211#discussion_r1662491404).

To fix this missing alerts issue when connecting to reader from the bottom bar while the totals view isn't shown, the `sheet` is moved back to `PointOfSaleDashboardView`. The view needs to have `TotalsViewModel` as an `@ObservedObject` in order for any changes of the totals VM's `@Pubished vars` to trigger UI updates.

## Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->

Prerequisite: the store is eligible for POS and the feature switch is enabled in Menu > Settings > Experimental Features > POS
* Launch app
* Go to Menu > Point of Sale
* Tap `Connect now` in the bottom bar --> the reader connection alerts should be shown
---
- [x] @jaclync tests connecting reader in the bottom bar when the totals view is shown
- [x] @jaclync tests connecting reader from the payment collection flow in the totals view

## Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->

Before this PR in trunk, tapping `Connect now` from the bottom bar in the product selector view was a no-op.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->


https://github.com/woocommerce/woocommerce-ios/assets/1945542/178ed450-6f6f-4f94-babf-5329cb611ed0



---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.