### PR TITLE
[Analytics Hub] Encapsulate logic for loading Google Campaigns card in card view model

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/AnalyticsHubViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/AnalyticsHubViewModel.swift
@@ -168,7 +168,7 @@ final class AnalyticsHubViewModel: ObservableObject {
         case .giftCards:
             isPluginActive(SitePlugin.SupportedPlugin.WCGiftCards)
         case .googleCampaigns:
-            googleCampaignsCard.isEligibleForGoogleAds
+            isPluginActive(SitePlugin.SupportedPlugin.GoogleForWooCommerce) && googleCampaignsCard.isEligibleForGoogleAds
         default:
             true
         }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/AnalyticsHubViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/AnalyticsHubViewModel.swift
@@ -48,6 +48,10 @@ final class AnalyticsHubViewModel: ObservableObject {
                                                                  analytics: analytics)
         self.usageTracksEventEmitter = usageTracksEventEmitter
 
+        self.googleCampaignsCard = GoogleAdsCampaignReportCardViewModel(siteID: siteID,
+                                                                        timeRange: selectedType,
+                                                                        usageTracksEventEmitter: usageTracksEventEmitter)
+
         bindViewModelsWithData()
         bindCardSettingsWithData()
     }
@@ -128,11 +132,7 @@ final class AnalyticsHubViewModel: ObservableObject {
 
     /// Google Campaigns Card ViewModel
     ///
-    var googleCampaignsCard: GoogleAdsCampaignReportCardViewModel {
-        GoogleAdsCampaignReportCardViewModel(siteID: siteID,
-                                             timeRange: timeRangeSelectionType,
-                                             usageTracksEventEmitter: usageTracksEventEmitter)
-    }
+    var googleCampaignsCard: GoogleAdsCampaignReportCardViewModel
 
     /// View model for `AnalyticsHubCustomizeView`, to customize the cards in the Analytics Hub.
     ///
@@ -603,6 +603,10 @@ private extension AnalyticsHubViewModel {
                 self.timeRangeCard = AnalyticsHubViewModel.timeRangeCard(timeRangeSelection: self.timeRangeSelection,
                                                                          usageTracksEventEmitter: self.usageTracksEventEmitter,
                                                                          analytics: self.analytics)
+
+                self.googleCampaignsCard = GoogleAdsCampaignReportCardViewModel(siteID: siteID,
+                                                                                timeRange: newSelectionType,
+                                                                                usageTracksEventEmitter: usageTracksEventEmitter)
 
                 // Update data on range selection change
                 Task.init {

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/Report Cards/GoogleAdsCampaignReportCard.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/Report Cards/GoogleAdsCampaignReportCard.swift
@@ -108,23 +108,11 @@ private extension GoogleAdsCampaignReportCard {
 // MARK: Previews
 struct GoogleAdsCampaignReportCardPreviews: PreviewProvider {
     static var previews: some View {
-        let viewModel = GoogleAdsCampaignReportCardViewModel(currentPeriodStats: GoogleAdsCampaignReportCardViewModel.sampleStats(),
-                                                             previousPeriodStats: GoogleAdsCampaignReportCardViewModel.sampleStats(),
+        let viewModel = GoogleAdsCampaignReportCardViewModel(siteID: 123,
                                                              timeRange: .today,
-                                                             usageTracksEventEmitter: StoreStatsUsageTracksEventEmitter(),
-                                                             storeAdminURL: "https://woocommerce.com")
+                                                             usageTracksEventEmitter: StoreStatsUsageTracksEventEmitter())
         GoogleAdsCampaignReportCard(viewModel: viewModel, onCreateNewCampaign: {})
             .addingTopAndBottomDividers()
             .previewLayout(.sizeThatFits)
-
-        let emptyViewModel = GoogleAdsCampaignReportCardViewModel(currentPeriodStats: nil,
-                                                                  previousPeriodStats: nil,
-                                                                  timeRange: .today,
-                                                                  usageTracksEventEmitter: StoreStatsUsageTracksEventEmitter(),
-                                                                  storeAdminURL: "https://woocommerce.com")
-        GoogleAdsCampaignReportCard(viewModel: emptyViewModel, onCreateNewCampaign: {})
-            .addingTopAndBottomDividers()
-            .previewLayout(.sizeThatFits)
-            .previewDisplayName("No data")
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/Report Cards/GoogleAdsCampaignReportCardViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Analytics Hub/Report Cards/GoogleAdsCampaignReportCardViewModel.swift
@@ -10,13 +10,13 @@ final class GoogleAdsCampaignReportCardViewModel: ObservableObject {
     private let stores: StoresManager
     private let analytics: Analytics
 
-    /// Google Ads campaign creation eligibility checker
+    /// Google Ads campaign creation eligibility checker. Optimistically defaults to `true`, to show loading view while checking eligibility.
     ///
     private let googleAdsEligibilityChecker: GoogleAdsEligibilityChecker
 
     /// Whether the store is eligible for Google Ads campaign creation.
     ///
-    @Published private(set) var isEligibleForGoogleAds: Bool = false
+    @Published private(set) var isEligibleForGoogleAds: Bool = true
 
     /// Campaign stats for the current period
     ///

--- a/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Analytics Hub/AnalyticsHubViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Analytics Hub/AnalyticsHubViewModelTests.swift
@@ -28,8 +28,7 @@ final class AnalyticsHubViewModelTests: XCTestCase {
         // Given
         let storage = MockStorageManager()
         insertActivePlugins([SitePlugin.SupportedPlugin.WCProductBundles.first,
-                             SitePlugin.SupportedPlugin.WCGiftCards.first,
-                             SitePlugin.SupportedPlugin.GoogleForWooCommerce.first],
+                             SitePlugin.SupportedPlugin.WCGiftCards.first],
                             to: storage)
         let vm = createViewModel(storage: storage)
         stores.whenReceivingAction(ofType: StatsActionV4.self) { action in
@@ -56,17 +55,6 @@ final class AnalyticsHubViewModelTests: XCTestCase {
                 break
             }
         }
-        stores.whenReceivingAction(ofType: GoogleAdsAction.self) { action in
-            switch action {
-            case let .checkConnection(_, completion):
-                completion(.success(GoogleAdsConnection.fake().copy(rawStatus: "connected")))
-            case let .retrieveCampaignStats(_, _, _, _, _, completion):
-                let campaignStats = GoogleAdsCampaignStats.fake().copy(totals: .fake().copy(sales: 285))
-                completion(.success(campaignStats))
-            default:
-                break
-            }
-        }
 
         // When
         await vm.updateData()
@@ -79,7 +67,6 @@ final class AnalyticsHubViewModelTests: XCTestCase {
         XCTAssertFalse(vm.sessionsCard.isRedacted)
         XCTAssertFalse(vm.bundlesCard.isRedacted)
         XCTAssertFalse(vm.giftCardsCard.isRedacted)
-        XCTAssertFalse(vm.googleCampaignsCard.isRedacted)
 
         XCTAssertEqual(vm.revenueCard.leadingValue, "$62")
         XCTAssertEqual(vm.ordersCard.leadingValue, "15")
@@ -89,7 +76,6 @@ final class AnalyticsHubViewModelTests: XCTestCase {
         XCTAssertEqual(vm.bundlesCard.bundlesSold, "3")
         XCTAssertEqual(vm.bundlesCard.bundlesSoldData.count, 1)
         XCTAssertEqual(vm.giftCardsCard.leadingValue, "20")
-        XCTAssertEqual(vm.googleCampaignsCard.statValue, "$285")
     }
 
     func test_cards_viewmodels_redacted_while_updating_from_network() async {
@@ -102,7 +88,6 @@ final class AnalyticsHubViewModelTests: XCTestCase {
         var loadingBundlesStatsCardRedacted: Bool = false
         var loadingBundlesSoldCardRedacted: Bool = false
         var loadingGiftCardsCardRedacted: Bool = false
-        var loadingGoogleCampaignsCardRedacted: Bool = false
         let storage = MockStorageManager()
         insertActivePlugins([SitePlugin.SupportedPlugin.WCProductBundles.first,
                              SitePlugin.SupportedPlugin.WCGiftCards.first,
@@ -141,17 +126,6 @@ final class AnalyticsHubViewModelTests: XCTestCase {
                 break
             }
         }
-        stores.whenReceivingAction(ofType: GoogleAdsAction.self) { action in
-            switch action {
-            case let .checkConnection(_, completion):
-                completion(.success(GoogleAdsConnection.fake().copy(rawStatus: "connected")))
-            case let .retrieveCampaignStats(_, _, _, _, _, completion):
-                loadingGoogleCampaignsCardRedacted = vm.googleCampaignsCard.isRedacted
-                completion(.success(GoogleAdsCampaignStats.fake()))
-            default:
-                break
-            }
-        }
 
         // When
         await vm.updateData()
@@ -165,7 +139,6 @@ final class AnalyticsHubViewModelTests: XCTestCase {
         XCTAssertTrue(loadingBundlesStatsCardRedacted)
         XCTAssertTrue(loadingBundlesSoldCardRedacted)
         XCTAssertTrue(loadingGiftCardsCardRedacted)
-        XCTAssertTrue(loadingGoogleCampaignsCardRedacted)
     }
 
     func test_bundles_card_shows_correct_loading_state_and_data_with_network_update() {
@@ -585,80 +558,6 @@ final class AnalyticsHubViewModelTests: XCTestCase {
 
         // Then
         XCTAssertFalse(vm.enabledCards.contains(.giftCards))
-    }
-
-    @MainActor
-    func test_google_campaigns_card_is_displayed_when_plugin_active_and_google_ads_connected() async {
-        // Given
-        let storage = MockStorageManager()
-        storage.insertSampleSystemPlugin(readOnlySystemPlugin: .fake().copy(siteID: sampleSiteID,
-                                                                            name: SitePlugin.SupportedPlugin.GoogleForWooCommerce.first,
-                                                                            active: true))
-        let vm = createViewModel(storage: storage)
-        stores.whenReceivingAction(ofType: StatsActionV4.self) { action in
-            switch action {
-            case let .retrieveCustomStats(_, _, _, _, _, _, _, completion):
-                completion(.success(.fake()))
-            case let .retrieveTopEarnerStats(_, _, _, _, _, _, _, _, completion):
-                completion(.success(.fake()))
-            case let .retrieveSiteSummaryStats(_, _, _, _, _, _, completion):
-                completion(.success(.fake()))
-            default:
-                break
-            }
-        }
-        stores.whenReceivingAction(ofType: GoogleAdsAction.self) { action in
-            switch action {
-            case let .checkConnection(_, completion):
-                completion(.success(GoogleAdsConnection.fake().copy(rawStatus: "connected")))
-            case let .retrieveCampaignStats(_, _, _, _, _, completion):
-                completion(.success(.fake()))
-            default:
-                break
-            }
-        }
-
-        // When
-        await vm.updateData()
-
-        // Then
-        XCTAssertTrue(vm.enabledCards.contains(.googleCampaigns))
-    }
-
-    @MainActor
-    func test_google_campaigns_card_not_displayed_when_plugin_active_and_google_ads_disconnected() async {
-        // Given
-        let storage = MockStorageManager()
-        storage.insertSampleSystemPlugin(readOnlySystemPlugin: .fake().copy(siteID: sampleSiteID,
-                                                                            name: SitePlugin.SupportedPlugin.GoogleForWooCommerce.first,
-                                                                            active: true))
-        let vm = createViewModel(storage: storage)
-        stores.whenReceivingAction(ofType: StatsActionV4.self) { action in
-            switch action {
-            case let .retrieveCustomStats(_, _, _, _, _, _, _, completion):
-                completion(.success(.fake()))
-            case let .retrieveTopEarnerStats(_, _, _, _, _, _, _, _, completion):
-                completion(.success(.fake()))
-            case let .retrieveSiteSummaryStats(_, _, _, _, _, _, completion):
-                completion(.success(.fake()))
-            default:
-                break
-            }
-        }
-        stores.whenReceivingAction(ofType: GoogleAdsAction.self) { action in
-            switch action {
-            case let .checkConnection(_, completion):
-                completion(.success(GoogleAdsConnection.fake().copy(rawStatus: "disconnected")))
-            default:
-                break
-            }
-        }
-
-        // When
-        await vm.updateData()
-
-        // Then
-        XCTAssertFalse(vm.enabledCards.contains(.googleCampaigns))
     }
 
     @MainActor

--- a/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Analytics Hub/AnalyticsHubViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Analytics Hub/AnalyticsHubViewModelTests.swift
@@ -90,8 +90,7 @@ final class AnalyticsHubViewModelTests: XCTestCase {
         var loadingGiftCardsCardRedacted: Bool = false
         let storage = MockStorageManager()
         insertActivePlugins([SitePlugin.SupportedPlugin.WCProductBundles.first,
-                             SitePlugin.SupportedPlugin.WCGiftCards.first,
-                             SitePlugin.SupportedPlugin.GoogleForWooCommerce.first],
+                             SitePlugin.SupportedPlugin.WCGiftCards.first],
                             to: storage)
         let vm = createViewModel(storage: storage)
         stores.whenReceivingAction(ofType: StatsActionV4.self) { action in

--- a/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Analytics Hub/Report Cards/GoogleAdsCampaignReportCardViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Analytics Hub/Report Cards/GoogleAdsCampaignReportCardViewModelTests.swift
@@ -8,34 +8,66 @@ final class GoogleAdsCampaignReportCardViewModelTests: XCTestCase {
     private var eventEmitter: StoreStatsUsageTracksEventEmitter!
     private var analyticsProvider: MockAnalyticsProvider!
     private var analytics: Analytics!
+    private var stores: MockStoresManager!
 
+    private let sampleSiteID: Int64 = 12345
     private let sampleAdminURL = "https://example.com/wp-admin/"
 
     override func setUp() {
         analyticsProvider = MockAnalyticsProvider()
         analytics = WooAnalytics(analyticsProvider: analyticsProvider)
         eventEmitter = StoreStatsUsageTracksEventEmitter(analytics: analytics)
+        stores = MockStoresManager(sessionManager: .makeForTesting(defaultSite: .fake().copy(adminURL: sampleAdminURL)))
         ServiceLocator.setCurrencySettings(CurrencySettings()) // Default is US
     }
 
-    func test_GoogleAdsCampaignReportCardViewModel_inits_with_expected_values() throws {
+    func test_isEligibleForGoogleAds_true_when_eligible_for_GoogleAds() async {
         // Given
-        let campaignName = "Spring Ad Campaign"
-        let vm = GoogleAdsCampaignReportCardViewModel(
-            currentPeriodStats: GoogleAdsCampaignStats.fake().copy(totals: .fake().copy(sales: 12345),
-                                                                   campaigns: [.fake().copy(campaignName: campaignName,
-                                                                                            subtotals: .init(sales: 1234.56,
-                                                                                                             spend: 200,
-                                                                                                             clicks: 0,
-                                                                                                             impressions: 0,
-                                                                                                             conversions: 0)),
-                                                                               .fake()]),
-            previousPeriodStats: GoogleAdsCampaignStats.fake().copy(totals: .fake().copy(sales: 6172.5)),
-            timeRange: .today,
-            isRedacted: false,
-            usageTracksEventEmitter: eventEmitter,
-            storeAdminURL: sampleAdminURL
-        )
+        let vm = GoogleAdsCampaignReportCardViewModel(siteID: sampleSiteID,
+                                                      timeRange: .today,
+                                                      usageTracksEventEmitter: eventEmitter,
+                                                      googleAdsEligibilityChecker: MockGoogleAdsEligibilityChecker(isEligible: true))
+
+        // When
+        await vm.reload()
+
+        // Then
+        XCTAssertTrue(vm.isEligibleForGoogleAds)
+    }
+
+    func test_isEligibleForGoogleAds_false_when_not_eligible_for_GoogleAds() async {
+        // Given
+        let vm = GoogleAdsCampaignReportCardViewModel(siteID: sampleSiteID,
+                                                      timeRange: .today,
+                                                      usageTracksEventEmitter: eventEmitter,
+                                                      googleAdsEligibilityChecker: MockGoogleAdsEligibilityChecker(isEligible: false))
+
+        // When
+        await vm.reload()
+
+        // Then
+        XCTAssertFalse(vm.isEligibleForGoogleAds)
+    }
+
+    func test_GoogleAdsCampaignReportCardViewModel_sets_expected_values_from_campaign_data() async throws {
+        // Given
+        let campaignStats = sampleCampaignStats()
+        stores.whenReceivingAction(ofType: GoogleAdsAction.self) { action in
+            switch action {
+            case let .retrieveCampaignStats(_, _, _, _, _, onCompletion):
+                onCompletion(.success(campaignStats))
+            default:
+                break
+            }
+        }
+        let vm = GoogleAdsCampaignReportCardViewModel(siteID: sampleSiteID,
+                                                      timeRange: .today,
+                                                      usageTracksEventEmitter: eventEmitter,
+                                                      stores: stores,
+                                                      googleAdsEligibilityChecker: MockGoogleAdsEligibilityChecker(isEligible: true))
+
+        // When
+        await vm.reload()
 
         // Then
         XCTAssertFalse(vm.isRedacted)
@@ -43,83 +75,95 @@ final class GoogleAdsCampaignReportCardViewModelTests: XCTestCase {
 
         // Check metric stats data
         assertEqual("$12,345", vm.statValue)
-        assertEqual("+100%", vm.deltaValue)
+        assertEqual("+0%", vm.deltaValue)
 
         // Check campaigns data
-        assertEqual(2, vm.campaignsData.count)
+        assertEqual(5, vm.campaignsData.count)
         let firstCampaign = try XCTUnwrap(vm.campaignsData.first)
-        assertEqual(campaignName, firstCampaign.name)
+        assertEqual(campaignStats.campaigns.last?.campaignName, firstCampaign.name)
         assertEqual(true, firstCampaign.details.contains("$200"))
         assertEqual("$1,234.56", firstCampaign.value)
         XCTAssertFalse(vm.showCampaignsError)
 
     }
 
-    func test_GoogleAdsCampaignReportCardViewModel_contains_expected_reportURL_elements() throws {
+    func test_reportViewModel_contains_expected_reportURL_elements() throws {
         // When
-        let vm = GoogleAdsCampaignReportCardViewModel(currentPeriodStats: nil,
-                                                      previousPeriodStats: nil,
+        let vm = GoogleAdsCampaignReportCardViewModel(siteID: sampleSiteID,
                                                       timeRange: .monthToDate,
                                                       usageTracksEventEmitter: eventEmitter,
-                                                      storeAdminURL: sampleAdminURL)
-        let productsCardReportURL = try XCTUnwrap(vm.reportViewModel?.initialURL)
-        let productsCardURLQueryItems = try XCTUnwrap(URLComponents(url: productsCardReportURL, resolvingAgainstBaseURL: false)?.queryItems)
+                                                      stores: stores,
+                                                      googleAdsEligibilityChecker: MockGoogleAdsEligibilityChecker(isEligible: true))
+        let reportURL = try XCTUnwrap(vm.reportViewModel?.initialURL)
+        let reportURLQueryItems = try XCTUnwrap(URLComponents(url: reportURL, resolvingAgainstBaseURL: false)?.queryItems)
 
         // Then
-        XCTAssertTrue(productsCardReportURL.relativeString.contains(sampleAdminURL))
-        XCTAssertTrue(productsCardURLQueryItems.contains(URLQueryItem(name: "path", value: "/google/reports")))
-        XCTAssertTrue(productsCardURLQueryItems.contains(URLQueryItem(name: "period", value: "month")))
+        XCTAssertTrue(reportURL.relativeString.contains(sampleAdminURL))
+        XCTAssertTrue(reportURLQueryItems.contains(URLQueryItem(name: "path", value: "/google/reports")))
+        XCTAssertTrue(reportURLQueryItems.contains(URLQueryItem(name: "period", value: "month")))
     }
 
     func test_GoogleAdsCampaignReportCardViewModel_shows_error_when_current_stats_are_nil() {
         // Given
-        let vm = GoogleAdsCampaignReportCardViewModel(currentPeriodStats: nil,
-                                                      previousPeriodStats: .fake(),
+        let vm = GoogleAdsCampaignReportCardViewModel(siteID: sampleSiteID,
                                                       timeRange: .monthToDate,
-                                                      usageTracksEventEmitter: eventEmitter)
+                                                      usageTracksEventEmitter: eventEmitter,
+                                                      stores: stores,
+                                                      googleAdsEligibilityChecker: MockGoogleAdsEligibilityChecker(isEligible: true))
 
         // Then
         XCTAssertTrue(vm.showCampaignsError)
     }
 
-    func test_GoogleAdsCampaignReportCardViewModel_provides_expected_values_when_redacted() throws {
+    func test_GoogleAdsCampaignReportCardViewModel_sets_expected_values_when_syncing_remotely() async throws {
         // Given
-        let vm = GoogleAdsCampaignReportCardViewModel(currentPeriodStats: nil,
-                                                      previousPeriodStats: nil,
+        var isRedactedWhileSyncing: Bool = false
+        var reportViewModelWhileSyncing: AnalyticsReportLinkViewModel?
+        var showingCampaignsErrorWhileSyncing: Bool = false
+        let vm = GoogleAdsCampaignReportCardViewModel(siteID: sampleSiteID,
                                                       timeRange: .monthToDate,
-                                                      isRedacted: true,
                                                       usageTracksEventEmitter: eventEmitter,
-                                                      storeAdminURL: sampleAdminURL)
+                                                      stores: stores,
+                                                      googleAdsEligibilityChecker: MockGoogleAdsEligibilityChecker(isEligible: true))
+        stores.whenReceivingAction(ofType: GoogleAdsAction.self) { action in
+            switch action {
+            case let .retrieveCampaignStats(_, _, _, _, _, onCompletion):
+                isRedactedWhileSyncing = vm.isRedacted
+                reportViewModelWhileSyncing = vm.reportViewModel
+                showingCampaignsErrorWhileSyncing = vm.showCampaignsError
+                onCompletion(.success(self.sampleCampaignStats()))
+            default:
+                break
+            }
+        }
+
+        // When
+        await vm.reload()
 
         // Then
-        XCTAssertTrue(vm.isRedacted)
-        XCTAssertNotNil(vm.reportViewModel)
-
-        assertEqual("1000", vm.statValue)
-        assertEqual("0%", vm.deltaValue)
-
-        // Then
-        let expectedPlaceholder = TopPerformersRow.Data(showImage: false, name: "Campaign", details: "Spend: $100", value: "$500")
-        let firstCampaign = try XCTUnwrap(vm.campaignsData.first)
-        assertEqual(expectedPlaceholder.showImage, firstCampaign.showImage)
-        assertEqual(expectedPlaceholder.name, firstCampaign.name)
-        assertEqual(expectedPlaceholder.details, firstCampaign.details)
-        assertEqual(expectedPlaceholder.value, firstCampaign.value)
-        XCTAssertFalse(vm.showCampaignsError)
+        XCTAssertTrue(isRedactedWhileSyncing)
+        XCTAssertNotNil(reportViewModelWhileSyncing)
+        XCTAssertFalse(showingCampaignsErrorWhileSyncing)
     }
 
-    func test_campaignData_includes_top_five_campaigns() throws {
+    func test_campaignData_includes_top_five_campaigns() async throws {
         // Given
-        let vm = GoogleAdsCampaignReportCardViewModel(
-            currentPeriodStats: GoogleAdsCampaignStats.fake().copy(campaigns: [.fake().copy(subtotals: .fake().copy(sales: 123)),
-                                                                               .fake().copy(subtotals: .fake().copy(sales: 234)),
-                                                                               .fake().copy(subtotals: .fake().copy(sales: 345)),
-                                                                               .fake().copy(subtotals: .fake().copy(sales: 456)),
-                                                                               .fake().copy(subtotals: .fake().copy(sales: 567)),
-                                                                               .fake().copy(subtotals: .fake().copy(sales: 678))]),
-            previousPeriodStats: nil,
-            timeRange: .today,
-            usageTracksEventEmitter: eventEmitter)
+        stores.whenReceivingAction(ofType: GoogleAdsAction.self) { action in
+            switch action {
+            case let .retrieveCampaignStats(_, _, _, _, _, onCompletion):
+                onCompletion(.success(self.sampleCampaignStats()))
+            default:
+                break
+            }
+        }
+        let vm = GoogleAdsCampaignReportCardViewModel(siteID: sampleSiteID,
+                                                      timeRange: .today,
+                                                      usageTracksEventEmitter: eventEmitter,
+                                                      stores: stores,
+                                                      googleAdsEligibilityChecker: MockGoogleAdsEligibilityChecker(isEligible: true))
+
+        // When
+        await vm.reload()
 
         // Then
         // Only five campaigns are included
@@ -127,30 +171,35 @@ final class GoogleAdsCampaignReportCardViewModelTests: XCTestCase {
 
         // First campaign has the top sales amount
         let firstCampaign = try XCTUnwrap(vm.campaignsData.first)
-        assertEqual("$678", firstCampaign.value)
+        assertEqual("$1,234.56", firstCampaign.value)
 
         // Campaign with lowest sales amount was dropped
-        XCTAssertFalse(vm.campaignsData.contains(where: { $0.value == "$123" }))
+        XCTAssertFalse(vm.campaignsData.contains(where: { $0.value == "$234" }))
     }
 
-    func test_changing_selectedStat_updates_displayed_values() throws {
+    func test_changing_selectedStat_updates_displayed_values() async throws {
         // Given
-        let vm = GoogleAdsCampaignReportCardViewModel(
-            currentPeriodStats: GoogleAdsCampaignStats.fake().copy(totals: .fake().copy(sales: 12345, spend: 300),
-                                                                   campaigns: [.fake().copy(subtotals: .fake().copy(sales: 1234.56,
-                                                                                                             spend: 200)),
-                                                                               .fake()]),
-            previousPeriodStats: GoogleAdsCampaignStats.fake().copy(totals: .fake().copy(sales: 6172.5, spend: 100)),
-            timeRange: .today,
-            usageTracksEventEmitter: eventEmitter
-        )
+        stores.whenReceivingAction(ofType: GoogleAdsAction.self) { action in
+            switch action {
+            case let .retrieveCampaignStats(_, _, _, _, _, onCompletion):
+                onCompletion(.success(self.sampleCampaignStats()))
+            default:
+                break
+            }
+        }
+        let vm = GoogleAdsCampaignReportCardViewModel(siteID: sampleSiteID,
+                                                      timeRange: .today,
+                                                      usageTracksEventEmitter: eventEmitter,
+                                                      stores: stores,
+                                                      googleAdsEligibilityChecker: MockGoogleAdsEligibilityChecker(isEligible: true))
 
         // When
+        await vm.reload()
         vm.selectedStat = .spend
 
         // Then
         assertEqual("$300", vm.statValue)
-        assertEqual("+200%", vm.deltaValue)
+        assertEqual("+0%", vm.deltaValue)
 
         // Check campaigns data
         let firstCampaign = try XCTUnwrap(vm.campaignsData.first)
@@ -160,8 +209,7 @@ final class GoogleAdsCampaignReportCardViewModelTests: XCTestCase {
 
     func test_onDisplayCallToAction_tracks_expected_event() throws {
         // Given
-        let vm = GoogleAdsCampaignReportCardViewModel(currentPeriodStats: nil,
-                                                      previousPeriodStats: nil,
+        let vm = GoogleAdsCampaignReportCardViewModel(siteID: sampleSiteID,
                                                       timeRange: .today,
                                                       usageTracksEventEmitter: eventEmitter,
                                                       analytics: analytics)
@@ -173,5 +221,19 @@ final class GoogleAdsCampaignReportCardViewModelTests: XCTestCase {
         assertEqual(["googleads_entry_point_displayed"], analyticsProvider.receivedEvents)
         let sourceProperty = try XCTUnwrap(analyticsProvider.receivedProperties.first?["source"] as? String)
         assertEqual("analytics_hub", sourceProperty)
+    }
+}
+
+private extension GoogleAdsCampaignReportCardViewModelTests {
+    func sampleCampaignStats() -> GoogleAdsCampaignStats {
+        GoogleAdsCampaignStats.fake().copy(totals: .fake().copy(sales: 12345, spend: 300),
+                                           campaigns: [.fake().copy(subtotals: .fake().copy(sales: 234)),
+                                                       .fake().copy(subtotals: .fake().copy(sales: 345)),
+                                                       .fake().copy(subtotals: .fake().copy(sales: 456)),
+                                                       .fake().copy(subtotals: .fake().copy(sales: 567)),
+                                                       .fake().copy(subtotals: .fake().copy(sales: 678)),
+                                                       .fake().copy(campaignName: "Spring Ad Campaign",
+                                                                                subtotals: .fake().copy(sales: 1234.56,
+                                                                                                        spend: 200))])
     }
 }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of: #13368
<!-- Id number of the GitHub issue this PR addresses. -->

## Why
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This encapsulates the logic for loading the Google Campaigns card in the card view model. This reduces the amount of logic in the main analytics hub view model and makes it clearer what data is being loaded and handled for this card.

## How
 - Introduces `GoogleAdsEligibilityChecker` to check for eligibility to display the analytics card and call to action. This ensures the card and its call to action is only displayed if the store is eligible for campaign creation.
- Introduces a `reload()` method that is called from `AnalyticsHubViewModel` when the card data needs to be reloaded. This uses the selected time range to retrieve the stats data from remote.
- Introduces an `isEligibleForGoogleAds` property that is set when the eligibility is checked remotely, and is used in `AnalyticsHubViewModel` to determine if the card can be displayed and in the card view model to determine if the call to action can be displayed.
- Moves the remote methods (syncing stats data and checking eligibility) into the card view model, along with the `isRedacted` property to determine if the card data is being loaded.
- Updates the stats properties in the card view model to be published properties instead of computed properties, and binds them to the fetched stats data.

## Testing steps
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->

Prerequisite: Install, activate, and set up the Google Ads plugin to a test site following pe5sF9-2Qo-p2. Ensure that you're using the plugin version 2.7.5 or above. You can use Charles Proxy to mock different responses to the stats requests (e.g. [this mock response](https://github.com/woocommerce/woocommerce-ios/blob/f41d4f416ba94f7254f4d40066ca8d058ac950a3/Networking/NetworkingTests/Responses/google-ads-reports-programs-without-data.json#L4) for campaign analytics.)

1. Build and run the app.
2. Tap "View all store analytics" to open the analytics hub.
3. If needed, mock the response to the stats request to load campaign analytics.
4. Confirm the Google Campaigns card loads with the mocked analytics.

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.