### PR TITLE
Google Ads: Add tracking

### DIFF
--- a/WooCommerce/Classes/Analytics/WooAnalyticsEvent+GoogleAds.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsEvent+GoogleAds.swift
@@ -1,0 +1,52 @@
+import Foundation
+
+extension WooAnalyticsEvent {
+    enum GoogleAds {
+        enum Source: String {
+            case moreMenu = "more_menu"
+            case myStore = "my_store"
+        }
+
+        private enum Keys: String {
+            case hasCampaigns = "has_campaigns"
+            case source
+        }
+
+        /// When the Google for Woo entry point is shown to the user.
+        static func entryPointDisplayed(source: Source) -> WooAnalyticsEvent {
+            WooAnalyticsEvent(statName: .googleAdsEntryPointDisplayed,
+                              properties: [Keys.source.rawValue: source.rawValue])
+        }
+
+        /// When the Google for Woo entry point is tapped by the user and opens to campaign creation.
+        static func entryPointTapped(source: Source, hasCampaigns: Bool) -> WooAnalyticsEvent {
+            WooAnalyticsEvent(statName: .googleAdsEntryPointTapped,
+                              properties: [Keys.source.rawValue: source.rawValue,
+                                           Keys.hasCampaigns.rawValue: hasCampaigns])
+        }
+
+        /// When the Google for Woo web view is first loaded.
+        static func flowStarted(source: Source) -> WooAnalyticsEvent {
+            WooAnalyticsEvent(statName: .googleAdsFlowStarted,
+                              properties: [Keys.source.rawValue: source.rawValue])
+        }
+
+        /// When the Google for Woo web view is dismissed without completing the flow.
+        static func flowCanceled(source: Source) -> WooAnalyticsEvent {
+            WooAnalyticsEvent(statName: .googleAdsFlowCanceled,
+                              properties: [Keys.source.rawValue: source.rawValue])
+        }
+
+        /// When the Google for Woo web view returns an error.
+        static func flowError(source: Source) -> WooAnalyticsEvent {
+            WooAnalyticsEvent(statName: .googleAdsFlowError,
+                              properties: [Keys.source.rawValue: source.rawValue])
+        }
+
+        /// When the Google for Woo web view is automatically dismissed after completing the creation
+        static func campaignCreationSuccess(source: Source) -> WooAnalyticsEvent {
+            WooAnalyticsEvent(statName: .googleAdsCampaignCreationSuccess,
+                              properties: [Keys.source.rawValue: source.rawValue])
+        }
+    }
+}

--- a/WooCommerce/Classes/Analytics/WooAnalyticsEvent+GoogleAds.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsEvent+GoogleAds.swift
@@ -7,9 +7,15 @@ extension WooAnalyticsEvent {
             case myStore = "my_store"
         }
 
+        enum FlowType: String {
+            case campaignCreation = "campaign_creation"
+            case dashboard = "dashboard"
+        }
+
         private enum Keys: String {
             case hasCampaigns = "has_campaigns"
             case source
+            case type
         }
 
         /// When the Google for Woo entry point is shown to the user.
@@ -19,9 +25,10 @@ extension WooAnalyticsEvent {
         }
 
         /// When the Google for Woo entry point is tapped by the user and opens to campaign creation.
