### PR TITLE
[Woo POS] Open Create Order from Simple Payments modal

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,6 +1,9 @@
 *** PLEASE FOLLOW THIS FORMAT: [<priority indicator, more stars = higher priority>] <description> [<PR URL>]
 *** Use [*****] to indicate smoke tests of all critical flows should be run on the final IPA before release (e.g. major library or OS update).
 
+20.0
+-----
+- [*] Added Universal Link to Create Order: /mobile/orders/create. [https://github.com/woocommerce/woocommerce-ios/pull/13541]
 
 19.9
 -----

--- a/WooCommerce/Classes/App Intents/CreateOrderAppIntent.swift
+++ b/WooCommerce/Classes/App Intents/CreateOrderAppIntent.swift
@@ -10,7 +10,7 @@ struct CreateOrderAppIntent: AppIntent {
 
     @MainActor
     func perform() async throws -> some IntentResult {
-        MainTabBarController.presentOrderCreationFlow()
+        AppDelegate.shared.tabBarController?.navigate(to: OrdersDestination.createOrder)
         ServiceLocator.analytics.track(event: .AppIntents.shortcutWasOpened(with: .createOrder))
 
         return .result()

--- a/WooCommerce/Classes/AppDelegate.swift
+++ b/WooCommerce/Classes/AppDelegate.swift
@@ -192,7 +192,8 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     }
 
     func application(_ application: UIApplication, performActionFor shortcutItem: UIApplicationShortcutItem, completionHandler: @escaping (Bool) -> Void) {
-        guard let quickAction = QuickAction(rawValue: shortcutItem.type) else {
+        guard let quickAction = QuickAction(rawValue: shortcutItem.type),
+            let tabBarController else {
             completionHandler(false)
             return
         }
@@ -201,13 +202,13 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
             MainTabBarController.presentAddProductFlow()
             completionHandler(true)
         case QuickAction.addOrder:
-            MainTabBarController.presentOrderCreationFlow()
+            tabBarController.navigate(to: OrdersDestination.createOrder)
             completionHandler(true)
         case QuickAction.openOrders:
-            MainTabBarController.switchToOrdersTab()
+            tabBarController.navigate(to: OrdersDestination.orderList)
             completionHandler(true)
         case QuickAction.collectPayment:
-            MainTabBarController.presentCollectPayment()
+            tabBarController.navigate(to: PaymentsMenuDestination.collectPayment)
             completionHandler(true)
         }
     }

--- a/WooCommerce/Classes/Destinations/OrdersDestination.swift
+++ b/WooCommerce/Classes/Destinations/OrdersDestination.swift
@@ -1,0 +1,6 @@
+import Foundation
+
+enum OrdersDestination: DeepLinkDestinationProtocol {
+    case orderList
+    case createOrder
+}

--- a/WooCommerce/Classes/JustInTimeMessages/UniversalLinkRouter+JustInTimeMessages.swift
+++ b/WooCommerce/Classes/JustInTimeMessages/UniversalLinkRouter+JustInTimeMessages.swift
@@ -4,7 +4,7 @@ import Combine
 extension UniversalLinkRouter {
     static func justInTimeMessagesUniversalLinkRouter(tabBarController: MainTabBarController?,
                                                       urlOpener: URLOpener) -> UniversalLinkRouter {
-        UniversalLinkRouter(routes: Self.defaultRoutes(tabBarController: tabBarController),
+        UniversalLinkRouter(routes: Self.defaultRoutes(navigator: tabBarController),
                             bouncingURLOpener: urlOpener,
                             analyticsTracker: nil)
     }

--- a/WooCommerce/Classes/POS/Presentation/SimpleProductsOnlyInformation.swift
+++ b/WooCommerce/Classes/POS/Presentation/SimpleProductsOnlyInformation.swift
@@ -2,6 +2,13 @@ import SwiftUI
 
 struct SimpleProductsOnlyInformation: View {
     @Binding var isPresented: Bool
+    let deepLinkNavigator: DeepLinkNavigator?
+
+    init(isPresented: Binding<Bool>,
+         deepLinkNavigator: DeepLinkNavigator? = AppDelegate.shared.tabBarController) {
+        self._isPresented = isPresented
+        self.deepLinkNavigator = deepLinkNavigator
+    }
 
     var body: some View {
         VStack(spacing: Constants.contentBlockSpacing) {
@@ -20,7 +27,7 @@ struct SimpleProductsOnlyInformation: View {
                         .font(.posDetail)
 
                     Button {
-                        
+                        deepLinkNavigator?.navigate(to: OrdersDestination.createOrder)
                     } label: {
                         Label(Localization.modalAction, systemImage: "plus")
                             .font(.posDetail)
@@ -93,5 +100,6 @@ private extension SimpleProductsOnlyInformation {
 }
 
 #Preview {
-    SimpleProductsOnlyInformation(isPresented: .constant(true))
+    SimpleProductsOnlyInformation(isPresented: .constant(true),
+                                  deepLinkNavigator: nil)
 }

--- a/WooCommerce/Classes/POS/Presentation/SimpleProductsOnlyInformation.swift
+++ b/WooCommerce/Classes/POS/Presentation/SimpleProductsOnlyInformation.swift
@@ -19,7 +19,9 @@ struct SimpleProductsOnlyInformation: View {
                     Text(Localization.modalHint)
                         .font(.posDetail)
 
-                    Button { } label: {
+                    Button {
+                        
+                    } label: {
                         Label(Localization.modalAction, systemImage: "plus")
                             .font(.posDetail)
                     }

--- a/WooCommerce/Classes/Universal Links/Routes/OrdersRoute.swift
+++ b/WooCommerce/Classes/Universal Links/Routes/OrdersRoute.swift
@@ -1,0 +1,50 @@
+import Foundation
+
+/// Links supported URLs with an /orders root path to various destinations in the Payments Hub Menu
+///
+struct OrdersRoute: Route {
+    private let deepLinkNavigator: DeepLinkNavigator
+
+    init(deepLinkNavigator: DeepLinkNavigator) {
+        self.deepLinkNavigator = deepLinkNavigator
+    }
+
+    func canHandle(subPath: String) -> Bool {
+        return deepLinkDestination(for: subPath) != nil
+    }
+
+    func perform(for subPath: String, with parameters: [String: String]) -> Bool {
+        guard let destination = deepLinkDestination(for: subPath) else {
+            return false
+        }
+
+        deepLinkNavigator.navigate(to: destination)
+
+        return true
+    }
+}
+
+private extension OrdersRoute {
+    func deepLinkDestination(for ordersDeepLinkSubPath: String) -> (any DeepLinkDestinationProtocol)? {
+        guard ordersDeepLinkSubPath.hasPrefix(Constants.ordersRoot) else {
+            return nil
+        }
+
+        let destinationSubPath = ordersDeepLinkSubPath
+            .removingPrefix(Constants.ordersRoot)
+            .removingPrefix("/")
+
+        switch destinationSubPath {
+        case "":
+            return OrdersDestination.orderList
+        case "create":
+            return OrdersDestination.createOrder
+        default:
+            return nil
+        }
+    }
+
+    enum Constants {
+        static let ordersRoot = "orders"
+    }
+}

--- a/WooCommerce/Classes/Universal Links/UniversalLinkRouter.swift
+++ b/WooCommerce/Classes/Universal Links/UniversalLinkRouter.swift
@@ -23,20 +23,21 @@ struct UniversalLinkRouter {
     }
 
     static func defaultUniversalLinkRouter(tabBarController: MainTabBarController) -> UniversalLinkRouter {
-        UniversalLinkRouter(routes: UniversalLinkRouter.defaultRoutes(tabBarController: tabBarController))
+        UniversalLinkRouter(routes: UniversalLinkRouter.defaultRoutes(navigator: tabBarController))
     }
 
     /// Add your route here if you want it to be considered when matching for an incoming universal link.
     /// As we only perform one action to avoid conflicts, order matters (only the first matched route will be called to perform its action)
     /// If `tabBarController: nil` is passed, some routes will not work, e.g. Payments related routes, which require the tab bar for navigation.
     ///
-    static func defaultRoutes(tabBarController: MainTabBarController?) -> [Route] {
+    static func defaultRoutes(navigator: DeepLinkNavigator?) -> [Route] {
         let routes: [Route] = [OrderDetailsRoute(), MyStoreRoute()]
-        guard let tabBarController = tabBarController else {
+        guard let navigator = navigator else {
             DDLogWarn("⛔️ Unable to create tab bar dependent Universal Link routes, some links will not be handled")
             return routes
         }
-        return routes + [PaymentsRoute(deepLinkNavigator: tabBarController)]
+        return routes + [PaymentsRoute(deepLinkNavigator: navigator),
+                         OrdersRoute(deepLinkNavigator: navigator)]
     }
 
     func handle(url: URL) {

--- a/WooCommerce/Classes/ViewRelated/MainTabBarController.swift
+++ b/WooCommerce/Classes/ViewRelated/MainTabBarController.swift
@@ -517,8 +517,18 @@ extension MainTabBarController {
 //
 extension MainTabBarController: DeepLinkNavigator {
     func navigate(to destination: any DeepLinkDestinationProtocol) {
-        navigateTo(.hubMenu) { [weak self] in
-            self?.hubMenuTabCoordinator?.navigate(to: destination)
+        switch destination {
+        case is HubMenuDestination,
+            is PaymentsMenuDestination:
+            navigateTo(.hubMenu) { [weak self] in
+                self?.hubMenuTabCoordinator?.navigate(to: destination)
+            }
+        case is OrdersDestination:
+            navigateTo(.orders) {
+                Self.ordersTabSplitViewWrapper()?.navigate(to: destination)
+            }
+        default:
+            return
         }
     }
 }

--- a/WooCommerce/Classes/ViewRelated/MainTabBarController.swift
+++ b/WooCommerce/Classes/ViewRelated/MainTabBarController.swift
@@ -436,19 +436,6 @@ extension MainTabBarController {
         })
     }
 
-    static func presentOrderCreationFlow() {
-        switchToOrdersTab {
-            let tabBar = AppDelegate.shared.tabBarController
-            let ordersContainerController = tabBar?.ordersContainerController
-
-            guard let ordersSplitViewWrapperController = ordersContainerController?.wrappedController as? OrdersSplitViewWrapperController else {
-                return
-            }
-
-            ordersSplitViewWrapperController.presentOrderCreationFlow()
-        }
-    }
-
     static func presentOrderCreationFlow(for customerID: Int64, billing: Address?, shipping: Address?) {
         switchToOrdersTab {
             let tabBar = AppDelegate.shared.tabBarController

--- a/WooCommerce/Classes/ViewRelated/Orders/OrdersSplitViewWrapperController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/OrdersSplitViewWrapperController.swift
@@ -184,6 +184,20 @@ private extension OrdersSplitViewWrapperController {
     }
 }
 
+extension OrdersSplitViewWrapperController: DeepLinkNavigator {
+    func navigate(to destination: any DeepLinkDestinationProtocol) {
+        guard let ordersDestination = destination as? OrdersDestination else {
+            return
+        }
+        switch ordersDestination {
+        case .createOrder:
+            presentOrderCreationFlow()
+        case .orderList:
+            return
+        }
+    }
+}
+
 extension OrdersSplitViewWrapperController {
     private enum Localization {
         static let ordersTabTitle = NSLocalizedString("Orders", comment: "The title of the Orders tab.")

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -826,6 +826,9 @@
 		20D3D42B2C64D7CC004CE6E3 /* SimpleProductsOnlyInformation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 20D3D42A2C64D7CC004CE6E3 /* SimpleProductsOnlyInformation.swift */; };
 		20D3D42F2C64F175004CE6E3 /* POSSecondaryButtonStyle.swift in Sources */ = {isa = PBXBuildFile; fileRef = 20D3D42E2C64F175004CE6E3 /* POSSecondaryButtonStyle.swift */; };
 		20D3D4312C64F202004CE6E3 /* POSButtonStyleConstants.swift in Sources */ = {isa = PBXBuildFile; fileRef = 20D3D4302C64F202004CE6E3 /* POSButtonStyleConstants.swift */; };
+		20D3D4332C65E59B004CE6E3 /* OrdersRoute.swift in Sources */ = {isa = PBXBuildFile; fileRef = 20D3D4322C65E59B004CE6E3 /* OrdersRoute.swift */; };
+		20D3D4352C65E640004CE6E3 /* OrdersDestination.swift in Sources */ = {isa = PBXBuildFile; fileRef = 20D3D4342C65E640004CE6E3 /* OrdersDestination.swift */; };
+		20D3D4372C65EF72004CE6E3 /* OrdersRouteTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 20D3D4362C65EF72004CE6E3 /* OrdersRouteTests.swift */; };
 		20D5CB512AFCF856009A39C3 /* PaymentsRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 20D5CB502AFCF856009A39C3 /* PaymentsRow.swift */; };
 		20D5CB532AFCF8E7009A39C3 /* PaymentsToggleRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 20D5CB522AFCF8E7009A39C3 /* PaymentsToggleRow.swift */; };
 		20DA6DDB2B681175002AA0FB /* AdaptiveModalContainer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 20DA6DDA2B681175002AA0FB /* AdaptiveModalContainer.swift */; };
@@ -3831,6 +3834,9 @@
 		20D3D42A2C64D7CC004CE6E3 /* SimpleProductsOnlyInformation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SimpleProductsOnlyInformation.swift; sourceTree = "<group>"; };
 		20D3D42E2C64F175004CE6E3 /* POSSecondaryButtonStyle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = POSSecondaryButtonStyle.swift; sourceTree = "<group>"; };
 		20D3D4302C64F202004CE6E3 /* POSButtonStyleConstants.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = POSButtonStyleConstants.swift; sourceTree = "<group>"; };
+		20D3D4322C65E59B004CE6E3 /* OrdersRoute.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OrdersRoute.swift; sourceTree = "<group>"; };
+		20D3D4342C65E640004CE6E3 /* OrdersDestination.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OrdersDestination.swift; sourceTree = "<group>"; };
+		20D3D4362C65EF72004CE6E3 /* OrdersRouteTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OrdersRouteTests.swift; sourceTree = "<group>"; };
 		20D5CB502AFCF856009A39C3 /* PaymentsRow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaymentsRow.swift; sourceTree = "<group>"; };
 		20D5CB522AFCF8E7009A39C3 /* PaymentsToggleRow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaymentsToggleRow.swift; sourceTree = "<group>"; };
 		20DA6DDA2B681175002AA0FB /* AdaptiveModalContainer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AdaptiveModalContainer.swift; sourceTree = "<group>"; };
@@ -7380,6 +7386,7 @@
 			isa = PBXGroup;
 			children = (
 				0388E1A529E04433007DF84D /* PaymentsRouteTests.swift */,
+				20D3D4362C65EF72004CE6E3 /* OrdersRouteTests.swift */,
 			);
 			path = Routes;
 			sourceTree = "<group>";
@@ -7644,6 +7651,7 @@
 			children = (
 				20AE33C42B0510BF00527B60 /* PaymentsMenuDestination.swift */,
 				20AE33C62B0510D200527B60 /* HubMenuDestination.swift */,
+				20D3D4342C65E640004CE6E3 /* OrdersDestination.swift */,
 			);
 			path = Destinations;
 			sourceTree = "<group>";
@@ -10463,6 +10471,7 @@
 				039298C72A45EE3900F393D5 /* MyStoreRoute.swift */,
 				B958A7C828B3D47B00823EEF /* Route.swift */,
 				B95112D928BF79CA00D9578D /* PaymentsRoute.swift */,
+				20D3D4322C65E59B004CE6E3 /* OrdersRoute.swift */,
 			);
 			path = Routes;
 			sourceTree = "<group>";
@@ -15017,6 +15026,7 @@
 				02C7EE8A2B21B951008B7DF8 /* ProductWithQuantityStepperViewModel.swift in Sources */,
 				02A410F52583A84C005E2925 /* SpacerTableViewCell.swift in Sources */,
 				02BBD6EB29A316FB00243BE2 /* StoreOnboardingCoordinator.swift in Sources */,
+				20D3D4352C65E640004CE6E3 /* OrdersDestination.swift in Sources */,
 				0258B4DA2B159A0F008FEA07 /* Publisher+WithPrevious.swift in Sources */,
 				D881FE062579DC78008DE6F2 /* NotWPAccountViewModel.swift in Sources */,
 				311D21ED264AF0E700102316 /* CardReaderSettingsAlerts.swift in Sources */,
@@ -15291,6 +15301,7 @@
 				0294F8AB25E8A12C005B537A /* WooTabNavigationController.swift in Sources */,
 				029F29FA24D93E9E004751CA /* EditableProductModel.swift in Sources */,
 				027179E22C08817F0049F0BD /* CardPresentPaymentService.swift in Sources */,
+				20D3D4332C65E59B004CE6E3 /* OrdersRoute.swift in Sources */,
 				31FC8CE927B476BA004B9456 /* CardReaderSettingsResultsControllers.swift in Sources */,
 				022266BC2AE7707000614F34 /* ConfigurableBundleItemViewModel.swift in Sources */,
 				D449C52926DFBCCC00D75B02 /* WhatsNewHostingController.swift in Sources */,
@@ -16665,6 +16676,7 @@
 				02645D8A27BA2EDB0065DC68 /* NSAttributedString+AttributesTests.swift in Sources */,
 				6856D2A5C2076F5BF14F2C11 /* KeyboardStateProviderTests.swift in Sources */,
 				B9DA153E28101BE100FC67DD /* MockOrderRefundsOptionsDeterminer.swift in Sources */,
+				20D3D4372C65EF72004CE6E3 /* OrdersRouteTests.swift in Sources */,
 				09C6A26227C01166001FAD73 /* BulkUpdateViewModelTests.swift in Sources */,
 				261F1A7C29C2B09D001D9861 /* FreeTrialBannerViewModelTests.swift in Sources */,
 				6856D806DE7DB61522D54044 /* NSMutableAttributedStringHelperTests.swift in Sources */,

--- a/WooCommerce/WooCommerceTests/Universal Links/Routes/OrdersRouteTests.swift
+++ b/WooCommerce/WooCommerceTests/Universal Links/Routes/OrdersRouteTests.swift
@@ -1,0 +1,59 @@
+import XCTest
+
+@testable import WooCommerce
+
+final class OrdersRouteTests: XCTestCase {
+    private var deepLinkNavigator: MockDeepLinkNavigator!
+    private var sut: OrdersRoute!
+
+    override func setUp() {
+        deepLinkNavigator = MockDeepLinkNavigator()
+        sut = OrdersRoute(deepLinkNavigator: deepLinkNavigator)
+    }
+
+    func test_canHandle_returns_true_for_create_order_deep_link_path() {
+        XCTAssertTrue(sut.canHandle(subPath: "orders/create"))
+    }
+
+    func test_canHandle_returns_true_for_order_list_deep_link_path() {
+        XCTAssertTrue(sut.canHandle(subPath: "orders/"))
+    }
+
+    func test_performAction_forwards_orders_deep_link_to_orders_controller() throws {
+        // Given
+        let path = "orders"
+
+        // When
+        let reportedHandled = sut.perform(for: path, with: [:])
+
+        // Then
+        XCTAssertTrue(reportedHandled)
+        let navigatedDestination = try XCTUnwrap(deepLinkNavigator.spyNavigatedDestination as? OrdersDestination)
+        assertEqual(OrdersDestination.orderList, navigatedDestination)
+    }
+
+    func test_performAction_forwards_create_order_deep_link_to_orders_controller() throws {
+        // Given
+        let path = "orders/create"
+
+        // When
+        let reportedHandled = sut.perform(for: path, with: [:])
+
+        // Then
+        XCTAssertTrue(reportedHandled)
+        let navigatedDestination = try XCTUnwrap(deepLinkNavigator.spyNavigatedDestination as? OrdersDestination)
+        assertEqual(OrdersDestination.createOrder, navigatedDestination)
+    }
+
+    func test_performAction_does_not_forward_unrecognised_deep_link_to_hub_menu() {
+        // Given
+        let path = "orders/some-future-feature"
+
+        // When
+        let reportedHandled = sut.perform(for: path, with: [:])
+
+        // Then
+        XCTAssertFalse(reportedHandled)
+        XCTAssertFalse(deepLinkNavigator.spyDidNavigate)
+    }
+}

--- a/WooCommerce/WooCommerceTests/Universal Links/UniversalLinkRouterTests.swift
+++ b/WooCommerce/WooCommerceTests/Universal Links/UniversalLinkRouterTests.swift
@@ -160,6 +160,22 @@ final class UniversalLinkRouterTests: XCTestCase {
         // Then
         XCTAssertEqual(bouncingURL, url)
     }
+
+    func test_defaultUniversalLinkRouter_includes_expected_routes() {
+        // Given
+        let mockNavigator = MockDeepLinkNavigator()
+
+        // When
+        let routes = UniversalLinkRouter.defaultRoutes(navigator: mockNavigator)
+
+        // Then
+        assertEqual(4, routes.count)
+
+        XCTAssert(routes.contains { $0 is OrderDetailsRoute })
+        XCTAssert(routes.contains { $0 is MyStoreRoute })
+        XCTAssert(routes.contains { $0 is PaymentsRoute })
+        XCTAssert(routes.contains { $0 is OrdersRoute })
+    }
 }
 
 private extension UniversalLinkRouterTests {


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #13357 
Merge after: #13533 
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

This PR adds the action for the `+ Create an order in store management` button on the POS modal giving details of why only simple products can be added to an order.

This is achieved using a new deeplink – it's worth testing this as a Universal Link as well.

## Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->

1. Launch the app and enter POS mode
2. Observe the "Showing simple products only" banner is shown.
3. Tap the banner or the banner's info icon.
4. On the modal that's shown, tap `+ Create an order in store management`
5. Observe that you're taken to the Orders tab, and the `Create Order` screen is shown.
6. Take a payment for a non-simple product.

To test the Universal Link:

1. Add a note in Apple's Notes app, including the following URL: `https://woocommerce.com/mobile/orders/create`
2. Tap the link
3. Observe that Woo opens, you're taken to the Orders tab, and the `Create Order` screen is shown.

## Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->

I added some unit tests to make sure we include all the Routes in the deeplink handling code – missing those out means that a subset of the links wouldn't work.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

https://github.com/user-attachments/assets/2af27815-97d9-4799-b904-8c8b01d53966




---
- [x] I have considered adding unit tests for this change. If I decided not to add them, I have provided a brief explanation below (optional):
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
- [ ] This PR includes refactoring; smoke testing of the entire section is needed.