### PR TITLE
Product Creation AI: Upload packaging image upon saving product

### DIFF
--- a/WooCommerce/Classes/ServiceLocator/ProductImageUploader.swift
+++ b/WooCommerce/Classes/ServiceLocator/ProductImageUploader.swift
@@ -173,11 +173,11 @@ final class ProductImageUploader: ProductImageUploaderProtocol {
         // The product has to exist remotely in order to save its images remotely.
         // In product creation, this save function should be called after a new product is saved remotely for the first time.
         guard key.isLocalID == false else {
-            return
+            return onProductSave(.failure(ProductImageUploaderError.noRemoteProductIDFound))
         }
 
         guard let handler = actionHandlersByProduct[key] else {
-            return
+            return onProductSave(.failure(ProductImageUploaderError.noActionHandlerFound))
         }
 
         guard handler.productImageStatuses.hasPendingUpload else {
@@ -264,6 +264,8 @@ private extension ProductOrVariationID {
 
 /// Possible errors from background image upload.
 enum ProductImageUploaderError: Error {
+    case noActionHandlerFound
+    case noRemoteProductIDFound
     case failedSavingProductAfterImageUpload(error: Error)
     case failedUploadingImage(error: Error)
 }

--- a/WooCommerce/Classes/ServiceLocator/ProductImageUploader.swift
+++ b/WooCommerce/Classes/ServiceLocator/ProductImageUploader.swift
@@ -180,13 +180,6 @@ final class ProductImageUploader: ProductImageUploaderProtocol {
             return onProductSave(.failure(ProductImageUploaderError.noActionHandlerFound))
         }
 
-        guard handler.productImageStatuses.hasPendingUpload else {
-            updateProductIDOfImagesUploadedUsingLocalProductID(siteID: key.siteID,
-                                                               productOrVariationID: key.productOrVariationID,
-                                                               images: handler.productImageStatuses.images)
-            return
-        }
-
         let imagesSaver: ProductImagesSaver
         if let productImagesSaver = imagesSaverByProduct[key] {
             imagesSaver = productImagesSaver

--- a/WooCommerce/Classes/ViewRelated/MainTabBarController.swift
+++ b/WooCommerce/Classes/ViewRelated/MainTabBarController.swift
@@ -676,7 +676,7 @@ private extension MainTabBarController {
             switch error.error {
             case .failedSavingProductAfterImageUpload:
                 self.handleErrorSavingProductAfterImageUpload(error)
-            case .failedUploadingImage:
+            case .failedUploadingImage, .noActionHandlerFound, .noRemoteProductIDFound:
                 self.handleErrorUploadingImage(error)
             }
         }

--- a/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductWithAI/Preview/ProductDetailPreviewView.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductWithAI/Preview/ProductDetailPreviewView.swift
@@ -132,7 +132,7 @@ struct ProductDetailPreviewView: View {
                 }
             }
             .onDisappear {
-                viewModel.onDisappear()
+                viewModel.onViewDisappear()
             }
             .onChange(of: viewModel.errorState) { newValue in
                 isShowingErrorAlert = newValue != .none

--- a/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductWithAI/Preview/ProductDetailPreviewView.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductWithAI/Preview/ProductDetailPreviewView.swift
@@ -131,6 +131,9 @@ struct ProductDetailPreviewView: View {
                     await viewModel.generateProductDetails()
                 }
             }
+            .onDisappear {
+                viewModel.onDisappear()
+            }
             .onChange(of: viewModel.errorState) { newValue in
                 isShowingErrorAlert = newValue != .none
             }

--- a/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductWithAI/Preview/ProductDetailPreviewViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductWithAI/Preview/ProductDetailPreviewViewModel.swift
@@ -146,6 +146,13 @@ final class ProductDetailPreviewViewModel: ObservableObject {
         return ResultsController<StorageProductTag>(storageManager: storageManager, matching: predicate, sortedBy: [descriptor])
     }()
 
+    private lazy var productImageActionHandler: ProductImageActionHandler = {
+        let key = ProductImageUploaderKey(siteID: siteID,
+                                          productOrVariationID: .product(id: localProductID),
+                                          isLocalID: true)
+        return productImageUploader.actionHandler(key: key, originalStatuses: [])
+    }()
+
     init(siteID: Int64,
          productFeatures: String,
          imageState: ImageState,
@@ -663,11 +670,6 @@ private extension ProductDetailPreviewViewModel {
         guard case let .success(packagingImage) = imageState else {
             return
         }
-        let productImageActionHandler = productImageUploader
-            .actionHandler(key: .init(siteID: siteID,
-                                      productOrVariationID: .product(id: localProductID),
-                                      isLocalID: true),
-                           originalStatuses: [])
         switch packagingImage.source {
         case let .asset(asset):
             productImageActionHandler.uploadMediaAssetToSiteMediaLibrary(asset: .phAsset(asset: asset))

--- a/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductWithAI/Preview/ProductDetailPreviewViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductWithAI/Preview/ProductDetailPreviewViewModel.swift
@@ -291,8 +291,8 @@ final class ProductDetailPreviewViewModel: ObservableObject {
         })
     }
 
-    func onDisappear() {
-        cancelBackgroundImageUpload()
+    func onViewDisappear() {
+        cancelBackgroundImageUploadIfNeeded()
     }
 }
 
@@ -710,7 +710,10 @@ private extension ProductDetailPreviewViewModel {
         }
     }
 
-    func cancelBackgroundImageUpload() {
+    func cancelBackgroundImageUploadIfNeeded() {
+        guard isSavingProduct, case .success = imageState else {
+            return
+        }
         let id: ProductOrVariationID = .product(id: createdProductID ?? localProductID)
         productImageUploader.startEmittingErrors(key: .init(siteID: siteID,
                                                             productOrVariationID: id,

--- a/WooCommerce/Classes/ViewRelated/Products/Media/ProductImagesSaver.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Media/ProductImagesSaver.swift
@@ -40,7 +40,7 @@ final class ProductImagesSaver {
                                                          onProductSave: @escaping (Result<[ProductImage], Error>) -> Void) {
         let imageStatuses = imageActionHandler.productImageStatuses
         guard imageStatuses.hasPendingUpload else {
-            return
+            return saveProductImages(imageStatuses.images, onProductSave: onProductSave)
         }
 
         imageStatusesToSave = imageStatuses

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/Add Product/AddProductWithAI/ProductDetailPreviewViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/Add Product/AddProductWithAI/ProductDetailPreviewViewModelTests.swift
@@ -580,7 +580,6 @@ final class ProductDetailPreviewViewModelTests: XCTestCase {
 
         let productImagesUploader = MockProductImageUploader()
         let expectedImage = ProductImage.fake().copy(imageID: 14324)
-        productImagesUploader.whenHasUnsavedChangesOnImagesIsCalled(thenReturn: true)
         productImagesUploader.whenProductIsSaved(thenReturn: .success([expectedImage]))
 
         var savedProduct: Product?


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #13299 
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This PR handles the packaging image upload after saving a product. Changes include:
- Handled background image uploads with local product ID immediately when "Save as draft" is tapped. I'm using 0 as the ID as this seems to be the default ID used for the product form too, but I'm not sure if I understand correctly. Let me know what you think.
- Updated the product when all images are uploaded.
- Canceled background image upload when the view is dismissed.

## Testing steps
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->
- Log in to a store eligible for Jetpack AI features.
- Navigate to the Products tab and select "+" > Create product with AI.
- Select a product packaging then continue.
- After generated product details are populated, tap Save as draft.
- After saving product completes, confirm that the product form is displayed with the uploaded packaging image.


## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

https://github.com/woocommerce/woocommerce-ios/assets/5533851/50864967-5af2-489a-91e1-f482d8d950ff



---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
