### PR TITLE
Blaze: Fallback to default URL when product permalink cannot be decoded

### DIFF
--- a/Networking/Networking/Model/Product/Product.swift
+++ b/Networking/Networking/Model/Product/Product.swift
@@ -759,6 +759,13 @@ public struct Product: Codable, GeneratedCopiable, Equatable, GeneratedFakeable 
     }
 }
 
+public extension Product {
+    /// Default product URL {site_url}?post_type=product&p={product_id} works for all sites.
+    func alternativePermalink(with siteURL: String) -> String {
+        String(format: "%@?post_type=product&p=%d", siteURL, productID)
+    }
+}
+
 /// Defines all of the Product CodingKeys
 ///
 private extension Product {

--- a/Networking/NetworkingTests/Mapper/ProductMapperTests.swift
+++ b/Networking/NetworkingTests/Mapper/ProductMapperTests.swift
@@ -28,6 +28,8 @@ final class ProductMapperTests: XCTestCase {
             XCTAssertEqual(product.name, "Book the Green Room")
             XCTAssertEqual(product.slug, "book-the-green-room")
             XCTAssertEqual(product.permalink, "https://example.com/product/book-the-green-room/")
+            XCTAssertEqual(product.alternativePermalink(with: "https://example.com"),
+                           "https://example.com?post_type=product&p=\(dummyProductID)")
 
             let dateCreated = DateFormatter.Defaults.dateTimeFormatter.date(from: "2019-02-19T17:33:31")
             let dateModified = DateFormatter.Defaults.dateTimeFormatter.date(from: "2019-02-19T17:48:01")

--- a/WooCommerce/Classes/ViewRelated/Blaze/AdDestination/BlazeAdDestinationSettingViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Blaze/AdDestination/BlazeAdDestinationSettingViewModel.swift
@@ -116,8 +116,19 @@ final class BlazeAdDestinationSettingViewModel: ObservableObject {
 
     func calculateRemainingCharacters() -> Int {
         let remainingCharacters = Constant.maxParameterLength - parameters.convertToQueryString().count
+        let parameterLengthInBaseURL: Int = {
+            if let url = URL(string: baseURL),
+               let urlComponents = URLComponents(url: url, resolvingAgainstBaseURL: false),
+               let queryItems = urlComponents.queryItems, queryItems.isNotEmpty {
+                return queryItems
+                    .map { "\($0.name)=\($0.value ?? "")" }
+                    .joined(separator: "&")
+                    .count
+            }
+            return 0
+        }()
         // Should stop at zero and not show negative number.
-        return max(0, remainingCharacters)
+        return max(0, remainingCharacters - parameterLengthInBaseURL)
     }
 
     func selectParameter(item: BlazeAdURLParameter) {

--- a/WooCommerce/Classes/ViewRelated/Blaze/AdDestination/BlazeAdDestinationSettingViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Blaze/AdDestination/BlazeAdDestinationSettingViewModel.swift
@@ -68,7 +68,7 @@ final class BlazeAdDestinationSettingViewModel: ObservableObject {
                     // Once a parameter is updated, clear the selected parameter to prepare for the next add/update action.
                     clearSelectedParameter()
                 } else {
-                    self.parameters.append(BlazeAdURLParameter(key: key, value: value))
+                    self.addNewParameter(item: BlazeAdURLParameter(key: key, value: value))
                 }
             }
         )
@@ -133,6 +133,10 @@ final class BlazeAdDestinationSettingViewModel: ObservableObject {
 
     func selectParameter(item: BlazeAdURLParameter) {
         selectedParameter = item
+    }
+
+    func addNewParameter(item: BlazeAdURLParameter) {
+        parameters.append(item)
     }
 
     func deleteParameter(at offsets: IndexSet) {

--- a/WooCommerce/Classes/ViewRelated/Blaze/AdDestination/BlazeAdDestinationSettingViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Blaze/AdDestination/BlazeAdDestinationSettingViewModel.swift
@@ -68,7 +68,7 @@ final class BlazeAdDestinationSettingViewModel: ObservableObject {
                     // Once a parameter is updated, clear the selected parameter to prepare for the next add/update action.
                     clearSelectedParameter()
                 } else {
-                    self.addNewParameter(item: BlazeAdURLParameter(key: key, value: value))
+                    addNewParameter(item: BlazeAdURLParameter(key: key, value: value))
                 }
             }
         )

--- a/WooCommerce/Classes/ViewRelated/Blaze/CampaignCreation/BlazeCampaignCreationFormViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Blaze/CampaignCreation/BlazeCampaignCreationFormViewModel.swift
@@ -128,7 +128,7 @@ final class BlazeCampaignCreationFormViewModel: ObservableObject {
         })
     }
 
