### PR TITLE
[Woo POS] Reader not connected in checkout view

### DIFF
--- a/WooCommerce/Classes/POS/Presentation/Card Present Payments/Reader Messages/PointOfSaleCardPresentPaymentDisconnectedMessageViewModel.swift
+++ b/WooCommerce/Classes/POS/Presentation/Card Present Payments/Reader Messages/PointOfSaleCardPresentPaymentDisconnectedMessageViewModel.swift
@@ -2,6 +2,7 @@ import Foundation
 
 struct PointOfSaleCardPresentPaymentReaderDisconnectedMessageViewModel {
     let title = Localization.title
+    let instruction = Localization.instruction
     let collectPaymentButtonViewModel: CardPresentPaymentsModalButtonViewModel
 
     init(collectPaymentAction: @escaping () -> Void) {
@@ -14,15 +15,21 @@ struct PointOfSaleCardPresentPaymentReaderDisconnectedMessageViewModel {
 private extension PointOfSaleCardPresentPaymentReaderDisconnectedMessageViewModel {
     enum Localization {
         static let title = NSLocalizedString(
-            "pointOfSale.cardPresent.readerDisconnected.title",
-            value: "Reader disconnected",
-            comment: "Error message. Presented to users when reader is disconnected on the Point of Sale Checkout"
+            "pointOfSale.cardPresent.readerNotConnected.title",
+            value: "Reader not connected",
+            comment: "Error message. Presented to users when card reader is not connected on the Point of Sale Checkout"
+        )
+
+        static let instruction = NSLocalizedString(
+            "pointOfSale.cardPresent.readerNotConnected.instruction",
+            value: "To process this payment, please connect your reader.",
+            comment: "Instruction to merchants shown on the Point of Sale Checkout, so they can take a card payment."
         )
 
         static let collectPayment =  NSLocalizedString(
-            "pointOfSale.cardPresent.readerDisconnected.button.title",
-            value: "Collect Payment",
-            comment: "Button to try to collect a payment again. Presented to users after connecting to reader fails on the Point of Sale Checkout"
+            "pointOfSale.cardPresent.readerNotConnected.button.title",
+            value: "Connect to reader",
+            comment: "Button to connect to the card reader, shown on the Point of Sale Checkout as a primary CTA."
         )
     }
 }

--- a/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/Reader Messages/PointOfSaleCardPresentPaymentDisconnectedMessageView.swift
+++ b/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/Reader Messages/PointOfSaleCardPresentPaymentDisconnectedMessageView.swift
@@ -4,24 +4,26 @@ struct PointOfSaleCardPresentPaymentReaderDisconnectedMessageView: View {
     let viewModel: PointOfSaleCardPresentPaymentReaderDisconnectedMessageViewModel
 
     var body: some View {
-        HStack(alignment: .center) {
-            Spacer()
-            VStack(alignment: .center) {
-                VStack(alignment: .center, spacing: PointOfSaleCardPresentPaymentLayout.textSpacing) {
-                    Text(viewModel.title)
-                        .font(.posTitle)
-                        .foregroundStyle(Color.posPrimaryTexti3)
-                        .bold()
-                }
+        VStack(alignment: .center, spacing: PointOfSaleCardPresentPaymentLayout.errorElementSpacing) {
+            POSErrorExclamationMark()
 
-                HStack {
-                    Button(viewModel.collectPaymentButtonViewModel.title, action: viewModel.collectPaymentButtonViewModel.actionHandler)
-                }
-                .padding()
+            VStack(alignment: .center, spacing: PointOfSaleCardPresentPaymentLayout.textSpacing) {
+                Text(viewModel.title)
+                    .font(.posTitle)
+                    .foregroundStyle(Color.posPrimaryTexti3)
+                    .bold()
+                Text(viewModel.instruction)
+                    .font(.posBody)
+                    .foregroundStyle(Color.posPrimaryTexti3)
             }
-            .multilineTextAlignment(.center)
-            Spacer()
+
+            Button(action: viewModel.collectPaymentButtonViewModel.actionHandler) {
+                Text(viewModel.collectPaymentButtonViewModel.title)
+            }
+            .buttonStyle(POSPrimaryButtonStyle())
+            .padding(.horizontal, 40)
         }
+        .multilineTextAlignment(.center)
     }
 }
 

--- a/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/Reader Messages/PointOfSaleCardPresentPaymentDisconnectedMessageView.swift
+++ b/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/Reader Messages/PointOfSaleCardPresentPaymentDisconnectedMessageView.swift
@@ -21,8 +21,8 @@ struct PointOfSaleCardPresentPaymentReaderDisconnectedMessageView: View {
                 Text(viewModel.collectPaymentButtonViewModel.title)
             }
             .buttonStyle(POSPrimaryButtonStyle())
-            .padding(.horizontal, 40)
         }
+        .padding(.horizontal, PointOfSaleCardPresentPaymentLayout.horizontalPadding)
         .multilineTextAlignment(.center)
     }
 }

--- a/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/Reader Messages/PointOfSaleCardPresentPaymentLayout.swift
+++ b/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/Reader Messages/PointOfSaleCardPresentPaymentLayout.swift
@@ -6,4 +6,5 @@ enum PointOfSaleCardPresentPaymentLayout {
     static let textSpacing: CGFloat = 4
     static let errorElementSpacing: CGFloat = 40
     static let errorIconSize: CGFloat = 64
+    static let horizontalPadding: CGFloat = 40
 }

--- a/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/Reader Messages/PointOfSaleCardPresentPaymentLayout.swift
+++ b/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/Reader Messages/PointOfSaleCardPresentPaymentLayout.swift
@@ -4,4 +4,5 @@ enum PointOfSaleCardPresentPaymentLayout {
     static let headerSize: CGSize = .init(width: 156, height: 156)
     static let headerSpacing: CGFloat = 72
     static let textSpacing: CGFloat = 4
+    static let errorElementSpacing: CGFloat = 40
 }

--- a/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/Reader Messages/PointOfSaleCardPresentPaymentLayout.swift
+++ b/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/Reader Messages/PointOfSaleCardPresentPaymentLayout.swift
@@ -5,4 +5,5 @@ enum PointOfSaleCardPresentPaymentLayout {
     static let headerSpacing: CGFloat = 72
     static let textSpacing: CGFloat = 4
     static let errorElementSpacing: CGFloat = 40
+    static let errorIconSize: CGFloat = 64
 }

--- a/WooCommerce/Classes/POS/Presentation/CartView.swift
+++ b/WooCommerce/Classes/POS/Presentation/CartView.swift
@@ -110,7 +110,6 @@ private extension CartView {
         static let clearButtonBorderWidth: CGFloat = 2
         static let clearButtonTextPadding = EdgeInsets(top: 8, leading: 24, bottom: 8, trailing: 24)
         static let checkoutButtonPadding: CGFloat = 16
-        static let checkoutButtonHeight: CGFloat = 80
         static let itemHorizontalPadding: CGFloat = 8
         static let horizontalPadding: CGFloat = 16
         static let verticalPadding: CGFloat = 8
@@ -141,14 +140,9 @@ private extension CartView {
         Button {
             cartViewModel.submitCart()
         } label: {
-            HStack {
-                Spacer()
-                Text("Check out")
-                Spacer()
-            }
-            .frame(minHeight: Constants.checkoutButtonHeight)
+            Text("Check out")
         }
-        .buttonStyle(POSCheckoutButtonStyle())
+        .buttonStyle(POSPrimaryButtonStyle())
     }
 
     @ViewBuilder
@@ -166,16 +160,6 @@ private extension CartView {
             }
 
         }
-    }
-}
-
-struct POSCheckoutButtonStyle: ButtonStyle {
-    func makeBody(configuration: Configuration) -> some View {
-        configuration.label
-            .font(.system(size: 24, weight: .bold))
-            .background(Color.posCheckoutBackground)
-            .foregroundColor(Color.white)
-            .cornerRadius(8.0)
     }
 }
 

