### PR TITLE
[Woo POS] Update test_isSyncingOrder

### DIFF
--- a/WooCommerce/WooCommerceTests/POS/ViewModels/TotalsViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/POS/ViewModels/TotalsViewModelTests.swift
@@ -26,6 +26,7 @@ final class TotalsViewModelTests: XCTestCase {
                               isSyncingOrder: false)
         cancellables = []
     }
+
     override func tearDown() {
         cancellables.forEach {
             $0.cancel()
@@ -34,27 +35,30 @@ final class TotalsViewModelTests: XCTestCase {
 
         super.tearDown()
     }
-    func test_isSyncingOrder() async throws {
+
+    func test_isSyncingOrder_when_syncOrder_called() async throws {
         // Given
         let item = Self.makeItem()
         let expectation = XCTestExpectation(description: "Expect isSyncingOrder to be true after syncOrder is called")
-        var expectedSyncing = false
-        XCTAssertEqual(sut.isSyncingOrder, expectedSyncing)
+        XCTAssertEqual(sut.isSyncingOrder, false)
+        var isSyncingOrderChecked = false
 
         sut.$isSyncingOrder
             .dropFirst()
             .sink { value in
-                XCTAssertEqual(value, expectedSyncing)
-                expectation.fulfill()
-                expectedSyncing = !value
+                if !isSyncingOrderChecked {
+                    XCTAssertEqual(value, true)
+                    expectation.fulfill()
+                    isSyncingOrderChecked = true
+                }
             }
             .store(in: &cancellables)
 
         // When/Then
-        expectedSyncing = true
         await sut.syncOrder(for: [CartItem(id: UUID(), item: item, quantity: 1)], allItems: [item])
         await fulfillment(of: [expectation], timeout: 2.0)
     }
+
     func test_on_checkOutTapped_startSyncOrder() {}
     func test_stopSyncOrder() {}
     func test_order() {}


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

#13217
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

- Updated **test_isSyncingOrder** in **TotalsViewModelTests**

## Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: https://woomobilep2.wordpress.com/2024/05/06/woocommerce-mobile-quality-report-march-april/#comment-12036 -->

- make sure CI passes

---
- [x] I have considered adding unit tests for this change. If I decided not to add them, I have provided a brief explanation below (optional):
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
- [ ] This PR includes refactoring; smoke testing of the entire section is needed.
