### PR TITLE
Disable checkout button if there are no items in cart

### DIFF
--- a/WooCommerce/Classes/POS/Presentation/CartView.swift
+++ b/WooCommerce/Classes/POS/Presentation/CartView.swift
@@ -127,6 +127,7 @@ private extension CartView {
         }
         .buttonStyle(.borderedProminent)
         .tint(Color.primaryTint)
+        .disabled(cartViewModel.itemsInCart.isEmpty)
     }
 
     var addMoreButton: some View {


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

Minor fix to disable checkout button in POS if there are no items in cart. I have a feeling we already had it like that before but maybe we lost it in one of the merges.

## Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: https://woomobilep2.wordpress.com/2024/05/06/woocommerce-mobile-quality-report-march-april/#comment-12036 -->

- Enter POS
- You should see the cart view but the Checkout button should be disabled
- Add few products in the cart
- Now the Checkout button should be enabled
- Remove items from the cart
- Checkout button should be disabled

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

![Simulator Screenshot - iPad Pro (11-inch) (4th generation) 17 2 - 2024-07-22 at 12 54 45](https://github.com/user-attachments/assets/e25654b9-96bd-4f94-90a6-e133c8706a70)

![Simulator Screenshot - iPad Pro (11-inch) (4th generation) 17 2 - 2024-07-22 at 12 54 42](https://github.com/user-attachments/assets/ab944a2a-5d36-43c6-9fff-f8f1354a731d)

---
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
