### PR TITLE
[Woo POS] M2: Fix extra padding appearing after removing the tab

### DIFF
--- a/WooCommerce/Classes/AppDelegate.swift
+++ b/WooCommerce/Classes/AppDelegate.swift
@@ -278,6 +278,7 @@ extension AppDelegate {
             return
         }
         tabBarController.tabBar.isHidden = hidden
+        tabBarController.selectedViewController?.view.layoutIfNeeded()
     }
 }
 


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #13432
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

- There was an issue with the POS view layout when we initially enter POS.
- We are hiding the tabbar when we are entering POS but the system does not layout the view properly (probably some Swiftui and UIKit combo issue), so there was a need for calling `layoutIfNeeded` on the current tabBarViewControllers viewController.

## Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: https://woomobilep2.wordpress.com/2024/05/06/woocommerce-mobile-quality-report-march-april/#comment-12036 -->

- Open Woo app
- Open Menu -> Point of Sale
- Check that there is no extra bottom space below the floating action control

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

| Before      | After |
| ----------- | ----------- |
| ![Simulator Screenshot - iPad Pro (11-inch) (4th generation) 17 2 - 2024-08-09 at 11 47 34](https://github.com/user-attachments/assets/07616ac7-0b8f-493d-9043-6996550ef5a5)      | ![Simulator Screenshot - iPad Pro (11-inch) (4th generation) 17 2 - 2024-08-09 at 11 44 35](https://github.com/user-attachments/assets/81c77421-7433-46bd-8f51-01ecd65c5de0)       |

![fab toolbar](https://github.com/user-attachments/assets/6b0acd1b-3ead-4c67-b574-faf107e08940)

---
- [x] I have considered adding unit tests for this change. If I decided not to add them, I have provided a brief explanation below (optional):
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
- [ ] This PR includes refactoring; smoke testing of the entire section is needed.
