### PR TITLE
Add missing tracking events for custom range on stats dashboard cards

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -5,6 +5,7 @@
 19.9
 -----
 - [**] Fixed Collect Payment from the menu on iPads running iOS 16 [https://github.com/woocommerce/woocommerce-ios/pull/13491]
+- [Internal] Added missing events for custom range on the stats dashboard card. [https://github.com/woocommerce/woocommerce-ios/pull/13506]
 
 19.8
 -----

--- a/WooCommerce/Classes/ViewRelated/Dashboard/StoreStats/StorePerformanceView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/StoreStats/StorePerformanceView.swift
@@ -80,6 +80,7 @@ struct StorePerformanceView: View {
                              endDate: viewModel.endDateForCustomRange,
                              customApplyButtonTitle: viewModel.buttonTitleForCustomRange,
                              datesSelected: { start, end in
+                viewModel.trackCustomRangeEvent(.DashboardCustomRange.customRangeConfirmed(isEditing: viewModel.timeRange.isCustomTimeRange))
                 viewModel.didSelectTimeRange(.custom(from: start, to: end))
             })
         }
@@ -124,6 +125,7 @@ private extension StorePerformanceView {
                 if viewModel.timeRange.isCustomTimeRange {
                     Button {
                         viewModel.trackInteraction()
+                        viewModel.trackCustomRangeEvent(.DashboardCustomRange.editButtonTapped())
                         showingCustomRangePicker = true
                     } label: {
                         HStack {
@@ -144,6 +146,11 @@ private extension StorePerformanceView {
 
                 if newTimeRange.isCustomTimeRange {
                     showingCustomRangePicker = true
+                    if viewModel.timeRange.isCustomTimeRange {
+                        viewModel.trackCustomRangeEvent(.DashboardCustomRange.editButtonTapped())
+                    } else {
+                        viewModel.trackCustomRangeEvent(.DashboardCustomRange.addButtonTapped())
+                    }
                 } else {
                     viewModel.didSelectTimeRange(newTimeRange)
                 }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/StoreStats/StorePerformanceViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/StoreStats/StorePerformanceViewModel.swift
@@ -129,7 +129,6 @@ final class StorePerformanceViewModel: ObservableObject {
 
         shouldHighlightStats = false
         analytics.track(event: .Dashboard.dashboardMainStatsDate(timeRange: timeRange))
-
     }
 
     func didSelectStatsInterval(at index: Int?) {
@@ -213,6 +212,7 @@ final class StorePerformanceViewModel: ObservableObject {
         analytics.track(event: .DynamicDashboard.dashboardCardInteracted(type: .performance))
     }
 
+    /// To be triggered from the UI for custom range related events
     func trackCustomRangeEvent(_ event: WooAnalyticsEvent) {
         analytics.track(event: event)
     }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/StoreStats/StorePerformanceViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/StoreStats/StorePerformanceViewModel.swift
@@ -129,6 +129,7 @@ final class StorePerformanceViewModel: ObservableObject {
 
         shouldHighlightStats = false
         analytics.track(event: .Dashboard.dashboardMainStatsDate(timeRange: timeRange))
+
     }
 
     func didSelectStatsInterval(at index: Int?) {
@@ -210,6 +211,10 @@ final class StorePerformanceViewModel: ObservableObject {
     func trackInteraction() {
         usageTracksEventEmitter.interacted()
         analytics.track(event: .DynamicDashboard.dashboardCardInteracted(type: .performance))
+    }
+
+    func trackCustomRangeEvent(_ event: WooAnalyticsEvent) {
+        analytics.track(event: event)
     }
 
     func onViewAppear() {

--- a/WooCommerce/Classes/ViewRelated/Dashboard/TopPerformers/TopPerformersDashboardView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/TopPerformers/TopPerformersDashboardView.swift
@@ -69,6 +69,7 @@ struct TopPerformersDashboardView: View {
                              endDate: viewModel.endDateForCustomRange,
                              customApplyButtonTitle: viewModel.buttonTitleForCustomRange,
                              datesSelected: { start, end in
+                viewModel.trackCustomRangeEvent(.DashboardCustomRange.customRangeConfirmed(isEditing: viewModel.timeRange.isCustomTimeRange))
                 viewModel.didSelectTimeRange(.custom(from: start, to: end))
             })
         }
@@ -116,6 +117,7 @@ private extension TopPerformersDashboardView {
                 if viewModel.timeRange.isCustomTimeRange {
                     Button {
                         viewModel.trackInteraction()
+                        viewModel.trackCustomRangeEvent(.DashboardCustomRange.editButtonTapped())
                         showingCustomRangePicker = true
                     } label: {
                         HStack {
@@ -136,6 +138,11 @@ private extension TopPerformersDashboardView {
 
                 if newTimeRange.isCustomTimeRange {
                     showingCustomRangePicker = true
+                    if viewModel.timeRange.isCustomTimeRange {
+                        viewModel.trackCustomRangeEvent(.DashboardCustomRange.editButtonTapped())
+                    } else {
+                        viewModel.trackCustomRangeEvent(.DashboardCustomRange.addButtonTapped())
+                    }
                 } else {
                     viewModel.didSelectTimeRange(newTimeRange)
                 }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/TopPerformers/TopPerformersDashboardViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/TopPerformers/TopPerformersDashboardViewModel.swift
@@ -38,6 +38,9 @@ final class TopPerformersDashboardViewModel: ObservableObject {
         guard let self else { return }
 
         trackInteraction()
+        if timeRange.isCustomTimeRange {
+            trackCustomRangeEvent(.DashboardCustomRange.interacted())
+        }
         selectedItem = topPerformersItem
     }
 
@@ -145,6 +148,11 @@ final class TopPerformersDashboardViewModel: ObservableObject {
     func trackInteraction() {
         analytics.track(event: .DynamicDashboard.dashboardCardInteracted(type: .topPerformers))
         usageTracksEventEmitter.interacted()
+    }
+
+    /// To be triggered from the UI for custom range related events
+    func trackCustomRangeEvent(_ event: WooAnalyticsEvent) {
+        analytics.track(event: event)
     }
 
     func onViewAppear() {


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #13499
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This PR adds the missing custom range events on both the Performance and Top Performers cards:

Event name | Properties | Triggers
--- | --- | ---
*_dashboard_stats_custom_range_add_button_tapped |  | When the user taps the button to add a custom range
*_dashboard_stats_custom_range_confirmed | is_editing: true or false | When the user confirms a date range for a custom range tab
*_dashboard_stats_custom_range_tab_selected | | When the user selects the custom range tab of Dashboard stats.
*_dashboard_stats_custom_range_edit_button_tapped | | When the user taps the button to edit the date range on the custom range tab of Dashboard stats.
*_dashboard_stats_custom_range_interacted |  | When the user taps on the chart on custom range to see metrics for specific periods.

## Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->
- Log in to a store and enable Performance and Top Performers cards on the dashboard.
- Select the custom range icon in the time range picker of the Performance card, confirm that `dashboard_stats_custom_range_add_button_tapped` is tracked. 
- Select a range and confirm that `dashboard_stats_custom_range_confirmed` is tracked with `is_editing` = false.
- Select the custom range icon again, and confirm that `dashboard_stats_custom_range_edit_button_tapped` is tracked.
- Select another range and  confirm that `dashboard_stats_custom_range_confirmed` is tracked with `is_editing` = true.
- Select the date range button, confirm that `dashboard_stats_custom_range_edit_button_tapped` is tracked.
- Dismiss the date picker and tap on any point of the chart if there are any stats. Confirm that `dashboard_stats_custom_range_interacted` is tracked.
- Repeat the same tests for the Top Performers card.
- For the interaction event, confirm that `dashboard_stats_custom_range_interacted` is tracked only when selecting any product for a custom range.

Note: if you test this PR on a beta/production build, please check the events on Tracks' live events.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->
N/A

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
- [ ] This PR includes refactoring; smoke testing of the entire section is needed.