### PR TITLE
[Watch] Add Sentry Support

### DIFF
--- a/Networking/Networking.xcodeproj/project.pbxproj
+++ b/Networking/Networking.xcodeproj/project.pbxproj
@@ -323,6 +323,7 @@
 		269014D22BEA9309006056E0 /* DotcomRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = B557DA0E20975E07005962F4 /* DotcomRequest.swift */; };
 		269014D32BEA9309006056E0 /* AuthenticatedDotcomRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = EEFAA57A295D7793003583BE /* AuthenticatedDotcomRequest.swift */; };
 		269014D42BEA9335006056E0 /* UserAgent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45551F112523E7F1007EF104 /* UserAgent.swift */; };
+		26AE25F52C6C0A110032A600 /* Account.swift in Sources */ = {isa = PBXBuildFile; fileRef = B505F6CE20BEE38B00BB1B69 /* Account.swift */; };
 		26B15E442A269F79000C35E4 /* ip-location.json in Resources */ = {isa = PBXBuildFile; fileRef = 26B15E432A269F79000C35E4 /* ip-location.json */; };
 		26B542452BEAC6A6003A55B5 /* Pods_NetworkingWatchOS.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 6132DCC72AA9C070E2033628 /* Pods_NetworkingWatchOS.framework */; };
 		26BD9FCD2965EC3C004E0D15 /* product-variations-bulk-create.json in Resources */ = {isa = PBXBuildFile; fileRef = 26BD9FCC2965EC3C004E0D15 /* product-variations-bulk-create.json */; };
@@ -4715,6 +4716,7 @@
 				26CFDEDF2C0295D5005ABC31 /* NoteMedia.swift in Sources */,
 				263A6DB22BEAA3EC00C292B2 /* CodingUserInfoKey+Woo.swift in Sources */,
 				263A6DB12BEAA33900C292B2 /* WCAnalyticsStats.swift in Sources */,
+				26AE25F52C6C0A110032A600 /* Account.swift in Sources */,
 				263A6DAD2BEAA32800C292B2 /* OrderStatsV4Mapper.swift in Sources */,
 				263A6DAE2BEAA32800C292B2 /* OrderStatsV4.swift in Sources */,
 				26373E132BFCEDCD008E6735 /* OrderTaxLine.swift in Sources */,

--- a/Networking/Networking/Model/Account.swift
+++ b/Networking/Networking/Model/Account.swift
@@ -3,7 +3,7 @@ import Codegen
 
 /// WordPress.com Account
 ///
