### PR TITLE
Enhancements on UI of Product Creation with AI

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Coupons/Add and Edit Coupons/AddEditCoupon.swift
+++ b/WooCommerce/Classes/ViewRelated/Coupons/Add and Edit Coupons/AddEditCoupon.swift
@@ -249,7 +249,7 @@ struct AddEditCoupon: View {
                         .padding(.bottom, Constants.verticalSpacing)
 
                         Button {
-                            // This should be replaced with `@FocusState` when we drop support for iOS 14
+                            // TODO: This should be replaced with `@FocusState` when we drop support for iOS 14
                             UIApplication.shared.sendAction(#selector(UIResponder.resignFirstResponder), to: nil, from: nil, for: nil)
                             viewModel.completeCouponAddEdit(coupon: viewModel.populatedCoupon, onUpdateFinished: {
                                 dismissHandler()

--- a/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductWithAI/StartingInfo/ProductCreationAIStartingInfoView.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductWithAI/StartingInfo/ProductCreationAIStartingInfoView.swift
@@ -101,6 +101,14 @@ struct ProductCreationAIStartingInfoView: View {
                     }
                 }
             }
+            .gesture(DragGesture().onChanged { value in
+                // Dismiss the keyboard when a downward swipe gesture is detected.
+                editorIsFocused = false
+            })
+            .onTapGesture {
+                // Dismiss the keyboard when the view is tapped.
+                editorIsFocused = false
+            }
             .padding(insets: Layout.insets)
         }
         .safeAreaInset(edge: .bottom) {

--- a/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductWithAI/StartingInfo/ProductCreationAIStartingInfoView.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductWithAI/StartingInfo/ProductCreationAIStartingInfoView.swift
@@ -119,6 +119,7 @@ struct ProductCreationAIStartingInfoView: View {
                 }
                 .padding(insets: Layout.insets)
             }
+            .scrollDismissesKeyboard(.immediately)
         }
         .safeAreaInset(edge: .bottom) {
             VStack {

--- a/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductWithAI/StartingInfo/ProductCreationAIStartingInfoView.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductWithAI/StartingInfo/ProductCreationAIStartingInfoView.swift
@@ -101,10 +101,6 @@ struct ProductCreationAIStartingInfoView: View {
                     }
                 }
             }
-            .gesture(DragGesture().onChanged { value in
-                // Dismiss the keyboard when a downward swipe gesture is detected.
-                editorIsFocused = false
-            })
             .onTapGesture {
                 // Dismiss the keyboard when the view is tapped.
                 editorIsFocused = false

--- a/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductWithAI/StartingInfo/ProductCreationAIStartingInfoView.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductWithAI/StartingInfo/ProductCreationAIStartingInfoView.swift
@@ -45,16 +45,12 @@ struct ProductCreationAIStartingInfoView: View {
                                         .focused($editorIsFocused)
                                     // Scrolls to the "TextEditor" view with a smooth animation while typing.
                                         .onChange(of: viewModel.features) { _ in
-                                            withAnimation {
-                                                proxy.scrollTo(Constant.textEditorID, anchor: .top)
-                                            }
+                                            scrollToTextEditor(using: proxy)
                                         }
                                     // Scrolls to the "TextEditor" view with a smooth animation when the editor is focused in a small screen.
                                     .onChange(of: editorIsFocused) { isFocused in
                                         if isFocused {
-                                            withAnimation {
-                                                proxy.scrollTo(Constant.textEditorID, anchor: .top)
-                                            }
+                                            scrollToTextEditor(using: proxy)
                                         }
                                     }
                                     // Placeholder text
@@ -188,6 +184,12 @@ private extension ProductCreationAIStartingInfoView {
         .buttonStyle(PrimaryButtonStyle())
         .disabled(viewModel.features.isEmpty)
     }
+
+    private func scrollToTextEditor(using proxy: ScrollViewProxy) {
+        withAnimation {
+            proxy.scrollTo(Constant.textEditorID, anchor: .top)
+        }
+    }
 }
 
 private extension ProductCreationAIStartingInfoView {
@@ -213,7 +215,7 @@ private extension ProductCreationAIStartingInfoView {
             static let cameraSFSymbol = "camera"
         }
     }
-    
+
     enum Constant {
         static let textEditorID = "TextEditor"
     }

--- a/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductWithAI/StartingInfo/ProductCreationAIStartingInfoView.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductWithAI/StartingInfo/ProductCreationAIStartingInfoView.swift
@@ -87,7 +87,7 @@ struct ProductCreationAIStartingInfoView: View {
                             RoundedRectangle(cornerRadius: Layout.cornerRadius).stroke(editorIsFocused ? Color(.brand) : Color(.separator))
                         )
                     }
-                    if viewModel.featureFlagService.isFeatureFlagEnabled(.productCreationAIv2M3) && viewModel.features.isNotEmpty {
+                    if viewModel.featureFlagService.isFeatureFlagEnabled(.productCreationAIv2M3) && (editorIsFocused || viewModel.features.isNotEmpty) {
                         ProductCreationAIPromptProgressBar(text: $viewModel.features)
                     }
 

--- a/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductWithAI/StartingInfo/ProductCreationAIStartingInfoView.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductWithAI/StartingInfo/ProductCreationAIStartingInfoView.swift
@@ -126,6 +126,7 @@ struct ProductCreationAIStartingInfoView: View {
         }
         .safeAreaInset(edge: .bottom) {
             VStack {
+                Divider()
                 // CTA to generate product details.
                 generateButton
                     .padding()

--- a/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductWithAI/StartingInfo/ProductCreationAIStartingInfoView.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductWithAI/StartingInfo/ProductCreationAIStartingInfoView.swift
@@ -37,7 +37,7 @@ struct ProductCreationAIStartingInfoView: View {
                             VStack(spacing: 0) {
                                 ZStack(alignment: .topLeading) {
                                     TextEditor(text: $viewModel.features)
-                                        .id("TextEditor")
+                                        .id(Constant.textEditorID)
                                         .bodyStyle()
                                         .foregroundStyle(.secondary)
                                         .padding(insets: Layout.messageContentInsets)
@@ -46,14 +46,14 @@ struct ProductCreationAIStartingInfoView: View {
                                     // Scrolls to the "TextEditor" view with a smooth animation while typing.
                                         .onChange(of: viewModel.features) { _ in
                                             withAnimation {
-                                                proxy.scrollTo("TextEditor", anchor: .top)
+                                                proxy.scrollTo(Constant.textEditorID, anchor: .top)
                                             }
                                         }
                                     // Scrolls to the "TextEditor" view with a smooth animation when the editor is focused in a small screen.
                                     .onChange(of: editorIsFocused) { isFocused in
                                         if isFocused {
                                             withAnimation {
-                                                proxy.scrollTo("TextEditor", anchor: .top)
+                                                proxy.scrollTo(Constant.textEditorID, anchor: .top)
                                             }
                                         }
                                     }
@@ -212,6 +212,10 @@ private extension ProductCreationAIStartingInfoView {
             static let spacing: CGFloat = 4
             static let cameraSFSymbol = "camera"
         }
+    }
+    
+    enum Constant {
+        static let textEditorID = "TextEditor"
     }
 
     enum Localization {

--- a/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductWithAI/StartingInfo/ProductCreationAIStartingInfoView.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductWithAI/StartingInfo/ProductCreationAIStartingInfoView.swift
@@ -87,7 +87,7 @@ struct ProductCreationAIStartingInfoView: View {
                             RoundedRectangle(cornerRadius: Layout.cornerRadius).stroke(editorIsFocused ? Color(.brand) : Color(.separator))
                         )
                     }
-                    if viewModel.featureFlagService.isFeatureFlagEnabled(.productCreationAIv2M3) {
+                    if viewModel.featureFlagService.isFeatureFlagEnabled(.productCreationAIv2M3) && viewModel.features.isNotEmpty {
                         ProductCreationAIPromptProgressBar(text: $viewModel.features)
                     }
 

--- a/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductWithAI/StartingInfo/ProductCreationAIStartingInfoView.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductWithAI/StartingInfo/ProductCreationAIStartingInfoView.swift
@@ -49,6 +49,14 @@ struct ProductCreationAIStartingInfoView: View {
                                                 proxy.scrollTo("TextEditor", anchor: .top)
                                             }
                                         }
+                                    // Scrolls to the "TextEditor" view with a smooth animation when the editor is focused in a small screen.
+                                    .onChange(of: editorIsFocused) { isFocused in
+                                        if isFocused {
+                                            withAnimation {
+                                                proxy.scrollTo("TextEditor", anchor: .top)
+                                            }
+                                        }
+                                    }
                                     // Placeholder text
                                     placeholderText
                                 }
@@ -114,14 +122,6 @@ struct ProductCreationAIStartingInfoView: View {
                     editorIsFocused = false
                 }
                 .padding(insets: Layout.insets)
-            }
-            // Scrolls to the "TextEditor" view with a smooth animation when the editor is focused in a small screen.
-            .onChange(of: editorIsFocused) { isFocused in
-                if isFocused {
-                    withAnimation {
-                        proxy.scrollTo("TextEditor", anchor: .top)
-                    }
-                }
             }
         }
         .safeAreaInset(edge: .bottom) {

--- a/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductWithAI/StartingInfo/PromptProgressBar/ProductCreationAIPromptProgressBarViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductWithAI/StartingInfo/PromptProgressBar/ProductCreationAIPromptProgressBarViewModel.swift
@@ -20,11 +20,11 @@ class ProductCreationAIPromptProgressBarViewModel: ObservableObject {
         switch wordCount {
         case 0:
             status = .start
-        case 1...10:
+        case 1...7:
             status = .inProgress
-        case 11...19:
+        case 8...17:
             status = .halfway
-        case 20...30:
+        case 18...27:
             status = .almostDone
         default:
             status = .completed


### PR DESCRIPTION
Closes: #13295 

## Description
This PR addresses feedback shared by @joe-keenan regarding improvements suggested after PR #13280. For more context, refer to the discussion at C03L1NF1EA3/p1720618158166209.

#### Changes Implemented:

1. **Advice Block Visibility**:
   - The advice block is now hidden until the text field is focused or at least one character has been typed.

2. **Keyboard Dismissal**:
   - The keyboard can now be dismissed by tapping on the view.

3. **Dividing Line**:
   - Added a thin dividing line on top of the “Generate” button section for better visual separation.

4. **Automatic Scrolling**:
   - The screen now automatically scrolls the text field to the top when it gains focus to ensure that the advice box is not overlaid by the keyboard. This is particularly useful on small screens.
   - When the user is typing in the text field, the text field will be maintained at the top. This is particularly useful on small screens.

5. **Progress Bar Update**:
   - Changed the number of words required for the progress bar.

## Testing
Check the UI changes and if the focus of the text field tapping on it or while typing works correctly.

## Screenshots
<img src="https://github.com/user-attachments/assets/013498e0-85d1-4996-b76f-7dd0c6e87e9f" width=300 />


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
