### PR TITLE
Show cached content & loading indicator on the top performers view

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Dashboard/TopPerformers/TopPerformerDataViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/TopPerformers/TopPerformerDataViewController.swift
@@ -35,7 +35,7 @@ final class TopPerformerDataViewController: UIViewController {
     private let storageManager: StorageManagerType
     private let usageTracksEventEmitter: StoreStatsUsageTracksEventEmitter
 
-    private lazy var viewModel = TopPerformersPeriodViewModel(state: .loading) { [weak self] topPerformersItem in
+    private lazy var viewModel = TopPerformersPeriodViewModel(state: .loading(cached: [])) { [weak self] topPerformersItem in
         guard let self else { return }
         self.usageTracksEventEmitter.interacted()
         self.presentProductDetails(statsItem: topPerformersItem)
@@ -99,7 +99,7 @@ final class TopPerformerDataViewController: UIViewController {
 
 private extension TopPerformerDataViewController {
     func updateUIInLoadingState() {
-        viewModel.update(state: .loading)
+        viewModel.update(state: .loading(cached: []))
         if #unavailable(iOS 16.0) {
             hostingController?.view.invalidateIntrinsicContentSize()
         }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/TopPerformers/TopPerformersDashboardView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/TopPerformers/TopPerformersDashboardView.swift
@@ -35,8 +35,8 @@ struct TopPerformersDashboardView: View {
             } else {
                 timeRangeBar
                     .padding(.horizontal, Layout.padding)
-                    .redacted(reason: viewModel.syncingData ? [.placeholder] : [])
-                    .shimmering(active: viewModel.syncingData)
+                    .redacted(reason: viewModel.periodViewModel.redacted.header ? [.placeholder] : [])
+                    .shimmering(active: viewModel.periodViewModel.redacted.header)
 
                 Divider()
 
@@ -47,8 +47,8 @@ struct TopPerformersDashboardView: View {
 
                 viewAllAnalyticsButton
                     .padding(.horizontal, Layout.padding)
-                    .redacted(reason: viewModel.syncingData ? [.placeholder] : [])
-                    .shimmering(active: viewModel.syncingData)
+                    .redacted(reason: viewModel.periodViewModel.redacted.actionButton ? [.placeholder] : [])
+                    .shimmering(active: viewModel.periodViewModel.redacted.actionButton)
             }
 
         }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/TopPerformers/TopPerformersDashboardViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/TopPerformers/TopPerformersDashboardViewModel.swift
@@ -200,6 +200,9 @@ private extension TopPerformersDashboardViewModel {
     }
 
     func updateUIInLoadingState() {
+        guard ServiceLocator.featureFlagService.isFeatureFlagEnabled(.backgroundTasks) else {
+            return periodViewModel.update(state: .loading(cached: []))
+        }
         let items = topEarnerStats?.items?.sorted(by: >) ?? []
         periodViewModel.update(state: .loading(cached: items))
     }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/TopPerformers/TopPerformersDashboardViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/TopPerformers/TopPerformersDashboardViewModel.swift
@@ -30,7 +30,7 @@ final class TopPerformersDashboardViewModel: ObservableObject {
         Date()
     }
 
-    lazy var periodViewModel = TopPerformersPeriodViewModel(state: .loading) { [weak self] topPerformersItem in
+    lazy var periodViewModel = TopPerformersPeriodViewModel(state: .loading(cached: [])) { [weak self] topPerformersItem in
         guard let self else { return }
 
         trackInteraction()
@@ -200,7 +200,8 @@ private extension TopPerformersDashboardViewModel {
     }
 
     func updateUIInLoadingState() {
-        periodViewModel.update(state: .loading)
+        let items = topEarnerStats?.items?.sorted(by: >) ?? []
+        periodViewModel.update(state: .loading(cached: items))
     }
 
     func updateUIInLoadedState() {

--- a/WooCommerce/Classes/ViewRelated/Dashboard/TopPerformers/TopPerformersPeriodView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/TopPerformers/TopPerformersPeriodView.swift
@@ -13,10 +13,10 @@ struct TopPerformersPeriodView: View {
             TopPerformersView(itemTitle: Localization.productsTitle,
                               valueTitle: Localization.itemsSoldTitle,
                               rows: viewModel.rows,
-                              isRedacted: viewModel.isRedacted)
+                              isRedacted: viewModel.redacted.rows)
             .padding(Layout.padding)
-            .redacted(reason: viewModel.isRedacted ? .placeholder : [])
-            .shimmering(active: viewModel.isRedacted)
+            .redacted(reason: viewModel.redacted.rows ? .placeholder : [])
+            .shimmering(active: viewModel.redacted.rows)
         } else {
             TopPerformersEmptyView()
         }
@@ -42,7 +42,7 @@ private extension TopPerformersPeriodView {
 
 struct DashboardTopPerformersView_Previews: PreviewProvider {
     static var previews: some View {
-        TopPerformersPeriodView(viewModel: .init(state: .loading, onTap: { _ in }))
+        TopPerformersPeriodView(viewModel: .init(state: .loading(cached: []), onTap: { _ in }))
         TopPerformersPeriodView(viewModel: .init(state: .loaded(rows: [.init(productID: 12,
                                                                                 productName: "Fun product",
                                                                                 quantity: 6,

--- a/WooCommerce/Classes/ViewRelated/Dashboard/TopPerformers/TopPerformersPeriodViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/TopPerformers/TopPerformersPeriodViewModel.swift
@@ -5,13 +5,53 @@ import struct Yosemite.TopEarnerStatsItem
 final class TopPerformersPeriodViewModel: ObservableObject {
     /// UI state of the dashboard top performers.
     enum State {
-        /// Shows placeholder rows.
-        case loading
+        /// Shows placeholder rows with cached content.
+        case loading(cached: [TopEarnerStatsItem])
         /// Shows either an empty view or a list of top performing rows.
         case loaded(rows: [TopEarnerStatsItem])
     }
 
-    @Published private(set) var isRedacted: Bool = false
+    /// Defines the possible redacted states
+    enum Redacted {
+        /// None of the content is redacted
+        case none
+        /// All content should be redacted
+        case full
+        /// Some content should be redacted as there is available cached content.
+        case cached
+
+        /// Defines if the header should be redacted.
+        var header: Bool {
+            switch self {
+            case .full:
+                return true
+            case .none, .cached:
+                return false
+            }
+        }
+
+        /// Defines if the item rows should be redacted.
+        var rows: Bool {
+            switch self {
+            case .full:
+                return true
+            case .none, .cached:
+                return false
+            }
+        }
+
+        /// Defines if the action button should be redacted.
+        var actionButton: Bool {
+            switch self {
+            case .full, .cached:
+                return true
+            case .none:
+                return false
+            }
+        }
+    }
+
+    @Published private(set) var redacted: Redacted = .none
     @Published private(set) var rows: [TopPerformersRow.Data] = []
 
     private var state: State
@@ -32,21 +72,26 @@ final class TopPerformersPeriodViewModel: ObservableObject {
     /// Updates the state based on the data loading status.
     func update(state: State) {
         switch state {
-        case .loading:
-            isRedacted = true
-            rows = placeholderRows
+        case .loading(let cachedItems):
+            let rows = buildRows(items: cachedItems)
+            self.redacted = rows.isNotEmpty ? .cached : .full
+            self.rows = rows.isNotEmpty ? rows : placeholderRows
         case .loaded(let items):
-            isRedacted = false
-            let rows = items.map { item in
-                TopPerformersRow.Data(imageURL: URL(string: item.imageUrl ?? ""),
-                                      name: item.productName ?? "",
-                                      details: Localization.netSales(value: item.totalString),
-                                      value: "\(item.quantity)",
-                                      tapHandler: { [weak self] in
-                    self?.onTap(item)
-                })
-            }
-            self.rows = rows
+            redacted = .none
+            rows = buildRows(items: items)
+        }
+    }
+
+    /// Build view rows based on the given `TopEarnerStatsItem`
+    private func buildRows(items: [TopEarnerStatsItem]) -> [TopPerformersRow.Data] {
+        items.map { item in
+            TopPerformersRow.Data(imageURL: URL(string: item.imageUrl ?? ""),
+                                  name: item.productName ?? "",
+                                  details: Localization.netSales(value: item.totalString),
+                                  value: "\(item.quantity)",
+                                  tapHandler: { [weak self] in
+                self?.onTap(item)
+            })
         }
     }
 }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/TopPerformersPeriodViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/TopPerformersPeriodViewModelTests.swift
@@ -6,11 +6,24 @@ final class TopPerformersPeriodViewModelTests: XCTestCase {
 
     func test_init_with_loading_state_sets_isRedacted_and_placeholder_rows() throws {
         // Given
-        let viewModel = TopPerformersPeriodViewModel(state: .loading, onTap: { _ in })
+        let viewModel = TopPerformersPeriodViewModel(state: .loading(cached: []), onTap: { _ in })
 
         // Then
-        XCTAssertTrue(viewModel.isRedacted)
+        XCTAssertTrue(viewModel.redacted.rows)
+        XCTAssertTrue(viewModel.redacted.header)
+        XCTAssertTrue(viewModel.redacted.actionButton)
         XCTAssertEqual(viewModel.rows.count, 3)
+    }
+
+    func test_init_with_loading_cached_state_sets_isRedacted_and_cached_rows() throws {
+        // Given
+        let viewModel = TopPerformersPeriodViewModel(state: .loading(cached: [.fake()]), onTap: { _ in })
+
+        // Then
+        XCTAssertFalse(viewModel.redacted.rows)
+        XCTAssertFalse(viewModel.redacted.header)
+        XCTAssertTrue(viewModel.redacted.actionButton)
+        XCTAssertEqual(viewModel.rows.count, 1)
     }
 
     func test_init_with_loaded_state_and_empty_rows_sets_isRedacted_and_empty_rows() throws {
@@ -18,7 +31,9 @@ final class TopPerformersPeriodViewModelTests: XCTestCase {
         let viewModel = TopPerformersPeriodViewModel(state: .loaded(rows: []), onTap: { _ in })
 
         // Then
-        XCTAssertFalse(viewModel.isRedacted)
+        XCTAssertFalse(viewModel.redacted.rows)
+        XCTAssertFalse(viewModel.redacted.header)
+        XCTAssertFalse(viewModel.redacted.actionButton)
         XCTAssertEqual(viewModel.rows.count, 0)
     }
 
@@ -27,7 +42,9 @@ final class TopPerformersPeriodViewModelTests: XCTestCase {
         let viewModel = TopPerformersPeriodViewModel(state: .loaded(rows: [.fake()]), onTap: { _ in })
 
         // Then
-        XCTAssertFalse(viewModel.isRedacted)
+        XCTAssertFalse(viewModel.redacted.rows)
+        XCTAssertFalse(viewModel.redacted.header)
+        XCTAssertFalse(viewModel.redacted.actionButton)
         XCTAssertEqual(viewModel.rows.count, 1)
     }
 
@@ -38,22 +55,26 @@ final class TopPerformersPeriodViewModelTests: XCTestCase {
         let viewModel = TopPerformersPeriodViewModel(state: .loaded(rows: [.fake()]), onTap: { _ in })
 
         // When
-        viewModel.update(state: .loading)
+        viewModel.update(state: .loading(cached: []))
 
         // Then
-        XCTAssertTrue(viewModel.isRedacted)
+        XCTAssertTrue(viewModel.redacted.rows)
+        XCTAssertTrue(viewModel.redacted.header)
+        XCTAssertTrue(viewModel.redacted.actionButton)
         XCTAssertEqual(viewModel.rows.count, 3)
     }
 
     func test_updateState_with_loaded_state_sets_isRedacted_and_rows() throws {
         // Given
-        let viewModel = TopPerformersPeriodViewModel(state: .loading, onTap: { _ in })
+        let viewModel = TopPerformersPeriodViewModel(state: .loading(cached: []), onTap: { _ in })
 
         // When
         viewModel.update(state: .loaded(rows: [.fake()]))
 
         // Then
-        XCTAssertFalse(viewModel.isRedacted)
+        XCTAssertFalse(viewModel.redacted.rows)
+        XCTAssertFalse(viewModel.redacted.header)
+        XCTAssertFalse(viewModel.redacted.actionButton)
         XCTAssertEqual(viewModel.rows.count, 1)
     }
 }


### PR DESCRIPTION
Part of #13370

# Why

This PR makes sure to show cached content(when available) on the top performer's dashboard card.

# How

- Add a new redacted enum to have more granularity on what elements of the view to redact.
- Update the loading state to include a new array of cached items.

# Demo

https://github.com/user-attachments/assets/6e9bc9bb-ef30-4101-8b31-f2eca175861d

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
