### PR TITLE
Show Cached Content on the performance card

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Dashboard/StoreStats/StorePerformanceView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/StoreStats/StorePerformanceView.swift
@@ -60,8 +60,8 @@ struct StorePerformanceView: View {
 
                 viewAllAnalyticsButton
                     .padding(.horizontal, Layout.padding)
-                    .redacted(reason: viewModel.showRedactedState ? [.placeholder] : [])
-                    .shimmering(active: viewModel.showRedactedState)
+                    .redacted(reason: viewModel.syncingData ? [.placeholder] : [])
+                    .shimmering(active: viewModel.syncingData)
             } else {
                 contentUnavailableView
                     .padding(.horizontal, Layout.padding)

--- a/WooCommerce/Classes/ViewRelated/Dashboard/StoreStats/StorePerformanceView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/StoreStats/StorePerformanceView.swift
@@ -40,28 +40,28 @@ struct StorePerformanceView: View {
             } else if viewModel.statsVersion == .v4 {
                 timeRangeBar
                     .padding(.horizontal, Layout.padding)
-                    .redacted(reason: viewModel.syncingData ? [.placeholder] : [])
-                    .shimmering(active: viewModel.syncingData)
+                    .redacted(reason: viewModel.showRedactedState ? [.placeholder] : [])
+                    .shimmering(active: viewModel.showRedactedState)
 
                 Divider()
 
                 statsView
                     .padding(.vertical, Layout.padding)
-                    .redacted(reason: viewModel.syncingData ? [.placeholder] : [])
-                    .shimmering(active: viewModel.syncingData)
+                    .redacted(reason: viewModel.showRedactedState ? [.placeholder] : [])
+                    .shimmering(active: viewModel.showRedactedState)
 
                 chartView
                     .padding(.horizontal, Layout.padding)
-                    .redacted(reason: viewModel.syncingData ? [.placeholder] : [])
-                    .shimmering(active: viewModel.syncingData)
+                    .redacted(reason: viewModel.showRedactedState ? [.placeholder] : [])
+                    .shimmering(active: viewModel.showRedactedState)
 
                 Divider()
                     .padding(.leading, Layout.padding)
 
                 viewAllAnalyticsButton
                     .padding(.horizontal, Layout.padding)
-                    .redacted(reason: viewModel.syncingData ? [.placeholder] : [])
-                    .shimmering(active: viewModel.syncingData)
+                    .redacted(reason: viewModel.showRedactedState ? [.placeholder] : [])
+                    .shimmering(active: viewModel.showRedactedState)
             } else {
                 contentUnavailableView
                     .padding(.horizontal, Layout.padding)

--- a/WooCommerce/Classes/ViewRelated/Dashboard/StoreStats/StorePerformanceViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/StoreStats/StorePerformanceViewModel.swift
@@ -71,6 +71,16 @@ final class StorePerformanceViewModel: ObservableObject {
         return true
     }
 
+    /// Determines if the redacted state should be shown.
+    /// `True`when fetching data for the first time, otherwise `false` as cached data should be presented.
+    ///
+    var showRedactedState: Bool {
+        guard ServiceLocator.featureFlagService.isFeatureFlagEnabled(.backgroundTasks) else {
+            return syncingData
+        }
+        return syncingData && periodViewModel?.noDataFound == true
+    }
+
     init(siteID: Int64,
          siteTimezone: TimeZone = .siteTimezone,
          stores: StoresManager = ServiceLocator.stores,
@@ -130,6 +140,12 @@ final class StorePerformanceViewModel: ObservableObject {
 
     @MainActor
     func reloadData() async {
+
+        // Preemptively show any cached content
+        if ServiceLocator.featureFlagService.isFeatureFlagEnabled(.backgroundTasks) {
+            periodViewModel?.loadCachedContent()
+        }
+
         syncingData = true
         loadingError = nil
         waitingTracker = WaitingTimeTracker(trackScenario: .dashboardMainStats)

--- a/WooCommerce/Classes/ViewRelated/Dashboard/StoreStats/StoreStatsPeriodViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/StoreStats/StoreStatsPeriodViewModel.swift
@@ -114,6 +114,13 @@ final class StoreStatsPeriodViewModel {
         return ResultsController(storageManager: storageManager, matching: predicate, sortedBy: [])
     }()
 
+    /// Returns `true` if there is no content for the selected time range.
+    /// Useful for knowing when we are fetching data for the first time.
+    ///
+    var noDataFound: Bool {
+        siteStatsResultsController.isEmpty || orderStatsResultsController.isEmpty || siteStatsResultsController.isEmpty
+    }
+
     // MARK: - Configurations
 
     /// Updated externally when reloading data.
@@ -145,6 +152,14 @@ final class StoreStatsPeriodViewModel {
 
         // Make sure the ResultsControllers are ready to observe changes to the data even before the view loads
         configureResultsControllers()
+    }
+
+    /// Manually update datasources using the already fetched information
+    ///
+    func loadCachedContent() {
+        updateOrderDataIfNeeded()
+        updateSiteVisitDataIfNeeded()
+        updateSiteSummaryDataIfNeeded()
     }
 }
 


### PR DESCRIPTION
part of #13136 

# Why

This PR Makes sure that any cached content on the **performance card** will be shown while the update data request happens in the background.

At first, this could seem a bit unintuitive but the following PRs will add:
- Last updated timestamp
- Refreshing/loading indicator

Once these changes are done, the experience will feel a lot nicer to the user.

# How

- Do not show the redacted state if there is any cached content
- Setup the respective `resultsController` before fetching data so cached content is propagated via the current observable chains.


# Demo

https://github.com/user-attachments/assets/b3c7541a-24b3-4896-b233-9451d7d25ec0

# Testing

- Make sure the performance card is visible in the dashboard
- Switch across time ranges
- See that once a time range data is downloaded, switching back and forth shows the cached content and does not show the redacted state
- See that switching to a new time rage (like a custom range) does shows the redacted view


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
