### PR TITLE
[Woo POS] Add isCartEmpty to cart view model and add tests

### DIFF
--- a/WooCommerce/Classes/POS/Presentation/CartView.swift
+++ b/WooCommerce/Classes/POS/Presentation/CartView.swift
@@ -127,7 +127,7 @@ private extension CartView {
         }
         .buttonStyle(.borderedProminent)
         .tint(Color.primaryTint)
-        .disabled(cartViewModel.itemsInCart.isEmpty)
+        .disabled(cartViewModel.isCartEmpty)
     }
 
     var addMoreButton: some View {

--- a/WooCommerce/Classes/POS/ViewModels/CartViewModel.swift
+++ b/WooCommerce/Classes/POS/ViewModels/CartViewModel.swift
@@ -20,6 +20,10 @@ final class CartViewModel: ObservableObject {
         orderStage != .finalizing
     }
 
+    var isCartEmpty: Bool {
+        return itemsInCart.isEmpty
+    }
+
     init(orderStage: AnyPublisher<PointOfSaleDashboardViewModel.OrderStage, Never>) {
         cartSubmissionPublisher = cartSubmissionSubject.eraseToAnyPublisher()
         addMoreToCartActionPublisher = addMoreToCartActionSubject.eraseToAnyPublisher()

--- a/WooCommerce/WooCommerceTests/POS/ViewModels/CartViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/POS/ViewModels/CartViewModelTests.swift
@@ -157,6 +157,18 @@ final class CartViewModelTests: XCTestCase {
         // Then
         XCTAssertEqual(sut.cartLabelColor, expectedCartLabelColor)
     }
+
+    func test_isCartEmpty() {
+        // Given
+        let item = Self.makeItem()
+        XCTAssertTrue(sut.isCartEmpty)
+
+        // When
+        sut.addItemToCart(item)
+
+        // Then
+        XCTAssertFalse(sut.isCartEmpty)
+    }
 }
 
 private extension CartViewModelTests {


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

Added helper property to `CartViewModel` to check if the cart is empty or not. Based on https://github.com/woocommerce/woocommerce-ios/pull/13393#pullrequestreview-2192761574

## Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: https://woomobilep2.wordpress.com/2024/05/06/woocommerce-mobile-quality-report-march-april/#comment-12036 -->

- Enter POS
- You should see the cart view but the Checkout button should be disabled
- Add few products in the cart
- Now the Checkout button should be enabled
- Remove items from the cart
- Checkout button should be disabled

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
