### PR TITLE
[GLA Analytics] Display new Google Campaigns card with metric selection in Analytics Hub

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -10,6 +10,7 @@
 - [Internal] Removed feature flag for product description AI [https://github.com/woocommerce/woocommerce-ios/pull/13334]
 - [Internal] Removed feature flag for product sharing AI [https://github.com/woocommerce/woocommerce-ios/pull/13337]
 - [Internal] Removed feature flag for product description AI tooltip [https://github.com/woocommerce/woocommerce-ios/pull/13341]
+- [**] Stats: The Google Campaigns analytics card now supports selecting any available campaign metric. [https://github.com/woocommerce/woocommerce-ios/pull/13366]
 
 19.5
 -----

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/AnalyticsHubView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/AnalyticsHubView.swift
@@ -134,7 +134,7 @@ private extension AnalyticsHubView {
         case .giftCards:
             AnalyticsReportCard(viewModel: viewModel.giftCardsCard)
         case .googleCampaigns:
-            AnalyticsTopPerformersCard(campaignsViewModel: viewModel.googleCampaignsCard)
+            GoogleAdsCampaignReportCard(viewModel: viewModel.googleCampaignsCard)
         }
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/Report Cards/GoogleAdsCampaignReportCard.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/Report Cards/GoogleAdsCampaignReportCard.swift
@@ -7,7 +7,7 @@ struct GoogleAdsCampaignReportCard: View {
     @State private var showingWebReport: Bool = false
 
     /// View model to drive the view content.
-    @StateObject var viewModel: GoogleAdsCampaignReportCardViewModel
+    @ObservedObject var viewModel: GoogleAdsCampaignReportCardViewModel
 
     var body: some View {
         VStack(alignment: .leading) {

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/Report Cards/GoogleAdsCampaignReportCardViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/Report Cards/GoogleAdsCampaignReportCardViewModel.swift
@@ -54,12 +54,6 @@ final class GoogleAdsCampaignReportCardViewModel: ObservableObject {
 
 extension GoogleAdsCampaignReportCardViewModel {
 
-    /// Card Title
-    ///
-    var title: String {
-        Localization.title
-    }
-
     // MARK: Selected Stat (Total)
 
     /// Value for the selected stat
@@ -99,12 +93,6 @@ extension GoogleAdsCampaignReportCardViewModel {
 
     // MARK: Campaigns report
 
-    /// Title for campaigns list.
-    ///
-    var campaignsTitle: String {
-        Localization.campaignsTitle
-    }
-
     /// Campaigns data to render.
     ///
     var campaignsData: [TopPerformersRow.Data] {
@@ -115,12 +103,6 @@ extension GoogleAdsCampaignReportCardViewModel {
     ///
     var showCampaignsError: Bool {
         isRedacted ? false : currentPeriodStats == nil
-    }
-
-    /// Error message if there was an error loading campaigns part of the card.
-    ///
-    var campaignsErrorMessage: String {
-        Localization.noCampaignStats
     }
 
     /// View model for the web analytics report link
@@ -166,48 +148,12 @@ extension GoogleAdsCampaignReportCardViewModel {
     }
 }
 
-/// Convenience extension to create an `AnalyticsItemsSoldCard` from a view model.
-///
-extension AnalyticsTopPerformersCard {
-    init(campaignsViewModel: GoogleAdsCampaignReportCardViewModel) {
-        // Header with selected metric stats
-        self.title = campaignsViewModel.title
-        self.statTitle = campaignsViewModel.selectedStat.displayName
-        self.statValue = campaignsViewModel.statValue
-        self.delta = campaignsViewModel.deltaValue
-        self.deltaBackgroundColor = campaignsViewModel.deltaBackgroundColor
-        self.deltaTextColor = campaignsViewModel.deltaTextColor
-        self.isStatsRedacted = campaignsViewModel.isRedacted
-        // This card gets its metrics and campaigns list from the same source.
-        // If there is a problem loading stats data, the error message only appears once at the bottom of the card.
-        self.showStatsError = false
-        self.statsErrorMessage = ""
-        self.reportViewModel = campaignsViewModel.reportViewModel
-
-        // Top performers (campaigns) list
-        self.topPerformersTitle = campaignsViewModel.campaignsTitle
-        self.topPerformersData = campaignsViewModel.campaignsData
-        self.isTopPerformersRedacted = campaignsViewModel.isRedacted
-        self.showTopPerformersError = campaignsViewModel.showCampaignsError
-        self.topPerformersErrorMessage = campaignsViewModel.campaignsErrorMessage
-    }
-}
-
 // MARK: Constants
 private extension GoogleAdsCampaignReportCardViewModel {
     enum Localization {
         static let reportTitle = NSLocalizedString("analyticsHub.googleCampaigns.reportTitle",
                                                    value: "Programs Report",
                                                    comment: "Title for the Google Programs report linked in the Analytics Hub")
-        static let title = NSLocalizedString("analyticsHub.googleCampaigns.title",
-                                             value: "Google Campaigns",
-                                             comment: "Title for the Google campaigns card on the analytics hub screen.").localizedUppercase
-        static let campaignsTitle = NSLocalizedString("analyticsHub.googleCampaigns.campaignsList.title",
-                                                      value: "Campaigns",
-                                                      comment: "Title for the list of campaigns on the Google campaigns card on the analytics hub screen.")
-        static let noCampaignStats = NSLocalizedString("analyticsHub.googleCampaigns.noCampaignStats",
-                                                       value: "Unable to load Google campaigns analytics",
-                                                       comment: "Text displayed when there is an error loading Google Ads campaigns stats data.")
         static func spend(value: String) -> String {
             String.localizedStringWithFormat(NSLocalizedString("analyticsHub.googleCampaigns.spendSubtitle",
                                                                value: "Spend: %@",


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #13279
<!-- Id number of the GitHub issue this PR addresses. -->

## Why
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This replaces the existing static Google Campaigns card with the new card, including metric selection to view all available campaign metrics.

## How

* In `AnalyticsHubView`, we now display the new `GoogleAdsCampaignReportCard` card view for the Google Campaigns card.
* In `GoogleAdsCampaignReportCard` the view model is wrapped as an `ObservedObject` to make sure it picks up changes coming from `AnalyticsHubViewModel` (e.g. as the data is loaded there).
* Removes unused properties from the view model (only needed to show the campaign data in `AnalyticsTopPerformersCard`).

## Testing steps
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->

Prerequisite: A store with the Google Listings & Ads extension active and set up, with Google Ads connected. Alternately, use a proxy server (e.g. Charles Proxy) to mock the responses using the [connection response mock](https://github.com/woocommerce/woocommerce-ios/blob/b49851e44aed9a4f5e460ae8f165138c6396fd5d/Networking/NetworkingTests/Responses/gla-connection-without-data-envelope.json) and [stats response mock](https://github.com/woocommerce/woocommerce-ios/blob/b49851e44aed9a4f5e460ae8f165138c6396fd5d/Networking/NetworkingTests/Responses/google-ads-reports-programs-without-data.json).

1. On the My Store dashboard, select "View all store analytics" to open the Analytics Hub.
2. Confirm the Google Campaigns card loads with the Total Sales stat and list of top campaigns by sales.
3. Open the dropdown Metric menu and select a new metric. Confirm the new total is displayed and the campaign list now shows the top campaigns for that metric.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

https://github.com/user-attachments/assets/2895c031-5022-47b1-961c-9a6ac9355719



---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.