### PR TITLE
[Woo POS] Remove logic duplication on reloading data

### DIFF
--- a/WooCommerce/Classes/POS/ViewModels/ItemListViewModel.swift
+++ b/WooCommerce/Classes/POS/ViewModels/ItemListViewModel.swift
@@ -47,30 +47,7 @@ final class ItemListViewModel: ObservableObject {
 
     @MainActor
     func reload() async {
-        do {
-            // TODO:
-            // Resolve duplication with populatePointOfSaleItems()
-            state = .loading
-            let newItems = try await itemProvider.providePointOfSaleItems()
-            if newItems.count == 0 {
-                let itemListEmpty = EmptyModel(title: Constants.emptyProductsTitle,
-                                                  subtitle: Constants.emptyProductsSubtitle,
-                                                  hint: Constants.emptyProductsHint,
-                                                  buttonText: Constants.emptyProductsButtonTitle)
-                state = .empty(itemListEmpty)
-            } else {
-                // Only clears in-memory items if the `do` block continues, otherwise we keep them in memory.
-                items.removeAll()
-                items = newItems
-                state = .loaded(items)
-            }
-        } catch {
-            DDLogError("Error on reload while updating product data: \(error)")
-            let itemListError = ErrorModel(title: Constants.failedToLoadTitle,
-                                      subtitle: Constants.failedToLoadSubtitle,
-                                      buttonText: Constants.failedToLoadButtonTitle)
-            state = .error(itemListError)
-        }
+        await populatePointOfSaleItems()
     }
 }
 

--- a/WooCommerce/WooCommerceTests/POS/ViewModels/ItemListViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/POS/ViewModels/ItemListViewModelTests.swift
@@ -23,6 +23,58 @@ final class ItemListViewModelTests: XCTestCase {
         super.tearDown()
     }
 
