### PR TITLE
Save Core Data Context on Key App State Transitions

### DIFF
--- a/WooCommerce/Classes/AppDelegate.swift
+++ b/WooCommerce/Classes/AppDelegate.swift
@@ -223,7 +223,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         // Schedule the background app refresh when sending the app to the background.
         // The OS is in charge of determining when these tasks will run based on app usage patterns.
         appRefreshHandler.scheduleAppRefresh()
-      
+
         // When the app is put into the background, it's important to ensure that any pending changes to
         // Core Data context are saved to avoid data loss.
         ServiceLocator.storageManager.viewStorage.saveIfNeeded()

--- a/WooCommerce/Classes/AppDelegate.swift
+++ b/WooCommerce/Classes/AppDelegate.swift
@@ -1,5 +1,4 @@
 import UIKit
-import CoreData
 import Storage
 import class Networking.UserAgent
 import Experiments
@@ -178,6 +177,10 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 
             // add our notification request
             UNUserNotificationCenter.current().add(request)
+
+            // When the app is put into an incative state, it's important to ensure that any pending changes to
+            // Core Data context are saved to avoid data loss.
+            ServiceLocator.storageManager.viewStorage.saveIfNeeded()
         }
     }
 
@@ -209,6 +212,10 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 
         // Don't track startup waiting time if app is backgrounded before everything is loaded
         cancelStartupWaitingTimeTracker()
+
+        // When the app is put into the background, it's important to ensure that any pending changes to
+        // Core Data context are saved to avoid data loss.
+        ServiceLocator.storageManager.viewStorage.saveIfNeeded()
     }
 
     func applicationWillEnterForeground(_ application: UIApplication) {
@@ -228,6 +235,9 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     func applicationWillTerminate(_ application: UIApplication) {
         DDLogVerbose("👀 Application terminating...")
         NotificationCenter.default.post(name: .applicationTerminating, object: nil)
+
+        // Save changes in the application's managed object context before the application terminates.
+        ServiceLocator.storageManager.viewStorage.saveIfNeeded()
     }
 
     func application(_ application: UIApplication,


### PR DESCRIPTION
### Summary

This PR introduces changes to ensure that any pending changes to the Core Data context are saved during crucial application state transitions. This is essential to prevent data loss and maintain data integrity.

More context: peaMlT-Jf#comment-1773

### Changes
- **applicationDidEnterBackground**: Added a call to `ServiceLocator.storageManager.viewStorage.saveIfNeeded()` to ensure that the Core Data context is saved when the application enters the background.
- **applicationWillTerminate**: Added a call to `ServiceLocator.storageManager.viewStorage.saveIfNeeded()` to ensure that the Core Data context is saved when the application terminates.
- **applicationWillResignActive**: Added a call to `ServiceLocator.storageManager.viewStorage.saveIfNeeded()` to ensure that the Core Data context is saved when the application resigns active state.

### Rationale

When the application transitions states (such as entering background, terminating, or resigning active), there is a risk of losing any unsaved data in the Core Data context. By saving the context during these transitions, we can mitigate this risk and ensure a more robust data management process. Note that the method called `ServiceLocator.storageManager.viewStorage.saveIfNeeded()` will do the saving operations just if there are changes, so this will not affect performance or whatever, it's just an extra check.
This is something done also in Apple's examples about Core Data.

### Testing
Add some prints, and
- Verifiy that the save operation is called when the app enters the background.
- Verifiy that the save operation is called when the app terminates.
- Verifiy that the save operation is called when the app resigns active state.
- If there are no data changes, it's fine that you will not see any print.

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
