### PR TITLE
[GLA Analytics] Update Google Campaigns card data based on selected stat

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/Report Cards/GoogleAdsCampaignReportCard.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/Report Cards/GoogleAdsCampaignReportCard.swift
@@ -21,15 +21,15 @@ struct GoogleAdsCampaignReportCard: View {
                 .padding(.bottom, Layout.columnSpacing)
 
             HStack {
-                Text(viewModel.totalSales)
+                Text(viewModel.statValue)
                     .titleStyle()
                     .frame(maxWidth: .infinity, alignment: .leading)
                     .redacted(reason: viewModel.isRedacted ? .placeholder : [])
                     .shimmering(active: viewModel.isRedacted)
 
-                DeltaTag(value: viewModel.delta.string,
-                         backgroundColor: viewModel.delta.direction.deltaBackgroundColor,
-                         textColor: viewModel.delta.direction.deltaTextColor)
+                DeltaTag(value: viewModel.deltaValue,
+                         backgroundColor: viewModel.deltaBackgroundColor,
+                         textColor: viewModel.deltaTextColor)
                     .redacted(reason: viewModel.isRedacted ? .placeholder : [])
                     .shimmering(active: viewModel.isRedacted)
             }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/Report Cards/GoogleAdsCampaignReportCardViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/Report Cards/GoogleAdsCampaignReportCardViewModel.swift
@@ -33,9 +33,9 @@ final class GoogleAdsCampaignReportCardViewModel: ObservableObject {
     ///
     let allStats = GoogleAdsCampaignStatsTotals.TotalData.allCases
 
-    /// The currently selected stat to display.
+    /// The currently selected stat to display. Defaults to total sales.
     ///
-    @Published var selectedStat: GoogleAdsCampaignStatsTotals.TotalData
+    @Published var selectedStat: GoogleAdsCampaignStatsTotals.TotalData = .sales
 
     init(currentPeriodStats: GoogleAdsCampaignStats?,
          previousPeriodStats: GoogleAdsCampaignStats?,
@@ -49,7 +49,6 @@ final class GoogleAdsCampaignReportCardViewModel: ObservableObject {
         self.isRedacted = isRedacted
         self.usageTracksEventEmitter = usageTracksEventEmitter
         self.storeAdminURL = storeAdminURL
-        self.selectedStat = .sales
     }
 }
 
@@ -61,28 +60,41 @@ extension GoogleAdsCampaignReportCardViewModel {
         Localization.title
     }
 
-    // MARK: Total Sales
+    // MARK: Selected Stat (Total)
 
-    /// Total Sales title
+    /// Value for the selected stat
     ///
-    var totalSalesTitle: String {
-        return Localization.totalSales
-    }
-
-    /// Total Sales value
-    ///
-    var totalSales: String {
+    var statValue: String {
         guard !isRedacted else {
             return "1000"
         }
-        return StatsDataTextFormatter.formatAmount(currentPeriodStats?.totals.sales)
+        return StatsDataTextFormatter.createGoogleCampaignsStatText(for: selectedStat, from: currentPeriodStats)
     }
 
-    /// Total Sales delta percentage
+    /// Delta percentage for the selected stat
     ///
-    var delta: DeltaPercentage {
+    private var delta: DeltaPercentage {
         isRedacted ? DeltaPercentage(string: "0%", direction: .zero)
-        : StatsDataTextFormatter.createDeltaPercentage(from: previousPeriodStats?.totals.sales, to: currentPeriodStats?.totals.sales)
+        : StatsDataTextFormatter.createDeltaPercentage(from: previousPeriodStats?.totals.getDoubleValue(for: selectedStat),
+                                                       to: currentPeriodStats?.totals.getDoubleValue(for: selectedStat))
+    }
+
+    /// Delta text for the selected stat
+    ///
+    var deltaValue: String {
+        delta.string
+    }
+
+    /// Delta text color for the selected stat
+    ///
+    var deltaTextColor: UIColor {
+        delta.direction.deltaTextColor
+    }
+
+    /// Delta background color for the selected stat
+    ///
+    var deltaBackgroundColor: UIColor {
+        delta.direction.deltaBackgroundColor
     }
 
     // MARK: Campaigns report
@@ -150,11 +162,11 @@ extension AnalyticsTopPerformersCard {
     init(campaignsViewModel: GoogleAdsCampaignReportCardViewModel) {
         // Header with selected metric stats
         self.title = campaignsViewModel.title
-        self.statTitle = campaignsViewModel.totalSalesTitle
-        self.statValue = campaignsViewModel.totalSales
-        self.delta = campaignsViewModel.delta.string
-        self.deltaBackgroundColor = campaignsViewModel.delta.direction.deltaBackgroundColor
-        self.deltaTextColor = campaignsViewModel.delta.direction.deltaTextColor
+        self.statTitle = campaignsViewModel.selectedStat.displayName
+        self.statValue = campaignsViewModel.statValue
+        self.delta = campaignsViewModel.deltaValue
+        self.deltaBackgroundColor = campaignsViewModel.deltaBackgroundColor
+        self.deltaTextColor = campaignsViewModel.deltaTextColor
         self.isStatsRedacted = campaignsViewModel.isRedacted
         // This card gets its metrics and campaigns list from the same source.
         // If there is a problem loading stats data, the error message only appears once at the bottom of the card.
@@ -183,9 +195,6 @@ private extension GoogleAdsCampaignReportCardViewModel {
         static let campaignsTitle = NSLocalizedString("analyticsHub.googleCampaigns.campaignsList.title",
                                                       value: "Campaigns",
                                                       comment: "Title for the list of campaigns on the Google campaigns card on the analytics hub screen.")
-        static let totalSales = NSLocalizedString("analyticsHub.googleCampaigns.totalSalesTitle",
-                                                  value: "Total Sales",
-                                                  comment: "Title for the Total Sales column on the Google Ads campaigns card on the analytics hub screen.")
         static let noCampaignStats = NSLocalizedString("analyticsHub.googleCampaigns.noCampaignStats",
                                                        value: "Unable to load Google campaigns analytics",
                                                        comment: "Text displayed when there is an error loading Google Ads campaigns stats data.")
@@ -203,39 +212,39 @@ private extension GoogleAdsCampaignReportCardViewModel {
 extension GoogleAdsCampaignReportCardViewModel {
     static func sampleStats() -> GoogleAdsCampaignStats {
         GoogleAdsCampaignStats(siteID: 1234,
-                               totals: GoogleAdsCampaignStatsTotals(sales: 2234, spend: nil, clicks: nil, impressions: nil, conversions: nil),
+                               totals: GoogleAdsCampaignStatsTotals(sales: 2234, spend: 225, clicks: 2345, impressions: 23456, conversions: 1032),
                                campaigns: [GoogleAdsCampaignStatsItem(campaignID: 1,
                                                                       campaignName: "Spring Sale Campaign",
                                                                       rawStatus: "enabled",
                                                                       subtotals: GoogleAdsCampaignStatsTotals(sales: 1232,
                                                                                                               spend: 100,
-                                                                                                              clicks: nil,
-                                                                                                              impressions: nil,
-                                                                                                              conversions: nil)),
+                                                                                                              clicks: 1000,
+                                                                                                              impressions: 10000,
+                                                                                                              conversions: 400)),
                                            GoogleAdsCampaignStatsItem(campaignID: 2,
                                                                       campaignName: "Summer Campaign",
                                                                       rawStatus: "enabled",
                                                                       subtotals: GoogleAdsCampaignStatsTotals(sales: 800,
                                                                                                               spend: 50,
-                                                                                                              clicks: nil,
-                                                                                                              impressions: nil,
-                                                                                                              conversions: nil)),
+                                                                                                              clicks: 900,
+                                                                                                              impressions: 5000,
+                                                                                                              conversions: 300)),
                                            GoogleAdsCampaignStatsItem(campaignID: 3,
                                                                       campaignName: "Winter Campaign",
                                                                       rawStatus: "enabled",
                                                                       subtotals: GoogleAdsCampaignStatsTotals(sales: 750,
                                                                                                               spend: 50,
-                                                                                                              clicks: nil,
-                                                                                                              impressions: nil,
-                                                                                                              conversions: nil)),
+                                                                                                              clicks: 800,
+                                                                                                              impressions: 4000,
+                                                                                                              conversions: 200)),
                                            GoogleAdsCampaignStatsItem(campaignID: 4,
                                                                       campaignName: "New Year Campaign",
                                                                       rawStatus: "enabled",
                                                                       subtotals: GoogleAdsCampaignStatsTotals(sales: 200,
                                                                                                               spend: 25,
-                                                                                                              clicks: nil,
-                                                                                                              impressions: nil,
-                                                                                                              conversions: nil))],
+                                                                                                              clicks: 300,
+                                                                                                              impressions: 1000,
+                                                                                                              conversions: 50))],
                                nextPageToken: nil)
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Factories/StatsDataTextFormatter.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Factories/StatsDataTextFormatter.swift
@@ -180,12 +180,31 @@ struct StatsDataTextFormatter {
                          currencyFormatter: currencyFormatter,
                          currencyCode: currencyCode,
                          numberOfFractionDigits: numberOfFractionDigits)
-        case .clicks:
-            return NumberFormatter.localizedString(from: campaignStats.totals.getDoubleValue(for: .clicks) as NSNumber) ?? Constants.placeholderText
-        case .impressions:
-            return NumberFormatter.localizedString(from: campaignStats.totals.getDoubleValue(for: .impressions) as NSNumber) ?? Constants.placeholderText
-        case .conversions:
-            return NumberFormatter.localizedString(from: campaignStats.totals.getDoubleValue(for: .conversions) as NSNumber) ?? Constants.placeholderText
+        case .clicks, .impressions, .conversions:
+            return NumberFormatter.localizedString(from: campaignStats.totals.getDoubleValue(for: stat) as NSNumber) ?? Constants.placeholderText
+        }
+    }
+
+    /// Creates the text to display for a campaign stat subtotal, from the provided campaign.
+    ///
+    static func createGoogleCampaignsSubtotalText(for stat: GoogleAdsCampaignStatsTotals.TotalData,
+                                                  from campaign: GoogleAdsCampaignStatsItem,
+                                                  currencyFormatter: CurrencyFormatter = CurrencyFormatter(currencySettings: ServiceLocator.currencySettings),
+                                                  currencyCode: String = ServiceLocator.currencySettings.currencyCode.rawValue,
+                                                  numberOfFractionDigits: Int = ServiceLocator.currencySettings.fractionDigits) -> String {
+        switch stat {
+        case .sales:
+            formatAmount(campaign.subtotals.sales,
+                         currencyFormatter: currencyFormatter,
+                         currencyCode: currencyCode,
+                         numberOfFractionDigits: numberOfFractionDigits)
+        case .spend:
+            formatAmount(campaign.subtotals.spend,
+                         currencyFormatter: currencyFormatter,
+                         currencyCode: currencyCode,
+                         numberOfFractionDigits: numberOfFractionDigits)
+        case .clicks, .impressions, .conversions:
+            NumberFormatter.localizedString(from: campaign.subtotals.getDoubleValue(for: stat) as NSNumber) ?? Constants.placeholderText
         }
     }
 

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Factories/StatsDataTextFormatter.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Factories/StatsDataTextFormatter.swift
@@ -157,6 +157,38 @@ struct StatsDataTextFormatter {
                             numberOfFractionDigits: numberOfFractionDigits)
     }
 
