### PR TITLE
[GLA Analytics] Fetch data and display Google Campaigns card in Analytics Hub

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -2,7 +2,7 @@
 
 19.4
 -----
-
+- [**] Stats: The Analytics Hub (accessed by tapping "View all store analytics" on the My Store dashboard) now includes analytics for Google Ads campaigns, when the Google Listings & Ads extension is active and connected to Google. [https://github.com/woocommerce/woocommerce-ios/pull/13245]
 
 19.3
 -----

--- a/Storage/Storage/Model/AnalyticsCard.swift
+++ b/Storage/Storage/Model/AnalyticsCard.swift
@@ -23,5 +23,6 @@ public struct AnalyticsCard: Codable, Hashable, Equatable, GeneratedCopiable {
         case sessions
         case bundles
         case giftCards
+        case googleCampaigns
     }
 }

--- a/WooCommerce/Classes/Extensions/SitePlugin+Woo.swift
+++ b/WooCommerce/Classes/Extensions/SitePlugin+Woo.swift
@@ -12,5 +12,6 @@ extension SitePlugin {
         public static let WCCompositeProducts = "WooCommerce Composite Products"
         public static let square = "WooCommerce Square"
         public static let WCGiftCards = ["WooCommerce Gift Cards", "Woo Gift Cards"]
+        public static let GoogleForWooCommerce = ["Google Listings and Ads", "Google for WooCommerce"]
     }
 }

--- a/WooCommerce/Classes/System/WooConstants.swift
+++ b/WooCommerce/Classes/System/WooConstants.swift
@@ -338,6 +338,8 @@ extension WooConstants {
 
         case giftCardsExtension = "https://woocommerce.com/products/gift-cards/"
 
+        case googleAdsExtension = "https://woocommerce.com/products/google-listings-and-ads/"
+
         case wooPaymentsStartupGuide = "https://woocommerce.com/document/woopayments/startup-guide/"
 
         // swiftlint:disable:next line_length

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/AnalyticsHubView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/AnalyticsHubView.swift
@@ -133,6 +133,8 @@ private extension AnalyticsHubView {
             AnalyticsTopPerformersCard(bundlesViewModel: viewModel.bundlesCard)
         case .giftCards:
             AnalyticsReportCard(viewModel: viewModel.giftCardsCard)
+        case .googleCampaigns:
+            EmptyView() // TODO: Return Google Campaigns card
         }
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/AnalyticsHubView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/AnalyticsHubView.swift
@@ -134,7 +134,7 @@ private extension AnalyticsHubView {
         case .giftCards:
             AnalyticsReportCard(viewModel: viewModel.giftCardsCard)
         case .googleCampaigns:
-            EmptyView() // TODO: Return Google Campaigns card
+            AnalyticsTopPerformersCard(campaignsViewModel: viewModel.googleCampaignsCard)
         }
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/AnalyticsHubViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/AnalyticsHubViewModel.swift
@@ -126,6 +126,16 @@ final class AnalyticsHubViewModel: ObservableObject {
                                      usageTracksEventEmitter: usageTracksEventEmitter)
     }
 
+    /// Google Campaigns Card ViewModel
+    ///
+    var googleCampaignsCard: GoogleAdsCampaignReportCardViewModel {
+        GoogleAdsCampaignReportCardViewModel(currentPeriodStats: currentGoogleCampaignStats,
+                                             previousPeriodStats: previousGoogleCampaignStats,
+                                             timeRange: timeRangeSelectionType,
+                                             isRedacted: isLoadingGoogleCampaignStats,
+                                             usageTracksEventEmitter: usageTracksEventEmitter)
+    }
+
     /// View model for `AnalyticsHubCustomizeView`, to customize the cards in the Analytics Hub.
     ///
     @Published var customizeAnalyticsViewModel: AnalyticsHubCustomizeViewModel?
