### PR TITLE
Google Ads: Reload dashboard card and hub menu after campaign creation success

### DIFF
--- a/WooCommerce/Classes/GoogleAds/GoogleAdsCampaignCoordinator.swift
+++ b/WooCommerce/Classes/GoogleAds/GoogleAdsCampaignCoordinator.swift
@@ -17,7 +17,7 @@ final class GoogleAdsCampaignCoordinator: NSObject, Coordinator {
 
     private let analytics: Analytics
 
-    private let onCompletion: () -> Void
+    private let onCompletion: (_ createdNewCampaign: Bool) -> Void
 
     private var hasTrackedStartEvent = false
 
@@ -28,7 +28,7 @@ final class GoogleAdsCampaignCoordinator: NSObject, Coordinator {
          shouldAuthenticateAdminPage: Bool,
          navigationController: UINavigationController,
          analytics: Analytics = ServiceLocator.analytics,
-         onCompletion: @escaping () -> Void) {
+         onCompletion: @escaping (Bool) -> Void) {
         self.siteID = siteID
         self.siteAdminURL = siteAdminURL
         self.source = source
@@ -55,7 +55,7 @@ final class GoogleAdsCampaignCoordinator: NSObject, Coordinator {
 extension GoogleAdsCampaignCoordinator: UIAdaptivePresentationControllerDelegate {
     // Triggered when swiping to dismiss the view.
     func presentationControllerDidDismiss(_ presentationController: UIPresentationController) {
-        onCompletion()
+        onCompletion(false)
         analytics.track(event: .GoogleAds.flowCanceled(source: source))
     }
 }
@@ -64,7 +64,7 @@ extension GoogleAdsCampaignCoordinator: UIAdaptivePresentationControllerDelegate
 //
 private extension GoogleAdsCampaignCoordinator {
     @objc func dismissCampaignView() {
-        onCompletion()
+        onCompletion(false)
         navigationController.dismiss(animated: true)
         analytics.track(event: .GoogleAds.flowCanceled(source: source))
     }
@@ -123,7 +123,7 @@ private extension GoogleAdsCampaignCoordinator {
             navigationController.dismiss(animated: true) { [self] in
                 showSuccessView()
             }
-            onCompletion()
+            onCompletion(true)
             DDLogDebug("🎉 Google Ads campaign creation success")
         }
     }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/DashboardCustomization/DashboardCard+UI.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/DashboardCustomization/DashboardCard+UI.swift
@@ -76,8 +76,8 @@ private extension DashboardCard.CardType {
             comment: "Name for the Most active coupons dashboard card in the Customize Dashboard screen"
         )
         static let googleAds = NSLocalizedString(
-            "dashboardCard.name.googleAds",
-            value: "Google ads campaigns",
+            "dashboardCard.name.googleAdsCampaigns",
+            value: "Google Ads campaigns",
             comment: "Name for the Google Ads campaigns dashboard card in the Customize Dashboard screen"
         )
     }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/DashboardViewHostingController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/DashboardViewHostingController.swift
@@ -329,7 +329,11 @@ private extension DashboardViewHostingController {
             shouldStartCampaignCreation: forCampaignCreation,
             shouldAuthenticateAdminPage: viewModel.stores.shouldAuthenticateAdminPage(for: site),
             navigationController: navigationController,
-            onCompletion: {}
+            onCompletion: { [weak self] createdNewCampaign in
+                if createdNewCampaign {
+                    self?.viewModel.googleAdsDashboardCardViewModel.reloadCard()
+                }
+            }
         )
         coordinator.start()
         googleAdsCampaignCoordinator = coordinator

--- a/WooCommerce/Classes/ViewRelated/Dashboard/DashboardViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/DashboardViewModel.swift
@@ -421,7 +421,7 @@ private extension DashboardViewModel {
                     }
                 case .googleAds:
                     group.addTask { [weak self] in
-                        await self?.googleAdsDashboardCardViewModel.fetchLastCampaign()
+                        await self?.googleAdsDashboardCardViewModel.reloadCard()
                     }
                 }
             }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/GoogleAds/GoogleAdsDashboardCard.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/GoogleAds/GoogleAdsDashboardCard.swift
