### PR TITLE
Create and schedule the Order Sync background task

### DIFF
--- a/WooCommerce/Classes/AppDelegate.swift
+++ b/WooCommerce/Classes/AppDelegate.swift
@@ -55,6 +55,10 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 
     private lazy var requirementsChecker = RequirementsChecker(baseViewController: tabBarController)
 
+    /// Handles events to background refresh the app.
+    ///
+    private let appRefreshHandler = BackgroundTaskRefreshDispatcher()
+
     // MARK: - AppDelegate Methods
 
     func application(_ application: UIApplication, willFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]? = nil) -> Bool {
@@ -117,6 +121,9 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 
         // Start app navigation.
         appCoordinator?.start()
+
+        // Register for background app refresh events.
+        appRefreshHandler.registerSystemTaskIdentifier()
 
         return true
     }
@@ -209,6 +216,10 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 
         // Don't track startup waiting time if app is backgrounded before everything is loaded
         cancelStartupWaitingTimeTracker()
+
+        // Schedule the background app refresh when sending the app to the background.
+        // The OS is in charge of determining when these tasks will run based on app usage patterns.
+        appRefreshHandler.scheduleAppRefresh()
     }
 
     func applicationWillEnterForeground(_ application: UIApplication) {

--- a/WooCommerce/Classes/Tools/BackgroundTasks/BackgroundTaskRefreshDispatcher.swift
+++ b/WooCommerce/Classes/Tools/BackgroundTasks/BackgroundTaskRefreshDispatcher.swift
@@ -1,0 +1,50 @@
+import Foundation
+import BackgroundTasks
+
+final class BackgroundTaskRefreshDispatcher {
+
+    // System background task identifier. Should match the info.plist value.
+    static let taskIdentifier = "com.automattic.woocommerce.refresh"
+
+    /// Schedule the app refresh background task.
+    ///
+    func scheduleAppRefresh() {
+        let request = BGAppRefreshTaskRequest(identifier: Self.taskIdentifier)
+        request.earliestBeginDate = Date(timeIntervalSinceNow: 30 * 60) // Fetch no earlier than 30 minutes from now.
+        do {
+            try BGTaskScheduler.shared.submit(request)
+        } catch {
+            DDLogError("⛔️ Could not schedule app refresh: \(error)")
+        }
+    }
+
+    /// Registers a closure to be invoked when the system wants to perform a background task.
+    ///
+    func registerSystemTaskIdentifier() {
+        BGTaskScheduler.shared.register(forTaskWithIdentifier: Self.taskIdentifier, using: nil) { task in
+            guard let refreshTask = task as? BGAppRefreshTask else {
+                return
+            }
+            self.handleAppRefresh(backgroundTask: refreshTask)
+        }
+    }
+
+    /// Handle the app specific tasks to be performed with an app refresh background task.
+    ///
+    private func handleAppRefresh(backgroundTask: BGAppRefreshTask) {
+
+        guard let siteID = ServiceLocator.stores.sessionManager.defaultStoreID else {
+            return
+        }
+
+        // Schedule a new refresh task.
+        scheduleAppRefresh()
+
+        let ordersSyncTask = OrderSyncBackgroundTask(siteID: siteID, backgroundTask: backgroundTask).dispatch()
+
+        // Provide the background task with an expiration handler that cancels the operation.
+        backgroundTask.expirationHandler = {
+            ordersSyncTask.cancel()
+        }
+     }
+}

--- a/WooCommerce/Classes/Tools/BackgroundTasks/BackgroundTaskRefreshDispatcher.swift
+++ b/WooCommerce/Classes/Tools/BackgroundTasks/BackgroundTaskRefreshDispatcher.swift
@@ -9,6 +9,12 @@ final class BackgroundTaskRefreshDispatcher {
     /// Schedule the app refresh background task.
     ///
     func scheduleAppRefresh() {
+
+        // Do not run this code while running test because this framework is not enabled in the simulator
+        guard Self.isNotRunningTests() else {
+            return
+        }
+
         let request = BGAppRefreshTaskRequest(identifier: Self.taskIdentifier)
         request.earliestBeginDate = Date(timeIntervalSinceNow: 30 * 60) // Fetch no earlier than 30 minutes from now.
         do {
@@ -21,6 +27,12 @@ final class BackgroundTaskRefreshDispatcher {
     /// Registers a closure to be invoked when the system wants to perform a background task.
     ///
     func registerSystemTaskIdentifier() {
+
+        // Do not run this code while running test because this framework is not enabled in the simulator
+        guard Self.isNotRunningTests() else {
+            return
+        }
+
         BGTaskScheduler.shared.register(forTaskWithIdentifier: Self.taskIdentifier, using: nil) { task in
             guard let refreshTask = task as? BGAppRefreshTask else {
                 return
@@ -47,4 +59,10 @@ final class BackgroundTaskRefreshDispatcher {
             ordersSyncTask.cancel()
         }
      }
+}
+
+private extension BackgroundTaskRefreshDispatcher {
+    static func isNotRunningTests() -> Bool {
+        return NSClassFromString("XCTestCase") == nil
+    }
 }

--- a/WooCommerce/Classes/Tools/BackgroundTasks/OrderSyncBackgroundTask.swift
+++ b/WooCommerce/Classes/Tools/BackgroundTasks/OrderSyncBackgroundTask.swift
@@ -1,0 +1,82 @@
+import BackgroundTasks
+import Foundation
+import Yosemite
+
+/// Task to sync orders in the background
+///
+struct OrderSyncBackgroundTask {
+
+    let siteID: Int64
+
+    let stores: StoresManager
+
+    let backgroundTask: BGAppRefreshTask
+
+    init(siteID: Int64, backgroundTask: BGAppRefreshTask, stores: StoresManager = ServiceLocator.stores) {
+        self.siteID = siteID
+        self.backgroundTask = backgroundTask
+        self.stores = stores
+    }
+
+    /// Runs the sync task.
+    /// Marks the `backgroundTask` as completed when finished.
+    /// Returns a `task` to be canceled when required.
+    ///
+    func dispatch() -> Task<Void, Never> {
+        Task { @MainActor in
+            do {
+                let filters = await fetchFilters()
+                try await syncOrders(filters: filters)
+                DDLogError("🟢 Successfully synced orders in the background")
+                backgroundTask.setTaskCompleted(success: true)
+            } catch {
+                DDLogError("⛔️ Error synching orders in the background: \(error)")
+                backgroundTask.setTaskCompleted(success: false)
+            }
+        }
+    }
+
+    /// Fetch the stored filters settings.
+    /// Needed to request the correct type of orders.
+    ///
+    @MainActor
+    private func fetchFilters() async -> FilterOrderListViewModel.Filters {
+        return await withCheckedContinuation { continuation in
+            let action = AppSettingsAction.loadOrdersSettings(siteID: siteID) { (result) in
+                switch result {
+                case .success(let settings):
+                    let filters = FilterOrderListViewModel.Filters(orderStatus: settings.orderStatusesFilter,
+                                                                   dateRange: settings.dateRangeFilter,
+                                                                   product: settings.productFilter,
+                                                                   customer: settings.customerFilter,
+                                                                   numberOfActiveFilters: settings.numberOfActiveFilters())
+                    continuation.resume(returning: filters)
+                case .failure:
+                    continuation.resume(returning: .init()) // No filters found
+                }
+            }
+            stores.dispatch(action)
+        }
+    }
+
+    /// Syncs(fetch and stores) the latest orders for a given site and filters.
+    ///
+    @MainActor
+    private func syncOrders(filters: FilterOrderListViewModel.Filters) async throws {
+        return try await withCheckedThrowingContinuation { continuation in
+            let useCase = OrderListSyncActionUseCase(siteID: siteID, filters: filters)
+            let action = useCase.actionFor(pageNumber: SyncingCoordinator.Defaults.pageFirstIndex,
+                                           pageSize: SyncingCoordinator.Defaults.pageSize,
+                                           reason: .backgroundFetch,
+                                           lastFullSyncTimestamp: nil, // TODO: Send timestamp later, when we are saving and fetching timestamps
+                                           completionHandler: { timeInterval, error in
+                if let error {
+                    continuation.resume(throwing: error)
+                } else {
+                    continuation.resume(returning: ())
+                }
+            })
+            stores.dispatch(action)
+        }
+    }
+}

--- a/WooCommerce/Classes/ViewRelated/Orders/OrderListSyncActionUseCase.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrderListSyncActionUseCase.swift
@@ -45,6 +45,7 @@ struct OrderListSyncActionUseCase {
         case newFiltersApplied = "new_filters_applied"
         case pullToRefresh = "pull_to_refresh"
         case viewWillAppear = "view_will_appear"
+        case backgroundFetch = "background_fetch"
     }
 
     let siteID: Int64

--- a/WooCommerce/Resources/Info.plist
+++ b/WooCommerce/Resources/Info.plist
@@ -2,6 +2,10 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>BGTaskSchedulerPermittedIdentifiers</key>
+	<array>
+		<string>com.automattic.woocommerce.refresh</string>
+	</array>
 	<key>CFBundleDevelopmentRegion</key>
 	<string>$(DEVELOPMENT_LANGUAGE)</string>
 	<key>CFBundleDisplayName</key>
@@ -83,6 +87,41 @@
 	<array>
 		<string>Noticons.ttf</string>
 	</array>
+	<key>UIApplicationShortcutItems</key>
+	<array>
+		<dict>
+			<key>UIApplicationShortcutItemIconSymbolName</key>
+			<string>plus</string>
+			<key>UIApplicationShortcutItemTitle</key>
+			<string>AddOrderAction.Title</string>
+			<key>UIApplicationShortcutItemType</key>
+			<string>AddOrderAction</string>
+		</dict>
+		<dict>
+			<key>UIApplicationShortcutItemIconFile</key>
+			<string>pages</string>
+			<key>UIApplicationShortcutItemTitle</key>
+			<string>OpenOrdersAction.Title</string>
+			<key>UIApplicationShortcutItemType</key>
+			<string>OpenOrdersAction</string>
+		</dict>
+		<dict>
+			<key>UIApplicationShortcutItemIconSymbolName</key>
+			<string>plus</string>
+			<key>UIApplicationShortcutItemTitle</key>
+			<string>AddProductAction.Title</string>
+			<key>UIApplicationShortcutItemType</key>
+			<string>AddProductAction</string>
+		</dict>
+		<dict>
+			<key>UIApplicationShortcutItemIconFile</key>
+			<string>icon-money</string>
+			<key>UIApplicationShortcutItemTitle</key>
+			<string>CollectPaymentAction.Title</string>
+			<key>UIApplicationShortcutItemType</key>
+			<string>CollectPaymentAction</string>
+		</dict>
+	</array>
 	<key>UIBackgroundModes</key>
 	<array>
 		<string>fetch</string>
@@ -110,40 +149,5 @@
 	</array>
 	<key>UIViewControllerBasedStatusBarAppearance</key>
 	<true/>
-	<key>UIApplicationShortcutItems</key>
-	<array>
-		<dict>
-			<key>UIApplicationShortcutItemType</key>
-			<string>AddOrderAction</string>
-			<key>UIApplicationShortcutItemTitle</key>
-			<string>AddOrderAction.Title</string>
-			<key>UIApplicationShortcutItemIconSymbolName</key>
-			<string>plus</string>
-		</dict>
-		<dict>
-			<key>UIApplicationShortcutItemType</key>
-			<string>OpenOrdersAction</string>
-			<key>UIApplicationShortcutItemTitle</key>
-			<string>OpenOrdersAction.Title</string>
-			<key>UIApplicationShortcutItemIconFile</key>
-			<string>pages</string>
-		</dict>
-		<dict>
-			<key>UIApplicationShortcutItemType</key>
-			<string>AddProductAction</string>
-			<key>UIApplicationShortcutItemTitle</key>
-			<string>AddProductAction.Title</string>
-			<key>UIApplicationShortcutItemIconSymbolName</key>
-			<string>plus</string>
-		</dict>
-		<dict>
-			<key>UIApplicationShortcutItemType</key>
-			<string>CollectPaymentAction</string>
-			<key>UIApplicationShortcutItemTitle</key>
-			<string>CollectPaymentAction.Title</string>
-			<key>UIApplicationShortcutItemIconFile</key>
-			<string>icon-money</string>
-		</dict>
-	</array>
 </dict>
 </plist>

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -1034,6 +1034,8 @@
 		26B9875F273CB6AA0090E8CA /* SimplePaymentsNoteViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26B9875E273CB6AA0090E8CA /* SimplePaymentsNoteViewModelTests.swift */; };
 		26BBEA8528C6ADAC00ED7F6C /* Images.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 26FFD32628C6A0A4002E5E5E /* Images.xcassets */; };
 		26BBEA8628C6AE1400ED7F6C /* UIImage+Widgets.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26FFD32928C6A0F4002E5E5E /* UIImage+Widgets.swift */; };
+		26BCA0402C35E9A9000BE96C /* BackgroundTaskRefreshDispatcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26BCA03F2C35E9A9000BE96C /* BackgroundTaskRefreshDispatcher.swift */; };
+		26BCA0422C35EDBF000BE96C /* OrderSyncBackgroundTask.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26BCA0412C35EDBF000BE96C /* OrderSyncBackgroundTask.swift */; };
 		26C0D1E32B460E5700F6EDA5 /* OrderNotificationViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2679F02C2AAADB1C00AF80C5 /* OrderNotificationViewModel.swift */; };
 		26C0D1E42B460E9000F6EDA5 /* AppLocalizedString.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F50FE4228CAEBA800C89201 /* AppLocalizedString.swift */; };
 		26C0D1E52B460EB700F6EDA5 /* WooConstants.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5D1AFBF20BC67C200DB0E8C /* WooConstants.swift */; };
