### PR TITLE
New feature flag `productCreationAIv2M3`

### DIFF
--- a/Experiments/Experiments/DefaultFeatureFlagService.swift
+++ b/Experiments/Experiments/DefaultFeatureFlagService.swift
@@ -92,6 +92,8 @@ public struct DefaultFeatureFlagService: FeatureFlagService {
             return true
         case .productCreationAIv2M1:
             return buildConfig == .localDeveloper || buildConfig == .alpha
+        case .productCreationAIv2M3:
+            return buildConfig == .localDeveloper || buildConfig == .alpha
         case .googleAdsCampaignCreationOnWebView:
             return buildConfig == .localDeveloper || buildConfig == .alpha
         case .backgroundTasks:

--- a/Experiments/Experiments/FeatureFlag.swift
+++ b/Experiments/Experiments/FeatureFlag.swift
@@ -203,7 +203,7 @@ public enum FeatureFlag: Int {
     /// Enables M1 updates of product creation AI version 2
     ///
     case productCreationAIv2M1
-    
+
     /// Enables M3 updates of product creation AI version 2
     ///
     case productCreationAIv2M3

--- a/Experiments/Experiments/FeatureFlag.swift
+++ b/Experiments/Experiments/FeatureFlag.swift
@@ -203,6 +203,10 @@ public enum FeatureFlag: Int {
     /// Enables M1 updates of product creation AI version 2
     ///
     case productCreationAIv2M1
+    
+    /// Enables M3 updates of product creation AI version 2
+    ///
+    case productCreationAIv2M3
 
     /// Enables Google ads campaign creation on web view
     ///


### PR DESCRIPTION
Part of #13118

## Description
Added just a new feature flag to start the implementation of Product Creation with AI: v2 - Milestone 3.

## Testing
Just CI

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
