### PR TITLE
Product description AI: Remove the feature flag for onboarding

### DIFF
--- a/Experiments/Experiments/DefaultFeatureFlagService.swift
+++ b/Experiments/Experiments/DefaultFeatureFlagService.swift
@@ -48,8 +48,6 @@ public struct DefaultFeatureFlagService: FeatureFlagService {
             return true
         case .compositeProducts:
             return true
-        case .productDescriptionAIFromStoreOnboarding:
-            return !isUITesting
         case .readOnlyGiftCards:
             return true
         case .readOnlyMinMaxQuantities:

--- a/Experiments/Experiments/FeatureFlag.swift
+++ b/Experiments/Experiments/FeatureFlag.swift
@@ -112,10 +112,6 @@ public enum FeatureFlag: Int {
     ///
     case compositeProducts
 
-    /// Enables generating product description using AI from store onboarding.
-    ///
-    case productDescriptionAIFromStoreOnboarding
-
     /// Enables read-only support for the Gift Cards extension
     ///
     case readOnlyGiftCards

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -4,6 +4,7 @@
 -----
 - [Internal] Removed feature flag for product description AI [https://github.com/woocommerce/woocommerce-ios/pull/13334]
 - [Internal] Removed feature flag for product sharing AI [https://github.com/woocommerce/woocommerce-ios/pull/13337]
+- [Internal] Removed feature flag for product description AI tooltip [https://github.com/woocommerce/woocommerce-ios/pull/13341]
 
 19.5
 -----

--- a/WooCommerce/Classes/ViewRelated/Feature Highlight/ProductDescriptionAITooltipUseCase.swift
+++ b/WooCommerce/Classes/ViewRelated/Feature Highlight/ProductDescriptionAITooltipUseCase.swift
@@ -34,10 +34,6 @@ struct ProductDescriptionAITooltipUseCase {
 
     /// Tooltip will only be shown 3 times if the user never interacts with it.
     func shouldShowTooltip(for product: ProductFormDataModel) -> Bool {
-        guard featureFlagService.isFeatureFlagEnabled(.productDescriptionAIFromStoreOnboarding) else {
-            return false
-        }
-
         guard isDescriptionAIEnabled else {
             return false
         }

--- a/WooCommerce/Classes/ViewRelated/Feature Highlight/ProductDescriptionAITooltipUseCase.swift
+++ b/WooCommerce/Classes/ViewRelated/Feature Highlight/ProductDescriptionAITooltipUseCase.swift
@@ -1,16 +1,12 @@
 import Foundation
-import Experiments
 
 struct ProductDescriptionAITooltipUseCase {
     private let userDefaults: UserDefaults
-    private let featureFlagService: FeatureFlagService
     private let isDescriptionAIEnabled: Bool
 
     init(userDefaults: UserDefaults = UserDefaults.standard,
-         featureFlagService: FeatureFlagService = ServiceLocator.featureFlagService,
          isDescriptionAIEnabled: Bool) {
         self.userDefaults = userDefaults
-        self.featureFlagService = featureFlagService
         self.isDescriptionAIEnabled = isDescriptionAIEnabled
     }
 

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/DefaultProductFormTableViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/DefaultProductFormTableViewModel.swift
@@ -70,7 +70,7 @@ private extension DefaultProductFormTableViewModel {
             case .description(let editable):
                 let isDescriptionAIEnabled = editable
                 && isDescriptionAIEnabled
-                && featureFlagService.isFeatureFlagEnabled(.productDescriptionAIFromStoreOnboarding)
+
                 let descriptionRow: ProductFormSection.PrimaryFieldRow = .description(description: product.trimmedFullDescription,
                                                                                       isEditable: editable,
                                                                                       isDescriptionAIEnabled: isDescriptionAIEnabled)

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormAIEligibilityChecker.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormAIEligibilityChecker.swift
@@ -1,4 +1,3 @@
-import protocol Experiments.FeatureFlagService
 import struct Yosemite.Site
 
 /// AI-assisted features for product editing/creation.

--- a/WooCommerce/WooCommerceTests/Mocks/MockFeatureFlagService.swift
+++ b/WooCommerce/WooCommerceTests/Mocks/MockFeatureFlagService.swift
@@ -9,7 +9,6 @@ struct MockFeatureFlagService: FeatureFlagService {
     private let isDomainSettingsEnabled: Bool
     private let isSupportRequestEnabled: Bool
     private let jetpackSetupWithApplicationPassword: Bool
-    private let isProductDescriptionAIFromStoreOnboardingEnabled: Bool
     private let isReadOnlyGiftCardsEnabled: Bool
     private let isBlazeEnabled: Bool
     private let betterCustomerSelectionInOrder: Bool
@@ -32,7 +31,6 @@ struct MockFeatureFlagService: FeatureFlagService {
          isDomainSettingsEnabled: Bool = false,
          isSupportRequestEnabled: Bool = false,
          jetpackSetupWithApplicationPassword: Bool = false,
-         isProductDescriptionAIFromStoreOnboardingEnabled: Bool = false,
          isReadOnlyGiftCardsEnabled: Bool = false,
          isBlazeEnabled: Bool = false,
          betterCustomerSelectionInOrder: Bool = false,
@@ -54,7 +52,6 @@ struct MockFeatureFlagService: FeatureFlagService {
         self.isDomainSettingsEnabled = isDomainSettingsEnabled
         self.isSupportRequestEnabled = isSupportRequestEnabled
         self.jetpackSetupWithApplicationPassword = jetpackSetupWithApplicationPassword
-        self.isProductDescriptionAIFromStoreOnboardingEnabled = isProductDescriptionAIFromStoreOnboardingEnabled
         self.isReadOnlyGiftCardsEnabled = isReadOnlyGiftCardsEnabled
         self.isBlazeEnabled = isBlazeEnabled
         self.betterCustomerSelectionInOrder = betterCustomerSelectionInOrder
@@ -87,8 +84,6 @@ struct MockFeatureFlagService: FeatureFlagService {
             return isSupportRequestEnabled
         case .jetpackSetupWithApplicationPassword:
             return jetpackSetupWithApplicationPassword
-        case .productDescriptionAIFromStoreOnboarding:
-            return isProductDescriptionAIFromStoreOnboardingEnabled
         case .readOnlyGiftCards:
             return isReadOnlyGiftCardsEnabled
         case .betterCustomerSelectionInOrder:

--- a/WooCommerce/WooCommerceTests/ViewRelated/Feature Highlight/ProductDescriptionAITooltipUseCaseTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Feature Highlight/ProductDescriptionAITooltipUseCaseTests.swift
@@ -6,9 +6,7 @@ final class ProductDescriptionAITooltipUseCaseTests: XCTestCase {
     // MARK: isDescriptionAIEnabled
 
     func test_shouldShowTooltip_is_true_only_when_isDescriptionAIEnabled_is_true() {
-        let featureFlagService = MockFeatureFlagService(isProductDescriptionAIFromStoreOnboardingEnabled: true)
         var sut = ProductDescriptionAITooltipUseCase(userDefaults: MockUserDefaults(),
-                                                     featureFlagService: featureFlagService,
                                                      isDescriptionAIEnabled: true)
         sut.hasDismissedWriteWithAITooltip = false
         sut.numberOfTimesWriteWithAITooltipIsShown = 2
@@ -19,38 +17,8 @@ final class ProductDescriptionAITooltipUseCaseTests: XCTestCase {
     }
 
     func test_shouldShowTooltip_is_false_when_isDescriptionAIEnabled_is_false() {
-        let featureFlagService = MockFeatureFlagService(isProductDescriptionAIFromStoreOnboardingEnabled: true)
         var sut = ProductDescriptionAITooltipUseCase(userDefaults: MockUserDefaults(),
-                                                     featureFlagService: featureFlagService,
                                                      isDescriptionAIEnabled: false)
-        sut.hasDismissedWriteWithAITooltip = false
-        sut.numberOfTimesWriteWithAITooltipIsShown = 2
-
-        let product = Product.fake().copy(fullDescription: "")
-        let model = EditableProductModel(product: product)
-        XCTAssertFalse(sut.shouldShowTooltip(for: model))
-    }
-
-    // MARK: Feature flag
-
-    func test_shouldShowTooltip_is_true_only_when_isProductDescriptionAIFromStoreOnboardingEnabled_is_true() {
-        let featureFlagService = MockFeatureFlagService(isProductDescriptionAIFromStoreOnboardingEnabled: true)
-        var sut = ProductDescriptionAITooltipUseCase(userDefaults: MockUserDefaults(),
-                                                     featureFlagService: featureFlagService,
-                                                     isDescriptionAIEnabled: true)
-        sut.hasDismissedWriteWithAITooltip = false
-        sut.numberOfTimesWriteWithAITooltipIsShown = 2
-
-        let product = Product.fake().copy(fullDescription: "")
-        let model = EditableProductModel(product: product)
-        XCTAssertTrue(sut.shouldShowTooltip(for: model))
-    }
-
-    func test_shouldShowTooltip_is_false_when_isProductDescriptionAIFromStoreOnboardingEnabled_is_false() {
-        let featureFlagService = MockFeatureFlagService(isProductDescriptionAIFromStoreOnboardingEnabled: false)
-        var sut = ProductDescriptionAITooltipUseCase(userDefaults: MockUserDefaults(),
-                                                     featureFlagService: featureFlagService,
-                                                     isDescriptionAIEnabled: true)
         sut.hasDismissedWriteWithAITooltip = false
         sut.numberOfTimesWriteWithAITooltipIsShown = 2
 
@@ -62,9 +30,7 @@ final class ProductDescriptionAITooltipUseCaseTests: XCTestCase {
     // MARK: Product description
 
     func test_shouldShowTooltip_is_true_only_when_product_description_is_empty() {
-        let featureFlagService = MockFeatureFlagService(isProductDescriptionAIFromStoreOnboardingEnabled: true)
         var sut = ProductDescriptionAITooltipUseCase(userDefaults: MockUserDefaults(),
-                                                     featureFlagService: featureFlagService,
                                                      isDescriptionAIEnabled: true)
         sut.hasDismissedWriteWithAITooltip = false
         sut.numberOfTimesWriteWithAITooltipIsShown = 2
@@ -75,9 +41,7 @@ final class ProductDescriptionAITooltipUseCaseTests: XCTestCase {
     }
 
     func test_shouldShowTooltip_is_false_when_product_description_is_not_empty() {
-        let featureFlagService = MockFeatureFlagService(isProductDescriptionAIFromStoreOnboardingEnabled: false)
         var sut = ProductDescriptionAITooltipUseCase(userDefaults: MockUserDefaults(),
-                                                     featureFlagService: featureFlagService,
                                                      isDescriptionAIEnabled: true)
         sut.hasDismissedWriteWithAITooltip = false
         sut.numberOfTimesWriteWithAITooltipIsShown = 2
@@ -90,9 +54,7 @@ final class ProductDescriptionAITooltipUseCaseTests: XCTestCase {
     // MARK: Counter
 
     func test_shouldShowTooltip_is_true_only_when_counter_is_below_3() {
-        let featureFlagService = MockFeatureFlagService(isProductDescriptionAIFromStoreOnboardingEnabled: true)
         var sut = ProductDescriptionAITooltipUseCase(userDefaults: MockUserDefaults(),
-                                                     featureFlagService: featureFlagService,
                                                      isDescriptionAIEnabled: true)
         sut.hasDismissedWriteWithAITooltip = false
         sut.numberOfTimesWriteWithAITooltipIsShown = 2
@@ -103,9 +65,7 @@ final class ProductDescriptionAITooltipUseCaseTests: XCTestCase {
     }
 
     func test_shouldShowTooltip_is_false_when_counter_is_3() {
-        let featureFlagService = MockFeatureFlagService(isProductDescriptionAIFromStoreOnboardingEnabled: true)
         var sut = ProductDescriptionAITooltipUseCase(userDefaults: MockUserDefaults(),
-                                                     featureFlagService: featureFlagService,
                                                      isDescriptionAIEnabled: true)
         sut.numberOfTimesWriteWithAITooltipIsShown = 3
 
@@ -117,9 +77,7 @@ final class ProductDescriptionAITooltipUseCaseTests: XCTestCase {
     // MARK: Dismissed by user
 
     func test_shouldShowTooltip_is_true_only_when_hasDismissedWriteWithAITooltip_is_false() {
-        let featureFlagService = MockFeatureFlagService(isProductDescriptionAIFromStoreOnboardingEnabled: true)
         var sut = ProductDescriptionAITooltipUseCase(userDefaults: MockUserDefaults(),
-                                                     featureFlagService: featureFlagService,
                                                      isDescriptionAIEnabled: true)
         sut.numberOfTimesWriteWithAITooltipIsShown = 1
 
@@ -129,9 +87,7 @@ final class ProductDescriptionAITooltipUseCaseTests: XCTestCase {
     }
 
     func test_shouldShowTooltip_is_false_when_hasDismissedWriteWithAITooltip_is_true() {
-        let featureFlagService = MockFeatureFlagService(isProductDescriptionAIFromStoreOnboardingEnabled: true)
         var sut = ProductDescriptionAITooltipUseCase(userDefaults: MockUserDefaults(),
-                                                     featureFlagService: featureFlagService,
                                                      isDescriptionAIEnabled: true)
         sut.hasDismissedWriteWithAITooltip = true
         sut.numberOfTimesWriteWithAITooltipIsShown = 1

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/DefaultProductFormTableViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/Edit Product/DefaultProductFormTableViewModelTests.swift
@@ -692,14 +692,12 @@ final class DefaultProductFormTableViewModelTests: XCTestCase {
         let product = Product.fake().copy()
         let model = EditableProductModel(product: product)
         let actionsFactory = ProductFormActionsFactory(product: model, formType: .edit)
-        let featureFlagService = MockFeatureFlagService(isProductDescriptionAIFromStoreOnboardingEnabled: true)
 
         // When
         let tableViewModel = DefaultProductFormTableViewModel(product: model,
                                                               actionsFactory: actionsFactory,
                                                               currency: "",
-                                                              isDescriptionAIEnabled: true,
-                                                              featureFlagService: featureFlagService)
+                                                              isDescriptionAIEnabled: true)
 
         // Then
         guard case let .primaryFields(rows) = tableViewModel.sections[0] else {
@@ -733,14 +731,12 @@ final class DefaultProductFormTableViewModelTests: XCTestCase {
         let product = Product.fake().copy(fullDescription: "desc")
         let model = EditableProductModel(product: product)
         let actionsFactory = ProductFormActionsFactory(product: model, formType: .readonly)
-        let featureFlagService = MockFeatureFlagService(isProductDescriptionAIFromStoreOnboardingEnabled: true)
 
         // When
         let tableViewModel = DefaultProductFormTableViewModel(product: model,
                                                               actionsFactory: actionsFactory,
                                                               currency: "",
-                                                              isDescriptionAIEnabled: true,
-                                                              featureFlagService: featureFlagService)
+                                                              isDescriptionAIEnabled: true)
 
         // Then
         guard case let .primaryFields(rows) = tableViewModel.sections[0] else {
@@ -774,55 +770,12 @@ final class DefaultProductFormTableViewModelTests: XCTestCase {
         let product = Product.fake().copy()
         let model = EditableProductModel(product: product)
         let actionsFactory = ProductFormActionsFactory(product: model, formType: .edit)
-        let featureFlagService = MockFeatureFlagService(isProductDescriptionAIFromStoreOnboardingEnabled: true)
 
         // When
         let tableViewModel = DefaultProductFormTableViewModel(product: model,
                                                               actionsFactory: actionsFactory,
                                                               currency: "",
-                                                              isDescriptionAIEnabled: false,
-                                                              featureFlagService: featureFlagService)
-
-        // Then
-        guard case let .primaryFields(rows) = tableViewModel.sections[0] else {
-            XCTFail("Unexpected section at index 0: \(tableViewModel.sections)")
-            return
-        }
-        var containsDescriptionRow = false
-        var containsDescriptionAIRow = false
-        var containsLearnMoreAboutAIRow = false
-        for row in rows {
-            switch row {
-            case let .description(_, isEditable, isDescriptionAIEnabled):
-                containsDescriptionRow = true
-                XCTAssertTrue(isEditable)
-                XCTAssertFalse(isDescriptionAIEnabled)
-            case .descriptionAI:
-                containsDescriptionAIRow = true
-            case .learnMoreAboutAI:
-                containsLearnMoreAboutAIRow = true
-            default:
-                continue
-            }
-        }
-        XCTAssertTrue(containsDescriptionRow)
-        XCTAssertFalse(containsDescriptionAIRow)
-        XCTAssertFalse(containsLearnMoreAboutAIRow)
-    }
-
-    func test_descriptionAI_and_learnMoreAboutAI_rows_are_not_shown_when_productDescriptionAIFromStoreOnboarding_feature_is_disabled() {
-        // Given
-        let product = Product.fake().copy()
-        let model = EditableProductModel(product: product)
-        let actionsFactory = ProductFormActionsFactory(product: model, formType: .edit)
-        let featureFlagService = MockFeatureFlagService(isProductDescriptionAIFromStoreOnboardingEnabled: false)
-
-        // When
-        let tableViewModel = DefaultProductFormTableViewModel(product: model,
-                                                              actionsFactory: actionsFactory,
-                                                              currency: "",
-                                                              isDescriptionAIEnabled: false,
-                                                              featureFlagService: featureFlagService)
+                                                              isDescriptionAIEnabled: false)
 
         // Then
         guard case let .primaryFields(rows) = tableViewModel.sections[0] else {


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #13339 
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
We added the tooltip for onboarding product description AI more than a year ago. This PR removes the related feature flag.

## Testing steps
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->
- Log out of the app and log back into a store eligible for Jetpack AI.
- Navigate to the Products tab and select an existing product or create a new one.
- Confirm that you can see the tooltip for product description AI pointing to the Write with AI button.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

<img src="https://github.com/user-attachments/assets/8d3bcddb-669b-463e-9b10-430df05fb974" width=320 />


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
