### PR TITLE
Performance Card: Save and show last updated timestamp

### DIFF
--- a/WooCommerce/Classes/Tools/BackgroundTasks/DashboardTimestampStore.swift
+++ b/WooCommerce/Classes/Tools/BackgroundTasks/DashboardTimestampStore.swift
@@ -10,6 +10,7 @@ struct DashboardTimestampStore {
     ///
     enum Card: String, CaseIterable {
         case performance
+        case topPerformers
     }
 
     /// Supported time ranges

--- a/WooCommerce/Classes/ViewRelated/Dashboard/TopPerformers/TopPerformersDashboardView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/TopPerformers/TopPerformersDashboardView.swift
@@ -45,6 +45,11 @@ struct TopPerformersDashboardView: View {
                 Divider()
                     .padding(.leading, Layout.padding)
 
+                timestampView
+                    .renderedIf(viewModel.lastUpdatedTimestamp.isNotEmpty)
+                    .redacted(reason: viewModel.periodViewModel.redacted.rows ? [.placeholder] : [])
+                    .shimmering(active: viewModel.periodViewModel.redacted.rows)
+
                 viewAllAnalyticsButton
                     .padding(.horizontal, Layout.padding)
                     .redacted(reason: viewModel.periodViewModel.redacted.actionButton ? [.placeholder] : [])
@@ -156,6 +161,12 @@ private extension TopPerformersDashboardView {
             .frame(maxWidth: .infinity)
     }
 
+    var timestampView: some View {
+        Text(Localization.lastUpdatedText(time: viewModel.lastUpdatedTimestamp))
+            .footnoteStyle()
+            .frame(maxWidth: .infinity, alignment: .center)
+    }
+
     func productDetailView(for item: TopEarnerStatsItem) -> UIViewController {
         let loaderViewController = ProductLoaderViewController(model: .init(topEarnerStatsItem: item),
                                                                siteID: viewModel.siteID,
@@ -187,6 +198,10 @@ private extension TopPerformersDashboardView {
             value: "Custom",
             comment: "Title of the custom time range on the Top Performers card on the Dashboard screen"
         )
+        static func lastUpdatedText(time: String) -> String {
+            let format = NSLocalizedString("Last Updated: %@", comment: "Time for when the top performers card was last updated")
+            return String.localizedStringWithFormat(format, time)
+        }
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Dashboard/TopPerformers/TopPerformersDashboardViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/TopPerformers/TopPerformersDashboardViewModel.swift
@@ -42,6 +42,19 @@ final class TopPerformersDashboardViewModel: ObservableObject {
         resultsController?.fetchedObjects.first
     }
 
+    /// Returns the last updated timestamp for the current time range.
+    ///
+    var lastUpdatedTimestamp: String {
+        guard ServiceLocator.featureFlagService.isFeatureFlagEnabled(.backgroundTasks),
+              let timestamp = DashboardTimestampStore.loadTimestamp(for: .topPerformers, at: timeRange.timestampRange) else {
+            return ""
+        }
+
+        let formatter = timestamp.isSameDay(as: .now) ? DateFormatter.timeFormatter : DateFormatter.dateAndTimeFormatter
+        return formatter.string(from: timestamp)
+    }
+
+
     private var waitingTracker: WaitingTimeTracker?
     private let syncingDidFinishPublisher = PassthroughSubject<Error?, Never>()
     private var subscriptions = Set<AnyCancellable>()
@@ -248,6 +261,9 @@ private extension TopPerformersDashboardViewModel {
                 continuation.resume(with: voidResult)
             }))
         }
+
+        // Test if this reaches when an error is thrown
+        DashboardTimestampStore.saveTimestamp(.now, for: .topPerformers, at: timeRange.timestampRange)
     }
 }
 


### PR DESCRIPTION
Part of #13370

# How

This PR saves and displays the last updated sync timestamp on the top performers card.

# How

- Saves the timestamp when successfully loading stats
- Displays the timestamp when presenting the top performers card.

# Demo

https://github.com/user-attachments/assets/b091b549-21f4-4b9d-9004-6c7bfc08af8e

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
