### PR TITLE
[Mobile Payments] Fix Contact Support link in Onboarding

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -12,6 +12,7 @@
 - [*] Help & Support: Systems Status Report option now only shown on logged-in state. [https://github.com/woocommerce/woocommerce-ios/pull/13568]
 - [Internal] Products: Removed template option for product creation. [https://github.com/woocommerce/woocommerce-ios/pull/13594]
 - [Internal] Orders: Fixed "Receipt print button unresponsive after first tap". [https://github.com/woocommerce/woocommerce-ios/pull/13598]
+- [*] Payments: Fixed contact support link from some In Person Payments onboarding screens [https://github.com/woocommerce/woocommerce-ios/pull/13601]
 
 19.9
 -----

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Payments Menu/InPersonPaymentsMenu.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/Payments Menu/InPersonPaymentsMenu.swift
@@ -175,15 +175,14 @@ struct InPersonPaymentsMenu: View {
             .navigationDestination(isPresented: $viewModel.shouldShowOnboarding) {
                 CardPresentPaymentsOnboardingView(viewModel: viewModel.onboardingViewModel)
             }
+            .navigationDestination(isPresented: $viewModel.presentSupport) {
+                SupportForm(isPresented: $viewModel.presentSupport,
+                            viewModel: .init())
+            }
 
             if let onboardingNotice = viewModel.cardPresentPaymentsOnboardingNotice {
                 PermanentNoticeView(notice: onboardingNotice)
                     .transition(.opacity.animation(.easeInOut))
-                LazyNavigationLink(destination: SupportForm(isPresented: $viewModel.presentSupport,
-                                                            viewModel: .init()),
-                                   isActive: $viewModel.presentSupport) {
-                    EmptyView()
-                }
             }
         }
         .background {


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #13599
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

The contact support link on IPP onboarding screens was broken, when presented from the payments menu on iOS 17.

`LazyNavigationLink` is not working on iOS 17 in all cases – Using `navigationDestination` instead fixes the contact support link in IPP Onboarding screens when presented from the Payments menu.

See #13600 for more context.

## Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->

1. Launch the app on a phone running iOS 17
2. Select a store which is not passing IPP onboarding
3. Navigate to `Menu > Payments`
4. Wait for the onboarding notice to appear
5. Tap `Continue`
6. Tap `Contact support` on the onboarding screen which is shown
7. Observe that the support flow is correctly shown.

## Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->


It already worked in an actual payment, and in the Try out Tap to Pay on iPhone flow.

Also test it still works on iOS 16.


## Screenshots
<!-- Include before and after images or gifs when appropriate. -->


https://github.com/user-attachments/assets/4bd9e807-f99d-4a00-9fbd-9ff54ef6afc2


---
- [x] I have considered adding unit tests for this change. If I decided not to add them, I have provided a brief explanation below (optional):
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
- [ ] This PR includes refactoring; smoke testing of the entire section is needed.