### PR TITLE
[Woo POS] M2: 'Ready for payment' UI update

### DIFF
--- a/WooCommerce/Classes/POS/Presentation/Card Present Payments/Reader Messages/PointOfSaleCardPresentPaymentTapSwipeInsertCardMessageViewModel.swift
+++ b/WooCommerce/Classes/POS/Presentation/Card Present Payments/Reader Messages/PointOfSaleCardPresentPaymentTapSwipeInsertCardMessageViewModel.swift
@@ -35,31 +35,31 @@ private extension PointOfSaleCardPresentPaymentTapSwipeInsertCardMessageViewMode
 
         static let tapInsertOrSwipe = NSLocalizedString(
             "pointOfSale.cardPresent.presentCard.tapSwipeInsert",
-            value: "Tap, insert or swipe to pay",
+            value: "Tap, swipe, or insert card",
             comment: "Label asking users to present a card. Presented to users when a payment is going to be collected"
         )
 
         static let tapOrInsert = NSLocalizedString(
             "pointOfSale.cardPresent.presentCard.tapInsert",
-            value: "Tap or insert card to pay",
+            value: "Tap or insert card",
             comment: "Label asking users to present a card. Presented to users when a payment is going to be collected"
         )
 
         static let tap = NSLocalizedString(
             "pointOfSale.cardPresent.presentCard.tap",
-            value: "Tap card to pay",
+            value: "Tap card",
             comment: "Label asking users to present a card. Presented to users when a payment is going to be collected"
         )
 
         static let insert = NSLocalizedString(
             "pointOfSale.cardPresent.presentCard.insert",
-            value: "Insert card to pay",
+            value: "Insert card",
             comment: "Label asking users to present a card. Presented to users when a payment is going to be collected"
         )
 
         static let presentCard = NSLocalizedString(
             "pointOfSale.cardPresent.presentCard.present",
-            value: "Present card to pay",
+            value: "Present card",
             comment: "Label asking users to present a card. Presented to users when a payment is going to be collected"
         )
     }

