### PR TITLE
[GLA Analytics] UI for Google Campaigns card with metric selection

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/Report Cards/Components/StatSelectionBar.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/Report Cards/Components/StatSelectionBar.swift
@@ -1,0 +1,56 @@
+import SwiftUI
+
+struct StatSelectionBar<Stat: Hashable>: View {
+
+    /// List of all available stats
+    let allStats: [Stat]
+
+    /// Key path to find the stat title to be displayed
+    let titleKeyPath: KeyPath<Stat, String>
+
+    /// Callback for selection
+    let onSelection: ((Stat) -> Void)?
+
+    /// Currently selected stat
+    @Binding var selectedStat: Stat
+
+    var body: some View {
+        HStack {
+            AdaptiveStack(horizontalAlignment: .leading) {
+                Text(Localization.metric)
+                    .foregroundStyle(Color.primaryText)
+                    .subheadlineStyle()
+                Text(selectedStat[keyPath: titleKeyPath])
+                    .subheadlineStyle()
+            }
+            Spacer()
+            Menu {
+                ForEach(allStats, id: \.self) { stat in
+                    Button {
+                        selectedStat = stat
+                        onSelection?(stat)
+                    } label: {
+                        SelectableItemRow(title: stat[keyPath: titleKeyPath], selected: stat == selectedStat)
+                    }
+                }
+            } label: {
+                Image(systemName: "line.3.horizontal.decrease")
+                    .foregroundStyle(Color(.secondaryLabel))
+            }
+
+        }
+    }
+}
+
+private enum Localization {
+    static let metric = NSLocalizedString("analyticsHub.statSelectionBar.metricLabel",
+                                          value: "Metric",
+                                          comment: "Label for the selected metric on an analytics card in the Analytics Hub.")
+}
+
+#Preview {
+    StatSelectionBar<String>(allStats: ["Total Sales", "Spend", "Clicks", "Conversions"],
+                             titleKeyPath: \.self,
+                             onSelection: nil,
+                             selectedStat: .constant("Total Sales"))
+}

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/Report Cards/GoogleAdsCampaignReportCard.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/Report Cards/GoogleAdsCampaignReportCard.swift
@@ -1,0 +1,104 @@
+import SwiftUI
+
+/// Card to display a Google Ads Campaign stat and a list of campaigns for that stat on the Analytics Hub
+///
+struct GoogleAdsCampaignReportCard: View {
+    /// Whether the web report is displayed.
+    @State private var showingWebReport: Bool = false
+
+    /// View model to drive the view content.
+    @StateObject var viewModel: GoogleAdsCampaignReportCardViewModel
+
+    var body: some View {
+        VStack(alignment: .leading) {
+
+            Text(Localization.title)
+                .foregroundColor(Color(.text))
+                .footnoteStyle()
+
+            StatSelectionBar(allStats: viewModel.allStats, titleKeyPath: \.displayName, onSelection: nil, selectedStat: $viewModel.selectedStat)
+                .padding(.top, Layout.titleSpacing)
+                .padding(.bottom, Layout.columnSpacing)
+
+            HStack {
+                Text(viewModel.totalSales)
+                    .titleStyle()
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .redacted(reason: viewModel.isRedacted ? .placeholder : [])
+                    .shimmering(active: viewModel.isRedacted)
+
+                DeltaTag(value: viewModel.delta.string,
+                         backgroundColor: viewModel.delta.direction.deltaBackgroundColor,
+                         textColor: viewModel.delta.direction.deltaTextColor)
+                    .redacted(reason: viewModel.isRedacted ? .placeholder : [])
+                    .shimmering(active: viewModel.isRedacted)
+            }
+
+            TopPerformersView(itemTitle: Localization.campaignsTitle.localizedCapitalized,
+                              valueTitle: viewModel.selectedStat.displayName,
+                              rows: viewModel.campaignsData,
+                              isRedacted: viewModel.isRedacted)
+                .padding(.vertical, Layout.columnSpacing)
+                .renderedIf(!viewModel.showCampaignsError)
+
+            if viewModel.showCampaignsError {
+                Text(Localization.errorMessage)
+                    .foregroundColor(Color(.text))
+                    .subheadlineStyle()
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .padding(.vertical, Layout.columnSpacing)
+            }
+
+            if let reportViewModel = viewModel.reportViewModel {
+                AnalyticsReportLink(showingWebReport: $showingWebReport, reportViewModel: reportViewModel)
+            }
+        }
+        .padding(Layout.cardPadding)
+    }
+}
+
+// MARK: Constants
+private extension GoogleAdsCampaignReportCard {
+    enum Layout {
+        static let titleSpacing: CGFloat = 24
+        static let cardPadding: CGFloat = 16
+        static let columnSpacing: CGFloat = 10
+    }
+
+    enum Localization {
+        static let title = NSLocalizedString("analyticsHub.googleCampaigns.title",
+                                             value: "Google Campaigns",
+                                             comment: "Title for the Google campaigns card on the analytics hub screen.").localizedUppercase
+        static let campaignsTitle = NSLocalizedString("analyticsHub.googleCampaigns.campaignsList.title",
+                                                      value: "Campaigns",
+                                                      comment: "Title for the list of campaigns on the Google campaigns card on the analytics hub screen.")
+        static let errorMessage = NSLocalizedString("analyticsHub.googleCampaigns.noCampaignStats",
+                                                    value: "Unable to load Google campaigns analytics",
+                                                    comment: "Text displayed when there is an error loading Google Ads campaigns stats data.")
+    }
+}
+
+
+// MARK: Previews
+struct GoogleAdsCampaignReportCardPreviews: PreviewProvider {
+    static var previews: some View {
+        let viewModel = GoogleAdsCampaignReportCardViewModel(currentPeriodStats: GoogleAdsCampaignReportCardViewModel.sampleStats(),
+                                                             previousPeriodStats: GoogleAdsCampaignReportCardViewModel.sampleStats(),
+                                                             timeRange: .today,
+                                                             usageTracksEventEmitter: StoreStatsUsageTracksEventEmitter(),
+                                                             storeAdminURL: "https://woocommerce.com")
+        GoogleAdsCampaignReportCard(viewModel: viewModel)
+            .addingTopAndBottomDividers()
+            .previewLayout(.sizeThatFits)
+
+        let emptyViewModel = GoogleAdsCampaignReportCardViewModel(currentPeriodStats: nil,
+                                                                  previousPeriodStats: nil,
+                                                                  timeRange: .today,
+                                                                  usageTracksEventEmitter: StoreStatsUsageTracksEventEmitter(),
+                                                                  storeAdminURL: "https://woocommerce.com")
+        GoogleAdsCampaignReportCard(viewModel: emptyViewModel)
+            .addingTopAndBottomDividers()
+            .previewLayout(.sizeThatFits)
+            .previewDisplayName("No data")
+    }
+}

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/Report Cards/GoogleAdsCampaignReportCardViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/Report Cards/GoogleAdsCampaignReportCardViewModel.swift
@@ -4,7 +4,7 @@ import Yosemite
 /// Analytics Hub Google Ads Campaign Card ViewModel.
 /// Used to transmit Google Ads campaigns analytics data.
 ///
