### PR TITLE
[Woo POS] Make floating `Connect your reader` button start payment when tapped in checkout

### DIFF
--- a/WooCommerce/Classes/POS/Presentation/Card Present Payments/Reader Messages/PointOfSaleCardPresentPaymentDisconnectedMessageViewModel.swift
+++ b/WooCommerce/Classes/POS/Presentation/Card Present Payments/Reader Messages/PointOfSaleCardPresentPaymentDisconnectedMessageViewModel.swift
@@ -3,12 +3,12 @@ import Foundation
 struct PointOfSaleCardPresentPaymentReaderDisconnectedMessageViewModel {
     let title = Localization.title
     let instruction = Localization.instruction
-    let collectPaymentButtonViewModel: CardPresentPaymentsModalButtonViewModel
+    let connectReaderButtonViewModel: CardPresentPaymentsModalButtonViewModel
 
-    init(collectPaymentAction: @escaping () -> Void) {
-        self.collectPaymentButtonViewModel = CardPresentPaymentsModalButtonViewModel(
+    init(connectReaderAction: @escaping () -> Void) {
+        self.connectReaderButtonViewModel = CardPresentPaymentsModalButtonViewModel(
             title: Localization.collectPayment,
-            actionHandler: collectPaymentAction)
+            actionHandler: connectReaderAction)
     }
 }
 

--- a/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/Reader Messages/PointOfSaleCardPresentPaymentDisconnectedMessageView.swift
+++ b/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/Reader Messages/PointOfSaleCardPresentPaymentDisconnectedMessageView.swift
@@ -17,8 +17,8 @@ struct PointOfSaleCardPresentPaymentReaderDisconnectedMessageView: View {
                     .foregroundStyle(Color.posPrimaryTexti3)
             }
 
-            Button(action: viewModel.collectPaymentButtonViewModel.actionHandler) {
-                Text(viewModel.collectPaymentButtonViewModel.title)
+            Button(action: viewModel.connectReaderButtonViewModel.actionHandler) {
+                Text(viewModel.connectReaderButtonViewModel.title)
             }
             .buttonStyle(POSPrimaryButtonStyle())
         }
@@ -30,6 +30,6 @@ struct PointOfSaleCardPresentPaymentReaderDisconnectedMessageView: View {
 #Preview {
     PointOfSaleCardPresentPaymentReaderDisconnectedMessageView(
         viewModel: PointOfSaleCardPresentPaymentReaderDisconnectedMessageViewModel(
-            collectPaymentAction: {})
+            connectReaderAction: {})
     )
 }

--- a/WooCommerce/Classes/POS/Presentation/TotalsView.swift
+++ b/WooCommerce/Classes/POS/Presentation/TotalsView.swift
@@ -188,7 +188,7 @@ private extension TotalsView {
                 EmptyView()
             }
         case .disconnected:
-            PointOfSaleCardPresentPaymentReaderDisconnectedMessageView(viewModel: .init(collectPaymentAction: totalsViewModel.cardPaymentTapped))
+            PointOfSaleCardPresentPaymentReaderDisconnectedMessageView(viewModel: .init(connectReaderAction: totalsViewModel.connectReaderTapped))
         }
     }
 }

--- a/WooCommerce/Classes/POS/Utils/POSOrderPreviewService.swift
+++ b/WooCommerce/Classes/POS/Utils/POSOrderPreviewService.swift
@@ -8,10 +8,7 @@ import struct Yosemite.Order
 
 class POSOrderPreviewService: POSOrderServiceProtocol {
     func syncOrder(cart: [POSCartItem], order: Order?, allProducts: [any POSItem]) async throws -> Order {
-        if let order {
-            return order
-        }
-        return OrderFactory.emptyNewOrder
+        OrderFactory.emptyNewOrder
     }
 }
 #endif

--- a/WooCommerce/Classes/POS/ViewModels/PointOfSaleDashboardViewModel.swift
+++ b/WooCommerce/Classes/POS/ViewModels/PointOfSaleDashboardViewModel.swift
@@ -59,8 +59,8 @@ final class PointOfSaleDashboardViewModel: ObservableObject {
         totalsViewModel.startNewTransaction()
     }
 
-    private func startSyncingOrder(cartItems: [CartItem]) {
-        totalsViewModel.startSyncingOrder(with: cartItems, allItems: itemListViewModel.items)
+    private func cartSubmitted(cartItems: [CartItem]) {
+        totalsViewModel.checkOutTapped(with: cartItems, allItems: itemListViewModel.items)
     }
 }
 
