### PR TITLE
[Woo POS] M2: Cart Animation

### DIFF
--- a/WooCommerce/Classes/POS/Presentation/PointOfSaleDashboardView.swift
+++ b/WooCommerce/Classes/POS/Presentation/PointOfSaleDashboardView.swift
@@ -64,31 +64,24 @@ struct PointOfSaleDashboardView: View {
     }
 
     private var contentView: some View {
-        VStack {
+        GeometryReader { geometry in
             HStack {
-                switch viewModel.orderStage {
-                case .building:
-                    GeometryReader { geometry in
-                        HStack {
-                            productListView
-                            cartView
-                                .renderedIf(isCartShown)
-                                .frame(width: geometry.size.width * Constants.cartWidth)
-                        }
-                    }
-                case .finalizing:
-                    GeometryReader { geometry in
-                        HStack {
-                            if !viewModel.isTotalsViewFullScreen {
-                                cartView
-                                    .frame(width: geometry.size.width * Constants.cartWidth)
-                                Spacer()
-                            }
-                            totalsView
-                        }
-                    }
+                if viewModel.orderStage == .building {
+                    productListView
+                        .transition(.move(edge: .leading))
+                }
+
+                if !viewModel.isTotalsViewFullScreen {
+                    cartView
+                        .frame(width: geometry.size.width * Constants.cartWidth)
+                }
+
+                if viewModel.orderStage == .finalizing {
+                    totalsView
+                        .transition(.move(edge: .trailing))
                 }
             }
+            .animation(.default, value: viewModel.orderStage)
         }
     }
 }

--- a/WooCommerce/Classes/POS/Presentation/TotalsView.swift
+++ b/WooCommerce/Classes/POS/Presentation/TotalsView.swift
@@ -10,6 +10,7 @@ struct TotalsView: View {
     /// It allows for a simultaneous transition from the shimmering effect to the text fields,
     /// and movement from the center of the VStack to their respective positions.
     @Namespace private var totalsFieldAnimation
+    @State private var hasViewAppeared: Bool = false
 
     init(viewModel: PointOfSaleDashboardViewModel,
          totalsViewModel: TotalsViewModel,
@@ -36,10 +37,19 @@ struct TotalsView: View {
                         .animation(.default, value: totalsViewModel.isShimmering)
                 }
                 .animation(.default, value: totalsViewModel.isShowingCardReaderStatus)
+                .transaction { transaction in
+                    // Disable animations within the view while the view is appearing
+                    if !hasViewAppeared {
+                        transaction.animation = nil
+                    }
+                }
                 paymentsActionButtons
                     .padding()
                 Spacer()
             }
+        }
+        .onAppear {
+            hasViewAppeared = true
         }
         .onDisappear {
             totalsViewModel.onTotalsViewDisappearance()


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of: #13444
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

Adding Cart animation when switching between order building (product list), and order finalizing (checkout) states.

Cart animation is required for further transitions when switching between 'Ready for Payment' -> 'Payment Processing' states, so it's a good time to prepare a basic animation and view structure that supports transitions.

## Solution

I restructured the view for `SwiftUI` to pick up transitions between views:
- The same `CartView` is always part of the dashboard `HStack`
- `ProductList` conditionally appears on the leading side with a transition
- `TotalsView` conditionally appears on the trailing side with a transition

Triggering animation when `viewModel.orderStage` changes.

## Testing information

1. Open Woo -> Menu -> Point of Sale Mode
2. Add items to cart
3. Check out
4. Confirm CartView and TotalsView transitions with animation
5. Come back
6. Confirm CartView and ProductListView transitions with animation

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

https://github.com/user-attachments/assets/1ddc594c-2521-484a-97ab-fea5e312741b

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
- [x] This PR includes refactoring; smoke testing of the entire section is needed.