### PR TITLE
Update unit tests for `password` field in Product

### DIFF
--- a/Fakes/Fakes/Networking.generated.swift
+++ b/Fakes/Fakes/Networking.generated.swift
@@ -1235,13 +1235,13 @@ extension Networking.Product {
             bundleMinSize: .fake(),
             bundleMaxSize: .fake(),
             bundledItems: .fake(),
+            password: .fake(),
             compositeComponents: .fake(),
             subscription: .fake(),
             minAllowedQuantity: .fake(),
             maxAllowedQuantity: .fake(),
             groupOfQuantity: .fake(),
-            combineVariationQuantities: .fake(),
-            password: .fake()
+            combineVariationQuantities: .fake()
         )
     }
 }

--- a/Networking/Networking/Model/Copiable/Models+Copiable.generated.swift
+++ b/Networking/Networking/Model/Copiable/Models+Copiable.generated.swift
@@ -1928,13 +1928,13 @@ extension Networking.Product {
         bundleMinSize: NullableCopiableProp<Decimal> = .copy,
         bundleMaxSize: NullableCopiableProp<Decimal> = .copy,
         bundledItems: CopiableProp<[ProductBundleItem]> = .copy,
+        password: NullableCopiableProp<String> = .copy,
         compositeComponents: CopiableProp<[ProductCompositeComponent]> = .copy,
         subscription: NullableCopiableProp<ProductSubscription> = .copy,
         minAllowedQuantity: NullableCopiableProp<String> = .copy,
         maxAllowedQuantity: NullableCopiableProp<String> = .copy,
         groupOfQuantity: NullableCopiableProp<String> = .copy,
-        combineVariationQuantities: NullableCopiableProp<Bool> = .copy,
-        password: NullableCopiableProp<String> = .copy
+        combineVariationQuantities: NullableCopiableProp<Bool> = .copy
     ) -> Networking.Product {
         let siteID = siteID ?? self.siteID
         let productID = productID ?? self.productID
@@ -2005,13 +2005,13 @@ extension Networking.Product {
         let bundleMinSize = bundleMinSize ?? self.bundleMinSize
         let bundleMaxSize = bundleMaxSize ?? self.bundleMaxSize
         let bundledItems = bundledItems ?? self.bundledItems
+        let password = password ?? self.password
         let compositeComponents = compositeComponents ?? self.compositeComponents
         let subscription = subscription ?? self.subscription
         let minAllowedQuantity = minAllowedQuantity ?? self.minAllowedQuantity
         let maxAllowedQuantity = maxAllowedQuantity ?? self.maxAllowedQuantity
         let groupOfQuantity = groupOfQuantity ?? self.groupOfQuantity
         let combineVariationQuantities = combineVariationQuantities ?? self.combineVariationQuantities
-        let password = password ?? self.password
 
         return Networking.Product(
             siteID: siteID,
@@ -2083,13 +2083,13 @@ extension Networking.Product {
             bundleMinSize: bundleMinSize,
             bundleMaxSize: bundleMaxSize,
             bundledItems: bundledItems,
+            password: password,
             compositeComponents: compositeComponents,
             subscription: subscription,
             minAllowedQuantity: minAllowedQuantity,
             maxAllowedQuantity: maxAllowedQuantity,
             groupOfQuantity: groupOfQuantity,
-            combineVariationQuantities: combineVariationQuantities,
-            password: password
+            combineVariationQuantities: combineVariationQuantities
         )
     }
 }

--- a/Networking/Networking/Model/Copiable/Models+Copiable.generated.swift
+++ b/Networking/Networking/Model/Copiable/Models+Copiable.generated.swift
@@ -1933,7 +1933,8 @@ extension Networking.Product {
         minAllowedQuantity: NullableCopiableProp<String> = .copy,
         maxAllowedQuantity: NullableCopiableProp<String> = .copy,
         groupOfQuantity: NullableCopiableProp<String> = .copy,
-        combineVariationQuantities: NullableCopiableProp<Bool> = .copy
+        combineVariationQuantities: NullableCopiableProp<Bool> = .copy,
+        password: NullableCopiableProp<String> = .copy
     ) -> Networking.Product {
         let siteID = siteID ?? self.siteID
         let productID = productID ?? self.productID
@@ -2010,6 +2011,7 @@ extension Networking.Product {
         let maxAllowedQuantity = maxAllowedQuantity ?? self.maxAllowedQuantity
         let groupOfQuantity = groupOfQuantity ?? self.groupOfQuantity
         let combineVariationQuantities = combineVariationQuantities ?? self.combineVariationQuantities
+        let password = password ?? self.password
 
         return Networking.Product(
             siteID: siteID,

--- a/Networking/Networking/Model/Product/AIProduct.swift
+++ b/Networking/Networking/Model/Product/AIProduct.swift
@@ -195,12 +195,12 @@ public extension Product {
                   bundleMinSize: nil,
                   bundleMaxSize: nil,
                   bundledItems: [],
+                  password: nil,
                   compositeComponents: [],
                   subscription: nil,
                   minAllowedQuantity: nil,
                   maxAllowedQuantity: nil,
                   groupOfQuantity: nil,
-                  combineVariationQuantities: nil,
-                  password: nil)
+                  combineVariationQuantities: nil)
     }
 }

--- a/Networking/Networking/Model/Product/Product.swift
+++ b/Networking/Networking/Model/Product/Product.swift
@@ -255,13 +255,13 @@ public struct Product: Codable, GeneratedCopiable, Equatable, GeneratedFakeable 
                 bundleMinSize: Decimal?,
                 bundleMaxSize: Decimal?,
                 bundledItems: [ProductBundleItem],
+                password: String?,
                 compositeComponents: [ProductCompositeComponent],
                 subscription: ProductSubscription?,
                 minAllowedQuantity: String?,
                 maxAllowedQuantity: String?,
                 groupOfQuantity: String?,
-                combineVariationQuantities: Bool?,
-                password: String?) {
+                combineVariationQuantities: Bool?) {
         self.siteID = siteID
         self.productID = productID
         self.name = name
@@ -331,13 +331,13 @@ public struct Product: Codable, GeneratedCopiable, Equatable, GeneratedFakeable 
         self.bundleMinSize = bundleMinSize
         self.bundleMaxSize = bundleMaxSize
         self.bundledItems = bundledItems
+        self.password = password
         self.compositeComponents = compositeComponents
         self.subscription = subscription
         self.minAllowedQuantity = minAllowedQuantity.refinedMinMaxQuantityEmptyValue
         self.groupOfQuantity = groupOfQuantity.refinedMinMaxQuantityEmptyValue
         self.maxAllowedQuantity = maxAllowedQuantity
         self.combineVariationQuantities = combineVariationQuantities
-        self.password = password
     }
 
     /// The public initializer for Product.
