### PR TITLE
Top Performers: Add background update support

### DIFF
--- a/WooCommerce/Classes/Tools/BackgroundTasks/DashboardSyncBackgroundTask.swift
+++ b/WooCommerce/Classes/Tools/BackgroundTasks/DashboardSyncBackgroundTask.swift
@@ -32,8 +32,10 @@ struct DashboardSyncBackgroundTask {
                 switch card.type {
                 case .performance:
                     group.addTask { try await performanceTask() }
+                case .topPerformers:
+                    group.addTask { try await topPerformersTask() }
 
-                case .blaze, .coupons, .googleAds, .inbox, .lastOrders, .onboarding, .reviews, .stock, .topPerformers:
+                case .blaze, .coupons, .googleAds, .inbox, .lastOrders, .onboarding, .reviews, .stock:
                     DDLogInfo("⚠️ Synchronizing \(card.type.name) card in the background is not yet supported...")
                     return
                 }
@@ -48,17 +50,32 @@ struct DashboardSyncBackgroundTask {
         DDLogInfo("📱 Finished synchronizing dashboard cards in the background...")
     }
 
-    /// Load the supposed visible cards from storage.
+    /// Run the performance card update task.
     ///
     @MainActor
     private func performanceTask() async throws {
         do {
             DDLogInfo("📱 Synchronizing Performance card in the background...")
-            let useCase = PerformanceCardDataSyncUseCase(siteID: siteID, siteTimezone: siteTimezone)
+            let useCase = PerformanceCardDataSyncUseCase(siteID: siteID, siteTimezone: siteTimezone, stores: stores)
             try await useCase.sync()
             DDLogInfo("📱 Successfully synchronized Performance card in the background")
         } catch {
             DDLogError("⛔️ Error synchronizing Performance card in the background: \(error)")
+            throw error
+        }
+    }
+
+    /// Run the top performers card update task.
+    ///
+    @MainActor
+    private func topPerformersTask() async throws {
+        do {
+            DDLogInfo("📱 Synchronizing Top Performers card in the background...")
+            let useCase = TopPerformersCardDataSyncUseCase(siteID: siteID, siteTimezone: siteTimezone, stores: stores)
+            try await useCase.sync()
+            DDLogInfo("📱 Successfully synchronized Top Performers card in the background")
+        } catch {
+            DDLogError("⛔️ Error synchronizing Top Performers card in the background: \(error)")
             throw error
         }
     }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/TopPerformers/TopPerformersCardDataSyncUseCase.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/TopPerformers/TopPerformersCardDataSyncUseCase.swift
@@ -1,0 +1,74 @@
+import Foundation
+import Yosemite
+
+/// Abstracts the code needed to sync the information for the Dashboard performance card.
+///
+struct TopPerformersCardDataSyncUseCase {
+
+    static let topEarnerStatsLimit: Int = 5
+
+    let siteID: Int64
+    let siteTimezone: TimeZone
+    let timeRange: StatsTimeRangeV4?
+    let stores: StoresManager
+
+    /// The provided `timeRange` will be used. If non is provided, the last used one(stored in settings) will be used.
+    ///
+    init(siteID: Int64, siteTimezone: TimeZone, timeRange: StatsTimeRangeV4? = nil, stores: StoresManager = ServiceLocator.stores) {
+        self.siteID = siteID
+        self.siteTimezone = siteTimezone
+        self.timeRange = timeRange
+        self.stores = stores
+    }
+    
+    /// Sync all stats needed for the performance card.
+    ///
+    @MainActor
+    func sync() async throws {
+        let timeRange = await {
+            guard let initialTimeRange = self.timeRange else {
+                return await loadLastTimeRange()
+            }
+            return initialTimeRange
+        }()
+        
+        try await syncTopPerformersStats(timeRange: timeRange)
+    }
+
+    /// Loads the last selected time range in any. If there isn't any returns the `.today` range.
+    ///
+    @MainActor
+    private func loadLastTimeRange() async -> StatsTimeRangeV4 {
+        await withCheckedContinuation { continuation in
+            let action = AppSettingsAction.loadLastSelectedTopPerformersTimeRange(siteID: siteID) { timeRange in
+                continuation.resume(returning: timeRange ?? .today)
+            }
+            stores.dispatch(action)
+        }
+    }
+
+    /// Syncs top performance stats for a given time range.
+    ///
+    @MainActor
+    func syncTopPerformersStats(timeRange: StatsTimeRangeV4) async throws {
+        let currentDate = Date()
+        let latestDateToInclude = timeRange.latestDate(currentDate: currentDate, siteTimezone: siteTimezone)
+        let earliestDateToInclude = timeRange.earliestDate(latestDate: latestDateToInclude, siteTimezone: siteTimezone)
+        try await withCheckedThrowingContinuation { continuation in
+            stores.dispatch(StatsActionV4.retrieveTopEarnerStats(siteID: siteID,
+                                                                 timeRange: timeRange,
+                                                                 timeZone: siteTimezone,
+                                                                 earliestDateToInclude: earliestDateToInclude,
+                                                                 latestDateToInclude: latestDateToInclude,
+                                                                 quantity: Self.topEarnerStatsLimit,
+                                                                 forceRefresh: true,
+                                                                 saveInStorage: true,
+                                                                 onCompletion: { result in
+                let voidResult = result.map { _ in () } // Caller expects no entity in the result.
+                continuation.resume(with: voidResult)
+            }))
+        }
+
+        DashboardTimestampStore.saveTimestamp(.now, for: .topPerformers, at: timeRange.timestampRange)
+    }
+}

--- a/WooCommerce/Classes/ViewRelated/Dashboard/TopPerformers/TopPerformersCardDataSyncUseCase.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/TopPerformers/TopPerformersCardDataSyncUseCase.swift
@@ -20,7 +20,7 @@ struct TopPerformersCardDataSyncUseCase {
         self.timeRange = timeRange
         self.stores = stores
     }
-    
+
     /// Sync all stats needed for the performance card.
     ///
     @MainActor
@@ -31,7 +31,7 @@ struct TopPerformersCardDataSyncUseCase {
             }
             return initialTimeRange
         }()
