### PR TITLE
Blaze: Add a new status suspended for campaigns

### DIFF
--- a/Networking/Networking/Model/Blaze/BlazeCampaignListItem.swift
+++ b/Networking/Networking/Model/Blaze/BlazeCampaignListItem.swift
@@ -141,6 +141,7 @@ public extension BlazeCampaignListItem {
         case rejected
         case canceled
         case finished
+        case suspended
         case unknown
     }
 

--- a/WooCommerce/Classes/Extensions/BlazeCampaignListItem+Customizations.swift
+++ b/WooCommerce/Classes/Extensions/BlazeCampaignListItem+Customizations.swift
@@ -30,8 +30,10 @@ extension BlazeCampaignListItem.Status {
             return .withColorStudio(name: .green, shade: .shade60)
         case .scheduled, .finished:
             return .withColorStudio(name: .blue, shade: .shade80)
-        case .canceled, .rejected, .suspended:
+        case .canceled, .rejected:
             return .withColorStudio(name: .red, shade: .shade60)
+        case .suspended:
+            return .white
         case .pending:
             return .withColorStudio(name: .yellow, shade: .shade70)
         case .unknown:
@@ -45,8 +47,10 @@ extension BlazeCampaignListItem.Status {
             return .withColorStudio(name: .green, shade: .shade5)
         case .scheduled, .finished:
             return .withColorStudio(name: .blue, shade: .shade5)
-        case .canceled, .rejected, .suspended:
+        case .canceled, .rejected:
             return .withColorStudio(name: .red, shade: .shade5)
+        case .suspended:
+            return .withColorStudio(name: .red, shade: .shade60)
         case .pending:
             return .withColorStudio(name: .yellow, shade: .shade5)
         case .unknown:

--- a/WooCommerce/Classes/Extensions/BlazeCampaignListItem+Customizations.swift
+++ b/WooCommerce/Classes/Extensions/BlazeCampaignListItem+Customizations.swift
@@ -17,6 +17,8 @@ extension BlazeCampaignListItem.Status {
             return Localization.canceled
         case .finished:
             return Localization.completed
+        case .suspended:
+            return Localization.suspended
         case .unknown:
             return Localization.unknown
         }
@@ -28,7 +30,7 @@ extension BlazeCampaignListItem.Status {
             return .withColorStudio(name: .green, shade: .shade60)
         case .scheduled, .finished:
             return .withColorStudio(name: .blue, shade: .shade80)
-        case .canceled, .rejected:
+        case .canceled, .rejected, .suspended:
             return .withColorStudio(name: .red, shade: .shade60)
         case .pending:
             return .withColorStudio(name: .yellow, shade: .shade70)
@@ -43,7 +45,7 @@ extension BlazeCampaignListItem.Status {
             return .withColorStudio(name: .green, shade: .shade5)
         case .scheduled, .finished:
             return .withColorStudio(name: .blue, shade: .shade5)
-        case .canceled, .rejected:
+        case .canceled, .rejected, .suspended:
             return .withColorStudio(name: .red, shade: .shade5)
         case .pending:
             return .withColorStudio(name: .yellow, shade: .shade5)
@@ -76,6 +78,10 @@ extension BlazeCampaignListItem.Status {
         static let completed = NSLocalizedString("blazeCampaignListItem.status.completed",
                                                  value: "Completed",
                                                  comment: "Status name of a completed Blaze campaign"
+        )
+        static let suspended = NSLocalizedString("blazeCampaignListItem.status.suspended",
+                                                 value: "Suspended",
+                                                 comment: "Status name of a suspended Blaze campaign"
         )
         static let unknown = NSLocalizedString("blazeCampaignListItem.status.unknown",
                                                value: "Unknown",

--- a/WooCommerce/Classes/ViewRelated/Blaze/BlazeCampaignList/BlazeCampaignItemView.swift
+++ b/WooCommerce/Classes/ViewRelated/Blaze/BlazeCampaignList/BlazeCampaignItemView.swift
@@ -142,7 +142,7 @@ struct BlazeCampaignItemView_Previews: PreviewProvider {
                                                        productID: 33,
                                                        name: "Fluffy bunny pouch",
                                                        textSnippet: "Buy now!",
-                                                       uiStatus: BlazeCampaignListItem.Status.finished.rawValue,
+                                                       uiStatus: BlazeCampaignListItem.Status.suspended.rawValue,
                                                        imageURL: nil,
                                                        targetUrl: nil,
                                                        impressions: 112,


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #13607 
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This PR adds a new status suspended in preparation for the addition on the backend side [p1723590526363879-slack-C03L1NF1EA3]. For the status badge, I'm following Android to make the color stand out.

## Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->
The new status hasn't been added on the backend yet, so this cannot be tested with a real campaign. However, you can check the SwiftUI preview of `BlazeCampaignItemView` with a campaign of status suspended to see what it looks like on the UI.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->
<img width="409" alt="Screenshot 2024-08-15 at 09 15 13" src="https://github.com/user-attachments/assets/c49b7acc-5a0a-4ed8-b787-04698ea7b286">



---
- [x] I have considered adding unit tests for this change. If I decided not to add them, I have provided a brief explanation below (optional):
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
- [ ] This PR includes refactoring; smoke testing of the entire section is needed.
