### PR TITLE
Blaze: Update budget screen UI to support evergreen campaign creation

### DIFF
--- a/Experiments/Experiments/DefaultFeatureFlagService.swift
+++ b/Experiments/Experiments/DefaultFeatureFlagService.swift
@@ -90,6 +90,8 @@ public struct DefaultFeatureFlagService: FeatureFlagService {
             return buildConfig == .localDeveloper || buildConfig == .alpha
         case .viewEditCustomFieldsInProductsAndOrders:
             return buildConfig == .localDeveloper || buildConfig == .alpha
+        case .blazeEvergreenCampaigns:
+            return buildConfig == .localDeveloper || buildConfig == .alpha
         default:
             return true
         }

--- a/Experiments/Experiments/FeatureFlag.swift
+++ b/Experiments/Experiments/FeatureFlag.swift
@@ -195,4 +195,8 @@ public enum FeatureFlag: Int {
     /// Enables view/editing of custom fields (metadata) in both Products and Orders
     ///
     case viewEditCustomFieldsInProductsAndOrders
+
+    /// Supports evergreen campaigns for Blaze
+    ///
+    case blazeEvergreenCampaigns
 }

--- a/WooCommerce/Classes/ViewRelated/Blaze/BudgetSetting/BlazeBudgetSettingView.swift
+++ b/WooCommerce/Classes/ViewRelated/Blaze/BudgetSetting/BlazeBudgetSettingView.swift
@@ -68,11 +68,12 @@ private extension BlazeBudgetSettingView {
             }
 
             // Total budget amount details
