### PR TITLE
Google Ads: Add new dashboard card for Google ads

### DIFF
--- a/Storage/Storage/Model/DashboardCard.swift
+++ b/Storage/Storage/Model/DashboardCard.swift
@@ -31,6 +31,7 @@ public struct DashboardCard: Codable, Hashable, Equatable, GeneratedCopiable {
         case reviews
         case lastOrders
         case coupons
+        case googleAds
     }
 
     /// Card's availability state that determines whether it can be displayed and used.

--- a/WooCommerce/Classes/Analytics/WooAnalyticsEvent+DynamicDashboard.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsEvent+DynamicDashboard.swift
@@ -94,6 +94,8 @@ extension DashboardCard.CardType {
             "orders"
         case .coupons:
             "coupons"
+        case .googleAds:
+            "google-ads"
         }
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/DashboardCustomization/DashboardCard+UI.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/DashboardCustomization/DashboardCard+UI.swift
@@ -22,6 +22,8 @@ extension DashboardCard.CardType {
             Localization.lastOrders
         case .coupons:
             Localization.coupons
+        case .googleAds:
+            Localization.googleAds
         }
     }
 }
@@ -72,6 +74,11 @@ private extension DashboardCard.CardType {
             "dashboardCard.name.coupons",
             value: "Most active coupons",
             comment: "Name for the Most active coupons dashboard card in the Customize Dashboard screen"
+        )
+        static let googleAds = NSLocalizedString(
+            "dashboardCard.name.googleAds",
+            value: "Google for WooCommerce",
+            comment: "Name for the Google for WooCommerce dashboard card in the Customize Dashboard screen"
         )
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/DashboardCustomization/DashboardCard+UI.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/DashboardCustomization/DashboardCard+UI.swift
@@ -77,8 +77,8 @@ private extension DashboardCard.CardType {
         )
         static let googleAds = NSLocalizedString(
             "dashboardCard.name.googleAds",
-            value: "Google for WooCommerce",
-            comment: "Name for the Google for WooCommerce dashboard card in the Customize Dashboard screen"
+            value: "Google ads campaigns",
+            comment: "Name for the Google Ads campaigns dashboard card in the Customize Dashboard screen"
         )
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/DashboardView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/DashboardView.swift
@@ -234,7 +234,12 @@ private extension DashboardView {
                         } onViewOrderDetail: { order in
                             onViewOrderDetail?(order)
                         }
-
+                    case .googleAds:
+                        GoogleAdsDashboardCard(viewModel: viewModel.googleAdsDashboardCardViewModel, onCreateNewCampaign: {
+                            // TODO
+                        }, onShowAllCampaigns: {
+                            // TODO
+                        })
                     }
 
                     // Append feedback card after the first card

--- a/WooCommerce/Classes/ViewRelated/Dashboard/DashboardViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/DashboardViewModel.swift
@@ -27,6 +27,7 @@ final class DashboardViewModel: ObservableObject {
     let mostActiveCouponsViewModel: MostActiveCouponsCardViewModel
     let productStockCardViewModel: ProductStockDashboardCardViewModel
     let lastOrdersCardViewModel: LastOrdersDashboardCardViewModel
+    let googleAdsDashboardCardViewModel: GoogleAdsDashboardCardViewModel
 
     @Published var justInTimeMessagesWebViewModel: WebViewSheetViewModel? = nil
 
@@ -135,6 +136,7 @@ final class DashboardViewModel: ObservableObject {
         self.mostActiveCouponsViewModel = MostActiveCouponsCardViewModel(siteID: siteID)
         self.productStockCardViewModel = ProductStockDashboardCardViewModel(siteID: siteID)
         self.lastOrdersCardViewModel = LastOrdersDashboardCardViewModel(siteID: siteID)
+        self.googleAdsDashboardCardViewModel = GoogleAdsDashboardCardViewModel(siteID: siteID)
 
         self.themeInstaller = themeInstaller
         self.inboxEligibilityChecker = inboxEligibilityChecker
@@ -409,6 +411,9 @@ private extension DashboardViewModel {
                     group.addTask { [weak self] in
                         await self?.lastOrdersCardViewModel.reloadData()
                     }
+                case .googleAds:
+                    // TODO: fetch data
+                    break
                 }
             }
         }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/GoogleAds/GoogleAdsDashboardCard.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/GoogleAds/GoogleAdsDashboardCard.swift
