### PR TITLE
Background Updates: Add track events

### DIFF
--- a/WooCommerce/Classes/Analytics/WooAnalyticsEvent+BackgroudUpdates.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsEvent+BackgroudUpdates.swift
@@ -1,0 +1,30 @@
+import Foundation
+
+extension WooAnalyticsEvent {
+    enum BackgroundUpdates {
+
+        private enum Keys {
+            static let timeTaken = "time_taken"
+        }
+
+        static func dataSynced(timeTaken: TimeInterval) -> WooAnalyticsEvent {
+            WooAnalyticsEvent(statName: .backgroundDataSynced, properties: [Keys.timeTaken: timeTaken])
+        }
+
+        static func dataSyncError(_ error: Error) -> WooAnalyticsEvent {
+            WooAnalyticsEvent(statName: .backgroundDataSyncError, properties: [:], error: error)
+        }
+
+        static func orderPushNotificationSynced(timeTaken: TimeInterval) -> WooAnalyticsEvent {
+            WooAnalyticsEvent(statName: .pushNotificationOrderBackgroundSynced, properties: [Keys.timeTaken: timeTaken])
+        }
+
+        static func orderPushNotificationSyncError(_ error: Error) -> WooAnalyticsEvent {
+            WooAnalyticsEvent(statName: .pushNotificationOrderBackgroundSyncError, properties: [:], error: error)
+        }
+
+        static func disabled() -> WooAnalyticsEvent {
+            WooAnalyticsEvent(statName: .backgroundUpdatesDisabled, properties: [:])
+        }
+    }
+}

--- a/WooCommerce/Classes/Analytics/WooAnalyticsStat.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsStat.swift
@@ -1242,6 +1242,13 @@ enum WooAnalyticsStat: String {
     case googleAdsFlowCanceled = "googleads_flow_canceled"
     case googleAdsFlowError = "googleads_flow_error"
     case googleAdsCampaignCreationSuccess = "googleads_campaign_creation_success"
+
+    // MARK: Background Data Updates
+    case backgroundDataSynced = "background_data_synced"
+    case backgroundDataSyncError = "background_data_sync_error"
+    case pushNotificationOrderBackgroundSynced = "push_notification_order_background_synced"
+    case pushNotificationOrderBackgroundSyncError = "push_notification_order_background_sync_error"
+    case backgroundUpdatesDisabled = "background_updates_disabled"
 }
 
 extension WooAnalyticsStat {

--- a/WooCommerce/Classes/Notifications/PushNotificationBackgroundSynchronizer.swift
+++ b/WooCommerce/Classes/Notifications/PushNotificationBackgroundSynchronizer.swift
@@ -54,7 +54,7 @@ struct PushNotificationBackgroundSynchronizer {
                 try await synchronizeOrder(siteID: pushNotification.siteID, orderID: orderID)
             }
 
-            let timeTaken = Date.now.timeIntervalSince(startTime)
+            let timeTaken = round(Date.now.timeIntervalSince(startTime))
             ServiceLocator.analytics.track(event: .BackgroundUpdates.orderPushNotificationSynced(timeTaken: timeTaken))
 
             return .newData

--- a/WooCommerce/Classes/Notifications/PushNotificationBackgroundSynchronizer.swift
+++ b/WooCommerce/Classes/Notifications/PushNotificationBackgroundSynchronizer.swift
@@ -33,6 +33,9 @@ struct PushNotificationBackgroundSynchronizer {
         }
 
         do {
+
+            let startTime = Date.now
+
             // I'm not sure why we need to sync all notifications instead of only the current one.
             // This is legacy code copied from PushNotificationsManager
             try await synchronizeNotifications()
@@ -51,10 +54,14 @@ struct PushNotificationBackgroundSynchronizer {
                 try await synchronizeOrder(siteID: pushNotification.siteID, orderID: orderID)
             }
 
+            let timeTaken = Date.now.timeIntervalSince(startTime)
+            ServiceLocator.analytics.track(event: .BackgroundUpdates.orderPushNotificationSynced(timeTaken: timeTaken))
+
             return .newData
 
         } catch {
             DDLogError("⛔️ Error synchronizing notification dependencies: \(error)")
+            ServiceLocator.analytics.track(event: .BackgroundUpdates.orderPushNotificationSyncError(error))
             return .noData
         }
     }

--- a/WooCommerce/Classes/Tools/BackgroundTasks/BackgroundTaskRefreshDispatcher.swift
+++ b/WooCommerce/Classes/Tools/BackgroundTasks/BackgroundTaskRefreshDispatcher.swift
@@ -77,7 +77,7 @@ final class BackgroundTaskRefreshDispatcher {
                     }
                 }
 
-                let timeTaken = Date.now.timeIntervalSince(startTime)
+                let timeTaken = round(Date.now.timeIntervalSince(startTime))
                 ServiceLocator.analytics.track(event: .BackgroundUpdates.dataSynced(timeTaken: timeTaken))
                 backgroundTask.setTaskCompleted(success: true)
 

