### PR TITLE
[Woo POS] Add eligibility criteria to POS items

### DIFF
--- a/Networking/Networking.xcodeproj/project.pbxproj
+++ b/Networking/Networking.xcodeproj/project.pbxproj
@@ -505,6 +505,7 @@
 		621D043B29C9D4280040EC08 /* product-variation-alternative-types.json in Resources */ = {isa = PBXBuildFile; fileRef = 621D043A29C9D4280040EC08 /* product-variation-alternative-types.json */; };
 		6647C0161DAC6AB6570C53A7 /* Pods_Networking.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F3F25DC15EC1D7C631169CB5 /* Pods_Networking.framework */; };
 		6812FC012A6B27E100D7C625 /* InAppPurchasesTransactionMapperTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6812FC002A6B27E100D7C625 /* InAppPurchasesTransactionMapperTests.swift */; };
+		68255E442C60C6AA00090EBD /* products-load-all-for-eligibility-criteria.json in Resources */ = {isa = PBXBuildFile; fileRef = 68255E432C60C6AA00090EBD /* products-load-all-for-eligibility-criteria.json */; };
 		6846B0152A619A5C008EB143 /* InAppPurchasesTransactionMapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6846B0142A619A5C008EB143 /* InAppPurchasesTransactionMapper.swift */; };
 		6846B01B2A61B590008EB143 /* iap-transaction-handled.json in Resources */ = {isa = PBXBuildFile; fileRef = 6846B01A2A61B590008EB143 /* iap-transaction-handled.json */; };
 		684AB6D82AC2E93100106D7C /* order-with-special-character-currency.json in Resources */ = {isa = PBXBuildFile; fileRef = 684AB6D72AC2E93100106D7C /* order-with-special-character-currency.json */; };
@@ -1642,6 +1643,7 @@
 		61A45743E761BA40FF08B27D /* Pods-NetworkingWatchOS.release-alpha.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-NetworkingWatchOS.release-alpha.xcconfig"; path = "../Pods/Target Support Files/Pods-NetworkingWatchOS/Pods-NetworkingWatchOS.release-alpha.xcconfig"; sourceTree = "<group>"; };
 		621D043A29C9D4280040EC08 /* product-variation-alternative-types.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "product-variation-alternative-types.json"; sourceTree = "<group>"; };
 		6812FC002A6B27E100D7C625 /* InAppPurchasesTransactionMapperTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InAppPurchasesTransactionMapperTests.swift; sourceTree = "<group>"; };
+		68255E432C60C6AA00090EBD /* products-load-all-for-eligibility-criteria.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "products-load-all-for-eligibility-criteria.json"; sourceTree = "<group>"; };
 		6846B0142A619A5C008EB143 /* InAppPurchasesTransactionMapper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InAppPurchasesTransactionMapper.swift; sourceTree = "<group>"; };
 		6846B01A2A61B590008EB143 /* iap-transaction-handled.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "iap-transaction-handled.json"; sourceTree = "<group>"; };
 		684AB6D72AC2E93100106D7C /* order-with-special-character-currency.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "order-with-special-character-currency.json"; sourceTree = "<group>"; };
@@ -3426,6 +3428,7 @@
 				CE070A2F2BBC527900017578 /* gift-card-stats.json */,
 				CE070A332BBC52B200017578 /* gift-card-stats-without-data.json */,
 				68FBA53B2C290A5F0067B377 /* products-load-all-type-simple.json */,
+				68255E432C60C6AA00090EBD /* products-load-all-for-eligibility-criteria.json */,
 				CE21FB132C2AC87000303832 /* google-ads-reports-programs-without-data.json */,
 				CE21FB232C2C16DA00303832 /* google-ads-reports-programs.json */,
 			);
@@ -4471,6 +4474,7 @@
 				DEB387782C2A9ADC0025256E /* gla-connection-with-data-envelope.json in Resources */,
 				EE57C134297F985A00BC31E7 /* product-variations-bulk-update-without-data.json in Resources */,
 				CE865A9F2A41E42F0049B03C /* date-modified-gmt.json in Resources */,