@@ -29,7 +29,7 @@ struct GoogleAdsDashboardCard: View {
                 DashboardCardErrorView {
                     ServiceLocator.analytics.track(event: .DynamicDashboard.cardRetryTapped(type: .googleAds))
                     Task {
-                        await viewModel.fetchLastCampaign()
+                        await viewModel.reloadCard()
                     }
                 }
             } else if let campaign = viewModel.lastCampaign {

--- a/WooCommerce/Classes/ViewRelated/Dashboard/GoogleAds/GoogleAdsDashboardCardViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/GoogleAds/GoogleAdsDashboardCardViewModel.swift
@@ -57,7 +57,7 @@ final class GoogleAdsDashboardCardViewModel: ObservableObject {
     }
 
     @MainActor
-    func fetchLastCampaign() async {
+    func reloadCard() async {
         syncingError = nil
         syncingData = true
         analytics.track(event: .DynamicDashboard.cardLoadingStarted(type: .googleAds))
@@ -92,7 +92,7 @@ final class GoogleAdsDashboardCardViewModel: ObservableObject {
 
     func reloadCard() {
         Task {
-            await fetchLastCampaign()
+            await reloadCard()
         }
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/GoogleAds/GoogleAdsDashboardCardViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/GoogleAds/GoogleAdsDashboardCardViewModel.swift
@@ -89,6 +89,12 @@ final class GoogleAdsDashboardCardViewModel: ObservableObject {
     func onViewAppear() {
         viewAppeared = true
     }
+
+    func reloadCard() {
+        Task {
+            await fetchLastCampaign()
+        }
+    }
 }
 
 private extension GoogleAdsDashboardCardViewModel {

--- a/WooCommerce/Classes/ViewRelated/Hub Menu/HubMenuViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Hub Menu/HubMenuViewController.swift
@@ -99,7 +99,10 @@ private extension HubMenuViewController {
             shouldStartCampaignCreation: viewModel.hasGoogleAdsCampaigns,
             shouldAuthenticateAdminPage: viewModel.shouldAuthenticateAdminPage,
             navigationController: navigationController,
-            onCompletion: { [weak self] in
+            onCompletion: { [weak self] createdNewCampaign in
+                guard createdNewCampaign else {
+                    return
+                }
                 Task { @MainActor in
                     await self?.viewModel.refreshGoogleAdsCampaignCheck()
                 }

--- a/WooCommerce/Classes/ViewRelated/Hub Menu/HubMenuViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Hub Menu/HubMenuViewController.swift
@@ -103,9 +103,7 @@ private extension HubMenuViewController {
                 guard createdNewCampaign else {
                     return
                 }
-                Task { @MainActor in
-                    await self?.viewModel.refreshGoogleAdsCampaignCheck()
-                }
+                self?.viewModel.refreshGoogleAdsCampaignCheck()
             }
         )
         googleAdsCampaignCoordinator?.start()

--- a/WooCommerce/Classes/ViewRelated/Hub Menu/HubMenuViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Hub Menu/HubMenuViewModel.swift
@@ -156,6 +156,9 @@ final class HubMenuViewModel: ObservableObject {
     func viewDidAppear() {
         NotificationCenter.default.post(name: .hubMenuViewDidAppear, object: nil)
         viewAppeared = true
+        if !hasGoogleAdsCampaigns {
+            refreshGoogleAdsCampaignCheck()
+        }
     }
 
     /// Resets the menu elements displayed on the menu.
@@ -177,9 +180,10 @@ final class HubMenuViewModel: ObservableObject {
         showingReviewDetail = true
     }
 
-    @MainActor
-    func refreshGoogleAdsCampaignCheck() async {
-        hasGoogleAdsCampaigns = await checkIfSiteHasGoogleAdsCampaigns()
+    func refreshGoogleAdsCampaignCheck() {
+        Task { @MainActor in
+            hasGoogleAdsCampaigns = await checkIfSiteHasGoogleAdsCampaigns()
+        }
     }
 
     deinit {

--- a/WooCommerce/WooCommerceTests/GoogleAds/GoogleAdsCampaignCoordinatorTests.swift
+++ b/WooCommerce/WooCommerceTests/GoogleAds/GoogleAdsCampaignCoordinatorTests.swift
@@ -29,7 +29,7 @@ final class GoogleAdsCampaignCoordinatorTests: XCTestCase {
             shouldStartCampaignCreation: true,
             shouldAuthenticateAdminPage: false,
             navigationController: navigationController,
-            onCompletion: {}
+            onCompletion: { _ in }
         )
 
         // When
@@ -49,7 +49,7 @@ final class GoogleAdsCampaignCoordinatorTests: XCTestCase {
             shouldStartCampaignCreation: true,
             shouldAuthenticateAdminPage: true,
             navigationController: navigationController,
-            onCompletion: {}
+            onCompletion: { _ in }
         )
 
         // When

--- a/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/GoogleAds/GoogleAdsDashboardCardViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/GoogleAds/GoogleAdsDashboardCardViewModelTests.swift
@@ -53,7 +53,7 @@ final class GoogleAdsDashboardCardViewModelTests: XCTestCase {
         // When
         let error = NSError(domain: "Test", code: 500)
         mockRequest(lastCampaignResult: .failure(error))
-        await viewModel.fetchLastCampaign()
+        await viewModel.reloadCard()
 
         // Then
         XCTAssertEqual(viewModel.syncingError as? NSError, error)
@@ -70,7 +70,7 @@ final class GoogleAdsDashboardCardViewModelTests: XCTestCase {
         // When
         let lastCampaign = GoogleAdsCampaign.fake().copy(id: 14325)
         mockRequest(lastCampaignResult: .success([lastCampaign]))
-        await viewModel.fetchLastCampaign()
+        await viewModel.reloadCard()
 
         // Then
         XCTAssertEqual(viewModel.lastCampaign, lastCampaign)
@@ -86,7 +86,7 @@ final class GoogleAdsDashboardCardViewModelTests: XCTestCase {
         // When
         let error = NSError(domain: "Test", code: 500)
         mockRequest(lastCampaignResult: .failure(error))
-        await viewModel.fetchLastCampaign()
+        await viewModel.reloadCard()
 
         // Then
         XCTAssertFalse(viewModel.shouldShowCreateCampaignButton)
@@ -94,7 +94,7 @@ final class GoogleAdsDashboardCardViewModelTests: XCTestCase {
         // When
         let lastCampaign = GoogleAdsCampaign.fake().copy(id: 14325)
         mockRequest(lastCampaignResult: .success([lastCampaign]))
-        await viewModel.fetchLastCampaign()
+        await viewModel.reloadCard()
 
         // Then
         XCTAssertTrue(viewModel.shouldShowCreateCampaignButton)
@@ -118,7 +118,7 @@ final class GoogleAdsDashboardCardViewModelTests: XCTestCase {
                 break
             }
         }
-        await viewModel.fetchLastCampaign()
+        await viewModel.reloadCard()
 
         // Then
         XCTAssertFalse(viewModel.syncingData)
@@ -140,7 +140,7 @@ final class GoogleAdsDashboardCardViewModelTests: XCTestCase {
         )
         mockRequest(lastCampaignResult: .success([.fake().copy(id: 12423)]),
                     lastCampaignStatsResult: .success(statsResult))
-        await viewModel.fetchLastCampaign()
+        await viewModel.reloadCard()
 
         // Then
         XCTAssertEqual(viewModel.lastCampaignStats, totals)
@@ -162,7 +162,7 @@ final class GoogleAdsDashboardCardViewModelTests: XCTestCase {
         )
         mockRequest(lastCampaignResult: .success([campaign]),
                     lastCampaignStatsResult: .success(statsResult))
-        await viewModel.fetchLastCampaign()
+        await viewModel.reloadCard()
 
         // Then
         XCTAssertEqual(viewModel.lastCampaignStats, subtotals)


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #13288 
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This PR adds some updates to reload dashboard card and hub menu after campaign creation success. Changes include:
- Updated the coordinator's completion callback with a parameter for whether a campaign has been created.
- Triggered reloading dashboard card and checking campaigns on the hub menu upon campaign creation success.
- Triggered checking campaigns on the hub menu when the view re-appears in case the entry point needs to be updated.
- Also, updated the correct branding for Google Ads with capitalized words.

## Test step
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->
- Pre-requisite: Install, activate, and set up the Google Ads plugin to a test site following pe5sF9-2Qo-p2. Ensure that you're using the plugin version 2.7.5 or above. Remove any existing campaigns on your store.
- Build the app and log in to your store.
- Enable Google Ads card on the dashboard if you haven't already.
- On the dashboard card, tap Create campaign and proceed with the flow.
- After the campaign creation success, confirm that the card is reloaded with the latest campaign details.
- Switch to the Menu tab and tap on the Google Ads entry point.
- Confirm that the dashboard screen is now displayed.


## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

Before campaign creation | After campaign creation
--- | ---
<img src="https://github.com/woocommerce/woocommerce-ios/assets/5533851/c05f5f02-0cbf-4944-a4f1-3ce20cb499aa" width=320 /> | <img src="https://github.com/woocommerce/woocommerce-ios/assets/5533851/b9066af7-9536-44c5-81a7-2953da49652d" width=320 />



---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.