### PR TITLE
[Payments] Fix custom payment block on iPadOS16

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -5,6 +5,7 @@
 - [*] Add support to background update the order list and the dashboard analytics cards(Performance & Top Performers).
 - [*] Dynamic Dashboard: Display unavailable analytics view when logged in without WPCom. [https://github.com/woocommerce/woocommerce-ios/pull/13440]
 - [internal] Enable Blaze only if the store has Jetpack installed and connected. [https://github.com/woocommerce/woocommerce-ios/pull/13448]
+- [**] Fixed Collect Payment from the menu on iPads running iOS 16 [https://github.com/woocommerce/woocommerce-ios/pull/13486]
 
 19.7
 -----

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Payments Menu/InPersonPaymentsMenu.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Payments Menu/InPersonPaymentsMenu.swift
@@ -200,49 +200,19 @@ struct InPersonPaymentsMenu: View {
             }
         }
         .navigationTitle(CardPresentPaymentsOnboardingView.Localization.title)
-        .navigationDestination(for: InPersonPaymentsMenuNavigationDestination.self) { destination in
+        .navigationDestination(isPresented: $viewModel.presentCollectPayment) {
             if let orderViewModel = viewModel.orderViewModel {
-                OrderFormPresentationWrapper(dismissHandler: {
+                orderCreation(orderViewModel: orderViewModel)
+            } else {
+                EmptyView()
+            }
+        }
+        .navigationDestination(isPresented: $viewModel.presentPaymentMethods) {
+            if let paymentMethodsViewModel = viewModel.paymentMethodsViewModel {
+                PaymentMethodsWrapperHosted(viewModel: paymentMethodsViewModel,
+                                            dismiss: {
                     viewModel.dismissPaymentCollection()
-                    Task { @MainActor in
-                        await viewModel.onAppear()
-                    }
-                },
-                                             flow: .creation,
-                                             dismissLabel: .backButton,
-                                             viewModel: orderViewModel)
-                .navigationBarHidden(true)
-                .sheet(isPresented: $viewModel.presentCollectPaymentMigrationSheet, onDismiss: {
-                    // Custom amount sheet needs to be presented when the migration sheet is dismissed to avoid conflicting modals.
-                    if viewModel.presentCustomAmountAfterDismissingCollectPaymentMigrationSheet {
-                        orderViewModel.addCustomAmount()
-                    }
-                }) {
-                    SimplePaymentsMigrationView {
-                        viewModel.presentCustomAmountAfterDismissingCollectPaymentMigrationSheet = true
-                        viewModel.presentCollectPaymentMigrationSheet = false
-                    }
-                    .presentationDetents([.medium, .large])
-                }
-                .navigationDestination(isPresented: $viewModel.presentPaymentMethods) {
-                    if let paymentMethodsViewModel = viewModel.paymentMethodsViewModel {
-                        PaymentMethodsWrapperHosted(viewModel: paymentMethodsViewModel,
-                                                    dismiss: {
-                            viewModel.dismissPaymentCollection()
-                        })
-                    } else {
-                        EmptyView()
-                    }
-                }
-                .onAppear {
-                    DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
-                        guard viewModel.hasPresentedCollectPaymentMigrationSheet == false else {
-                            return
-                        }
-                        viewModel.presentCollectPaymentMigrationSheet = true
-                        viewModel.hasPresentedCollectPaymentMigrationSheet = true
-                    }
-                }
+                })
             } else {
                 EmptyView()
             }
@@ -276,6 +246,41 @@ struct InPersonPaymentsMenu: View {
             pendingDepositDays: 0,
             lastDeposit: nil,
             availableBalance: .zero))])
+    }
+
+    @ViewBuilder
+    private func orderCreation(orderViewModel: EditableOrderViewModel) -> some View {
+        OrderFormPresentationWrapper(dismissHandler: {
+            viewModel.dismissPaymentCollection()
+            Task { @MainActor in
+                await viewModel.onAppear()
+            }
+        },
+                                     flow: .creation,
+                                     dismissLabel: .backButton,
+                                     viewModel: orderViewModel)
+        .navigationBarHidden(true)
+        .sheet(isPresented: $viewModel.presentCollectPaymentMigrationSheet, onDismiss: {
+            // Custom amount sheet needs to be presented when the migration sheet is dismissed to avoid conflicting modals.
+            if viewModel.presentCustomAmountAfterDismissingCollectPaymentMigrationSheet {
+                orderViewModel.addCustomAmount()
+            }
+        }) {
+            SimplePaymentsMigrationView {
+                viewModel.presentCustomAmountAfterDismissingCollectPaymentMigrationSheet = true
+                viewModel.presentCollectPaymentMigrationSheet = false
+            }
+            .presentationDetents([.medium, .large])
+        }
+        .onAppear {
+            DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
+                guard viewModel.hasPresentedCollectPaymentMigrationSheet == false else {
+                    return
+                }
+                viewModel.presentCollectPaymentMigrationSheet = true
+                viewModel.hasPresentedCollectPaymentMigrationSheet = true
+            }
+        }
     }
 }
 
