### PR TITLE
Hot Fix: Bring back coupons menu item

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Hub Menu/HubMenuViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Hub Menu/HubMenuViewModel.swift
@@ -262,6 +262,7 @@ private extension HubMenuViewModel {
 
         items.append(WoocommerceAdmin())
         items.append(ViewStore())
+        items.append(Coupons())
         items.append(Reviews())
 
         if eligibleForInbox {

--- a/WooCommerce/WooCommerceTests/ViewRelated/HubMenu/HubMenuViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/HubMenu/HubMenuViewModelTests.swift
@@ -62,6 +62,36 @@ final class HubMenuViewModelTests: XCTestCase {
     }
 
     @MainActor
+    func test_generalMenuElements_include_the_correct_default_elements() {
+        // Given
+        let inboxEligibilityChecker = MockInboxEligibilityChecker()
+
+        let stores = MockStoresManager(sessionManager: .makeForTesting())
+        // Setting site ID is required before setting `Site`.
+        stores.updateDefaultStore(storeID: sampleSiteID)
+        stores.updateDefaultStore(.fake().copy(siteID: sampleSiteID))
+
+        // When
+        let viewModel = HubMenuViewModel(siteID: sampleSiteID,
+                                         tapToPayBadgePromotionChecker: TapToPayBadgePromotionChecker(),
+                                         stores: stores,
+                                         inboxEligibilityChecker: inboxEligibilityChecker)
+
+        viewModel.setupMenuElements()
+
+        // Then
+        let expectedElementsIDs = Set([
+            HubMenuViewModel.WoocommerceAdmin.id,
+            HubMenuViewModel.ViewStore.id,
+            HubMenuViewModel.Coupons.id,
+            HubMenuViewModel.Reviews.id,
+            HubMenuViewModel.Customers.id
+        ])
+        let generalElementsIds = Set(viewModel.generalElements.map { $0.self.id })
+        XCTAssertTrue(expectedElementsIDs.isSubset(of: generalElementsIds))
+    }
+
+    @MainActor
     func test_menuElements_do_not_include_inbox_when_store_has_ineligible_wc_version() {
         // Given the store is ineligible WC version for inbox and coupons feature is enabled in app settings
         let featureFlagService = MockFeatureFlagService(isInboxOn: true)


### PR DESCRIPTION

# Why

This PR brings back the Coupons hub menu item, which seems to have been mistakenly deleted in [this PR](https://github.com/woocommerce/woocommerce-ios/pull/13208/files#diff-a7353a3c9b54e18ce66e192000f034059a624c6824a359575150dc1788697d04L214-L219)

# How

- Add the Coupons Menu back & add unit tests for it.

# Screenshots

Before | After | After 2
--- | --- | ---
![before](https://github.com/user-attachments/assets/32349c46-11cf-4dfc-b3c1-1e0ad1e10944) | ![after-1](https://github.com/user-attachments/assets/b09064bb-dba7-45af-92b4-32ecd128d848) | ![after-2](https://github.com/user-attachments/assets/33084071-6ce2-4672-9fc9-9491f4df2084)

# Testing Steps

- Open the app and navigate to the Menu tab.
- See that the Coupons item is visible in the "General" section. 

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
