### PR TITLE
 Performance Card: Save and show last updated timestamp

### DIFF
--- a/WooCommerce/Classes/System/SessionManager.swift
+++ b/WooCommerce/Classes/System/SessionManager.swift
@@ -203,6 +203,7 @@ final class SessionManager: SessionManagerProtocol {
         defaults[.siteIDPendingStoreSwitch] = nil
         defaults[.expectedStoreNamePendingStoreSwitch] = nil
         defaults[.latestBackgroundOrderSyncDate] = nil
+        DashboardTimestampStore.resetStore()
         imageCache.clearCache()
     }
 

--- a/WooCommerce/Classes/Tools/BackgroundTasks/DashboardTimestampStore.swift
+++ b/WooCommerce/Classes/Tools/BackgroundTasks/DashboardTimestampStore.swift
@@ -1,0 +1,67 @@
+import Foundation
+import Yosemite
+
+/// Store to help save and load dashboard cards timestamp information.
+/// Uses `UserDefaults` as the default store.
+///
+struct DashboardTimestampStore {
+
+    /// Supported Cards
+    ///
+    enum Card: String, CaseIterable {
+        case performance
+    }
+
+    /// Supported time ranges
+    ///
+    enum TimeRange: String, CaseIterable {
+        case `default` // For cards that do not have multiple time ranges
+        case today
+        case week
+        case month
+        case year
+        case custom
+    }
+
+    /// Creates a conjoint key for the timestamp.
+    ///
+    private static func createKey(for card: Card, at range: TimeRange) -> String {
+        "\(card.rawValue)-\(range.rawValue)"
+    }
+
+    /// Saves a timestamp for the given card and range.
+    ///
+    static func saveTimestamp(_ timestamp: Date, for card: Card, at range: TimeRange, store: UserDefaults = UserDefaults.standard) {
+        store.set(timestamp, forKey: createKey(for: card, at: range))
+    }
+
+    /// Loads the timestamp for the given card and range.
+    ///
+    static func loadTimestamp(for card: Card, at range: TimeRange, store: UserDefaults = UserDefaults.standard) -> Date? {
+        store.object(forKey: createKey(for: card, at: range)) as? Date
+    }
+
+    /// Removes all saved timestamps.
+    ///
+    static func resetStore(store: UserDefaults = UserDefaults.standard) {
+        for card in Card.allCases {
+            for range in TimeRange.allCases {
+                store.removeObject(forKey: createKey(for: card, at: range))
+            }
+        }
+    }
+}
+
+/// Extension to convert the `StatsTimeRangeV4` into a `DashboardTimestampStore.TimeRange`
+///
+extension StatsTimeRangeV4 {
+    var timestampRange: DashboardTimestampStore.TimeRange {
+        switch self {
+        case .today: return .today
+        case .thisWeek: return .week
+        case .thisMonth: return .month
+        case .thisYear: return .year
+        case .custom: return .custom
+        }
+    }
+}

--- a/WooCommerce/Classes/ViewRelated/Dashboard/StoreStats/StorePerformanceView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/StoreStats/StorePerformanceView.swift
@@ -50,6 +50,11 @@ struct StorePerformanceView: View {
                     .redacted(reason: viewModel.showRedactedState ? [.placeholder] : [])
                     .shimmering(active: viewModel.showRedactedState)
 
+                timestampView
+                    .renderedIf(viewModel.lastUpdatedTimestamp.isNotEmpty)
+                    .redacted(reason: viewModel.showRedactedState ? [.placeholder] : [])
+                    .shimmering(active: viewModel.showRedactedState)
+
                 chartView
                     .padding(.horizontal, Layout.padding)
                     .redacted(reason: viewModel.showRedactedState ? [.placeholder] : [])
@@ -195,6 +200,12 @@ private extension StorePerformanceView {
                     .renderedIf(!viewModel.hasRevenue)
             }
         }
