### PR TITLE
[Woo POS] Remove private products from POS scope

### DIFF
--- a/Networking/Networking/Remote/ProductsRemote.swift
+++ b/Networking/Networking/Remote/ProductsRemote.swift
@@ -181,21 +181,19 @@ public final class ProductsRemote: Remote, ProductsRemoteProtocol {
         enqueue(request, mapper: mapper, completion: completion)
     }
 
-    /// Retrieves simple products
+    /// Retrieves simple products for the Point of Sale
     ///
     /// - Parameters:
     /// - siteID: Site for which we'll fetch remote products.
     ///
     public func loadAllSimpleProductsForPointOfSale(for siteID: Int64) async throws -> [Product] {
         let parameters = [
-            // TODO: Handle pagination
-            // Currently we just fetch the 1st page and 100 products
-            // https://github.com/woocommerce/woocommerce-ios/issues/12837
             ParameterKey.page: POSConstants.page,
             ParameterKey.perPage: POSConstants.productsPerPage,
             ParameterKey.productType: POSConstants.productType,
             ParameterKey.orderBy: OrderKey.name.value,
-            ParameterKey.order: Order.ascending.value
+            ParameterKey.order: Order.ascending.value,
+            ParameterKey.productStatus: POSConstants.productStatus,
         ]
         let request = JetpackRequest(wooApiVersion: .mark3,
                                      method: .get,
@@ -628,6 +626,7 @@ private extension ProductsRemote {
         static let page = "1"
         static let productsPerPage = "100"
         static let productType = "simple"
+        static let productStatus = "publish"
     }
 }
 

--- a/Yosemite/Yosemite/PointOfSale/POSProductProvider.swift
+++ b/Yosemite/Yosemite/PointOfSale/POSProductProvider.swift
@@ -31,7 +31,6 @@ public final class POSProductProvider: POSItemProvider {
             let products = try await productsRemote.loadAllSimpleProductsForPointOfSale(for: siteID)
 
             let eligibilityCriteria: [(Product) -> Bool] = [
-                isPublishedOrPrivateStatus,
                 isNotVirtual,
                 isNotDownloadable,
                 hasPrice
@@ -82,10 +81,6 @@ private extension POSProductProvider {
         return products.filter { product in
             criteria.allSatisfy { $0(product) }
         }
-    }
-
-    func isPublishedOrPrivateStatus(product: Product) -> Bool {
-        product.productStatus == .published || product.productStatus == .privateStatus
     }
 
     func isNotVirtual(product: Product) -> Bool {


### PR DESCRIPTION
## Description
Closes #13509

This PR addresses a minor improvement discussed here pdfdoF-5d5-p2#comment-6288 by reducing scope of POS products to have `product_status: publish` only. 

Since we can pass this parameter directly to the API via the remote, we also move this bit from the business to the network layer.

## Screenshots
| App product list | POS item list |
|--------|--------|
| ![Simulator Screenshot - iPad Pro (12 9-inch) (6th generation) - 2024-08-06 at 17 41 14](https://github.com/user-attachments/assets/ab796a3d-0ecc-410e-88e0-8eb1659f09dd) | ![Simulator Screenshot - iPad Pro (12 9-inch) (6th generation) - 2024-08-06 at 17 40 19](https://github.com/user-attachments/assets/86ae130f-a886-4996-a218-7a03e69f7c96) | 

## Testing
- In the app, create a product but don't publish it, save it as a `draft` or make or `private`.
- In the app, navigate to the `Products` tab and observe how it appears in the product list.
- Switch to POS mode
- Observe how the product does not appear in the POS item list. Only published products will appear.

The change does not need further unit tests, it is covered by existing `POSProductProviderTests`.

---
- [x] I have considered adding unit tests for this change. If I decided not to add them, I have provided a brief explanation below (optional):