@@ -2,7 +2,11 @@ import SwiftUI
 import struct Yosemite.DashboardCard
 
 struct GoogleAdsDashboardCard: View {
+    /// Scale of the view based on accessibility changes
+    @ScaledMetric private var scale: CGFloat = 1.0
+
     @ObservedObject private var viewModel: GoogleAdsDashboardCardViewModel
+
     private let onCreateNewCampaign: () -> Void
     private let onShowAllCampaigns: () -> Void
 
@@ -15,8 +19,16 @@ struct GoogleAdsDashboardCard: View {
     }
 
     var body: some View {
-        VStack(alignment: .leading, spacing: 0) {
+        VStack(alignment: .leading, spacing: Layout.padding) {
             header
+                .padding(.horizontal, Layout.padding)
+
+            // Introduction about Google Ads
+            noCampaignView
+                .padding(.horizontal, Layout.padding)
+
+            // Create campaign button
+            createCampaignButton
                 .padding(.horizontal, Layout.padding)
         }
         .padding(.vertical, Layout.padding)
@@ -49,27 +61,80 @@ private extension GoogleAdsDashboardCard {
             .disabled(viewModel.syncingData)
         }
     }
+
+    var noCampaignView: some View {
+        HStack(alignment: .top) {
+            Image(uiImage: .googleLogo)
+                .resizable()
+                .aspectRatio(contentMode: .fit)
+                .frame(width: Layout.imageSize * scale, height: Layout.imageSize * scale)
+
+            VStack(alignment: .leading) {
+                Text(Localization.NoCampaign.title)
+                    .headlineStyle()
+                Text(Localization.NoCampaign.subtitle)
+                    .subheadlineStyle()
+            }
+        }
+        .padding(Layout.contentPadding)
+        .background(
+            RoundedRectangle(cornerRadius: Layout.cornerRadius)
+                .fill(Color(uiColor: .init(light: UIColor.clear,
+                                           dark: UIColor.systemGray5)))
+        )
+        .overlay {
+            RoundedRectangle(cornerRadius: Layout.cornerRadius)
+                .stroke(Color(uiColor: .secondaryButtonDownBorder), lineWidth: Layout.strokeWidth)
+        }
+    }
+
+    var createCampaignButton: some View {
+        Button(Localization.createCampaign) {
+            onCreateNewCampaign()
+        }
+        .buttonStyle(SecondaryButtonStyle())
+    }
 }
 
 private extension GoogleAdsDashboardCard {
     enum Layout {
         static let padding: CGFloat = 16
-        static let cornerSize = CGSize(width: 8.0, height: 8.0)
+        static let cornerSize = CGSize(width: cornerRadius, height: cornerRadius)
         static let hideIconVerticalPadding: CGFloat = 8
-        static let dividerPadding = EdgeInsets(top: 0, leading: 16, bottom: 0, trailing: 0)
+        static let contentPadding: CGFloat = 16
+        static let strokeWidth: CGFloat = 1
+        static let cornerRadius: CGFloat = 8
+        static let imageSize: CGFloat = 44
     }
 
     enum Localization {
         static let hideCard = NSLocalizedString(
             "googleAdsDashboardCard.hideCard",
-            value: "Hide Google for WooCommerce",
-            comment: "Menu item to dismiss the Google for WooCommerce section on the Dashboard screen"
+            value: "Hide Google ads",
+            comment: "Menu item to dismiss the Google Ads campaigns section on the Dashboard screen"
         )
         static let viewAll = NSLocalizedString(
             "googleAdsDashboardCard.viewAll",
             value: "View all campaigns",
             comment: "Button to navigate to the Google Ads campaign dashboard."
         )
+        static let createCampaign = NSLocalizedString(
+            "googleAdsDashboardCard.createCampaign",
+            value: "Create Campaign",
+            comment: "Button that when tapped will launch create Google Ads campaign flow."
+        )
+        enum NoCampaign {
+            static let title = NSLocalizedString(
+                "googleAdsDashboardCard.noCampaign.title",
+                value: "Boost store traffic and sales with Google Ads",
+                comment: "Title label on the Google Ads campaigns section on the Dashboard screen"
+            )
+            static let subtitle = NSLocalizedString(
+                "googleAdsDashboardCard.noCampaign.subtitle",
+                value: "Create an ad campaign to promote your products across Google Search, Shopping, YouTube, Gmail, and the Display Network.",
+                comment: "Subtitle label on the Google Ads campaigns section on the Dashboard screen"
+            )
+        }
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Dashboard/GoogleAds/GoogleAdsDashboardCard.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/GoogleAds/GoogleAdsDashboardCard.swift
@@ -1,11 +1,80 @@
 import SwiftUI
+import struct Yosemite.DashboardCard
 
 struct GoogleAdsDashboardCard: View {
+    @ObservedObject private var viewModel: GoogleAdsDashboardCardViewModel
+    private let onCreateNewCampaign: () -> Void
+    private let onShowAllCampaigns: () -> Void
+
+    init(viewModel: GoogleAdsDashboardCardViewModel,
+         onCreateNewCampaign: @escaping () -> Void,
+         onShowAllCampaigns: @escaping () -> Void) {
+        self.viewModel = viewModel
+        self.onCreateNewCampaign = onCreateNewCampaign
+        self.onShowAllCampaigns = onShowAllCampaigns
+    }
+
     var body: some View {
-        Text(/*@START_MENU_TOKEN@*/"Hello, World!"/*@END_MENU_TOKEN@*/)
+        VStack(alignment: .leading, spacing: 0) {
+            header
+                .padding(.horizontal, Layout.padding)
+        }
+        .padding(.vertical, Layout.padding)
+        .background(Color(.listForeground(modal: false)))
+        .clipShape(RoundedRectangle(cornerSize: Layout.cornerSize))
+        .padding(.horizontal, Layout.padding)
+    }
+}
+
+private extension GoogleAdsDashboardCard {
+    var header: some View {
+        HStack {
+            Image(systemName: "exclamationmark.circle")
+                .foregroundStyle(Color.secondary)
+                .headlineStyle()
+                .renderedIf(viewModel.syncingError != nil)
+            Text(DashboardCard.CardType.googleAds.name)
+                .headlineStyle()
+            Spacer()
+            Menu {
+                Button(Localization.hideCard) {
+                    viewModel.dismissCard()
+                }
+            } label: {
+                Image(systemName: "ellipsis")
+                    .foregroundStyle(Color.secondary)
+                    .padding(.leading, Layout.padding)
+                    .padding(.vertical, Layout.hideIconVerticalPadding)
+            }
+            .disabled(viewModel.syncingData)
+        }
+    }
+}
+
+private extension GoogleAdsDashboardCard {
+    enum Layout {
+        static let padding: CGFloat = 16
+        static let cornerSize = CGSize(width: 8.0, height: 8.0)
+        static let hideIconVerticalPadding: CGFloat = 8
+        static let dividerPadding = EdgeInsets(top: 0, leading: 16, bottom: 0, trailing: 0)
+    }
+
+    enum Localization {
+        static let hideCard = NSLocalizedString(
+            "googleAdsDashboardCard.hideCard",
+            value: "Hide Google for WooCommerce",
+            comment: "Menu item to dismiss the Google for WooCommerce section on the Dashboard screen"
+        )
+        static let viewAll = NSLocalizedString(
+            "googleAdsDashboardCard.viewAll",
+            value: "View all campaigns",
+            comment: "Button to navigate to the Google Ads campaign dashboard."
+        )
     }
 }
 
 #Preview {
-    GoogleAdsDashboardCard()
+    GoogleAdsDashboardCard(viewModel: GoogleAdsDashboardCardViewModel(siteID: 135),
+                           onCreateNewCampaign: {},
+                           onShowAllCampaigns: {})
 }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/GoogleAds/GoogleAdsDashboardCard.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/GoogleAds/GoogleAdsDashboardCard.swift
@@ -1,0 +1,11 @@
+import SwiftUI
+
+struct GoogleAdsDashboardCard: View {
+    var body: some View {
+        Text(/*@START_MENU_TOKEN@*/"Hello, World!"/*@END_MENU_TOKEN@*/)
+    }
+}
+
+#Preview {
+    GoogleAdsDashboardCard()
+}

--- a/WooCommerce/Classes/ViewRelated/Dashboard/GoogleAds/GoogleAdsDashboardCardViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/GoogleAds/GoogleAdsDashboardCardViewModel.swift
@@ -7,16 +7,25 @@ final class GoogleAdsDashboardCardViewModel: ObservableObject {
     private let siteID: Int64
     private let stores: StoresManager
     private let analytics: Analytics
+    private let eligibilityChecker: GoogleAdsEligibilityChecker
 
+    @Published private(set) var canShowOnDashboard = false
     @Published private(set) var syncingError: Error?
     @Published private(set) var syncingData = false
 
     init(siteID: Int64,
+         eligibilityChecker: GoogleAdsEligibilityChecker = DefaultGoogleAdsEligibilityChecker(),
          stores: StoresManager = ServiceLocator.stores,
          analytics: Analytics = ServiceLocator.analytics) {
         self.siteID = siteID
         self.stores = stores
         self.analytics = analytics
+        self.eligibilityChecker = eligibilityChecker
+    }
+
+    @MainActor
+    func checkAvailability() async {
+        canShowOnDashboard = await eligibilityChecker.isSiteEligible(siteID: siteID)
     }
 
     func dismissCard() {

--- a/WooCommerce/Classes/ViewRelated/Dashboard/GoogleAds/GoogleAdsDashboardCardViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/GoogleAds/GoogleAdsDashboardCardViewModel.swift
@@ -1,6 +1,20 @@
 import Foundation
 import Yosemite
+import protocol WooFoundation.Analytics
 
 /// View model for `GoogleAdsDashboardCard`.
 final class GoogleAdsDashboardCardViewModel: ObservableObject {
+    private let siteID: Int64
+    private let stores: StoresManager
+    private let analytics: Analytics
+
+    @Published private(set) var syncingError: Error?
+
+    init(siteID: Int64,
+         stores: StoresManager = ServiceLocator.stores,
+         analytics: Analytics = ServiceLocator.analytics) {
+        self.siteID = siteID
+        self.stores = stores
+        self.analytics = analytics
+    }
 }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/GoogleAds/GoogleAdsDashboardCardViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/GoogleAds/GoogleAdsDashboardCardViewModel.swift
@@ -9,6 +9,7 @@ final class GoogleAdsDashboardCardViewModel: ObservableObject {
     private let analytics: Analytics
 
     @Published private(set) var syncingError: Error?
+    @Published private(set) var syncingData = false
 
     init(siteID: Int64,
          stores: StoresManager = ServiceLocator.stores,
@@ -16,5 +17,9 @@ final class GoogleAdsDashboardCardViewModel: ObservableObject {
         self.siteID = siteID
         self.stores = stores
         self.analytics = analytics
+    }
+
+    func dismissCard() {
+        // TODO
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/GoogleAds/GoogleAdsDashboardCardViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/GoogleAds/GoogleAdsDashboardCardViewModel.swift
@@ -1,0 +1,6 @@
+import Foundation
+import Yosemite
+
+/// View model for `GoogleAdsDashboardCard`.
+final class GoogleAdsDashboardCardViewModel: ObservableObject {
+}

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -2590,6 +2590,8 @@
 		DEB3879A2C32A6400025256E /* MockGoogleAdsEligibilityChecker.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEB387992C32A6400025256E /* MockGoogleAdsEligibilityChecker.swift */; };
 		DEB3879E2C34FE620025256E /* GoogleAdsCampaignCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEB3879D2C34FE620025256E /* GoogleAdsCampaignCoordinator.swift */; };
 		DEB387A02C35109E0025256E /* GoogleAdsCampaignCoordinatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEB3879F2C35109E0025256E /* GoogleAdsCampaignCoordinatorTests.swift */; };
+		DEB387A32C36474F0025256E /* GoogleAdsDashboardCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEB387A22C36474F0025256E /* GoogleAdsDashboardCard.swift */; };
+		DEB387A52C36479B0025256E /* GoogleAdsDashboardCardViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEB387A42C36479B0025256E /* GoogleAdsDashboardCardViewModel.swift */; };
 		DEBAB70B2A7A3FE000743185 /* StorePlanBannerPresenterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEBAB70A2A7A3FE000743185 /* StorePlanBannerPresenterTests.swift */; };
 		DEBAB70D2A7A6F1100743185 /* MockStorePlanSynchronizer.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEBAB70C2A7A6F1100743185 /* MockStorePlanSynchronizer.swift */; };
 		DEBAB70F2A7A6F3800743185 /* MockConnectivityObserver.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEBAB70E2A7A6F3800743185 /* MockConnectivityObserver.swift */; };