+    func test_itemListViewModel_when_populatePointOfSaleItems_is_called_then_items_are_populated() async {
+        // Given
+        XCTAssertEqual(sut.items.count, 0)
+        let expectedItems = Self.makeItems()
+
+        // When
+        await sut.populatePointOfSaleItems()
+
+        // Then
+        XCTAssertEqual(sut.items.count, expectedItems.count)
+    }
+
+    func test_itemListViewModel_when_populatePointOfSaleItems_is_called_multiple_times_then_items_are_not_aggregated() async {
+        // Given
+        XCTAssertEqual(sut.items.count, 0)
+        let expectedItems = Self.makeItems()
+
+        // When
+        await sut.populatePointOfSaleItems()
+        await sut.populatePointOfSaleItems()
+        await sut.populatePointOfSaleItems()
+
+        // Then
+        XCTAssertEqual(sut.items.count, expectedItems.count)
+    }
+
+    func test_itemListViewModel_when_reload_is_called_then_items_are_populated() async {
+        // Given
+        XCTAssertEqual(sut.items.count, 0)
+        let expectedItems = Self.makeItems()
+
+        // When
+        await sut.reload()
+
+        // Then
+        XCTAssertEqual(sut.items.count, expectedItems.count)
+    }
+
+    func test_itemListViewModel_when_reload_is_called_multiple_times_then_items_are_not_aggregated() async {
+        // Given
+        XCTAssertEqual(sut.items.count, 0)
+        let expectedItems = Self.makeItems()
+
+        // When
+        await sut.reload()
+        await sut.reload()
+        await sut.reload()
+
+        // Then
+        XCTAssertEqual(sut.items.count, expectedItems.count)
+    }
+
     func test_itemListViewModel_when_select_item_then_sends_item_to_publisher() {
         // Given
         let items = Self.makeItems()

--- a/WooCommerce/WooCommerceTests/POS/ViewModels/ItemListViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/POS/ViewModels/ItemListViewModelTests.swift
@@ -25,7 +25,7 @@ final class ItemListViewModelTests: XCTestCase {
 
     func test_itemListViewModel_when_select_item_then_sends_item_to_publisher() {
         // Given
-        let item = Self.makeItem()
+        let items = Self.makeItems()
         let expectation = XCTestExpectation(description: "Publisher should emit the selected item")
 
         var receivedItem: POSItem?
@@ -36,6 +36,9 @@ final class ItemListViewModelTests: XCTestCase {
         .store(in: &cancellables)
 
         // When
+        guard let item = items.first else {
+            return XCTFail("Expected an item, got none.")
+        }
         sut.select(item)
 
         // Then
@@ -49,7 +52,7 @@ final class ItemListViewModelTests: XCTestCase {
 
     func test_itemListViewModel_when_populatePointOfSaleItems_then_state_is_loaded() async {
         // Given
-        let expectedItem = Self.makeItem()
+        let expectedItems = Self.makeItems()
 
         XCTAssertEqual(sut.state, .loading)
 
@@ -57,7 +60,7 @@ final class ItemListViewModelTests: XCTestCase {
         await sut.populatePointOfSaleItems()
 
         // Then
-        XCTAssertEqual(sut.state, .loaded([expectedItem]))
+        XCTAssertEqual(sut.state, .loaded(expectedItems))
     }
 
     func test_itemListViewModel_when_populatePointOfSaleItems_has_no_items_then_state_is_loaded_empty() async {
@@ -97,16 +100,16 @@ final class ItemListViewModelTests: XCTestCase {
         XCTAssertEqual(sut.state, .error(expectedError))
     }
 
-    func test_itemListViewModel_when_reload_then_state_is_loaded_with_expected_item() async {
+    func test_itemListViewModel_when_reload_then_state_is_loaded_with_expected_items() async {
         // Given
         XCTAssertEqual(sut.state, .loading)
-        let expectedItem = Self.makeItem()
+        let expectedItems = Self.makeItems()
 
         // When
         await sut.reload()
 
         // Then
-        XCTAssertEqual(sut.state, .loaded([expectedItem]))
+        XCTAssertEqual(sut.state, .loaded(expectedItems))
     }
 
     func test_itemListViewModel_when_reload_throws_error_then_state_is_error() async {
@@ -142,20 +145,31 @@ private extension ItemListViewModelTests {
             if shouldReturnZeroItems {
                 return []
             }
-            let item = makeItem()
-            return [item]
+            return makeItems()
         }
     }
 
-    static func makeItem() -> POSItem {
-        let fakeUUID = UUID(uuidString: "DC55E3B9-9D83-4C07-82A7-4C300A50E84E") ?? UUID()
-        return POSProduct(itemID: fakeUUID,
-                          productID: 0,
-                          name: "",
-                          price: "",
-                          formattedPrice: "",
-                          itemCategories: [],
-                          productImageSource: nil,
-                          productType: .simple)
+    static func makeItems() -> [POSItem] {
+        let fakeUUID1 = UUID(uuidString: "DC55E3B9-9D83-4C07-82A7-4C300A50E84E") ?? UUID()
+        let fakeUUID2 = UUID(uuidString: "DC55E3B8-9D82-4C06-82A5-4C300A50E84A") ?? UUID()
+
+        let product1 = POSProduct(itemID: fakeUUID1,
+                                  productID: 0,
+                                  name: "Choco",
+                                  price: "2",
+                                  formattedPrice: "$2.00",
+                                  itemCategories: [],
+                                  productImageSource: nil,
+                                  productType: .simple)
+
+        let product2 = POSProduct(itemID: fakeUUID2,
+                                  productID: 1,
+                                  name: "Vanilla",
+                                  price: "3",
+                                  formattedPrice: "$3.00",
+                                  itemCategories: [],
+                                  productImageSource: nil,
+                                  productType: .simple)
+        return [product1, product2]
     }
 }


### PR DESCRIPTION
Closes: #13307

## Description
This PR removes the existing duplication between `reload()` and `populatePointOfSaleItems()` by making reload() just a wrapper for `populatePointOfSaleItems()`. We might want to add additional logic here when tackling the cases of loading state between the first time we enter POS mode, and subsequent times where we refresh data by reloading, but it feels that we can tackle this in the future when we actually implement those screens and cases.

We also use this opportunity to improve test coverage.

## Testing
- Run the POS mode
- Observe that products load, and reload on pull-to-refresh
- Add some products to the cart and tap "Checkout", then tap "Add More" to go back. Observe products are not reloaded and we still use what's in memory.
