### PR TITLE
[Woo POS] M2: Checkout update - distinguish between validatingOrder and preparingForPayment states

### DIFF
--- a/WooCommerce/Classes/POS/Presentation/Card Present Payments/PointOfSaleCardPresentPaymentEventPresentationStyle.swift
+++ b/WooCommerce/Classes/POS/Presentation/Card Present Payments/PointOfSaleCardPresentPaymentEventPresentationStyle.swift
@@ -109,25 +109,28 @@ extension CardPresentPaymentEventDetails {
                     cancelUpdateAction: cancelUpdate)))
 
         /// Payment messages
-        case .preparingForPayment(cancelPayment: let cancelPayment):
+        case .validatingOrder:
+            return .message(.validatingOrder(
+                viewModel: PointOfSaleCardPresentPaymentValidatingOrderMessageViewModel()))
+        case .preparingForPayment:
             return .message(.preparingForPayment(
                 viewModel: PointOfSaleCardPresentPaymentPreparingForPaymentMessageViewModel()))
 
-        case .tapSwipeOrInsertCard(inputMethods: let inputMethods, cancelPayment: let cancelPayment):
+        case .tapSwipeOrInsertCard(inputMethods: let inputMethods, cancelPayment: _):
             return .message(.tapSwipeOrInsertCard(
                 viewModel: PointOfSaleCardPresentPaymentTapSwipeInsertCardMessageViewModel(
                     inputMethods: inputMethods)))
 
-        case .paymentSuccess(done: let done):
+        case .paymentSuccess:
             return .message(.paymentSuccess(viewModel: PointOfSaleCardPresentPaymentSuccessMessageViewModel()))
 
-        case .paymentError(error: let error, tryAgain: let tryAgain, cancelPayment: let cancelPayment):
+        case .paymentError(error: let error, tryAgain: let tryAgain, cancelPayment: _):
             return .message(.paymentError(
                 viewModel: PointOfSaleCardPresentPaymentErrorMessageViewModel(
                     error: error,
                     tryAgainButtonAction: tryAgain)))
 
-        case .paymentErrorNonRetryable(error: let error, cancelPayment: let cancelPayment):
+        case .paymentErrorNonRetryable(error: let error, cancelPayment: _):
             return .message(.paymentErrorNonRetryable(
                 viewModel: PointOfSaleCardPresentPaymentNonRetryableErrorMessageViewModel(
                     error: error)))
@@ -148,8 +151,7 @@ extension CardPresentPaymentEventDetails {
                 viewModel: PointOfSaleCardPresentPaymentCancelledOnReaderMessageViewModel()))
 
         /// Not-yet supported types
-        case .selectSearchType,
-                .validatingOrder:
+        case .selectSearchType:
             return nil
         }
     }

