### PR TITLE
Display a total product price with quantity in Discount view to match what is displayed in Order view

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/EditableOrderViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/EditableOrderViewModel.swift
@@ -615,7 +615,7 @@ final class EditableOrderViewModel: ObservableObject {
         discountViewModel = .init(id: itemID,
                                   imageURL: rowViewModel.productRow.imageURL,
                                   name: rowViewModel.productRow.name,
-                                  price: rowViewModel.productRow.price,
+                                  totalPricePreDiscount: orderItem.subtotal,
                                   priceSummary: rowViewModel.productRow.priceSummaryViewModel,
                                   discountConfiguration: addProductDiscountConfiguration(on: orderItem))
     }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/ProductsSection/ProductDiscountView.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/ProductsSection/ProductDiscountView.swift
@@ -55,7 +55,7 @@ struct ProductDiscountView: View {
                     HStack {
                         Text(Localization.priceAfterDiscountLabel)
                         Spacer()
-                        if let price = viewModel.price {
+                        if let price = viewModel.totalPricePreDiscount {
                             Text(discountDetailsViewModel.calculatePriceAfterDiscount(price))
                         }
                     }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/ProductsSection/ProductDiscountViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/ProductsSection/ProductDiscountViewModel.swift
@@ -15,8 +15,8 @@ final class ProductDiscountViewModel: Identifiable {
     /// Product name
     let name: String
 
-    /// Product price
-    let price: String?
+    /// Total product price with quantity excluding discount
+    let totalPricePreDiscount: String?
 
     /// View model for `CollapsibleProductCardPriceSummary`
     let priceSummary: CollapsibleProductCardPriceSummaryViewModel
@@ -55,14 +55,14 @@ final class ProductDiscountViewModel: Identifiable {
     init(id: Int64,
          imageURL: URL?,
          name: String,
-         price: String?,
+         totalPricePreDiscount: String?,
          priceSummary: CollapsibleProductCardPriceSummaryViewModel,
          discountConfiguration: DiscountConfiguration?,
          currencyFormatter: CurrencyFormatter = CurrencyFormatter(currencySettings: ServiceLocator.currencySettings)) {
         self.id = id
         self.imageURL = imageURL
         self.name = name
-        self.price = price
+        self.totalPricePreDiscount = totalPricePreDiscount
         self.priceSummary = priceSummary
         addedDiscount = discountConfiguration?.addedDiscount ?? .zero
         hasDiscount = addedDiscount != 0


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #11393
<!-- Id number of the GitHub issue this PR addresses. -->

## Description

When fixing other parts of product pricing within Order view https://github.com/woocommerce/woocommerce-ios/pull/13305 I noticed a fairly easy solution for #11393.

### Problem

If the product quantity is more than 1, then "Price after discount" is displayed for all the quantity of the product within the Order view, and for a single item within the Discount view. We should make sure the presentation is consistent.

| Discount View | Order View |
|---------|---------|
| ![Add Discount - Discount page - Before](https://github.com/user-attachments/assets/e9b4ebaf-f1b7-4ba9-ae88-25a0b048049e) | ![Add Discount - Order - Before](https://github.com/user-attachments/assets/01599871-6d2f-4ddd-b5d4-363030b40b50) |


### Solution

Use `orderItem.subtotal` within Discount view, which is a pre-tax pre-discount product price multiplied by the quantity. After https://github.com/woocommerce/woocommerce-ios/pull/13305 is merged the fix will work well for both "Prices entered with tax" settings.

## Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->

## Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->

Steps to reproduce the behavior:
- Go to the orders tab
- Tap `+` to create an order
- Tap `Add Products` and select a product or variation
- Tap to expand the product card
- Increment the quantity to be larger than 1
- Tap `Add discount`
- Enter some non-zero amount to the text field
- Confirm the "Price after discount" field shows the total discounted price 
- Tap `Add` --> after syncing
- Confirm "Price after discount" field shows the total discounted price in the order form, the same as in Discount view

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

| Discount View | Order View |
|---------|---------|
| ![Add Discount - Discount Page - After](https://github.com/user-attachments/assets/31740806-f2ea-4b15-84b7-460a3676cbdc) | ![Add Discount - Order - After](https://github.com/user-attachments/assets/a37cdaca-5753-4836-97aa-1c999e9b4258) |



---
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.