--- a/WooCommerce/Classes/POS/Presentation/Reusable Views/POSErrorExclamationMark.swift
+++ b/WooCommerce/Classes/POS/Presentation/Reusable Views/POSErrorExclamationMark.swift
@@ -1,0 +1,13 @@
+import SwiftUI
+
+struct POSErrorExclamationMark: View {
+    var body: some View {
+        Image(systemName: "exclamationmark.circle.fill")
+            .font(.system(size: 64))
+            .foregroundStyle(Color.wooAmberShade60)
+    }
+}
+
+#Preview {
+    POSErrorExclamationMark()
+}

--- a/WooCommerce/Classes/POS/Presentation/Reusable Views/POSErrorExclamationMark.swift
+++ b/WooCommerce/Classes/POS/Presentation/Reusable Views/POSErrorExclamationMark.swift
@@ -3,7 +3,7 @@ import SwiftUI
 struct POSErrorExclamationMark: View {
     var body: some View {
         Image(systemName: "exclamationmark.circle.fill")
-            .font(.system(size: 64))
+            .font(.system(size: PointOfSaleCardPresentPaymentLayout.errorIconSize))
             .foregroundStyle(Color.wooAmberShade60)
     }
 }

--- a/WooCommerce/Classes/POS/Presentation/Reusable Views/POSPrimaryButtonStyle.swift
+++ b/WooCommerce/Classes/POS/Presentation/Reusable Views/POSPrimaryButtonStyle.swift
@@ -1,0 +1,23 @@
+import SwiftUI
+
+struct POSPrimaryButtonStyle: ButtonStyle {
+    func makeBody(configuration: Configuration) -> some View {
+        HStack {
+            Spacer()
+            configuration.label
+            Spacer()
+        }
+        .frame(minHeight: Constants.minButtonHeight)
+        .font(.system(.title2, weight: .bold))
+        .background(Color.posPrimaryButtonBackground)
+        .foregroundColor(Color.white)
+        .cornerRadius(Constants.cornerRadius)
+    }
+}
+
+private extension POSPrimaryButtonStyle {
+    enum Constants {
+        static let minButtonHeight: CGFloat = 80
+        static let cornerRadius: CGFloat = 8.0
+    }
+}

