### PR TITLE
Blaze: Track error for Blaze campaign creation failure

### DIFF
--- a/WooCommerce/Classes/Analytics/WooAnalyticsEvent+Blaze.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsEvent+Blaze.swift
@@ -179,8 +179,8 @@ extension WooAnalyticsEvent {
             }
 
             /// Tracked when campaign creation fails
-            static func campaignCreationFailed() -> WooAnalyticsEvent {
-                WooAnalyticsEvent(statName: .blazeCampaignCreationFailed, properties: [:])
+            static func campaignCreationFailed(error: Error) -> WooAnalyticsEvent {
+                WooAnalyticsEvent(statName: .blazeCampaignCreationFailed, properties: [:], error: error)
             }
         }
     }

--- a/WooCommerce/Classes/ViewRelated/Blaze/ConfirmPayment/BlazeConfirmPaymentViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Blaze/ConfirmPayment/BlazeConfirmPaymentViewModel.swift
@@ -133,7 +133,7 @@ final class BlazeConfirmPaymentViewModel: ObservableObject {
             analytics.track(event: .Blaze.Payment.campaignCreationSuccess())
             completionHandler()
         } catch {
-            analytics.track(event: .Blaze.Payment.campaignCreationFailed())
+            analytics.track(event: .Blaze.Payment.campaignCreationFailed(error: error))
             campaignCreationError = error as? BlazeCampaignCreationError ?? .failedToCreateCampaign
         }
         isCreatingCampaign = false


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #12859
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This PR adds a missing error to the tracking event of Blaze campaign creation failure.

## Testing steps
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->
- Log in to a store eligible for Blaze.
- Start campaign creation for a product by entering the necessary input for the flow.
- Before submitting for campaign creation, disconnect the Internet on your testing device.
- Submit the campaign and confirm that after the request times out, `blaze_campaign_creation_failed` is tracked with properties for the error of the failure.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->
N/A

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
