### PR TITLE
Dynamic Dashboard: Display unavailable analytics view when logged in without WPCom

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -3,6 +3,7 @@
 19.8
 -----
 - [*] Add support to background update the order list and the dashboard analytics cards(Performance & Top Performers).
+- [*] Dynamic Dashboard: Display unavailable analytics view when logged in without WPCom. [https://github.com/woocommerce/woocommerce-ios/pull/13440]
 
 19.7
 -----

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Coupons/MostActiveCouponsCard.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Coupons/MostActiveCouponsCard.swift
@@ -1,6 +1,5 @@
 import SwiftUI
 import Yosemite
-import enum Networking.DotcomError
 
 /// SwiftUI view for the most active coupons card.
 ///
@@ -9,7 +8,6 @@ struct MostActiveCouponsCard: View {
     @State private var showingCustomRangePicker = false
     private let onViewAllCoupons: () -> Void
     private let onViewCouponDetail: (_ coupon: Coupon) -> Void
-    @State private var showingSupportForm = false
 
     init(viewModel: MostActiveCouponsCardViewModel,
          onViewAllCoupons: @escaping () -> Void,
@@ -24,19 +22,17 @@ struct MostActiveCouponsCard: View {
             header
                 .padding(.horizontal, Layout.padding)
 
-            if let error = viewModel.syncingError {
-                if error as? DotcomError == .noRestRoute {
-                    contentUnavailableView
-                        .padding(.horizontal, Layout.padding)
-                } else {
-                    DashboardCardErrorView(onRetry: {
-                        ServiceLocator.analytics.track(event: .DynamicDashboard.cardRetryTapped(type: .coupons))
-                        Task {
-                            await viewModel.reloadData()
-                        }
-                    })
+            if !viewModel.analyticsEnabled {
+                UnavailableAnalyticsView(title: Localization.unavailableAnalytics)
                     .padding(.horizontal, Layout.padding)
-                }
+            } else if viewModel.syncingError != nil {
+                DashboardCardErrorView(onRetry: {
+                    ServiceLocator.analytics.track(event: .DynamicDashboard.cardRetryTapped(type: .coupons))
+                    Task {
+                        await viewModel.reloadData()
+                    }
+                })
+                .padding(.horizontal, Layout.padding)
             } else {
                 timeRangeBar
                     .padding(.horizontal, Layout.padding)
@@ -68,9 +64,6 @@ struct MostActiveCouponsCard: View {
                              datesSelected: { start, end in
                 viewModel.didSelectTimeRange(.custom(from: start, to: end))
             })
-        }
-        .sheet(isPresented: $showingSupportForm) {
-            supportForm
         }
     }
 }
@@ -189,36 +182,6 @@ private extension MostActiveCouponsCard {
         }
         .disabled(viewModel.syncingData)
     }
-
-    var contentUnavailableView: some View {
-        VStack(alignment: .center, spacing: Layout.padding) {
-            Image(uiImage: .noStoreImage)
-            Text(Localization.ContentUnavailable.title)
-                .headlineStyle()
-            Text(Localization.ContentUnavailable.details)
-                .bodyStyle()
-                .multilineTextAlignment(.center)
-            Button(Localization.ContentUnavailable.buttonTitle) {
-                showingSupportForm = true
-            }
-            .buttonStyle(SecondaryButtonStyle())
-        }
-        .frame(maxWidth: .infinity)
-    }
-
-    var supportForm: some View {
-        NavigationStack {
-            SupportForm(isPresented: $showingSupportForm,
-                        viewModel: SupportFormViewModel())
-            .toolbar {
-                ToolbarItem(placement: .confirmationAction) {
-                    Button(Localization.ContentUnavailable.done) {
-                        showingSupportForm = false
-                    }
-                }
-            }
-        }
-    }
 }
 
 private extension MostActiveCouponsCard {
@@ -254,29 +217,11 @@ private extension MostActiveCouponsCard {
             value: "Uses",
             comment: "Title in the coupons list on the coupons card on the Dashboard screen. Denotes the number of times the coupon has been used."
         )
-        enum ContentUnavailable {
-            static let title = NSLocalizedString(
-                "mostActiveCouponsCard.contentUnavailable.title",
-                value: "Unable to load coupon usage report",
-                comment: "Title when we can't load coupon usage report because user is on a deprecated WooCommerce Version"
-            )
-            static let details = NSLocalizedString(
-                "mostActiveCouponsCard.contentUnavailable.details",
-                value: "Make sure you are running the latest version of WooCommerce on your site" +
-                " and enabling Analytics in WooCommerce Settings.",
-                comment: "Text that explains how to update WooCommerce to get the latest stats"
-            )
-            static let buttonTitle = NSLocalizedString(
-                "mostActiveCouponsCard.contentUnavailable.buttonTitle",
-                value: "Still need help? Contact us",
-                comment: "Button title to contact support to get help with deprecated stats module"
-            )
-            static let done = NSLocalizedString(
-                "mostActiveCouponsCard.contentUnavailable.dismissSupport",
-                value: "Done",
-                comment: "Button to dismiss the support form from the Dashboard stats error screen."
-            )
-        }
+        static let unavailableAnalytics = NSLocalizedString(
+            "mostActiveCouponsCard.unavailableAnalyticsView.title",
+            value: "We can't display your store's coupon analytics",
+            comment: "Title when the Most Active Coupons card is disabled because the analytics feature is unavailable"
+        )
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Coupons/MostActiveCouponsCard.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Coupons/MostActiveCouponsCard.swift
@@ -219,7 +219,7 @@ private extension MostActiveCouponsCard {
         )
         static let unavailableAnalytics = NSLocalizedString(
             "mostActiveCouponsCard.unavailableAnalyticsView.title",
-            value: "We can't display your store's coupon analytics",
+            value: "Unable to display your store's coupon analytics",
             comment: "Title when the Most Active Coupons card is disabled because the analytics feature is unavailable"
         )
     }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Coupons/MostActiveCouponsCardViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Coupons/MostActiveCouponsCardViewModel.swift
@@ -2,6 +2,8 @@ import Foundation
 import Yosemite
 import protocol WooFoundation.Analytics
 import protocol Storage.StorageManagerType
+import enum Networking.DotcomError
+import enum Networking.NetworkError
 
 /// View model for `MostActiveCouponsCard`.
 ///
@@ -15,6 +17,7 @@ final class MostActiveCouponsCardViewModel: ObservableObject {
     @Published private(set) var syncingError: Error?
     @Published private(set) var rows: [MostActiveCouponRowViewModel] = []
     @Published private(set) var timeRangeText = ""
+    @Published private(set) var analyticsEnabled = true
 
     let siteID: Int64
     let siteTimezone: TimeZone
@@ -90,8 +93,15 @@ final class MostActiveCouponsCardViewModel: ObservableObject {
                 }
             }
 
+            analyticsEnabled = true
             analytics.track(event: .DynamicDashboard.cardLoadingCompleted(type: .coupons))
         } catch {
+            switch error {
+            case DotcomError.noRestRoute, NetworkError.notFound:
+                analyticsEnabled = false
+            default:
+                analyticsEnabled = true
+            }
             syncingError = error
             DDLogError("⛔️ Dashboard (Most active coupons) — Error loading most active coupons: \(error)")
             analytics.track(event: .DynamicDashboard.cardLoadingFailed(type: .coupons, error: error))

--- a/WooCommerce/Classes/ViewRelated/Dashboard/ProductStock/ProductStockDashboardCard.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/ProductStock/ProductStockDashboardCard.swift
@@ -250,7 +250,7 @@ private extension ProductStockDashboardCard {
         )
         static let unavailableAnalytics = NSLocalizedString(
             "productStockDashboardCard.unavailableAnalyticsView.title",
-            value: "We can't display your store's stock analytics",
+            value: "Unable to display your store's stock analytics",
             comment: "Title when the Stock card is disabled because the analytics feature is unavailable"
         )
     }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/ProductStock/ProductStockDashboardCard.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/ProductStock/ProductStockDashboardCard.swift