--- a/WooCommerce/Classes/POS/Presentation/TotalsView.swift
+++ b/WooCommerce/Classes/POS/Presentation/TotalsView.swift
@@ -11,7 +11,6 @@ struct TotalsView: View {
     /// It allows for a simultaneous transition from the shimmering effect to the text fields,
     /// and movement from the center of the VStack to their respective positions.
     @Namespace private var totalsFieldAnimation
-    @State private var hasViewAppeared: Bool = false
 
     init(viewModel: PointOfSaleDashboardViewModel,
          totalsViewModel: TotalsViewModel,
@@ -40,21 +39,12 @@ struct TotalsView: View {
                     }
                 }
                 .animation(.default, value: totalsViewModel.isShowingCardReaderStatus)
-                .transaction { transaction in
-                    // Disable animations within the view while the view is appearing
-                    if !hasViewAppeared {
-                        transaction.animation = nil
-                    }
-                }
                 paymentsActionButtons
                     .padding()
                 Spacer()
             }
         }
         .background(backgroundColor)
-        .onAppear {
-            hasViewAppeared = true
-        }
         .onDisappear {
             totalsViewModel.onTotalsViewDisappearance()
         }

--- a/WooCommerce/Classes/POS/Utils/Color+WooCommercePOS.swift
+++ b/WooCommerce/Classes/POS/Utils/Color+WooCommercePOS.swift
@@ -92,7 +92,7 @@ extension Color {
         Color(red: 198.0 / 255.0, green: 198.0 / 255.0, blue: 200.0 / 255.0)
     }
 
