### PR TITLE
[Woo POS] Analytics: Add `PointOfSaleTracksProvider` and `PointOfSaleAnalytics`

### DIFF
--- a/WooCommerce/Classes/POS/Analytics/PointOfSaleAnalytics.swift
+++ b/WooCommerce/Classes/POS/Analytics/PointOfSaleAnalytics.swift
@@ -1,29 +1,54 @@
+import Foundation
 import protocol WooFoundation.Analytics
 import protocol WooFoundation.AnalyticsProvider
 
 final class PointOfSaleAnalytics: Analytics {
-    init(userHasOptedIn: Bool, analyticsProvider: WooFoundation.AnalyticsProvider) {
-        self.userHasOptedIn = userHasOptedIn
+    var userHasOptedIn: Bool {
+        get {
+            guard let _ : Bool? = UserDefaults.standard.object(forKey: .userOptedInAnalytics) else {
+                return false
+            }
+            return true
+        }
+        set {
+            // Q: Do we want to use the same value as the WooCommerce app for now?
+            // or should we store it separately?
+            UserDefaults.standard.set(newValue, forKey: .userOptedInAnalytics)
+        }
+    }
+    var analyticsProvider: WooFoundation.AnalyticsProvider
+
+    init(analyticsProvider: WooFoundation.AnalyticsProvider) {
         self.analyticsProvider = analyticsProvider
     }
 
     func track(_ eventName: String, properties: [AnyHashable: Any]?, error: Error?) {
-        analyticsProvider.track(eventName)
+        // TODO: Actually track properties
+        guard userHasOptedIn else {
+            return
+        }
+        analyticsProvider.track(eventName, withProperties: properties)
     }
     
     func initialize() {
-        // Not implemented
+        refreshUserData()
+        // TODO: Observe notifications and app state
     }
     
     func refreshUserData() {
-        // Not implemented
+        guard userHasOptedIn else {
+            return
+        }
+        // TODO: Handle isAuthenticatedWithoutWPCom
     }
     
     func setUserHasOptedOut(_ optedOut: Bool) {
-        // Not implemented
+        // TODO: Not implemented
+        switch userHasOptedIn {
+        case true:
+            DDLogInfo("🔵 Tracking started.")
+        case false:
+            DDLogInfo("🔴 Tracking opt-out.")
+        }
     }
-    
-    var userHasOptedIn: Bool
-
-    var analyticsProvider: WooFoundation.AnalyticsProvider
 }

--- a/WooCommerce/Classes/POS/Analytics/PointOfSaleAnalytics.swift
+++ b/WooCommerce/Classes/POS/Analytics/PointOfSaleAnalytics.swift
@@ -11,8 +11,6 @@ final class PointOfSaleAnalytics: Analytics {
             return true
         }
         set {
-            // Q: Do we want to use the same value as the WooCommerce app for now?
-            // or should we store it separately?
             UserDefaults.standard.set(newValue, forKey: .userOptedInAnalytics)
         }
     }

--- a/WooCommerce/Classes/POS/Analytics/PointOfSaleAnalytics.swift
+++ b/WooCommerce/Classes/POS/Analytics/PointOfSaleAnalytics.swift
@@ -1,0 +1,29 @@
+import protocol WooFoundation.Analytics
+import protocol WooFoundation.AnalyticsProvider
+
+final class PointOfSaleAnalytics: Analytics {
+    init(userHasOptedIn: Bool, analyticsProvider: WooFoundation.AnalyticsProvider) {
+        self.userHasOptedIn = userHasOptedIn
+        self.analyticsProvider = analyticsProvider
+    }
+
+    func track(_ eventName: String, properties: [AnyHashable: Any]?, error: Error?) {
+        analyticsProvider.track(eventName)
+    }
+    
+    func initialize() {
+        // Not implemented
+    }
+    
+    func refreshUserData() {
+        // Not implemented
+    }
+    
+    func setUserHasOptedOut(_ optedOut: Bool) {
+        // Not implemented
+    }
+    
+    var userHasOptedIn: Bool
+
+    var analyticsProvider: WooFoundation.AnalyticsProvider
+}

