### PR TITLE
[GLA Analytics] Track when new metric is selected on Google Campaigns analytics card

### DIFF
--- a/WooCommerce/Classes/Analytics/WooAnalyticsEvent.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsEvent.swift
@@ -2665,6 +2665,8 @@ extension WooAnalyticsEvent {
             case compare
             case enabledCards = "enabled_cards"
             case disabledCards = "disabled_cards"
+            case card
+            case selectedMetric = "selected_metric"
         }
 
         /// Tracks when the "See more" button is tapped in My Store, to open the Analytics Hub.
@@ -2741,6 +2743,15 @@ extension WooAnalyticsEvent {
             WooAnalyticsEvent(statName: .analyticsHubSettingsSaved, properties: [
                 Keys.enabledCards.rawValue: cards.filter { $0.enabled }.map { $0.type.rawValue }.joined(separator: ","),
                 Keys.disabledCards.rawValue: cards.filter { !$0.enabled }.map { $0.type.rawValue }.joined(separator: ",")
+            ])
+        }
+
+        /// Tracks when a new metric is selected on a card in the Analytics Hub.
+        ///
+        static func selectedMetric(_ selectedMetric: String, for cardType: AnalyticsCard.CardType) -> WooAnalyticsEvent {
+            WooAnalyticsEvent(statName: .analyticsHubCardMetricSelected, properties: [
+                Keys.card.rawValue: cardType.rawValue,
+                Keys.selectedMetric.rawValue: selectedMetric
             ])
         }
     }

