### PR TITLE
[Woo POS] Specialize item list empty and error cases 

### DIFF
--- a/WooCommerce/Classes/POS/Presentation/ItemListView.swift
+++ b/WooCommerce/Classes/POS/Presentation/ItemListView.swift
@@ -16,20 +16,14 @@ struct ItemListView: View {
                 .font(Constants.titleFont)
                 .foregroundColor(Color.posPrimaryTexti3)
             switch viewModel.state {
-            case .loaded:
-                ScrollView {
-                    ForEach(viewModel.items, id: \.productID) { item in
-                        Button(action: {
-                            viewModel.select(item)
-                        }, label: {
-                            ItemCardView(item: item)
-                        })
-                    }
-                }
+            case .empty(let emptyVM):
+                emptyView(emptyVM)
             case .loading:
                 loadingView
-            case .error:
-                errorView
+            case .loaded(let items):
+                listView(items)
+            case .error(let errorVM):
+                errorView(errorVM)
             }
         }
         .refreshable {
@@ -51,10 +45,42 @@ private extension ItemListView {
         }
     }
 
-    var errorView: some View {
+    @ViewBuilder
+    func emptyView(_ emptyVM: ItemListEmpty) -> some View {
         VStack {
             Spacer()
-            Text("Error!!")
+            Text(emptyVM.title)
+            Text(emptyVM.subtitle)
+            Button(action: {
+                // TODO:
+                // Redirect the merchant to the app in order to create a new product
+                // https://github.com/woocommerce/woocommerce-ios/issues/13297
+            }, label: {
+                Text(emptyVM.buttonText)} 
+            )
+            Text(emptyVM.hint)
+            Spacer()
+        }
+    }
+
+    @ViewBuilder
+    func listView(_ items: [POSItem]) -> some View {
+        ScrollView {
+            ForEach(items, id: \.productID) { item in
+                Button(action: {
+                    viewModel.select(item)
+                }, label: {
+                    ItemCardView(item: item)
+                })
+            }
+        }
+    }
+
+    @ViewBuilder
+    func errorView(_ errorVM: ItemListError) -> some View {
+        VStack {
+            Spacer()
+            Text(errorVM.title)
             Button(action: {
                 Task {
                     await viewModel.populatePointOfSaleItems()

--- a/WooCommerce/Classes/POS/Presentation/ItemListView.swift
+++ b/WooCommerce/Classes/POS/Presentation/ItemListView.swift
@@ -16,14 +16,14 @@ struct ItemListView: View {
                 .font(Constants.titleFont)
                 .foregroundColor(Color.posPrimaryTexti3)
             switch viewModel.state {
-            case .empty(let emptyVM):
-                emptyView(emptyVM)
+            case .empty(let emptyModel):
+                emptyView(emptyModel)
             case .loading:
                 loadingView
             case .loaded(let items):
                 listView(items)
-            case .error(let errorVM):
-                errorView(errorVM)
+            case .error(let errorModel):
+                errorView(errorModel)
             }
         }
         .refreshable {

--- a/WooCommerce/Classes/POS/Presentation/ItemListView.swift
+++ b/WooCommerce/Classes/POS/Presentation/ItemListView.swift
@@ -46,19 +46,19 @@ private extension ItemListView {
     }
 
     @ViewBuilder
-    func emptyView(_ emptyVM: ItemListEmpty) -> some View {
+    func emptyView(_ content: ItemListViewModel.EmptyModel) -> some View {
         VStack {
             Spacer()
-            Text(emptyVM.title)
-            Text(emptyVM.subtitle)
+            Text(content.title)
+            Text(content.subtitle)
             Button(action: {
                 // TODO:
                 // Redirect the merchant to the app in order to create a new product
                 // https://github.com/woocommerce/woocommerce-ios/issues/13297
             }, label: {
-                Text(emptyVM.buttonText)} 
+                Text(content.buttonText)}
             )
-            Text(emptyVM.hint)
+            Text(content.hint)
             Spacer()
         }
     }
@@ -77,15 +77,17 @@ private extension ItemListView {
     }
 
     @ViewBuilder
-    func errorView(_ errorVM: ItemListError) -> some View {
+    func errorView(_ content: ItemListViewModel.ErrorModel) -> some View {
         VStack {
             Spacer()
-            Text(errorVM.title)
+            Text(content.title)
             Button(action: {
                 Task {
                     await viewModel.populatePointOfSaleItems()
                 }
-            }, label: { Text("Retry") })
+            }, label: {
+                Text(content.buttonText)
+            })
             Spacer()
         }
     }

--- a/WooCommerce/Classes/POS/ViewModels/ItemListViewModel.swift
+++ b/WooCommerce/Classes/POS/ViewModels/ItemListViewModel.swift
@@ -28,7 +28,7 @@ final class ItemListViewModel: ObservableObject {
             state = .loading
             items = try await itemProvider.providePointOfSaleItems()
             if items.count == 0 {
-                let itemListEmpty = ItemListEmpty(title: Constants.emptyProductsTitle,
+                let itemListEmpty = EmptyModel(title: Constants.emptyProductsTitle,
                                                   subtitle: Constants.emptyProductsSubtitle,
                                                   hint: Constants.emptyProductsHint,
                                                   buttonText: Constants.emptyProductsButtonTitle)
@@ -38,7 +38,7 @@ final class ItemListViewModel: ObservableObject {
             }
         } catch {
             DDLogError("Error on load while fetching product data: \(error)")
-            let itemListError = ItemListError(title: Constants.failedToLoadTitle,
+            let itemListError = ErrorModel(title: Constants.failedToLoadTitle,
                                       subtitle: Constants.failedToLoadSubtitle,
                                       buttonText: Constants.failedToLoadButtonTitle)
             state = .error(itemListError)
@@ -53,7 +53,7 @@ final class ItemListViewModel: ObservableObject {
             state = .loading
             let newItems = try await itemProvider.providePointOfSaleItems()
             if newItems.count == 0 {
-                let itemListEmpty = ItemListEmpty(title: Constants.emptyProductsTitle,
+                let itemListEmpty = EmptyModel(title: Constants.emptyProductsTitle,
                                                   subtitle: Constants.emptyProductsSubtitle,
                                                   hint: Constants.emptyProductsHint,
                                                   buttonText: Constants.emptyProductsButtonTitle)
@@ -66,7 +66,7 @@ final class ItemListViewModel: ObservableObject {
             }
         } catch {
             DDLogError("Error on reload while updating product data: \(error)")
-            let itemListError = ItemListError(title: Constants.failedToLoadTitle,
+            let itemListError = ErrorModel(title: Constants.failedToLoadTitle,
                                       subtitle: Constants.failedToLoadSubtitle,
                                       buttonText: Constants.failedToLoadButtonTitle)
             state = .error(itemListError)
@@ -76,14 +76,14 @@ final class ItemListViewModel: ObservableObject {
 
 extension ItemListViewModel {
     enum ItemListState: Equatable {
-        case empty(ItemListEmpty)
+        case empty(EmptyModel)
         // TODO:
         // Differentiate between loading on entering POS mode and reloading, as the
         // screens will be different:
         // https://github.com/woocommerce/woocommerce-ios/issues/13286
         case loading
         case loaded([POSItem])
-        case error(ItemListError)
+        case error(ErrorModel)
 
         // Equatable conformance for testing:
         static func == (lhs: ItemListViewModel.ItemListState, rhs: ItemListViewModel.ItemListState) -> Bool {
@@ -102,13 +102,13 @@ extension ItemListViewModel {
         }
     }
     
-    struct ItemListError: Equatable {
+    struct ErrorModel: Equatable {
         let title: String
         let subtitle: String
         let buttonText: String
     }
 
-    struct ItemListEmpty: Equatable {
+    struct EmptyModel: Equatable {
         // TODO:
         // Differentiate between empty with no products vs empty with no eligible products
         // https://github.com/woocommerce/woocommerce-ios/issues/12815

--- a/WooCommerce/Classes/POS/ViewModels/ItemListViewModel.swift
+++ b/WooCommerce/Classes/POS/ViewModels/ItemListViewModel.swift
@@ -101,7 +101,7 @@ extension ItemListViewModel {
             }
         }
     }
-    
+
     struct ErrorModel: Equatable {
         let title: String
         let subtitle: String
@@ -123,39 +123,39 @@ extension ItemListViewModel {
 private extension ItemListViewModel {
     enum Constants {
         static let emptyProductsTitle = NSLocalizedString(
-            "",
+            "pos.itemList.emptyProductsTitle",
             value: "No products",
-            comment: ""
+            comment: "Text appearing on the item list screen when there are no products to load."
         )
         static let emptyProductsSubtitle = NSLocalizedString(
-            "",
+            "pos.itemList.emptyProductsSubtitle",
             value: "Your store doesn't have any products",
-            comment: ""
+            comment: "Text appearing as subtitle on the item list screen when there are no products to load."
         )
         static let emptyProductsHint = NSLocalizedString(
-            "",
+            "pos.itemList.emptyProductsHint",
             value: "POS currently only supports simple products",
-            comment: ""
+            comment: "Text appearing on the item list screen as hint when there are no products to load."
         )
         static let emptyProductsButtonTitle = NSLocalizedString(
-            "",
+            "pos.itemList.emptyProductsButtonTitle",
             value: "Create a simple product",
-            comment: ""
+            comment: "Text for the button appearing on the item list screen when there are no products to load."
         )
         static let failedToLoadTitle = NSLocalizedString(
-            "",
+            "pos.itemList.failedToLoadTitle",
             value: "Error loading products",
-            comment: ""
+            comment: "Text appearing on the item list screen when there's an error loading products."
         )
         static let failedToLoadSubtitle = NSLocalizedString(
-            "",
+            "pos.itemList.failedToLoadSubtitle",
             value: "Give it another go?",
-            comment: ""
+            comment: "Text appearing on the item list screen as subtitle when there's an error loading products."
         )
         static let failedToLoadButtonTitle = NSLocalizedString(
-            "",
+            "pos.itemList.failedToLoadButtonTitle",
             value: "Retry",
-            comment: ""
+            comment: "Text for the button appearing on the item list screen when there's an error loading products."
         )
     }
 }

--- a/WooCommerce/Classes/POS/ViewModels/ItemListViewModel.swift
+++ b/WooCommerce/Classes/POS/ViewModels/ItemListViewModel.swift
@@ -3,35 +3,7 @@ import SwiftUI
 import protocol Yosemite.POSItem
 import protocol Yosemite.POSItemProvider
 
-struct ItemListError {
-    let title: String
-    let subtitle: String
-    let error: Error
-    let buttonText: String
-}
-
-struct ItemListEmpty {
-    // TODO:
-    // Differentiate between empty with no products vs empty with no eligible products
-    // https://github.com/woocommerce/woocommerce-ios/issues/12815
-    // https://github.com/woocommerce/woocommerce-ios/issues/12816
-    let title: String
-    let subtitle: String
-    let hint: String
-    let buttonText: String
-}
-
 final class ItemListViewModel: ObservableObject {
-    enum ItemListState {
-        case empty(ItemListEmpty)
-        // TODO:
-        // Differentiate between loading on entering POS mode and reloading, as the
-        // screens will be different:
-        // https://github.com/woocommerce/woocommerce-ios/issues/13286
-        case loading
-        case loaded([POSItem])
-        case error(ItemListError)
-    }
 
     @Published private(set) var items: [POSItem] = []
     @Published private(set) var state: ItemListState = .loading
@@ -56,21 +28,20 @@ final class ItemListViewModel: ObservableObject {
             state = .loading
             items = try await itemProvider.providePointOfSaleItems()
             if items.count == 0 {
-                let itemListEmpty = ItemListEmpty(title: "No products",
-                                                  subtitle: "Your store doesn't have any products",
-                                                  hint: "POS currently only supports simple products", 
-                                                  buttonText: "Create a simple product")
+                let itemListEmpty = ItemListEmpty(title: Constants.emptyProductsTitle,
+                                                  subtitle: Constants.emptyProductsSubtitle,
+                                                  hint: Constants.emptyProductsHint,
+                                                  buttonText: Constants.emptyProductsButtonTitle)
                 state = .empty(itemListEmpty)
             } else {
                 state = .loaded(items)
             }
         } catch {
             DDLogError("Error on load while fetching product data: \(error)")
-            let error = ItemListError(title: Constants.failedToLoadTitle,
+            let itemListError = ItemListError(title: Constants.failedToLoadTitle,
                                       subtitle: Constants.failedToLoadSubtitle,
-                                      error: error,
-                                      buttonText: "Retry")
-            state = .error(error)
+                                      buttonText: Constants.failedToLoadButtonTitle)
+            state = .error(itemListError)
         }
     }
 
@@ -82,10 +53,10 @@ final class ItemListViewModel: ObservableObject {
             state = .loading
             let newItems = try await itemProvider.providePointOfSaleItems()
             if newItems.count == 0 {
-                let itemListEmpty = ItemListEmpty(title: "No products",
-                                                  subtitle: "Your store doesn't have any products",
-                                                  hint: "POS currently only supports simple products",
-                                                  buttonText: "Create a simple product")
+                let itemListEmpty = ItemListEmpty(title: Constants.emptyProductsTitle,
+                                                  subtitle: Constants.emptyProductsSubtitle,
+                                                  hint: Constants.emptyProductsHint,
+                                                  buttonText: Constants.emptyProductsButtonTitle)
                 state = .empty(itemListEmpty)
             } else {
                 // Only clears in-memory items if the `do` block continues, otherwise we keep them in memory.
@@ -95,17 +66,82 @@ final class ItemListViewModel: ObservableObject {
             }
         } catch {
             DDLogError("Error on reload while updating product data: \(error)")
-            let error = ItemListError(title: Constants.failedToLoadTitle,
+            let itemListError = ItemListError(title: Constants.failedToLoadTitle,
                                       subtitle: Constants.failedToLoadSubtitle,
-                                      error: error,
-                                      buttonText: "Retry")
-            state = .error(error)
+                                      buttonText: Constants.failedToLoadButtonTitle)
+            state = .error(itemListError)
         }
+    }
+}
+
+extension ItemListViewModel {
+    enum ItemListState: Equatable {
+        case empty(ItemListEmpty)
+        // TODO:
+        // Differentiate between loading on entering POS mode and reloading, as the
+        // screens will be different:
+        // https://github.com/woocommerce/woocommerce-ios/issues/13286
+        case loading
+        case loaded([POSItem])
+        case error(ItemListError)
+
+        // Equatable conformance for testing:
+        static func == (lhs: ItemListViewModel.ItemListState, rhs: ItemListViewModel.ItemListState) -> Bool {
+            switch (lhs, rhs) {
+            case (.empty(let lhsItems), .empty(let rhsItems)):
+                return lhsItems == rhsItems
+            case (.loading, .loading):
+                return true
+            case (.loaded(let lhsItems), .loaded(let rhsItems)):
+                return lhsItems.map { $0.itemID } == rhsItems.map { $0.itemID }
+            case (.error(let lhsError), .error(let rhsError)):
+                return lhsError == rhsError
+            default:
+                return false
+            }
+        }
+    }
+    
+    struct ItemListError: Equatable {
+        let title: String
+        let subtitle: String
+        let buttonText: String
+    }
+
+    struct ItemListEmpty: Equatable {
+        // TODO:
+        // Differentiate between empty with no products vs empty with no eligible products
+        // https://github.com/woocommerce/woocommerce-ios/issues/12815
+        // https://github.com/woocommerce/woocommerce-ios/issues/12816
+        let title: String
+        let subtitle: String
+        let hint: String
+        let buttonText: String
     }
 }
 
 private extension ItemListViewModel {
     enum Constants {
+        static let emptyProductsTitle = NSLocalizedString(
+            "",
+            value: "No products",
+            comment: ""
+        )
+        static let emptyProductsSubtitle = NSLocalizedString(
+            "",
+            value: "Your store doesn't have any products",
+            comment: ""
+        )
+        static let emptyProductsHint = NSLocalizedString(
+            "",
+            value: "POS currently only supports simple products",
+            comment: ""
+        )
+        static let emptyProductsButtonTitle = NSLocalizedString(
+            "",
+            value: "Create a simple product",
+            comment: ""
+        )
         static let failedToLoadTitle = NSLocalizedString(
             "",
             value: "Error loading products",

--- a/WooCommerce/WooCommerceTests/POS/ViewModels/ItemListViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/POS/ViewModels/ItemListViewModelTests.swift
@@ -65,10 +65,10 @@ final class ItemListViewModelTests: XCTestCase {
         let itemProvider = MockPOSItemProvider()
         itemProvider.shouldReturnZeroItems = true
         let sut = ItemListViewModel(itemProvider: itemProvider)
-        let expectedResult = ItemListEmpty(title: "No products",
-                                           subtitle: "Your store doesn't have any products",
-                                           hint: "POS currently only supports simple products",
-                                           buttonText: "Create a simple product")
+        let expectedResult = ItemListViewModel.EmptyModel(title: "No products",
+                                                          subtitle: "Your store doesn't have any products",
+                                                          hint: "POS currently only supports simple products",
+                                                          buttonText: "Create a simple product")
 
         XCTAssertEqual(sut.state, .loading)
 
@@ -84,9 +84,9 @@ final class ItemListViewModelTests: XCTestCase {
         let itemProvider = MockPOSItemProvider()
         itemProvider.shouldThrowError = true
         let sut = ItemListViewModel(itemProvider: itemProvider)
-        let expectedError = ItemListError(title: "Error loading products",
-                                          subtitle: "Give it another go?",
-                                          buttonText: "Retry")
+        let expectedError = ItemListViewModel.ErrorModel(title: "Error loading products",
+                                                         subtitle: "Give it another go?",
+                                                         buttonText: "Retry")
 
         XCTAssertEqual(sut.state, .loading)
 
@@ -114,9 +114,9 @@ final class ItemListViewModelTests: XCTestCase {
         let itemProvider = MockPOSItemProvider()
         itemProvider.shouldThrowError = true
         let sut = ItemListViewModel(itemProvider: itemProvider)
-        let expectedError = ItemListError(title: "Error loading products",
-                                          subtitle: "Give it another go?",
-                                          buttonText: "Retry")
+        let expectedError = ItemListViewModel.ErrorModel(title: "Error loading products",
+                                                         subtitle: "Give it another go?",
+                                                         buttonText: "Retry")
 
         XCTAssertEqual(sut.state, .loading)
 

--- a/Yosemite/Yosemite/PointOfSale/POSItemProvider.swift
+++ b/Yosemite/Yosemite/PointOfSale/POSItemProvider.swift
@@ -9,6 +9,13 @@ public protocol POSItem {
     var productType: ProductType { get }
 }
 
+extension POSItem {
+    // Equatable conformance
+    static func == (lhs: Self, rhs: Self) -> Bool {
+        lhs.itemID == rhs.itemID
+    }
+}
+
 public protocol POSItemProvider {
     func providePointOfSaleItems() async throws -> [POSItem]
 }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #12846
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
This PR specializes further the different cases the `ItemList` can be at, by passing associated values and modelling the data we'll display in the view when we land on each case.

| Loading | Loaded | 
|--------|--------|
| ![simulator_screenshot_28B15C8C-1A0C-46EC-BFC0-A175491876A9](https://github.com/woocommerce/woocommerce-ios/assets/3812076/0a84e9bb-6faa-47a3-955c-e1d7ac28d8f1) | ![Simulator Screenshot - iPad Pro (12 9-inch) (6th generation) - 2024-07-11 at 11 20 37](https://github.com/woocommerce/woocommerce-ios/assets/3812076/31834847-e37d-448d-a5be-6e61960b3be7) |   

| Empty | Error |
|--------|--------|
| ![Simulator Screenshot - iPad Pro (12 9-inch) (6th generation) - 2024-07-11 at 11 20 41](https://github.com/woocommerce/woocommerce-ios/assets/3812076/446ec7cb-3ab2-4279-9f98-b4ca2263e0c8) | ![Simulator Screenshot - iPad Pro (12 9-inch) (6th generation) - 2024-07-11 at 11 21 54](https://github.com/woocommerce/woocommerce-ios/assets/3812076/883ed555-9032-420a-b41a-0e98106ea2f6) |

## Changes
`ItemListState` cases now have associated values: `empty(EmptyModel)`, `loaded([POSItem])`, and `error(ErrorModel)` which will be passed down to the views as needed. These hold either the list of items that have been loaded or the different data to be displayed.

## Testing
#### Case 1: Loading/Loaded
* Run the POS normally, observe that products are loading, then loaded, and re-loaded on pull-to-refresh

#### Case 2: Empty
* Update the `reload()` method to return a list of empty products:
```diff
    @MainActor
    func reload() async {
        do {
            state = .loading
-           let newItems = try await itemProvider.providePointOfSaleItems()
+           var newItems = try await itemProvider.providePointOfSaleItems()
+           newItems = []
            if newItems.count == 0 {
```
* Run the POS normally, observe that products are loaded and the `empty view` is shown on pull-to-refresh

#### Case 3: Error
* Update the `reload()` method to throw an error:
```diff
    @MainActor
    func reload() async {
        do {
            state = .loading
            let newItems = try await itemProvider.providePointOfSaleItems()
+          throw NSError(domain: "", code: 0)
            if newItems.count == 0 {
```
* Run the POS normally, observe that products are loaded and the `error view` is shown on pull-to-refresh