### PR TITLE
Subscriptions: Update logic for Report Subscription Issue button

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -4,6 +4,7 @@
 20.0
 -----
 - [*] Blaze: Now you can select media attached to the current product while creating Blaze ads. You don't have to scroll through all media in your store. [https://github.com/woocommerce/woocommerce-ios/pull/13540]
+- [*] Fix: "Report Subscription Issue" button in Subscriptions screen now works consistently. [https://github.com/woocommerce/woocommerce-ios/pull/13577]
 
 20.0
 -----

--- a/WooCommerce/Classes/ViewRelated/Upgrades/SubscriptionsView.swift
+++ b/WooCommerce/Classes/ViewRelated/Upgrades/SubscriptionsView.swift
@@ -109,7 +109,7 @@ private extension SubscriptionsView {
         }
 
         static let done = NSLocalizedString(
-            "subscriptionView.dismissSupport",
+            "subscriptionsView.dismissSupport",
             value: "Done",
             comment: "Button to dismiss the support form."
         )

--- a/WooCommerce/Classes/ViewRelated/Upgrades/SubscriptionsView.swift
+++ b/WooCommerce/Classes/ViewRelated/Upgrades/SubscriptionsView.swift
@@ -72,7 +72,7 @@ struct SubscriptionsView: View {
 
 private extension SubscriptionsView {
     var supportForm: some View {
-        NavigationView {
+        NavigationStack {
             SupportForm(isPresented: $isShowingSupport,
                         viewModel: SupportFormViewModel())
             .toolbar {
@@ -83,7 +83,6 @@ private extension SubscriptionsView {
                 }
             }
         }
-        .navigationViewStyle(.stack)
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Upgrades/SubscriptionsView.swift
+++ b/WooCommerce/Classes/ViewRelated/Upgrades/SubscriptionsView.swift
@@ -8,19 +8,10 @@ final class SubscriptionsHostingController: UIHostingController<SubscriptionsVie
     init(siteID: Int64) {
         let viewModel = SubscriptionsViewModel()
         super.init(rootView: .init(viewModel: viewModel))
-
-        rootView.onReportIssueTapped = { [weak self] in
-            self?.showContactSupportForm()
-        }
     }
 
     required init?(coder aDecoder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
-    }
-
-    private func showContactSupportForm() {
-        let supportController = SupportFormHostingController(viewModel: .init())
-        supportController.show(from: self)
     }
 }
 
@@ -35,6 +26,8 @@ struct SubscriptionsView: View {
     /// Closure to be invoked when the "Report Issue" button is tapped.
     ///
     var onReportIssueTapped: (() -> ())?
+
+    @State private var isShowingSupport = false
 
     var body: some View {
         List {
@@ -57,7 +50,7 @@ struct SubscriptionsView: View {
 
             Section(Localization.troubleshooting) {
                 Button(Localization.report) {
-                    onReportIssueTapped?()
+                    isShowingSupport = true
                 }
                 .linkStyle()
             }
@@ -71,6 +64,26 @@ struct SubscriptionsView: View {
         .task {
             viewModel.loadPlan()
         }
+        .sheet(isPresented: $isShowingSupport) {
+            supportForm
+        }
+    }
+}
+
+private extension SubscriptionsView {
+    var supportForm: some View {
+        NavigationView {
+            SupportForm(isPresented: $isShowingSupport,
+                        viewModel: SupportFormViewModel())
+            .toolbar {
+                ToolbarItem(placement: .confirmationAction) {
+                    Button(Localization.done) {
+                        isShowingSupport = false
+                    }
+                }
+            }
+        }
+        .navigationViewStyle(.stack)
     }
 }
 
@@ -94,6 +107,12 @@ private extension SubscriptionsView {
             let format = NSLocalizedString("Current: %@", comment: "Reads like: Current: Free Trial")
             return .localizedStringWithFormat(format, plan)
         }
+
+        static let done = NSLocalizedString(
+            "subscriptionView.dismissSupport",
+            value: "Done",
+            comment: "Button to dismiss the support form."
+        )
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Upgrades/UpgradesView.swift
+++ b/WooCommerce/Classes/ViewRelated/Upgrades/UpgradesView.swift
@@ -68,7 +68,7 @@ struct UpgradesView: View {
     }
 
     var body: some View {
-        NavigationView {
+        NavigationStack {
             VStack {
                 VStack {
                     // TODO: Once we remove iOS 15 support, we can do this with .toolbar instead.
@@ -145,9 +145,6 @@ struct UpgradesView: View {
             .navigationBarHidden(true)
             .background(Color(.systemGroupedBackground))
         }
-        // TODO: when we remove iOS 15 support, use NavigationStack instead.
-        // This is required to avoid a column layout on iPad, which looks strange.
-        .navigationViewStyle(.stack)
         .onDisappear {
             upgradesViewModel.onDisappear()
         }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #13564
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

On Jetpack-connected stores, when going to Hub menu > Subscriptions, the "Report Subscription Issue" button was not working.

This happened because the code that initialized the button handling was set in the `SubscriptionView`'s hosting controller, and there was [a recent Hack Week work](https://github.com/woocommerce/woocommerce-ios/pull/12283) that updated the Hub menu's navigation logic from using the hosting controller, to directly using the View. As such, the logic to set the button handling wasn't being run.

As the button is meant to open support form, this PR updates the logic so that the button handling is added directly inside the View, thus restoring the functionality. This is the same logic as used in other places such as `BlazeCampaignCreationForm` or `UnavailableAnalyticsView`.

The `SubscriptionsHostingController` itself is not deleted because it is still used in other places.

## Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->

1. Login to a Jetpack-connected store,
2. Go to Hub Menu > Subscriptions,
3. Tap Report Subscription Issue,
4. Ensure that the support form is opened.


https://github.com/user-attachments/assets/d543e181-e294-41f9-9cdc-05ba9cd22f50


