### PR TITLE
[Woo POS] Fix `Add More` payment race condition

### DIFF
--- a/WooCommerce/Classes/POS/Presentation/PointOfSaleDashboardView.swift
+++ b/WooCommerce/Classes/POS/Presentation/PointOfSaleDashboardView.swift
@@ -118,8 +118,7 @@ private extension PointOfSaleDashboardView {
 
     var totalsView: some View {
         TotalsView(viewModel: viewModel,
-                   totalsViewModel: totalsViewModel,
-                   cartViewModel: cartViewModel)
+                   totalsViewModel: totalsViewModel)
     }
 
     var productListView: some View {

--- a/WooCommerce/Classes/POS/Presentation/TotalsView.swift
+++ b/WooCommerce/Classes/POS/Presentation/TotalsView.swift
@@ -3,7 +3,6 @@ import SwiftUI
 struct TotalsView: View {
     @ObservedObject private var viewModel: PointOfSaleDashboardViewModel
     @ObservedObject private var totalsViewModel: TotalsViewModel
-    @ObservedObject private var cartViewModel: CartViewModel
     @Environment(\.posBackgroundAppearance) var backgroundAppearance
 
     /// Used together with .matchedGeometryEffect to synchronize the animations of shimmeringLineView and text fields.
@@ -14,11 +13,9 @@ struct TotalsView: View {
     @State private var isShowingTotalsFields: Bool
 
     init(viewModel: PointOfSaleDashboardViewModel,
-         totalsViewModel: TotalsViewModel,
-         cartViewModel: CartViewModel) {
+         totalsViewModel: TotalsViewModel) {
         self.viewModel = viewModel
         self.totalsViewModel = totalsViewModel
-        self.cartViewModel = cartViewModel
         self.isShowingTotalsFields = totalsViewModel.isShowingTotalsFields
     }
 
@@ -168,6 +165,7 @@ private extension TotalsView {
 private extension TotalsView {
     private var newTransactionButton: some View {
         Button(action: {
+            // TODO: This is the only place we use PointOfSaleDashboardViewModel in TotalsView – let's break that link.
             viewModel.startNewTransaction()
         }, label: {
             HStack(spacing: Constants.newTransactionButtonSpacing) {
@@ -279,8 +277,8 @@ private extension TotalsView {
     let itemsListViewModel = ItemListViewModel(itemProvider: POSItemProviderPreview())
     let posVM = PointOfSaleDashboardViewModel(cardPresentPaymentService: CardPresentPaymentPreviewService(),
                                               totalsViewModel: totalsVM,
-                                              cartViewModel: cartViewModel,
+                                              cartViewModel: CartViewModel(),
                                               itemListViewModel: itemsListViewModel)
-    return TotalsView(viewModel: posVM, totalsViewModel: totalsVM, cartViewModel: cartViewModel)
+    return TotalsView(viewModel: posVM, totalsViewModel: totalsVM)
 }
 #endif

--- a/WooCommerce/Classes/POS/ViewModels/CartViewModel.swift
+++ b/WooCommerce/Classes/POS/ViewModels/CartViewModel.swift
@@ -14,13 +14,9 @@ final class CartViewModel: CartViewModelProtocol {
     @Published private(set) var itemsInCart: [CartItem] = []
     var itemsInCartPublisher: Published<[CartItem]>.Publisher { $itemsInCart }
 
-    // It should be synced with the source of truth in `PointOfSaleDashboardViewModel`.
-    @Published private var orderStage: PointOfSaleDashboardViewModel.OrderStage = .building
     private var cancellables = Set<AnyCancellable>()
 
-    var canDeleteItemsFromCart: Bool {
-        orderStage != .finalizing
-    }
+    @Published var canDeleteItemsFromCart: Bool = true
 
     var isCartEmpty: Bool {
         return itemsInCart.isEmpty
@@ -29,12 +25,6 @@ final class CartViewModel: CartViewModelProtocol {
     init() {
         cartSubmissionPublisher = cartSubmissionSubject.eraseToAnyPublisher()
         addMoreToCartActionPublisher = addMoreToCartActionSubject.eraseToAnyPublisher()
-    }
-
-    func bind(to orderStagePublisher: AnyPublisher<PointOfSaleDashboardViewModel.OrderStage, Never>) {
-        orderStagePublisher
-            .assign(to: \.orderStage, on: self)
-            .store(in: &cancellables)
     }
 
     func addItemToCart(_ item: POSItem) {

--- a/WooCommerce/Classes/POS/ViewModels/CartViewModelProtocol.swift
+++ b/WooCommerce/Classes/POS/ViewModels/CartViewModelProtocol.swift
@@ -6,13 +6,12 @@ protocol CartViewModelProtocol: ObservableObject {
     var cartSubmissionPublisher: AnyPublisher<[CartItem], Never> { get }
     var addMoreToCartActionPublisher: AnyPublisher<Void, Never> { get }
     var itemsInCart: [CartItem] { get }
-    var canDeleteItemsFromCart: Bool { get }
+    var canDeleteItemsFromCart: Bool { get set }
     var itemToScrollToWhenCartUpdated: CartItem? { get }
     var itemsInCartLabel: String? { get }
     var cartLabelColor: Color { get }
     var itemsInCartPublisher: Published<[CartItem]>.Publisher { get }
 
-    func bind(to orderStagePublisher: AnyPublisher<PointOfSaleDashboardViewModel.OrderStage, Never>)
     func addItemToCart(_ item: POSItem)
     func removeItemFromCart(_ cartItem: CartItem)
     func removeAllItemsFromCart()

--- a/WooCommerce/Classes/POS/ViewModels/PointOfSaleDashboardViewModel.swift
+++ b/WooCommerce/Classes/POS/ViewModels/PointOfSaleDashboardViewModel.swift
@@ -143,7 +143,10 @@ private extension PointOfSaleDashboardViewModel {
     }
 
     private func observeOrderStage() {
-        cartViewModel.bind(to: $orderStage.eraseToAnyPublisher())
+        $orderStage.sink { [weak self] stage in
+            self?.cartViewModel.canDeleteItemsFromCart = stage == .building
+        }
+        .store(in: &cancellables)
     }
 }
 

--- a/WooCommerce/Classes/POS/ViewModels/PointOfSaleDashboardViewModel.swift
+++ b/WooCommerce/Classes/POS/ViewModels/PointOfSaleDashboardViewModel.swift
@@ -144,7 +144,12 @@ private extension PointOfSaleDashboardViewModel {
 
     private func observeOrderStage() {
         $orderStage.sink { [weak self] stage in
-            self?.cartViewModel.canDeleteItemsFromCart = stage == .building
+            guard let self else { return }
+            cartViewModel.canDeleteItemsFromCart = stage == .building
+
+            if stage == .building {
+                totalsViewModel.cancelReaderPreparation()
+            }
         }
         .store(in: &cancellables)
     }

--- a/WooCommerce/Classes/POS/ViewModels/PointOfSaleDashboardViewModel.swift
+++ b/WooCommerce/Classes/POS/ViewModels/PointOfSaleDashboardViewModel.swift
@@ -18,13 +18,7 @@ final class PointOfSaleDashboardViewModel: ObservableObject {
         case finalizing
     }
 
-    @Published private(set) var orderStage: OrderStage = .building {
-        didSet {
-            orderStageSubject.send(orderStage)
-        }
-    }
-
-    private let orderStageSubject = PassthroughSubject<OrderStage, Never>()
+    @Published private(set) var orderStage: OrderStage = .building
 
     @Published private(set) var isAddMoreDisabled: Bool = false
     @Published var isExitPOSDisabled: Bool = false
@@ -149,7 +143,7 @@ private extension PointOfSaleDashboardViewModel {
     }
 
     private func observeOrderStage() {
-        cartViewModel.bind(to: orderStageSubject.eraseToAnyPublisher())
+        cartViewModel.bind(to: $orderStage.eraseToAnyPublisher())
     }
 }
 

--- a/WooCommerce/Classes/POS/ViewModels/TotalsViewModel.swift
+++ b/WooCommerce/Classes/POS/ViewModels/TotalsViewModel.swift
@@ -139,8 +139,14 @@ final class TotalsViewModel: ObservableObject, TotalsViewModelProtocol {
         cardPresentPaymentInlineMessage = nil
     }
 
-    @MainActor
     func onTotalsViewDisappearance() {
+        // This is a backup – it's not called until transitions are complete when using the back button.
+        // The delay can lead to race conditions with tapping a card.
+        // It's likely that the payment will already have been cancelled due to the change of orderStage.
+        cancelReaderPreparation()
+    }
+
+    func cancelReaderPreparation() {
         cardPresentPaymentService.cancelPayment()
         startPaymentOnReaderConnection?.cancel()
     }

--- a/WooCommerce/Classes/POS/ViewModels/TotalsViewModelProtocol.swift
+++ b/WooCommerce/Classes/POS/ViewModels/TotalsViewModelProtocol.swift
@@ -35,5 +35,6 @@ protocol TotalsViewModelProtocol {
     func startNewTransaction()
     func checkOutTapped(with cartItems: [CartItem], allItems: [POSItem])
     func connectReaderTapped()
+    func cancelReaderPreparation()
     func onTotalsViewDisappearance()
 }

--- a/WooCommerce/WooCommerceTests/POS/Mocks/MockCartViewModel.swift
+++ b/WooCommerce/WooCommerceTests/POS/Mocks/MockCartViewModel.swift
@@ -18,8 +18,6 @@ class MockCartViewModel: CartViewModelProtocol {
     var itemsInCartLabel: String? = nil
     var cartLabelColor: Color = .clear
 
-    func bind(to orderStagePublisher: AnyPublisher<WooCommerce.PointOfSaleDashboardViewModel.OrderStage, Never>) {}
-
     func addItemToCart(_ item: any Yosemite.POSItem) {
         addItemToCartCalled = true
     }

--- a/WooCommerce/WooCommerceTests/POS/Mocks/MockTotalsViewModel.swift
+++ b/WooCommerce/WooCommerceTests/POS/Mocks/MockTotalsViewModel.swift
@@ -71,4 +71,9 @@ final class MockTotalsViewModel: TotalsViewModelProtocol {
     func onTotalsViewDisappearance() {
         // Provide a mock implementation if needed
     }
+
+    var spyCancelReaderPreparationCalled = false
+    func cancelReaderPreparation() {
+        spyCancelReaderPreparationCalled = true
+    }
 }

--- a/WooCommerce/WooCommerceTests/POS/ViewModels/CartViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/POS/ViewModels/CartViewModelTests.swift
@@ -7,37 +7,16 @@ import SwiftUI
 
 final class CartViewModelTests: XCTestCase {
 
-    private var orderStageSubject: PassthroughSubject<PointOfSaleDashboardViewModel.OrderStage, Never>!
     private var sut: CartViewModel!
 
     override func setUp() {
         super.setUp()
-        orderStageSubject = PassthroughSubject<PointOfSaleDashboardViewModel.OrderStage, Never>()
         sut = CartViewModel()
-        sut.bind(to: orderStageSubject.eraseToAnyPublisher())
     }
 
     override func tearDown() {
-        orderStageSubject = nil
         sut = nil
         super.tearDown()
-    }
-
-    func test_canDeleteItemsFromCart_when_orderStage_is_building_then_returns_true() {
-        // Given/When
-        XCTAssertEqual(sut.canDeleteItemsFromCart, true, "Initial state")
-        orderStageSubject.send(.finalizing)
-
-        // Then
-        XCTAssertEqual(sut.canDeleteItemsFromCart, false)
-    }
-
-    func test_canDeleteItemsFromCart_when_orderStage_is_finalizing_then_returns_false() {
-        // Given/When
-        orderStageSubject.send(.finalizing)
-
-        // Then
-        XCTAssertEqual(sut.canDeleteItemsFromCart, false)
     }
 
     func test_cart_when_submitCart_is_invoked_then_cartSubmissionPublisher_emits_cart_items() {

--- a/WooCommerce/WooCommerceTests/POS/ViewModels/PointOfSaleDashboardViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/POS/ViewModels/PointOfSaleDashboardViewModelTests.swift
@@ -345,6 +345,17 @@ final class PointOfSaleDashboardViewModelTests: XCTestCase {
         // Then
         XCTAssertTrue(mockCartViewModel.canDeleteItemsFromCart)
     }
+
+    func test_addMoreTapped_calls_totalsViewModel_cancelReaderPreparation() {
+        // Given
+        mockTotalsViewModel.spyCancelReaderPreparationCalled = false
+
+        // When
+        mockCartViewModel.addMoreToCartActionSubject.send(())
+
+        // Then
+        XCTAssertTrue(mockTotalsViewModel.spyCancelReaderPreparationCalled)
+    }
 }
 
 private extension PointOfSaleDashboardViewModelTests {

--- a/WooCommerce/WooCommerceTests/POS/ViewModels/PointOfSaleDashboardViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/POS/ViewModels/PointOfSaleDashboardViewModelTests.swift
@@ -322,6 +322,29 @@ final class PointOfSaleDashboardViewModelTests: XCTestCase {
         // Then
         XCTAssertFalse(sut.isInitialLoading)
     }
+
+    func test_cartSubmitted_sets_cartViewModel_canDeleteItems_false() {
+        // Given
+        XCTAssertTrue(mockCartViewModel.canDeleteItemsFromCart)
+
+        // When
+        mockCartViewModel.cartSubmissionSubject.send([CartItem(id: UUID(), item: Self.makeItem(), quantity: 1)])
+
+        // Then
+        XCTAssertFalse(mockCartViewModel.canDeleteItemsFromCart)
+    }
+
+    func test_addMoreTapped_sets_cartViewModel_canDeleteItems_true() {
+        // Given
+        mockCartViewModel.cartSubmissionSubject.send([CartItem(id: UUID(), item: Self.makeItem(), quantity: 1)])
+        XCTAssertFalse(mockCartViewModel.canDeleteItemsFromCart)
+
+        // When
+        mockCartViewModel.addMoreToCartActionSubject.send(())
+
+        // Then
+        XCTAssertTrue(mockCartViewModel.canDeleteItemsFromCart)
+    }
 }
 
 private extension PointOfSaleDashboardViewModelTests {


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #13495 
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

Previously, it was possible to go back from the Checkout screen, and still tap a card on the payment before it's cancelled.

This left the POS in a broken state, and required the app to be force quit to resolve it.

The issue was caused by the cancellation call happening when the `TotalsView` disappeared – i.e. when it finished transitioning off screen, which takes some time.

To fix it, we now call cancellation when the back button is tapped.

## Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->

This is easiest with the simulated card reader, but can be done with a real reader as well

1. Launch the app and go to POS mode
2. Connect the reader
3. Add something to the cart
4. Tap `Check out`
5. Wait until the screen shows `Tap, swipe, or insert your card`
6. If using the simulated reader, wait 3-4 seconds and then tap back. If using a physical reader, tap back and tap the card simultaneously.
7. Observe that it goes back as expected, you can change the order, and check out with a new total

## Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->

Cancel will be called multiple times – this is fine, the first call will win.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

### After fix

https://github.com/user-attachments/assets/1346a27f-508e-4d31-97b2-bdd96b8d033a

### Before fix
(note the state at the very end of this video)

https://github.com/user-attachments/assets/d4f939a5-8c2f-4fb8-af81-6470a13555eb

---
- [x] I have considered adding unit tests for this change. If I decided not to add them, I have provided a brief explanation below (optional):
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
- [ ] This PR includes refactoring; smoke testing of the entire section is needed.