### PR TITLE
Refresh Cards Stale data

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Dashboard/StoreStats/StorePerformanceView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/StoreStats/StorePerformanceView.swift
@@ -309,7 +309,7 @@ private extension StorePerformanceView {
         DashboardCardErrorView(onRetry: {
             ServiceLocator.analytics.track(event: .DynamicDashboard.cardRetryTapped(type: .performance))
             Task {
-                await viewModel.reloadData()
+                await viewModel.reloadDataIfNeeded(forceRefresh: true)
             }
         })
     }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/StoreStats/StoreStatsPeriodViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/StoreStats/StoreStatsPeriodViewModel.swift
@@ -105,7 +105,7 @@ final class StoreStatsPeriodViewModel {
     private lazy var summaryStatsResultsController: ResultsController<StorageSiteSummaryStats> = {
         let formattedDateString: String = {
             let date = timeRange.latestDate(currentDate: currentDate, siteTimezone: siteTimezone)
-            return StatsStoreV4.buildDateString(from: date, with: .day)
+            return StatsStoreV4.buildDateString(from: date, timeRange: .today)
         }()
         let predicate = NSPredicate(format: "siteID = %ld AND period == %@ AND date == %@",
                                     siteID,

--- a/WooCommerce/Classes/ViewRelated/Dashboard/TopPerformers/TopPerformerDataViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/TopPerformers/TopPerformerDataViewController.swift
@@ -159,7 +159,7 @@ private extension TopPerformerDataViewController {
     func createResultsController(siteTimeZone: TimeZone) -> ResultsController<StorageTopEarnerStats> {
         let formattedDateString: String = {
             let date = timeRange.latestDate(currentDate: currentDate, siteTimezone: siteTimeZone)
-            return StatsStoreV4.buildDateString(from: date, with: granularity)
+            return StatsStoreV4.buildDateString(from: date, timeRange: timeRange)
         }()
         let predicate = NSPredicate(format: "granularity = %@ AND date = %@ AND siteID = %ld", granularity.rawValue, formattedDateString, siteID)
         let descriptor = NSSortDescriptor(key: "date", ascending: true)

--- a/WooCommerce/Classes/ViewRelated/Dashboard/TopPerformers/TopPerformersDashboardView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/TopPerformers/TopPerformersDashboardView.swift
@@ -28,7 +28,7 @@ struct TopPerformersDashboardView: View {
                 DashboardCardErrorView(onRetry: {
                     ServiceLocator.analytics.track(event: .DynamicDashboard.cardRetryTapped(type: .topPerformers))
                     Task {
-                        await viewModel.reloadData()
+                        await viewModel.reloadDataIfNeeded(forceRefresh: true)
                     }
                 })
                 .padding(.horizontal, Layout.padding)

--- a/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Stats V4/StoreStatsPeriodViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Stats V4/StoreStatsPeriodViewModelTests.swift
@@ -79,7 +79,7 @@ final class StoreStatsPeriodViewModelTests: XCTestCase {
         XCTAssertEqual(conversionStatsTextValues, ["-"])
 
         // When
-        let dateString = StatsStoreV4.buildDateString(from: defaultDate, with: .day)
+        let dateString = StatsStoreV4.buildDateString(from: defaultDate, timeRange: .today)
         let siteSummaryStats = Yosemite.SiteSummaryStats.fake().copy(siteID: siteID, date: dateString, visitors: 22)
         insertSiteSummaryStats(siteSummaryStats, timeRange: timeRange)
 
@@ -149,7 +149,7 @@ final class StoreStatsPeriodViewModelTests: XCTestCase {
         observeStatsEmittedValues(viewModel: viewModel)
 
         // When
-        let dateString = StatsStoreV4.buildDateString(from: defaultDate, with: .day)
+        let dateString = StatsStoreV4.buildDateString(from: defaultDate, timeRange: .today)
         let siteSummaryStats = Yosemite.SiteSummaryStats.fake().copy(siteID: siteID, date: dateString, visitors: 15)
         insertSiteSummaryStats(siteSummaryStats, timeRange: timeRange)
 

--- a/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/StoreStats/StorePerformanceViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/StoreStats/StorePerformanceViewModelTests.swift
@@ -156,7 +156,7 @@ final class StorePerformanceViewModelTests: XCTestCase {
         XCTAssertEqual(viewModel.statsVersion, .v4) // Initial value
 
         // When
-        await viewModel.reloadData()
+        await viewModel.reloadDataIfNeeded(forceRefresh: true)
 
         // Then
         XCTAssertEqual(viewModel.statsVersion, .v3)
@@ -171,7 +171,7 @@ final class StorePerformanceViewModelTests: XCTestCase {
 
         // When
         viewModel.didSelectTimeRange(.thisMonth)
-        await viewModel.reloadData()
+        await viewModel.reloadDataIfNeeded(forceRefresh: true)
 
         // Then
         XCTAssertEqual(viewModel.siteVisitStatMode, .default)
@@ -190,7 +190,7 @@ final class StorePerformanceViewModelTests: XCTestCase {
         let endDate = Date().endOfDay(timezone: .current)
         let startDate = Date().startOfDay(timezone: .current)
         viewModel.didSelectTimeRange(.custom(from: startDate, to: endDate))
-        await viewModel.reloadData()
+        await viewModel.reloadDataIfNeeded(forceRefresh: true)
 
         // Then
         XCTAssertEqual(viewModel.siteVisitStatMode, .default)
@@ -209,7 +209,7 @@ final class StorePerformanceViewModelTests: XCTestCase {
         let endDate = Date()
         let startDate = try XCTUnwrap(endDate.adding(days: -10))
         viewModel.didSelectTimeRange(.custom(from: startDate, to: endDate))
-        await viewModel.reloadData()
+        await viewModel.reloadDataIfNeeded(forceRefresh: true)
 
         // Then
         XCTAssertEqual(viewModel.siteVisitStatMode, .redactedDueToCustomRange)
@@ -228,7 +228,7 @@ final class StorePerformanceViewModelTests: XCTestCase {
         let endDate = Date()
         let startDate = try XCTUnwrap(endDate.adding(days: -10))
         viewModel.didSelectTimeRange(.custom(from: startDate, to: endDate))
-        await viewModel.reloadData()
+        await viewModel.reloadDataIfNeeded(forceRefresh: true)
 
         // Then
         XCTAssertEqual(viewModel.siteVisitStatMode, .redactedDueToJetpack)
@@ -247,7 +247,7 @@ final class StorePerformanceViewModelTests: XCTestCase {
         let endDate = Date()
         let startDate = try XCTUnwrap(endDate.adding(days: -10))
         viewModel.didSelectTimeRange(.custom(from: startDate, to: endDate))
-        await viewModel.reloadData()
+        await viewModel.reloadDataIfNeeded(forceRefresh: true)
 
         // Then
         XCTAssertEqual(viewModel.siteVisitStatMode, .hidden)
@@ -261,7 +261,7 @@ final class StorePerformanceViewModelTests: XCTestCase {
         mockSyncAllStats(with: stores, visitorStatsError: SiteStatsStoreError.noPermission)
 
         // When
-        await viewModel.reloadData()
+        await viewModel.reloadDataIfNeeded(forceRefresh: true)
 
         // Then
         XCTAssertEqual(viewModel.siteVisitStatMode, .hidden)
@@ -277,7 +277,7 @@ final class StorePerformanceViewModelTests: XCTestCase {
         mockSyncAllStats(with: stores, visitorStatsError: SiteStatsStoreError.statsModuleDisabled)
 
         // When
-        await viewModel.reloadData()
+        await viewModel.reloadDataIfNeeded(forceRefresh: true)
 
         // Then
         XCTAssertEqual(viewModel.siteVisitStatMode, .hidden)
@@ -293,7 +293,7 @@ final class StorePerformanceViewModelTests: XCTestCase {
         mockSyncAllStats(with: stores, visitorStatsError: SiteStatsStoreError.statsModuleDisabled)
 
         // When
-        await viewModel.reloadData()
+        await viewModel.reloadDataIfNeeded(forceRefresh: true)
 
         // Then
         XCTAssertEqual(viewModel.siteVisitStatMode, .redactedDueToJetpack)

--- a/Yosemite/Yosemite/Model/Mocks/Graphs/ScreenshotsObjectGraph.swift
+++ b/Yosemite/Yosemite/Model/Mocks/Graphs/ScreenshotsObjectGraph.swift
@@ -230,7 +230,7 @@ struct ScreenshotObjectGraph: MockObjectGraph {
         )
     }
 
-    var thisMonthTopProducts: TopEarnerStats = createStats(siteID: 1, granularity: .month, items: [
+    var thisMonthTopProducts: TopEarnerStats = createStats(siteID: 1, timeRange: .thisMonth, granularity: .month, items: [
         createTopEarningItem(product: Products.akoyaPearlShades, quantity: 17),
         createTopEarningItem(product: Products.blackCoralShades, quantity: 11),
         createTopEarningItem(product: Products.coloradoShades, quantity: 5),

--- a/Yosemite/Yosemite/Model/Mocks/MockObjectGraph.swift
+++ b/Yosemite/Yosemite/Model/Mocks/MockObjectGraph.swift
@@ -473,10 +473,10 @@ extension MockObjectGraph {
         }
     }
 
-    static func createStats(siteID: Int64, granularity: StatGranularity, items: [TopEarnerStatsItem]) -> TopEarnerStats {
+    static func createStats(siteID: Int64, timeRange: StatsTimeRangeV4, granularity: StatGranularity, items: [TopEarnerStatsItem]) -> TopEarnerStats {
         TopEarnerStats(
             siteID: siteID,
-            date: StatsStoreV4.buildDateString(from: Date(), with: granularity),
+            date: StatsStoreV4.buildDateString(from: Date(), timeRange: timeRange),
             granularity: granularity,
             limit: "",
             items: items


### PR DESCRIPTION
closes #13377 

# Why

This PR adds support to refresh cached data(Performance, TopPerformace cards) when the cached data has been stored more than 30 minutes ago.

# How

- Update `StatsStoreV4` to fix a bug where custom ranges were overriding fixed ranges data.
- Update `Performance` & `TopPerformers` view models to not refresh their data if the timestamp has been saved recently (less than 30 minutes ago)
- Update `DashboardViewModel` to reload supported(background update) cards when the view appears.
- Make sure that when switching to a custom range, data is always refreshed as we don't support to store multiple custom ranges timestamps

# Demo

https://github.com/user-attachments/assets/6ee12a73-229d-48d3-9ade-55c8fc0cdf12

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