@@ -5571,6 +5573,8 @@
 		DEB387992C32A6400025256E /* MockGoogleAdsEligibilityChecker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockGoogleAdsEligibilityChecker.swift; sourceTree = "<group>"; };
 		DEB3879D2C34FE620025256E /* GoogleAdsCampaignCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GoogleAdsCampaignCoordinator.swift; sourceTree = "<group>"; };
 		DEB3879F2C35109E0025256E /* GoogleAdsCampaignCoordinatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GoogleAdsCampaignCoordinatorTests.swift; sourceTree = "<group>"; };
+		DEB387A22C36474F0025256E /* GoogleAdsDashboardCard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GoogleAdsDashboardCard.swift; sourceTree = "<group>"; };
+		DEB387A42C36479B0025256E /* GoogleAdsDashboardCardViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GoogleAdsDashboardCardViewModel.swift; sourceTree = "<group>"; };
 		DEBAB70A2A7A3FE000743185 /* StorePlanBannerPresenterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StorePlanBannerPresenterTests.swift; sourceTree = "<group>"; };
 		DEBAB70C2A7A6F1100743185 /* MockStorePlanSynchronizer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockStorePlanSynchronizer.swift; sourceTree = "<group>"; };
 		DEBAB70E2A7A6F3800743185 /* MockConnectivityObserver.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockConnectivityObserver.swift; sourceTree = "<group>"; };
@@ -11613,6 +11617,7 @@
 		CE85FD5120F677460080B73E /* Dashboard */ = {
 			isa = PBXGroup;
 			children = (
+				DEB387A12C3647300025256E /* GoogleAds */,
 				EE8B420A2BF9A1E40077C4E7 /* Orders */,
 				DE20045E2BF7090700660A72 /* ProductStock */,
 				EEC099342BF3C67200FBCF6C /* Coupons */,
@@ -12589,6 +12594,15 @@
 			children = (
 				DEB387972C2E803A0025256E /* DefaultGoogleAdsEligibilityCheckTests.swift */,
 				DEB3879F2C35109E0025256E /* GoogleAdsCampaignCoordinatorTests.swift */,
+			);
+			path = GoogleAds;
+			sourceTree = "<group>";
+		};
+		DEB387A12C3647300025256E /* GoogleAds */ = {
+			isa = PBXGroup;
+			children = (
+				DEB387A22C36474F0025256E /* GoogleAdsDashboardCard.swift */,
+				DEB387A42C36479B0025256E /* GoogleAdsDashboardCardViewModel.swift */,
 			);
 			path = GoogleAds;
 			sourceTree = "<group>";
@@ -14839,6 +14853,7 @@
 				B5DBF3CB20E149CC00B53AED /* AuthenticatedState.swift in Sources */,
 				B90DDF7C2A9E21DF009CFDA2 /* NewTaxRateSelectorView.swift in Sources */,
 				DE61979328A20C17005E4362 /* StorePickerViewModel.swift in Sources */,
+				DEB387A32C36474F0025256E /* GoogleAdsDashboardCard.swift in Sources */,
 				E1BE703A265E6F47006CA4D9 /* CardPresentModalScanningFailed.swift in Sources */,
 				D89CFFDD25B44468000E4683 /* ULAccountMismatchViewController.swift in Sources */,
 				03E471C6293A2E95001A58AD /* CardPresentModalBuiltInReaderCheckingDeviceSupport.swift in Sources */,
@@ -15266,6 +15281,7 @@
 				02DAE7FC291B7B8B009342B7 /* DomainSelectorViewModel.swift in Sources */,
 				26838356296F702B00CCF60A /* GenerateAllVariationsPresenter.swift in Sources */,
 				4521396E27FEE55200964ED3 /* FullScreenTextView.swift in Sources */,
+				DEB387A52C36479B0025256E /* GoogleAdsDashboardCardViewModel.swift in Sources */,
 				DE126D0B26CA2331007F901D /* ValidationErrorRow.swift in Sources */,
 				E1E649E92846188C0070B194 /* BetaFeature.swift in Sources */,
 				0286B27B23C7051F003D784B /* ProductImagesCollectionViewController.swift in Sources */,

--- a/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/DashboardViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/DashboardViewModelTests.swift
@@ -425,7 +425,8 @@ final class DashboardViewModelTests: XCTestCase {
                              DashboardCard(type: .reviews, availability: .show, enabled: false),
                              DashboardCard(type: .coupons, availability: .show, enabled: false),
                              DashboardCard(type: .stock, availability: .show, enabled: false),
-                             DashboardCard(type: .lastOrders, availability: .unavailable, enabled: false)]
+                             DashboardCard(type: .lastOrders, availability: .unavailable, enabled: false),
+                             DashboardCard(type: .googleAds, availability: .hide, enabled: false)]
 
         // When
         await viewModel.reloadAllData()
@@ -456,7 +457,8 @@ final class DashboardViewModelTests: XCTestCase {
                              DashboardCard(type: .reviews, availability: .show, enabled: false),
                              DashboardCard(type: .coupons, availability: .show, enabled: false),
                              DashboardCard(type: .stock, availability: .show, enabled: false),
-                             DashboardCard(type: .lastOrders, availability: .unavailable, enabled: false)]
+                             DashboardCard(type: .lastOrders, availability: .unavailable, enabled: false),
+                             DashboardCard(type: .googleAds, availability: .hide, enabled: false)]
 
         // When
         await viewModel.reloadAllData()
