### PR TITLE
[Mobile Payments] Fix IPP Onboarding for early-stage WooPayments accounts

### DIFF
--- a/Networking/Networking/Model/WCPayAccountStatusEnum.swift
+++ b/Networking/Networking/Model/WCPayAccountStatusEnum.swift
@@ -12,6 +12,8 @@ public enum WCPayAccountStatusEnum: Decodable, Hashable, GeneratedFakeable {
     /// though additional information might be required if another payment volume threshold is reached.
     case enabled
 
+    case pendingVerification
+
     /// This state occurs when there is required business information missing from the account.
     /// If `hasOverdueRequirements` is also true, then the deadline for providing that information HAS PASSED and
     /// the merchant will probably NOT be able to collect card present payments.
@@ -65,6 +67,8 @@ extension WCPayAccountStatusEnum: RawRepresentable {
             self = .complete
         case Keys.enabled:
             self = .enabled
+        case Keys.pendingVerification:
+            self = .pendingVerification
         case Keys.restricted:
             self = .restricted
         case Keys.restrictedSoon:
@@ -90,6 +94,7 @@ extension WCPayAccountStatusEnum: RawRepresentable {
         switch self {
         case .complete:               return Keys.complete
         case .enabled:                return Keys.enabled
+        case .pendingVerification:    return Keys.pendingVerification
         case .restricted:             return Keys.restricted
         case .restrictedSoon:         return Keys.restrictedSoon
         case .rejectedFraud:          return Keys.rejectedFraud
@@ -110,6 +115,7 @@ private enum Keys {
     /// The WCPay account has provided enough information to process payments and receive payouts temporarily
     /// but more information will be eventually required to continue processing payments
     static let enabled                = "enabled"
+    static let pendingVerification    = "pending_verification"
     /// The WCPay account is restricted - it is under review or has pending or overdue requirements.
     static let restricted             = "restricted"
     /// The WCPay account has required information missing but it's not restricted yet.

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -14,6 +14,7 @@
 - [Internal] Products: Removed template option for product creation. [https://github.com/woocommerce/woocommerce-ios/pull/13594]
 - [Internal] Orders: Fixed "Receipt print button unresponsive after first tap". [https://github.com/woocommerce/woocommerce-ios/pull/13598]
 - [*] Payments: Fixed contact support link from some In Person Payments onboarding screens [https://github.com/woocommerce/woocommerce-ios/pull/13601]
+- [*] Payments: Fixed issue where new WooPayments accounts couldn't be used for In Person Payments while they were pending verification [https://github.com/woocommerce/woocommerce-ios/pull/13610]
 
 19.9
 -----

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/CardPresentPaymentsOnboardingUseCase.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/CardPresentPaymentsOnboardingUseCase.swift
@@ -543,7 +543,8 @@ private extension CardPresentPaymentsOnboardingUseCase {
     func accountStatusAllowedForCardPresentPayments(account: PaymentGatewayAccount) -> Bool {
         account.wcpayStatus == .complete ||
         account.wcpayStatus == .enabled ||
-        account.wcpayStatus == .restrictedSoon
+        account.wcpayStatus == .restrictedSoon ||
+        account.wcpayStatus == .pendingVerification
     }
 
     func isNetworkError(_ error: Error) -> Bool {

--- a/WooCommerce/WooCommerceTests/ViewRelated/CardPresentPayments/CardPresentPaymentsOnboardingUseCaseTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/CardPresentPayments/CardPresentPaymentsOnboardingUseCaseTests.swift
@@ -907,6 +907,24 @@ class CardPresentPaymentsOnboardingUseCaseTests: XCTestCase {
         XCTAssertEqual(state, .completed(plugin: CardPresentPaymentsPluginState(preferred: .wcPay, available: [.wcPay])))
     }
 
+    func test_onboarding_returns_complete_when_account_status_is_pending_verification_using_wcpay_plugin() {
+        // Given
+        let accountStatus: WCPayAccountStatusEnum = .pendingVerification
+
+        setupCountry(country: .us)
+        setupWCPayPlugin(status: .active, version: WCPayPluginVersion.minimumSupportedVersion)
+        setupPaymentGatewayAccount(accountType: WCPayAccount.self, status: accountStatus)
+
+        // When
+        let useCase = CardPresentPaymentsOnboardingUseCase(storageManager: storageManager,
+                                                           stores: stores,
+                                                           cardPresentPaymentOnboardingStateCache: onboardingStateCache)
+        let state = useCase.state
+
+        // Then
+        XCTAssertEqual(state, .completed(plugin: CardPresentPaymentsPluginState(preferred: .wcPay, available: [.wcPay])))
+    }
+
     func test_onboarding_returns_complete_when_account_status_is_enabled_using_stripe_plugin() {
         // Given
         let accountStatus: WCPayAccountStatusEnum = .enabled


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #13581 
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

### Pending Verification
Pending Verification is a status added for a new WooPayments Stripe Connect account – it could be in place for up to 3 days.

This status only affects deposits, so payments should be allowed if this is recieved.

Previosuly, we decoded it as `unknown`, which meant a generic onboarding error was shown and it wasn't possible to take a payment until the verification was completed. Payments on the web continued to work.

This PR decodes the new status and treats it as `enabled`, allowing payments to be taken.

## Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->

1. Create a new Jurassic Ninja site – include WooCommerce, WooPayments, and WooPayments Dev Tools
2. Link the site with your Jetpack user
3. Add a US address in WooCommerce settings
4. Activate WooPayments
5. Go through the onboarding steps in WP-Admin > Payments > Activate
6. Launch the app and switch to your new site
7. Go to `Menu > Payments`
8. Tap the `Continue` button in the onboarding notice that shows
9. Skip the `Enable Pay in Person` alert that shows
10. Observe that you're not shown a generic `Unable to verify` onboarding error
11. Take a payment – observe that you can connect to the card reader and take payment as normal.


## Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->

Note that if you see the `Your account has pending requirements` skippable onboarding error, the automatic verification has already happened and you're not really testing this part of the flow. You'll have to either edit the response from the `wc/v3/payments/accounts` endpoint, or make a new Jurassic Ninja site to test it properly.

Seeing the skippable `Enable Pay in Person` prompt is always expected.


---
- [x] I have considered adding unit tests for this change. If I decided not to add them, I have provided a brief explanation below (optional):
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
- [ ] This PR includes refactoring; smoke testing of the entire section is needed.