@@ -4000,6 +4002,8 @@
 		26B98757273C5BE30090E8CA /* EditCustomerNoteViewModelProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditCustomerNoteViewModelProtocol.swift; sourceTree = "<group>"; };
 		26B9875C273C6A830090E8CA /* SimplePaymentsNoteViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SimplePaymentsNoteViewModel.swift; sourceTree = "<group>"; };
 		26B9875E273CB6AA0090E8CA /* SimplePaymentsNoteViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SimplePaymentsNoteViewModelTests.swift; sourceTree = "<group>"; };
+		26BCA03F2C35E9A9000BE96C /* BackgroundTaskRefreshDispatcher.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BackgroundTaskRefreshDispatcher.swift; sourceTree = "<group>"; };
+		26BCA0412C35EDBF000BE96C /* OrderSyncBackgroundTask.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OrderSyncBackgroundTask.swift; sourceTree = "<group>"; };
 		26C1633B29DA2CE700E482CE /* FreeTrialSummaryView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FreeTrialSummaryView.swift; sourceTree = "<group>"; };
 		26C6439227B5DBE900DD00D1 /* OrderSynchronizer.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = OrderSynchronizer.swift; sourceTree = "<group>"; };
 		26C6E8DF26E2B7BD00C7BB0F /* CountrySelectorViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CountrySelectorViewModel.swift; sourceTree = "<group>"; };
@@ -8108,6 +8112,15 @@
 			path = Summary;
 			sourceTree = "<group>";
 		};
+		26BCA03E2C35E965000BE96C /* BackgroundTasks */ = {
+			isa = PBXGroup;
+			children = (
+				26BCA03F2C35E9A9000BE96C /* BackgroundTaskRefreshDispatcher.swift */,
+				26BCA0412C35EDBF000BE96C /* OrderSyncBackgroundTask.swift */,
+			);
+			path = BackgroundTasks;
+			sourceTree = "<group>";
+		};
 		26C1633A29DA2CD800E482CE /* Free Trial */ = {
 			isa = PBXGroup;
 			children = (
@@ -9884,6 +9897,7 @@
 		B55D4C2220B716CE00D7A50F /* Tools */ = {
 			isa = PBXGroup;
 			children = (
+				26BCA03E2C35E965000BE96C /* BackgroundTasks */,
 				EEADF61C281A3DB7001B40F1 /* ShippingValueLocalizer */,
 				DE792E1926EF37D80071200C /* Connectivity */,
 				CECC759A23D61BCC00486676 /* AggregateData */,
@@ -15513,6 +15527,7 @@
 				DE5746362B4522ED0034B10D /* BlazeBudgetSettingViewModel.swift in Sources */,
 				B555530D21B57DC300449E71 /* UserNotificationsCenterAdapter.swift in Sources */,
 				45C8B2662316AB460002FA77 /* BillingAddressTableViewCell.swift in Sources */,
+				26BCA0422C35EDBF000BE96C /* OrderSyncBackgroundTask.swift in Sources */,
 				E11228BC2707161E004E9F2D /* CardPresentModalUpdateFailed.swift in Sources */,
 				B541B2152189EEA1008FE7C1 /* Scanner+Helpers.swift in Sources */,
 				4512054F2464741B005D68DE /* ProductVisibility.swift in Sources */,
@@ -15720,6 +15735,7 @@
 				DECE13FB27993F6500816ECD /* TitleAndSubtitleAndStatusTableViewCell.swift in Sources */,
 				DEFC9BE22B2FF62C00138B05 /* WooAnalyticsEvent+Themes.swift in Sources */,
 				EE35AFA32B0491960074E7AC /* SubscriptionTrialViewModel.swift in Sources */,
+				26BCA0402C35E9A9000BE96C /* BackgroundTaskRefreshDispatcher.swift in Sources */,
 				26E0AE1926335AA900A5EB3B /* Survey.swift in Sources */,
 				0371C3682875E47B00277E2C /* FeatureAnnouncementCardViewModel.swift in Sources */,
 				03EF24FA28BF5D21006A033E /* InPersonPaymentsCashOnDeliveryToggleRowViewModel.swift in Sources */,


### PR DESCRIPTION
part of #13131 

# Why

This PR adds the base code to register and act upon background refresh tasks.

# How

- Register and schedule a background task with identifier `com.automattic.woocommerce.refresh`
- When a background task is invoked, dispatch a `orders sync` task.

# Demo

https://github.com/woocommerce/woocommerce-ios/assets/562080/f023f95b-366d-4e8e-b259-f8d1e889ee0e


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
