### PR TITLE
Revert "Remove GhostableViewController Conformances for Crash Investigation

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Coupons/CouponListViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Coupons/CouponListViewController.swift
@@ -3,7 +3,7 @@ import UIKit
 import WordPressUI
 import Yosemite
 
-final class CouponListViewController: UIViewController {
+final class CouponListViewController: UIViewController, GhostableViewController {
     @IBOutlet private weak var tableView: UITableView!
     private let viewModel: CouponListViewModel
     private let siteID: Int64
@@ -86,7 +86,7 @@ final class CouponListViewController: UIViewController {
                 case .couponsDisabled:
                     self.displayCouponsDisabledOverlay()
                 case .loading:
-                    break
+                    self.displayPlaceholderCoupons()
                 case .coupons:
                     // the table view is reloaded when coupon view models are updated
                     // so there's no need to reload here
@@ -153,6 +153,7 @@ private extension CouponListViewController {
     ///
     func resetViews() {
         removeNoResultsOverlay()
+        removePlaceholderCoupons()
         stopFooterLoadingIndicator()
         if refreshControl.isRefreshing {
             refreshControl.endRefreshing()
@@ -269,6 +270,24 @@ private extension CouponListViewController {
         present(navigationController, animated: true, completion: nil)
     }
 }
+
+
+// MARK: - Placeholder cells
+//
+extension CouponListViewController {
+    /// Renders the Placeholder Coupons
+    ///
+    func displayPlaceholderCoupons() {
+        displayGhostContent()
+    }
+
+    /// Removes the Placeholder Coupons
+    ///
+    func removePlaceholderCoupons() {
+        removeGhostContent()
+    }
+}
+
 
 // MARK: - Empty state view controller
 //

--- a/WooCommerce/Classes/ViewRelated/ListSelector/PaginatedListSelectorViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/ListSelector/PaginatedListSelectorViewController.swift
@@ -54,7 +54,7 @@ extension PaginatedListSelectorDataSource {
 /// Displays a paginated list (implemented by table view) for the user to select a generic model.
 ///
 final class PaginatedListSelectorViewController<DataSource: PaginatedListSelectorDataSource, Model, StorageModel, Cell>: UIViewController,
-    UITableViewDataSource, UITableViewDelegate, UITableViewDragDelegate, PaginationTrackerDelegate
+    UITableViewDataSource, UITableViewDelegate, UITableViewDragDelegate, PaginationTrackerDelegate, GhostableViewController
 where DataSource.StorageModel == StorageModel, Model == DataSource.StorageModel.ReadOnlyType, Model: Equatable, DataSource.Cell == Cell {
     private let viewProperties: PaginatedListSelectorViewProperties
     private var dataSource: DataSource
@@ -381,6 +381,7 @@ private extension PaginatedListSelectorViewController {
     /// Renders the Placeholder Orders: For safety reasons, we'll also halt ResultsController <> UITableView glue.
     ///
     func displayPlaceholderProducts() {
+        displayGhostContent()
 
         resultsController.stopForwardingEvents()
     }
@@ -388,6 +389,7 @@ private extension PaginatedListSelectorViewController {
     /// Removes the Placeholder Products (and restores the ResultsController <> UITableView link).
     ///
     func removePlaceholderProducts() {
+        removeGhostContent()
         resultsController.startForwardingEvents(to: tableView)
         tableView.reloadData()
     }

--- a/WooCommerce/Classes/ViewRelated/Orders/OrderListViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrderListViewController.swift
@@ -29,7 +29,7 @@ protocol OrderListViewControllerDelegate: AnyObject {
 
 /// OrderListViewController: Displays the list of Orders associated to the active Store / Account.
 ///
-final class OrderListViewController: UIViewController {
+final class OrderListViewController: UIViewController, GhostableViewController {
     /// Callback closure when an order is selected either manually (by the user) or automatically in multi-column view.
     /// `allViewModels` is a list of order details view models that are available in a stack when the split view is collapsed
     /// so that the user can navigate between order details easily. `index` is the default index of order details to be shown.
@@ -678,6 +678,23 @@ extension OrderListViewController {
     }
 }
 
+// MARK: - Placeholders & Ghostable Table
+//
+private extension OrderListViewController {
+
+    /// Renders the Placeholder Orders
+    ///
+    func displayPlaceholderOrders() {
+        displayGhostContent()
+    }
+
+    /// Removes the Placeholder Orders (and restores the ResultsController <> UITableView link).
+    ///
+    func removePlaceholderOrders() {
+        removeGhostContent()
+    }
+}
+
 // MARK: - Empty state view configuration
 //
 private extension OrderListViewController {
@@ -895,7 +912,7 @@ private extension OrderListViewController {
         case .empty:
             displayEmptyViewController()
         case .placeholder:
-            break
+            displayPlaceholderOrders()
         case .syncing:
             ensureFooterSpinnerIsStarted()
         case .results:
@@ -908,7 +925,7 @@ private extension OrderListViewController {
         case .empty:
             removeEmptyViewController()
         case .placeholder:
-            break
+            removePlaceholderOrders()
         case .syncing:
             ensureFooterSpinnerIsStopped()
         case .results:

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Reviews/ProductReviewsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Reviews/ProductReviewsViewController.swift
@@ -2,7 +2,7 @@ import UIKit
 import Yosemite
 
 /// The UI that shows the approved Reviews related to a specific product.
-final class ProductReviewsViewController: UIViewController {
+final class ProductReviewsViewController: UIViewController, GhostableViewController {
 
     private let product: Product
 
@@ -236,7 +236,7 @@ private extension ProductReviewsViewController {
         case .results:
             break
         case .placeholder:
-            break
+            displayGhostContent()
         case .syncing:
             ensureFooterSpinnerIsStarted()
         }
@@ -251,7 +251,7 @@ private extension ProductReviewsViewController {
         case .results:
             break
         case .placeholder:
-            break
+            removeGhostContent()
         case .syncing:
             ensureFooterSpinnerIsStopped()
         }

--- a/WooCommerce/Classes/ViewRelated/Products/Variations/ProductVariationsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Variations/ProductVariationsViewController.swift
@@ -8,7 +8,7 @@ import protocol WooFoundation.Analytics
 
 /// Displays a paginated list of Product Variations with its price or visibility.
 ///
-final class ProductVariationsViewController: UIViewController {
+final class ProductVariationsViewController: UIViewController, GhostableViewController {
 
     /// Empty state screen
     ///
@@ -732,6 +732,7 @@ private extension ProductVariationsViewController {
             break
         case .syncing(let pageNumber):
             if pageNumber == syncingCoordinator.pageFirstIndex {
+                displayGhostContent(over: tableView)
                 hideMoreActionsNavigationBarButton()
             } else {
                 ensureFooterSpinnerIsStarted()
@@ -745,6 +746,7 @@ private extension ProductVariationsViewController {
         switch state {
         case .syncing:
             ensureFooterSpinnerIsStopped()
+            removeGhostContent()
             showOrHideMoreActionsNavigationBarButton()
         case .noResultsPlaceholder, .results:
             break

--- a/WooCommerce/Classes/ViewRelated/Reviews/ReviewsViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Reviews/ReviewsViewController.swift
@@ -2,7 +2,7 @@ import UIKit
 
 // MARK: - ReviewsViewController
 //
-final class ReviewsViewController: UIViewController {
+final class ReviewsViewController: UIViewController, GhostableViewController {
 
     typealias ViewModel = ReviewsViewModelOutput & ReviewsViewModelActionsHandler
 
@@ -153,7 +153,12 @@ final class ReviewsViewController: UIViewController {
 
         // Fix any incomplete animation of the refresh control
         // when switching tabs mid-animation
-        refreshControl.resetAnimation(in: tableView)
+        refreshControl.resetAnimation(in: tableView) { [unowned self] in
+            // ghost animation is also removed after switching tabs
+            // show make sure it's displayed again
+            self.removeGhostContent()
+            self.displayGhostContent()
+        }
     }
 
     override var shouldShowOfflineBanner: Bool {
@@ -410,7 +415,7 @@ private extension ReviewsViewController {
         case .results:
             break
         case .placeholder:
-            break
+            displayGhostContent()
         case .syncing(let pageNumber):
             if pageNumber != SyncingCoordinator.Defaults.pageFirstIndex {
                 ensureFooterSpinnerIsStarted()
@@ -427,10 +432,10 @@ private extension ReviewsViewController {
         case .results:
             break
         case .placeholder:
-            break
+            removeGhostContent()
         case .syncing:
             ensureFooterSpinnerIsStopped()
-            break
+            removeGhostContent()
         }
     }
 


### PR DESCRIPTION

## Description

This reverts commit 287a44e97a51cfa3d10b1f8f53f804154928d53d.

In that commit some conformances to `GhostableViewController` were removed in an attempt to fix a crash.

That change didn't have the intended impact.

More details here: p91TBi-bvX-p2


## Testing information
Using the network link conditioner set to Very Bad Network allows this testing to be done more easily.

On the product variations screen:

- tap into a variable product.
- tap Variations.
- observe place holder UI is shown while the variations load.

## Screenshots
**Before (production app 19.3 or later)**

https://github.com/user-attachments/assets/416fd889-db12-4637-b942-030748589f1d


**After**

https://github.com/user-attachments/assets/1b51d5a7-5a96-44ec-8c9b-79675c9f9f8d



---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
