### PR TITLE
Google Ads: Display bottom sheet upon campaign creation success

### DIFF
--- a/WooCommerce/Classes/GoogleAds/GoogleAdsCampaignCoordinator.swift
+++ b/WooCommerce/Classes/GoogleAds/GoogleAdsCampaignCoordinator.swift
@@ -11,6 +11,7 @@ final class GoogleAdsCampaignCoordinator: Coordinator {
 
     private let hasGoogleAdsCampaigns: Bool
     private let shouldAuthenticateAdminPage: Bool
+    private var bottomSheetPresenter: BottomSheetPresenter?
 
     init(siteID: Int64,
          siteAdminURL: String,
@@ -70,9 +71,9 @@ private extension GoogleAdsCampaignCoordinator {
         }) != nil
         if creationSucceeded {
             // dismisses the web view
-            navigationController.dismiss(animated: true)
-
-            // TODO: show success bottom sheet
+            navigationController.dismiss(animated: true) { [self] in
+                showSuccessView()
+            }
             DDLogDebug("🎉 Campaign creation success")
         }
     }
@@ -86,6 +87,29 @@ private extension GoogleAdsCampaignCoordinator {
             }
         }()
         return URL(string: siteAdminURL.appending(path))
+    }
+
+    func showSuccessView() {
+        bottomSheetPresenter = buildBottomSheetPresenter()
+        let controller = CelebrationHostingController(
+            title: Localization.successTitle,
+            subtitle: Localization.successSubtitle,
+            closeButtonTitle: Localization.successCTA,
+            image: .blazeSuccessImage,
+            onTappingDone: { [weak self] in
+            self?.bottomSheetPresenter?.dismiss()
+            self?.bottomSheetPresenter = nil
+        })
+        bottomSheetPresenter?.present(controller, from: navigationController)
+    }
+
+    func buildBottomSheetPresenter() -> BottomSheetPresenter {
+        BottomSheetPresenter(configure: { bottomSheet in
+            var sheet = bottomSheet
+            sheet.prefersEdgeAttachedInCompactHeight = true
+            sheet.prefersGrabberVisible = true
+            sheet.detents = [.medium(), .large()]
+        })
     }
 }
 
@@ -103,6 +127,21 @@ private extension GoogleAdsCampaignCoordinator {
             "googleAdsCampaignCoordinator.googleForWooCommerce",
             value: "Google for WooCommerce",
             comment: "Title of the Google Ads campaign view"
+        )
+        static let successTitle = NSLocalizedString(
+            "googleAdsCampaignCoordinator.successTitle",
+            value: "Ready to Go!",
+            comment: "Title of the celebration view when a Google ads campaign is successfully created."
+        )
+        static let successSubtitle = NSLocalizedString(
+            "googleAdsCampaignCoordinator.successSubtitle",
+            value: "Your new campaign has been created. Exciting times ahead for your sales!",
+            comment: "Subtitle of the celebration view when a Google Ads campaign is successfully created."
+        )
+        static let successCTA = NSLocalizedString(
+            "googleAdsCampaignCoordinator.successCTA",
+            value: "Done",
+            comment: "Button to dismiss the celebration view when a Google Ads campaign is successfully created."
         )
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Hub Menu/HubMenuViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Hub Menu/HubMenuViewController.swift
@@ -97,7 +97,12 @@ private extension HubMenuViewController {
             siteAdminURL: viewModel.woocommerceAdminURL.absoluteString,
             hasGoogleAdsCampaigns: viewModel.hasGoogleAdsCampaigns,
             shouldAuthenticateAdminPage: viewModel.shouldAuthenticateAdminPage,
-            navigationController: navigationController
+            navigationController: navigationController,
+            onCompletion: { [weak self] in
+                Task { @MainActor in
+                    await self?.viewModel.refreshGoogleAdsCampaignCheck()
+                }
+            }
         )
         googleAdsCampaignCoordinator?.start()
     }

--- a/WooCommerce/Classes/ViewRelated/Hub Menu/HubMenuViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Hub Menu/HubMenuViewModel.swift
@@ -173,6 +173,11 @@ final class HubMenuViewModel: ObservableObject {
         showingReviewDetail = true
     }
 
+    @MainActor
+    func refreshGoogleAdsCampaignCheck() async {
+        hasGoogleAdsCampaigns = await checkIfSiteHasGoogleAdsCampaigns()
+    }
+
     deinit {
         NotificationCenter.default.removeObserver(self, name: .setUpTapToPayViewDidAppear, object: nil)
     }

--- a/WooCommerce/WooCommerceTests/GoogleAds/GoogleAdsCampaignCoordinatorTests.swift
+++ b/WooCommerce/WooCommerceTests/GoogleAds/GoogleAdsCampaignCoordinatorTests.swift
@@ -27,7 +27,8 @@ final class GoogleAdsCampaignCoordinatorTests: XCTestCase {
             siteAdminURL: siteAdminURL,
             hasGoogleAdsCampaigns: true,
             shouldAuthenticateAdminPage: false,
-            navigationController: navigationController
+            navigationController: navigationController,
+            onCompletion: {}
         )
 
         // When
@@ -45,7 +46,8 @@ final class GoogleAdsCampaignCoordinatorTests: XCTestCase {
             siteAdminURL: siteAdminURL,
             hasGoogleAdsCampaigns: true,
             shouldAuthenticateAdminPage: true,
-            navigationController: navigationController
+            navigationController: navigationController,
+            onCompletion: {}
         )
 
         // When


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #13227 
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This PR updates `GoogleAdsCampaignCoordinator` to display a bottom sheet for campaign creation success. A completion closure has also been added to trigger fetching the campaign list again after dismissing the screen to ensure the correct page when tapping the entry point again.

Since there's no design for this screen, I'm using the same bottom sheet as Blaze, with a small adjustment in the wording.

## Testing steps
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->
- Pre-requisite: Install, activate, and set up the Google Ads plugin to a test site following pe5sF9-2Qo-p2. Ensure that you're using the plugin version 2.7.5 or above. Ensure to remove all campaigns in your store if you have any.
- Log in to your test store and navigate to the Menu tab.
- Select Google for WooCommerce. Confirm that the campaign creation page is displayed. Proceed to create a test campaign.
- When the campaign is created successfully, the web view should be dismissed. A bottom sheet should be displayed upon success.
- Tap on the entry point again, this time you should see the campaign dashboard page.


## Screenshots
<!-- Include before and after images or gifs when appropriate. -->
<img src="https://github.com/woocommerce/woocommerce-ios/assets/5533851/56b5045d-8a42-445b-8c27-fa1d86b77998" width=320 />


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.