+    }
+
+    var timestampView: some View {
+        Text(Localization.lastUpdatedText(time: viewModel.lastUpdatedTimestamp))
+            .footnoteStyle()
+            .frame(maxWidth: .infinity, alignment: .center)
     }
 
     func statsItemView(title: String, value: String, redactMode: RedactMode) -> some View {
@@ -382,6 +393,10 @@ private extension StorePerformanceView {
             value: "View all store analytics",
             comment: "Button to navigate to Analytics Hub."
         )
+        static func lastUpdatedText(time: String) -> String {
+            let format = NSLocalizedString("Last Updated: %@", comment: "Time for when the performance card was last updated")
+            return String.localizedStringWithFormat(format, time)
+        }
         enum ContentUnavailable {
             static let title = NSLocalizedString(
                 "storePerformanceView.contentUnavailable.title",

--- a/WooCommerce/Classes/Yosemite/DefaultStoresManager.swift
+++ b/WooCommerce/Classes/Yosemite/DefaultStoresManager.swift
@@ -272,6 +272,7 @@ class DefaultStoresManager: StoresManager {
         defaults[.hasDismissedWriteWithAITooltip] = nil
         defaults[.numberOfTimesWriteWithAITooltipIsShown] = nil
         defaults[.latestBackgroundOrderSyncDate] = nil
+        DashboardTimestampStore.resetStore()
         restoreSessionSiteIfPossible()
         ServiceLocator.pushNotesManager.reloadBadgeCount()
 

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -1075,6 +1075,7 @@
 		26DD32D42BEBCDFB00F2C69C /* WooConstants.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5D1AFBF20BC67C200DB0E8C /* WooConstants.swift */; };
 		26DD32D62BEBCE3900F2C69C /* UserDefaults+Woo.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5AA7B3E20ED81C2004DA14F /* UserDefaults+Woo.swift */; };
 		26DDA4A92C4839B8005FBEBF /* DashboardTimestampStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26DDA4A82C4839B8005FBEBF /* DashboardTimestampStore.swift */; };
+		26DDA4AB2C49627F005FBEBF /* DashboardTimestampStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26DDA4AA2C49627F005FBEBF /* DashboardTimestampStoreTests.swift */; };
 		26E0ADF12631D94D00A5EB3B /* TopBannerWrapperView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26E0ADF02631D94D00A5EB3B /* TopBannerWrapperView.swift */; };
 		26E0AE13263359F900A5EB3B /* View+Conditionals.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26E0AE12263359F900A5EB3B /* View+Conditionals.swift */; };
 		26E0AE1926335AA900A5EB3B /* Survey.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26E0AE1826335AA900A5EB3B /* Survey.swift */; };
@@ -4048,6 +4049,7 @@
 		26D9E54728C10A3B0098DF26 /* Experiments.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = Experiments.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		26DB7E3428636D2200506173 /* NonEditableOrderBanner.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NonEditableOrderBanner.swift; sourceTree = "<group>"; };
 		26DDA4A82C4839B8005FBEBF /* DashboardTimestampStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DashboardTimestampStore.swift; sourceTree = "<group>"; };
+		26DDA4AA2C49627F005FBEBF /* DashboardTimestampStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DashboardTimestampStoreTests.swift; sourceTree = "<group>"; };
 		26E0ADF02631D94D00A5EB3B /* TopBannerWrapperView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TopBannerWrapperView.swift; sourceTree = "<group>"; };
 		26E0AE12263359F900A5EB3B /* View+Conditionals.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "View+Conditionals.swift"; sourceTree = "<group>"; };
 		26E0AE1826335AA900A5EB3B /* Survey.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Survey.swift; sourceTree = "<group>"; };
@@ -9868,6 +9870,7 @@
 				B96B536A2816ECFC00F753E6 /* CardPresentPluginsDataProviderTests.swift */,
 				EEADF625281A65A9001B40F1 /* DefaultShippingValueLocalizerTests.swift */,
 				DE9A02A22A44441200193ABF /* RequirementsCheckerTests.swift */,
+				26DDA4AA2C49627F005FBEBF /* DashboardTimestampStoreTests.swift */,
 			);
 			path = Tools;
 			sourceTree = "<group>";
@@ -16315,6 +16318,7 @@
 				EEA693602B23303A00BAECA6 /* ProductCreationAISurveyUseCaseTests.swift in Sources */,
 				DE4B3B2C2692DC2200EEF2D8 /* ReviewOrderViewModelTests.swift in Sources */,
 				D89C009425B4E9E2000E4683 /* ULAccountMismatchViewControllerTests.swift in Sources */,
+				26DDA4AB2C49627F005FBEBF /* DashboardTimestampStoreTests.swift in Sources */,
 				573A960324F433DD0091F3A5 /* ProductsTopBannerFactoryTests.swift in Sources */,
 				EE2EDFE12987A189004E702B /* MockABTestVariationProvider.swift in Sources */,
 				0273707E24C0047800167204 /* SequenceHelpersTests.swift in Sources */,

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -1074,6 +1074,7 @@
 		26DB7E3528636D2200506173 /* NonEditableOrderBanner.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26DB7E3428636D2200506173 /* NonEditableOrderBanner.swift */; };
 		26DD32D42BEBCDFB00F2C69C /* WooConstants.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5D1AFBF20BC67C200DB0E8C /* WooConstants.swift */; };
 		26DD32D62BEBCE3900F2C69C /* UserDefaults+Woo.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5AA7B3E20ED81C2004DA14F /* UserDefaults+Woo.swift */; };
