### PR TITLE
Adds Site Address field to support form

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Help/SupportForm/SupportForm.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Help/SupportForm/SupportForm.swift
@@ -110,6 +110,22 @@ struct SupportForm: View {
                             )
                     }
 
+                    // Site Address Text Field
+                    VStack(alignment: .leading, spacing: Layout.subSectionsSpacing) {
+                        Text(Localization.siteAddress)
+                            .foregroundColor(Color(.text))
+                            .subheadlineStyle()
+
+                        TextField("", text: $viewModel.siteAddress)
+                            .keyboardType(.URL)
+                            .bodyStyle()
+                            .padding(insets: Layout.subjectInsets)
+                            .background(Color(.listForeground(modal: false)))
+                            .overlay(
+                                RoundedRectangle(cornerRadius: Layout.cornerRadius).stroke(Color(.separator))
+                            )
+                    }
+
                     // Description Text Editor
                     VStack(alignment: .leading, spacing: Layout.subSectionsSpacing) {
                         Text(Localization.message)
@@ -190,6 +206,7 @@ private extension SupportForm {
                                                   " and we will be in touch soon."].joined(),
                                                   comment: "Message info on the support screen.")
         static let subject = NSLocalizedString("Subject", comment: "Subject title on the support form")
+        static let siteAddress = NSLocalizedString("Site Address", comment: "Site Address title on the support form")
         static let message = NSLocalizedString("Message", comment: "Message on the support form")
         static let submitRequest = NSLocalizedString("Submit Support Request", comment: "Button title to submit a support request.")
 

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Help/SupportForm/SupportFormViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Help/SupportForm/SupportFormViewModel.swift
@@ -101,6 +101,10 @@ public final class SupportFormViewModel: ObservableObject {
     func onViewAppear() {
         analyticsProvider.track(.supportNewRequestViewed)
         requestZendeskIdentityIfNeeded()
+
+        if let siteAddress = ServiceLocator.stores.sessionManager.defaultSite?.url {
+            self.siteAddress = siteAddress
+        }
     }
 
     /// Selects an area.
@@ -122,7 +126,7 @@ public final class SupportFormViewModel: ObservableObject {
 
         showLoadingIndicator = true
         zendeskProvider.createSupportRequest(formID: area.datasource.formID,
-                                             customFields: area.datasource.customFields,
+                                             customFields: area.datasource.customFields(siteAddress: siteAddress),
                                              tags: assembleTags(),
                                              subject: subject,
                                              description: description) { [weak self] result in

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Help/SupportForm/SupportFormViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Help/SupportForm/SupportFormViewModel.swift
@@ -31,6 +31,10 @@ public final class SupportFormViewModel: ObservableObject {
     ///
     @Published var subject = ""
 
+    /// Variable that holds the siteAddress of the ticket.
+    ///
+    @Published var siteAddress = ""
+
     /// Variable that holds the description of the ticket.
     ///
     @Published var description = ""
@@ -58,7 +62,7 @@ public final class SupportFormViewModel: ObservableObject {
     /// Defines when the submit button should be enabled or not.
     ///
     var submitButtonDisabled: Bool {
-        area == nil || subject.isEmpty || description.isEmpty
+        area == nil || subject.isEmpty || siteAddress.isEmpty || description.isEmpty
     }
 
     var identitySubmitButtonDisabled: Bool {

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Help/SupportForm/SupportFormViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Help/SupportForm/SupportFormViewModel.swift
@@ -95,7 +95,7 @@ public final class SupportFormViewModel: ObservableObject {
          sourceTag: String? = nil,
          zendeskProvider: ZendeskManagerProtocol = ZendeskProvider.shared,
          analyticsProvider: Analytics = ServiceLocator.analytics,
-         defaultSite: Site? = ServiceLocator.stores.sessionManager.defaultSite) {
+         defaultSite: Site? = nil) {
         self.areas = areas
         self.sourceTag = sourceTag
         self.zendeskProvider = zendeskProvider

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Help/SupportForm/SupportFormViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Help/SupportForm/SupportFormViewModel.swift
@@ -1,6 +1,7 @@
 import Foundation
 import class WordPressShared.EmailFormatValidator
 import protocol WooFoundation.Analytics
+import struct Yosemite.Site
 
 /// Data Source for the Support Request
 ///
@@ -59,6 +60,10 @@ public final class SupportFormViewModel: ObservableObject {
     ///
     private let analyticsProvider: Analytics
 
+    /// To fetch the default site URL if possible.
+    ///
+    private let defaultSite: Site?
+
     /// Defines when the submit button should be enabled or not.
     ///
     var submitButtonDisabled: Bool {
@@ -89,11 +94,13 @@ public final class SupportFormViewModel: ObservableObject {
     init(areas: [Area] = wooSupportAreas(),
          sourceTag: String? = nil,
          zendeskProvider: ZendeskManagerProtocol = ZendeskProvider.shared,
-         analyticsProvider: Analytics = ServiceLocator.analytics) {
+         analyticsProvider: Analytics = ServiceLocator.analytics,
+         defaultSite: Site? = ServiceLocator.stores.sessionManager.defaultSite) {
         self.areas = areas
         self.sourceTag = sourceTag
         self.zendeskProvider = zendeskProvider
         self.analyticsProvider = analyticsProvider
+        self.defaultSite = defaultSite
     }
 
     /// Tracks when the support form is viewed.
@@ -102,9 +109,8 @@ public final class SupportFormViewModel: ObservableObject {
         analyticsProvider.track(.supportNewRequestViewed)
         requestZendeskIdentityIfNeeded()
 
-        if let siteAddress = ServiceLocator.stores.sessionManager.defaultSite?.url {
-            self.siteAddress = siteAddress
-        }
+        // Populates the site address field if there is any.
+        self.siteAddress = defaultSite?.url ?? ""
     }
 
     /// Selects an area.

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Help/SupportForm/SupportFormsDataSources.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Help/SupportForm/SupportFormsDataSources.swift
@@ -109,6 +109,16 @@ struct OtherPluginsSupportDataSource: SupportFormMetaDataSource {
     }
 }
 
+extension SupportFormMetaDataSource {
+    /// Adds site address to the datasource metadata
+    ///
+    func customFields(siteAddress: String) -> [Int64: String] {
+        var fields = customFields
+        fields[ZendeskForms.IDs.siteAddress] = siteAddress
+        return fields
+    }
+}
+
 /// Zendesk Constant Values
 ///
 private enum ZendeskForms {
@@ -119,6 +129,7 @@ private enum ZendeskForms {
         static let wooForm: Int64 = 189946
         static let category: Int64 = 25176003
         static let subCategory: Int64 = 25176023
+        static let siteAddress: Int64 = 22054927
     }
 
     /// Custom Field Values

--- a/WooCommerce/WooCommerceTests/Testing/MockZendeskManager.swift
+++ b/WooCommerce/WooCommerceTests/Testing/MockZendeskManager.swift
@@ -22,6 +22,10 @@ final class MockZendeskManager: ZendeskManagerProtocol {
     ///
     private(set) var latestInvokedTags: [String] = []
 
+    /// Tracks which custom fields were invoked via the create request method.
+    ///
+    private(set) var latestInvokedCustomFields: [Int64: String] = [:]
+
     func showNewRequestIfPossible(from controller: UIViewController, with sourceTag: String?) {
         let invocation = NewRequestIfPossibleInvocation(controller: controller, sourceTag: sourceTag)
         newRequestIfPossibleInvocations.append(invocation)
@@ -107,6 +111,7 @@ extension MockZendeskManager {
                               description: String,
                               onCompletion: @escaping (Result<Void, Error>) -> Void) {
         latestInvokedTags = tags
+        latestInvokedCustomFields = customFields
         if let stubbedCreateSupportRequestResult {
             onCompletion(stubbedCreateSupportRequestResult)
         }

--- a/WooCommerce/WooCommerceTests/Tools/Support/SupportDataSourcesTests.swift
+++ b/WooCommerce/WooCommerceTests/Tools/Support/SupportDataSourcesTests.swift
@@ -159,4 +159,16 @@ final class SupportDataSourcesTests: XCTestCase {
             360000089123 // Device Free Space
         ].sorted())
     }
+
+    func test_site_address_custom_field_is_inserted_correctly() {
+        // Given
+        let dataSOurce = MobileAppSupportDataSource(metadataProvider: SupportFormMetadataProvider())
+
+        // When
+        let customFields = dataSOurce.customFields(siteAddress: "site-address")
+
+        // Then
+        XCTAssertEqual(customFields[22054927], // Site Address
+                       "site-address")
+    }
 }

--- a/WooCommerce/WooCommerceTests/Tools/Support/SupportFormViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/Tools/Support/SupportFormViewModelTests.swift
@@ -164,6 +164,19 @@ final class SupportFormViewModelTests: XCTestCase {
             viewModel.shouldShowErrorAlert == true
         }
     }
+
+    func test() {
+        // Given
+        let zendesk = MockZendeskManager()
+        let area = SupportFormViewModel.Area(title: "Area 1", datasource: MockDataSource())
+        let viewModel = SupportFormViewModel(zendeskProvider: zendesk)
+
+        // When
+        zendesk.whenCreateSupportRequest(thenReturn: .success(()))
+        viewModel.selectArea(area)
+        viewModel.submitSupportRequest()
+
+    }
 }
 
 private extension SupportFormViewModelTests {

--- a/WooCommerce/WooCommerceTests/Tools/Support/SupportFormViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/Tools/Support/SupportFormViewModelTests.swift
@@ -1,4 +1,5 @@
 import XCTest
+import Yosemite
 @testable import WooCommerce
 
 @MainActor
@@ -165,17 +166,32 @@ final class SupportFormViewModelTests: XCTestCase {
         }
     }
 
-    func test() {
+    func test_site_address_is_sent_when_submitting_request() {
         // Given
         let zendesk = MockZendeskManager()
         let area = SupportFormViewModel.Area(title: "Area 1", datasource: MockDataSource())
         let viewModel = SupportFormViewModel(zendeskProvider: zendesk)
 
         // When
-        zendesk.whenCreateSupportRequest(thenReturn: .success(()))
         viewModel.selectArea(area)
+        viewModel.siteAddress = "site-address"
         viewModel.submitSupportRequest()
 
+        // Then
+        XCTAssertTrue(zendesk.latestInvokedCustomFields.values.contains("site-address"))
+    }
+
+    func test_default_site_is_populated_when_available() {
+        // Given
+        let zendesk = MockZendeskManager()
+        let defaultSite = Site.fake().copy(url: "site-address")
+        let viewModel = SupportFormViewModel(zendeskProvider: zendesk, defaultSite: defaultSite)
+
+        // When
+        viewModel.onViewAppear()
+
+        // Then
+        XCTAssertEqual(viewModel.siteAddress, defaultSite.url)
     }
 }
 

--- a/WooCommerce/WooCommerceTests/Tools/Support/SupportFormViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/Tools/Support/SupportFormViewModelTests.swift
@@ -11,6 +11,7 @@ final class SupportFormViewModelTests: XCTestCase {
         // When
         viewModel.area = nil
         viewModel.subject = ""
+        viewModel.siteAddress = ""
         viewModel.description = ""
 
         // Then
@@ -24,6 +25,7 @@ final class SupportFormViewModelTests: XCTestCase {
         // When
         viewModel.area = nil
         viewModel.subject = "Subject"
+        viewModel.siteAddress = "site-address"
         viewModel.description = ""
 
         // Then
@@ -37,19 +39,35 @@ final class SupportFormViewModelTests: XCTestCase {
         // When
         viewModel.area = nil
         viewModel.subject = ""
+        viewModel.siteAddress = ""
         viewModel.description = "Description"
 
         // Then
         XCTAssertTrue(viewModel.submitButtonDisabled)
     }
 
-    func test_submit_button_is_enabled_when_area_and_subject_and_description_are_not_empty() {
+    func test_submit_button_is_disabled_when_site_address_is_empty() {
         // Given
         let viewModel = SupportFormViewModel(areas: Self.sampleAreas())
 
         // When
         viewModel.area = viewModel.areas.first
         viewModel.subject = "Subject"
+        viewModel.description = "Description"
+        viewModel.siteAddress = ""
+
+        // Then
+        XCTAssertTrue(viewModel.submitButtonDisabled)
+    }
+
+    func test_submit_button_is_enabled_when_all_fields_are_not_empty() {
+        // Given
+        let viewModel = SupportFormViewModel(areas: Self.sampleAreas())
+
+        // When
+        viewModel.area = viewModel.areas.first
+        viewModel.subject = "Subject"
+        viewModel.siteAddress = "site-address"
         viewModel.description = "Description"
 
         // Then


### PR DESCRIPTION
Closes: #12935 

# Why

This PR adds a site address field to the support form.

# How

- Send the site address as a custom field
- ~Auto-fill the currently selected site (if any)~

# Demo

https://github.com/user-attachments/assets/bea097a5-2078-4d8b-b08b-3c8c95e1eba4

<img width="400" alt="prove" src="https://github.com/user-attachments/assets/40ae3927-766e-4e2e-a8ae-fc77f07fad15">

# Testing Steps

- Go to the app and try to send a support request.
- See that there is a new site address field that can be updated.
- Send the support request.
- ~Check that the support ticket has the "Website URL" field populated~

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.