### PR TITLE
Blaze: Remove remote feature flag check

### DIFF
--- a/Networking/Networking/Remote/FeatureFlagRemote.swift
+++ b/Networking/Networking/Remote/FeatureFlagRemote.swift
@@ -28,15 +28,12 @@ public class FeatureFlagRemote: Remote, FeatureFlagRemoteProtocol {
 
 public enum RemoteFeatureFlag: Decodable {
     case storeCreationCompleteNotification
-    case blaze
     case hardcodedPlanUpgradeDetailsMilestone1AreAccurate
 
     init?(rawValue: String) {
         switch rawValue {
         case "woo_notification_store_creation_ready":
             self = .storeCreationCompleteNotification
-        case "woo_blaze":
-            self = .blaze
         case "woo_hardcoded_plan_upgrade_details_milestone_1_are_accurate":
             self = .hardcodedPlanUpgradeDetailsMilestone1AreAccurate
         default:

--- a/WooCommerce/Classes/Blaze/BlazeEligibilityChecker.swift
+++ b/WooCommerce/Classes/Blaze/BlazeEligibilityChecker.swift
@@ -3,8 +3,8 @@ import Yosemite
 
 /// Protocol for checking Blaze eligibility for easier unit testing.
 protocol BlazeEligibilityCheckerProtocol {
-    func isSiteEligible(_ site: Site) async -> Bool
-    func isProductEligible(site: Site, product: ProductFormDataModel, isPasswordProtected: Bool) async -> Bool
+    func isSiteEligible(_ site: Site) -> Bool
+    func isProductEligible(site: Site, product: ProductFormDataModel, isPasswordProtected: Bool) -> Bool
 }
 
 /// Checks for Blaze eligibility for a site and its products.
@@ -17,47 +17,30 @@ final class BlazeEligibilityChecker: BlazeEligibilityCheckerProtocol {
 
     /// Checks if the site is eligible for Blaze.
     /// - Returns: Whether the site is eligible for Blaze.
-    @MainActor
-    func isSiteEligible(_ site: Site) async -> Bool {
-        await checkSiteEligibility(site)
+    func isSiteEligible(_ site: Site) -> Bool {
+        checkSiteEligibility(site)
     }
 
     /// Checks if the product is eligible for Blaze.
     /// - Parameter product: The product to check for Blaze eligibility.
     /// - Parameter isPasswordProtected: Whether the product is password protected.
     /// - Returns: Whether the product is eligible for Blaze.
-    @MainActor
-    func isProductEligible(site: Site, product: ProductFormDataModel, isPasswordProtected: Bool) async -> Bool {
+    func isProductEligible(site: Site, product: ProductFormDataModel, isPasswordProtected: Bool) -> Bool {
         guard product.status == .published && isPasswordProtected == false else {
             return false
         }
-        return await checkSiteEligibility(site)
+        return checkSiteEligibility(site)
     }
 }
 
 private extension BlazeEligibilityChecker {
-    @MainActor
-    func checkSiteEligibility(_ site: Site) async -> Bool {
+    func checkSiteEligibility(_ site: Site) -> Bool {
         guard site.isAdmin && site.canBlaze else {
             return false
         }
         guard stores.isAuthenticatedWithoutWPCom == false else {
             return false
         }
-        guard await isRemoteFeatureFlagEnabled(.blaze) else {
-            return false
-        }
         return true
-    }
-}
-
-private extension BlazeEligibilityChecker {
-    @MainActor
-    func isRemoteFeatureFlagEnabled(_ remoteFeatureFlag: RemoteFeatureFlag) async -> Bool {
-        await withCheckedContinuation { continuation in
-            stores.dispatch(FeatureFlagAction.isRemoteFeatureFlagEnabled(remoteFeatureFlag, defaultValue: false) { isEnabled in
-                continuation.resume(returning: isEnabled)
-            })
-        }
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Blaze/BlazeCampaignDashboardViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Blaze/BlazeCampaignDashboardViewModel.swift
@@ -122,7 +122,7 @@ final class BlazeCampaignDashboardViewModel: ObservableObject {
 
     @MainActor
     func checkAvailability() async {
-        isSiteEligibleForBlaze = await checkSiteEligibility()
+        isSiteEligibleForBlaze = checkSiteEligibility()
         try? await synchronizePublishedProducts()
         updateAvailability()
     }
@@ -134,7 +134,7 @@ final class BlazeCampaignDashboardViewModel: ObservableObject {
 
         analytics.track(event: .DynamicDashboard.cardLoadingStarted(type: .blaze))
 
-        isSiteEligibleForBlaze = await checkSiteEligibility()
+        isSiteEligibleForBlaze = checkSiteEligibility()
 
         guard isSiteEligibleForBlaze else {
             update(state: .empty)
@@ -196,12 +196,11 @@ final class BlazeCampaignDashboardViewModel: ObservableObject {
 
 // MARK: - Blaze campaigns
 private extension BlazeCampaignDashboardViewModel {
-    @MainActor
-    func checkSiteEligibility() async -> Bool {
+    func checkSiteEligibility() -> Bool {
         guard let site = stores.sessionManager.defaultSite else {
             return false
         }
-        return await blazeEligibilityChecker.isSiteEligible(site)
+        return blazeEligibilityChecker.isSiteEligible(site)
     }
 
     @MainActor

--- a/WooCommerce/Classes/ViewRelated/Hub Menu/HubMenuViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Hub Menu/HubMenuViewModel.swift
@@ -347,9 +347,7 @@ private extension HubMenuViewModel {
         /// Using task group would require more effort like this:
         /// https://www.hackingwithswift.com/quick-start/concurrency/how-to-handle-different-result-types-in-a-task-group
 
-        Task { @MainActor in
-            isSiteEligibleForBlaze = await blazeEligibilityChecker.isSiteEligible(site)
-        }
+        isSiteEligibleForBlaze = blazeEligibilityChecker.isSiteEligible(site)
 
         Task { @MainActor in
             isSiteEligibleForGoogleAds = await googleAdsEligibilityChecker.isSiteEligible(siteID: site.siteID)

--- a/WooCommerce/WooCommerceTests/Mocks/MockBlazeEligibilityChecker.swift
+++ b/WooCommerce/WooCommerceTests/Mocks/MockBlazeEligibilityChecker.swift
@@ -4,7 +4,6 @@ import Yosemite
 
 /// Mock version of `BlazeEligibilityChecker` for easier unit testing.
 final class MockBlazeEligibilityChecker: BlazeEligibilityCheckerProtocol {
-    private(set) var isSiteEligibleInvoked: Bool = false
 
     private let isSiteEligible: Bool
     private let isProductEligible: Bool
@@ -15,7 +14,6 @@ final class MockBlazeEligibilityChecker: BlazeEligibilityCheckerProtocol {
     }
 
     func isSiteEligible(_ site: Site) -> Bool {
-        isSiteEligibleInvoked = true
         return isSiteEligible
     }
 

--- a/WooCommerce/WooCommerceTests/Mocks/MockBlazeEligibilityChecker.swift
+++ b/WooCommerce/WooCommerceTests/Mocks/MockBlazeEligibilityChecker.swift
@@ -14,12 +14,12 @@ final class MockBlazeEligibilityChecker: BlazeEligibilityCheckerProtocol {
         self.isProductEligible = isProductEligible
     }
 
-    func isSiteEligible(_ site: Site) async -> Bool {
+    func isSiteEligible(_ site: Site) -> Bool {
         isSiteEligibleInvoked = true
         return isSiteEligible
     }
 
-    func isProductEligible(site: Site, product: WooCommerce.ProductFormDataModel, isPasswordProtected: Bool) async -> Bool {
+    func isProductEligible(site: Site, product: WooCommerce.ProductFormDataModel, isPasswordProtected: Bool) -> Bool {
         isProductEligible
     }
 }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Blaze/BlazeEligibilityCheckerTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Blaze/BlazeEligibilityCheckerTests.swift
@@ -18,23 +18,20 @@ final class BlazeEligibilityCheckerTests: XCTestCase {
 
     // MARK: - `isSiteEligible` for site
 
-    @MainActor
-    func test_isEligible_is_true_when_authenticated_with_wpcom_and_feature_flag_enabled_and_blaze_approved() async {
+    func test_isEligible_is_true_when_authenticated_with_wpcom_and_feature_flag_enabled_and_blaze_approved() {
         // Given
         stores.authenticate(credentials: .wpcom(username: "", authToken: "", siteAddress: ""))
         let site = mockSite(isEligibleForBlaze: true)
-        mockRemoteFeatureFlag(isEnabled: true)
         let checker = BlazeEligibilityChecker(stores: stores)
 
         // When
-        let isEligible = await checker.isSiteEligible(site)
+        let isEligible = checker.isSiteEligible(site)
 
         // Then
         XCTAssertTrue(isEligible)
     }
 
-    @MainActor
-    func test_isEligible_is_false_when_authenticated_without_wpcom() async {
+    func test_isEligible_is_false_when_authenticated_without_wpcom() {
         // Given
         let site = mockSite(isEligibleForBlaze: true)
         let nonWPCOMCredentialsValues: [Credentials] = [
@@ -47,53 +44,34 @@ final class BlazeEligibilityCheckerTests: XCTestCase {
             let checker = BlazeEligibilityChecker(stores: stores)
 
             // When
-            let isEligible = await checker.isSiteEligible(site)
+            let isEligible = checker.isSiteEligible(site)
 
             // Then
             XCTAssertFalse(isEligible)
         }
     }
 
-    @MainActor
-    func test_isEligible_is_false_when_remote_feature_is_disabled() async {
-        // Given
-        stores.authenticate(credentials: .wpcom(username: "", authToken: "", siteAddress: ""))
-        let site = mockSite(isEligibleForBlaze: true)
-        mockRemoteFeatureFlag(isEnabled: false)
-        let checker = BlazeEligibilityChecker(stores: stores)
-
-        // When
-        let isEligible = await checker.isSiteEligible(site)
-
-        // Then
-        XCTAssertFalse(isEligible)
-    }
-
-    @MainActor
-    func test_isEligible_is_false_when_blaze_is_not_approved() async {
+    func test_isEligible_is_false_when_blaze_is_not_approved() {
         // Given
         stores.authenticate(credentials: .wpcom(username: "", authToken: "", siteAddress: ""))
         let site = mockSite(isEligibleForBlaze: false)
-        mockRemoteFeatureFlag(isEnabled: true)
         let checker = BlazeEligibilityChecker(stores: stores)
 
         // When
-        let isEligible = await checker.isSiteEligible(site)
+        let isEligible = checker.isSiteEligible(site)
 
         // Then
         XCTAssertFalse(isEligible)
     }
 
-    @MainActor
-    func test_isEligible_is_false_when_site_user_is_not_admin() async {
+    func test_isEligible_is_false_when_site_user_is_not_admin() {
         // Given
         stores.authenticate(credentials: .wpcom(username: "", authToken: "", siteAddress: ""))
         let site = mockSite(isEligibleForBlaze: true, isAdmin: false)
-        mockRemoteFeatureFlag(isEnabled: true)
         let checker = BlazeEligibilityChecker(stores: stores)
 
         // When
-        let isEligible = await checker.isSiteEligible(site)
+        let isEligible = checker.isSiteEligible(site)
 
         // Then
         XCTAssertFalse(isEligible)
@@ -101,17 +79,15 @@ final class BlazeEligibilityCheckerTests: XCTestCase {
 
     // MARK: - `isProductEligible`
 
-    @MainActor
-    func test_isProductEligible_is_true_when_wpcom_auth_and_feature_flag_enabled_and_blaze_approved_and_product_public_without_password() async {
+    func test_isProductEligible_is_true_when_wpcom_auth_and_feature_flag_enabled_and_blaze_approved_and_product_public_without_password() {
         // Given
         stores.authenticate(credentials: .wpcom(username: "", authToken: "", siteAddress: ""))
         let site = mockSite(isEligibleForBlaze: true)
-        mockRemoteFeatureFlag(isEnabled: true)
         let checker = BlazeEligibilityChecker(stores: stores)
         let product = Product.fake().copy(statusKey: ProductStatus.published.rawValue)
 
         // When
-        let isEligible = await checker.isProductEligible(
+        let isEligible = checker.isProductEligible(
             site: site,
             product: EditableProductModel(product: product),
             isPasswordProtected: false
@@ -121,8 +97,7 @@ final class BlazeEligibilityCheckerTests: XCTestCase {
         XCTAssertTrue(isEligible)
     }
 
-    @MainActor
-    func test_isProductEligible_is_false_when_product_is_not_public() async {
+    func test_isProductEligible_is_false_when_product_is_not_public() {
         // Given
         let nonPublicStatuses: [ProductStatus] = [.draft, .pending, .privateStatus, .autoDraft, .custom("status")]
         let checker = BlazeEligibilityChecker(stores: stores)
@@ -131,7 +106,7 @@ final class BlazeEligibilityCheckerTests: XCTestCase {
             let product = Product.fake().copy(statusKey: nonPublicStatus.rawValue)
 
             // When
-            let isEligible = await checker.isProductEligible(
+            let isEligible = checker.isProductEligible(
                 site: mockSite(isEligibleForBlaze: true),
                 product: EditableProductModel(product: product),
                 isPasswordProtected: false
@@ -142,14 +117,13 @@ final class BlazeEligibilityCheckerTests: XCTestCase {
         }
     }
 
-    @MainActor
-    func test_isProductEligible_is_false_when_product_is_password_protected() async {
+    func test_isProductEligible_is_false_when_product_is_password_protected() {
         // Given
         let checker = BlazeEligibilityChecker(stores: stores)
         let product = Product.fake().copy(statusKey: ProductStatus.published.rawValue)
 
         // When
-        let isEligible = await checker.isProductEligible(
+        let isEligible = checker.isProductEligible(
             site: mockSite(isEligibleForBlaze: true),
             product: EditableProductModel(product: product),
             isPasswordProtected: true
@@ -159,8 +133,7 @@ final class BlazeEligibilityCheckerTests: XCTestCase {
         XCTAssertFalse(isEligible)
     }
 
-    @MainActor
-    func test_isProductEligible_is_false_when_authenticated_without_wpcom() async {
+    func test_isProductEligible_is_false_when_authenticated_without_wpcom() {
         // Given
         let nonWPCOMCredentialsValues: [Credentials] = [
             .applicationPassword(username: "", password: "", siteAddress: ""),
@@ -173,7 +146,7 @@ final class BlazeEligibilityCheckerTests: XCTestCase {
             let checker = BlazeEligibilityChecker(stores: stores)
 
             // When
-            let isEligible = await checker.isProductEligible(
+            let isEligible = checker.isProductEligible(
                 site: mockSite(isEligibleForBlaze: false),
                 product: EditableProductModel(product: product),
                 isPasswordProtected: false
@@ -184,36 +157,15 @@ final class BlazeEligibilityCheckerTests: XCTestCase {
         }
     }
 
-    @MainActor
-    func test_isProductEligible_is_false_when_remote_feature_is_disabled() async {
-        // Given
-        stores.authenticate(credentials: .wpcom(username: "", authToken: "", siteAddress: ""))
-        mockRemoteFeatureFlag(isEnabled: false)
-        let checker = BlazeEligibilityChecker(stores: stores)
-        let product = Product.fake().copy(statusKey: ProductStatus.published.rawValue)
-
-        // When
-        let isEligible = await checker.isProductEligible(
-            site: mockSite(isEligibleForBlaze: true),
-            product: EditableProductModel(product: product),
-            isPasswordProtected: false
-        )
-
-        // Then
-        XCTAssertFalse(isEligible)
-    }
-
-    @MainActor
-    func test_isProductEligible_is_false_when_blaze_is_not_approved() async {
+    func test_isProductEligible_is_false_when_blaze_is_not_approved() {
         // Given
         stores.authenticate(credentials: .wpcom(username: "", authToken: "", siteAddress: ""))
         let site = mockSite(isEligibleForBlaze: false)
-        mockRemoteFeatureFlag(isEnabled: true)
         let checker = BlazeEligibilityChecker(stores: stores)
         let product = Product.fake().copy(statusKey: ProductStatus.published.rawValue)
 
         // When
-        let isEligible = await checker.isProductEligible(
+        let isEligible = checker.isProductEligible(
             site: site,
             product: EditableProductModel(product: product),
             isPasswordProtected: false
@@ -229,14 +181,5 @@ private extension BlazeEligibilityCheckerTests {
         Site.fake().copy(siteID: 134,
                          canBlaze: isEligibleForBlaze,
                          isAdmin: isAdmin)
-    }
-
-    func mockRemoteFeatureFlag(isEnabled: Bool) {
-        stores.whenReceivingAction(ofType: FeatureFlagAction.self) { action in
-            guard case let .isRemoteFeatureFlagEnabled(_, _, completion) = action else {
-                return  XCTFail()
-            }
-            completion(isEnabled)
-        }
     }
 }

--- a/WooCommerce/WooCommerceTests/ViewRelated/HubMenu/HubMenuViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/HubMenu/HubMenuViewModelTests.swift
@@ -142,9 +142,7 @@ final class HubMenuViewModelTests: XCTestCase {
                                          tapToPayBadgePromotionChecker: TapToPayBadgePromotionChecker(),
                                          stores: stores,
                                          blazeEligibilityChecker: blazeEligibilityChecker)
-        waitUntil {
-            blazeEligibilityChecker.isSiteEligibleInvoked
-        }
+
         viewModel.setupMenuElements()
 
         // Then

--- a/Yosemite/YosemiteTests/Stores/FeatureFlagStoreTests.swift
+++ b/Yosemite/YosemiteTests/Stores/FeatureFlagStoreTests.swift
@@ -70,7 +70,7 @@ final class FeatureFlagStoreTests: XCTestCase {
 
     func test_isRemoteFeatureFlagEnabled_returns_default_value_when_remote_response_does_not_include_input_flag() throws {
         // Given
-        remote.whenLoadingAllFeatureFlags(thenReturn: .success([.blaze: true]))
+        remote.whenLoadingAllFeatureFlags(thenReturn: .success([.storeCreationCompleteNotification: true]))
 
         // When
         let isEnabled = waitFor { promise in

--- a/Yosemite/YosemiteTests/Stores/FeatureFlagStoreTests.swift
+++ b/Yosemite/YosemiteTests/Stores/FeatureFlagStoreTests.swift
@@ -70,7 +70,7 @@ final class FeatureFlagStoreTests: XCTestCase {
 
     func test_isRemoteFeatureFlagEnabled_returns_default_value_when_remote_response_does_not_include_input_flag() throws {
         // Given
-        remote.whenLoadingAllFeatureFlags(thenReturn: .success([.storeCreationCompleteNotification: true]))
+        remote.whenLoadingAllFeatureFlags(thenReturn: .success([.hardcodedPlanUpgradeDetailsMilestone1AreAccurate: true]))
 
         // When
         let isEnabled = waitFor { promise in


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #13181 
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This PR removes the remote feature flag check for Blaze eligibility. The check is now synchronous since we no longer have to check with the remote.

## Testing steps
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->
- Log in to a store eligible for Blaze.
- Confirm that Blaze entry points in the Hub menu and dashboard are still available.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

Dashboard | Hub menu
--- | ---
<img src="https://github.com/user-attachments/assets/8c2c8c1d-9815-4891-9dca-9822fd364f49" width=320 /> | <img src="https://github.com/user-attachments/assets/fd90df69-dd57-419e-b41f-2a126171b59a" width=320 />


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
