### PR TITLE
Fix crash for product publishing by removing the animation when reloading linked product banner

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewController.swift
@@ -790,19 +790,6 @@ private extension ProductFormViewController {
         reconfigureDataSource(tableViewModel: tableViewModel, statuses: productImageActionHandler.productImageStatuses)
     }
 
-    func findLinkedPromoCellIndexPath() -> IndexPath? {
-        for (sectionIndex, section) in tableViewModel.sections.enumerated() {
-            if case .primaryFields(rows: let sectionRows) = section {
-                for (rowIndex, row) in sectionRows.enumerated() {
-                    if case .linkedProductsPromo = row {
-                        return IndexPath(row: rowIndex, section: sectionIndex)
-                    }
-                }
-            }
-        }
-        return nil
-    }
-
     func onProductUpdated(product: ProductModel) {
         updateMoreDetailsButtonVisibility()
         tableViewModel = DefaultProductFormTableViewModel(product: product,

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewController.swift
@@ -779,7 +779,7 @@ private extension ProductFormViewController {
         }
     }
 
-    /// Updates table viewmodel and datasource and attempts to animate cell deletion/insertion.
+    /// Updates table view model and datasource.
     ///
     func reloadLinkedPromoCell() {
         tableViewModel = DefaultProductFormTableViewModel(product: viewModel.productModel,
@@ -787,9 +787,7 @@ private extension ProductFormViewController {
                                                           currency: currency,
                                                           isDescriptionAIEnabled: aiEligibilityChecker.isFeatureEnabled(.description))
 
-        reconfigureDataSource(tableViewModel: tableViewModel, statuses: productImageActionHandler.productImageStatuses) { [weak self] in
-            self?.tableView.reloadData()
-        }
+        reconfigureDataSource(tableViewModel: tableViewModel, statuses: productImageActionHandler.productImageStatuses)
     }
 
     func findLinkedPromoCellIndexPath() -> IndexPath? {

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewController.swift
@@ -781,25 +781,14 @@ private extension ProductFormViewController {
 
     /// Updates table viewmodel and datasource and attempts to animate cell deletion/insertion.
     ///
-    func reloadLinkedPromoCellAnimated() {
-        let indexPathBeforeReload = findLinkedPromoCellIndexPath()
+    func reloadLinkedPromoCell() {
         tableViewModel = DefaultProductFormTableViewModel(product: viewModel.productModel,
                                                           actionsFactory: viewModel.actionsFactory,
                                                           currency: currency,
                                                           isDescriptionAIEnabled: aiEligibilityChecker.isFeatureEnabled(.description))
-        let indexPathAfterReload = findLinkedPromoCellIndexPath()
 
         reconfigureDataSource(tableViewModel: tableViewModel, statuses: productImageActionHandler.productImageStatuses) { [weak self] in
-            guard let self = self else { return }
-
-            switch (indexPathBeforeReload, indexPathAfterReload) {
-            case (let indexPathBeforeReload?, nil):
-                self.tableView.deleteRows(at: [indexPathBeforeReload], with: .left)
-            case (nil, let indexPathAfterReload?):
-                self.tableView.insertRows(at: [indexPathAfterReload], with: .automatic)
-            default:
-                self.tableView.reloadData()
-            }
+            self?.tableView.reloadData()
         }
     }
 
@@ -892,7 +881,7 @@ private extension ProductFormViewController {
         }
         tableViewDataSource.reloadLinkedPromoAction = { [weak self] in
             guard let self = self else { return }
-            self.reloadLinkedPromoCellAnimated()
+            self.reloadLinkedPromoCell()
         }
         tableViewDataSource.descriptionAIAction = { [weak self] in
             self?.showProductDescriptionAI()
@@ -1004,7 +993,7 @@ private extension ProductFormViewController {
 
                 // Show linked products promo banner after product save
                 (self?.viewModel as? ProductFormViewModel)?.isLinkedProductsPromoEnabled = true
-                self?.reloadLinkedPromoCellAnimated()
+                self?.reloadLinkedPromoCell()
                 onCompletion(.success(()))
             }
         }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #13449 
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
When working on #13410, I updated the logic for the Blaze button on the product form to make it appear synchronously instead of async since the eligibility check is now synchronous. 

For a store eligible for Blaze that hasn't dismissed the linked product banner on the product form, publishing a product would make both the Blaze button and linked product banner appear on the product form. The linked product banner was displayed using an insertion animation, which is corrupted if the Blaze button is displayed at the same time, causing the crash.

This PR fixes this crash by replacing the unnecessary animation when displaying the linked product banner with a simple table reloading. This should update the form with the banner and the Blaze button without crashing the app.

## Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->
- Log in to a store eligible for Blaze that hasn't dismissed the linked products banner on the product form.
- Create a new product or open an existing draft product.
- Tap Publish on the product form and confirm that the app doesn't crash.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

https://github.com/user-attachments/assets/97048f8e-29cc-4ba2-9a88-2c21b376499c



---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
- [ ] This PR includes refactoring; smoke testing of the entire section is needed.