@@ -226,6 +236,14 @@ final class AnalyticsHubViewModel: ObservableObject {
     ///
     @Published private var previousGiftCardStats: GiftCardStats? = nil
 
+    /// Google campaigns stats for the current selected time period. Used in the Google campaigns card.
+    ///
+    @Published private var currentGoogleCampaignStats: GoogleAdsCampaignStats? = nil
+
+    /// Google campaigns stats for the previous selected time period. Used in the Google campaigns card.
+    ///
+    @Published private var previousGoogleCampaignStats: GoogleAdsCampaignStats? = nil
+
     /// Loading state for order stats.
     ///
     @Published private var isLoadingOrderStats = false
@@ -245,6 +263,10 @@ final class AnalyticsHubViewModel: ObservableObject {
     /// Loading stats for gift card stats.
     ///
     @Published private var isLoadingGiftCardStats = false
+
+    /// Loading state for Google campaign stats.
+    ///
+    @Published private var isLoadingGoogleCampaignStats = false
 
     /// Time Range selection data defining the current and previous time period
     ///

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/AnalyticsHubViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/AnalyticsHubViewModel.swift
@@ -170,7 +170,7 @@ final class AnalyticsHubViewModel: ObservableObject {
         case .giftCards:
             isPluginActive(SitePlugin.SupportedPlugin.WCGiftCards)
         case .googleCampaigns:
-            false // TODO: Check Google extension status
+            isPluginActive(SitePlugin.SupportedPlugin.GoogleForWooCommerce)
         default:
             true
         }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/AnalyticsHubViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/AnalyticsHubViewModel.swift
@@ -159,6 +159,8 @@ final class AnalyticsHubViewModel: ObservableObject {
             isPluginActive(SitePlugin.SupportedPlugin.WCProductBundles)
         case .giftCards:
             isPluginActive(SitePlugin.SupportedPlugin.WCGiftCards)
+        case .googleCampaigns:
+            false // TODO: Check Google extension status
         default:
             true
         }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/AnalyticsHubViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/AnalyticsHubViewModel.swift
@@ -638,6 +638,12 @@ private extension AnalyticsHubViewModel {
         self.previousOrderStats = nil
         self.itemsSoldStats = nil
         self.siteStats = nil
+        self.currentBundleStats = nil
+        self.previousBundleStats = nil
+        self.currentGiftCardStats = nil
+        self.previousGiftCardStats = nil
+        self.currentGoogleCampaignStats = nil
+        self.previousGoogleCampaignStats = nil
     }
 
     func bindViewModelsWithData() {

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/Customize/AnalyticsCard+UI.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/Customize/AnalyticsCard+UI.swift
@@ -18,6 +18,8 @@ extension AnalyticsCard {
             return Localization.bundles
         case .giftCards:
             return Localization.giftCards
+        case .googleCampaigns:
+            return Localization.googleCampaigns
         }
     }
 }
@@ -43,5 +45,8 @@ private extension AnalyticsCard {
         static let giftCards = NSLocalizedString("analyticsHub.customize.giftCards",
                                                  value: "Gift Cards",
                                                  comment: "Name for the Gift Cards analytics card in the Customize Analytics screen")
+        static let googleCampaigns = NSLocalizedString("analyticsHub.customize.googleCampaigns",
+                                                       value: "Google Campaigns",
+                                                       comment: "Name for the Google Campaigns analytics card in the Customize Analytics screen")
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/Customize/AnalyticsHubCustomizeViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/Customize/AnalyticsHubCustomizeViewModel.swift
@@ -85,6 +85,8 @@ final class AnalyticsHubCustomizeViewModel: ObservableObject, Identifiable {
             WooConstants.URLs.jetpackStats.asURL()
         case .giftCards:
             WooConstants.URLs.giftCardsExtension.asURL()
+        case .googleCampaigns:
+            nil // TODO: Return Google extension product URL
         case .revenue, .orders, .products:
             nil
         }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/Customize/AnalyticsHubCustomizeViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/Customize/AnalyticsHubCustomizeViewModel.swift
@@ -86,7 +86,7 @@ final class AnalyticsHubCustomizeViewModel: ObservableObject, Identifiable {
         case .giftCards:
             WooConstants.URLs.giftCardsExtension.asURL()
         case .googleCampaigns:
-            nil // TODO: Return Google extension product URL
+            WooConstants.URLs.googleAdsExtension.asURL()
         case .revenue, .orders, .products:
             nil
         }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/Report Cards/Components/AnalyticsWebReport.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/Report Cards/Components/AnalyticsWebReport.swift
@@ -64,7 +64,7 @@ struct AnalyticsWebReport {
         case .giftCards:
             return "/analytics/gift-cards"
         case .googlePrograms:
-            return "/google/reports&reportKey=programs"
+            return "/google/reports"
         }
     }
 

--- a/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Analytics Hub/AnalyticsHubViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Analytics Hub/AnalyticsHubViewModelTests.swift
@@ -554,6 +554,36 @@ final class AnalyticsHubViewModelTests: XCTestCase {
         // Then
         XCTAssertFalse(vm.enabledCards.contains(.giftCards))
     }
+
+    @MainActor
+    func test_google_campaigns_card_is_displayed_when_plugin_active() {
+        // Given
+        let storage = MockStorageManager()
+        storage.insertSampleSystemPlugin(readOnlySystemPlugin: .fake().copy(siteID: sampleSiteID,
+                                                                            name: SitePlugin.SupportedPlugin.GoogleForWooCommerce.first,
+                                                                            active: true))
+
+        // When
+        let vm = createViewModel(storage: storage)
+
+        // Then
+        XCTAssertTrue(vm.enabledCards.contains(.googleCampaigns))
+    }
+
+    @MainActor
+    func test_google_campaigns_card_not_displayed_when_plugin_inactive() {
+        // Given
+        let storage = MockStorageManager()
+        storage.insertSampleSystemPlugin(readOnlySystemPlugin: .fake().copy(siteID: sampleSiteID,
+                                                                            name: SitePlugin.SupportedPlugin.GoogleForWooCommerce.first,
+                                                                            active: false))
+
+        // When
+        let vm = createViewModel(storage: storage)
+
+        // Then
+        XCTAssertFalse(vm.enabledCards.contains(.googleCampaigns))
+    }
 }
 
 private extension AnalyticsHubViewModelTests {

--- a/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Analytics Hub/AnalyticsHubViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Analytics Hub/AnalyticsHubViewModelTests.swift
@@ -300,7 +300,8 @@ final class AnalyticsHubViewModelTests: XCTestCase {
                              AnalyticsCard(type: .products, enabled: false),
                              AnalyticsCard(type: .sessions, enabled: false),
                              AnalyticsCard(type: .bundles, enabled: true),
-                             AnalyticsCard(type: .giftCards, enabled: true)]
+                             AnalyticsCard(type: .giftCards, enabled: true),
+                             AnalyticsCard(type: .googleCampaigns, enabled: true)]
         assertEqual(expectedCards, storedAnalyticsCards)
     }
 

