### PR TITLE
Hot Fix: Fix Watch App with Application Passwords

### DIFF
--- a/Networking/Networking/ApplicationPassword/ApplicationPasswordStorage.swift
+++ b/Networking/Networking/ApplicationPassword/ApplicationPasswordStorage.swift
@@ -5,18 +5,18 @@ import KeychainAccess
 import WordPressShared
 #endif
 
-struct ApplicationPasswordStorage {
+public struct ApplicationPasswordStorage {
     /// Stores the application password
     ///
     private let keychain: Keychain
 
-    init(keychain: Keychain = Keychain(service: WooConstants.keychainServiceName)) {
+    public init(keychain: Keychain = Keychain(service: WooConstants.keychainServiceName)) {
         self.keychain = keychain
     }
 
     /// Returns the saved application password if available
     ///
-    var applicationPassword: ApplicationPassword? {
+    public var applicationPassword: ApplicationPassword? {
         guard let password = keychain.password,
               let username = keychain.username,
               let uuid = keychain.uuid else {
@@ -29,7 +29,7 @@ struct ApplicationPasswordStorage {
     ///
     /// - Parameter password: `ApplicationPasword` to be saved
     ///
-    func saveApplicationPassword(_ password: ApplicationPassword) {
+    public func saveApplicationPassword(_ password: ApplicationPassword) {
         keychain.username = password.wpOrgUsername
         keychain.password = password.password.secretValue
         keychain.uuid = password.uuid
@@ -37,7 +37,7 @@ struct ApplicationPasswordStorage {
 
     /// Removes the currently saved password from storage
     ///
-    func removeApplicationPassword() {
+    public func removeApplicationPassword() {
         // Delete password from keychain
         keychain.username = nil
         keychain.password = nil

--- a/Networking/Networking/Network/AlamofireNetwork.swift
+++ b/Networking/Networking/Network/AlamofireNetwork.swift
@@ -32,24 +32,7 @@ public class AlamofireNetwork: Network {
     ///
     public required init(credentials: Credentials?, sessionManager: Alamofire.Session? = nil) {
         self.requestConverter = RequestConverter(credentials: credentials)
-
-        // When `DefaultRequestAuthenticator` receives a `credential.applicationPassword` case it doesn't use the information provided in the credential object.
-        // Instead, it fetches it from the Keychain, as it is assumes that the application password credentials are already saved.
-        // This does not work in the watch app, because the keychains are not shared/connected.
-        // To solve this issue without doing a major refactor on how credentials are stored and used,
-        // We are providing an specific application password use case only when running this code in the watch.
-        let applicationPasswordUseCase: ApplicationPasswordUseCase? = {
-#if os(watchOS)
-            if let credentials, case let .applicationPassword(username, password, siteAddress) = credentials {
-                let appPassword = ApplicationPassword(wpOrgUsername: username, password: .init(password), uuid: UUID().uuidString.lowercased())
-                return OneTimeApplicationPasswordUseCase(applicationPassword: appPassword, siteAddress: siteAddress)
-            }
-#endif
-            return nil
-        }()
-
-        self.requestAuthenticator = RequestProcessor(requestAuthenticator: DefaultRequestAuthenticator(credentials: credentials,
-                                                                                                       applicationPasswordUseCase: applicationPasswordUseCase))
+        self.requestAuthenticator = RequestProcessor(requestAuthenticator: DefaultRequestAuthenticator(credentials: credentials))
         if let sessionManager {
             self.alamofireSession = sessionManager
         }

--- a/WooCommerce/Classes/System/WatchDependencies.swift
+++ b/WooCommerce/Classes/System/WatchDependencies.swift
@@ -2,8 +2,12 @@ import Foundation
 
 #if canImport(Networking)
 import enum Networking.Credentials
+import struct Networking.ApplicationPasswordStorage
+import struct Networking.ApplicationPassword
 #elseif canImport(NetworkingWatchOS)
 import enum NetworkingWatchOS.Credentials
+import struct NetworkingWatchOS.ApplicationPasswordStorage
+import struct NetworkingWatchOS.ApplicationPassword
 #endif
 
 #if canImport(WooFoundation)
@@ -22,11 +26,34 @@ public struct WatchDependencies: Codable, Equatable {
     let storeName: String
     let currencySettings: CurrencySettings
     let credentials: Credentials
+    let applicationPassword: ApplicationPassword?
 
+    /// Uses the provided application password
+    /// 
+    public init(storeID: Int64,
+                storeName: String,
+                currencySettings: CurrencySettings,
+                credentials: Credentials,
+                applicationPassword: ApplicationPassword?) {
+        self.storeID = storeID
+        self.storeName = storeName
+        self.currencySettings = currencySettings
+        self.credentials = credentials
+        self.applicationPassword = applicationPassword
+
+    }
+
+    /// Uses the stored application password
+    ///
     public init(storeID: Int64, storeName: String, currencySettings: CurrencySettings, credentials: Credentials) {
         self.storeID = storeID
         self.storeName = storeName
         self.currencySettings = currencySettings
         self.credentials = credentials
+
+        // Always get the stored application password as the application networking classes rely on it.
+        // Ideally this should be refactored to live in the credentials object.
+        self.applicationPassword = ApplicationPasswordStorage().applicationPassword
+
     }
 }

--- a/WooCommerce/Classes/System/WatchDependencies.swift
+++ b/WooCommerce/Classes/System/WatchDependencies.swift
@@ -29,7 +29,7 @@ public struct WatchDependencies: Codable, Equatable {
     let applicationPassword: ApplicationPassword?
 
     /// Uses the provided application password
-    /// 
+    ///
     public init(storeID: Int64,
                 storeName: String,
                 currencySettings: CurrencySettings,

--- a/WooCommerce/Classes/System/WatchDependenciesSynchronizer.swift
+++ b/WooCommerce/Classes/System/WatchDependenciesSynchronizer.swift
@@ -1,6 +1,6 @@
 import WatchConnectivity
 import Combine
-import enum Networking.Credentials
+import Networking
 import class WooFoundation.CurrencySettings
 
 /// Type that syncs the necessary dependencies to the watch session.


### PR DESCRIPTION
# Why

A user reported that they are not able to use the watch app when logging in with their site credentials. This PR attempts to fix that.

# How

- Reverts the previous hotfix https://github.com/woocommerce/woocommerce-ios/pull/13468 as it does not cover all application password cases.

- Syncs the application password from the phone to the watch using the `ApplicationPasswordStorage` class. This ensures the application is read and stored in the same way. This is needed because the Networking authenticator classes(the ones that were causing the error) read the application password from the keychain.

# Demo

In the demo, we can see how the error state gets solved via the app update.

https://github.com/user-attachments/assets/fbdabbdb-ae34-4365-ade9-b4ae524e520a

# Tested Scenarios

- Login to a store with site credentials / application passwords natively
- Install the watch app
- See that stats and orders load successfully.

---

- Login to a store with site credentials / application via web     
- Install the watch app
- See that stats and orders load successfully.

----

- Login to a store with wpcom credentials
- Install the watch app
- See that stats and orders load successfully.


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
- [ ] This PR includes refactoring; smoke testing of the entire section is needed.