### PR TITLE
[Woo POS] Create payment service mock for unit testing

### DIFF
--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -524,6 +524,7 @@
 		02CA63DB23D1ADD100BBF148 /* MediaPickingCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02CA63D723D1ADD100BBF148 /* MediaPickingCoordinator.swift */; };
 		02CA63DC23D1ADD100BBF148 /* DeviceMediaLibraryPicker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02CA63D823D1ADD100BBF148 /* DeviceMediaLibraryPicker.swift */; };
 		02CA63DD23D1ADD100BBF148 /* MediaPickingContext.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02CA63D923D1ADD100BBF148 /* MediaPickingContext.swift */; };
+		02CD3BFE2C35D04C00E575C4 /* MockCardPresentPaymentService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02CD3BFD2C35D04C00E575C4 /* MockCardPresentPaymentService.swift */; };
 		02CE43022768CBF60006EAEF /* ProductSKUBarcodeScannerCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02CE43012768CBF60006EAEF /* ProductSKUBarcodeScannerCoordinator.swift */; };
 		02CE4304276993DA0006EAEF /* CaptureDevicePermissionChecker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02CE4303276993DA0006EAEF /* CaptureDevicePermissionChecker.swift */; };
 		02CE4307276994920006EAEF /* ProductSKUBarcodeScannerCoordinatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02CE4306276994920006EAEF /* ProductSKUBarcodeScannerCoordinatorTests.swift */; };
@@ -3522,6 +3523,7 @@
 		02CA63D723D1ADD100BBF148 /* MediaPickingCoordinator.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MediaPickingCoordinator.swift; sourceTree = "<group>"; };
 		02CA63D823D1ADD100BBF148 /* DeviceMediaLibraryPicker.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DeviceMediaLibraryPicker.swift; sourceTree = "<group>"; };
 		02CA63D923D1ADD100BBF148 /* MediaPickingContext.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MediaPickingContext.swift; sourceTree = "<group>"; };
+		02CD3BFD2C35D04C00E575C4 /* MockCardPresentPaymentService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockCardPresentPaymentService.swift; sourceTree = "<group>"; };
 		02CE43012768CBF60006EAEF /* ProductSKUBarcodeScannerCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductSKUBarcodeScannerCoordinator.swift; sourceTree = "<group>"; };
 		02CE4303276993DA0006EAEF /* CaptureDevicePermissionChecker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CaptureDevicePermissionChecker.swift; sourceTree = "<group>"; };
 		02CE4306276994920006EAEF /* ProductSKUBarcodeScannerCoordinatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductSKUBarcodeScannerCoordinatorTests.swift; sourceTree = "<group>"; };
@@ -7197,6 +7199,14 @@
 				0230B4D72C3345DF00F2F660 /* PointOfSaleCardPresentPaymentCaptureFailedView.swift */,
 			);
 			path = "Presented Views";