-    static var posCheckoutBackground: Color {
+    static var posPrimaryButtonBackground: Color {
         Color(uiColor: .wooCommercePurple(.shade50))
     }
 }

--- a/WooCommerce/Classes/POS/ViewModels/TotalsViewModel.swift
+++ b/WooCommerce/Classes/POS/ViewModels/TotalsViewModel.swift
@@ -157,7 +157,6 @@ extension TotalsViewModel {
             isSyncingOrder = false
         }
         do {
-            isSyncingOrder = true
             let syncedOrder = try await orderService.syncOrder(cart: cart, order: order, allProducts: allItems)
             self.updateOrder(syncedOrder)
             isSyncingOrder = false

--- a/WooCommerce/Classes/POS/ViewModels/TotalsViewModel.swift
+++ b/WooCommerce/Classes/POS/ViewModels/TotalsViewModel.swift
@@ -19,19 +19,19 @@ final class TotalsViewModel: ObservableObject, TotalsViewModelProtocol {
     }
 
     @Published var showsCardReaderSheet: Bool = false
-    @Published var cardPresentPaymentEvent: CardPresentPaymentEvent = .idle
-    @Published var cardPresentPaymentAlertViewModel: PointOfSaleCardPresentPaymentAlertType?
+    @Published private(set) var cardPresentPaymentEvent: CardPresentPaymentEvent = .idle
+    @Published private(set) var cardPresentPaymentAlertViewModel: PointOfSaleCardPresentPaymentAlertType?
     @Published private(set) var cardPresentPaymentInlineMessage: PointOfSaleCardPresentPaymentMessageType?
     @Published private(set) var isShowingCardReaderStatus: Bool = false
     @Published private(set) var isShowingTotalsFields: Bool = false
 
     @Published private(set) var order: Order? = nil
     private var totalsCalculator: OrderTotalsCalculator? = nil
-    @Published var paymentState: PaymentState
+    @Published private(set) var paymentState: PaymentState
 
-    @Published var isSyncingOrder: Bool
+    @Published private(set) var isSyncingOrder: Bool
 
-    @Published var connectionStatus: CardReaderConnectionStatus = .disconnected
+    @Published private(set) var connectionStatus: CardReaderConnectionStatus = .disconnected
 
     @Published var formattedCartTotalPrice: String?
     @Published var formattedOrderTotalPrice: String?

--- a/WooCommerce/Classes/POS/ViewModels/TotalsViewModel.swift
+++ b/WooCommerce/Classes/POS/ViewModels/TotalsViewModel.swift
@@ -9,8 +9,6 @@ import class WooFoundation.CurrencyFormatter
 import class WooFoundation.CurrencySettings
 
 final class TotalsViewModel: ObservableObject, TotalsViewModelProtocol {
-    var isPriceFieldRedacted: Bool
-
     enum PaymentState {
         case idle
         case acceptingCard
@@ -89,7 +87,6 @@ final class TotalsViewModel: ObservableObject, TotalsViewModelProtocol {
         self.currencyFormatter = currencyFormatter
         self.paymentState = paymentState
         self.isSyncingOrder = isSyncingOrder
-        self.isPriceFieldRedacted = false
         self.formattedCartTotalPrice = nil
         self.formattedOrderTotalPrice = nil
         self.formattedOrderTotalTaxPrice = nil

--- a/WooCommerce/Classes/POS/ViewModels/TotalsViewModelProtocol.swift
+++ b/WooCommerce/Classes/POS/ViewModels/TotalsViewModelProtocol.swift
@@ -25,7 +25,6 @@ protocol TotalsViewModelProtocol {
 
 
     var isShimmering: Bool { get }
-    var isPriceFieldRedacted: Bool { get }
     var isTotalPriceFieldRedacted: Bool { get }
     var isSubtotalFieldRedacted: Bool { get }
     var isTaxFieldRedacted: Bool { get }

--- a/WooCommerce/Classes/POS/ViewModels/TotalsViewModelProtocol.swift
+++ b/WooCommerce/Classes/POS/ViewModels/TotalsViewModelProtocol.swift
@@ -3,12 +3,12 @@ import struct Yosemite.Order
 import protocol Yosemite.POSItem
 
 protocol TotalsViewModelProtocol {
-    var isSyncingOrder: Bool { get set }
-    var paymentState: TotalsViewModel.PaymentState { get set }
+    var isSyncingOrder: Bool { get }
+    var paymentState: TotalsViewModel.PaymentState { get }
     var showsCardReaderSheet: Bool { get set }
-    var cardPresentPaymentAlertViewModel: PointOfSaleCardPresentPaymentAlertType? { get set }
-    var cardPresentPaymentEvent: CardPresentPaymentEvent { get set }
-    var connectionStatus: CardReaderConnectionStatus { get set }
+    var cardPresentPaymentAlertViewModel: PointOfSaleCardPresentPaymentAlertType? { get }
+    var cardPresentPaymentEvent: CardPresentPaymentEvent { get }
+    var connectionStatus: CardReaderConnectionStatus { get }
     var formattedCartTotalPrice: String? { get }
     var formattedOrderTotalPrice: String? { get }
     var formattedOrderTotalTaxPrice: String? { get }

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -801,6 +801,7 @@
 		20762BA72C18B55100758305 /* CardPresentPaymentsTransactionAlertsProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 20762BA62C18B55100758305 /* CardPresentPaymentsTransactionAlertsProvider.swift */; };
 		207823E32C5D18CE00025A59 /* PointOfSaleCardPresentPaymentConnectionSuccessAlertViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 207823E22C5D18CE00025A59 /* PointOfSaleCardPresentPaymentConnectionSuccessAlertViewModel.swift */; };
 		207823E52C5D1B2F00025A59 /* PointOfSaleCardPresentPaymentConnectionSuccessAlertView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 207823E42C5D1B2F00025A59 /* PointOfSaleCardPresentPaymentConnectionSuccessAlertView.swift */; };
+		207823E72C5D346300025A59 /* POSPrimaryButtonStyle.swift in Sources */ = {isa = PBXBuildFile; fileRef = 207823E62C5D346300025A59 /* POSPrimaryButtonStyle.swift */; };
 		209AD3D02AC1EDDA00825D76 /* WooPaymentsDepositsCurrencyOverviewViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 209AD3CF2AC1EDDA00825D76 /* WooPaymentsDepositsCurrencyOverviewViewModel.swift */; };
 		209AD3D22AC1EDF600825D76 /* WooPaymentsDepositsCurrencyOverviewView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 209AD3D12AC1EDF600825D76 /* WooPaymentsDepositsCurrencyOverviewView.swift */; };
 		209B15672AD85F070094152A /* OperatingSystemVersion+Localization.swift in Sources */ = {isa = PBXBuildFile; fileRef = 209B15662AD85F070094152A /* OperatingSystemVersion+Localization.swift */; };
@@ -3799,6 +3800,7 @@
 		20762BA62C18B55100758305 /* CardPresentPaymentsTransactionAlertsProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardPresentPaymentsTransactionAlertsProvider.swift; sourceTree = "<group>"; };
 		207823E22C5D18CE00025A59 /* PointOfSaleCardPresentPaymentConnectionSuccessAlertViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PointOfSaleCardPresentPaymentConnectionSuccessAlertViewModel.swift; sourceTree = "<group>"; };
 		207823E42C5D1B2F00025A59 /* PointOfSaleCardPresentPaymentConnectionSuccessAlertView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PointOfSaleCardPresentPaymentConnectionSuccessAlertView.swift; sourceTree = "<group>"; };
+		207823E62C5D346300025A59 /* POSPrimaryButtonStyle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = POSPrimaryButtonStyle.swift; sourceTree = "<group>"; };
 		20929C9DFB2CE5CB264C27EC /* Pods-Woo Watch App.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Woo Watch App.debug.xcconfig"; path = "../Pods/Target Support Files/Pods-Woo Watch App/Pods-Woo Watch App.debug.xcconfig"; sourceTree = "<group>"; };
 		209AD3CF2AC1EDDA00825D76 /* WooPaymentsDepositsCurrencyOverviewViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WooPaymentsDepositsCurrencyOverviewViewModel.swift; sourceTree = "<group>"; };
 		209AD3D12AC1EDF600825D76 /* WooPaymentsDepositsCurrencyOverviewView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WooPaymentsDepositsCurrencyOverviewView.swift; sourceTree = "<group>"; };
@@ -5979,6 +5981,7 @@
 				01620C4D2C5394B200D3EA2F /* POSProgressViewStyle.swift */,
 				204D1D612C5A50840064A6BE /* POSModalViewModifier.swift */,
 				01D0823F2C5B9EAB007FE81F /* POSBackgroundAppearanceKey.swift */,
+				207823E62C5D346300025A59 /* POSPrimaryButtonStyle.swift */,
 			);
 			path = "Reusable Views";
 			sourceTree = "<group>";