-final class GoogleAdsCampaignReportCardViewModel {
+final class GoogleAdsCampaignReportCardViewModel: ObservableObject {
     /// Campaign stats for the current period
     ///
     private var currentPeriodStats: GoogleAdsCampaignStats?
@@ -29,6 +29,14 @@ final class GoogleAdsCampaignReportCardViewModel {
     ///
     var isRedacted: Bool
 
+    /// All available stats for Google Ads campaigns.
+    ///
+    let allStats = GoogleAdsCampaignStatsTotals.TotalData.allCases
+
+    /// The currently selected stat to display.
+    ///
+    @Published var selectedStat: GoogleAdsCampaignStatsTotals.TotalData
+
     init(currentPeriodStats: GoogleAdsCampaignStats?,
          previousPeriodStats: GoogleAdsCampaignStats?,
          timeRange: AnalyticsHubTimeRangeSelection.SelectionType,
@@ -41,6 +49,7 @@ final class GoogleAdsCampaignReportCardViewModel {
         self.isRedacted = isRedacted
         self.usageTracksEventEmitter = usageTracksEventEmitter
         self.storeAdminURL = storeAdminURL
+        self.selectedStat = .sales
     }
 }
 
@@ -187,5 +196,46 @@ private extension GoogleAdsCampaignReportCardViewModel {
                                                                + "The placeholder is a formatted monetary amount, e.g. Spend: $123."),
                                              value)
         }
+    }
+}
+
+// MARK: - Methods for rendering a SwiftUI Preview
+extension GoogleAdsCampaignReportCardViewModel {
+    static func sampleStats() -> GoogleAdsCampaignStats {
+        GoogleAdsCampaignStats(siteID: 1234,
+                               totals: GoogleAdsCampaignStatsTotals(sales: 2234, spend: nil, clicks: nil, impressions: nil, conversions: nil),
+                               campaigns: [GoogleAdsCampaignStatsItem(campaignID: 1,
+                                                                      campaignName: "Spring Sale Campaign",
+                                                                      rawStatus: "enabled",
+                                                                      subtotals: GoogleAdsCampaignStatsTotals(sales: 1232,
+                                                                                                              spend: 100,
+                                                                                                              clicks: nil,
+                                                                                                              impressions: nil,
+                                                                                                              conversions: nil)),
+                                           GoogleAdsCampaignStatsItem(campaignID: 2,
+                                                                      campaignName: "Summer Campaign",
+                                                                      rawStatus: "enabled",
+                                                                      subtotals: GoogleAdsCampaignStatsTotals(sales: 800,
+                                                                                                              spend: 50,
+                                                                                                              clicks: nil,
+                                                                                                              impressions: nil,
+                                                                                                              conversions: nil)),
+                                           GoogleAdsCampaignStatsItem(campaignID: 3,
+                                                                      campaignName: "Winter Campaign",
+                                                                      rawStatus: "enabled",
+                                                                      subtotals: GoogleAdsCampaignStatsTotals(sales: 750,
+                                                                                                              spend: 50,
+                                                                                                              clicks: nil,
+                                                                                                              impressions: nil,
+                                                                                                              conversions: nil)),
+                                           GoogleAdsCampaignStatsItem(campaignID: 4,
+                                                                      campaignName: "New Year Campaign",
+                                                                      rawStatus: "enabled",
+                                                                      subtotals: GoogleAdsCampaignStatsTotals(sales: 200,
+                                                                                                              spend: 25,
+                                                                                                              clicks: nil,
+                                                                                                              impressions: nil,
+                                                                                                              conversions: nil))],
+                               nextPageToken: nil)
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Factories/WCAnalyticsStatsTotals+UI.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Factories/WCAnalyticsStatsTotals+UI.swift
@@ -89,3 +89,66 @@ extension GiftCardStatsTotals: ParsableStatsTotals {
         }
     }
 }