@@ -78,7 +78,7 @@ private extension PointOfSaleDashboardViewModel {
             .sink { [weak self] cartItems in
                 guard let self else { return }
                 self.orderStage = .finalizing
-                self.startSyncingOrder(cartItems: cartItems)
+                self.cartSubmitted(cartItems: cartItems)
             }
             .store(in: &cancellables)
     }

--- a/WooCommerce/Classes/POS/ViewModels/TotalsViewModel.swift
+++ b/WooCommerce/Classes/POS/ViewModels/TotalsViewModel.swift
@@ -240,6 +240,15 @@ private extension TotalsViewModel {
             }
             .assign(to: &$connectionStatus)
 
+        $connectionStatus.filter { $0 == .connected }
+            .removeDuplicates()
+            .sink { _ in
+                Task { @MainActor [weak self] in
+                    await self?.prepareConnectedReaderForPayment()
+                }
+            }
+            .store(in: &cancellables)
+
         Publishers.CombineLatest4($connectionStatus, $isSyncingOrder, $cardPresentPaymentInlineMessage, $order)
             .map { connectionStatus, isSyncingOrder, message, order in
                 guard order != nil,

--- a/WooCommerce/Classes/POS/ViewModels/TotalsViewModel.swift
+++ b/WooCommerce/Classes/POS/ViewModels/TotalsViewModel.swift
@@ -77,6 +77,8 @@ final class TotalsViewModel: ObservableObject, TotalsViewModelProtocol {
     private let cardPresentPaymentService: CardPresentPaymentFacade
     private let currencyFormatter: CurrencyFormatter
 
+    private var cancellables: Set<AnyCancellable> = []
+
     init(orderService: POSOrderServiceProtocol,
          cardPresentPaymentService: CardPresentPaymentFacade,
          currencyFormatter: CurrencyFormatter,
@@ -123,9 +125,17 @@ final class TotalsViewModel: ObservableObject, TotalsViewModelProtocol {
         }
     }
 
-    func cardPaymentTapped() {
-        Task { @MainActor in
-            await collectPayment()
+    func connectReaderTapped() {
+        Task { @MainActor [weak self] in
+            guard let self else {
+                return
+            }
+
+            do {
+                let _ = try await cardPresentPaymentService.connectReader(using: .bluetooth)
+            } catch {
+                DDLogError("🔴 POS reader connection error: \(error)")
+            }
         }
     }
 

--- a/WooCommerce/Classes/POS/ViewModels/TotalsViewModel.swift
+++ b/WooCommerce/Classes/POS/ViewModels/TotalsViewModel.swift
@@ -171,7 +171,7 @@ extension TotalsViewModel {
             self.updateOrder(syncedOrder)
             isSyncingOrder = false
             await prepareConnectedReaderForPayment()
-            DDLogInfo("🟢 [POS] Synced order: \(order)")
+            DDLogInfo("🟢 [POS] Synced order: \(syncedOrder)")
         } catch {
             DDLogError("🔴 [POS] Error syncing order: \(error)")
         }

--- a/WooCommerce/Classes/POS/ViewModels/TotalsViewModel.swift
+++ b/WooCommerce/Classes/POS/ViewModels/TotalsViewModel.swift
@@ -106,11 +106,11 @@ final class TotalsViewModel: ObservableObject, TotalsViewModelProtocol {
     var formattedOrderTotalPricePublisher: Published<String?>.Publisher { $formattedOrderTotalPrice }
     var formattedOrderTotalTaxPricePublisher: Published<String?>.Publisher { $formattedOrderTotalTaxPrice }
 
-    func calculateAmountsTapped(with cartItems: [CartItem], allItems: [POSItem]) {
+    func checkOutTapped(with cartItems: [CartItem], allItems: [POSItem]) {
         startSyncingOrder(with: cartItems, allItems: allItems)
     }
 
-    func startSyncingOrder(with cartItems: [CartItem], allItems: [POSItem]) {
+    private func startSyncingOrder(with cartItems: [CartItem], allItems: [POSItem]) {
         guard CartItem.areOrderAndCartDifferent(order: order, cartItems: cartItems) else {
             Task { @MainActor in
                 await prepareConnectedReaderForPayment()

--- a/WooCommerce/Classes/POS/ViewModels/TotalsViewModel.swift
+++ b/WooCommerce/Classes/POS/ViewModels/TotalsViewModel.swift
@@ -124,11 +124,7 @@ final class TotalsViewModel: ObservableObject, TotalsViewModelProtocol {
     }
 
     func connectReaderTapped() {
-        Task { @MainActor [weak self] in
-            guard let self else {
-                return
-            }
-
+        Task { @MainActor in
             do {
                 let _ = try await cardPresentPaymentService.connectReader(using: .bluetooth)
             } catch {

--- a/WooCommerce/Classes/POS/ViewModels/TotalsViewModelProtocol.swift
+++ b/WooCommerce/Classes/POS/ViewModels/TotalsViewModelProtocol.swift
@@ -33,7 +33,7 @@ protocol TotalsViewModelProtocol {
     var order: Order? { get }
 
     func startNewTransaction()
-    func cardPaymentTapped()
     func checkOutTapped(with cartItems: [CartItem], allItems: [POSItem])
+    func connectReaderTapped()
     func onTotalsViewDisappearance()
 }

--- a/WooCommerce/Classes/POS/ViewModels/TotalsViewModelProtocol.swift
+++ b/WooCommerce/Classes/POS/ViewModels/TotalsViewModelProtocol.swift
@@ -32,9 +32,8 @@ protocol TotalsViewModelProtocol {
     var showRecalculateButton: Bool { get }
     var order: Order? { get }
 
-    func startSyncingOrder(with cartItems: [CartItem], allItems: [POSItem])
     func startNewTransaction()
-    func calculateAmountsTapped(with cartItems: [CartItem], allItems: [POSItem])
     func cardPaymentTapped()
+    func checkOutTapped(with cartItems: [CartItem], allItems: [POSItem])
     func onTotalsViewDisappearance()
 }

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -803,6 +803,7 @@
 		207823E52C5D1B2F00025A59 /* PointOfSaleCardPresentPaymentConnectionSuccessAlertView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 207823E42C5D1B2F00025A59 /* PointOfSaleCardPresentPaymentConnectionSuccessAlertView.swift */; };
 		207823E72C5D346300025A59 /* POSPrimaryButtonStyle.swift in Sources */ = {isa = PBXBuildFile; fileRef = 207823E62C5D346300025A59 /* POSPrimaryButtonStyle.swift */; };
 		207823E92C5D3A1700025A59 /* POSErrorExclamationMark.swift in Sources */ = {isa = PBXBuildFile; fileRef = 207823E82C5D3A1700025A59 /* POSErrorExclamationMark.swift */; };
+		207E71CB2C60F765008540FC /* MockPOSOrderService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 207E71CA2C60F765008540FC /* MockPOSOrderService.swift */; };
 		209AD3D02AC1EDDA00825D76 /* WooPaymentsDepositsCurrencyOverviewViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 209AD3CF2AC1EDDA00825D76 /* WooPaymentsDepositsCurrencyOverviewViewModel.swift */; };
 		209AD3D22AC1EDF600825D76 /* WooPaymentsDepositsCurrencyOverviewView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 209AD3D12AC1EDF600825D76 /* WooPaymentsDepositsCurrencyOverviewView.swift */; };
 		209B15672AD85F070094152A /* OperatingSystemVersion+Localization.swift in Sources */ = {isa = PBXBuildFile; fileRef = 209B15662AD85F070094152A /* OperatingSystemVersion+Localization.swift */; };
@@ -3803,6 +3804,7 @@
 		207823E42C5D1B2F00025A59 /* PointOfSaleCardPresentPaymentConnectionSuccessAlertView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PointOfSaleCardPresentPaymentConnectionSuccessAlertView.swift; sourceTree = "<group>"; };
 		207823E62C5D346300025A59 /* POSPrimaryButtonStyle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = POSPrimaryButtonStyle.swift; sourceTree = "<group>"; };
 		207823E82C5D3A1700025A59 /* POSErrorExclamationMark.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = POSErrorExclamationMark.swift; sourceTree = "<group>"; };
+		207E71CA2C60F765008540FC /* MockPOSOrderService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockPOSOrderService.swift; sourceTree = "<group>"; };
 		20929C9DFB2CE5CB264C27EC /* Pods-Woo Watch App.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Woo Watch App.debug.xcconfig"; path = "../Pods/Target Support Files/Pods-Woo Watch App/Pods-Woo Watch App.debug.xcconfig"; sourceTree = "<group>"; };
 		209AD3CF2AC1EDDA00825D76 /* WooPaymentsDepositsCurrencyOverviewViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WooPaymentsDepositsCurrencyOverviewViewModel.swift; sourceTree = "<group>"; };
 		209AD3D12AC1EDF600825D76 /* WooPaymentsDepositsCurrencyOverviewView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WooPaymentsDepositsCurrencyOverviewView.swift; sourceTree = "<group>"; };
@@ -7115,6 +7117,7 @@
 			isa = PBXGroup;
 			children = (
 				02CD3BFD2C35D04C00E575C4 /* MockCardPresentPaymentService.swift */,
+				207E71CA2C60F765008540FC /* MockPOSOrderService.swift */,
 				C7F746C22C485B3B0023ADD0 /* MockCartViewModel.swift */,
 				C7F746C62C4866810023ADD0 /* MockTotalsViewModel.swift */,
 				019C5EB12C5171E6005B82D3 /* MockItemListViewModel.swift */,
@@ -16640,6 +16643,7 @@
 				CC04918F292BD6AC00F719D8 /* StatsDataTextFormatterTests.swift in Sources */,
 				02BC5AA524D27F8900C43326 /* ProductVariationFormViewModel+UpdatesTests.swift in Sources */,
 				D8736B5122EB69E300A14A29 /* OrderDetailsViewModelTests.swift in Sources */,
+				207E71CB2C60F765008540FC /* MockPOSOrderService.swift in Sources */,
 				02C0CD2E23B5E3AE00F880B1 /* DefaultImageServiceTests.swift in Sources */,
 				B993051E2B7CC2A400456E35 /* LocallyStoredStateNameRetrieverTests.swift in Sources */,
 				DE7E5E8A2B4D4015002E28D2 /* BlazeTargetDeviceViewModelTests.swift in Sources */,

--- a/WooCommerce/WooCommerceTests/POS/Mocks/MockCardPresentPaymentService.swift
+++ b/WooCommerce/WooCommerceTests/POS/Mocks/MockCardPresentPaymentService.swift
@@ -27,7 +27,9 @@ final class MockCardPresentPaymentService: CardPresentPaymentFacade {
         // no-op
     }
 
+    var onCollectPaymentCalled: (() -> Void)?
     func collectPayment(for order: Yosemite.Order, using connectionMethod: CardReaderConnectionMethod) async throws -> CardPresentPaymentResult {
+        onCollectPaymentCalled?()
         paymentEvent = .show(eventDetails: CardPresentPaymentEventDetails.paymentSuccess(done: {}))
         return .success(CardPresentPaymentTransaction(receiptURL: URL(string: "https://example.net/receipts/123")!))
     }

--- a/WooCommerce/WooCommerceTests/POS/Mocks/MockPOSOrderService.swift
+++ b/WooCommerce/WooCommerceTests/POS/Mocks/MockPOSOrderService.swift
@@ -1,0 +1,16 @@
+import Foundation
+@testable import Yosemite
+
+class MockPOSOrderService: POSOrderServiceProtocol {
+    var orderToReturn: Order?
+    func syncOrder(cart: [Yosemite.POSCartItem], order: Yosemite.Order?, allProducts: [any Yosemite.POSItem]) async throws -> Yosemite.Order {
+        guard let order = orderToReturn else {
+            throw MockPOSOrderServiceError.noOrderToReturn
+        }
+        return order
+    }
+}
+
+enum MockPOSOrderServiceError: Error {
+    case noOrderToReturn
+}

--- a/WooCommerce/WooCommerceTests/POS/Mocks/MockTotalsViewModel.swift
+++ b/WooCommerce/WooCommerceTests/POS/Mocks/MockTotalsViewModel.swift
@@ -64,7 +64,7 @@ final class MockTotalsViewModel: TotalsViewModelProtocol {
         isSyncingOrder = true
     }
 
-    func cardPaymentTapped() {
+    func connectReaderTapped() {
         // Provide a mock implementation if needed
     }
 

--- a/WooCommerce/WooCommerceTests/POS/Mocks/MockTotalsViewModel.swift
+++ b/WooCommerce/WooCommerceTests/POS/Mocks/MockTotalsViewModel.swift
@@ -56,16 +56,12 @@ final class MockTotalsViewModel: TotalsViewModelProtocol {
         formattedOrderTotalTaxPrice != nil && formattedOrderTotalPrice != nil && isSyncingOrder == false
     }
 
-    func startSyncingOrder(with cartItems: [CartItem], allItems: [POSItem]) {
-        isSyncingOrder = true
-    }
-
     func startNewTransaction() {
         paymentState = .acceptingCard
     }
 
-    func calculateAmountsTapped(with cartItems: [CartItem], allItems: [POSItem]) {
-        // Provide a mock implementation if needed
+    func checkOutTapped(with cartItems: [CartItem], allItems: [POSItem]) {
+        isSyncingOrder = true
     }
 
     func cardPaymentTapped() {

--- a/WooCommerce/WooCommerceTests/POS/ViewModels/PointOfSaleDashboardViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/POS/ViewModels/PointOfSaleDashboardViewModelTests.swift
@@ -94,7 +94,7 @@ final class PointOfSaleDashboardViewModelTests: XCTestCase {
 
         // When
         let customCartItems = [CartItem(id: UUID(), item: Self.makeItem(), quantity: 1)]
-        sut.totalsViewModel.startSyncingOrder(with: customCartItems, allItems: [])
+        sut.totalsViewModel.checkOutTapped(with: customCartItems, allItems: [])
 
         wait(for: [expectation], timeout: 1.0)
     }

--- a/WooCommerce/WooCommerceTests/POS/ViewModels/TotalsViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/POS/ViewModels/TotalsViewModelTests.swift
@@ -114,18 +114,35 @@ final class TotalsViewModelTests: XCTestCase {
         XCTAssertTrue(sut.isShowingTotalsFields)
     }
 
-    func test_when_a_reader_connects_collect_payment_is_attempted() async {
+    func test_when_a_reader_connects_collectPayment_is_attempted() async {
         // Given
         orderService.orderToReturn = Order.fake().copy(items: [OrderItem.fake()])
         await sut.syncOrder(for: [], allItems: [])
 
-        // When
         waitFor { promise in
             self.cardPresentPaymentService.onCollectPaymentCalled = {
                 // Then
                 promise(())
             }
+            // When
             self.cardPresentPaymentService.connectedReader = .init(name: "Test reader", batteryLevel: 0.7)
+        }
+    }
+
+    func test_if_a_reader_is_already_connected_collectPayment_is_attempted_immediately() async {
+        // Given
+        cardPresentPaymentService.connectedReader = .init(name: "Test reader", batteryLevel: 0.7)
+
+        orderService.orderToReturn = Order.fake().copy(items: [OrderItem.fake()])
+        await sut.syncOrder(for: [], allItems: [])
+
+        waitFor { promise in
+            self.cardPresentPaymentService.onCollectPaymentCalled = {
+                // Then
+                promise(())
+            }
+            // When
+            self.sut.checkOutTapped(with: [], allItems: [])
         }
     }
 }

--- a/WooCommerce/WooCommerceTests/POS/ViewModels/TotalsViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/POS/ViewModels/TotalsViewModelTests.swift
@@ -10,12 +10,12 @@ final class TotalsViewModelTests: XCTestCase {
 
     private var sut: TotalsViewModel!
     private var cardPresentPaymentService: MockCardPresentPaymentService!
-    private var orderService: POSOrderServiceProtocol!
+    private var orderService: MockPOSOrderService!
 
     override func setUp() {
         super.setUp()
         cardPresentPaymentService = MockCardPresentPaymentService()
-        orderService = POSOrderPreviewService()
+        orderService = MockPOSOrderService()
         sut = TotalsViewModel(orderService: orderService,
                               cardPresentPaymentService: cardPresentPaymentService,
                               currencyFormatter: .init(currencySettings: .init()),
@@ -42,6 +42,8 @@ final class TotalsViewModelTests: XCTestCase {
         // Given
         let paymentState: TotalsViewModel.PaymentState = .acceptingCard
         let item = Self.makeItem()
+
+        orderService.orderToReturn = Order.fake()
 
         await sut.syncOrder(for: [CartItem(id: UUID(), item: item, quantity: 1)], allItems: [item])
         XCTAssertNotNil(sut.order)
@@ -73,6 +75,7 @@ final class TotalsViewModelTests: XCTestCase {
 
     func test_isShowingCardReaderStatus_when_connected_and_payment_message_exists_then_true() async throws {
         // Given
+        orderService.orderToReturn = Order.fake()
         cardPresentPaymentService.connectedReader = CardPresentPaymentCardReader(name: "Test", batteryLevel: 0.5)
         cardPresentPaymentService.paymentEvent = .show(eventDetails: .preparingForPayment(cancelPayment: {}))
 

--- a/WooCommerce/WooCommerceTests/POS/ViewModels/TotalsViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/POS/ViewModels/TotalsViewModelTests.swift
@@ -23,7 +23,7 @@ final class TotalsViewModelTests: XCTestCase {
                               isSyncingOrder: false)
     }
     func test_isSyncingOrder() {}
-    func test_startSyncOrder() {}
+    func test_on_checkOutTapped_startSyncOrder() {}
     func test_stopSyncOrder() {}
     func test_order() {}
     func test_formattedPrice() {}

--- a/WooCommerce/WooCommerceTests/POS/ViewModels/TotalsViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/POS/ViewModels/TotalsViewModelTests.swift
@@ -5,6 +5,7 @@ import XCTest
 @testable import struct Yosemite.Order
 @testable import struct Yosemite.POSProduct
 @testable import protocol Yosemite.POSItem
+@testable import struct Yosemite.OrderItem
 
 final class TotalsViewModelTests: XCTestCase {
 
@@ -111,6 +112,21 @@ final class TotalsViewModelTests: XCTestCase {
         cardPresentPaymentService.paymentEvent = .show(eventDetails: .preparingForPayment(cancelPayment: {}))
 
         XCTAssertTrue(sut.isShowingTotalsFields)
+    }
+
+    func test_when_a_reader_connects_collect_payment_is_attempted() async {
+        // Given
+        orderService.orderToReturn = Order.fake().copy(items: [OrderItem.fake()])
+        await sut.syncOrder(for: [], allItems: [])
+
+        // When
+        waitFor { promise in
+            self.cardPresentPaymentService.onCollectPaymentCalled = {
+                // Then
+                promise(())
+            }
+            self.cardPresentPaymentService.connectedReader = .init(name: "Test reader", batteryLevel: 0.7)
+        }
     }
 }
 


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #13431 
Merge after: #13505
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

This PR addresses the unfinished parts of #13414 after #13505.

> Finally, the remaining thing to do is make payment start when you use the floating action button to connect the reader:
> 
> > The payment preparation process should start whether the small floating button is used, or the large purple button.
> > 
> > This should only happen when we're actually on the Checkout screen.

We achieve this by observing `TotalsViewModel.connectionStatus` while the `TotalsView` is visible and there isn't a reader connected. When a reader connects, we call `collectPayment`, having first waited for the order sync to complete.

We only observe the connected reader status while the `TotalsView` is visible, so we don't start any payments for connections started on the Product List.

## Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->

1. Launch the app
2. Go to POS mode
3. Don't connect the reader, just add something to the cart
4. Tap Check out
5. On the Checkout screen, tap the floating `Connect your reader` button
6. Observe that when the connection completes, we prepare the reader for payment.

## Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->

There are a few criteria which affect how the merchant can get to a connected reader. 
- The purple CTA will show when the order's created, synced, and there's no reader connected. 
- The floating button always shows, and can be accessed from other screens
- We only listen to the reader connection status to start payments automatically (whichever button is used to start the connection) when the TotalsView is shown.
- But we shouldn't start that payment if the order hasn't synced at the moment the connection starts, even on `TotalsView` – in that case, delay until we finish syncing the order.
- And if the reader's already connected when the `TotalsView` shows, we should start the payment as soon as the order syncs

I've tested several scenarios here:

- [x] Instructions above
- [x] As above, but go back after first seeing the checkout, without connecting a reader, change the order, then complete the steps.
- [x] Breakpoint the Order Sync network request, and complete the connection before the order is synced – it should work when you let the breakpoint continue
- [x] Test with the big purple `Connect your reader` CTA that it still works correctly
- [x] Test that if you tap `Check out` with a reader connected, payment starts immediately.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->


https://github.com/user-attachments/assets/1de52515-d0d7-4f19-8eae-f58b37d02a5a


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
- [ ] This PR includes refactoring; smoke testing of the entire section is needed.