-        
+
         try await syncTopPerformersStats(timeRange: timeRange)
     }
 

--- a/WooCommerce/Classes/ViewRelated/Dashboard/TopPerformers/TopPerformersDashboardViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/TopPerformers/TopPerformersDashboardViewModel.swift
@@ -183,7 +183,7 @@ private extension TopPerformersDashboardViewModel {
             }
             .store(in: &subscriptions)
     }
-    
+
     @MainActor
     func loadLastTimeRange() async -> StatsTimeRangeV4? {
         await withCheckedContinuation { continuation in
@@ -193,12 +193,12 @@ private extension TopPerformersDashboardViewModel {
             stores.dispatch(action)
         }
     }
-    
+
     func saveLastTimeRange(_ timeRange: StatsTimeRangeV4) {
         let action = AppSettingsAction.setLastSelectedTopPerformersTimeRange(siteID: siteID, timeRange: timeRange)
         stores.dispatch(action)
     }
-    
+
     func updateResultsController() {
         let resultsController = createResultsController(timeRange: timeRange)
         self.resultsController = resultsController
@@ -208,14 +208,14 @@ private extension TopPerformersDashboardViewModel {
         resultsController.onDidResetContent = { [weak self] in
             self?.updateUIInLoadedState()
         }
-        
+
         do {
             try resultsController.performFetch()
         } catch {
             ServiceLocator.crashLogging.logError(error)
         }
     }
-    
+
     func updateUIInLoadingState() {
         guard ServiceLocator.featureFlagService.isFeatureFlagEnabled(.backgroundTasks) else {
             return periodViewModel.update(state: .loading(cached: []))
@@ -223,7 +223,7 @@ private extension TopPerformersDashboardViewModel {
         let items = topEarnerStats?.items?.sorted(by: >) ?? []
         periodViewModel.update(state: .loading(cached: items))
     }
-    
+
     func updateUIInLoadedState() {
         guard !syncingData else {
             return
@@ -233,7 +233,7 @@ private extension TopPerformersDashboardViewModel {
         }
         periodViewModel.update(state: .loaded(rows: items))
     }
-    
+
     func createResultsController(timeRange: StatsTimeRangeV4) -> ResultsController<StorageTopEarnerStats> {
         let granularity = timeRange.topEarnerStatsGranularity
         let formattedDateString: String = {
@@ -242,7 +242,7 @@ private extension TopPerformersDashboardViewModel {
         }()
         let predicate = NSPredicate(format: "granularity = %@ AND date = %@ AND siteID = %ld", granularity.rawValue, formattedDateString, siteID)
         let descriptor = NSSortDescriptor(key: "date", ascending: true)
-        
+
         return ResultsController<StorageTopEarnerStats>(storageManager: storageManager, matching: predicate, sortedBy: [descriptor])
     }
 }

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -1035,6 +1035,7 @@
 		26CFDEE62C038C7D005ABC31 /* OrderNotificationDataService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26CFDEE42C038C39005ABC31 /* OrderNotificationDataService.swift */; };
 		26D1E9E82949818B00A7DC62 /* AnalyticsHubTimeRageAdapter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26D1E9E72949818B00A7DC62 /* AnalyticsHubTimeRageAdapter.swift */; };
 		26D57CF72B59820600E8EFB8 /* View+ContainerBackground.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26D57CF62B59820600E8EFB8 /* View+ContainerBackground.swift */; };
+		26D86B692C50110600435411 /* TopPerformersCardDataSyncUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26D86B682C50110600435411 /* TopPerformersCardDataSyncUseCase.swift */; };
 		26D9E54428C107F80098DF26 /* WooFoundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 26D9E54328C107F80098DF26 /* WooFoundation.framework */; };
 		26D9E54828C10A3B0098DF26 /* Experiments.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 26D9E54728C10A3B0098DF26 /* Experiments.framework */; };
 		26DB7E3528636D2200506173 /* NonEditableOrderBanner.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26DB7E3428636D2200506173 /* NonEditableOrderBanner.swift */; };