@@ -415,8 +420,7 @@ struct InPersonPaymentsMenu_Previews: PreviewProvider {
             cardPresentPaymentsConfiguration: .init(country: .US),
             onboardingUseCase: CardPresentPaymentsOnboardingUseCase(),
             cardReaderSupportDeterminer: CardReaderSupportDeterminer(siteID: 0),
-            wooPaymentsDepositService: WooPaymentsDepositService(siteID: 0, credentials: .init(authToken: ""))),
-        navigationPath: .constant(NavigationPath()))
+            wooPaymentsDepositService: WooPaymentsDepositService(siteID: 0, credentials: .init(authToken: ""))))
     static var previews: some View {
         NavigationStack {
             InPersonPaymentsMenu(viewModel: viewModel)

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Payments Menu/InPersonPaymentsMenu.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Payments Menu/InPersonPaymentsMenu.swift
@@ -207,16 +207,6 @@ struct InPersonPaymentsMenu: View {
                 EmptyView()
             }
         }
-        .navigationDestination(isPresented: $viewModel.presentPaymentMethods) {
-            if let paymentMethodsViewModel = viewModel.paymentMethodsViewModel {
-                PaymentMethodsWrapperHosted(viewModel: paymentMethodsViewModel,
-                                            dismiss: {
-                    viewModel.dismissPaymentCollection()
-                })
-            } else {
-                EmptyView()
-            }
-        }
     }
 
     @ViewBuilder
@@ -260,6 +250,16 @@ struct InPersonPaymentsMenu: View {
                                      dismissLabel: .backButton,
                                      viewModel: orderViewModel)
         .navigationBarHidden(true)
