### PR TITLE
[Woo POS] Remove padding from cart and product list views

### DIFF
--- a/WooCommerce/Classes/POS/Presentation/PointOfSaleDashboardView.swift
+++ b/WooCommerce/Classes/POS/Presentation/PointOfSaleDashboardView.swift
@@ -89,8 +89,6 @@ struct PointOfSaleDashboardView: View {
                     }
                 }
             }
-            .frame(maxHeight: .infinity)
-            .padding()
         }
     }
 }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

When merging changes from different PRs padding was reintroduced to the POS dashboard view. Removing it in this PR.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

### Before
![Simulator Screenshot - iPad Air 11-inch (M2) - 2024-07-29 at 15 38 11](https://github.com/user-attachments/assets/c2985a91-f105-4db3-b773-9c08fa75a577)

### After
![Simulator Screenshot - iPad Air 11-inch (M2) - 2024-07-29 at 15 44 19](https://github.com/user-attachments/assets/9b10c170-1c42-417c-bc68-ace81d1cc15a)

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.