### PR TITLE
[GLA Analytics] Add UI for Google Campaigns call to action

### DIFF
--- a/WooCommerce/Classes/Analytics/WooAnalyticsEvent+GoogleAds.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsEvent+GoogleAds.swift
@@ -5,6 +5,7 @@ extension WooAnalyticsEvent {
         enum Source: String {
             case moreMenu = "more_menu"
             case myStore = "my_store"
+            case analyticsHub = "analytics_hub"
         }
 
         enum FlowType: String {

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/AnalyticsHubView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/AnalyticsHubView.swift
@@ -6,6 +6,8 @@ import SwiftUI
 ///
 final class AnalyticsHubHostingViewController: UIHostingController<AnalyticsHubView> {
 
+    private let viewModel: AnalyticsHubViewModel
+
     /// Presents an error notice in the tab bar context after this `self` is dismissed.
     ///
     private let systemNoticePresenter: NoticePresenter
@@ -15,20 +17,25 @@ final class AnalyticsHubHostingViewController: UIHostingController<AnalyticsHubV
     ///
     var notice: Notice?
 
+    /// Coordinator to handle Google Ads campaign creation.
+    private var googleAdsCampaignCoordinator: GoogleAdsCampaignCoordinator?
+
     init(siteID: Int64,
          timeZone: TimeZone,
          timeRange: StatsTimeRangeV4,
          systemNoticePresenter: NoticePresenter = ServiceLocator.noticePresenter,
          usageTracksEventEmitter: StoreStatsUsageTracksEventEmitter) {
-        let viewModel = AnalyticsHubViewModel(siteID: siteID, timeZone: timeZone, statsTimeRange: timeRange, usageTracksEventEmitter: usageTracksEventEmitter)
+        self.viewModel = AnalyticsHubViewModel(siteID: siteID, timeZone: timeZone, statsTimeRange: timeRange, usageTracksEventEmitter: usageTracksEventEmitter)
         self.systemNoticePresenter = systemNoticePresenter
-        super.init(rootView: AnalyticsHubView(viewModel: viewModel))
+        super.init(rootView: AnalyticsHubView(viewModel: self.viewModel))
 
         // Needed to pop the hosting controller from within the SwiftUI view
         rootView.dismissWithNotice = { [weak self] notice in
             self?.notice = notice
             self?.navigationController?.popViewController(animated: true)
         }
+
+        configureGoogleAdsCard()
     }
 
     @available(*, unavailable)
@@ -44,6 +51,48 @@ final class AnalyticsHubHostingViewController: UIHostingController<AnalyticsHubV
     }
 }
 
+// MARK: Google Ads campaigns
+private extension AnalyticsHubHostingViewController {
+    func configureGoogleAdsCard() {
+        rootView.onCreateNewGoogleAdsCampaign = { [weak self] in
+            self?.startGoogleAdsCampaignCreation()
+        }
+    }
+
+    /// Initializes a `GoogleAdsCampaignCoordinator` to handle campaign creation.
+    ///
+    func startGoogleAdsCampaignCreation() {
+        guard let site = viewModel.stores.sessionManager.defaultSite,
+              let navigationController else {
+            return
+        }
+
+        let coordinator = GoogleAdsCampaignCoordinator(
+            siteID: viewModel.siteID,
+            siteAdminURL: site.adminURLWithFallback()?.absoluteString ?? site.adminURL,
+            source: .analyticsHub,
+            shouldStartCampaignCreation: true,
+            shouldAuthenticateAdminPage: viewModel.stores.shouldAuthenticateAdminPage(for: site),
+            navigationController: navigationController,
+            onCompletion: { [weak self] createdNewCampaign in
+                if createdNewCampaign {
+                    Task { @MainActor in
+                        await self?.viewModel.updateData(for: [.googleCampaigns])
+                    }
+                }
+            }
+        )
+        coordinator.start()
+        googleAdsCampaignCoordinator = coordinator
+
+        viewModel.analytics.track(event: .GoogleAds.entryPointTapped(
+            source: .analyticsHub,
+            type: .campaignCreation,
+            hasCampaigns: viewModel.googleCampaignsCard.hasPaidCampaigns
+        ))
+    }
+}
+
 /// Main Analytics Hub View
 ///
 struct AnalyticsHubView: View {
@@ -55,6 +104,9 @@ struct AnalyticsHubView: View {
     /// Needed because we need access to the UIHostingController `popViewController` method.
     ///
     var dismissWithNotice: ((Notice) -> Void) = { _ in }
+
+    /// Set this closure with UIKit code to create a new Google Ads campaign.
+    var onCreateNewGoogleAdsCampaign: (() -> Void)?
 
     @StateObject var viewModel: AnalyticsHubViewModel
 

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/AnalyticsHubView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/AnalyticsHubView.swift
@@ -186,7 +186,10 @@ private extension AnalyticsHubView {
         case .giftCards:
             AnalyticsReportCard(viewModel: viewModel.giftCardsCard)
         case .googleCampaigns:
-            GoogleAdsCampaignReportCard(viewModel: viewModel.googleCampaignsCard)
+            GoogleAdsCampaignReportCard(viewModel: viewModel.googleCampaignsCard,
+                                        onCreateNewCampaign: {
+                onCreateNewGoogleAdsCampaign?()
+            })
         }
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/AnalyticsHubViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/AnalyticsHubViewModel.swift
@@ -9,11 +9,11 @@ import protocol WooFoundation.Analytics
 ///
 final class AnalyticsHubViewModel: ObservableObject {
 
-    private let siteID: Int64
-    private let stores: StoresManager
+    let siteID: Int64
+    let stores: StoresManager
     private let storage: StorageManagerType
     private let timeZone: TimeZone
-    private let analytics: Analytics
+    let analytics: Analytics
 
     private var subscriptions = Set<AnyCancellable>()
 

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/Report Cards/AnalyticsCTACard.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/Report Cards/AnalyticsCTACard.swift
@@ -22,7 +22,7 @@ struct AnalyticsCTACard: View {
 
     /// Action for the call to action button
     ///
-    let buttonAction: () async -> Void
+    let buttonAction: () -> Void
 
     var body: some View {
         VStack(alignment: .leading, spacing: Layout.titleSpacing) {
@@ -35,9 +35,7 @@ struct AnalyticsCTACard: View {
                 .bodyStyle()
 
             Button {
-                Task { @MainActor in
-                    await buttonAction()
-                }
+                buttonAction()
             } label: {
                 Text(buttonLabel)
             }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/Report Cards/AnalyticsSessionsReportCard.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/Report Cards/AnalyticsSessionsReportCard.swift
@@ -13,9 +13,11 @@ struct AnalyticsSessionsReportCard: View {
                              message: Localization.sessionsCTAMessage,
                              buttonLabel: Localization.sessionsCTAButton,
                              isLoading: $isEnablingJetpackStats) {
-                isEnablingJetpackStats = true
-                await viewModel.enableJetpackStats()
-                isEnablingJetpackStats = false
+                Task { @MainActor in
+                    isEnablingJetpackStats = true
+                    await viewModel.enableJetpackStats()
+                    isEnablingJetpackStats = false
+                }
             }.onAppear {
                 viewModel.trackJetpackStatsCTAShown()
             }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/Report Cards/GoogleAdsCampaignReportCard.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/Report Cards/GoogleAdsCampaignReportCard.swift
@@ -9,51 +9,62 @@ struct GoogleAdsCampaignReportCard: View {
     /// View model to drive the view content.
     @ObservedObject var viewModel: GoogleAdsCampaignReportCardViewModel
 
+    /// Closure to perform when new Google Ads campaign is created.
+    let onCreateNewCampaign: () -> Void
+
     var body: some View {
-        VStack(alignment: .leading) {
+        if viewModel.showCampaignCTA {
+            AnalyticsCTACard(title: Localization.title,
+                             message: Localization.CallToAction.message,
+                             buttonLabel: Localization.CallToAction.button,
+                             isLoading: .constant(false),
+                             buttonAction: onCreateNewCampaign)
+        } else {
+            VStack(alignment: .leading) {
 
-            Text(Localization.title)
-                .foregroundColor(Color(.text))
-                .footnoteStyle()
+                Text(Localization.title)
+                    .foregroundColor(Color(.text))
+                    .footnoteStyle()
 
-            StatSelectionBar(allStats: viewModel.allStats, titleKeyPath: \.displayName, onSelection: viewModel.onSelection, selectedStat: $viewModel.selectedStat)
-                .padding(.top, Layout.titleSpacing)
-                .padding(.bottom, Layout.columnSpacing)
+                StatSelectionBar(allStats: viewModel.allStats, titleKeyPath: \.displayName, onSelection: viewModel.onSelection, selectedStat: $viewModel.selectedStat)
+                    .padding(.top, Layout.titleSpacing)
+                    .padding(.bottom, Layout.columnSpacing)
 
-            HStack {
-                Text(viewModel.statValue)
-                    .titleStyle()
-                    .frame(maxWidth: .infinity, alignment: .leading)
+                HStack {
+                    Text(viewModel.statValue)
+                        .titleStyle()
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                        .redacted(reason: viewModel.isRedacted ? .placeholder : [])
+                        .shimmering(active: viewModel.isRedacted)
+
+                    DeltaTag(value: viewModel.deltaValue,
+                             backgroundColor: viewModel.deltaBackgroundColor,
+                             textColor: viewModel.deltaTextColor)
                     .redacted(reason: viewModel.isRedacted ? .placeholder : [])
                     .shimmering(active: viewModel.isRedacted)
+                }
 
-                DeltaTag(value: viewModel.deltaValue,
-                         backgroundColor: viewModel.deltaBackgroundColor,
-                         textColor: viewModel.deltaTextColor)
-                    .redacted(reason: viewModel.isRedacted ? .placeholder : [])
-                    .shimmering(active: viewModel.isRedacted)
-            }
-
-            TopPerformersView(itemTitle: Localization.campaignsTitle.localizedCapitalized,
-                              valueTitle: viewModel.selectedStat.displayName,
-                              rows: viewModel.campaignsData,
-                              isRedacted: viewModel.isRedacted)
+                TopPerformersView(itemTitle: Localization.campaignsTitle.localizedCapitalized,
+                                  valueTitle: viewModel.selectedStat.displayName,
+                                  rows: viewModel.campaignsData,
+                                  isRedacted: viewModel.isRedacted)
                 .padding(.vertical, Layout.columnSpacing)
                 .renderedIf(!viewModel.showCampaignsError)
 
-            if viewModel.showCampaignsError {
-                Text(Localization.errorMessage)
-                    .foregroundColor(Color(.text))
-                    .subheadlineStyle()
-                    .frame(maxWidth: .infinity, alignment: .leading)
-                    .padding(.vertical, Layout.columnSpacing)
-            }
+                if viewModel.showCampaignsError {
+                    Text(Localization.errorMessage)
+                        .foregroundColor(Color(.text))
+                        .subheadlineStyle()
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                        .padding(.vertical, Layout.columnSpacing)
+                }
 
-            if let reportViewModel = viewModel.reportViewModel {
-                AnalyticsReportLink(showingWebReport: $showingWebReport, reportViewModel: reportViewModel)
+                if let reportViewModel = viewModel.reportViewModel {
+                    AnalyticsReportLink(showingWebReport: $showingWebReport, reportViewModel: reportViewModel)
+                }
             }
+            .padding(Layout.cardPadding)
         }
-        .padding(Layout.cardPadding)
     }
 }
 
@@ -75,6 +86,15 @@ private extension GoogleAdsCampaignReportCard {
         static let errorMessage = NSLocalizedString("analyticsHub.googleCampaigns.noCampaignStats",
                                                     value: "Unable to load Google campaigns analytics",
                                                     comment: "Text displayed when there is an error loading Google Ads campaigns stats data.")
+
+        enum CallToAction {
+            static let message = NSLocalizedString("analyticsHub.googleCampaignsCTA.message",
+                                                   value: "Drive sales and generate more traffic with Google Ads.",
+                                                   comment: "Text displayed in the Analytics Hub when there are no Google Ads campaign analytics.")
+            static let button = NSLocalizedString("analyticsHub.googleCampaignCTA.button",
+                                                  value: "Add paid campaign",
+                                                  comment: "Label for button to create a paid Google Ads campaign.")
+        }
     }
 }
 
@@ -87,7 +107,7 @@ struct GoogleAdsCampaignReportCardPreviews: PreviewProvider {
                                                              timeRange: .today,
                                                              usageTracksEventEmitter: StoreStatsUsageTracksEventEmitter(),
                                                              storeAdminURL: "https://woocommerce.com")
-        GoogleAdsCampaignReportCard(viewModel: viewModel)
+        GoogleAdsCampaignReportCard(viewModel: viewModel, onCreateNewCampaign: {})
             .addingTopAndBottomDividers()
             .previewLayout(.sizeThatFits)
 
@@ -96,7 +116,7 @@ struct GoogleAdsCampaignReportCardPreviews: PreviewProvider {
                                                                   timeRange: .today,
                                                                   usageTracksEventEmitter: StoreStatsUsageTracksEventEmitter(),
                                                                   storeAdminURL: "https://woocommerce.com")
-        GoogleAdsCampaignReportCard(viewModel: emptyViewModel)
+        GoogleAdsCampaignReportCard(viewModel: emptyViewModel, onCreateNewCampaign: {})
             .addingTopAndBottomDividers()
             .previewLayout(.sizeThatFits)
             .previewDisplayName("No data")

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/Report Cards/GoogleAdsCampaignReportCard.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/Report Cards/GoogleAdsCampaignReportCard.swift
@@ -19,6 +19,9 @@ struct GoogleAdsCampaignReportCard: View {
                              buttonLabel: Localization.CallToAction.button,
                              isLoading: .constant(false),
                              buttonAction: onCreateNewCampaign)
+            .onAppear(perform: {
+                viewModel.onDisplayCallToAction()
+            })
         } else {
             VStack(alignment: .leading) {
 

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/Report Cards/GoogleAdsCampaignReportCard.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/Report Cards/GoogleAdsCampaignReportCard.swift
@@ -29,7 +29,10 @@ struct GoogleAdsCampaignReportCard: View {
                     .foregroundColor(Color(.text))
                     .footnoteStyle()
 
-                StatSelectionBar(allStats: viewModel.allStats, titleKeyPath: \.displayName, onSelection: viewModel.onSelection, selectedStat: $viewModel.selectedStat)
+                StatSelectionBar(allStats: viewModel.allStats,
+                                 titleKeyPath: \.displayName,
+                                 onSelection: viewModel.onSelection,
+                                 selectedStat: $viewModel.selectedStat)
                     .padding(.top, Layout.titleSpacing)
                     .padding(.bottom, Layout.columnSpacing)
 

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/Report Cards/GoogleAdsCampaignReportCard.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/Report Cards/GoogleAdsCampaignReportCard.swift
@@ -17,7 +17,7 @@ struct GoogleAdsCampaignReportCard: View {
             AnalyticsCTACard(title: Localization.title,
                              message: Localization.CallToAction.message,
                              buttonLabel: Localization.CallToAction.button,
-                             isLoading: .constant(false),
+                             isLoading: .constant(false), // No loading indicator needed
                              buttonAction: onCreateNewCampaign)
             .onAppear(perform: {
                 viewModel.onDisplayCallToAction()

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/Report Cards/GoogleAdsCampaignReportCardViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/Report Cards/GoogleAdsCampaignReportCardViewModel.swift
@@ -160,6 +160,21 @@ extension GoogleAdsCampaignReportCardViewModel {
     }
 }
 
+// MARK: Google Ads Campaign Creation
+extension GoogleAdsCampaignReportCardViewModel {
+    /// Whether to show the call to action to create a new campaign.
+    ///
+    var showCampaignCTA: Bool {
+        false // TODO-13368: Add logic for when to show the call to action
+    }
+
+    /// Whether there are paid campaigns to display.
+    ///
+    var hasPaidCampaigns: Bool {
+        campaignsData.isNotEmpty
+    }
+}
+
 // MARK: Constants
 private extension GoogleAdsCampaignReportCardViewModel {
     enum Localization {

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/Report Cards/GoogleAdsCampaignReportCardViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/Report Cards/GoogleAdsCampaignReportCardViewModel.swift
@@ -173,6 +173,12 @@ extension GoogleAdsCampaignReportCardViewModel {
     var hasPaidCampaigns: Bool {
         campaignsData.isNotEmpty
     }
+
+    /// Tracks when the call to action is displayed.
+    ///
+    func onDisplayCallToAction() {
+        analytics.track(event: .GoogleAds.entryPointDisplayed(source: .analyticsHub))
+    }
 }
 
 // MARK: Constants

--- a/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Analytics Hub/Report Cards/GoogleAdsCampaignReportCardViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Analytics Hub/Report Cards/GoogleAdsCampaignReportCardViewModelTests.swift
@@ -158,4 +158,20 @@ final class GoogleAdsCampaignReportCardViewModelTests: XCTestCase {
         assertEqual("$200", firstCampaign.value)
     }
 
+    func test_onDisplayCallToAction_tracks_expected_event() throws {
+        // Given
+        let vm = GoogleAdsCampaignReportCardViewModel(currentPeriodStats: nil,
+                                                      previousPeriodStats: nil,
+                                                      timeRange: .today,
+                                                      usageTracksEventEmitter: eventEmitter,
+                                                      analytics: analytics)
+
+        // When
+        vm.onDisplayCallToAction()
+
+        // Then
+        assertEqual(["googleads_entry_point_displayed"], analyticsProvider.receivedEvents)
+        let sourceProperty = try XCTUnwrap(analyticsProvider.receivedProperties.first?["source"] as? String)
+        assertEqual("analytics_hub", sourceProperty)
+    }
 }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #13383
<!-- Id number of the GitHub issue this PR addresses. -->

## Why
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
We want to add a call to action to create a paid campaign on the Google Campaigns analytics card, when there are no campaigns to display. This adds the UI for that call to action.

Note: We haven't yet implemented the logic for displaying the call to action, so for now it won't be shown.

## How
* Integrates the `GoogleAdsCampaignCoordinator` into the Analytics Hub, for showing the campaign creation flow:
   * Adds `analytics_hub` as a source for campaign creation, for Tracks events.
   * Adds the coordinator to `AnalyticsHubHostingViewController`, so it can start the campaign creation flow with UIKit. The coordinator is configured to track the analytics hub as the source, and if a campaign is successfully created it will reload the Google Campaigns card.
   * Adds the closure `onCreateNewGoogleAdsCampaign` to start the coordinator.
   * Tracks when the call to action is tapped (checking a new property `hasPaidCampaigns` from the card view model to set the appropriate `hasCampaigns` custom prop on the event).
* Adds the call to action UI to `GoogleAdsCampaignReportCard`:
   * Shows an `AnalyticsCTACard` if the view model `showCampaignCTA` property is true. (For now, that property is always false.)
   * Tracks when the call to action is displayed.
* Updates `AnalyticsCTACard` to support synchronous methods for the button action.

## Testing steps
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->

Prerequisite: The Google Listings & Ads extension should be activated and set up, with Google Ads connected. You can manually set `showCampaignCTA` in the card view model to `true` to test the new call to action UI.

1. Build and run the app.
2. Select "View all store analytics" on a dashboard card to open the Analytics Hub.
3. Confirm the Google Campaigns card appears with the call to action.
4. Tap on "Add paid campaign" and confirm a web view appears to start the campaign creation flow.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->
Call to action|Campaign creation
-|-
![Simulator Screenshot - iPhone 15 Plus - 2024-07-22 at 10 58 38](https://github.com/user-attachments/assets/ba279509-8d54-4fcc-88ce-33e7587b36da)|![Simulator Screenshot - iPhone 15 Plus - 2024-07-22 at 10 58 45](https://github.com/user-attachments/assets/311819da-0779-4fe3-8770-eee36b42d386)

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.