### PR TITLE
Background tasks: Fetch the order from a push notification

### DIFF
--- a/Networking/Networking/Model/MetaContainer.swift
+++ b/Networking/Networking/Model/MetaContainer.swift
@@ -9,6 +9,9 @@ public struct MetaContainer {
     ///
     let payload: [String: AnyCodable]
 
+    public init(payload: [String: AnyCodable]) {
+        self.payload = payload
+    }
 
     /// Returns the Meta Link associated with the specified key (if any).
     ///

--- a/WooCommerce/Classes/Notifications/PushNotificationBackgroundSynchronizer.swift
+++ b/WooCommerce/Classes/Notifications/PushNotificationBackgroundSynchronizer.swift
@@ -43,7 +43,7 @@ struct PushNotificationBackgroundSynchronizer {
             }
 
             // Sync the order list data
-            _ = await OrderListSyncBackgroundTask(siteID: pushNotification.siteID, backgroundTask: nil).dispatch().result
+            _ = await OrderListSyncBackgroundTask(siteID: pushNotification.siteID, backgroundTask: nil, stores: stores).dispatch().result
 
             // There is a change that the specific order was not fetched in the previous operation, specially if the user has some filters set.
             // In that case, specifically sync the notification order so it's available for the user when they tap the notification.

--- a/WooCommerce/Classes/Notifications/PushNotificationBackgroundSynchronizer.swift
+++ b/WooCommerce/Classes/Notifications/PushNotificationBackgroundSynchronizer.swift
@@ -1,0 +1,123 @@
+import protocol Storage.StorageType
+import Yosemite
+
+/// Type that fetches the necessary resources when a push notification arrives in the background.
+/// Current it fetches:
+/// - Notifications
+/// - Orders List (If needed)
+/// - Notification Order (If needed)
+///
+struct PushNotificationBackgroundSynchronizer {
+
+    /// Push notification user info
+    ///
+    private let userInfo: [AnyHashable: Any]
+
+    private let stores: StoresManager
+
+    private let storage: StorageType
+
+    init(userInfo: [AnyHashable: Any], stores: StoresManager = ServiceLocator.stores, storage: StorageType = ServiceLocator.storageManager.viewStorage) {
+        self.userInfo = userInfo
+        self.stores = stores
+        self.storage = storage
+    }
+
+    /// Starts the sync process
+    ///
+    @MainActor
+    func sync() async -> UIBackgroundFetchResult {
+
+        guard let pushNotification = PushNotification.from(userInfo: userInfo) else {
+            return .noData
+        }
+
+        do {
+            // I'm not sure why we need to sync all notifications instead of only the current one.
+            // This is legacy code copied from PushNotificationsManager
+            try await synchronizeNotifications()
+
+            // Find the orderID from the previously synced notification.
+            guard let orderID = getOrderID(noteID: pushNotification.noteID) else {
+                return .newData
+            }
+
+            // Sync the order list data
+            _ = await OrderListSyncBackgroundTask(siteID: pushNotification.siteID, backgroundTask: nil).dispatch().result
+
+            // There is a change that the specific order was not fetched in the previous operation, specially if the user has some filters set.
+            // In that case, specifically sync the notification order so it's available for the user when they tap the notification.
+            if isOrderNotSynced(siteID: pushNotification.siteID, orderID: orderID) {
+                try await synchronizeOrder(siteID: pushNotification.siteID, orderID: orderID)
+            }
+
+            return .newData
+
+        } catch {
+            DDLogError("⛔️ Error synchronizing notification dependencies: \(error)")
+            return .noData
+        }
+    }
+
+    /// Synchronizes all of the Notifications.
+    ///
+    @MainActor
+    private func synchronizeNotifications() async throws {
+        return try await withCheckedThrowingContinuation { continuation in
+            let action = NotificationAction.synchronizeNotifications { error in
+                DDLogInfo("📱 Finished Synchronizing Notifications!")
+                if let error {
+                    continuation.resume(throwing: error)
+                } else {
+                    continuation.resume()
+                }
+            }
+
+            DDLogInfo("📱 Synchronizing Notifications...")
+            stores.dispatch(action)
+        }
+    }
+
+    /// Synchronizes an specific order.
+    ///
+    @MainActor
+    private func synchronizeOrder(siteID: Int64, orderID: Int64) async throws {
+        try await withCheckedThrowingContinuation { continuation in
+            let action = OrderAction.retrieveOrderRemotely(siteID: siteID, orderID: orderID) { result in
+                DDLogInfo("📱 Finished Synchronizing Order \(orderID)!")
+                switch result {
+                case .success:
+                    continuation.resume()
+                case .failure(let error):
+                    continuation.resume(throwing: error)
+                }
+            }
+
+            DDLogInfo("📱 Synchronizing Order \(orderID) ...")
+            stores.dispatch(action)
+        }
+    }
+
+    /// Tries to find the `orderID` of an already stored order note object.
+    /// Returns `nil` if the note is not stored or of its not an order note.
+    ///
+    @MainActor
+    private func getOrderID(noteID: Int64) -> Int64? {
+        guard let note = storage.loadNotification(noteID: noteID)?.toReadOnly() else {
+            return nil
+        }
+
+        guard let orderID = note.meta.identifier(forKey: .order), note.kind == .storeOrder else {
+            return nil
+        }
+
+        return Int64(orderID)
+    }
+
+    /// Checks if an order does not exists  in our storage layer.
+    ///
+    @MainActor
+    private func isOrderNotSynced(siteID: Int64, orderID: Int64) -> Bool {
+        storage.loadOrder(siteID: siteID, orderID: orderID) == nil
+    }
+}

--- a/WooCommerce/Classes/Notifications/PushNotificationsManager.swift
+++ b/WooCommerce/Classes/Notifications/PushNotificationsManager.swift
@@ -305,7 +305,11 @@ extension PushNotificationsManager {
             backgroundNotificationsSubject.send(notification)
         }
 
-        return await PushNotificationBackgroundSynchronizer(userInfo: userInfo, stores: configuration.storesManager).sync()
+        if ServiceLocator.featureFlagService.isFeatureFlagEnabled(.backgroundTasks) {
+            return await PushNotificationBackgroundSynchronizer(userInfo: userInfo, stores: configuration.storesManager).sync()
+        } else {
+            return await synchronizeNotifications()
+        }
     }
 
     func requestLocalNotification(_ notification: LocalNotification, trigger: UNNotificationTrigger?) async {

--- a/WooCommerce/Classes/Notifications/PushNotificationsManager.swift
+++ b/WooCommerce/Classes/Notifications/PushNotificationsManager.swift
@@ -305,7 +305,7 @@ extension PushNotificationsManager {
             backgroundNotificationsSubject.send(notification)
         }
 
-        return await synchronizeNotifications()
+        return await PushNotificationBackgroundSynchronizer(userInfo: userInfo, stores: configuration.storesManager).sync()
     }
 
     func requestLocalNotification(_ notification: LocalNotification, trigger: UNNotificationTrigger?) async {

--- a/WooCommerce/Classes/Tools/BackgroundTasks/BackgroundTaskRefreshDispatcher.swift
+++ b/WooCommerce/Classes/Tools/BackgroundTasks/BackgroundTaskRefreshDispatcher.swift
@@ -52,7 +52,7 @@ final class BackgroundTaskRefreshDispatcher {
         // Schedule a new refresh task.
         scheduleAppRefresh()
 
-        let ordersSyncTask = OrderSyncBackgroundTask(siteID: siteID, backgroundTask: backgroundTask).dispatch()
+        let ordersSyncTask = OrderListSyncBackgroundTask(siteID: siteID, backgroundTask: backgroundTask).dispatch()
 
         // Provide the background task with an expiration handler that cancels the operation.
         backgroundTask.expirationHandler = {

--- a/WooCommerce/Classes/Tools/BackgroundTasks/OrderListSyncBackgroundTask.swift
+++ b/WooCommerce/Classes/Tools/BackgroundTasks/OrderListSyncBackgroundTask.swift
@@ -109,7 +109,7 @@ private struct CurrentOrderListSyncUseCase {
                 if let error {
                     continuation.resume(throwing: error)
                 } else {
-                    continuation.resume(returning: ())
+                    continuation.resume()
                 }
             })
             stores.dispatch(action)

--- a/WooCommerce/Classes/Tools/BackgroundTasks/OrderListSyncBackgroundTask.swift
+++ b/WooCommerce/Classes/Tools/BackgroundTasks/OrderListSyncBackgroundTask.swift
@@ -4,7 +4,7 @@ import Yosemite
 
 /// Task to sync orders in the background
 ///
-struct OrderSyncBackgroundTask {
+struct OrderListSyncBackgroundTask {
 
     /// The last time we successfully run a sync update.
     ///
@@ -21,9 +21,9 @@ struct OrderSyncBackgroundTask {
 
     let stores: StoresManager
 
-    let backgroundTask: BGAppRefreshTask
+    let backgroundTask: BGAppRefreshTask?
 
-    init(siteID: Int64, backgroundTask: BGAppRefreshTask, stores: StoresManager = ServiceLocator.stores) {
+    init(siteID: Int64, backgroundTask: BGAppRefreshTask?, stores: StoresManager = ServiceLocator.stores) {
         self.siteID = siteID
         self.backgroundTask = backgroundTask
         self.stores = stores
@@ -36,17 +36,40 @@ struct OrderSyncBackgroundTask {
     func dispatch() -> Task<Void, Never> {
         Task { @MainActor in
             do {
-                let filters = await fetchFilters()
-                try await syncOrders(filters: filters)
-                Self.latestSyncDate = Date.now
 
-                DDLogError("🟢 Successfully synced orders in the background")
-                backgroundTask.setTaskCompleted(success: true)
+                DDLogInfo("📱 Synchronizing orders in the background...")
+
+                let useCase = CurrentOrderListSyncUseCase(siteID: siteID, stores: stores)
+                try await useCase.sync()
+
+                DDLogInfo("📱 Successfully synchronized orders in the background")
+                backgroundTask?.setTaskCompleted(success: true)
             } catch {
-                DDLogError("⛔️ Error synching orders in the background: \(error)")
-                backgroundTask.setTaskCompleted(success: false)
+                DDLogError("⛔️ Error synchronizing orders in the background: \(error)")
+                backgroundTask?.setTaskCompleted(success: false)
             }
         }
+    }
+}
+
+/// UseCase to sync the order list with the current store filters.
+///
+private struct CurrentOrderListSyncUseCase {
+
+    let siteID: Int64
+
+    let stores: StoresManager
+
+    init(siteID: Int64, stores: StoresManager = ServiceLocator.stores) {
+        self.siteID = siteID
+        self.stores = stores
+    }
+
+    /// Syncs the order list with the current store filters.
+    ///
+    func sync() async throws {
+        let filters = await fetchFilters()
+        try await syncOrders(filters: filters)
     }
 
     /// Fetch the stored filters settings.

--- a/WooCommerce/Classes/ViewRelated/Orders/OrderListViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrderListViewController.swift
@@ -92,8 +92,8 @@ final class OrderListViewController: UIViewController {
     /// Timestamp for last successful sync.
     ///
     private(set) var lastFullSyncTimestamp: Date? = {
-        if ServiceLocator.featureFlagService.isFeatureFlagEnabled(.backgroundTasks), OrderSyncBackgroundTask.latestSyncDate != Date.distantPast {
-            return OrderSyncBackgroundTask.latestSyncDate
+        if ServiceLocator.featureFlagService.isFeatureFlagEnabled(.backgroundTasks), OrderListSyncBackgroundTask.latestSyncDate != Date.distantPast {
+            return OrderListSyncBackgroundTask.latestSyncDate
         } else {
             return nil
         }
@@ -304,8 +304,8 @@ private extension OrderListViewController {
             ///
             if let lastFullSyncTimestamp = self.lastFullSyncTimestamp,
                ServiceLocator.featureFlagService.isFeatureFlagEnabled(.backgroundTasks),
-               OrderSyncBackgroundTask.latestSyncDate > lastFullSyncTimestamp {
-                self.lastFullSyncTimestamp = OrderSyncBackgroundTask.latestSyncDate
+               OrderListSyncBackgroundTask.latestSyncDate > lastFullSyncTimestamp {
+                self.lastFullSyncTimestamp = OrderListSyncBackgroundTask.latestSyncDate
             }
 
             // Avoid synchronizing if the view is not visible. The refresh will be handled in

--- a/WooCommerce/Classes/ViewRelated/Orders/OrdersRootViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrdersRootViewController.swift
@@ -421,7 +421,7 @@ extension OrdersRootViewController: OrderListViewControllerDelegate {
     func orderListViewControllerSyncTimestampChanged(_ syncTimestamp: Date) {
         if ServiceLocator.featureFlagService.isFeatureFlagEnabled(.backgroundTasks) {
             let dateFormatter = syncTimestamp.isSameDay(as: Date.now) ? DateFormatter.timeFormatter : DateFormatter.dateAndTimeFormatter
-            filtersBar.setLastUpdatedTime(dateFormatter.string(from: syncTimestamp))
+            filtersBar.setLastUpdatedTime(dateFormatter.string(from: syncTimestamp)) // TODO: Also do it in view will appear or something
         }
     }
 

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -877,6 +877,7 @@
 		260DE20C28CA8F31009ECD7C /* Networking.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 260DE20B28CA8F31009ECD7C /* Networking.framework */; };
 		26100B202722FCAD00473045 /* MockCardPresentPaymentsOnboardingUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26100B1F2722FCAD00473045 /* MockCardPresentPaymentsOnboardingUseCase.swift */; };
 		2611EE59243A473300A74490 /* ProductCategoryListViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2611EE58243A473300A74490 /* ProductCategoryListViewModelTests.swift */; };
+		26132B3C2C3DA20C004C157F /* PushNotificationBackgroundSynchronizer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26132B3B2C3DA20C004C157F /* PushNotificationBackgroundSynchronizer.swift */; };
 		2614EB1C24EB611200968D4B /* TopBannerViewTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2614EB1B24EB611200968D4B /* TopBannerViewTests.swift */; };
 		2619FA2C25C897930006DAFF /* AddAttributeOptionsViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2619FA2B25C897930006DAFF /* AddAttributeOptionsViewModelTests.swift */; };
 		261AA309275178FA009530FE /* PaymentMethodsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 261AA308275178FA009530FE /* PaymentMethodsView.swift */; };
@@ -1039,7 +1040,7 @@
 		26BBEA8528C6ADAC00ED7F6C /* Images.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 26FFD32628C6A0A4002E5E5E /* Images.xcassets */; };
 		26BBEA8628C6AE1400ED7F6C /* UIImage+Widgets.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26FFD32928C6A0F4002E5E5E /* UIImage+Widgets.swift */; };
 		26BCA0402C35E9A9000BE96C /* BackgroundTaskRefreshDispatcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26BCA03F2C35E9A9000BE96C /* BackgroundTaskRefreshDispatcher.swift */; };
-		26BCA0422C35EDBF000BE96C /* OrderSyncBackgroundTask.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26BCA0412C35EDBF000BE96C /* OrderSyncBackgroundTask.swift */; };
+		26BCA0422C35EDBF000BE96C /* OrderListSyncBackgroundTask.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26BCA0412C35EDBF000BE96C /* OrderListSyncBackgroundTask.swift */; };
 		26C0D1E32B460E5700F6EDA5 /* OrderNotificationViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2679F02C2AAADB1C00AF80C5 /* OrderNotificationViewModel.swift */; };
 		26C0D1E42B460E9000F6EDA5 /* AppLocalizedString.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F50FE4228CAEBA800C89201 /* AppLocalizedString.swift */; };
 		26C0D1E52B460EB700F6EDA5 /* WooConstants.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5D1AFBF20BC67C200DB0E8C /* WooConstants.swift */; };
