### PR TITLE
[Woo POS] Handle ItemSelector loading and error states

### DIFF
--- a/WooCommerce/Classes/POS/Presentation/ItemListView.swift
+++ b/WooCommerce/Classes/POS/Presentation/ItemListView.swift
@@ -10,12 +10,12 @@ struct ItemListView: View {
 
     var body: some View {
         VStack {
-            Text("Products")
+            Text(Localization.productSelectorTitle)
                 .frame(maxWidth: .infinity, alignment: .leading)
                 .padding(.vertical, 8)
                 .font(Constants.titleFont)
                 .foregroundColor(Color.posPrimaryTexti3)
-            if viewModel.isSyncingItems {
+            if viewModel.state == .loading {
                 Spacer()
                 Text("Loading...")
                 Spacer()
@@ -43,9 +43,25 @@ struct ItemListView: View {
     }
 }
 
+/// View helpers
+///
+private extension ItemListView {
+    
+}
+
+/// Constants
+///
 private extension ItemListView {
     enum Constants {
         static let titleFont: Font = .system(size: 40, weight: .bold, design: .default)
+    }
+
+    enum Localization {
+        static let productSelectorTitle = NSLocalizedString(
+            "pos.itemlistview.productSelectorTitle",
+            value: "Products",
+            comment: "Title of the Point of Sale product selector"
+        )
     }
 }
 

--- a/WooCommerce/Classes/POS/Presentation/ItemListView.swift
+++ b/WooCommerce/Classes/POS/Presentation/ItemListView.swift
@@ -2,9 +2,9 @@ import SwiftUI
 import protocol Yosemite.POSItem
 
 struct ItemListView: View {
-    @ObservedObject var viewModel: ItemSelectorViewModel
+    @ObservedObject var viewModel: ItemListViewModel
 
-    init(viewModel: ItemSelectorViewModel) {
+    init(viewModel: ItemListViewModel) {
         self.viewModel = viewModel
     }
 
@@ -83,6 +83,6 @@ private extension ItemListView {
 
 #if DEBUG
 #Preview {
-    ItemListView(viewModel: ItemSelectorViewModel(itemProvider: POSItemProviderPreview()))
+    ItemListView(viewModel: ItemListViewModel(itemProvider: POSItemProviderPreview()))
 }
 #endif

--- a/WooCommerce/Classes/POS/Presentation/ItemListView.swift
+++ b/WooCommerce/Classes/POS/Presentation/ItemListView.swift
@@ -19,6 +19,10 @@ struct ItemListView: View {
                 Spacer()
                 Text("Loading...")
                 Spacer()
+            } else if viewModel.state == .error {
+                Spacer()
+                Text("Error!!")
+                Spacer()
             } else {
                 ScrollView {
                     ForEach(viewModel.items, id: \.productID) { item in

--- a/WooCommerce/Classes/POS/Presentation/ItemListView.swift
+++ b/WooCommerce/Classes/POS/Presentation/ItemListView.swift
@@ -15,15 +15,8 @@ struct ItemListView: View {
                 .padding(.vertical, 8)
                 .font(Constants.titleFont)
                 .foregroundColor(Color.posPrimaryTexti3)
-            if viewModel.state == .loading {
-                Spacer()
-                Text("Loading...")
-                Spacer()
-            } else if viewModel.state == .error {
-                Spacer()
-                Text("Error!!")
-                Spacer()
-            } else {
+            switch viewModel.state {
+            case .loaded:
                 ScrollView {
                     ForEach(viewModel.items, id: \.productID) { item in
                         Button(action: {
@@ -33,6 +26,10 @@ struct ItemListView: View {
                         })
                     }
                 }
+            case .loading:
+                loadingView
+            case .error:
+                errorView
             }
         }
         .refreshable {
@@ -43,10 +40,29 @@ struct ItemListView: View {
     }
 }
 
-/// View helpers
+/// View Helpers
 ///
 private extension ItemListView {
-    
+    var loadingView: some View {
+        VStack {
+            Spacer()
+            Text("Loading...")
+            Spacer()
+        }
+    }
+
+    var errorView: some View {
+        VStack {
+            Spacer()
+            Text("Error!!")
+            Button(action: {
+                Task {
+                    await viewModel.populatePointOfSaleItems()
+                }
+            }, label: { Text("Retry") })
+            Spacer()
+        }
+    }
 }
 
 /// Constants

--- a/WooCommerce/Classes/POS/Presentation/PointOfSaleDashboardView.swift
+++ b/WooCommerce/Classes/POS/Presentation/PointOfSaleDashboardView.swift
@@ -71,7 +71,7 @@ struct PointOfSaleDashboardView: View {
             }
         })
         .task {
-            await viewModel.itemSelectorViewModel.populatePointOfSaleItems()
+            await viewModel.itemListViewModel.populatePointOfSaleItems()
         }
     }
 }
@@ -104,7 +104,7 @@ private extension PointOfSaleDashboardView {
     }
 
     var productListView: some View {
-        ItemListView(viewModel: viewModel.itemSelectorViewModel)
+        ItemListView(viewModel: viewModel.itemListViewModel)
     }
 }
 

--- a/WooCommerce/Classes/POS/Presentation/TotalsView.swift
+++ b/WooCommerce/Classes/POS/Presentation/TotalsView.swift
@@ -49,7 +49,7 @@ struct TotalsView: View {
                             Button("Calculate amounts") {
                                 totalsViewModel.calculateAmountsTapped(
                                     with: viewModel.cartViewModel.itemsInCart,
-                                    allItems: viewModel.itemSelectorViewModel.items)
+                                    allItems: viewModel.itemListViewModel.items)
                             }
                         }
                     }

--- a/WooCommerce/Classes/POS/ViewModels/ItemListViewModel.swift
+++ b/WooCommerce/Classes/POS/ViewModels/ItemListViewModel.swift
@@ -40,6 +40,7 @@ final class ItemListViewModel: ObservableObject {
     @MainActor
     func populatePointOfSaleItems() async {
         do {
+            state = .loading
             items = try await itemProvider.providePointOfSaleItems()
             state = .loaded
         } catch {
@@ -51,8 +52,8 @@ final class ItemListViewModel: ObservableObject {
     @MainActor
     func reload() async {
         do {
+            state = .loading
             let newItems = try await itemProvider.providePointOfSaleItems()
-            throw NSError(domain: "", code: 0)
             // Only clears in-memory items if the `do` block continues, otherwise we keep them in memory.
             items.removeAll()
             items = newItems

--- a/WooCommerce/Classes/POS/ViewModels/ItemListViewModel.swift
+++ b/WooCommerce/Classes/POS/ViewModels/ItemListViewModel.swift
@@ -3,8 +3,8 @@ import SwiftUI
 import protocol Yosemite.POSItem
 import protocol Yosemite.POSItemProvider
 
-final class ItemSelectorViewModel: ObservableObject {
-    enum ItemSelectorState {
+final class ItemListViewModel: ObservableObject {
+    enum ItemListState {
         // TODO:
         // Differentiate between loading on entering POS mode and reloading, as the
         // screens will be different:
@@ -21,7 +21,7 @@ final class ItemSelectorViewModel: ObservableObject {
     }
 
     @Published private(set) var items: [POSItem] = []
-    @Published private(set) var state: ItemSelectorState = .loading
+    @Published private(set) var state: ItemListState = .loading
 
     private let itemProvider: POSItemProvider
     private let selectedItemSubject: PassthroughSubject<POSItem, Never> = .init()
@@ -52,6 +52,7 @@ final class ItemSelectorViewModel: ObservableObject {
     func reload() async {
         do {
             let newItems = try await itemProvider.providePointOfSaleItems()
+            throw NSError(domain: "", code: 0)
             // Only clears in-memory items if the `do` block continues, otherwise we keep them in memory.
             items.removeAll()
             items = newItems

--- a/WooCommerce/Classes/POS/ViewModels/ItemSelectorViewModel.swift
+++ b/WooCommerce/Classes/POS/ViewModels/ItemSelectorViewModel.swift
@@ -11,8 +11,10 @@ final class ItemSelectorViewModel: ObservableObject {
     }
 
     @Published private(set) var items: [POSItem] = []
-    @Published private(set) var isSyncingItems: Bool = true
     @Published private(set) var state: ItemSelectorState = .loading
+    var isSyncingItems: Bool {
+        state == .loading
+    }
 
     private let itemProvider: POSItemProvider
     private let selectedItemSubject: PassthroughSubject<POSItem, Never> = .init()
@@ -30,19 +32,16 @@ final class ItemSelectorViewModel: ObservableObject {
 
     @MainActor
     func populatePointOfSaleItems() async {
-        isSyncingItems = true
         do {
             items = try await itemProvider.providePointOfSaleItems()
         } catch {
             DDLogError("Error on load while fetching product data: \(error)")
         }
-        isSyncingItems = false
         state = .loaded
     }
 
     @MainActor
     func reload() async {
-        isSyncingItems = true
         do {
             let newItems = try await itemProvider.providePointOfSaleItems()
             // Only clears in-memory items if the `do` block continues, otherwise we keep them in memory.
@@ -51,7 +50,6 @@ final class ItemSelectorViewModel: ObservableObject {
         } catch {
             DDLogError("Error on reload while updating product data: \(error)")
         }
-        isSyncingItems = false
         state = .loaded
     }
 }

--- a/WooCommerce/Classes/POS/ViewModels/ItemSelectorViewModel.swift
+++ b/WooCommerce/Classes/POS/ViewModels/ItemSelectorViewModel.swift
@@ -4,13 +4,20 @@ import protocol Yosemite.POSItem
 import protocol Yosemite.POSItemProvider
 
 final class ItemSelectorViewModel: ObservableObject {
-    let selectedItemPublisher: AnyPublisher<POSItem, Never>
+    enum ItemSelectorState {
+        case loading
+        case loaded
+        case error
+    }
 
     @Published private(set) var items: [POSItem] = []
     @Published private(set) var isSyncingItems: Bool = true
+    @Published private(set) var state: ItemSelectorState = .loading
 
     private let itemProvider: POSItemProvider
     private let selectedItemSubject: PassthroughSubject<POSItem, Never> = .init()
+
+    let selectedItemPublisher: AnyPublisher<POSItem, Never>
 
     init(itemProvider: POSItemProvider) {
         self.itemProvider = itemProvider
@@ -30,6 +37,7 @@ final class ItemSelectorViewModel: ObservableObject {
             DDLogError("Error on load while fetching product data: \(error)")
         }
         isSyncingItems = false
+        state = .loaded
     }
 
     @MainActor
@@ -44,5 +52,6 @@ final class ItemSelectorViewModel: ObservableObject {
             DDLogError("Error on reload while updating product data: \(error)")
         }
         isSyncingItems = false
+        state = .loaded
     }
 }

--- a/WooCommerce/Classes/POS/ViewModels/ItemSelectorViewModel.swift
+++ b/WooCommerce/Classes/POS/ViewModels/ItemSelectorViewModel.swift
@@ -5,16 +5,23 @@ import protocol Yosemite.POSItemProvider
 
 final class ItemSelectorViewModel: ObservableObject {
     enum ItemSelectorState {
+        // TODO:
+        // Differentiate between loading on entering POS mode and reloading, as the
+        // screens will be different:
+        // https://github.com/woocommerce/woocommerce-ios/issues/13286
         case loading
+        // TODO:
+        // Differentiate between loaded with products vs with no products vs with no eligible products
+        // https://github.com/woocommerce/woocommerce-ios/issues/12815
+        // https://github.com/woocommerce/woocommerce-ios/issues/12816
         case loaded
+        // TODO:
+        // https://github.com/woocommerce/woocommerce-ios/issues/12846
         case error
     }
 
     @Published private(set) var items: [POSItem] = []
     @Published private(set) var state: ItemSelectorState = .loading
-    var isSyncingItems: Bool {
-        state == .loading
-    }
 
     private let itemProvider: POSItemProvider
     private let selectedItemSubject: PassthroughSubject<POSItem, Never> = .init()

--- a/WooCommerce/Classes/POS/ViewModels/ItemSelectorViewModel.swift
+++ b/WooCommerce/Classes/POS/ViewModels/ItemSelectorViewModel.swift
@@ -34,10 +34,11 @@ final class ItemSelectorViewModel: ObservableObject {
     func populatePointOfSaleItems() async {
         do {
             items = try await itemProvider.providePointOfSaleItems()
+            state = .loaded
         } catch {
             DDLogError("Error on load while fetching product data: \(error)")
+            state = .error
         }
-        state = .loaded
     }
 
     @MainActor
@@ -47,9 +48,10 @@ final class ItemSelectorViewModel: ObservableObject {
             // Only clears in-memory items if the `do` block continues, otherwise we keep them in memory.
             items.removeAll()
             items = newItems
+            state = .loaded
         } catch {
             DDLogError("Error on reload while updating product data: \(error)")
+            state = .error
         }
-        state = .loaded
     }
 }

--- a/WooCommerce/Classes/POS/ViewModels/PointOfSaleDashboardViewModel.swift
+++ b/WooCommerce/Classes/POS/ViewModels/PointOfSaleDashboardViewModel.swift
@@ -11,7 +11,7 @@ import struct Yosemite.POSCartItem
 import struct Yosemite.Order
 
 final class PointOfSaleDashboardViewModel: ObservableObject {
-    let itemSelectorViewModel: ItemSelectorViewModel
+    let itemListViewModel: ItemListViewModel
     private(set) lazy var cartViewModel: CartViewModel = CartViewModel(orderStage: $orderStage.eraseToAnyPublisher())
     let totalsViewModel: TotalsViewModel
 
@@ -39,7 +39,7 @@ final class PointOfSaleDashboardViewModel: ObservableObject {
          currencyFormatter: CurrencyFormatter) {
         self.cardReaderConnectionViewModel = CardReaderConnectionViewModel(cardPresentPayment: cardPresentPaymentService)
 
-        self.itemSelectorViewModel = .init(itemProvider: itemProvider)
+        self.itemListViewModel = .init(itemProvider: itemProvider)
         self.totalsViewModel = TotalsViewModel(orderService: orderService,
                                                cardPresentPaymentService: cardPresentPaymentService,
                                                currencyFormatter: currencyFormatter)
@@ -62,7 +62,7 @@ final class PointOfSaleDashboardViewModel: ObservableObject {
 
 private extension PointOfSaleDashboardViewModel {
     func observeSelectedItemToAddToCart() {
-        itemSelectorViewModel.selectedItemPublisher.sink { [weak self] selectedItem in
+        itemListViewModel.selectedItemPublisher.sink { [weak self] selectedItem in
             self?.cartViewModel.addItemToCart(selectedItem)
         }
         .store(in: &cancellables)
@@ -104,7 +104,7 @@ private extension PointOfSaleDashboardViewModel {
 private extension PointOfSaleDashboardViewModel {
     func startSyncingOrder(cartItems: [CartItem]) {
         totalsViewModel.startSyncingOrder(with: cartItems,
-                                          allItems: itemSelectorViewModel.items)
+                                          allItems: itemListViewModel.items)
     }
 }
 

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -1476,8 +1476,8 @@
 		6832C7CA26DA5C4500BA4088 /* LabeledTextViewTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6832C7C926DA5C4500BA4088 /* LabeledTextViewTableViewCell.swift */; };
 		6832C7CC26DA5FDF00BA4088 /* LabeledTextViewTableViewCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = 6832C7CB26DA5FDE00BA4088 /* LabeledTextViewTableViewCell.xib */; };
 		683421642ACE9391009021D7 /* ProductDiscountView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 683421632ACE9391009021D7 /* ProductDiscountView.swift */; };
-		683763162C2E44B800AD51D0 /* ItemSelectorViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 683763152C2E44B800AD51D0 /* ItemSelectorViewModel.swift */; };
-		683763182C2E497000AD51D0 /* ItemSelectorViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 683763172C2E497000AD51D0 /* ItemSelectorViewModelTests.swift */; };
+		683763162C2E44B800AD51D0 /* ItemListViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 683763152C2E44B800AD51D0 /* ItemListViewModel.swift */; };
+		683763182C2E497000AD51D0 /* ItemListViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 683763172C2E497000AD51D0 /* ItemListViewModelTests.swift */; };
 		6837631A2C2E6F5900AD51D0 /* CartViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 683763192C2E6F5900AD51D0 /* CartViewModelTests.swift */; };
 		6837631C2C2E847D00AD51D0 /* CartViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6837631B2C2E847D00AD51D0 /* CartViewModel.swift */; };
 		683AA9D62A303CB70099F7BA /* UpgradesViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 683AA9D52A303CB70099F7BA /* UpgradesViewModelTests.swift */; };
@@ -4432,8 +4432,8 @@
 		6832C7C926DA5C4500BA4088 /* LabeledTextViewTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LabeledTextViewTableViewCell.swift; sourceTree = "<group>"; };
 		6832C7CB26DA5FDE00BA4088 /* LabeledTextViewTableViewCell.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = LabeledTextViewTableViewCell.xib; sourceTree = "<group>"; };
 		683421632ACE9391009021D7 /* ProductDiscountView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductDiscountView.swift; sourceTree = "<group>"; };
-		683763152C2E44B800AD51D0 /* ItemSelectorViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ItemSelectorViewModel.swift; sourceTree = "<group>"; };
-		683763172C2E497000AD51D0 /* ItemSelectorViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ItemSelectorViewModelTests.swift; sourceTree = "<group>"; };
+		683763152C2E44B800AD51D0 /* ItemListViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ItemListViewModel.swift; sourceTree = "<group>"; };
+		683763172C2E497000AD51D0 /* ItemListViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ItemListViewModelTests.swift; sourceTree = "<group>"; };
 		683763192C2E6F5900AD51D0 /* CartViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CartViewModelTests.swift; sourceTree = "<group>"; };
 		6837631B2C2E847D00AD51D0 /* CartViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CartViewModel.swift; sourceTree = "<group>"; };
 		683AA9D52A303CB70099F7BA /* UpgradesViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UpgradesViewModelTests.swift; sourceTree = "<group>"; };
@@ -6689,7 +6689,7 @@
 			isa = PBXGroup;
 			children = (
 				026826922BF59D830036F959 /* PointOfSaleDashboardViewModel.swift */,
-				683763152C2E44B800AD51D0 /* ItemSelectorViewModel.swift */,
+				683763152C2E44B800AD51D0 /* ItemListViewModel.swift */,
 				6837631B2C2E847D00AD51D0 /* CartViewModel.swift */,
 				6885E2CB2C32B14B004C8D70 /* TotalsViewModel.swift */,
 			);
@@ -12243,7 +12243,7 @@
 			isa = PBXGroup;
 			children = (
 				DABF35262C11B426006AF826 /* PointOfSaleDashboardViewModelTests.swift */,
-				683763172C2E497000AD51D0 /* ItemSelectorViewModelTests.swift */,
+				683763172C2E497000AD51D0 /* ItemListViewModelTests.swift */,
 				683763192C2E6F5900AD51D0 /* CartViewModelTests.swift */,
 				6885E2CD2C32B2E2004C8D70 /* TotalsViewModelTests.swift */,
 			);
@@ -14883,7 +14883,7 @@
 				6837631C2C2E847D00AD51D0 /* CartViewModel.swift in Sources */,
 				45CDAFAE2434CFCA00F83C22 /* ProductCatalogVisibilityViewController.swift in Sources */,
 				D85B8333222FABD1002168F3 /* StatusListTableViewCell.swift in Sources */,
-				683763162C2E44B800AD51D0 /* ItemSelectorViewModel.swift in Sources */,
+				683763162C2E44B800AD51D0 /* ItemListViewModel.swift in Sources */,
 				DE2E8EB729547771002E4B14 /* ApplicationPasswordDisabledViewModel.swift in Sources */,
 				0259D65D2582248D003B1CD6 /* PrintShippingLabelViewController.swift in Sources */,
 				D881A31B256B5CC500FE5605 /* ULErrorViewController.swift in Sources */,
@@ -16467,7 +16467,7 @@
 				FE3E427726A8545B00C596CE /* MockRoleEligibilityUseCase.swift in Sources */,
 				02F67FF525806E0100C3BAD2 /* ShippingLabelTrackingURLGeneratorTests.swift in Sources */,
 				CE29FEF62C009F5F007679C2 /* ShippingLineRowViewModelTests.swift in Sources */,
-				683763182C2E497000AD51D0 /* ItemSelectorViewModelTests.swift in Sources */,
+				683763182C2E497000AD51D0 /* ItemListViewModelTests.swift in Sources */,
 				20CCBF212B0E15C0003102E6 /* WooPaymentsDepositsCurrencyOverviewViewModelTests.swift in Sources */,
 				2602A64227BD89CE00B347F1 /* NewOrderInitialStatusResolverTests.swift in Sources */,
 				DE6D84A52C3B8C9C0014FBFF /* GoogleAdsDashboardCardViewModelTests.swift in Sources */,

--- a/WooCommerce/WooCommerceTests/POS/ViewModels/ItemListViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/POS/ViewModels/ItemListViewModelTests.swift
@@ -5,103 +5,103 @@ import Combine
 @testable import protocol Yosemite.POSItem
 @testable import struct Yosemite.POSProduct
 
-final class ItemSelectorViewModelTests: XCTestCase {
+final class ItemListViewModelTests: XCTestCase {
     private var itemProvider: POSItemProvider!
-    private var itemSelector: ItemSelectorViewModel!
+    private var sut: ItemListViewModel!
 
     private var cancellables: Set<AnyCancellable> = []
 
     override func setUp() {
         super.setUp()
         itemProvider = MockPOSItemProvider()
-        itemSelector = ItemSelectorViewModel(itemProvider: itemProvider)
+        sut = ItemListViewModel(itemProvider: itemProvider)
     }
 
     override func tearDown() {
         itemProvider = nil
-        itemSelector = nil
+        sut = nil
         super.tearDown()
     }
 
-    func test_itemSelector_when_select_item_then_sends_item_to_publisher() {
+    func test_itemListViewModel_when_select_item_then_sends_item_to_publisher() {
         // Given
         let item = Self.makeItem()
         let expectation = XCTestExpectation(description: "Publisher should emit the selected item")
 
         var receivedItem: POSItem?
-        itemSelector.selectedItemPublisher.sink { item in
+        sut.selectedItemPublisher.sink { item in
             receivedItem = item
             expectation.fulfill()
         }
         .store(in: &cancellables)
 
         // When
-        itemSelector.select(item)
+        sut.select(item)
 
         // Then
         XCTAssertEqual(receivedItem?.productID, item.productID)
     }
 
-    func test_itemSelector_when_initilized_then_state_is_loading() {
+    func test_itemListViewModel_when_initilized_then_state_is_loading() {
         // Given/When/Then
-        XCTAssertEqual(itemSelector.state, .loading)
+        XCTAssertEqual(sut.state, .loading)
     }
 
-    func test_itemSelector_when_populatePointOfSaleItems_then_state_is_loaded() async {
+    func test_itemListViewModel_when_populatePointOfSaleItems_then_state_is_loaded() async {
         // Given
-        XCTAssertEqual(itemSelector.state, .loading)
+        XCTAssertEqual(sut.state, .loading)
 
         // When
-        await itemSelector.populatePointOfSaleItems()
+        await sut.populatePointOfSaleItems()
 
         // Then
-        XCTAssertEqual(itemSelector.state, .loaded)
+        XCTAssertEqual(sut.state, .loaded)
     }
 
-    func test_itemSelector_when_populatePointOfSaleItems_throws_error_then_state_is_error() async {
-        // Given
-        let itemProvider = MockPOSItemProvider()
-        itemProvider.shouldThrowError = true
-        let itemSelector = ItemSelectorViewModel(itemProvider: itemProvider)
-
-        XCTAssertEqual(itemSelector.state, .loading)
-
-        // When
-        await itemSelector.populatePointOfSaleItems()
-
-        // Then
-        XCTAssertEqual(itemSelector.state, .error)
-    }
-
-    func test_itemSelector_when_reload_then_state_is_loaded() async {
-        // Given
-        XCTAssertEqual(itemSelector.state, .loading)
-
-        // When
-        await itemSelector.reload()
-
-        // Then
-        XCTAssertEqual(itemSelector.state, .loaded)
-    }
-
-    func test_itemSelector_when_reload_throws_error_then_state_is_error() async {
+    func test_itemListViewModel_when_populatePointOfSaleItems_throws_error_then_state_is_error() async {
         // Given
         let itemProvider = MockPOSItemProvider()
         itemProvider.shouldThrowError = true
-        let itemSelector = ItemSelectorViewModel(itemProvider: itemProvider)
+        let sut = ItemListViewModel(itemProvider: itemProvider)
 
-        XCTAssertEqual(itemSelector.state, .loading)
+        XCTAssertEqual(sut.state, .loading)
 
         // When
-        await itemSelector.reload()
+        await sut.populatePointOfSaleItems()
 
         // Then
-        XCTAssertEqual(itemSelector.state, .error)
+        XCTAssertEqual(sut.state, .error)
+    }
+
+    func test_itemListViewModel_when_reload_then_state_is_loaded() async {
+        // Given
+        XCTAssertEqual(sut.state, .loading)
+
+        // When
+        await sut.reload()
+
+        // Then
+        XCTAssertEqual(sut.state, .loaded)
+    }
+
+    func test_itemListViewModel_when_reload_throws_error_then_state_is_error() async {
+        // Given
+        let itemProvider = MockPOSItemProvider()
+        itemProvider.shouldThrowError = true
+        let sut = ItemListViewModel(itemProvider: itemProvider)
+
+        XCTAssertEqual(sut.state, .loading)
+
+        // When
+        await sut.reload()
+
+        // Then
+        XCTAssertEqual(sut.state, .error)
     }
 
 }
 
-private extension ItemSelectorViewModelTests {
+private extension ItemListViewModelTests {
     final class MockPOSItemProvider: POSItemProvider {
         var items: [POSItem] = []
         var shouldThrowError = false

--- a/WooCommerce/WooCommerceTests/POS/ViewModels/ItemSelectorViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/POS/ViewModels/ItemSelectorViewModelTests.swift
@@ -23,26 +23,6 @@ final class ItemSelectorViewModelTests: XCTestCase {
         super.tearDown()
     }
 
-    func test_isSyncingItems_is_true_when_populatePointOfSaleItems_is_invoked_then_switches_to_false_when_completed() async {
-        XCTAssertEqual(itemSelector.isSyncingItems, true, "Precondition")
-
-        // Given/When
-        await itemSelector.populatePointOfSaleItems()
-
-        // Then
-        XCTAssertEqual(itemSelector.isSyncingItems, false)
-    }
-
-    func test_isSyncingItems_is_true_when_reload_is_invoked_then_switches_to_false_when_completed() async {
-        XCTAssertEqual(itemSelector.isSyncingItems, true, "Precondition")
-
-        // Given/When
-        await itemSelector.reload()
-
-        // Then
-        XCTAssertEqual(itemSelector.isSyncingItems, false)
-    }
-
     func test_itemSelector_when_select_item_then_sends_item_to_publisher() {
         // Given
         let item = Self.makeItem()

--- a/WooCommerce/WooCommerceTests/POS/ViewModels/ItemSelectorViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/POS/ViewModels/ItemSelectorViewModelTests.swift
@@ -62,6 +62,33 @@ final class ItemSelectorViewModelTests: XCTestCase {
         XCTAssertEqual(receivedItem?.productID, item.productID)
     }
 
+    func test_itemSelector_when_initilized_then_state_is_loading() {
+        // Given/When/Then
+        XCTAssertEqual(itemSelector.state, .loading)
+    }
+
+    func test_itemSelector_when_populatePointOfSaleItems_then_state_is_loaded() async {
+        // Given
+        XCTAssertEqual(itemSelector.state, .loading)
+
+        // When
+        await itemSelector.populatePointOfSaleItems()
+
+        // Then
+        XCTAssertEqual(itemSelector.state, .loaded)
+    }
+
+    func test_itemSelector_when_reload_then_state_is_loaded() async {
+        // Given
+        XCTAssertEqual(itemSelector.state, .loading)
+        
+        // When
+        await itemSelector.reload()
+
+        // Then
+        XCTAssertEqual(itemSelector.state, .loaded)
+    }
+
 }
 
 private extension ItemSelectorViewModelTests {

--- a/WooCommerce/WooCommerceTests/POS/ViewModels/ItemSelectorViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/POS/ViewModels/ItemSelectorViewModelTests.swift
@@ -78,10 +78,25 @@ final class ItemSelectorViewModelTests: XCTestCase {
         XCTAssertEqual(itemSelector.state, .loaded)
     }
 
+    func test_itemSelector_when_populatePointOfSaleItems_throws_error_then_state_is_error() async {
+        // Given
+        let itemProvider = MockPOSItemProvider()
+        itemProvider.shouldThrowError = true
+        let itemSelector = ItemSelectorViewModel(itemProvider: itemProvider)
+
+        XCTAssertEqual(itemSelector.state, .loading)
+
+        // When
+        await itemSelector.populatePointOfSaleItems()
+
+        // Then
+        XCTAssertEqual(itemSelector.state, .error)
+    }
+
     func test_itemSelector_when_reload_then_state_is_loaded() async {
         // Given
         XCTAssertEqual(itemSelector.state, .loading)
-        
+
         // When
         await itemSelector.reload()
 
@@ -89,13 +104,32 @@ final class ItemSelectorViewModelTests: XCTestCase {
         XCTAssertEqual(itemSelector.state, .loaded)
     }
 
+    func test_itemSelector_when_reload_throws_error_then_state_is_error() async {
+        // Given
+        let itemProvider = MockPOSItemProvider()
+        itemProvider.shouldThrowError = true
+        let itemSelector = ItemSelectorViewModel(itemProvider: itemProvider)
+
+        XCTAssertEqual(itemSelector.state, .loading)
+
+        // When
+        await itemSelector.reload()
+
+        // Then
+        XCTAssertEqual(itemSelector.state, .error)
+    }
+
 }
 
 private extension ItemSelectorViewModelTests {
     final class MockPOSItemProvider: POSItemProvider {
         var items: [POSItem] = []
+        var shouldThrowError = false
 
         func providePointOfSaleItems() async throws -> [Yosemite.POSItem] {
+            if shouldThrowError {
+                throw NSError(domain: "Some error", code: 0)
+            }
             let item = makeItem()
             return [item]
         }

--- a/WooCommerce/WooCommerceTests/POS/ViewModels/PointOfSaleDashboardViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/POS/ViewModels/PointOfSaleDashboardViewModelTests.swift
@@ -73,7 +73,7 @@ final class PointOfSaleDashboardViewModelTests: XCTestCase {
         let expectedCartCollapsedState = false
 
         // When
-        sut.itemSelectorViewModel.select(item)
+        sut.itemListViewModel.select(item)
 
         // Then
         XCTAssertEqual(sut.cartViewModel.itemsInCart.isEmpty, expectedCartEmpty)


### PR DESCRIPTION
Closes: #13276

## Description
Heading to M2, this PR adds an internal `ItemSelectorState` to the item selector, so the view can handle loading/loaded/error screens easily based on mutually exclusive cases, rather than relying on multiple boolean flags.

In future PRs we'll handle the cases more in detail (for example, loaded with products, without products, or without eligible products), as well as the different types of errors and their CTAs. All of this is outside of the scope of this PR.

## Changes
* Removes `isSyncingItems` flag in favour of `ItemSelectorState` state
* Loads different views based on state, and moves view states to computed variables
* Adds unit tests for state changes

| Loading | Loaded | Error |
|--------|--------|--------|
| ![simulator_screenshot_28B15C8C-1A0C-46EC-BFC0-A175491876A9](https://github.com/woocommerce/woocommerce-ios/assets/3812076/0a84e9bb-6faa-47a3-955c-e1d7ac28d8f1) | ![simulator_screenshot_D8A7D690-3056-4DEC-AC76-73D376724A8B](https://github.com/woocommerce/woocommerce-ios/assets/3812076/31834847-e37d-448d-a5be-6e61960b3be7) | ![simulator_screenshot_F0E904C5-8B72-446E-9792-1315A11E2178](https://github.com/woocommerce/woocommerce-ios/assets/3812076/02ee992d-b67e-4a29-9949-5a89497a5d98) | 

## Testing 
- Update the `ItemSelectorViewModel.reload()` method to throw an error:
```diff 
    func reload() async {
        do {
            let newItems = try await itemProvider.providePointOfSaleItems()
+            throw NSError(domain: "", code: 0)
            // Only clears in-memory items if the `do` block continues, otherwise we keep them in memory.
            items.removeAll()
            items = newItems
            state = .loaded
        } catch {
            DDLogError("Error on reload while updating product data: \(error)")
            state = .error
        }
    }
```
* Run the app, in POS mode:
  * Observe the `Loading...` screen upon opening POS
  * Observe the product list is loaded
  * Pull-to-refresh. Observe the `Error!!` screen being presented. There's a quick "retry" button just for debugging, feel free to tap there and observe the product list is re-loaded after a second or two.
