### PR TITLE
[Woo POS] M2: Add animation to loading and syncing order checkout UI

### DIFF
--- a/WooCommerce/Classes/POS/Presentation/TotalsView.swift
+++ b/WooCommerce/Classes/POS/Presentation/TotalsView.swift
@@ -55,19 +55,22 @@ private extension TotalsView {
                 subtotalFieldView(title: Localization.subtotal,
                                   formattedPrice: totalsViewModel.formattedCartTotalPrice,
                                   shimmeringActive: totalsViewModel.isShimmering,
-                                  redacted: totalsViewModel.isSubtotalFieldRedacted)
+                                  redacted: totalsViewModel.isSubtotalFieldRedacted,
+                                  matchedGeometryId: Constants.matchedGeometrySubtotalId)
                 Spacer().frame(height: Constants.subtotalsVerticalSpacing)
                 subtotalFieldView(title: Localization.taxes,
                                   formattedPrice: totalsViewModel.formattedOrderTotalTaxPrice,
                                   shimmeringActive: totalsViewModel.isShimmering,
-                                  redacted: totalsViewModel.isTaxFieldRedacted)
+                                  redacted: totalsViewModel.isTaxFieldRedacted,
+                                  matchedGeometryId: Constants.matchedGeometryTaxId)
                 Spacer().frame(height: Constants.totalVerticalSpacing)
                 Divider()
                     .overlay(Color.posTotalsSeparator)
                 Spacer().frame(height: Constants.totalVerticalSpacing)
                 totalFieldView(formattedPrice: totalsViewModel.formattedOrderTotalPrice,
                                shimmeringActive: totalsViewModel.isShimmering,
-                               redacted: totalsViewModel.isTotalPriceFieldRedacted)
+                               redacted: totalsViewModel.isTotalPriceFieldRedacted,
+                               matchedGeometryId: Constants.matchedGeometryTotalId)
             }
             .padding(Constants.totalsLineViewPadding)
             .frame(minWidth: Constants.pricesIdealWidth)
@@ -77,10 +80,14 @@ private extension TotalsView {
     }
 
     @ViewBuilder
