### PR TITLE
Google Ads: Enable feature flag in production

### DIFF
--- a/Experiments/Experiments/DefaultFeatureFlagService.swift
+++ b/Experiments/Experiments/DefaultFeatureFlagService.swift
@@ -95,7 +95,7 @@ public struct DefaultFeatureFlagService: FeatureFlagService {
         case .productCreationAIv2M3:
             return buildConfig == .localDeveloper || buildConfig == .alpha
         case .googleAdsCampaignCreationOnWebView:
-            return buildConfig == .localDeveloper || buildConfig == .alpha
+            return true
         case .backgroundTasks:
             return buildConfig == .localDeveloper || buildConfig == .alpha
         default:

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -2,11 +2,11 @@
 
 19.6
 -----
+- [**] Google Ads campaign management is now available for stores with plugin version 2.7.5 or later. [https://github.com/woocommerce/woocommerce-ios/pull/13331]
 
 
 19.5
 -----
-
 - [**] Cash Payment: Set the payment method and payment method title to orders completed with cash payment. [https://github.com/woocommerce/woocommerce-ios/pull/13257]
 
 19.4


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #13129 
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This PR enables the feature flag to make Google Ads campaign management available in production.

## Testing steps
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->
- Pre-requisite: Install, activate, and set up the Google Ads plugin to a test site following pe5sF9-2Qo-p2. Ensure that you're using the plugin version 2.7.5 or above.
- Build the app and log in to your store.
- Enable Google Ads card on the dashboard if you haven't already.
- If your store has no campaign, confirm that the empty state is displayed.
- Tap on Create campaign to create a new campaign for your store.
- After campaign creation, confirm that the total stats view is displayed.
- Switch to the menu tab, and confirm that there's an entry point to Google Ads named Google for WooCommerce.
- Tap on the item, and confirm that the Google Ads dashboard page is presented if there's existing campaign on your store, or the campaign creation page otherwise.
- Switch to a store ineligible for Google Ads - confirm that entry points on the dashboard and hub menu screens are not available.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->
Dashboard card empty state | Dashboard card with data  | Hub menu 
--- | --- | ---
<img src="https://github.com/user-attachments/assets/d33ca763-5669-415d-85e8-bb5974682cb2" width=320 /> | <img src="https://github.com/user-attachments/assets/f6645227-391a-48bd-96d8-7c499eb0ebb1" width=320 /> | <img src="https://github.com/user-attachments/assets/abfd7a3d-17e7-4cc5-a26d-9c1ce949ada5" width=320 />


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
