### PR TITLE
Dynamic dashboard: Remove M2 feature flag

### DIFF
--- a/Experiments/Experiments/DefaultFeatureFlagService.swift
+++ b/Experiments/Experiments/DefaultFeatureFlagService.swift
@@ -80,8 +80,6 @@ public struct DefaultFeatureFlagService: FeatureFlagService {
             return (buildConfig == .localDeveloper || buildConfig == .alpha) && !isUITesting
         case .displayPointOfSaleToggle:
             return buildConfig == .localDeveloper || buildConfig == .alpha
-        case .dynamicDashboardM2:
-            return true
         case .productCreationAIv2M1:
             return true
         case .productCreationAIv2M3:

--- a/Experiments/Experiments/FeatureFlag.swift
+++ b/Experiments/Experiments/FeatureFlag.swift
@@ -176,10 +176,6 @@ public enum FeatureFlag: Int {
     ///
     case displayPointOfSaleToggle
 
-    /// Enables new dashboard cards on the My Store screen.
-    ///
-    case dynamicDashboardM2
-
     /// Enables M1 updates of product creation AI version 2
     ///
     case productCreationAIv2M1

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -8,6 +8,7 @@
 - [Internal] Removed feature flag for product sharing AI [https://github.com/woocommerce/woocommerce-ios/pull/13337]
 - [Internal] Removed feature flag for product description AI tooltip [https://github.com/woocommerce/woocommerce-ios/pull/13341]
 - [Internal] Removed feature flag for the native Blaze campaign creation flow. [https://github.com/woocommerce/woocommerce-ios/pull/13356]
+- [Internal] Removed feature flag for dynamic dashboard M2. [https://github.com/woocommerce/woocommerce-ios/pull/13359]
 
 19.5
 -----

--- a/WooCommerce/Classes/ViewRelated/Dashboard/DashboardViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/DashboardViewModel.swift
@@ -378,37 +378,22 @@ private extension DashboardViewModel {
                         await self?.reloadBlazeCampaignView()
                     }
                 case .inbox:
-                    guard featureFlagService.isFeatureFlagEnabled(.dynamicDashboardM2), isEligibleForInbox else {
-                        return
-                    }
                     group.addTask { [weak self] in
                         await self?.inboxViewModel.reloadData()
                     }
                 case .coupons:
-                    guard featureFlagService.isFeatureFlagEnabled(.dynamicDashboardM2) else {
-                        return
-                    }
                     group.addTask { [weak self] in
                         await self?.mostActiveCouponsViewModel.reloadData()
                     }
                 case .stock:
-                    guard featureFlagService.isFeatureFlagEnabled(.dynamicDashboardM2) else {
-                        return
-                    }
                     group.addTask { [weak self] in
                         await self?.productStockCardViewModel.reloadData()
                     }
                 case .reviews:
-                    guard featureFlagService.isFeatureFlagEnabled(.dynamicDashboardM2) else {
-                        return
-                    }
                     group.addTask { [weak self] in
                         await self?.reviewsViewModel.reloadData()
                     }
                 case .lastOrders:
-                    guard featureFlagService.isFeatureFlagEnabled(.dynamicDashboardM2) else {
-                        return
-                    }
                     group.addTask { [weak self] in
                         await self?.lastOrdersCardViewModel.reloadData()
                     }
@@ -461,9 +446,6 @@ private extension DashboardViewModel {
     }
 
     func checkInboxEligibility() {
-        guard featureFlagService.isFeatureFlagEnabled(.dynamicDashboardM2) else {
-            return
-        }
         isEligibleForInbox = inboxEligibilityChecker.isEligibleForInbox(siteID: siteID)
     }
 
@@ -540,20 +522,17 @@ private extension DashboardViewModel {
                                    availability: canShowBlaze ? .show : .hide,
                                    enabled: canShowBlaze))
 
-        let dynamicDashboardM2 = featureFlagService.isFeatureFlagEnabled(.dynamicDashboardM2)
-        if dynamicDashboardM2 {
-            cards.append(DashboardCard(type: .inbox,
-                                       availability: canShowInbox ? .show : .hide,
-                                       enabled: false))
-            cards.append(DashboardCard(type: .reviews, availability: .show, enabled: false))
-            cards.append(DashboardCard(type: .coupons, availability: .show, enabled: false))
-            cards.append(DashboardCard(type: .stock, availability: .show, enabled: false))
-
-            // When not available, Last orders cards need to be hidden from Dashboard, but appear on Customize as "Unavailable"
-            cards.append(DashboardCard(type: .lastOrders,
-                                       availability: canShowLastOrders ? .show : .unavailable,
-                                       enabled: false))
-        }
+        cards.append(DashboardCard(type: .inbox,
+                                   availability: canShowInbox ? .show : .hide,
+                                   enabled: false))
+        cards.append(DashboardCard(type: .reviews, availability: .show, enabled: false))
+        cards.append(DashboardCard(type: .coupons, availability: .show, enabled: false))
+        cards.append(DashboardCard(type: .stock, availability: .show, enabled: false))
+        
+        // When not available, Last orders cards need to be hidden from Dashboard, but appear on Customize as "Unavailable"
+        cards.append(DashboardCard(type: .lastOrders,
+                                   availability: canShowLastOrders ? .show : .unavailable,
+                                   enabled: false))
 
         cards.append(DashboardCard(type: .googleAds,
                                    availability: canShowGoogle ? .show : .hide,
@@ -620,10 +599,6 @@ private extension DashboardViewModel {
     /// - Parameter hasOrders: A Boolean indicating whether the site has orders. If the site has no orders,
     ///   the app will display the "Share Your Store" card, and the notice should remain hidden.
     func configureNewCardsNotice(hasOrders: Bool) {
-        guard featureFlagService.isFeatureFlagEnabled(.dynamicDashboardM2) && hasOrders else {
-            return
-        }
-
         let savedCardTypes = Set(savedCards.map { $0.type })
         let savedCardContainsAllNewCards = Constants.m2CardSet.isSubset(of: savedCardTypes)
 

--- a/WooCommerce/Classes/ViewRelated/Dashboard/DashboardViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/DashboardViewModel.swift
@@ -528,7 +528,7 @@ private extension DashboardViewModel {
         cards.append(DashboardCard(type: .reviews, availability: .show, enabled: false))
         cards.append(DashboardCard(type: .coupons, availability: .show, enabled: false))
         cards.append(DashboardCard(type: .stock, availability: .show, enabled: false))
-        
+
         // When not available, Last orders cards need to be hidden from Dashboard, but appear on Customize as "Unavailable"
         cards.append(DashboardCard(type: .lastOrders,
                                    availability: canShowLastOrders ? .show : .unavailable,
@@ -599,6 +599,10 @@ private extension DashboardViewModel {
     /// - Parameter hasOrders: A Boolean indicating whether the site has orders. If the site has no orders,
     ///   the app will display the "Share Your Store" card, and the notice should remain hidden.
     func configureNewCardsNotice(hasOrders: Bool) {
+        guard hasOrders else {
+            return
+        }
+
         let savedCardTypes = Set(savedCards.map { $0.type })
         let savedCardContainsAllNewCards = Constants.m2CardSet.isSubset(of: savedCardTypes)
 

--- a/WooCommerce/WooCommerceTests/Mocks/MockFeatureFlagService.swift
+++ b/WooCommerce/WooCommerceTests/Mocks/MockFeatureFlagService.swift
@@ -18,7 +18,6 @@ struct MockFeatureFlagService: FeatureFlagService {
     private let sideBySideViewForOrderForm: Bool
     private let isSubscriptionsInOrderCreationCustomersEnabled: Bool
     private let isDisplayPointOfSaleToggleEnabled: Bool
-    private let isDynamicDashboardM2Enabled: Bool
     private let isProductCreationAIv2M1Enabled: Bool
     private let googleAdsCampaignCreationOnWebView: Bool
 
@@ -38,7 +37,6 @@ struct MockFeatureFlagService: FeatureFlagService {
          sideBySideViewForOrderForm: Bool = false,
          isSubscriptionsInOrderCreationCustomersEnabled: Bool = false,
          isDisplayPointOfSaleToggleEnabled: Bool = false,
-         isDynamicDashboardM2Enabled: Bool = false,
          isProductCreationAIv2M1Enabled: Bool = false,
          googleAdsCampaignCreationOnWebView: Bool = false) {
         self.isInboxOn = isInboxOn
@@ -57,7 +55,6 @@ struct MockFeatureFlagService: FeatureFlagService {
         self.sideBySideViewForOrderForm = sideBySideViewForOrderForm
         self.isSubscriptionsInOrderCreationCustomersEnabled = isSubscriptionsInOrderCreationCustomersEnabled
         self.isDisplayPointOfSaleToggleEnabled = isDisplayPointOfSaleToggleEnabled
-        self.isDynamicDashboardM2Enabled = isDynamicDashboardM2Enabled
         self.isProductCreationAIv2M1Enabled = isProductCreationAIv2M1Enabled
         self.googleAdsCampaignCreationOnWebView = googleAdsCampaignCreationOnWebView
     }
@@ -96,8 +93,6 @@ struct MockFeatureFlagService: FeatureFlagService {
             return isSubscriptionsInOrderCreationCustomersEnabled
         case .displayPointOfSaleToggle:
             return isDisplayPointOfSaleToggleEnabled
-        case .dynamicDashboardM2:
-            return isDynamicDashboardM2Enabled
         case .productCreationAIv2M1:
             return isProductCreationAIv2M1Enabled
         case .googleAdsCampaignCreationOnWebView:


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #13101 
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This PR removes the feature flag for dynamic dashboard M2 since the feature has been released for a few weeks now.

## Testing steps
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->
- Log out and log back into a store.
- If the store has any orders, there should be a dot on the Edit button and a card at the bottom suggesting adding new cards. Otherwise, the share store card should be displayed.
- Tap on the Edit button on the dashboard screen and confirm that M2 cards are available to select.


## Screenshots
<!-- Include before and after images or gifs when appropriate. -->
<img src="https://github.com/user-attachments/assets/e0b425ef-78f6-4941-aea9-209aa67d6be9" width=320 />


---
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
