### PR TITLE
Google Ads: Add an additional check for campaign creation success

### DIFF
--- a/Experiments/Experiments/DefaultFeatureFlagService.swift
+++ b/Experiments/Experiments/DefaultFeatureFlagService.swift
@@ -89,7 +89,7 @@ public struct DefaultFeatureFlagService: FeatureFlagService {
         case .productCreationAIv2M3:
             return buildConfig == .localDeveloper || buildConfig == .alpha
         case .googleAdsCampaignCreationOnWebView:
-            return true
+            return buildConfig == .localDeveloper || buildConfig == .alpha
         case .backgroundTasks:
             return buildConfig == .localDeveloper || buildConfig == .alpha
         default:

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -4,7 +4,6 @@
 -----
 
 - [*] Order Creation: Improved tax-inclusive product price presentation [https://github.com/woocommerce/woocommerce-ios/pull/13305]
-- [**] Google Ads campaign management is now available for stores with plugin version 2.7.5 or later. [https://github.com/woocommerce/woocommerce-ios/pull/13331]
 - [**] Product Creation AI: Milestone 1 which simplifies package photo flow and revamps UI. [https://github.com/woocommerce/woocommerce-ios/pull/13331]
 - [internal] Blaze: Check that product URL is not empty before campaign creation. [https://github.com/woocommerce/woocommerce-ios/pull/13351]
 - [Internal] Removed feature flag for product description AI [https://github.com/woocommerce/woocommerce-ios/pull/13334]

--- a/WooCommerce/Classes/GoogleAds/GoogleAdsCampaignCoordinator.swift
+++ b/WooCommerce/Classes/GoogleAds/GoogleAdsCampaignCoordinator.swift
@@ -113,10 +113,14 @@ private extension GoogleAdsCampaignCoordinator {
         let components = URLComponents(url: url, resolvingAgainstBaseURL: true)
         let queryItems = components?.queryItems
         let creationSucceeded = queryItems?.first(where: {
-            $0.name == Constants.campaignParam &&
-            $0.value == Constants.savedValue
+            $0.name == Constants.Parameters.campaign &&
+            $0.value == Constants.ParameterValues.saved
         }) != nil
-        if creationSucceeded {
+        let setupAndCreationSucceed = queryItems?.first(where: {
+            $0.name == Constants.Parameters.guide &&
+            $0.value == Constants.ParameterValues.creationSuccess
+        }) != nil
+        if creationSucceeded || setupAndCreationSucceed {
             analytics.track(event: .GoogleAds.campaignCreationSuccess(source: source))
 
             // dismisses the web view
@@ -131,9 +135,9 @@ private extension GoogleAdsCampaignCoordinator {
     func createGoogleAdsCampaignURL() -> URL? {
         let path: String = {
             if shouldStartCampaignCreation {
-                Constants.campaignCreationPath
+                Constants.Path.campaignCreation
             } else {
-                Constants.campaignDashboardPath
+                Constants.Path.campaignDashboard
             }
         }()
         return URL(string: siteAdminURL.appending(path))
@@ -166,10 +170,20 @@ private extension GoogleAdsCampaignCoordinator {
 
 private extension GoogleAdsCampaignCoordinator {
     enum Constants {
-        static let campaignDashboardPath = "admin.php?page=wc-admin&path=%2Fgoogle%2Fdashboard"
-        static let campaignCreationPath = "admin.php?page=wc-admin&path=%2Fgoogle%2Fdashboard&subpath=%2Fcampaigns%2Fcreate"
-        static let campaignParam = "campaign"
-        static let savedValue = "saved"
+        enum Path {
+            static let campaignDashboard = "admin.php?page=wc-admin&path=%2Fgoogle%2Fdashboard"
+            static let campaignCreation = "admin.php?page=wc-admin&path=%2Fgoogle%2Fdashboard&subpath=%2Fcampaigns%2Fcreate"
+        }
+
+        enum Parameters {
+            static let campaign = "campaign"
+            static let guide = "guide"
+        }
+        
+        enum ParameterValues {
+            static let saved = "saved"
+            static let creationSuccess = "campaign-creation-success"
+        }
     }
 
     enum Localization {

--- a/WooCommerce/Classes/GoogleAds/GoogleAdsCampaignCoordinator.swift
+++ b/WooCommerce/Classes/GoogleAds/GoogleAdsCampaignCoordinator.swift
@@ -179,7 +179,7 @@ private extension GoogleAdsCampaignCoordinator {
             static let campaign = "campaign"
             static let guide = "guide"
         }
-        
+
         enum ParameterValues {
             static let saved = "saved"
             static let creationSuccess = "campaign-creation-success"

--- a/WooCommerce/Classes/GoogleAds/GoogleAdsCampaignCoordinator.swift
+++ b/WooCommerce/Classes/GoogleAds/GoogleAdsCampaignCoordinator.swift
@@ -79,7 +79,6 @@ private extension GoogleAdsCampaignCoordinator {
         }
 
         let redirectHandler: (URL) -> Void = { [weak self] newURL in
-            DDLogDebug("🧭 Current url: \(newURL.absoluteString)")
             guard let self else { return }
             if newURL != url {
                 checkIfCampaignCreationSucceeded(url: newURL)

--- a/WooCommerce/Classes/GoogleAds/GoogleAdsCampaignCoordinator.swift
+++ b/WooCommerce/Classes/GoogleAds/GoogleAdsCampaignCoordinator.swift
@@ -79,6 +79,7 @@ private extension GoogleAdsCampaignCoordinator {
         }
 
         let redirectHandler: (URL) -> Void = { [weak self] newURL in
+            DDLogDebug("🧭 Current url: \(newURL.absoluteString)")
             guard let self else { return }
             if newURL != url {
                 checkIfCampaignCreationSucceeded(url: newURL)
@@ -118,7 +119,8 @@ private extension GoogleAdsCampaignCoordinator {
         }) != nil
         let setupAndCreationSucceed = queryItems?.first(where: {
             $0.name == Constants.Parameters.guide &&
-            $0.value == Constants.ParameterValues.creationSuccess
+            ($0.value == Constants.ParameterValues.creationSuccess ||
+             $0.value == Constants.ParameterValues.submissionSuccess)
         }) != nil
         if creationSucceeded || setupAndCreationSucceed {
             analytics.track(event: .GoogleAds.campaignCreationSuccess(source: source))
@@ -183,6 +185,7 @@ private extension GoogleAdsCampaignCoordinator {
         enum ParameterValues {
             static let saved = "saved"
             static let creationSuccess = "campaign-creation-success"
+            static let submissionSuccess = "submission-success"
         }
     }
 

--- a/WooCommerce/Classes/GoogleAds/GoogleAdsEligibilityChecker.swift
+++ b/WooCommerce/Classes/GoogleAds/GoogleAdsEligibilityChecker.swift
@@ -32,6 +32,7 @@ final class DefaultGoogleAdsEligibilityChecker: GoogleAdsEligibilityChecker {
             }
         } catch {
             DDLogError("⛔️ Error checking Google ads connection: \(error)")
+            return false
         }
 
         /// Ensures that the plugin is running the correct version.

--- a/WooCommerce/Classes/ViewRelated/Hub Menu/HubMenuViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Hub Menu/HubMenuViewModel.swift
@@ -326,17 +326,6 @@ private extension HubMenuViewModel {
                 self?.updateMenuItemEligibility(with: site)
             }
             .store(in: &cancellables)
-
-        $currentSite
-            .compactMap { $0 }
-            .asyncMap { [weak self] site -> Bool in
-                guard let self else {
-                    return false
-                }
-                return await checkIfSiteHasGoogleAdsCampaigns()
-            }
-            .receive(on: DispatchQueue.main)
-            .assign(to: &$hasGoogleAdsCampaigns)
     }
 
     func updateMenuItemEligibility(with site: Yosemite.Site) {
@@ -347,6 +336,7 @@ private extension HubMenuViewModel {
 
         Task { @MainActor in
             isSiteEligibleForGoogleAds = await googleAdsEligibilityChecker.isSiteEligible(siteID: site.siteID)
+            hasGoogleAdsCampaigns = await checkIfSiteHasGoogleAdsCampaigns()
         }
     }
 

--- a/WooCommerce/Classes/ViewRelated/Hub Menu/HubMenuViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Hub Menu/HubMenuViewModel.swift
@@ -352,6 +352,9 @@ private extension HubMenuViewModel {
 
     @MainActor
     func checkIfSiteHasGoogleAdsCampaigns() async -> Bool {
+        guard isSiteEligibleForGoogleAds else {
+            return false
+        }
         do {
             let campaigns = try await fetchGoogleAdsCampaigns()
             return campaigns.isNotEmpty

--- a/WooCommerce/WooCommerceTests/GoogleAds/DefaultGoogleAdsEligibilityCheckTests.swift
+++ b/WooCommerce/WooCommerceTests/GoogleAds/DefaultGoogleAdsEligibilityCheckTests.swift
@@ -32,6 +32,21 @@ final class DefaultGoogleAdsEligibilityCheckerTests: XCTestCase {
     }
 
     @MainActor
+    func test_isSiteEligible_returns_false_checking_connection_fails() async {
+        // Given
+        let featureFlagService = MockFeatureFlagService(googleAdsCampaignCreationOnWebView: true)
+        let checker = DefaultGoogleAdsEligibilityChecker(stores: stores, featureFlagService: featureFlagService)
+        let connection = GoogleAdsConnection.fake().copy(rawStatus: "incomplete")
+        mockRequests(adsConnection: nil)
+
+        // When
+        let result = await checker.isSiteEligible(siteID: sampleSite)
+
+        // Then
+        XCTAssertFalse(result)
+    }
+
+    @MainActor
     func test_isSiteEligible_returns_false_if_google_ads_account_is_not_connected() async {
         // Given
         let featureFlagService = MockFeatureFlagService(googleAdsCampaignCreationOnWebView: true)

--- a/WooCommerce/WooCommerceTests/ViewRelated/HubMenu/HubMenuViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/HubMenu/HubMenuViewModelTests.swift
@@ -496,7 +496,7 @@ final class HubMenuViewModelTests: XCTestCase {
         var fetchAdsCampaignsTriggered = false
         stores.whenReceivingAction(ofType: GoogleAdsAction.self) { action in
             switch action {
-            case let .fetchAdsCampaigns(siteID, onCompletion):
+            case let .fetchAdsCampaigns(_, onCompletion):
                 onCompletion(.success([]))
                 fetchAdsCampaignsTriggered = true
             default:
@@ -504,10 +504,14 @@ final class HubMenuViewModelTests: XCTestCase {
             }
         }
 
+        let eligibilityChecker = MockGoogleAdsEligibilityChecker(isEligible: true)
+
         // When
         let viewModel = HubMenuViewModel(siteID: sampleSiteID,
                                          tapToPayBadgePromotionChecker: TapToPayBadgePromotionChecker(),
-                                         stores: stores)
+                                         stores: stores,
+                                         googleAdsEligibilityChecker: eligibilityChecker)
+        viewModel.refreshGoogleAdsCampaignCheck()
         waitUntil {
             fetchAdsCampaignsTriggered
         }
@@ -527,7 +531,7 @@ final class HubMenuViewModelTests: XCTestCase {
         var fetchAdsCampaignsTriggered = false
         stores.whenReceivingAction(ofType: GoogleAdsAction.self) { action in
             switch action {
-            case let .fetchAdsCampaigns(siteID, onCompletion):
+            case let .fetchAdsCampaigns(_, onCompletion):
                 let campaign = GoogleAdsCampaign.fake().copy(id: 134254)
                 onCompletion(.success([campaign]))
                 fetchAdsCampaignsTriggered = true
@@ -536,10 +540,14 @@ final class HubMenuViewModelTests: XCTestCase {
             }
         }
 
+        let eligibilityChecker = MockGoogleAdsEligibilityChecker(isEligible: true)
+
         // When
         let viewModel = HubMenuViewModel(siteID: sampleSiteID,
                                          tapToPayBadgePromotionChecker: TapToPayBadgePromotionChecker(),
-                                         stores: stores)
+                                         stores: stores,
+                                         googleAdsEligibilityChecker: eligibilityChecker)
+        viewModel.refreshGoogleAdsCampaignCheck()
         waitUntil {
             fetchAdsCampaignsTriggered
         }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #13363 
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
There's an edge case where the Google Ads campaign creation page redirects to the setup page for sites that have an incomplete setup. This PR adds a check to catch campaign creation success for this case since the callback URL has a different parameter in this case.

Internal discussion: p1721204809893599-slack-C03L1NF1EA3

Also: The eligibility check has also been updated to ensure stores without complete a setup do not have access to Google Ads on the app. 


## Testing steps
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->
1. Testing Google Ads entry point
- Create a new JN site and install WooCommerce and Google Ads plugin without setting up the plugin.
- Log in to the app and switch to the new test store.
- Confirm that the entry points to Google Ads on both dashboard and hub menu are not available.

2. Testing campaign creation success

Since it's not straightforward to reproduce the case where the setup page is displayed, the best bet is to follow the steps in #13331 to confirm that campaign creation completion is still detected correctly.

Otherwise, please feel free to set up a new test store with Google Ads and test the first campaign creation on the app to confirm that campaign creation detection works as expected.


## Screenshots
<!-- Include before and after images or gifs when appropriate. -->
N/A

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.