### PR TITLE
Product creation AI: Fix issue replacing packaging photo and layout for package photo view

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductWithAI/ImageSelection/PackagePhotoView.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductWithAI/ImageSelection/PackagePhotoView.swift
@@ -67,19 +67,12 @@ struct PackagePhotoView: View {
         }
         .padding(Layout.padding)
         .background(Color(.systemColor(.systemGray6)))
-        .clipShape(
-            .rect(
-                bottomLeadingRadius: Layout.textFieldOverlayCornerRadius,
-                bottomTrailingRadius: Layout.textFieldOverlayCornerRadius
-            )
-        )
     }
 
     enum Layout {
         static let spacing: CGFloat = 16
         static let cornerRadius: CGFloat = 4
         static let padding = EdgeInsets(top: 12, leading: 16, bottom: 12, trailing: 16)
-        static let textFieldOverlayCornerRadius: CGFloat = 8
         static let packagePhotoSize: CGFloat = 48
         static let ellipisButtonSize: CGFloat = 24
     }

--- a/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductWithAI/ImageSelection/PackagePhotoView.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductWithAI/ImageSelection/PackagePhotoView.swift
@@ -26,7 +26,9 @@ struct PackagePhotoView: View {
     }
 
     var body: some View {
-        HStack(alignment: .center, spacing: Layout.spacing) {
+        AdaptiveStack(horizontalAlignment: .leading,
+                      verticalAlignment: .center,
+                      spacing: Layout.spacing) {
             EditableImageView(imageState: imageState,
                               emptyContent: {})
             .frame(width: Layout.packagePhotoSize * scale, height: Layout.packagePhotoSize * scale)
@@ -41,6 +43,7 @@ struct PackagePhotoView: View {
                         .footnoteStyle()
                 }
             }
+            .frame(maxWidth: .infinity, alignment: .leading)
 
             Spacer()
 

--- a/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductWithAI/Preview/ProductDetailPreviewView.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductWithAI/Preview/ProductDetailPreviewView.swift
@@ -260,6 +260,7 @@ private extension ProductDetailPreviewView {
                              onTapRemovePhoto: {
                 viewModel.didTapRemovePhoto()
             })
+            .clipShape(RoundedRectangle(cornerRadius: Layout.cornerRadius))
         }
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductWithAI/StartingInfo/ProductCreationAIStartingInfoView.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductWithAI/StartingInfo/ProductCreationAIStartingInfoView.swift
@@ -53,6 +53,11 @@ struct ProductCreationAIStartingInfoView: View {
                             case .empty:
                                 readTextFromPhotoButton
                                     .padding(insets: Layout.readTextFromPhotoButtonInsets)
+                                    .mediaSourceActionSheet(showsActionSheet: $viewModel.isShowingMediaPickerSourceSheet, selectMedia: { source in
+                                        Task { @MainActor in
+                                            await viewModel.selectImage(from: source)
+                                        }
+                                    })
                             case .loading, .success:
                                 PackagePhotoView(title: Localization.photoSelected,
                                                  imageState: viewModel.imageState,
@@ -64,6 +69,11 @@ struct ProductCreationAIStartingInfoView: View {
                                 },
                                                  onTapRemovePhoto: {
                                     viewModel.didTapRemovePhoto()
+                                })
+                                .mediaSourceActionSheet(showsActionSheet: $viewModel.isShowingMediaPickerSourceSheet, selectMedia: { source in
+                                    Task { @MainActor in
+                                        await viewModel.selectImage(from: source)
+                                    }
                                 })
                             }
                         }
@@ -123,11 +133,6 @@ private extension ProductCreationAIStartingInfoView {
             }
             Spacer()
         }
-        .mediaSourceActionSheet(showsActionSheet: $viewModel.isShowingMediaPickerSourceSheet, selectMedia: { source in
-            Task { @MainActor in
-                await viewModel.selectImage(from: source)
-            }
-        })
     }
 
     var placeholderText: some View {

--- a/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductWithAI/StartingInfo/ProductCreationAIStartingInfoView.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductWithAI/StartingInfo/ProductCreationAIStartingInfoView.swift
@@ -70,6 +70,12 @@ struct ProductCreationAIStartingInfoView: View {
                                                  onTapRemovePhoto: {
                                     viewModel.didTapRemovePhoto()
                                 })
+                                .clipShape(
+                                    .rect(
+                                        bottomLeadingRadius: Layout.cornerRadius,
+                                        bottomTrailingRadius: Layout.cornerRadius
+                                    )
+                                )
                                 .mediaSourceActionSheet(showsActionSheet: $viewModel.isShowingMediaPickerSourceSheet, selectMedia: { source in
                                     Task { @MainActor in
                                         await viewModel.selectImage(from: source)


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #13308 
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This PR fixes a few issues related to the package photo view:
- Added a missing modifier on the package photo view on the starting view to support replacing photos.
- Moved the `clipShape` modifier to the call site since the corners of the view are different between the starting and preview views. 
- Support large font size by replacing the wrapping `HStack` with `AdaptiveStack`.

## Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->
- Log in to a store eligible for Jetpack AI features.
- Navigate to the Products tab and select "+" > Create product with AI.
- Select a product packaging image.
- Tap on the ellipsis menu > Replace photo. Confirm that the media selection sheet is displayed.
- Select a new photo or continue with the current one.
- On the preview view, confirm that the package photo view has rounded corners in all 4 corners.
- Switch the device font size to a really large font. Confirm that the contents on the package photo view is readable.


## Screenshots
<!-- Include before and after images or gifs when appropriate. -->
Before | After 
--- | ---
<img src="https://github.com/user-attachments/assets/77c5f846-17ee-4358-a123-7751da421f3d" width=320 /> | <img src="https://github.com/user-attachments/assets/10e68fd2-be10-4378-9f2b-9f502b9722d5" width=320 />
<img src="https://github.com/user-attachments/assets/373d88f6-2e3e-4aaa-a7c3-8330629d0a29" width=320 /> | <img src="https://github.com/user-attachments/assets/e29bb7a0-4ebb-4c68-99bd-aa94f31af0a8" width=320 />

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
