### PR TITLE
[Products] Remove Networking and Yosemite support for product template creation

### DIFF
--- a/Networking/Networking/Remote/ProductsRemote.swift
+++ b/Networking/Networking/Remote/ProductsRemote.swift
@@ -47,7 +47,6 @@ public protocol ProductsRemoteProtocol {
                         pageSize: Int,
                         productStatus: ProductStatus?,
                         completion: @escaping (Result<[Int64], Error>) -> Void)
-    func createTemplateProduct(for siteID: Int64, template: ProductsRemote.TemplateType, completion: @escaping (Result<Int64, Error>) -> Void)
     func loadNumberOfProducts(siteID: Int64) async throws -> Int64
 
     func loadStock(for siteID: Int64,
@@ -437,19 +436,6 @@ public final class ProductsRemote: Remote, ProductsRemoteProtocol {
         enqueue(request, mapper: mapper, completion: completion)
     }
 
-    /// Creates a product using the provided template.
-    /// Finishes with a completion block with the product ID.
-    /// The created product has an `auto-draft` status.
-    ///
-    public func createTemplateProduct(for siteID: Int64, template: ProductsRemote.TemplateType, completion: @escaping (Result<Int64, Error>) -> Void) {
-        let parameters = [ParameterKey.templateName: template.rawValue]
-        let path = Path.templateProducts
-        let request = JetpackRequest(wooApiVersion: .wcAdmin, method: .post, siteID: siteID, path: path, parameters: parameters, availableAsRESTRequest: true)
-        let mapper = EntityIDMapper()
-
-        enqueue(request, mapper: mapper, completion: completion)
-    }
-
     public func loadNumberOfProducts(siteID: Int64) async throws -> Int64 {
         let path = Path.productsTotal
         let request = JetpackRequest(wooApiVersion: .mark3, method: .get, siteID: siteID, path: path, availableAsRESTRequest: true)
@@ -562,16 +548,6 @@ public extension ProductsRemote {
         case descending
     }
 
-    /// Supported types for creating a template product.
-    ///
-    enum TemplateType: String {
-        case physical
-        case digital
-        case variable
-        case external
-        case grouped
-    }
-
     enum Default {
         public static let pageSize: Int   = 25
         public static let pageNumber: Int = Remote.Default.firstPageNumber
@@ -580,7 +556,6 @@ public extension ProductsRemote {
 
     private enum Path {
         static let products   = "products"
-        static let templateProducts   = "onboarding/tasks/create_product_from_template"
         static let productsTotal = "reports/products/totals"
         static let stockReports = "reports/stock"
         static let productReports = "reports/products"
@@ -605,7 +580,6 @@ public extension ProductsRemote {
         static let fields: String     = "_fields"
         static let images: String = "images"
         static let id: String         = "id"
-        static let templateName: String = "template_name"
         static let type = "type"
         static let products = "products"
         static let variations = "variations"

--- a/Networking/NetworkingTests/Remote/ProductsRemoteTests.swift
+++ b/Networking/NetworkingTests/Remote/ProductsRemoteTests.swift
@@ -688,23 +688,6 @@ final class ProductsRemoteTests: XCTestCase {
         XCTAssertFalse(queryParameters.contains(emptyParam), "Unexpected empty query param: \(emptyParam)")
     }
 
-    func test_create_template_product_returns_product_id() throws {
-        // Given
-        let remote = ProductsRemote(network: network)
-        network.simulateResponse(requestUrlSuffix: "onboarding/tasks/create_product_from_template", filename: "product-id-only")
-
-        // When
-        let result = waitFor { promise in
-            remote.createTemplateProduct(for: self.sampleSiteID, template: .physical) { result in
-                promise(result)
-            }
-        }
-
-        // Then
-        let productID = try XCTUnwrap(result.get())
-        XCTAssertEqual(productID, 3946)
-    }
-
     // MARK: - `loadNumberOfProducts`
 
     func test_loadNumberOfProducts_returns_sum_of_all_product_types() async throws {

--- a/Yosemite/Yosemite/Actions/ProductAction.swift
+++ b/Yosemite/Yosemite/Actions/ProductAction.swift
@@ -116,10 +116,6 @@ public enum ProductAction: Action {
                                  status: ProductStatus? = nil,
                                  onCompletion: (Result<Bool, Error>) -> Void)
 
-    /// Creates a product using the provided template type.
-    ///
-    case createTemplateProduct(siteID: Int64, template: ProductsRemote.TemplateType, onCompletion: (Result<Product, Error>) -> Void)
-
     /// Identifies the language from the given string
     ///
     case identifyLanguage(siteID: Int64,

--- a/Yosemite/Yosemite/Stores/ProductStore.swift
+++ b/Yosemite/Yosemite/Stores/ProductStore.swift
@@ -118,8 +118,6 @@ public class ProductStore: Store {
             replaceProductLocally(product: product, onCompletion: onCompletion)
         case let .checkIfStoreHasProducts(siteID, status, onCompletion):
             checkIfStoreHasProducts(siteID: siteID, status: status, onCompletion: onCompletion)
-        case let .createTemplateProduct(siteID, template, onCompletion):
-            createTemplateProduct(siteID: siteID, template: template, onCompletion: onCompletion)
         case let .identifyLanguage(siteID, string, feature, completion):
             identifyLanguage(siteID: siteID,
                              string: string, feature: feature,
@@ -586,21 +584,6 @@ private extension ProductStore {
             switch result {
             case .success(let ids):
                 onCompletion(.success(ids.isEmpty == false))
-            case .failure(let error):
-                onCompletion(.failure(error))
-            }
-        }
-    }
-
-    /// Creates a product using the provided template type.
-    /// The created product is not stored locally.
-    ///
-    func createTemplateProduct(siteID: Int64, template: ProductsRemote.TemplateType, onCompletion: @escaping (Result<Product, Error>) -> Void) {
-        remote.createTemplateProduct(for: siteID, template: template) { [remote] result in
-            switch result {
-            case .success(let productID):
-                remote.loadProduct(for: siteID, productID: productID, completion: onCompletion)
-
             case .failure(let error):
                 onCompletion(.failure(error))
             }

--- a/Yosemite/YosemiteTests/Mocks/Networking/Remote/MockProductsRemote.swift
+++ b/Yosemite/YosemiteTests/Mocks/Networking/Remote/MockProductsRemote.swift
@@ -269,10 +269,6 @@ extension MockProductsRemote: ProductsRemoteProtocol {
         // no-op
     }
 
-    func createTemplateProduct(for siteID: Int64, template: ProductsRemote.TemplateType, completion: @escaping (Result<Int64, Error>) -> Void) {
-        // no-op
-    }
-
     func loadNumberOfProducts(siteID: Int64) async throws -> Int64 {
         guard let result = loadNumberOfProductsResultsBySiteID[siteID] else {
             throw NetworkError.notFound()

--- a/Yosemite/YosemiteTests/Stores/ProductStoreTests.swift
+++ b/Yosemite/YosemiteTests/Stores/ProductStoreTests.swift
@@ -1871,25 +1871,6 @@ final class ProductStoreTests: XCTestCase {
         XCTAssertFalse(hasPublishedProducts)
     }
 
-    func test_create_template_product_invokes_correct_network_calls() {
-        // Given
-        let productStore = ProductStore(dispatcher: dispatcher, storageManager: storageManager, network: network)
-        network.simulateResponse(requestUrlSuffix: "onboarding/tasks/create_product_from_template", filename: "product-id-only")
-        network.simulateResponse(requestUrlSuffix: "products/3946", filename: "product")
-
-        // When
-        let result: Result<Networking.Product, Error> = waitFor { promise in
-            let action = ProductAction.createTemplateProduct(siteID: self.sampleSiteID, template: .physical) { result in
-                promise(result)
-            }
-            productStore.onAction(action)
-        }
-
-        // Then
-        XCTAssertTrue(result.isSuccess)
-        XCTAssertNotNil(try? result.get())
-    }
-
     // MARK: - ProductAction.generateProductDescription
 
     func test_generateProductDescription_returns_text_on_success() throws {


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #12338 
⚠️ Depends on https://github.com/woocommerce/woocommerce-ios/pull/13594 ⚠️ 
<!-- Id number of the GitHub issue this PR addresses. -->

## Description

In https://github.com/woocommerce/woocommerce-ios/pull/13594 we removed the UI layer support for creating products with a template. This template product creation was meant to provide sample product data, but this relied on remote data that was removed with the core changes in https://github.com/woocommerce/woocommerce/pull/38343.

This PR removes the support in the Networking and Yosemite layers for creating products from a template, since we no longer need that support in the app.

## Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->

These changes don't affect the UI layer, but you can re-test the product creation flows to confirm everything still works as expected.

On a store not eligible for AI:

1. Go to the Products tab.
2. Tap the add product button.
3. Confirm a bottom sheet appears with product type options (e.g. physical, virtual, variable).
4. Confirm that selecting an product type proceeds as expected to the product form for that type.

On a store eligible for AI (hosted on WordPress.com or with the Jetpack AI assistant):

1. Go to the Products tab.
2. Tap the add product button.
3. Confirm a bottom sheet appears with the AI and manual creation options (no change from previous behavior).
4. Confirm that selecting an option proceeds as expected to product creation.


---
- [x] I have considered adding unit tests for this change. If I decided not to add them, I have provided a brief explanation below (optional):
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
- [ ] This PR includes refactoring; smoke testing of the entire section is needed.