--- a/WooCommerce/Classes/Analytics/WooAnalyticsStat.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsStat.swift
@@ -205,6 +205,7 @@ enum WooAnalyticsStat: String {
     case analyticsHubViewFullReportTapped = "analytics_hub_view_full_report_tapped"
     case analyticsHubSettingsOpened = "analytics_hub_settings_opened"
     case analyticsHubSettingsSaved = "analytics_hub_settings_saved"
+    case analyticsHubCardMetricSelected = "analytics_hub_card_metric_selected"
 
     // MARK: Blaze Events
     //

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/Report Cards/GoogleAdsCampaignReportCard.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/Report Cards/GoogleAdsCampaignReportCard.swift
@@ -16,7 +16,7 @@ struct GoogleAdsCampaignReportCard: View {
                 .foregroundColor(Color(.text))
                 .footnoteStyle()
 
-            StatSelectionBar(allStats: viewModel.allStats, titleKeyPath: \.displayName, onSelection: nil, selectedStat: $viewModel.selectedStat)
+            StatSelectionBar(allStats: viewModel.allStats, titleKeyPath: \.displayName, onSelection: viewModel.onSelection, selectedStat: $viewModel.selectedStat)
                 .padding(.top, Layout.titleSpacing)
                 .padding(.bottom, Layout.columnSpacing)
 

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/Report Cards/GoogleAdsCampaignReportCardViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/Report Cards/GoogleAdsCampaignReportCardViewModel.swift
@@ -1,10 +1,13 @@
 import Foundation
 import Yosemite
+import protocol WooFoundation.Analytics
 
 /// Analytics Hub Google Ads Campaign Card ViewModel.
 /// Used to transmit Google Ads campaigns analytics data.
 ///
 final class GoogleAdsCampaignReportCardViewModel: ObservableObject {
+    private let analytics: Analytics
+
     /// Campaign stats for the current period
     ///
     private var currentPeriodStats: GoogleAdsCampaignStats?
@@ -42,13 +45,22 @@ final class GoogleAdsCampaignReportCardViewModel: ObservableObject {
          timeRange: AnalyticsHubTimeRangeSelection.SelectionType,
          isRedacted: Bool = false,
          usageTracksEventEmitter: StoreStatsUsageTracksEventEmitter,
-         storeAdminURL: String? = ServiceLocator.stores.sessionManager.defaultSite?.adminURL) {
+         storeAdminURL: String? = ServiceLocator.stores.sessionManager.defaultSite?.adminURL,
+         analytics: Analytics = ServiceLocator.analytics) {
         self.currentPeriodStats = currentPeriodStats
         self.previousPeriodStats = previousPeriodStats
         self.timeRange = timeRange
         self.isRedacted = isRedacted
         self.usageTracksEventEmitter = usageTracksEventEmitter
         self.storeAdminURL = storeAdminURL
+        self.analytics = analytics
+    }
+
+    /// Closure to perform when a new stat is selected on the Google Campaigns card.
+    ///
+    func onSelection(_ stat: GoogleAdsCampaignStatsTotals.TotalData) {
+        usageTracksEventEmitter.interacted()
+        analytics.track(event: .AnalyticsHub.selectedMetric(stat.tracksIdentifier, for: .googleCampaigns))
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/Report Cards/GoogleAdsCampaignStatsTotals+UI.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/Report Cards/GoogleAdsCampaignStatsTotals+UI.swift
@@ -1,0 +1,43 @@
+import Foundation
+import struct Yosemite.GoogleAdsCampaignStatsTotals
+
+extension GoogleAdsCampaignStatsTotals.TotalData {
+    /// Localized name to display for each of the total data stats.
+    var displayName: String {
+        switch self {
+        case .sales:
+            Localization.sales
+        case .spend:
+            Localization.spend
+        case .clicks:
+            Localization.clicks
+        case .impressions:
+            Localization.impressions
+        case .conversions:
+            Localization.conversions
+        }
+    }
+
+    /// Identifier for each of the total data stats to use in Tracks events.
+    var tracksIdentifier: String {
+        self.rawValue
+    }
+}
+
+private enum Localization {
+    static let sales = NSLocalizedString("googleAdsCampaignStatsTotals.totalData.sales",
+                                         value: "Total Sales",
+                                         comment: "Display name for the total sales stat in Google Ads campaign stats")
+    static let spend = NSLocalizedString("googleAdsCampaignStatsTotals.totalData.spend",
+                                         value: "Total Spend",
+                                         comment: "Display name for the total spend stat in Google Ads campaign stats")
+    static let clicks = NSLocalizedString("googleAdsCampaignStatsTotals.totalData.clicks",
+                                          value: "Clicks",
+                                          comment: "Display name for the clicks stat in Google Ads campaign stats")
+    static let impressions = NSLocalizedString("googleAdsCampaignStatsTotals.totalData.impressions",
+                                               value: "Impressions",
+                                               comment: "Display name for the impressions stat in Google Ads campaign stats")
+    static let conversions = NSLocalizedString("googleAdsCampaignStatsTotals.totalData.conversions",
+                                               value: "Conversions",
+                                               comment: "Display name for the conversions stat in Google Ads campaign stats")
+}

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Factories/WCAnalyticsStatsTotals+UI.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Factories/WCAnalyticsStatsTotals+UI.swift
@@ -94,27 +94,12 @@ extension GiftCardStatsTotals: ParsableStatsTotals {
 
 extension GoogleAdsCampaignStatsTotals: ParsableStatsTotals {
     /// Represents a type of Google Ads campaigns total data
-    enum TotalData: Double, CaseIterable {
+    enum TotalData: String, CaseIterable {
         case sales
         case spend
         case clicks
         case impressions
         case conversions
-
-        var displayName: String {
-            switch self {
-            case .sales:
-                Localization.sales
-            case .spend:
-                Localization.spend
-            case .clicks:
-                Localization.clicks
-            case .impressions:
-                Localization.impressions
-            case .conversions:
-                Localization.conversions
-            }
-        }
     }
 
     func getDoubleValue(for data: TotalData) -> Double {
@@ -130,25 +115,5 @@ extension GoogleAdsCampaignStatsTotals: ParsableStatsTotals {
         case .conversions:
             ((conversions ?? 0) as NSNumber).doubleValue
         }
-    }
-}
-
-private extension GoogleAdsCampaignStatsTotals {
-    enum Localization {
-        static let sales = NSLocalizedString("googleAdsCampaignStatsTotals.totalData.sales",
-                                             value: "Total Sales",
-                                             comment: "Display name for the total sales stat in Google Ads campaign stats")
-        static let spend = NSLocalizedString("googleAdsCampaignStatsTotals.totalData.spend",
-                                             value: "Total Spend",
-                                             comment: "Display name for the total spend stat in Google Ads campaign stats")
-        static let clicks = NSLocalizedString("googleAdsCampaignStatsTotals.totalData.clicks",
-                                              value: "Clicks",
-                                              comment: "Display name for the clicks stat in Google Ads campaign stats")
-        static let impressions = NSLocalizedString("googleAdsCampaignStatsTotals.totalData.impressions",
-                                                   value: "Impressions",
-                                                   comment: "Display name for the impressions stat in Google Ads campaign stats")
-        static let conversions = NSLocalizedString("googleAdsCampaignStatsTotals.totalData.conversions",
-                                                   value: "Conversions",
-                                                   comment: "Display name for the conversions stat in Google Ads campaign stats")
     }
 }

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -2232,6 +2232,7 @@
 		CEA455C52BB44F9E00D932CF /* ProductsReportItem+Woo.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEA455C42BB44F9E00D932CF /* ProductsReportItem+Woo.swift */; };
 		CEA455C72BB5CA5E00D932CF /* AnalyticsSessionsUnavailableCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEA455C62BB5CA5E00D932CF /* AnalyticsSessionsUnavailableCard.swift */; };
 		CEA455C92BB5DA4C00D932CF /* AnalyticsSessionsReportCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEA455C82BB5DA4C00D932CF /* AnalyticsSessionsReportCard.swift */; };
+		CEA7C32D2C47C9BD00528450 /* GoogleAdsCampaignStatsTotals+UI.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEA7C32C2C47C9BD00528450 /* GoogleAdsCampaignStatsTotals+UI.swift */; };
 		CEA9C8E02B6D323A000FE114 /* AnalyticsWebReportTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEA9C8DF2B6D323A000FE114 /* AnalyticsWebReportTests.swift */; };
 		CEC8188C2A3B7C8B00459843 /* AppStartupWaitingTimeTracker.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEC8188B2A3B7C8B00459843 /* AppStartupWaitingTimeTracker.swift */; };
 		CEC8188E2A3C75DD00459843 /* AppStartupWaitingTimeTrackerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEC8188D2A3C75DD00459843 /* AppStartupWaitingTimeTrackerTests.swift */; };