@@ -3890,6 +3891,7 @@
 		260DE20B28CA8F31009ECD7C /* Networking.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = Networking.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		26100B1F2722FCAD00473045 /* MockCardPresentPaymentsOnboardingUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockCardPresentPaymentsOnboardingUseCase.swift; sourceTree = "<group>"; };
 		2611EE58243A473300A74490 /* ProductCategoryListViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductCategoryListViewModelTests.swift; sourceTree = "<group>"; };
+		26132B3B2C3DA20C004C157F /* PushNotificationBackgroundSynchronizer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PushNotificationBackgroundSynchronizer.swift; sourceTree = "<group>"; };
 		2614EB1B24EB611200968D4B /* TopBannerViewTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TopBannerViewTests.swift; sourceTree = "<group>"; };
 		2619FA2B25C897930006DAFF /* AddAttributeOptionsViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddAttributeOptionsViewModelTests.swift; sourceTree = "<group>"; };
 		261AA308275178FA009530FE /* PaymentMethodsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaymentMethodsView.swift; sourceTree = "<group>"; };
@@ -4024,7 +4026,7 @@
 		26B9875C273C6A830090E8CA /* SimplePaymentsNoteViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SimplePaymentsNoteViewModel.swift; sourceTree = "<group>"; };
 		26B9875E273CB6AA0090E8CA /* SimplePaymentsNoteViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SimplePaymentsNoteViewModelTests.swift; sourceTree = "<group>"; };
 		26BCA03F2C35E9A9000BE96C /* BackgroundTaskRefreshDispatcher.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BackgroundTaskRefreshDispatcher.swift; sourceTree = "<group>"; };
-		26BCA0412C35EDBF000BE96C /* OrderSyncBackgroundTask.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OrderSyncBackgroundTask.swift; sourceTree = "<group>"; };
+		26BCA0412C35EDBF000BE96C /* OrderListSyncBackgroundTask.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OrderListSyncBackgroundTask.swift; sourceTree = "<group>"; };
 		26C1633B29DA2CE700E482CE /* FreeTrialSummaryView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FreeTrialSummaryView.swift; sourceTree = "<group>"; };
 		26C6439227B5DBE900DD00D1 /* OrderSynchronizer.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = OrderSynchronizer.swift; sourceTree = "<group>"; };
 		26C6E8DF26E2B7BD00C7BB0F /* CountrySelectorViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CountrySelectorViewModel.swift; sourceTree = "<group>"; };
@@ -8169,7 +8171,7 @@
 			isa = PBXGroup;
 			children = (
 				26BCA03F2C35E9A9000BE96C /* BackgroundTaskRefreshDispatcher.swift */,