@@ -538,6 +538,9 @@ public struct Product: Codable, GeneratedCopiable, Equatable, GeneratedFakeable 
         let bundleMaxSize = container.failsafeDecodeIfPresent(decimalForKey: .bundleMaxSize)
         let bundledItems = try container.decodeIfPresent([ProductBundleItem].self, forKey: .bundledItems) ?? []
 
+        // Password
+        let password = container.failsafeDecodeIfPresent(stringForKey: .password)
+        
         // Composite Product properties
         let compositeComponents = try container.decodeIfPresent([ProductCompositeComponent].self, forKey: .compositeComponents) ?? []
 
@@ -553,9 +556,6 @@ public struct Product: Codable, GeneratedCopiable, Equatable, GeneratedFakeable 
         if let combineVariationQuantitiesString = container.failsafeDecodeIfPresent(stringForKey: .combineVariations) {
             combineVariationQuantities = combineVariationQuantitiesString == Values.combineVariationQuantitiesTrueValue
         }
-
-        // Password
-        let password = container.failsafeDecodeIfPresent(stringForKey: .password)
 
         self.init(siteID: siteID,
                   productID: productID,
@@ -626,13 +626,13 @@ public struct Product: Codable, GeneratedCopiable, Equatable, GeneratedFakeable 
                   bundleMinSize: bundleMinSize,
                   bundleMaxSize: bundleMaxSize,
                   bundledItems: bundledItems,
+                  password: password,
                   compositeComponents: compositeComponents,
                   subscription: subscription,
                   minAllowedQuantity: minAllowedQuantity,
                   maxAllowedQuantity: maxAllowedQuantity,
                   groupOfQuantity: groupOfQuantity,
-                  combineVariationQuantities: combineVariationQuantities,
-                  password: password)
+                  combineVariationQuantities: combineVariationQuantities)
     }
 
     public func encode(to encoder: Encoder) throws {
@@ -845,6 +845,8 @@ private extension Product {
         case bundleMinSize                  = "bundle_min_size"
         case bundleMaxSize                  = "bundle_max_size"
         case bundledItems                   = "bundled_items"
+        
+        case password = "post_password"
 
         case compositeComponents    = "composite_components"
 
@@ -852,8 +854,6 @@ private extension Product {
         case maxAllowedQuantity     = "max_quantity"
         case groupOfQuantity        = "group_of_quantity"
         case combineVariations      = "combine_variations"
-
-        case password = "post_password"
     }
 
     enum MetadataKeys {

--- a/Networking/Networking/Model/Product/Product.swift
+++ b/Networking/Networking/Model/Product/Product.swift
@@ -540,7 +540,7 @@ public struct Product: Codable, GeneratedCopiable, Equatable, GeneratedFakeable 
 
         // Password
         let password = container.failsafeDecodeIfPresent(stringForKey: .password)
-        
+
         // Composite Product properties
         let compositeComponents = try container.decodeIfPresent([ProductCompositeComponent].self, forKey: .compositeComponents) ?? []
 
@@ -845,7 +845,7 @@ private extension Product {
         case bundleMinSize                  = "bundle_min_size"
         case bundleMaxSize                  = "bundle_max_size"
         case bundledItems                   = "bundled_items"
-        
+
         case password = "post_password"
 
         case compositeComponents    = "composite_components"

--- a/Networking/NetworkingTests/Mapper/ProductMapperTests.swift
+++ b/Networking/NetworkingTests/Mapper/ProductMapperTests.swift
@@ -102,6 +102,7 @@ final class ProductMapperTests: XCTestCase {
             XCTAssertEqual(product.menuOrder, 0)
             XCTAssertEqual(product.productType, ProductType(rawValue: "booking"))
             XCTAssertTrue(product.isSampleItem)
+            XCTAssertEqual(product.password, "Fortuna Major")
         }
     }
 

--- a/Networking/NetworkingTests/Remote/ProductsRemoteTests.swift
+++ b/Networking/NetworkingTests/Remote/ProductsRemoteTests.swift
@@ -111,13 +111,13 @@ final class ProductsRemoteTests: XCTestCase {
                                       bundleStockStatus: nil,
                                       bundleStockQuantity: nil,
                                       bundledItems: [],
+                                      password: nil,
                                       compositeComponents: [],
                                       subscription: nil,
                                       minAllowedQuantity: nil,
                                       maxAllowedQuantity: nil,
                                       groupOfQuantity: nil,
-                                      combineVariationQuantities: nil,
-                                      password: nil)
+                                      combineVariationQuantities: nil)
         XCTAssertEqual(addedProduct, expectedProduct)
     }
 
@@ -225,13 +225,13 @@ final class ProductsRemoteTests: XCTestCase {
                                       bundleStockStatus: nil,
                                       bundleStockQuantity: nil,
                                       bundledItems: [],
+                                      password: nil,
                                       compositeComponents: [],
                                       subscription: nil,
                                       minAllowedQuantity: nil,
                                       maxAllowedQuantity: nil,
                                       groupOfQuantity: nil,
-                                      combineVariationQuantities: nil,
-                                      password: nil)
+                                      combineVariationQuantities: nil)
         XCTAssertEqual(deletedProduct, expectedProduct)
     }
 

