### PR TITLE
Background Task: Order Sync timestamp handling

### DIFF
--- a/Experiments/Experiments/DefaultFeatureFlagService.swift
+++ b/Experiments/Experiments/DefaultFeatureFlagService.swift
@@ -92,6 +92,8 @@ public struct DefaultFeatureFlagService: FeatureFlagService {
             return buildConfig == .localDeveloper || buildConfig == .alpha
         case .googleAdsCampaignCreationOnWebView:
             return buildConfig == .localDeveloper || buildConfig == .alpha
+        case .backgroundTasks:
+            return buildConfig == .localDeveloper || buildConfig == .alpha
         default:
             return true
         }

--- a/Experiments/Experiments/FeatureFlag.swift
+++ b/Experiments/Experiments/FeatureFlag.swift
@@ -203,4 +203,8 @@ public enum FeatureFlag: Int {
     /// Enables Google ads campaign creation on web view
     ///
     case googleAdsCampaignCreationOnWebView
+
+    /// Code hidden while the background tasks feature is developed
+    ///
+    case backgroundTasks
 }

--- a/WooCommerce/Classes/Extensions/UserDefaults+Woo.swift
+++ b/WooCommerce/Classes/Extensions/UserDefaults+Woo.swift
@@ -55,6 +55,9 @@ extension UserDefaults {
 
         // Watch
         case watchDependencies
+
+        // Background Task Refresh
+        case latestBackgroundOrderSyncDate
     }
 }
 

--- a/WooCommerce/Classes/Tools/BackgroundTasks/OrderSyncBackgroundTask.swift
+++ b/WooCommerce/Classes/Tools/BackgroundTasks/OrderSyncBackgroundTask.swift
@@ -6,6 +6,17 @@ import Yosemite
 ///
 struct OrderSyncBackgroundTask {
 
+    /// The last time we successfully run a sync update.
+    ///
+    static private(set) var latestSyncDate: Date {
+        get {
+            return UserDefaults.standard[.latestBackgroundOrderSyncDate] as? Date ?? Date.distantPast
+        }
+        set {
+            return UserDefaults.standard[.latestBackgroundOrderSyncDate] = newValue
+        }
+    }
+
     let siteID: Int64
 
     let stores: StoresManager
@@ -27,6 +38,8 @@ struct OrderSyncBackgroundTask {
             do {
                 let filters = await fetchFilters()
                 try await syncOrders(filters: filters)
+                Self.latestSyncDate = Date.now
+
                 DDLogError("🟢 Successfully synced orders in the background")
                 backgroundTask.setTaskCompleted(success: true)
             } catch {


### PR DESCRIPTION
Closes: #13131

# Why

This PR ensures that the order list is not automatically synced if it hasn't passed at least 30 minutes from the sync.

# How

- Store the time when a background orders sync is successful.
- Update the order list so that it not also takes into account the foreground-local sync but also the background sync
- Increase the sync waiting time from 30s to 30m, this will live under a feature flag while the feature is being developed.

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