-				26BCA0412C35EDBF000BE96C /* OrderSyncBackgroundTask.swift */,
+				26BCA0412C35EDBF000BE96C /* OrderListSyncBackgroundTask.swift */,
 			);
 			path = BackgroundTasks;
 			sourceTree = "<group>";
@@ -10350,6 +10352,7 @@
 				B555530E21B57DE700449E71 /* ApplicationAdapter.swift */,
 				B56C721121B5B44000E5E85B /* PushNotificationsConfiguration.swift */,
 				B5BBD6DD21B1703600E3207E /* PushNotificationsManager.swift */,
+				26132B3B2C3DA20C004C157F /* PushNotificationBackgroundSynchronizer.swift */,
 				B555530C21B57DC300449E71 /* UserNotificationsCenterAdapter.swift */,
 				0221121D288973C20028F0AF /* LocalNotification.swift */,
 				026D68482A0E060A00D8C22C /* LocalNotificationScheduler.swift */,
@@ -15616,7 +15619,7 @@
 				DE5746362B4522ED0034B10D /* BlazeBudgetSettingViewModel.swift in Sources */,
 				B555530D21B57DC300449E71 /* UserNotificationsCenterAdapter.swift in Sources */,
 				45C8B2662316AB460002FA77 /* BillingAddressTableViewCell.swift in Sources */,
