### PR TITLE
[Woo POS] Remove cart collapse behavior.

### DIFF
--- a/WooCommerce/Classes/POS/Presentation/CartView.swift
+++ b/WooCommerce/Classes/POS/Presentation/CartView.swift
@@ -13,10 +13,6 @@ struct CartView: View {
     var body: some View {
         VStack {
             HStack {
-                Image(uiImage: .shoppingCartIcon)
-                    .resizable()
-                    .frame(width: Constants.iconSize, height: Constants.iconSize)
-                    .foregroundColor(.black)
                 Text("Cart")
                     .font(Constants.primaryFont)
                     .foregroundColor(Color.posPrimaryTexti3)
@@ -78,7 +74,6 @@ struct CartView: View {
 
 private extension CartView {
     enum Constants {
-        static let iconSize: CGFloat = 40
         static let primaryFont: Font = .system(size: 40, weight: .bold, design: .default)
         static let secondaryFont: Font = .system(size: 20, weight: .semibold, design: .default)
     }

--- a/WooCommerce/Classes/POS/Presentation/CartView.swift
+++ b/WooCommerce/Classes/POS/Presentation/CartView.swift
@@ -13,9 +13,9 @@ struct CartView: View {
     var body: some View {
         VStack {
             HStack {
-                Text("Cart")
+                Text(Localization.cartTitle)
                     .font(Constants.primaryFont)
-                    .foregroundColor(Color.posPrimaryTexti3)
+                    .foregroundColor(cartViewModel.cartLabelColor)
                 Spacer()
                 if let temsInCartLabel = cartViewModel.itemsInCartLabel {
                     Text(temsInCartLabel)
@@ -24,7 +24,7 @@ struct CartView: View {
                     Button {
                         cartViewModel.removeAllItemsFromCart()
                     } label: {
-                        Text("Clear all")
+                        Text(Localization.clearButtonTitle)
                             .font(Constants.secondaryFont)
                             .foregroundColor(Color.init(uiColor: .wooCommercePurple(.shade60)))
                     }
@@ -76,6 +76,17 @@ private extension CartView {
     enum Constants {
         static let primaryFont: Font = .system(size: 40, weight: .bold, design: .default)
         static let secondaryFont: Font = .system(size: 20, weight: .semibold, design: .default)
+    }
+
+    enum Localization {
+        static let cartTitle = NSLocalizedString(
+            "pos.cartView.cartTitle",
+            value: "Cart",
+            comment: "Title at the header for the Cart view.")
+        static let clearButtonTitle = NSLocalizedString(
+            "pos.cartView.clearButtonTitle",
+            value: "Clear",
+            comment: "Title for the 'Clear' button to remove all products from the Cart.")
     }
 }
 

--- a/WooCommerce/Classes/POS/Presentation/CartView.swift
+++ b/WooCommerce/Classes/POS/Presentation/CartView.swift
@@ -28,13 +28,13 @@ struct CartView: View {
                             .font(Constants.secondaryFont)
                             .foregroundColor(Color.init(uiColor: .wooCommercePurple(.shade60)))
                     }
-                    .padding(.horizontal, 8)
+                    .padding(.horizontal, Constants.itemHorizontalPadding)
                     .renderedIf(cartViewModel.canDeleteItemsFromCart)
                 }
             }
             .frame(maxWidth: .infinity, alignment: .leading)
-            .padding(.horizontal, 32)
-            .padding(.vertical, 8)
+            .padding(.horizontal, Constants.horizontalPadding)
+            .padding(.vertical, Constants.verticalPadding)
             .font(.title)
             .foregroundColor(Color.white)
             if cartViewModel.itemsInCart.isEmpty {
@@ -72,10 +72,10 @@ struct CartView: View {
             switch viewModel.orderStage {
             case .building:
                 checkoutButton
-                    .padding(32)
+                    .padding(Constants.checkoutButtonPadding)
             case .finalizing:
                 addMoreButton
-                    .padding(32)
+                    .padding(Constants.checkoutButtonPadding)
                     .disabled(viewModel.isAddMoreDisabled)
             }
         }
@@ -88,6 +88,10 @@ private extension CartView {
     enum Constants {
         static let primaryFont: Font = .system(size: 40, weight: .bold, design: .default)
         static let secondaryFont: Font = .system(size: 20, weight: .semibold, design: .default)
+        static let checkoutButtonPadding: CGFloat = 32
+        static let itemHorizontalPadding: CGFloat = 8
+        static let horizontalPadding: CGFloat = 32
+        static let verticalPadding: CGFloat = 8
     }
 
     enum Localization {

--- a/WooCommerce/Classes/POS/Presentation/CartView.swift
+++ b/WooCommerce/Classes/POS/Presentation/CartView.swift
@@ -17,8 +17,8 @@ struct CartView: View {
                     .font(Constants.primaryFont)
                     .foregroundColor(cartViewModel.cartLabelColor)
                 Spacer()
-                if let temsInCartLabel = cartViewModel.itemsInCartLabel {
-                    Text(temsInCartLabel)
+                if let itemsInCartLabel = cartViewModel.itemsInCartLabel {
+                    Text(itemsInCartLabel)
                         .font(Constants.secondaryFont)
                         .foregroundColor(Color.posSecondaryTexti3)
                     Button {
@@ -37,21 +37,33 @@ struct CartView: View {
             .padding(.vertical, 8)
             .font(.title)
             .foregroundColor(Color.white)
-            ScrollViewReader { proxy in
-                ScrollView {
-                    ForEach(cartViewModel.itemsInCart, id: \.id) { cartItem in
-                        ItemRowView(cartItem: cartItem,
-                                    onItemRemoveTapped: cartViewModel.canDeleteItemsFromCart ? {
-                            cartViewModel.removeItemFromCart(cartItem)
-                        } : nil)
-                        .id(cartItem.id)
-                    }
+            if cartViewModel.itemsInCart.isEmpty {
+                VStack {
+                    Spacer()
+                    Image(uiImage: .shoppingBagsImage)
+                    Text(Localization.addItemsToCartHint)
+                        .font(Constants.secondaryFont)
+                        .foregroundColor(Color.posSecondaryTexti3)
+                        .multilineTextAlignment(.center)
+                    Spacer()
                 }
-                .onChange(of: cartViewModel.itemToScrollToWhenCartUpdated?.id) { _ in
-                    if viewModel.orderStage == .building,
-                       let last = cartViewModel.itemToScrollToWhenCartUpdated?.id {
-                        withAnimation {
-                            proxy.scrollTo(last)
+            } else {
+                ScrollViewReader { proxy in
+                    ScrollView {
+                        ForEach(cartViewModel.itemsInCart, id: \.id) { cartItem in
+                            ItemRowView(cartItem: cartItem,
+                                        onItemRemoveTapped: cartViewModel.canDeleteItemsFromCart ? {
+                                cartViewModel.removeItemFromCart(cartItem)
+                            } : nil)
+                            .id(cartItem.id)
+                        }
+                    }
+                    .onChange(of: cartViewModel.itemToScrollToWhenCartUpdated?.id) { _ in
+                        if viewModel.orderStage == .building,
+                           let last = cartViewModel.itemToScrollToWhenCartUpdated?.id {
+                            withAnimation {
+                                proxy.scrollTo(last)
+                            }
                         }
                     }
                 }
@@ -87,6 +99,10 @@ private extension CartView {
             "pos.cartView.clearButtonTitle",
             value: "Clear",
             comment: "Title for the 'Clear' button to remove all products from the Cart.")
+        static let addItemsToCartHint = NSLocalizedString(
+            "pos.cartView.addItemsToCartHint",
+            value: "Tap on a product to \n add it to the cart",
+            comment: "Hint to add products to the Cart when this is empty.")
     }
 }
 

--- a/WooCommerce/Classes/POS/Presentation/PointOfSaleDashboardView.swift
+++ b/WooCommerce/Classes/POS/Presentation/PointOfSaleDashboardView.swift
@@ -71,7 +71,7 @@ private extension PointOfSaleDashboardView {
     enum Constants {
         // For the moment we're just considering landscape for the POS mode
         // https://github.com/woocommerce/woocommerce-ios/issues/13251
-        static let cartWidth: CGFloat = 0.3
+        static let cartWidth: CGFloat = 0.35
     }
 }
 

--- a/WooCommerce/Classes/POS/Presentation/PointOfSaleDashboardView.swift
+++ b/WooCommerce/Classes/POS/Presentation/PointOfSaleDashboardView.swift
@@ -16,20 +16,11 @@ struct PointOfSaleDashboardView: View {
             HStack {
                 switch viewModel.orderStage {
                 case .building:
-                    if viewModel.isCartCollapsed {
-                        // 1. Initial state: Product list is visible and cart is collapsed
-                        productListView
-                            .frame(maxWidth: .infinity)
-                        Spacer()
-                        collapsedCartView
-                    } else {
-                        // 2. Products in cart: Both product list and cart are visible
-                        GeometryReader { geometry in
-                            HStack {
-                                productListView
-                                cartView
-                                    .frame(width: geometry.size.width * Constants.cartWidth)
-                            }
+                    GeometryReader { geometry in
+                        HStack {
+                            productListView
+                            cartView
+                                .frame(width: geometry.size.width * Constants.cartWidth)
                         }
                     }
                 case .finalizing:
@@ -80,7 +71,7 @@ private extension PointOfSaleDashboardView {
     enum Constants {
         // For the moment we're just considering landscape for the POS mode
         // https://github.com/woocommerce/woocommerce-ios/issues/13251
-        static let cartWidth: CGFloat = 0.4
+        static let cartWidth: CGFloat = 0.3
     }
 }
 

--- a/WooCommerce/Classes/POS/ViewModels/CartViewModel.swift
+++ b/WooCommerce/Classes/POS/ViewModels/CartViewModel.swift
@@ -54,6 +54,14 @@ final class CartViewModel: ObservableObject {
         }
     }
 
+    var cartLabelColor: Color {
+        if itemsInCart.isEmpty {
+            Color.posSecondaryTexti3
+        } else {
+            Color.posPrimaryTexti3
+        }
+    }
+
     func submitCart() {
         cartSubmissionSubject.send(itemsInCart)
     }

--- a/WooCommerce/Classes/POS/ViewModels/PointOfSaleDashboardViewModel.swift
+++ b/WooCommerce/Classes/POS/ViewModels/PointOfSaleDashboardViewModel.swift
@@ -15,8 +15,6 @@ final class PointOfSaleDashboardViewModel: ObservableObject {
     private(set) lazy var cartViewModel: CartViewModel = CartViewModel(orderStage: $orderStage.eraseToAnyPublisher())
     let totalsViewModel: TotalsViewModel
 
-    @Published private(set) var isCartCollapsed: Bool = true
-
     let cardReaderConnectionViewModel: CardReaderConnectionViewModel
 
     enum OrderStage {
@@ -45,7 +43,6 @@ final class PointOfSaleDashboardViewModel: ObservableObject {
                                                currencyFormatter: currencyFormatter)
 
         observeSelectedItemToAddToCart()
-        observeCartItemsForCollapsedState()
         observeCartSubmission()
         observeCartAddMoreAction()
         observeCartItemsToCheckIfCartIsEmpty()
@@ -66,12 +63,6 @@ private extension PointOfSaleDashboardViewModel {
             self?.cartViewModel.addItemToCart(selectedItem)
         }
         .store(in: &cancellables)
-    }
-
-    func observeCartItemsForCollapsedState() {
-        cartViewModel.$itemsInCart
-            .map { $0.isEmpty }
-            .assign(to: &$isCartCollapsed)
     }
 
     func observeCartSubmission() {

--- a/WooCommerce/WooCommerceTests/POS/ViewModels/CartViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/POS/ViewModels/CartViewModelTests.swift
@@ -1,5 +1,6 @@
 import XCTest
 import Combine
+import SwiftUI
 @testable import WooCommerce
 @testable import protocol Yosemite.POSItem
 @testable import struct Yosemite.POSProduct
@@ -127,7 +128,7 @@ final class CartViewModelTests: XCTestCase {
         XCTAssertEqual(expectedItem.item.itemID, lastItem.itemID)
     }
 
-    func test_itemsInCartLabel() {
+    func test_itemsInCartLabel_when_addItemToCart_then_label_updates_accordingly() {
         XCTAssertNil(sut.itemsInCartLabel, "Initial state")
 
         // Given
@@ -140,6 +141,21 @@ final class CartViewModelTests: XCTestCase {
 
         sut.addItemToCart(anotherItem)
         XCTAssertEqual(sut.itemsInCartLabel, "2 items")
+    }
+
+    func test_cartLabelColor_when_addItemToCart_then_color_updates_accordingly() {
+        // Given
+        let item = Self.makeItem()
+        let initialCartLabelColor = Color.posSecondaryTexti3
+        let expectedCartLabelColor = Color.posSecondaryTexti3
+
+        XCTAssertEqual(sut.cartLabelColor, initialCartLabelColor)
+
+        // When
+        sut.addItemToCart(item)
+
+        // Then
+        XCTAssertEqual(sut.cartLabelColor, expectedCartLabelColor)
     }
 }
 

--- a/WooCommerce/WooCommerceTests/POS/ViewModels/CartViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/POS/ViewModels/CartViewModelTests.swift
@@ -147,7 +147,7 @@ final class CartViewModelTests: XCTestCase {
         // Given
         let item = Self.makeItem()
         let initialCartLabelColor = Color.posSecondaryTexti3
-        let expectedCartLabelColor = Color.posSecondaryTexti3
+        let expectedCartLabelColor = Color.posPrimaryTexti3
 
         XCTAssertEqual(sut.cartLabelColor, initialCartLabelColor)
 

--- a/WooCommerce/WooCommerceTests/POS/ViewModels/PointOfSaleDashboardViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/POS/ViewModels/PointOfSaleDashboardViewModelTests.swift
@@ -35,14 +35,12 @@ final class PointOfSaleDashboardViewModelTests: XCTestCase {
 
     func test_viewmodel_when_loaded_then_has_expected_initial_setup() {
         // Given
-        let expectedCartCollapsedState = true
         let expectedAddMoreButtonDisabledState = false
         let expectedExitPOSButtonDisabledState = false
         let expectedOrderStage = PointOfSaleDashboardViewModel.OrderStage.building
 
         // When/Then
         XCTAssertEqual(sut.orderStage, expectedOrderStage)
-        XCTAssertEqual(sut.isCartCollapsed, expectedCartCollapsedState)
         XCTAssertEqual(sut.isAddMoreDisabled, expectedAddMoreButtonDisabledState)
         XCTAssertEqual(sut.isExitPOSDisabled, expectedExitPOSButtonDisabledState)
     }
@@ -52,7 +50,6 @@ final class PointOfSaleDashboardViewModelTests: XCTestCase {
         let expectedOrderStage = PointOfSaleDashboardViewModel.OrderStage.building
         let expectedCartEmpty = true
         let expectedPaymentState = TotalsViewModel.PaymentState.acceptingCard
-        let expectedCartCollapsedState = true
 
         // When
         sut.startNewTransaction()
@@ -61,7 +58,6 @@ final class PointOfSaleDashboardViewModelTests: XCTestCase {
         XCTAssertEqual(sut.orderStage, expectedOrderStage)
         XCTAssertEqual(sut.cartViewModel.itemsInCart.isEmpty, expectedCartEmpty)
         XCTAssertEqual(sut.totalsViewModel.paymentState, expectedPaymentState)
-        XCTAssertEqual(sut.isCartCollapsed, expectedCartCollapsedState)
         XCTAssertNil(sut.totalsViewModel.order)
     }
 
@@ -70,7 +66,6 @@ final class PointOfSaleDashboardViewModelTests: XCTestCase {
         let item = Self.makeItem()
         let expectedCartEmpty = false
         let expectedOrderStage = PointOfSaleDashboardViewModel.OrderStage.building
-        let expectedCartCollapsedState = false
 
         // When
         sut.itemListViewModel.select(item)
@@ -78,7 +73,6 @@ final class PointOfSaleDashboardViewModelTests: XCTestCase {
         // Then
         XCTAssertEqual(sut.cartViewModel.itemsInCart.isEmpty, expectedCartEmpty)
         XCTAssertEqual(sut.orderStage, expectedOrderStage)
-        XCTAssertEqual(sut.isCartCollapsed, expectedCartCollapsedState)
     }
 
     // TODO:


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #13318
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
In the new design iteration the Cart view is always visible, so we can remove the collapse/expanse behaviour when the cart is empty or has products.

Please note the UI is not final yet, so we haven't addressed the fine-tuned details, just the overall view and its behaviour.

| Empty Cart | Cart with items |
|--------|--------|
| ![Simulator Screenshot - iPad Pro (12 9-inch) (6th generation) - 2024-07-16 at 10 19 51](https://github.com/user-attachments/assets/4de9b8ac-9f3e-4f0e-9261-e4f141eef273) | ![Simulator Screenshot - iPad Pro (12 9-inch) (6th generation) - 2024-07-16 at 10 19 55](https://github.com/user-attachments/assets/42ebd44f-697e-484e-b68c-1c0c8273bb99) | 

## Changes
* Removed collapse/expanse behavior
* Removed cart icon
* Updated cart strings
* Added background image
* Updated unit tests

## Testing
* In POS mode, observe that when the cart is empty we have a greyed-out "Cart" title, some shopping bags image, and a hint to add products to cart
* Add products to cart
* Observe the "Cart" title colour is updated to a darker one and the item counter and "clear" button appears.
* If the cart is emptied, the view switches back to its initial state