+    // MARK: Google Ads Campaign Stats
+
+    /// Creates the text to display for a campaign stats metric, from the provided stats.
+    ///
+    static func createGoogleCampaignsStatText(for stat: GoogleAdsCampaignStatsTotals.TotalData,
+                                              from campaignStats: GoogleAdsCampaignStats?,
+                                              currencyFormatter: CurrencyFormatter = CurrencyFormatter(currencySettings: ServiceLocator.currencySettings),
+                                              currencyCode: String = ServiceLocator.currencySettings.currencyCode.rawValue,
+                                              numberOfFractionDigits: Int = ServiceLocator.currencySettings.fractionDigits) -> String {
+        guard let campaignStats else {
+            return Constants.placeholderText
+        }
+        switch stat {
+        case .sales:
+            return formatAmount(campaignStats.totals.sales,
+                         currencyFormatter: currencyFormatter,
+                         currencyCode: currencyCode,
+                         numberOfFractionDigits: numberOfFractionDigits)
+        case .spend:
+            return formatAmount(campaignStats.totals.spend,
+                         currencyFormatter: currencyFormatter,
+                         currencyCode: currencyCode,
+                         numberOfFractionDigits: numberOfFractionDigits)
+        case .clicks:
+            return NumberFormatter.localizedString(from: campaignStats.totals.getDoubleValue(for: .clicks) as NSNumber) ?? Constants.placeholderText
+        case .impressions:
+            return NumberFormatter.localizedString(from: campaignStats.totals.getDoubleValue(for: .impressions) as NSNumber) ?? Constants.placeholderText
+        case .conversions:
+            return NumberFormatter.localizedString(from: campaignStats.totals.getDoubleValue(for: .conversions) as NSNumber) ?? Constants.placeholderText
+        }
+    }
+
     // MARK: Generic helpers
 
     /// Creates the text to display for an amount with currency settings.
