### PR TITLE
[Woo POS] M2: loading and syncing order in checkout UI update

### DIFF
--- a/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/PointOfSaleLoadingView.swift
+++ b/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/PointOfSaleLoadingView.swift
@@ -6,7 +6,8 @@ struct PointOfSaleLoadingView: View {
             Spacer()
             VStack(alignment: .center) {
                 Spacer()
-                progressView
+                ProgressView()
+                    .progressViewStyle(POSProgressViewStyle())
                 Spacer().frame(height: Layout.progressViewSpacing)
                 Text(Localization.title)
                     .font(.posBody)
@@ -19,16 +20,6 @@ struct PointOfSaleLoadingView: View {
             .multilineTextAlignment(.center)
             Spacer()
         }
-    }
-
-    private var progressView: some View {
-        ProgressView()
-            .progressViewStyle(IndefiniteCircularProgressViewStyle(
-                size: Layout.progressViewSize,
-                lineWidth: Layout.progressViewLineWidth,
-                lineCap: .butt,
-                circleColor: Color(.wooCommercePurple(.shade10)),
-                fillColor: Color(.wooCommercePurple(.shade50))))
     }
 }
 
@@ -48,8 +39,6 @@ private extension PointOfSaleLoadingView {
     }
 
     enum Layout {
-        static let progressViewSize: CGFloat = 112
-        static let progressViewLineWidth: CGFloat = 48
         static let textSpacing: CGFloat = 16
         static let progressViewSpacing: CGFloat = 72
     }