+
+// MARK: - Parsable Google Ads Campaigns Stats
+
+extension GoogleAdsCampaignStatsTotals: ParsableStatsTotals {
+    /// Represents a type of Google Ads campaigns total data
+    enum TotalData: Double, CaseIterable {
+        case sales
+        case spend
+        case clicks
+        case impressions
+        case conversions
+
+        var displayName: String {
+            switch self {
+            case .sales:
+                Localization.sales
+            case .spend:
+                Localization.spend
+            case .clicks:
+                Localization.clicks
+            case .impressions:
+                Localization.impressions
+            case .conversions:
+                Localization.conversions
+            }
+        }
+    }
+
+    func getDoubleValue(for data: TotalData) -> Double {
+        switch data {
+        case .sales:
+            ((sales ?? 0) as NSNumber).doubleValue
+        case .spend:
+            ((spend ?? 0) as NSNumber).doubleValue
+        case .clicks:
+            Double(clicks ?? 0)
+        case .impressions:
+            Double(impressions ?? 0)
+        case .conversions:
+            ((conversions ?? 0) as NSNumber).doubleValue
+        }
+    }
+}
+
+private extension GoogleAdsCampaignStatsTotals {
+    enum Localization {
+        static let sales = NSLocalizedString("googleAdsCampaignStatsTotals.totalData.sales",
+                                             value: "Total Sales",
+                                             comment: "Display name for the total sales stat in Google Ads campaign stats")
+        static let spend = NSLocalizedString("googleAdsCampaignStatsTotals.totalData.spend",
+                                             value: "Total Spend",
+                                             comment: "Display name for the total spend stat in Google Ads campaign stats")
+        static let clicks = NSLocalizedString("googleAdsCampaignStatsTotals.totalData.clicks",
+                                              value: "Clicks",
+                                              comment: "Display name for the clicks stat in Google Ads campaign stats")
+        static let impressions = NSLocalizedString("googleAdsCampaignStatsTotals.totalData.impressions",
+                                                   value: "Impressions",
+                                                   comment: "Display name for the impressions stat in Google Ads campaign stats")
+        static let conversions = NSLocalizedString("googleAdsCampaignStatsTotals.totalData.conversions",
+                                                   value: "Conversions",
+                                                   comment: "Display name for the conversions stat in Google Ads campaign stats")
+    }
+}

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -2130,6 +2130,7 @@
 		CE13681529FBD42100EBF43C /* QuantityRules.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE13681429FBD42100EBF43C /* QuantityRules.swift */; };
 		CE13681729FBD94300EBF43C /* QuantityRulesViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE13681629FBD94300EBF43C /* QuantityRulesViewModel.swift */; };
 		CE14452E2188C11700A991D8 /* ZendeskManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE14452D2188C11700A991D8 /* ZendeskManager.swift */; };
