### PR TITLE
Add activity indicator on top of authenticated web view

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -4,6 +4,7 @@
 20.0
 -----
 - [*] Blaze: Now you can select media attached to the current product while creating Blaze ads. You don't have to scroll through all media in your store. [https://github.com/woocommerce/woocommerce-ios/pull/13540]
+- [*] Better experience for embedded web view with loading indicator. [https://github.com/woocommerce/woocommerce-ios/pull/13587]
 - [*] Settings: Fixed error updating site name when authenticated without WPCom. [https://github.com/woocommerce/woocommerce-ios/pull/13567]
 
 19.9

--- a/WooCommerce/Classes/Authentication/AuthenticatedWebViewController.swift
+++ b/WooCommerce/Classes/Authentication/AuthenticatedWebViewController.swift
@@ -11,6 +11,14 @@ final class AuthenticatedWebViewController: UIViewController {
 
     private let viewModel: AuthenticatedWebViewModel
 
+    private lazy var activityIndicator: UIActivityIndicatorView = {
+        let activityIndicator = UIActivityIndicatorView(style: .medium)
+        activityIndicator.color = .gray
+        activityIndicator.hidesWhenStopped = true
+        activityIndicator.translatesAutoresizingMaskIntoConstraints = false
+        return activityIndicator
+    }()
+
     /// Main web view
     private lazy var webView: WKWebView = {
         let webView = WKWebView(frame: .zero)
@@ -83,6 +91,7 @@ final class AuthenticatedWebViewController: UIViewController {
         super.viewDidLoad()
         configureNavigationBar()
         configureWebView()
+        configureActivityIndicator()
         configureProgressBar()
         startLoading()
     }
@@ -111,6 +120,14 @@ private extension AuthenticatedWebViewController {
 
         extendContentUnderSafeAreas()
         webView.configureForSandboxEnvironment()
+    }
+
+    func configureActivityIndicator() {
+        view.addSubview(activityIndicator)
+        NSLayoutConstraint.activate([
+            activityIndicator.centerXAnchor.constraint(equalTo: webView.centerXAnchor),
+            activityIndicator.centerYAnchor.constraint(equalTo: webView.centerYAnchor)
+        ])
     }
 
     func extendContentUnderSafeAreas() {
@@ -193,17 +210,24 @@ extension AuthenticatedWebViewController: WKNavigationDelegate {
 
     func webView(_ webView: WKWebView, didStartProvisionalNavigation navigation: WKNavigation!) {
         progressBar.setProgress(0, animated: false)
+        activityIndicator.startAnimating()
     }
 
     func webView(_ webView: WKWebView, didFinish navigation: WKNavigation!) {
+        activityIndicator.stopAnimating()
         guard let url = webView.url else {
             return
         }
         viewModel.didFinishNavigation(for: url)
     }
 
+    func webView(_ webView: WKWebView, didFail navigation: WKNavigation!, withError error: any Error) {
+        activityIndicator.stopAnimating()
+    }
+
     func webView(_ webView: WKWebView, didFailProvisionalNavigation navigation: WKNavigation!, withError error: Error) {
         viewModel.didFailProvisionalNavigation(with: error)
+        activityIndicator.stopAnimating()
     }
 }
 


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #13561 
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This PR adds an activity indicator on top of the authenticated web view to avoid showing a blank page when loading its content.

## Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->
- Log in to a WPCom store or a self-hosted store with site credentials.
- Navigate to the Hub Menu and select WooCommerce Admin.
- Confirm that there is a loading indicator on top of the web view when the auto-authentication is in progress.


## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

https://github.com/user-attachments/assets/7c9bed22-7692-4c99-8c17-4dbb2ca29e1d



---
- [x] I have considered adding unit tests for this change. If I decided not to add them, I have provided a brief explanation below (optional):
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
- [ ] This PR includes refactoring; smoke testing of the entire section is needed.
