### PR TITLE
[Woo POS] Update product list & cart UI for landscape

### DIFF
--- a/WooCommerce/Classes/POS/Presentation/ItemListView.swift
+++ b/WooCommerce/Classes/POS/Presentation/ItemListView.swift
@@ -31,9 +31,6 @@ struct ItemListView: View {
                 }
             }
         }
-        .task {
-            await viewModel.populatePointOfSaleItems()
-        }
         .refreshable {
             await viewModel.reload()
         }

--- a/WooCommerce/Classes/POS/Presentation/PointOfSaleDashboardView.swift
+++ b/WooCommerce/Classes/POS/Presentation/PointOfSaleDashboardView.swift
@@ -16,12 +16,22 @@ struct PointOfSaleDashboardView: View {
             HStack {
                 switch viewModel.orderStage {
                 case .building:
-                    productListView
-                    Spacer()
                     if viewModel.isCartCollapsed {
+                        // 1. Initial state: Product list is visible and cart is collapsed
+                        productListView
+                            .frame(maxWidth: .infinity)
+                        Spacer()
                         collapsedCartView
                     } else {
-                        cartView
+                        // 2. Products in cart: Both product list and cart are visible
+                        GeometryReader { geometry in
+                            HStack {
+                                productListView
+                                    .frame(width: geometry.size.width * Constants.productListWidth)
+                                cartView
+                                    .frame(width: geometry.size.width * Constants.cartWidth)
+                            }
+                        }
                     }
                 case .finalizing:
                     cartView
@@ -57,6 +67,18 @@ struct PointOfSaleDashboardView: View {
     }
 }
 
+private extension PointOfSaleDashboardView {
+    enum Constants {
+        // TODO:
+        // https://github.com/woocommerce/woocommerce-ios/issues/13240
+        // The current design only accounts for landscape, switching to portrait
+        // will need to be handled by resizing components and line-breaking for strings
+        // and other elements
+        static let productListWidth: CGFloat = 0.7
+        static let cartWidth: CGFloat = 0.3
+    }
+}
+
 /// Helpers to generate all Dashboard subviews
 private extension PointOfSaleDashboardView {
     var collapsedCartView: some View {
@@ -66,7 +88,6 @@ private extension PointOfSaleDashboardView {
     var cartView: some View {
         CartView(viewModel: viewModel,
                  cartViewModel: viewModel.cartViewModel)
-        .frame(maxWidth: .infinity)
     }
 
     var totalsView: some View {
@@ -79,7 +100,6 @@ private extension PointOfSaleDashboardView {
 
     var productListView: some View {
         ItemListView(viewModel: viewModel.itemSelectorViewModel)
-            .frame(maxWidth: .infinity)
     }
 }
 

--- a/WooCommerce/Classes/POS/Presentation/PointOfSaleDashboardView.swift
+++ b/WooCommerce/Classes/POS/Presentation/PointOfSaleDashboardView.swift
@@ -64,6 +64,9 @@ struct PointOfSaleDashboardView: View {
                 }
             }
         })
+        .task {
+            await viewModel.itemSelectorViewModel.populatePointOfSaleItems()
+        }
     }
 }
 

--- a/WooCommerce/Classes/POS/Presentation/PointOfSaleDashboardView.swift
+++ b/WooCommerce/Classes/POS/Presentation/PointOfSaleDashboardView.swift
@@ -29,7 +29,6 @@ struct PointOfSaleDashboardView: View {
                                 productListView
                                     .frame(width: geometry.size.width * Constants.productListWidth)
                                 cartView
-                                    .frame(width: geometry.size.width * Constants.cartWidth)
                             }
                         }
                     }
@@ -72,13 +71,9 @@ struct PointOfSaleDashboardView: View {
 
 private extension PointOfSaleDashboardView {
     enum Constants {
-        // TODO:
-        // https://github.com/woocommerce/woocommerce-ios/issues/13240
-        // The current design only accounts for landscape, switching to portrait
-        // will need to be handled by resizing components and line-breaking for strings
-        // and other elements
-        static let productListWidth: CGFloat = 0.7
-        static let cartWidth: CGFloat = 0.3
+        // For the moment we're just considering landscape for the POS mode
+        // https://github.com/woocommerce/woocommerce-ios/issues/13251
+        static let productListWidth: CGFloat = 0.6
     }
 }
 


### PR DESCRIPTION
Closes https://github.com/woocommerce/woocommerce-ios/issues/13216

## Description
This PR updates the current view distribution of 50/50 for the Product List and Cart views, and makes it 70/30 instead, following the focus of using the tablet mainly in landscape mode for the POC delivery.

This change also exacerbated the issue of refreshing data too often, since the `populatePointOfSaleItems()` was called from  the subview. This is something that was introduced on the refactoring here https://github.com/woocommerce/woocommerce-ios/pull/13188#discussion_r1658059617 and we planned to revert back to the original usage (only load products once on POS load, then on demand upon pull-to-refresh).

![Simulator Screenshot - iPad Pro (12 9-inch) (6th generation) - 2024-07-04 at 10 50 13](https://github.com/woocommerce/woocommerce-ios/assets/3812076/50c4aa90-4f99-4484-8c73-01a6a548146d)

We'll be dealing with portrait mode in M2 as needed, for example by adapting the screen to a different size than 70/30, adjusting line-breaks, making some components smaller, etc, ... another option could be to use 50/50 on portrait, which solves all the issues in one go, but we're pending on design iterations:

<img width="684" alt="Screenshot 2024-07-04 at 14 12 38" src="https://github.com/woocommerce/woocommerce-ios/assets/3812076/5f3ac174-22ca-4f33-aa11-5a639eca3438">


## Testing information
- Run the POS in landscape
- Observe that when adding products to the cart, the `CartView` does no longer cover half of the screen, but 30% of it.
- Tap checkout, then go back to edit the order. Observe that products are still loaded and there's no "loading..." screen in between
