### PR TITLE
[Woo POS] Payment error UI updates

### DIFF
--- a/WooCommerce/Classes/POS/Presentation/Card Present Payments/Reader Messages/PointOfSaleCardPresentPaymentErrorMessageViewModel.swift
+++ b/WooCommerce/Classes/POS/Presentation/Card Present Payments/Reader Messages/PointOfSaleCardPresentPaymentErrorMessageViewModel.swift
@@ -5,6 +5,7 @@ struct PointOfSaleCardPresentPaymentErrorMessageViewModel {
     let title = Localization.title
     let message: String
     let tryAgainButtonViewModel: CardPresentPaymentsModalButtonViewModel
+    let exitButtonViewModel: CardPresentPaymentsModalButtonViewModel?
 
     init(error: Error,
          tryAgainButtonAction: @escaping () -> Void) {
@@ -12,6 +13,9 @@ struct PointOfSaleCardPresentPaymentErrorMessageViewModel {
         self.tryAgainButtonViewModel = CardPresentPaymentsModalButtonViewModel(
             title: Localization.tryAgain,
             actionHandler: tryAgainButtonAction)
+        self.exitButtonViewModel = CardPresentPaymentsModalButtonViewModel(
+            title: Localization.exitOrder,
+            actionHandler: { })
     }
 
     private static func message(for error: Error) -> String {
@@ -33,8 +37,16 @@ private extension PointOfSaleCardPresentPaymentErrorMessageViewModel {
 
         static let tryAgain =  NSLocalizedString(
             "pointOfSale.cardPresent.paymentError.tryAgain.button.title",
-            value: "Try Again",
-            comment: "Button to try to collect a payment again. Presented to users after collecting a payment fails on the Point of Sale Checkout"
+            value: "Try payment again",
+            comment: "Button to try to collect a payment again. Presented to users after collecting a " +
+            "payment fails on the Point of Sale Checkout"
+        )
+
+        static let exitOrder =  NSLocalizedString(
+            "pointOfSale.cardPresent.paymentError.exitOrder.button.title",
+            value: "Exit order",
+            comment: "Button to leave the order when a card payment fails. Presented to users after " +
+            "collecting a payment fails on the Point of Sale Checkout"
         )
     }
 }

--- a/WooCommerce/Classes/POS/Presentation/Card Present Payments/Reader Messages/PointOfSaleCardPresentPaymentNonRetryableErrorMessageViewModel.swift
+++ b/WooCommerce/Classes/POS/Presentation/Card Present Payments/Reader Messages/PointOfSaleCardPresentPaymentNonRetryableErrorMessageViewModel.swift
@@ -4,9 +4,13 @@ import enum Yosemite.CardReaderServiceError
 struct PointOfSaleCardPresentPaymentNonRetryableErrorMessageViewModel {
     let title = Localization.title
     let message: String
+    let startAgainButtonViewModel: CardPresentPaymentsModalButtonViewModel
 
     init(error: Error) {
         self.message = Self.message(for: error)
+        self.startAgainButtonViewModel = CardPresentPaymentsModalButtonViewModel(
+            title: Localization.startAgain,
+            actionHandler: { })
     }
 
     private static func message(for error: Error) -> String {
@@ -25,5 +29,11 @@ private extension PointOfSaleCardPresentPaymentNonRetryableErrorMessageViewModel
             value: "Payment failed",
             comment: "Error message. Presented to users after collecting a payment fails on the Point of Sale Checkout"
         )
+
+        static let startAgain = NSLocalizedString(
+            "pointOfSale.cardPresent.paymentErrorNonRetryable.startAgain.button.title",
+            value: "Start again",
+            comment: "Title of the button used on a non-retryable card payment error from the Point of Sale Checkout " +
+            "to go back and start the order from scratch.")
     }
 }

--- a/WooCommerce/Classes/POS/Presentation/Card Present Payments/Reader Messages/PointOfSaleCardPresentPaymentNonRetryableErrorMessageViewModel.swift
+++ b/WooCommerce/Classes/POS/Presentation/Card Present Payments/Reader Messages/PointOfSaleCardPresentPaymentNonRetryableErrorMessageViewModel.swift
@@ -4,11 +4,12 @@ import enum Yosemite.CardReaderServiceError
 struct PointOfSaleCardPresentPaymentNonRetryableErrorMessageViewModel {
     let title = Localization.title
     let message: String
-    let startAgainButtonViewModel: CardPresentPaymentsModalButtonViewModel
+    let nextStep: String = Localization.nextStep
+    let tryAnotherPaymentMethodButtonViewModel: CardPresentPaymentsModalButtonViewModel
 
     init(error: Error) {
         self.message = Self.message(for: error)
-        self.startAgainButtonViewModel = CardPresentPaymentsModalButtonViewModel(
+        self.tryAnotherPaymentMethodButtonViewModel = CardPresentPaymentsModalButtonViewModel(
             title: Localization.startAgain,
             actionHandler: { })
     }
@@ -31,9 +32,15 @@ private extension PointOfSaleCardPresentPaymentNonRetryableErrorMessageViewModel
         )
 
         static let startAgain = NSLocalizedString(
-            "pointOfSale.cardPresent.paymentErrorNonRetryable.startAgain.button.title",
-            value: "Start again",
-            comment: "Title of the button used on a non-retryable card payment error from the Point of Sale Checkout " +
-            "to go back and start the order from scratch.")
+            "pointOfSale.cardPresent.paymentErrorNonRetryable.tryAnotherPaymentMethod.button.title",
+            value: "Try another payment method",
+            comment: "Title of the button used on a card payment error from the Point of Sale Checkout " +
+            "to go back and try another payment method.")
+
+        static let nextStep = NSLocalizedString(
+            "pointOfSale.cardPresent.paymentErrorNonRetryable.nextStep.instruction",
+            value: "If you’d like to continue processing this transaction, please retry the payment.",
+            comment: "Instruction used on a card payment error from the Point of Sale Checkout " +
+            "telling the merchant how to continue with the payment.")
     }
 }

