### PR TITLE
[Woo POS] Throw error when fetch request fails

### DIFF
--- a/Yosemite/Yosemite/PointOfSale/POSProductProvider.swift
+++ b/Yosemite/Yosemite/PointOfSale/POSProductProvider.swift
@@ -40,11 +40,11 @@ public final class POSProductProvider: POSItemProvider {
             return mapProductsToPOSItems(products: filteredProducts)
         } catch {
             DDLogError("Failed to retrieve products. Error: \(error)")
-            throw POSError.requestFailed
+            throw POSProductProviderError.requestFailed
         }
     }
 
-    enum POSError: Error {
+    enum POSProductProviderError: Error {
         case requestFailed
     }
 

--- a/Yosemite/Yosemite/PointOfSale/POSProductProvider.swift
+++ b/Yosemite/Yosemite/PointOfSale/POSProductProvider.swift
@@ -39,15 +39,13 @@ public final class POSProductProvider: POSItemProvider {
 
             return mapProductsToPOSItems(products: filteredProducts)
         } catch {
-            // TODO:
-            // - Handle case for empty product list, or not empty but no eligible products
-            // https://github.com/woocommerce/woocommerce-ios/issues/12815
-            // https://github.com/woocommerce/woocommerce-ios/issues/12816
-            // - Handle case for error when fetching products
-            // https://github.com/woocommerce/woocommerce-ios/issues/12846
-            DDLogError("No POS items")
-            return []
+            DDLogError("Failed to retrieve products. Error: \(error)")
+            throw POSError.requestFailed
         }
+    }
+
+    enum POSError: Error {
+        case requestFailed
     }
 
     // Maps result to POSProduct, and populate the output with:

--- a/Yosemite/YosemiteTests/PointOfSale/POSProductProviderTests.swift
+++ b/Yosemite/YosemiteTests/PointOfSale/POSProductProviderTests.swift
@@ -24,8 +24,24 @@ final class POSProductProviderTests: XCTestCase {
         super.tearDown()
     }
 
+    func test_POSItemProvider_when_fails_request_then_throws_error() async throws {
+        // Given
+        let expectedError = POSProductProvider.POSError.requestFailed
+        network.simulateError(requestUrlSuffix: "products", error: expectedError)
+
+        // When
+        do {
+            _ = try await itemProvider.providePointOfSaleItems()
+            XCTFail("Expected an error, but got success.")
+        } catch {
+            // Then
+            XCTAssertEqual(error as? POSProductProvider.POSError, expectedError)
+        }
+    }
+
     func test_POSItemProvider_provides_no_items_when_store_has_no_products() async throws {
         // Given/When
+        network.simulateResponse(requestUrlSuffix: "products", filename: "empty-data-array")
         let expectedItems = try await itemProvider.providePointOfSaleItems()
 
         // Then

--- a/Yosemite/YosemiteTests/PointOfSale/POSProductProviderTests.swift
+++ b/Yosemite/YosemiteTests/PointOfSale/POSProductProviderTests.swift
@@ -26,7 +26,7 @@ final class POSProductProviderTests: XCTestCase {
 
     func test_POSItemProvider_when_fails_request_then_throws_error() async throws {
         // Given
-        let expectedError = POSProductProvider.POSError.requestFailed
+        let expectedError = POSProductProvider.POSProductProviderError.requestFailed
         network.simulateError(requestUrlSuffix: "products", error: expectedError)
 
         // When
@@ -35,7 +35,7 @@ final class POSProductProviderTests: XCTestCase {
             XCTFail("Expected an error, but got success.")
         } catch {
             // Then
-            XCTAssertEqual(error as? POSProductProvider.POSError, expectedError)
+            XCTAssertEqual(error as? POSProductProvider.POSProductProviderError, expectedError)
         }
     }
 


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #13565 

## Description
Up until now, if the remote failed to return products within `providePointOfSaleItems()` in Yosemite, we were just retuning an empty array rather of products, rather than handling the error. This would cause that a merchant see the "Empty products" screen rather than the "Error" screen if the fetch request fails at this point. 

This PR addresses this by throwing, rather than returning an empty array, if this happens.

## Changes
* `POSProductProvider` throws `POSError.requestFailed` if the request fails
* Updated unit tests to cover empty and error cases

## Testing
Via proxyman/network tool, or by updating the `POSProductProvider.providePointOfSaleItems()` method, return an empty array and an error, and observe the correct screens appear when running the POS:

* Empty case: 
```diff
    public func providePointOfSaleItems() async throws -> [POSItem] {
        do {
            var products = try await productsRemote.loadAllSimpleProductsForPointOfSale(for: siteID)
+          products = []
```

![Simulator Screenshot - iPad Pro (12 9-inch) (6th generation) - 2024-08-13 at 09 34 16](https://github.com/user-attachments/assets/8e6e9549-8ae7-4c5c-8476-10cfedab8dfc)

* Error case:
```diff
    public func providePointOfSaleItems() async throws -> [POSItem] {
        do {
            var products = try await productsRemote.loadAllSimpleProductsForPointOfSale(for: siteID)
+          throw NSError(domain: "", code: 0)
```

![Simulator Screenshot - iPad Pro (12 9-inch) (6th generation) - 2024-08-13 at 09 32 54](https://github.com/user-attachments/assets/4e52fed8-92a5-48d8-93f7-11bfd30a3140)

