### PR TITLE
Fixes displaying timestamp in the orders list

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Orders/OrdersRootViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrdersRootViewController.swift
@@ -433,6 +433,12 @@ extension OrdersRootViewController: OrderListViewControllerDelegate {
 
     private func updateTimeoutText() {
         let syncTimestamp = OrderListSyncBackgroundTask.latestSyncDate
+
+        // Prevents an old date to be displayed when there isn't a sync timestamp.
+        guard syncTimestamp != .distantPast else {
+            return
+        }
+
         let dateFormatter = syncTimestamp.isSameDay(as: Date.now) ? DateFormatter.timeFormatter : DateFormatter.dateAndTimeFormatter
         filtersBar.setLastUpdatedTime(dateFormatter.string(from: syncTimestamp))
     }


### PR DESCRIPTION
# Why

This is just a quick PR to address an edge case where an ancient date was shown on the orders list when syncing data for the first time.

# How

Hide the timestamp label when the date equals the `.distantPast` value.

# Demo

https://github.com/user-attachments/assets/d3e70759-864a-4d2f-9193-7827169d810b

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
- [x] This PR includes refactoring; smoke testing of the entire section is needed.