### PR TITLE
[Tooling] Reduce max Pull Request size, excluding tests

### DIFF
--- a/Dangerfile
+++ b/Dangerfile
@@ -35,7 +35,10 @@ tracks_checker.check_tracks_changes(
 
 view_changes_checker.check
 
-pr_size_checker.check_diff_size(max_size: 500)
+pr_size_checker.check_diff_size(
+  max_size: 300,
+  file_selector: ->(path) { !path.include?('Tests/') }
+)
 
 # skip remaining checks if the PR is still a Draft
 if github.pr_draft?


### PR DESCRIPTION
## Description
This PR aligns the PR size Danger check to the one on [WooCommerce Android](https://github.com/woocommerce/woocommerce-android/blob/72a70d47d762ff7d8987eecc380fbeef70956bf7/Dangerfile#L37): PRs having a max limit size of 300, but ignoring anything related to tests.

## Testing information
A possible way to test this is create a branch off this branch, create a PR with changes and make sure it correctly ignores changes made to test-related files and that the new maximum is 300 lines.

---
- [x] I have considered adding unit tests for this change. If I decided not to add them, I have provided a brief explanation below (optional):
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
