### PR TITLE
Quick Fix: Don't highlight order cell on iPad OS 16 and 16.1 to avoid crashes

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -6,7 +6,7 @@
 -----
 - [**] Fixed Collect Payment from the menu on iPads running iOS 16 [https://github.com/woocommerce/woocommerce-ios/pull/13491]
 - [Internal] Added missing events for custom range on the stats dashboard card. [https://github.com/woocommerce/woocommerce-ios/pull/13506]
-- [Internal] Disable focus for order rows on iPadOS 16 and 16.1 to avoid crashes. [https://github.com/woocommerce/woocommerce-ios/pull/13512]
+- [**] Disable focus for order rows on iPadOS 16 and 16.1 to avoid crashes. [https://github.com/woocommerce/woocommerce-ios/pull/13512]
 
 19.8
 -----

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -6,7 +6,7 @@
 -----
 - [**] Fixed Collect Payment from the menu on iPads running iOS 16 [https://github.com/woocommerce/woocommerce-ios/pull/13491]
 - [Internal] Added missing events for custom range on the stats dashboard card. [https://github.com/woocommerce/woocommerce-ios/pull/13506]
-- [Internal] Do not highlight order rows on iPadOS 16 and 16.1 to avoid crashes. [https://github.com/woocommerce/woocommerce-ios/pull/13512]
+- [Internal] Disable focus for order rows on iPadOS 16 and 16.1 to avoid crashes. [https://github.com/woocommerce/woocommerce-ios/pull/13512]
 
 19.8
 -----

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -6,6 +6,7 @@
 -----
 - [**] Fixed Collect Payment from the menu on iPads running iOS 16 [https://github.com/woocommerce/woocommerce-ios/pull/13491]
 - [Internal] Added missing events for custom range on the stats dashboard card. [https://github.com/woocommerce/woocommerce-ios/pull/13506]
+- [Internal] Do not highlight order rows on iPadOS 16 and 16.1 to avoid crashes. [https://github.com/woocommerce/woocommerce-ios/pull/13512]
 
 19.8
 -----

--- a/WooCommerce/Classes/ViewRelated/Orders/OrderListViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrderListViewController.swift
@@ -570,6 +570,10 @@ private extension OrderListViewController {
     /// Removes the selected state otherwise.
     ///
     func highlightSelectedRowIfNeeded(shouldScrollIfNeeded: Bool = false) {
+        guard supportsHighlighting() else {
+            return
+        }
+
         guard let selectedOrderID, let orderIndexPath = indexPath(for: selectedOrderID) else {
             tableView.deselectSelectedRowWithAnimation(true)
             return
@@ -582,6 +586,25 @@ private extension OrderListViewController {
                 tableView.scrollToRow(at: orderIndexPath, at: .none, animated: true)
             }
         }
+    }
+
+    /// Highlighting crashes on iPad iOS 16 and iOS 16.1 versions
+    /// peaMlT-Ng-p2
+    /// https://github.com/woocommerce/woocommerce-ios/issues/13485
+    private func supportsHighlighting() -> Bool {
+        guard UIDevice.current.userInterfaceIdiom == .pad else {
+            return true
+        }
+
+        let systemVersion = ProcessInfo.processInfo.operatingSystemVersion
+        let majorVersion = systemVersion.majorVersion
+        let minorVersion = systemVersion.minorVersion
+
+        if majorVersion == 16 && (minorVersion == 0 || minorVersion == 1) {
+            return false
+        }
+
+        return true
     }
 
     /// Checks to see if there is a selected order ID, and selects its order.

--- a/WooCommerce/Classes/ViewRelated/Orders/OrderListViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrderListViewController.swift
@@ -360,6 +360,7 @@ private extension OrderListViewController {
         tableView.sectionFooterHeight = .leastNonzeroMagnitude
         tableView.rowHeight = UITableView.automaticDimension
         tableView.estimatedRowHeight = UITableView.automaticDimension
+        tableView.allowsFocus = supportsFocus()
     }
 
     /// Registers all of the available table view cells and headers
@@ -570,10 +571,6 @@ private extension OrderListViewController {
     /// Removes the selected state otherwise.
     ///
     func highlightSelectedRowIfNeeded(shouldScrollIfNeeded: Bool = false) {
-        guard supportsHighlighting() else {
-            return
-        }
-
         guard let selectedOrderID, let orderIndexPath = indexPath(for: selectedOrderID) else {
             tableView.deselectSelectedRowWithAnimation(true)
             return
@@ -588,10 +585,10 @@ private extension OrderListViewController {
         }
     }
 
-    /// Highlighting crashes on iPad iOS 16 and iOS 16.1 versions
+    /// Focus code crashes on iPadOS 16 and 16.1 versions
     /// peaMlT-Ng-p2
     /// https://github.com/woocommerce/woocommerce-ios/issues/13485
-    private func supportsHighlighting() -> Bool {
+    private func supportsFocus() -> Bool {
         guard UIDevice.current.userInterfaceIdiom == .pad else {
             return true
         }

--- a/WooCommerce/Classes/ViewRelated/Orders/OrderListViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrderListViewController.swift
@@ -593,15 +593,11 @@ private extension OrderListViewController {
             return true
         }
 
-        let systemVersion = ProcessInfo.processInfo.operatingSystemVersion
-        let majorVersion = systemVersion.majorVersion
-        let minorVersion = systemVersion.minorVersion
-
-        if majorVersion == 16 && (minorVersion == 0 || minorVersion == 1) {
+        if #available(iOS 16.2, *) {
+            return true
+        } else {
             return false
         }
-
-        return true
     }
 
     /// Checks to see if there is a selected order ID, and selects its order.


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #13485
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
Context peaMlT-Ng-p2

This a quick fix to avoid a crash on iPadOS 16 and 16.1 when selecting order and refreshing. Given the low usage of this particular setup and the fact that it no longer crashes with a higher iOS version, disabling `allowFocus` looks to be enough.

## Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->

### iPadOS 16 / 16.1

1. Select orders tab
2. Tap on the order
3. Pull to refresh
4. Confirm there's no crash

### iPadOS 16.2+

1. Select orders tab
2. Tap on the order
3. Pull to refresh
4. Confirm there's no crash

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

---
- [x] I have considered adding unit tests for this change. If I decided not to add them, I have provided a brief explanation below (optional):
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
- [x] This PR includes refactoring; smoke testing of the entire section is needed.