--- a/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Analytics Hub/Report Cards/GoogleAdsCampaignReportCardViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Analytics Hub/Report Cards/GoogleAdsCampaignReportCardViewModelTests.swift
@@ -67,7 +67,7 @@ final class GoogleAdsCampaignReportCardViewModelTests: XCTestCase {
 
         // Then
         XCTAssertTrue(productsCardReportURL.relativeString.contains(sampleAdminURL))
-        XCTAssertTrue(productsCardURLQueryItems.contains(URLQueryItem(name: "path", value: "/google/reports&reportKey=programs")))
+        XCTAssertTrue(productsCardURLQueryItems.contains(URLQueryItem(name: "path", value: "/google/reports")))
         XCTAssertTrue(productsCardURLQueryItems.contains(URLQueryItem(name: "period", value: "month")))
     }
 


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #13222
Closes: #13228
<!-- Id number of the GitHub issue this PR addresses. -->

## Why
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This makes the Google Campaigns card available in the Analytics Hub, if the Google Listings & Ads extension is active and Google Ads is connected on the store. It fetches and displays campaign analytics in the card.

## How

* Adds `googleCampaigns` as a type of AnalyticsCard.
* Adds `GoogleForWooCommerce` as a supported plugin in `SitePlugin.SupportedPlugin`.
* Adds the URL for the extension product page to the known URLs in `WooConstants`.
   * Sets this as the `promoURL` for `googleCampaigns` in `AnalyticsHubCustomizeViewModel`, if the card can't be displayed (extension is not active or Google Ads is not connected).
