### PR TITLE
[Payments] Fix custom payment block on iPadOS16 using navigationPath to show payment methods

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -2,6 +2,10 @@
 *** Use [*****] to indicate smoke tests of all critical flows should be run on the final IPA before release (e.g. major library or OS update).
 
 
+19.9
+-----
+- [**] Fixed Collect Payment from the menu on iPads running iOS 16 [https://github.com/woocommerce/woocommerce-ios/pull/13491]
+
 19.8
 -----
 - [*] Add support to background update the order list and the dashboard analytics cards(Performance & Top Performers).

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Payments Menu/InPersonPaymentsMenu.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Payments Menu/InPersonPaymentsMenu.swift
@@ -224,7 +224,8 @@ struct InPersonPaymentsMenu: View {
                     }
                     .presentationDetents([.medium, .large])
                 }
-                .navigationDestination(isPresented: $viewModel.presentPaymentMethods) {
+                
+                .navigationDestination(for: CollectPaymentNavigationDestination.self) { destination in
                     if let paymentMethodsViewModel = viewModel.paymentMethodsViewModel {
                         PaymentMethodsWrapperHosted(viewModel: paymentMethodsViewModel,
                                                     dismiss: {

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Payments Menu/InPersonPaymentsMenu.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Payments Menu/InPersonPaymentsMenu.swift
@@ -224,7 +224,7 @@ struct InPersonPaymentsMenu: View {
                     }
                     .presentationDetents([.medium, .large])
                 }
-                
+
                 .navigationDestination(for: CollectPaymentNavigationDestination.self) { destination in
                     if let paymentMethodsViewModel = viewModel.paymentMethodsViewModel {
                         PaymentMethodsWrapperHosted(viewModel: paymentMethodsViewModel,

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Payments Menu/InPersonPaymentsMenuViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Payments Menu/InPersonPaymentsMenuViewModel.swift
@@ -31,8 +31,6 @@ final class InPersonPaymentsMenuViewModel: ObservableObject {
     @Published var hasPresentedCollectPaymentMigrationSheet: Bool = false
     /// Whether the custom amount flow should be presented after dismissing the payment collection migration sheet.
     @Published var presentCustomAmountAfterDismissingCollectPaymentMigrationSheet: Bool = false
-    /// Whether the payment methods view is shown after creating an order.
-    @Published var presentPaymentMethods: Bool = false
     @Published var presentSetUpTryOutTapToPay: Bool = false
     @Published var presentAboutTapToPay: Bool = false
     @Published var presentTapToPayFeedback: Bool = false
@@ -272,12 +270,11 @@ private extension InPersonPaymentsMenuViewModel {
                             dependencies.noticePresenter.enqueue(notice: .init(title: description, feedbackType: .error))
                     }
                 }
-            presentPaymentMethods = true
+            navigationPath.append(CollectPaymentNavigationDestination.paymentMethods)
         }
 
         presentCustomAmountAfterDismissingCollectPaymentMigrationSheet = false
         hasPresentedCollectPaymentMigrationSheet = false
-        presentPaymentMethods = false
         navigationPathBeforePaymentCollection = navigationPath
         navigationPath.append(InPersonPaymentsMenuNavigationDestination.collectPayment)
     }
@@ -446,6 +443,10 @@ extension InPersonPaymentsMenuViewModel: DeepLinkNavigator {
 /// Used in `NavigationPath` for programatic navigation in `NavigationStack` for deeplinking.
 enum InPersonPaymentsMenuNavigationDestination {
     case collectPayment
+}
+
+enum CollectPaymentNavigationDestination {
+    case paymentMethods
 }
 
 private enum Constants {


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #13365
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
Combining `navigationDestination(isPresented:)` with `navigationDestination(for:)` causes various issues with the navigation, differing between iOS 16 and 17.

Using iOS 16, attempts to collect a custom amount via the Payments menu always failed, getting stuck when the user tapped `Collect Payment`.

To fix it, I’ve standardised on navigation path bindings for both collectPayment and paymentMethod destinations.

Supersedes #13486, which did it the other way around.

## Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->

Using an iPad or simulator running iPadOS 16.x

1. Launch the app
2. Go to `Menu > Payments > Collect Payment`
3. Tap `Custom Amount`
4. Add a custom amount
5. Tap `Collect Payment`
6. Observe that you can complete a payment using any of the payment methods.


## Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->

This same method is used for deeplinks to collect payment. You can test this by long pressing on the app icon on the home screen, and selecting the collect payment action

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
- [ ] This PR includes refactoring; smoke testing of the entire section is needed.