### PR TITLE
[Prologue] Reinstate Starting a new store webview hotfix

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -3,6 +3,9 @@
 19.8
 -----
 
+19.7.1
+-----
+- [***] Prologue: Restored web view for `Starting a new store?` button [https://github.com/woocommerce/woocommerce-ios/pull/13518]
 
 19.7
 -----

--- a/WooCommerce/Classes/Authentication/AuthenticationManager.swift
+++ b/WooCommerce/Classes/Authentication/AuthenticationManager.swift
@@ -552,6 +552,16 @@ extension AuthenticationManager: WordPressAuthenticatorDelegate {
         }
         analytics.track(wooEvent, withError: error)
     }
+
+    func showSiteCreationGuide(in navigationController: UINavigationController) {
+        analytics.track(event: .StoreCreation.loginPrologueStartingANewStoreTapped())
+
+        guard let url = try? AuthenticationConstants.hostingURL.asURL() else {
+            return
+        }
+        let webView = SFSafariViewController(url: url)
+        navigationController.present(webView, animated: true)
+    }
 }
 
 // MARK: - Private helpers


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #13515
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

We mistakenly removed the handler for the starting a new store button on the start screen in WCiOS 19.6. This commit restores the webview presentation code.

This is a hotfix on 19.7

## Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->

1. Launch the app
2. Sign out if required
3. Tap `Starting a new store?`
4. Observe that the webview is shown with details for options about starting a new store

## Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->


---
- [x] I have considered adding unit tests for this change. If I decided not to add them, I have provided a brief explanation below (optional):
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
- [ ] This PR includes refactoring; smoke testing of the entire section is needed.