### PR TITLE
Background Tasks: Timestamp fixes

### DIFF
--- a/WooCommerce/Classes/Tools/BackgroundTasks/OrderListSyncBackgroundTask.swift
+++ b/WooCommerce/Classes/Tools/BackgroundTasks/OrderListSyncBackgroundTask.swift
@@ -8,7 +8,7 @@ struct OrderListSyncBackgroundTask {
 
     /// The last time we successfully run a sync update.
     ///
-    static private(set) var latestSyncDate: Date {
+    static var latestSyncDate: Date {
         get {
             return UserDefaults.standard[.latestBackgroundOrderSyncDate] as? Date ?? Date.distantPast
         }
@@ -41,6 +41,7 @@ struct OrderListSyncBackgroundTask {
 
                 let useCase = CurrentOrderListSyncUseCase(siteID: siteID, stores: stores)
                 try await useCase.sync()
+                Self.latestSyncDate = Date.now
 
                 DDLogInfo("📱 Successfully synchronized orders in the background")
                 backgroundTask?.setTaskCompleted(success: true)

--- a/WooCommerce/Classes/Tools/BackgroundTasks/OrderListSyncBackgroundTask.swift
+++ b/WooCommerce/Classes/Tools/BackgroundTasks/OrderListSyncBackgroundTask.swift
@@ -105,7 +105,7 @@ private struct CurrentOrderListSyncUseCase {
             let action = useCase.actionFor(pageNumber: SyncingCoordinator.Defaults.pageFirstIndex,
                                            pageSize: SyncingCoordinator.Defaults.pageSize,
                                            reason: .backgroundFetch,
-                                           lastFullSyncTimestamp: nil, // TODO: Send timestamp later, when we are saving and fetching timestamps
+                                           lastFullSyncTimestamp: OrderListSyncBackgroundTask.latestSyncDate,
                                            completionHandler: { timeInterval, error in
                 if let error {
                     continuation.resume(throwing: error)

--- a/WooCommerce/Classes/ViewRelated/Orders/OrderListViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrderListViewController.swift
@@ -90,18 +90,15 @@ final class OrderListViewController: UIViewController {
     private let syncingCoordinator = SyncingCoordinator()
 
     /// Timestamp for last successful sync.
+    /// Reads and feeds from `OrderListSyncBackgroundTask.latestSyncDate`
     ///
-    private(set) var lastFullSyncTimestamp: Date? = {
-        if ServiceLocator.featureFlagService.isFeatureFlagEnabled(.backgroundTasks), OrderListSyncBackgroundTask.latestSyncDate != Date.distantPast {
-            return OrderListSyncBackgroundTask.latestSyncDate
-        } else {
-            return nil
+    private(set) var lastFullSyncTimestamp: Date {
+        get {
+            OrderListSyncBackgroundTask.latestSyncDate
         }
-    }() {
-        didSet {
-            if let lastFullSyncTimestamp {
-                delegate?.orderListViewControllerSyncTimestampChanged(lastFullSyncTimestamp)
-            }
+        set {
+            OrderListSyncBackgroundTask.latestSyncDate = newValue
+            delegate?.orderListViewControllerSyncTimestampChanged(newValue)
         }
     }
 
@@ -300,17 +297,12 @@ private extension OrderListViewController {
         viewModel.onShouldResynchronizeIfViewIsVisible = { [weak self] in
             guard let self else { return }
 
-            /// Update the `lastFullSyncTimestamp` in case orders have been updated on a background task.
-            ///
-            if let lastFullSyncTimestamp = self.lastFullSyncTimestamp,
-               ServiceLocator.featureFlagService.isFeatureFlagEnabled(.backgroundTasks),
-               OrderListSyncBackgroundTask.latestSyncDate > lastFullSyncTimestamp {
-                self.lastFullSyncTimestamp = OrderListSyncBackgroundTask.latestSyncDate
-            }
-
             // Avoid synchronizing if the view is not visible. The refresh will be handled in
             // `viewWillAppear` instead.
             guard self.viewIfLoaded?.window != nil else { return }
+
+            // Send a delegate event in case the updated happened while the app was in the background.
+            self.delegate?.orderListViewControllerSyncTimestampChanged(lastFullSyncTimestamp)
 
             self.syncingCoordinator.resynchronize(reason: SyncReason.viewWillAppear.rawValue)
         }
@@ -354,10 +346,6 @@ private extension OrderListViewController {
     ///
     func configureSyncingCoordinator() {
         syncingCoordinator.delegate = self
-
-        if let lastFullSyncTimestamp {
-            delegate?.orderListViewControllerSyncTimestampChanged(lastFullSyncTimestamp)
-        }
     }
 
     /// Setup: TableView
@@ -458,10 +446,10 @@ extension OrderListViewController: SyncingCoordinatorDelegate {
     ///
     func sync(pageNumber: Int, pageSize: Int, reason: String? = nil, retryTimeout: Bool, onCompletion: ((Bool) -> Void)? = nil) {
         // Decide if we need to continue with the sync depending on custom conditions between sync reason and latest sync
-        if let syncReason = SyncReason(rawValue: reason ?? ""), let lastSyncTime = lastFullSyncTimestamp, pageNumber == syncingCoordinator.pageFirstIndex {
+        if let syncReason = SyncReason(rawValue: reason ?? ""), pageNumber == syncingCoordinator.pageFirstIndex {
 
             switch syncReason {
-            case .viewWillAppear where Date().timeIntervalSince(lastSyncTime) < minimalIntervalBetweenSync:
+            case .viewWillAppear where Date().timeIntervalSince(lastFullSyncTimestamp) < minimalIntervalBetweenSync:
                 onCompletion?(true) // less than 30m from last full sync
                 return
             case .viewWillAppear where ServiceLocator.featureFlagService.isFeatureFlagEnabled(.backgroundTasks):

--- a/WooCommerce/Classes/ViewRelated/Orders/OrdersRootViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrdersRootViewController.swift
@@ -127,6 +127,7 @@ final class OrdersRootViewController: UIViewController {
 
         // Clears application icon badge
         ServiceLocator.pushNotesManager.resetBadgeCount(type: .storeOrder)
+        updateTimeoutText()
     }
 
     /// Shows `SearchViewController`.
@@ -419,10 +420,7 @@ extension OrdersRootViewController: OrderListViewControllerDelegate {
     }
 
     func orderListViewControllerSyncTimestampChanged(_ syncTimestamp: Date) {
-        if ServiceLocator.featureFlagService.isFeatureFlagEnabled(.backgroundTasks) {
-            let dateFormatter = syncTimestamp.isSameDay(as: Date.now) ? DateFormatter.timeFormatter : DateFormatter.dateAndTimeFormatter
-            filtersBar.setLastUpdatedTime(dateFormatter.string(from: syncTimestamp)) // TODO: Also do it in view will appear or something
-        }
+        updateTimeoutText()
     }
 
     func orderListScrollViewDidScroll(_ scrollView: UIScrollView) {
@@ -431,6 +429,16 @@ extension OrdersRootViewController: OrderListViewControllerDelegate {
 
     func clearFilters() {
         filters = FilterOrderListViewModel.Filters()
+    }
+
+    private func updateTimeoutText() {
+        guard ServiceLocator.featureFlagService.isFeatureFlagEnabled(.backgroundTasks) else {
+            return
+        }
+
+        let syncTimestamp = OrderListSyncBackgroundTask.latestSyncDate
+        let dateFormatter = syncTimestamp.isSameDay(as: Date.now) ? DateFormatter.timeFormatter : DateFormatter.dateAndTimeFormatter
+        filtersBar.setLastUpdatedTime(dateFormatter.string(from: syncTimestamp))
     }
 }
 


### PR DESCRIPTION
Closes: #13282

# Why

This PR adds some changes to improve how the last updated timestamp is handled

# How

- Use the `OrderListSyncBackgroundTask. latestSyncDate` as the unique source of truth.
- Ensure the timestamp text is updated when coming from the background or changing views.

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