+		CE14DEE62C3D5D68002A90B5 /* StatSelectionBar.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE14DEE52C3D5D68002A90B5 /* StatSelectionBar.swift */; };
 		CE15524A21FFB10100EAA690 /* ApplicationLogViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE15524921FFB10100EAA690 /* ApplicationLogViewController.swift */; };
 		CE16177A21B7192A00B82A47 /* AuthenticationConstants.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE16177921B7192A00B82A47 /* AuthenticationConstants.swift */; };
 		CE1CCB402056F21C000EE3AC /* Style.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE1CCB3F2056F21C000EE3AC /* Style.swift */; };
@@ -5120,6 +5121,7 @@
 		CE13681429FBD42100EBF43C /* QuantityRules.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QuantityRules.swift; sourceTree = "<group>"; };
 		CE13681629FBD94300EBF43C /* QuantityRulesViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QuantityRulesViewModel.swift; sourceTree = "<group>"; };
 		CE14452D2188C11700A991D8 /* ZendeskManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ZendeskManager.swift; sourceTree = "<group>"; };
+		CE14DEE52C3D5D68002A90B5 /* StatSelectionBar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StatSelectionBar.swift; sourceTree = "<group>"; };
 		CE15524921FFB10100EAA690 /* ApplicationLogViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ApplicationLogViewController.swift; sourceTree = "<group>"; };
 		CE16177921B7192A00B82A47 /* AuthenticationConstants.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthenticationConstants.swift; sourceTree = "<group>"; };
 		CE1CCB3F2056F21C000EE3AC /* Style.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Style.swift; sourceTree = "<group>"; };
@@ -11728,6 +11730,7 @@
 				CEDBDA462B6BEF2E002047D4 /* AnalyticsWebReport.swift */,
 				CE6A8FB32B724D7C0063564D /* AnalyticsReportLink.swift */,
 				CE6A8FB52B725A690063564D /* AnalyticsReportLinkViewModel.swift */,
+				CE14DEE52C3D5D68002A90B5 /* StatSelectionBar.swift */,
 			);
 			path = Components;
 			sourceTree = "<group>";
@@ -15241,6 +15244,7 @@
 				DEC2962326BD4E6E005A056B /* ShippingLabelCustomsFormInput.swift in Sources */,
 				E1E649EB28461EDF0070B194 /* BetaFeaturesConfiguration.swift in Sources */,
 				26309F17277D0AEA0012797F /* SafeAreaInsetsKey.swift in Sources */,
+				CE14DEE62C3D5D68002A90B5 /* StatSelectionBar.swift in Sources */,
 				867EA0AC2B8F09280064BCA7 /* CustomerSelector+Filter.swift in Sources */,
 				B9CA4F352AB2F33200285AB9 /* SelectedStoredTaxRateFetcher.swift in Sources */,
 				DE4D23AA29B1B0CA003A4B5D /* WPCom2FALoginView.swift in Sources */,

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -2131,6 +2131,7 @@
 		CE13681729FBD94300EBF43C /* QuantityRulesViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE13681629FBD94300EBF43C /* QuantityRulesViewModel.swift */; };
 		CE14452E2188C11700A991D8 /* ZendeskManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE14452D2188C11700A991D8 /* ZendeskManager.swift */; };
 		CE14DEE62C3D5D68002A90B5 /* StatSelectionBar.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE14DEE52C3D5D68002A90B5 /* StatSelectionBar.swift */; };
+		CE14DEE82C3D8D1D002A90B5 /* GoogleAdsCampaignReportCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE14DEE72C3D8D1D002A90B5 /* GoogleAdsCampaignReportCard.swift */; };
 		CE15524A21FFB10100EAA690 /* ApplicationLogViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE15524921FFB10100EAA690 /* ApplicationLogViewController.swift */; };
 		CE16177A21B7192A00B82A47 /* AuthenticationConstants.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE16177921B7192A00B82A47 /* AuthenticationConstants.swift */; };
 		CE1CCB402056F21C000EE3AC /* Style.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE1CCB3F2056F21C000EE3AC /* Style.swift */; };
