### PR TITLE
[Custom Fields] Entry point design in product details

### DIFF
--- a/WooCommerce/Classes/Extensions/UIImage+Woo.swift
+++ b/WooCommerce/Classes/Extensions/UIImage+Woo.swift
@@ -981,6 +981,12 @@ extension UIImage {
         return UIImage.gridicon(.money, size: CGSize(width: 24, height: 24))
     }
 
+    /// Custom Fields Icon
+    ///
+    static var customFieldsImage: UIImage {
+        return UIImage.gridicon(.alignLeft, size: CGSize(width: 24, height: 24))
+    }
+
     /// Print Icon
     ///
     static var print: UIImage {

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/DefaultProductFormTableViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/DefaultProductFormTableViewModel.swift
@@ -102,6 +102,9 @@ private extension DefaultProductFormTableViewModel {
             switch action {
             case .priceSettings(let editable, _):
                 return .price(viewModel: priceSettingsRow(product: product, isEditable: editable), isEditable: editable)
+            case .customFields:
+                // showing "Reviews" row just as a test. TODO-13507: replace it with actual custom fields viewModel.
+                return .customFields(viewModel: reviewsRow(product: product))
             case .reviews:
                 return .reviews(viewModel: reviewsRow(product: product), ratingCount: product.ratingCount, averageRating: product.averageRating)
             case .productType(let editable):

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/DefaultProductFormTableViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/DefaultProductFormTableViewModel.swift
@@ -103,8 +103,7 @@ private extension DefaultProductFormTableViewModel {
             case .priceSettings(let editable, _):
                 return .price(viewModel: priceSettingsRow(product: product, isEditable: editable), isEditable: editable)
             case .customFields:
-                // showing "Reviews" row just as a test. TODO-13507: replace it with actual custom fields viewModel.
-                return .customFields(viewModel: reviewsRow(product: product))
+                return .customFields(viewModel: customFieldsRow())
             case .reviews:
                 return .reviews(viewModel: reviewsRow(product: product), ratingCount: product.ratingCount, averageRating: product.averageRating)
             case .productType(let editable):
@@ -255,6 +254,14 @@ private extension DefaultProductFormTableViewModel {
                      tintColor: tintColor,
                      isActionable: priceViewModel.isActionable,
                      hideSeparator: hideSeparator)
+    }
+
+    func customFieldsRow() -> ProductFormSection.SettingsRow.ViewModel {
+        return ProductFormSection.SettingsRow.ViewModel(
+            icon: UIImage.customFieldsImage,
+            title: Localization.customFieldsTitle,
+            details: Localization.customFieldsDetails
+        )
     }
 
     func reviewsRow(product: ProductFormDataModel) -> ProductFormSection.SettingsRow.ViewModel {
@@ -781,6 +788,19 @@ private extension DefaultProductFormTableViewModel.Localization {
                                                     comment: "Format of the sale period on the Price Settings row from a certain date")
         static let saleDateFormatTo = NSLocalizedString("Sale dates: Until %@",
                                                     comment: "Format of the sale period on the Price Settings row until a certain date")
+
+        // Custom fields
+        static let customFieldsTitle = NSLocalizedString(
+            "defaultProductFormTableViewModel.customFieldsDetails",
+            value: "Custom Fields",
+            comment: "Title for the Custom Fields row"
+        )
+
+        static let customFieldsDetails = NSLocalizedString(
+            "defaultProductFormTableViewModel.customFieldsDetails",
+            value: "View and edit the product's custom fields",
+            comment: "Details text for the Custom Fields row"
+        )
 
         // Reviews
         static let emptyReviews = NSLocalizedString("No (approved) reviews",

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormActionsFactory.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormActionsFactory.swift
@@ -9,6 +9,7 @@ enum ProductFormEditAction: Equatable {
     case description(editable: Bool)
     case promoteWithBlaze
     case priceSettings(editable: Bool, hideSeparator: Bool)
+    case customFields
     case reviews
     case productType(editable: Bool)
     case inventorySettings(editable: Bool)
@@ -73,6 +74,7 @@ struct ProductFormActionsFactory: ProductFormActionsFactoryProtocol {
     private let isBundledProductsEnabled: Bool
     private let isCompositeProductsEnabled: Bool
     private let isMinMaxQuantitiesEnabled: Bool
+    private let isCustomFieldsEnabled: Bool
 
     // TODO: Remove default parameter
     init(product: EditableProductModel,
@@ -83,6 +85,8 @@ struct ProductFormActionsFactory: ProductFormActionsFactoryProtocol {
          isBundledProductsEnabled: Bool = ServiceLocator.featureFlagService.isFeatureFlagEnabled(.productBundles),
          isCompositeProductsEnabled: Bool = ServiceLocator.featureFlagService.isFeatureFlagEnabled(.compositeProducts),
          isMinMaxQuantitiesEnabled: Bool = ServiceLocator.featureFlagService.isFeatureFlagEnabled(.readOnlyMinMaxQuantities),
+         isCustomFieldsEnabled: Bool =
+         ServiceLocator.featureFlagService.isFeatureFlagEnabled(.viewEditCustomFieldsInProductsAndOrders),
          variationsPrice: VariationsPrice = .unknown,
          stores: StoresManager = ServiceLocator.stores) {
         self.product = product
@@ -95,6 +99,7 @@ struct ProductFormActionsFactory: ProductFormActionsFactoryProtocol {
         self.isBundledProductsEnabled = isBundledProductsEnabled
         self.isCompositeProductsEnabled = isCompositeProductsEnabled
         self.isMinMaxQuantitiesEnabled = isMinMaxQuantitiesEnabled
+        self.isCustomFieldsEnabled = isCustomFieldsEnabled
         self.stores = stores
     }
 
@@ -176,6 +181,7 @@ private extension ProductFormActionsFactory {
 
         let actions: [ProductFormEditAction?] = [
             .priceSettings(editable: editable, hideSeparator: false),
+            isCustomFieldsEnabled ? .customFields: nil,
             shouldShowReviewsRow ? .reviews: nil,
             shouldShowShippingSettingsRow ? .shippingSettings(editable: editable): nil,
             .inventorySettings(editable: canEditInventorySettingsRow),
@@ -401,6 +407,9 @@ private extension ProductFormActionsFactory {
         switch action {
         case .priceSettings:
             // The price settings action is always visible in the settings section.
+            return true
+        case .customFields:
+            // The custom fields action is always visible in the settings section.
             return true
         case .subscriptionFreeTrial:
             // The Free trial row is always visible in the settings section for a subscription product.

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormSection+ReusableTableRow.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormSection+ReusableTableRow.swift
@@ -77,6 +77,7 @@ extension ProductFormSection.SettingsRow: ReusableTableRow {
     var cellTypes: [UITableViewCell.Type] {
         switch self {
         case .price,
+             .customFields,
              .productType,
              .inventory,
              .shipping,
@@ -112,6 +113,7 @@ extension ProductFormSection.SettingsRow: ReusableTableRow {
     private var cellType: UITableViewCell.Type {
         switch self {
         case .price,
+             .customFields,
              .productType,
              .inventory,
              .shipping,

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormTableViewDataSource.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormTableViewDataSource.swift
@@ -365,6 +365,7 @@ private extension ProductFormTableViewDataSource {
     func configureCellInSettingsFieldsSection(_ cell: UITableViewCell, row: ProductFormSection.SettingsRow) {
         switch row {
         case .price(let viewModel, _),
+             .customFields(let viewModel),
              .inventory(let viewModel, _),
              .productType(let viewModel, _),
              .shipping(let viewModel, _),

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormTableViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormTableViewModel.swift
@@ -28,6 +28,7 @@ enum ProductFormSection: Equatable {
 
     enum SettingsRow: Equatable {
         case price(viewModel: ViewModel, isEditable: Bool)
+        case customFields(viewModel: ViewModel)
         case reviews(viewModel: ViewModel, ratingCount: Int, averageRating: String)
         case productType(viewModel: ViewModel, isEditable: Bool)
         case shipping(viewModel: ViewModel, isEditable: Bool)

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewController.swift
@@ -434,6 +434,9 @@ final class ProductFormViewController<ViewModel: ProductFormViewModelProtocol>: 
                 eventLogger.logPriceSettingsTapped()
                 editPriceSettings()
             case .reviews:
+                // TODO-13507: add tap handling.
+                return
+            case .customFields:
                 ServiceLocator.analytics.track(.productDetailViewReviewsTapped)
                 showReviews()
             case .downloadableFiles(_, let isEditable):

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewController.swift
@@ -433,10 +433,10 @@ final class ProductFormViewController<ViewModel: ProductFormViewModelProtocol>: 
                 }
                 eventLogger.logPriceSettingsTapped()
                 editPriceSettings()
-            case .reviews:
+            case .customFields:
                 // TODO-13507: add tap handling.
                 return
-            case .customFields:
+            case .reviews:
                 ServiceLocator.analytics.track(.productDetailViewReviewsTapped)
                 showReviews()
             case .downloadableFiles(_, let isEditable):

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormViewController.swift
@@ -434,7 +434,7 @@ final class ProductFormViewController<ViewModel: ProductFormViewModelProtocol>: 
                 eventLogger.logPriceSettingsTapped()
                 editPriceSettings()
             case .customFields:
-                // TODO-13507: add tap handling.
+                // TODO-13493: add tap handling.
                 return
             case .reviews:
                 ServiceLocator.analytics.track(.productDetailViewReviewsTapped)


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of: #13493
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

This PR adds the "Custom Fields" row in a simple product's Product Details. The purpose is simply to add a working entry point to enable further development. The design follows this:

<img width="42%" alt="Screenshot 2024-08-06 at 20 29 32" src="https://github.com/user-attachments/assets/407626e7-f155-40b5-91e9-502d25a85ec4">

## Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->

1. Run app
2. Go to Products, open a simple product,
3. Ensure the **Custom Fields** row appear similar to the design above.