### PR TITLE
[GLA Analytics] Display Google Campaigns call to action when no there are no campaigns in the selected time range

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -2,7 +2,7 @@
 
 19.7
 -----
-
+- [*] Stats: The Google Campaign analytics card now has a call to action to create a paid campaign if there are no campaign analytics for the selected time period. [https://github.com/woocommerce/woocommerce-ios/pull/13397]
 
 19.6
 -----

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/AnalyticsHubView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/AnalyticsHubView.swift
@@ -77,7 +77,7 @@ private extension AnalyticsHubHostingViewController {
             onCompletion: { [weak self] createdNewCampaign in
                 if createdNewCampaign {
                     Task { @MainActor in
-                        await self?.viewModel.updateData(for: [.googleCampaigns])
+                        await self?.viewModel.googleCampaignsCard.onGoogleCampaignCreated()
                     }
                 }
             }
@@ -88,7 +88,7 @@ private extension AnalyticsHubHostingViewController {
         viewModel.analytics.track(event: .GoogleAds.entryPointTapped(
             source: .analyticsHub,
             type: .campaignCreation,
-            hasCampaigns: viewModel.googleCampaignsCard.hasPaidCampaigns
+            hasCampaigns: viewModel.googleCampaignsCard.campaignsData.isNotEmpty
         ))
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/Report Cards/GoogleAdsCampaignReportCardViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/Report Cards/GoogleAdsCampaignReportCardViewModel.swift
@@ -14,7 +14,7 @@ final class GoogleAdsCampaignReportCardViewModel: ObservableObject {
     ///
     private let googleAdsEligibilityChecker: GoogleAdsEligibilityChecker
 
-    /// Whether the store is eligible for Google Ads campaign creation.
+    /// Whether the store is eligible for Google Ads campaign creation. Optimistically defaults to `true`, to show loading view while checking eligibility.
     ///
     @Published private(set) var isEligibleForGoogleAds: Bool = true
 
@@ -221,7 +221,7 @@ extension GoogleAdsCampaignReportCardViewModel {
     /// Whether to show the call to action to create a new campaign.
     ///
     var showCampaignCTA: Bool {
-        false // TODO-13368: Add logic for when to show the call to action
+        !hasPaidCampaigns && isEligibleForGoogleAds
     }
 
     /// Whether there are paid campaigns to display.

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/Report Cards/GoogleAdsCampaignReportCardViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/Report Cards/GoogleAdsCampaignReportCardViewModel.swift
@@ -221,7 +221,10 @@ extension GoogleAdsCampaignReportCardViewModel {
     /// Whether to show the call to action to create a new campaign.
     ///
     var showCampaignCTA: Bool {
-        !hasPaidCampaigns && isEligibleForGoogleAds
+        guard !isRedacted, !showCampaignsError else {
+            return false
+        }
+        return isEligibleForGoogleAds && !hasPaidCampaigns
     }
 
     /// Whether there are paid campaigns to display.

--- a/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Analytics Hub/Report Cards/GoogleAdsCampaignReportCardViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Analytics Hub/Report Cards/GoogleAdsCampaignReportCardViewModelTests.swift
@@ -222,6 +222,135 @@ final class GoogleAdsCampaignReportCardViewModelTests: XCTestCase {
         let sourceProperty = try XCTUnwrap(analyticsProvider.receivedProperties.first?["source"] as? String)
         assertEqual("analytics_hub", sourceProperty)
     }
+
+    func test_showCampaignsCTA_is_false_when_card_is_loading() async {
+        // Given
+        var showCampaignCTAWhileLoading: Bool?
+        let vm = GoogleAdsCampaignReportCardViewModel(siteID: sampleSiteID,
+                                                      timeRange: .today,
+                                                      usageTracksEventEmitter: eventEmitter,
+                                                      stores: stores,
+                                                      googleAdsEligibilityChecker: MockGoogleAdsEligibilityChecker(isEligible: true))
+        stores.whenReceivingAction(ofType: GoogleAdsAction.self) { action in
+            switch action {
+            case let .retrieveCampaignStats(_, _, _, _, _, onCompletion):
+                showCampaignCTAWhileLoading = vm.showCampaignCTA
+                onCompletion(.success(.fake()))
+            default:
+                break
+            }
+        }
+
+        // When
+        await vm.reload()
+
+        // Then
+        assertEqual(false, showCampaignCTAWhileLoading)
+    }
+
+    func test_showCampaignsCTA_is_false_when_card_has_loading_error() async {
+        // Given
+        let vm = GoogleAdsCampaignReportCardViewModel(siteID: sampleSiteID,
+                                                      timeRange: .today,
+                                                      usageTracksEventEmitter: eventEmitter,
+                                                      stores: stores,
+                                                      googleAdsEligibilityChecker: MockGoogleAdsEligibilityChecker(isEligible: true))
+        stores.whenReceivingAction(ofType: GoogleAdsAction.self) { action in
+            switch action {
+            case let .retrieveCampaignStats(_, _, _, _, _, onCompletion):
+                onCompletion(.failure(NSError(domain: "", code: 0)))
+            default:
+                break
+            }
+        }
+
+        // When
+        await vm.reload()
+
+        // Then
+        XCTAssertFalse(vm.showCampaignCTA)
+    }
+
+    func test_showCampaignsCTA_is_false_when_card_has_campaigns_data() async {
+        // Given
+        let vm = GoogleAdsCampaignReportCardViewModel(siteID: sampleSiteID,
+                                                      timeRange: .today,
+                                                      usageTracksEventEmitter: eventEmitter,
+                                                      stores: stores,
+                                                      googleAdsEligibilityChecker: MockGoogleAdsEligibilityChecker(isEligible: true))
+        stores.whenReceivingAction(ofType: GoogleAdsAction.self) { action in
+            switch action {
+            case let .retrieveCampaignStats(_, _, _, _, _, onCompletion):
+                onCompletion(.success(.fake().copy(campaigns: [.fake()])))
+            default:
+                break
+            }
+        }
+
+        // When
+        await vm.reload()
+
+        // Then
+        XCTAssertFalse(vm.showCampaignCTA)
+    }
+
+    func test_showCampaignsCTA_is_false_when_store_is_ineligible_for_Google_Ads() {
+        // Given
+        let vm = GoogleAdsCampaignReportCardViewModel(siteID: sampleSiteID,
+                                                      timeRange: .today,
+                                                      usageTracksEventEmitter: eventEmitter,
+                                                      stores: stores,
+                                                      googleAdsEligibilityChecker: MockGoogleAdsEligibilityChecker(isEligible: false))
+
+        // Then
+        XCTAssertFalse(vm.showCampaignCTA)
+    }
+
+    func test_showCampaignsCTA_is_true_when_eligible_for_Google_Ads_and_no_campaigns_in_stats() async {
+        // Given
+        let vm = GoogleAdsCampaignReportCardViewModel(siteID: sampleSiteID,
+                                                      timeRange: .today,
+                                                      usageTracksEventEmitter: eventEmitter,
+                                                      stores: stores,
+                                                      googleAdsEligibilityChecker: MockGoogleAdsEligibilityChecker(isEligible: true))
+        stores.whenReceivingAction(ofType: GoogleAdsAction.self) { action in
+            switch action {
+            case let .retrieveCampaignStats(_, _, _, _, _, onCompletion):
+                onCompletion(.success(.fake()))
+            default:
+                break
+            }
+        }
+
+        // When
+        await vm.reload()
+
+        // Then
+        XCTAssertTrue(vm.showCampaignCTA)
+    }
+
+    func test_showCampaignsCTA_is_false_when_campaign_was_successfully_created() async {
+        // Given
+        let vm = GoogleAdsCampaignReportCardViewModel(siteID: sampleSiteID,
+                                                      timeRange: .today,
+                                                      usageTracksEventEmitter: eventEmitter,
+                                                      stores: stores,
+                                                      googleAdsEligibilityChecker: MockGoogleAdsEligibilityChecker(isEligible: true))
+        stores.whenReceivingAction(ofType: GoogleAdsAction.self) { action in
+            switch action {
+            case let .retrieveCampaignStats(_, _, _, _, _, onCompletion):
+                onCompletion(.success(.fake()))
+            default:
+                break
+            }
+        }
+
+        // When
+        await vm.onGoogleCampaignCreated()
+
+        // Then
+        XCTAssertFalse(vm.showCampaignCTA)
+    }
 }
 
 private extension GoogleAdsCampaignReportCardViewModelTests {


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #13368
⚠️ Based on https://github.com/woocommerce/woocommerce-ios/pull/13398 ⚠️ 
<!-- Id number of the GitHub issue this PR addresses. -->

## Why
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This displays the call to action to create a campaign on the Google Campaigns card in the Analytics Hub when there are no campaign analytics in the selected time range.

## How
* Sets `showCampaignCTA` in `GoogleAdsCampaignReportCardViewModel`:
   * The CTA is not displayed while the card is loading or if there is an error loading the stats data.
   * The CTA is displayed if the store is eligible and there are no campaigns in the stats data.
* Adds a closure `onGoogleCampaignCreated()` called when a campaign is successfully created. This reloads the card data and hides the CTA. (There won't be campaign stats for the new campaign immediately, so this ensures the call to action is dismissed.)

## Testing steps
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->

Prerequisite: Install, activate, and set up the Google Ads plugin to a test site following pe5sF9-2Qo-p2. Ensure that you're using the plugin version 2.7.5 or above. You can use Charles Proxy to mock different responses to the stats requests (e.g. [this mock response](https://github.com/woocommerce/woocommerce-ios/blob/f41d4f416ba94f7254f4d40066ca8d058ac950a3/Networking/NetworkingTests/Responses/google-ads-reports-programs-without-data.json#L4) for campaign analytics.)

Store with campaign analytics:

1. Build and run the app.
2. Tap "View all store analytics" to open the analytics hub.
3. If needed, mock the response to the stats request to load campaign analytics.
4. Confirm the Google Campaigns card loads with the mocked analytics.

Store without campaign analytics:

1. Build and run the app.
2. Tap "View all store analytics" to open the analytics hub.
3. If needed, mock the response to the stats request to return no campaign analytics.
4. Confirm the Google Campaigns card loads the call to action.
5. Tap "Add paid campaign" to start the campaign creation flow.
6. Create a new campaign.
7. When the web view closes, confirm the Google Campaigns card reloads and you see an empty analytics card (because there aren't any stats yet for the new campaign) and not the call to action.

## Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->

Additional scenarios tested:

* A network error or malformed response results in the Google Campaigns card loaded with an error message.
* If the plugin is not active, or the store is otherwise ineligible, the card is not displayed in the analytics hub.
* Closing the campaign creation flow without creating a campaign doesn't reload the Google Campaigns card.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

Card loads with campaign analytics:

https://github.com/user-attachments/assets/ebd534a9-c60f-49c9-b53c-9dff0f815e1c

Card loads call to action and completes campaign creation flow:


https://github.com/user-attachments/assets/73918c27-d149-4601-b1f4-95249b35ee66



---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.