-				26BCA0422C35EDBF000BE96C /* OrderSyncBackgroundTask.swift in Sources */,
+				26BCA0422C35EDBF000BE96C /* OrderListSyncBackgroundTask.swift in Sources */,
 				E11228BC2707161E004E9F2D /* CardPresentModalUpdateFailed.swift in Sources */,
 				B541B2152189EEA1008FE7C1 /* Scanner+Helpers.swift in Sources */,
 				4512054F2464741B005D68DE /* ProductVisibility.swift in Sources */,
@@ -16058,6 +16061,7 @@
 				26B9875D273C6A830090E8CA /* SimplePaymentsNoteViewModel.swift in Sources */,
 				CE6302482BAB60AE00E3325C /* CustomerDetailViewModel.swift in Sources */,
 				DEF36DEA2898D3CF00178AC2 /* AuthenticatedWebViewModel.swift in Sources */,
+				26132B3C2C3DA20C004C157F /* PushNotificationBackgroundSynchronizer.swift in Sources */,
 				6885E2CC2C32B14B004C8D70 /* TotalsViewModel.swift in Sources */,
 				45A0E4CB2566B56000D4E8C3 /* NumberOfLinkedProductsTableViewCell.swift in Sources */,
 				038BC37F29C37B0E00EAF565 /* SetUpTapToPayCompleteViewController.swift in Sources */,

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -878,6 +878,7 @@
 		26100B202722FCAD00473045 /* MockCardPresentPaymentsOnboardingUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26100B1F2722FCAD00473045 /* MockCardPresentPaymentsOnboardingUseCase.swift */; };
 		2611EE59243A473300A74490 /* ProductCategoryListViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2611EE58243A473300A74490 /* ProductCategoryListViewModelTests.swift */; };
 		26132B3C2C3DA20C004C157F /* PushNotificationBackgroundSynchronizer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26132B3B2C3DA20C004C157F /* PushNotificationBackgroundSynchronizer.swift */; };