@@ -15352,6 +15355,7 @@
 				02CA63DC23D1ADD100BBF148 /* DeviceMediaLibraryPicker.swift in Sources */,
 				021A84E0257DFC2A00BC71D1 /* RefundShippingLabelViewController.swift in Sources */,
 				0373A12F2A1D1F2100731236 /* DotView.swift in Sources */,
+				207823E72C5D346300025A59 /* POSPrimaryButtonStyle.swift in Sources */,
 				DE279BA826E9C8E3002BA963 /* ShippingLabelSinglePackage.swift in Sources */,
 				028FF8E32AA1E1C60038964F /* ProductDetailsCellViewModel+AddOns.swift in Sources */,
 				DEC2962726C17AD8005A056B /* ShippingLabelCustomsForm+Localization.swift in Sources */,

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -802,6 +802,7 @@
 		207823E32C5D18CE00025A59 /* PointOfSaleCardPresentPaymentConnectionSuccessAlertViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 207823E22C5D18CE00025A59 /* PointOfSaleCardPresentPaymentConnectionSuccessAlertViewModel.swift */; };
 		207823E52C5D1B2F00025A59 /* PointOfSaleCardPresentPaymentConnectionSuccessAlertView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 207823E42C5D1B2F00025A59 /* PointOfSaleCardPresentPaymentConnectionSuccessAlertView.swift */; };
 		207823E72C5D346300025A59 /* POSPrimaryButtonStyle.swift in Sources */ = {isa = PBXBuildFile; fileRef = 207823E62C5D346300025A59 /* POSPrimaryButtonStyle.swift */; };
