### PR TITLE
Unit tests for HelpAndSupportViewModel

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Help/HelpAndSupportViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Help/HelpAndSupportViewController.swift
@@ -65,6 +65,20 @@ final class HelpAndSupportViewController: UIViewController {
     ///
     private let sourceTag: String?
 
+    private lazy var viewModel = HelpAndSupportViewModel(
+        isAuthenticated: ServiceLocator.stores.isAuthenticated,
+        isZendeskEnabled: ZendeskProvider.shared.zendeskEnabled,
+        isMacCatalyst: isMacCatalyst
+    )
+
+    private var isMacCatalyst: Bool {
+        #if targetEnvironment(macCatalyst)
+        return true
+        #else
+        return false
+        #endif
+    }
+
     init?(customHelpCenterContent: CustomHelpCenterContent, sourceTag: String? = nil, coder: NSCoder) {
         self.customHelpCenterContent = customHelpCenterContent
         self.sourceTag = sourceTag
@@ -145,38 +159,17 @@ private extension HelpAndSupportViewController {
         try? paymentGatewayAccountsResultsController?.performFetch()
     }
 
-    /// Disable Zendesk if configuration on ZD init fails.
+    /// Configure sections using ViewModel
     ///
     func configureSections() {
         let helpAndSupportTitle = NSLocalizedString("HOW CAN WE HELP?", comment: "My Store > Settings > Help & Support section title")
-        #if !targetEnvironment(macCatalyst)
-        guard ZendeskProvider.shared.zendeskEnabled == true else {
-            sections = [Section(title: helpAndSupportTitle, rows: [.helpCenter])]
-            return
-        }
-
-        sections = [
-            Section(title: helpAndSupportTitle, rows: calculateRows())
-        ]
-        #else
-        sections = [Section(title: helpAndSupportTitle, rows: [.helpCenter])]
-        #endif
-    }
-
-    private func calculateRows() -> [Row] {
-        var rows: [Row] = [.helpCenter, .contactSupport, .contactEmail, .applicationLog]
-
-        if ServiceLocator.stores.isAuthenticated {
-            rows.append(contentsOf: [.systemStatusReport])
-        }
-
-        return rows
+        sections = [Section(title: helpAndSupportTitle, rows: viewModel.getRows())]
     }
 
     /// Register table cells.
     ///
     func registerTableViewCells() {
-        for row in Row.allCases {
+        for row in HelpAndSupportRow.allCases {
             tableView.registerNib(for: row.type)
         }
     }
@@ -200,7 +193,7 @@ private extension HelpAndSupportViewController {
 
     /// Cells currently configured in the order they appear on screen
     ///
-    func configure(_ cell: UITableViewCell, for row: Row, at indexPath: IndexPath) {
+    func configure(_ cell: UITableViewCell, for row: HelpAndSupportRow, at indexPath: IndexPath) {
         switch cell {
         case let cell as ValueOneTableViewCell where row == .helpCenter:
             configureHelpCenter(cell: cell)
@@ -277,12 +270,11 @@ private extension HelpAndSupportViewController {
     }
 }
 
-
 // MARK: - Convenience Methods
 //
 private extension HelpAndSupportViewController {
 
-    func rowAtIndexPath(_ indexPath: IndexPath) -> Row {
+    func rowAtIndexPath(_ indexPath: IndexPath) -> HelpAndSupportRow {
         return sections[indexPath.section].rows[indexPath.row]
     }
 
@@ -423,7 +415,6 @@ extension HelpAndSupportViewController: UITableViewDelegate {
     }
 }
 
-
 // MARK: - Private Types
 //
 private struct Constants {
@@ -433,10 +424,12 @@ private struct Constants {
 
 private struct Section {
     let title: String?
-    let rows: [Row]
+    let rows: [HelpAndSupportRow]
 }
 
-private enum Row: CaseIterable {
+// MARK: - Row type
+//
+enum HelpAndSupportRow: CaseIterable {
     case helpCenter
     case contactSupport
     case contactEmail
@@ -445,15 +438,7 @@ private enum Row: CaseIterable {
 
     var type: UITableViewCell.Type {
         switch self {
-        case .helpCenter:
-            return ValueOneTableViewCell.self
-        case .contactSupport:
-            return ValueOneTableViewCell.self
-        case .contactEmail:
-            return ValueOneTableViewCell.self
-        case .applicationLog:
-            return ValueOneTableViewCell.self
-        case .systemStatusReport:
+        case .helpCenter, .contactSupport, .contactEmail, .applicationLog, .systemStatusReport:
             return ValueOneTableViewCell.self
         }
     }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Help/HelpAndSupportViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Help/HelpAndSupportViewModel.swift
@@ -1,7 +1,7 @@
 import Foundation
 import UIKit
 
-class HelpAndSupportViewModel {
+struct HelpAndSupportViewModel {
     private let isAuthenticated: Bool
     private let isZendeskEnabled: Bool
     private let isMacCatalyst: Bool

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Help/HelpAndSupportViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Help/HelpAndSupportViewModel.swift
@@ -1,0 +1,30 @@
+import Foundation
+import UIKit
+
+class HelpAndSupportViewModel {
+    private let isAuthenticated: Bool
+    private let isZendeskEnabled: Bool
+    private let isMacCatalyst: Bool
+
+    init(isAuthenticated: Bool, isZendeskEnabled: Bool, isMacCatalyst: Bool) {
+        self.isAuthenticated = isAuthenticated
+        self.isZendeskEnabled = isZendeskEnabled
+        self.isMacCatalyst = isMacCatalyst
+    }
+
+    func getRows() -> [HelpAndSupportRow] {
+        if isMacCatalyst {
+            return [.helpCenter]
+        }
+
+        guard isZendeskEnabled else {
+            return [.helpCenter]
+        }
+
+        var rows: [HelpAndSupportRow] = [.helpCenter, .contactSupport, .contactEmail, .applicationLog]
+        if isAuthenticated {
+            rows.append(.systemStatusReport)
+        }
+        return rows
+    }
+}

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -1672,6 +1672,8 @@
 		8697AFBD2B60F56A00EFAF21 /* BlazeAdDestinationSettingViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8697AFBC2B60F56A00EFAF21 /* BlazeAdDestinationSettingViewModelTests.swift */; };
 		8697AFBF2B622DEA00EFAF21 /* BlazeAddParameterViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8697AFBE2B622DEA00EFAF21 /* BlazeAddParameterViewModelTests.swift */; };
 		86A4EBBD2B2F1306008011F5 /* ThemesPreviewViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 86A4EBBC2B2F1306008011F5 /* ThemesPreviewViewModel.swift */; };
+		86B3E2552C6B1F160002420B /* HelpAndSupportViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 86B3E2542C6B1F160002420B /* HelpAndSupportViewModel.swift */; };
+		86B3E2572C6B249C0002420B /* HelpAndSupportViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 86B3E2562C6B249C0002420B /* HelpAndSupportViewModelTests.swift */; };
 		86DBBB0BDEA3488E2BEBB314 /* Pods_WooCommerce.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = BABE5E07DD787ECA6D2A76DE /* Pods_WooCommerce.framework */; };
 		86DE68822B4BA47A00B437A6 /* BlazeAdDestinationSettingViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 86DE68812B4BA47900B437A6 /* BlazeAdDestinationSettingViewModel.swift */; };
 		86E40AED2B597DEC00990365 /* BlazeCampaignCreationCoordinatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 86E40AEC2B597DEC00990365 /* BlazeCampaignCreationCoordinatorTests.swift */; };
@@ -4629,6 +4631,8 @@
 		8697AFBC2B60F56A00EFAF21 /* BlazeAdDestinationSettingViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BlazeAdDestinationSettingViewModelTests.swift; sourceTree = "<group>"; };
 		8697AFBE2B622DEA00EFAF21 /* BlazeAddParameterViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BlazeAddParameterViewModelTests.swift; sourceTree = "<group>"; };
 		86A4EBBC2B2F1306008011F5 /* ThemesPreviewViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ThemesPreviewViewModel.swift; sourceTree = "<group>"; };
+		86B3E2542C6B1F160002420B /* HelpAndSupportViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HelpAndSupportViewModel.swift; sourceTree = "<group>"; };
+		86B3E2562C6B249C0002420B /* HelpAndSupportViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HelpAndSupportViewModelTests.swift; sourceTree = "<group>"; };
 		86DE68812B4BA47900B437A6 /* BlazeAdDestinationSettingViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BlazeAdDestinationSettingViewModel.swift; sourceTree = "<group>"; };
 		86E40AEC2B597DEC00990365 /* BlazeCampaignCreationCoordinatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BlazeCampaignCreationCoordinatorTests.swift; sourceTree = "<group>"; };
 		86F0896E2B307D7E00D668A1 /* ThemesPreviewViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ThemesPreviewViewModelTests.swift; sourceTree = "<group>"; };
@@ -11350,6 +11354,7 @@
 				E1ED16E3266E10A10037B8DB /* ApplicationLogViewModel.swift */,
 				262EB5AC298C70BC009DCC36 /* SupportForm */,
 				DEC51AFE276AEE79009F3DF4 /* SystemStatusReport */,
+				86B3E2542C6B1F160002420B /* HelpAndSupportViewModel.swift */,
 			);
 			path = Help;
 			sourceTree = "<group>";
@@ -12804,6 +12809,7 @@
 				E10DFC77267331590083AFF2 /* ApplicationLogViewModelTests.swift */,
 				DEC51B03276B30F6009F3DF4 /* SystemStatusReportViewModelTests.swift */,
 				DEDA8DBF2B19CDC50076BF0F /* ThemeSettingViewModelTests.swift */,
+				86B3E2562C6B249C0002420B /* HelpAndSupportViewModelTests.swift */,
 			);
 			path = Settings;
 			sourceTree = "<group>";
@@ -14928,6 +14934,7 @@
 				CE2A9FBF23BFB1BE002BEC1C /* LedgerTableViewCell.swift in Sources */,
 				035DBA47292D0995003E5125 /* CardPresentPaymentPreflightController.swift in Sources */,
 				0230B4D82C3345DF00F2F660 /* PointOfSaleCardPresentPaymentCaptureFailedView.swift in Sources */,
+				86B3E2552C6B1F160002420B /* HelpAndSupportViewModel.swift in Sources */,
 				B58B4AC02108FF6100076FDD /* Array+Helpers.swift in Sources */,
 				B90C65CD29ACE2D6004CAB9E /* CardPresentPaymentOnboardingStateCache.swift in Sources */,
 				028AFFB32484ED2800693C09 /* Dictionary+Logging.swift in Sources */,
@@ -16504,6 +16511,7 @@
 				CE7CEC2D2C2EF0E50066FD53 /* GoogleAdsCampaignReportCardViewModelTests.swift in Sources */,
 				03EF250028C0E9EE006A033E /* InPersonPaymentsCashOnDeliveryToggleRowViewModelTests.swift in Sources */,
 				EE5B5BB62AB31C7D009BCBD6 /* ProductCreationAIEligibilityCheckerTests.swift in Sources */,
+				86B3E2572C6B249C0002420B /* HelpAndSupportViewModelTests.swift in Sources */,
 				DE2FE5832924DA2F0018040A /* JetpackSetupRequiredViewModelTests.swift in Sources */,
 				AEB4DB99290AE8F300AE4340 /* MockCookieJar.swift in Sources */,
 				02A275C423FE5B64005C560F /* MockPHAssetImageLoader.swift in Sources */,

--- a/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Settings/HelpAndSupportViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Settings/HelpAndSupportViewModelTests.swift
@@ -1,0 +1,49 @@
+import XCTest
+@testable import WooCommerce
+
+class HelpAndSupportViewModelTests: XCTestCase {
+    func test_mac_catalyst_environment_shows_only_help_center() {
+        let viewModel = HelpAndSupportViewModel(isAuthenticated: true, isZendeskEnabled: true, isMacCatalyst: true)
+        let rows = viewModel.getRows()
+        XCTAssertEqual(rows, [.helpCenter])
+    }
+
+    func test_zendesk_disabled_shows_only_help_center() {
+        let viewModel = HelpAndSupportViewModel(isAuthenticated: true, isZendeskEnabled: false, isMacCatalyst: false)
+        let rows = viewModel.getRows()
+        XCTAssertEqual(rows, [.helpCenter])
+    }
+
+    func test_unauthenticated_user_does_not_see_system_status_report() {
+        let viewModel = HelpAndSupportViewModel(isAuthenticated: false, isZendeskEnabled: true, isMacCatalyst: false)
+        let rows = viewModel.getRows()
+        XCTAssertEqual(rows, [.helpCenter, .contactSupport, .contactEmail, .applicationLog])
+        XCTAssertFalse(rows.contains(.systemStatusReport))
+    }
+
+    func test_authenticated_user_sees_all_options() {
+        let viewModel = HelpAndSupportViewModel(isAuthenticated: true, isZendeskEnabled: true, isMacCatalyst: false)
+        let rows = viewModel.getRows()
+        XCTAssertEqual(rows, [.helpCenter, .contactSupport, .contactEmail, .applicationLog, .systemStatusReport])
+    }
+
+    func test_row_order_is_correct() {
+        let viewModel = HelpAndSupportViewModel(isAuthenticated: true, isZendeskEnabled: true, isMacCatalyst: false)
+        let rows = viewModel.getRows()
+        XCTAssertEqual(rows.first, .helpCenter)
+        XCTAssertEqual(rows.last, .systemStatusReport)
+    }
+
+    func test_help_center_always_present() {
+        let viewModels = [
+            HelpAndSupportViewModel(isAuthenticated: true, isZendeskEnabled: true, isMacCatalyst: true),
+            HelpAndSupportViewModel(isAuthenticated: false, isZendeskEnabled: false, isMacCatalyst: false),
+            HelpAndSupportViewModel(isAuthenticated: true, isZendeskEnabled: true, isMacCatalyst: false)
+        ]
+
+        for viewModel in viewModels {
+            let rows = viewModel.getRows()
+            XCTAssertTrue(rows.contains(.helpCenter), "Help Center should always be present")
+        }
+    }
+}

--- a/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Settings/HelpAndSupportViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Settings/HelpAndSupportViewModelTests.swift
@@ -1,7 +1,7 @@
 import XCTest
 @testable import WooCommerce
 
-class HelpAndSupportViewModelTests: XCTestCase {
+final class HelpAndSupportViewModelTests: XCTestCase {
     func test_mac_catalyst_environment_shows_only_help_center() {
         let viewModel = HelpAndSupportViewModel(isAuthenticated: true, isZendeskEnabled: true, isMacCatalyst: true)
         let rows = viewModel.getRows()

--- a/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Settings/HelpAndSupportViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Settings/HelpAndSupportViewModelTests.swift
@@ -2,48 +2,59 @@ import XCTest
 @testable import WooCommerce
 
 final class HelpAndSupportViewModelTests: XCTestCase {
-    func test_mac_catalyst_environment_shows_only_help_center() {
+    func test_given_mac_catalyst_environment_when_getting_rows_then_only_help_center_is_shown() {
+        // Given
         let viewModel = HelpAndSupportViewModel(isAuthenticated: true, isZendeskEnabled: true, isMacCatalyst: true)
+
+        // When
         let rows = viewModel.getRows()
+
+        // Then
         XCTAssertEqual(rows, [.helpCenter])
     }
 
-    func test_zendesk_disabled_shows_only_help_center() {
+    func test_given_zendesk_disabled_when_getting_rows_then_only_help_center_is_shown() {
+        // Given
         let viewModel = HelpAndSupportViewModel(isAuthenticated: true, isZendeskEnabled: false, isMacCatalyst: false)
+
+        // When
         let rows = viewModel.getRows()
+
+        // Then
         XCTAssertEqual(rows, [.helpCenter])
     }
 
-    func test_unauthenticated_user_does_not_see_system_status_report() {
+    func test_given_unauthenticated_user_when_getting_rows_then_system_status_report_is_not_shown() {
+        // Given
         let viewModel = HelpAndSupportViewModel(isAuthenticated: false, isZendeskEnabled: true, isMacCatalyst: false)
+
+        // When
         let rows = viewModel.getRows()
+
+        // Then, .systemStatusReport should not be included.
         XCTAssertEqual(rows, [.helpCenter, .contactSupport, .contactEmail, .applicationLog])
-        XCTAssertFalse(rows.contains(.systemStatusReport))
     }
 
-    func test_authenticated_user_sees_all_options() {
+    func test_given_authenticated_user_when_getting_rows_then_all_options_are_shown() {
+        // Given
         let viewModel = HelpAndSupportViewModel(isAuthenticated: true, isZendeskEnabled: true, isMacCatalyst: false)
+
+        // When
         let rows = viewModel.getRows()
+
+        // Then
         XCTAssertEqual(rows, [.helpCenter, .contactSupport, .contactEmail, .applicationLog, .systemStatusReport])
     }
 
-    func test_row_order_is_correct() {
+    func test_given_all_options_when_getting_rows_then_order_is_correct() {
+        // Given
         let viewModel = HelpAndSupportViewModel(isAuthenticated: true, isZendeskEnabled: true, isMacCatalyst: false)
+
+        // When
         let rows = viewModel.getRows()
+
+        // Then
         XCTAssertEqual(rows.first, .helpCenter)
         XCTAssertEqual(rows.last, .systemStatusReport)
-    }
-
-    func test_help_center_always_present() {
-        let viewModels = [
-            HelpAndSupportViewModel(isAuthenticated: true, isZendeskEnabled: true, isMacCatalyst: true),
-            HelpAndSupportViewModel(isAuthenticated: false, isZendeskEnabled: false, isMacCatalyst: false),
-            HelpAndSupportViewModel(isAuthenticated: true, isZendeskEnabled: true, isMacCatalyst: false)
-        ]
-
-        for viewModel in viewModels {
-            let rows = viewModel.getRows()
-            XCTAssertTrue(rows.contains(.helpCenter), "Help Center should always be present")
-        }
     }
 }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

part of #13560 
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

This PR actions on the suggestion added in https://github.com/woocommerce/woocommerce-ios/pull/13568#discussion_r1713656412

To make the SSR hiding case testable, this PR refactors the row content generation for HelpAndSupport to be done inside `HelpAndSupportViewModel`.

Afterward, unit test is also introduced to test the various ways row contents are generated.

## Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->

- Ensure introduced unit tests pass
- Smoke test the Help and Support form (e.g: during login, or in Hub menu > Settings > Help and Support)