### PR TITLE
Product Sharing with AI: Remove feature flag

### DIFF
--- a/Experiments/Experiments/DefaultFeatureFlagService.swift
+++ b/Experiments/Experiments/DefaultFeatureFlagService.swift
@@ -56,8 +56,6 @@ public struct DefaultFeatureFlagService: FeatureFlagService {
             return true
         case .euShippingNotification:
             return true
-        case .shareProductAI:
-            return true
         case .betterCustomerSelectionInOrder:
             return true
         case .hazmatShipping:

--- a/Experiments/Experiments/FeatureFlag.swift
+++ b/Experiments/Experiments/FeatureFlag.swift
@@ -128,10 +128,6 @@ public enum FeatureFlag: Int {
     ///
     case euShippingNotification
 
-    /// Enables generating share product content using AI
-    ///
-    case shareProductAI
-
     /// Enables the improvements in the customer selection logic when creating an order
     ///
     case betterCustomerSelectionInOrder

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -3,6 +3,7 @@
 19.6
 -----
 - [Internal] Removed feature flag for product description AI [https://github.com/woocommerce/woocommerce-ios/pull/13334]
+- [Internal] Removed feature flag for product sharing AI [https://github.com/woocommerce/woocommerce-ios/pull/13337]
 
 19.5
 -----

--- a/WooCommerce/Classes/ViewRelated/Products/ShareProduct/ShareProductAIEligibilityChecker.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ShareProduct/ShareProductAIEligibilityChecker.swift
@@ -7,19 +7,12 @@ protocol ShareProductAIEligibilityChecker {
 
 struct DefaultShareProductAIEligibilityChecker: ShareProductAIEligibilityChecker {
     private let site: Site?
-    private let featureFlagService: FeatureFlagService
 
-    init(site: Site? = ServiceLocator.stores.sessionManager.defaultSite,
-         featureFlagService: FeatureFlagService = ServiceLocator.featureFlagService) {
+    init(site: Site? = ServiceLocator.stores.sessionManager.defaultSite) {
         self.site = site
-        self.featureFlagService = featureFlagService
     }
 
     var canGenerateShareProductMessageUsingAI: Bool {
-        guard featureFlagService.isFeatureFlagEnabled(.shareProductAI) else {
-            return false
-        }
-
         guard let site else {
             return false
         }

--- a/WooCommerce/WooCommerceTests/Mocks/MockFeatureFlagService.swift
+++ b/WooCommerce/WooCommerceTests/Mocks/MockFeatureFlagService.swift
@@ -12,7 +12,6 @@ struct MockFeatureFlagService: FeatureFlagService {
     private let isProductDescriptionAIFromStoreOnboardingEnabled: Bool
     private let isReadOnlyGiftCardsEnabled: Bool
     private let isBlazeEnabled: Bool
-    private let isShareProductAIEnabled: Bool
     private let betterCustomerSelectionInOrder: Bool
     private let productBundles: Bool
     private let productBundlesInOrderForm: Bool
@@ -36,7 +35,6 @@ struct MockFeatureFlagService: FeatureFlagService {
          isProductDescriptionAIFromStoreOnboardingEnabled: Bool = false,
          isReadOnlyGiftCardsEnabled: Bool = false,
          isBlazeEnabled: Bool = false,
-         isShareProductAIEnabled: Bool = false,
          betterCustomerSelectionInOrder: Bool = false,
          productBundles: Bool = false,
          productBundlesInOrderForm: Bool = false,
@@ -59,7 +57,6 @@ struct MockFeatureFlagService: FeatureFlagService {
         self.isProductDescriptionAIFromStoreOnboardingEnabled = isProductDescriptionAIFromStoreOnboardingEnabled
         self.isReadOnlyGiftCardsEnabled = isReadOnlyGiftCardsEnabled
         self.isBlazeEnabled = isBlazeEnabled
-        self.isShareProductAIEnabled = isShareProductAIEnabled
         self.betterCustomerSelectionInOrder = betterCustomerSelectionInOrder
         self.productBundles = productBundles
         self.productBundlesInOrderForm = productBundlesInOrderForm
@@ -94,8 +91,6 @@ struct MockFeatureFlagService: FeatureFlagService {
             return isProductDescriptionAIFromStoreOnboardingEnabled
         case .readOnlyGiftCards:
             return isReadOnlyGiftCardsEnabled
-        case .shareProductAI:
-            return isShareProductAIEnabled
         case .betterCustomerSelectionInOrder:
             return betterCustomerSelectionInOrder
         case .productBundles:

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/ShareProduct/DefaultShareProductAIEligibilityCheckerTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/ShareProduct/DefaultShareProductAIEligibilityCheckerTests.swift
@@ -4,8 +4,7 @@ import XCTest
 final class DefaultShareProductAIEligibilityCheckerTests: XCTestCase {
     func test_canGenerateShareProductMessageUsingAI_is_enabled_when_site_is_wpcom() {
         // Given
-        let featureFlagService = MockFeatureFlagService(isShareProductAIEnabled: true)
-        let checker = DefaultShareProductAIEligibilityChecker(site: .fake().copy(isWordPressComStore: true), featureFlagService: featureFlagService)
+        let checker = DefaultShareProductAIEligibilityChecker(site: .fake().copy(isWordPressComStore: true))
 
         // Then
         XCTAssertTrue(checker.canGenerateShareProductMessageUsingAI)
@@ -13,8 +12,7 @@ final class DefaultShareProductAIEligibilityCheckerTests: XCTestCase {
 
     func test_canGenerateShareProductMessageUsingAI_is_disabled_when_site_is_not_wpcom() {
         // Given
-        let featureFlagService = MockFeatureFlagService(isShareProductAIEnabled: true)
-        let checker = DefaultShareProductAIEligibilityChecker(site: .fake().copy(isWordPressComStore: false), featureFlagService: featureFlagService)
+        let checker = DefaultShareProductAIEligibilityChecker(site: .fake().copy(isWordPressComStore: false))
 
         // Then
         XCTAssertFalse(checker.canGenerateShareProductMessageUsingAI)
@@ -22,9 +20,7 @@ final class DefaultShareProductAIEligibilityCheckerTests: XCTestCase {
 
     func test_canGenerateShareProductMessageUsingAI_is_enabled_when_site_is_not_wpcom_and_ai_assistant_feature_is_active() throws {
         // Given
-        let featureFlagService = MockFeatureFlagService(isShareProductAIEnabled: true)
-        let checker = DefaultShareProductAIEligibilityChecker(site: .fake().copy(isAIAssistantFeatureActive: true, isWordPressComStore: false),
-                                                              featureFlagService: featureFlagService)
+        let checker = DefaultShareProductAIEligibilityChecker(site: .fake().copy(isAIAssistantFeatureActive: true, isWordPressComStore: false))
 
         // Then
         XCTAssertTrue(checker.canGenerateShareProductMessageUsingAI)
@@ -32,17 +28,7 @@ final class DefaultShareProductAIEligibilityCheckerTests: XCTestCase {
 
     func test_canGenerateShareProductMessageUsingAI_is_disabled_when_site_is_nil() {
         // Given
-        let featureFlagService = MockFeatureFlagService(isShareProductAIEnabled: true)
-        let checker = DefaultShareProductAIEligibilityChecker(site: nil, featureFlagService: featureFlagService)
-
-        // Then
-        XCTAssertFalse(checker.canGenerateShareProductMessageUsingAI)
-    }
-
-    func test_canGenerateShareProductMessageUsingAI_is_disabled_when_site_is_wpcom_and_feature_flag_is_off() {
-        // Given
-        let featureFlagService = MockFeatureFlagService(isShareProductAIEnabled: false)
-        let checker = DefaultShareProductAIEligibilityChecker(site: .fake().copy(isWordPressComStore: true), featureFlagService: featureFlagService)
+        let checker = DefaultShareProductAIEligibilityChecker(site: nil)
 
         // Then
         XCTAssertFalse(checker.canGenerateShareProductMessageUsingAI)


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #13336 
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
Product sharing with AI has been completed for a year, so this feature removes the related feature flag.

## Testing steps
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->
- Log in to a store eligible for Jetpack AI.
- Navigate to the Products tab and select an existing published product or create a new one.
- Tap on the Share button on the top right and confirm that an option to generate sharing message with AI is available.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

<img src="https://github.com/user-attachments/assets/a4eda172-f16d-4722-ab8e-2edc81e84853" width=320 />

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