-    var adDestinationViewModel: BlazeAdDestinationSettingViewModel? {
+    lazy private(set) var adDestinationViewModel: BlazeAdDestinationSettingViewModel? = {
         // Only create viewModel (and thus show the ad destination setting) if these two URLs exist.
         guard let productURL, let siteURL else {
             DDLogError("Error: unable to create BlazeAdDestinationSettingViewModel because productURL and/or siteURL is empty.")
@@ -142,7 +142,7 @@ final class BlazeCampaignCreationFormViewModel: ObservableObject {
                 self.targetUrl = targetUrl
                 self.urlParams = urlParams
         }
-    }
+    }()
 
     // For Ad destination purposes
     private var productURL: String? {

--- a/WooCommerce/Classes/ViewRelated/Blaze/CampaignCreation/BlazeCampaignCreationFormViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Blaze/CampaignCreation/BlazeCampaignCreationFormViewModel.swift
@@ -146,12 +146,11 @@ final class BlazeCampaignCreationFormViewModel: ObservableObject {
 
     // For Ad destination purposes
     private var productURL: String? {
-        let productLink = product?.permalink
-        if let productLink, let siteURL, productLink.isEmpty {
+        if let product, let siteURL, product.permalink.isEmpty {
             /// fallback to the default product URL {site_url}?post_type=product&p={product_id}
-            return String(format: "%@?post_type=product&p=%d", siteURL, productID)
+            return product.alternativePermalink(with: siteURL)
         }
-        return productLink
+        return product?.permalink
     }
     private var siteURL: String? { stores.sessionManager.defaultSite?.url }
 

--- a/WooCommerce/Classes/ViewRelated/Blaze/CampaignCreation/BlazeCampaignCreationFormViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Blaze/CampaignCreation/BlazeCampaignCreationFormViewModel.swift
@@ -145,7 +145,14 @@ final class BlazeCampaignCreationFormViewModel: ObservableObject {
     }
 
     // For Ad destination purposes
-    private var productURL: String? { product?.permalink }
+    private var productURL: String? {
+        let productLink = product?.permalink
+        if let productLink, let siteURL, productLink.isEmpty {
+            /// fallback to the default product URL {site_url}?post_type=product&p={product_id}
+            return String(format: "%@?post_type=product&p=%d", siteURL, productID)
+        }
+        return productLink
+    }
     private var siteURL: String? { stores.sessionManager.defaultSite?.url }
 
     @Published private(set) var budgetDetailText: String = ""

--- a/WooCommerce/WooCommerceTests/ViewRelated/Blaze/BlazeAdDestinationSettingViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Blaze/BlazeAdDestinationSettingViewModelTests.swift
@@ -77,6 +77,20 @@ final class BlazeAdDestinationSettingViewModelTests: XCTestCase {
         XCTAssertTrue(sut.shouldDisableAddParameterButton)
     }
 
+    func test_parameter_list_is_correct_when_there_are_parameters_in_base_url() {
+        // Given
+        let defaultParam = "product=bonsai-plant"
+        let sut =  BlazeAdDestinationSettingViewModel(
+            productURL: sampleProductURL + "?" + defaultParam,
+            homeURL: sampleHomeURL,
+            finalDestinationURL: sampleProductURL,
+            onSave: { _, _ in }
+        )
+
+        // Then
+        XCTAssertEqual(sut.parameters, [])
+    }
+
     func test_when_destination_changed_then_final_url_is_updated() {
         // Given
         let sut =  BlazeAdDestinationSettingViewModel(
@@ -94,6 +108,23 @@ final class BlazeAdDestinationSettingViewModelTests: XCTestCase {
         let updatedURL = "\(sampleHomeURL)?\(threeParameters)"
         XCTAssertEqual(sut.selectedDestinationType, .home)
         XCTAssertTrue(sut.finalDestinationLabel.contains(updatedURL))
+    }
+
+    func test_final_url_is_correct_when_there_are_parameters_in_base_url() {
+        // Given
+        let productURL = sampleProductURL + "?product=bonsai-plant"
+        let sut =  BlazeAdDestinationSettingViewModel(
+            productURL: productURL,
+            homeURL: sampleHomeURL,
+            finalDestinationURL: productURL,
+            onSave: { _, _ in }
+        )
+
+        // When
+        sut.addNewParameter(item: .init(key: "test", value: "123"))
+
+        // Then
+        XCTAssertTrue(sut.finalDestinationLabel.hasSuffix(productURL + "&test=123"))
     }
 
     func test_given_existing_parameters_then_remaining_characters_count_is_correct() {
@@ -124,6 +155,27 @@ final class BlazeAdDestinationSettingViewModelTests: XCTestCase {
 
         // Then
         XCTAssertEqual(sut.parameters.count, 2)
+    }
+
+    func test_remaining_character_count_is_correct_when_there_are_parameters_in_base_url() {
+        // Given
+        let defaultParam = "product=bonsai-plant"
+        let sut =  BlazeAdDestinationSettingViewModel(
+            productURL: sampleProductURL,
+            homeURL: sampleHomeURL,
+            finalDestinationURL: sampleProductURL + "?" + defaultParam,
+            onSave: { _, _ in }
+        )
+
+        // Then
+        XCTAssertEqual(sut.calculateRemainingCharacters(), maxParameterLength - defaultParam.count)
+
+        // When
+        sut.addNewParameter(item: .init(key: "test", value: "123"))
+
+        // Then
+        XCTAssertEqual(sut.calculateRemainingCharacters(),
+                       maxParameterLength - defaultParam.count - "&test=123".count)
     }
 
     // MARK: Completion block

--- a/WooCommerce/WooCommerceTests/ViewRelated/Blaze/BlazeCampaignCreationFormViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Blaze/BlazeCampaignCreationFormViewModelTests.swift
@@ -10,7 +10,7 @@ import struct Networking.BlazeAISuggestion
 final class BlazeCampaignCreationFormViewModelTests: XCTestCase {
 
     private let sampleSiteID: Int64 = 322
-
+    private let sampleSiteAddress = "https://example.com"
     private let sampleProductID: Int64 = 433
 
     private var sampleProduct: Product {
@@ -44,7 +44,7 @@ final class BlazeCampaignCreationFormViewModelTests: XCTestCase {
 
     override func setUp() {
         super.setUp()
-        stores = MockStoresManager(sessionManager: .testingInstance)
+        stores = MockStoresManager(sessionManager: .makeForTesting(defaultSite: Site.fake().copy(url: sampleSiteAddress)))
         storageManager = MockStorageManager()
         imageLoader = MockProductUIImageLoader()
         analyticsProvider = MockAnalyticsProvider()
@@ -104,6 +104,21 @@ final class BlazeCampaignCreationFormViewModelTests: XCTestCase {
 
         // Then
         XCTAssertEqual(viewModel.description, "")
+    }
+
+    @MainActor
+    func test_ad_destination_product_url_is_updated_correctly_if_empty() async throws {
+        // Given
+        insertProduct(sampleProduct.copy(permalink: ""))
+        let viewModel = BlazeCampaignCreationFormViewModel(siteID: sampleSiteID,
+                                                           productID: sampleProductID,
+                                                           stores: stores,
+                                                           storage: storageManager,
+                                                           productImageLoader: imageLoader,
+                                                           onCompletion: {})
+
+        // Then
+        XCTAssertEqual(viewModel.adDestinationViewModel?.productURL, sampleSiteAddress + "?post_type=product&p=\(sampleProductID)")
     }
 
     // MARK: On load

--- a/WooCommerce/WooCommerceTests/ViewRelated/Blaze/BlazeCampaignCreationFormViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Blaze/BlazeCampaignCreationFormViewModelTests.swift
@@ -463,32 +463,6 @@ final class BlazeCampaignCreationFormViewModelTests: XCTestCase {
         XCTAssertTrue(viewModel.isShowingMissingImageErrorAlert)
     }
 
-    @MainActor
-    func test_it_shows_error_if_confirmed_with_empty_product_url() async throws {
-        // Given
-        // Product with empty product URL
-        insertProduct(sampleProduct.copy(permalink: ""))
-        mockAISuggestionsSuccess(sampleAISuggestions)
-        mockDownloadImage(sampleImage)
-
-        let viewModel = BlazeCampaignCreationFormViewModel(siteID: sampleSiteID,
-                                                           productID: sampleProductID,
-                                                           stores: stores,
-                                                           storage: storageManager,
-                                                           productImageLoader: imageLoader,
-                                                           analytics: analytics,
-                                                           onCompletion: {})
-        await viewModel.downloadProductImage()
-
-        await viewModel.loadAISuggestions()
-
-        // When
-        viewModel.didTapConfirmDetails()
-
-        // Then
-        XCTAssertTrue(viewModel.isShowingMissingDestinationURLAlert)
-    }
-
     // MARK: Analytics
     @MainActor
     func test_event_is_tracked_on_appear() async throws {


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #13355 
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This PR updates the logic of Blaze's ad destination to support sites with custom permalink settings and applies a fallback URL when product permalinks cannot be decoded.

Changes include:
- `BlazeCampaignCreationFormViewModel`:
  - Keep `adDestinationViewModel` a lazy variable to avoid unnecessary recreating the view model when the creation form is re-rendered.
  - Fallback to a default form for the product URL when product permalink cannot be decoded following Hicham's suggestion (p1722281016526459/1722280392.435889-slack-C03L1NF1EA3).
- `BlazeAdDestinationSettingsViewModel`:
  - Update the logic to not include the default params in the base URL in the param list.
  - Update the count of remaining characters for params when there are params in the base URL.

## Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->
- In a test store eligible for Blaze, go to wp-admin > Settings > Permalink > switch to Plain option.
- Log in to your test store on the app.
- Select an existing published product and tap Promote with Blaze.
- Select Ad destination and confirm that:
  - The product URL includes a default param for the product page. 
  - The default param should not be included in the param list (not editable)
  - The remaining character count for URL param should be correct for both the product URL and home URL.
  - Enter a custom param and save the change.
  - Select Ad destination again and confirm that only the custom param is listed in the param list.
- Change [this line](https://github.com/woocommerce/woocommerce-ios/blob/599d1d95e712aaccaa65babdc81b594b2ce40ffd/Networking/Networking/Model/Product/Product.swift#L358) in the Product.swift file to return an empty string instead of decoding the value.
- Rebuild and run the app. 
- Select an existing published product and tap Promote with Blaze.
- Select Ad destination and confirm that the product URL is available in the default form `{site_url}?post_type=product&p={product_id}`. All the logic regarding param list and remaining character count should still be correct.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->
Product URL | Home URL
--- | ---
<img src="https://github.com/user-attachments/assets/55a39175-1b5e-4704-90dd-f76376a0fb11" width=320 /> | <img src="https://github.com/user-attachments/assets/48746a43-ad78-48e5-bdd4-a3c3595be5c9" width=320 />


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
- [ ] This PR includes refactoring; smoke testing of the entire section is needed.