+				68255E442C60C6AA00090EBD /* products-load-all-for-eligibility-criteria.json in Resources */,
 				2683D71024456EE4002A1589 /* categories-extra.json in Resources */,
 				A69FE19D2588D70E0059A96B /* order-with-deleted-refunds.json in Resources */,
 				E18152C228F85E0A0011A0EC /* iap-products.json in Resources */,

--- a/Networking/NetworkingTests/Responses/products-load-all-for-eligibility-criteria.json
+++ b/Networking/NetworkingTests/Responses/products-load-all-for-eligibility-criteria.json
@@ -1,0 +1,580 @@
+{
+    "data": [
+        {
+            "id": 208,
+            "name": "Dymo LabelWriter 4XL",
+            "slug": "dymo-labelwriter-4xl",
+            "permalink": "https://example.com/product/dymo-labelwriter-4xl/",
+            "date_created": "2018-05-07T21:02:28",
+            "date_created_gmt": "2018-05-07T21:02:28",
+            "date_modified": "2019-02-19T18:22:50",
+            "date_modified_gmt": "2019-02-19T18:22:50",
+            "type": "simple",
+            "status": "publish",
+            "featured": false,
+            "catalog_visibility": "visible",
+            "description": "<ul class=\"a-unordered-list a-vertical a-spacing-none\">\n<li><span class=\"a-list-item\">Print Extra Large Shipping Labels up to 4” x 6”</span></li>\n<li><span class=\"a-list-item\">Select from over 60 professional label templates and customize text and graphics with free DYMO Label Software</span></li>\n<li><span class=\"a-list-item\">Compatible with Microsoft Office, Quickbooks, and More</span></li>\n<li><span class=\"a-list-item\">Print shipping labels directly from popular online selling platforms such as DYMO Stamps, eBay, Amazon, Etsy, and Iabol</span></li>\n<li><span class=\"a-list-item\">Direct thermal printing eliminates the need for costly ink or toner</span></li>\n<li><span class=\"a-list-item\">Print USPS-approved DYMO Stamps from your desktop - no monthly fee, contracts, or commitments (US only)</span></li>\n<li><span class=\"a-list-item\">System Requirements: Windows 7 or later, Mac OS v10.10 or later</span></li>\n<li><span class=\"a-list-item\">Includes: LabelWriter® 4XL printer, adapter, power cable, USB 2.0 cable, Quick Start guide, and starter roll of 4x6 extra large shipping labels</span></li>\n<li><span class=\"a-list-item\">For best results use DYMO authentic labels only</span></li>\n<li>Bonus: 1 extra roll of labels when you pay with points!</li>\n</ul>\n<div class=\"a-row a-expander-container a-expander-inline-container\" aria-live=\"polite\">\n<div class=\"a-expander-content a-expander-extend-content a-expander-content-expanded\" aria-expanded=\"true\"></div>\n</div>\n",
+            "short_description": "<h4 class=\"a-spacing-mini a-color-secondary a-text-italic\">High Volume Jobs? Not a Problem.</h4>\n<p class=\"a-spacing-base\">The DYMO LabelWriter 4XL is a wide-format label printer that accommodates the entire line of LabelWriter labels for maximum flexibility, and is also compatible with a variety of popular online selling platforms and shipping carriers. It&#8217;s ideal for extra-large shipping and warehouse labels, along with label styles for file folders, name badges, and more. It&#8217;s ideal for extra-large shipping and warehouse labels, including 4 inch international shipping labels, along with label styles for file folders, name badges, online postage, mailing and shipping labels, and more.</p>\n",
+            "sku": "",
+            "price": "216",
+            "regular_price": "279",
+            "sale_price": "216",
+            "date_on_sale_from": null,
+            "date_on_sale_from_gmt": null,
+            "date_on_sale_to": null,
+            "date_on_sale_to_gmt": null,
+            "price_html": "<del><span class=\"woocommerce-Price-amount amount\"><span class=\"woocommerce-Price-currencySymbol\">&#36;</span>279.00</span></del> <ins><span class=\"woocommerce-Price-amount amount\"><span class=\"woocommerce-Price-currencySymbol\">&#36;</span>216.00</span></ins>",
+            "on_sale": true,
+            "purchasable": true,
+            "total_sales": 2,
+            "virtual": false,
+            "downloadable": false,
+            "downloads": [],
+            "download_limit": -1,
+            "download_expiry": -1,
+            "external_url": "",
+            "button_text": "",
+            "tax_status": "taxable",
+            "tax_class": "",
+            "manage_stock": false,
+            "stock_quantity": null,
+            "stock_status": "onbackorder",
+            "backorders": "no",
+            "backorders_allowed": false,
+            "backordered": true,
+            "sold_individually": true,
+            "weight": "64",
+            "dimensions": {
+                "length": "10.2",
+                "width": "10",
+                "height": "10"
+            },
+            "shipping_required": true,
+            "shipping_taxable": true,
+            "shipping_class": "",
+            "shipping_class_id": 0,
+            "reviews_allowed": true,
+            "average_rating": "0.00",
+            "rating_count": 0,
+            "related_ids": [
+                26,
+                27,
+                28,
+                29
+            ],
+            "upsell_ids": [],
+            "cross_sell_ids": [],
+            "parent_id": 0,
+            "purchase_note": "",
+            "categories": [
+                {
+                    "id": 15,
+                    "name": "Accessories",
+                    "slug": "accessories"
+                }
+            ],
+            "tags": [],
+            "images": [
+                {
+                    "id": 209,
+                    "date_created": "2018-05-07T21:02:45",
+                    "date_created_gmt": "2018-05-07T21:02:45",
+                    "date_modified": "2018-05-07T21:03:04",
+                    "date_modified_gmt": "2018-05-07T21:03:04",
+                    "src": "https://i0.wp.com/thuy-nonjtpk.mystagingwebsite.com/wp-content/uploads/2018/05/71PEq6VvFjL._SL1500_.jpg?fit=1500%2C1500&ssl=1",
+                    "name": "Dymo LabelWriter 4XL",
+                    "alt": ""
+                }
+            ],
+            "attributes": [],
+            "default_attributes": [],
+            "variations": [],
+            "grouped_products": [],
+            "menu_order": 0,
+            "meta_data": [
+                {
+                    "id": 5981,
+                    "key": "_wpas_done_all",
+                    "value": "1"
+                },
+                {
+                    "id": 6847,
+                    "key": "_wc_pre_orders_enabled",
+                    "value": "yes"
+                },
+                {
+                    "id": 6848,
+                    "key": "_wc_pre_orders_availability_datetime",
+                    "value": "1587262140"
+                },
+                {
+                    "id": 6849,
+                    "key": "_wc_pre_orders_fee",
+                    "value": "2"
+                },
+                {
+                    "id": 6850,
+                    "key": "_wc_pre_orders_when_to_charge",
+                    "value": "upon_release"
+                }
+            ],
+            "jetpack_publicize_connections": [],
+            "_links": {
+                "self": [
+                    {
+                        "href": "https://example.com/wp-json/wc/v3/products/208"
+                    }
+                ],
+                "collection": [
+                    {
+                        "href": "https://example.com/wp-json/wc/v3/products"
+                    }
+                ]
+            }
+        },
+        {
+            "id": 35,
+            "name": "Virtual Polo",
+            "slug": "virtual-polo",
+            "permalink": "https://example.com/product/virtual-polo/",
+            "date_created": "2018-01-26T21:49:46",
+            "date_created_gmt": "2018-01-26T21:49:46",
+            "date_modified": "2018-09-19T17:46:25",
+            "date_modified_gmt": "2018-09-19T17:46:25",
+            "type": "simple",
+            "status": "publish",
+            "featured": false,
+            "catalog_visibility": "visible",
+            "description": "<p>Pellentesque habitant morbi tristique senectus et netus et malesuada fames ac turpis egestas. Vestibulum tortor quam, feugiat vitae, ultricies eget, tempor sit amet, ante. Donec eu libero sit amet quam egestas semper. Aenean ultricies mi vitae est. Mauris placerat eleifend leo.</p>\n",
+            "short_description": "",
+            "sku": "",
+            "price": "207",
+            "regular_price": "207",
+            "sale_price": "",
+            "date_on_sale_from": null,
+            "date_on_sale_from_gmt": null,
+            "date_on_sale_to": null,
+            "date_on_sale_to_gmt": null,
+            "price_html": "<span class=\"woocommerce-Price-amount amount\"><span class=\"woocommerce-Price-currencySymbol\">&#36;</span>207.00</span>",
+            "on_sale": false,
+            "purchasable": true,
+            "total_sales": 2,
+            "virtual": true,
+            "downloadable": false,
+            "downloads": [],
+            "download_limit": -1,
+            "download_expiry": -1,
+            "external_url": "",
+            "button_text": "",
+            "tax_status": "taxable",
+            "tax_class": "",
+            "manage_stock": false,
+            "stock_quantity": null,
+            "stock_status": "instock",
+            "backorders": "no",
+            "backorders_allowed": false,
+            "backordered": false,
+            "sold_individually": false,
+            "weight": "",
+            "dimensions": {
+                "length": "",
+                "width": "",
+                "height": ""
+            },
+            "shipping_required": true,
+            "shipping_taxable": true,
+            "shipping_class": "",
+            "shipping_class_id": 0,
+            "reviews_allowed": true,
+            "average_rating": "0.00",
+            "rating_count": 0,
+            "related_ids": [
+                36,
+                37,
+                34
+            ],
+            "upsell_ids": [],
+            "cross_sell_ids": [],
+            "parent_id": 0,
+            "purchase_note": "",
+            "categories": [
+                {
+                    "id": 17,
+                    "name": "Tshirts",
+                    "slug": "tshirts"
+                }
+            ],
+            "tags": [],
+            "images": [
+                {
+                    "id": 16,
+                    "date_created": "2018-01-26T21:49:45",
+                    "date_created_gmt": "2018-01-26T21:49:45",
+                    "date_modified": "2018-01-26T21:49:45",
+                    "date_modified_gmt": "2018-01-26T21:49:45",
+                    "src": "https://i1.wp.com/thuy-nonjtpk.mystagingwebsite.com/wp-content/uploads/2018/01/polo.jpg?fit=801%2C800&ssl=1",
+                    "name": "Polo",
+                    "alt": ""
+                }
+            ],
+            "attributes": [],
+            "default_attributes": [],
+            "variations": [],
+            "grouped_products": [],
+            "menu_order": 0,
+            "meta_data": [
+                {
+                    "id": 104,
+                    "key": "_customize_changeset_uuid",
+                    "value": "e96101a5-dc4f-4cd7-8f38-30db941b1a97"
+                }
+            ],
+            "jetpack_publicize_connections": [],
+            "_links": {
+                "self": [
+                    {
+                        "href": "https://example.com/wp-json/wc/v3/products/35"
+                    }
+                ],
+                "collection": [
+                    {
+                        "href": "https://example.com/wp-json/wc/v3/products"
+                    }
+                ]
+            }
+        },
+        {
+            "id": 34,
+            "name": "Downloadable Long Sleeve Tee",
+            "slug": "downloadable-long-sleeve-tee",
+            "permalink": "https://example.com/product/downloadable-long-sleeve-tee/",
+            "date_created": "2018-01-26T21:49:46",
+            "date_created_gmt": "2018-01-26T21:49:46",
+            "date_modified": "2018-09-19T17:46:38",
+            "date_modified_gmt": "2018-09-19T17:46:38",
+            "type": "simple",
+            "status": "publish",
+            "featured": false,
+            "catalog_visibility": "visible",
+            "description": "<p>Pellentesque habitant morbi tristique senectus et netus et malesuada fames ac turpis egestas. Vestibulum tortor quam, feugiat vitae, ultricies eget, tempor sit amet, ante. Donec eu libero sit amet quam egestas semper. Aenean ultricies mi vitae est. Mauris placerat eleifend leo.</p>\n",
+            "short_description": "",
+            "sku": "",
+            "price": "2517",
+            "regular_price": "2517",
+            "sale_price": "",
+            "date_on_sale_from": null,
+            "date_on_sale_from_gmt": null,
+            "date_on_sale_to": null,
+            "date_on_sale_to_gmt": null,
+            "price_html": "<span class=\"woocommerce-Price-amount amount\"><span class=\"woocommerce-Price-currencySymbol\">&#36;</span>2,517.00</span>",
+            "on_sale": false,
+            "purchasable": true,
+            "total_sales": 3,
+            "virtual": false,
+            "downloadable": true,
+            "downloads": [],
+            "download_limit": -1,
+            "download_expiry": -1,
+            "external_url": "",
+            "button_text": "",
+            "tax_status": "taxable",
+            "tax_class": "",
+            "manage_stock": false,
+            "stock_quantity": null,
+            "stock_status": "instock",
+            "backorders": "no",
+            "backorders_allowed": false,
+            "backordered": false,
+            "sold_individually": false,
+            "weight": "",
+            "dimensions": {
+                "length": "",
+                "width": "",
+                "height": ""
+            },
+            "shipping_required": true,
+            "shipping_taxable": true,
+            "shipping_class": "",
+            "shipping_class_id": 0,
+            "reviews_allowed": true,
+            "average_rating": "0.00",
+            "rating_count": 0,
+            "related_ids": [
+                36,
+                37,
+                35
+            ],
+            "upsell_ids": [],
+            "cross_sell_ids": [],
+            "parent_id": 0,
+            "purchase_note": "",
+            "categories": [
+                {
+                    "id": 17,
+                    "name": "Tshirts",
+                    "slug": "tshirts"
+                }
+            ],
+            "tags": [],
+            "images": [
+                {
+                    "id": 15,
+                    "date_created": "2018-01-26T21:49:45",
+                    "date_created_gmt": "2018-01-26T21:49:45",
+                    "date_modified": "2018-01-26T21:49:45",
+                    "date_modified_gmt": "2018-01-26T21:49:45",
+                    "src": "https://i2.wp.com/thuy-nonjtpk.mystagingwebsite.com/wp-content/uploads/2018/01/long-sleeve-tee.jpg?fit=801%2C801&ssl=1",
+                    "name": "Long Sleeve Tee",
+                    "alt": ""
+                }
+            ],
+            "attributes": [],
+            "default_attributes": [],
+            "variations": [],
+            "grouped_products": [],
+            "menu_order": 0,
+            "meta_data": [
+                {
+                    "id": 101,
+                    "key": "_customize_changeset_uuid",
+                    "value": "e96101a5-dc4f-4cd7-8f38-30db941b1a97"
+                }
+            ],
+            "jetpack_publicize_connections": [],
+            "_links": {
+                "self": [
+                    {
+                        "href": "https://example.com/wp-json/wc/v3/products/34"
+                    }
+                ],
+                "collection": [
+                    {
+                        "href": "https://example.com/wp-json/wc/v3/products"
+                    }
+                ]
+            }
+        },
+        {
+            "id": 33,
+            "name": "Private Hoodie",
+            "slug": "private-hoodie",
+            "permalink": "https://example.com/product/private-hoodie/",
+            "date_created": "2018-01-26T21:49:46",
+            "date_created_gmt": "2018-01-26T21:49:46",
+            "date_modified": "2018-01-26T21:49:46",
+            "date_modified_gmt": "2018-01-26T21:49:46",
+            "type": "simple",
+            "status": "private",
+            "featured": true,
+            "catalog_visibility": "visible",
+            "description": "<p>Pellentesque habitant morbi tristique senectus et netus et malesuada fames ac turpis egestas. Vestibulum tortor quam, feugiat vitae, ultricies eget, tempor sit amet, ante. Donec eu libero sit amet quam egestas semper. Aenean ultricies mi vitae est. Mauris placerat eleifend leo.</p>\n",
+            "short_description": "",
+            "sku": "",
+            "price": "42",
+            "regular_price": "45",
+            "sale_price": "42",
+            "date_on_sale_from": null,
+            "date_on_sale_from_gmt": null,
+            "date_on_sale_to": null,
+            "date_on_sale_to_gmt": null,
+            "price_html": "<del><span class=\"woocommerce-Price-amount amount\"><span class=\"woocommerce-Price-currencySymbol\">&#36;</span>45.00</span></del> <ins><span class=\"woocommerce-Price-amount amount\"><span class=\"woocommerce-Price-currencySymbol\">&#36;</span>42.00</span></ins>",
+            "on_sale": true,
+            "purchasable": true,
+            "total_sales": 2,
+            "virtual": false,
+            "downloadable": false,
+            "downloads": [],
+            "download_limit": -1,
+            "download_expiry": -1,
+            "external_url": "",
+            "button_text": "",
+            "tax_status": "taxable",
+            "tax_class": "",
+            "manage_stock": false,
+            "stock_quantity": null,
+            "stock_status": "instock",
+            "backorders": "no",
+            "backorders_allowed": false,
+            "backordered": false,
+            "sold_individually": false,
+            "weight": "",
+            "dimensions": {
+                "length": "",
+                "width": "",
+                "height": ""
+            },
+            "shipping_required": true,
+            "shipping_taxable": true,
+            "shipping_class": "",
+            "shipping_class_id": 0,
+            "reviews_allowed": true,
+            "average_rating": "0.00",
+            "rating_count": 0,
+            "related_ids": [
+                31,
+                32,
+                30
+            ],
+            "upsell_ids": [],
+            "cross_sell_ids": [],
+            "parent_id": 0,
+            "purchase_note": "",
+            "categories": [
+                {
+                    "id": 16,
+                    "name": "Hoodies",
+                    "slug": "hoodies"
+                }
+            ],
+            "tags": [],
+            "images": [
+                {
+                    "id": 14,
+                    "date_created": "2018-01-26T21:49:45",
+                    "date_created_gmt": "2018-01-26T21:49:45",
+                    "date_modified": "2018-01-26T21:49:45",
+                    "date_modified_gmt": "2018-01-26T21:49:45",
+                    "src": "https://i0.wp.com/thuy-nonjtpk.mystagingwebsite.com/wp-content/uploads/2018/01/hoodie.jpg?fit=801%2C801&ssl=1",
+                    "name": "Hoodie",
+                    "alt": ""
+                }
+            ],
+            "attributes": [],
+            "default_attributes": [],
+            "variations": [],
+            "grouped_products": [],
+            "menu_order": 0,
+            "meta_data": [
+                {
+                    "id": 98,
+                    "key": "_customize_changeset_uuid",
+                    "value": "e96101a5-dc4f-4cd7-8f38-30db941b1a97"
+                }
+            ],
+            "jetpack_publicize_connections": [],
+            "_links": {
+                "self": [
+                    {
+                        "href": "https://example.com/wp-json/wc/v3/products/33"
+                    }
+                ],
+                "collection": [
+                    {
+                        "href": "https://example.com/wp-json/wc/v3/products"
+                    }
+                ]
+            }
+        },
+        {
+            "id": 32,
+            "name": "Hoodie with Zipper without price",
+            "slug": "hoodie-with-zipper-without-price",
+            "permalink": "https://example.com/product/hoodie-with-zipper-without-price/",
+            "date_created": "2018-01-26T21:49:46",
+            "date_created_gmt": "2018-01-26T21:49:46",
+            "date_modified": "2018-09-19T17:46:50",
+            "date_modified_gmt": "2018-09-19T17:46:50",
+            "type": "simple",
+            "status": "publish",
+            "featured": true,
+            "catalog_visibility": "visible",
+            "description": "<p>Pellentesque habitant morbi tristique senectus et netus et malesuada fames ac turpis egestas. Vestibulum tortor quam, feugiat vitae, ultricies eget, tempor sit amet, ante. Donec eu libero sit amet quam egestas semper. Aenean ultricies mi vitae est. Mauris placerat eleifend leo.</p>\n",
+            "short_description": "",
+            "sku": "",
+            "price": "",
+            "regular_price": "",
+            "sale_price": "",
+            "date_on_sale_from": null,
+            "date_on_sale_from_gmt": null,
+            "date_on_sale_to": null,
+            "date_on_sale_to_gmt": null,
+            "price_html": "<span class=\"woocommerce-Price-amount amount\"><span class=\"woocommerce-Price-currencySymbol\">&#36;</span>4,537.00</span>",
+            "on_sale": false,
+            "purchasable": true,
+            "total_sales": 5,
+            "virtual": false,
+            "downloadable": false,
+            "downloads": [],
+            "download_limit": -1,
+            "download_expiry": -1,
+            "external_url": "",
+            "button_text": "",
+            "tax_status": "taxable",
+            "tax_class": "",
+            "manage_stock": false,
+            "stock_quantity": null,
+            "stock_status": "instock",
+            "backorders": "no",
+            "backorders_allowed": false,
+            "backordered": false,
+            "sold_individually": false,
+            "weight": "",
+            "dimensions": {
+                "length": "",
+                "width": "",
+                "height": ""
+            },
+            "shipping_required": true,
+            "shipping_taxable": true,
+            "shipping_class": "",
+            "shipping_class_id": 0,
+            "reviews_allowed": true,
+            "average_rating": "0.00",
+            "rating_count": 0,
+            "related_ids": [
+                30,
+                31,
+                33
+            ],
+            "upsell_ids": [],
+            "cross_sell_ids": [],
+            "parent_id": 0,
+            "purchase_note": "",
+            "categories": [
+                {
+                    "id": 16,
+                    "name": "Hoodies",
+                    "slug": "hoodies"
+                }
+            ],
+            "tags": [],
+            "images": [
+                {
+                    "id": 13,
+                    "date_created": "2018-01-26T21:49:45",
+                    "date_created_gmt": "2018-01-26T21:49:45",
+                    "date_modified": "2018-01-26T21:49:45",
+                    "date_modified_gmt": "2018-01-26T21:49:45",
+                    "src": "https://i1.wp.com/thuy-nonjtpk.mystagingwebsite.com/wp-content/uploads/2018/01/hoodie-with-zipper.jpg?fit=800%2C800&ssl=1",
+                    "name": "Hoodie with Zipper",
+                    "alt": ""
+                }
+            ],
+            "attributes": [],
+            "default_attributes": [],
+            "variations": [],
+            "grouped_products": [],
+            "menu_order": 0,
+            "meta_data": [
+                {
+                    "id": 95,
+                    "key": "_customize_changeset_uuid",
+                    "value": "e96101a5-dc4f-4cd7-8f38-30db941b1a97"
+                }
+            ],
+            "jetpack_publicize_connections": [],
+            "_links": {
+                "self": [
+                    {
+                        "href": "https://example.com/wp-json/wc/v3/products/32"
+                    }
+                ],
+                "collection": [
+                    {
+                        "href": "https://example.com/wp-json/wc/v3/products"
+                    }
+                ]
+            }
+        }
+    ]
+}