+		207823E92C5D3A1700025A59 /* POSErrorExclamationMark.swift in Sources */ = {isa = PBXBuildFile; fileRef = 207823E82C5D3A1700025A59 /* POSErrorExclamationMark.swift */; };
 		209AD3D02AC1EDDA00825D76 /* WooPaymentsDepositsCurrencyOverviewViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 209AD3CF2AC1EDDA00825D76 /* WooPaymentsDepositsCurrencyOverviewViewModel.swift */; };
 		209AD3D22AC1EDF600825D76 /* WooPaymentsDepositsCurrencyOverviewView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 209AD3D12AC1EDF600825D76 /* WooPaymentsDepositsCurrencyOverviewView.swift */; };
 		209B15672AD85F070094152A /* OperatingSystemVersion+Localization.swift in Sources */ = {isa = PBXBuildFile; fileRef = 209B15662AD85F070094152A /* OperatingSystemVersion+Localization.swift */; };
@@ -3801,6 +3802,7 @@
 		207823E22C5D18CE00025A59 /* PointOfSaleCardPresentPaymentConnectionSuccessAlertViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PointOfSaleCardPresentPaymentConnectionSuccessAlertViewModel.swift; sourceTree = "<group>"; };
 		207823E42C5D1B2F00025A59 /* PointOfSaleCardPresentPaymentConnectionSuccessAlertView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PointOfSaleCardPresentPaymentConnectionSuccessAlertView.swift; sourceTree = "<group>"; };
 		207823E62C5D346300025A59 /* POSPrimaryButtonStyle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = POSPrimaryButtonStyle.swift; sourceTree = "<group>"; };
+		207823E82C5D3A1700025A59 /* POSErrorExclamationMark.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = POSErrorExclamationMark.swift; sourceTree = "<group>"; };
 		20929C9DFB2CE5CB264C27EC /* Pods-Woo Watch App.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Woo Watch App.debug.xcconfig"; path = "../Pods/Target Support Files/Pods-Woo Watch App/Pods-Woo Watch App.debug.xcconfig"; sourceTree = "<group>"; };
 		209AD3CF2AC1EDDA00825D76 /* WooPaymentsDepositsCurrencyOverviewViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WooPaymentsDepositsCurrencyOverviewViewModel.swift; sourceTree = "<group>"; };
 		209AD3D12AC1EDF600825D76 /* WooPaymentsDepositsCurrencyOverviewView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WooPaymentsDepositsCurrencyOverviewView.swift; sourceTree = "<group>"; };
@@ -5982,6 +5984,7 @@
 				204D1D612C5A50840064A6BE /* POSModalViewModifier.swift */,
 				01D0823F2C5B9EAB007FE81F /* POSBackgroundAppearanceKey.swift */,
 				207823E62C5D346300025A59 /* POSPrimaryButtonStyle.swift */,