@@ -167,13 +199,13 @@ struct StatsDataTextFormatter {
                              currencyFormatter: CurrencyFormatter = CurrencyFormatter(currencySettings: ServiceLocator.currencySettings),
                              currencyCode: String = ServiceLocator.currencySettings.currencyCode.rawValue,
                              numberOfFractionDigits: Int = ServiceLocator.currencySettings.fractionDigits) -> String {
-      guard let amount else {
-          return Constants.placeholderText
-      }
-      // If amount is an integer, no decimal points are shown.
-      let numberOfDecimals: Int? = amount.rounded(.plain, scale: numberOfFractionDigits).isInteger ? 0 : nil
-      return currencyFormatter.formatAmount(amount, with: currencyCode, numberOfDecimals: numberOfDecimals) ?? String()
-  }
+        guard let amount else {
+            return Constants.placeholderText
+        }
+        // If amount is an integer, no decimal points are shown.
+        let numberOfDecimals: Int? = amount.rounded(.plain, scale: numberOfFractionDigits).isInteger ? 0 : nil
+        return currencyFormatter.formatAmount(amount, with: currencyCode, numberOfDecimals: numberOfDecimals) ?? String()
+    }
 }
 
 extension StatsDataTextFormatter {

--- a/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Analytics Hub/AnalyticsHubViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Analytics Hub/AnalyticsHubViewModelTests.swift
@@ -89,7 +89,7 @@ final class AnalyticsHubViewModelTests: XCTestCase {
         XCTAssertEqual(vm.bundlesCard.bundlesSold, "3")
         XCTAssertEqual(vm.bundlesCard.bundlesSoldData.count, 1)
         XCTAssertEqual(vm.giftCardsCard.leadingValue, "20")
-        XCTAssertEqual(vm.googleCampaignsCard.totalSales, "$285")
+        XCTAssertEqual(vm.googleCampaignsCard.statValue, "$285")
     }
 
     func test_cards_viewmodels_redacted_while_updating_from_network() async {

--- a/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Analytics Hub/Report Cards/GoogleAdsCampaignReportCardViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Analytics Hub/Report Cards/GoogleAdsCampaignReportCardViewModelTests.swift
@@ -42,8 +42,8 @@ final class GoogleAdsCampaignReportCardViewModelTests: XCTestCase {
         XCTAssertNotNil(vm.reportViewModel)
 
         // Check metric stats data
-        assertEqual("$12,345", vm.totalSales)
-        assertEqual(DeltaPercentage(string: "+100%", direction: .positive), vm.delta)
+        assertEqual("$12,345", vm.statValue)
+        assertEqual("+100%", vm.deltaValue)
 
         // Check campaigns data
         assertEqual(2, vm.campaignsData.count)
@@ -95,8 +95,8 @@ final class GoogleAdsCampaignReportCardViewModelTests: XCTestCase {
         XCTAssertTrue(vm.isRedacted)
         XCTAssertNotNil(vm.reportViewModel)
 
-        assertEqual("1000", vm.totalSales)
-        assertEqual(DeltaPercentage(string: "0%", direction: .zero), vm.delta)
+        assertEqual("1000", vm.statValue)
+        assertEqual("0%", vm.deltaValue)
 
         // Then
         let expectedPlaceholder = TopPerformersRow.Data(showImage: false, name: "Campaign", details: "Spend: $100", value: "$500")

--- a/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Analytics Hub/Report Cards/GoogleAdsCampaignReportCardViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Analytics Hub/Report Cards/GoogleAdsCampaignReportCardViewModelTests.swift
@@ -133,4 +133,29 @@ final class GoogleAdsCampaignReportCardViewModelTests: XCTestCase {
         XCTAssertFalse(vm.campaignsData.contains(where: { $0.value == "$123" }))
     }
 
+    func test_changing_selectedStat_updates_displayed_values() throws {
+        // Given
+        let vm = GoogleAdsCampaignReportCardViewModel(
+            currentPeriodStats: GoogleAdsCampaignStats.fake().copy(totals: .fake().copy(sales: 12345, spend: 300),
+                                                                   campaigns: [.fake().copy(subtotals: .fake().copy(sales: 1234.56,
+                                                                                                             spend: 200)),
+                                                                               .fake()]),
+            previousPeriodStats: GoogleAdsCampaignStats.fake().copy(totals: .fake().copy(sales: 6172.5, spend: 100)),
+            timeRange: .today,
+            usageTracksEventEmitter: eventEmitter
+        )
+
+        // When
+        vm.selectedStat = .spend
+
+        // Then
+        assertEqual("$300", vm.statValue)
+        assertEqual("+200%", vm.deltaValue)
+
+        // Check campaigns data
+        let firstCampaign = try XCTUnwrap(vm.campaignsData.first)
+        assertEqual(true, firstCampaign.details.contains("$1,234.56"))
+        assertEqual("$200", firstCampaign.value)
+    }
+
 }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Factories/StatsDataTextFormatterTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Factories/StatsDataTextFormatterTests.swift
@@ -758,4 +758,83 @@ final class StatsDataTextFormatterTests: XCTestCase {
         // Then
         XCTAssertEqual(formattedAmount, "$62.86")
     }
+
+    // MARK: Google Campaign Stats
+
+    func test_createGoogleCampaignsStatText_returns_placeholder_on_nil_stats() {
+        // Given
+        for stat in GoogleAdsCampaignStatsTotals.TotalData.allCases {
+            // When
+            let text = StatsDataTextFormatter.createGoogleCampaignsStatText(for: stat, from: nil)
+
+            // Then
+            XCTAssertEqual(text, "-", "Expected \"-\" placeholder for \(stat) text but actual text was \"\(text)\" instead")
+        }
+    }
+
+    func test_createGoogleCampaignsStatText_returns_expected_sales_text() {
+        // Given
+        let amount: Decimal = 1232
+
+        // When
+        let text = StatsDataTextFormatter.createGoogleCampaignsStatText(for: .sales,
+                                                                        from: .fake().copy(totals: .fake().copy(sales: amount)),
+                                                                        currencyFormatter: currencyFormatter,
+                                                                        currencyCode: currencyCode.rawValue,
+                                                                        numberOfFractionDigits: fractionDigits)
+
+        // Then
+        assertEqual("$1,232", text)
+    }
+
+    func test_createGoogleCampaignsStatText_returns_expected_spend_text() {
+        // Given
+        let amount: Decimal = 1232
+
+        // When
+        let text = StatsDataTextFormatter.createGoogleCampaignsStatText(for: .spend,
+                                                                        from: .fake().copy(totals: .fake().copy(spend: amount)),
+                                                                        currencyFormatter: currencyFormatter,
+                                                                        currencyCode: currencyCode.rawValue,
+                                                                        numberOfFractionDigits: fractionDigits)
+
+        // Then
+        assertEqual("$1,232", text)
+    }
+
+    func test_createGoogleCampaignsStatText_returns_expected_clicks_text() {
+        // Given
+        let amount = 1232
+
+        // When
+        let text = StatsDataTextFormatter.createGoogleCampaignsStatText(for: .clicks,
+                                                                        from: .fake().copy(totals: .fake().copy(clicks: amount)))
+
+        // Then
+        assertEqual("1,232", text)
+    }
+
+    func test_createGoogleCampaignsStatText_returns_expected_impressions_text() {
+        // Given
+        let amount = 1232
+
+        // When
+        let text = StatsDataTextFormatter.createGoogleCampaignsStatText(for: .impressions,
+                                                                        from: .fake().copy(totals: .fake().copy(impressions: amount)))
+
+        // Then
+        assertEqual("1,232", text)
+    }
+
+    func test_createGoogleCampaignsStatText_returns_expected_conversions_text() {
+        // Given
+        let amount: Decimal = 1232
+
+        // When
+        let text = StatsDataTextFormatter.createGoogleCampaignsStatText(for: .conversions,
+                                                                        from: .fake().copy(totals: .fake().copy(conversions: amount)))
+
+        // Then
+        assertEqual("1,232", text)
+    }
 }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Factories/StatsDataTextFormatterTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Factories/StatsDataTextFormatterTests.swift
@@ -837,4 +837,70 @@ final class StatsDataTextFormatterTests: XCTestCase {
         // Then
         assertEqual("1,232", text)
     }
+
+    func test_createGoogleCampaignsSubtotalText_returns_expected_sales_text() {
+        // Given
+        let campaign = GoogleAdsCampaignStatsItem.fake().copy(subtotals: .fake().copy(sales: 1232))
+
+        // When
+        let text = StatsDataTextFormatter.createGoogleCampaignsSubtotalText(for: .sales,
+                                                                            from: campaign,
+                                                                            currencyFormatter: currencyFormatter,
+                                                                            currencyCode: currencyCode.rawValue,
+                                                                            numberOfFractionDigits: fractionDigits)
+
+        // Then
+        assertEqual("$1,232", text)
+    }
+
+    func test_createGoogleCampaignsSubtotalText_returns_expected_spend_text() {
+        // Given
+        let campaign = GoogleAdsCampaignStatsItem.fake().copy(subtotals: .fake().copy(spend: 1232))
+
+        // When
+        let text = StatsDataTextFormatter.createGoogleCampaignsSubtotalText(for: .spend,
+                                                                            from: campaign,
+                                                                            currencyFormatter: currencyFormatter,
+                                                                            currencyCode: currencyCode.rawValue,
+                                                                            numberOfFractionDigits: fractionDigits)
+
+        // Then
+        assertEqual("$1,232", text)
+    }
+
+    func test_createGoogleCampaignsSubtotalText_returns_expected_clicks_text() {
+        // Given
+        let campaign = GoogleAdsCampaignStatsItem.fake().copy(subtotals: .fake().copy(clicks: 1232))
+
+        // When
+        let text = StatsDataTextFormatter.createGoogleCampaignsSubtotalText(for: .clicks,
+                                                                            from: campaign)
+
+        // Then
+        assertEqual("1,232", text)
+    }
+
+    func test_createGoogleCampaignsSubtotalText_returns_expected_impressions_text() {
+        // Given
+        let campaign = GoogleAdsCampaignStatsItem.fake().copy(subtotals: .fake().copy(impressions: 1232))
+
+        // When
+        let text = StatsDataTextFormatter.createGoogleCampaignsSubtotalText(for: .impressions,
+                                                                            from: campaign)
+
+        // Then
+        assertEqual("1,232", text)
+    }
+
+    func test_createGoogleCampaignsSubtotalText_returns_expected_conversions_text() {
+        // Given
+        let campaign = GoogleAdsCampaignStatsItem.fake().copy(subtotals: .fake().copy(conversions: 1232))
+
+        // When
+        let text = StatsDataTextFormatter.createGoogleCampaignsSubtotalText(for: .conversions,
+                                                                            from: campaign)
+
+        // Then
+        assertEqual("1,232", text)
+    }
 }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of: #13279
<!-- Id number of the GitHub issue this PR addresses. -->

## Why
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
We want to support selecting a metric on the Google Campaigns card, to show that metric's data. This PR handles updating the card data according to the selected stat.

## How
* Adds helpers to `StatsDataTextFormatter` to return the expected value text based on the stats data and requested stat.
   * There is a helper for the stats totals (top of the card) and the campaign subtotals (top performers list).
   * Depending on the stat, the text will be formatted as a currency amount (e.g. `$1,234.56`) or a localized string (e.g. `1,234`).
* Updates `GoogleAdsCampaignReportCardViewModel`:
   * The total stats value and delta are now based on the selected stat, and the old properties for the total sales stat are removed.
   * The campaigns data is now sorted by the selected stat value and the displayed subtotals are updated based on the selected stat.
   * The selected stat is total sales by default, so this doesn't change the existing behavior on the Google Campaigns card in the app yet. (It will always show total sales, until we replace the card being shown in the analytics hub with the new one.)

## Testing steps

You can test that the current app behavior has not changed:

Prerequisite: A store with the Google Listings & Ads extension active and set up, with Google Ads connected. Alternately, use a proxy server (e.g. Charles Proxy) to mock the responses using the [connection response mock](https://github.com/woocommerce/woocommerce-ios/blob/b49851e44aed9a4f5e460ae8f165138c6396fd5d/Networking/NetworkingTests/Responses/gla-connection-without-data-envelope.json) and [stats response mock](https://github.com/woocommerce/woocommerce-ios/blob/b49851e44aed9a4f5e460ae8f165138c6396fd5d/Networking/NetworkingTests/Responses/google-ads-reports-programs-without-data.json).

1. On the My Store dashboard, select "View all store analytics" to open the Analytics Hub.
2. Confirm the Google Campaigns card loads with the Total Sales stat and a list of the top campaigns for the selected time period, with the campaign title and spend in each row and the total sales subtotal on the right.

## Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->

You can use SwiftUI previews to preview the new stat selection behavior for `GoogleAdsCampaignReportCard` (see below for screencast).

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->


https://github.com/user-attachments/assets/de1c6aab-b570-441b-8c40-04044e3091a5



---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.