### PR TITLE
Settings: Fix SSR decode error for WPORG login request

### DIFF
--- a/Networking/Networking.xcodeproj/project.pbxproj
+++ b/Networking/Networking.xcodeproj/project.pbxproj
@@ -1172,6 +1172,7 @@
 		EE66BB022B2893AF00518DAF /* theme-install-success.json in Resources */ = {isa = PBXBuildFile; fileRef = EE66BB012B2893AF00518DAF /* theme-install-success.json */; };
 		EE66BB042B28975B00518DAF /* theme-install-already-installed.json in Resources */ = {isa = PBXBuildFile; fileRef = EE66BB032B28975B00518DAF /* theme-install-already-installed.json */; };
 		EE66BB062B29791500518DAF /* theme-activate-success.json in Resources */ = {isa = PBXBuildFile; fileRef = EE66BB052B29791500518DAF /* theme-activate-success.json */; };
+		EE6C6B702C6A190500632BDA /* systemStatus-inconsistent-page-id-data-type.json in Resources */ = {isa = PBXBuildFile; fileRef = EE6C6B6F2C6A190500632BDA /* systemStatus-inconsistent-page-id-data-type.json */; };
 		EE6FDCFC2966A70400E1CECF /* product-without-data.json in Resources */ = {isa = PBXBuildFile; fileRef = EE6FDCFB2966A70400E1CECF /* product-without-data.json */; };
 		EE71CC3D2951A8EA0074D908 /* ApplicationPasswordStorage.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE71CC3C2951A8EA0074D908 /* ApplicationPasswordStorage.swift */; };
 		EE71CC412951CE700074D908 /* generate-application-password-using-wporg-creds-success.json in Resources */ = {isa = PBXBuildFile; fileRef = EE71CC402951CE700074D908 /* generate-application-password-using-wporg-creds-success.json */; };
