### PR TITLE
Product Creation AI: Add tracking events for v2

### DIFF
--- a/WooCommerce/Classes/Analytics/WooAnalyticsEvent+ProductCreationAI.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsEvent+ProductCreationAI.swift
@@ -119,7 +119,7 @@ extension WooAnalyticsEvent {
         }
 
         /// When the user taps on the “Undo edits” button
-        static func undoEditTapped(field: ProductDetailPreviewViewModel.EditableField) -> WooAnalyticsEvent {
+        static func undoEditTapped(for field: ProductDetailPreviewViewModel.EditableField) -> WooAnalyticsEvent {
             WooAnalyticsEvent(statName: .productCreationAIUndoEditTapped, properties: [Key.field.rawValue: field.rawValue])
         }
     }

--- a/WooCommerce/Classes/Analytics/WooAnalyticsEvent+ProductCreationAI.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsEvent+ProductCreationAI.swift
@@ -96,16 +96,6 @@ extension WooAnalyticsEvent {
             WooAnalyticsEvent(statName: .productCreationAITextDetectionFailed, properties: [:], error: error)
         }
 
-        /// When the user taps on the “Generate Product Details” button on the starting info screen
-        static func generateProductDetailsButtonTapped() -> WooAnalyticsEvent {
-            WooAnalyticsEvent(statName: .productCreationAIGenerateProductDetailsButtonTapped, properties: [:])
-        }
-
-        /// When the user taps on the “Generate Again” button
-        static func generateAgainButtonTapped() -> WooAnalyticsEvent {
-            WooAnalyticsEvent(statName: .productCreationAIGenerateAgainButtonTapped, properties: [:])
-        }
-
         /// Upon successfully generating options of Name, Summary and Description fields.
         static func nameDescriptionOptionsGenerated(nameCount: Int,
                                                     shortDescriptionCount: Int,

--- a/WooCommerce/Classes/Analytics/WooAnalyticsEvent+ProductCreationAI.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsEvent+ProductCreationAI.swift
@@ -6,7 +6,7 @@ extension WooAnalyticsEvent {
             case value
             case isFirstAttempt = "is_first_attempt"
             case numberOfTexts = "number_of_texts"
-            case names
+            case name
             case shortDescription = "short_description"
             case description
             case field
@@ -102,7 +102,7 @@ extension WooAnalyticsEvent {
                                                     descriptionCount: Int) -> WooAnalyticsEvent {
             WooAnalyticsEvent(statName: .productCreationAIGeneratedNameDescriptionOptions,
                               properties: [
-                                Key.names.rawValue: nameCount,
+                                Key.name.rawValue: nameCount,
                                 Key.shortDescription.rawValue: shortDescriptionCount,
                                 Key.description.rawValue: descriptionCount
                               ])

--- a/WooCommerce/Classes/Analytics/WooAnalyticsEvent+ProductCreationAI.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsEvent+ProductCreationAI.swift
@@ -3,8 +3,13 @@ import Foundation
 extension WooAnalyticsEvent {
     enum ProductCreationAI {
         private enum Key: String {
-            case value = "value"
+            case value
             case isFirstAttempt = "is_first_attempt"
+            case numberOfTexts = "number_of_texts"
+            case names
+            case shortDescription = "short_description"
+            case description
+            case field
         }
 
         static func entryPointDisplayed() -> WooAnalyticsEvent {
@@ -74,6 +79,48 @@ extension WooAnalyticsEvent {
                 WooAnalyticsEvent(statName: .productCreationAISurveySkipButtonTapped,
                                   properties: [:])
             }
+        }
+
+        /// When the user taps on the “Read text from product photo” button or the “Replace photo” button
+        static func packagePhotoSelectionFlowStarted() -> WooAnalyticsEvent {
+            WooAnalyticsEvent(statName: .productCreationAIStartedPackagePhotoSelectionFlow, properties: [:])
+        }
+
+        /// Finished detecting text from the package photo
+        static func packagePhotoTextDetected(wordCount: Int) -> WooAnalyticsEvent {
+            WooAnalyticsEvent(statName: .productCreationAITextDetected, properties: [Key.numberOfTexts.rawValue: wordCount])
+        }
+
+        /// When text detection fails
+        static func packagePhotoTextDetectionFailed(error: Error) -> WooAnalyticsEvent {
+            WooAnalyticsEvent(statName: .productCreationAITextDetectionFailed, properties: [:], error: error)
+        }
+
+        /// When the user taps on the “Generate Product Details” button on the starting info screen
+        static func generateProductDetailsButtonTapped() -> WooAnalyticsEvent {
+            WooAnalyticsEvent(statName: .productCreationAIGenerateProductDetailsButtonTapped, properties: [:])
+        }
+
+        /// When the user taps on the “Generate Again” button
+        static func generateAgainButtonTapped() -> WooAnalyticsEvent {
+            WooAnalyticsEvent(statName: .productCreationAIGenerateAgainButtonTapped, properties: [:])
+        }
+
+        /// Upon successfully generating options of Name, Summary and Description fields.
+        static func nameDescriptionOptionsGenerated(nameCount: Int,
+                                                    shortDescriptionCount: Int,
+                                                    descriptionCount: Int) -> WooAnalyticsEvent {
+            WooAnalyticsEvent(statName: .productCreationAIGeneratedNameDescriptionOptions,
+                              properties: [
+                                Key.names.rawValue: nameCount,
+                                Key.shortDescription.rawValue: shortDescriptionCount,
+                                Key.description.rawValue: descriptionCount
+                              ])
+        }
+
+        /// When the user taps on the “Undo edits” button
+        static func undoEditTapped(field: ProductDetailPreviewViewModel.EditableField) -> WooAnalyticsEvent {
+            WooAnalyticsEvent(statName: .productCreationAIUndoEditTapped, properties: [Key.field.rawValue: field.rawValue])
         }
     }
 }

--- a/WooCommerce/Classes/Analytics/WooAnalyticsStat.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsStat.swift
@@ -962,8 +962,6 @@ enum WooAnalyticsStat: String {
     case productCreationAIStartedPackagePhotoSelectionFlow = "product_creation_ai_started_package_photo_selection_flow"
     case productCreationAITextDetected = "product_creation_ai_text_detected"
     case productCreationAITextDetectionFailed = "product_creation_ai_text_detection_failed"
-    case productCreationAIGenerateProductDetailsButtonTapped = "product_creation_ai_generate_product_details_button_tapped"
-    case productCreationAIGenerateAgainButtonTapped = "product_creation_ai_generate_again_button_tapped"
     case productCreationAIGeneratedNameDescriptionOptions = "product_creation_ai_generated_name_description_options"
     case productCreationAIUndoEditTapped = "product_creation_ai_undo_edit_tapped"
     

--- a/WooCommerce/Classes/Analytics/WooAnalyticsStat.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsStat.swift
@@ -962,7 +962,7 @@ enum WooAnalyticsStat: String {
     case productCreationAIStartedPackagePhotoSelectionFlow = "product_creation_ai_started_package_photo_selection_flow"
     case productCreationAITextDetected = "product_creation_ai_text_detected"
     case productCreationAITextDetectionFailed = "product_creation_ai_text_detection_failed"
-    case productCreationAIGenerateProductDetailsButtonTapped = "product_creation_ai_generate_product_detais_button_tapped"
+    case productCreationAIGenerateProductDetailsButtonTapped = "product_creation_ai_generate_product_details_button_tapped"
     case productCreationAIGenerateAgainButtonTapped = "product_creation_ai_generate_again_button_tapped"
     case productCreationAIGeneratedNameDescriptionOptions = "product_creation_ai_generated_name_description_options"
     case productCreationAIUndoEditTapped = "product_creation_ai_undo_edit_tapped"

--- a/WooCommerce/Classes/Analytics/WooAnalyticsStat.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsStat.swift
@@ -958,6 +958,15 @@ enum WooAnalyticsStat: String {
     case productCreationAISurveyStartSurveyButtonTapped = "product_creation_ai_survey_start_survey_button_tapped"
     case productCreationAISurveySkipButtonTapped = "product_creation_ai_survey_skip_button_tapped"
 
+    // V2 events
+    case productCreationAIStartedPackagePhotoSelectionFlow = "product_creation_ai_started_package_photo_selection_flow"
+    case productCreationAITextDetected = "product_creation_ai_text_detected"
+    case productCreationAITextDetectionFailed = "product_creation_ai_text_detection_failed"
+    case productCreationAIGenerateProductDetailsButtonTapped = "product_creation_ai_generate_product_detais_button_tapped"
+    case productCreationAIGenerateAgainButtonTapped = "product_creation_ai_generate_again_button_tapped"
+    case productCreationAIGeneratedNameDescriptionOptions = "product_creation_ai_generated_name_description_options"
+    case productCreationAIUndoEditTapped = "product_creation_ai_undo_edit_tapped"
+    
     // MARK: Remote Request Events
     //
     case jetpackTunnelTimeout = "jetpack_tunnel_timeout"

--- a/WooCommerce/Classes/Analytics/WooAnalyticsStat.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsStat.swift
@@ -964,7 +964,7 @@ enum WooAnalyticsStat: String {
     case productCreationAITextDetectionFailed = "product_creation_ai_text_detection_failed"
     case productCreationAIGeneratedNameDescriptionOptions = "product_creation_ai_generated_name_description_options"
     case productCreationAIUndoEditTapped = "product_creation_ai_undo_edit_tapped"
-    
+
     // MARK: Remote Request Events
     //
     case jetpackTunnelTimeout = "jetpack_tunnel_timeout"

--- a/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductWithAI/Preview/ProductDetailPreviewView.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductWithAI/Preview/ProductDetailPreviewView.swift
@@ -232,9 +232,7 @@ private extension ProductDetailPreviewView {
 
     var generateAgainButton: some View {
         Button {
-            Task { @MainActor in
-                await viewModel.generateProductDetails()
-            }
+            viewModel.didTapGenerateAgain()
         } label: {
             Text(Localization.generateAgain)
         }

--- a/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductWithAI/Preview/ProductDetailPreviewViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductWithAI/Preview/ProductDetailPreviewViewModel.swift
@@ -7,9 +7,9 @@ import protocol Storage.StorageManagerType
 /// View model for `ProductDetailPreviewView`
 ///
 final class ProductDetailPreviewViewModel: ObservableObject {
-    enum EditableField: Equatable {
+    enum EditableField: String {
         case name
-        case shortDescription
+        case shortDescription = "short_description"
         case description
     }
 

--- a/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductWithAI/Preview/ProductDetailPreviewViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductWithAI/Preview/ProductDetailPreviewViewModel.swift
@@ -186,6 +186,11 @@ final class ProductDetailPreviewViewModel: ObservableObject {
             let aiTone = userDefaults.aiTone(for: siteID)
             let aiProduct = try await generateProduct(language: language,
                                                            tone: aiTone)
+            analytics.track(event: .ProductCreationAI.nameDescriptionOptionsGenerated(
+                nameCount: aiProduct.names.count,
+                shortDescriptionCount: aiProduct.shortDescriptions.count,
+                descriptionCount: aiProduct.descriptions.count
+            ))
             try displayAIProductDetails(aiProduct: aiProduct)
             generatedAIProduct = aiProduct
             isGeneratingDetails = false
@@ -226,6 +231,13 @@ final class ProductDetailPreviewViewModel: ObservableObject {
                                                         isUseful: vote == .up))
 
         shouldShowFeedbackView = false
+    }
+
+    func didTapGenerateAgain() {
+        analytics.track(event: .ProductCreationAI.generateAgainButtonTapped())
+        Task { @MainActor in
+            await generateProductDetails()
+        }
     }
 
     // MARK: Switch options
@@ -272,6 +284,8 @@ final class ProductDetailPreviewViewModel: ObservableObject {
 //
 extension ProductDetailPreviewViewModel {
     func undoEdits(in updatedField: EditableField) {
+        analytics.track(event: .ProductCreationAI.undoEditTapped(for: updatedField))
+
         guard let generatedAIProduct else {
             return
         }

--- a/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductWithAI/Preview/ProductDetailPreviewViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductWithAI/Preview/ProductDetailPreviewViewModel.swift
@@ -234,7 +234,7 @@ final class ProductDetailPreviewViewModel: ObservableObject {
     }
 
     func didTapGenerateAgain() {
-        analytics.track(event: .ProductCreationAI.generateAgainButtonTapped())
+        analytics.track(event: .ProductCreationAI.generateDetailsTapped(isFirstAttempt: false))
         Task { @MainActor in
             await generateProductDetails()
         }

--- a/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductWithAI/StartingInfo/ProductCreationAIStartingInfoView.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductWithAI/StartingInfo/ProductCreationAIStartingInfoView.swift
@@ -148,7 +148,6 @@ private extension ProductCreationAIStartingInfoView {
         Button {
             // continue
             editorIsFocused = false
-            viewModel.didTapContinue()
             onContinueWithFeatures(viewModel.features)
         } label: {
             Text(Localization.generateProductDetails)

--- a/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductWithAI/StartingInfo/ProductCreationAIStartingInfoViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductWithAI/StartingInfo/ProductCreationAIStartingInfoViewModel.swift
@@ -49,12 +49,12 @@ final class ProductCreationAIStartingInfoViewModel: ObservableObject {
     }
 
     func didTapReadTextFromPhoto() {
-        // TODO: 13103 - Add tracking
+        analytics.track(event: .ProductCreationAI.packagePhotoSelectionFlowStarted())
         isShowingMediaPickerSourceSheet = true
     }
 
     func didTapContinue() {
-        // TODO: 13103 - Add tracking
+        analytics.track(event: .ProductCreationAI.generateProductDetailsButtonTapped())
     }
 
     func didTapViewPhoto() {
@@ -62,7 +62,7 @@ final class ProductCreationAIStartingInfoViewModel: ObservableObject {
     }
 
     func didTapReplacePhoto() {
-        // TODO: 13103 Add tracking
+        analytics.track(event: .ProductCreationAI.packagePhotoSelectionFlowStarted())
         isShowingMediaPickerSourceSheet = true
     }
 
@@ -104,13 +104,14 @@ private extension ProductCreationAIStartingInfoViewModel {
                 throw ScanError.noTextDetected
             }
             self.features = texts.joined(separator: " ")
+            analytics.track(event: .ProductCreationAI.packagePhotoTextDetected(wordCount: texts.count))
         } catch {
             switch error {
             case ScanError.noTextDetected:
                 textDetectionErrorMessage = Localization.noTextDetected
                 DDLogError("⛔️ No text detected from image.")
             default:
-                // TODO: 13103 - Add tracking
+                analytics.track(event: .ProductCreationAI.packagePhotoTextDetectionFailed(error: error))
                 textDetectionErrorMessage = Localization.textDetectionFailed
                 DDLogError("⛔️ Error scanning text from image: \(error)")
             }

--- a/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductWithAI/StartingInfo/ProductCreationAIStartingInfoViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductWithAI/StartingInfo/ProductCreationAIStartingInfoViewModel.swift
@@ -53,10 +53,6 @@ final class ProductCreationAIStartingInfoViewModel: ObservableObject {
         isShowingMediaPickerSourceSheet = true
     }
 
-    func didTapContinue() {
-        analytics.track(event: .ProductCreationAI.generateProductDetailsButtonTapped())
-    }
-
     func didTapViewPhoto() {
         isShowingViewPhotoSheet = true
     }
@@ -159,8 +155,8 @@ extension ProductCreationAIStartingInfoViewModel {
             )
         }
     }
-}
 
-private enum ScanError: Error {
-    case noTextDetected
+    enum ScanError: Error {
+        case noTextDetected
+    }
 }

--- a/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductWithAI/StartingInfo/ProductCreationAIStartingInfoViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductWithAI/StartingInfo/ProductCreationAIStartingInfoViewModel.swift
@@ -106,12 +106,12 @@ private extension ProductCreationAIStartingInfoViewModel {
             self.features = texts.joined(separator: " ")
             analytics.track(event: .ProductCreationAI.packagePhotoTextDetected(wordCount: texts.count))
         } catch {
+            analytics.track(event: .ProductCreationAI.packagePhotoTextDetectionFailed(error: error))
             switch error {
             case ScanError.noTextDetected:
                 textDetectionErrorMessage = Localization.noTextDetected
                 DDLogError("⛔️ No text detected from image.")
             default:
-                analytics.track(event: .ProductCreationAI.packagePhotoTextDetectionFailed(error: error))
                 textDetectionErrorMessage = Localization.textDetectionFailed
                 DDLogError("⛔️ Error scanning text from image: \(error)")
             }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #13304 
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This PR adds tracking for the updated flow of product creation AI. New events include:

Event name | Properties | Triggers
-- | -- | --
*_product_creation_ai_started_package_photo_selection_flow |   | When the user taps on the “Read text from product photo” button or the “Replace photo” button
*_product_creation_ai_text_detected | number_of_texts : Number of texts detected, zero if none detected | Finished detecting text from the package photo
*_product_creation_ai_text_detection_failed | Error detail properties | When text detection fails
*_product_creation_ai_generated_name_description_options | names: Total number of name options generated by AIshort_description: Total number of short description options generated by AIdescription: Total number of description options generated by AI | Upon successfully generating options of Name, Summary and Description fields.
*_product_creation_ai_undo_edit_tapped | field: name \| short_description \| description | When the user taps on the “Undo edits” button



## Testing steps
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->
- Build the app and log in to a store eligible for product creation AI.
- Navigate to Products tab > tap "+" > Create product with AI.
- Tap on "Read text from product photo" and confirm that `product_creation_ai_started_package_photo_selection_flow` is tracked.
- Select a photo without any text, and confirm that `product_creation_ai_text_detection_failed` is tracked with `ScanError.noTextDetected`.
- Tap on the ellipsis button > Replace photo > confirm that `product_creation_ai_text_detection_failed` is tracked with `ScanError.noTextDetected`.
- Select a valid package photo > confirm that `product_creation_ai_text_detected` is tracked with the correct number of detected words.
- Tap Generate product details, confirm that `product_creation_ai_generate_details_tapped` is tracked with `is_first_attempt` being true.
- After the product generation completes, confirm that `product_creation_ai_generated_name_description_options` is tracked with the correct number of options for name, short description and description.
- Tap to edit either of those 3 fields and then tap Undo Edits, confirm that `product_creation_ai_undo_edit_tapped` with the correct `field` value.
- Tap Generate again, confirm that `product_creation_ai_generate_details_tapped` is tracked with `is_first_attempt` being false.


## Screenshots
<!-- Include before and after images or gifs when appropriate. -->
N/A

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