--- a/WooCommerce/Classes/POS/Presentation/Card Present Payments/Reader Messages/PointOfSaleCardPresentPaymentMessageType.swift
+++ b/WooCommerce/Classes/POS/Presentation/Card Present Payments/Reader Messages/PointOfSaleCardPresentPaymentMessageType.swift
@@ -1,6 +1,7 @@
 import Foundation
 
 enum PointOfSaleCardPresentPaymentMessageType {
+    case validatingOrder(viewModel: PointOfSaleCardPresentPaymentValidatingOrderMessageViewModel)
     case preparingForPayment(viewModel: PointOfSaleCardPresentPaymentPreparingForPaymentMessageViewModel)
     case tapSwipeOrInsertCard(viewModel: PointOfSaleCardPresentPaymentTapSwipeInsertCardMessageViewModel)
     case processing(viewModel: PointOfSaleCardPresentPaymentProcessingMessageViewModel)

--- a/WooCommerce/Classes/POS/Presentation/Card Present Payments/Reader Messages/PointOfSaleCardPresentPaymentPreparingForPaymentMessageViewModel.swift
+++ b/WooCommerce/Classes/POS/Presentation/Card Present Payments/Reader Messages/PointOfSaleCardPresentPaymentPreparingForPaymentMessageViewModel.swift
@@ -8,14 +8,14 @@ struct PointOfSaleCardPresentPaymentPreparingForPaymentMessageViewModel {
 private extension PointOfSaleCardPresentPaymentPreparingForPaymentMessageViewModel {
     enum Localization {
         static let title = NSLocalizedString(
-            "pointOfSale.cardPresent.preparingCardReader.title",
-            value: "Preparing card reader",
+            "pointOfSale.cardPresent.preparingForPayment.title",
+            value: "Getting ready",
             comment: "Title shown on the Point of Sale checkout while the reader is being prepared."
         )
         static let message = NSLocalizedString(
-            "pointOfSale.cardPresent.preparingCardReader.message",
-            value: "Checking order",
-            comment: "Message shown on the Point of Sale checkout while the reader is being prepared and order being checked."
+            "pointOfSale.cardPresent.preparingForPayment.message",
+            value: "Preparing card for payment",
+            comment: "Message shown on the Point of Sale checkout while the reader is being prepared."
         )
     }
 }

--- a/WooCommerce/Classes/POS/Presentation/Card Present Payments/Reader Messages/PointOfSaleCardPresentPaymentValidatingOrderMessageViewModel.swift
+++ b/WooCommerce/Classes/POS/Presentation/Card Present Payments/Reader Messages/PointOfSaleCardPresentPaymentValidatingOrderMessageViewModel.swift
@@ -1,0 +1,21 @@
+import Foundation
+
+struct PointOfSaleCardPresentPaymentValidatingOrderMessageViewModel {
+    let title: String = Localization.title
+    let message: String = Localization.message
+}
+
+private extension PointOfSaleCardPresentPaymentValidatingOrderMessageViewModel {
+    enum Localization {
+        static let title = NSLocalizedString(
+            "pointOfSale.cardPresent.validatingOrder.title",
+            value: "Getting ready",
+            comment: "Title shown on the Point of Sale checkout while the order is being validated."
+        )
+        static let message = NSLocalizedString(
+            "pointOfSale.cardPresent.validatingOrder.message",
+            value: "Checking order",
+            comment: "Message shown on the Point of Sale checkout while the order is being validated."
+        )
+    }
+}

--- a/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/PointOfSaleCardPresentPaymentInLineMessage.swift
+++ b/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/PointOfSaleCardPresentPaymentInLineMessage.swift
@@ -11,6 +11,8 @@ struct PointOfSaleCardPresentPaymentInLineMessage: View {
 
         // TODO: replace temporary inline message UI based on design
         switch messageType {
+        case .validatingOrder(let viewModel):
+            PointOfSaleCardPresentPaymentValidatingOrderMessageView(viewModel: viewModel)
         case .preparingForPayment(let viewModel):
             PointOfSaleCardPresentPaymentPreparingForPaymentMessageView(viewModel: viewModel)
         case .tapSwipeOrInsertCard(let viewModel):

--- a/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/Reader Messages/PointOfSaleCardPresentPaymentValidatingOrderMessageView.swift
+++ b/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/Reader Messages/PointOfSaleCardPresentPaymentValidatingOrderMessageView.swift
@@ -1,0 +1,16 @@
+import SwiftUI
+
+struct PointOfSaleCardPresentPaymentValidatingOrderMessageView: View {
+    let viewModel: PointOfSaleCardPresentPaymentValidatingOrderMessageViewModel
+
+    var body: some View {
+        POSCardPresentPaymentMessageView(viewModel: .init(showProgress: true,
+                                                          title: viewModel.title,
+                                                          message: viewModel.message))
+    }
+}
+
+#Preview {
+    PointOfSaleCardPresentPaymentValidatingOrderMessageView(
+        viewModel: PointOfSaleCardPresentPaymentValidatingOrderMessageViewModel())
+}

--- a/WooCommerce/Classes/POS/ViewModels/PointOfSaleDashboardViewModel.swift
+++ b/WooCommerce/Classes/POS/ViewModels/PointOfSaleDashboardViewModel.swift
@@ -115,6 +115,7 @@ private extension PointOfSaleDashboardViewModel {
                     return true
                 case .idle,
                         .acceptingCard,
+                        .validatingOrder,
                         .preparingReader:
                     return isSyncingOrder
                 }
@@ -128,6 +129,7 @@ private extension PointOfSaleDashboardViewModel {
                     return true
                 case .idle,
                         .acceptingCard,
+                        .validatingOrder,
                         .preparingReader,
                         .cardPaymentSuccessful:
                     return false
@@ -142,6 +144,7 @@ private extension PointOfSaleDashboardViewModel {
                         .cardPaymentSuccessful:
                     return true
                 case .idle,
+                        .validatingOrder,
                         .preparingReader,
                         .acceptingCard:
                     return false

--- a/WooCommerce/Classes/POS/ViewModels/TotalsViewModel.swift
+++ b/WooCommerce/Classes/POS/ViewModels/TotalsViewModel.swift
@@ -13,6 +13,7 @@ final class TotalsViewModel: ObservableObject, TotalsViewModelProtocol {
     enum PaymentState {
         case idle
         case acceptingCard
+        case validatingOrder
         case preparingReader
         case processingPayment
         case cardPaymentSuccessful
@@ -278,6 +279,8 @@ private extension TotalsViewModel.PaymentState {
         case .idle:
             self = .idle
         case .show(.validatingOrder):
+            self = .validatingOrder
+        case .show(.preparingForPayment):
             self = .preparingReader
         case .show(.tapSwipeOrInsertCard):
             self = .acceptingCard

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -21,6 +21,8 @@
 /* End PBXAggregateTarget section */
 
 /* Begin PBXBuildFile section */
+		011DF3442C53A5CF000AFDD9 /* PointOfSaleCardPresentPaymentValidatingOrderMessageViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 011DF3432C53A5CF000AFDD9 /* PointOfSaleCardPresentPaymentValidatingOrderMessageViewModel.swift */; };
+		011DF3462C53A919000AFDD9 /* PointOfSaleCardPresentPaymentValidatingOrderMessageView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 011DF3452C53A919000AFDD9 /* PointOfSaleCardPresentPaymentValidatingOrderMessageView.swift */; };
 		0157A9962C4FEA7200866FFD /* PointOfSaleLoadingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0157A9952C4FEA7200866FFD /* PointOfSaleLoadingView.swift */; };
 		01620C4E2C5394B200D3EA2F /* POSProgressViewStyle.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01620C4D2C5394B200D3EA2F /* POSProgressViewStyle.swift */; };
 		01664F9E2C50E685007CB5DD /* Font+WooCommercePOS.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01664F9D2C50E685007CB5DD /* Font+WooCommercePOS.swift */; };
@@ -3001,6 +3003,8 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		011DF3432C53A5CF000AFDD9 /* PointOfSaleCardPresentPaymentValidatingOrderMessageViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PointOfSaleCardPresentPaymentValidatingOrderMessageViewModel.swift; sourceTree = "<group>"; };
+		011DF3452C53A919000AFDD9 /* PointOfSaleCardPresentPaymentValidatingOrderMessageView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PointOfSaleCardPresentPaymentValidatingOrderMessageView.swift; sourceTree = "<group>"; };
 		0157A9952C4FEA7200866FFD /* PointOfSaleLoadingView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PointOfSaleLoadingView.swift; sourceTree = "<group>"; };
 		01620C4D2C5394B200D3EA2F /* POSProgressViewStyle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = POSProgressViewStyle.swift; sourceTree = "<group>"; };
 		01664F9D2C50E685007CB5DD /* Font+WooCommercePOS.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Font+WooCommercePOS.swift"; sourceTree = "<group>"; };
@@ -7561,6 +7565,7 @@
 				205B7ECE2C19FD5200D14A36 /* PointOfSaleCardPresentPaymentSuccessMessageViewModel.swift */,
 				205B7ECC2C19FD2F00D14A36 /* PointOfSaleCardPresentPaymentDisplayReaderMessageMessageViewModel.swift */,
 				0230B4D12C333E0800F2F660 /* PointOfSaleCardPresentPaymentCaptureErrorMessageViewModel.swift */,
+				011DF3432C53A5CF000AFDD9 /* PointOfSaleCardPresentPaymentValidatingOrderMessageViewModel.swift */,
 			);
 			path = "Reader Messages";
 			sourceTree = "<group>";
@@ -7576,6 +7581,7 @@
 				205E794E2C207D38001BA266 /* PointOfSaleCardPresentPaymentNonRetryableErrorMessageView.swift */,
 				205E79502C207FAE001BA266 /* PointOfSaleCardPresentPaymentDisplayReaderMessageMessageView.swift */,
 				0230B4D52C33454900F2F660 /* PointOfSaleCardPresentPaymentCaptureErrorMessageView.swift */,
+				011DF3452C53A919000AFDD9 /* PointOfSaleCardPresentPaymentValidatingOrderMessageView.swift */,
 			);
 			path = "Reader Messages";
 			sourceTree = "<group>";
@@ -14985,6 +14991,7 @@
 				DED039292BC7A04B005D0571 /* StorePerformanceView.swift in Sources */,
 				03E471C4293A1F8D001A58AD /* BuiltInReaderConnectionAlertsProvider.swift in Sources */,
 				20CC1EDD2AFA99DF006BD429 /* InPersonPaymentsMenuViewModel.swift in Sources */,
+				011DF3462C53A919000AFDD9 /* PointOfSaleCardPresentPaymentValidatingOrderMessageView.swift in Sources */,
 				D8736B7522F1FE1600A14A29 /* BadgeLabel.swift in Sources */,
 				EE4C45652C352D60001A3D94 /* AIToneVoice.swift in Sources */,
 				DE85E4ED2AB416F5008789E1 /* AddProductWithAIActionSheet.swift in Sources */,
@@ -15846,6 +15853,7 @@
 				20AE33C72B0510D200527B60 /* HubMenuDestination.swift in Sources */,
 				CE24BCCF212DE8A6001CD12E /* HeadlineLabelTableViewCell.swift in Sources */,
 				0245465D24EE779D004F531C /* ProductFormEventLogger.swift in Sources */,
+				011DF3442C53A5CF000AFDD9 /* PointOfSaleCardPresentPaymentValidatingOrderMessageViewModel.swift in Sources */,
 				20AE33C52B0510BF00527B60 /* PaymentsMenuDestination.swift in Sources */,
 				B53B898D20D462A000EDB467 /* DefaultStoresManager.swift in Sources */,
 				24F98C502502AEE200F49B68 /* EventLogging.swift in Sources */,


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Further development of [#13345](https://github.com/woocommerce/woocommerce-ios/pull/13427)
<!-- Id number of the GitHub issue this PR addresses. -->

## Description

According to requirements, we need to distinguish between "Checking order" and "Preparing for payment" states:

<img width="990" alt="image" src="https://github.com/user-attachments/assets/ee3d51ec-9386-47d3-ba38-24df0de1261b">

## Solution

We have all the infrastructure to handle this state. For now it was not handled in any way, therefore I created an additional `<...>validatingOrder` payment state that is shown before `<...>prepareForPayment` state.

## Testing information
1. Open Woo -> Menu -> Point of Sale Mode
2. Connect Reader
3. Add items to the cart
4. Check out
5. Confirm that first "Checking order" then "Preparing for payment" states appear

## Screenshots

https://github.com/user-attachments/assets/00a31456-67b9-4472-bca1-5f7e78a21737


- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.