* Displays an `AnalyticsTopPerformersCard` with the Google Campaigns view model in `AnalyticsHubView` when the card is enabled.
* Adds the logic to fetch the data and display the card to `AnalyticsHubViewModel`:
   * Adds the card view model property `googleCampaignsCard`.
   * Adds properties for the card's stats and loading status, and helpers to retrieve the stats data when the card is enabled.
   * Adds a property `isGoogleAdsConnected`. This optimistically defaults to true (so the card can be displayed and its data fetched) and there is a new helper to check the connection status remotely and update this property. I experimented with defaulting this to `false` and performing the check when the view is loaded, but this makes it significantly more complex to handle both the list of enabled cards and the data fetching. Defaulting to `true` felt like an acceptable tradeoff given that we expect most merchants with the extension to have it fully set up.

## Testing steps
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->

Prerequisite: A store with the Google Listings & Ads extension active and set up, with Google Ads connected. Alternately, use a proxy server (e.g. Charles Proxy) to mock the responses using the [connection response mock](https://github.com/woocommerce/woocommerce-ios/blob/b49851e44aed9a4f5e460ae8f165138c6396fd5d/Networking/NetworkingTests/Responses/gla-connection-without-data-envelope.json) and [stats response mock](https://github.com/woocommerce/woocommerce-ios/blob/b49851e44aed9a4f5e460ae8f165138c6396fd5d/Networking/NetworkingTests/Responses/google-ads-reports-programs-without-data.json).

1. On the My Store dashboard, select "View all store analytics" to open the Analytics Hub.
2. Confirm the Google Campaigns card loads with the Total Sales stat and a list of campaigns for the selected time period.
3. Confirm the "See Report" link opens a web view with the extension's Programs report.
4. Confirm you can edit the Analytics Hub to enable/disable and reorder the Campaigns card.

## Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->

Other scenarios:

* Google Listings & Ads extension not installed/active.
* Extension is active but Google Ads is not connected.

In these scenarios, the card should be hidden. Editing the Analytics Hub will show the Google Campaigns card with an "Explore" button to open the product page (no option to enable/disable or reorder the card).

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

Store with Google Ads connected:

Google Campaigns card|Customize Analytics Hub
-|-
![Simulator Screenshot - iPhone 15 Plus - 2024-07-04 at 13 41 36](https://github.com/woocommerce/woocommerce-ios/assets/8658164/64e767f6-aace-4ac0-bdfe-3179b62c9104)|![Simulator Screenshot - iPhone 15 Plus - 2024-07-04 at 13 41 50](https://github.com/woocommerce/woocommerce-ios/assets/8658164/173b485e-925f-4d81-ad45-a95c180473a0)

Store without extension/without Google Ads connected:

Customize Analytics Hub|"Explore" button (product page)
-|-
![Simulator Screenshot - iPhone 15 Plus - 2024-07-04 at 12 19 04](https://github.com/woocommerce/woocommerce-ios/assets/8658164/c6ae5da4-107d-4c9c-8830-1632703207ea)|![Simulator Screenshot - iPhone 15 Plus - 2024-07-04 at 12 19 12](https://github.com/woocommerce/woocommerce-ios/assets/8658164/992acd56-002b-43e1-a2a1-586cbf33b93e)

---
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.