@@ -5224,6 +5225,7 @@
 		CEA455C42BB44F9E00D932CF /* ProductsReportItem+Woo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ProductsReportItem+Woo.swift"; sourceTree = "<group>"; };
 		CEA455C62BB5CA5E00D932CF /* AnalyticsSessionsUnavailableCard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnalyticsSessionsUnavailableCard.swift; sourceTree = "<group>"; };
 		CEA455C82BB5DA4C00D932CF /* AnalyticsSessionsReportCard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnalyticsSessionsReportCard.swift; sourceTree = "<group>"; };
+		CEA7C32C2C47C9BD00528450 /* GoogleAdsCampaignStatsTotals+UI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "GoogleAdsCampaignStatsTotals+UI.swift"; sourceTree = "<group>"; };
 		CEA9C8DF2B6D323A000FE114 /* AnalyticsWebReportTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnalyticsWebReportTests.swift; sourceTree = "<group>"; };
 		CEC8188B2A3B7C8B00459843 /* AppStartupWaitingTimeTracker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppStartupWaitingTimeTracker.swift; sourceTree = "<group>"; };
 		CEC8188D2A3C75DD00459843 /* AppStartupWaitingTimeTrackerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppStartupWaitingTimeTrackerTests.swift; sourceTree = "<group>"; };
@@ -11916,6 +11918,7 @@
 				CEA455C02BB3446D00D932CF /* BundlesReportCardViewModel.swift */,
 				CE070A3D2BBC608A00017578 /* GiftCardsReportCardViewModel.swift */,
 				CE21FB252C2DB3A900303832 /* GoogleAdsCampaignReportCardViewModel.swift */,
+				CEA7C32C2C47C9BD00528450 /* GoogleAdsCampaignStatsTotals+UI.swift */,
 			);
 			path = "Report Cards";
 			sourceTree = "<group>";
@@ -15349,6 +15352,7 @@
 				26838356296F702B00CCF60A /* GenerateAllVariationsPresenter.swift in Sources */,
 				4521396E27FEE55200964ED3 /* FullScreenTextView.swift in Sources */,
 				453F52A32C3C3474006CBA2F /* ProductCreationAIPromptProgressBar.swift in Sources */,
+				CEA7C32D2C47C9BD00528450 /* GoogleAdsCampaignStatsTotals+UI.swift in Sources */,
 				DEB387A52C36479B0025256E /* GoogleAdsDashboardCardViewModel.swift in Sources */,
 				DE126D0B26CA2331007F901D /* ValidationErrorRow.swift in Sources */,
 				E1E649E92846188C0070B194 /* BetaFeature.swift in Sources */,


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #13349
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

Adds a new Tracks event to track when a metric is selected on the Google Campaigns card in the Analytics Hub:

* `analytics_hub_card_metric_selected` (Event registration: https://github.com/Automattic/tracks-events-registration/pull/2551)
   * Custom prop: `card` with the name of the card (`googleCampaigns`).
   * Custom prop: `selected_metric` with the selected metric (e.g. `sales` or `spend`).

## Testing steps
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->

Prerequisite: A store with the Google Listings & Ads extension active and set up, with Google Ads connected. Alternately, use a proxy server (e.g. Charles Proxy) to mock the responses using the [connection response mock](https://github.com/woocommerce/woocommerce-ios/blob/b49851e44aed9a4f5e460ae8f165138c6396fd5d/Networking/NetworkingTests/Responses/gla-connection-without-data-envelope.json) and [stats response mock](https://github.com/woocommerce/woocommerce-ios/blob/b49851e44aed9a4f5e460ae8f165138c6396fd5d/Networking/NetworkingTests/Responses/google-ads-reports-programs-without-data.json).

1. On the My Store dashboard, select "View all store analytics" to open the Analytics Hub.
2. Confirm the Google Campaigns card loads with the Total Sales stat and list of top campaigns by sales.
3. Open the dropdown Metric menu and select a new metric. Confirm the new event is tracked with the expected custom props.

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.