-        static func entryPointTapped(source: Source, hasCampaigns: Bool) -> WooAnalyticsEvent {
+        static func entryPointTapped(source: Source, type: FlowType, hasCampaigns: Bool) -> WooAnalyticsEvent {
             WooAnalyticsEvent(statName: .googleAdsEntryPointTapped,
                               properties: [Keys.source.rawValue: source.rawValue,
+                                           Keys.type.rawValue: type.rawValue,
                                            Keys.hasCampaigns.rawValue: hasCampaigns])
         }
 

--- a/WooCommerce/Classes/Analytics/WooAnalyticsEvent+GoogleAds.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsEvent+GoogleAds.swift
@@ -8,7 +8,7 @@ extension WooAnalyticsEvent {
         }
 
         enum FlowType: String {
-            case campaignCreation = "campaign_creation"
+            case campaignCreation = "creation"
             case dashboard = "dashboard"
         }
 

--- a/WooCommerce/Classes/Analytics/WooAnalyticsEvent+GoogleAds.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsEvent+GoogleAds.swift
@@ -38,9 +38,10 @@ extension WooAnalyticsEvent {
         }
 
         /// When the Google for Woo web view returns an error.
-        static func flowError(source: Source) -> WooAnalyticsEvent {
+        static func flowError(source: Source, error: Error) -> WooAnalyticsEvent {
             WooAnalyticsEvent(statName: .googleAdsFlowError,
-                              properties: [Keys.source.rawValue: source.rawValue])
+                              properties: [Keys.source.rawValue: source.rawValue],
+                              error: error)
         }
 
         /// When the Google for Woo web view is automatically dismissed after completing the creation

--- a/WooCommerce/Classes/Analytics/WooAnalyticsStat.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsStat.swift
@@ -1226,6 +1226,14 @@ enum WooAnalyticsStat: String {
     case watchOrdersListOpened = "watch_orders_list_opened"
     case watchPushNotificationTapped = "watch_push_notification_tapped"
     case watchOrderDetailOpened = "watch_order_detail_opened"
+
+    // MARK: Google ads campaign management
+    case googleAdsEntryPointDisplayed = "googleads_entry_point_displayed"
+    case googleAdsEntryPointTapped = "googleads_entry_point_tapped"
+    case googleAdsFlowStarted = "googleads_flow_started"
+    case googleAdsFlowCanceled = "googleads_flow_canceled"
+    case googleAdsFlowError = "googleads_flow_error"
+    case googleAdsCampaignCreationSuccess = "googleads_campaign_creation_success"
 }
 
 extension WooAnalyticsStat {

--- a/WooCommerce/Classes/Authentication/AuthenticatedWebViewController.swift
+++ b/WooCommerce/Classes/Authentication/AuthenticatedWebViewController.swift
@@ -195,6 +195,13 @@ extension AuthenticatedWebViewController: WKNavigationDelegate {
         progressBar.setProgress(0, animated: false)
     }
 
+    func webView(_ webView: WKWebView, didFinish navigation: WKNavigation!) {
+        guard let url = webView.url else {
+            return
+        }
+        viewModel.didFinishNavigation(for: url)
+    }
+
     func webView(_ webView: WKWebView, didFailProvisionalNavigation navigation: WKNavigation!, withError error: Error) {
         viewModel.didFailProvisionalNavigation(with: error)
     }

--- a/WooCommerce/Classes/Authentication/AuthenticatedWebViewModel.swift
+++ b/WooCommerce/Classes/Authentication/AuthenticatedWebViewModel.swift
@@ -30,6 +30,9 @@ protocol AuthenticatedWebViewModel {
     /// Handler after receiving response for a navigation
     func decidePolicy(for response: URLResponse) async -> WKNavigationResponsePolicy
 
+    /// Triggered when a navigation completes.
+    func didFinishNavigation(for url: URL)
+
     /// Triggered when provisional navigation fails
     ///
     func didFailProvisionalNavigation(with error: Error)
@@ -40,6 +43,10 @@ protocol AuthenticatedWebViewModel {
 extension AuthenticatedWebViewModel {
     func decidePolicy(for response: URLResponse) async -> WKNavigationResponsePolicy {
         return .allow
+    }
+
+    func didFinishNavigation(for url: URL) {
+        // NO-OP
     }
 
     func didFailProvisionalNavigation(with error: Error) {

--- a/WooCommerce/Classes/GoogleAds/GoogleAdsCampaignCoordinator.swift
+++ b/WooCommerce/Classes/GoogleAds/GoogleAdsCampaignCoordinator.swift
@@ -1,5 +1,6 @@
 import Foundation
 import Yosemite
+import protocol WooFoundation.Analytics
 
 /// Reusable coordinator to handle Google Ads campaigns.
 ///
@@ -8,24 +9,31 @@ final class GoogleAdsCampaignCoordinator: NSObject, Coordinator {
 
     private let siteID: Int64
     private let siteAdminURL: String
+    private let source: WooAnalyticsEvent.GoogleAds.Source
 
     private let shouldStartCampaignCreation: Bool
     private let shouldAuthenticateAdminPage: Bool
     private var bottomSheetPresenter: BottomSheetPresenter?
 
+    private let analytics: Analytics
+
     private let onCompletion: () -> Void
 
     init(siteID: Int64,
          siteAdminURL: String,
+         source: WooAnalyticsEvent.GoogleAds.Source,
          shouldStartCampaignCreation: Bool,
          shouldAuthenticateAdminPage: Bool,
          navigationController: UINavigationController,
+         analytics: Analytics = ServiceLocator.analytics,
          onCompletion: @escaping () -> Void) {
         self.siteID = siteID
         self.siteAdminURL = siteAdminURL
+        self.source = source
         self.shouldAuthenticateAdminPage = shouldAuthenticateAdminPage
         self.shouldStartCampaignCreation = shouldStartCampaignCreation
         self.navigationController = navigationController
+        self.analytics = analytics
         self.onCompletion = onCompletion
     }
 

--- a/WooCommerce/Classes/GoogleAds/GoogleAdsCampaignCoordinator.swift
+++ b/WooCommerce/Classes/GoogleAds/GoogleAdsCampaignCoordinator.swift
@@ -54,6 +54,7 @@ extension GoogleAdsCampaignCoordinator: UIAdaptivePresentationControllerDelegate
     // Triggered when swiping to dismiss the view.
     func presentationControllerDidDismiss(_ presentationController: UIPresentationController) {
         onCompletion()
+        analytics.track(event: .GoogleAds.flowCanceled(source: source))
     }
 }
 
@@ -63,6 +64,7 @@ private extension GoogleAdsCampaignCoordinator {
     @objc func dismissCampaignView() {
         onCompletion()
         navigationController.dismiss(animated: true)
+        analytics.track(event: .GoogleAds.flowCanceled(source: source))
     }
 
     func createCampaignViewController(with url: URL) -> UIViewController {

--- a/WooCommerce/Classes/GoogleAds/GoogleAdsCampaignCoordinator.swift
+++ b/WooCommerce/Classes/GoogleAds/GoogleAdsCampaignCoordinator.swift
@@ -95,6 +95,8 @@ private extension GoogleAdsCampaignCoordinator {
             $0.value == Constants.savedValue
         }) != nil
         if creationSucceeded {
+            analytics.track(event: .GoogleAds.campaignCreationSuccess(source: source))
+
             // dismisses the web view
             navigationController.dismiss(animated: true) { [self] in
                 showSuccessView()

--- a/WooCommerce/Classes/ViewRelated/Dashboard/DashboardViewHostingController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/DashboardViewHostingController.swift
@@ -325,6 +325,7 @@ private extension DashboardViewHostingController {
         let coordinator = GoogleAdsCampaignCoordinator(
             siteID: viewModel.siteID,
             siteAdminURL: site.adminURLWithFallback()?.absoluteString ?? site.adminURL,
+            source: .myStore,
             shouldStartCampaignCreation: forCampaignCreation,
             shouldAuthenticateAdminPage: viewModel.stores.shouldAuthenticateAdminPage(for: site),
             navigationController: navigationController,

--- a/WooCommerce/Classes/ViewRelated/Dashboard/DashboardViewHostingController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/DashboardViewHostingController.swift
@@ -333,6 +333,9 @@ private extension DashboardViewHostingController {
         )
         coordinator.start()
         googleAdsCampaignCoordinator = coordinator
+
+        let hasCampaigns = viewModel.googleAdsDashboardCardViewModel.lastCampaign != nil
+        ServiceLocator.analytics.track(event: .GoogleAds.entryPointTapped(source: .myStore, hasCampaigns: hasCampaigns))
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Dashboard/DashboardViewHostingController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/DashboardViewHostingController.swift
@@ -335,7 +335,11 @@ private extension DashboardViewHostingController {
         googleAdsCampaignCoordinator = coordinator
 
         let hasCampaigns = viewModel.googleAdsDashboardCardViewModel.lastCampaign != nil
-        ServiceLocator.analytics.track(event: .GoogleAds.entryPointTapped(source: .myStore, hasCampaigns: hasCampaigns))
+        ServiceLocator.analytics.track(event: .GoogleAds.entryPointTapped(
+            source: .myStore,
+            type: forCampaignCreation ? .campaignCreation : .dashboard,
+            hasCampaigns: hasCampaigns
+        ))
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Dashboard/GoogleAds/GoogleAdsDashboardCard.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/GoogleAds/GoogleAdsDashboardCard.swift
@@ -72,6 +72,9 @@ struct GoogleAdsDashboardCard: View {
         .background(Color(.listForeground(modal: false)))
         .clipShape(RoundedRectangle(cornerSize: Layout.cornerSize))
         .padding(.horizontal, Layout.padding)
+        .onAppear {
+            viewModel.onViewAppear()
+        }
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Dashboard/GoogleAds/GoogleAdsDashboardCardViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/GoogleAds/GoogleAdsDashboardCardViewModel.swift
@@ -31,6 +31,8 @@ final class GoogleAdsDashboardCardViewModel: ObservableObject {
     @Published private(set) var lastCampaign: GoogleAdsCampaign?
     @Published private(set) var lastCampaignStats: GoogleAdsCampaignStatsTotals?
 
+    @Published private var viewAppeared = false
+
     private var subscriptions: Set<AnyCancellable> = []
 
     init(siteID: Int64,
@@ -83,15 +85,19 @@ final class GoogleAdsDashboardCardViewModel: ObservableObject {
             DDLogError("⛔️ Error loading Google ads campaigns: \(error)")
         }
     }
+
+    func onViewAppear() {
+        viewAppeared = true
+    }
 }
 
 private extension GoogleAdsDashboardCardViewModel {
 
     func trackEntryPointDisplayedIfNeeded() {
         $canShowOnDashboard.removeDuplicates()
-            .combineLatest($syncingData.removeDuplicates())
-            .filter { canShow, syncingData in
-                return canShow && !syncingData
+            .combineLatest($syncingData.removeDuplicates(), $viewAppeared)
+            .filter { canShow, syncingData, viewAppeared in
+                return canShow && !syncingData && viewAppeared
             }
             .sink { [weak self] _ in
                 guard let self else { return }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/GoogleAds/GoogleAdsDashboardCardViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/GoogleAds/GoogleAdsDashboardCardViewModel.swift
@@ -97,6 +97,7 @@ private extension GoogleAdsDashboardCardViewModel {
         $canShowOnDashboard.removeDuplicates()
             .combineLatest($syncingData.removeDuplicates(), $viewAppeared)
             .filter { canShow, syncingData, viewAppeared in
+                // only tracks the display if the view is done loaded and visible.
                 return canShow && !syncingData && viewAppeared
             }
             .sink { [weak self] _ in

--- a/WooCommerce/Classes/ViewRelated/Hub Menu/HubMenuViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Hub Menu/HubMenuViewController.swift
@@ -95,6 +95,7 @@ private extension HubMenuViewController {
         googleAdsCampaignCoordinator = GoogleAdsCampaignCoordinator(
             siteID: viewModel.siteID,
             siteAdminURL: viewModel.woocommerceAdminURL.absoluteString,
+            source: .moreMenu,
             shouldStartCampaignCreation: viewModel.hasGoogleAdsCampaigns,
             shouldAuthenticateAdminPage: viewModel.shouldAuthenticateAdminPage,
             navigationController: navigationController,

--- a/WooCommerce/Classes/ViewRelated/Hub Menu/HubMenuViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Hub Menu/HubMenuViewController.swift
@@ -106,6 +106,8 @@ private extension HubMenuViewController {
             }
         )
         googleAdsCampaignCoordinator?.start()
+
+        ServiceLocator.analytics.track(event: .GoogleAds.entryPointTapped(source: .moreMenu, hasCampaigns: viewModel.hasGoogleAdsCampaigns))
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Hub Menu/HubMenuViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Hub Menu/HubMenuViewController.swift
@@ -107,7 +107,11 @@ private extension HubMenuViewController {
         )
         googleAdsCampaignCoordinator?.start()
 
-        ServiceLocator.analytics.track(event: .GoogleAds.entryPointTapped(source: .moreMenu, hasCampaigns: viewModel.hasGoogleAdsCampaigns))
+        ServiceLocator.analytics.track(event: .GoogleAds.entryPointTapped(
+            source: .moreMenu,
+            type: viewModel.hasGoogleAdsCampaigns ? .dashboard : .campaignCreation,
+            hasCampaigns: viewModel.hasGoogleAdsCampaigns
+        ))
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Hub Menu/HubMenuViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Hub Menu/HubMenuViewModel.swift
@@ -64,6 +64,8 @@ final class HubMenuViewModel: ObservableObject {
     @Published var showingReviewDetail = false
     @Published var showingCoupons = false
 
+    @Published private(set) var viewAppeared = false
+
     @Published private(set) var shouldAuthenticateAdminPage = false
 
     @Published private(set) var hasGoogleAdsCampaigns = false
@@ -153,6 +155,7 @@ final class HubMenuViewModel: ObservableObject {
 
     func viewDidAppear() {
         NotificationCenter.default.post(name: .hubMenuViewDidAppear, object: nil)
+        viewAppeared = true
     }
 
     /// Resets the menu elements displayed on the menu.
@@ -383,9 +386,9 @@ private extension HubMenuViewModel {
 
     func observeGoogleAdsEntryPointAvailability() {
         $isSiteEligibleForGoogleAds.removeDuplicates()
-            .withLatestFrom($currentSite.removeDuplicates())
-            .filter { isEligible, currentSite in
-                return isEligible && currentSite != nil
+            .combineLatest($viewAppeared)
+            .filter { isEligible, viewAppeared in
+                return isEligible && viewAppeared
             }
             .sink { _ in
                 ServiceLocator.analytics.track(event: .GoogleAds.entryPointDisplayed(source: .moreMenu))

--- a/WooCommerce/Classes/ViewRelated/Hub Menu/HubMenuViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Hub Menu/HubMenuViewModel.swift
@@ -146,6 +146,7 @@ final class HubMenuViewModel: ObservableObject {
                                                            featureFlagService: featureFlagService)
         observeSiteForUIUpdates()
         observePlanName()
+        observeGoogleAdsEntryPointAvailability()
         tapToPayBadgePromotionChecker.$shouldShowTapToPayBadges.share().assign(to: &$shouldShowNewFeatureBadgeOnPayments)
         createCardPresentPaymentService()
     }
@@ -378,6 +379,18 @@ private extension HubMenuViewModel {
             }
         }
         .assign(to: &$planName)
+    }
+
+    func observeGoogleAdsEntryPointAvailability() {
+        $isSiteEligibleForGoogleAds.removeDuplicates()
+            .withLatestFrom($currentSite.removeDuplicates())
+            .filter { isEligible, currentSite in
+                return isEligible && currentSite != nil
+            }
+            .sink { _ in
+                ServiceLocator.analytics.track(event: .GoogleAds.entryPointDisplayed(source: .moreMenu))
+            }
+            .store(in: &cancellables)
     }
 
     @MainActor

--- a/WooCommerce/Classes/ViewRelated/Hub Menu/HubMenuViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Hub Menu/HubMenuViewModel.swift
@@ -388,6 +388,7 @@ private extension HubMenuViewModel {
         $isSiteEligibleForGoogleAds.removeDuplicates()
             .combineLatest($viewAppeared)
             .filter { isEligible, viewAppeared in
+                // only tracks the display if the view appeared
                 return isEligible && viewAppeared
             }
             .sink { _ in

--- a/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/AuthenticatedWebView.swift
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/AuthenticatedWebView.swift
@@ -7,6 +7,9 @@ final class DefaultAuthenticatedWebViewModel: AuthenticatedWebViewModel {
     let title: String
     let initialURL: URL?
 
+    /// Optional closure for when a web page loads successfully.
+    let pageLoadHandler: ((URL) -> Void)?
+
     /// A url to trigger dismissing of the web view.
     let urlToTriggerExit: String?
 
@@ -22,11 +25,13 @@ final class DefaultAuthenticatedWebViewModel: AuthenticatedWebViewModel {
     init(title: String = "",
          initialURL: URL,
          urlToTriggerExit: String? = nil,
+         pageLoadHandler: ((URL) -> Void)? = nil,
          redirectHandler: ((URL) -> Void)? = nil,
          errorHandler: ((Error) -> Void)? = nil) {
         self.title = title
         self.initialURL = initialURL
         self.urlToTriggerExit = urlToTriggerExit
+        self.pageLoadHandler = pageLoadHandler
         self.redirectHandler = redirectHandler
         self.errorHandler = errorHandler
     }
@@ -51,6 +56,10 @@ final class DefaultAuthenticatedWebViewModel: AuthenticatedWebViewModel {
 
     func decidePolicy(for navigationURL: URL) async -> WKNavigationActionPolicy {
         .allow
+    }
+
+    func didFinishNavigation(for url: URL) {
+        pageLoadHandler?(url)
     }
 
     func didFailProvisionalNavigation(with error: Error) {

--- a/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/AuthenticatedWebView.swift
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/AuthenticatedWebView.swift
@@ -16,14 +16,19 @@ final class DefaultAuthenticatedWebViewModel: AuthenticatedWebViewModel {
     /// Otherwise, the closure is triggered whenever the web view redirects to a new URL.
     let redirectHandler: ((URL) -> Void)?
 
+    /// Optional closure for when a web page fails to load.
+    let errorHandler: ((Error) -> Void)?
+
     init(title: String = "",
          initialURL: URL,
          urlToTriggerExit: String? = nil,
-         redirectHandler: ((URL) -> Void)? = nil) {
+         redirectHandler: ((URL) -> Void)? = nil,
+         errorHandler: ((Error) -> Void)? = nil) {
         self.title = title
         self.initialURL = initialURL
         self.urlToTriggerExit = urlToTriggerExit
         self.redirectHandler = redirectHandler
+        self.errorHandler = errorHandler
     }
 
     func handleDismissal() {
@@ -46,6 +51,10 @@ final class DefaultAuthenticatedWebViewModel: AuthenticatedWebViewModel {
 
     func decidePolicy(for navigationURL: URL) async -> WKNavigationActionPolicy {
         .allow
+    }
+
+    func didFailProvisionalNavigation(with error: Error) {
+        errorHandler?(error)
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/AuthenticatedWebView.swift
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/AuthenticatedWebView.swift
@@ -7,7 +7,7 @@ final class DefaultAuthenticatedWebViewModel: AuthenticatedWebViewModel {
     let title: String
     let initialURL: URL?
 
-    /// Optional closure for when a web page loads successfully.
+    /// Optional closure for when the web page loads the initial URL successfully.
     let pageLoadHandler: ((URL) -> Void)?
 
     /// A url to trigger dismissing of the web view.

--- a/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/WebView.swift
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/WebView.swift
@@ -11,6 +11,7 @@ final class WebViewHostingController: UIHostingController<WebView> {
          disableLinkClicking: Bool = false,
          onCommit: ((WKWebView)->Void)? = nil,
          urlToTriggerExit: String? = nil,
+         pageLoadHandler: ((URL) -> Void)? = nil,
          redirectHandler: ((URL) -> Void)? = nil,
          errorHandler: ((Error) -> Void)? = nil) {
         super.init(rootView: WebView(isPresented: .constant(true),
@@ -18,6 +19,7 @@ final class WebViewHostingController: UIHostingController<WebView> {
                                      disableLinkClicking: disableLinkClicking,
                                      onCommit: onCommit,
                                      urlToTriggerExit: urlToTriggerExit,
+                                     pageLoadHandler: pageLoadHandler,
                                      redirectHandler: redirectHandler,
                                      errorHandler: errorHandler))
     }
@@ -56,6 +58,9 @@ struct WebView: UIViewRepresentable {
     /// A url to trigger dismissing of the web view.
     let urlToTriggerExit: String?
 
+    /// Optional closure for when a web page loads successfully.
+    let pageLoadHandler: ((URL) -> Void)?
+
     /// Closure to determine the action given the redirect URL.
     /// If `urlToTriggerExit` is provided, this closure is triggered only when
     /// a redirect URL matches `urlToTriggerExit`.
@@ -73,6 +78,7 @@ struct WebView: UIViewRepresentable {
         disableLinkClicking: Bool = false,
         onCommit: ((WKWebView)->Void)? = nil,
         urlToTriggerExit: String? = nil,
+        pageLoadHandler: ((URL) -> Void)? = nil,
         redirectHandler: ((URL) -> Void)? = nil,
         errorHandler: ((Error) -> Void)? = nil
     ) {
@@ -81,6 +87,7 @@ struct WebView: UIViewRepresentable {
         self.disableLinkClicking = disableLinkClicking
         self.onCommit = onCommit
         self.urlToTriggerExit = urlToTriggerExit
+        self.pageLoadHandler = pageLoadHandler
         self.redirectHandler = redirectHandler
         self.errorHandler = errorHandler
     }
@@ -152,6 +159,13 @@ struct WebView: UIViewRepresentable {
 
         func webView(_ webView: WKWebView, didCommit navigation: WKNavigation!) {
             parent.onCommit?(webView)
+        }
+
+        func webView(_ webView: WKWebView, didFinish navigation: WKNavigation!) {
+            guard let url = webView.url else {
+                return
+            }
+            parent.pageLoadHandler?(url)
         }
 
         func webView(_ webView: WKWebView, didFailProvisionalNavigation navigation: WKNavigation!, withError error: Error) {

--- a/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/WebView.swift
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/WebView.swift
@@ -58,7 +58,7 @@ struct WebView: UIViewRepresentable {
     /// A url to trigger dismissing of the web view.
     let urlToTriggerExit: String?
 
-    /// Optional closure for when a web page loads successfully.
+    /// Optional closure for when the web page loads the initial URL successfully.
     let pageLoadHandler: ((URL) -> Void)?
 
     /// Closure to determine the action given the redirect URL.

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -2518,6 +2518,7 @@
 		DE69C54F27BCB4B7000BB888 /* CouponRestrictionsViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE69C54E27BCB4B6000BB888 /* CouponRestrictionsViewModelTests.swift */; };
 		DE69C55527C5E317000BB888 /* ShippingLabelSampleData.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE69C55427C5E317000BB888 /* ShippingLabelSampleData.swift */; };
 		DE6D84A52C3B8C9C0014FBFF /* GoogleAdsDashboardCardViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE6D84A42C3B8C9C0014FBFF /* GoogleAdsDashboardCardViewModelTests.swift */; };
+		DE6D84A92C3D07850014FBFF /* WooAnalyticsEvent+GoogleAds.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE6D84A82C3D07850014FBFF /* WooAnalyticsEvent+GoogleAds.swift */; };
 		DE6F997B2BE9E5CA0007B2DD /* Settings.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = DE6F997A2BE9E5CA0007B2DD /* Settings.storyboard */; };
 		DE6F997E2BEE00C50007B2DD /* InboxDashboardCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE6F997D2BEE00C50007B2DD /* InboxDashboardCard.swift */; };
 		DE6F99802BEE04310007B2DD /* InboxDashboardCardViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE6F997F2BEE04310007B2DD /* InboxDashboardCardViewModel.swift */; };
@@ -5514,6 +5515,7 @@
 		DE69C54E27BCB4B6000BB888 /* CouponRestrictionsViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CouponRestrictionsViewModelTests.swift; sourceTree = "<group>"; };
 		DE69C55427C5E317000BB888 /* ShippingLabelSampleData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShippingLabelSampleData.swift; sourceTree = "<group>"; };
 		DE6D84A42C3B8C9C0014FBFF /* GoogleAdsDashboardCardViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GoogleAdsDashboardCardViewModelTests.swift; sourceTree = "<group>"; };
+		DE6D84A82C3D07850014FBFF /* WooAnalyticsEvent+GoogleAds.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "WooAnalyticsEvent+GoogleAds.swift"; sourceTree = "<group>"; };
 		DE6F997A2BE9E5CA0007B2DD /* Settings.storyboard */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.storyboard; path = Settings.storyboard; sourceTree = "<group>"; };
 		DE6F997D2BEE00C50007B2DD /* InboxDashboardCard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InboxDashboardCard.swift; sourceTree = "<group>"; };
 		DE6F997F2BEE04310007B2DD /* InboxDashboardCardViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InboxDashboardCardViewModel.swift; sourceTree = "<group>"; };
@@ -9438,6 +9440,7 @@
 				0204E3612B8CD40B00F1B5FD /* WooAnalyticsEvent+Products.swift */,
 				DE12BED82B95C30800B19C01 /* WooAnalyticsEvent+DashboardCustomRange.swift */,
 				DE74A45C2BDA203E0009C415 /* WooAnalyticsEvent+DynamicDashboard.swift */,
+				DE6D84A82C3D07850014FBFF /* WooAnalyticsEvent+GoogleAds.swift */,
 			);
 			path = Analytics;
 			sourceTree = "<group>";
@@ -14652,6 +14655,7 @@
 				DED91DFA2AD78A3A00CDCC53 /* BlazeCampaignItemView.swift in Sources */,
 				31FC8CE727B47591004B9456 /* CardReaderSettingsDataSource.swift in Sources */,
 				02B2829027C352DA004A332A /* RefreshableScrollView.swift in Sources */,
+				DE6D84A92C3D07850014FBFF /* WooAnalyticsEvent+GoogleAds.swift in Sources */,
 				DE7842F726F2E9340030C792 /* UIViewController+Connectivity.swift in Sources */,
 				E1C47209267A1ECC00D06DA1 /* CrashLoggingStack.swift in Sources */,
 				B991F5382B7BCA27001ADF83 /* LocallyStoredStateNameRetriever.swift in Sources */,

--- a/WooCommerce/WooCommerceTests/GoogleAds/GoogleAdsCampaignCoordinatorTests.swift
+++ b/WooCommerce/WooCommerceTests/GoogleAds/GoogleAdsCampaignCoordinatorTests.swift
@@ -25,6 +25,7 @@ final class GoogleAdsCampaignCoordinatorTests: XCTestCase {
         let coordinator = GoogleAdsCampaignCoordinator(
             siteID: 123,
             siteAdminURL: siteAdminURL,
+            source: .myStore,
             shouldStartCampaignCreation: true,
             shouldAuthenticateAdminPage: false,
             navigationController: navigationController,
@@ -44,6 +45,7 @@ final class GoogleAdsCampaignCoordinatorTests: XCTestCase {
         let coordinator = GoogleAdsCampaignCoordinator(
             siteID: 123,
             siteAdminURL: siteAdminURL,
+            source: .myStore,
             shouldStartCampaignCreation: true,
             shouldAuthenticateAdminPage: true,
             navigationController: navigationController,

--- a/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/GoogleAds/GoogleAdsDashboardCardViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/GoogleAds/GoogleAdsDashboardCardViewModelTests.swift
@@ -104,7 +104,6 @@ final class GoogleAdsDashboardCardViewModelTests: XCTestCase {
     func test_syncingData_is_false_immediately_after_fetching_last_campaign_completes( ) async {
         // Given
         let viewModel = GoogleAdsDashboardCardViewModel(siteID: sampleSiteID, stores: stores)
-        XCTAssertFalse(viewModel.syncingData)
 
         // When
         stores.whenReceivingAction(ofType: GoogleAdsAction.self) { action in


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #13273 
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This PR adds tracking events for the Google Ads integration in the web view.

Event | Trigger | Properties
-- | -- | --
googleads_entry_point_displayed | When the Google for Woo entry point is shown to the user. | source
googleads_entry_point_tapped | When the Google for Woo entry point is tapped by the user and opens to campaign creation. | source, type, has_campaigns
googleads_flow_started | When the Google for Woo webview is first loaded. | source
googleads_flow_canceled | When the Google for Woo webview is dismissed without completing the flow. | source
googleads_campaign_creation_success | When the Google for Woo webview is automatically dismissed after completing the creation | source
googleads_flow_error | When the Google for Woo webview returns an error. | source

To support tracking web flow errors, `DefaultAuthenticatedWebViewModel` and `WebViewHostingController` has been updated with a new closure to be triggered when loading a web page fails.

## Testing steps
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->
- Pre-requisite: Install, activate, and set up the Google Ads plugin to a test site following pe5sF9-2Qo-p2. Ensure that you're using the plugin version 2.7.5 or above.
- Build the app and log in to your store.
- Enable Google Ads card on the dashboard if you haven't already.
- Confirm that `googleads_entry_point_displayed` is tracked with `source: my_store`.
- Tap on either the Create campaign button or existing campaign detail, and confirm that `googleads_entry_point_tapped` is tracked with `source: my_store` and the correct value for `has_campaigns` depending on whether your store has existing campaigns.
- Switch to the menu tab, confirm that `googleads_entry_point_displayed` is tracked with `source: more_menu`.
- Tap on the Google for WooCommerce item, confirm that `googleads_entry_point_tapped` is tracked with `source: my_store` and the correct value for `has_campaigns` depending on whether your store has existing campaigns.
- When the web view first loaded, confirm that `googleads_flow_started` is tracked with the correct `source` property.
- Dismiss the web view, confirm that `googleads_flow_canceled` is tracked with the correct `source` property.
- Create a campaign on the web view. After the creation completes, confirm that `googleads_campaign_creation_success` is tracked with the correct `source` property.
- Turn off the internet connection and tap on the entry point again. After the loading fails, confirm that `googleads_flow_error` is tracked with the correct `source` property and error details.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->
N/A

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.