@@ -480,7 +482,8 @@ final class DashboardViewModelTests: XCTestCase {
         let expectedCards = [DashboardCard(type: .onboarding, availability: .show, enabled: true),
                              DashboardCard(type: .performance, availability: .unavailable, enabled: false),
                              DashboardCard(type: .topPerformers, availability: .unavailable, enabled: false),
-                             DashboardCard(type: .blaze, availability: .hide, enabled: false)]
+                             DashboardCard(type: .blaze, availability: .hide, enabled: false),
+                             DashboardCard(type: .googleAds, availability: .hide, enabled: false)]
 
         // When
         await viewModel.reloadAllData()
@@ -579,7 +582,8 @@ final class DashboardViewModelTests: XCTestCase {
 
         let storedCards = [DashboardCard(type: .topPerformers, availability: .show, enabled: true),
                            DashboardCard(type: .onboarding, availability: .show, enabled: true),
-                           DashboardCard(type: .performance, availability: .show, enabled: true)]
+                           DashboardCard(type: .performance, availability: .show, enabled: true),
+                           DashboardCard(type: .googleAds, availability: .hide, enabled: false)]
 
         mockReloadingData(storedDashboardCards: storedCards)
 

--- a/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/DashboardViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/DashboardViewModelTests.swift
@@ -16,6 +16,7 @@ final class DashboardViewModelTests: XCTestCase {
 
     private let blazeEligibilityChecker = MockBlazeEligibilityChecker(isSiteEligible: true)
     private let inboxEligibilityChecker = MockInboxEligibilityChecker()
+    private let googleAdsEligibilityChecker = MockGoogleAdsEligibilityChecker(isEligible: false)
 
     /// Mock Storage: InMemory
     private var storageManager: MockStorageManager!
@@ -414,7 +415,8 @@ final class DashboardViewModelTests: XCTestCase {
                                            storageManager: storageManager,
                                            featureFlags: featureFlagService,
                                            blazeEligibilityChecker: blazeEligibilityChecker,
-                                           inboxEligibilityChecker: inboxEligibilityChecker)
+                                           inboxEligibilityChecker: inboxEligibilityChecker,
+                                           googleAdsEligibilityChecker: googleAdsEligibilityChecker)
         mockReloadingData(storeHasOrders: false)
 
         let expectedCards = [DashboardCard(type: .onboarding, availability: .show, enabled: true),
@@ -446,7 +448,8 @@ final class DashboardViewModelTests: XCTestCase {
                                            storageManager: storageManager,
                                            featureFlags: featureFlagService,
                                            blazeEligibilityChecker: blazeEligibilityChecker,
-                                           inboxEligibilityChecker: inboxEligibilityChecker)
+                                           inboxEligibilityChecker: inboxEligibilityChecker,
+                                           googleAdsEligibilityChecker: googleAdsEligibilityChecker)
         mockReloadingData(storeHasOrders: false)
 
         let expectedCards = [DashboardCard(type: .onboarding, availability: .show, enabled: true),
@@ -476,7 +479,8 @@ final class DashboardViewModelTests: XCTestCase {
                                            stores: stores,
                                            storageManager: storageManager,
                                            featureFlags: featureFlagService,
-                                           blazeEligibilityChecker: blazeEligibilityChecker)
+                                           blazeEligibilityChecker: blazeEligibilityChecker,
+                                           googleAdsEligibilityChecker: googleAdsEligibilityChecker)
         mockReloadingData(storeHasOrders: false)
 
         let expectedCards = [DashboardCard(type: .onboarding, availability: .show, enabled: true),
@@ -503,7 +507,8 @@ final class DashboardViewModelTests: XCTestCase {
                                            stores: stores,
                                            storageManager: storageManager,
                                            featureFlags: featureFlagService,
-                                           blazeEligibilityChecker: blazeEligibilityChecker)
+                                           blazeEligibilityChecker: blazeEligibilityChecker,
+                                           googleAdsEligibilityChecker: googleAdsEligibilityChecker)
 
         mockReloadingData(storeHasOrders: true)
 