--- a/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/Reader Messages/POSCardPresentPaymentMessageView.swift
+++ b/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/Reader Messages/POSCardPresentPaymentMessageView.swift
@@ -1,67 +1,64 @@
 import SwiftUI
 
 struct POSCardPresentPaymentMessageViewModel {
-    let imageName: String?
-    let showProgress: Bool?
+    var imageName: String? = nil
+    var showProgress: Bool = false
     let title: String
-    let message: String?
-    let buttons: [CardPresentPaymentsModalButtonViewModel]
-
-    init(imageName: String? = nil,
-         showProgress: Bool? = nil,
-         title: String,
-         message: String? = nil,
-         buttons: [CardPresentPaymentsModalButtonViewModel] = []) {
-        self.imageName = imageName
-        self.showProgress = showProgress
-        self.title = title
-        self.message = message
-        self.buttons = buttons
-    }
+    var message: String? = nil
+    var buttons: [CardPresentPaymentsModalButtonViewModel] = []
 }
 
 struct POSCardPresentPaymentMessageView: View {
     let viewModel: POSCardPresentPaymentMessageViewModel
 
     var body: some View {
-        VStack {
-            if let imageName = viewModel.imageName {
-                Image(imageName)
-                    .resizable()
-                    .aspectRatio(contentMode: .fit)
-                    .frame(width: Layout.imageSize, height: Layout.imageSize)
-            }
-            if let showProgress = viewModel.showProgress, showProgress == true {
-                ProgressView()
-                    .progressViewStyle(IndefiniteCircularProgressViewStyle(
-                        size: Layout.progressViewSize,
-                        lineWidth: Layout.progressViewLineWidth))
-            }
-            Text(viewModel.title)
-                .font(Font.system(size: 48, weight: .bold))
-                .foregroundColor(Color(UIColor.wooCommercePurple(.shade80)))
-            if let message = viewModel.message {
-                Text(message)
-                    .font(Font.system(size: 20))
-                    .foregroundColor(Color(UIColor.wooCommercePurple(.shade70)))
-            }
-            if viewModel.buttons.isNotEmpty {
-                HStack {
-                    ForEach(viewModel.buttons) { buttonModel in
-                        Button(buttonModel.title, action: buttonModel.actionHandler)
+        HStack(alignment: .center) {
+            Spacer()
+            VStack(alignment: .center, spacing: Layout.verticalSpacing) {
+                if let imageName = viewModel.imageName {
+                    Image(imageName)
+                        .resizable()
+                        .aspectRatio(contentMode: .fit)
+                        .frame(width: Layout.imageSize, height: Layout.imageSize)
+                }
+
+                if viewModel.showProgress {
+                    ProgressView()
+                        .progressViewStyle(POSProgressViewStyle())
+                }
+
+                VStack(alignment: .center, spacing: Layout.textSpacing) {
+                    Text(viewModel.title)
+                        .foregroundStyle(Color(.neutral(.shade40)))
+                        .font(.posBody)
+
+                    if let message = viewModel.message {
+                        Text(message)
+                            .font(.posTitle)
+                            .foregroundStyle(Color(.neutral(.shade60)))
+                            .bold()
                     }
                 }
-                .padding()
+
+                if viewModel.buttons.isNotEmpty {
+                    HStack {
+                        ForEach(viewModel.buttons) { buttonModel in
+                            Button(buttonModel.title, action: buttonModel.actionHandler)
+                        }
+                    }
+                    .padding()
+                }
             }
+            .multilineTextAlignment(.center)
+            Spacer()
         }
-        .multilineTextAlignment(.center)
     }
 }
 
 private extension POSCardPresentPaymentMessageView {
     enum Layout {
-        static let progressViewSize: CGFloat = 80
-        static let progressViewLineWidth: CGFloat = 4
         static let imageSize: CGFloat = 104
+        static let textSpacing: CGFloat = 4
+        static let verticalSpacing: CGFloat = 72
     }
 }

--- a/WooCommerce/Classes/POS/Presentation/PointOfSaleDashboardView.swift
+++ b/WooCommerce/Classes/POS/Presentation/PointOfSaleDashboardView.swift
@@ -124,9 +124,6 @@ private extension PointOfSaleDashboardView {
         TotalsView(viewModel: viewModel,
                    totalsViewModel: totalsViewModel,
                    cartViewModel: cartViewModel)
-            .background(Color(UIColor.systemBackground))
-            .frame(maxWidth: .infinity)
-            .cornerRadius(16)
     }
 
     var productListView: some View {

--- a/WooCommerce/Classes/POS/Presentation/Reusable Views/POSProgressViewStyle.swift
+++ b/WooCommerce/Classes/POS/Presentation/Reusable Views/POSProgressViewStyle.swift
@@ -1,0 +1,15 @@
+import SwiftUI
+import WooFoundation
+
+struct POSProgressViewStyle: ProgressViewStyle {
+    func makeBody(configuration: Configuration) -> some View {
+        ProgressView(configuration)
+            .progressViewStyle(IndefiniteCircularProgressViewStyle(
+                size: 112,
+                lineWidth: 48,
+                lineCap: .butt,
+                circleColor: Color(.wooCommercePurple(.shade10)),
+                fillColor: Color(.wooCommercePurple(.shade50))
+            ))
+    }
+}

--- a/WooCommerce/Classes/POS/Presentation/TotalsView.swift
+++ b/WooCommerce/Classes/POS/Presentation/TotalsView.swift
@@ -22,48 +22,8 @@ struct TotalsView: View {
                         .font(.title)
                         .padding()
                     Spacer()
-                    VStack(alignment: .leading, spacing: 32) {
-                        HStack {
-                            VStack(spacing: Constants.totalsVerticalSpacing) {
-                                priceFieldView(title: Localization.subtotal,
-                                               formattedPrice: totalsViewModel.formattedCartTotalPrice,
-                                               shimmeringActive: totalsViewModel.isShimmering,
-                                               redacted: totalsViewModel.isSubtotalFieldRedacted)
-                                Divider()
-                                    .overlay(Color.posTotalsSeparator)
-                                priceFieldView(title: Localization.taxes,
-                                               formattedPrice:
-                                                totalsViewModel.formattedOrderTotalTaxPrice,
-                                               shimmeringActive: totalsViewModel.isShimmering,
-                                               redacted: totalsViewModel.isTaxFieldRedacted)
-                                Divider()
-                                    .overlay(Color.posTotalsSeparator)
-                                totalPriceView(formattedPrice: totalsViewModel.formattedOrderTotalPrice,
-                                               shimmeringActive: totalsViewModel.isShimmering,
-                                               redacted: totalsViewModel.isTotalPriceFieldRedacted)
-                            }
-                            .padding()
-                            .frame(idealWidth: Constants.pricesIdealWidth)
-                        }
-                        .overlay(
-                            RoundedRectangle(cornerRadius: Constants.defaultBorderLineCornerRadius)
-                                .stroke(Color.posTotalsSeparator, lineWidth: Constants.defaultBorderLineWidth)
-                        )
-                        if totalsViewModel.showRecalculateButton {
-                            Button(Localization.calculateAmounts) {
-                                totalsViewModel.calculateAmountsTapped(
-                                    with: cartViewModel.itemsInCart,
-                                    allItems: viewModel.itemListViewModel.items)
-                            }
-                        }
-                    }
-                    .padding(Constants.totalsPadding)
+                    totalsLinesView
                 }
-                .background(
-                    LinearGradient(gradient: Gradient(stops: gradientStops),
-                                   startPoint: .top,
-                                   endPoint: .bottom)
-                )
                 paymentsActionButtons
                     .padding()
             }
@@ -72,20 +32,61 @@ struct TotalsView: View {
             totalsViewModel.onTotalsViewDisappearance()
         }
     }
+}
 
-    private var gradientStops: [Gradient.Stop] {
-        if totalsViewModel.paymentState == .cardPaymentSuccessful {
-            return [
-                Gradient.Stop(color: Color.clear, location: 0.0),
-                Gradient.Stop(color: Color.posTotalsGradientGreen, location: 1.0)
-            ]
+private extension TotalsView {
+    var totalsLinesView: some View {
+        HStack(alignment: .center) {
+            Spacer()
+            VStack() {
+                priceFieldView(title: Localization.subtotal,
+                               formattedPrice: totalsViewModel.formattedCartTotalPrice,
+                               shimmeringActive: totalsViewModel.isShimmering,
+                               redacted: totalsViewModel.isSubtotalFieldRedacted)
+                Spacer().frame(height: Constants.subtotalsVerticalSpacing)
+                priceFieldView(title: Localization.taxes,
+                               formattedPrice:
+                                totalsViewModel.formattedOrderTotalTaxPrice,
+                               shimmeringActive: totalsViewModel.isShimmering,
+                               redacted: totalsViewModel.isTaxFieldRedacted)
+                Spacer().frame(height: Constants.totalVerticalSpacing)
+                Divider()
+                    .overlay(Color.posTotalsSeparator)
+                Spacer().frame(height: Constants.totalVerticalSpacing)
+                totalPriceFieldView(formattedPrice: totalsViewModel.formattedOrderTotalPrice,
+                                    shimmeringActive: totalsViewModel.isShimmering,
+                                    redacted: totalsViewModel.isTotalPriceFieldRedacted)
+            }
+            .padding(Constants.totalsLineViewPadding)
+            .frame(minWidth: Constants.pricesIdealWidth)
+            .fixedSize(horizontal: true, vertical: false)
+            Spacer()
         }
-        else {
-            return [
-                Gradient.Stop(color: Color.clear, location: 0.0),
-                Gradient.Stop(color: Color.posTotalsGradientPurple, location: 1.0)
-            ]
+    }
+
+    @ViewBuilder
+    func priceFieldView(title: String, formattedPrice: String?, shimmeringActive: Bool, redacted: Bool) -> some View {
+        HStack(alignment: .top, spacing: .zero) {
+            Text(title)
+                .font(Constants.subtotalTitleFont)
+            Spacer()
+            Text(formattedPrice ?? "")
+                .font(Constants.subtotalAmountFont)
         }
+        .foregroundColor(Color.primaryText)
+    }
+
+    @ViewBuilder
+    func totalPriceFieldView(formattedPrice: String?, shimmeringActive: Bool, redacted: Bool) -> some View {
+        HStack(alignment: .top, spacing: .zero) {
+            Text(Localization.total)
+                .font(Constants.totalTitleFont)
+                .fontWeight(.semibold)
+            Spacer(minLength: Constants.totalsHorizontalSpacing)
+            Text(formattedPrice ?? "")
+                .font(Constants.totalAmountFont)
+        }
+        .foregroundColor(Color.primaryText)
     }
 }
 
@@ -136,47 +137,22 @@ private extension TotalsView {
                                                                               actionHandler: totalsViewModel.cardPaymentTapped)]))
         }
     }