@@ -3971,6 +3972,7 @@
 		26CFDEE42C038C39005ABC31 /* OrderNotificationDataService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OrderNotificationDataService.swift; sourceTree = "<group>"; };
 		26D1E9E72949818B00A7DC62 /* AnalyticsHubTimeRageAdapter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnalyticsHubTimeRageAdapter.swift; sourceTree = "<group>"; };
 		26D57CF62B59820600E8EFB8 /* View+ContainerBackground.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "View+ContainerBackground.swift"; sourceTree = "<group>"; };
+		26D86B682C50110600435411 /* TopPerformersCardDataSyncUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TopPerformersCardDataSyncUseCase.swift; sourceTree = "<group>"; };
 		26D9E54328C107F80098DF26 /* WooFoundation.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = WooFoundation.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		26D9E54728C10A3B0098DF26 /* Experiments.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = Experiments.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		26DB7E3428636D2200506173 /* NonEditableOrderBanner.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NonEditableOrderBanner.swift; sourceTree = "<group>"; };
@@ -12315,6 +12317,7 @@
 				02E4908829AE49B9005942AE /* TopPerformersEmptyView.swift */,
 				DE74A4512BCF87120009C415 /* TopPerformersDashboardView.swift */,
 				DE74A4532BCF88420009C415 /* TopPerformersDashboardViewModel.swift */,
+				26D86B682C50110600435411 /* TopPerformersCardDataSyncUseCase.swift */,
 			);
 			path = TopPerformers;
 			sourceTree = "<group>";
@@ -15809,6 +15812,7 @@
 				57A25C7625ACE9BC00A54A62 /* OrderFulfillmentUseCase.swift in Sources */,
 				DE0134152A2EED52000A6F54 /* ProductSharingMessageGenerationView.swift in Sources */,
 				EEADF622281A40CB001B40F1 /* ShippingValueLocalizer.swift in Sources */,
+				26D86B692C50110600435411 /* TopPerformersCardDataSyncUseCase.swift in Sources */,
 				C7F746C92C4868670023ADD0 /* TotalsViewModelProtocol.swift in Sources */,
 				262C922126F1370000011F92 /* StorePickerError.swift in Sources */,
 				4515C89825D6C00E0099C8E3 /* ShippingLabelAddressFormViewModel.swift in Sources */,


### PR DESCRIPTION
Closes: #13370

# Why

This PR adds the ability to refresh the top performer's card data with a background update task.

# How
- Abstracts the code needed to sync the information for the Dashboard  top performer's card.
- Update the  top performer's card view model to sync data using the new use case
- Add background task for the top performer's card.

# Demo
https://github.com/user-attachments/assets/c131e01d-8dfd-45bc-afc9-32ac20c82822

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