--- a/WooCommerce/Classes/Tools/BackgroundTasks/BackgroundTaskRefreshDispatcher.swift
+++ b/WooCommerce/Classes/Tools/BackgroundTasks/BackgroundTaskRefreshDispatcher.swift
@@ -1,3 +1,4 @@
+import UIKit
 import Foundation
 import BackgroundTasks
 
@@ -38,6 +39,10 @@ final class BackgroundTaskRefreshDispatcher {
                 return
             }
             self.handleAppRefresh(backgroundTask: refreshTask)
+        }
+
+        if UIApplication.shared.backgroundRefreshStatus != .available {
+            ServiceLocator.analytics.track(event: .BackgroundUpdates.disabled())
         }
     }
 

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -851,6 +851,7 @@
 		261F1A7C29C2B09D001D9861 /* FreeTrialBannerViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 261F1A7B29C2B09D001D9861 /* FreeTrialBannerViewModelTests.swift */; };
 		262418332B8D3630009A3834 /* ApplicationPasswordTutorial.swift in Sources */ = {isa = PBXBuildFile; fileRef = 262418322B8D3630009A3834 /* ApplicationPasswordTutorial.swift */; };
 		262418372B9044FF009A3834 /* ApplicationPasswordTutorialViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 262418362B9044FF009A3834 /* ApplicationPasswordTutorialViewModel.swift */; };
+		262562352C52A6410075A8CC /* WooAnalyticsEvent+BackgroudUpdates.swift in Sources */ = {isa = PBXBuildFile; fileRef = 262562342C52A6410075A8CC /* WooAnalyticsEvent+BackgroudUpdates.swift */; };
 		262619F12C03AB9600BD733B /* OrderDetailLoader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 262619F02C03AB9600BD733B /* OrderDetailLoader.swift */; };
 		262619F22C03BD9200BD733B /* OrderNotificationDataService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26CFDEE42C038C39005ABC31 /* OrderNotificationDataService.swift */; };
 		26281776278F0B0100C836D3 /* View+NoticesModifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26281775278F0B0100C836D3 /* View+NoticesModifier.swift */; };
@@ -3831,6 +3832,7 @@
 		261F1A7B29C2B09D001D9861 /* FreeTrialBannerViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FreeTrialBannerViewModelTests.swift; sourceTree = "<group>"; };
 		262418322B8D3630009A3834 /* ApplicationPasswordTutorial.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ApplicationPasswordTutorial.swift; sourceTree = "<group>"; };
 		262418362B9044FF009A3834 /* ApplicationPasswordTutorialViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ApplicationPasswordTutorialViewModel.swift; sourceTree = "<group>"; };
+		262562342C52A6410075A8CC /* WooAnalyticsEvent+BackgroudUpdates.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "WooAnalyticsEvent+BackgroudUpdates.swift"; sourceTree = "<group>"; };
 		262619F02C03AB9600BD733B /* OrderDetailLoader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OrderDetailLoader.swift; sourceTree = "<group>"; };
 		26281775278F0B0100C836D3 /* View+NoticesModifier.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "View+NoticesModifier.swift"; sourceTree = "<group>"; };
 		262A098A2628C51D0033AD20 /* OrderAddOnListViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OrderAddOnListViewModel.swift; sourceTree = "<group>"; };
@@ -9241,6 +9243,7 @@
 				DE12BED82B95C30800B19C01 /* WooAnalyticsEvent+DashboardCustomRange.swift */,
 				DE74A45C2BDA203E0009C415 /* WooAnalyticsEvent+DynamicDashboard.swift */,
 				DE6D84A82C3D07850014FBFF /* WooAnalyticsEvent+GoogleAds.swift */,
+				262562342C52A6410075A8CC /* WooAnalyticsEvent+BackgroudUpdates.swift */,
 			);
 			path = Analytics;
 			sourceTree = "<group>";
@@ -14407,6 +14410,7 @@
 				26D1E9E82949818B00A7DC62 /* AnalyticsHubTimeRageAdapter.swift in Sources */,
 				CE32B11A20BF8E32006FBCF4 /* UIButton+Helpers.swift in Sources */,
 				02667A1C2AC159A000C77B56 /* GiftCardCodeScannerNavigationView.swift in Sources */,
+				262562352C52A6410075A8CC /* WooAnalyticsEvent+BackgroudUpdates.swift in Sources */,
 				45BBFBC5274FDCE900213001 /* HubMenu.swift in Sources */,
 				02A9BCD62737F73C00159C79 /* JetpackBenefitItem.swift in Sources */,
 				027EB56E29C0602D003CE551 /* StoreOnboardingLaunchStoreViewModel.swift in Sources */,


### PR DESCRIPTION
closes #13155 

# Why

This PR add track events to the background update project.

```
- *_background_data_sync_error  |  params: error

- *_push_notification_order_background_synced  |  params: time_taken

- *_push_notification_order_background_sync_error  |  params: error

- *_background_updates_disabled
```

## Events 

- https://github.com/Automattic/tracks-events-registration/pull/2578
- https://github.com/Automattic/tracks-events-registration/pull/2579
- https://github.com/Automattic/tracks-events-registration/pull/2580
- https://github.com/Automattic/tracks-events-registration/pull/2581
- https://github.com/Automattic/tracks-events-registration/pull/2582

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