--- a/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/PointOfSaleCardPresentPaymentInLineMessage.swift
+++ b/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/PointOfSaleCardPresentPaymentInLineMessage.swift
@@ -8,7 +8,6 @@ struct PointOfSaleCardPresentPaymentInLineMessage: View {
     }
 
     var body: some View {
-
         // TODO: replace temporary inline message UI based on design
         switch messageType {
         case .validatingOrder(let viewModel):

--- a/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/PointOfSaleLoadingView.swift
+++ b/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/PointOfSaleLoadingView.swift
@@ -14,7 +14,6 @@ struct PointOfSaleLoadingView: View {
                 Spacer().frame(height: Layout.textSpacing)
                 Text(Localization.subtitle)
                     .font(.posTitle)
-                    .bold()
                 Spacer()
             }
             .multilineTextAlignment(.center)

--- a/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/Reader Messages/PointOfSaleCardPresentPaymentActivityIndicatingMessageView.swift
+++ b/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/Reader Messages/PointOfSaleCardPresentPaymentActivityIndicatingMessageView.swift
@@ -10,7 +10,7 @@ struct PointOfSaleCardPresentPaymentActivityIndicatingMessageView: View {
                 .progressViewStyle(POSProgressViewStyle())
                 .frame(width: PointOfSaleCardPresentPaymentLayout.headerSize.width,
                        height: PointOfSaleCardPresentPaymentLayout.headerSize.height)
-            VStack(alignment: .center, spacing: PointOfSaleCardPresentPaymentLayout.textSpacing) {
+            VStack(alignment: .center, spacing: PointOfSaleCardPresentPaymentLayout.smallTextSpacing) {
                 Text(title)
                     .foregroundStyle(Color(.neutral(.shade40)))
                     .font(.posBody)

--- a/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/Reader Messages/PointOfSaleCardPresentPaymentActivityIndicatingMessageView.swift
+++ b/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/Reader Messages/PointOfSaleCardPresentPaymentActivityIndicatingMessageView.swift
@@ -18,7 +18,6 @@ struct PointOfSaleCardPresentPaymentActivityIndicatingMessageView: View {
                 Text(message)
                     .font(.posTitle)
                     .foregroundStyle(Color(.neutral(.shade60)))
-                    .bold()
             }
         }
         .multilineTextAlignment(.center)

--- a/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/Reader Messages/PointOfSaleCardPresentPaymentActivityIndicatingMessageView.swift
+++ b/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/Reader Messages/PointOfSaleCardPresentPaymentActivityIndicatingMessageView.swift
@@ -5,27 +5,23 @@ struct PointOfSaleCardPresentPaymentActivityIndicatingMessageView: View {
     let message: String
 
     var body: some View {
-        HStack(alignment: .center) {
-            Spacer()
-            VStack(alignment: .center, spacing: PointOfSaleCardPresentPaymentLayout.headerSpacing) {
-                ProgressView()
-                    .progressViewStyle(POSProgressViewStyle())
-                    .frame(width: PointOfSaleCardPresentPaymentLayout.headerSize.width,
-                           height: PointOfSaleCardPresentPaymentLayout.headerSize.height)
-                VStack(alignment: .center, spacing: PointOfSaleCardPresentPaymentLayout.textSpacing) {
-                    Text(title)
-                        .foregroundStyle(Color(.neutral(.shade40)))
-                        .font(.posBody)
+        VStack(alignment: .center, spacing: PointOfSaleCardPresentPaymentLayout.headerSpacing) {
+            ProgressView()
+                .progressViewStyle(POSProgressViewStyle())
+                .frame(width: PointOfSaleCardPresentPaymentLayout.headerSize.width,
+                       height: PointOfSaleCardPresentPaymentLayout.headerSize.height)
+            VStack(alignment: .center, spacing: PointOfSaleCardPresentPaymentLayout.textSpacing) {
+                Text(title)
+                    .foregroundStyle(Color(.neutral(.shade40)))
+                    .font(.posBody)
 
-                    Text(message)
-                        .font(.posTitle)
-                        .foregroundStyle(Color(.neutral(.shade60)))
-                        .bold()
-                }
+                Text(message)
+                    .font(.posTitle)
+                    .foregroundStyle(Color(.neutral(.shade60)))
+                    .bold()
             }
-            .multilineTextAlignment(.center)
-            Spacer()
         }
+        .multilineTextAlignment(.center)
     }
 }
 

--- a/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/Reader Messages/PointOfSaleCardPresentPaymentCancelledOnReaderMessageView.swift
+++ b/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/Reader Messages/PointOfSaleCardPresentPaymentCancelledOnReaderMessageView.swift
@@ -8,7 +8,6 @@ struct PointOfSaleCardPresentPaymentCancelledOnReaderMessageView: View {
             Text(viewModel.title)
                 .font(.posTitle)
                 .foregroundStyle(Color.posPrimaryTexti3)
-                .bold()
         }
         .multilineTextAlignment(.center)
     }

--- a/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/Reader Messages/PointOfSaleCardPresentPaymentCancelledOnReaderMessageView.swift
+++ b/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/Reader Messages/PointOfSaleCardPresentPaymentCancelledOnReaderMessageView.swift
@@ -4,17 +4,13 @@ struct PointOfSaleCardPresentPaymentCancelledOnReaderMessageView: View {
     let viewModel: PointOfSaleCardPresentPaymentCancelledOnReaderMessageViewModel
 
     var body: some View {
-        HStack(alignment: .center) {
-            Spacer()
-            VStack(alignment: .center, spacing: PointOfSaleCardPresentPaymentLayout.textSpacing) {
-                Text(viewModel.title)
-                    .font(.posTitle)
-                    .foregroundStyle(Color.posPrimaryTexti3)
-                    .bold()
-            }
-            .multilineTextAlignment(.center)
-            Spacer()
+        VStack(alignment: .center, spacing: PointOfSaleCardPresentPaymentLayout.textSpacing) {
+            Text(viewModel.title)
+                .font(.posTitle)
+                .foregroundStyle(Color.posPrimaryTexti3)
+                .bold()
         }
+        .multilineTextAlignment(.center)
     }
 }
 

--- a/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/Reader Messages/PointOfSaleCardPresentPaymentDisconnectedMessageView.swift
+++ b/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/Reader Messages/PointOfSaleCardPresentPaymentDisconnectedMessageView.swift
@@ -11,7 +11,6 @@ struct PointOfSaleCardPresentPaymentReaderDisconnectedMessageView: View {
                 Text(viewModel.title)
                     .font(.posTitle)
                     .foregroundStyle(Color.posPrimaryTexti3)
-                    .bold()
                 Text(viewModel.instruction)
                     .font(.posBody)
                     .foregroundStyle(Color.posPrimaryTexti3)

--- a/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/Reader Messages/PointOfSaleCardPresentPaymentDisplayReaderMessageMessageView.swift
+++ b/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/Reader Messages/PointOfSaleCardPresentPaymentDisplayReaderMessageMessageView.swift
@@ -4,30 +4,26 @@ struct PointOfSaleCardPresentPaymentDisplayReaderMessageMessageView: View {
     let viewModel: PointOfSaleCardPresentPaymentDisplayReaderMessageMessageViewModel
 
     var body: some View {
-        HStack(alignment: .center) {
-            Spacer()
-            VStack(alignment: .center, spacing: Layout.headerSpacing) {
-                Image(viewModel.imageName)
-                    .resizable()
-                    .aspectRatio(contentMode: .fill)
-                    .frame(width: PointOfSaleCardPresentPaymentLayout.headerSize.width,
-                           height: PointOfSaleCardPresentPaymentLayout.headerSize.height)
+        VStack(alignment: .center, spacing: Layout.headerSpacing) {
+            Image(viewModel.imageName)
+                .resizable()
+                .aspectRatio(contentMode: .fill)
+                .frame(width: PointOfSaleCardPresentPaymentLayout.headerSize.width,
+                       height: PointOfSaleCardPresentPaymentLayout.headerSize.height)
 
-                VStack(alignment: .center, spacing: Layout.textSpacing) {
-                    Text(viewModel.title)
-                        .foregroundStyle(.white)
-                        .font(.posBody)
+            VStack(alignment: .center, spacing: Layout.textSpacing) {
+                Text(viewModel.title)
+                    .foregroundStyle(.white)
+                    .font(.posBody)
 
-                    Text(viewModel.message)
-                        .font(.posTitle)
-                        .foregroundStyle(.white)
-                        .bold()
-                }
+                Text(viewModel.message)
+                    .font(.posTitle)
+                    .foregroundStyle(.white)
+                    .bold()
             }
-            .padding(.bottom)
-            .multilineTextAlignment(.center)
-            Spacer()
         }
+        .padding(.bottom)
+        .multilineTextAlignment(.center)
     }
 }
 

--- a/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/Reader Messages/PointOfSaleCardPresentPaymentDisplayReaderMessageMessageView.swift
+++ b/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/Reader Messages/PointOfSaleCardPresentPaymentDisplayReaderMessageMessageView.swift
@@ -19,7 +19,6 @@ struct PointOfSaleCardPresentPaymentDisplayReaderMessageMessageView: View {
                 Text(viewModel.message)
                     .font(.posTitle)
                     .foregroundStyle(.white)
-                    .bold()
             }
         }
         .padding(.bottom)

--- a/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/Reader Messages/PointOfSaleCardPresentPaymentErrorMessageView.swift
+++ b/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/Reader Messages/PointOfSaleCardPresentPaymentErrorMessageView.swift
@@ -5,28 +5,24 @@ struct PointOfSaleCardPresentPaymentErrorMessageView: View {
     let viewModel: PointOfSaleCardPresentPaymentErrorMessageViewModel
 
     var body: some View {
-        HStack(alignment: .center) {
-            Spacer()
-            VStack(alignment: .center) {
-                VStack(alignment: .center, spacing: PointOfSaleCardPresentPaymentLayout.textSpacing) {
-                    Text(viewModel.title)
-                        .foregroundStyle(Color.posPrimaryTexti3)
-                        .font(.posBody)
+        VStack(alignment: .center) {
+            VStack(alignment: .center, spacing: PointOfSaleCardPresentPaymentLayout.textSpacing) {
+                Text(viewModel.title)
+                    .foregroundStyle(Color.posPrimaryTexti3)
+                    .font(.posBody)
 
-                    Text(viewModel.message)
-                        .font(.posTitle)
-                        .foregroundStyle(Color.posPrimaryTexti3)
-                        .bold()
-                }
-
-                HStack {
-                    Button(viewModel.tryAgainButtonViewModel.title, action: viewModel.tryAgainButtonViewModel.actionHandler)
-                }
-                .padding()
+                Text(viewModel.message)
+                    .font(.posTitle)
+                    .foregroundStyle(Color.posPrimaryTexti3)
+                    .bold()
             }
-            .multilineTextAlignment(.center)
-            Spacer()
+
+            HStack {
+                Button(viewModel.tryAgainButtonViewModel.title, action: viewModel.tryAgainButtonViewModel.actionHandler)
+            }
+            .padding()
         }
+        .multilineTextAlignment(.center)
     }
 }
 

--- a/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/Reader Messages/PointOfSaleCardPresentPaymentErrorMessageView.swift
+++ b/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/Reader Messages/PointOfSaleCardPresentPaymentErrorMessageView.swift
@@ -6,7 +6,7 @@ struct PointOfSaleCardPresentPaymentErrorMessageView: View {
 
     var body: some View {
         VStack(alignment: .center, spacing: PointOfSaleCardPresentPaymentLayout.errorElementSpacing) {
-            POSErrorExclamationMark()
+            POSErrorXMark()
             VStack(alignment: .center, spacing: PointOfSaleCardPresentPaymentLayout.textSpacing) {
                 Text(viewModel.title)
                     .foregroundStyle(Color.primaryText)

--- a/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/Reader Messages/PointOfSaleCardPresentPaymentErrorMessageView.swift
+++ b/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/Reader Messages/PointOfSaleCardPresentPaymentErrorMessageView.swift
@@ -5,24 +5,32 @@ struct PointOfSaleCardPresentPaymentErrorMessageView: View {
     let viewModel: PointOfSaleCardPresentPaymentErrorMessageViewModel
 
     var body: some View {
-        VStack(alignment: .center) {
+        VStack(alignment: .center, spacing: PointOfSaleCardPresentPaymentLayout.errorElementSpacing) {
+            POSErrorExclamationMark()
             VStack(alignment: .center, spacing: PointOfSaleCardPresentPaymentLayout.textSpacing) {
                 Text(viewModel.title)
-                    .foregroundStyle(Color.posPrimaryTexti3)
-                    .font(.posBody)
+                    .foregroundStyle(Color.primaryText)
+                    .font(.posTitle)
 
                 Text(viewModel.message)
-                    .font(.posTitle)
-                    .foregroundStyle(Color.posPrimaryTexti3)
-                    .bold()
+                    .font(.posBody)
+                    .foregroundStyle(Color.primaryText)
             }
 
-            HStack {
-                Button(viewModel.tryAgainButtonViewModel.title, action: viewModel.tryAgainButtonViewModel.actionHandler)
+            VStack(spacing: PointOfSaleCardPresentPaymentLayout.buttonSpacing) {
+                Button(viewModel.tryAgainButtonViewModel.title,
+                       action: viewModel.tryAgainButtonViewModel.actionHandler)
+                .buttonStyle(POSPrimaryButtonStyle())
+
+                if let exitButtonViewModel = viewModel.exitButtonViewModel {
+                    Button(exitButtonViewModel.title,
+                           action: exitButtonViewModel.actionHandler)
+                    .buttonStyle(POSSecondaryButtonStyle())
+                }
             }
-            .padding()
         }
         .multilineTextAlignment(.center)
+        .frame(maxWidth: PointOfSaleCardPresentPaymentLayout.errorContentMaxWidth)
     }
 }
 

--- a/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/Reader Messages/PointOfSaleCardPresentPaymentLayout.swift
+++ b/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/Reader Messages/PointOfSaleCardPresentPaymentLayout.swift
@@ -3,10 +3,12 @@ import Foundation
 enum PointOfSaleCardPresentPaymentLayout {
     static let headerSize: CGSize = .init(width: 156, height: 156)
     static let headerSpacing: CGFloat = 72
-    static let textSpacing: CGFloat = 4
+    static let textSpacing: CGFloat = 16
+    static let smallTextSpacing: CGFloat = 8
     static let buttonSpacing: CGFloat = 24
     static let errorElementSpacing: CGFloat = 40
     static let errorIconSize: CGFloat = 64
+    static let largeErrorIconSize: CGFloat = 84
     static let horizontalPadding: CGFloat = 40
     static let errorContentMaxWidth: CGFloat = 604
 }

--- a/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/Reader Messages/PointOfSaleCardPresentPaymentLayout.swift
+++ b/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/Reader Messages/PointOfSaleCardPresentPaymentLayout.swift
@@ -4,7 +4,9 @@ enum PointOfSaleCardPresentPaymentLayout {
     static let headerSize: CGSize = .init(width: 156, height: 156)
     static let headerSpacing: CGFloat = 72
     static let textSpacing: CGFloat = 4
+    static let buttonSpacing: CGFloat = 24
     static let errorElementSpacing: CGFloat = 40
     static let errorIconSize: CGFloat = 64
     static let horizontalPadding: CGFloat = 40
+    static let errorContentMaxWidth: CGFloat = 604
 }

--- a/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/Reader Messages/PointOfSaleCardPresentPaymentNonRetryableErrorMessageView.swift
+++ b/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/Reader Messages/PointOfSaleCardPresentPaymentNonRetryableErrorMessageView.swift
@@ -5,21 +5,17 @@ struct PointOfSaleCardPresentPaymentNonRetryableErrorMessageView: View {
     let viewModel: PointOfSaleCardPresentPaymentNonRetryableErrorMessageViewModel
 
     var body: some View {
-        HStack(alignment: .center) {
-            Spacer()
-            VStack(alignment: .center, spacing: PointOfSaleCardPresentPaymentLayout.textSpacing) {
-                Text(viewModel.title)
-                    .foregroundStyle(Color.posPrimaryTexti3)
-                    .font(.posBody)
+        VStack(alignment: .center, spacing: PointOfSaleCardPresentPaymentLayout.textSpacing) {
+            Text(viewModel.title)
+                .foregroundStyle(Color.posPrimaryTexti3)
+                .font(.posBody)
 
-                Text(viewModel.message)
-                    .font(.posTitle)
-                    .foregroundStyle(Color.posPrimaryTexti3)
-                    .bold()
-            }
-            .multilineTextAlignment(.center)
-            Spacer()
+            Text(viewModel.message)
+                .font(.posTitle)
+                .foregroundStyle(Color.posPrimaryTexti3)
+                .bold()
         }
+        .multilineTextAlignment(.center)
     }
 }
 

--- a/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/Reader Messages/PointOfSaleCardPresentPaymentNonRetryableErrorMessageView.swift
+++ b/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/Reader Messages/PointOfSaleCardPresentPaymentNonRetryableErrorMessageView.swift
@@ -5,16 +5,24 @@ struct PointOfSaleCardPresentPaymentNonRetryableErrorMessageView: View {
     let viewModel: PointOfSaleCardPresentPaymentNonRetryableErrorMessageViewModel
 
     var body: some View {
-        VStack(alignment: .center, spacing: PointOfSaleCardPresentPaymentLayout.textSpacing) {
-            Text(viewModel.title)
-                .foregroundStyle(Color.posPrimaryTexti3)
-                .font(.posBody)
+        VStack(alignment: .center, spacing: PointOfSaleCardPresentPaymentLayout.errorElementSpacing) {
+            POSErrorExclamationMark()
+            VStack(alignment: .center, spacing: PointOfSaleCardPresentPaymentLayout.textSpacing) {
+                Text(viewModel.title)
+                    .foregroundStyle(Color.primaryText)
+                    .font(.posTitle)
 
-            Text(viewModel.message)
-                .font(.posTitle)
-                .foregroundStyle(Color.posPrimaryTexti3)
+                Text(viewModel.message)
+                    .font(.posBody)
+                    .foregroundStyle(Color.primaryText)
+            }
+
+            Button(viewModel.startAgainButtonViewModel.title,
+                   action: viewModel.startAgainButtonViewModel.actionHandler)
+            .buttonStyle(POSPrimaryButtonStyle())
         }
         .multilineTextAlignment(.center)
+        .frame(maxWidth: PointOfSaleCardPresentPaymentLayout.errorContentMaxWidth)
     }
 }
 

--- a/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/Reader Messages/PointOfSaleCardPresentPaymentNonRetryableErrorMessageView.swift
+++ b/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/Reader Messages/PointOfSaleCardPresentPaymentNonRetryableErrorMessageView.swift
@@ -6,19 +6,22 @@ struct PointOfSaleCardPresentPaymentNonRetryableErrorMessageView: View {
 
     var body: some View {
         VStack(alignment: .center, spacing: PointOfSaleCardPresentPaymentLayout.errorElementSpacing) {
-            POSErrorExclamationMark()
+            POSErrorXMark()
             VStack(alignment: .center, spacing: PointOfSaleCardPresentPaymentLayout.textSpacing) {
                 Text(viewModel.title)
                     .foregroundStyle(Color.primaryText)
                     .font(.posTitle)
 
-                Text(viewModel.message)
-                    .font(.posBody)
-                    .foregroundStyle(Color.primaryText)
+                VStack(alignment: .center, spacing: PointOfSaleCardPresentPaymentLayout.smallTextSpacing) {
+                    Text(viewModel.message)
+                    Text(viewModel.nextStep)
+                }
+                .font(.posBody)
+                .foregroundStyle(Color.primaryText)
             }
 
-            Button(viewModel.startAgainButtonViewModel.title,
-                   action: viewModel.startAgainButtonViewModel.actionHandler)
+            Button(viewModel.tryAnotherPaymentMethodButtonViewModel.title,
+                   action: viewModel.tryAnotherPaymentMethodButtonViewModel.actionHandler)
             .buttonStyle(POSPrimaryButtonStyle())
         }
         .multilineTextAlignment(.center)

--- a/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/Reader Messages/PointOfSaleCardPresentPaymentNonRetryableErrorMessageView.swift
+++ b/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/Reader Messages/PointOfSaleCardPresentPaymentNonRetryableErrorMessageView.swift
@@ -13,7 +13,6 @@ struct PointOfSaleCardPresentPaymentNonRetryableErrorMessageView: View {
             Text(viewModel.message)
                 .font(.posTitle)
                 .foregroundStyle(Color.posPrimaryTexti3)
-                .bold()
         }
         .multilineTextAlignment(.center)
     }

--- a/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/Reader Messages/PointOfSaleCardPresentPaymentProcessingMessageView.swift
+++ b/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/Reader Messages/PointOfSaleCardPresentPaymentProcessingMessageView.swift
@@ -4,30 +4,26 @@ struct PointOfSaleCardPresentPaymentProcessingMessageView: View {
     let viewModel: PointOfSaleCardPresentPaymentProcessingMessageViewModel
 
     var body: some View {
-        HStack(alignment: .center) {
-            Spacer()
-            VStack(alignment: .center, spacing: Layout.headerSpacing) {
-                Image(viewModel.imageName)
-                    .resizable()
-                    .aspectRatio(contentMode: .fill)
-                    .frame(width: PointOfSaleCardPresentPaymentLayout.headerSize.width,
-                           height: PointOfSaleCardPresentPaymentLayout.headerSize.height)
+        VStack(alignment: .center, spacing: Layout.headerSpacing) {
+            Image(viewModel.imageName)
+                .resizable()
+                .aspectRatio(contentMode: .fill)
+                .frame(width: PointOfSaleCardPresentPaymentLayout.headerSize.width,
+                       height: PointOfSaleCardPresentPaymentLayout.headerSize.height)
 
-                VStack(alignment: .center, spacing: Layout.textSpacing) {
-                    Text(viewModel.title)
-                        .foregroundStyle(.white)
-                        .font(.posBody)
+            VStack(alignment: .center, spacing: Layout.textSpacing) {
+                Text(viewModel.title)
+                    .foregroundStyle(.white)
+                    .font(.posBody)
 
-                    Text(viewModel.message)
-                        .font(.posTitle)
-                        .foregroundStyle(Color.posQuaternaryTextInverted)
-                        .bold()
-                }
+                Text(viewModel.message)
+                    .font(.posTitle)
+                    .foregroundStyle(Color.posQuaternaryTextInverted)
+                    .bold()
             }
-            .padding(.bottom)
-            .multilineTextAlignment(.center)
-            Spacer()
         }
+        .padding(.bottom)
+        .multilineTextAlignment(.center)
     }
 }
 

--- a/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/Reader Messages/PointOfSaleCardPresentPaymentProcessingMessageView.swift
+++ b/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/Reader Messages/PointOfSaleCardPresentPaymentProcessingMessageView.swift
@@ -19,7 +19,6 @@ struct PointOfSaleCardPresentPaymentProcessingMessageView: View {
                 Text(viewModel.message)
                     .font(.posTitle)
                     .foregroundStyle(Color.posQuaternaryTextInverted)
-                    .bold()
             }
         }
         .padding(.bottom)

--- a/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/Reader Messages/PointOfSaleCardPresentPaymentSuccessMessageView.swift
+++ b/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/Reader Messages/PointOfSaleCardPresentPaymentSuccessMessageView.swift
@@ -4,25 +4,21 @@ struct PointOfSaleCardPresentPaymentSuccessMessageView: View {
     let viewModel: PointOfSaleCardPresentPaymentSuccessMessageViewModel
 
     var body: some View {
-        HStack(alignment: .center) {
-            Spacer()
-            VStack(alignment: .center, spacing: Constants.headerSpacing) {
-                successIcon
-                VStack(alignment: .center, spacing: Constants.textSpacing) {
-                    Text(viewModel.title)
-                        .font(.posTitle)
+        VStack(alignment: .center, spacing: Constants.headerSpacing) {
+            successIcon
+            VStack(alignment: .center, spacing: Constants.textSpacing) {
+                Text(viewModel.title)
+                    .font(.posTitle)
+                    .foregroundStyle(Color.posPrimaryTexti3)
+                    .bold()
+                if let message = viewModel.message {
+                    Text(message)
+                        .font(.posBody)
                         .foregroundStyle(Color.posPrimaryTexti3)
-                        .bold()
-                    if let message = viewModel.message {
-                        Text(message)
-                            .font(.posBody)
-                            .foregroundStyle(Color.posPrimaryTexti3)
-                    }
                 }
             }
-            .multilineTextAlignment(.center)
-            Spacer()
         }
+        .multilineTextAlignment(.center)
     }
 
     private var successIcon: some View {

--- a/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/Reader Messages/PointOfSaleCardPresentPaymentSuccessMessageView.swift
+++ b/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/Reader Messages/PointOfSaleCardPresentPaymentSuccessMessageView.swift
@@ -10,7 +10,6 @@ struct PointOfSaleCardPresentPaymentSuccessMessageView: View {
                 Text(viewModel.title)
                     .font(.posTitle)
                     .foregroundStyle(Color.posPrimaryTexti3)
-                    .bold()
                 if let message = viewModel.message {
                     Text(message)
                         .font(.posBody)

--- a/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/Reader Messages/PointOfSaleCardPresentPaymentTapSwipeInsertCardMessageView.swift
+++ b/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/Reader Messages/PointOfSaleCardPresentPaymentTapSwipeInsertCardMessageView.swift
@@ -10,7 +10,7 @@ struct PointOfSaleCardPresentPaymentTapSwipeInsertCardMessageView: View {
                 .aspectRatio(contentMode: .fill)
                 .frame(width: PointOfSaleCardPresentPaymentLayout.headerSize.width,
                        height: PointOfSaleCardPresentPaymentLayout.headerSize.height)
-            VStack(alignment: .center, spacing: PointOfSaleCardPresentPaymentLayout.textSpacing) {
+            VStack(alignment: .center, spacing: PointOfSaleCardPresentPaymentLayout.smallTextSpacing) {
                 Text(viewModel.title)
                     .foregroundStyle(Color.posPrimaryTexti3)
                     .font(.posBody)

--- a/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/Reader Messages/PointOfSaleCardPresentPaymentTapSwipeInsertCardMessageView.swift
+++ b/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/Reader Messages/PointOfSaleCardPresentPaymentTapSwipeInsertCardMessageView.swift
@@ -4,28 +4,24 @@ struct PointOfSaleCardPresentPaymentTapSwipeInsertCardMessageView: View {
     let viewModel: PointOfSaleCardPresentPaymentTapSwipeInsertCardMessageViewModel
 
     var body: some View {
-        HStack(alignment: .center) {
-            Spacer()
-            VStack(alignment: .center, spacing: PointOfSaleCardPresentPaymentLayout.headerSpacing) {
-                Image(viewModel.imageName)
-                    .resizable()
-                    .aspectRatio(contentMode: .fill)
-                    .frame(width: PointOfSaleCardPresentPaymentLayout.headerSize.width,
-                           height: PointOfSaleCardPresentPaymentLayout.headerSize.height)
-                VStack(alignment: .center, spacing: PointOfSaleCardPresentPaymentLayout.textSpacing) {
-                    Text(viewModel.title)
-                        .foregroundStyle(Color.posPrimaryTexti3)
-                        .font(.posBody)
+        VStack(alignment: .center, spacing: PointOfSaleCardPresentPaymentLayout.headerSpacing) {
+            Image(viewModel.imageName)
+                .resizable()
+                .aspectRatio(contentMode: .fill)
+                .frame(width: PointOfSaleCardPresentPaymentLayout.headerSize.width,
+                       height: PointOfSaleCardPresentPaymentLayout.headerSize.height)
+            VStack(alignment: .center, spacing: PointOfSaleCardPresentPaymentLayout.textSpacing) {
+                Text(viewModel.title)
+                    .foregroundStyle(Color.posPrimaryTexti3)
+                    .font(.posBody)
 
-                    Text(viewModel.message)
-                        .font(.posTitle)
-                        .foregroundStyle(Color.posPrimaryTexti3)
-                        .bold()
-                }
+                Text(viewModel.message)
+                    .font(.posTitle)
+                    .foregroundStyle(Color.posPrimaryTexti3)
+                    .bold()
             }
-            .multilineTextAlignment(.center)
-            Spacer()
         }
+        .multilineTextAlignment(.center)
     }
 }
 

--- a/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/Reader Messages/PointOfSaleCardPresentPaymentTapSwipeInsertCardMessageView.swift
+++ b/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/Reader Messages/PointOfSaleCardPresentPaymentTapSwipeInsertCardMessageView.swift
@@ -18,7 +18,6 @@ struct PointOfSaleCardPresentPaymentTapSwipeInsertCardMessageView: View {
                 Text(viewModel.message)
                     .font(.posTitle)
                     .foregroundStyle(Color.posPrimaryTexti3)
-                    .bold()
             }
         }
         .multilineTextAlignment(.center)

--- a/WooCommerce/Classes/POS/Presentation/Order Messages/PointOfSaleOrderSyncErrorMessageView.swift
+++ b/WooCommerce/Classes/POS/Presentation/Order Messages/PointOfSaleOrderSyncErrorMessageView.swift
@@ -15,7 +15,6 @@ struct PointOfSaleOrderSyncErrorMessageView: View {
                     Text(viewModel.title)
                         .foregroundStyle(Color.posPrimaryTexti3)
                         .font(.posTitle)
-                        .bold()
 
                     Text(viewModel.message)
                         .foregroundStyle(Color.posPrimaryTexti3)

--- a/WooCommerce/Classes/POS/Presentation/Reusable Views/POSErrorXMark.swift
+++ b/WooCommerce/Classes/POS/Presentation/Reusable Views/POSErrorXMark.swift
@@ -1,0 +1,13 @@
+import SwiftUI
+
+struct POSErrorXMark: View {
+    var body: some View {
+        Image(systemName: "xmark.circle.fill")
+            .font(.system(size: PointOfSaleCardPresentPaymentLayout.largeErrorIconSize))
+            .foregroundStyle(Color(.wooCommerceAmber(.shade60)))
+    }
+}
+
+#Preview {
+    POSErrorXMark()
+}

--- a/WooCommerce/Classes/POS/Presentation/TotalsView.swift
+++ b/WooCommerce/Classes/POS/Presentation/TotalsView.swift
@@ -216,7 +216,11 @@ private extension TotalsView {
         switch totalsViewModel.connectionStatus {
         case .connected:
             if let inlinePaymentMessage = totalsViewModel.cardPresentPaymentInlineMessage {
-                PointOfSaleCardPresentPaymentInLineMessage(messageType: inlinePaymentMessage)
+                HStack(alignment: .center) {
+                    Spacer()
+                    PointOfSaleCardPresentPaymentInLineMessage(messageType: inlinePaymentMessage)
+                    Spacer()
+                }
             } else {
                 EmptyView()
             }

--- a/WooCommerce/Classes/POS/Utils/Font+WooCommercePOS.swift
+++ b/WooCommerce/Classes/POS/Utils/Font+WooCommercePOS.swift
@@ -2,7 +2,7 @@ import SwiftUI
 
 extension Font {
     static let posBody: Font = Font.system(size: UIFontMetrics.default.scaledValue(for: 24))
-    static let posTitle: Font = Font.largeTitle
+    static let posTitle: Font = Font.largeTitle.bold()
     static let posDetail: Font = Font.system(size: UIFontMetrics.default.scaledValue(for: 16))
     static let posModalBody: Font = Font.system(size: UIFontMetrics.default.scaledValue(for: 24))
     static let posModalTitle: Font = Font.system(size: UIFontMetrics.default.scaledValue(for: 36), weight: .bold)

--- a/WooCommerce/Classes/POS/ViewModels/PointOfSaleDashboardViewModel.swift
+++ b/WooCommerce/Classes/POS/ViewModels/PointOfSaleDashboardViewModel.swift
@@ -101,6 +101,7 @@ private extension PointOfSaleDashboardViewModel {
             .map { paymentState, orderState in
                 switch paymentState {
                 case .processingPayment,
+                        .paymentError,
                         .cardPaymentSuccessful:
                     return true
                 case .idle,
@@ -121,6 +122,7 @@ private extension PointOfSaleDashboardViewModel {
                         .acceptingCard,
                         .validatingOrder,
                         .preparingReader,
+                        .paymentError,
                         .cardPaymentSuccessful:
                     return false
                 }
@@ -131,6 +133,7 @@ private extension PointOfSaleDashboardViewModel {
             .map { paymentState in
                 switch paymentState {
                 case .processingPayment,
+                        .paymentError,
                         .cardPaymentSuccessful:
                     return true
                 case .idle,

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -814,6 +814,7 @@
 		20A3AFE12B0F750B0033AF2D /* MockInPersonPaymentsCashOnDeliveryToggleRowViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 20A3AFE02B0F750B0033AF2D /* MockInPersonPaymentsCashOnDeliveryToggleRowViewModel.swift */; };
 		20A3AFE32B10EF860033AF2D /* CardReaderSettingsFlowPresentingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 20A3AFE22B10EF860033AF2D /* CardReaderSettingsFlowPresentingView.swift */; };
 		20A3AFE52B10EF970033AF2D /* TapToPaySettingsFlowPresentingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 20A3AFE42B10EF970033AF2D /* TapToPaySettingsFlowPresentingView.swift */; };
+		20ADE9412C6A02B700C91265 /* POSErrorXMark.swift in Sources */ = {isa = PBXBuildFile; fileRef = 20ADE9402C6A02B700C91265 /* POSErrorXMark.swift */; };
 		20AE33C52B0510BF00527B60 /* PaymentsMenuDestination.swift in Sources */ = {isa = PBXBuildFile; fileRef = 20AE33C42B0510BF00527B60 /* PaymentsMenuDestination.swift */; };
 		20AE33C72B0510D200527B60 /* HubMenuDestination.swift in Sources */ = {isa = PBXBuildFile; fileRef = 20AE33C62B0510D200527B60 /* HubMenuDestination.swift */; };
 		20B0D65E2AD45BDE0059735A /* AboutTapToPayContactlessLimitViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 20B0D65D2AD45BDE0059735A /* AboutTapToPayContactlessLimitViewModelTests.swift */; };
@@ -3825,6 +3826,7 @@
 		20A3AFE02B0F750B0033AF2D /* MockInPersonPaymentsCashOnDeliveryToggleRowViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockInPersonPaymentsCashOnDeliveryToggleRowViewModel.swift; sourceTree = "<group>"; };
 		20A3AFE22B10EF860033AF2D /* CardReaderSettingsFlowPresentingView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardReaderSettingsFlowPresentingView.swift; sourceTree = "<group>"; };
 		20A3AFE42B10EF970033AF2D /* TapToPaySettingsFlowPresentingView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TapToPaySettingsFlowPresentingView.swift; sourceTree = "<group>"; };
+		20ADE9402C6A02B700C91265 /* POSErrorXMark.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = POSErrorXMark.swift; sourceTree = "<group>"; };
 		20AE33C42B0510BF00527B60 /* PaymentsMenuDestination.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaymentsMenuDestination.swift; sourceTree = "<group>"; };
 		20AE33C62B0510D200527B60 /* HubMenuDestination.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HubMenuDestination.swift; sourceTree = "<group>"; };
 		20B0D65D2AD45BDE0059735A /* AboutTapToPayContactlessLimitViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AboutTapToPayContactlessLimitViewModelTests.swift; sourceTree = "<group>"; };
@@ -6016,6 +6018,7 @@
 				20D3D42E2C64F175004CE6E3 /* POSSecondaryButtonStyle.swift */,
 				20D3D4302C64F202004CE6E3 /* POSButtonStyleConstants.swift */,
 				207823E82C5D3A1700025A59 /* POSErrorExclamationMark.swift */,
+				20ADE9402C6A02B700C91265 /* POSErrorXMark.swift */,
 			);
 			path = "Reusable Views";
 			sourceTree = "<group>";
@@ -14567,6 +14570,7 @@
 				CCF87BBE279047BC00461C43 /* InfiniteScrollList.swift in Sources */,
 				DE8AA0B52BBEBE590084D2CC /* ViewControllerContainer.swift in Sources */,
 				DE7E5E8C2B4E9353002E28D2 /* ErrorStateView.swift in Sources */,
+				20ADE9412C6A02B700C91265 /* POSErrorXMark.swift in Sources */,
 				DE63115B2AF1E13200587641 /* WPComLoginCoordinator.swift in Sources */,
 				EE3B17B62AA03837004D3E0C /* CelebrationView.swift in Sources */,
 				D85A3C5226C15DE200C0E026 /* InPersonPaymentsPluginNotSupportedVersionView.swift in Sources */,


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of: #13481 
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

This PR does initial, visual-only updates to the payment failed errors.

Not covered:
 - making the CTA on non-retryable errors actually work (you're a bit stuck on that screen)
 - showing `Try another payment method` vs `Try again` on retryable errors of different types
 - making the `Exit order` button on retryable orders work (it will only show for `Try again` errors)

## Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->

Edit a POS-eligible product to have a sale price ending in `.01` – [see error amounts here](https://docs.stripe.com/terminal/references/testing#physical-test-cards)

1. Lauch the app and go to POS
2. Add your error product to the cart
3. Check out
4. Tap your card
5. Observe that you're shown the new error design
6. Tap `Try again`
7. Observe that you're shown the new non-retryable error

## Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->

I have moved the code to center the views of various payment events to the TotalsView: aca6912 – please note that these are correctly positioned when shown in line and when shown full screen.

I updated the definition for `posTitle` to be bold, because it always is – when merging this, we should check that we don't double-bold any new calls to `posTitle`

No unit tests because this is UI-only code

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->


https://github.com/user-attachments/assets/d2c54a66-9c34-469a-804d-df33f4b53339



---
- [x] I have considered adding unit tests for this change. If I decided not to add them, I have provided a brief explanation below (optional):
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
- [ ] This PR includes refactoring; smoke testing of the entire section is needed.