@@ -2,14 +2,12 @@ import Kingfisher
 import SwiftUI
 import struct Yosemite.ProductReport
 import struct Yosemite.DashboardCard
-import enum Networking.DotcomError
 
 /// View for displaying stock based on status on the dashboard.
 ///
 struct ProductStockDashboardCard: View {
     @ObservedObject private var viewModel: ProductStockDashboardCardViewModel
     @ScaledMetric private var scale: CGFloat = 1.0
-    @State private var showingSupportForm = false
     @State private var selectedItem: ProductReport?
 
     init(viewModel: ProductStockDashboardCardViewModel) {
@@ -28,19 +26,17 @@ struct ProductStockDashboardCard: View {
 
             Divider()
 
-            if let error = viewModel.syncingError {
-                if error as? DotcomError == .noRestRoute {
-                    contentUnavailableView
-                        .padding(.horizontal, Layout.padding)
-                } else {
-                    DashboardCardErrorView(onRetry: {
-                        ServiceLocator.analytics.track(event: .DynamicDashboard.cardRetryTapped(type: .stock))
-                        Task {
-                            await viewModel.reloadData()
-                        }
-                    })
+            if !viewModel.analyticsEnabled {
+                UnavailableAnalyticsView(title: Localization.unavailableAnalytics)
                     .padding(.horizontal, Layout.padding)
-                }
+            } else if viewModel.syncingError != nil {
+                DashboardCardErrorView(onRetry: {
+                    ServiceLocator.analytics.track(event: .DynamicDashboard.cardRetryTapped(type: .stock))
+                    Task {
+                        await viewModel.reloadData()
+                    }
+                })
+                .padding(.horizontal, Layout.padding)
             }
 
             Group {
@@ -59,9 +55,6 @@ struct ProductStockDashboardCard: View {
         .background(Color(.listForeground(modal: false)))
         .clipShape(RoundedRectangle(cornerSize: Layout.cornerSize))
         .padding(.horizontal, Layout.padding)
-        .sheet(isPresented: $showingSupportForm) {
-            supportForm
-        }
         .sheet(item: $selectedItem) { item in
             ViewControllerContainer(productDetailView(for: item))
         }
@@ -187,36 +180,6 @@ private extension ProductStockDashboardCard {
         .frame(maxWidth: .infinity)
     }
 
-    var contentUnavailableView: some View {
-        VStack(alignment: .center, spacing: Layout.padding) {
-            Image(uiImage: .noStoreImage)
-            Text(Localization.ContentUnavailable.title)
-                .headlineStyle()
-            Text(Localization.ContentUnavailable.details)
-                .bodyStyle()
-                .multilineTextAlignment(.center)
-            Button(Localization.ContentUnavailable.buttonTitle) {
-                showingSupportForm = true
-            }
-            .buttonStyle(SecondaryButtonStyle())
-        }
-        .frame(maxWidth: .infinity)
-    }
-
-    var supportForm: some View {
-        NavigationStack {
-            SupportForm(isPresented: $showingSupportForm,
-                        viewModel: SupportFormViewModel())
-            .toolbar {
-                ToolbarItem(placement: .confirmationAction) {
-                    Button(Localization.ContentUnavailable.done) {
-                        showingSupportForm = false
-                    }
-                }
-            }
-        }
-    }
-
     func productDetailView(for item: ProductReport) -> UIViewController {
         let model: ProductLoaderViewController.Model = {
             if let variationID = item.variationID {
@@ -285,29 +248,11 @@ private extension ProductStockDashboardCard {
             comment: "Text on the empty state of the Stock section on the My Store screen. " +
             "Reads as: No item found with Out of stock status"
         )
-        enum ContentUnavailable {
-            static let title = NSLocalizedString(
-                "productStockDashboardCard.contentUnavailable.title",
-                value: "Unable to load stock report",
-                comment: "Title when we can't load stock report because user is on a deprecated WooCommerce Version"
-            )
-            static let details = NSLocalizedString(
-                "productStockDashboardCard.contentUnavailable.details",
-                value: "Make sure you are running the latest version of WooCommerce on your site" +
-                " and enabling Analytics in WooCommerce Settings.",
-                comment: "Text that explains how to update WooCommerce to get the latest stats"
-            )
-            static let buttonTitle = NSLocalizedString(
-                "productStockDashboardCard.contentUnavailable.buttonTitle",
-                value: "Still need help? Contact us",
-                comment: "Button title to contact support to get help with deprecated stats module"
-            )
-            static let done = NSLocalizedString(
-                "productStockDashboardCard.contentUnavailable.dismissSupport",
-                value: "Done",
-                comment: "Button to dismiss the support form from the Dashboard stock card error screen."
-            )
-        }
+        static let unavailableAnalytics = NSLocalizedString(
+            "productStockDashboardCard.unavailableAnalyticsView.title",
+            value: "We can't display your store's stock analytics",
+            comment: "Title when the Stock card is disabled because the analytics feature is unavailable"
+        )
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Dashboard/StoreStats/StorePerformanceView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/StoreStats/StorePerformanceView.swift
@@ -364,7 +364,7 @@ private extension StorePerformanceView {
         }
         static let unavailableAnalytics = NSLocalizedString(
             "storePerformanceView.unavailableAnalyticsView.title",
-            value: "We can't display your store's performance",
+            value: "Unable to display your store's performance",
             comment: "Title when the Performance card is disabled because the analytics feature is unavailable"
         )
     }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/StoreStats/StorePerformanceView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/StoreStats/StorePerformanceView.swift
@@ -7,7 +7,6 @@ import struct Yosemite.DashboardCard
 struct StorePerformanceView: View {
     @ObservedObject private var viewModel: StorePerformanceViewModel
     @State private var showingCustomRangePicker = false
-    @State private var showingSupportForm = false
 
     private var statsValueColor: Color {
         guard viewModel.hasRevenue else {
@@ -68,7 +67,7 @@ struct StorePerformanceView: View {
                     .redacted(reason: viewModel.syncingData ? [.placeholder] : [])
                     .shimmering(active: viewModel.syncingData)
             } else {
-                contentUnavailableView
+                UnavailableAnalyticsView()
                     .padding(.horizontal, Layout.padding)
             }
         }
@@ -83,9 +82,6 @@ struct StorePerformanceView: View {
                              datesSelected: { start, end in
                 viewModel.didSelectTimeRange(.custom(from: start, to: end))
             })
-        }
-        .sheet(isPresented: $showingSupportForm) {
-            supportForm
         }
         .onAppear {
             viewModel.onViewAppear()
@@ -289,22 +285,6 @@ private extension StorePerformanceView {
         .disabled(viewModel.syncingData)
     }
 
-    var contentUnavailableView: some View {
-        VStack(alignment: .center, spacing: Layout.padding) {
-            Image(uiImage: .noStoreImage)
-            Text(Localization.ContentUnavailable.title)
-                .headlineStyle()
-            Text(Localization.ContentUnavailable.details)
-                .bodyStyle()
-                .multilineTextAlignment(.center)
-            Button(Localization.ContentUnavailable.buttonTitle) {
-                showingSupportForm = true
-            }
-            .buttonStyle(SecondaryButtonStyle())
-        }
-        .frame(maxWidth: .infinity)
-    }
-
     var errorStateView: some View {
         DashboardCardErrorView(onRetry: {
             ServiceLocator.analytics.track(event: .DynamicDashboard.cardRetryTapped(type: .performance))
@@ -312,21 +292,6 @@ private extension StorePerformanceView {
                 await viewModel.reloadDataIfNeeded(forceRefresh: true)
             }
         })
-    }
-
-    var supportForm: some View {
-        NavigationView {
-            SupportForm(isPresented: $showingSupportForm,
-                        viewModel: SupportFormViewModel())
-            .toolbar {
-                ToolbarItem(placement: .confirmationAction) {
-                    Button(Localization.ContentUnavailable.done) {
-                        showingSupportForm = false
-                    }
-                }
-            }
-        }
-        .navigationViewStyle(.stack)
     }
 }
 
@@ -396,29 +361,6 @@ private extension StorePerformanceView {
         static func lastUpdatedText(time: String) -> String {
             let format = NSLocalizedString("Last Updated: %@", comment: "Time for when the performance card was last updated")
             return String.localizedStringWithFormat(format, time)
-        }
-        enum ContentUnavailable {
-            static let title = NSLocalizedString(
-                "storePerformanceView.contentUnavailable.title",
-                value: "We can’t display your store’s analytics",
-                comment: "Title when we can't show stats because user is on a deprecated WooCommerce Version"
-            )
-            static let details = NSLocalizedString(
-                "storePerformanceView.contentUnavailable.details",
-                value: "Make sure you are running the latest version of WooCommerce on your site" +
-                " and enabling Analytics in WooCommerce Settings.",
-                comment: "Text that explains how to update WooCommerce to get the latest stats"
-            )
-            static let buttonTitle = NSLocalizedString(
-                "storePerformanceView.contentUnavailable.buttonTitle",
-                value: "Still need help? Contact us",
-                comment: "Button title to contact support to get help with deprecated stats module"
-            )
-            static let done = NSLocalizedString(
-                "storePerformanceView.contentUnavailable.dismissSupport",
-                value: "Done",
-                comment: "Button to dismiss the support form from the Dashboard stats error screen."
-            )
         }
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/StoreStats/StorePerformanceView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/StoreStats/StorePerformanceView.swift
@@ -67,7 +67,7 @@ struct StorePerformanceView: View {
                     .redacted(reason: viewModel.syncingData ? [.placeholder] : [])
                     .shimmering(active: viewModel.syncingData)
             } else {
-                UnavailableAnalyticsView()
+                UnavailableAnalyticsView(title: Localization.unavailableAnalytics)
                     .padding(.horizontal, Layout.padding)
             }
         }
@@ -362,6 +362,11 @@ private extension StorePerformanceView {
             let format = NSLocalizedString("Last Updated: %@", comment: "Time for when the performance card was last updated")
             return String.localizedStringWithFormat(format, time)
         }
+        static let unavailableAnalytics = NSLocalizedString(
+            "storePerformanceView.unavailableAnalyticsView.title",
+            value: "We can't display your store's performance",
+            comment: "Title when the Performance card is disabled because the analytics feature is unavailable"
+        )
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Dashboard/StoreStats/StorePerformanceView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/StoreStats/StorePerformanceView.swift
@@ -37,7 +37,7 @@ struct StorePerformanceView: View {
             if viewModel.loadingError != nil {
                 errorStateView
                     .padding(.horizontal, Layout.padding)
-            } else if viewModel.statsVersion == .v4 {
+            } else if viewModel.analyticsEnabled {
                 timeRangeBar
                     .padding(.horizontal, Layout.padding)
                     .redacted(reason: viewModel.showRedactedState ? [.placeholder] : [])
@@ -99,7 +99,7 @@ private extension StorePerformanceView {
             Image(systemName: "exclamationmark.circle")
                 .foregroundStyle(Color.secondary)
                 .headlineStyle()
-                .renderedIf(viewModel.statsVersion == .v3 || viewModel.loadingError != nil)
+                .renderedIf(!viewModel.analyticsEnabled || viewModel.loadingError != nil)
 
             Text(DashboardCard.CardType.performance.name)
                 .headlineStyle()

--- a/WooCommerce/Classes/ViewRelated/Dashboard/TopPerformers/TopPerformersDashboardView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/TopPerformers/TopPerformersDashboardView.swift
@@ -24,7 +24,10 @@ struct TopPerformersDashboardView: View {
             header
                 .padding(.horizontal, Layout.padding)
 
-            if viewModel.syncingError != nil {
+            if !viewModel.analyticsEnabled {
+                UnavailableAnalyticsView()
+                    .padding(.horizontal, Layout.padding)
+            } else if viewModel.syncingError != nil {
                 DashboardCardErrorView(onRetry: {
                     ServiceLocator.analytics.track(event: .DynamicDashboard.cardRetryTapped(type: .topPerformers))
                     Task {

--- a/WooCommerce/Classes/ViewRelated/Dashboard/TopPerformers/TopPerformersDashboardView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/TopPerformers/TopPerformersDashboardView.swift
@@ -207,7 +207,7 @@ private extension TopPerformersDashboardView {
         }
         static let unavailableAnalytics = NSLocalizedString(
             "topPerformersDashboardView.unavailableAnalyticsView.title",
-            value: "We can't display your store's top performers",
+            value: "Unable to display your store's top performers",
             comment: "Title when the Top Performers card is disabled because the analytics feature is unavailable"
         )
     }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/TopPerformers/TopPerformersDashboardView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/TopPerformers/TopPerformersDashboardView.swift
@@ -25,7 +25,7 @@ struct TopPerformersDashboardView: View {
                 .padding(.horizontal, Layout.padding)
 
             if !viewModel.analyticsEnabled {
-                UnavailableAnalyticsView()
+                UnavailableAnalyticsView(title: Localization.unavailableAnalytics)
                     .padding(.horizontal, Layout.padding)
             } else if viewModel.syncingError != nil {
                 DashboardCardErrorView(onRetry: {
@@ -205,6 +205,11 @@ private extension TopPerformersDashboardView {
             let format = NSLocalizedString("Last Updated: %@", comment: "Time for when the top performers card was last updated")
             return String.localizedStringWithFormat(format, time)
         }
+        static let unavailableAnalytics = NSLocalizedString(
+            "topPerformersDashboardView.unavailableAnalyticsView.title",
+            value: "We can't display your store's top performers",
+            comment: "Title when the Top Performers card is disabled because the analytics feature is unavailable"
+        )
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Dashboard/UnavailableAnalyticsView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/UnavailableAnalyticsView.swift
@@ -5,19 +5,25 @@ import SwiftUI
 struct UnavailableAnalyticsView: View {
     @State private var showingSupportForm = false
 
+    private let title: String
+
+    init(title: String = Localization.title) {
+        self.title = title
+    }
+
     var body: some View {
         VStack(alignment: .center, spacing: Layout.padding) {
             Image(uiImage: .noStoreImage)
-            Text(Localization.title)
+            Text(title)
                 .headlineStyle()
             Text(Localization.details)
                 .bodyStyle()
-                .multilineTextAlignment(.center)
             Button(Localization.buttonTitle) {
                 showingSupportForm = true
             }
             .buttonStyle(SecondaryButtonStyle())
         }
+        .multilineTextAlignment(.center)
         .frame(maxWidth: .infinity)
         .sheet(isPresented: $showingSupportForm) {
             supportForm
@@ -50,7 +56,7 @@ private extension UnavailableAnalyticsView {
     enum Localization {
         static let title = NSLocalizedString(
             "unavailableAnalyticsView.title",
-            value: "We can’t display your store’s analytics",
+            value: "We can't display your store's analytics",
             comment: "Title when the Analytics feature is unavailable"
         )
         static let details = NSLocalizedString(

--- a/WooCommerce/Classes/ViewRelated/Dashboard/UnavailableAnalyticsView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/UnavailableAnalyticsView.swift
@@ -1,0 +1,77 @@
+import SwiftUI
+
+/// Reusable view for when Analytics module is disabled.
+///
+struct UnavailableAnalyticsView: View {
+    @State private var showingSupportForm = false
+
+    var body: some View {
+        VStack(alignment: .center, spacing: Layout.padding) {
+            Image(uiImage: .noStoreImage)
+            Text(Localization.title)
+                .headlineStyle()
+            Text(Localization.details)
+                .bodyStyle()
+                .multilineTextAlignment(.center)
+            Button(Localization.buttonTitle) {
+                showingSupportForm = true
+            }
+            .buttonStyle(SecondaryButtonStyle())
+        }
+        .frame(maxWidth: .infinity)
+        .sheet(isPresented: $showingSupportForm) {
+            supportForm
+        }
+    }
+}
+
+private extension UnavailableAnalyticsView {
+    var supportForm: some View {
+        NavigationView {
+            SupportForm(isPresented: $showingSupportForm,
+                        viewModel: SupportFormViewModel())
+            .toolbar {
+                ToolbarItem(placement: .confirmationAction) {
+                    Button(Localization.done) {
+                        showingSupportForm = false
+                    }
+                }
+            }
+        }
+        .navigationViewStyle(.stack)
+    }
+}
+
+private extension UnavailableAnalyticsView {
+    enum Layout {
+        static let padding: CGFloat = 16
+    }
+
+    enum Localization {
+        static let title = NSLocalizedString(
+            "unavailableAnalyticsView.title",
+            value: "We can’t display your store’s analytics",
+            comment: "Title when the Analytics feature is unavailable"
+        )
+        static let details = NSLocalizedString(
+            "unavailableAnalyticsView.details",
+            value: "Make sure you are running the latest version of WooCommerce on your site" +
+            " and enabling Analytics in WooCommerce Settings.",
+            comment: "Text that explains how to get access to the Analytics module"
+        )
+        static let buttonTitle = NSLocalizedString(
+            "unavailableAnalyticsView.buttonTitle",
+            value: "Still need help? Contact us",
+            comment: "Button title to contact support to get help with unavailable Analytics module"
+        )
+        static let done = NSLocalizedString(
+            "unavailableAnalyticsView.dismissSupport",
+            value: "Done",
+            comment: "Button to dismiss the support form."
+        )
+    }
+}
+
+#Preview {
+    UnavailableAnalyticsView()
+}

--- a/WooCommerce/Classes/ViewRelated/Dashboard/UnavailableAnalyticsView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/UnavailableAnalyticsView.swift
@@ -7,7 +7,7 @@ struct UnavailableAnalyticsView: View {
 
     private let title: String
 
-    init(title: String = Localization.title) {
+    init(title: String) {
         self.title = title
     }
 
@@ -54,11 +54,6 @@ private extension UnavailableAnalyticsView {
     }
 
     enum Localization {
-        static let title = NSLocalizedString(
-            "unavailableAnalyticsView.title",
-            value: "We can't display your store's analytics",
-            comment: "Title when the Analytics feature is unavailable"
-        )
         static let details = NSLocalizedString(
             "unavailableAnalyticsView.details",
             value: "Make sure you are running the latest version of WooCommerce on your site" +
@@ -79,5 +74,5 @@ private extension UnavailableAnalyticsView {
 }
 
 #Preview {
-    UnavailableAnalyticsView()
+    UnavailableAnalyticsView(title: "No analytics available")
 }

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -2430,6 +2430,7 @@
 		DE2FE59029261DED0018040A /* SiteCredentialLoginViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE2FE58F29261DED0018040A /* SiteCredentialLoginViewModelTests.swift */; };
 		DE2FE595292737330018040A /* JetpackSetupView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE2FE594292737330018040A /* JetpackSetupView.swift */; };
 		DE2FE597292737630018040A /* JetpackSetupViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE2FE596292737630018040A /* JetpackSetupViewModel.swift */; };
+		DE3144862C5780250015F089 /* UnavailableAnalyticsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE3144852C5780250015F089 /* UnavailableAnalyticsView.swift */; };
 		DE3404E828B4B96800CF0D97 /* NonAtomicSiteViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE3404E728B4B96800CF0D97 /* NonAtomicSiteViewModel.swift */; };
 		DE3404EA28B4C1D000CF0D97 /* NonAtomicSiteViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE3404E928B4C1D000CF0D97 /* NonAtomicSiteViewModelTests.swift */; };
 		DE34771327F174C8009CA300 /* StatusView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE34771227F174C8009CA300 /* StatusView.swift */; };
@@ -5400,6 +5401,7 @@
 		DE2FE58F29261DED0018040A /* SiteCredentialLoginViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SiteCredentialLoginViewModelTests.swift; sourceTree = "<group>"; };
 		DE2FE594292737330018040A /* JetpackSetupView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JetpackSetupView.swift; sourceTree = "<group>"; };
 		DE2FE596292737630018040A /* JetpackSetupViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JetpackSetupViewModel.swift; sourceTree = "<group>"; };
+		DE3144852C5780250015F089 /* UnavailableAnalyticsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UnavailableAnalyticsView.swift; sourceTree = "<group>"; };
 		DE3404E728B4B96800CF0D97 /* NonAtomicSiteViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NonAtomicSiteViewModel.swift; sourceTree = "<group>"; };
 		DE3404E928B4C1D000CF0D97 /* NonAtomicSiteViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NonAtomicSiteViewModelTests.swift; sourceTree = "<group>"; };
 		DE34771227F174C8009CA300 /* StatusView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StatusView.swift; sourceTree = "<group>"; };
@@ -11513,6 +11515,7 @@
 				DE8AA0B22BBE55E40084D2CC /* DashboardViewHostingController.swift */,
 				028E1F6F2833DD0A001F8829 /* DashboardViewModel.swift */,
 				DE74A45A2BD9048E0009C415 /* DashboardCardErrorView.swift */,
+				DE3144852C5780250015F089 /* UnavailableAnalyticsView.swift */,
 				579CDEFE274D7E7900E8903D /* StoreStatsUsageTracksEventEmitter.swift */,
 				DE74A4502BCF86F60009C415 /* TopPerformers */,
 				DEA6BCAD2BC6A9A50017D671 /* StoreStats */,
@@ -14569,6 +14572,7 @@
 				B9B7E2E629FBF96100F9CED1 /* ProductSelectorViewModelTracker.swift in Sources */,
 				0286B27F23C70557003D784B /* ColumnFlowLayout.swift in Sources */,
 				DEE6437626D87C4100888A75 /* PrintCustomsFormsView.swift in Sources */,
+				DE3144862C5780250015F089 /* UnavailableAnalyticsView.swift in Sources */,
 				450C2CB624D1ABB200D570DD /* ProductImagesGalleryViewController.swift in Sources */,
 				EEA6935E2B231C6600BAECA6 /* ProductCreationAISurveyConfirmationViewModel.swift in Sources */,
 				B9EF083F2886CE3300D96C58 /* HostingTableViewCell.swift in Sources */,


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of: #13157 
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
Previously, we were displaying the analytics unavailable view only when logged in with WPCom because only `DotComError.noRestRoute` error is checked. When logged in without WPCom, network error code 404 is returned instead.

This PR adds improvements for 4 cards: performance, top performers, stock, and most active coupon cards. Changes include:
- Created a reusable view `UnavailableAnalyticsView` to be displayed on all 4 cards when the analytics module is unavailable.
- Updated the logic for all 4 cards to check for both `DotcomError.noRestRoute` and `NetworkError.notFound` to display the unavailable analytics view.
- Customized title for the unavailable analytics view on each card.

## Testing steps
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->
- Create a JN site with Woo but no Jetpack.
- Disable the Analytics feature in Woo > Settings > Advanced > Features.
- Log in to the store on the app with an application password and confirm that the analytics unavailable view is displayed on all 4 cards: performance, top performers, stock, and most active coupon cards.
- Repeat the same steps for a Jetpack/WPCom store to confirm the same behavior.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

Performance | Top Performers | Coupons | Stock
--- | --- | --- | ---
<img src="https://github.com/user-attachments/assets/5d9241c2-bfc5-4895-b141-b3960b805f7e" width=320 /> | <img src="https://github.com/user-attachments/assets/4831d345-8644-4adf-befd-35a0c92d1867" width=320 /> | <img src="https://github.com/user-attachments/assets/805e4728-55bb-4d81-ac6b-b2f6622177fa" width=320 /> | <img src="https://github.com/user-attachments/assets/6b4e469c-4f25-4357-8533-c770e7b39143" width=320 />


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