--- a/Networking/NetworkingTests/Remote/ProductsRemoteTests.swift
+++ b/Networking/NetworkingTests/Remote/ProductsRemoteTests.swift
@@ -116,7 +116,8 @@ final class ProductsRemoteTests: XCTestCase {
                                       minAllowedQuantity: nil,
                                       maxAllowedQuantity: nil,
                                       groupOfQuantity: nil,
-                                      combineVariationQuantities: nil)
+                                      combineVariationQuantities: nil,
+                                      password: nil)
         XCTAssertEqual(addedProduct, expectedProduct)
     }
 
@@ -229,7 +230,8 @@ final class ProductsRemoteTests: XCTestCase {
                                       minAllowedQuantity: nil,
                                       maxAllowedQuantity: nil,
                                       groupOfQuantity: nil,
-                                      combineVariationQuantities: nil)
+                                      combineVariationQuantities: nil,
+                                      password: nil)
         XCTAssertEqual(deletedProduct, expectedProduct)
     }
 
@@ -296,7 +298,7 @@ final class ProductsRemoteTests: XCTestCase {
 
     /// Verifies that loadAllProducts properly relays Networking Layer errors.
     ///
-    func testLoadAllProductsProperlyRelaysNetwokingErrors() {
+    func test_loadAllProducts_properly_relays_netwoking_errors() {
         let remote = ProductsRemote(network: network)
         let expectation = self.expectation(description: "Load all products returns error")
 
@@ -318,7 +320,7 @@ final class ProductsRemoteTests: XCTestCase {
 
     /// Verifies that loadProduct properly parses the `product` sample response.
     ///
-    func testLoadSingleProductProperlyReturnsParsedProduct() throws {
+    func test_loadSingleProduct_properly_returns_parsed_product() throws {
         // Given
         let remote = ProductsRemote(network: network)
         let expectation = self.expectation(description: "Load single product")
@@ -344,7 +346,7 @@ final class ProductsRemoteTests: XCTestCase {
 
     /// Verifies that loadProduct properly parses the `product-external` sample response.
     ///
-    func testLoadSingleExternalProductProperlyReturnsParsedProduct() throws {
+    func test_loadSingleExternalProduct_properly_returns_parsed_product() throws {
         // Given
         let remote = ProductsRemote(network: network)
         network.simulateResponse(requestUrlSuffix: "products/\(sampleProductID)", filename: "product-external")
@@ -370,7 +372,7 @@ final class ProductsRemoteTests: XCTestCase {
 
     /// Verifies that loadProduct properly relays any Networking Layer errors.
     ///
-    func testLoadSingleProductProperlyRelaysNetwokingErrors() throws {
+    func test_loadSingleProduct_properly_relays_netwoking_errors() throws {
         // Given
         let remote = ProductsRemote(network: network)
         let expectation = self.expectation(description: "Load single product returns error")
@@ -522,7 +524,7 @@ final class ProductsRemoteTests: XCTestCase {
 
     /// Verifies that updateProduct properly parses the `product-update` sample response.
     ///
-    func testUpdateProductProperlyReturnsParsedProduct() {
+    func test_updateProduct_properly_returns_parsed_product() {
         // Given
         let remote = ProductsRemote(network: network)
         network.simulateResponse(requestUrlSuffix: "products/\(sampleProductID)", filename: "product-update")
@@ -548,7 +550,7 @@ final class ProductsRemoteTests: XCTestCase {
 
     /// Verifies that updateProduct properly relays Networking Layer errors.
     ///
-    func testUpdateProductProperlyRelaysNetwokingErrors() {
+    func test_updateProduct_properly_relays_netwoking_errors() {
         // Given
         let remote = ProductsRemote(network: network)
 

--- a/Networking/NetworkingTests/Responses/product-without-data.json
+++ b/Networking/NetworkingTests/Responses/product-without-data.json
@@ -14,6 +14,7 @@
     "description": "<p>This is the party room!</p>\n",
     "short_description": "[contact-form]\n<p>The green room&#8217;s max capacity is 30 people. Reserving the date / time of your event is free. We can also accommodate large groups, with seating for 85 board game players at a time. If you have a large group, let us know and we&#8217;ll send you our large group rate.</p>\n<p>GROUP RATES</p>\n<p>Reserve your event for up to 30 guests for $100.</p>\n",
     "sku": "",
+    "post_password": "Fortuna Major",
     "price": "0",
     "regular_price": "",
     "sale_price": "",

--- a/Networking/NetworkingTests/Responses/product.json
+++ b/Networking/NetworkingTests/Responses/product.json
@@ -15,6 +15,7 @@
             "description": "<p>This is the party room!</p>\n",
             "short_description": "[contact-form]\n<p>The green room&#8217;s max capacity is 30 people. Reserving the date / time of your event is free. We can also accommodate large groups, with seating for 85 board game players at a time. If you have a large group, let us know and we&#8217;ll send you our large group rate.</p>\n<p>GROUP RATES</p>\n<p>Reserve your event for up to 30 guests for $100.</p>\n",
             "sku": "",
+            "post_password": "Fortuna Major",
             "price": "0",
             "regular_price": "",
             "sale_price": "",

--- a/WooCommerce/Classes/Extensions/Product+SwiftUIPreviewHelpers.swift
+++ b/WooCommerce/Classes/Extensions/Product+SwiftUIPreviewHelpers.swift
@@ -74,13 +74,13 @@ extension Product {
                 bundleMinSize: nil,
                 bundleMaxSize: nil,
                 bundledItems: [],
+                password: nil,
                 compositeComponents: [],
                 subscription: nil,
                 minAllowedQuantity: nil,
                 maxAllowedQuantity: nil,
                 groupOfQuantity: nil,
-                combineVariationQuantities: nil,
-                password: nil)
+                combineVariationQuantities: nil)
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Products/Add Product/ProductFactory.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Add Product/ProductFactory.swift
@@ -101,12 +101,12 @@ private extension ProductFactory {
                 bundleMinSize: nil,
                 bundleMaxSize: nil,
                 bundledItems: [],
+                password: nil,
                 compositeComponents: [],
                 subscription: type == .subscription ? .empty : nil,
                 minAllowedQuantity: nil,
                 maxAllowedQuantity: nil,
                 groupOfQuantity: nil,
-                combineVariationQuantities: nil,
-                password: nil)
+                combineVariationQuantities: nil)
     }
 }

--- a/Yosemite/Yosemite/Model/Mocks/MockObjectGraph.swift
+++ b/Yosemite/Yosemite/Model/Mocks/MockObjectGraph.swift
@@ -317,13 +317,13 @@ extension MockObjectGraph {
             bundleMinSize: nil,
             bundleMaxSize: nil,
             bundledItems: [],
+            password: nil,
             compositeComponents: [],
             subscription: nil,
             minAllowedQuantity: nil,
             maxAllowedQuantity: nil,
             groupOfQuantity: nil,
-            combineVariationQuantities: nil,
-            password: nil
+            combineVariationQuantities: nil
         )
     }
 }

--- a/Yosemite/Yosemite/Model/Storage/Product+ReadOnlyConvertible.swift
+++ b/Yosemite/Yosemite/Model/Storage/Product+ReadOnlyConvertible.swift
@@ -186,13 +186,13 @@ extension Storage.Product: ReadOnlyConvertible {
                        bundleMinSize: bundleMinSize?.decimalValue,
                        bundleMaxSize: bundleMaxSize?.decimalValue,
                        bundledItems: bundledItemsArray.map { $0.toReadOnly() },
+                       password: password,
                        compositeComponents: compositeComponentsArray.map { $0.toReadOnly() },
                        subscription: subscription?.toReadOnly(),
                        minAllowedQuantity: minAllowedQuantity,
                        maxAllowedQuantity: maxAllowedQuantity,
                        groupOfQuantity: groupOfQuantity,
-                       combineVariationQuantities: combineVariationQuantities?.boolValue,
-                       password: password)
+                       combineVariationQuantities: combineVariationQuantities?.boolValue)
     }
 
     // MARK: - Private Helpers


### PR DESCRIPTION
Part of #13387

## Description
I added extra tests for the new `password` field in the Product model, specifically in `ProductRemoteTests` (also updating some method names) and `ProductMapperTests`. Additionally, I updated the generated Copiable file, which I forgot to do last time, and fixed the order of the `password` field in the Product `init` method.

## Testing
Unit tests should pass. No changes in the UI at the moment.

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
- [ ] This PR includes refactoring; smoke testing of the entire section is needed.