-    func subtotalFieldView(title: String, formattedPrice: String?, shimmeringActive: Bool, redacted: Bool) -> some View {
+    func subtotalFieldView(title: String,
+                           formattedPrice: String?,
+                           shimmeringActive: Bool,
+                           redacted: Bool,
+                           matchedGeometryId: String) -> some View {
         if shimmeringActive {
             shimmeringLineView(width: Constants.shimmeringWidth, height: Constants.subtotalsShimmeringHeight)
-                .matchedGeometryEffect(id: "subtotalFieldView:_\(title)", in: totalsFieldAnimation)
+                .matchedGeometryEffect(id: matchedGeometryId, in: totalsFieldAnimation)
         } else {
             HStack(alignment: .top, spacing: .zero) {
                 Text(title)
@@ -91,15 +98,18 @@ private extension TotalsView {
                     .redacted(reason: redacted ? [.placeholder] : [])
             }
             .foregroundColor(Color.primaryText)
-            .matchedGeometryEffect(id: "subtotalFieldView:_\(title)", in: totalsFieldAnimation)
+            .matchedGeometryEffect(id: matchedGeometryId, in: totalsFieldAnimation)
         }
     }
 
     @ViewBuilder
-    func totalFieldView(formattedPrice: String?, shimmeringActive: Bool, redacted: Bool) -> some View {
+    func totalFieldView(formattedPrice: String?,
+                        shimmeringActive: Bool,
+                        redacted: Bool,
+                        matchedGeometryId: String) -> some View {
         if shimmeringActive {
             shimmeringLineView(width: Constants.shimmeringWidth, height: Constants.totalShimmeringHeight)
-                .matchedGeometryEffect(id: "totalFieldView", in: totalsFieldAnimation)
+                .matchedGeometryEffect(id: matchedGeometryId, in: totalsFieldAnimation)
         } else {
             HStack(alignment: .top, spacing: .zero) {
                 Text(Localization.total)
@@ -111,7 +121,7 @@ private extension TotalsView {
                     .redacted(reason: redacted ? [.placeholder] : [])
             }
             .foregroundColor(Color.primaryText)
-            .matchedGeometryEffect(id: "totalFieldView", in: totalsFieldAnimation)
+            .matchedGeometryEffect(id: matchedGeometryId, in: totalsFieldAnimation)
         }
     }
 
@@ -197,6 +207,11 @@ private extension TotalsView {
         static let newTransactionButtonSpacing: CGFloat = 20
         static let newTransactionButtonPadding: CGFloat = 16
         static let newTransactionButtonFont: Font = Font.system(size: 32, weight: .medium)
+
+        /// Used for synchronizing animations of shimmeringLine and textField
+        static let matchedGeometrySubtotalId: String = UUID().uuidString
+        static let matchedGeometryTaxId: String = UUID().uuidString
+        static let matchedGeometryTotalId: String = UUID().uuidString
     }
 
     enum Localization {

--- a/WooCommerce/Classes/POS/Presentation/TotalsView.swift
+++ b/WooCommerce/Classes/POS/Presentation/TotalsView.swift
@@ -5,6 +5,9 @@ struct TotalsView: View {
     @ObservedObject private var totalsViewModel: TotalsViewModel
     @ObservedObject private var cartViewModel: CartViewModel
 
+    /// Used for synchronizing totals fields animation
+    @Namespace private var totalsFieldAnimation
+
     init(viewModel: PointOfSaleDashboardViewModel,
          totalsViewModel: TotalsViewModel,
          cartViewModel: CartViewModel) {
@@ -18,14 +21,16 @@ struct TotalsView: View {
             VStack(alignment: .center) {
                 Spacer()
                 VStack(alignment: .center, spacing: Constants.verticalSpacing) {
-                    if !totalsViewModel.isSyncingOrder {
+                    if totalsViewModel.isShowingCardPresentPaymentStatus {
                         cardReaderView
                             .font(.title)
                             .padding()
+                            .transition(.opacity)
                     }
 
                     totalsFieldsView
                 }
+                .animation(.default, value: totalsViewModel.isShowingCardPresentPaymentStatus)
                 paymentsActionButtons
                     .padding()
                 Spacer()
@@ -70,6 +75,7 @@ private extension TotalsView {
     func subtotalFieldView(title: String, formattedPrice: String?, shimmeringActive: Bool, redacted: Bool) -> some View {
         if shimmeringActive {
             shimmeringLineView(width: Constants.shimmeringWidth, height: Constants.subtotalsShimmeringHeight)
+                .matchedGeometryEffect(id: "subtotalFieldView:_\(title)", in: totalsFieldAnimation)
         } else {
             HStack(alignment: .top, spacing: .zero) {
                 Text(title)
@@ -80,6 +86,8 @@ private extension TotalsView {
                     .redacted(reason: redacted ? [.placeholder] : [])
             }
             .foregroundColor(Color.primaryText)
+            .matchedGeometryEffect(id: "subtotalFieldView:_\(title)", in: totalsFieldAnimation)
+            .animation(.default, value: totalsViewModel.isShimmering)
         }
     }
 
@@ -87,6 +95,7 @@ private extension TotalsView {
     func totalFieldView(formattedPrice: String?, shimmeringActive: Bool, redacted: Bool) -> some View {
         if shimmeringActive {
             shimmeringLineView(width: Constants.shimmeringWidth, height: Constants.totalShimmeringHeight)
+                .matchedGeometryEffect(id: "totalFieldView", in: totalsFieldAnimation)
         } else {
             HStack(alignment: .top, spacing: .zero) {
                 Text(Localization.total)
@@ -98,6 +107,9 @@ private extension TotalsView {
                     .redacted(reason: redacted ? [.placeholder] : [])
             }
             .foregroundColor(Color.primaryText)
+            .transition(.opacity)
+            .matchedGeometryEffect(id: "totalFieldView", in: totalsFieldAnimation)
+            .animation(.default, value: totalsViewModel.isShimmering)
         }
     }
 

--- a/WooCommerce/Classes/POS/Presentation/TotalsView.swift
+++ b/WooCommerce/Classes/POS/Presentation/TotalsView.swift
@@ -29,6 +29,8 @@ struct TotalsView: View {
                     }
 
                     totalsFieldsView
+                        .transition(.opacity)
+                        .animation(.default, value: totalsViewModel.isShimmering)
                 }
                 .animation(.default, value: totalsViewModel.isShowingCardReaderStatus)
                 paymentsActionButtons
@@ -87,7 +89,6 @@ private extension TotalsView {
             }
             .foregroundColor(Color.primaryText)
             .matchedGeometryEffect(id: "subtotalFieldView:_\(title)", in: totalsFieldAnimation)
-            .animation(.default, value: totalsViewModel.isShimmering)
         }
     }
 
@@ -107,9 +108,7 @@ private extension TotalsView {
                     .redacted(reason: redacted ? [.placeholder] : [])
             }
             .foregroundColor(Color.primaryText)
-            .transition(.opacity)
             .matchedGeometryEffect(id: "totalFieldView", in: totalsFieldAnimation)
-            .animation(.default, value: totalsViewModel.isShimmering)
         }
     }
 

--- a/WooCommerce/Classes/POS/Presentation/TotalsView.swift
+++ b/WooCommerce/Classes/POS/Presentation/TotalsView.swift
@@ -5,7 +5,10 @@ struct TotalsView: View {
     @ObservedObject private var totalsViewModel: TotalsViewModel
     @ObservedObject private var cartViewModel: CartViewModel
 
-    /// Used for synchronizing totals fields animation
+    /// Used together with .matchedGeometryEffect to synchronize the animations of shimmeringLineView and text fields.
+    /// This makes SwiftUI treat these views as a single entity in the context of animation.
+    /// It allows for a simultaneous transition from the shimmering effect to the text fields,
+    /// and movement from the center of the VStack to their respective positions.
     @Namespace private var totalsFieldAnimation
 
     init(viewModel: PointOfSaleDashboardViewModel,

--- a/WooCommerce/Classes/POS/Presentation/TotalsView.swift
+++ b/WooCommerce/Classes/POS/Presentation/TotalsView.swift
@@ -21,7 +21,7 @@ struct TotalsView: View {
             VStack(alignment: .center) {
                 Spacer()
                 VStack(alignment: .center, spacing: Constants.verticalSpacing) {
-                    if totalsViewModel.isShowingCardPresentPaymentStatus {
+                    if totalsViewModel.isShowingCardReaderStatus {
                         cardReaderView
                             .font(.title)
                             .padding()
@@ -30,7 +30,7 @@ struct TotalsView: View {
 
                     totalsFieldsView
                 }
-                .animation(.default, value: totalsViewModel.isShowingCardPresentPaymentStatus)
+                .animation(.default, value: totalsViewModel.isShowingCardReaderStatus)
                 paymentsActionButtons
                     .padding()
                 Spacer()

--- a/WooCommerce/Classes/POS/ViewModels/TotalsViewModel.swift
+++ b/WooCommerce/Classes/POS/ViewModels/TotalsViewModel.swift
@@ -233,9 +233,7 @@ private extension TotalsViewModel {
             }
             .assign(to: &$connectionStatus)
 
-        Publishers.CombineLatest3($connectionStatus.removeDuplicates(),
-                                  $isSyncingOrder.removeDuplicates(),
-                                  $cardPresentPaymentInlineMessage)
+        Publishers.CombineLatest3($connectionStatus, $isSyncingOrder, $cardPresentPaymentInlineMessage)
             .map { connectionStatus, isSyncingOrder, message in
                 if isSyncingOrder {
                     return false

--- a/WooCommerce/Classes/POS/ViewModels/TotalsViewModel.swift
+++ b/WooCommerce/Classes/POS/ViewModels/TotalsViewModel.swift
@@ -1,4 +1,5 @@
 import SwiftUI
+import Combine
 import protocol Yosemite.POSOrderServiceProtocol
 import protocol Yosemite.POSItem
 import struct Yosemite.Order
@@ -23,6 +24,7 @@ final class TotalsViewModel: ObservableObject, TotalsViewModelProtocol {
     @Published var cardPresentPaymentEvent: CardPresentPaymentEvent = .idle
     @Published var cardPresentPaymentAlertViewModel: PointOfSaleCardPresentPaymentAlertType?
     @Published private(set) var cardPresentPaymentInlineMessage: PointOfSaleCardPresentPaymentMessageType?
+    @Published private(set) var isShowingCardPresentPaymentStatus: Bool = false
 
     @Published private(set) var order: Order? = nil
     private var totalsCalculator: OrderTotalsCalculator? = nil
@@ -230,6 +232,22 @@ private extension TotalsViewModel {
                 connectedReader == nil ? .disconnected: .connected
             }
             .assign(to: &$connectionStatus)
+
+        Publishers.CombineLatest3($connectionStatus.removeDuplicates(),
+                                  $isSyncingOrder.removeDuplicates(),
+                                  $cardPresentPaymentInlineMessage)
+            .map { connectionStatus, isSyncingOrder, message in
+                if isSyncingOrder {
+                    return false
+                }
+
+                if connectionStatus == .connected {
+                    return message != nil
+                }
+
+                return true
+            }
+            .assign(to: &$isShowingCardPresentPaymentStatus)
     }
 
     func observeCardPresentPaymentEvents() {

--- a/WooCommerce/Classes/POS/ViewModels/TotalsViewModel.swift
+++ b/WooCommerce/Classes/POS/ViewModels/TotalsViewModel.swift
@@ -24,7 +24,7 @@ final class TotalsViewModel: ObservableObject, TotalsViewModelProtocol {
     @Published var cardPresentPaymentEvent: CardPresentPaymentEvent = .idle
     @Published var cardPresentPaymentAlertViewModel: PointOfSaleCardPresentPaymentAlertType?
     @Published private(set) var cardPresentPaymentInlineMessage: PointOfSaleCardPresentPaymentMessageType?
-    @Published private(set) var isShowingCardPresentPaymentStatus: Bool = false
+    @Published private(set) var isShowingCardReaderStatus: Bool = false
 
     @Published private(set) var order: Order? = nil
     private var totalsCalculator: OrderTotalsCalculator? = nil
@@ -247,7 +247,7 @@ private extension TotalsViewModel {
 
                 return true
             }
-            .assign(to: &$isShowingCardPresentPaymentStatus)
+            .assign(to: &$isShowingCardReaderStatus)
     }
 
     func observeCardPresentPaymentEvents() {

--- a/WooCommerce/WooCommerceTests/POS/ViewModels/TotalsViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/POS/ViewModels/TotalsViewModelTests.swift
@@ -58,6 +58,35 @@ final class TotalsViewModelTests: XCTestCase {
         XCTAssertNil(sut.order)
         XCTAssertNil(sut.cardPresentPaymentInlineMessage)
     }
+
+    func test_isShowingCardPresentPaymentStatus_when_order_syncing_then_false() {
+        // Given
+        sut.isSyncingOrder = true
+
+        // Then
+        XCTAssertFalse(sut.isShowingCardPresentPaymentStatus)
+    }
+
+
+    func test_isShowingCardPresentPaymentStatus_when_connected_and_payment_message_exists_then_true() {
+        // Given
+        sut.isSyncingOrder = false
+        cardPresentPaymentService.connectedReader = CardPresentPaymentCardReader(name: "Test", batteryLevel: 0.5)
+        cardPresentPaymentService.paymentEvent = .show(eventDetails: .preparingForPayment(cancelPayment: {}))
+
+        // Then
+        XCTAssertTrue(sut.isShowingCardPresentPaymentStatus)
+    }
+
+    func test_isShowingCardPresentPaymentStatus_when_connected_and_no_payment_message_then_false() {
+        // Given
+        sut.isSyncingOrder = false
+        cardPresentPaymentService.connectedReader = CardPresentPaymentCardReader(name: "Test", batteryLevel: 0.5)
+        cardPresentPaymentService.paymentEvent = .idle
+
+        // Then
+        XCTAssertFalse(sut.isShowingCardPresentPaymentStatus)
+    }
 }
 
 private extension TotalsViewModelTests {

--- a/WooCommerce/WooCommerceTests/POS/ViewModels/TotalsViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/POS/ViewModels/TotalsViewModelTests.swift
@@ -59,33 +59,33 @@ final class TotalsViewModelTests: XCTestCase {
         XCTAssertNil(sut.cardPresentPaymentInlineMessage)
     }
 
-    func test_isShowingCardPresentPaymentStatus_when_order_syncing_then_false() {
+    func test_isShowingCardReaderStatus_when_order_syncing_then_false() {
         // Given
         sut.isSyncingOrder = true
 
         // Then
-        XCTAssertFalse(sut.isShowingCardPresentPaymentStatus)
+        XCTAssertFalse(sut.isShowingCardReaderStatus)
     }
 
 
-    func test_isShowingCardPresentPaymentStatus_when_connected_and_payment_message_exists_then_true() {
+    func test_isShowingCardReaderStatus_when_connected_and_payment_message_exists_then_true() {
         // Given
         sut.isSyncingOrder = false
         cardPresentPaymentService.connectedReader = CardPresentPaymentCardReader(name: "Test", batteryLevel: 0.5)
         cardPresentPaymentService.paymentEvent = .show(eventDetails: .preparingForPayment(cancelPayment: {}))
 
         // Then
-        XCTAssertTrue(sut.isShowingCardPresentPaymentStatus)
+        XCTAssertTrue(sut.isShowingCardReaderStatus)
     }
 
-    func test_isShowingCardPresentPaymentStatus_when_connected_and_no_payment_message_then_false() {
+    func test_isShowingCardReaderStatus_when_connected_and_no_payment_message_then_false() {
         // Given
         sut.isSyncingOrder = false
         cardPresentPaymentService.connectedReader = CardPresentPaymentCardReader(name: "Test", batteryLevel: 0.5)
         cardPresentPaymentService.paymentEvent = .idle
 
         // Then
-        XCTAssertFalse(sut.isShowingCardPresentPaymentStatus)
+        XCTAssertFalse(sut.isShowingCardReaderStatus)
     }
 }
 


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Wraps up the work in https://github.com/woocommerce/woocommerce-ios/pull/13427
<!-- Id number of the GitHub issue this PR addresses. -->

## Description

Added basic animations checkout is transitioning from only showing totals view to showing both totals and card reader views.

## Solution

Explanations on commit messages:
- [Add isShowingCardPresentPaymentStatus to TotalsViewModel to control r…](https://github.com/woocommerce/woocommerce-ios/pull/13437/commits/204329009bda85633e91a016d0a1ea64d38f1d46) 
- [Create animation for cardReaderView appearance on TotalsView](https://github.com/woocommerce/woocommerce-ios/pull/13437/commits/f0a5b3648ecf58a42426d5099b490ab637d232b2)

## Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->

**Reader disconnected**
1. Open Woo -> Menu -> Point of Sale Mode
4. Disconnect Reader
5. Add items to the cart
6. Check out
7. Confirm that at first totals view appears in the center while it's loading, when the order is synced, order totals appears together with **Reader Disconnected** Message with an animation

**Reader connected**
1. Open Woo -> Menu -> Point of Sale Mode
2. Connect Reader
4. Add items to the cart
5. Check out
6. Confirm that at first totals view appears in the center while it's loading, when the order is synced, order totals appear and when order is validated, then reader view appears with an animation

⚠️ When Reader is connected, and we Checkout -> Come Back -> Checkout -> Come back -> Checkout quickly, we can notice issues with animation appearing, disappearing, and re-appearing again. However, it's not an issue with animation but rather with payment states.  If we leave and quickly come back `cardPresentPaymentInlineMessage` changes from "Some value" -> `nil` -> "Some value". If I don't come back quickly, `cardPresentPaymentInlineMessage` is set to `nil` after a small delay. 

## Screenshots

#### Reader Disconnected

https://github.com/user-attachments/assets/effd53b1-5efa-40f8-a02f-8fa8fe1bf9be

#### Reader Connected

https://github.com/user-attachments/assets/2656536b-0587-43d9-9657-17c212368ecd

#### Expectations from designs

https://github.com/user-attachments/assets/b15a7a22-2053-47db-a1b9-6f9c24a3da47

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.