### PR TITLE
Google Ads: Enable feature flag in production

### DIFF
--- a/Experiments/Experiments/DefaultFeatureFlagService.swift
+++ b/Experiments/Experiments/DefaultFeatureFlagService.swift
@@ -85,7 +85,7 @@ public struct DefaultFeatureFlagService: FeatureFlagService {
         case .productCreationAIv2M3:
             return buildConfig == .localDeveloper || buildConfig == .alpha
         case .googleAdsCampaignCreationOnWebView:
-            return buildConfig == .localDeveloper || buildConfig == .alpha
+            return true
         case .backgroundTasks:
             return buildConfig == .localDeveloper || buildConfig == .alpha
         default:

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -3,6 +3,7 @@
 19.7
 -----
 - [*] Stats: The Google Campaign analytics card now has a call to action to create a paid campaign if there are no campaign analytics for the selected time period. [https://github.com/woocommerce/woocommerce-ios/pull/13397]
+- [**] Google Ads campaign management is now available for stores with plugin version 2.7.7 or later. [https://github.com/woocommerce/woocommerce-ios/pull/13421]
 
 19.6
 -----

--- a/WooCommerce/Classes/GoogleAds/GoogleAdsEligibilityChecker.swift
+++ b/WooCommerce/Classes/GoogleAds/GoogleAdsEligibilityChecker.swift
@@ -78,9 +78,9 @@ private extension DefaultGoogleAdsEligibilityChecker {
     enum Constants {
         static let pluginSlug = "google-listings-and-ads/google-listings-and-ads.php"
 
-        /// Version 2.7.5 is required to check for campaign creation success on the web.
-        /// Ref: https://github.com/woocommerce/google-listings-and-ads/releases/tag/2.7.5.
+        /// Version 2.7.7 is required for an optimized experience of the plugin on the mobile web.
+        /// Ref: https://github.com/woocommerce/google-listings-and-ads/releases/tag/2.7.7.
         /// We can remove this limit once we support native experience.
-        static let pluginMinimumVersion = "2.7.5"
+        static let pluginMinimumVersion = "2.7.7"
     }
 }

--- a/WooCommerce/WooCommerceTests/GoogleAds/DefaultGoogleAdsEligibilityCheckTests.swift
+++ b/WooCommerce/WooCommerceTests/GoogleAds/DefaultGoogleAdsEligibilityCheckTests.swift
@@ -68,7 +68,7 @@ final class DefaultGoogleAdsEligibilityCheckerTests: XCTestCase {
         let checker = DefaultGoogleAdsEligibilityChecker(stores: stores, featureFlagService: featureFlagService)
         let plugin = SystemPlugin.fake().copy(siteID: sampleSite,
                                               plugin: pluginSlug,
-                                              version: "2.7.4",
+                                              version: "2.7.6",
                                               active: true)
         let connection = GoogleAdsConnection.fake().copy(rawStatus: "connected")
         mockRequests(syncedPlugins: [plugin], adsConnection: connection)
@@ -87,7 +87,7 @@ final class DefaultGoogleAdsEligibilityCheckerTests: XCTestCase {
         let checker = DefaultGoogleAdsEligibilityChecker(stores: stores, featureFlagService: featureFlagService)
         let plugin = SystemPlugin.fake().copy(siteID: sampleSite,
                                               plugin: pluginSlug,
-                                              version: "2.7.5",
+                                              version: "2.7.7",
                                               active: true)
         let connection = GoogleAdsConnection.fake().copy(rawStatus: "connected")
         mockRequests(syncedPlugins: [plugin], adsConnection: connection)


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #13129 
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This PR enables the feature flag to make Google Ads campaign management available in production. Also, the minimum version required to enable Google Ads campaign creation on the app has been bumped to 2.7.7 to support a better experience of the plugin on the mobile web view.

## Testing steps
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->
- Pre-requisite: Install, activate, and set up the Google Ads plugin to a test site following pe5sF9-2Qo-p2. Ensure that you're using the plugin version 2.7.5 or above.
- Build the app and log in to your store.
- Enable Google Ads card on the dashboard if you haven't already.
- If your store has no campaign, confirm that the empty state is displayed.
- Tap on Create campaign to create a new campaign for your store.
- After campaign creation, confirm that the total stats view is displayed.
- Switch to the menu tab, and confirm that there's an entry point to Google Ads named Google for WooCommerce.
- Tap on the item, and confirm that the Google Ads dashboard page is presented if there's existing campaign on your store, or the campaign creation page otherwise.
- Switch to a store ineligible for Google Ads - confirm that entry points on the dashboard and hub menu screens are not available.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->
Dashboard card empty state | Dashboard card with data  | Hub menu 
--- | --- | ---
<img src="https://github.com/user-attachments/assets/d33ca763-5669-415d-85e8-bb5974682cb2" width=320 /> | <img src="https://github.com/user-attachments/assets/f6645227-391a-48bd-96d8-7c499eb0ebb1" width=320 /> | <img src="https://github.com/user-attachments/assets/abfd7a3d-17e7-4cc5-a26d-9c1ce949ada5" width=320 />




---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
