### PR TITLE
[Woo POS] Add simple-only product banner to dashboard

### DIFF
--- a/WooCommerce/Classes/POS/Presentation/ItemListView.swift
+++ b/WooCommerce/Classes/POS/Presentation/ItemListView.swift
@@ -10,11 +10,7 @@ struct ItemListView: View {
 
     var body: some View {
         VStack {
-            Text(Localization.productSelectorTitle)
-                .frame(maxWidth: .infinity, alignment: .leading)
-                .padding(.vertical, 8)
-                .font(Constants.titleFont)
-                .foregroundColor(Color.posPrimaryTexti3)
+            headerView()
             switch viewModel.state {
             case .empty(let emptyModel):
                 emptyView(emptyModel)
@@ -37,6 +33,48 @@ struct ItemListView: View {
 /// View Helpers
 ///
 private extension ItemListView {
+    @ViewBuilder
+    func headerView() -> some View {
+        switch viewModel.isBannerVisible {
+        case true:
+            VStack {
+                Text(Localization.productSelectorTitle)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .padding(.vertical, 8)
+                    .font(Constants.titleFont)
+                    .foregroundColor(Color.posPrimaryTexti3)
+                // TODO:
+                // Separate the banner card to its own view
+                HStack {
+                    Image(uiImage: .infoImage)
+                    VStack {
+                        Text("Showing simple products only")
+                        Text("Only simple physical products are available with POS right now.")
+                        Text("Other product types, such as variable and virtual, will become available in future updates.")
+                    }
+                    Button(action: {
+                        viewModel.toggleBanner()
+                    }, label: {
+                        Image(uiImage: .closeButton)
+                    })
+                }
+            }
+        case false:
+            HStack {
+                Text(Localization.productSelectorTitle)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .padding(.vertical, 8)
+                    .font(Constants.titleFont)
+                    .foregroundColor(Color.posPrimaryTexti3)
+                Spacer()
+                Button(action: {
+                    viewModel.toggleBanner()
+                }, label: {
+                    Image(uiImage: .infoImage)
+                })
+            }
+        }
+    }
     var loadingView: some View {
         VStack {
             Spacer()

--- a/WooCommerce/Classes/POS/Presentation/ItemListView.swift
+++ b/WooCommerce/Classes/POS/Presentation/ItemListView.swift
@@ -39,12 +39,12 @@ private extension ItemListView {
         switch viewModel.shouldShowHeaderBanner {
         case true:
             VStack {
-                headertextView
+                headerTextView
                 bannerCardView
             }
         case false:
             HStack {
-                headertextView
+                headerTextView
                 Spacer()
                 Button(action: {
                     viewModel.toggleBanner()
@@ -84,7 +84,7 @@ private extension ItemListView {
         .background(Color.posBackgroundWhitei3)
     }
 
-    var headertextView: some View {
+    var headerTextView: some View {
         Text(Localization.productSelectorTitle)
             .frame(maxWidth: .infinity, alignment: .leading)
             .padding(.vertical, 8)

--- a/WooCommerce/Classes/POS/Presentation/ItemListView.swift
+++ b/WooCommerce/Classes/POS/Presentation/ItemListView.swift
@@ -67,6 +67,7 @@ private extension ItemListView {
                 Text(Localization.headerBannerSubtitle)
                 Text(Localization.headerBannerHint)
             }
+            Spacer()
             VStack {
                 Button(action: {
                     viewModel.toggleBanner()

--- a/WooCommerce/Classes/POS/Presentation/ItemListView.swift
+++ b/WooCommerce/Classes/POS/Presentation/ItemListView.swift
@@ -26,7 +26,7 @@ struct ItemListView: View {
         .refreshable {
             await viewModel.reload()
         }
-        .padding(.horizontal, 32)
+        .padding(.horizontal, Constants.itemListPadding)
         .background(Color.posBackgroundGreyi3)
     }
 }
@@ -87,7 +87,7 @@ private extension ItemListView {
     var headerTextView: some View {
         Text(Localization.productSelectorTitle)
             .frame(maxWidth: .infinity, alignment: .leading)
-            .padding(.vertical, 8)
+            .padding(.vertical, Constants.headerPadding)
             .font(Constants.titleFont)
             .foregroundColor(Color.posPrimaryTexti3)
     }
@@ -158,6 +158,8 @@ private extension ItemListView {
         static let infoIconSize: CGFloat = 48
         static let closeIconSize: CGFloat = 26
         static let iconPadding: CGFloat = 24
+        static let headerPadding: CGFloat = 8
+        static let itemListPadding: CGFloat = 32
     }
 
     enum Localization {

--- a/WooCommerce/Classes/POS/Presentation/ItemListView.swift
+++ b/WooCommerce/Classes/POS/Presentation/ItemListView.swift
@@ -35,37 +35,15 @@ struct ItemListView: View {
 private extension ItemListView {
     @ViewBuilder
     func headerView() -> some View {
-        switch viewModel.isBannerVisible {
+        switch viewModel.shouldShowHeaderBanner {
         case true:
             VStack {
-                Text(Localization.productSelectorTitle)
-                    .frame(maxWidth: .infinity, alignment: .leading)
-                    .padding(.vertical, 8)
-                    .font(Constants.titleFont)
-                    .foregroundColor(Color.posPrimaryTexti3)
-                // TODO:
-                // Separate the banner card to its own view
-                HStack {
-                    Image(uiImage: .infoImage)
-                    VStack {
-                        Text("Showing simple products only")
-                        Text("Only simple physical products are available with POS right now.")
-                        Text("Other product types, such as variable and virtual, will become available in future updates.")
-                    }
-                    Button(action: {
-                        viewModel.toggleBanner()
-                    }, label: {
-                        Image(uiImage: .closeButton)
-                    })
-                }
+                headertextView
+                bannerCardView
             }
         case false:
             HStack {
-                Text(Localization.productSelectorTitle)
-                    .frame(maxWidth: .infinity, alignment: .leading)
-                    .padding(.vertical, 8)
-                    .font(Constants.titleFont)
-                    .foregroundColor(Color.posPrimaryTexti3)
+                headertextView
                 Spacer()
                 Button(action: {
                     viewModel.toggleBanner()
@@ -75,6 +53,31 @@ private extension ItemListView {
             }
         }
     }
+
+    var bannerCardView: some View {
+        HStack {
+            Image(uiImage: .infoImage)
+            VStack {
+                Text(Localization.headerBannerTitle)
+                Text(Localization.headerBannerSubtitle)
+                Text(Localization.headerBannerHint)
+            }
+            Button(action: {
+                viewModel.toggleBanner()
+            }, label: {
+                Image(uiImage: .closeButton)
+            })
+        }
+    }
+
+    var headertextView: some View {
+        Text(Localization.productSelectorTitle)
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .padding(.vertical, 8)
+            .font(Constants.titleFont)
+            .foregroundColor(Color.posPrimaryTexti3)
+    }
+
     var loadingView: some View {
         VStack {
             Spacer()
@@ -143,6 +146,21 @@ private extension ItemListView {
             "pos.itemlistview.productSelectorTitle",
             value: "Products",
             comment: "Title of the Point of Sale product selector"
+        )
+        static let headerBannerTitle = NSLocalizedString(
+            "pos.itemlistview.headerBannerTitle",
+            value: "Showing simple products only",
+            comment: "Title of the product selector header banner, which explains current POS limitations"
+        )
+        static let headerBannerSubtitle = NSLocalizedString(
+            "pos.itemlistview.headerBannerSubtitle",
+            value: "Only simple physical products are available with POS right now.",
+            comment: "Subtitle of the product selector header banner, which explains current POS limitations"
+        )
+        static let headerBannerHint = NSLocalizedString(
+            "pos.itemlistview.headerBannerHint",
+            value: "Other product types, such as variable and virtual, will become available in future updates.",
+            comment: "Additional text within the product selector header banner, which explains current POS limitations"
         )
     }
 }

--- a/WooCommerce/Classes/POS/Presentation/ItemListView.swift
+++ b/WooCommerce/Classes/POS/Presentation/ItemListView.swift
@@ -58,6 +58,7 @@ private extension ItemListView {
     var bannerCardView: some View {
         HStack {
             Image(uiImage: .infoImage)
+                .padding(Constants.iconPadding)
                 .frame(width: Constants.infoIconSize, height: Constants.infoIconSize)
                 .foregroundColor(Color.primaryTint)
             VStack(alignment: .leading) {
@@ -74,6 +75,7 @@ private extension ItemListView {
                         .frame(width: Constants.closeIconSize, height: Constants.closeIconSize)
                         .foregroundColor(.gray)
                 })
+                .padding(Constants.iconPadding)
                 Spacer()
             }
         }
@@ -154,6 +156,7 @@ private extension ItemListView {
         static let bannerHeight: CGFloat = 120
         static let infoIconSize: CGFloat = 48
         static let closeIconSize: CGFloat = 26
+        static let iconPadding: CGFloat = 24
     }
 
     enum Localization {

--- a/WooCommerce/Classes/POS/Presentation/ItemListView.swift
+++ b/WooCommerce/Classes/POS/Presentation/ItemListView.swift
@@ -58,7 +58,7 @@ private extension ItemListView {
     var bannerCardView: some View {
         HStack {
             Image(uiImage: .infoImage)
-                .frame(width: 48, height: 48)
+                .frame(width: Constants.infoIconSize, height: Constants.infoIconSize)
                 .foregroundColor(Color.primaryTint)
             VStack(alignment: .leading) {
                 Text(Localization.headerBannerTitle)
@@ -71,13 +71,13 @@ private extension ItemListView {
                     viewModel.toggleBanner()
                 }, label: {
                     Image(uiImage: .closeButton)
-                        .frame(width: 26, height: 26)
+                        .frame(width: Constants.closeIconSize, height: Constants.closeIconSize)
                         .foregroundColor(.gray)
                 })
                 Spacer()
             }
         }
-        .frame(maxWidth: .infinity, maxHeight: 120 * scale)
+        .frame(maxWidth: .infinity, maxHeight: Constants.bannerHeight * scale)
         .background(Color.posBackgroundWhitei3)
     }
 
@@ -151,6 +151,9 @@ private extension ItemListView {
     enum Constants {
         static let titleFont: Font = .system(size: 40, weight: .bold, design: .default)
         static let bannerTitleFont: Font = .system(size: 26, weight: .bold, design: .default)
+        static let bannerHeight: CGFloat = 120
+        static let infoIconSize: CGFloat = 48
+        static let closeIconSize: CGFloat = 26
     }
 
     enum Localization {

--- a/WooCommerce/Classes/POS/Presentation/ItemListView.swift
+++ b/WooCommerce/Classes/POS/Presentation/ItemListView.swift
@@ -2,6 +2,7 @@ import SwiftUI
 import protocol Yosemite.POSItem
 
 struct ItemListView: View {
+    @ScaledMetric private var scale: CGFloat = 1.0
     @ObservedObject var viewModel: ItemListViewModel
 
     init(viewModel: ItemListViewModel) {
@@ -57,17 +58,27 @@ private extension ItemListView {
     var bannerCardView: some View {
         HStack {
             Image(uiImage: .infoImage)
-            VStack {
+                .frame(width: 48, height: 48)
+                .foregroundColor(Color.primaryTint)
+            VStack(alignment: .leading) {
                 Text(Localization.headerBannerTitle)
+                    .font(Constants.bannerTitleFont)
                 Text(Localization.headerBannerSubtitle)
                 Text(Localization.headerBannerHint)
             }
-            Button(action: {
-                viewModel.toggleBanner()
-            }, label: {
-                Image(uiImage: .closeButton)
-            })
+            VStack {
+                Button(action: {
+                    viewModel.toggleBanner()
+                }, label: {
+                    Image(uiImage: .closeButton)
+                        .frame(width: 26, height: 26)
+                        .foregroundColor(.gray)
+                })
+                Spacer()
+            }
         }
+        .frame(maxWidth: .infinity, maxHeight: 120 * scale)
+        .background(Color.posBackgroundWhitei3)
     }
 
     var headertextView: some View {
@@ -139,6 +150,7 @@ private extension ItemListView {
 private extension ItemListView {
     enum Constants {
         static let titleFont: Font = .system(size: 40, weight: .bold, design: .default)
+        static let bannerTitleFont: Font = .system(size: 26, weight: .bold, design: .default)
     }
 
     enum Localization {

--- a/WooCommerce/Classes/POS/ViewModels/ItemListViewModel.swift
+++ b/WooCommerce/Classes/POS/ViewModels/ItemListViewModel.swift
@@ -7,7 +7,7 @@ final class ItemListViewModel: ObservableObject {
 
     @Published private(set) var items: [POSItem] = []
     @Published private(set) var state: ItemListState = .loading
-    @Published private(set) var isBannerVisible: Bool = true
+    @Published private(set) var shouldShowHeaderBanner: Bool = true
 
     private let itemProvider: POSItemProvider
     private let selectedItemSubject: PassthroughSubject<POSItem, Never> = .init()
@@ -52,7 +52,7 @@ final class ItemListViewModel: ObservableObject {
     }
 
     func toggleBanner() {
-        isBannerVisible.toggle()
+        shouldShowHeaderBanner.toggle()
     }
 }
 

--- a/WooCommerce/Classes/POS/ViewModels/ItemListViewModel.swift
+++ b/WooCommerce/Classes/POS/ViewModels/ItemListViewModel.swift
@@ -7,6 +7,7 @@ final class ItemListViewModel: ObservableObject {
 
     @Published private(set) var items: [POSItem] = []
     @Published private(set) var state: ItemListState = .loading
+    @Published private(set) var isBannerVisible: Bool = true
 
     private let itemProvider: POSItemProvider
     private let selectedItemSubject: PassthroughSubject<POSItem, Never> = .init()
@@ -48,6 +49,10 @@ final class ItemListViewModel: ObservableObject {
     @MainActor
     func reload() async {
         await populatePointOfSaleItems()
+    }
+
+    func toggleBanner() {
+        isBannerVisible.toggle()
     }
 }
 

--- a/WooCommerce/WooCommerceTests/POS/ViewModels/ItemListViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/POS/ViewModels/ItemListViewModelTests.swift
@@ -182,6 +182,17 @@ final class ItemListViewModelTests: XCTestCase {
         XCTAssertEqual(sut.state, .error(expectedError))
     }
 
+    func test_shouldShowHeaderBanner_state_toggles_when_toggleBanner_is_called() {
+        // Given
+        XCTAssertEqual(sut.shouldShowHeaderBanner, true)
+
+        // When
+        sut.toggleBanner()
+
+        // Then
+        XCTAssertEqual(sut.shouldShowHeaderBanner, false)
+    }
+
 }
 
 private extension ItemListViewModelTests {


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #13317

## Description
This PR adds a toggeable banner to the header of the item list view, in order to the current POS constraint for simple products only.

Please note the UI is not final yet, so we haven't addressed the fine-tuned details, just the overall view and its behaviour. In future PRs we also want to tie the banner display to once per app-install, at the moment will just appear all the time by default on init.

| Initial | Collapsed |
|--------|--------|
| ![Simulator Screenshot - iPad Pro (12 9-inch) (6th generation) - 2024-07-15 at 18 05 02](https://github.com/user-attachments/assets/36f8838e-4bf4-44ea-806a-fe9137584a27) | ![Simulator Screenshot - iPad Pro (12 9-inch) (6th generation) - 2024-07-15 at 18 05 05](https://github.com/user-attachments/assets/a1cfbead-18e7-45c4-88c9-56b10171541d) | 

## Testing
* In POS mode
* Observe the banner appearing at the top of the product list
* Tap the `x` icon and observe it collapses. Tap the `i` icon and observe it expands again.