+        .navigationDestination(isPresented: $viewModel.presentPaymentMethods) {
+            if let paymentMethodsViewModel = viewModel.paymentMethodsViewModel {
+                PaymentMethodsWrapperHosted(viewModel: paymentMethodsViewModel,
+                                            dismiss: {
+                    viewModel.dismissPaymentCollection()
+                })
+            } else {
+                EmptyView()
+            }
+        }
         .sheet(isPresented: $viewModel.presentCollectPaymentMigrationSheet, onDismiss: {
             // Custom amount sheet needs to be presented when the migration sheet is dismissed to avoid conflicting modals.
             if viewModel.presentCustomAmountAfterDismissingCollectPaymentMigrationSheet {

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Payments Menu/InPersonPaymentsMenuViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Payments Menu/InPersonPaymentsMenuViewModel.swift
@@ -7,9 +7,6 @@ import Combine
 
 @MainActor
 final class InPersonPaymentsMenuViewModel: ObservableObject {
-    @Binding var navigationPath: NavigationPath
-    private var navigationPathBeforePaymentCollection: NavigationPath?
-
     @Published private(set) var shouldShowTapToPaySection: Bool = true
     @Published private(set) var shouldShowCardReaderSection: Bool = true
     @Published private(set) var shouldShowPaymentOptionsSection: Bool = false
@@ -33,6 +30,7 @@ final class InPersonPaymentsMenuViewModel: ObservableObject {
     @Published var presentCustomAmountAfterDismissingCollectPaymentMigrationSheet: Bool = false
     /// Whether the payment methods view is shown after creating an order.
     @Published var presentPaymentMethods: Bool = false
+    @Published var presentCollectPayment: Bool = false
     @Published var presentSetUpTryOutTapToPay: Bool = false
     @Published var presentAboutTapToPay: Bool = false
     @Published var presentTapToPayFeedback: Bool = false
@@ -106,11 +104,9 @@ final class InPersonPaymentsMenuViewModel: ObservableObject {
 
     init(siteID: Int64,
          dependencies: Dependencies,
-         navigationPath: Binding<NavigationPath>,
          payInPersonToggleViewModel: InPersonPaymentsCashOnDeliveryToggleRowViewModelProtocol = InPersonPaymentsCashOnDeliveryToggleRowViewModel()) {
         self.siteID = siteID
         self.dependencies = dependencies
-        self._navigationPath = navigationPath
         self.payInPersonToggleViewModel = payInPersonToggleViewModel
         observeOnboardingChanges()
         runCardPresentPaymentsOnboardingIfPossible()
@@ -128,9 +124,8 @@ final class InPersonPaymentsMenuViewModel: ObservableObject {
 
     /// Called when payment collection is shown to leave the payment collection flow.
     func dismissPaymentCollection() {
-        while navigationPath != navigationPathBeforePaymentCollection {
-            navigationPath.removeLast()
-        }
+        presentPaymentMethods = false
+        presentCollectPayment = false
     }
 
     private func updateOutputProperties() async {
@@ -278,8 +273,7 @@ private extension InPersonPaymentsMenuViewModel {
         presentCustomAmountAfterDismissingCollectPaymentMigrationSheet = false
         hasPresentedCollectPaymentMigrationSheet = false
         presentPaymentMethods = false
-        navigationPathBeforePaymentCollection = navigationPath
-        navigationPath.append(InPersonPaymentsMenuNavigationDestination.collectPayment)
+        presentCollectPayment = true
     }
 }
 
@@ -440,12 +434,6 @@ extension InPersonPaymentsMenuViewModel: DeepLinkNavigator {
             presentSetUpTryOutTapToPay = true
         }
     }
-}
-
-/// Destination views that the IPP menu can navigate to.
-/// Used in `NavigationPath` for programatic navigation in `NavigationStack` for deeplinking.
-enum InPersonPaymentsMenuNavigationDestination {
-    case collectPayment
 }
 
 private enum Constants {

--- a/WooCommerce/Classes/ViewRelated/Hub Menu/HubMenu.swift
+++ b/WooCommerce/Classes/ViewRelated/Hub Menu/HubMenu.swift
@@ -28,8 +28,8 @@ struct HubMenu: View {
                 .navigationDestination(for: String.self) { id in
                     detailView(menuID: id)
                 }
-                .navigationDestination(for: HubMenuNavigationDestination.self) { destination in
-                    detailView(destination: destination)
+                .navigationDestination(isPresented: $viewModel.showingPayments) {
+                    paymentsView
                 }
                 .navigationDestination(isPresented: $viewModel.showingReviewDetail) {
                     reviewDetailView
@@ -188,17 +188,6 @@ private extension HubMenu {
                 }
             default:
                 fatalError("🚨 Unsupported menu item")
-            }
-        }
-        .navigationBarTitleDisplayMode(.inline)
-    }
-
-    @ViewBuilder
-    func detailView(destination: HubMenuNavigationDestination) -> some View {
-        Group {
-            switch destination {
-                case .payments:
-                    paymentsView
             }
         }
         .navigationBarTitleDisplayMode(.inline)

--- a/WooCommerce/Classes/ViewRelated/Hub Menu/HubMenuViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Hub Menu/HubMenuViewModel.swift
@@ -117,8 +117,7 @@ final class HubMenuViewModel: ObservableObject {
                 onboardingUseCase: CardPresentPaymentsOnboardingUseCase(),
                 cardReaderSupportDeterminer: CardReaderSupportDeterminer(siteID: siteID),
                 wooPaymentsDepositService: WooPaymentsDepositService(siteID: siteID,
-                                                                     credentials: credentials)),
-            navigationPath: navigationPathBinding)
+                                                                     credentials: credentials)))
     }()
 
     private(set) var cardPresentPaymentService: CardPresentPaymentFacade?

--- a/WooCommerce/Classes/ViewRelated/Hub Menu/HubMenuViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Hub Menu/HubMenuViewModel.swift
@@ -63,6 +63,7 @@ final class HubMenuViewModel: ObservableObject {
 
     @Published var showingReviewDetail = false
     @Published var showingCoupons = false
+    @Published var showingPayments = false
 
     @Published private(set) var viewAppeared = false
 
@@ -101,15 +102,6 @@ final class HubMenuViewModel: ObservableObject {
     let tapToPayBadgePromotionChecker: TapToPayBadgePromotionChecker
 
     lazy var inPersonPaymentsMenuViewModel: InPersonPaymentsMenuViewModel = {
-        // There is no straightforward way to convert a @Published var to a Binding value because we cannot use $self.
-        let navigationPathBinding = Binding(
-            get: { [weak self] in
-                self?.navigationPath ?? NavigationPath()
-            },
-            set: { [weak self] in
-                self?.navigationPath = $0
-            }
-        )
         return InPersonPaymentsMenuViewModel(
             siteID: siteID,
             dependencies: .init(
@@ -170,8 +162,7 @@ final class HubMenuViewModel: ObservableObject {
 
     /// Shows the payments menu from the hub menu root view.
     func showPayments() {
-        navigationPath = .init()
-        navigationPath.append(HubMenuNavigationDestination.payments)
+        showingPayments = true
     }
 
     func showReviewDetails(using parcel: ProductReviewFromNoteParcel) {


### PR DESCRIPTION

<!-- Remember about a good descriptive title. -->

Closes: #13365
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

Using iOS 16, attempts to collect a custom amount via the Payments menu always failed, getting stuck when the user tapped `Collect Payment`.

This was due to mixing two different approaches to `navigationDestination` – using a path, and using isPresented variables. This appears to be unsupported, or at least buggy on iOS 16, it’s unclear which as it’s not documented as a limitation.

The issue manifested as the `presentPaymentMethods` binding not being respected, so it never moved on to let the user choose a payment method, but nor could they back out of the screen either.

To fix it, I’ve removed use of the path and standardised on `isPresented` bindings for both collectPayment and paymentMethod destinations.

## Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->

Using an iPad or simulator running iPadOS 16.x

1. Launch the app
2. Go to `Menu > Payments > Collect Payment`
3. Tap `Custom Amount`
4. Add a custom amount
5. Tap `Collect Payment`
6. Observe that you can complete a payment using any of the payment methods.

## Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->

This same method is used for deeplinks to collect payment. You can test this by long pressing on the app icon on the home screen, and selecting the collect payment action

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->


https://github.com/user-attachments/assets/bd4e9627-29f3-4101-a948-957d0f61c0cc


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
- [ ] This PR includes refactoring; smoke testing of the entire section is needed.