-
-    @ViewBuilder func priceFieldView(title: String, formattedPrice: String?, shimmeringActive: Bool, redacted: Bool) -> some View {
-        HStack(alignment: .top, spacing: .zero) {
-            Text(title)
-                .font(Constants.subtotalTitleFont)
-            Spacer()
-            Text(formattedPrice ?? "-----")
-                .font(Constants.subtotalAmountFont)
-                .redacted(reason: redacted ? [.placeholder] : [])
-                .shimmering(active: shimmeringActive)
-        }
-        .foregroundColor(Color.primaryText)
-    }
-
-    @ViewBuilder func totalPriceView(formattedPrice: String?, shimmeringActive: Bool, redacted: Bool) -> some View {
-        HStack(alignment: .top, spacing: .zero) {
-            Text(Localization.total)
-                .font(Constants.totalTitleFont)
-                .fontWeight(.semibold)
-            Spacer()
-            Text(formattedPrice ?? "-----")
-                .font(Constants.totalAmountFont)
-                .redacted(reason: redacted ? [.placeholder] : [])
-                .shimmering(active: shimmeringActive)
-        }
-        .foregroundColor(Color(UIColor.wooCommercePurple(.shade80)))
-    }
 }
 
 private extension TotalsView {
     enum Constants {
-        static let pricesIdealWidth: CGFloat = 380
+        static let pricesIdealWidth: CGFloat = 382
         static let defaultBorderLineWidth: CGFloat = 1
         static let defaultBorderLineCornerRadius: CGFloat = 8
 
-        static let totalsVerticalSpacing: CGFloat = 10
-        static let totalsPadding: CGFloat = 50
-        static let subtotalTitleFont: Font = Font.system(size: 20)
-        static let subtotalAmountFont: Font = Font.system(size: 20)
-        static let totalTitleFont: Font = Font.system(size: 21, weight: .semibold)
-        static let totalAmountFont: Font = Font.system(size: 40, weight: .bold)
+        static let totalsLineViewPadding: EdgeInsets = .init(top: 20, leading: 24, bottom: 20, trailing: 24)
+        static let subtotalsVerticalSpacing: CGFloat = 8
+        static let totalVerticalSpacing: CGFloat = 16
+        static let totalsHorizontalSpacing: CGFloat = 24
+        static let subtotalTitleFont: Font = Font.system(size: 24)
+        static let subtotalAmountFont: Font = Font.system(size: 24)
+        static let totalTitleFont: Font = Font.system(.largeTitle, design: .default, weight: .medium)
+        static let totalAmountFont: Font = Font.system(.largeTitle, design: .default, weight: .bold)
 
         static let newTransactionButtonSpacing: CGFloat = 20
         static let newTransactionButtonPadding: CGFloat = 16

--- a/WooCommerce/Classes/POS/Presentation/TotalsView.swift
+++ b/WooCommerce/Classes/POS/Presentation/TotalsView.swift
@@ -22,7 +22,7 @@ struct TotalsView: View {
                         .font(.title)
                         .padding()
                     Spacer()
-                    totalsLinesView
+                    totalsFieldsView
                 }
                 paymentsActionButtons
                     .padding()
@@ -35,27 +35,26 @@ struct TotalsView: View {
 }
 
 private extension TotalsView {
-    var totalsLinesView: some View {
+    var totalsFieldsView: some View {
         HStack(alignment: .center) {
             Spacer()
             VStack() {
-                priceFieldView(title: Localization.subtotal,
-                               formattedPrice: totalsViewModel.formattedCartTotalPrice,
-                               shimmeringActive: totalsViewModel.isShimmering,
-                               redacted: totalsViewModel.isSubtotalFieldRedacted)
+                subtotalFieldView(title: Localization.subtotal,
+                                  formattedPrice: totalsViewModel.formattedCartTotalPrice,
+                                  shimmeringActive: totalsViewModel.isShimmering,
+                                  redacted: totalsViewModel.isSubtotalFieldRedacted)
                 Spacer().frame(height: Constants.subtotalsVerticalSpacing)
-                priceFieldView(title: Localization.taxes,
-                               formattedPrice:
-                                totalsViewModel.formattedOrderTotalTaxPrice,
-                               shimmeringActive: totalsViewModel.isShimmering,
-                               redacted: totalsViewModel.isTaxFieldRedacted)
+                subtotalFieldView(title: Localization.taxes,
+                                  formattedPrice: totalsViewModel.formattedOrderTotalTaxPrice,
+                                  shimmeringActive: totalsViewModel.isShimmering,
+                                  redacted: totalsViewModel.isTaxFieldRedacted)
                 Spacer().frame(height: Constants.totalVerticalSpacing)
                 Divider()
                     .overlay(Color.posTotalsSeparator)
                 Spacer().frame(height: Constants.totalVerticalSpacing)
-                totalPriceFieldView(formattedPrice: totalsViewModel.formattedOrderTotalPrice,
-                                    shimmeringActive: totalsViewModel.isShimmering,
-                                    redacted: totalsViewModel.isTotalPriceFieldRedacted)
+                totalFieldView(formattedPrice: totalsViewModel.formattedOrderTotalPrice,
+                               shimmeringActive: totalsViewModel.isShimmering,
+                               redacted: totalsViewModel.isTotalPriceFieldRedacted)
             }
             .padding(Constants.totalsLineViewPadding)
             .frame(minWidth: Constants.pricesIdealWidth)
@@ -65,28 +64,47 @@ private extension TotalsView {
     }
 
     @ViewBuilder
-    func priceFieldView(title: String, formattedPrice: String?, shimmeringActive: Bool, redacted: Bool) -> some View {
-        HStack(alignment: .top, spacing: .zero) {
-            Text(title)
-                .font(Constants.subtotalTitleFont)
-            Spacer()
-            Text(formattedPrice ?? "")
-                .font(Constants.subtotalAmountFont)
+    func subtotalFieldView(title: String, formattedPrice: String?, shimmeringActive: Bool, redacted: Bool) -> some View {
+        if shimmeringActive {
+            shimmeringLineView(width: Constants.shimmeringWidth, height: Constants.subtotalsShimmeringHeight)
+        } else {
+            HStack(alignment: .top, spacing: .zero) {
+                Text(title)
+                    .font(Constants.subtotalTitleFont)
+                Spacer()
+                Text(formattedPrice ?? "")
+                    .font(Constants.subtotalAmountFont)
+                    .redacted(reason: redacted ? [.placeholder] : [])
+            }
+            .foregroundColor(Color.primaryText)
         }
-        .foregroundColor(Color.primaryText)
     }
 
     @ViewBuilder
-    func totalPriceFieldView(formattedPrice: String?, shimmeringActive: Bool, redacted: Bool) -> some View {
-        HStack(alignment: .top, spacing: .zero) {
-            Text(Localization.total)
-                .font(Constants.totalTitleFont)
-                .fontWeight(.semibold)
-            Spacer(minLength: Constants.totalsHorizontalSpacing)
-            Text(formattedPrice ?? "")
-                .font(Constants.totalAmountFont)
+    func totalFieldView(formattedPrice: String?, shimmeringActive: Bool, redacted: Bool) -> some View {
+        if shimmeringActive {
+            shimmeringLineView(width: Constants.shimmeringWidth, height: Constants.totalShimmeringHeight)
+        } else {
+            HStack(alignment: .top, spacing: .zero) {
+                Text(Localization.total)
+                    .font(Constants.totalTitleFont)
+                    .fontWeight(.semibold)
+                Spacer(minLength: Constants.totalsHorizontalSpacing)
+                Text(formattedPrice ?? "")
+                    .font(Constants.totalAmountFont)
+                    .redacted(reason: redacted ? [.placeholder] : [])
+            }
+            .foregroundColor(Color.primaryText)
         }
-        .foregroundColor(Color.primaryText)
+    }
+
+    func shimmeringLineView(width: CGFloat, height: CGFloat) -> some View {
+        Color.posTotalsSeparator
+            .frame(width: width, height: height)
+            .fixedSize(horizontal: true, vertical: true)
+            .redacted(reason: [.placeholder])
+            .shimmering(active: true)
+            .cornerRadius(Constants.shimmeringCornerRadius)
     }
 }
 
@@ -153,6 +171,11 @@ private extension TotalsView {
         static let subtotalAmountFont: Font = Font.system(size: 24)
         static let totalTitleFont: Font = Font.system(.largeTitle, design: .default, weight: .medium)
         static let totalAmountFont: Font = Font.system(.largeTitle, design: .default, weight: .bold)
+
+        static let shimmeringCornerRadius: CGFloat = 4
+        static let shimmeringWidth: CGFloat = 334
+        static let subtotalsShimmeringHeight: CGFloat = 36
+        static let totalShimmeringHeight: CGFloat = 40
 
         static let newTransactionButtonSpacing: CGFloat = 20
         static let newTransactionButtonPadding: CGFloat = 16

--- a/WooCommerce/Classes/POS/Presentation/TotalsView.swift
+++ b/WooCommerce/Classes/POS/Presentation/TotalsView.swift
@@ -15,7 +15,8 @@ struct TotalsView: View {
 
     var body: some View {
         HStack {
-            VStack(alignment: .leading) {
+            VStack(alignment: .center) {
+                Spacer()
                 VStack(alignment: .center, spacing: Constants.verticalSpacing) {
                     if !totalsViewModel.isSyncingOrder {
                         cardReaderView
@@ -27,6 +28,7 @@ struct TotalsView: View {
                 }
                 paymentsActionButtons
                     .padding()
+                Spacer()
             }
         }
         .onDisappear {
@@ -162,7 +164,7 @@ private extension TotalsView {
         static let defaultBorderLineWidth: CGFloat = 1
         static let defaultBorderLineCornerRadius: CGFloat = 8
 
-        static let verticalSpacing: CGFloat = 80
+        static let verticalSpacing: CGFloat = 56
 
         static let totalsLineViewPadding: EdgeInsets = .init(top: 20, leading: 24, bottom: 20, trailing: 24)
         static let subtotalsVerticalSpacing: CGFloat = 8

--- a/WooCommerce/Classes/POS/Presentation/TotalsView.swift
+++ b/WooCommerce/Classes/POS/Presentation/TotalsView.swift
@@ -16,12 +16,13 @@ struct TotalsView: View {
     var body: some View {
         HStack {
             VStack(alignment: .leading) {
-                VStack {
-                    Spacer()
-                    cardReaderView
-                        .font(.title)
-                        .padding()
-                    Spacer()
+                VStack(alignment: .center, spacing: Constants.verticalSpacing) {
+                    if !totalsViewModel.isSyncingOrder {
+                        cardReaderView
+                            .font(.title)
+                            .padding()
+                    }
+
                     totalsFieldsView
                 }
                 paymentsActionButtons
@@ -145,9 +146,7 @@ private extension TotalsView {
             if let inlinePaymentMessage = totalsViewModel.cardPresentPaymentInlineMessage {
                 PointOfSaleCardPresentPaymentInLineMessage(messageType: inlinePaymentMessage)
             } else {
-                POSCardPresentPaymentMessageView(viewModel: .init(title: "Reader connected",
-                                                                  buttons: [.init(title: "Collect Payment",
-                                                                                  actionHandler: totalsViewModel.cardPaymentTapped)]))
+                EmptyView()
             }
         case .disconnected:
             POSCardPresentPaymentMessageView(viewModel: .init(title: "Reader disconnected",
@@ -162,6 +161,8 @@ private extension TotalsView {
         static let pricesIdealWidth: CGFloat = 382
         static let defaultBorderLineWidth: CGFloat = 1
         static let defaultBorderLineCornerRadius: CGFloat = 8
+
+        static let verticalSpacing: CGFloat = 80
 
         static let totalsLineViewPadding: EdgeInsets = .init(top: 20, leading: 24, bottom: 20, trailing: 24)
         static let subtotalsVerticalSpacing: CGFloat = 8

--- a/WooCommerce/Classes/POS/Utils/Color+WooCommercePOS.swift
+++ b/WooCommerce/Classes/POS/Utils/Color+WooCommercePOS.swift
@@ -78,14 +78,6 @@ extension Color {
         Color(red: 198.0 / 255.0, green: 198.0 / 255.0, blue: 200.0 / 255.0)
     }
 
-    static var posTotalsGradientPurple: Color {
-        Color(red: 231.0 / 255.0, green: 227.0 / 255.0, blue: 243.0 / 255.0)
-    }
-
-    static var posTotalsGradientGreen: Color {
-        Color(red: 239.0 / 255.0, green: 246.0 / 255.0, blue: 235.0 / 255.0)
-    }
-
     static var posCheckoutBackground: Color {
         Color(uiColor: .wooCommercePurple(.shade50))
     }

--- a/WooCommerce/Classes/POS/ViewModels/TotalsViewModel.swift
+++ b/WooCommerce/Classes/POS/ViewModels/TotalsViewModel.swift
@@ -111,6 +111,9 @@ final class TotalsViewModel: ObservableObject, TotalsViewModelProtocol {
 
     func startSyncingOrder(with cartItems: [CartItem], allItems: [POSItem]) {
         guard CartItem.areOrderAndCartDifferent(order: order, cartItems: cartItems) else {
+            Task { @MainActor in
+                await prepareConnectedReaderForPayment()
+            }
             return
         }
         // calculate totals and sync order if there was a change in the cart

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -22,6 +22,7 @@
 
 /* Begin PBXBuildFile section */
 		0157A9962C4FEA7200866FFD /* PointOfSaleLoadingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0157A9952C4FEA7200866FFD /* PointOfSaleLoadingView.swift */; };
+		01620C4E2C5394B200D3EA2F /* POSProgressViewStyle.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01620C4D2C5394B200D3EA2F /* POSProgressViewStyle.swift */; };
 		01664F9E2C50E685007CB5DD /* Font+WooCommercePOS.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01664F9D2C50E685007CB5DD /* Font+WooCommercePOS.swift */; };
 		016BCAFF2C4F907F009D8367 /* CartViewModelProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 016BCAFE2C4F907F009D8367 /* CartViewModelProtocol.swift */; };
 		0202B68D23876BC100F3EBE0 /* ProductsTabProductViewModel+ProductVariation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0202B68C23876BC100F3EBE0 /* ProductsTabProductViewModel+ProductVariation.swift */; };
@@ -3001,6 +3002,7 @@
 
 /* Begin PBXFileReference section */
 		0157A9952C4FEA7200866FFD /* PointOfSaleLoadingView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PointOfSaleLoadingView.swift; sourceTree = "<group>"; };
+		01620C4D2C5394B200D3EA2F /* POSProgressViewStyle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = POSProgressViewStyle.swift; sourceTree = "<group>"; };
 		01664F9D2C50E685007CB5DD /* Font+WooCommercePOS.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Font+WooCommercePOS.swift"; sourceTree = "<group>"; };
 		016BCAFE2C4F907F009D8367 /* CartViewModelProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CartViewModelProtocol.swift; sourceTree = "<group>"; };
 		0202B68C23876BC100F3EBE0 /* ProductsTabProductViewModel+ProductVariation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ProductsTabProductViewModel+ProductVariation.swift"; sourceTree = "<group>"; };
@@ -5943,6 +5945,14 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		01620C4C2C5394A400D3EA2F /* Reusable Views */ = {
+			isa = PBXGroup;
+			children = (
+				01620C4D2C5394B200D3EA2F /* POSProgressViewStyle.swift */,
+			);
+			path = "Reusable Views";
+			sourceTree = "<group>";
+		};
 		0202B6932387ACE000F3EBE0 /* TabBar */ = {
 			isa = PBXGroup;
 			children = (
@@ -6569,6 +6579,7 @@
 		026826A12BF59DED0036F959 /* Presentation */ = {
 			isa = PBXGroup;
 			children = (
+				01620C4C2C5394A400D3EA2F /* Reusable Views */,
 				02EFDAD62C12D32700131820 /* Toolbar */,
 				02E71DB42C118C470036C2FD /* Card Present Payments */,
 				026826B02BF59E170036F959 /* CardReaderConnection */,
@@ -15006,6 +15017,7 @@
 				020B2F9423BDDBDC00BD79AD /* ProductUpdateError+UI.swift in Sources */,
 				205E79462C204387001BA266 /* PointOfSaleCardPresentPaymentCancelledOnReaderMessageViewModel.swift in Sources */,
 				029D025C2C231A1F00CB1E75 /* PointOfSaleCardPresentPaymentReaderUpdateCompletionAlertViewModel.swift in Sources */,
+				01620C4E2C5394B200D3EA2F /* POSProgressViewStyle.swift in Sources */,
 				021125A52578E5730075AD2A /* BoldableTextView.swift in Sources */,
 				CE85FD5A20F7A7640080B73E /* TableFooterView.swift in Sources */,
 				CC254F2D26C17AB5005F3C82 /* BottomButtonView.swift in Sources */,


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #13345
<!-- Id number of the GitHub issue this PR addresses. -->

## Description

Improving Checkout UI:
1. Update Totals View according to designs
2. Update the flow so Reader View would appear after the order is synced, a reader disconnected, or payment started
3. Update POSCardPresentPaymentMessageView layout

## Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->

**Reader disconnected**
1. Open Woo -> Menu -> Point of Sale Mode
4. Disconnect Reader
5. Add items to the cart
6. Check out
7. Confirm that at first totals view appears in the center while it's loading, when the order is synced, order totals appears together with **Reader Disconnected** Message

**Reader connected**
1. Open Woo -> Menu -> Point of Sale Mode
2. Connect Reader
4. Add items to the cart
5. Check out
6. Confirm that at first totals view appears in the center while it's loading, when the order is synced, order totals appear
8. After a slight delay, "checking order" view appears and payment starts

**Reader connected & coming back to order**
1. Open Woo -> Menu -> Point of Sale Mode
2. Connect Reader
3. Add items to the cart
4. Check out
5. Come back
7. Change nothing, and check out again
9. Confirm payment process restarts automatically

## Screenshots

#### Result

https://github.com/user-attachments/assets/d7209f98-0947-4d03-b103-cd4680e3ecd0

#### Expectations from designs

https://github.com/user-attachments/assets/b15a7a22-2053-47db-a1b9-6f9c24a3da47

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.