--- a/WooCommerce/Classes/POS/Analytics/PointOfSaleAnalytics.swift
+++ b/WooCommerce/Classes/POS/Analytics/PointOfSaleAnalytics.swift
@@ -5,7 +5,7 @@ import protocol WooFoundation.AnalyticsProvider
 final class PointOfSaleAnalytics: Analytics {
     var userHasOptedIn: Bool {
         get {
-            guard let _ : Bool? = UserDefaults.standard.object(forKey: .userOptedInAnalytics) else {
+            guard let _: Bool? = UserDefaults.standard.object(forKey: .userOptedInAnalytics) else {
                 return false
             }
             return true
@@ -29,19 +29,19 @@ final class PointOfSaleAnalytics: Analytics {
         }
         analyticsProvider.track(eventName, withProperties: properties)
     }
-    
+
     func initialize() {
         refreshUserData()
         // TODO: Observe notifications and app state
     }
-    
+
     func refreshUserData() {
         guard userHasOptedIn else {
             return
         }
         // TODO: Handle isAuthenticatedWithoutWPCom
     }
-    
+
     func setUserHasOptedOut(_ optedOut: Bool) {
         // TODO: Not implemented
         switch userHasOptedIn {

--- a/WooCommerce/Classes/POS/Analytics/PointOfSaleTracksProvider.swift
+++ b/WooCommerce/Classes/POS/Analytics/PointOfSaleTracksProvider.swift
@@ -1,0 +1,37 @@
+import Foundation
+import AutomatticTracks
+import protocol WooFoundation.AnalyticsProvider
+
+public class PointOfSaleTracksProvider: NSObject, AnalyticsProvider {
+    private static let contextManager: TracksContextManager = TracksContextManager()
+    
+    private static let tracksService: TracksService = {
+        let tracksService = TracksService(contextManager: contextManager)!
+        tracksService.eventNamePrefix = "woocommerceios_pos"
+        return tracksService
+    }()
+}
+
+public extension PointOfSaleTracksProvider {
+    func refreshUserData() {
+        // Not implemented
+    }
+
+    func track(_ eventName: String) {
+        track(eventName, withProperties: nil)
+    }
+
+    func track(_ eventName: String, withProperties properties: [AnyHashable: Any]?) {
+        // Properties not implemented
+        Self.tracksService.trackEventName(eventName)
+        DDLogInfo("🔵 Tracked \(eventName)")
+    }
+
+    func clearEvents() {
+        // Not implemented
+    }
+
+    func clearUsers() {
+        // Not implemented
+    }
+}

--- a/WooCommerce/Classes/POS/Analytics/PointOfSaleTracksProvider.swift
+++ b/WooCommerce/Classes/POS/Analytics/PointOfSaleTracksProvider.swift
@@ -4,7 +4,7 @@ import protocol WooFoundation.AnalyticsProvider
 
 public class PointOfSaleTracksProvider: NSObject, AnalyticsProvider {
     private static let contextManager: TracksContextManager = TracksContextManager()
-    
+
     private static let tracksService: TracksService = {
         guard let tracksService = TracksService(contextManager: contextManager) else {
             fatalError("Failed to create TracksService instance", file: #file, line: #line)

--- a/WooCommerce/Classes/POS/Analytics/PointOfSaleTracksProvider.swift
+++ b/WooCommerce/Classes/POS/Analytics/PointOfSaleTracksProvider.swift
@@ -6,7 +6,9 @@ public class PointOfSaleTracksProvider: NSObject, AnalyticsProvider {
     private static let contextManager: TracksContextManager = TracksContextManager()
     
     private static let tracksService: TracksService = {
-        let tracksService = TracksService(contextManager: contextManager)!
+        guard let tracksService = TracksService(contextManager: contextManager) else {
+            fatalError("Failed to create TracksService instance", file: #file, line: #line)
+        }
         tracksService.eventNamePrefix = "woocommerceios_pos"
         return tracksService
     }()
@@ -14,7 +16,9 @@ public class PointOfSaleTracksProvider: NSObject, AnalyticsProvider {
 
 public extension PointOfSaleTracksProvider {
     func refreshUserData() {
-        // Not implemented
+        // Not implemented.
+        // We need to track merchant switches between opted in and opted out as anonymous users
+        // also other metadata based on specific stores might be necessary
     }
 
     func track(_ eventName: String) {
@@ -22,16 +26,16 @@ public extension PointOfSaleTracksProvider {
     }
 
     func track(_ eventName: String, withProperties properties: [AnyHashable: Any]?) {
-        // Properties not implemented
+        // TODO: Properties not implemented
         Self.tracksService.trackEventName(eventName)
         DDLogInfo("🔵 Tracked \(eventName)")
     }
 
     func clearEvents() {
-        // Not implemented
+        Self.tracksService.clearQueuedEvents()
     }
 
     func clearUsers() {
-        // Not implemented
+        // TODO: Not implemented
     }
 }

--- a/WooCommerce/Classes/POS/Presentation/PointOfSaleEntryPointView.swift
+++ b/WooCommerce/Classes/POS/Presentation/PointOfSaleEntryPointView.swift
@@ -18,11 +18,13 @@ struct PointOfSaleEntryPointView: View {
          currencyFormatter: CurrencyFormatter) {
         self.hideAppTabBar = hideAppTabBar
 
+        let analytics = PointOfSaleAnalytics(analyticsProvider: PointOfSaleTracksProvider())
         let totalsViewModel = TotalsViewModel(orderService: orderService,
                                               cardPresentPaymentService: cardPresentPaymentService,
                                               currencyFormatter: currencyFormatter,
                                               paymentState: .acceptingCard)
-        let cartViewModel = CartViewModel()
+
+        let cartViewModel = CartViewModel(analytics: analytics)
         let itemListViewModel = ItemListViewModel(itemProvider: itemProvider)
 
         self._viewModel = StateObject(wrappedValue: PointOfSaleDashboardViewModel(

--- a/WooCommerce/Classes/POS/ViewModels/CartViewModel.swift
+++ b/WooCommerce/Classes/POS/ViewModels/CartViewModel.swift
@@ -22,7 +22,11 @@ final class CartViewModel: CartViewModelProtocol {
         return itemsInCart.isEmpty
     }
 
-    init() {
+    private var analytics: PointOfSaleAnalytics?
+
+    init(analytics: PointOfSaleAnalytics? = nil) {
+        self.analytics = analytics
+
         cartSubmissionPublisher = cartSubmissionSubject.eraseToAnyPublisher()
         addMoreToCartActionPublisher = addMoreToCartActionSubject.eraseToAnyPublisher()
     }
@@ -30,11 +34,14 @@ final class CartViewModel: CartViewModelProtocol {
     func addItemToCart(_ item: POSItem) {
         let cartItem = CartItem(id: UUID(), item: item, quantity: 1)
         itemsInCart.append(cartItem)
-        
-        let posAnalyticsProvider = PointOfSaleTracksProvider()
-        let posAnalytics = PointOfSaleAnalytics(analyticsProvider: posAnalyticsProvider)
-        
-        posAnalytics.track("test_item_added_to_cart", properties: [:], error: nil)
+
+        guard let analytics = analytics else {
+            return
+        }
+        // TODO:
+        // - Update analytics property to not be Optional
+        // - Move events to a pos-wide enum
+        analytics.track("test_item_added_to_cart", properties: [:], error: nil)
     }
 
     func removeItemFromCart(_ cartItem: CartItem) {

--- a/WooCommerce/Classes/POS/ViewModels/CartViewModel.swift
+++ b/WooCommerce/Classes/POS/ViewModels/CartViewModel.swift
@@ -30,6 +30,12 @@ final class CartViewModel: CartViewModelProtocol {
     func addItemToCart(_ item: POSItem) {
         let cartItem = CartItem(id: UUID(), item: item, quantity: 1)
         itemsInCart.append(cartItem)
+        
+        let posAnalyticsProvider = PointOfSaleTracksProvider()
+        let posAnalytics = PointOfSaleAnalytics(userHasOptedIn: true,
+                                                analyticsProvider: posAnalyticsProvider)
+        
+        posAnalytics.track("test_item_added_to_cart", properties: [:], error: nil)
     }
 
     func removeItemFromCart(_ cartItem: CartItem) {

--- a/WooCommerce/Classes/POS/ViewModels/CartViewModel.swift
+++ b/WooCommerce/Classes/POS/ViewModels/CartViewModel.swift
@@ -32,8 +32,7 @@ final class CartViewModel: CartViewModelProtocol {
         itemsInCart.append(cartItem)
         
         let posAnalyticsProvider = PointOfSaleTracksProvider()
-        let posAnalytics = PointOfSaleAnalytics(userHasOptedIn: true,
-                                                analyticsProvider: posAnalyticsProvider)
+        let posAnalytics = PointOfSaleAnalytics(analyticsProvider: posAnalyticsProvider)
         
         posAnalytics.track("test_item_added_to_cart", properties: [:], error: nil)
     }

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -1493,6 +1493,8 @@
 		68600A8F2C65BC5500252EDD /* PointOfSaleItemListErrorView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 68600A8E2C65BC5500252EDD /* PointOfSaleItemListErrorView.swift */; };
 		68600A912C65BC9C00252EDD /* PointOfSaleItemListEmptyView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 68600A902C65BC9C00252EDD /* PointOfSaleItemListEmptyView.swift */; };
 		68674D312B6C895D00E93FBD /* ReceiptEligibilityUseCaseTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 68674D302B6C895D00E93FBD /* ReceiptEligibilityUseCaseTests.swift */; };
+		687010762C6C8BE000C8AEA8 /* PointOfSaleTracksProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 687010752C6C8BE000C8AEA8 /* PointOfSaleTracksProvider.swift */; };
+		687010782C6C8C3F00C8AEA8 /* PointOfSaleAnalytics.swift in Sources */ = {isa = PBXBuildFile; fileRef = 687010772C6C8C3F00C8AEA8 /* PointOfSaleAnalytics.swift */; };
 		68709D3D2A2ED94900A7FA6C /* UpgradesView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 68709D3C2A2ED94900A7FA6C /* UpgradesView.swift */; };
 		68709D402A2EE2DC00A7FA6C /* UpgradesViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 68709D3F2A2EE2DC00A7FA6C /* UpgradesViewModel.swift */; };
 		6879B8DB287AFFA100A0F9A8 /* CardReaderManualsViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6879B8DA287AFFA100A0F9A8 /* CardReaderManualsViewModelTests.swift */; };
@@ -4448,6 +4450,8 @@
 		68600A8E2C65BC5500252EDD /* PointOfSaleItemListErrorView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PointOfSaleItemListErrorView.swift; sourceTree = "<group>"; };
 		68600A902C65BC9C00252EDD /* PointOfSaleItemListEmptyView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PointOfSaleItemListEmptyView.swift; sourceTree = "<group>"; };
 		68674D302B6C895D00E93FBD /* ReceiptEligibilityUseCaseTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReceiptEligibilityUseCaseTests.swift; sourceTree = "<group>"; };
+		687010752C6C8BE000C8AEA8 /* PointOfSaleTracksProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PointOfSaleTracksProvider.swift; sourceTree = "<group>"; };
+		687010772C6C8C3F00C8AEA8 /* PointOfSaleAnalytics.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PointOfSaleAnalytics.swift; sourceTree = "<group>"; };
 		68709D3C2A2ED94900A7FA6C /* UpgradesView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UpgradesView.swift; sourceTree = "<group>"; };
 		68709D3F2A2EE2DC00A7FA6C /* UpgradesViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UpgradesViewModel.swift; sourceTree = "<group>"; };
 		6879B8DA287AFFA100A0F9A8 /* CardReaderManualsViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardReaderManualsViewModelTests.swift; sourceTree = "<group>"; };
@@ -6969,6 +6973,7 @@
 		029327662BF59D2D00D703E7 /* POS */ = {
 			isa = PBXGroup;
 			children = (
+				687010742C6C8BC400C8AEA8 /* Analytics */,
 				2004E2C02C076CCA00D62521 /* Card Present Payments */,
 				68F151DF2C0DA7800082AEC8 /* Models */,
 				026826912BF59D7A0036F959 /* ViewModels */,
@@ -9187,6 +9192,15 @@
 				571FDDAD24C768DC00D486A5 /* MockZendeskManager.swift */,
 			);
 			path = Testing;
+			sourceTree = "<group>";
+		};
+		687010742C6C8BC400C8AEA8 /* Analytics */ = {
+			isa = PBXGroup;
+			children = (
+				687010752C6C8BE000C8AEA8 /* PointOfSaleTracksProvider.swift */,
+				687010772C6C8C3F00C8AEA8 /* PointOfSaleAnalytics.swift */,
+			);
+			path = Analytics;
 			sourceTree = "<group>";
 		};
 		68709D3E2A2EE2C000A7FA6C /* InAppPurchases */ = {
@@ -14873,6 +14887,7 @@
 				AE6DBE3B2732CAAD00957E7A /* AdaptiveStack.swift in Sources */,
 				03A6C18628B8CC7F00AADF23 /* InPersonPaymentsOnboardingErrorButtonViewModel.swift in Sources */,
 				024DF3052372ADCD006658FE /* KeyboardScrollable.swift in Sources */,
+				687010762C6C8BE000C8AEA8 /* PointOfSaleTracksProvider.swift in Sources */,
 				BAE4F8432734325C00871344 /* SettingsViewModel.swift in Sources */,
 				26CE6F342B7D4C27008DB858 /* Error+Timeout.swift in Sources */,
 				B946880C29B626A1000646B0 /* SpotlightManager.swift in Sources */,
@@ -15514,6 +15529,7 @@
 				4520A15E2722BA3E001FA573 /* OrderDateRangeFilter+Utils.swift in Sources */,
 				DEF8CF0F29A890E900800A60 /* JetpackBenefitsViewModel.swift in Sources */,
 				B946880E29B627EB000646B0 /* SearchableActivityConvertable.swift in Sources */,
+				687010782C6C8C3F00C8AEA8 /* PointOfSaleAnalytics.swift in Sources */,
 				EE09DE0B2C2D6E5100A32680 /* SelectPackageImageCoordinator.swift in Sources */,
 				DE621F6A29D67E1B000DE3BD /* WooAnalyticsEvent+JetpackSetup.swift in Sources */,
 				DE78DE422B2813E4002E58DE /* ThemesCarouselViewModel.swift in Sources */,

--- a/WooCommerce/WooCommerceTests/POS/ViewModels/CartViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/POS/ViewModels/CartViewModelTests.swift
@@ -8,10 +8,14 @@ import SwiftUI
 final class CartViewModelTests: XCTestCase {
 
     private var sut: CartViewModel!
+    private var analytics: PointOfSaleAnalytics!
+    private var analyticsProvider: MockAnalyticsProvider!
 
     override func setUp() {
         super.setUp()
-        sut = CartViewModel()
+        analyticsProvider = MockAnalyticsProvider()
+        analytics = PointOfSaleAnalytics(analyticsProvider: analyticsProvider)
+        sut = CartViewModel(analytics: analytics)
     }
 
     override func tearDown() {
@@ -148,6 +152,18 @@ final class CartViewModelTests: XCTestCase {
 
         // Then
         XCTAssertFalse(sut.isCartEmpty)
+    }
+
+    func test_receivedEvents_when_addItemToCart_then_tracks_item_added_to_cart_event() {
+        // Given
+        let expectedEvent = "test_item_added_to_cart"
+        let item = Self.makeItem()
+
+        // When
+        sut.addItemToCart(item)
+
+        // Then
+        XCTAssertEqual(analyticsProvider.receivedEvents.first, expectedEvent)
     }
 }
 


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Partially addresses https://github.com/woocommerce/woocommerce-ios/issues/13277
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
This PR starts the analytics implementation for POS by creating the initial `PointOfSaleTracksProvider` and `PointOfSaleAnalytics`, as well as adding a dummy event `woocommerceios_pos_test_item_added_to_cart` by DI'ing the service into the `CartViewModel`.

I've added a couple of comments and several `TODO` items that can be tackled in this same PR, or separately. It seems that this is the minimum change we need to start tracking events. Happy to iterate on the approach as well, if something doesn't seem quite right.

## Testing
* Run the POS and tap any item to add it to the cart
* Observe how the `woocommerceios_pos_test_item_added_to_cart` event shows up in the console, and is shown in the track events tool*

(*) It does not show in mc immediately, it may take a while to do so (same for the app), and I found some inconsistencies on how does it show. For example on my initial attempt I used `woocommerceios_pos_pos_test_item_added_to_cart` (not the _pos_ duplication) and this can be found in events, as well as the graph with the data points:

<img width="1701" alt="Screenshot 2024-08-14 at 16 32 34" src="https://github.com/user-attachments/assets/0ffbf891-e1db-410d-9ef0-8f0be744e10b">

However for `woocommerceios_pos_test_item_added_to_cart` does not show the graph, but events can still be seen under the Live tab:

<img width="821" alt="Screenshot 2024-08-14 at 16 29 42" src="https://github.com/user-attachments/assets/f92e6ef1-ccf1-44b4-ace8-772bb47a5cd2">
