### PR TITLE
Background Updates: Show Order Sync timestamp

### DIFF
--- a/WooCommerce/Classes/System/SessionManager.swift
+++ b/WooCommerce/Classes/System/SessionManager.swift
@@ -202,6 +202,7 @@ final class SessionManager: SessionManagerProtocol {
         defaults[.themesPendingInstall] = nil
         defaults[.siteIDPendingStoreSwitch] = nil
         defaults[.expectedStoreNamePendingStoreSwitch] = nil
+        defaults[.latestBackgroundOrderSyncDate] = nil
         imageCache.clearCache()
     }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Filters/FilteredOrdersHeaderBar.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Filters/FilteredOrdersHeaderBar.swift
@@ -6,6 +6,7 @@ import UIKit
 final class FilteredOrdersHeaderBar: UIView {
 
     @IBOutlet private weak var mainLabel: UILabel!
+    @IBOutlet private weak var lastUpdatedLabel: UILabel!
     @IBOutlet private weak var filterButton: UIButton!
 
     private let bottomBorder = CALayer()
@@ -13,6 +14,10 @@ final class FilteredOrdersHeaderBar: UIView {
     /// The number of filters applied
     ///
     private var numberOfFilters = 0
+
+    /// The time when the orders where updated
+    ///
+    private var lastUpdatedText = ""
 
     var onAction: (() -> Void)?
 
@@ -32,6 +37,11 @@ final class FilteredOrdersHeaderBar: UIView {
         numberOfFilters = filters
         configureLabels()
         configureButtons()
+    }
+
+    func setLastUpdatedTime(_ time: String) {
+        lastUpdatedText = time
+        configureLabels()
     }
 
     @IBAction private func filterButtonTapped(_ sender: Any) {
@@ -63,6 +73,10 @@ private extension FilteredOrdersHeaderBar {
     func configureLabels() {
         mainLabel.applyHeadlineStyle()
         mainLabel.text = numberOfFilters == 0 ? Localization.noFiltersApplied : Localization.filtersApplied
+
+        lastUpdatedLabel.applySecondaryFootnoteStyle()
+        lastUpdatedLabel.text = Localization.lastUpdatedText(time: lastUpdatedText)
+        lastUpdatedLabel.isHidden = lastUpdatedText.isEmpty
     }
 
     /// Setup: Buttons
@@ -92,5 +106,9 @@ private extension FilteredOrdersHeaderBar {
         static let buttonWithActiveFilters =
             NSLocalizedString("Filter (%ld)",
                               comment: "Title of the toolbar button to filter orders with filters applied.")
+        static func lastUpdatedText(time: String) -> String {
+            let format = NSLocalizedString("Last Updated: %@",comment: "Time for when the orders were last updated")
+            return String.localizedStringWithFormat(format, time)
+        }
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Filters/FilteredOrdersHeaderBar.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Filters/FilteredOrdersHeaderBar.swift
@@ -107,7 +107,7 @@ private extension FilteredOrdersHeaderBar {
             NSLocalizedString("Filter (%ld)",
                               comment: "Title of the toolbar button to filter orders with filters applied.")
         static func lastUpdatedText(time: String) -> String {
-            let format = NSLocalizedString("Last Updated: %@",comment: "Time for when the orders were last updated")
+            let format = NSLocalizedString("Last Updated: %@", comment: "Time for when the orders were last updated")
             return String.localizedStringWithFormat(format, time)
         }
     }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Filters/FilteredOrdersHeaderBar.xib
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Filters/FilteredOrdersHeaderBar.xib
@@ -11,17 +11,23 @@
         <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner"/>
         <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
         <view opaque="NO" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" id="eDg-Zp-eCF" customClass="FilteredOrdersHeaderBar" customModule="WooCommerce" customModuleProvider="target">
-            <rect key="frame" x="0.0" y="0.0" width="375" height="36"/>
+            <rect key="frame" x="0.0" y="0.0" width="375" height="67"/>
             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
             <subviews>
                 <stackView opaque="NO" contentMode="scaleToFill" spacing="20" translatesAutoresizingMaskIntoConstraints="NO" id="hrV-V9-BdB">
-                    <rect key="frame" x="16" y="8" width="343" height="20"/>
+                    <rect key="frame" x="16" y="8" width="343" height="51"/>
                     <subviews>
-                        <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="Uce-kq-wOt">
-                            <rect key="frame" x="0.0" y="0.0" width="41.5" height="20"/>
+                        <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="4" translatesAutoresizingMaskIntoConstraints="NO" id="Uce-kq-wOt">
+                            <rect key="frame" x="0.0" y="0.0" width="41.5" height="51"/>
                             <subviews>
-                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="r3U-zo-uYF">
-                                    <rect key="frame" x="0.0" y="0.0" width="41.5" height="20"/>
+                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="252" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="r3U-zo-uYF">
+                                    <rect key="frame" x="0.0" y="0.0" width="41.5" height="20.5"/>
+                                    <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                    <nil key="textColor"/>
+                                    <nil key="highlightedColor"/>
+                                </label>
+                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="rLu-fm-bTC" userLabel="Last Updated Label">
+                                    <rect key="frame" x="0.0" y="24.5" width="41.5" height="26.5"/>
                                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                     <nil key="textColor"/>
                                     <nil key="highlightedColor"/>
@@ -29,11 +35,11 @@
                             </subviews>
                         </stackView>
                         <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="dRc-UB-LAM">
-                            <rect key="frame" x="61.5" y="0.0" width="175.5" height="20"/>
+                            <rect key="frame" x="61.5" y="0.0" width="175.5" height="51"/>
                             <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                         </view>
                         <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="3R4-Zy-CEM">
-                            <rect key="frame" x="257" y="0.0" width="86" height="20"/>
+                            <rect key="frame" x="257" y="0.0" width="86" height="51"/>
                             <constraints>
                                 <constraint firstAttribute="width" relation="greaterThanOrEqual" id="HKe-ba-c7Z"/>
                             </constraints>
@@ -57,9 +63,10 @@
             <freeformSimulatedSizeMetrics key="simulatedDestinationMetrics"/>
             <connections>
                 <outlet property="filterButton" destination="3R4-Zy-CEM" id="Cah-6b-bfB"/>
+                <outlet property="lastUpdatedLabel" destination="rLu-fm-bTC" id="XQY-3n-lw2"/>
                 <outlet property="mainLabel" destination="r3U-zo-uYF" id="2bV-ER-1xX"/>
             </connections>
-            <point key="canvasLocation" x="81.884057971014499" y="-96.428571428571431"/>
+            <point key="canvasLocation" x="81.884057971014499" y="-86.049107142857139"/>
         </view>
     </objects>
 </document>

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Filters/FilteredOrdersHeaderBar.xib
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Filters/FilteredOrdersHeaderBar.xib
@@ -1,55 +1,65 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="19529" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="32700.99.1234" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="19519"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="22685"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
         <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner"/>
         <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
-        <view opaque="NO" contentMode="scaleToFill" insetsLayoutMarginsFromSafeArea="NO" id="eDg-Zp-eCF" customClass="FilteredOrdersHeaderBar" customModule="WooCommerce" customModuleProvider="target">
-            <rect key="frame" x="0.0" y="0.0" width="375" height="44"/>
+        <view opaque="NO" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" id="eDg-Zp-eCF" customClass="FilteredOrdersHeaderBar" customModule="WooCommerce" customModuleProvider="target">
+            <rect key="frame" x="0.0" y="0.0" width="375" height="36"/>
             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
             <subviews>
-                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="r3U-zo-uYF">
-                    <rect key="frame" x="16" y="0.0" width="41.5" height="44"/>
-                    <constraints>
-                        <constraint firstAttribute="height" constant="44" id="nJf-yc-v2W"/>
-                    </constraints>
-                    <fontDescription key="fontDescription" type="system" pointSize="17"/>
-                    <nil key="textColor"/>
-                    <nil key="highlightedColor"/>
-                </label>
-                <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="3R4-Zy-CEM">
-                    <rect key="frame" x="305" y="0.0" width="54" height="44"/>
-                    <constraints>
-                        <constraint firstAttribute="width" relation="greaterThanOrEqual" id="HKe-ba-c7Z"/>
-                    </constraints>
-                    <inset key="imageEdgeInsets" minX="0.0" minY="0.0" maxX="2.2250738585072014e-308" maxY="0.0"/>
-                    <state key="normal" title="Button"/>
-                    <connections>
-                        <action selector="filterButtonTapped:" destination="eDg-Zp-eCF" eventType="touchUpInside" id="8Et-eL-Ur8"/>
-                    </connections>
-                </button>
+                <stackView opaque="NO" contentMode="scaleToFill" spacing="20" translatesAutoresizingMaskIntoConstraints="NO" id="hrV-V9-BdB">
+                    <rect key="frame" x="16" y="8" width="343" height="20"/>
+                    <subviews>
+                        <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="Uce-kq-wOt">
+                            <rect key="frame" x="0.0" y="0.0" width="41.5" height="20"/>
+                            <subviews>
+                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="r3U-zo-uYF">
+                                    <rect key="frame" x="0.0" y="0.0" width="41.5" height="20"/>
+                                    <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                    <nil key="textColor"/>
+                                    <nil key="highlightedColor"/>
+                                </label>
+                            </subviews>
+                        </stackView>
+                        <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="dRc-UB-LAM">
+                            <rect key="frame" x="61.5" y="0.0" width="175.5" height="20"/>
+                            <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                        </view>
+                        <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="3R4-Zy-CEM">
+                            <rect key="frame" x="257" y="0.0" width="86" height="20"/>
+                            <constraints>
+                                <constraint firstAttribute="width" relation="greaterThanOrEqual" id="HKe-ba-c7Z"/>
+                            </constraints>
+                            <inset key="imageEdgeInsets" minX="0.0" minY="0.0" maxX="2.2250738585072014e-308" maxY="0.0"/>
+                            <state key="normal" title="Button"/>
+                            <connections>
+                                <action selector="filterButtonTapped:" destination="eDg-Zp-eCF" eventType="touchUpInside" id="8Et-eL-Ur8"/>
+                            </connections>
+                        </button>
+                    </subviews>
+                    <viewLayoutGuide key="safeArea" id="O2z-EJ-XRj"/>
+                </stackView>
             </subviews>
-            <viewLayoutGuide key="safeArea" id="DSK-6z-QUa"/>
+            <viewLayoutGuide key="safeArea" id="iLp-Xv-4wn"/>
             <constraints>
-                <constraint firstItem="3R4-Zy-CEM" firstAttribute="top" secondItem="eDg-Zp-eCF" secondAttribute="top" id="Gqp-AK-j9u"/>
-                <constraint firstItem="DSK-6z-QUa" firstAttribute="bottom" secondItem="3R4-Zy-CEM" secondAttribute="bottom" id="VSR-Qd-Cs2"/>
-                <constraint firstItem="r3U-zo-uYF" firstAttribute="top" secondItem="eDg-Zp-eCF" secondAttribute="top" id="Vq0-Yg-FRD"/>
-                <constraint firstAttribute="bottom" secondItem="r3U-zo-uYF" secondAttribute="bottom" id="W7n-Hy-Hyd"/>
-                <constraint firstItem="r3U-zo-uYF" firstAttribute="leading" secondItem="DSK-6z-QUa" secondAttribute="leading" constant="16" id="pG9-uN-iXD"/>
-                <constraint firstItem="DSK-6z-QUa" firstAttribute="trailing" secondItem="3R4-Zy-CEM" secondAttribute="trailing" constant="16" id="sfp-QN-QDn"/>
+                <constraint firstAttribute="bottomMargin" secondItem="hrV-V9-BdB" secondAttribute="bottom" id="17F-Tz-u3i"/>
+                <constraint firstAttribute="topMargin" secondItem="hrV-V9-BdB" secondAttribute="top" id="72O-3b-e5w"/>
+                <constraint firstItem="hrV-V9-BdB" firstAttribute="leading" secondItem="iLp-Xv-4wn" secondAttribute="leading" constant="16" id="F6e-Nm-Kc4"/>
+                <constraint firstItem="hrV-V9-BdB" firstAttribute="trailing" secondItem="iLp-Xv-4wn" secondAttribute="trailing" constant="-16" id="c5H-jX-XYc"/>
             </constraints>
             <freeformSimulatedSizeMetrics key="simulatedDestinationMetrics"/>
             <connections>
                 <outlet property="filterButton" destination="3R4-Zy-CEM" id="Cah-6b-bfB"/>
                 <outlet property="mainLabel" destination="r3U-zo-uYF" id="2bV-ER-1xX"/>
             </connections>
-            <point key="canvasLocation" x="81.884057971014499" y="-99.107142857142847"/>
+            <point key="canvasLocation" x="81.884057971014499" y="-96.428571428571431"/>
         </view>
     </objects>
 </document>

--- a/WooCommerce/Classes/ViewRelated/Orders/OrderListViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrderListViewController.swift
@@ -91,8 +91,8 @@ final class OrderListViewController: UIViewController {
 
     /// Timestamp for last successful sync.
     ///
-    @Published private(set) var lastFullSyncTimestamp: Date? = {
-        if ServiceLocator.featureFlagService.isFeatureFlagEnabled(.backgroundTasks) {
+    private(set) var lastFullSyncTimestamp: Date? = {
+        if ServiceLocator.featureFlagService.isFeatureFlagEnabled(.backgroundTasks), OrderSyncBackgroundTask.latestSyncDate != Date.distantPast {
             return OrderSyncBackgroundTask.latestSyncDate
         } else {
             return nil
@@ -354,6 +354,10 @@ private extension OrderListViewController {
     ///
     func configureSyncingCoordinator() {
         syncingCoordinator.delegate = self
+
+        if let lastFullSyncTimestamp {
+            delegate?.orderListViewControllerSyncTimestampChanged(lastFullSyncTimestamp)
+        }
     }
 
     /// Setup: TableView

--- a/WooCommerce/Classes/ViewRelated/Orders/OrderListViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrderListViewController.swift
@@ -14,6 +14,10 @@ protocol OrderListViewControllerDelegate: AnyObject {
     ///
     func orderListViewControllerWillSynchronizeOrders(_ viewController: UIViewController)
 
+    /// Called when new the order list has been synced and the sync timestamp changes.
+    ///
+    func orderListViewControllerSyncTimestampChanged(_ syncTimestamp: Date)
+
     /// Called when an order list `UIScrollView`'s `scrollViewDidScroll` event is triggered from the user.
     ///
     func orderListScrollViewDidScroll(_ scrollView: UIScrollView)
@@ -87,7 +91,19 @@ final class OrderListViewController: UIViewController {
 
     /// Timestamp for last successful sync.
     ///
-    private var lastFullSyncTimestamp: Date?
+    @Published private(set) var lastFullSyncTimestamp: Date? = {
+        if ServiceLocator.featureFlagService.isFeatureFlagEnabled(.backgroundTasks) {
+            return OrderSyncBackgroundTask.latestSyncDate
+        } else {
+            return nil
+        }
+    }() {
+        didSet {
+            if let lastFullSyncTimestamp {
+                delegate?.orderListViewControllerSyncTimestampChanged(lastFullSyncTimestamp)
+            }
+        }
+    }
 
     /// Minimum time interval allowed between full sync.
     ///
@@ -282,12 +298,19 @@ private extension OrderListViewController {
     ///
     func configureViewModel() {
         viewModel.onShouldResynchronizeIfViewIsVisible = { [weak self] in
-            guard let self = self,
-                  // Avoid synchronizing if the view is not visible. The refresh will be handled in
-                  // `viewWillAppear` instead.
-                  self.viewIfLoaded?.window != nil else {
-                return
+            guard let self else { return }
+
+            /// Update the `lastFullSyncTimestamp` in case orders have been updated on a background task.
+            ///
+            if let lastFullSyncTimestamp = self.lastFullSyncTimestamp,
+               ServiceLocator.featureFlagService.isFeatureFlagEnabled(.backgroundTasks),
+               OrderSyncBackgroundTask.latestSyncDate > lastFullSyncTimestamp {
+                self.lastFullSyncTimestamp = OrderSyncBackgroundTask.latestSyncDate
             }
+
+            // Avoid synchronizing if the view is not visible. The refresh will be handled in
+            // `viewWillAppear` instead.
+            guard self.viewIfLoaded?.window != nil else { return }
 
             self.syncingCoordinator.resynchronize(reason: SyncReason.viewWillAppear.rawValue)
         }
@@ -431,10 +454,7 @@ extension OrderListViewController: SyncingCoordinatorDelegate {
     ///
     func sync(pageNumber: Int, pageSize: Int, reason: String? = nil, retryTimeout: Bool, onCompletion: ((Bool) -> Void)? = nil) {
         // Decide if we need to continue with the sync depending on custom conditions between sync reason and latest sync
-        if let syncReason = SyncReason(rawValue: reason ?? ""), pageNumber == syncingCoordinator.pageFirstIndex {
-
-            // If there is no local sync timestamp use the background task sync timestamp.
-            let lastSyncTime = lastFullSyncTimestamp ?? OrderSyncBackgroundTask.latestSyncDate
+        if let syncReason = SyncReason(rawValue: reason ?? ""), let lastSyncTime = lastFullSyncTimestamp, pageNumber == syncingCoordinator.pageFirstIndex {
 
             switch syncReason {
             case .viewWillAppear where Date().timeIntervalSince(lastSyncTime) < minimalIntervalBetweenSync:

--- a/WooCommerce/Classes/ViewRelated/Orders/OrdersRootViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrdersRootViewController.swift
@@ -418,6 +418,13 @@ extension OrdersRootViewController: OrderListViewControllerDelegate {
         // Do nothing here
     }
 
+    func orderListViewControllerSyncTimestampChanged(_ syncTimestamp: Date) {
+        if ServiceLocator.featureFlagService.isFeatureFlagEnabled(.backgroundTasks) {
+            let dateFormatter = syncTimestamp.isSameDay(as: Date.now) ? DateFormatter.timeFormatter : DateFormatter.dateAndTimeFormatter
+            filtersBar.setLastUpdatedTime(dateFormatter.string(from: syncTimestamp))
+        }
+    }
+
     func orderListScrollViewDidScroll(_ scrollView: UIScrollView) {
         hiddenScrollView.updateFromScrollViewDidScrollEventForLargeTitleWorkaround(scrollView)
     }

--- a/WooCommerce/Classes/Yosemite/DefaultStoresManager.swift
+++ b/WooCommerce/Classes/Yosemite/DefaultStoresManager.swift
@@ -271,6 +271,7 @@ class DefaultStoresManager: StoresManager {
         defaults[.usedProductDescriptionAI] = nil
         defaults[.hasDismissedWriteWithAITooltip] = nil
         defaults[.numberOfTimesWriteWithAITooltipIsShown] = nil
+        defaults[.latestBackgroundOrderSyncDate] = nil
         restoreSessionSiteIfPossible()
         ServiceLocator.pushNotesManager.reloadBadgeCount()
 


### PR DESCRIPTION
Closes: #13138

# Why

This PR shows the latest order sync time in the orders list screen


# How

- Update the filter bar to display the order sync timestamp
- Make sure the correct timestamp is displayed, depending if its the local or the background one.
- Clear timestamp when the store switches or when the user logs out. 

# Screenshot

<img width="431" alt="Screenshot 2024-07-05 at 11 28 53 AM" src="https://github.com/woocommerce/woocommerce-ios/assets/562080/8c2e12fb-e0a1-4c3e-b448-d0b566a0a5d5">


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