--- a/Yosemite/YosemiteTests/PointOfSale/POSProductProviderTests.swift
+++ b/Yosemite/YosemiteTests/PointOfSale/POSProductProviderTests.swift
@@ -38,6 +38,7 @@ final class POSProductProviderTests: XCTestCase {
         let expectedProductID: Int64 = 208
         let expectedProductPrice = "216"
         let expectedFormattedPrice = "$216.00"
+        let expectedNumberOfEligibleProducts = 6
 
         // When
         network.simulateResponse(requestUrlSuffix: "products", filename: "products-load-all-type-simple")
@@ -47,9 +48,30 @@ final class POSProductProviderTests: XCTestCase {
         guard let product = expectedItems.first else {
             return XCTFail("No eligible products")
         }
+        XCTAssertEqual(expectedItems.count, expectedNumberOfEligibleProducts)
         XCTAssertEqual(product.name, expectedProductName)
         XCTAssertEqual(product.productID, expectedProductID)
         XCTAssertEqual(product.price, expectedProductPrice)
         XCTAssertEqual(product.formattedPrice, expectedFormattedPrice)
+    }
+
+    func test_POSItemProvider_when_eligibility_criteria_applies_then_returns_correct_number_of_items() async throws {
+        // Given
+        let expectedNumberOfItems = 2
+        let expectedItemNames = ["Dymo LabelWriter 4XL", "Private Hoodie"]
+
+        // When
+        network.simulateResponse(requestUrlSuffix: "products", filename: "products-load-all-for-eligibility-criteria")
+        let expectedItems = try await itemProvider.providePointOfSaleItems()
+
+        // Then
+        XCTAssertEqual(expectedItems.count, expectedNumberOfItems)
+
+        guard let firstEligibleItem = expectedItems.first,
+              let secondEligibleItem = expectedItems.last else {
+            return XCTFail("Expected \(expectedNumberOfItems) eligible items. Got \(expectedItems.count) instead.")
+        }
+        XCTAssertEqual(firstEligibleItem.name, expectedItemNames.first)
+        XCTAssertEqual(secondEligibleItem.name, expectedItemNames.last)
     }
 }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #13394
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
Apologies for the 500+ PR, most of it is the JSON file that we use for the unit tests 🙇 

