### PR TITLE
Settings: Fix store name update when authenticated without WPCom

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -4,6 +4,7 @@
 20.0
 -----
 - [*] Blaze: Now you can select media attached to the current product while creating Blaze ads. You don't have to scroll through all media in your store. [https://github.com/woocommerce/woocommerce-ios/pull/13540]
+- [*] Settings: Fix error updating site name when authenticated without WPCom. [https://github.com/woocommerce/woocommerce-ios/pull/13567]
 
 20.0
 -----

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -4,7 +4,7 @@
 20.0
 -----
 - [*] Blaze: Now you can select media attached to the current product while creating Blaze ads. You don't have to scroll through all media in your store. [https://github.com/woocommerce/woocommerce-ios/pull/13540]
-- [*] Settings: Fix error updating site name when authenticated without WPCom. [https://github.com/woocommerce/woocommerce-ios/pull/13567]
+- [*] Settings: Fixed error updating site name when authenticated without WPCom. [https://github.com/woocommerce/woocommerce-ios/pull/13567]
 
 20.0
 -----

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -6,10 +6,6 @@
 - [*] Blaze: Now you can select media attached to the current product while creating Blaze ads. You don't have to scroll through all media in your store. [https://github.com/woocommerce/woocommerce-ios/pull/13540]
 - [*] Settings: Fixed error updating site name when authenticated without WPCom. [https://github.com/woocommerce/woocommerce-ios/pull/13567]
 
-20.0
------
-
-
 19.9
 -----
 - [*] Enabled Blaze for JCP sites with Blaze plugin [https://github.com/woocommerce/woocommerce-ios/pull/13500]

--- a/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Onboarding/StoreNameSetupViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Onboarding/StoreNameSetupViewModelTests.swift
@@ -2,7 +2,6 @@ import XCTest
 @testable import Yosemite
 @testable import WooCommerce
 
-@MainActor
 final class StoreNameSetupViewModelTests: XCTestCase {
 
     private var stores: MockStoresManager!
@@ -49,7 +48,7 @@ final class StoreNameSetupViewModelTests: XCTestCase {
         // Given
         let viewModel = StoreNameSetupViewModel(siteID: 123, name: "Test", stores: stores, onNameSaved: {})
         XCTAssertFalse(viewModel.isSavingInProgress)
-        mockStoreNameUpdate(result: .success(Site.fake()))
+        mockStoreNameUpdate(result: .success(Void()))
 
         // When
         viewModel.name = "Miffy"
@@ -59,13 +58,14 @@ final class StoreNameSetupViewModelTests: XCTestCase {
         XCTAssertFalse(viewModel.isSavingInProgress)
     }
 
+    @MainActor
     func test_onNameSaved_is_triggered_upon_saving_store_name_success() async {
         // Given
         var onNameSavedTriggered = false
         let viewModel = StoreNameSetupViewModel(siteID: 123, name: "Test", stores: stores, onNameSaved: {
             onNameSavedTriggered = true
         })
-        mockStoreNameUpdate(result: .success(Site.fake()))
+        mockStoreNameUpdate(result: .success(Void()))
 
         // When
         viewModel.name = "Miffy"
@@ -75,6 +75,7 @@ final class StoreNameSetupViewModelTests: XCTestCase {
         XCTAssertTrue(onNameSavedTriggered)
     }
 
+    @MainActor
     func test_errorMessage_is_updated_upon_saving_store_name_failure() async {
         // Given
         let viewModel = StoreNameSetupViewModel(siteID: 123, name: "Test", stores: stores, onNameSaved: {})
@@ -89,12 +90,13 @@ final class StoreNameSetupViewModelTests: XCTestCase {
         XCTAssertNotNil(viewModel.errorMessage)
     }
 
+    @MainActor
     func test_default_store_name_is_updated_upon_saving_store_name_completes() async {
         // Given
         let originalSite = Site.fake().copy(siteID: 123, name: "Test")
         stores = MockStoresManager(sessionManager: .makeForTesting(authenticated: true, defaultSite: originalSite))
         let viewModel = StoreNameSetupViewModel(siteID: originalSite.siteID, name: originalSite.name, stores: stores, onNameSaved: {})
-        mockStoreNameUpdate(result: .success(Site.fake().copy(siteID: 123, name: "Miffy")))
+        mockStoreNameUpdate(result: .success(Void()))
 
         // When
         viewModel.name = "Miffy"
@@ -106,7 +108,7 @@ final class StoreNameSetupViewModelTests: XCTestCase {
 }
 
 private extension StoreNameSetupViewModelTests {
-    func mockStoreNameUpdate(result: Result<Site, Error>) {
+    func mockStoreNameUpdate(result: Result<Void, Error>) {
         stores.whenReceivingAction(ofType: SiteAction.self) { action in
             switch action {
             case let .updateSiteTitle(_, _, completion):

--- a/Yosemite/Yosemite/Actions/SiteAction.swift
+++ b/Yosemite/Yosemite/Actions/SiteAction.swift
@@ -35,7 +35,7 @@ public enum SiteAction: Action {
     ///   - title: The title to update
     ///   - completion: Called when the result of the update is available.
     ///
-    case updateSiteTitle(siteID: Int64, title: String, completion: (Result<Site, Error>) -> Void)
+    case updateSiteTitle(siteID: Int64, title: String, completion: (Result<Void, Error>) -> Void)
 
     /// Upload store profiler answers
     ///


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #13562 
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
Previously, we were fetching the updated site and upserting the result to storage as part of the name update. The site fetch API uses WPCom API and fails if the user is authenticated without WPCom.

This PR fixes this issue by removing the site fetching. Instead, the site in the local storage is updated immediately with the new name. The default site in the stores manager is updated as well, but separately.

## Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->
- Log in to a self-hosted store with site credentials.
- Navigate to Menu > Settings > Store name.
- Change the name of the store and tap Save.
- After the save completes, the store name screen should be dismissed immediately. 
- Navigate to the My Store tab, confirm that the new name is displayed.
- Log out and log in to a test store with a WPCom account. Confirm that updating site name still works correctly, and the new name is displayed correctly on both the Menu and My Store tabs.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

https://github.com/user-attachments/assets/90752c1e-37da-4971-9c2d-35e95911fb2c



---
- [x] I have considered adding unit tests for this change. If I decided not to add them, I have provided a brief explanation below (optional):
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
- [ ] This PR includes refactoring; smoke testing of the entire section is needed.
