### PR TITLE
[Woo POS] Extract product header for reusability

### DIFF
--- a/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/PointOfSaleItemListEmptyView.swift
+++ b/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/PointOfSaleItemListEmptyView.swift
@@ -3,11 +3,7 @@ import SwiftUI
 struct PointOfSaleItemListEmptyView: View {
     var body: some View {
         VStack(alignment: .center, spacing: PointOfSaleItemListErrorLayout.headerSpacing) {
-            Text(Localization.productTitle)
-                .frame(maxWidth: .infinity, alignment: .leading)
-                .padding(.vertical, PointOfSaleItemListErrorLayout.headerPadding)
-                .font(.posTitle)
-                .foregroundColor(Color.posPrimaryTexti3)
+            POSHeaderTitleView(foregroundColor: .posIconGrayi3)
             Spacer()
             Image(systemName: Constants.iconSystemName)
                 .resizable()
@@ -38,11 +34,6 @@ private extension PointOfSaleItemListEmptyView {
         static let iconSize: CGFloat = 100
     }
     enum Localization {
-        static let productTitle = NSLocalizedString(
-            "pos.pointOfSaleItemListEmptyView.productTitle",
-            value: "Products",
-            comment: "Title for the Point of Sale screen"
-        )
         static let emptyProductsTitle = NSLocalizedString(
             "pos.pointOfSaleItemListEmptyView.emptyProductsTitle",
             value: "No supported products found",

--- a/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/PointOfSaleItemListErrorLayout.swift
+++ b/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/PointOfSaleItemListErrorLayout.swift
@@ -4,4 +4,5 @@ enum PointOfSaleItemListErrorLayout {
     static let headerPadding: CGFloat = 8
     static let headerSpacing: CGFloat = 16
     static let buttonWidth: CGFloat = 600
+    static let verticalPadding: CGFloat = 16
 }

--- a/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/PointOfSaleItemListErrorView.swift
+++ b/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/PointOfSaleItemListErrorView.swift
@@ -11,7 +11,7 @@ struct PointOfSaleItemListErrorView: View {
 
     var body: some View {
         VStack(alignment: .center, spacing: PointOfSaleItemListErrorLayout.headerSpacing) {
-            POSHeaderTitleView()
+            POSHeaderTitleView(foregroundColor: .posIconGrayi3)
             Spacer()
             POSErrorExclamationMark()
             Text(error.title)

--- a/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/PointOfSaleItemListErrorView.swift
+++ b/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/PointOfSaleItemListErrorView.swift
@@ -21,7 +21,7 @@ struct PointOfSaleItemListErrorView: View {
             Text(error.subtitle)
                 .foregroundStyle(Color.posPrimaryTexti3)
                 .font(.posBody)
-                .padding([.leading, .trailing])
+                .padding([.leading, .trailing, .bottom])
             Button(action: {
                 onRetry?()
             }, label: {

--- a/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/PointOfSaleItemListErrorView.swift
+++ b/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/PointOfSaleItemListErrorView.swift
@@ -11,11 +11,7 @@ struct PointOfSaleItemListErrorView: View {
 
     var body: some View {
         VStack(alignment: .center, spacing: PointOfSaleItemListErrorLayout.headerSpacing) {
-            Text(Localization.productTitle)
-                .frame(maxWidth: .infinity, alignment: .leading)
-                .padding(.vertical, PointOfSaleItemListErrorLayout.headerPadding)
-                .font(Font.posTitle)
-                .foregroundColor(Color.posPrimaryTexti3)
+            POSHeaderTitleView()
             Spacer()
             POSErrorExclamationMark()
             Text(error.title)
@@ -35,15 +31,5 @@ struct PointOfSaleItemListErrorView: View {
             .frame(width: PointOfSaleItemListErrorLayout.buttonWidth)
             Spacer()
         }
-    }
-}
-
-private extension PointOfSaleItemListErrorView {
-    enum Localization {
-        static let productTitle = NSLocalizedString(
-            "pos.pointOfSaleItemListErrorView.productTitle",
-            value: "Products",
-            comment: "Title for the Point of Sale screen"
-        )
     }
 }

--- a/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/PointOfSaleItemListErrorView.swift
+++ b/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/PointOfSaleItemListErrorView.swift
@@ -13,22 +13,27 @@ struct PointOfSaleItemListErrorView: View {
         VStack(alignment: .center, spacing: PointOfSaleItemListErrorLayout.headerSpacing) {
             POSHeaderTitleView(foregroundColor: .posIconGrayi3)
             Spacer()
-            POSErrorExclamationMark()
-            Text(error.title)
-                .foregroundStyle(Color.posPrimaryTexti3)
-                .font(.posTitle)
-                .bold()
-            Text(error.subtitle)
-                .foregroundStyle(Color.posPrimaryTexti3)
-                .font(.posBody)
-                .padding([.leading, .trailing, .bottom])
-            Button(action: {
-                onRetry?()
-            }, label: {
-                Text(error.buttonText)
-            })
-            .buttonStyle(POSPrimaryButtonStyle())
-            .frame(width: PointOfSaleItemListErrorLayout.buttonWidth)
+            VStack(alignment: .center) {
+                POSErrorExclamationMark()
+                    .padding(.bottom)
+                Text(error.title)
+                    .foregroundStyle(Color.posPrimaryTexti3)
+                    .font(.posTitle)
+                    .bold()
+                    .padding(.bottom, PointOfSaleItemListErrorLayout.verticalPadding)
+                Text(error.subtitle)
+                    .foregroundStyle(Color.posPrimaryTexti3)
+                    .font(.posBody)
+                    .padding([.leading, .trailing])
+                    .padding(.bottom, PointOfSaleItemListErrorLayout.verticalPadding)
+                Button(action: {
+                    onRetry?()
+                }, label: {
+                    Text(error.buttonText)
+                })
+                .buttonStyle(POSPrimaryButtonStyle())
+                .frame(width: PointOfSaleItemListErrorLayout.buttonWidth)
+            }
             Spacer()
         }
     }

--- a/WooCommerce/Classes/POS/Presentation/ItemListView.swift
+++ b/WooCommerce/Classes/POS/Presentation/ItemListView.swift
@@ -28,7 +28,6 @@ struct ItemListView: View {
         .refreshable {
             await viewModel.reload()
         }
-        .padding(.horizontal, Constants.itemListPadding)
         .background(Color.posBackgroundGreyi3)
     }
 }
@@ -119,6 +118,7 @@ private extension ItemListView {
                 }
             }
             .padding(.bottom, floatingControlAreaSize.height)
+            .padding(.horizontal, Constants.itemListPadding)
         }
     }
 }

--- a/WooCommerce/Classes/POS/Presentation/ItemListView.swift
+++ b/WooCommerce/Classes/POS/Presentation/ItemListView.swift
@@ -40,7 +40,7 @@ private extension ItemListView {
     var headerView: some View {
         VStack {
             HStack {
-                headerTextView
+                POSHeaderTitleView()
                 if !viewModel.shouldShowHeaderBanner {
                     Spacer()
                     Button(action: {
@@ -106,14 +106,6 @@ private extension ItemListView {
         }
     }
 
-    var headerTextView: some View {
-        Text(Localization.productSelectorTitle)
-            .frame(maxWidth: .infinity, alignment: .leading)
-            .padding(.vertical, Constants.headerPadding)
-            .font(Constants.titleFont)
-            .foregroundColor(Color.posPrimaryTexti3)
-    }
-
     @ViewBuilder
     func listView(_ items: [POSItem]) -> some View {
         ScrollView {
@@ -135,7 +127,6 @@ private extension ItemListView {
 ///
 private extension ItemListView {
     enum Constants {
-        static let titleFont: Font = .system(size: 40, weight: .bold, design: .default)
         static let bannerTitleFont: Font = .system(size: 24, weight: .bold, design: .default)
         static let bannerSubtitleFont: Font = .system(size: 16, weight: .medium, design: .default)
         static let bannerHeight: CGFloat = 164
@@ -146,16 +137,10 @@ private extension ItemListView {
         static let bannerInfoIconSize: CGFloat = 44
         static let closeIconSize: CGFloat = 26
         static let iconPadding: CGFloat = 26
-        static let headerPadding: CGFloat = 8
         static let itemListPadding: CGFloat = 16
     }
 
     enum Localization {
-        static let productSelectorTitle = NSLocalizedString(
-            "pos.itemlistview.productSelectorTitle",
-            value: "Products",
-            comment: "Title of the Point of Sale product selector"
-        )
         static let headerBannerTitle = NSLocalizedString(
             "pos.itemlistview.headerBannerTitle",
             value: "Showing simple products only",

--- a/WooCommerce/Classes/POS/Presentation/Reusable Views/POSHeaderTitleView.swift
+++ b/WooCommerce/Classes/POS/Presentation/Reusable Views/POSHeaderTitleView.swift
@@ -1,0 +1,29 @@
+import SwiftUI
+
+struct POSHeaderTitleView: View {
+    var body: some View {
+        Text(Localization.productSelectorTitle)
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .padding(.vertical, Constants.headerPadding)
+            .font(.posHeaderTitle)
+            .foregroundColor(Color.posPrimaryTexti3)
+    }
+}
+
+private extension POSHeaderTitleView {
+    enum Localization {
+        static let productSelectorTitle = NSLocalizedString(
+            "pos.headerTitleView.productSelectorTitle",
+            value: "Products",
+            comment: "Title at the top of the Point of Sale product selector screen."
+        )
+    }
+
+    enum Constants {
+        static let headerPadding: CGFloat = 8
+    }
+}
+
+#Preview {
+    POSHeaderTitleView()
+}

--- a/WooCommerce/Classes/POS/Presentation/Reusable Views/POSHeaderTitleView.swift
+++ b/WooCommerce/Classes/POS/Presentation/Reusable Views/POSHeaderTitleView.swift
@@ -1,12 +1,14 @@
 import SwiftUI
 
 struct POSHeaderTitleView: View {
+    var foregroundColor: Color = Color.posPrimaryTexti3
+
     var body: some View {
         Text(Localization.productSelectorTitle)
             .frame(maxWidth: .infinity, alignment: .leading)
-            .padding(.vertical, Constants.headerPadding)
+            .padding(Constants.padding)
             .font(.posHeaderTitle)
-            .foregroundColor(Color.posPrimaryTexti3)
+            .foregroundColor(foregroundColor)
     }
 }
 
@@ -20,7 +22,10 @@ private extension POSHeaderTitleView {
     }
 
     enum Constants {
-        static let headerPadding: CGFloat = 8
+        static let padding: EdgeInsets = .init(top: 24,
+                                               leading: 16,
+                                               bottom: 24,
+                                               trailing: 16)
     }
 }
 

--- a/WooCommerce/Classes/POS/Utils/Font+WooCommercePOS.swift
+++ b/WooCommerce/Classes/POS/Utils/Font+WooCommercePOS.swift
@@ -6,7 +6,7 @@ extension Font {
     static let posDetail: Font = Font.system(size: UIFontMetrics.default.scaledValue(for: 16))
     static let posModalBody: Font = Font.system(size: UIFontMetrics.default.scaledValue(for: 24))
     static let posModalTitle: Font = Font.system(size: UIFontMetrics.default.scaledValue(for: 36), weight: .bold)
-    static let posHeaderTitle: Font = Font.system(size: 40,
+    static let posHeaderTitle: Font = Font.system(size: UIFontMetrics.default.scaledValue(for: 40),
                                                   weight: .bold,
                                                   design: .default)
 }

--- a/WooCommerce/Classes/POS/Utils/Font+WooCommercePOS.swift
+++ b/WooCommerce/Classes/POS/Utils/Font+WooCommercePOS.swift
@@ -6,4 +6,7 @@ extension Font {
     static let posDetail: Font = Font.system(size: UIFontMetrics.default.scaledValue(for: 16))
     static let posModalBody: Font = Font.system(size: UIFontMetrics.default.scaledValue(for: 24))
     static let posModalTitle: Font = Font.system(size: UIFontMetrics.default.scaledValue(for: 36), weight: .bold)
+    static let posHeaderTitle: Font = Font.system(size: 40,
+                                                  weight: .bold,
+                                                  design: .default)
 }

--- a/WooCommerce/Classes/POS/Utils/Font+WooCommercePOS.swift
+++ b/WooCommerce/Classes/POS/Utils/Font+WooCommercePOS.swift
@@ -6,7 +6,7 @@ extension Font {
     static let posDetail: Font = Font.system(size: UIFontMetrics.default.scaledValue(for: 16))
     static let posModalBody: Font = Font.system(size: UIFontMetrics.default.scaledValue(for: 24))
     static let posModalTitle: Font = Font.system(size: UIFontMetrics.default.scaledValue(for: 36), weight: .bold)
-    static let posHeaderTitle: Font = Font.system(size: UIFontMetrics.default.scaledValue(for: 40),
+    static let posHeaderTitle: Font = Font.system(size: UIFontMetrics.default.scaledValue(for: 36),
                                                   weight: .bold,
                                                   design: .default)
 }

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -1476,6 +1476,7 @@
 		6837631A2C2E6F5900AD51D0 /* CartViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 683763192C2E6F5900AD51D0 /* CartViewModelTests.swift */; };
 		6837631C2C2E847D00AD51D0 /* CartViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6837631B2C2E847D00AD51D0 /* CartViewModel.swift */; };
 		683AA9D62A303CB70099F7BA /* UpgradesViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 683AA9D52A303CB70099F7BA /* UpgradesViewModelTests.swift */; };
+		683DF5FF2C6AF46500A5CDC6 /* POSHeaderTitleView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 683DF5FE2C6AF46500A5CDC6 /* POSHeaderTitleView.swift */; };
 		684AB83A2870677F003DFDD1 /* CardReaderManualsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 684AB8392870677F003DFDD1 /* CardReaderManualsView.swift */; };
 		684AB83C2873DF04003DFDD1 /* CardReaderManualsViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 684AB83B2873DF04003DFDD1 /* CardReaderManualsViewModel.swift */; };
 		6850C5EE2B69E6580026A93B /* ReceiptViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6850C5ED2B69E6580026A93B /* ReceiptViewModel.swift */; };
@@ -4428,6 +4429,7 @@
 		683763192C2E6F5900AD51D0 /* CartViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CartViewModelTests.swift; sourceTree = "<group>"; };
 		6837631B2C2E847D00AD51D0 /* CartViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CartViewModel.swift; sourceTree = "<group>"; };
 		683AA9D52A303CB70099F7BA /* UpgradesViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UpgradesViewModelTests.swift; sourceTree = "<group>"; };
+		683DF5FE2C6AF46500A5CDC6 /* POSHeaderTitleView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = POSHeaderTitleView.swift; sourceTree = "<group>"; };
 		684AB8392870677F003DFDD1 /* CardReaderManualsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardReaderManualsView.swift; sourceTree = "<group>"; };
 		684AB83B2873DF04003DFDD1 /* CardReaderManualsViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardReaderManualsViewModel.swift; sourceTree = "<group>"; };
 		6850C5ED2B69E6580026A93B /* ReceiptViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReceiptViewModel.swift; sourceTree = "<group>"; };
@@ -6024,6 +6026,7 @@
 				20D3D42E2C64F175004CE6E3 /* POSSecondaryButtonStyle.swift */,
 				20D3D4302C64F202004CE6E3 /* POSButtonStyleConstants.swift */,
 				207823E82C5D3A1700025A59 /* POSErrorExclamationMark.swift */,
+				683DF5FE2C6AF46500A5CDC6 /* POSHeaderTitleView.swift */,
 			);
 			path = "Reusable Views";
 			sourceTree = "<group>";
@@ -14572,6 +14575,7 @@
 				31FC8CE727B47591004B9456 /* CardReaderSettingsDataSource.swift in Sources */,
 				02B2829027C352DA004A332A /* RefreshableScrollView.swift in Sources */,
 				DE6D84A92C3D07850014FBFF /* WooAnalyticsEvent+GoogleAds.swift in Sources */,
+				683DF5FF2C6AF46500A5CDC6 /* POSHeaderTitleView.swift in Sources */,
 				DE7842F726F2E9340030C792 /* UIViewController+Connectivity.swift in Sources */,
 				019C5EB02C516F7B005B82D3 /* ItemListViewModelProtocol.swift in Sources */,
 				E1C47209267A1ECC00D06DA1 /* CrashLoggingStack.swift in Sources */,


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #13559

## Description
This PR addresses styling the `Products` title in different screens, by using a common component for reusability.

| Default | Error | Empty |
|--------|--------|--------|
| ![Simulator Screenshot - iPad Pro (12 9-inch) (6th generation) - 2024-08-13 at 09 38 33](https://github.com/user-attachments/assets/20dcc067-3c57-4a95-9619-aaa81b8e59d5) | ![Simulator Screenshot - iPad Pro (12 9-inch) (6th generation) - 2024-08-13 at 09 32 54](https://github.com/user-attachments/assets/4e52fed8-92a5-48d8-93f7-11bfd30a3140) | ![Simulator Screenshot - iPad Pro (12 9-inch) (6th generation) - 2024-08-13 at 09 34 16](https://github.com/user-attachments/assets/8e6e9549-8ae7-4c5c-8476-10cfedab8dfc) | 

## Changes
* Created a `POSHeaderTitleView` component
* Added a new `posHeaderTitle` font to `Woo+WooCommercePOS`

## Testing
1. Load the POS normally. Observe the `Products` title at the top of the screen
2. Load the POS with an error loading products. Observe the `Products` title at the top of the screen
```
@MainActor
func populatePointOfSaleItems() async {
  do { throw NSError( ... )
```
3. Load the POS empty. Observe the greyed-out `Products` title at the top of the screen
```
@MainActor
func populatePointOfSaleItems() async {
  do { items = []
```