+				207823E82C5D3A1700025A59 /* POSErrorExclamationMark.swift */,
 			);
 			path = "Reusable Views";
 			sourceTree = "<group>";
@@ -15570,6 +15573,7 @@
 				B554E1792152F20000F31188 /* UINavigationBar+Appearance.swift in Sources */,
 				26AE31B0251E602D004B1BCE /* RefundShippingDetailsTableViewCell.swift in Sources */,
 				26F115AD2C4997EA0019CD73 /* PerformanceCardDataSyncUseCase.swift in Sources */,
+				207823E92C5D3A1700025A59 /* POSErrorExclamationMark.swift in Sources */,
 				020732062988AC4D000A53C2 /* DomainContactInfoFormViewModel.swift in Sources */,
 				68E4E8B52C0EF39D00CFA0C3 /* PreviewHelpers.swift in Sources */,
 				EE8B42092BF668540077C4E7 /* MostActiveCouponRow.swift in Sources */,

--- a/WooCommerce/WooCommerceTests/POS/Mocks/MockTotalsViewModel.swift
+++ b/WooCommerce/WooCommerceTests/POS/Mocks/MockTotalsViewModel.swift
@@ -31,10 +31,6 @@ final class MockTotalsViewModel: TotalsViewModelProtocol {
         isSyncingOrder
     }
 
-    var isPriceFieldRedacted: Bool {
-        formattedOrderTotalTaxPrice == nil || isSyncingOrder
-    }
-
     var isSubtotalFieldRedacted: Bool {
         formattedCartTotalPrice == nil || isSyncingOrder
     }

--- a/WooCommerce/WooCommerceTests/POS/ViewModels/TotalsViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/POS/ViewModels/TotalsViewModelTests.swift
@@ -71,10 +71,13 @@ final class TotalsViewModelTests: XCTestCase {
         XCTAssertFalse(sut.isShowingCardReaderStatus)
     }
 
