### PR TITLE
Background Tasks: Show Orders Refresh Indicator

### DIFF
--- a/WooCommerce/Classes/Extensions/UIRefreshControl+Woo.swift
+++ b/WooCommerce/Classes/Extensions/UIRefreshControl+Woo.swift
@@ -10,4 +10,19 @@ extension UIRefreshControl {
             completion?()
         }
     }
+
+    /// Manually triggers the refresh animation and scrolls the table view to make it visible.
+    ///
+    func showRefreshAnimation(on tableView: UITableView) {
+        DispatchQueue.main.async {
+            self.beginRefreshing()
+
+            // Apply some offset so that the refresh control can actually be seen
+            // But only if the table is already at the top of to not disrupt any scrolling offset.
+            if tableView.contentOffset.y == 0 {
+                let contentOffset = CGPoint(x: 0, y: -self.frame.height)
+                tableView.setContentOffset(contentOffset, animated: true)
+            }
+        }
+    }
 }

--- a/WooCommerce/Classes/ViewRelated/Orders/OrderListViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrderListViewController.swift
@@ -464,6 +464,8 @@ extension OrderListViewController: SyncingCoordinatorDelegate {
             case .viewWillAppear where Date().timeIntervalSince(lastSyncTime) < minimalIntervalBetweenSync:
                 onCompletion?(true) // less than 30m from last full sync
                 return
+            case .viewWillAppear where ServiceLocator.featureFlagService.isFeatureFlagEnabled(.backgroundTasks):
+                refreshControl.showRefreshAnimation(on: self.tableView)
             default:
                 break
             }
@@ -509,6 +511,7 @@ extension OrderListViewController: SyncingCoordinatorDelegate {
                 }
 
                 self.transitionToResultsUpdatedState()
+                self.refreshControl.endRefreshing()
                 onCompletion?(error == nil)
         }
 


### PR DESCRIPTION
closes #13138 

# Why

This PR makes sure that the refresh control is visible when manually triggering an order sync refresh.

# How

- Create an extension method to show the refresh control programmatically
- Call the extension when updating the order list from a view will appear scenario.

# Demo

https://github.com/woocommerce/woocommerce-ios/assets/562080/0d78f2e5-edb6-4ac7-b538-e61c20c7eb70

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
