### PR TITLE
Product creation AI: Update layout for starting information screen

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductWithAI/AIToneVoice/ToneOfVoiceView.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductWithAI/AIToneVoice/ToneOfVoiceView.swift
@@ -4,7 +4,7 @@ struct ToneOfVoiceView: View {
     @ObservedObject var viewModel: AIToneVoiceViewModel
 
     var body: some View {
-        HStack(alignment: .center) {
+        AdaptiveStack(horizontalAlignment: .leading, verticalAlignment: .center) {
             Text(Localization.title)
                 .bodyStyle()
 

--- a/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductWithAI/ImageSelection/PackagePhotoView.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductWithAI/ImageSelection/PackagePhotoView.swift
@@ -32,7 +32,7 @@ struct PackagePhotoView: View {
             EditableImageView(imageState: imageState,
                               emptyContent: {})
             .frame(width: Layout.packagePhotoSize * scale, height: Layout.packagePhotoSize * scale)
-            .cornerRadius(Layout.cornerRadius)
+            .cornerRadius(Layout.imageCornerRadius)
 
             VStack(alignment: .leading, spacing: 0) {
                 Text(title)
@@ -63,7 +63,7 @@ struct PackagePhotoView: View {
                 }
             } label: {
                 Image(systemName: "ellipsis")
-                    .frame(width: Layout.ellipisButtonSize * scale, height: Layout.ellipisButtonSize * scale)
+                    .frame(width: Layout.ellipsisButtonSize * scale, height: Layout.ellipsisButtonSize * scale)
                     .bodyStyle()
                     .foregroundStyle(Color.secondary)
             }
@@ -71,14 +71,16 @@ struct PackagePhotoView: View {
         .padding(Layout.padding)
         .background(Color(light: Color(.systemColor(.systemGray6)),
                           dark: Color(.systemColor(.systemGray5))))
+        .clipShape(RoundedRectangle(cornerRadius: Layout.viewCornerRadius))
     }
 
     enum Layout {
         static let spacing: CGFloat = 16
-        static let cornerRadius: CGFloat = 4
+        static let imageCornerRadius: CGFloat = 4
         static let padding = EdgeInsets(top: 12, leading: 16, bottom: 12, trailing: 16)
         static let packagePhotoSize: CGFloat = 48
-        static let ellipisButtonSize: CGFloat = 24
+        static let ellipsisButtonSize: CGFloat = 24
+        static let viewCornerRadius: CGFloat = 8
     }
 
     enum Localization {

--- a/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductWithAI/ImageSelection/PackagePhotoView.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductWithAI/ImageSelection/PackagePhotoView.swift
@@ -69,7 +69,8 @@ struct PackagePhotoView: View {
             }
         }
         .padding(Layout.padding)
-        .background(Color(.systemColor(.systemGray6)))
+        .background(Color(light: Color(.systemColor(.systemGray6)),
+                          dark: Color(.systemColor(.systemGray5))))
     }
 
     enum Layout {

--- a/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductWithAI/Preview/ProductDetailPreviewView.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductWithAI/Preview/ProductDetailPreviewView.swift
@@ -258,7 +258,6 @@ private extension ProductDetailPreviewView {
                              onTapRemovePhoto: {
                 viewModel.didTapRemovePhoto()
             })
-            .clipShape(RoundedRectangle(cornerRadius: Layout.cornerRadius))
         }
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductWithAI/StartingInfo/ProductCreationAIStartingInfoView.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductWithAI/StartingInfo/ProductCreationAIStartingInfoView.swift
@@ -130,6 +130,7 @@ private extension ProductCreationAIStartingInfoView {
                 })
         case .loading, .success:
             PackagePhotoView(title: Localization.photoSelected,
+                             subTitle: Localization.textAddedToInfo,
                              imageState: viewModel.imageState,
                              onTapViewPhoto: {
                 viewModel.didTapViewPhoto()
@@ -277,6 +278,11 @@ private extension ProductCreationAIStartingInfoView {
             "productCreationAIStartingInfoView.photoSelected",
             value: "Photo selected",
             comment: "Text to explain that a package photo has been selected in starting info screen."
+        )
+        static let textAddedToInfo = NSLocalizedString(
+            "productCreationAIStartingInfoView.textAddedToInfo",
+            value: "Photo text added to starting info",
+            comment: "Text to explain that text scanned from a package photo has been added to the starting info screen."
         )
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductWithAI/StartingInfo/ProductCreationAIStartingInfoView.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductWithAI/StartingInfo/ProductCreationAIStartingInfoView.swift
@@ -123,7 +123,6 @@ private extension ProductCreationAIStartingInfoView {
         switch viewModel.imageState {
         case .empty:
             readTextFromPhotoButton
-                .padding(insets: Layout.readTextFromPhotoButtonInsets)
                 .mediaSourceActionSheet(showsActionSheet: $viewModel.isShowingMediaPickerSourceSheet, selectMedia: { source in
                     Task { @MainActor in
                         await viewModel.selectImage(from: source)
@@ -156,25 +155,45 @@ private extension ProductCreationAIStartingInfoView {
     }
 
     var readTextFromPhotoButton: some View {
-        HStack {
-            Button {
-                viewModel.didTapReadTextFromPhoto()
-            } label: {
-                HStack(alignment: .center, spacing: Layout.UsePackagePhoto.spacing) {
+        Button {
+            viewModel.didTapReadTextFromPhoto()
+        } label: {
+            AdaptiveStack(horizontalAlignment: .leading,
+                          verticalAlignment: .top,
+                          spacing: Layout.UsePackagePhoto.spacing) {
+                VStack {
                     Image(systemName: Layout.UsePackagePhoto.cameraSFSymbol)
                         .renderingMode(.template)
+                        .resizable()
+                        .aspectRatio(contentMode: .fit)
                         .fontWeight(.semibold)
                         .foregroundStyle(Color.accentColor)
-                        .bodyStyle()
-                        .padding(Layout.UsePackagePhoto.padding)
-
-                    Text(Localization.readTextFromPhoto)
-                        .fontWeight(.semibold)
-                        .foregroundStyle(Color.accentColor)
-                        .bodyStyle()
+                        .frame(width: Layout.UsePackagePhoto.imageSize * scale,
+                               height: Layout.UsePackagePhoto.imageSize * scale)
                 }
+                .frame(width: Layout.UsePackagePhoto.imageHolderViewSize * scale,
+                       height: Layout.UsePackagePhoto.imageHolderViewSize * scale)
+                .background(Color(light: Color(.systemColor(.systemGray5)),
+                                  dark: Color(.systemColor(.systemGray4))))
+                .clipShape(RoundedRectangle(cornerRadius: Layout.UsePackagePhoto.imageHolderViewCornerRadius))
+
+                VStack(alignment: .leading) {
+                    Text(Localization.scanPhotoTitle)
+                        .fontWeight(.semibold)
+                        .foregroundStyle(Color.accentColor)
+                        .bodyStyle()
+                    Text(Localization.scanPhotoDescription)
+                        .footnoteStyle()
+                }
+                .multilineTextAlignment(.leading)
+
+                Spacer()
             }
-            Spacer()
+            .frame(maxWidth: .infinity)
+            .padding(Layout.insets)
+            .background(Color(light: Color(.systemColor(.systemGray6)),
+                              dark: Color(.systemColor(.systemGray5))))
+            .clipShape(RoundedRectangle(cornerRadius: Layout.cornerRadius))
         }
     }
 
@@ -214,11 +233,12 @@ private extension ProductCreationAIStartingInfoView {
         static let messageContentInsets: EdgeInsets = .init(top: 10, leading: 10, bottom: 10, trailing: 10)
         static let placeholderInsets: EdgeInsets = .init(top: 16, leading: 16, bottom: 16, trailing: 16)
         static let dividerHeight: CGFloat = 1
-        static let readTextFromPhotoButtonInsets: EdgeInsets = .init(top: 11, leading: 16, bottom: 11, trailing: 16)
 
         enum UsePackagePhoto {
-            static let padding: CGFloat = 4
-            static let spacing: CGFloat = 4
+            static let imageSize: CGFloat = 24
+            static let imageHolderViewSize: CGFloat = 48
+            static let imageHolderViewCornerRadius: CGFloat = 4
+            static let spacing: CGFloat = 16
             static let cameraSFSymbol = "camera"
         }
     }
@@ -244,10 +264,15 @@ private extension ProductCreationAIStartingInfoView {
             value: "For example: Black cotton t-shirt, soft fabric, durable stitching, unique design",
             comment: "Placeholder text on the product features field"
         )
-        static let readTextFromPhoto = NSLocalizedString(
-            "productCreationAIStartingInfoView.readTextFromPhoto",
-            value: "Read text from product photo",
-            comment: "Button to upload package photo to read text from the photo"
+        static let scanPhotoTitle = NSLocalizedString(
+            "productCreationAIStartingInfoView.scanPhotoTitle",
+            value: "Scan a product photo",
+            comment: "Title of button to upload package photo to read text from the photo"
+        )
+        static let scanPhotoDescription = NSLocalizedString(
+            "productCreationAIStartingInfoView.scanPhotoDescription",
+            value: "Add a text scanned from a photo",
+            comment: "Description of button to upload package photo to read text from the photo"
         )
         static let generateProductDetails = NSLocalizedString(
             "productCreationAIStartingInfoView.generateProductDetails",

--- a/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductWithAI/StartingInfo/ProductCreationAIStartingInfoView.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductWithAI/StartingInfo/ProductCreationAIStartingInfoView.swift
@@ -140,12 +140,6 @@ private extension ProductCreationAIStartingInfoView {
                              onTapRemovePhoto: {
                 viewModel.didTapRemovePhoto()
             })
-            .clipShape(
-                .rect(
-                    bottomLeadingRadius: Layout.cornerRadius,
-                    bottomTrailingRadius: Layout.cornerRadius
-                )
-            )
             .mediaSourceActionSheet(showsActionSheet: $viewModel.isShowingMediaPickerSourceSheet, selectMedia: { source in
                 Task { @MainActor in
                     await viewModel.selectImage(from: source)

--- a/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductWithAI/StartingInfo/PromptProgressBar/ProductCreationAIPromptProgressBar.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductWithAI/StartingInfo/PromptProgressBar/ProductCreationAIPromptProgressBar.swift
@@ -23,7 +23,8 @@ struct ProductCreationAIPromptProgressBar: View {
             .animation(.easeIn, value: viewModel.status)
         })
         .padding(Layout.padding)
-        .background(Color(UIColor.listBackground))
+        .background(Color(light: Color(.systemColor(.systemGray6)),
+                          dark: Color(.systemColor(.systemGray5))))
         .cornerRadius(Layout.radius)
         .onAppear(perform: {
             viewModel.updateText(to: text)


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #13384 
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

This PR updates the layout of the starting information screen following the update in p1721186923084509/1720515544.395649-slack-C03L1NF1EA3.

## Testing steps
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->
- Log in to a store eligible for Jetpack AI.
- Navigate to the Products tab > + > Create product with AI.
- Confirm that the layout is correct for the starting information screen in light mode, dark mode, and in different font sizes.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->
Light mode | Dark mode | Large font
--- | ---| ---
<img src="https://github.com/user-attachments/assets/8ade0b04-b6b1-400a-82b0-285e6c04dd0c" width=320 /> | <img src="https://github.com/user-attachments/assets/79138335-6862-4b05-b7e8-039456355c33" width=320 /> | <img src="https://github.com/user-attachments/assets/c772ae50-e761-4c12-870a-b5d3c66dff88" width=320 />


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