@@ -2319,6 +2320,7 @@
 		EE66BB012B2893AF00518DAF /* theme-install-success.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "theme-install-success.json"; sourceTree = "<group>"; };
 		EE66BB032B28975B00518DAF /* theme-install-already-installed.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "theme-install-already-installed.json"; sourceTree = "<group>"; };
 		EE66BB052B29791500518DAF /* theme-activate-success.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "theme-activate-success.json"; sourceTree = "<group>"; };
+		EE6C6B6F2C6A190500632BDA /* systemStatus-inconsistent-page-id-data-type.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "systemStatus-inconsistent-page-id-data-type.json"; sourceTree = "<group>"; };
 		EE6FDCFB2966A70400E1CECF /* product-without-data.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "product-without-data.json"; sourceTree = "<group>"; };
 		EE71CC3C2951A8EA0074D908 /* ApplicationPasswordStorage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ApplicationPasswordStorage.swift; sourceTree = "<group>"; };
 		EE71CC402951CE700074D908 /* generate-application-password-using-wporg-creds-success.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "generate-application-password-using-wporg-creds-success.json"; sourceTree = "<group>"; };
@@ -2990,6 +2992,7 @@
 		B559EBA820A0B5B100836CD4 /* Responses */ = {
 			isa = PBXGroup;
 			children = (
+				EE6C6B6F2C6A190500632BDA /* systemStatus-inconsistent-page-id-data-type.json */,
 				DEB3878E2C2D71A10025256E /* gla-campaign-list-with-data-envelope.json */,
 				DEB3878D2C2D71A10025256E /* gla-campaign-list-without-data-envelope.json */,
 				DEB387772C2A9ADC0025256E /* gla-connection-with-data-envelope.json */,
@@ -4336,6 +4339,7 @@
 				EE57C144297FCCA700BC31E7 /* product-shipping-classes-load-one-without-data.json in Resources */,
 				028CB71B290224D700331C09 /* create-account-error-username.json in Resources */,
 				EEA6583E2966B41E00112DF0 /* products-load-all-without-data.json in Resources */,
+				EE6C6B702C6A190500632BDA /* systemStatus-inconsistent-page-id-data-type.json in Resources */,
 				68F48B1328E3E5750045C15B /* wc-analytics-customers.json in Resources */,
 				D88D5A41230BC5DA007B6E01 /* reviews-all.json in Resources */,
 				DEDA8DB72B187E770076BF0F /* theme-mine-success.json in Resources */,

--- a/Networking/Networking/Model/SystemStatusDetails/SystemStatus+Page.swift
+++ b/Networking/Networking/Model/SystemStatusDetails/SystemStatus+Page.swift
@@ -13,7 +13,7 @@ public extension SystemStatus {
         public init(from decoder: Decoder) throws {
             let container = try decoder.container(keyedBy: CodingKeys.self)
             self.pageName = try container.decodeIfPresent(String.self, forKey: .pageName) ?? ""
-            /// `page_id` is sent as an `Int` in wporg login case
+            /// `page_id` is sent as a number for some JSON objects in wporg login case
             self.pageID = container.failsafeDecodeIfPresent(targetType: String.self,
                                                             forKey: .pageID,
                                                             alternativeTypes: [.decimal(transform: { NSDecimalNumber(decimal: $0).stringValue })]) ?? ""

--- a/Networking/Networking/Model/SystemStatusDetails/SystemStatus+Page.swift
+++ b/Networking/Networking/Model/SystemStatusDetails/SystemStatus+Page.swift
@@ -10,6 +10,27 @@ public extension SystemStatus {
         public let block: String?
         public let shortcodeRequired, shortcodePresent, blockPresent, blockRequired: Bool
 
+        public init(from decoder: Decoder) throws {
+            let container = try decoder.container(keyedBy: CodingKeys.self)
+            self.pageName = try container.decodeIfPresent(String.self, forKey: .pageName) ?? ""
+            /// `page_id` is sent as an `Int` in wporg login case
+            self.pageID = container.failsafeDecodeIfPresent(targetType: String.self,
+                                                            forKey: .pageID,
+                                                            alternativeTypes: [.decimal(transform: { NSDecimalNumber(decimal: $0).stringValue })]) ?? ""
+
+            self.pageSet = try container.decodeIfPresent(Bool.self, forKey: .pageSet) ?? false
+            self.pageExists = try container.decodeIfPresent(Bool.self, forKey: .pageExists) ?? false
+            self.pageVisible = try container.decodeIfPresent(Bool.self, forKey: .pageVisible) ?? false
+
+            self.shortcode = try container.decodeIfPresent(String.self, forKey: .shortcode) ?? ""
+            self.block = try container.decodeIfPresent(String.self, forKey: .block) ?? ""
+
+            self.shortcodeRequired = try container.decodeIfPresent(Bool.self, forKey: .shortcodeRequired) ?? false
+            self.shortcodePresent = try container.decodeIfPresent(Bool.self, forKey: .shortcodePresent) ?? false
+            self.blockPresent = try container.decodeIfPresent(Bool.self, forKey: .blockPresent) ?? false
+            self.blockRequired = try container.decodeIfPresent(Bool.self, forKey: .blockRequired) ?? false
+        }
+
         enum CodingKeys: String, CodingKey {
             case pageName = "page_name"
             case pageID = "page_id"

--- a/Networking/NetworkingTests/Mapper/SystemStatusMapperTests.swift
+++ b/Networking/NetworkingTests/Mapper/SystemStatusMapperTests.swift
@@ -108,6 +108,56 @@ final class SystemStatusMapperTests: XCTestCase {
         XCTAssertEqual(report.pages.count, 5)
         XCTAssertEqual(report.postTypeCounts.count, 3)
     }
+
+    func test_system_status_fields_are_properly_parsed_when_response_has_inconsistent_data_type_for_page_id() throws {
+        // When
+        let report = try mapLoadSystemStatusResponseWithInconsistentPageIdDataType()
+
+        // Then
+        XCTAssertEqual(report.environment?.homeURL, "https://additional-beetle.jurassic.ninja")
+        XCTAssertEqual(report.environment?.siteURL, "https://additional-beetle.jurassic.ninja")
+        XCTAssertEqual(report.environment?.version, "5.9.0")
+        XCTAssertEqual(report.environment?.wpVersion, "5.8.2")
+        XCTAssertEqual(report.environment?.phpVersion, "7.4.26")
+        XCTAssertEqual(report.environment?.curlVersion, "7.47.0, OpenSSL/1.0.2g")
+        XCTAssertEqual(report.environment?.mysqlVersion, "5.7.33-0ubuntu0.16.04.1-log")
+
+        XCTAssertEqual(report.database?.wcDatabaseVersion, "5.9.0")
+        XCTAssertEqual(report.database?.databasePrefix, "wp_")
+        XCTAssertEqual(report.database?.databaseTables.woocommerce.count, 14)
+        XCTAssertEqual(report.database?.databaseTables.other.count, 29)
+
+        XCTAssertEqual(report.activePlugins.count, 4)
+        XCTAssertEqual(report.activePlugins[0].siteID, dummySiteID)
+        XCTAssertEqual(report.inactivePlugins.count, 2)
+        XCTAssertEqual(report.inactivePlugins[1].siteID, dummySiteID)
+        XCTAssertEqual(report.dropinPlugins.count, 2)
+        XCTAssertEqual(report.dropinPlugins[0].name, "advanced-cache.php")
+        XCTAssertEqual(report.mustUsePlugins.count, 1)
+        XCTAssertEqual(report.mustUsePlugins[0].name, "WP.com Site Helper")
+
+        XCTAssertEqual(report.theme?.name, "Twenty Twenty-One")
+        XCTAssertEqual(report.theme?.version, "1.4")
+        XCTAssertEqual(report.theme?.authorURL, "https://wordpress.org/")
+        XCTAssertEqual(report.theme?.hasWoocommerceSupport, true)
+        XCTAssertEqual(report.theme?.overrides.count, 0)
+
+        XCTAssertEqual(report.settings?.apiEnabled, false)
+        XCTAssertEqual(report.settings?.currency, "USD")
+        XCTAssertEqual(report.settings?.currencySymbol, "&#36;")
+        XCTAssertEqual(report.settings?.currencyPosition, "left")
+        XCTAssertEqual(report.settings?.numberOfDecimals, 2)
+        XCTAssertEqual(report.settings?.thousandSeparator, ",")
+        XCTAssertEqual(report.settings?.decimalSeparator, ".")
+        XCTAssertEqual(report.settings?.taxonomies["external"], "external")
+        XCTAssertEqual(report.settings?.productVisibilityTerms["exclude-from-catalog"], "exclude-from-catalog")
+
+        XCTAssertEqual(report.security?.secureConnection, true)
+        XCTAssertEqual(report.security?.hideErrors, false)
+
+        XCTAssertEqual(report.pages.count, 5)
+        XCTAssertEqual(report.postTypeCounts.count, 3)
+    }
 }
 
 private extension SystemStatusMapperTests {
@@ -132,5 +182,11 @@ private extension SystemStatusMapperTests {
     ///
     func mapLoadSystemStatusResponseWithoutDataEnvelope() throws -> SystemStatus {
         return try mapReport(from: "systemStatus-without-data")
+    }
+
+    /// Returns the SystemStatus output upon receiving `systemStatus-inconsistent-page-id-data-type.json`
+    ///
+    func mapLoadSystemStatusResponseWithInconsistentPageIdDataType() throws -> SystemStatus {
+        return try mapReport(from: "systemStatus-inconsistent-page-id-data-type")
     }
 }

--- a/Networking/NetworkingTests/Responses/systemStatus-inconsistent-page-id-data-type.json
+++ b/Networking/NetworkingTests/Responses/systemStatus-inconsistent-page-id-data-type.json
@@ -1,0 +1,483 @@
+{
+    "environment": {
+        "home_url": "https://additional-beetle.jurassic.ninja",
+        "site_url": "https://additional-beetle.jurassic.ninja",
+        "version": "5.9.0",
+        "log_directory": "/srv/users/user9fe179e8/apps/user9fe179e8/public/wp-content/uploads/wc-logs/",
+        "log_directory_writable": true,
+        "wp_version": "5.8.2",
+        "wp_multisite": false,
+        "wp_memory_limit": 268435456,
+        "wp_debug_mode": true,
+        "wp_cron": true,
+        "language": "en_US",
+        "external_object_cache": null,
+        "server_info": "Apache/2.4.51 (Unix) OpenSSL/1.0.2g",
+        "php_version": "7.4.26",
+        "php_post_max_size": 1073741824,
+        "php_max_execution_time": 30,
+        "php_max_input_vars": 5000,
+        "curl_version": "7.47.0, OpenSSL/1.0.2g",
+        "suhosin_installed": false,
+        "max_upload_size": 536870912,
+        "mysql_version": "5.7.33",
+        "mysql_version_string": "5.7.33-0ubuntu0.16.04.1-log",
+        "default_timezone": "UTC",
+        "fsockopen_or_curl_enabled": true,
+        "soapclient_enabled": true,
+        "domdocument_enabled": true,
+        "gzip_enabled": true,
+        "mbstring_enabled": true,
+        "remote_post_successful": true,
+        "remote_post_response": 200,
+        "remote_get_successful": true,
+        "remote_get_response": 200
+    },
+    "database": {
+        "wc_database_version": "5.9.0",
+        "database_prefix": "wp_",
+        "maxmind_geoip_database": "",
+        "database_tables": {
+            "woocommerce": {
+                "wp_woocommerce_sessions": {
+                    "data": "0.02",
+                    "index": "0.02",
+                    "engine": "InnoDB"
+                },
+                "wp_woocommerce_api_keys": {
+                    "data": "0.02",
+                    "index": "0.03",
+                    "engine": "InnoDB"
+                },
+                "wp_woocommerce_attribute_taxonomies": {
+                    "data": "0.02",
+                    "index": "0.02",
+                    "engine": "InnoDB"
+                },
+                "wp_woocommerce_downloadable_product_permissions": {
+                    "data": "0.02",
+                    "index": "0.06",
+                    "engine": "InnoDB"
+                },
+                "wp_woocommerce_order_items": {
+                    "data": "0.02",
+                    "index": "0.02",
+                    "engine": "InnoDB"
+                },
+                "wp_woocommerce_order_itemmeta": {
+                    "data": "0.02",
+                    "index": "0.03",
+                    "engine": "InnoDB"
+                },
+                "wp_woocommerce_tax_rates": {
+                    "data": "0.02",
+                    "index": "0.06",
+                    "engine": "InnoDB"
+                },
+                "wp_woocommerce_tax_rate_locations": {
+                    "data": "0.02",
+                    "index": "0.03",
+                    "engine": "InnoDB"
+                },
+                "wp_woocommerce_shipping_zones": {
+                    "data": "0.02",
+                    "index": "0.00",
+                    "engine": "InnoDB"
+                },
+                "wp_woocommerce_shipping_zone_locations": {
+                    "data": "0.02",
+                    "index": "0.03",
+                    "engine": "InnoDB"
+                },
+                "wp_woocommerce_shipping_zone_methods": {
+                    "data": "0.02",
+                    "index": "0.00",
+                    "engine": "InnoDB"
+                },
+                "wp_woocommerce_payment_tokens": {
+                    "data": "0.02",
+                    "index": "0.02",
+                    "engine": "InnoDB"
+                },
+                "wp_woocommerce_payment_tokenmeta": {
+                    "data": "0.02",
+                    "index": "0.03",
+                    "engine": "InnoDB"
+                },
+                "wp_woocommerce_log": {
+                    "data": "0.02",
+                    "index": "0.02",
+                    "engine": "InnoDB"
+                }
+            },
+            "other": {
+                "wp_actionscheduler_actions": {
+                    "data": "0.02",
+                    "index": "0.13",
+                    "engine": "InnoDB"
+                },
+                "wp_actionscheduler_claims": {
+                    "data": "0.02",
+                    "index": "0.02",
+                    "engine": "InnoDB"
+                },
+                "wp_actionscheduler_groups": {
+                    "data": "0.02",
+                    "index": "0.02",
+                    "engine": "InnoDB"
+                },
+                "wp_actionscheduler_logs": {
+                    "data": "0.02",
+                    "index": "0.03",
+                    "engine": "InnoDB"
+                },
+                "wp_commentmeta": {
+                    "data": "0.02",
+                    "index": "0.03",
+                    "engine": "InnoDB"
+                },
+                "wp_comments": {
+                    "data": "0.02",
+                    "index": "0.09",
+                    "engine": "InnoDB"
+                },
+                "wp_links": {
+                    "data": "0.02",
+                    "index": "0.02",
+                    "engine": "InnoDB"
+                },
+                "wp_options": {
+                    "data": "3.48",
+                    "index": "0.06",
+                    "engine": "InnoDB"
+                },
+                "wp_postmeta": {
+                    "data": "0.02",
+                    "index": "0.03",
+                    "engine": "InnoDB"
+                },
+                "wp_posts": {
+                    "data": "0.02",
+                    "index": "0.06",
+                    "engine": "InnoDB"
+                },
+                "wp_termmeta": {
+                    "data": "0.02",
+                    "index": "0.03",
+                    "engine": "InnoDB"
+                },
+                "wp_terms": {
+                    "data": "0.02",
+                    "index": "0.03",
+                    "engine": "InnoDB"
+                },
+                "wp_term_relationships": {
+                    "data": "0.02",
+                    "index": "0.02",
+                    "engine": "InnoDB"
+                },
+                "wp_term_taxonomy": {
+                    "data": "0.02",
+                    "index": "0.03",
+                    "engine": "InnoDB"
+                },
+                "wp_usermeta": {
+                    "data": "0.02",
+                    "index": "0.03",
+                    "engine": "InnoDB"
+                },
+                "wp_users": {
+                    "data": "0.02",
+                    "index": "0.05",
+                    "engine": "InnoDB"
+                },
+                "wp_wc_admin_notes": {
+                    "data": "0.05",
+                    "index": "0.00",
+                    "engine": "InnoDB"
+                },
+                "wp_wc_admin_note_actions": {
+                    "data": "0.02",
+                    "index": "0.02",
+                    "engine": "InnoDB"
+                },
+                "wp_wc_category_lookup": {
+                    "data": "0.02",
+                    "index": "0.00",
+                    "engine": "InnoDB"
+                },
+                "wp_wc_customer_lookup": {
+                    "data": "0.02",
+                    "index": "0.03",
+                    "engine": "InnoDB"
+                },
+                "wp_wc_download_log": {
+                    "data": "0.02",
+                    "index": "0.03",
+                    "engine": "InnoDB"
+                },
+                "wp_wc_order_coupon_lookup": {
+                    "data": "0.02",
+                    "index": "0.03",
+                    "engine": "InnoDB"
+                },
+                "wp_wc_order_product_lookup": {
+                    "data": "0.02",
+                    "index": "0.06",
+                    "engine": "InnoDB"
+                },
+                "wp_wc_order_stats": {
+                    "data": "0.02",
+                    "index": "0.05",
+                    "engine": "InnoDB"
+                },
+                "wp_wc_order_tax_lookup": {
+                    "data": "0.02",
+                    "index": "0.03",
+                    "engine": "InnoDB"
+                },
+                "wp_wc_product_meta_lookup": {
+                    "data": "0.02",
+                    "index": "0.09",
+                    "engine": "InnoDB"
+                },
+                "wp_wc_reserved_stock": {
+                    "data": "0.02",
+                    "index": "0.00",
+                    "engine": "InnoDB"
+                },
+                "wp_wc_tax_rate_classes": {
+                    "data": "0.02",
+                    "index": "0.02",
+                    "engine": "InnoDB"
+                },
+                "wp_wc_webhooks": {
+                    "data": "0.02",
+                    "index": "0.02",
+                    "engine": "InnoDB"
+                }
+            }
+        },
+        "database_size": {
+            "data": 4.3499999999999925,
+            "index": 1.4300000000000006
+        }
+    },
+    "active_plugins":[
+        {
+            "plugin":"woocommerce\/woocommerce.php",
+            "name":"WooCommerce",
+            "version":"5.8.0",
+            "version_latest":"5.8.0",
+            "url":"https:\/\/woocommerce.com\/",
+            "author_name":"Automattic",
+            "author_url":"https:\/\/woocommerce.com",
+            "network_activated":false
+        },
+        {
+            "plugin":"woocommerce-payments\/woocommerce-payments.php",
+            "name":"WooCommerce Payments",
+            "version":"3.1.0",
+            "version_latest":"3.1.0",
+            "url":"https:\/\/woocommerce.com\/payments\/",
+            "author_name":"Automattic",
+            "author_url":"https:\/\/woocommerce.com\/",
+            "network_activated":false
+        },
+        {
+            "plugin":"woocommerce-subscriptions\/woocommerce-subscriptions",
+            "name":"WooCommerce Subscriptions",
+            "version":"3.1.6",
+            "version_latest":"3.1.6",
+            "url":"https:\/\/www.woocommerce.com\/products\/woocommerce-subscriptions\/",
+            "author_name":"Automattic",
+            "author_url":"https:\/\/woocommerce.com\/",
+            "network_activated":false
+        },
+        {
+            "plugin":"jetpack\/jetpack.php",
+            "name":"Jetpack",
+            "version":"10.2",
+            "version_latest":"10.2.1",
+            "url":"https:\/\/jetpack.com",
+            "author_name":"Automattic",
+            "author_url":"https:\/\/jetpack.com",
+            "network_activated":false
+        }
+    ],
+    "inactive_plugins":[
+        {
+            "plugin":"akismet\/akismet.php",
+            "name":"Akismet Anti-Spam",
+            "version":"4.2.1",
+            "version_latest":"4.2.1",
+            "url":"https:\/\/akismet.com\/",
+            "author_name":"Automattic",
+            "author_url":"https:\/\/automattic.com\/wordpress-plugins\/",
+            "network_activated":false
+        },
+        {
+            "plugin":"hello.php",
+            "name":"Hello Dolly",
+            "version":"1.7.2",
+            "version_latest":"1.7.2",
+            "url":"http:\/\/wordpress.org\/plugins\/hello-dolly\/",
+            "author_name":"Matt Mullenweg",
+            "author_url":"http:\/\/ma.tt\/",
+            "network_activated":false
+        }
+    ],
+    "dropins_mu_plugins": {
+        "dropins": [
+            {
+                "plugin": "advanced-cache.php",
+                "name": "advanced-cache.php"
+            },
+            {
+                "plugin": "object-cache.php",
+                "name": "Memcached"
+            }
+        ],
+        "mu_plugins": [
+            {
+                "plugin": "wpcomsh-loader.php",
+                "name": "WP.com Site Helper",
+                "version": "",
+                "url": "",
+                "author_name": "",
+                "author_url": ""
+            }
+        ]
+    },
+    "theme": {
+        "name": "Twenty Twenty-One",
+        "version": "1.4",
+        "version_latest": "1.4",
+        "author_url": "https://wordpress.org/",
+        "is_child_theme": false,
+        "has_woocommerce_support": true,
+        "has_woocommerce_file": false,
+        "has_outdated_templates": false,
+        "overrides": [],
+        "parent_name": "",
+        "parent_version": "",
+        "parent_version_latest": "",
+        "parent_author_url": ""
+    },
+    "settings": {
+        "api_enabled": false,
+        "force_ssl": false,
+        "currency": "USD",
+        "currency_symbol": "&#36;",
+        "currency_position": "left",
+        "thousand_separator": ",",
+        "decimal_separator": ".",
+        "number_of_decimals": 2,
+        "geolocation_enabled": false,
+        "taxonomies": {
+            "external": "external",
+            "grouped": "grouped",
+            "simple": "simple",
+            "subscription": "subscription",
+            "variable": "variable",
+            "variable-subscription": "variable subscription"
+        },
+        "product_visibility_terms": {
+            "exclude-from-catalog": "exclude-from-catalog",
+            "exclude-from-search": "exclude-from-search",
+            "featured": "featured",
+            "outofstock": "outofstock",
+            "rated-1": "rated-1",
+            "rated-2": "rated-2",
+            "rated-3": "rated-3",
+            "rated-4": "rated-4",
+            "rated-5": "rated-5"
+        },
+        "woocommerce_com_connected": "no"
+    },
+    "security": {
+        "secure_connection": true,
+        "hide_errors": false
+    },
+    "pages": [
+        {
+            "page_name": "Shop base",
+            "page_id": "5",
+            "page_set": true,
+            "page_exists": true,
+            "page_visible": true,
+            "shortcode": "",
+            "block": "",
+            "shortcode_required": false,
+            "shortcode_present": false,
+            "block_present": false,
+            "block_required": false
+        },
+        {
+            "page_name": "Cart",
+            "page_id": "6",
+            "page_set": true,
+            "page_exists": true,
+            "page_visible": true,
+            "shortcode": "[woocommerce_cart]",
+            "block": "woocommerce/cart",
+            "shortcode_required": true,
+            "shortcode_present": true,
+            "block_present": false,
+            "block_required": true
+        },
+        {
+            "page_name": "Checkout",
+            "page_id": 7,
+            "page_set": true,
+            "page_exists": true,
+            "page_visible": true,
+            "shortcode": "[woocommerce_checkout]",
+            "block": "woocommerce/checkout",
+            "shortcode_required": true,
+            "shortcode_present": true,
+            "block_present": false,
+            "block_required": true
+        },
+        {
+            "page_name": "My account",
+            "page_id": 8,
+            "page_set": true,
+            "page_exists": true,
+            "page_visible": true,
+            "shortcode": "[woocommerce_my_account]",
+            "block": "",
+            "shortcode_required": true,
+            "shortcode_present": true,
+            "block_present": false,
+            "block_required": false
+        },
+        {
+            "page_name": "Terms and conditions",
+            "page_id": "",
+            "page_set": false,
+            "page_exists": false,
+            "page_visible": false,
+            "shortcode": "",
+            "block": "",
+            "shortcode_required": false,
+            "shortcode_present": false,
+            "block_present": false,
+            "block_required": false
+        }
+    ],
+    "post_type_counts": [
+        {
+            "type": "attachment",
+            "count": "1"
+        },
+        {
+            "type": "page",
+            "count": "7"
+        },
+        {
+            "type": "post",
+            "count": "2"
+        }
+    ]
+}

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -4,6 +4,7 @@
 20.0
 -----
 - [*] Blaze: Now you can select media attached to the current product while creating Blaze ads. You don't have to scroll through all media in your store. [https://github.com/woocommerce/woocommerce-ios/pull/13540]
+- [internal] Fix SSR parsing error for WPORG login. [https://github.com/woocommerce/woocommerce-ios/pull/13579]
 
 20.0
 -----

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -4,11 +4,7 @@
 20.0
 -----
 - [*] Blaze: Now you can select media attached to the current product while creating Blaze ads. You don't have to scroll through all media in your store. [https://github.com/woocommerce/woocommerce-ios/pull/13540]
-- [internal] Fix SSR parsing error for WPORG login. [https://github.com/woocommerce/woocommerce-ios/pull/13579]
-
-20.0
------
-
+- [*] Fix SSR parsing error for WPORG login. [https://github.com/woocommerce/woocommerce-ios/pull/13579]
 - [*] Settings: Fixed error updating site name when authenticated without WPCom. [https://github.com/woocommerce/woocommerce-ios/pull/13567]
 
 19.9


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #13563 
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

Handles the case in which `/wc/v3/system_status` response contains inconsistent data type for the `page_id` field. 

This issue happens when a store doesn't have Jetpack, and we send requests directly to `https://<site_address>/?rest_route=/wc/v3/system_status`, skipping Jetpack tunnel. 

Changes
- Manually decode `Page` structs to parse both String and Number data types for `page_id`.
- Add a sample JSON response which has inconsistent data types for `page_id`.
- Unit test that mapper parses the sample JSON response. 

## Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->
1. Create a Woo Store without Jetpack.
2. Login into the mobile app using your wporg site credentials.
3. Navigate to `Menu` -> `Settings`
4. Tap `Help & Support` -> `System Status Report`
5. Validate that the SSR is loaded successfully without any error alerts.
6. Create a Woo Store with the Jetpack plugin.
7. Connect your WPCOM account to the Jetpack plugin.
8. Login into the mobile app using your WPCOM credentials.
9. Repeat steps 3 - 5. 

## Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->
- Test that SSR can be loaded for stores with and without Jetpack. 
- Verify that the manual `Page` decoding code [here](https://github.com/woocommerce/woocommerce-ios/pull/13579/files#diff-ff093b8b2bfab5763e287763044bc7b962cb55582af62b741296e0a2776d1736) is correct. 
## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

![Simulator Screen Recording - iPhone 15 Pro - 2024-08-12 at 17 40 57](https://github.com/user-attachments/assets/65890466-40bb-459c-a830-82c55eaa61d0)

---
- [x] I have considered adding unit tests for this change. If I decided not to add them, I have provided a brief explanation below (optional):
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
- [ ] This PR includes refactoring; smoke testing of the entire section is needed.