--- a/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/Reader Messages/POSCardPresentPaymentMessageView.swift
+++ b/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/Reader Messages/POSCardPresentPaymentMessageView.swift
@@ -34,13 +34,14 @@ struct POSCardPresentPaymentMessageView: View {
                 if let imageName = viewModel.imageName {
                     Image(imageName)
                         .resizable()
-                        .aspectRatio(contentMode: .fit)
+                        .aspectRatio(contentMode: .fill)
                         .frame(width: Layout.imageSize, height: Layout.imageSize)
                 }
 
                 if viewModel.showProgress {
                     ProgressView()
                         .progressViewStyle(POSProgressViewStyle())
+                        .frame(width: Layout.imageSize, height: Layout.imageSize)
                 }
 
                 VStack(alignment: .center, spacing: Layout.textSpacing) {
@@ -73,7 +74,7 @@ struct POSCardPresentPaymentMessageView: View {
 
 private extension POSCardPresentPaymentMessageView {
     enum Layout {
-        static let imageSize: CGFloat = 104
+        static let imageSize: CGFloat = 156
         static let textSpacing: CGFloat = 4
         static let verticalSpacing: CGFloat = 72
     }

--- a/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/Reader Messages/POSCardPresentPaymentMessageView.swift
+++ b/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/Reader Messages/POSCardPresentPaymentMessageView.swift
@@ -8,8 +8,24 @@ struct POSCardPresentPaymentMessageViewModel {
     var buttons: [CardPresentPaymentsModalButtonViewModel] = []
 }
 
+struct POSCardPresentPaymentMessageViewStyle {
+    var titleColor: Color
+    var messageColor: Color
+
+    static let dimmed = POSCardPresentPaymentMessageViewStyle(
+        titleColor: Color(.neutral(.shade40)),
+        messageColor: Color(.neutral(.shade60))
+    )
+
+    static let standard = POSCardPresentPaymentMessageViewStyle(
+        titleColor: .posPrimaryTexti3,
+        messageColor: .posPrimaryTexti3
+    )
+}
+
 struct POSCardPresentPaymentMessageView: View {
     let viewModel: POSCardPresentPaymentMessageViewModel
+    var style: POSCardPresentPaymentMessageViewStyle = .standard
 
     var body: some View {
         HStack(alignment: .center) {
@@ -29,13 +45,13 @@ struct POSCardPresentPaymentMessageView: View {
 
                 VStack(alignment: .center, spacing: Layout.textSpacing) {
                     Text(viewModel.title)
-                        .foregroundStyle(Color(.neutral(.shade40)))
+                        .foregroundStyle(style.titleColor)
                         .font(.posBody)
 
                     if let message = viewModel.message {
                         Text(message)
                             .font(.posTitle)
-                            .foregroundStyle(Color(.neutral(.shade60)))
+                            .foregroundStyle(style.messageColor)
                             .bold()
                     }
                 }

--- a/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/Reader Messages/PointOfSaleCardPresentPaymentPreparingForPaymentMessageView.swift
+++ b/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/Reader Messages/PointOfSaleCardPresentPaymentPreparingForPaymentMessageView.swift
@@ -4,9 +4,10 @@ struct PointOfSaleCardPresentPaymentPreparingForPaymentMessageView: View {
     let viewModel: PointOfSaleCardPresentPaymentPreparingForPaymentMessageViewModel
 
     var body: some View {
-        POSCardPresentPaymentMessageView(viewModel: .init(showProgress: true,
-                                                          title: viewModel.title,
-                                                          message: viewModel.message))
+        let messageViewModel = POSCardPresentPaymentMessageViewModel(showProgress: true,
+                                                                     title: viewModel.title,
+                                                                     message: viewModel.message)
+        POSCardPresentPaymentMessageView(viewModel: messageViewModel, style: .dimmed)
     }
 }
 

--- a/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/Reader Messages/PointOfSaleCardPresentPaymentTapSwipeInsertCardMessageView.swift
+++ b/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/Reader Messages/PointOfSaleCardPresentPaymentTapSwipeInsertCardMessageView.swift
@@ -4,9 +4,10 @@ struct PointOfSaleCardPresentPaymentTapSwipeInsertCardMessageView: View {
     let viewModel: PointOfSaleCardPresentPaymentTapSwipeInsertCardMessageViewModel
 
     var body: some View {
-        POSCardPresentPaymentMessageView(viewModel: .init(imageName: viewModel.imageName,
-                                                          title: viewModel.title,
-                                                          message: viewModel.message))
+        let messageViewModel = POSCardPresentPaymentMessageViewModel(imageName: viewModel.imageName,
+                                                                     title: viewModel.title,
+                                                                     message: viewModel.message)
+        POSCardPresentPaymentMessageView(viewModel: messageViewModel, style: .standard)
     }
 }
 

--- a/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/Reader Messages/PointOfSaleCardPresentPaymentValidatingOrderMessageView.swift
+++ b/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/Reader Messages/PointOfSaleCardPresentPaymentValidatingOrderMessageView.swift
@@ -4,9 +4,10 @@ struct PointOfSaleCardPresentPaymentValidatingOrderMessageView: View {
     let viewModel: PointOfSaleCardPresentPaymentValidatingOrderMessageViewModel
 
     var body: some View {
-        POSCardPresentPaymentMessageView(viewModel: .init(showProgress: true,
-                                                          title: viewModel.title,
-                                                          message: viewModel.message))
+        let messageViewModel = POSCardPresentPaymentMessageViewModel(showProgress: true,
+                                                                     title: viewModel.title,
+                                                                     message: viewModel.message)
+        POSCardPresentPaymentMessageView(viewModel: messageViewModel, style: .dimmed)
     }
 }
 

--- a/WooCommerce/Classes/POS/Presentation/Reusable Views/POSProgressViewStyle.swift
+++ b/WooCommerce/Classes/POS/Presentation/Reusable Views/POSProgressViewStyle.swift
@@ -5,7 +5,7 @@ struct POSProgressViewStyle: ProgressViewStyle {
     func makeBody(configuration: Configuration) -> some View {
         ProgressView(configuration)
             .progressViewStyle(IndefiniteCircularProgressViewStyle(
-                size: 112,
+                size: 108,
                 lineWidth: 48,
                 lineCap: .butt,
                 circleColor: Color(.wooCommercePurple(.shade10)),

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -7580,14 +7580,14 @@
 			isa = PBXGroup;
 			children = (
 				02CD3BFB2C3491DA00E575C4 /* Presented Views */,
+				DA1D68BF2C36EF840097859A /* POSCardPresentPaymentMessageView.swift */,
+				011DF3452C53A919000AFDD9 /* PointOfSaleCardPresentPaymentValidatingOrderMessageView.swift */,
 				205E79472C204B21001BA266 /* PointOfSaleCardPresentPaymentPreparingForPaymentMessageView.swift */,
 				205E794A2C2051B5001BA266 /* PointOfSaleCardPresentPaymentTapSwipeInsertCardMessageView.swift */,
-				DA1D68BF2C36EF840097859A /* POSCardPresentPaymentMessageView.swift */,
 				205E794C2C2057B9001BA266 /* PointOfSaleCardPresentPaymentErrorMessageView.swift */,
 				205E794E2C207D38001BA266 /* PointOfSaleCardPresentPaymentNonRetryableErrorMessageView.swift */,
 				205E79502C207FAE001BA266 /* PointOfSaleCardPresentPaymentDisplayReaderMessageMessageView.swift */,
 				0230B4D52C33454900F2F660 /* PointOfSaleCardPresentPaymentCaptureErrorMessageView.swift */,
-				011DF3452C53A919000AFDD9 /* PointOfSaleCardPresentPaymentValidatingOrderMessageView.swift */,
 			);
 			path = "Reader Messages";
 			sourceTree = "<group>";


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #13346
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

Updated UI for "Ready for payment" - "Tap, swipe, or insert card" state, according to designs TfaZ4LUkEwEGrxfnEFzvJj-fi-2530_20890

I'm leaving this nice animation as a lower-priority task for now https://github.com/woocommerce/woocommerce-ios/issues/13444, I think we can finish the flows and then add it. Let me know if you think differently.

Most of the work was already done in the previous PRs:
- Added 2 styles for message view to support dimmed labels and standard labels. I think it's likely that we can use `POSCardPresentPaymentMessageView` for all the happy path with a few styling adjustments but will require a different view for all the error states since they are too different
- Adjusted `POSCardPresentPaymentMessageView` image and progress view sizing so they would have matching frames and look nicely when transitioning from one state to another
- Updated localized text according to design requirements

## Testing information

1. Open Woo -> Menu -> Point of Sale Mode
2. Connect Reader
3. Add items to the cart
4. Check out
5. Confirm that "Checking Order" ->  "Getting ready" -> "Ready for Payment" states appear according to designs TfaZ4LUkEwEGrxfnEFzvJj-fi-2530_20890

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

https://github.com/user-attachments/assets/cb631beb-5c52-4f3e-b3ed-cd0c60505c19

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
- [x] This PR includes refactoring; smoke testing of the entire section is needed.