### PR TITLE
Improvements in Product Creation with AI Starting View

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductWithAI/StartingInfo/ProductCreationAIStartingInfoView.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductWithAI/StartingInfo/ProductCreationAIStartingInfoView.swift
@@ -35,27 +35,23 @@ struct ProductCreationAIStartingInfoView: View {
                     VStack(alignment: .leading, spacing: Layout.textFieldBlockSpacing) {
                         VStack(alignment: .leading, spacing: Layout.editorBlockSpacing) {
                             VStack(spacing: 0) {
-                                ZStack(alignment: .topLeading) {
-                                    TextEditor(text: $viewModel.features)
-                                        .id(Constant.textEditorID)
-                                        .bodyStyle()
-                                        .foregroundStyle(.secondary)
-                                        .padding(insets: Layout.messageContentInsets)
-                                        .frame(minHeight: Layout.minimumEditorHeight, maxHeight: .infinity)
-                                        .focused($editorIsFocused)
-                                    // Scrolls to the "TextEditor" view with a smooth animation while typing.
-                                        .onChange(of: viewModel.features) { _ in
-                                            scrollToTextEditor(using: proxy)
-                                        }
-                                    // Scrolls to the "TextEditor" view with a smooth animation when the editor is focused in a small screen.
+                                TextField(Localization.placeholder, text: $viewModel.features, axis: .vertical)
+                                    .id(Constant.textFieldID)
+                                    .bodyStyle()
+                                    .foregroundStyle(.secondary)
+                                    .lineLimit(Constant.textFieldMinLineLenght...)
+                                    .padding(insets: Layout.messageContentInsets)
+                                    .focused($editorIsFocused)
+                                // Scrolls to the "TextField" view with a smooth animation while typing.
+                                    .onChange(of: viewModel.features) { _ in
+                                        scrollToTextField(using: proxy)
+                                    }
+                                // Scrolls to the "TextField" view with a smooth animation when the editor is focused in a small screen.
                                     .onChange(of: editorIsFocused) { isFocused in
                                         if isFocused {
-                                            scrollToTextEditor(using: proxy)
+                                            scrollToTextField(using: proxy)
                                         }
                                     }
-                                    // Placeholder text
-                                    placeholderText
-                                }
 
                                 Divider()
                                     .frame(height: Layout.dividerHeight)
@@ -185,9 +181,9 @@ private extension ProductCreationAIStartingInfoView {
         .disabled(viewModel.features.isEmpty)
     }
 
-    private func scrollToTextEditor(using proxy: ScrollViewProxy) {
+    private func scrollToTextField(using proxy: ScrollViewProxy) {
         withAnimation {
-            proxy.scrollTo(Constant.textEditorID, anchor: .top)
+            proxy.scrollTo(Constant.textFieldID, anchor: .top)
         }
     }
 }
@@ -217,7 +213,8 @@ private extension ProductCreationAIStartingInfoView {
     }
 
     enum Constant {
-        static let textEditorID = "TextEditor"
+        static let textFieldID = "TextField"
+        static let textFieldMinLineLenght = 3
     }
 
     enum Localization {

--- a/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductWithAI/StartingInfo/ProductCreationAIStartingInfoView.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductWithAI/StartingInfo/ProductCreationAIStartingInfoView.swift
@@ -123,7 +123,7 @@ struct ProductCreationAIStartingInfoView: View {
         }
         .toolbar {
             ToolbarItem(placement: .confirmationAction) {
-                generateButtonToolbar
+                generateButton(isPrimary: false)
                     .renderedIf(isCompact)
             }
         }
@@ -131,7 +131,7 @@ struct ProductCreationAIStartingInfoView: View {
             VStack {
                 Divider()
                 // CTA to generate product details.
-                generateButtonMain
+                generateButton(isPrimary: true)
                     .padding()
             }
             .background(Color(uiColor: .systemBackground))
@@ -170,7 +170,7 @@ private extension ProductCreationAIStartingInfoView {
         }
     }
 
-    var generateButtonMain: some View {
+    func generateButton(isPrimary: Bool) -> some View {
         Button {
             // continue
             editorIsFocused = false
@@ -178,18 +178,9 @@ private extension ProductCreationAIStartingInfoView {
         } label: {
             Text(Localization.generateProductDetails)
         }
-        .buttonStyle(PrimaryButtonStyle())
-        .disabled(viewModel.features.isEmpty)
-    }
-
-    var generateButtonToolbar: some View {
-        Button {
-            // continue
-            editorIsFocused = false
-            onContinueWithFeatures(viewModel.features)
-        } label: {
-            Text(Localization.generateProductDetails)
-        }
+        .if(isPrimary, transform: { button in
+            button.buttonStyle(PrimaryButtonStyle())
+        })
         .disabled(viewModel.features.isEmpty)
     }
 

--- a/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductWithAI/StartingInfo/ProductCreationAIStartingInfoView.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductWithAI/StartingInfo/ProductCreationAIStartingInfoView.swift
@@ -6,7 +6,7 @@ struct ProductCreationAIStartingInfoView: View {
     @ObservedObject private var viewModel: ProductCreationAIStartingInfoViewModel
     @ScaledMetric private var scale: CGFloat = 1.0
     @FocusState private var editorIsFocused: Bool
-    @Environment(\.verticalSizeClass) var verticalSizeClass
+    @Environment(\.verticalSizeClass) private var verticalSizeClass
 
     private var isCompact: Bool {
         verticalSizeClass == .compact
@@ -43,7 +43,7 @@ struct ProductCreationAIStartingInfoView: View {
                                 .id(Constant.textFieldID)
                                 .bodyStyle()
                                 .foregroundStyle(.secondary)
-                                .lineLimit(Constant.textFieldMinLineLenght...)
+                                .lineLimit(Constant.textFieldMinLineLength...)
                                 .padding(insets: Layout.messageContentInsets)
                                 .focused($editorIsFocused)
                                 // Scrolls to the "TextField" view with a smooth animation while typing.
@@ -217,7 +217,7 @@ private extension ProductCreationAIStartingInfoView {
 
     enum Constant {
         static let textFieldID = "TextField"
-        static let textFieldMinLineLenght = 3
+        static let textFieldMinLineLength = 3
     }
 
     enum Localization {

--- a/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductWithAI/StartingInfo/ProductCreationAIStartingInfoView.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductWithAI/StartingInfo/ProductCreationAIStartingInfoView.swift
@@ -36,22 +36,22 @@ struct ProductCreationAIStartingInfoView: View {
                         VStack(alignment: .leading, spacing: Layout.editorBlockSpacing) {
                             VStack(spacing: 0) {
                                 TextField(Localization.placeholder, text: $viewModel.features, axis: .vertical)
-                                    .id(Constant.textFieldID)
-                                    .bodyStyle()
-                                    .foregroundStyle(.secondary)
-                                    .lineLimit(Constant.textFieldMinLineLenght...)
-                                    .padding(insets: Layout.messageContentInsets)
-                                    .focused($editorIsFocused)
+                                .id(Constant.textFieldID)
+                                .bodyStyle()
+                                .foregroundStyle(.secondary)
+                                .lineLimit(Constant.textFieldMinLineLenght...)
+                                .padding(insets: Layout.messageContentInsets)
+                                .focused($editorIsFocused)
                                 // Scrolls to the "TextField" view with a smooth animation while typing.
-                                    .onChange(of: viewModel.features) { _ in
+                                .onChange(of: viewModel.features) { _ in
+                                    scrollToTextField(using: proxy)
+                                }
+                                // Scrolls to the "TextField" view with a smooth animation when the editor is focused in a small screen.
+                                .onChange(of: editorIsFocused) { isFocused in
+                                    if isFocused {
                                         scrollToTextField(using: proxy)
                                     }
-                                // Scrolls to the "TextField" view with a smooth animation when the editor is focused in a small screen.
-                                    .onChange(of: editorIsFocused) { isFocused in
-                                        if isFocused {
-                                            scrollToTextField(using: proxy)
-                                        }
-                                    }
+                                }
 
                                 Divider()
                                     .frame(height: Layout.dividerHeight)

--- a/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductWithAI/StartingInfo/ProductCreationAIStartingInfoView.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductWithAI/StartingInfo/ProductCreationAIStartingInfoView.swift
@@ -6,7 +6,11 @@ struct ProductCreationAIStartingInfoView: View {
     @ObservedObject private var viewModel: ProductCreationAIStartingInfoViewModel
     @ScaledMetric private var scale: CGFloat = 1.0
     @FocusState private var editorIsFocused: Bool
+    @Environment(\.verticalSizeClass) var verticalSizeClass
 
+    private var isCompact: Bool {
+        verticalSizeClass == .compact
+    }
     private let onContinueWithFeatures: (String) -> Void
 
     init(viewModel: ProductCreationAIStartingInfoViewModel,
@@ -117,14 +121,21 @@ struct ProductCreationAIStartingInfoView: View {
             }
             .scrollDismissesKeyboard(.immediately)
         }
+        .toolbar {
+            ToolbarItem(placement: .confirmationAction) {
+                generateButtonToolbar
+                    .renderedIf(isCompact)
+            }
+        }
         .safeAreaInset(edge: .bottom) {
             VStack {
                 Divider()
                 // CTA to generate product details.
-                generateButton
+                generateButtonMain
                     .padding()
             }
             .background(Color(uiColor: .systemBackground))
+            .renderedIf(!isCompact)
         }
         .sheet(isPresented: $viewModel.isShowingViewPhotoSheet, content: {
             if case let .success(image) = viewModel.imageState {
@@ -159,7 +170,7 @@ private extension ProductCreationAIStartingInfoView {
         }
     }
 
-    var generateButton: some View {
+    var generateButtonMain: some View {
         Button {
             // continue
             editorIsFocused = false
@@ -170,6 +181,18 @@ private extension ProductCreationAIStartingInfoView {
         .buttonStyle(PrimaryButtonStyle())
         .disabled(viewModel.features.isEmpty)
     }
+
+    var generateButtonToolbar: some View {
+        Button {
+            // continue
+            editorIsFocused = false
+            onContinueWithFeatures(viewModel.features)
+        } label: {
+            Text(Localization.generateProductDetails)
+        }
+        .disabled(viewModel.features.isEmpty)
+    }
+
 
     private func scrollToTextField(using proxy: ScrollViewProxy) {
         withAnimation {

--- a/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductWithAI/StartingInfo/ProductCreationAIStartingInfoView.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductWithAI/StartingInfo/ProductCreationAIStartingInfoView.swift
@@ -159,16 +159,6 @@ private extension ProductCreationAIStartingInfoView {
         }
     }
 
-    var placeholderText: some View {
-        Text(Localization.placeholder)
-            .foregroundColor(Color(.placeholderText))
-            .bodyStyle()
-            .padding(insets: Layout.placeholderInsets)
-            // Allows gestures to pass through to the `TextEditor`.
-            .allowsHitTesting(false)
-            .renderedIf(viewModel.features.isEmpty)
-    }
-
     var generateButton: some View {
         Button {
             // continue

--- a/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductWithAI/StartingInfo/ProductCreationAIStartingInfoView.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductWithAI/StartingInfo/ProductCreationAIStartingInfoView.swift
@@ -188,7 +188,6 @@ private extension ProductCreationAIStartingInfoView {
         static let textFieldBlockSpacing: CGFloat = 24
 
         static let editorBlockSpacing: CGFloat = 8
-        static let minimumEditorHeight: CGFloat = 70
         static let cornerRadius: CGFloat = 8
         static let messageContentInsets: EdgeInsets = .init(top: 10, leading: 10, bottom: 10, trailing: 10)
         static let placeholderInsets: EdgeInsets = .init(top: 16, leading: 16, bottom: 16, trailing: 16)

--- a/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductWithAI/StartingInfo/PromptProgressBar/ProductCreationAIPromptProgressBar.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductWithAI/StartingInfo/PromptProgressBar/ProductCreationAIPromptProgressBar.swift
@@ -25,6 +25,9 @@ struct ProductCreationAIPromptProgressBar: View {
         .padding(Layout.padding)
         .background(Color(UIColor.listBackground))
         .cornerRadius(Layout.radius)
+        .onAppear(perform: {
+            viewModel.updateText(to: text)
+        })
         .onChange(of: text, perform: { newText in
             viewModel.updateText(to: newText)
         })


### PR DESCRIPTION
## Description
Following what comes out in this PR https://github.com/woocommerce/woocommerce-ios/pull/13329#issuecomment-2235933352 I made the following improvements:
- When navigating back from the preview screen, the advice block is visible but the progress bar is reset. Now the progress bar keeps its status.
- When navigating back from the preview screen, the text view collapsed instead of displaying all the content as before. Now I substituted the `TextEditor` with a `TextField` which seems to be more reliable under this aspect, and I fixed the issue.
- Previously, the UX/UI was not the best in landscape mode, given the new advice block. Now, for vertical size classes equal to `compact`, the main button for generating the preview will disappear, and it will appear on the navigation bar.

## Testing information
1. Start doing a smoke test, making sure that everything works properly as before.
2. Navigating back from the previous screen, should still display the prompt text expanded and also the advice block with the right progress.
3. Rotate the screen to landscape mode on the iPhone: you will notice that the "Generate" button is on the navigation bar (top right side). Go back to portrait mode, and the main button for generating the preview should be visible again, while the one in the navigation bar should disappear..

## Screenshots

| Portrait mode             |  Landscape mode |
:-------------------------:|:-------------------------:
![Simulator Screenshot - iPhone 15 Pro Max - 2024-07-18 at 16 11 09](https://github.com/user-attachments/assets/602bdc13-37d6-404d-acb0-29b2b9cefcaa) | ![Simulator Screenshot - iPhone 15 Pro Max - 2024-07-18 at 16 11 31](https://github.com/user-attachments/assets/219c8711-4bf3-4289-b7a5-42c0d6ec07e8)



---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