+            // If the campaign is evergreen, display the weekly budget instead
             VStack {
-                Text(Localization.totalSpend)
+                Text(viewModel.isEvergreen ? Localization.weeklySpend : Localization.totalSpend)
                     .subheadlineStyle()
 
-                Text(viewModel.totalAmountText)
+                Text(viewModel.isEvergreen ? viewModel.weeklyAmountText : viewModel.totalAmountText)
                     .bold()
                     .largeTitleStyle()
 
@@ -80,6 +81,7 @@ private extension BlazeBudgetSettingView {
                     .foregroundColor(Color.secondary)
                     .bold()
                     .largeTitleStyle()
+                    .renderedIf(viewModel.isEvergreen == false)
             }
 
             // Daily amount slider and estimated impression
@@ -269,6 +271,11 @@ private extension BlazeBudgetSettingView {
             "blazeBudgetSettingView.totalSpend",
             value: "Total spend",
             comment: "Label for total spend on the Blaze budget setting screen"
+        )
+        static let weeklySpend = NSLocalizedString(
+            "blazeBudgetSettingView.weeklySpend",
+            value: "Weekly spend",
+            comment: "Label for weekly spend on the Blaze budget setting screen"
         )
         static let estimatedImpressions = NSLocalizedString(
             "blazeBudgetSettingView.estimatedImpressions",

--- a/WooCommerce/Classes/ViewRelated/Blaze/BudgetSetting/BlazeBudgetSettingView.swift
+++ b/WooCommerce/Classes/ViewRelated/Blaze/BudgetSetting/BlazeBudgetSettingView.swift
@@ -68,15 +68,15 @@ private extension BlazeBudgetSettingView {
             }
 
             // Total budget amount details
-            // If the campaign is evergreen, display the weekly budget instead
             VStack {
-                Text(viewModel.isEvergreen ? Localization.weeklySpend : Localization.totalSpend)
+                Text(viewModel.totalAmountTitle)
                     .subheadlineStyle()
 
-                Text(viewModel.isEvergreen ? viewModel.weeklyAmountText : viewModel.totalAmountText)
+                Text(viewModel.totalAmountText)
                     .bold()
                     .largeTitleStyle()
 
+                // Hide the duration if the campaign is evergreen
                 Text(viewModel.formattedTotalDuration)
                     .foregroundColor(Color.secondary)
                     .bold()
@@ -191,12 +191,13 @@ private extension BlazeBudgetSettingView {
 
                 Spacer().frame(height: Layout.sectionSpacing)
 
+                // Toggle to switch between evergreen and not. Hidden under a feature flag.
                 Toggle(Localization.evergreenCampaign, isOn: $viewModel.isEvergreen)
                     .toggleStyle(.switch)
                     .padding(Layout.contentPadding)
                     .renderedIf(ServiceLocator.featureFlagService.isFeatureFlagEnabled(.blazeEvergreenCampaigns))
 
-                // Duration slider
+                // Duration slider - available only if the campaign is not evergreen
                 VStack(spacing: Layout.sectionContentSpacing) {
                     Text(viewModel.formatDayCount(duration))
                         .fontWeight(.semibold)
@@ -274,16 +275,6 @@ private extension BlazeBudgetSettingView {
             "blazeBudgetSettingView.subtitle",
             value: "How much would you like to spend on your product promotion campaign?",
             comment: "Subtitle of the Blaze budget setting screen"
-        )
-        static let totalSpend = NSLocalizedString(
-            "blazeBudgetSettingView.totalSpend",
-            value: "Total spend",
-            comment: "Label for total spend on the Blaze budget setting screen"
-        )
-        static let weeklySpend = NSLocalizedString(
-            "blazeBudgetSettingView.weeklySpend",
-            value: "Weekly spend",
-            comment: "Label for weekly spend on the Blaze budget setting screen"
         )
         static let estimatedImpressions = NSLocalizedString(
             "blazeBudgetSettingView.estimatedImpressions",

--- a/WooCommerce/Classes/ViewRelated/Blaze/BudgetSetting/BlazeBudgetSettingView.swift
+++ b/WooCommerce/Classes/ViewRelated/Blaze/BudgetSetting/BlazeBudgetSettingView.swift
@@ -334,6 +334,6 @@ private extension BlazeBudgetSettingView {
 struct BlazeBudgetSettingView_Previews: PreviewProvider {
     static var previews: some View {
         let tomorrow = Date.now + 60 * 60 * 24 // Current date + 1 day
-        BlazeBudgetSettingView(viewModel: BlazeBudgetSettingViewModel(siteID: 123, dailyBudget: 5, duration: 7, startDate: tomorrow) { _, _, _ in })
+        BlazeBudgetSettingView(viewModel: BlazeBudgetSettingViewModel(siteID: 123, dailyBudget: 5, isEvergreen: true, duration: 7, startDate: tomorrow) { _, _, _ in })
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Blaze/BudgetSetting/BlazeBudgetSettingView.swift
+++ b/WooCommerce/Classes/ViewRelated/Blaze/BudgetSetting/BlazeBudgetSettingView.swift
@@ -189,10 +189,12 @@ private extension BlazeBudgetSettingView {
         NavigationView {
             ScrollView {
 
+                Spacer().frame(height: Layout.sectionSpacing)
+
                 Toggle(Localization.evergreenCampaign, isOn: $viewModel.isEvergreen)
                     .toggleStyle(.switch)
                     .padding(Layout.contentPadding)
-                    .padding(.top, Layout.sectionSpacing)
+                    .renderedIf(ServiceLocator.featureFlagService.isFeatureFlagEnabled(.blazeEvergreenCampaigns))
 
                 // Duration slider
                 VStack(spacing: Layout.sectionContentSpacing) {

--- a/WooCommerce/Classes/ViewRelated/Blaze/BudgetSetting/BlazeBudgetSettingView.swift
+++ b/WooCommerce/Classes/ViewRelated/Blaze/BudgetSetting/BlazeBudgetSettingView.swift
@@ -358,6 +358,6 @@ struct BlazeBudgetSettingView_Previews: PreviewProvider {
                                                                       dailyBudget: 5,
                                                                       isEvergreen: true,
                                                                       duration: 7,
-                                                                      startDate: tomorrow) { _, _, _ in })
+                                                                      startDate: tomorrow) { _, _, _, _ in })
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Blaze/BudgetSetting/BlazeBudgetSettingView.swift
+++ b/WooCommerce/Classes/ViewRelated/Blaze/BudgetSetting/BlazeBudgetSettingView.swift
@@ -188,6 +188,12 @@ private extension BlazeBudgetSettingView {
     var durationSettingView: some View {
         NavigationView {
             ScrollView {
+
+                Toggle(Localization.evergreenCampaign, isOn: $viewModel.isEvergreen)
+                    .toggleStyle(.switch)
+                    .padding(Layout.contentPadding)
+                    .padding(.top, Layout.sectionSpacing)
+
                 // Duration slider
                 VStack(spacing: Layout.sectionContentSpacing) {
                     Text(viewModel.formatDayCount(duration))
@@ -199,7 +205,7 @@ private extension BlazeBudgetSettingView {
                            step: Double(BlazeBudgetSettingViewModel.Constants.dayCountSliderStep))
                 }
                 .padding(Layout.contentPadding)
-                .padding(.top, Layout.sectionSpacing)
+                .renderedIf(viewModel.isEvergreen == false)
 
                 // Start date picker
                 VStack {
@@ -335,12 +341,21 @@ private extension BlazeBudgetSettingView {
             value: "Failed to estimate impressions. Retry?",
             comment: "Button to retry fetching estimated impressions on the Blaze campaign duration setting screen"
         )
+        static let evergreenCampaign = NSLocalizedString(
+            "blazeBudgetSettingView.evergreenCampaign",
+            value: "Run until I stop it",
+            comment: "Switch to toggle evergreen mode on or off for a Blaze campaign."
+        )
     }
 }
 
 struct BlazeBudgetSettingView_Previews: PreviewProvider {
     static var previews: some View {
         let tomorrow = Date.now + 60 * 60 * 24 // Current date + 1 day
-        BlazeBudgetSettingView(viewModel: BlazeBudgetSettingViewModel(siteID: 123, dailyBudget: 5, isEvergreen: true, duration: 7, startDate: tomorrow) { _, _, _ in })
+        BlazeBudgetSettingView(viewModel: BlazeBudgetSettingViewModel(siteID: 123,
+                                                                      dailyBudget: 5,
+                                                                      isEvergreen: true,
+                                                                      duration: 7,
+                                                                      startDate: tomorrow) { _, _, _ in })
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Blaze/BudgetSetting/BlazeBudgetSettingViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Blaze/BudgetSetting/BlazeBudgetSettingViewModel.swift
@@ -16,7 +16,7 @@ final class BlazeBudgetSettingViewModel: ObservableObject {
     @Published private(set) var forecastedImpressionState = ForecastedImpressionState.loading
 
     // Whether the campaign should have no end date
-    @Published private(set) var isEvergreen: Bool
+    @Published var isEvergreen: Bool
 
     let dailyAmountSliderRange = Constants.minimumDailyAmount...Constants.maximumDailyAmount
 

--- a/WooCommerce/Classes/ViewRelated/Blaze/BudgetSetting/BlazeBudgetSettingViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Blaze/BudgetSetting/BlazeBudgetSettingViewModel.swift
@@ -15,6 +15,9 @@ final class BlazeBudgetSettingViewModel: ObservableObject {
 
     @Published private(set) var forecastedImpressionState = ForecastedImpressionState.loading
 
+    // Whether the campaign should have no end date
+    @Published private(set) var isEvergreen: Bool
+
     let dailyAmountSliderRange = Constants.minimumDailyAmount...Constants.maximumDailyAmount
 
     /// Using Double because Slider doesn't work with Int
@@ -68,6 +71,7 @@ final class BlazeBudgetSettingViewModel: ObservableObject {
 
     init(siteID: Int64,
          dailyBudget: Double,
+         isEvergreen: Bool,
          duration: Int,
          startDate: Date,
          locale: Locale = .current,
@@ -78,6 +82,7 @@ final class BlazeBudgetSettingViewModel: ObservableObject {
          onCompletion: @escaping BlazeBudgetSettingCompletionHandler) {
         self.siteID = siteID
         self.dailyAmount = dailyBudget
+        self.isEvergreen = isEvergreen
         self.dayCount = Double(duration)
         self.startDate = startDate
         self.locale = locale

--- a/WooCommerce/Classes/ViewRelated/Blaze/BudgetSetting/BlazeBudgetSettingViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Blaze/BudgetSetting/BlazeBudgetSettingViewModel.swift
@@ -39,7 +39,7 @@ final class BlazeBudgetSettingViewModel: ObservableObject {
     }
 
     var totalAmountText: String {
-        let duration = isEvergreen ? 7 : dayCount
+        let duration = isEvergreen ? Double(Constants.dayCountInWeek) : dayCount
         let totalBudget = calculateTotalBudget(dailyBudget: dailyAmount, dayCount: duration)
         return String.localizedStringWithFormat(Localization.totalBudget, totalBudget)
     }
@@ -201,6 +201,7 @@ extension BlazeBudgetSettingViewModel {
         static let minimumDayCount = 1
         static let maximumDayCount = 28
         static let defaultDayCount = 7
+        static let dayCountInWeek = 7
         static let dayCountSliderStep = 1
     }
 

--- a/WooCommerce/Classes/ViewRelated/Blaze/BudgetSetting/BlazeBudgetSettingViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Blaze/BudgetSetting/BlazeBudgetSettingViewModel.swift
@@ -34,6 +34,11 @@ final class BlazeBudgetSettingViewModel: ObservableObject {
         return String.localizedStringWithFormat(Localization.dailyAmount, formattedAmount)
     }
 
+    var weeklyAmountText: String {
+        let totalBudget = calculateTotalBudget(dailyBudget: dailyAmount, dayCount: 7)
+        return String.localizedStringWithFormat(Localization.totalBudget, totalBudget)
+    }
+
     var totalAmountText: String {
         let totalBudget = calculateTotalBudget(dailyBudget: dailyAmount, dayCount: dayCount)
         return String.localizedStringWithFormat(Localization.totalBudget, totalBudget)
@@ -46,8 +51,13 @@ final class BlazeBudgetSettingViewModel: ObservableObject {
     }
 
     var formattedDateRange: String {
-        let endDate = calculateEndDate(from: startDate, dayCount: dayCount)
-        return dateFormatter.string(from: startDate, to: endDate)
+        if isEvergreen {
+            let formattedStartDate = startDate.toString(dateStyle: .medium, timeStyle: .none)
+            return String(format: Localization.evergreenCampaignDate, formattedStartDate)
+        } else {
+            let endDate = calculateEndDate(from: startDate, dayCount: dayCount)
+            return dateFormatter.string(from: startDate, to: endDate)
+        }
     }
 
     private let dateFormatter: DateIntervalFormatter = {
@@ -235,6 +245,12 @@ extension BlazeBudgetSettingViewModel {
             value: "$%.0f USD",
             comment: "The formatted total budget for a Blaze campaign, fixed in USD. " +
             "Reads as $11 USD. Keep %.0f as is."
+        )
+        static let evergreenCampaignDate = NSLocalizedString(
+            "blazeBudgetSettingViewModel.evergreenCampaignDate",
+            value: "Starting from %1$@",
+            comment: "The formatted date for an evergreen Blaze campaign, with the starting date in the placeholder. " +
+            "Read as Starting from May 11."
         )
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Blaze/BudgetSetting/BlazeBudgetSettingViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Blaze/BudgetSetting/BlazeBudgetSettingViewModel.swift
@@ -74,7 +74,7 @@ final class BlazeBudgetSettingViewModel: ObservableObject {
     private let stores: StoresManager
     private let analytics: Analytics
 
-    typealias BlazeBudgetSettingCompletionHandler = (_ dailyBudget: Double, _ duration: Int, _ startDate: Date) -> Void
+    typealias BlazeBudgetSettingCompletionHandler = (_ dailyBudget: Double, _ isEvergreen: Bool, _ duration: Int, _ startDate: Date) -> Void
     private let completionHandler: BlazeBudgetSettingCompletionHandler
 
     private var settingSubscription: AnyCancellable?
@@ -122,7 +122,7 @@ final class BlazeBudgetSettingViewModel: ObservableObject {
         let totalBudget = calculateTotalBudget(dailyBudget: dailyAmount, dayCount: dayCount)
         analytics.track(event: .Blaze.Budget.updateTapped(duration: days,
                                                           totalBudget: totalBudget))
-        completionHandler(dailyAmount, days, startDate)
+        completionHandler(dailyAmount, isEvergreen, days, startDate)
     }
 
     @MainActor

--- a/WooCommerce/Classes/ViewRelated/Blaze/BudgetSetting/BlazeBudgetSettingViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Blaze/BudgetSetting/BlazeBudgetSettingViewModel.swift
@@ -34,13 +34,13 @@ final class BlazeBudgetSettingViewModel: ObservableObject {
         return String.localizedStringWithFormat(Localization.dailyAmount, formattedAmount)
     }
 
-    var weeklyAmountText: String {
-        let totalBudget = calculateTotalBudget(dailyBudget: dailyAmount, dayCount: 7)
-        return String.localizedStringWithFormat(Localization.totalBudget, totalBudget)
+    var totalAmountTitle: String {
+        isEvergreen ? Localization.weeklySpend : Localization.totalSpend
     }
 
     var totalAmountText: String {
-        let totalBudget = calculateTotalBudget(dailyBudget: dailyAmount, dayCount: dayCount)
+        let duration = isEvergreen ? 7 : dayCount
+        let totalBudget = calculateTotalBudget(dailyBudget: dailyAmount, dayCount: duration)
         return String.localizedStringWithFormat(Localization.totalBudget, totalBudget)
     }
 
@@ -251,6 +251,16 @@ extension BlazeBudgetSettingViewModel {
             value: "Starting from %1$@",
             comment: "The formatted date for an evergreen Blaze campaign, with the starting date in the placeholder. " +
             "Read as Starting from May 11."
+        )
+        static let totalSpend = NSLocalizedString(
+            "blazeBudgetSettingViewModel.totalSpend",
+            value: "Total spend",
+            comment: "Label for total spend on the Blaze budget setting screen"
+        )
+        static let weeklySpend = NSLocalizedString(
+            "blazeBudgetSettingViewModel.weeklySpend",
+            value: "Weekly spend",
+            comment: "Label for weekly spend on the Blaze budget setting screen"
         )
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Blaze/CampaignCreation/BlazeCampaignCreationFormViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Blaze/CampaignCreation/BlazeCampaignCreationFormViewModel.swift
@@ -1,4 +1,5 @@
 import Foundation
+import Experiments
 import Yosemite
 import WooFoundation
 import protocol Storage.StorageManagerType
@@ -37,7 +38,7 @@ final class BlazeCampaignCreationFormViewModel: ObservableObject {
     }
 
     // Whether the campaign should have no end date
-    private var isEvergreen = true
+    private var isEvergreen: Bool
 
     // Budget details
     private var startDate = Date.now + 60 * 60 * 24 // Current date + 1 day
@@ -252,6 +253,7 @@ final class BlazeCampaignCreationFormViewModel: ObservableObject {
          storage: StorageManagerType = ServiceLocator.storageManager,
          productImageLoader: ProductUIImageLoader = DefaultProductUIImageLoader(phAssetImageLoaderProvider: { PHImageManager.default() }),
          analytics: Analytics = ServiceLocator.analytics,
+         featureFlagService: FeatureFlagService = ServiceLocator.featureFlagService,
          onCompletion: @escaping () -> Void) {
         self.siteID = siteID
         self.productID = productID
@@ -261,6 +263,9 @@ final class BlazeCampaignCreationFormViewModel: ObservableObject {
         self.analytics = analytics
         self.completionHandler = onCompletion
         self.targetUrn = String(format: Constants.targetUrnFormat, siteID, productID)
+
+        // sets isEvergreen = true by default if evergreen campaigns are supported
+        self.isEvergreen = featureFlagService.isFeatureFlagEnabled(.blazeEvergreenCampaigns)
 
         updateBudgetDetails()
         updateTargetLanguagesText()

--- a/WooCommerce/Classes/ViewRelated/Blaze/CampaignCreation/BlazeCampaignCreationFormViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Blaze/CampaignCreation/BlazeCampaignCreationFormViewModel.swift
@@ -409,7 +409,7 @@ private extension BlazeCampaignCreationFormViewModel {
     func updateBudgetDetails() {
         let formattedStartDate = dateFormatter.string(for: startDate) ?? ""
         if isEvergreen {
-            let weeklyAmount = String.localizedStringWithFormat(Localization.totalBudget, dailyBudget * Double(7))
+            let weeklyAmount = String.localizedStringWithFormat(Localization.totalBudget, dailyBudget * Double(Constants.dayCountInWeek))
             budgetDetailText = String(format: Localization.evergreenCampaignWeeklyBudget, weeklyAmount, formattedStartDate)
         } else {
             let amount = String.localizedStringWithFormat(Localization.totalBudget, dailyBudget * Double(duration))
@@ -492,6 +492,7 @@ private extension BlazeCampaignCreationFormViewModel {
         static let oneDayInSeconds: Double = 86400
         static let targetUrnFormat = "urn:wpcom:post:%d:%d"
         static let defaultCurrency = "USD"
+        static let dayCountInWeek = 7
     }
     enum Localization {
         static let budgetSingleDay = NSLocalizedString(

--- a/WooCommerce/Classes/ViewRelated/Blaze/CampaignCreation/BlazeCampaignCreationFormViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Blaze/CampaignCreation/BlazeCampaignCreationFormViewModel.swift
@@ -409,7 +409,10 @@ private extension BlazeCampaignCreationFormViewModel {
     func updateBudgetDetails() {
         let formattedStartDate = dateFormatter.string(for: startDate) ?? ""
         if isEvergreen {
-            let weeklyAmount = String.localizedStringWithFormat(Localization.totalBudget, dailyBudget * Double(Constants.dayCountInWeek))
+            let weeklyAmount = String.localizedStringWithFormat(
+                Localization.totalBudget,
+                dailyBudget * Double(BlazeBudgetSettingViewModel.Constants.dayCountInWeek)
+            )
             budgetDetailText = String(format: Localization.evergreenCampaignWeeklyBudget, weeklyAmount, formattedStartDate)
         } else {
             let amount = String.localizedStringWithFormat(Localization.totalBudget, dailyBudget * Double(duration))
@@ -492,7 +495,6 @@ private extension BlazeCampaignCreationFormViewModel {
         static let oneDayInSeconds: Double = 86400
         static let targetUrnFormat = "urn:wpcom:post:%d:%d"
         static let defaultCurrency = "USD"
-        static let dayCountInWeek = 7
     }
     enum Localization {
         static let budgetSingleDay = NSLocalizedString(

--- a/WooCommerce/Classes/ViewRelated/Blaze/CampaignCreation/BlazeCampaignCreationFormViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Blaze/CampaignCreation/BlazeCampaignCreationFormViewModel.swift
@@ -68,9 +68,10 @@ final class BlazeCampaignCreationFormViewModel: ObservableObject {
                                     isEvergreen: isEvergreen,
                                     duration: duration,
                                     startDate: startDate,
-                                    targetOptions: targetOptions) { [weak self] dailyBudget, duration, startDate in
+                                    targetOptions: targetOptions) { [weak self] dailyBudget, isEvegreen, duration, startDate in
             guard let self else { return }
             self.startDate = startDate
+            self.isEvergreen = isEvegreen
             self.duration = duration
             self.dailyBudget = dailyBudget
             self.updateBudgetDetails()
@@ -406,13 +407,18 @@ private extension BlazeCampaignCreationFormViewModel {
 
 private extension BlazeCampaignCreationFormViewModel {
     func updateBudgetDetails() {
-        let amount = String.localizedStringWithFormat(Localization.totalBudget, dailyBudget * Double(duration))
-        let date = dateFormatter.string(for: startDate) ?? ""
-        budgetDetailText = String.pluralize(
-            duration,
-            singular: String(format: Localization.budgetSingleDay, amount, duration, date),
-            plural: String(format: Localization.budgetMultipleDays, amount, duration, date)
-        )
+        let formattedStartDate = dateFormatter.string(for: startDate) ?? ""
+        if isEvergreen {
+            let weeklyAmount = String.localizedStringWithFormat(Localization.totalBudget, dailyBudget * Double(7))
+            budgetDetailText = String(format: Localization.evergreenCampaignWeeklyBudget, weeklyAmount, formattedStartDate)
+        } else {
+            let amount = String.localizedStringWithFormat(Localization.totalBudget, dailyBudget * Double(duration))
+            budgetDetailText = String.pluralize(
+                duration,
+                singular: String(format: Localization.budgetSingleDay, amount, duration, formattedStartDate),
+                plural: String(format: Localization.budgetMultipleDays, amount, duration, formattedStartDate)
+            )
+        }
     }
 
     func updateTargetLanguagesText() {
@@ -499,6 +505,12 @@ private extension BlazeCampaignCreationFormViewModel {
             value: "%1$@, %2$d days from %3$@",
             comment: "Blaze campaign budget details with duration in plural form. " +
             "Reads like: $35, 15 days from Dec 31"
+        )
+        static let evergreenCampaignWeeklyBudget = NSLocalizedString(
+            "blazeCampaignCreationFormViewModel.evergreenCampaignWeeklyBudget",
+            value: "%1$@ weekly starting from %2$@",
+            comment: "The formatted weekly budget for an evergreen Blaze campaign with a starting date. " +
+            "Reads as $11 USD weekly starting from May 11 2024."
         )
         static let totalBudget = NSLocalizedString(
             "blazeCampaignCreationFormViewModel.totalBudget",

--- a/WooCommerce/Classes/ViewRelated/Blaze/CampaignCreation/BlazeCampaignCreationFormViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Blaze/CampaignCreation/BlazeCampaignCreationFormViewModel.swift
@@ -36,6 +36,9 @@ final class BlazeCampaignCreationFormViewModel: ObservableObject {
         }
     }
 
+    // Whether the campaign should have no end date
+    private var isEvergreen = true
+
     // Budget details
     private var startDate = Date.now + 60 * 60 * 24 // Current date + 1 day
     private var dailyBudget = BlazeBudgetSettingViewModel.Constants.minimumDailyAmount
@@ -61,6 +64,7 @@ final class BlazeCampaignCreationFormViewModel: ObservableObject {
     var budgetSettingViewModel: BlazeBudgetSettingViewModel {
         BlazeBudgetSettingViewModel(siteID: siteID,
                                     dailyBudget: dailyBudget,
+                                    isEvergreen: isEvergreen,
                                     duration: duration,
                                     startDate: startDate,
                                     targetOptions: targetOptions) { [weak self] dailyBudget, duration, startDate in

--- a/WooCommerce/WooCommerceTests/Mocks/MockFeatureFlagService.swift
+++ b/WooCommerce/WooCommerceTests/Mocks/MockFeatureFlagService.swift
@@ -20,6 +20,7 @@ struct MockFeatureFlagService: FeatureFlagService {
     private let isDisplayPointOfSaleToggleEnabled: Bool
     private let isProductCreationAIv2M1Enabled: Bool
     private let googleAdsCampaignCreationOnWebView: Bool
+    private let blazeEvergreenCampaigns: Bool
 
     init(isInboxOn: Bool = false,
          isShowInboxCTAEnabled: Bool = false,
@@ -38,7 +39,8 @@ struct MockFeatureFlagService: FeatureFlagService {
          isSubscriptionsInOrderCreationCustomersEnabled: Bool = false,
          isDisplayPointOfSaleToggleEnabled: Bool = false,
          isProductCreationAIv2M1Enabled: Bool = false,
-         googleAdsCampaignCreationOnWebView: Bool = false) {
+         googleAdsCampaignCreationOnWebView: Bool = false,
+         blazeEvergreenCampaigns: Bool = false) {
         self.isInboxOn = isInboxOn
         self.isShowInboxCTAEnabled = isShowInboxCTAEnabled
         self.isUpdateOrderOptimisticallyOn = isUpdateOrderOptimisticallyOn
@@ -57,6 +59,7 @@ struct MockFeatureFlagService: FeatureFlagService {
         self.isDisplayPointOfSaleToggleEnabled = isDisplayPointOfSaleToggleEnabled
         self.isProductCreationAIv2M1Enabled = isProductCreationAIv2M1Enabled
         self.googleAdsCampaignCreationOnWebView = googleAdsCampaignCreationOnWebView
+        self.blazeEvergreenCampaigns = blazeEvergreenCampaigns
     }
 
     func isFeatureFlagEnabled(_ featureFlag: FeatureFlag) -> Bool {
@@ -97,6 +100,8 @@ struct MockFeatureFlagService: FeatureFlagService {
             return isProductCreationAIv2M1Enabled
         case .googleAdsCampaignCreationOnWebView:
             return googleAdsCampaignCreationOnWebView
+        case .blazeEvergreenCampaigns:
+            return blazeEvergreenCampaigns
         default:
             return false
         }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Blaze/BlazeBudgetSettingViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Blaze/BlazeBudgetSettingViewModelTests.swift
@@ -2,7 +2,6 @@ import XCTest
 @testable import WooCommerce
 @testable import Yosemite
 
-@MainActor
 final class BlazeBudgetSettingViewModelTests: XCTestCase {
     private var analyticsProvider: MockAnalyticsProvider!
     private var analytics: WooAnalytics!
@@ -24,38 +23,45 @@ final class BlazeBudgetSettingViewModelTests: XCTestCase {
         let initialStartDate = Date(timeIntervalSinceNow: 0)
         let expectedStartDate = Date(timeIntervalSinceNow: 86400) // Next day
         var finalDailyBudget: Double?
+        var finalIsEverGreen: Bool?
         var finalDuration: Int?
         var finalStartDate: Date?
         let viewModel = BlazeBudgetSettingViewModel(siteID: 123,
                                                     dailyBudget: 11,
+                                                    isEvergreen: true,
                                                     duration: 3,
-                                                    startDate: initialStartDate) { dailyBudget, duration, startDate in
+                                                    startDate: initialStartDate) { dailyBudget, isEvergreen, duration, startDate in
             finalDuration = duration
+            finalIsEverGreen = isEvergreen
             finalDailyBudget = dailyBudget
             finalStartDate = startDate
         }
 
         // When
+        viewModel.isEvergreen = false
         viewModel.dailyAmount = 80
         viewModel.didTapApplyDuration(dayCount: 7, since: expectedStartDate)
         viewModel.confirmSettings()
 
         // Then
+        XCTAssertEqual(finalIsEverGreen, false)
         XCTAssertEqual(finalDailyBudget, 80)
         XCTAssertEqual(finalDuration, 7)
         XCTAssertEqual(finalStartDate, expectedStartDate)
     }
 
+    @MainActor
     func test_updateImpressions_updates_forecastedImpressionState_correctly_when_fetching_impression_succeeds() async {
         // Given
         let stores = MockStoresManager(sessionManager: .makeForTesting())
         let viewModel = BlazeBudgetSettingViewModel(siteID: 123,
                                                     dailyBudget: 15,
+                                                    isEvergreen: true,
                                                     duration: 3,
                                                     startDate: .now,
                                                     locale: Locale(identifier: "en_US"),
                                                     stores: stores,
-                                                    onCompletion: { _, _, _ in })
+                                                    onCompletion: { _, _, _, _ in })
 
         // When
         let expectedImpression = BlazeImpressions(totalImpressionsMin: 1000, totalImpressionsMax: 5000)
@@ -74,15 +80,17 @@ final class BlazeBudgetSettingViewModelTests: XCTestCase {
         XCTAssertEqual(viewModel.forecastedImpressionState, .result(formattedResult: "1,000 - 5,000"))
     }
 
+    @MainActor
     func test_updateImpressions_updates_forecastedImpressionState_correctly_when_fetching_impression_fails() async {
         // Given
         let stores = MockStoresManager(sessionManager: .makeForTesting())
         let viewModel = BlazeBudgetSettingViewModel(siteID: 123,
                                                     dailyBudget: 15,
+                                                    isEvergreen: true,
                                                     duration: 3,
                                                     startDate: .now,
                                                     stores: stores,
-                                                    onCompletion: { _, _, _ in })
+                                                    onCompletion: { _, _, _, _ in })
 
         // When
         let expectedError = NSError(domain: "Test", code: 500)
@@ -101,6 +109,7 @@ final class BlazeBudgetSettingViewModelTests: XCTestCase {
         XCTAssertEqual(viewModel.forecastedImpressionState, .failure)
     }
 
+    @MainActor
     func test_retryFetchingImpressions_requests_fetching_impression_with_latest_settings() async throws {
         // Given
         var fetchInput: BlazeForecastedImpressionsInput?
@@ -110,12 +119,13 @@ final class BlazeBudgetSettingViewModelTests: XCTestCase {
         let stores = MockStoresManager(sessionManager: .makeForTesting())
         let viewModel = BlazeBudgetSettingViewModel(siteID: 123,
                                                     dailyBudget: 15,
+                                                    isEvergreen: true,
                                                     duration: 3,
                                                     startDate: .now,
                                                     timeZone: timeZone,
                                                     targetOptions: targetOptions,
                                                     stores: stores,
-                                                    onCompletion: { _, _, _ in })
+                                                    onCompletion: { _, _, _, _ in })
 
         // When
         stores.whenReceivingAction(ofType: BlazeAction.self) { action in
@@ -145,10 +155,11 @@ final class BlazeBudgetSettingViewModelTests: XCTestCase {
         // Given
         let viewModel = BlazeBudgetSettingViewModel(siteID: 123,
                                                     dailyBudget: 15,
+                                                    isEvergreen: true,
                                                     duration: 3,
                                                     startDate: .now,
                                                     analytics: analytics,
-                                                    onCompletion: { _, _, _ in })
+                                                    onCompletion: { _, _, _, _ in })
 
 
         // When
@@ -165,10 +176,11 @@ final class BlazeBudgetSettingViewModelTests: XCTestCase {
         // Given
         let viewModel = BlazeBudgetSettingViewModel(siteID: 123,
                                                     dailyBudget: 15,
+                                                    isEvergreen: true,
                                                     duration: 3,
                                                     startDate: .now,
                                                     analytics: analytics,
-                                                    onCompletion: { _, _, _ in })
+                                                    onCompletion: { _, _, _, _ in })
 
 
         // When

--- a/WooCommerce/WooCommerceTests/ViewRelated/Blaze/BlazeBudgetSettingViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Blaze/BlazeBudgetSettingViewModelTests.swift
@@ -18,6 +18,25 @@ final class BlazeBudgetSettingViewModelTests: XCTestCase {
         super.tearDown()
     }
 
+    func test_totalAmountText_is_updated_correctly_depending_on_isEvergreen() {
+        // Given
+        let initialStartDate = Date(timeIntervalSinceNow: 0)
+        let viewModel = BlazeBudgetSettingViewModel(siteID: 123,
+                                                    dailyBudget: 11,
+                                                    isEvergreen: false,
+                                                    duration: 3,
+                                                    startDate: initialStartDate) { _, _, _, _ in }
+
+        // Then
+        XCTAssertEqual(viewModel.totalAmountText, "$33 USD") // total spend for 3 days
+
+        // When
+        viewModel.isEvergreen = true
+
+        // Then
+        XCTAssertEqual(viewModel.totalAmountText, "$77 USD") // weekly spend
+    }
+
     func test_confirmSettings_triggers_onCompletion_with_updated_details() {
         // Given
         let initialStartDate = Date(timeIntervalSinceNow: 0)

--- a/WooCommerce/WooCommerceTests/ViewRelated/Blaze/BlazeCampaignCreationFormViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Blaze/BlazeCampaignCreationFormViewModelTests.swift
@@ -61,8 +61,7 @@ final class BlazeCampaignCreationFormViewModelTests: XCTestCase {
     }
 
     // MARK: Initial values
-    @MainActor
-    func test_image_is_empty_initially() async throws {
+    func test_image_is_empty_initially() throws {
         // Given
         insertProduct(sampleProduct)
         let viewModel = BlazeCampaignCreationFormViewModel(siteID: sampleSiteID,
@@ -76,8 +75,7 @@ final class BlazeCampaignCreationFormViewModelTests: XCTestCase {
         XCTAssertNil(viewModel.image)
     }
 
-    @MainActor
-    func test_tagline_is_empty_initially() async throws {
+    func test_tagline_is_empty_initially() throws {
         // Given
         insertProduct(sampleProduct)
         let viewModel = BlazeCampaignCreationFormViewModel(siteID: sampleSiteID,
@@ -91,8 +89,7 @@ final class BlazeCampaignCreationFormViewModelTests: XCTestCase {
         XCTAssertEqual(viewModel.tagline, "")
     }
 
-    @MainActor
-    func test_description_is_empty_initially() async throws {
+    func test_description_is_empty_initially() throws {
         // Given
         insertProduct(sampleProduct)
         let viewModel = BlazeCampaignCreationFormViewModel(siteID: sampleSiteID,
@@ -106,8 +103,7 @@ final class BlazeCampaignCreationFormViewModelTests: XCTestCase {
         XCTAssertEqual(viewModel.description, "")
     }
 
-    @MainActor
-    func test_ad_destination_product_url_is_updated_correctly_if_empty() async throws {
+    func test_ad_destination_product_url_is_updated_correctly_if_empty() throws {
         // Given
         insertProduct(sampleProduct.copy(permalink: ""))
         let viewModel = BlazeCampaignCreationFormViewModel(siteID: sampleSiteID,
@@ -119,6 +115,38 @@ final class BlazeCampaignCreationFormViewModelTests: XCTestCase {
 
         // Then
         XCTAssertEqual(viewModel.adDestinationViewModel?.productURL, sampleSiteAddress + "?post_type=product&p=\(sampleProductID)")
+    }
+
+    func test_isEvergreen_is_false_when_feature_flag_is_disabled() {
+        // Given
+        insertProduct(sampleProduct)
+        let featureFlagService = MockFeatureFlagService(blazeEvergreenCampaigns: false)
+        let viewModel = BlazeCampaignCreationFormViewModel(siteID: sampleSiteID,
+                                                           productID: sampleProductID,
+                                                           stores: stores,
+                                                           storage: storageManager,
+                                                           productImageLoader: imageLoader,
+                                                           featureFlagService: featureFlagService,
+                                                           onCompletion: {})
+
+        // Then
+        XCTAssertFalse(viewModel.budgetSettingViewModel.isEvergreen)
+    }
+
+    func test_isEvergreen_is_true_when_feature_flag_is_enabled() {
+        // Given
+        insertProduct(sampleProduct)
+        let featureFlagService = MockFeatureFlagService(blazeEvergreenCampaigns: true)
+        let viewModel = BlazeCampaignCreationFormViewModel(siteID: sampleSiteID,
+                                                           productID: sampleProductID,
+                                                           stores: stores,
+                                                           storage: storageManager,
+                                                           productImageLoader: imageLoader,
+                                                           featureFlagService: featureFlagService,
+                                                           onCompletion: {})
+
+        // Then
+        XCTAssertTrue(viewModel.budgetSettingViewModel.isEvergreen)
     }
 
     // MARK: On load


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #12538
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This PR adds UI changes to support evergreen campaign creation. Since the API requests have yet to be updated, all these changes are hidden under a new feature flag. Evergreen is enabled by default when the feature is enabled.

## Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->
- Enable the feature flag `blazeEvergreenCampaigns` and build the app.
- Log in to a store eligible for Blaze.
- Start the Blaze campaign creation flow with a published product.
- Confirm that the budget field displays the weekly budget with a starting date.
- Tap the budget field, confirm that the weekly budget is displayed instead of the total budget. The duration mentions only the starting date.
- Tap Edit on the duration and confirm that "Run until I stop it" is enabled. This wording has been copied from the web.
- Toggle the evegreen switch and confirm that the duration slider is now available. Save the change of the budget to go back to the creation form.
- Confirm that the budget field now displays the total budget with a duration.
- Disable `blazeEvergreenCampaigns` feature flag and confirm that the new updates are no longer available.


## Screenshots
<!-- Include before and after images or gifs when appropriate. -->
\ | Evergreen | Not evergreen
--- | --- | ---
Budget field | <img src="https://github.com/user-attachments/assets/556a51ce-ce32-47d3-afdd-17c790b1d672" width=320 /> | <img src="https://github.com/user-attachments/assets/7207b898-070a-4dce-a2c9-1d3851f4dc24" width=320 />
Budget screen | <img src="https://github.com/user-attachments/assets/3ddb6892-92f4-4f7c-b406-bbfe60d8f254" width=320 /> | <img src="https://github.com/user-attachments/assets/d9688a29-2208-41be-b30a-8ce0b6b3641f" width=320 />
Duration screen | <img src="https://github.com/user-attachments/assets/92423995-9635-4c5b-a198-35615401f187" width=320 /> | <img src="https://github.com/user-attachments/assets/98abb682-be3f-4bd8-a124-c8b621f65bf3" width=320 />


---
- [x] I have considered adding unit tests for this change. If I decided not to add them, I have provided a brief explanation below (optional):
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
- [ ] This PR includes refactoring; smoke testing of the entire section is needed.
