### PR TITLE
Product Creation AI: Undoable text fields and summary option switch

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductWithAI/Preview/ProductDetailPreviewView.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductWithAI/Preview/ProductDetailPreviewView.swift
@@ -44,6 +44,9 @@ struct ProductDetailPreviewView: View {
 
                     // Product description
                     descriptionTextField
+
+                    // Switch between options for product name and summary
+                    summaryOptionsSwitch
                 }
 
                 // Package photo
@@ -198,6 +201,27 @@ private extension ProductDetailPreviewView {
         .focused($focusedField, equals: FocusedField.description)
     }
 
+    var summaryOptionsSwitch: some View {
+        HStack {
+            Text("Option 1 of 3")
+                .secondaryBodyStyle()
+
+            Spacer()
+
+            OptionSwitchButton(isForward: false) {
+                // TODO: move to previous option
+            }
+            .disabled(true) // TODO: set this to false for non-first options
+
+            OptionSwitchButton(isForward: true) {
+                // TODO: move to next option
+            }
+            .disabled(false) // TODO: set this to true for last option
+        }
+        .padding(.top, Layout.contentVerticalSpacing)
+        .renderedIf(viewModel.isGeneratingDetails == false) // TODO: also hidden when there is 1 option only?
+    }
+
     var feedbackBanner: some View {
         FeedbackView(title: Localization.feedbackQuestion,
                      backgroundColor: Constants.feedbackViewColor,
@@ -350,6 +374,22 @@ private extension ProductDetailPreviewView {
             .redacted(reason: isLoading ? .placeholder : [])
             .shimmering(active: isLoading)
             .roundedRectBorderStyle(strokeColor: isFocused ? .accentColor : ProductDetailPreviewView.Constants.separatorColor)
+        }
+    }
+
+    struct OptionSwitchButton: View {
+        let isForward: Bool
+        let action: () -> Void
+
+        var body: some View {
+            Button(action: action) {
+                Image(systemName: isForward ? "chevron.forward" : "chevron.backward")
+                    .fontWeight(.semibold)
+                    .padding(Layout.fieldInsets)
+                    .foregroundStyle(Color.accentColor)
+                    .roundedRectBorderStyle()
+            }
+            .buttonStyle(.plain)
         }
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductWithAI/Preview/ProductDetailPreviewView.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductWithAI/Preview/ProductDetailPreviewView.swift
@@ -5,6 +5,7 @@ import SwiftUI
 struct ProductDetailPreviewView: View {
     @ObservedObject private var viewModel: ProductDetailPreviewViewModel
     @State private var isShowingErrorAlert: Bool = false
+    @FocusState private var focusedField: FocusedField?
 
     private let onDismiss: () -> Void
 
@@ -159,36 +160,42 @@ struct ProductDetailPreviewView: View {
 //
 private extension ProductDetailPreviewView {
     var nameTextField: some View {
-        TextField(Localization.productNamePlaceholder,
-                  text: $viewModel.productName,
-                  axis: .vertical)
-        .textFieldStyle(.plain)
-        .padding(Layout.fieldInsets)
-        .redacted(reason: viewModel.isGeneratingDetails ? .placeholder : [])
-        .shimmering(active: viewModel.isGeneratingDetails)
-        .roundedRectBorderStyle()
+        UndoableTextField(placeholder: Localization.productNamePlaceholder,
+                          content: $viewModel.productName,
+                          isLoading: viewModel.isGeneratingDetails,
+                          isFocused: focusedField == .name,
+                          shouldEnableUndo: viewModel.hasChangesToProductName,
+                          onUndoEdits: {
+            // TODO: update this
+            viewModel.productName = viewModel.generatedProduct?.name ?? ""
+        })
+        .focused($focusedField, equals: FocusedField.name)
     }
 
     var shortDescriptionTextField: some View {
-        TextField(Localization.productShortDescriptionPlaceholder,
-                  text: $viewModel.productShortDescription,
-                  axis: .vertical)
-        .textFieldStyle(.plain)
-        .padding(Layout.fieldInsets)
-        .redacted(reason: viewModel.isGeneratingDetails ? .placeholder : [])
-        .shimmering(active: viewModel.isGeneratingDetails)
-        .roundedRectBorderStyle()
+        UndoableTextField(placeholder: Localization.productShortDescriptionPlaceholder,
+                          content: $viewModel.productShortDescription,
+                          isLoading: viewModel.isGeneratingDetails,
+                          isFocused: focusedField == .shortDescription,
+                          shouldEnableUndo: viewModel.hasChangesToProductShortDescription,
+                          onUndoEdits: {
+            // TODO: update this
+            viewModel.productShortDescription = viewModel.generatedProduct?.shortDescription ?? ""
+        })
+        .focused($focusedField, equals: FocusedField.shortDescription)
     }
 
     var descriptionTextField: some View {
-        TextField(Localization.productDescriptionPlaceholder,
-                  text: $viewModel.productDescription,
-                  axis: .vertical)
-        .textFieldStyle(.plain)
-        .padding(Layout.fieldInsets)
-        .redacted(reason: viewModel.isGeneratingDetails ? .placeholder : [])
-        .shimmering(active: viewModel.isGeneratingDetails)
-        .roundedRectBorderStyle()
+        UndoableTextField(placeholder: Localization.productDescriptionPlaceholder,
+                          content: $viewModel.productDescription,
+                          isLoading: viewModel.isGeneratingDetails,
+                          isFocused: focusedField == .description,
+                          shouldEnableUndo: viewModel.hasChangesToProductDescription,
+                          onUndoEdits: {
+            // TODO: update this
+            viewModel.productDescription = viewModel.generatedProduct?.fullDescription ?? ""
+        })
+        .focused($focusedField, equals: FocusedField.description)
     }
 
     var feedbackBanner: some View {
@@ -298,23 +305,72 @@ private extension ProductDetailPreviewView {
                 .clipShape(.rect(cornerRadius: 10))
         }
     }
+
+    enum FocusedField: Equatable {
+        case name
+        case shortDescription
+        case description
+    }
+
+    struct UndoableTextField: View {
+        let placeholder: String
+        @Binding var content: String
+
+        let isLoading: Bool
+        let isFocused: Bool
+        let shouldEnableUndo: Bool
+        let onUndoEdits: () -> Void
+
+        var body: some View {
+            VStack {
+                TextField(placeholder,
+                          text: $content,
+                          axis: .vertical)
+                .textFieldStyle(.plain)
+                .padding(Layout.fieldInsets)
+
+                if shouldEnableUndo {
+                    Divider()
+                        .frame(height: ProductDetailPreviewView.Layout.borderWidth)
+                        .foregroundStyle(Color.accentColor)
+
+                    Button(action: onUndoEdits) {
+                        HStack {
+                            Image(systemName: "arrow.counterclockwise")
+                            Text(Localization.undoEdits)
+                            Spacer()
+                        }
+                        .fontWeight(.semibold)
+                        .foregroundStyle(Color.accentColor)
+                        .padding(Layout.fieldInsets)
+                    }
+                    .buttonStyle(.plain)
+                }
+            }
+            .redacted(reason: isLoading ? .placeholder : [])
+            .shimmering(active: isLoading)
+            .roundedRectBorderStyle(strokeColor: isFocused ? .accentColor : ProductDetailPreviewView.Constants.separatorColor)
+        }
+    }
 }
 
 // MARK: - Rounded rect overlay
 //
 private struct RoundedBorder: ViewModifier {
+    let strokeColor: Color
+
     func body(content: Content) -> some View {
         content
             .overlay(
                 RoundedRectangle(cornerRadius: ProductDetailPreviewView.Layout.cornerRadius)
-                    .stroke(ProductDetailPreviewView.Constants.separatorColor, lineWidth: ProductDetailPreviewView.Layout.borderWidth)
+                    .stroke(strokeColor, lineWidth: ProductDetailPreviewView.Layout.borderWidth)
             )
     }
 }
 
 private extension View {
-    func roundedRectBorderStyle() -> some View {
-        modifier(RoundedBorder())
+    func roundedRectBorderStyle(strokeColor: Color = ProductDetailPreviewView.Constants.separatorColor) -> some View {
+        modifier(RoundedBorder(strokeColor: strokeColor))
     }
 }
 
@@ -444,6 +500,11 @@ fileprivate extension ProductDetailPreviewView {
             "productDetailPreviewView.addedToProduct",
             value: "Photo will be added to product",
             comment: "Text to explain that a package photo has been selected in product preview screen."
+        )
+        static let undoEdits = NSLocalizedString(
+            "productDetailPreviewView.undoEdits",
+            value: "Undo edits",
+            comment: "Button to undo edits for generated product name or summary in product preview screen."
         )
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductWithAI/Preview/ProductDetailPreviewViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductWithAI/Preview/ProductDetailPreviewViewModel.swift
@@ -30,6 +30,30 @@ final class ProductDetailPreviewViewModel: ObservableObject {
     @Published var isShowingViewPhotoSheet = false
     @Published var notice: Notice?
 
+    /// Temporary logic check to enable the undo option for product name
+    var hasChangesToProductName: Bool {
+        guard let generatedProduct else {
+            return false
+        }
+        return productName != generatedProduct.name
+    }
+
+    /// Temporary logic check to enable the undo option for product short description
+    var hasChangesToProductShortDescription: Bool {
+        guard let generatedProduct else {
+            return false
+        }
+        return productShortDescription != generatedProduct.shortDescription
+    }
+
+    /// Temporary logic check to enable the undo option for product description
+    var hasChangesToProductDescription: Bool {
+        guard let generatedProduct else {
+            return false
+        }
+        return productDescription != generatedProduct.fullDescription
+    }
+
     private let productFeatures: String
 
     private let siteID: Int64


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #13109 
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This PR adds UI updates for the summary section of product creation AI preview screen:
- Added an option to undo changes to the product name, short description, and full description fields. There's temporary logic to check for changes of text fields, which will need to be updated depending on how the data structure for the summary options will be.
- Added the UI for switching between options for product summary.

## Testing steps
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->
- Log in to a store eligible for Jetpack AI features.
- Navigate to the Products tab and select "+" > Create product with AI.
- Enter some keywords or select a product packaging then continue.
- After generated product details are populated, tap on product name/short description/full description field.
- Confirm that the fields are highlighted when in focus.
- Type to edit the initial contents. Confirm that the undo button for each field is displayed when its content is updated.
- Tap on Undo, the initial content should be restored.
- Confirm that there's a view underneath the summary fields for switching options. This view is purely UI for now and will need to be updated to function.


## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

https://github.com/woocommerce/woocommerce-ios/assets/5533851/d25bbe9d-7b77-4e7f-8ad7-fc5de060a14f



---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
