### PR TITLE
[Product Creation with AI: v2] Reduce network calls

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductWithAI/Preview/ProductDetailPreviewViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductWithAI/Preview/ProductDetailPreviewViewModel.swift
@@ -123,6 +123,8 @@ final class ProductDetailPreviewViewModel: ObservableObject {
     private var weightUnit: String?
     private var dimensionUnit: String?
     private let shippingValueLocalizer: ShippingValueLocalizer
+    private var hasSyncedCategories: Bool = false
+    private var hasSyncedTags: Bool = false
 
     private var subscriptions: Set<AnyCancellable> = []
 

--- a/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductWithAI/Preview/ProductDetailPreviewViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductWithAI/Preview/ProductDetailPreviewViewModel.swift
@@ -123,8 +123,8 @@ final class ProductDetailPreviewViewModel: ObservableObject {
     private var weightUnit: String?
     private var dimensionUnit: String?
     private let shippingValueLocalizer: ShippingValueLocalizer
-    private var hasSyncedCategories: Bool = false
-    private var hasSyncedTags: Bool = false
+    private var hasSyncedCategories = false
+    private var hasSyncedTags = false
 
     private var subscriptions: Set<AnyCancellable> = []
 

--- a/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductWithAI/Preview/ProductDetailPreviewViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductWithAI/Preview/ProductDetailPreviewViewModel.swift
@@ -445,15 +445,24 @@ private extension ProductDetailPreviewViewModel {
 private extension ProductDetailPreviewViewModel {
     @MainActor
     func fetchPrerequisites() async throws {
-        await withThrowingTaskGroup(of: Void.self) { group in
+        await withThrowingTaskGroup(of: Void.self) { [weak self] group in
+            guard let self else { return }
             group.addTask {
                 await self.fetchSettingsIfNeeded()
             }
             group.addTask {
+                guard self.hasSyncedCategories == false else {
+                    return
+                }
                 try await self.synchronizeAllCategories()
+                self.hasSyncedCategories = true
             }
             group.addTask {
+                guard self.hasSyncedTags == false else {
+                    return
+                }
                 try await self.synchronizeAllTags()
+                self.hasSyncedTags = true
             }
         }
     }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #13287 
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

While generating the AI product again (by tapping the "Generate Again" button") from the product preview screen, we don't have to fetch the categories and tags once again. 

Changes
- Add properties to track whether we have already fetched the categories and tags.
- Sync categories and tags only one time. 
- Unit tests

## Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->

Install proxyman or a similar setup to intercept network requests. 

1. Create a JN site with Jetpack AI plugin
2. Turn on `productCreationAIv2M1` feature flag
3. Build and run the app
4. Navigate to the products tab
5. Tap `+` button on top right
6. Tap "Create a product with AI"
7.  Select a package photo or enter product features.
8. Tap "Generate Product Details", and you will land on the new product preview screen
9. From proxyman validate the network requests for synchronizing tags and categories are sent. (GET requests to `wc/v3/products/tags` and `wc/v3/products/categories`
10. Tap on the "Generate Again" button to generate the AI product once again.
11. From proxyman validate the network requests for synchronizing tags and categories are not sent. (GET requests to `wc/v3/products/tags` and `wc/v3/products/categories`
12. The product generation should finish and work as before.

## Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->
- Smoke test the AI generation flow by creating a product and saving it. Ensure that tags and categories are saved as before.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->
<img src="https://github.com/woocommerce/woocommerce-ios/assets/524475/14d91c42-9651-4d2b-81e1-e10925f45ed0" width="320"/>


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.