### PR TITLE
Dismiss Payment Provider view after the selection

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/InPersonPaymentsSelectPluginView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/InPersonPaymentsSelectPluginView.swift
@@ -43,6 +43,7 @@ struct InPersonPaymentsSelectPluginRow: View {
 }
 
 struct InPersonPaymentsSelectPluginView: View {
+    @Environment(\.presentationMode) var presentation
     @State var selectedPlugin: CardPresentPaymentsPlugin?
     let onPluginSelected: (CardPresentPaymentsPlugin) -> Void
 
@@ -93,6 +94,7 @@ struct InPersonPaymentsSelectPluginView: View {
             return DDLogError("Attempt to confirm a payment gateway selection with no gateway selected")
         }
         onPluginSelected(selectedPlugin)
+        presentation.wrappedValue.dismiss()
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Payments Menu/InPersonPaymentsMenuViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Payments Menu/InPersonPaymentsMenuViewModel.swift
@@ -214,7 +214,6 @@ final class InPersonPaymentsMenuViewModel: ObservableObject {
     func preferredPluginSelected(plugin: CardPresentPaymentsPlugin) {
         dependencies.onboardingUseCase.clearPluginSelection()
         dependencies.onboardingUseCase.selectPlugin(plugin)
-        presentManagePaymentGateways = false
     }
 
     lazy var aboutTapToPayViewModel: AboutTapToPayViewModel = {


### PR DESCRIPTION
Closes: #12818

<!-- Remember about a good descriptive title. -->


<!-- Id number of the GitHub issue this PR addresses. -->

## Description

Payment Provider selection view is not dismissed (popped) after a provider is selected. However, it looks like there was an intention to do that since view presenting `presentManagePaymentGateways` `Binding` var was set to `false` after the plugin selection.

NavigationLink within PaymentsRow presents the view when isActive Binding is enabled. However, it doesn't automatically pop the view when the binding's value is disabled. The value turns false when the view is popped (dismissed) in another way.

This change:
- Dismisses payment provider selection view using Environment presentation variable
- Removes presentManagePaymentGateways = false

## Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->

## Testing information

1. Configure a store with multiple payment providers (WooPayments and Stripe)
2. Open Menu
3. Payments
4. Confirm Payment Provider option is available
5. Tap "Payment Provider" row
6. Change provider
7. Tap "Confirm Payment Method"
8. Confirm the view is dismissed and a new provider is selected

## Screenshots

https://github.com/woocommerce/woocommerce-ios/assets/4062343/a6882427-4715-4bb4-814f-ec38708d7620

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.