### PR TITLE
Background Update for Performance Card

### DIFF
--- a/WooCommerce/Classes/Notifications/PushNotificationBackgroundSynchronizer.swift
+++ b/WooCommerce/Classes/Notifications/PushNotificationBackgroundSynchronizer.swift
@@ -43,7 +43,7 @@ struct PushNotificationBackgroundSynchronizer {
             }
 
             // Sync the order list data
-            _ = await OrderListSyncBackgroundTask(siteID: pushNotification.siteID, backgroundTask: nil, stores: stores).dispatch().result
+            try await OrderListSyncBackgroundTask(siteID: pushNotification.siteID, stores: stores).dispatch()
 
             // There is a change that the specific order was not fetched in the previous operation, specially if the user has some filters set.
             // In that case, specifically sync the notification order so it's available for the user when they tap the notification.

--- a/WooCommerce/Classes/Tools/BackgroundTasks/BackgroundTaskRefreshDispatcher.swift
+++ b/WooCommerce/Classes/Tools/BackgroundTasks/BackgroundTaskRefreshDispatcher.swift
@@ -11,7 +11,7 @@ final class BackgroundTaskRefreshDispatcher {
     func scheduleAppRefresh() {
 
         // Do not run this code while running test because this framework is not enabled in the simulator
-        guard Self.isNotRunningTests() else {
+        guard Self.isNotRunningTests(), ServiceLocator.featureFlagService.isFeatureFlagEnabled(.backgroundTasks) else {
             return
         }
 
@@ -29,7 +29,7 @@ final class BackgroundTaskRefreshDispatcher {
     func registerSystemTaskIdentifier() {
 
         // Do not run this code while running test because this framework is not enabled in the simulator
-        guard Self.isNotRunningTests() else {
+        guard Self.isNotRunningTests(), ServiceLocator.featureFlagService.isFeatureFlagEnabled(.backgroundTasks) else {
             return
         }
 

--- a/WooCommerce/Classes/Tools/BackgroundTasks/BackgroundTaskRefreshDispatcher.swift
+++ b/WooCommerce/Classes/Tools/BackgroundTasks/BackgroundTaskRefreshDispatcher.swift
@@ -53,10 +53,12 @@ final class BackgroundTaskRefreshDispatcher {
         scheduleAppRefresh()
 
         let ordersSyncTask = OrderListSyncBackgroundTask(siteID: siteID, backgroundTask: backgroundTask).dispatch()
+        let dashboardSyncTask = DashboardSyncBackgroundTask(siteID: siteID, backgroundTask: backgroundTask).dispatch()
 
         // Provide the background task with an expiration handler that cancels the operation.
         backgroundTask.expirationHandler = {
             ordersSyncTask.cancel()
+            dashboardSyncTask.cancel()
         }
      }
 }

--- a/WooCommerce/Classes/Tools/BackgroundTasks/DashboardSyncBackgroundTask.swift
+++ b/WooCommerce/Classes/Tools/BackgroundTasks/DashboardSyncBackgroundTask.swift
@@ -1,0 +1,68 @@
+import BackgroundTasks
+import Foundation
+import Yosemite
+
+/// Task to sync dashboard card data in the background.
+///
+struct DashboardSyncBackgroundTask {
+
+    let siteID: Int64
+
+    let siteTimezone: TimeZone
+
+    let stores: StoresManager
+
+    let backgroundTask: BGAppRefreshTask?
+
+    init(siteID: Int64, siteTimezone: TimeZone = .siteTimezone, backgroundTask: BGAppRefreshTask?, stores: StoresManager = ServiceLocator.stores) {
+        self.siteID = siteID
+        self.siteTimezone = siteTimezone
+        self.backgroundTask = backgroundTask
+        self.stores = stores
+    }
+
+    /// Runs the sync task.
+    /// Marks the `backgroundTask` as completed when finished.
+    /// Returns a `task` to be canceled when required.
+    ///
+    func dispatch() -> Task<Void, Never> {
+        Task { @MainActor in
+            do {
+                DDLogInfo("📱 Synchronizing dashboard cards in the background...")
+
+                let dashboardCards = await loadDashboardCardsFromStorage()
+                for card in dashboardCards {
+
+                    switch card.type {
+                    case .performance:
+
+                        DDLogInfo("📱 Synchronizing Performance card in the background...")
+                        let useCase = PerformanceCardDataSyncUseCase(siteID: siteID, siteTimezone: siteTimezone)
+                        try await useCase.sync()
+                        DDLogInfo("📱 Successfully synchronized \(card.type.name) in the background")
+                        backgroundTask?.setTaskCompleted(success: true)
+
+                    case .blaze, .coupons, .googleAds, .inbox, .lastOrders, .onboarding, .reviews, .stock, .topPerformers:
+                        DDLogInfo("⚠️ Synchronizing \(card.type.name) card in the background is not yet supported...")
+                        return
+                    }
+                }
+            } catch {
+                DDLogError("⛔️ Error synchronizing dashboard cards in the background: \(error)")
+                backgroundTask?.setTaskCompleted(success: false)
+            }
+        }
+    }
+
+    /// Load the supposed visible cards from storage.
+    ///
+    @MainActor
+    private func loadDashboardCardsFromStorage() async -> [DashboardCard] {
+        await withCheckedContinuation { continuation in
+            stores.dispatch(AppSettingsAction.loadDashboardCards(siteID: siteID, onCompletion: { cards in
+                let visibleCards = cards?.filter { $0.enabled && $0.availability == .show }
+                continuation.resume(returning: visibleCards ?? [])
+            }))
+        }
+    }
+}

--- a/WooCommerce/Classes/ViewRelated/Dashboard/DashboardViewHostingController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/DashboardViewHostingController.swift
@@ -14,6 +14,7 @@ final class DashboardViewHostingController: UIHostingController<DashboardView> {
     private var googleAdsCampaignCoordinator: GoogleAdsCampaignCoordinator?
     private var jetpackSetupCoordinator: JetpackSetupCoordinator?
     private var modalJustInTimeMessageHostingController: ConstraintsUpdatingHostingController<JustInTimeMessageModal_UIKit>?
+    private var isAppActive = true
 
     /// Presenter for the privacy choices banner
     private lazy var privacyBannerPresenter = PrivacyBannerPresenter()
@@ -68,6 +69,7 @@ final class DashboardViewHostingController: UIHostingController<DashboardView> {
         registerUserActivity()
         presentPrivacyBannerIfNeeded()
         observeModalJustInTimeMessages()
+        registerForSystemNotifications()
 
         Task {
             await viewModel.reloadAllData()
@@ -137,6 +139,31 @@ private extension DashboardViewHostingController {
             let inboxViewModel = InboxViewModel(siteID: viewModel.siteID)
             let hostingController = UIHostingController(rootView: Inbox(viewModel: inboxViewModel))
             show(hostingController, sender: self)
+        }
+    }
+
+    func registerForSystemNotifications() {
+        NotificationCenter.default.addObserver(self, selector: #selector(handleAppDeactivation),
+                                               name: UIApplication.willResignActiveNotification, object: nil)
+        NotificationCenter.default.addObserver(self, selector: #selector(handleAppActivation),
+                                               name: UIApplication.didBecomeActiveNotification, object: nil)
+    }
+
+    /// Tracks when the app goes to background.
+    ///
+    @objc func handleAppDeactivation() {
+        isAppActive = false
+    }
+
+    /// Call on `viewModel.onViewAppear` when the view appears due to coming from the background.
+    ///
+    @objc func handleAppActivation() {
+        // Avoid reloading if the view is not visible. The refresh will be handled in
+        // `viewWillAppear/onAppear` instead.
+        guard !isAppActive, viewIfLoaded?.window != nil else { return }
+        isAppActive = true
+        Task {
+            await viewModel.onViewAppear()
         }
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/StoreStats/PerformanceCardDataSyncUseCase.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/StoreStats/PerformanceCardDataSyncUseCase.swift
@@ -22,7 +22,7 @@ struct PerformanceCardDataSyncUseCase {
     /// Sync all stats needed for the performance card.
     ///
     @MainActor
-    func fetch() async throws {
+    func sync() async throws {
         let timeRange = await {
             guard let initialTimeRange = self.timeRange else {
                 return await loadLastTimeRange()

--- a/WooCommerce/Classes/ViewRelated/Dashboard/StoreStats/PerformanceCardDataSyncUseCase.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/StoreStats/PerformanceCardDataSyncUseCase.swift
@@ -1,0 +1,139 @@
+import Foundation
+import Yosemite
+
+/// Abstracts the code needed to sync the information for the Dashboard performance card.
+///
+struct PerformanceCardDataSyncUseCase {
+
+    let siteID: Int64
+    let siteTimezone: TimeZone
+    let timeRange: StatsTimeRangeV4?
+    let stores: StoresManager
+
+    /// The provided `timeRange` will be used. If non is provided, the last used one(stored in settings) will be used.
+    ///
+    init(siteID: Int64, siteTimezone: TimeZone, timeRange: StatsTimeRangeV4? = nil, stores: StoresManager = ServiceLocator.stores) {
+        self.siteID = siteID
+        self.siteTimezone = siteTimezone
+        self.timeRange = timeRange
+        self.stores = stores
+    }
+
+    /// Sync all stats needed for the performance card.
+    ///
+    @MainActor
+    func fetch() async throws {
+        let timeRange = await {
+            guard let initialTimeRange = self.timeRange else {
+                return await loadLastTimeRange()
+            }
+            return initialTimeRange
+        }()
+
+        try await syncAllStats(timeRange: timeRange)
+    }
+
+    /// Loads the last selected time range in any. If there isn't any returns the `.today` range.
+    ///
+    @MainActor
+    private func loadLastTimeRange() async -> StatsTimeRangeV4 {
+        await withCheckedContinuation { continuation in
+            let action = AppSettingsAction.loadLastSelectedPerformanceTimeRange(siteID: siteID) { timeRange in
+                continuation.resume(returning: timeRange ?? .today)
+            }
+            stores.dispatch(action)
+        }
+    }
+
+    /// Orchestrate all networks request needed for the performance card.
+    ///
+    @MainActor
+    private func syncAllStats(timeRange: StatsTimeRangeV4) async throws {
+        let currentDate = Date()
+        let latestDateToInclude = timeRange.latestDate(currentDate: currentDate, siteTimezone: siteTimezone)
+
+        try await withThrowingTaskGroup(of: Void.self) { group in
+            group.addTask {
+                try await self.syncStats(timeRange: timeRange, latestDateToInclude: latestDateToInclude)
+            }
+
+            group.addTask {
+                try await self.syncSiteVisitStats(timeRange: timeRange, latestDateToInclude: latestDateToInclude)
+            }
+
+            group.addTask {
+                try await self.syncSiteSummaryStats(timeRange: timeRange, latestDateToInclude: latestDateToInclude)
+            }
+
+            // rethrow any failure.
+            for try await _ in group {
+                // no-op if result doesn't throw any error
+            }
+        }
+
+        DashboardTimestampStore.saveTimestamp(.now, for: .performance, at: timeRange.timestampRange)
+    }
+
+    /// Syncs store stats for dashboard UI.
+    @MainActor
+    func syncStats(timeRange: StatsTimeRangeV4, latestDateToInclude: Date) async throws {
+        let earliestDateToInclude = timeRange.earliestDate(latestDate: latestDateToInclude, siteTimezone: siteTimezone)
+        try await withCheckedThrowingContinuation { continuation in
+            stores.dispatch(StatsActionV4.retrieveStats(siteID: siteID,
+                                                        timeRange: timeRange,
+                                                        timeZone: siteTimezone,
+                                                        earliestDateToInclude: earliestDateToInclude,
+                                                        latestDateToInclude: latestDateToInclude,
+                                                        quantity: timeRange.maxNumberOfIntervals,
+                                                        forceRefresh: true,
+                                                        onCompletion: { result in
+                continuation.resume(with: result)
+            }))
+        }
+    }
+
+    /// Syncs visitor stats for dashboard UI.
+    @MainActor
+    func syncSiteVisitStats(timeRange: StatsTimeRangeV4, latestDateToInclude: Date) async throws {
+        guard stores.isAuthenticatedWithoutWPCom == false else { // Visit stats are only available for stores connected to WPCom
+            return
+        }
+
+        try await withCheckedThrowingContinuation { continuation in
+            stores.dispatch(StatsActionV4.retrieveSiteVisitStats(siteID: siteID,
+                                                                 siteTimezone: siteTimezone,
+                                                                 timeRange: timeRange,
+                                                                 latestDateToInclude: latestDateToInclude,
+                                                                 onCompletion: { result in
+                if case let .failure(error) = result {
+                    DDLogError("⛔️ Error synchronizing visitor stats: \(error)")
+                }
+                continuation.resume(with: result)
+            }))
+        }
+    }
+
+    /// Syncs summary stats for dashboard UI.
+    @MainActor
+    func syncSiteSummaryStats(timeRange: StatsTimeRangeV4, latestDateToInclude: Date) async throws {
+        guard stores.isAuthenticatedWithoutWPCom == false else { // Summary stats are only available for stores connected to WPCom
+            return
+        }
+
+        try await withCheckedThrowingContinuation { continuation in
+            stores.dispatch(StatsActionV4.retrieveSiteSummaryStats(siteID: siteID,
+                                                                   siteTimezone: siteTimezone,
+                                                                   period: timeRange.summaryStatsGranularity,
+                                                                   quantity: 1,
+                                                                   latestDateToInclude: latestDateToInclude,
+                                                                   saveInStorage: true) { result in
+                if case let .failure(error) = result {
+                    DDLogError("⛔️ Error synchronizing summary stats: \(error)")
+                }
+
+                let voidResult = result.map { _ in () } // Caller expects no entity in the result.
+                continuation.resume(with: voidResult)
+            })
+        }
+    }
+}

--- a/WooCommerce/Classes/ViewRelated/Dashboard/StoreStats/StorePerformanceViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/StoreStats/StorePerformanceViewModel.swift
@@ -164,7 +164,7 @@ final class StorePerformanceViewModel: ObservableObject {
         analytics.track(event: .DynamicDashboard.cardLoadingStarted(type: .performance))
         do {
             currentDate = .now // Legacy code from when code was outside of `PerformanceCardDataSyncUseCase`
-            let syncUseCase = PerformanceCardDataSyncUseCase(siteID: siteID, siteTimezone: siteTimezone, timeRange: timeRange)
+            let syncUseCase = PerformanceCardDataSyncUseCase(siteID: siteID, siteTimezone: siteTimezone, timeRange: timeRange, stores: stores)
             try await syncUseCase.sync()
 
             trackDashboardStatsSyncComplete()

--- a/WooCommerce/Classes/ViewRelated/Dashboard/StoreStats/StorePerformanceViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/StoreStats/StorePerformanceViewModel.swift
@@ -163,7 +163,10 @@ final class StorePerformanceViewModel: ObservableObject {
         waitingTracker = WaitingTimeTracker(trackScenario: .dashboardMainStats)
         analytics.track(event: .DynamicDashboard.cardLoadingStarted(type: .performance))
         do {
-            try await syncAllStats()
+            currentDate = .now // Legacy code from when code was outside of `PerformanceCardDataSyncUseCase`
+            let syncUseCase = PerformanceCardDataSyncUseCase(siteID: siteID, siteTimezone: siteTimezone, timeRange: timeRange)
+            try await syncUseCase.sync()
+
             trackDashboardStatsSyncComplete()
             statsVersion = .v4
             switch timeRange {
@@ -422,96 +425,6 @@ private extension StorePerformanceViewModel {
 // MARK: - Syncing data
 //
 private extension StorePerformanceViewModel {
-    @MainActor
-    func syncAllStats() async throws {
-        currentDate = Date()
-        let latestDateToInclude = timeRange.latestDate(currentDate: currentDate, siteTimezone: siteTimezone)
-
-        try await withThrowingTaskGroup(of: Void.self) { group in
-            group.addTask { [weak self] in
-                try await self?.syncStats(latestDateToInclude: latestDateToInclude)
-            }
-
-            group.addTask { [weak self] in
-                try await self?.syncSiteVisitStats(latestDateToInclude: latestDateToInclude)
-            }
-
-            group.addTask { [weak self] in
-                try await self?.syncSiteSummaryStats(latestDateToInclude: latestDateToInclude)
-            }
-
-            // rethrow any failure.
-            for try await _ in group {
-                // no-op if result doesn't throw any error
-            }
-        }
-
-        DashboardTimestampStore.saveTimestamp(.now, for: .performance, at: timeRange.timestampRange)
-    }
-
-    /// Syncs store stats for dashboard UI.
-    @MainActor
-    func syncStats(latestDateToInclude: Date) async throws {
-        let earliestDateToInclude = timeRange.earliestDate(latestDate: latestDateToInclude, siteTimezone: siteTimezone)
-        try await withCheckedThrowingContinuation { continuation in
-            stores.dispatch(StatsActionV4.retrieveStats(siteID: siteID,
-                                                        timeRange: timeRange,
-                                                        timeZone: siteTimezone,
-                                                        earliestDateToInclude: earliestDateToInclude,
-                                                        latestDateToInclude: latestDateToInclude,
-                                                        quantity: timeRange.maxNumberOfIntervals,
-                                                        forceRefresh: true,
-                                                        onCompletion: { result in
-                continuation.resume(with: result)
-            }))
-        }
-    }
-
-    /// Syncs visitor stats for dashboard UI.
-    @MainActor
-    func syncSiteVisitStats(latestDateToInclude: Date) async throws {
-        guard stores.isAuthenticatedWithoutWPCom == false else { // Visit stats are only available for stores connected to WPCom
-            return
-        }
-
-        try await withCheckedThrowingContinuation { continuation in
-            stores.dispatch(StatsActionV4.retrieveSiteVisitStats(siteID: siteID,
-                                                                 siteTimezone: siteTimezone,
-                                                                 timeRange: timeRange,
-                                                                 latestDateToInclude: latestDateToInclude,
-                                                                 onCompletion: { result in
-                if case let .failure(error) = result {
-                    DDLogError("⛔️ Error synchronizing visitor stats: \(error)")
-                }
-                continuation.resume(with: result)
-            }))
-        }
-    }
-
-    /// Syncs summary stats for dashboard UI.
-    @MainActor
-    func syncSiteSummaryStats(latestDateToInclude: Date) async throws {
-        guard stores.isAuthenticatedWithoutWPCom == false else { // Summary stats are only available for stores connected to WPCom
-            return
-        }
-
-        try await withCheckedThrowingContinuation { continuation in
-            stores.dispatch(StatsActionV4.retrieveSiteSummaryStats(siteID: siteID,
-                                                                   siteTimezone: siteTimezone,
-                                                                   period: timeRange.summaryStatsGranularity,
-                                                                   quantity: 1,
-                                                                   latestDateToInclude: latestDateToInclude,
-                                                                   saveInStorage: true) { result in
-                   if case let .failure(error) = result {
-                       DDLogError("⛔️ Error synchronizing summary stats: \(error)")
-                   }
-
-                   let voidResult = result.map { _ in () } // Caller expects no entity in the result.
-                continuation.resume(with: voidResult)
-               })
-        }
-    }
-
     private func handleSyncError(error: Error) {
         switch error {
         case let siteStatsStoreError as SiteStatsStoreError:

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -1090,6 +1090,7 @@
 		26ED9660274328BC00FA00A1 /* SimplePaymentsSummaryViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26ED965F274328BC00FA00A1 /* SimplePaymentsSummaryViewModel.swift */; };
 		26EE795F2AA795A000857293 /* Networking.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = B5C3B5E220D189E60072CB9D /* Networking.framework */; };
 		26EE79602AA795EC00857293 /* WooConstants.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5D1AFBF20BC67C200DB0E8C /* WooConstants.swift */; };
+		26F115AD2C4997EA0019CD73 /* PerformanceCardDataSyncUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26F115AC2C4997EA0019CD73 /* PerformanceCardDataSyncUseCase.swift */; };
 		26F300902B33C71B00EDE717 /* TwoFAScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26F3008F2B33C71B00EDE717 /* TwoFAScreen.swift */; };
 		26F65C9825DEDAF0008FAE29 /* GenerateVariationUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26F65C9725DEDAF0008FAE29 /* GenerateVariationUseCase.swift */; };
 		26F65C9E25DEDE67008FAE29 /* GenerateVariationUseCaseTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26F65C9D25DEDE67008FAE29 /* GenerateVariationUseCaseTests.swift */; };
@@ -4063,6 +4064,7 @@
 		26E7EE7329365F0700793045 /* TopPerformersView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TopPerformersView.swift; sourceTree = "<group>"; };
 		26ED965F274328BC00FA00A1 /* SimplePaymentsSummaryViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SimplePaymentsSummaryViewModel.swift; sourceTree = "<group>"; };
 		26EE795E2AA7924700857293 /* NotificationExtension.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = NotificationExtension.entitlements; sourceTree = "<group>"; };
+		26F115AC2C4997EA0019CD73 /* PerformanceCardDataSyncUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PerformanceCardDataSyncUseCase.swift; sourceTree = "<group>"; };
 		26F3008F2B33C71B00EDE717 /* TwoFAScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TwoFAScreen.swift; sourceTree = "<group>"; };
 		26F65C9725DEDAF0008FAE29 /* GenerateVariationUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GenerateVariationUseCase.swift; sourceTree = "<group>"; };
 		26F65C9D25DEDE67008FAE29 /* GenerateVariationUseCaseTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GenerateVariationUseCaseTests.swift; sourceTree = "<group>"; };
@@ -12630,6 +12632,7 @@
 				DED0392C2BC7DAFD005D0571 /* StatsTimeRangePicker.swift */,
 				DED039282BC7A04B005D0571 /* StorePerformanceView.swift */,
 				DED0392A2BC7A076005D0571 /* StorePerformanceViewModel.swift */,
+				26F115AC2C4997EA0019CD73 /* PerformanceCardDataSyncUseCase.swift */,
 				DEA6BCAE2BC6A9B10017D671 /* StoreStatsChart.swift */,
 				DEA6BCB02BC6AA040017D671 /* StoreStatsChartViewModel.swift */,
 			);
@@ -15717,6 +15720,7 @@
 				205E79402C1CA213001BA266 /* PointOfSaleCardPresentPaymentMessageType.swift in Sources */,
 				B554E1792152F20000F31188 /* UINavigationBar+Appearance.swift in Sources */,
 				26AE31B0251E602D004B1BCE /* RefundShippingDetailsTableViewCell.swift in Sources */,
+				26F115AD2C4997EA0019CD73 /* PerformanceCardDataSyncUseCase.swift in Sources */,
 				020732062988AC4D000A53C2 /* DomainContactInfoFormViewModel.swift in Sources */,
 				68E4E8B52C0EF39D00CFA0C3 /* PreviewHelpers.swift in Sources */,
 				EE8B42092BF668540077C4E7 /* MostActiveCouponRow.swift in Sources */,

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -1091,6 +1091,7 @@
 		26EE795F2AA795A000857293 /* Networking.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = B5C3B5E220D189E60072CB9D /* Networking.framework */; };
 		26EE79602AA795EC00857293 /* WooConstants.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5D1AFBF20BC67C200DB0E8C /* WooConstants.swift */; };
 		26F115AD2C4997EA0019CD73 /* PerformanceCardDataSyncUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26F115AC2C4997EA0019CD73 /* PerformanceCardDataSyncUseCase.swift */; };
+		26F115AF2C49A9250019CD73 /* DashboardSyncBackgroundTask.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26F115AE2C49A9250019CD73 /* DashboardSyncBackgroundTask.swift */; };
 		26F300902B33C71B00EDE717 /* TwoFAScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26F3008F2B33C71B00EDE717 /* TwoFAScreen.swift */; };
 		26F65C9825DEDAF0008FAE29 /* GenerateVariationUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26F65C9725DEDAF0008FAE29 /* GenerateVariationUseCase.swift */; };
 		26F65C9E25DEDE67008FAE29 /* GenerateVariationUseCaseTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26F65C9D25DEDE67008FAE29 /* GenerateVariationUseCaseTests.swift */; };
@@ -4065,6 +4066,7 @@
 		26ED965F274328BC00FA00A1 /* SimplePaymentsSummaryViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SimplePaymentsSummaryViewModel.swift; sourceTree = "<group>"; };
 		26EE795E2AA7924700857293 /* NotificationExtension.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = NotificationExtension.entitlements; sourceTree = "<group>"; };
 		26F115AC2C4997EA0019CD73 /* PerformanceCardDataSyncUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PerformanceCardDataSyncUseCase.swift; sourceTree = "<group>"; };
+		26F115AE2C49A9250019CD73 /* DashboardSyncBackgroundTask.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DashboardSyncBackgroundTask.swift; sourceTree = "<group>"; };
 		26F3008F2B33C71B00EDE717 /* TwoFAScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TwoFAScreen.swift; sourceTree = "<group>"; };
 		26F65C9725DEDAF0008FAE29 /* GenerateVariationUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GenerateVariationUseCase.swift; sourceTree = "<group>"; };
 		26F65C9D25DEDE67008FAE29 /* GenerateVariationUseCaseTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GenerateVariationUseCaseTests.swift; sourceTree = "<group>"; };
@@ -8163,6 +8165,7 @@
 			children = (
 				26BCA03F2C35E9A9000BE96C /* BackgroundTaskRefreshDispatcher.swift */,
 				26BCA0412C35EDBF000BE96C /* OrderListSyncBackgroundTask.swift */,
+				26F115AE2C49A9250019CD73 /* DashboardSyncBackgroundTask.swift */,
 				26DDA4A82C4839B8005FBEBF /* DashboardTimestampStore.swift */,
 			);
 			path = BackgroundTasks;
@@ -16116,6 +16119,7 @@
 				4590B6A8261F0F8300A6FCE0 /* SegmentedView.swift in Sources */,
 				DE77889826FCA39B008DFF44 /* TitleAndSubtitleRow.swift in Sources */,
 				B6930BDA293FD1EE00C6FFDB /* AnalyticsHubLastQuarterRangeData.swift in Sources */,
+				26F115AF2C49A9250019CD73 /* DashboardSyncBackgroundTask.swift in Sources */,
 				02DE5CA9279F857D007CBEF3 /* Double+Rounding.swift in Sources */,
 				02A65301246AA63600755A01 /* ProductDetailsFactory.swift in Sources */,
 				D449C51D26DE6B5000D75B02 /* LargeTitle.swift in Sources */,


### PR DESCRIPTION
Closes: #13369

# Why

This PR adds the ability to refresh the performance card data with a background update task.

# How
- Abstracts the code needed to sync the information for the Dashboard performance card.
- Update the performance card view model to sync data using the new use case
- Add background task for the performance card.
- Make sure dashboard cards are reloaded when coming from the background.

# Demo

https://github.com/user-attachments/assets/871da236-8e8b-44ab-b239-098a7c03a537

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