+		26DDA4A92C4839B8005FBEBF /* DashboardTimestampStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26DDA4A82C4839B8005FBEBF /* DashboardTimestampStore.swift */; };
 		26E0ADF12631D94D00A5EB3B /* TopBannerWrapperView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26E0ADF02631D94D00A5EB3B /* TopBannerWrapperView.swift */; };
 		26E0AE13263359F900A5EB3B /* View+Conditionals.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26E0AE12263359F900A5EB3B /* View+Conditionals.swift */; };
 		26E0AE1926335AA900A5EB3B /* Survey.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26E0AE1826335AA900A5EB3B /* Survey.swift */; };
@@ -4046,6 +4047,7 @@
 		26D9E54328C107F80098DF26 /* WooFoundation.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = WooFoundation.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		26D9E54728C10A3B0098DF26 /* Experiments.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = Experiments.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		26DB7E3428636D2200506173 /* NonEditableOrderBanner.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NonEditableOrderBanner.swift; sourceTree = "<group>"; };
+		26DDA4A82C4839B8005FBEBF /* DashboardTimestampStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DashboardTimestampStore.swift; sourceTree = "<group>"; };
 		26E0ADF02631D94D00A5EB3B /* TopBannerWrapperView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TopBannerWrapperView.swift; sourceTree = "<group>"; };
 		26E0AE12263359F900A5EB3B /* View+Conditionals.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "View+Conditionals.swift"; sourceTree = "<group>"; };
 		26E0AE1826335AA900A5EB3B /* Survey.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Survey.swift; sourceTree = "<group>"; };
@@ -8157,6 +8159,7 @@
 			children = (
 				26BCA03F2C35E9A9000BE96C /* BackgroundTaskRefreshDispatcher.swift */,
 				26BCA0412C35EDBF000BE96C /* OrderListSyncBackgroundTask.swift */,
+				26DDA4A82C4839B8005FBEBF /* DashboardTimestampStore.swift */,
 			);
 			path = BackgroundTasks;
 			sourceTree = "<group>";
@@ -15475,6 +15478,7 @@
 				D8752EF7265E60F4008ACC80 /* PaymentCaptureCelebration.swift in Sources */,
 				B98BA12D2AE90023006F1E4A /* OrderCustomAmountsSection.swift in Sources */,
 				205B7EC72C19FCA700D14A36 /* PointOfSaleCardPresentPaymentPreparingForPaymentMessageViewModel.swift in Sources */,
+				26DDA4A92C4839B8005FBEBF /* DashboardTimestampStore.swift in Sources */,
 				DE7E5E882B4D16EB002E28D2 /* BlazeTargetDevicePickerView.swift in Sources */,
 				EE6B2AD129DC522300048A8F /* StoreCreationProgressView.swift in Sources */,
 				B58B4AB62108F11C00076FDD /* Notice.swift in Sources */,

--- a/WooCommerce/WooCommerceTests/Tools/DashboardTimestampStoreTests.swift
+++ b/WooCommerce/WooCommerceTests/Tools/DashboardTimestampStoreTests.swift
@@ -1,0 +1,44 @@
+import XCTest
+@testable import WooCommerce
+
+final class DashboardTimestampStoreTests: XCTestCase {
+
+    func test_timestamps_are_stored_correctly() throws {
+        // Given
+        let store = try XCTUnwrap(UserDefaults(suiteName: "test-store"))
+
+        // When
+        for card in DashboardTimestampStore.Card.allCases {
+            for range in DashboardTimestampStore.TimeRange.allCases {
+                DashboardTimestampStore.saveTimestamp(.now, for: card, at: range, store: store)
+            }
+        }
+
+        // Then
+        for card in DashboardTimestampStore.Card.allCases {
+            for range in DashboardTimestampStore.TimeRange.allCases {
+                XCTAssertNotNil(DashboardTimestampStore.loadTimestamp(for: card, at: range, store: store))
+            }
+        }
+    }
+
+    func test_timestamps_are_deleted_correctly() throws {
+        // Given
+        let store = try XCTUnwrap(UserDefaults(suiteName: "test-store"))
+        for card in DashboardTimestampStore.Card.allCases {
+            for range in DashboardTimestampStore.TimeRange.allCases {
+                DashboardTimestampStore.saveTimestamp(.now, for: card, at: range, store: store)
+            }
+        }
+
+        // When
+        DashboardTimestampStore.resetStore(store: store)
+
+        // Then
+        for card in DashboardTimestampStore.Card.allCases {
+            for range in DashboardTimestampStore.TimeRange.allCases {
+                XCTAssertNil(DashboardTimestampStore.loadTimestamp(for: card, at: range, store: store))
+            }
+        }
+    }
+}


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of #13369 

# How

This PR saves and displays the last updated sync timestamp on the performance card.

# How

- Creates a new timestamp store to store and load timestamps on user defaults
- Saves the timestamp when successfully loading stats
- Displays the timestamp when presenting the performance card.
- Removes the timestamp when logging out from the store or when switching stores.

# Demo

https://github.com/user-attachments/assets/b4476a96-0ba1-489b-abb0-71ff6103351b

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
