### PR TITLE
Fix large text in Barcode scanner

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -4,7 +4,7 @@
 -----
 - [*] Add support to background update the order list and the dashboard analytics cards(Performance & Top Performers).
 - [*] Dynamic Dashboard: Display unavailable analytics view when logged in without WPCom. [https://github.com/woocommerce/woocommerce-ios/pull/13440]
-- [*] Fix large text support in Bar Code Scanner.
+- [*] Fix large text support in Bar Code Scanner. [https://github.com/woocommerce/woocommerce-ios/pull/13464]
 - [internal] Enable Blaze only if the store has Jetpack installed and connected. [https://github.com/woocommerce/woocommerce-ios/pull/13448]
 
 19.7

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -4,6 +4,7 @@
 -----
 - [*] Add support to background update the order list and the dashboard analytics cards(Performance & Top Performers).
 - [*] Dynamic Dashboard: Display unavailable analytics view when logged in without WPCom. [https://github.com/woocommerce/woocommerce-ios/pull/13440]
+- [*] Fix large text support in Bar Code Scanner.
 - [internal] Enable Blaze only if the store has Jetpack installed and connected. [https://github.com/woocommerce/woocommerce-ios/pull/13448]
 
 19.7

--- a/WooCommerce/Classes/ViewRelated/Products/SKU Scanner/CodeScannerViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/SKU Scanner/CodeScannerViewController.swift
@@ -272,6 +272,7 @@ private extension CodeScannerViewController {
         instructionLabel.textColor = .white
         instructionLabel.textInsets = Constants.instructionTextInsets
         instructionLabel.text = instructionText
+        instructionLabel.numberOfLines = 0
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Products/SKU Scanner/ProductSKUInputScannerViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/SKU Scanner/ProductSKUInputScannerViewController.swift
@@ -59,8 +59,9 @@ private extension ProductSKUInputScannerViewController {
 
 private extension ProductSKUInputScannerViewController {
     enum Localization {
-        static let title = NSLocalizedString("Scan barcode to update SKU", comment: "Navigation bar title for scanning a barcode to use as a product's SKU.")
-        static let instructionText = NSLocalizedString("Scan product barcode",
+        static let title = NSLocalizedString("Scan barcode or QRCode to update SKU",
+                                             comment: "Navigation bar title for scanning a barcode or QRCode to use as a product's SKU.")
+        static let instructionText = NSLocalizedString("Scan product barcode or QRCode",
                                                        comment: "The instruction text below the scan area in the barcode scanner for product SKU.")
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Products/SKU Scanner/ProductSKUInputScannerViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/SKU Scanner/ProductSKUInputScannerViewController.swift
@@ -59,9 +59,11 @@ private extension ProductSKUInputScannerViewController {
 
 private extension ProductSKUInputScannerViewController {
     enum Localization {
-        static let title = NSLocalizedString("Scan barcode or QRCode to update SKU",
-                                             comment: "Navigation bar title for scanning a barcode or QRCode to use as a product's SKU.")
-        static let instructionText = NSLocalizedString("Scan product barcode or QRCode",
+        static let title = NSLocalizedString("ProductSKUInputScanner.titleView",
+                                             value: "Scan barcode or QR Code to update SKU",
+                                             comment: "Navigation bar title for scanning a barcode or QR Code to use as a product's SKU.")
+        static let instructionText = NSLocalizedString("ProductSKUInputScanner.instructionText",
+                                                       value: "Scan product barcode or QR Code",
                                                        comment: "The instruction text below the scan area in the barcode scanner for product SKU.")
     }
 }


### PR DESCRIPTION
## Description
This PR addresses two issues in the code scanner functionality:
1. **Fix Text Overflow:** Large text in the Barcode scanner was previously being cut off. This has now been fixed to ensure all text is displayed correctly.
2. **Clarify QR Code Support:** It is now made clearer that the code scanner also supports QR codes. Previously, only barcodes were mentioned, which could lead to confusion.

## Testing information
- Verified that large text in the Barcode scanner is fully visible and no longer gets cut off.
- Confirm that both barcodes and QR codes are supported.

## Screenshots
| Before with old text and slightly larger font            |  After with old text and large font | After with new text (in english) and large font |
:-------------------------:|:-------------------------:|:-------------------------:
![IMG_9BF801C9F2FB-1](https://github.com/user-attachments/assets/4ff067ee-1e26-4d6f-9b5d-547015d5c3b2) | ![Simulator Screenshot - iPhone 15 Pro Max - 2024-07-31 at 12 46 17](https://github.com/user-attachments/assets/bd49a8eb-2f1d-4ffd-878f-9100f6fcfc31) | ![Simulator Screenshot - iPhone 15 Pro Max - 2024-07-31 at 12 54 24](https://github.com/user-attachments/assets/90a5d4e9-c689-4636-927d-05a5b4d5d87e)



---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
- [ ] This PR includes refactoring; smoke testing of the entire section is needed.