+		26132B3E2C3DA989004C157F /* PushNotificationBackgroundSynchronizerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26132B3D2C3DA989004C157F /* PushNotificationBackgroundSynchronizerTests.swift */; };
 		2614EB1C24EB611200968D4B /* TopBannerViewTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2614EB1B24EB611200968D4B /* TopBannerViewTests.swift */; };
 		2619FA2C25C897930006DAFF /* AddAttributeOptionsViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2619FA2B25C897930006DAFF /* AddAttributeOptionsViewModelTests.swift */; };
 		261AA309275178FA009530FE /* PaymentMethodsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 261AA308275178FA009530FE /* PaymentMethodsView.swift */; };
@@ -3892,6 +3893,7 @@
 		26100B1F2722FCAD00473045 /* MockCardPresentPaymentsOnboardingUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockCardPresentPaymentsOnboardingUseCase.swift; sourceTree = "<group>"; };
 		2611EE58243A473300A74490 /* ProductCategoryListViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductCategoryListViewModelTests.swift; sourceTree = "<group>"; };
 		26132B3B2C3DA20C004C157F /* PushNotificationBackgroundSynchronizer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PushNotificationBackgroundSynchronizer.swift; sourceTree = "<group>"; };
+		26132B3D2C3DA989004C157F /* PushNotificationBackgroundSynchronizerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PushNotificationBackgroundSynchronizerTests.swift; sourceTree = "<group>"; };
 		2614EB1B24EB611200968D4B /* TopBannerViewTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TopBannerViewTests.swift; sourceTree = "<group>"; };
 		2619FA2B25C897930006DAFF /* AddAttributeOptionsViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddAttributeOptionsViewModelTests.swift; sourceTree = "<group>"; };
 		261AA308275178FA009530FE /* PaymentMethodsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaymentMethodsView.swift; sourceTree = "<group>"; };
@@ -10171,6 +10173,7 @@
 			isa = PBXGroup;
 			children = (
 				B5718D6421B56B3F0026C9F0 /* PushNotificationsManagerTests.swift */,