+			sourceTree = "<group>";
+		};
+		02CD3BFC2C35D01600E575C4 /* Mocks */ = {
+			isa = PBXGroup;
+			children = (
+				02CD3BFD2C35D04C00E575C4 /* MockCardPresentPaymentService.swift */,
+			);
+			path = Mocks;
 			sourceTree = "<group>";
 		};
 		02CE43052769946A0006EAEF /* SKU Scanner */ = {
@@ -12175,6 +12185,7 @@
 		DABF35242C11B40C006AF826 /* POS */ = {
 			isa = PBXGroup;
 			children = (
+				02CD3BFC2C35D01600E575C4 /* Mocks */,
 				DABF35252C11B412006AF826 /* ViewModels */,
 			);
 			path = POS;
@@ -16527,6 +16538,7 @@
 				DE3877E4283E35E80075D87E /* DiscountTypeBottomSheetListSelectorCommandTests.swift in Sources */,
 				025678C725773399009D7E6C /* Collection+ShippingLabelTests.swift in Sources */,
 				02BC5AA624D27F8900C43326 /* ProductVariationFormViewModel+ChangesTests.swift in Sources */,
+				02CD3BFE2C35D04C00E575C4 /* MockCardPresentPaymentService.swift in Sources */,
 				EE8A30472B74F3A8001D7C66 /* OrderAttributionInfo+OriginTests.swift in Sources */,
 				03A6C18428B52B1500AADF23 /* InPersonPaymentsCashOnDeliveryPaymentGatewayNotSetUpViewModelTests.swift in Sources */,
 				DE74A44F2BCE2FCF0009C415 /* StorePerformanceViewModelTests.swift in Sources */,

--- a/WooCommerce/WooCommerceTests/POS/Mocks/MockCardPresentPaymentService.swift
+++ b/WooCommerce/WooCommerceTests/POS/Mocks/MockCardPresentPaymentService.swift
@@ -1,0 +1,26 @@
+import Foundation
+import Combine
+import struct Yosemite.Order
+@testable import WooCommerce
+
+struct MockCardPresentPaymentService: CardPresentPaymentFacade {
+    let paymentEventPublisher: AnyPublisher<CardPresentPaymentEvent, Never> = Just(.idle).eraseToAnyPublisher()
+
+    let connectedReaderPublisher: AnyPublisher<CardPresentPaymentCardReader?, Never> = Just(nil).eraseToAnyPublisher()
+
+    func connectReader(using connectionMethod: CardReaderConnectionMethod) async throws -> CardPresentPaymentReaderConnectionResult {
+        .connected(CardPresentPaymentCardReader(name: "Test reader", batteryLevel: 0.85))
+    }
+
+    func disconnectReader() {
+        // no-op
+    }
+
+    func collectPayment(for order: Yosemite.Order, using connectionMethod: CardReaderConnectionMethod) async throws -> CardPresentPaymentResult {
+        .success(CardPresentPaymentTransaction(receiptURL: URL(string: "https://example.net/receipts/123")!))
+    }
+
+    func cancelPayment() {
+        // no-op
+    }
+}

--- a/WooCommerce/WooCommerceTests/POS/Mocks/MockCardPresentPaymentService.swift
+++ b/WooCommerce/WooCommerceTests/POS/Mocks/MockCardPresentPaymentService.swift
@@ -3,10 +3,21 @@ import Combine
 import struct Yosemite.Order
 @testable import WooCommerce
 
-struct MockCardPresentPaymentService: CardPresentPaymentFacade {
-    let paymentEventPublisher: AnyPublisher<CardPresentPaymentEvent, Never> = Just(.idle).eraseToAnyPublisher()
+final class MockCardPresentPaymentService: CardPresentPaymentFacade {
+    // MARK: - Variables for emitting events in unit tests
 
-    let connectedReaderPublisher: AnyPublisher<CardPresentPaymentCardReader?, Never> = Just(nil).eraseToAnyPublisher()
+    @Published var paymentEvent: CardPresentPaymentEvent = .idle
+    @Published var connectedReader: CardPresentPaymentCardReader?
+
+    // MARK: - CardPresentPaymentFacade
+
+    var paymentEventPublisher: AnyPublisher<CardPresentPaymentEvent, Never> {
+        $paymentEvent.eraseToAnyPublisher()
+    }
+
+    var connectedReaderPublisher: AnyPublisher<CardPresentPaymentCardReader?, Never> {
+        $connectedReader.eraseToAnyPublisher()
+    }
 
     func connectReader(using connectionMethod: CardReaderConnectionMethod) async throws -> CardPresentPaymentReaderConnectionResult {
         .connected(CardPresentPaymentCardReader(name: "Test reader", batteryLevel: 0.85))

--- a/WooCommerce/WooCommerceTests/POS/ViewModels/PointOfSaleDashboardViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/POS/ViewModels/PointOfSaleDashboardViewModelTests.swift
@@ -10,13 +10,13 @@ import XCTest
 final class PointOfSaleDashboardViewModelTests: XCTestCase {
 
     private var sut: PointOfSaleDashboardViewModel!
-    private var cardPresentPaymentService: CardPresentPaymentPreviewService!
+    private var cardPresentPaymentService: MockCardPresentPaymentService!
     private var itemProvider: MockPOSItemProvider!
     private var orderService: POSOrderServiceProtocol!
 
     override func setUp() {
         super.setUp()
-        cardPresentPaymentService = CardPresentPaymentPreviewService()
+        cardPresentPaymentService = MockCardPresentPaymentService()
         itemProvider = MockPOSItemProvider()
         orderService = POSOrderPreviewService()
         sut = PointOfSaleDashboardViewModel(itemProvider: itemProvider,


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #13077 

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

Currently, we're using `CardPresentPaymentPreviewService` in `PointOfSaleDashboardViewModelTests`. This is a quick PR to add a simple mock for `CardPresentPaymentFacade` with variables for emitting events.

## Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->

There are no changes in the app layer, just CI checks are sufficient.

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.