### PR TITLE
[Woo POS] Disable CTA to go back to product selector when order is being synced

### DIFF
--- a/WooCommerce/Classes/POS/ViewModels/PointOfSaleDashboardViewModel.swift
+++ b/WooCommerce/Classes/POS/ViewModels/PointOfSaleDashboardViewModel.swift
@@ -108,8 +108,8 @@ private extension PointOfSaleDashboardViewModel {
 
 private extension PointOfSaleDashboardViewModel {
     func observePaymentStateForButtonDisabledProperties() {
-        totalsViewModel.$paymentState
-            .map { paymentState in
+        Publishers.CombineLatest(totalsViewModel.$paymentState, totalsViewModel.$isSyncingOrder)
+            .map { paymentState, isSyncingOrder in
                 switch paymentState {
                 case .processingPayment,
                         .cardPaymentSuccessful:
@@ -117,7 +117,7 @@ private extension PointOfSaleDashboardViewModel {
                 case .idle,
                         .acceptingCard,
                         .preparingReader:
-                    return false
+                    return isSyncingOrder
                 }
             }
             .assign(to: &$isAddMoreDisabled)


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #
<!-- Id number of the GitHub issue this PR addresses. -->
13127

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This PR prevents an issue that could occur by navigating back to the product selection/cart screen and adding new products to the order while the order is being synced.

From the GitHub Issue bug description:

> When checking out with an updated cart before the previous order sync result comes back like when the network is slower, the order total could become inconsistent with what's in the cart UI. 

With this PR the Add More button is disabled while the order is being synced to prevent the possibility of an inconsistent order total.

## Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->

Prerequisite: the store is eligible for POS and the feature switch is enabled in Menu > Settings > Experimental Features > POS

Launch app
Go to Menu > Point of Sale
Add an item to cart, tap Checkout, then try to quickly tap Add More. Note that this isn't possible because Add More is disabled while the order is being synced. After syncing completes the button should be enabled.



## Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: https://woomobilep2.wordpress.com/2024/05/06/woocommerce-mobile-quality-report-march-april/#comment-12036 -->

If this is tricky to reproduce try simulating a slow connection on a device via Settings > Developer > Network Link Conditioner. There you can enable a slower network condition like "Edge".

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->
**Before**
![Before (enabled button) Screenshot 2024-07-09](https://github.com/woocommerce/woocommerce-ios/assets/4787447/aefec8f9-34f2-4130-a13b-501af06bbc43)

**After**
![After (disabled button) Screenshot 2024-07-09](https://github.com/woocommerce/woocommerce-ios/assets/4787447/1ebae647-616e-4fc9-a1c7-6e1cecb671f8)

---
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