+				26132B3D2C3DA989004C157F /* PushNotificationBackgroundSynchronizerTests.swift */,
 				026D684A2A0E0A9600D8C22C /* LocalNotificationSchedulerTests.swift */,
 				26A280D52B45F00F00ACEE87 /* OrderNotificationViewModelTests.swift */,
 			);
@@ -16244,6 +16247,7 @@
 				26FE09E124DB8FA000B9BDF5 /* SurveyCoordinatorControllerTests.swift in Sources */,
 				CE91BEA029FBE9E100B6E1AF /* QuantityRulesViewModelTests.swift in Sources */,
 				0277AEAB256CAA5300F45C4A /* MockShippingLabelAddress.swift in Sources */,
+				26132B3E2C3DA989004C157F /* PushNotificationBackgroundSynchronizerTests.swift in Sources */,
 				CEEF74322B9A2F9400B03948 /* ProductsReportCardViewModelTests.swift in Sources */,
 				D83F593D225B4B5000626E75 /* ManualTrackingViewControllerTests.swift in Sources */,
 				CC53FB402759042600C4CA4F /* ProductSelectorViewModelTests.swift in Sources */,

--- a/WooCommerce/WooCommerceTests/Notifications/PushNotificationBackgroundSynchronizerTests.swift
+++ b/WooCommerce/WooCommerceTests/Notifications/PushNotificationBackgroundSynchronizerTests.swift
@@ -1,0 +1,137 @@
+import XCTest
+import Yosemite
+import Networking
+import Storage
+@testable import WooCommerce
+
+final class PushNotificationBackgroundSynchronizerTests: XCTestCase {
+
+    var stores: MockStoresManager!
+    var storage: MockStorageManager!
+
+    @MainActor
+    override func setUp() async throws {
+        stores = MockStoresManager(sessionManager: .testingInstance)
+        storage = MockStorageManager()
+    }
+
+    @MainActor
+    func test_synchronizer_stores_order_notification_when_exists_in_order_list() async {
+        // Given
+        mockOrderInOrderListResponses()
+
+        // When
+        let synchronizer = PushNotificationBackgroundSynchronizer(userInfo: Self.sampleUserInfo, stores: stores, storage: storage.viewStorage)
+        let syncResult = await synchronizer.sync()
+
+        // Then
+        let storedOrder = storage.viewStorage.loadOrder(siteID: Self.sampleSiteID, orderID: Self.sampleOrderID)
+        XCTAssertNotNil(storedOrder)
+        XCTAssertEqual(syncResult, .newData)
+    }
+
+    @MainActor
+    func test_synchronizer_stores_order_notification_when_does_not_exists_in_order_list() async {
+        // Given
+        mockOrderNotInOrdersList()
+
+        // When
+        let synchronizer = PushNotificationBackgroundSynchronizer(userInfo: Self.sampleUserInfo, stores: stores, storage: storage.viewStorage)
+        let syncResult = await synchronizer.sync()
+
+        // Then
+        let storedOrder = storage.viewStorage.loadOrder(siteID: Self.sampleSiteID, orderID: Self.sampleOrderID)
+        XCTAssertNotNil(storedOrder)
+        XCTAssertEqual(syncResult, .newData)
+    }
+}
+
+// MARK: Helpers
+private extension PushNotificationBackgroundSynchronizerTests {
+    /// Responses when the order exists in the order list
+    ///
+    func mockOrderInOrderListResponses() {
+        // Mock sync notifications
+        stores.whenReceivingAction(ofType: NotificationAction.self) { action in
+            switch action {
+            case let .synchronizeNotifications(onCompletion):
+                self.storage.insertSampleNote(readOnlyNote: Self.sampleNote)
+                onCompletion(nil)
+            default:
+                break
+            }
+        }
+
+        // Mock fetch order filters
+        stores.whenReceivingAction(ofType: AppSettingsAction.self) { action in
+            switch action {
+            case let .loadOrdersSettings(_, onCompletion):
+                onCompletion(.success(.init(siteID: 123, orderStatusesFilter: nil, dateRangeFilter: nil, productFilter: nil, customerFilter: nil)))
+            default:
+                break
+            }
+        }
+
+        // Mock sync order list
+        stores.whenReceivingAction(ofType: OrderAction.self) { action in
+            switch action {
+            case let .fetchFilteredOrders(_, _, _, _, _, _, _, _, _, onCompletion):
+                self.storage.insertSampleOrder(readOnlyOrder: Self.sampleOrder)
+                onCompletion(0, .success([Self.sampleOrder]))
+            default:
+                break
+            }
+        }
+    }
+
+    /// Responses when the order does not exists the order list.
+    ///
+    func mockOrderNotInOrdersList() {
+        mockOrderInOrderListResponses()
+
+        // Mock sync order list & single order
+        stores.whenReceivingAction(ofType: OrderAction.self) { action in
+            switch action {
+            case let .fetchFilteredOrders(_, _, _, _, _, _, _, _, _, onCompletion):
+                onCompletion(0, .success([]))
+            case let .retrieveOrderRemotely(_, _, onCompletion):
+                self.storage.insertSampleOrder(readOnlyOrder: Self.sampleOrder)
+                onCompletion(.success(Self.sampleOrder))
+            default:
+                break
+            }
+        }
+    }
+}
+
+// MARK: Sample Objects
+private extension PushNotificationBackgroundSynchronizerTests {
+    private static let sampleSiteID: Int64 = 123
+
+    private static let sampleNoteID: Int64 = 1234
+
+    private static let sampleOrderType = "store_order"
+
+    private static let sampleOrderID: Int64 = 12345
+
+    static var sampleUserInfo: [String: Any] = [APNSKey.siteID: sampleSiteID,
+                                               APNSKey.identifier: sampleNoteID,
+                                               APNSKey.aps: [APNSKey.alert: [
+                                                APNSKey.alertTitle: ""
+                                               ]],
+                                               APNSKey.type: sampleOrderType]
+
+    static var sampleNote: Yosemite.Note = {
+        let payload: [String: AnyCodable] = [MetaContainer.Containers.ids.rawValue:
+                                                [MetaContainer.Keys.site.rawValue: sampleSiteID,
+                                                 MetaContainer.Keys.order.rawValue: sampleOrderID]]
+        let meta = MetaContainer(payload: payload)
+        return Note.fake().copy(noteID: sampleNoteID,
+                                kind: .storeOrder,
+                                type: sampleOrderType,
+                                metaAsData: (try? JSONEncoder().encode(payload)) ?? Data(),
+                                meta: meta)
+    }()
+
+    static var sampleOrder = Order.fake().copy(siteID: sampleSiteID, orderID: sampleOrderID)
+}

--- a/Yosemite/YosemiteTests/Mocks/MockStorageManager+Sample.swift
+++ b/Yosemite/YosemiteTests/Mocks/MockStorageManager+Sample.swift
@@ -238,4 +238,14 @@ extension MockStorageManager {
 
         return newInboxNote
     }
+
+    /// Inserts a new sample note into the specified context.
+    ///
+    @discardableResult
+    func insertSampleNote(readOnlyNote: Note) -> StorageNote {
+        let newNote = viewStorage.insertNewObject(ofType: StorageNote.self)
+        newNote.update(with: readOnlyNote)
+
+        return newNote
+    }
 }


### PR DESCRIPTION
Closes: #13133 

# Why

This PR makes sure to do the following when an order push notification arrives.

- Sync order list
- Sync order 

With the intention of having information as fresh as possible when the user opens the app

# How

- Create a new `PushNotificationBackgroundSynchronizer` that takes care of synchronizing the necessary dependencies for a push notification.

- Update the order loader so it navigates directly to the order detail screen if it finds an stored order. In any case, the order will be reloaded in the order details screen

- Light clean ups and renames.

# Demo

https://github.com/woocommerce/woocommerce-ios/assets/562080/760c43e9-f527-4a4b-958a-c4c51d902d31


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
