### PR TITLE
Optimize last order dashboard card and keep order status consistent

### DIFF
--- a/Networking/Networking/Model/Address.swift
+++ b/Networking/Networking/Model/Address.swift
@@ -3,7 +3,7 @@ import Codegen
 
 /// Represents an Address Entity.
 ///
-public struct Address: Codable, GeneratedFakeable, GeneratedCopiable {
+public struct Address: Codable, Sendable, GeneratedFakeable, GeneratedCopiable {
     public let firstName: String
     public let lastName: String
     public let company: String?

--- a/Networking/Networking/Model/Order.swift
+++ b/Networking/Networking/Model/Order.swift
@@ -3,7 +3,7 @@ import Codegen
 
 /// Represents an Order Entity.
 ///
-public struct Order: Decodable, GeneratedCopiable, GeneratedFakeable {
+public struct Order: Decodable, Sendable, GeneratedCopiable, GeneratedFakeable {
     public let siteID: Int64
     public let orderID: Int64
     public let parentID: Int64

--- a/Networking/Networking/Model/OrderAttributionInfo.swift
+++ b/Networking/Networking/Model/OrderAttributionInfo.swift
@@ -3,7 +3,7 @@ import Codegen
 
 /// Order's attribution info helps to know the source of the order
 ///
-public struct OrderAttributionInfo: Equatable, GeneratedFakeable, GeneratedCopiable {
+public struct OrderAttributionInfo: Equatable, Sendable, GeneratedFakeable, GeneratedCopiable {
     public let sourceType: String?
     public let campaign: String?
     public let source: String?

--- a/Networking/Networking/Model/OrderCouponLine.swift
+++ b/Networking/Networking/Model/OrderCouponLine.swift
@@ -3,7 +3,7 @@ import Codegen
 
 /// Represents a CouponLine Entity within an Order.
 ///
-public struct OrderCouponLine: Codable, Equatable, GeneratedFakeable, GeneratedCopiable {
+public struct OrderCouponLine: Codable, Equatable, Sendable, GeneratedFakeable, GeneratedCopiable {
     public let couponID: Int64
     public let code: String
     public let discount: String

--- a/Networking/Networking/Model/OrderFeeLine.swift
+++ b/Networking/Networking/Model/OrderFeeLine.swift
@@ -3,7 +3,7 @@ import Codegen
 
 /// Represents a FeeLine Entity within an Order.
 ///
-public struct OrderFeeLine: Equatable, Codable, GeneratedFakeable, GeneratedCopiable {
+public struct OrderFeeLine: Equatable, Codable, Sendable, GeneratedFakeable, GeneratedCopiable {
     public let feeID: Int64
 
     /// Fee Name

--- a/Networking/Networking/Model/OrderFeeTaxStatus.swift
+++ b/Networking/Networking/Model/OrderFeeTaxStatus.swift
@@ -4,7 +4,7 @@ import Codegen
 /// Represents a OrderFeeTaxStatus Entity.
 ///
 
-public enum OrderFeeTaxStatus: Codable, Hashable, GeneratedFakeable {
+public enum OrderFeeTaxStatus: Codable, Hashable, Sendable, GeneratedFakeable {
     case taxable
     case none
 }

--- a/Networking/Networking/Model/OrderGiftCard.swift
+++ b/Networking/Networking/Model/OrderGiftCard.swift
@@ -3,7 +3,7 @@ import Codegen
 
 /// OrderGiftCard entity: Represents a gift card applied to an order.
 ///
-public struct OrderGiftCard: Codable, Equatable, GeneratedFakeable, GeneratedCopiable {
+public struct OrderGiftCard: Codable, Equatable, Sendable, GeneratedFakeable, GeneratedCopiable {
 
     /// Remote ID for the gift card
     ///

--- a/Networking/Networking/Model/OrderItem.swift
+++ b/Networking/Networking/Model/OrderItem.swift
@@ -3,7 +3,7 @@ import Codegen
 
 /// Represents an Order's Item Entity.
 ///
-public struct OrderItem: Codable, Equatable, Hashable, GeneratedFakeable, GeneratedCopiable {
+public struct OrderItem: Codable, Equatable, Hashable, Sendable, GeneratedFakeable, GeneratedCopiable {
     public let itemID: Int64
     public let name: String
 

--- a/Networking/Networking/Model/OrderItemAttribute.swift
+++ b/Networking/Networking/Model/OrderItemAttribute.swift
@@ -8,7 +8,7 @@ import Codegen
 ///
 /// Only attributes with `String` values are supported.
 ///
-public struct OrderItemAttribute: Decodable, Hashable, Equatable, GeneratedFakeable, GeneratedCopiable {
+public struct OrderItemAttribute: Decodable, Hashable, Equatable, Sendable, GeneratedFakeable, GeneratedCopiable {
     public let metaID: Int64
     public let name: String
     public let value: String

--- a/Networking/Networking/Model/OrderItemProductAddOn.swift
+++ b/Networking/Networking/Model/OrderItemProductAddOn.swift
@@ -3,7 +3,7 @@ import Codegen
 /// Represents a product add-on (from the Product Add-ons extension) of an `OrderItem` in its `attributes` (meta) property.
 /// The value type is string but could be from different types like numbers in the API.
 ///
-public struct OrderItemProductAddOn: Decodable, Hashable, Equatable, GeneratedFakeable, GeneratedCopiable {
+public struct OrderItemProductAddOn: Decodable, Hashable, Equatable, Sendable, GeneratedFakeable, GeneratedCopiable {
     /// The ID can be `nil` (e.g. when WCPay plugin is active).
     public let addOnID: Int64?
     public let key: String

--- a/Networking/Networking/Model/OrderItemTax.swift
+++ b/Networking/Networking/Model/OrderItemTax.swift
@@ -3,7 +3,7 @@ import Codegen
 
 /// Represents the Taxes for a specific Order Item.
 ///
-public struct OrderItemTax: Codable, Equatable, Hashable, GeneratedFakeable {
+public struct OrderItemTax: Codable, Equatable, Hashable, Sendable, GeneratedFakeable {
 
     /// Tax ID for line item
     ///

--- a/Networking/Networking/Model/OrderMetaData.swift
+++ b/Networking/Networking/Model/OrderMetaData.swift
@@ -4,7 +4,7 @@ import Codegen
 /// Represents the metadata within an Order
 /// Currently only handles `String` metadata values
 ///
-public struct OrderMetaData: Codable, Equatable {
+public struct OrderMetaData: Codable, Equatable, Sendable {
     public let metadataID: Int64
     public let key: String
     public let value: String

--- a/Networking/Networking/Model/OrderRefundCondensed.swift
+++ b/Networking/Networking/Model/OrderRefundCondensed.swift
@@ -3,7 +3,7 @@ import Codegen
 
 /// Represents an Order Refund Entity.
 ///
-public struct OrderRefundCondensed: Decodable, Equatable, GeneratedFakeable {
+public struct OrderRefundCondensed: Decodable, Equatable, Sendable, GeneratedFakeable {
     public let refundID: Int64
     public let reason: String?
     public let total: String

--- a/Networking/Networking/Model/OrderStatusEnum.swift
+++ b/Networking/Networking/Model/OrderStatusEnum.swift
@@ -67,7 +67,7 @@ public extension OrderStatusEnum {
             )
         case .refunded:
             return NSLocalizedString(
-                "orderStatusEnum.localizedName.autoDraft",
+                "orderStatusEnum.localizedName.refunded",
                 value: "Refunded",
                 comment: "Display label for refunded order status."
             )

--- a/Networking/Networking/Model/OrderStatusEnum.swift
+++ b/Networking/Networking/Model/OrderStatusEnum.swift
@@ -6,7 +6,7 @@ import Codegen
 /// The order of the statuses declaration is according to the Order's lifecycle
 /// and it is used to determine the user facing display order
 ///
-public enum OrderStatusEnum: Codable, Hashable, Comparable, GeneratedFakeable {
+public enum OrderStatusEnum: Codable, Hashable, Comparable, Sendable, GeneratedFakeable {
     case autoDraft
     case pending
     case processing

--- a/Networking/Networking/Model/OrderStatusEnum.swift
+++ b/Networking/Networking/Model/OrderStatusEnum.swift
@@ -18,6 +18,65 @@ public enum OrderStatusEnum: Codable, Hashable, Comparable, Sendable, GeneratedF
     case custom(String)
 }
 
+public extension OrderStatusEnum {
+    /// Returns the localized text version of the Enum
+    ///
+    var localizedName: String {
+        switch self {
+        case .autoDraft:
+            return NSLocalizedString(
+                "orderStatusEnum.localizedName.autoDraft",
+                value: "Draft",
+                comment: "Display label for auto-draft order status."
+            )
+        case .pending:
+            return NSLocalizedString(
+                "orderStatusEnum.localizedName.pending",
+                value: "Pending Payment",
+                comment: "Display label for pending order status."
+            )
+        case .processing:
+            return NSLocalizedString(
+                "orderStatusEnum.localizedName.processing",
+                value: "Processing",
+                comment: "Display label for processing order status."
+            )
+        case .onHold:
+            return NSLocalizedString(
+                "orderStatusEnum.localizedName.onHold",
+                value: "On hold",
+                comment: "Display label for on hold order status."
+            )
+        case .failed:
+            return NSLocalizedString(
+                "orderStatusEnum.localizedName.failed",
+                value: "Failed",
+                comment: "Display label for failed order status."
+            )
+        case .cancelled:
+            return NSLocalizedString(
+                "orderStatusEnum.localizedName.cancelled",
+                value: "Cancelled",
+                comment: "Display label for cancelled order status."
+            )
+        case .completed:
+            return NSLocalizedString(
+                "orderStatusEnum.localizedName.completed",
+                value: "Completed",
+                comment: "Display label for completed order status."
+            )
+        case .refunded:
+            return NSLocalizedString(
+                "orderStatusEnum.localizedName.autoDraft",
+                value: "Refunded",
+                comment: "Display label for refunded order status."
+            )
+        case .custom(let payload):
+            return payload // unable to localize at runtime.
+        }
+    }
+}
+
 /// RawRepresentable Conformance
 ///
 extension OrderStatusEnum: RawRepresentable {

--- a/Networking/Networking/Model/OrderTaxLine.swift
+++ b/Networking/Networking/Model/OrderTaxLine.swift
@@ -3,7 +3,7 @@ import Codegen
 
 /// Represents a TaxLine Entity within an Order.
 ///
-public struct OrderTaxLine: Decodable, Equatable, GeneratedFakeable, GeneratedCopiable {
+public struct OrderTaxLine: Decodable, Equatable, Sendable, GeneratedFakeable, GeneratedCopiable {
     public let taxID: Int64
     public let rateCode: String
     public let rateID: Int64

--- a/Networking/Networking/Model/ShippingLine.swift
+++ b/Networking/Networking/Model/ShippingLine.swift
@@ -3,7 +3,7 @@ import Codegen
 
 /// Represents a Shipping Line Entity.
 ///
-public struct ShippingLine: Codable, Equatable, GeneratedFakeable, GeneratedCopiable {
+public struct ShippingLine: Codable, Equatable, Sendable, GeneratedFakeable, GeneratedCopiable {
     public let shippingID: Int64
     public let methodTitle: String
 

--- a/Networking/Networking/Model/ShippingLineTax.swift
+++ b/Networking/Networking/Model/ShippingLineTax.swift
@@ -3,7 +3,7 @@ import Codegen
 
 /// Represents the taxes for a specific shipping item.
 ///
-public struct ShippingLineTax: Decodable, Hashable, GeneratedFakeable {
+public struct ShippingLineTax: Decodable, Hashable, Sendable, GeneratedFakeable {
 
     /// Tax ID for shipping item
     ///

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -2,6 +2,7 @@
 
 19.7
 -----
+- [*] Order status is consistent across the order list/dashboard card/filter list/search list. [https://github.com/woocommerce/woocommerce-ios/pull/13408]
 - [*] Stats: The Google Campaign analytics card now has a call to action to create a paid campaign if there are no campaign analytics for the selected time period. [https://github.com/woocommerce/woocommerce-ios/pull/13397]
 
 19.6

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Onboarding/StoreOnboardingViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Onboarding/StoreOnboardingViewModel.swift
@@ -108,7 +108,7 @@ class StoreOnboardingViewModel: ObservableObject {
         }
 
         analytics.track(event: .DynamicDashboard.cardLoadingStarted(type: .onboarding))
-        await update(state: .loading)
+        update(state: .loading)
 
         let tasks: [StoreOnboardingTaskViewModel]
         var syncingError: Error?
@@ -120,12 +120,12 @@ class StoreOnboardingViewModel: ObservableObject {
         }
 
         if tasks.isNotEmpty {
-            await checkIfAllTasksAreCompleted(tasks)
-            await update(state: .loaded(rows: tasks))
+            checkIfAllTasksAreCompleted(tasks)
+            update(state: .loaded(rows: tasks))
         } else if taskViewModels.isNotEmpty {
-            await update(state: .loaded(rows: taskViewModels))
+            update(state: .loaded(rows: taskViewModels))
         } else {
-            await update(state: .failed)
+            update(state: .failed)
         }
 
         if let syncingError {

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Onboarding/StoreOnboardingViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Onboarding/StoreOnboardingViewModel.swift
@@ -156,7 +156,6 @@ private extension StoreOnboardingViewModel {
             .map { .init(task: $0, badgeText: nil) }
     }
 
-    @MainActor
     func update(state: State) {
         switch state {
         case .loading:
@@ -178,7 +177,6 @@ private extension StoreOnboardingViewModel {
         onStateChange?()
     }
 
-    @MainActor
     func checkIfAllTasksAreCompleted(_ tasksFromServer: [StoreOnboardingTaskViewModel]) {
         guard tasksFromServer.isNotEmpty else {
             return

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Orders/LastOrdersDashboardCardViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Orders/LastOrdersDashboardCardViewModel.swift
@@ -149,6 +149,10 @@ final class LastOrdersDashboardCardViewModel: ObservableObject {
 
     @MainActor
     func updateOrderStatus(_ status: OrderStatusRow) async {
+        guard selectedOrderStatus != status.status else {
+            /// Do nothing if the same status is selected.
+            return
+        }
         selectedOrderStatus = status.status
         stores.dispatch(AppSettingsAction.setLastSelectedOrderStatus(siteID: siteID, status: selectedOrderStatus?.rawValue))
 

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Reviews/ReviewsDashboardCardViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Reviews/ReviewsDashboardCardViewModel.swift
@@ -259,7 +259,7 @@ private extension ReviewsDashboardCardViewModel {
                     }
                 }
                 // rethrow any failure.
-                for try await result in group {
+                for try await _ in group {
                     // no-op if result doesn't throw any error
                 }
             }

--- a/WooCommerce/Classes/ViewRelated/Orders/Cells/OrderListCellViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Cells/OrderListCellViewModel.swift
@@ -17,12 +17,10 @@ import WooFoundationWatchOS
 //
 struct OrderListCellViewModel {
     private let order: Order
-    private let orderStatus: OrderStatus?
     private let currencyFormatter: CurrencyFormatter
 
-    init(order: Order, status: OrderStatus?, currencySettings: CurrencySettings) {
+    init(order: Order, currencySettings: CurrencySettings) {
         self.order = order
-        self.orderStatus = status
         self.currencyFormatter = CurrencyFormatter(currencySettings: currencySettings)
     }
 
@@ -69,15 +67,13 @@ struct OrderListCellViewModel {
     /// Status of the order
     ///
     var status: OrderStatusEnum {
-        return orderStatus?.status ?? order.status
+        return order.status
     }
 
     /// Textual representation of the status
     ///
-    /// There are unsupported extensions with even more statuses available.
-    /// So if orderStatus doesn't have a name, let's use the order.status to display those as slugs.
     var statusString: String {
-        return orderStatus?.name ?? order.status.rawValue
+        return order.status.localizedName
     }
 
     /// The localized unabbreviated total for a given order item, which includes the currency.

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Filters/FilterOrderListViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Filters/FilterOrderListViewModel.swift
@@ -166,28 +166,7 @@ extension OrderStatusEnum: FilterType {
 
     /// Returns the localized text version of the Enum
     ///
-    var description: String {
-        switch self {
-        case .autoDraft:
-            return NSLocalizedString("Draft", comment: "Display label for auto-draft order status.")
-        case .pending:
-            return NSLocalizedString("Pending", comment: "Display label for pending order status.")
-        case .processing:
-            return NSLocalizedString("Processing", comment: "Display label for processing order status.")
-        case .onHold:
-            return NSLocalizedString("On hold", comment: "Display label for on hold order status.")
-        case .failed:
-            return NSLocalizedString("Failed", comment: "Display label for failed order status.")
-        case .cancelled:
-            return NSLocalizedString("Cancelled", comment: "Display label for cancelled order status.")
-        case .completed:
-            return NSLocalizedString("Completed", comment: "Display label for completed order status.")
-        case .refunded:
-            return NSLocalizedString("Refunded", comment: "Display label for refunded order status.")
-        case .custom(let payload):
-            return payload // unable to localize at runtime.
-        }
-    }
+    var description: String { localizedName }
 }
 
 extension Array: FilterType where Element == OrderStatusEnum {

--- a/WooCommerce/Classes/ViewRelated/Orders/OrderListViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrderListViewModel.swift
@@ -298,10 +298,6 @@ private extension OrderListViewModel {
             ServiceLocator.crashLogging.logError(error)
         }
     }
-
-    func lookUpOrderStatus(for order: Order) -> OrderStatus? {
-        return currentSiteStatuses.first(where: { $0.status == order.status })
-    }
 }
 
 // MARK: - Banners
@@ -332,9 +328,7 @@ extension OrderListViewModel {
             return nil
         }
 
-        let status = lookUpOrderStatus(for: order)
-
-        return OrderListCellViewModel(order: order, status: status, currencySettings: ServiceLocator.currencySettings)
+        return OrderListCellViewModel(order: order, currencySettings: ServiceLocator.currencySettings)
     }
 
     /// Creates an `OrderDetailsViewModel` for the `Order` pointed to by `objectID`.

--- a/WooCommerce/Woo Watch App/Orders/OrdersListViewModel.swift
+++ b/WooCommerce/Woo Watch App/Orders/OrdersListViewModel.swift
@@ -63,7 +63,7 @@ final class OrdersListViewModel: ObservableObject {
     ///
     static func viewOrders(from remoteOrders: [Order], currencySettings: CurrencySettings) -> [OrdersListView.Order] {
         remoteOrders.map { order in
-            let orderViewModel = OrderListCellViewModel(order: order, status: nil, currencySettings: currencySettings)
+            let orderViewModel = OrderListCellViewModel(order: order, currencySettings: currencySettings)
 
             let items = order.items.enumerated().map { index, orderItem in
                 OrdersListView.OrderItem(id: orderItem.itemID,

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/OrderListCellViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/OrderListCellViewModelTests.swift
@@ -12,7 +12,7 @@ final class OrderListCellViewModelTests: XCTestCase {
         let expectedYearString = DateFormatter.yearFormatter.string(from: order.dateCreated)
 
         // When
-        let viewModel = OrderListCellViewModel(order: order, status: nil, currencySettings: ServiceLocator.currencySettings)
+        let viewModel = OrderListCellViewModel(order: order, currencySettings: ServiceLocator.currencySettings)
 
         // Then
         let formatted = viewModel.dateCreated
@@ -26,7 +26,7 @@ final class OrderListCellViewModelTests: XCTestCase {
         let expectedYearString = DateFormatter.yearFormatter.string(from: order.dateCreated)
 
         // When
-        let viewModel = OrderListCellViewModel(order: order, status: nil, currencySettings: ServiceLocator.currencySettings)
+        let viewModel = OrderListCellViewModel(order: order, currencySettings: ServiceLocator.currencySettings)
 
         // Then
         let formatted = viewModel.dateCreated
@@ -34,32 +34,16 @@ final class OrderListCellViewModelTests: XCTestCase {
         XCTAssertTrue(formatted.contains(expectedYearString))
     }
 
-    func test_OrderStatus_is_used_when_passed_to_view_model() {
-        // Given
-        let order = MockOrders().sampleOrder()
-        let orderStatus = OrderStatus(name: UUID().uuidString,
-                                      siteID: 0,
-                                      slug: UUID().uuidString,
-                                      total: 0)
-
-        // When
-        let viewModel = OrderListCellViewModel(order: order, status: orderStatus, currencySettings: ServiceLocator.currencySettings)
-
-        // Then
-        XCTAssertEqual(viewModel.status, .custom(orderStatus.slug))
-        XCTAssertEqual(viewModel.statusString, orderStatus.name)
-    }
-
-    func test_status_from_order_is_used_when_OrderStatus_is_nil() {
+    func test_status_from_order_is_used() {
         // Given
         let order = MockOrders().sampleOrder()
 
         // When
-        let viewModel = OrderListCellViewModel(order: order, status: nil, currencySettings: ServiceLocator.currencySettings)
+        let viewModel = OrderListCellViewModel(order: order, currencySettings: ServiceLocator.currencySettings)
 
         // Then
         XCTAssertEqual(viewModel.status, order.status)
-        XCTAssertEqual(viewModel.statusString, order.status.rawValue)
+        XCTAssertEqual(viewModel.statusString, order.status.localizedName)
     }
 
     func test_OrderListCell_accessoryView_uses_chevron_with_tertiaryLabel_tint_as_disclosure_indicator() {
@@ -68,7 +52,7 @@ final class OrderListCellViewModelTests: XCTestCase {
         let expectedImage = UIImage(systemName: "chevron.forward")
 
         // When
-        let viewModel = OrderListCellViewModel(order: order, status: nil, currencySettings: ServiceLocator.currencySettings)
+        let viewModel = OrderListCellViewModel(order: order, currencySettings: ServiceLocator.currencySettings)
 
         // Then
         guard let accessoryView = viewModel.accessoryView else {

--- a/WooCommerce/WooCommerceTests/ViewRelated/Search/Order/OrderSearchUICommandTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Search/Order/OrderSearchUICommandTests.swift
@@ -58,7 +58,6 @@ final class OrderSearchUICommandTests: XCTestCase {
 
         // Then
         XCTAssertNotNil(cellViewModel, "Expected createCellViewModel to return an OrderListCellViewModel instance")
-        XCTAssertEqual(cellViewModel.statusString, "on-hold", "Expected order status name to match")
         XCTAssertEqual(cellViewModel.status, .onHold, "Expected createCellViewModel to return on hold status")
     }
 

--- a/Yosemite/Yosemite/Model/Enums/StatsTimeRangeV4.swift
+++ b/Yosemite/Yosemite/Model/Enums/StatsTimeRangeV4.swift
@@ -8,7 +8,7 @@ import Foundation
 /// - thisMonth: daily data starting 1st of this month until now.
 /// - thisYear: monthly data starting January of this year until now.
 /// - custom: Data for a custom date range.
-public enum StatsTimeRangeV4 {
+public enum StatsTimeRangeV4: Sendable {
     case today
     case thisWeek
     case thisMonth


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of #13048 
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This PR adds a few updates to the last order dashboard card:
- Fixed concurrency warnings related to the order dashboard card (and some minor ones in other cards) when the concurrency check is set to `targeted` (part of #13001).
- Ignore order status selection on the dashboard card when the selected status is the same as the current status.
- Unified the display name for order status between the dashboard card and the order list:
  - On the order list, display the localized name of order status instead of the name returned from the remote.
  - Moved the logic for localized name of `OrderStatusEnum`  to the source file. This is necessary because `OrderListCellViewModel` is also used by the watch app which imports the `NetworkingWatchOS` module instead of `Yosemite`. Moving the extension to the source file makes it possible to reuse the same logic in different modules.

## Testing steps
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->
- Log in to a store with existing orders.
- Confirm that order status is consistent between the order list - order dashboard card - order filter list - order search list.
- Confirm that `pending` status is displayed as `Pending Payment`.
- Since the localized strings will need to be localized as part of the code freeze, order status on the above screen is always English at the moment.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->
N/A

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
