### PR TITLE
[Woo POS] Use full-screen when empty or error cases

### DIFF
--- a/WooCommerce/Classes/POS/Presentation/ItemListView.swift
+++ b/WooCommerce/Classes/POS/Presentation/ItemListView.swift
@@ -47,7 +47,9 @@ private extension ItemListView {
                 headerTextView
                 Spacer()
                 Button(action: {
-                    viewModel.toggleBanner()
+                    // TODO:
+                    // https://github.com/woocommerce/woocommerce-ios/issues/13357
+                    debugPrint("Not implemented")
                 }, label: {
                     Image(uiImage: .infoImage)
                 })
@@ -70,7 +72,7 @@ private extension ItemListView {
             Spacer()
             VStack {
                 Button(action: {
-                    viewModel.toggleBanner()
+                    viewModel.dismissBanner()
                 }, label: {
                     Image(uiImage: .closeButton)
                         .frame(width: Constants.closeIconSize, height: Constants.closeIconSize)

--- a/WooCommerce/Classes/POS/Presentation/PointOfSaleDashboardView.swift
+++ b/WooCommerce/Classes/POS/Presentation/PointOfSaleDashboardView.swift
@@ -11,13 +11,8 @@ struct PointOfSaleDashboardView: View {
         self.totalsViewModel = viewModel.totalsViewModel
     }
 
-    var shouldBeHidden: Bool {
-        switch viewModel.itemListViewModel.state {
-        case .empty, .error:
-            return true
-        default:
-            return false
-        }
+    private var isCartShown: Bool {
+        !viewModel.itemListViewModel.isEmptyOrError
     }
 
     var body: some View {
@@ -29,7 +24,7 @@ struct PointOfSaleDashboardView: View {
                         HStack {
                             productListView
                             cartView
-                                .renderedIf(!shouldBeHidden)
+                                .renderedIf(isCartShown)
                                 .frame(width: geometry.size.width * Constants.cartWidth)
                         }
                     }

--- a/WooCommerce/Classes/POS/Presentation/PointOfSaleDashboardView.swift
+++ b/WooCommerce/Classes/POS/Presentation/PointOfSaleDashboardView.swift
@@ -11,6 +11,15 @@ struct PointOfSaleDashboardView: View {
         self.totalsViewModel = viewModel.totalsViewModel
     }
 
+    var shouldBeHidden: Bool {
+        switch viewModel.itemListViewModel.state {
+        case .empty, .error:
+            return true
+        default:
+            return false
+        }
+    }
+
     var body: some View {
         VStack {
             HStack {
@@ -20,6 +29,7 @@ struct PointOfSaleDashboardView: View {
                         HStack {
                             productListView
                             cartView
+                                .renderedIf(!shouldBeHidden)
                                 .frame(width: geometry.size.width * Constants.cartWidth)
                         }
                     }

--- a/WooCommerce/Classes/POS/ViewModels/ItemListViewModel.swift
+++ b/WooCommerce/Classes/POS/ViewModels/ItemListViewModel.swift
@@ -23,13 +23,9 @@ final class ItemListViewModel: ObservableObject {
         // - Loading the item list
         // - Hasn't been already been previously dismissed
         if isHeaderBannerDismissed {
-            return false
-        }
-        switch state {
-        case .loaded:
-            return true
-        default:
-            return false
+            false
+        } else {
+            state.isLoaded
         }
     }
 
@@ -90,6 +86,15 @@ extension ItemListViewModel {
         case loading
         case loaded([POSItem])
         case error(ErrorModel)
+
+        var isLoaded: Bool {
+            switch self {
+            case .loaded:
+                return true
+            default:
+                return false
+            }
+        }
 
         // Equatable conformance for testing:
         static func == (lhs: ItemListViewModel.ItemListState, rhs: ItemListViewModel.ItemListState) -> Bool {

--- a/WooCommerce/Classes/POS/ViewModels/ItemListViewModel.swift
+++ b/WooCommerce/Classes/POS/ViewModels/ItemListViewModel.swift
@@ -41,11 +41,6 @@ final class ItemListViewModel: ObservableObject {
     @MainActor
     func populatePointOfSaleItems() async {
         do {
-            // 1. Error out:
-            //throw NSError(domain: "", code: 0)
-            // 2. Empty case:
-            // TODO
-            // Default:
             state = .loading
             items = try await itemProvider.providePointOfSaleItems()
             if items.count == 0 {

--- a/WooCommerce/Classes/POS/ViewModels/ItemListViewModel.swift
+++ b/WooCommerce/Classes/POS/ViewModels/ItemListViewModel.swift
@@ -9,6 +9,15 @@ final class ItemListViewModel: ObservableObject {
     @Published private(set) var state: ItemListState = .loading
     @Published private(set) var isHeaderBannerDismissed: Bool = false
 
+    var isEmptyOrError: Bool {
+        switch state {
+        case .empty, .error:
+            return true
+        default:
+            return false
+        }
+    }
+
     var shouldShowHeaderBanner: Bool {
         // The banner it's only shown when:
         // - Loading the item list

--- a/WooCommerce/Classes/POS/ViewModels/ItemListViewModel.swift
+++ b/WooCommerce/Classes/POS/ViewModels/ItemListViewModel.swift
@@ -7,7 +7,22 @@ final class ItemListViewModel: ObservableObject {
 
     @Published private(set) var items: [POSItem] = []
     @Published private(set) var state: ItemListState = .loading
-    @Published private(set) var shouldShowHeaderBanner: Bool = true
+    @Published private(set) var isHeaderBannerDismissed: Bool = false
+
+    var shouldShowHeaderBanner: Bool {
+        // The banner it's only shown when:
+        // - Loading the item list
+        // - Hasn't been already been previously dismissed
+        if isHeaderBannerDismissed {
+            return false
+        }
+        switch state {
+        case .loaded:
+            return true
+        default:
+            return false
+        }
+    }
 
     private let itemProvider: POSItemProvider
     private let selectedItemSubject: PassthroughSubject<POSItem, Never> = .init()
@@ -26,6 +41,11 @@ final class ItemListViewModel: ObservableObject {
     @MainActor
     func populatePointOfSaleItems() async {
         do {
+            // 1. Error out:
+            //throw NSError(domain: "", code: 0)
+            // 2. Empty case:
+            // TODO
+            // Default:
             state = .loading
             items = try await itemProvider.providePointOfSaleItems()
             if items.count == 0 {
@@ -51,8 +71,8 @@ final class ItemListViewModel: ObservableObject {
         await populatePointOfSaleItems()
     }
 
-    func toggleBanner() {
-        shouldShowHeaderBanner.toggle()
+    func dismissBanner() {
+        isHeaderBannerDismissed = true
     }
 }
 

--- a/WooCommerce/Classes/POS/ViewModels/ItemListViewModel.swift
+++ b/WooCommerce/Classes/POS/ViewModels/ItemListViewModel.swift
@@ -22,11 +22,7 @@ final class ItemListViewModel: ObservableObject {
         // The banner it's only shown when:
         // - Loading the item list
         // - Hasn't been already been previously dismissed
-        if isHeaderBannerDismissed {
-            false
-        } else {
-            state.isLoaded
-        }
+        !isHeaderBannerDismissed && state.isLoaded
     }
 
     private let itemProvider: POSItemProvider

--- a/WooCommerce/WooCommerceTests/POS/ViewModels/ItemListViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/POS/ViewModels/ItemListViewModelTests.swift
@@ -182,17 +182,51 @@ final class ItemListViewModelTests: XCTestCase {
         XCTAssertEqual(sut.state, .error(expectedError))
     }
 
-    func test_shouldShowInitialHeaderBanner_is_updated_when_dismissBanner_is_called() {
+    func test_isHeaderBannerDismissed_when_dismissBanner_is_called_then_returns_true() {
         // Given
-        XCTAssertEqual(sut.shouldShowHeaderBanner, true)
+        XCTAssertEqual(sut.isHeaderBannerDismissed, false)
 
         // When
         sut.dismissBanner()
 
         // Then
+        XCTAssertEqual(sut.isHeaderBannerDismissed, true)
+    }
+
+    func test_shouldShowHeaderBanner_when_itemListViewModel_is_loading_then_returns_false() {
+        // Given/When/Then
+        XCTAssertEqual(sut.state, .loading)
         XCTAssertEqual(sut.shouldShowHeaderBanner, false)
     }
 
+    func test_shouldShowHeaderBanner_when_itemListViewModel_throws_error_then_returns_false() async {
+        // Given
+        let itemProvider = MockPOSItemProvider()
+        itemProvider.shouldThrowError = true
+        let sut = ItemListViewModel(itemProvider: itemProvider)
+        let expectedError = ItemListViewModel.ErrorModel(title: "Error loading products",
+                                                         subtitle: "Give it another go?",
+                                                         buttonText: "Retry")
+
+        // When
+        await sut.populatePointOfSaleItems()
+
+        // Then
+        XCTAssertEqual(sut.state, .error(expectedError))
+        XCTAssertEqual(sut.shouldShowHeaderBanner, false)
+    }
+
+    func test_shouldShowHeaderBanner_when_itemListViewModel_loaded_then_returns_true() async {
+        // Given
+        let expectedItems = Self.makeItems()
+
+        // When
+        await sut.populatePointOfSaleItems()
+
+        // Then
+        XCTAssertEqual(sut.state, .loaded(expectedItems))
+        XCTAssertEqual(sut.shouldShowHeaderBanner, true)
+    }
 }
 
 private extension ItemListViewModelTests {

--- a/WooCommerce/WooCommerceTests/POS/ViewModels/ItemListViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/POS/ViewModels/ItemListViewModelTests.swift
@@ -227,6 +227,40 @@ final class ItemListViewModelTests: XCTestCase {
         XCTAssertEqual(sut.state, .loaded(expectedItems))
         XCTAssertEqual(sut.shouldShowHeaderBanner, true)
     }
+
+    func test_isEmptyOrError_when_itemListViewModel_loaded_normally_then_returns_false() async {
+        // Given/When
+        await sut.populatePointOfSaleItems()
+
+        // Then
+        XCTAssertEqual(sut.isEmptyOrError, false)
+    }
+
+    func test_isEmptyOrError_when_itemListViewModel_is_empty_then_returns_true() async {
+        // Given
+        let itemProvider = MockPOSItemProvider()
+        itemProvider.shouldReturnZeroItems = true
+        let sut = ItemListViewModel(itemProvider: itemProvider)
+
+        // When
+        await sut.populatePointOfSaleItems()
+
+        // Then
+        XCTAssertEqual(sut.isEmptyOrError, true)
+    }
+
+    func test_isEmptyOrError_when_itemListViewModel_throws_error_then_returns_true() async {
+        // Given
+        let itemProvider = MockPOSItemProvider()
+        itemProvider.shouldThrowError = true
+        let sut = ItemListViewModel(itemProvider: itemProvider)
+
+        // When
+        await sut.populatePointOfSaleItems()
+
+        // Then
+        XCTAssertEqual(sut.isEmptyOrError, true)
+    }
 }
 
 private extension ItemListViewModelTests {

--- a/WooCommerce/WooCommerceTests/POS/ViewModels/ItemListViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/POS/ViewModels/ItemListViewModelTests.swift
@@ -261,6 +261,27 @@ final class ItemListViewModelTests: XCTestCase {
         // Then
         XCTAssertEqual(sut.isEmptyOrError, true)
     }
+
+    func test_state_when_itemListViewModel_loaded_normally_then_returns_isLoaded_true() async {
+        // Given/When
+        await sut.populatePointOfSaleItems()
+
+        // Then
+        XCTAssertEqual(sut.state.isLoaded, true)
+    }
+
+    func test_state_when_itemListViewModel_throws_error_then_returns_isLoaded_false() async {
+        // Given
+        let itemProvider = MockPOSItemProvider()
+        itemProvider.shouldThrowError = true
+        let sut = ItemListViewModel(itemProvider: itemProvider)
+
+        // When
+        await sut.populatePointOfSaleItems()
+
+        // Then
+        XCTAssertEqual(sut.state.isLoaded, false)
+    }
 }
 
 private extension ItemListViewModelTests {

--- a/WooCommerce/WooCommerceTests/POS/ViewModels/ItemListViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/POS/ViewModels/ItemListViewModelTests.swift
@@ -182,12 +182,12 @@ final class ItemListViewModelTests: XCTestCase {
         XCTAssertEqual(sut.state, .error(expectedError))
     }
 
-    func test_shouldShowHeaderBanner_state_toggles_when_toggleBanner_is_called() {
+    func test_shouldShowInitialHeaderBanner_is_updated_when_dismissBanner_is_called() {
         // Given
         XCTAssertEqual(sut.shouldShowHeaderBanner, true)
 
         // When
-        sut.toggleBanner()
+        sut.dismissBanner()
 
         // Then
         XCTAssertEqual(sut.shouldShowHeaderBanner, false)


### PR DESCRIPTION
Addresses part of https://github.com/woocommerce/woocommerce-ios/issues/13360

## Description:
When an error happens on the item list view, designs require that we have a full-screen to display them, however at the moment, when the product list fails to load products this will only affect the `ItemListView`, so the `CartView` and the `HeaderBannerView` would still render onscreen despite the error.

We address this by hiding all subview components if the state is `.empty` or `.error`.

We also address part of the new banner behaviour described here: https://github.com/woocommerce/woocommerce-ios/issues/13357 , where there are 2 banners, one that appears only on initializing the list (the existing one), and a different one when we toggle the `(i)` button (to be implemented), by not toggling it anymore, but just dismissing it.

## Changes
- Removed `toggleBanner()`. The initial banner can only be dismissed, the one that can be toggled will be implemented on https://github.com/woocommerce/woocommerce-ios/issues/13357
- `CartView` will be hidden when `.empty` or error `.states`,  possibly we'll add other states in the future as well, like loading.
- Updated unit tests

## Testing:
- Run the POS, observe that all view components (header banner, product list, cart view) load properly. 
- Observe that by tapping `x` on the header view this is dismissed, and doesn't appear again upon tapping on the `(i)` icon.

| Normal load | Banner dismissed |
|--------|--------|
| ![Simulator Screenshot - iPad Pro (12 9-inch) (6th generation) - 2024-07-17 at 15 17 02](https://github.com/user-attachments/assets/c6f993f2-cbf4-488c-a8dc-a4ac090cc5b2) | ![Simulator Screenshot - iPad Pro (12 9-inch) (6th generation) - 2024-07-17 at 15 17 07](https://github.com/user-attachments/assets/6b8b9618-1bf5-464b-8996-325cad4af202) | 

- Update `populatePointOfSaleItems()` to throw an error:
```diff
    @MainActor
    func populatePointOfSaleItems() async {
-        do {
+        do { throw NSError(domain: "", code: 0)
```
- Re-run the POS, observe that the error view takes the full screen (header banner and cart view are hidden)

![Simulator Screenshot - iPad Pro (12 9-inch) (6th generation) - 2024-07-17 at 15 19 37](https://github.com/user-attachments/assets/46887fbb-c4c1-45bf-93b9-679801b9cf15)