-public struct Account: Decodable, Equatable, GeneratedFakeable {
+public struct Account: Codable, Equatable, GeneratedFakeable {
 
     /// Dotcom UserID
     ///

--- a/Podfile
+++ b/Podfile
@@ -150,6 +150,7 @@ end
 target 'Woo Watch App' do
   project 'WooCommerce/WooCommerce.xcodeproj'
   platform :watchos, app_watchos_deployment_target.version
+  pod 'Sentry', '~> 8.26.0'
   networking_watch_os_pods
 end
 

--- a/Podfile
+++ b/Podfile
@@ -150,7 +150,7 @@ end
 target 'Woo Watch App' do
   project 'WooCommerce/WooCommerce.xcodeproj'
   platform :watchos, app_watchos_deployment_target.version
-  pod 'Sentry', '~> 8.26.0'
+  pod 'Sentry', '~> 8.33.0'
   networking_watch_os_pods
 end
 

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -62,6 +62,7 @@ DEPENDENCIES:
   - Gridicons (~> 1.2.0)
   - KeychainAccess (~> 4.2.2)
   - Kingfisher (~> 7.6.2)
+  - Sentry (~> 8.26.0)
   - Sourcery (~> 1.0.3)
   - StripeTerminal (~> 3.3.1)
   - SwiftLint (= 0.54.0)
@@ -141,6 +142,6 @@ SPEC CHECKSUMS:
   ZendeskSupportProvidersSDK: 2fbd2a9597af5d69760088bfb5e0e595e942f218
   ZendeskSupportSDK: 22156384d20d30b0aeb263c03f49bef44e1364b2
 
-PODFILE CHECKSUM: 4141cf67ffcfd52e6c6c1fa01fbeb5fb66095c57
+PODFILE CHECKSUM: efac12de2a1846dac2bbe6d5b83d2fddae670274
 
 COCOAPODS: 1.15.2

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -12,9 +12,9 @@ PODS:
   - Kingfisher (7.6.2)
   - NSObject-SafeExpectations (0.0.6)
   - "NSURL+IDN (0.4)"
-  - Sentry (8.26.0):
-    - Sentry/Core (= 8.26.0)
-  - Sentry/Core (8.26.0)
+  - Sentry (8.33.0):
+    - Sentry/Core (= 8.33.0)
+  - Sentry/Core (8.33.0)
   - Sodium (0.9.1)
   - Sourcery (1.0.3)
   - StripeTerminal (3.3.1)
@@ -62,7 +62,7 @@ DEPENDENCIES:
   - Gridicons (~> 1.2.0)
   - KeychainAccess (~> 4.2.2)
   - Kingfisher (~> 7.6.2)
-  - Sentry (~> 8.26.0)
+  - Sentry (~> 8.33.0)
   - Sourcery (~> 1.0.3)
   - StripeTerminal (~> 3.3.1)
   - SwiftLint (= 0.54.0)
@@ -118,7 +118,7 @@ SPEC CHECKSUMS:
   Kingfisher: 6c5449c6450c5239166510ba04afe374a98afc4f
   NSObject-SafeExpectations: c01c8881cbd97efad6f668286b913cd0b7d62ab5
   "NSURL+IDN": afc873e639c18138a1589697c3add197fe8679ca
-  Sentry: 74a073c71c998117edb08f56f443c83570a31bed
+  Sentry: 8560050221424aef0bebc8e31eedf00af80f90a6
   Sodium: 23d11554ecd556196d313cf6130d406dfe7ac6da
   Sourcery: 70a6048014bd4f37ea80e6bd4354d47bf3b760e1
   StripeTerminal: 369ef0cf0b90d838f42be1a0b371475986f4b79f
@@ -142,6 +142,6 @@ SPEC CHECKSUMS:
   ZendeskSupportProvidersSDK: 2fbd2a9597af5d69760088bfb5e0e595e942f218
   ZendeskSupportSDK: 22156384d20d30b0aeb263c03f49bef44e1364b2
 
-PODFILE CHECKSUM: efac12de2a1846dac2bbe6d5b83d2fddae670274
+PODFILE CHECKSUM: a002b9df7ed686d617617980f204eb3f190614be
 
 COCOAPODS: 1.15.2

--- a/WooCommerce/Classes/ServiceLocator/CrashLoggingStack.swift
+++ b/WooCommerce/Classes/ServiceLocator/CrashLoggingStack.swift
@@ -1,5 +1,9 @@
 import Foundation
+#if canImport(WooFoundation)
 import WooFoundation
+#elseif canImport(WooFoundationWatchOS)
+import WooFoundationWatchOS
+#endif
 
 protocol CrashLoggingStack: CrashLogger {
     /// Forces the application to crash

--- a/WooCommerce/Classes/System/SessionManager.swift
+++ b/WooCommerce/Classes/System/SessionManager.swift
@@ -59,11 +59,11 @@ final class SessionManager: SessionManagerProtocol {
             guard let storeID = self.defaultStoreID, let credentials = self.loadCredentials() else {
                 return nil
             }
-            return WatchDependencies(storeID: storeID, 
+            return WatchDependencies(storeID: storeID,
                                      storeName: defaultSite?.name ?? "",
                                      currencySettings: ServiceLocator.currencySettings,
                                      credentials: credentials,
-                                     enablesCrashReports: defaults[.userOptedInCrashLogging] ?? true, 
+                                     enablesCrashReports: defaults[.userOptedInCrashLogging] ?? true,
                                      account: defaultAccount)
         }()
 

--- a/WooCommerce/Classes/System/SessionManager.swift
+++ b/WooCommerce/Classes/System/SessionManager.swift
@@ -59,7 +59,11 @@ final class SessionManager: SessionManagerProtocol {
             guard let storeID = self.defaultStoreID, let storeName = self.defaultSite?.name, let credentials = self.loadCredentials() else {
                 return nil
             }
-            return WatchDependencies(storeID: storeID, storeName: storeName, currencySettings: ServiceLocator.currencySettings, credentials: credentials)
+            return WatchDependencies(storeID: storeID, 
+                                     storeName: storeName,
+                                     currencySettings: ServiceLocator.currencySettings,
+                                     credentials: credentials,
+                                     enablesCrashReports: defaults[.userOptedInCrashLogging] ?? true)
         }()
 
         return WatchDependenciesSynchronizer(storedDependencies: storedDependencies)

--- a/WooCommerce/Classes/System/SessionManager.swift
+++ b/WooCommerce/Classes/System/SessionManager.swift
@@ -56,14 +56,15 @@ final class SessionManager: SessionManagerProtocol {
     ///
     private lazy var watchDependenciesSynchronizer = {
         let storedDependencies: WatchDependencies? = {
-            guard let storeID = self.defaultStoreID, let storeName = self.defaultSite?.name, let credentials = self.loadCredentials() else {
+            guard let storeID = self.defaultStoreID, let credentials = self.loadCredentials() else {
                 return nil
             }
             return WatchDependencies(storeID: storeID, 
-                                     storeName: storeName,
+                                     storeName: defaultSite?.name ?? "",
                                      currencySettings: ServiceLocator.currencySettings,
                                      credentials: credentials,
-                                     enablesCrashReports: defaults[.userOptedInCrashLogging] ?? true)
+                                     enablesCrashReports: defaults[.userOptedInCrashLogging] ?? true, 
+                                     account: defaultAccount)
         }()
 
         return WatchDependenciesSynchronizer(storedDependencies: storedDependencies)
@@ -96,6 +97,7 @@ final class SessionManager: SessionManagerProtocol {
         didSet {
             defaults[.defaultAccountID] = defaultAccount?.userID
             NotificationCenter.default.post(name: .defaultAccountWasUpdated, object: defaultAccount)
+            watchDependenciesSynchronizer.account = defaultAccount
         }
     }
 

--- a/WooCommerce/Classes/System/WatchDependencies.swift
+++ b/WooCommerce/Classes/System/WatchDependencies.swift
@@ -1,13 +1,9 @@
 import Foundation
 
 #if canImport(Networking)
-import enum Networking.Credentials
-import struct Networking.ApplicationPasswordStorage
-import struct Networking.ApplicationPassword
+import Networking
 #elseif canImport(NetworkingWatchOS)
-import enum NetworkingWatchOS.Credentials
-import struct NetworkingWatchOS.ApplicationPasswordStorage
-import struct NetworkingWatchOS.ApplicationPassword
+import NetworkingWatchOS
 #endif
 
 #if canImport(WooFoundation)
@@ -28,6 +24,7 @@ public struct WatchDependencies: Codable, Equatable {
     let credentials: Credentials
     let applicationPassword: ApplicationPassword?
     let enablesCrashReports: Bool
+    let account: Account?
 
     /// Uses the provided application password
     ///
@@ -36,28 +33,35 @@ public struct WatchDependencies: Codable, Equatable {
                 currencySettings: CurrencySettings,
                 credentials: Credentials,
                 applicationPassword: ApplicationPassword?,
-                enablesCrashReports: Bool) {
+                enablesCrashReports: Bool,
+                account: Account?) {
         self.storeID = storeID
         self.storeName = storeName
         self.currencySettings = currencySettings
         self.credentials = credentials
         self.applicationPassword = applicationPassword
         self.enablesCrashReports = enablesCrashReports
+        self.account = account
 
     }
 
     /// Uses the stored application password
     ///
-    public init(storeID: Int64, storeName: String, currencySettings: CurrencySettings, credentials: Credentials, enablesCrashReports: Bool) {
+    public init(storeID: Int64,
+                storeName: String,
+                currencySettings: CurrencySettings,
+                credentials: Credentials,
+                enablesCrashReports: Bool,
+                account: Account?) {
         self.storeID = storeID
         self.storeName = storeName
         self.currencySettings = currencySettings
         self.credentials = credentials
         self.enablesCrashReports = enablesCrashReports
+        self.account = account
 
         // Always get the stored application password as the application networking classes rely on it.
         // Ideally this should be refactored to live in the credentials object.
         self.applicationPassword = ApplicationPasswordStorage().applicationPassword
-
     }
 }

--- a/WooCommerce/Classes/System/WatchDependencies.swift
+++ b/WooCommerce/Classes/System/WatchDependencies.swift
@@ -27,6 +27,7 @@ public struct WatchDependencies: Codable, Equatable {
     let currencySettings: CurrencySettings
     let credentials: Credentials
     let applicationPassword: ApplicationPassword?
+    let enablesCrashReports: Bool
 
     /// Uses the provided application password
     ///
@@ -34,22 +35,25 @@ public struct WatchDependencies: Codable, Equatable {
                 storeName: String,
                 currencySettings: CurrencySettings,
                 credentials: Credentials,
-                applicationPassword: ApplicationPassword?) {
+                applicationPassword: ApplicationPassword?,
+                enablesCrashReports: Bool) {
         self.storeID = storeID
         self.storeName = storeName
         self.currencySettings = currencySettings
         self.credentials = credentials
         self.applicationPassword = applicationPassword
+        self.enablesCrashReports = enablesCrashReports
 
     }
 
     /// Uses the stored application password
     ///
-    public init(storeID: Int64, storeName: String, currencySettings: CurrencySettings, credentials: Credentials) {
+    public init(storeID: Int64, storeName: String, currencySettings: CurrencySettings, credentials: Credentials, enablesCrashReports: Bool) {
         self.storeID = storeID
         self.storeName = storeName
         self.currencySettings = currencySettings
         self.credentials = credentials
+        self.enablesCrashReports = enablesCrashReports
 
         // Always get the stored application password as the application networking classes rely on it.
         // Ideally this should be refactored to live in the credentials object.

--- a/WooCommerce/Woo Watch App/App/AppDelegate.swift
+++ b/WooCommerce/Woo Watch App/App/AppDelegate.swift
@@ -2,6 +2,7 @@ import WatchKit
 import UserNotifications
 import CocoaLumberjack
 import struct NetworkingWatchOS.Note
+import Sentry
 
 
 class AppDelegate: NSObject, ObservableObject, WKApplicationDelegate {
@@ -15,6 +16,13 @@ class AppDelegate: NSObject, ObservableObject, WKApplicationDelegate {
     /// This type should be replaced from the main WooApp file.
     ///
     var appBindings: AppBindings = AppBindings()
+
+    /// Handles and configures the crash logging system.
+    ///
+    let crashLoggingStack = WatchCrashLoggingStack()
+
+
+    var crashy: Int!
 
     /// Setup code after the app finishes launching
     ///
@@ -30,6 +38,15 @@ class AppDelegate: NSObject, ObservableObject, WKApplicationDelegate {
     ///
     func applicationWillEnterForeground() {
         appBindings.refreshData.send()
+
+        DispatchQueue.main.asyncAfter(deadline: .now() + 3) {
+            if Int.random(in: 1...3) == 2 {
+                DDLogInfo("I'm about to crash for accessing crashy variable")
+                os_log("I'm about to crash for accessing crashy variable")
+                self.crashy = self.crashy + 1
+            }
+//            SentrySDK.capture(error: NSError(domain: "Test WatchOS Crash", code: 103))
+        }
     }
 
     /// Sets up CocoaLumberjack logging.

--- a/WooCommerce/Woo Watch App/App/AppDelegate.swift
+++ b/WooCommerce/Woo Watch App/App/AppDelegate.swift
@@ -18,8 +18,9 @@ class AppDelegate: NSObject, ObservableObject, WKApplicationDelegate {
     var appBindings: AppBindings = AppBindings()
 
     /// Handles and configures the crash logging system.
+    /// This type should be assigned from the main WooApp file.
     ///
-    let crashLoggingStack = WatchCrashLoggingStack()
+    var crashLoggingStack: WatchCrashLoggingStack?
 
     /// Setup code after the app finishes launching
     ///
@@ -50,7 +51,7 @@ class AppDelegate: NSObject, ObservableObject, WKApplicationDelegate {
     /// Perform the necessary updates when dependencies are updated.
     ///
     func onUpdateDependencies(dependencies: WatchDependencies?) {
-        crashLoggingStack.updateUserData(enablesCrashReports: dependencies?.enablesCrashReports ?? true, account: dependencies?.account)
+        crashLoggingStack?.updateUserData(enablesCrashReports: dependencies?.enablesCrashReports ?? true, account: dependencies?.account)
     }
 }
 

--- a/WooCommerce/Woo Watch App/App/AppDelegate.swift
+++ b/WooCommerce/Woo Watch App/App/AppDelegate.swift
@@ -46,6 +46,12 @@ class AppDelegate: NSObject, ObservableObject, WKApplicationDelegate {
         DDLog.add(DDOSLogger.sharedInstance)
         DDLog.add(fileLogger)
     }
+
+    /// Perform the necessary updates when dependencies are updated.
+    ///
+    func onUpdateDependencies(dependencies: WatchDependencies?) {
+        crashLoggingStack.updateUserData(enablesCrashReports: dependencies?.enablesCrashReports ?? true)
+    }
 }
 
 extension AppDelegate: UNUserNotificationCenterDelegate {

--- a/WooCommerce/Woo Watch App/App/AppDelegate.swift
+++ b/WooCommerce/Woo Watch App/App/AppDelegate.swift
@@ -21,9 +21,6 @@ class AppDelegate: NSObject, ObservableObject, WKApplicationDelegate {
     ///
     let crashLoggingStack = WatchCrashLoggingStack()
 
-
-    var crashy: Int!
-
     /// Setup code after the app finishes launching
     ///
     func applicationDidFinishLaunching() {
@@ -38,15 +35,6 @@ class AppDelegate: NSObject, ObservableObject, WKApplicationDelegate {
     ///
     func applicationWillEnterForeground() {
         appBindings.refreshData.send()
-
-        DispatchQueue.main.asyncAfter(deadline: .now() + 3) {
-            if Int.random(in: 1...3) == 2 {
-                DDLogInfo("I'm about to crash for accessing crashy variable")
-                os_log("I'm about to crash for accessing crashy variable")
-                self.crashy = self.crashy + 1
-            }
-//            SentrySDK.capture(error: NSError(domain: "Test WatchOS Crash", code: 103))
-        }
     }
 
     /// Sets up CocoaLumberjack logging.

--- a/WooCommerce/Woo Watch App/App/AppDelegate.swift
+++ b/WooCommerce/Woo Watch App/App/AppDelegate.swift
@@ -50,7 +50,7 @@ class AppDelegate: NSObject, ObservableObject, WKApplicationDelegate {
     /// Perform the necessary updates when dependencies are updated.
     ///
     func onUpdateDependencies(dependencies: WatchDependencies?) {
-        crashLoggingStack.updateUserData(enablesCrashReports: dependencies?.enablesCrashReports ?? true)
+        crashLoggingStack.updateUserData(enablesCrashReports: dependencies?.enablesCrashReports ?? true, account: dependencies?.account)
     }
 }
 

--- a/WooCommerce/Woo Watch App/App/Crash/CrashLogging.swift
+++ b/WooCommerce/Woo Watch App/App/Crash/CrashLogging.swift
@@ -98,8 +98,6 @@ public class CrashLogging {
             DDLogDebug("📜 Events will not be sent because user has opted-out.")
         }
 
-        os_log("I'm about to send a crash event")
-
         /// If we shouldn't send the event we have nothing else to do here
         guard let event = event, shouldSendEvent else {
             return nil

--- a/WooCommerce/Woo Watch App/App/Crash/CrashLogging.swift
+++ b/WooCommerce/Woo Watch App/App/Crash/CrashLogging.swift
@@ -88,8 +88,7 @@ public class CrashLogging {
     func beforeSend(event: Sentry.Event?) -> Sentry.Event? {
 
         #if DEBUG
-        //let shouldSendEvent = UserDefaults.standard.bool(forKey: Self.forceCrashLoggingKey) && !dataProvider.userHasOptedOut
-        let shouldSendEvent = true
+        let shouldSendEvent = UserDefaults.standard.bool(forKey: Self.forceCrashLoggingKey) && !dataProvider.userHasOptedOut
         #else
         let shouldSendEvent = !dataProvider.userHasOptedOut
         #endif
@@ -109,8 +108,9 @@ public class CrashLogging {
 
         event.tags?["locale"] = NSLocale.current.language.languageCode?.identifier
 
+        // TODO: Apple watchOS does not exposes app state like iOS from UIApplication. This has to me implemented when required.
         /// Always provide a value in order to determine how often we're unable to retrieve application state
-        event.tags?["app.state"] = "unknown" // TODO: Track application states somehow
+        event.tags?["app.state"] = "unknown"
 
         /// Read the current user from the Data Provider (though the Data Provider can decide not to provide it for functional or privacy reasons)
         event.user = dataProvider.currentUser?.sentryUser

--- a/WooCommerce/Woo Watch App/App/Crash/CrashLogging.swift
+++ b/WooCommerce/Woo Watch App/App/Crash/CrashLogging.swift
@@ -1,9 +1,209 @@
-//
-//  CrashLogging.swift
-//  Woo Watch App
-//
-//  Created by Ernesto Carrion on 11/08/24.
-//  Copyright © 2024 Automattic. All rights reserved.
-//
-
 import Foundation
+import Sentry
+import WooFoundationWatchOS
+import CocoaLumberjack
+
+/// This class is copied from the Tacks Library and it is adapted for the Woo Watch App.
+/// This should be removed/replaced when the Tracks Library properly supports watchOS.
+///
+/// A class that provides support for logging crashes. Not compatible with Objective-C.
+public class CrashLogging {
+
+    /// We haven't fully evicted global state from all of Tracks yet, so we keep a global reference around for now
+    struct Internals {
+        static var crashLogging: CrashLogging?
+    }
+
+    private let dataProvider: CrashLoggingDataProvider
+
+    /// If you set this key to `true` in UserDefaults, crash logging will be
+    /// sent even in DEBUG builds. If it is `false` or not present, then
+    /// crash log events will only be sent in Release builds.
+    public static let forceCrashLoggingKey = "force-crash-logging"
+
+    public let flushTimeout: TimeInterval
+
+    /// Initializes the crash logging system
+    ///
+    /// - Parameters:
+    ///   - dataProvider: An object that provides any configuration to the crash logging system
+    ///   - eventLogging: An associated `EventLogging` object that provides integration between the Crash Logging and Event Logging subsystems
+    ///   - flushTimeout: The `TimeInterval` to wait for when flushing events and crahses queued to be sent to the remote
+    public init(
+        dataProvider: CrashLoggingDataProvider,
+        flushTimeout: TimeInterval = 15
+    ) {
+        self.dataProvider = dataProvider
+        self.flushTimeout = flushTimeout
+    }
+
+    /// Starts the CrashLogging subsystem by initializing Sentry.
+    ///
+    /// Should be called as early as possible in the application lifecycle
+    public func start() throws -> CrashLogging {
+
+        /// Validate the DSN ourselves before initializing, because the SentrySDK silently prints the error to the log instead of telling us if the DSN is valid
+        _ = try SentryDsn(string: self.dataProvider.sentryDSN)
+
+        SentrySDK.start { options in
+            options.dsn = self.dataProvider.sentryDSN
+
+            options.debug = true
+            options.diagnosticLevel = .error
+
+            options.environment = self.dataProvider.buildType
+            options.enableAutoSessionTracking = self.dataProvider.shouldEnableAutomaticSessionTracking
+            options.enableAppHangTracking = self.dataProvider.enableAppHangTracking
+            options.enableCaptureFailedRequests = self.dataProvider.enableCaptureFailedRequests
+
+            options.beforeSend = self.beforeSend
+
+            /// Attach stack traces to non-fatal errors
+            options.attachStacktrace = true
+
+            // Events
+            options.sampleRate = NSNumber(value: min(max(self.dataProvider.errorEventsSamplingRate, 0), 1))
+
+            // Performance monitoring options
+            options.enableAutoPerformanceTracing = self.dataProvider.enableAutoPerformanceTracking
+            options.tracesSampler = { _ in
+                // To keep our implementation as Sentry agnostic as possible, we don't pass the
+                // input `SamplingContext` down the chain.
+                NSNumber(value: self.dataProvider.tracesSampler())
+            }
+            options.enableNetworkTracking = self.dataProvider.enableNetworkTracking
+            options.enableFileIOTracing = self.dataProvider.enableFileIOTracking
+            options.enableCoreDataTracing = self.dataProvider.enableCoreDataTracking
+            #if os(iOS) || os(tvOS) || targetEnvironment(macCatalyst)
+                options.enableUserInteractionTracing = self.dataProvider.enableUserInteractionTracing
+                options.enableUIViewControllerTracing = self.dataProvider.enableUIViewControllerTracking
+            #endif
+        }
+
+        Internals.crashLogging = self
+
+        return self
+    }
+
+    func beforeSend(event: Sentry.Event?) -> Sentry.Event? {
+
+        #if DEBUG
+        //let shouldSendEvent = UserDefaults.standard.bool(forKey: Self.forceCrashLoggingKey) && !dataProvider.userHasOptedOut
+        let shouldSendEvent = true
+        #else
+        let shouldSendEvent = !dataProvider.userHasOptedOut
+        #endif
+
+        if shouldSendEvent == false {
+            DDLogDebug("📜 Events will not be sent because user has opted-out.")
+        }
+
+        os_log("I'm about to send a crash event")
+
+        /// If we shouldn't send the event we have nothing else to do here
+        guard let event = event, shouldSendEvent else {
+            return nil
+        }
+
+        if event.tags == nil {
+            event.tags = [String: String]()
+        }
+
+        event.tags?["locale"] = NSLocale.current.language.languageCode?.identifier
+
+        /// Always provide a value in order to determine how often we're unable to retrieve application state
+        event.tags?["app.state"] = "unknown" // TODO: Track application states somehow
+
+        /// Read the current user from the Data Provider (though the Data Provider can decide not to provide it for functional or privacy reasons)
+        event.user = dataProvider.currentUser?.sentryUser
+
+        return event
+    }
+
+    /// Immediately crashes the application and generates a crash report.
+    public func crash() {
+        SentrySDK.crash()
+    }
+
+    enum Errors: LocalizedError {
+        case unableToConstructAuthStringError
+    }
+}
+
+
+// MARK: - User Tracking
+extension CrashLogging {
+
+    internal var currentUser: Sentry.User {
+
+        let anonymousUser = TracksUser(userID: nil, email: nil, username: nil).sentryUser
+
+        /// Don't continue if the data source doesn't yet have a user
+        guard let user = dataProvider.currentUser else { return anonymousUser }
+        let data = dataProvider.additionalUserData
+
+        return user.sentryUser(withData: data)
+    }
+
+    /// Causes the Crash Logging System to refresh its knowledge about the current state of the system.
+    ///
+    /// This is required in situations like login / logout, when the system otherwise might not
+    /// know a change has occured.
+    ///
+    /// Calling this method in these situations prevents
+    public func setNeedsDataRefresh() {
+        SentrySDK.setUser(currentUser)
+    }
+}
+
+/// This class is copied from the Tacks Library and it is adapted for the Woo Watch App.
+/// This should be removed/replaced when the Tracks Library properly supports watchOS.
+///
+public struct TracksUser {
+    public let userID: String?
+    public let email: String?
+    public let username: String?
+
+    public init(userID: String?, email: String?, username: String?) {
+        self.userID = userID
+        self.email = email
+        self.username = username
+    }
+
+    public init(email: String) {
+        self.userID = nil
+        self.email = email
+        self.username = nil
+    }
+}
+
+/// This class is copied from the Tacks Library and it is adapted for the Woo Watch App.
+/// This should be removed/replaced when the Tracks Library properly supports watchOS.
+///
+internal extension TracksUser {
+
+    var sentryUser: Sentry.User {
+
+        let user = Sentry.User()
+
+        if let userID = self.userID {
+            user.userId = userID
+        }
+
+        if let email = self.email {
+            user.email = email
+        }
+
+        if let username = user.username {
+            user.username = username
+        }
+
+        return user
+    }
+
+    func sentryUser(withData additionalUserData: [String: Any]) -> Sentry.User {
+        let user = self.sentryUser
+        user.data = additionalUserData
+        return user
+    }
+}

--- a/WooCommerce/Woo Watch App/App/Crash/CrashLogging.swift
+++ b/WooCommerce/Woo Watch App/App/Crash/CrashLogging.swift
@@ -88,7 +88,8 @@ public class CrashLogging {
     func beforeSend(event: Sentry.Event?) -> Sentry.Event? {
 
         #if DEBUG
-        let shouldSendEvent = UserDefaults.standard.bool(forKey: Self.forceCrashLoggingKey) && !dataProvider.userHasOptedOut
+        //let shouldSendEvent = UserDefaults.standard.bool(forKey: Self.forceCrashLoggingKey) && !dataProvider.userHasOptedOut
+        let shouldSendEvent = !dataProvider.userHasOptedOut
         #else
         let shouldSendEvent = !dataProvider.userHasOptedOut
         #endif

--- a/WooCommerce/Woo Watch App/App/Crash/CrashLogging.swift
+++ b/WooCommerce/Woo Watch App/App/Crash/CrashLogging.swift
@@ -1,0 +1,9 @@
+//
+//  CrashLogging.swift
+//  Woo Watch App
+//
+//  Created by Ernesto Carrion on 11/08/24.
+//  Copyright © 2024 Automattic. All rights reserved.
+//
+
+import Foundation

--- a/WooCommerce/Woo Watch App/App/Crash/CrashLoggingDataProvider.swift
+++ b/WooCommerce/Woo Watch App/App/Crash/CrashLoggingDataProvider.swift
@@ -1,9 +1,97 @@
-//
-//  CrashLoggingDataProvider.swift
-//  Woo Watch App
-//
-//  Created by Ernesto Carrion on 11/08/24.
-//  Copyright © 2024 Automattic. All rights reserved.
-//
-
 import Foundation
+
+/// This class is copied from the Tacks Library and it is adapted for the Woo Watch App.
+/// This should be removed/replaced when the Tracks Library properly supports watchOS.
+///
+
+public protocol CrashLoggingDataProvider {
+    var sentryDSN: String { get }
+    var userHasOptedOut: Bool { get }
+    var buildType: String { get }
+    var currentUser: TracksUser? { get }
+    var additionalUserData: [String: Any] { get }
+    var errorEventsSamplingRate: Double { get }
+    var shouldEnableAutomaticSessionTracking: Bool { get }
+    var performanceTracking: PerformanceTracking { get }
+    /// Whether app hang are captured.
+    var enableAppHangTracking: Bool { get }
+    /// Whether HTTP client errors are captured.
+    var enableCaptureFailedRequests: Bool { get }
+}
+
+/// Default implementations of common protocol properties
+public extension CrashLoggingDataProvider {
+
+    var additionalUserData: [String: Any] {
+        return [ : ]
+    }
+
+    var shouldEnableAutomaticSessionTracking: Bool {
+        return false
+    }
+
+    /// Performance tracking is disabled by default to avoid accidentally logging what could be a significant number of extra events
+    /// and blow up our events budget.
+    var performanceTracking: PerformanceTracking { .disabled }
+
+    var enableAutoPerformanceTracking: Bool {
+        switch performanceTracking {
+        case .enabled: return true
+        case .disabled: return false
+        }
+    }
+
+    var tracesSampler: PerformanceTracking.Sampler {
+        guard case .enabled(let config) = performanceTracking else { return { 0.0 } }
+        return config.sampler
+    }
+
+    var tracesSampleRate: Double {
+        guard case .enabled(let config) = performanceTracking else { return 0.0 }
+        return config.sampleRate
+    }
+
+    var profilingRate: Double {
+        guard case .enabled(let config) = performanceTracking else { return 0.0 }
+        return config.profilingRate
+    }
+
+    var enableUIViewControllerTracking: Bool {
+        guard case .enabled(let config) = performanceTracking else { return false }
+        return config.trackViewControllers
+    }
+
+    var enableNetworkTracking: Bool {
+        guard case .enabled(let config) = performanceTracking else { return false }
+        return config.trackNetwork
+    }
+
+    var enableFileIOTracking: Bool {
+        guard case .enabled(let config) = performanceTracking else { return false }
+        return config.trackFileIO
+    }
+
+    var enableCoreDataTracking: Bool {
+        guard case .enabled(let config) = performanceTracking else { return false }
+        return config.trackCoreData
+    }
+
+    var enableUserInteractionTracing: Bool {
+        guard case .enabled(let config) = performanceTracking else { return false }
+        return config.trackUserInteraction
+    }
+
+    /// App hang tracking is disabled by default to avoid unexpected events being tracked.
+    var enableAppHangTracking: Bool {
+        return false
+    }
+
+    /// HTTP client errors are disabled by default to avoid unexpected events being tracked.
+    var enableCaptureFailedRequests: Bool {
+        return false
+    }
+
+    var errorEventsSamplingRate: Double {
+        return 1.0
+    }
+}

--- a/WooCommerce/Woo Watch App/App/Crash/CrashLoggingDataProvider.swift
+++ b/WooCommerce/Woo Watch App/App/Crash/CrashLoggingDataProvider.swift
@@ -1,0 +1,9 @@
+//
+//  CrashLoggingDataProvider.swift
+//  Woo Watch App
+//
+//  Created by Ernesto Carrion on 11/08/24.
+//  Copyright © 2024 Automattic. All rights reserved.
+//
+
+import Foundation

--- a/WooCommerce/Woo Watch App/App/Crash/CrashLoggingDataProvider.swift
+++ b/WooCommerce/Woo Watch App/App/Crash/CrashLoggingDataProvider.swift
@@ -23,7 +23,7 @@ public protocol CrashLoggingDataProvider {
 public extension CrashLoggingDataProvider {
 
     var additionalUserData: [String: Any] {
-        return [ : ]
+        return [:]
     }
 
     var shouldEnableAutomaticSessionTracking: Bool {

--- a/WooCommerce/Woo Watch App/App/Crash/PerformanceTracking.swift
+++ b/WooCommerce/Woo Watch App/App/Crash/PerformanceTracking.swift
@@ -1,9 +1,64 @@
-//
-//  PerformanceTracking.swift
-//  Woo Watch App
-//
-//  Created by Ernesto Carrion on 11/08/24.
-//  Copyright © 2024 Automattic. All rights reserved.
-//
+/// This class is copied from the Tacks Library and it is adapted for the Woo Watch App.
+/// This should be removed/replaced when the Tracks Library properly supports watchOS.
+///
 
-import Foundation
+/// Defines whether to enable performance tracking, and if so, how to configure it.
+public enum PerformanceTracking {
+
+    public typealias Sampler = () -> Double
+
+    case disabled
+    case enabled(Configuration)
+
+    /// Describe the configuration of the performance tracking functionality.
+    ///
+    /// – SeeAlso: The [Sentry docs](https://docs.sentry.io/platforms/apple/guides/ios/performance/instrumentation/automatic-instrumentation/#uiviewcontroller-tracking).
+    public struct Configuration {
+        /// This parameter allows clients to change the sample rate at runtime.
+        ///
+        /// - Important: The returned value must be between 0.0 (no events) and 1.0 (all events).
+        public let sampler: Sampler
+        /// Defaults to `true`.
+        public let trackCoreData: Bool
+        /// Defaults to `true`.
+        public let trackFileIO: Bool
+        /// Defaults to `true`.
+        public let trackNetwork: Bool
+        /// Defaults to `true`.
+        ///
+        /// – Note: This is only read in iOS, tvOS, and Mac Catalyst clients, i.e. those with UIKit.
+        public let trackUserInteraction: Bool
+        /// Defaults to `true`.
+        ///
+        /// - Note: As per the Sentry documentation, this only tracks first-party `UIViewController` subclasses. No SwiftUI views or third-party screens.
+        /// – Note: This is only read in iOS, tvOS, and Mac Catalyst clients, i.e. those with UIKit.
+        public let trackViewControllers: Bool
+
+        /// The percent of *sampled* transactions that will be included in detailed stack-trace level *profiling*.
+        /// Must be in the range `(0.0)...(1.0)`
+        public let profilingRate: Double
+
+        // Compute the sample rate at runtime, to account for it accessing mutable state.
+        // Clamp it between 0.0 and 1.0—the values Sentry uses.
+        var sampleRate: Double { min(max(sampler(), 0.0), 1.0) }
+
+
+        public init(
+            sampler: @escaping Sampler = { 0.1 },
+            profilingRate: Double = 0.0,
+            trackCoreData: Bool = true,
+            trackFileIO: Bool = true,
+            trackNetwork: Bool = true,
+            trackUserInteraction: Bool = true,
+            trackViewControllers: Bool = true
+        ) {
+            self.sampler = sampler
+            self.profilingRate = min(max(profilingRate, 0.0), 1.0)
+            self.trackCoreData = trackCoreData
+            self.trackFileIO = trackFileIO
+            self.trackNetwork = trackNetwork
+            self.trackUserInteraction = trackUserInteraction
+            self.trackViewControllers = trackViewControllers
+        }
+    }
+}

--- a/WooCommerce/Woo Watch App/App/Crash/PerformanceTracking.swift
+++ b/WooCommerce/Woo Watch App/App/Crash/PerformanceTracking.swift
@@ -12,7 +12,7 @@ public enum PerformanceTracking {
 
     /// Describe the configuration of the performance tracking functionality.
     ///
-    /// – SeeAlso: 
+    /// – SeeAlso:
     /// The [Sentry docs](https://docs.sentry.io/platforms/apple/guides/ios/performance/instrumentation/automatic-instrumentation/#uiviewcontroller-tracking).
     public struct Configuration {
         /// This parameter allows clients to change the sample rate at runtime.

--- a/WooCommerce/Woo Watch App/App/Crash/PerformanceTracking.swift
+++ b/WooCommerce/Woo Watch App/App/Crash/PerformanceTracking.swift
@@ -1,0 +1,9 @@
+//
+//  PerformanceTracking.swift
+//  Woo Watch App
+//
+//  Created by Ernesto Carrion on 11/08/24.
+//  Copyright © 2024 Automattic. All rights reserved.
+//
+
+import Foundation

--- a/WooCommerce/Woo Watch App/App/Crash/PerformanceTracking.swift
+++ b/WooCommerce/Woo Watch App/App/Crash/PerformanceTracking.swift
@@ -12,7 +12,8 @@ public enum PerformanceTracking {
 
     /// Describe the configuration of the performance tracking functionality.
     ///
-    /// – SeeAlso: The [Sentry docs](https://docs.sentry.io/platforms/apple/guides/ios/performance/instrumentation/automatic-instrumentation/#uiviewcontroller-tracking).
+    /// – SeeAlso: 
+    /// The [Sentry docs](https://docs.sentry.io/platforms/apple/guides/ios/performance/instrumentation/automatic-instrumentation/#uiviewcontroller-tracking).
     public struct Configuration {
         /// This parameter allows clients to change the sample rate at runtime.
         ///

--- a/WooCommerce/Woo Watch App/App/Crash/WatchCrashLoggingStack.swift
+++ b/WooCommerce/Woo Watch App/App/Crash/WatchCrashLoggingStack.swift
@@ -28,15 +28,15 @@ struct WatchCrashLoggingStack: CrashLoggingStack {
         DDLogWarn("logError not supported")
     }
 
-    func logMessage(_ message: String, properties: [String : Any]?, level: SeverityLevel) {
+    func logMessage(_ message: String, properties: [String: Any]?, level: SeverityLevel) {
         DDLogWarn("logMessage not supported")
     }
 
-    func logError(_ error: Error, userInfo: [String : Any]?, level: SeverityLevel) {
+    func logError(_ error: Error, userInfo: [String: Any]?, level: SeverityLevel) {
         DDLogWarn("logError not supported")
     }
 
-    func logFatalErrorAndExit(_ error: Error, userInfo: [String : Any]?) -> Never {
+    func logFatalErrorAndExit(_ error: Error, userInfo: [String: Any]?) -> Never {
         DDLogWarn("logFatalErrorAndExit not supported")
         fatalError(error.localizedDescription)
     }

--- a/WooCommerce/Woo Watch App/App/Crash/WatchCrashLoggingStack.swift
+++ b/WooCommerce/Woo Watch App/App/Crash/WatchCrashLoggingStack.swift
@@ -44,6 +44,11 @@ struct WatchCrashLoggingStack: CrashLoggingStack {
     func setNeedsDataRefresh() {
         crashLogging.setNeedsDataRefresh()
     }
+
+    func updateUserData(enablesCrashReports: Bool) {
+        crashLoggingDataProvider.userHasOptedOut = !enablesCrashReports
+        setNeedsDataRefresh()
+    }
 }
 
 /// Minimal version of `WCCrashLoggingDataProvider` for the watch app.
@@ -54,9 +59,7 @@ class WatchCrashLoggingDataProvider: CrashLoggingDataProvider {
         ApiCredentials.sentryDSN
     }
 
-    var userHasOptedOut: Bool {
-        false // TODO: Read from user defaults
-    }
+    var userHasOptedOut: Bool = false
 
     var buildType: String {
 #if DEBUG

--- a/WooCommerce/Woo Watch App/App/Crash/WatchCrashLoggingStack.swift
+++ b/WooCommerce/Woo Watch App/App/Crash/WatchCrashLoggingStack.swift
@@ -1,4 +1,5 @@
 import WooFoundationWatchOS
+import NetworkingWatchOS
 
 /// Minimal version of `WCCrashLoggingStack` for the watch app.
 ///
@@ -45,7 +46,15 @@ struct WatchCrashLoggingStack: CrashLoggingStack {
         crashLogging.setNeedsDataRefresh()
     }
 
-    func updateUserData(enablesCrashReports: Bool) {
+    func updateUserData(enablesCrashReports: Bool, account: Account?) {
+        let user: TracksUser? = {
+            guard let account = account else {
+                return nil
+            }
+            return TracksUser(userID: "\(account.userID)", email: account.email, username: account.username)
+        }()
+
+        crashLoggingDataProvider.currentUser = user
         crashLoggingDataProvider.userHasOptedOut = !enablesCrashReports
         setNeedsDataRefresh()
     }
@@ -71,7 +80,5 @@ class WatchCrashLoggingDataProvider: CrashLoggingDataProvider {
 #endif
     }
 
-    var currentUser: TracksUser? {
-        nil // TODO: Sync account data
-    }
+    var currentUser: TracksUser?
 }

--- a/WooCommerce/Woo Watch App/App/Crash/WatchCrashLoggingStack.swift
+++ b/WooCommerce/Woo Watch App/App/Crash/WatchCrashLoggingStack.swift
@@ -1,9 +1,74 @@
-//
-//  WatchCrashLoggingDataprovider.swift
-//  Woo Watch App
-//
-//  Created by Ernesto Carrion on 11/08/24.
-//  Copyright © 2024 Automattic. All rights reserved.
-//
+import WooFoundationWatchOS
 
-import Foundation
+/// Minimal version of `WCCrashLoggingStack` for the watch app.
+///
+struct WatchCrashLoggingStack: CrashLoggingStack {
+    private let crashLogging: CrashLogging
+    private let crashLoggingDataProvider = WatchCrashLoggingDataProvider()
+
+    init() {
+        self.crashLogging = CrashLogging(dataProvider: crashLoggingDataProvider)
+        do {
+            _ = try crashLogging.start()
+        } catch {
+            DDLogError("⛔️ Unable to start WatchCrashLoggingStack: \(error)")
+        }
+    }
+
+    func crash() {
+        crashLogging.crash()
+    }
+
+    var queuedLogFileCount: Int {
+        DDLogWarn("queuedLogFileCount not supported")
+        return 0
+    }
+
+    func logError(_ error: Error) {
+        DDLogWarn("logError not supported")
+    }
+
+    func logMessage(_ message: String, properties: [String : Any]?, level: SeverityLevel) {
+        DDLogWarn("logMessage not supported")
+    }
+
+    func logError(_ error: Error, userInfo: [String : Any]?, level: SeverityLevel) {
+        DDLogWarn("logError not supported")
+    }
+
+    func logFatalErrorAndExit(_ error: Error, userInfo: [String : Any]?) -> Never {
+        DDLogWarn("logFatalErrorAndExit not supported")
+        fatalError(error.localizedDescription)
+    }
+
+    func setNeedsDataRefresh() {
+        crashLogging.setNeedsDataRefresh()
+    }
+}
+
+/// Minimal version of `WCCrashLoggingDataProvider` for the watch app.
+///
+class WatchCrashLoggingDataProvider: CrashLoggingDataProvider {
+
+    var sentryDSN: String {
+        ApiCredentials.sentryDSN
+    }
+
+    var userHasOptedOut: Bool {
+        false // TODO: Read from user defaults
+    }
+
+    var buildType: String {
+#if DEBUG
+        "localDeveloper"
+#elseif ALPHA
+        "alpha"
+#else
+        "appStore"
+#endif
+    }
+
+    var currentUser: TracksUser? {
+        nil // TODO: Sync account data
+    }
+}

--- a/WooCommerce/Woo Watch App/App/Crash/WatchCrashLoggingStack.swift
+++ b/WooCommerce/Woo Watch App/App/Crash/WatchCrashLoggingStack.swift
@@ -1,0 +1,9 @@
+//
+//  WatchCrashLoggingDataprovider.swift
+//  Woo Watch App
+//
+//  Created by Ernesto Carrion on 11/08/24.
+//  Copyright © 2024 Automattic. All rights reserved.
+//
+
+import Foundation

--- a/WooCommerce/Woo Watch App/App/Crash/WatchCrashLoggingStack.swift
+++ b/WooCommerce/Woo Watch App/App/Crash/WatchCrashLoggingStack.swift
@@ -7,8 +7,11 @@ struct WatchCrashLoggingStack: CrashLoggingStack {
     private let crashLogging: CrashLogging
     private let crashLoggingDataProvider = WatchCrashLoggingDataProvider()
 
-    init() {
+    init(account: Account?) {
+        crashLoggingDataProvider.currentUser = Self.tracksUserFrom(account)
         self.crashLogging = CrashLogging(dataProvider: crashLoggingDataProvider)
+        self.crashLogging.setNeedsDataRefresh()
+
         do {
             _ = try crashLogging.start()
         } catch {
@@ -47,16 +50,16 @@ struct WatchCrashLoggingStack: CrashLoggingStack {
     }
 
     func updateUserData(enablesCrashReports: Bool, account: Account?) {
-        let user: TracksUser? = {
-            guard let account = account else {
-                return nil
-            }
-            return TracksUser(userID: "\(account.userID)", email: account.email, username: account.username)
-        }()
-
-        crashLoggingDataProvider.currentUser = user
+        crashLoggingDataProvider.currentUser = Self.tracksUserFrom(account)
         crashLoggingDataProvider.userHasOptedOut = !enablesCrashReports
         setNeedsDataRefresh()
+    }
+
+    static func tracksUserFrom(_ account: Account?) -> TracksUser? {
+        guard let account = account else {
+            return nil
+        }
+        return TracksUser(userID: "\(account.userID)", email: account.email, username: account.username)
     }
 }
 

--- a/WooCommerce/Woo Watch App/App/WooApp.swift
+++ b/WooCommerce/Woo Watch App/App/WooApp.swift
@@ -43,6 +43,9 @@ struct Woo_Watch_AppApp: App {
             }
             .environmentObject(tracksProvider)
             .task {
+                // Create the crash logging stack with the known account to properly identify crashes
+                delegate.crashLoggingStack = WatchCrashLoggingStack(account: phoneDependencySynchronizer.dependencies?.account)
+
                 // For some reason I can't use the bindings directly from our AppDelegate.
                 // We need to store them in this type assign them to the delegate for further modification.
                 delegate.appBindings = appBindings

--- a/WooCommerce/Woo Watch App/App/WooApp.swift
+++ b/WooCommerce/Woo Watch App/App/WooApp.swift
@@ -54,6 +54,10 @@ struct Woo_Watch_AppApp: App {
                 // Tracks
                 tracksProvider.sendTracksEvent(.watchAppOpened)
             }
+            .onChange(of: phoneDependencySynchronizer.dependencies, perform: { newDependencies in
+                // Make sure the app delegate performs any update needed when we find new dependencies.
+                delegate.onUpdateDependencies(dependencies: newDependencies)
+            })
         }
     }
 }

--- a/WooCommerce/Woo Watch App/Dependencies/Environment+Dependencies.swift
+++ b/WooCommerce/Woo Watch App/Dependencies/Environment+Dependencies.swift
@@ -23,7 +23,7 @@ extension WatchDependencies {
     ///
     static func fake() -> Self {
         .init(storeID: .zero,
-              storeName: "", 
+              storeName: "",
               currencySettings: CurrencySettings(),
               credentials: .init(authToken: ""),
               enablesCrashReports: true,

--- a/WooCommerce/Woo Watch App/Dependencies/Environment+Dependencies.swift
+++ b/WooCommerce/Woo Watch App/Dependencies/Environment+Dependencies.swift
@@ -22,6 +22,11 @@ extension WatchDependencies {
     /// Fake object, useful as a default value and for previews.
     ///
     static func fake() -> Self {
-        .init(storeID: .zero, storeName: "", currencySettings: CurrencySettings(), credentials: .init(authToken: ""), enablesCrashReports: true)
+        .init(storeID: .zero,
+              storeName: "", 
+              currencySettings: CurrencySettings(),
+              credentials: .init(authToken: ""),
+              enablesCrashReports: true,
+              account: .init(userID: .zero, displayName: "", email: "", username: "", gravatarUrl: nil))
     }
 }

--- a/WooCommerce/Woo Watch App/Dependencies/Environment+Dependencies.swift
+++ b/WooCommerce/Woo Watch App/Dependencies/Environment+Dependencies.swift
@@ -22,6 +22,6 @@ extension WatchDependencies {
     /// Fake object, useful as a default value and for previews.
     ///
     static func fake() -> Self {
-        .init(storeID: .zero, storeName: "", currencySettings: CurrencySettings(), credentials: .init(authToken: ""))
+        .init(storeID: .zero, storeName: "", currencySettings: CurrencySettings(), credentials: .init(authToken: ""), enablesCrashReports: true)
     }
 }

--- a/WooCommerce/Woo Watch App/Dependencies/PhoneDependenciesSynchronizer.swift
+++ b/WooCommerce/Woo Watch App/Dependencies/PhoneDependenciesSynchronizer.swift
@@ -144,7 +144,8 @@ private extension WatchDependencies {
                                  storeName: storeName,
                                  currencySettings: currencySettings,
                                  credentials: credentials.replacingSecret(secret),
-                                 applicationPassword: applicationPassword)
+                                 applicationPassword: applicationPassword,
+                                 enablesCrashReports: enablesCrashReports)
     }
 }
 

--- a/WooCommerce/Woo Watch App/Dependencies/PhoneDependenciesSynchronizer.swift
+++ b/WooCommerce/Woo Watch App/Dependencies/PhoneDependenciesSynchronizer.swift
@@ -145,7 +145,8 @@ private extension WatchDependencies {
                                  currencySettings: currencySettings,
                                  credentials: credentials.replacingSecret(secret),
                                  applicationPassword: applicationPassword,
-                                 enablesCrashReports: enablesCrashReports)
+                                 enablesCrashReports: enablesCrashReports,
+                                 account: account)
     }
 }
 

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -999,6 +999,12 @@
 		26A0B2D72BFBA536002E9620 /* OrdersListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26A0B2D62BFBA536002E9620 /* OrdersListView.swift */; };
 		26A280D62B45F00F00ACEE87 /* OrderNotificationViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26A280D52B45F00F00ACEE87 /* OrderNotificationViewModelTests.swift */; };
 		26A280D72B46027A00ACEE87 /* OrderNotificationView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26CA2BC52AAA1773003B16C2 /* OrderNotificationView.swift */; };
+		26A52EEA2C69AE6B000B1CFB /* CrashLogging.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26A52EE92C69AE6B000B1CFB /* CrashLogging.swift */; };
+		26A52EEC2C69B480000B1CFB /* CrashLoggingDataProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26A52EEB2C69B480000B1CFB /* CrashLoggingDataProvider.swift */; };
+		26A52EEE2C69B51D000B1CFB /* PerformanceTracking.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26A52EED2C69B51D000B1CFB /* PerformanceTracking.swift */; };
+		26A52EF02C69B8F5000B1CFB /* WatchCrashLoggingStack.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26A52EEF2C69B8F5000B1CFB /* WatchCrashLoggingStack.swift */; };
+		26A52EF12C69B947000B1CFB /* ApiCredentials.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5A8F8A720B84D3F00D211DE /* ApiCredentials.swift */; };
+		26A52EF22C69BD14000B1CFB /* CrashLoggingStack.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1C47208267A1ECC00D06DA1 /* CrashLoggingStack.swift */; };
 		26A630ED253F3B5C00CBC3B1 /* RefundCreationUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26A630EC253F3B5C00CBC3B1 /* RefundCreationUseCase.swift */; };
 		26A630F3253F3CFE00CBC3B1 /* RefundCreationUseCaseTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26A630F2253F3CFE00CBC3B1 /* RefundCreationUseCaseTests.swift */; };
 		26A630FE253F63C300CBC3B1 /* RefundableOrderItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26A630FD253F63C300CBC3B1 /* RefundableOrderItem.swift */; };
@@ -3986,6 +3992,10 @@
 		26A0B2D22BF9A78C002E9620 /* StoreInfoFormatter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StoreInfoFormatter.swift; sourceTree = "<group>"; };
 		26A0B2D62BFBA536002E9620 /* OrdersListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OrdersListView.swift; sourceTree = "<group>"; };
 		26A280D52B45F00F00ACEE87 /* OrderNotificationViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OrderNotificationViewModelTests.swift; sourceTree = "<group>"; };
+		26A52EE92C69AE6B000B1CFB /* CrashLogging.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CrashLogging.swift; sourceTree = "<group>"; };
+		26A52EEB2C69B480000B1CFB /* CrashLoggingDataProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CrashLoggingDataProvider.swift; sourceTree = "<group>"; };
+		26A52EED2C69B51D000B1CFB /* PerformanceTracking.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PerformanceTracking.swift; sourceTree = "<group>"; };
+		26A52EEF2C69B8F5000B1CFB /* WatchCrashLoggingStack.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WatchCrashLoggingStack.swift; sourceTree = "<group>"; };
 		26A630EC253F3B5C00CBC3B1 /* RefundCreationUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RefundCreationUseCase.swift; sourceTree = "<group>"; };
 		26A630F2253F3CFE00CBC3B1 /* RefundCreationUseCaseTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RefundCreationUseCaseTests.swift; sourceTree = "<group>"; };
 		26A630FD253F63C300CBC3B1 /* RefundableOrderItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RefundableOrderItem.swift; sourceTree = "<group>"; };
@@ -8022,6 +8032,17 @@
 			path = Orders;
 			sourceTree = "<group>";
 		};
+		26A52EE82C69AE1C000B1CFB /* Crash */ = {
+			isa = PBXGroup;
+			children = (
+				26A52EEF2C69B8F5000B1CFB /* WatchCrashLoggingStack.swift */,
+				26A52EEB2C69B480000B1CFB /* CrashLoggingDataProvider.swift */,
+				26A52EED2C69B51D000B1CFB /* PerformanceTracking.swift */,
+				26A52EE92C69AE6B000B1CFB /* CrashLogging.swift */,
+			);
+			path = Crash;
+			sourceTree = "<group>";
+		};
 		26A630F8253F62AD00CBC3B1 /* UseCases */ = {
 			isa = PBXGroup;
 			children = (
@@ -8145,6 +8166,7 @@
 				26CFDED92C029322005ABC31 /* AppDelegate.swift */,
 				26CFDEDB2C02932C005ABC31 /* AppBindings.swift */,
 				261C21542C08D8E20051AF19 /* WatchTracksProvider.swift */,
+				26A52EE82C69AE1C000B1CFB /* Crash */,
 			);
 			path = App;
 			sourceTree = "<group>";
@@ -14239,6 +14261,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				26A52EF22C69BD14000B1CFB /* CrashLoggingStack.swift in Sources */,
 				26CFDEE22C029A5A005ABC31 /* PushNotification.swift in Sources */,
 				26CA47222BFD82B900E54348 /* TimeZone+Woo.swift in Sources */,
 				264E9E952BF400AD009C48FD /* StoreInfoDataService.swift in Sources */,
@@ -14246,16 +14269,20 @@
 				26CFDEE32C029AD2005ABC31 /* Dictionary+Woo.swift in Sources */,
 				26373E2E2BFD2F46008E6735 /* OrdersListViewModel.swift in Sources */,
 				26A0B2D72BFBA536002E9620 /* OrdersListView.swift in Sources */,
+				26A52EF12C69B947000B1CFB /* ApiCredentials.swift in Sources */,
 				262619F12C03AB9600BD733B /* OrderDetailLoader.swift in Sources */,
 				26B984D42BEECC610052658C /* Environment+Dependencies.swift in Sources */,
 				26F81B1A2BE433A2009EC58E /* MyStoreView.swift in Sources */,
+				26A52EF02C69B8F5000B1CFB /* WatchCrashLoggingStack.swift in Sources */,
 				268631CF2C07D38C00521364 /* WooAnalyticsStat.swift in Sources */,
 				26373E2F2BFD7C18008E6735 /* OrderListCellViewModel.swift in Sources */,
 				26CFDEDA2C029322005ABC31 /* AppDelegate.swift in Sources */,
 				264E9E942BF1D1DF009C48FD /* AppLocalizedString.swift in Sources */,
+				26A52EEE2C69B51D000B1CFB /* PerformanceTracking.swift in Sources */,
 				26A0B2D42BF9A78C002E9620 /* StoreInfoFormatter.swift in Sources */,
 				26DD32D42BEBCDFB00F2C69C /* WooConstants.swift in Sources */,
 				269FFA4B2BF544C9004E6B86 /* MyStoreViewModel.swift in Sources */,
+				26A52EEA2C69AE6B000B1CFB /* CrashLogging.swift in Sources */,
 				26CA47202BFD823200E54348 /* Date+Woo.swift in Sources */,
 				26B984D62BEECF260052658C /* ConnectView.swift in Sources */,
 				26DD32D62BEBCE3900F2C69C /* UserDefaults+Woo.swift in Sources */,
@@ -14264,6 +14291,7 @@
 				269FFA482BF516BA004E6B86 /* Logging.swift in Sources */,
 				26F81B182BE433A2009EC58E /* WooApp.swift in Sources */,
 				26CA47212BFD82AE00E54348 /* DateFormatter+Helpers.swift in Sources */,
+				26A52EEC2C69B480000B1CFB /* CrashLoggingDataProvider.swift in Sources */,
 				26CFDEDC2C02932C005ABC31 /* AppBindings.swift in Sources */,
 				2604C3BA2BE977F000250465 /* PhoneDependenciesSynchronizer.swift in Sources */,
 				26A000772BE9D9030071DB1E /* WooConstants.swift in Sources */,

--- a/WooFoundation/WooFoundation.xcodeproj/project.pbxproj
+++ b/WooFoundation/WooFoundation.xcodeproj/project.pbxproj
@@ -36,6 +36,7 @@
 		26A0B2CF2BF9A51E002E9620 /* CurrencyFormatter.swift in Sources */ = {isa = PBXBuildFile; fileRef = B9C9C65B283E71C8001B879F /* CurrencyFormatter.swift */; };
 		26A0B2D02BF9A550002E9620 /* NSDecimalNumber+Helpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = B9C9C658283E7195001B879F /* NSDecimalNumber+Helpers.swift */; };
 		26A0B2D12BF9A58C002E9620 /* Double+Woo.swift in Sources */ = {isa = PBXBuildFile; fileRef = B9C9C65F283E71F4001B879F /* Double+Woo.swift */; };
+		26A52EF32C69BE5E000B1CFB /* CrashLogger.swift in Sources */ = {isa = PBXBuildFile; fileRef = 689D11CF2891B3A300F6A83F /* CrashLogger.swift */; };
 		26AF1F5328B8362800937BA9 /* UIColor+SemanticColors.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26AF1F4F28B8362800937BA9 /* UIColor+SemanticColors.swift */; };
 		26AF1F5428B8362800937BA9 /* ColorStudio.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26AF1F5028B8362800937BA9 /* ColorStudio.swift */; };
 		26AF1F5528B8362800937BA9 /* UIColor+ColorStudio.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26AF1F5128B8362800937BA9 /* UIColor+ColorStudio.swift */; };
@@ -669,6 +670,7 @@
 				264E9EA32BF403E1009C48FD /* Date+StartAndEnd.swift in Sources */,
 				26A0B2CF2BF9A51E002E9620 /* CurrencyFormatter.swift in Sources */,
 				269FFA4C2BF5AFC8004E6B86 /* CurrencySettings.swift in Sources */,
+				26A52EF32C69BE5E000B1CFB /* CrashLogger.swift in Sources */,
 				269FFA4D2BF5AFCF004E6B86 /* CurrencyCode.swift in Sources */,
 				264E9EA42BF4040E009C48FD /* Logging.swift in Sources */,
 				26A0B2D12BF9A58C002E9620 /* Double+Woo.swift in Sources */,


### PR DESCRIPTION
Closes: #13497

# Why

This PR integrates Sentry on the Watch App. Ref pe5pgL-5uP-p2 

# How

- Adopt Sentry SDK
- Update the watch app to sync the account and privacy settings
- Configure sentry as closely as possible as it is configured on the iOS App.

# Screenshots

Watch Crash | User Information
--- | ---
<img width="843" alt="crash" src="https://github.com/user-attachments/assets/09c3ef63-6f54-45a7-bf96-3390e9c8bad1"> | <img width="346" alt="user" src="https://github.com/user-attachments/assets/6dad970d-53ac-4659-a378-58cdbc261242">

# Tested Scenarios

1. Launching the app and logging in with a WPCom account
2. Launching the app and logging in with an application password account
3. Updating from an already WPCom logged-in app
3. Updating from an already WPCom logged-in application password app.


---
- [x] I have considered adding unit tests for this change. If I decided not to add them, I have provided a brief explanation below (optional):
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
- [x] This PR includes refactoring; smoke testing of the entire section is needed.
