### PR TITLE
[Orders] Update documentation for lossy list decoding for order item attributes

### DIFF
--- a/Networking/Networking/Model/OrderItem.swift
+++ b/Networking/Networking/Model/OrderItem.swift
@@ -113,7 +113,8 @@ public struct OrderItem: Codable, Equatable, Hashable, GeneratedFakeable, Genera
         let total = try container.decode(String.self, forKey: .total)
         let totalTax = try container.decode(String.self, forKey: .totalTax)
 
-        // Use failsafe decoding to discard any attributes with non-string values (currently not supported).
+        // Use failsafe lossy decoding to silently discard any attributes with non-string values.
+        // Non-string values are not supported; instead of silently decoding them as empty strings (causing confusion in the UI) we now discard them.
         let allAttributes = container.failsafeDecodeIfPresent(lossyList: [OrderItemAttribute].self, forKey: .attributes)
         attributes = allAttributes.filter { !$0.name.hasPrefix("_") } // Exclude private items (marked with an underscore)
 


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This updates the documentation in `OrderItem` to explain why we silently discard order item attributes with non-string values. For more context: peaMlT-h6-p2#comment-1758


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.