This PR adds further eligibility criteria to the simple products that we fetch from the API, and later map to become POS products. Initially we just take all simple products, now we add the following additional constraints to which products can be displayed and used in POS mode:

- Status: Published, or private.
- Product price: Must have price.
- Virtual: False. Only physical products are allowed.
- Downloadable: False. Only physical products are allowed.

❓ Question: Some of these properties can be set directly in the network request (eg: virtual, downloadable, ... as we do with the simple type) so we can directly fetch a narrower list, however, other properties like the product status does not accept an array of values, but only one value. 

For this reason I've opted to keep all criteria in the same place in this PR, but I'm happy to iterate further if you think it would make more sense to just move part of this to the networking layer and keep eligibility criteria within the business layer to a minimum.

## Changes
We apply a filter to the Products we get from the network, before mapping them to be POS items, so only those that fit our eligibility criteria will be effectively mapped.

## Screenshots
| Before (all simple products) vs After (eligible products only) |
|--------|
| ![simulator_screenshot_43B4122E-8B46-4428-9295-F888D6817BD9](https://github.com/user-attachments/assets/a1eb7e7b-4545-4d26-a6d3-e32ac010ba06) |
| ![Simulator Screenshot - iPad Pro (12 9-inch) (6th generation) - 2024-08-05 at 16 14 58](https://github.com/user-attachments/assets/1fb1eee1-9925-4737-8d16-b467eb0e3fce) | 

## Testing
- Run the POS using a store with products that should not be eligible, eg: Virtual products, downloadable products, products without price.
- Observe that non-eligible products do not show in the dashboard.
