### PR TITLE
[Mobile Payments] Make plugin endpoints usable with site credentials

### DIFF
--- a/Networking/Networking/Remote/SitePluginsRemote.swift
+++ b/Networking/Networking/Remote/SitePluginsRemote.swift
@@ -52,7 +52,12 @@ public class SitePluginsRemote: Remote, SitePluginsRemoteProtocol {
                               slug: String,
                               completion: @escaping (Result<SitePlugin, Error>) -> Void) {
         let path = Constants.sitePluginsPath
-        let request = JetpackRequest(wooApiVersion: .none, method: .post, siteID: siteID, path: path, parameters: [Constants.slugParameter: slug])
+        let request = JetpackRequest(wooApiVersion: .none, 
+                                     method: .post,
+                                     siteID: siteID,
+                                     path: path,
+                                     parameters: [Constants.slugParameter: slug],
+                                     availableAsRESTRequest: true)
         let mapper = SitePluginMapper(siteID: siteID)
         enqueue(request, mapper: mapper, completion: completion)
     }
@@ -72,7 +77,7 @@ public class SitePluginsRemote: Remote, SitePluginsRemoteProtocol {
                                      method: .post,
                                      siteID: siteID,
                                      path: path,
-                                     parameters: [Constants.statusParameter: Constants.statusActive])
+                                     parameters: [Constants.statusParameter: Constants.statusActive], availableAsRESTRequest: true)
         let mapper = SitePluginMapper(siteID: siteID)
         enqueue(request, mapper: mapper, completion: completion)
     }
@@ -88,7 +93,12 @@ public class SitePluginsRemote: Remote, SitePluginsRemoteProtocol {
                                  pluginName: String,
                                  completion: @escaping (Result<SitePlugin, Error>) -> Void) {
         let path = String(format: "%@/%@", Constants.sitePluginsPath, pluginName)
-        let request = JetpackRequest(wooApiVersion: .none, method: .get, siteID: siteID, path: path, parameters: nil)
+        let request = JetpackRequest(wooApiVersion: .none, 
+                                     method: .get,
+                                     siteID: siteID,
+                                     path: path,
+                                     parameters: nil,
+                                     availableAsRESTRequest: true)
         let mapper = SitePluginMapper(siteID: siteID)
         enqueue(request, mapper: mapper, completion: completion)
     }

--- a/Networking/Networking/Remote/SitePluginsRemote.swift
+++ b/Networking/Networking/Remote/SitePluginsRemote.swift
@@ -52,7 +52,7 @@ public class SitePluginsRemote: Remote, SitePluginsRemoteProtocol {
                               slug: String,
                               completion: @escaping (Result<SitePlugin, Error>) -> Void) {
         let path = Constants.sitePluginsPath
-        let request = JetpackRequest(wooApiVersion: .none, 
+        let request = JetpackRequest(wooApiVersion: .none,
                                      method: .post,
                                      siteID: siteID,
                                      path: path,
@@ -93,7 +93,7 @@ public class SitePluginsRemote: Remote, SitePluginsRemoteProtocol {
                                  pluginName: String,
                                  completion: @escaping (Result<SitePlugin, Error>) -> Void) {
         let path = String(format: "%@/%@", Constants.sitePluginsPath, pluginName)
-        let request = JetpackRequest(wooApiVersion: .none, 
+        let request = JetpackRequest(wooApiVersion: .none,
                                      method: .get,
                                      siteID: siteID,
                                      path: path,

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -4,10 +4,7 @@
 20.0
 -----
 - [*] Blaze: Now you can select media attached to the current product while creating Blaze ads. You don't have to scroll through all media in your store. [https://github.com/woocommerce/woocommerce-ios/pull/13540]
-
-20.0
------
-
+- [*] Payments: fixed issue where site credential login couldn't be used to install plugins, e.g. WooPayments [https://github.com/woocommerce/woocommerce-ios/pull/13582]
 
 19.9
 -----


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #13570
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

There is a flow to install the WooPayments plugin for eligible stores which aren't using it.

This flow fails when done while logged in with site credentials, rather than Jetpack. This PR makes it work for that login approach.

## Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->

1. Create a new Jurassic Ninja site, with WooCommerce installed. Do not install Jetpack.
2. Skip the guided setup on the web.
3. Set the site address to the USA
4. Launch the app and log in to your new store using site credentials
5. Go to Menu -> Payments.
6. See the “In-Person Payment setup is incomplete” message at the bottom of the Payments section. Tap “Continue setup.”
7. See the “Install WooCommerce Payments” prompt. Tap “Install WooCommerce Payments.”
8. Observe that the plugin installs successfully
9. Tap `Activate WooCommerce Payments`
10. Observe that the plugin activates successfully
11. Try to complete onboarding – it might work, but will probably result in a generic error – this is due to #13581 


## Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->

No unit tests as there's no reasonable way to check the JetpackRequest init call parameters in tests.

---
- [x] I have considered adding unit tests for this change. If I decided not to add them, I have provided a brief explanation below (optional):
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
- [ ] This PR includes refactoring; smoke testing of the entire section is needed.