### PR TITLE
Blaze: Hide product destination URL if product URL is empty

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -6,6 +6,7 @@
 - [*] Stats: The Google Campaign analytics card now has a call to action to create a paid campaign if there are no campaign analytics for the selected time period. [https://github.com/woocommerce/woocommerce-ios/pull/13397]
 - [**] Google Ads campaign management is now available for stores with plugin version 2.7.7 or later. [https://github.com/woocommerce/woocommerce-ios/pull/13421]
 - [*] Product Creation AI: Progress bar and guidance text to encourage users to enter product features. [https://github.com/woocommerce/woocommerce-ios/pull/13412]
+- [*] Blaze: Hide the product URL destination in campaign creation if the URL is empty. [https://github.com/woocommerce/woocommerce-ios/pull/13430]
 
 19.6
 -----

--- a/WooCommerce/Classes/ViewRelated/Blaze/AdDestination/BlazeAdDestinationSettingView.swift
+++ b/WooCommerce/Classes/ViewRelated/Blaze/AdDestination/BlazeAdDestinationSettingView.swift
@@ -18,10 +18,12 @@ struct BlazeAdDestinationSettingView: View {
         NavigationView {
             List {
                 Section {
-                    destinationItem(title: Localization.productURLLabel,
-                                    subtitle: String(format: Localization.destinationUrlSubtitle, viewModel.productURL),
-                                    type: DestinationType.product)
-                    .listRowInsets(EdgeInsets())
+                    if viewModel.productURL.isNotEmpty {
+                        destinationItem(title: Localization.productURLLabel,
+                                        subtitle: String(format: Localization.destinationUrlSubtitle, viewModel.productURL),
+                                        type: DestinationType.product)
+                        .listRowInsets(EdgeInsets())
+                    }
 
                     destinationItem(title: Localization.siteHomeLabel,
                                     subtitle: String(format: Localization.destinationUrlSubtitle, viewModel.homeURL),


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of #13355
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
Currently, when a product URL is empty, we are still enabling the option for Blaze destination if a user enters any URL parameter. This is an edge case, and it'd be nice if we support selecting product URL, but it might be tricky to validate the URL. This PR adds a simple solution to hide the option when the product URL is not available for now.

## Testing steps
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->
- Prerequisites: Change [this line](https://github.com/woocommerce/woocommerce-ios/blob/trunk/Networking/Networking/Model/Product/Product.swift#L354) and return an empty string instead of decoding the value.
- Log in to a store eligible for Blaze.
- Navigate to the products tab.
- Open a product's detail page.
- Tap on the "Promote with Blaze" button > select Ad Destination.
- Confirm that the option for product URL is not available.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->
<img src="https://github.com/user-attachments/assets/1f9d81c0-b6ad-450a-8603-25e06f0afd6a" width=320 />


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
