### PR TITLE
[Blaze] Jetpack plugin for eligibility

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -3,6 +3,7 @@
 19.8
 -----
 - [*] Add support to background update the order list and the dashboard analytics cards(Performance & Top Performers).
+- [internal] Enable Blaze only if the store has Jetpack installed and connected. [https://github.com/woocommerce/woocommerce-ios/pull/13448]
 
 19.7
 -----

--- a/WooCommerce/Classes/Blaze/BlazeEligibilityChecker.swift
+++ b/WooCommerce/Classes/Blaze/BlazeEligibilityChecker.swift
@@ -38,6 +38,9 @@ private extension BlazeEligibilityChecker {
         guard site.isAdmin && site.canBlaze else {
             return false
         }
+        guard site.isJetpackConnected && site.isJetpackThePluginInstalled else {
+            return false
+        }
         guard stores.isAuthenticatedWithoutWPCom == false else {
             return false
         }

--- a/WooCommerce/Classes/Blaze/BlazeEligibilityChecker.swift
+++ b/WooCommerce/Classes/Blaze/BlazeEligibilityChecker.swift
@@ -38,9 +38,14 @@ private extension BlazeEligibilityChecker {
         guard site.isAdmin && site.canBlaze else {
             return false
         }
+
+        /// Blaze DSP requires a Jetpack full sync to work. So, Jetpack CP sites are excluded from Blaze.
+        /// More discussion links at - https://github.com/woocommerce/woocommerce-ios/issues/13057
+        ///
         guard site.isJetpackConnected && site.isJetpackThePluginInstalled else {
             return false
         }
+
         guard stores.isAuthenticatedWithoutWPCom == false else {
             return false
         }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Blaze/BlazeEligibilityCheckerTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Blaze/BlazeEligibilityCheckerTests.swift
@@ -77,6 +77,35 @@ final class BlazeEligibilityCheckerTests: XCTestCase {
         XCTAssertFalse(isEligible)
     }
 
+    func test_isEligible_is_false_when_jetpack_not_installed() {
+        // Given
+        stores.authenticate(credentials: .wpcom(username: "", authToken: "", siteAddress: ""))
+        let site = mockSite(isEligibleForBlaze: true,
+                            isJetpackThePluginInstalled: false)
+        let checker = BlazeEligibilityChecker(stores: stores)
+
+        // When
+        let isEligible = checker.isSiteEligible(site)
+
+        // Then
+        XCTAssertFalse(isEligible)
+    }
+
+    func test_isEligible_is_false_when_jetpack_installed_but_not_connected() {
+        // Given
+        stores.authenticate(credentials: .wpcom(username: "", authToken: "", siteAddress: ""))
+        let site = mockSite(isEligibleForBlaze: true,
+                            isJetpackThePluginInstalled: true,
+                            isJetpackConnected: false)
+        let checker = BlazeEligibilityChecker(stores: stores)
+
+        // When
+        let isEligible = checker.isSiteEligible(site)
+
+        // Then
+        XCTAssertFalse(isEligible)
+    }
+
     // MARK: - `isProductEligible`
 
     func test_isProductEligible_is_true_when_wpcom_auth_and_feature_flag_enabled_and_blaze_approved_and_product_public_without_password() {
@@ -177,8 +206,13 @@ final class BlazeEligibilityCheckerTests: XCTestCase {
 }
 
 private extension BlazeEligibilityCheckerTests {
-    func mockSite(isEligibleForBlaze: Bool, isAdmin: Bool = true) -> Site {
+    func mockSite(isEligibleForBlaze: Bool,
+                  isAdmin: Bool = true,
+                  isJetpackThePluginInstalled: Bool = true,
+                  isJetpackConnected: Bool = true) -> Site {
         Site.fake().copy(siteID: 134,
+                         isJetpackThePluginInstalled: isJetpackThePluginInstalled,
+                         isJetpackConnected: isJetpackConnected,
                          canBlaze: isEligibleForBlaze,
                          isAdmin: isAdmin)
     }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #13057
<!-- Id number of the GitHub issue this PR addresses. -->


## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

Enables Blaze only for Woo stores with Jetpack plugin installation and valid Jetpack connection. 


## Testing steps
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->
- Create a new JN store with only WooCommerce and don't install Jetpack.
- Finish the WooCommerce setup process and connect your WPCOM account. This establishes a Jetpack Connection between the store and WPCOM servers. (Jetpack sync included in WooCommerce core)
- Publish a new product.
- Login into the app.
- In the Dashboard, you shouldn't see the Blaze card.
- Open the product detail screen, and you shouldn't see the option to promote the product using Blaze.
- Navigate to the Menu tab and you shouldn't see the Blaze option. 
- Install the Jetpack plugin on your store and finish the setup process.
- Stop and relaunch the Woo app.
- In the Dashboard, you should see the Blaze card to promote the product.
- Open the product detail screen, and you should see the option to promote the product using Blaze.
- Navigate to the Menu tab, and you should see the Blaze option. 
- Refer to the screenshots below for clarity.
- Login into a WPCOM atomic store and validate that the above mentioned Blaze entry points are visible. 

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->
| Screen | Without Jetpack | With Jetpack |
|--------|--------|--------|
| Dashboard | ![Simulator Screenshot - iPhone 15 Pro Max - 2024-07-30 at 08 45 32](https://github.com/user-attachments/assets/58e66370-3e5f-4b4f-9006-f9e51cd31549) | ![Simulator Screenshot - iPhone 15 Pro Max - 2024-07-30 at 08 39 20](https://github.com/user-attachments/assets/de2c91ba-017e-41be-84ac-8bae4171ccbd) |
| Product detail | ![Simulator Screenshot - iPhone 15 Pro Max - 2024-07-30 at 08 45 39](https://github.com/user-attachments/assets/df933e56-bf09-436a-b8ed-7bad87bcf962) | ![Simulator Screenshot - iPhone 15 Pro Max - 2024-07-30 at 08 39 23](https://github.com/user-attachments/assets/dd4ea896-030d-49d5-986f-b457974a45c7) |
| Menu | ![Simulator Screenshot - iPhone 15 Pro Max - 2024-07-30 at 08 45 41](https://github.com/user-attachments/assets/ac0ee954-1397-4541-ba5b-34911309a2a0) | ![Simulator Screenshot - iPhone 15 Pro Max - 2024-07-30 at 08 39 27](https://github.com/user-attachments/assets/5c97baa4-8ab7-4968-b1c2-59957e78d0c9) | 

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
- [ ] This PR includes refactoring; smoke testing of the entire section is needed.