@@ -5122,6 +5123,7 @@
 		CE13681629FBD94300EBF43C /* QuantityRulesViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QuantityRulesViewModel.swift; sourceTree = "<group>"; };
 		CE14452D2188C11700A991D8 /* ZendeskManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ZendeskManager.swift; sourceTree = "<group>"; };
 		CE14DEE52C3D5D68002A90B5 /* StatSelectionBar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StatSelectionBar.swift; sourceTree = "<group>"; };
+		CE14DEE72C3D8D1D002A90B5 /* GoogleAdsCampaignReportCard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GoogleAdsCampaignReportCard.swift; sourceTree = "<group>"; };
 		CE15524921FFB10100EAA690 /* ApplicationLogViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ApplicationLogViewController.swift; sourceTree = "<group>"; };
 		CE16177921B7192A00B82A47 /* AuthenticationConstants.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthenticationConstants.swift; sourceTree = "<group>"; };
 		CE1CCB3F2056F21C000EE3AC /* Style.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Style.swift; sourceTree = "<group>"; };
@@ -11914,6 +11916,7 @@
 				CEF2DD852B558E3E00A3DD0B /* AnalyticsCTACard.swift */,
 				CEA455C62BB5CA5E00D932CF /* AnalyticsSessionsUnavailableCard.swift */,
 				CEA455C82BB5DA4C00D932CF /* AnalyticsSessionsReportCard.swift */,
+				CE14DEE72C3D8D1D002A90B5 /* GoogleAdsCampaignReportCard.swift */,
 				CEEF74212B99EC5800B03948 /* AnalyticsReportCardProtocol.swift */,
 				CEEF74242B99EF1200B03948 /* RevenueReportCardViewModel.swift */,
 				CEEF74292B9A02EB00B03948 /* OrdersReportCardViewModel.swift */,
@@ -15451,6 +15454,7 @@
 				4A68E3E32941D4CE004AC3DC /* WordPressLibraryLogger.swift in Sources */,
 				174CA86E27DBFD2D00126524 /* ShareAppTextItemActivitySource.swift in Sources */,
 				262C921F26EEF8B100011F92 /* Binding.swift in Sources */,
+				CE14DEE82C3D8D1D002A90B5 /* GoogleAdsCampaignReportCard.swift in Sources */,
 				DE4FB7732812AE96003D20D6 /* FilterListView.swift in Sources */,
 				02521E11243DC3C400DC7810 /* CancellableMedia.swift in Sources */,
 				DE74A4522BCF87120009C415 /* TopPerformersDashboardView.swift in Sources */,


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of: #13279
<!-- Id number of the GitHub issue this PR addresses. -->

## Why
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
We want to add the ability to select which metric to display in the Google Campaigns card in the Analytics Hub.

This adds new UI for the card with the metric selector. It isn't used in the app yet and selecting a new metric has no effect for now on the displayed stats.

## How

* Adds an extension for `GoogleAdsCampaignStatsTotals` conforming to `ParsableStatsTotals`, and with a `displayName` property so we can display a localized name for the selected metric.
* Adds a `StatSelectionBar` SwiftUI component. This is a row with the label `Metric` and the selected stat on the left, and an icon to open the menu on the right.
* Adds a `GoogleAdsCampaignReportCard` SwiftUI view. Instead of adding an optional, generic `StatSelectionBar` to `AnalyticsTopPerformersCard`, we now have a view specifically for the Google Campaigns card with the new selector.
* Updates `GoogleAdsCampaignReportCardViewModel` to work with the new card view:
   * Makes the view model an `ObservableObject`.
   * Adds the `allStats` property with a list of all available stats totals.
   * Adds the `selectedStat` property for the currently selected stat.
   * Adds sample data for the SwiftUI preview.

## Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->
Google Campaigns card|Card with open menu|Card with sync error
-|-|-
![Screenshot 2024-07-10 at 12 40 59](https://github.com/woocommerce/woocommerce-ios/assets/8658164/91c14026-b2f1-4c94-8e29-dda2f83c0397)|![Screenshot 2024-07-10 at 13 00 39](https://github.com/woocommerce/woocommerce-ios/assets/8658164/128581e4-3422-4c73-afe7-013589b82ff2)|![Screenshot 2024-07-10 at 12 41 12](https://github.com/woocommerce/woocommerce-ios/assets/8658164/712e2ba1-de3e-4817-a37e-7602297e838a)

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.