-    func test_isShowingCardReaderStatus_when_connected_and_payment_message_exists_then_true() {
+    func test_isShowingCardReaderStatus_when_connected_and_payment_message_exists_then_true() async throws {
         // Given
         cardPresentPaymentService.connectedReader = CardPresentPaymentCardReader(name: "Test", batteryLevel: 0.5)
         cardPresentPaymentService.paymentEvent = .show(eventDetails: .preparingForPayment(cancelPayment: {}))
+
+        let item = Self.makeItem()
+        await sut.syncOrder(for: [CartItem(id: UUID(), item: item, quantity: 1)], allItems: [item])
 
         // Then
         XCTAssertTrue(sut.isShowingCardReaderStatus)

--- a/WooCommerce/WooCommerceTests/POS/ViewModels/TotalsViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/POS/ViewModels/TotalsViewModelTests.swift
@@ -61,7 +61,11 @@ final class TotalsViewModelTests: XCTestCase {
 
     func test_isShowingCardReaderStatus_when_order_syncing_then_false() {
         // Given
-        sut.isSyncingOrder = true
+        sut = TotalsViewModel(orderService: orderService,
+                              cardPresentPaymentService: cardPresentPaymentService,
+                              currencyFormatter: .init(currencySettings: .init()),
+                              paymentState: .acceptingCard,
+                              isSyncingOrder: true)
 
         // Then
         XCTAssertFalse(sut.isShowingCardReaderStatus)
@@ -69,7 +73,6 @@ final class TotalsViewModelTests: XCTestCase {
 
     func test_isShowingCardReaderStatus_when_connected_and_payment_message_exists_then_true() {
         // Given
-        sut.isSyncingOrder = false
         cardPresentPaymentService.connectedReader = CardPresentPaymentCardReader(name: "Test", batteryLevel: 0.5)
         cardPresentPaymentService.paymentEvent = .show(eventDetails: .preparingForPayment(cancelPayment: {}))
 
@@ -79,7 +82,6 @@ final class TotalsViewModelTests: XCTestCase {
 
     func test_isShowingCardReaderStatus_when_connected_and_no_payment_message_then_false() {
         // Given
-        sut.isSyncingOrder = false
         cardPresentPaymentService.connectedReader = CardPresentPaymentCardReader(name: "Test", batteryLevel: 0.5)
         cardPresentPaymentService.paymentEvent = .idle
 


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of: #13431
Merge after: #13496
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

This PR updates the view shown on the Checkout screen when there's no card reader connected to match designs for the new POS.

I took the opportunity to extract the primary POS CTA style and reuse it, and also made a reusable ❗ view, as some of the other errors will use that image as well.

The animations were a little broken before – much of this was due to the card reader view showing before the order is created, then quickly disappearing when we started to sync the order. Adding a check for `order != nil` improved the animation a lot.

Finally, I made some access control improvements on the TotalsViewModel, to make it easier to reason about changes to the state while I was working on the transitions.

## Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->

1. Launch the app and open POS mode
2. Add something to the cart
3. Check out
4. Observe that the new `Reader not connected` alert appears matching designs TfaZ4LUkEwEGrxfnEFzvJj-fi-2530_16156


## Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->

Note that I removed the block on TotalsView animations before it appears. This didn't seem to make any positive contribution to the feel of the animation, and it stopped the slide-in animation from working.

With the card reader connected, if you go back from the Checkout to the product list, then forward again quickly without changing anything, the animations are still a bit strange. This is fine if you wait a few seconds for the payment intent cancellation to be completed, and we have another issue to address it: #13495 

Finally, the remaining thing to do is make payment start when you use the floating action button to connect the reader:

> The payment preparation process should start whether the small floating button is used, or the large purple button.
> 
> This should only happen when we're actually on the Checkout screen.
> 
> Note – if it proves difficult to correctly implement this automatic payment preparation, we can show the Collect Payment button in this case instead. Don't spend a long time on making that work!

I'll address that in the next PR

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->


https://github.com/user-attachments/assets/f7b14291-afab-4893-81ef-57e50fe50717


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
- [ ] This PR includes refactoring; smoke testing of the entire section is needed.