### PR TITLE
Product Creation with AI: Fix media picker popover layout on iPad

### DIFF
--- a/WooCommerce/Classes/View Modifiers/View+MediaSourceActionSheet.swift
+++ b/WooCommerce/Classes/View Modifiers/View+MediaSourceActionSheet.swift
@@ -13,23 +13,21 @@ struct MediaSourceActionSheet: ViewModifier {
 
     func body(content: Content) -> some View {
         content
-            .actionSheet(isPresented: showsActionSheet) {
-                ActionSheet(title: Text(Localization.title),
-                            message: nil,
-                            buttons: [
-                                (UIImagePickerController.isSourceTypeAvailable(.camera) ?
-                                    .default(Text(Localization.camera)) {
-                                        selectMedia(.camera)
-                                    } : nil),
-                                .default(Text(Localization.photoLibrary)) {
-                                    selectMedia(.photoLibrary)
-                                },
-                                .default(Text(Localization.siteMediaLibrary)) {
-                                    selectMedia(.siteMediaLibrary)
-                                },
-                                .cancel()
-                            ].compactMap { $0 })
-            }
+            .confirmationDialog(Text(Localization.title), isPresented: showsActionSheet, actions: {
+                if UIImagePickerController.isSourceTypeAvailable(.camera) {
+                    Button(Localization.camera) {
+                        selectMedia(.camera)
+                    }
+                }
+
+                Button(Localization.photoLibrary) {
+                    selectMedia(.photoLibrary)
+                }
+
+                Button(Localization.siteMediaLibrary) {
+                    selectMedia(.siteMediaLibrary)
+                }
+            })
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductWithAI/StartingInfo/ProductCreationAIStartingInfoView.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductWithAI/StartingInfo/ProductCreationAIStartingInfoView.swift
@@ -97,11 +97,6 @@ struct ProductCreationAIStartingInfoView: View {
                 ViewPackagePhoto(image: image.image, isShowing: $viewModel.isShowingViewPhotoSheet)
             }
         })
-        .mediaSourceActionSheet(showsActionSheet: $viewModel.isShowingMediaPickerSourceSheet, selectMedia: { source in
-            Task { @MainActor in
-                await viewModel.selectImage(from: source)
-            }
-        })
         .notice($viewModel.notice)
     }
 }
@@ -128,6 +123,11 @@ private extension ProductCreationAIStartingInfoView {
             }
             Spacer()
         }
+        .mediaSourceActionSheet(showsActionSheet: $viewModel.isShowingMediaPickerSourceSheet, selectMedia: { source in
+            Task { @MainActor in
+                await viewModel.selectImage(from: source)
+            }
+        })
     }
 
     var placeholderText: some View {


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #13291 
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This PR fixes the media picker popover on iPad by replacing the deprecated `actionSheet` modifier with `confirmationDialog`. The action sheet has also been updated to point to the photo button on the starting view rather than the whole view.

## Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->
- Build and run the app on an iPad.
- Log in to a store eligible for Jetpack AI.
- Navigate to the Products tab and select "+" > Create product with AI.
- Tap on the Read text from product photo button.
- Confirm that the media source picker is displayed in full in a popover.

Please feel free to test the same steps on an iPhone to confirm that the action sheet still looks correctly.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->
Before | After 
--- | ---
<img src="https://private-user-images.githubusercontent.com/5533851/345264095-e6aa41ca-e3ce-4b4c-a35e-ca6b9822ea10.png?jwt=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJnaXRodWIuY29tIiwiYXVkIjoicmF3LmdpdGh1YnVzZXJjb250ZW50LmNvbSIsImtleSI6ImtleTUiLCJleHAiOjE3MjA2MDAzMTUsIm5iZiI6MTcyMDYwMDAxNSwicGF0aCI6Ii81NTMzODUxLzM0NTI2NDA5NS1lNmFhNDFjYS1lM2NlLTRiNGMtYTM1ZS1jYTZiOTgyMmVhMTAucG5nP1gtQW16LUFsZ29yaXRobT1BV1M0LUhNQUMtU0hBMjU2JlgtQW16LUNyZWRlbnRpYWw9QUtJQVZDT0RZTFNBNTNQUUs0WkElMkYyMDI0MDcxMCUyRnVzLWVhc3QtMSUyRnMzJTJGYXdzNF9yZXF1ZXN0JlgtQW16LURhdGU9MjAyNDA3MTBUMDgyNjU1WiZYLUFtei1FeHBpcmVzPTMwMCZYLUFtei1TaWduYXR1cmU9NGM0OTgwOGY4MWIwZDNiNWVhNGUxNjNjN2E3NmJiOWYwNjViZGUxMWRiYzA5ODk2ZDg3YjEzNjMwNWE0NWE4NiZYLUFtei1TaWduZWRIZWFkZXJzPWhvc3QmYWN0b3JfaWQ9MCZrZXlfaWQ9MCZyZXBvX2lkPTAifQ.zi8hDuKwa3lS_M-Ib04mSF0Amm0QqLnEOvPU1qhT0Mg" width=350 /> | <img src="https://github.com/woocommerce/woocommerce-ios/assets/5533851/6b9d87e8-ba6f-409a-b586-c37eac836c57" width=320 />


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