@@ -529,7 +534,8 @@ final class DashboardViewModelTests: XCTestCase {
                                            stores: stores,
                                            storageManager: storageManager,
                                            featureFlags: featureFlagService,
-                                           blazeEligibilityChecker: blazeEligibilityChecker)
+                                           blazeEligibilityChecker: blazeEligibilityChecker,
+                                           googleAdsEligibilityChecker: googleAdsEligibilityChecker)
         mockReloadingData()
 
         // Last orders cards need to be set with availability: .show and enabled: false to make them available.
@@ -553,7 +559,8 @@ final class DashboardViewModelTests: XCTestCase {
                                            storageManager: storageManager,
                                            featureFlags: featureFlagService,
                                            userDefaults: userDefaults,
-                                           blazeEligibilityChecker: blazeEligibilityChecker)
+                                           blazeEligibilityChecker: blazeEligibilityChecker,
+                                           googleAdsEligibilityChecker: googleAdsEligibilityChecker)
 
         mockReloadingData()
 
@@ -578,7 +585,8 @@ final class DashboardViewModelTests: XCTestCase {
                                            stores: stores,
                                            storageManager: storageManager,
                                            featureFlags: featureFlagService,
-                                           blazeEligibilityChecker: blazeEligibilityChecker)
+                                           blazeEligibilityChecker: blazeEligibilityChecker,
+                                           googleAdsEligibilityChecker: googleAdsEligibilityChecker)
 
         let storedCards = [DashboardCard(type: .topPerformers, availability: .show, enabled: true),
                            DashboardCard(type: .onboarding, availability: .show, enabled: true),
@@ -607,7 +615,8 @@ final class DashboardViewModelTests: XCTestCase {
                                            stores: stores,
                                            storageManager: storageManager,
                                            featureFlags: featureFlagService,
-                                           blazeEligibilityChecker: blazeEligibilityChecker)
+                                           blazeEligibilityChecker: blazeEligibilityChecker,
+                                           googleAdsEligibilityChecker: googleAdsEligibilityChecker)
 
         let storedCards = [DashboardCard(type: .onboarding, availability: .show, enabled: true),
                            DashboardCard(type: .performance, availability: .show, enabled: true),
@@ -624,6 +633,31 @@ final class DashboardViewModelTests: XCTestCase {
 
         let topPerformersCard = try XCTUnwrap(viewModel.dashboardCards.first(where: {$0.type == .topPerformers }))
         XCTAssertFalse(topPerformersCard.enabled)
+    }
+
+    @MainActor
+    func test_dashboard_cards_contain_google_ads_card_when_store_is_eligible() async {
+        // Given
+        let featureFlagService = MockFeatureFlagService(isDynamicDashboardM2Enabled: true)
+        let googleAdsEligibilityChecker = MockGoogleAdsEligibilityChecker(isEligible: true)
+
+        let viewModel = DashboardViewModel(siteID: sampleSiteID,
+                                           stores: stores,
+                                           storageManager: storageManager,
+                                           featureFlags: featureFlagService,
+                                           blazeEligibilityChecker: blazeEligibilityChecker,
+                                           googleAdsEligibilityChecker: googleAdsEligibilityChecker)
+
+        mockReloadingData()
+
+        // Google card need to be set with availability: .show and enabled: true by default if available.
+        let expectedGoogleCard = DashboardCard(type: .googleAds, availability: .show, enabled: true)
+
+        // When
+        await viewModel.reloadAllData()
+
+        // Then
+        XCTAssertTrue(viewModel.dashboardCards.contains(expectedGoogleCard))
     }
 
     // MARK: Show New Cards Notice


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of #13230 
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This PR adds a new dashboard card type for Google Ads. For simplicity, we're treating the card similarly to Blaze. i.e, if a store is eligible for creating Google Ads campaigns on the app, the dashboard card will be available and enabled by default.

The card in this PR is using a temporary design and wording. I'll work on displaying the last campaign on the card in a subsequent PR. This card is displayed with the feature flag `googleAdsCampaignCreationOnWebView`, so it doesn't depend on the `dynamicDashboardM2` feature flag.

## Testing steps
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->
- Pre-requisite: Install, activate, and set up the Google Ads plugin to a test site following pe5sF9-2Qo-p2. Ensure that you're using the plugin version 2.7.5 or above.
- Build the app and log in to your store.
- Confirm that a dashboard card called Google Ads Campaigns is displayed at the bottom of the dashboard screen.
- Switch to a different store without the Google Ads plugin and confirm that the Google Ads dashboard card is unavailable.
- Switch back to the initial store. Disable the feature flag `googleAdsCampaignCreationOnWebView` and rebuild the app.
- Confirm that the Google Ads dashboard card is unavailable. 

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

<img src="https://github.com/woocommerce/woocommerce-ios/assets/5533851/302c4a9e-13e2-41c7-88f9-c4642d72c137" width=320 />


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.