### PR TITLE
[Woo POS] Darker background for half-screen error views

### DIFF
--- a/WooCommerce/Classes/POS/Presentation/TotalsView.swift
+++ b/WooCommerce/Classes/POS/Presentation/TotalsView.swift
@@ -235,6 +235,24 @@ private extension TotalsView {
 }
 
 private extension TotalsView {
+    struct CardReaderViewLayout {
+        let backgroundColor: Color
+        let topPadding: CGFloat?
+        let bottomPadding: CGFloat?
+
+        static let primary = CardReaderViewLayout(
+            backgroundColor: .clear,
+            topPadding: nil,
+            bottomPadding: 8
+        )
+
+        static let dark = CardReaderViewLayout(
+            backgroundColor: Color(.quaternarySystemFill),
+            topPadding: 40,
+            bottomPadding: 40
+        )
+    }
+
     /// Creates a Spacer with backgroundColor and optional fixed height
     private func filledSpacer(backgroundColor: Color = .clear, height: CGFloat? = nil) -> some View {
         return ZStack {
@@ -321,26 +339,6 @@ private extension TotalsView {
             "pos.totalsView.calculateAmounts",
             value: "Calculate amounts",
             comment: "Button title for calculate amounts button")
-    }
-}
-
-private extension TotalsView {
-    struct CardReaderViewLayout {
-        let backgroundColor: Color
-        let topPadding: CGFloat?
-        let bottomPadding: CGFloat?
-
-        static let primary = CardReaderViewLayout(
-            backgroundColor: .clear,
-            topPadding: nil,
-            bottomPadding: 8
-        )
-
-        static let dark = CardReaderViewLayout(
-            backgroundColor: Color(.quaternarySystemFill),
-            topPadding: 40,
-            bottomPadding: 40
-        )
     }
 }
 

--- a/WooCommerce/Classes/POS/Presentation/TotalsView.swift
+++ b/WooCommerce/Classes/POS/Presentation/TotalsView.swift
@@ -24,13 +24,22 @@ struct TotalsView: View {
             switch totalsViewModel.orderState {
             case .idle, .syncing, .loaded:
                 VStack(alignment: .center) {
-                    Spacer()
+                    ZStack {
+                        Spacer()
+                    }
+                    .background(cardReaderViewLayout.backgroundColor)
+                    .if(cardReaderViewLayout.topPadding != nil) {
+                        $0.frame(height: cardReaderViewLayout.topPadding)
+                    }
+
                     VStack(alignment: .center, spacing: Constants.verticalSpacing) {
                         if totalsViewModel.isShowingCardReaderStatus {
                             cardReaderView
                                 .font(.title)
-                                .padding()
+                                .padding([.top, .leading, .trailing])
+                                .padding(.bottom, cardReaderViewLayout.bottomPadding)
                                 .transition(.opacity)
+                                .background(cardReaderViewLayout.backgroundColor)
                         }
 
                         if isShowingTotalsFields {
@@ -65,6 +74,22 @@ struct TotalsView: View {
         default:
             .clear
         }
+    }
+
+    private var cardReaderViewLayout: CardReaderViewLayout {
+        guard totalsViewModel.isShowingCardReaderStatus else {
+            return .primary
+        }
+
+        if totalsViewModel.paymentState == .validatingOrderError {
+            return .dark
+        }
+
+        if totalsViewModel.connectionStatus == .disconnected {
+            return .dark
+        }
+
+        return .primary
     }
 }
 
@@ -288,6 +313,26 @@ private extension TotalsView {
             "pos.totalsView.calculateAmounts",
             value: "Calculate amounts",
             comment: "Button title for calculate amounts button")
+    }
+}
+
+private extension TotalsView {
+    struct CardReaderViewLayout {
+        let backgroundColor: Color
+        let topPadding: CGFloat?
+        let bottomPadding: CGFloat?
+
+        static let primary = CardReaderViewLayout(
+            backgroundColor: .clear,
+            topPadding: nil,
+            bottomPadding: 8
+        )
+
+        static let dark = CardReaderViewLayout(
+            backgroundColor: Color(.quaternarySystemFill),
+            topPadding: 40,
+            bottomPadding: 40
+        )
     }
 }
 

--- a/WooCommerce/Classes/POS/Presentation/TotalsView.swift
+++ b/WooCommerce/Classes/POS/Presentation/TotalsView.swift
@@ -24,13 +24,8 @@ struct TotalsView: View {
             switch totalsViewModel.orderState {
             case .idle, .syncing, .loaded:
                 VStack(alignment: .center) {
-                    ZStack {
-                        Spacer()
-                    }
-                    .background(cardReaderViewLayout.backgroundColor)
-                    .if(cardReaderViewLayout.topPadding != nil) {
-                        $0.frame(height: cardReaderViewLayout.topPadding)
-                    }
+                    filledSpacer(backgroundColor: cardReaderViewLayout.backgroundColor,
+                                 height: cardReaderViewLayout.topPadding)
 
                     VStack(alignment: .center, spacing: Constants.verticalSpacing) {
                         if totalsViewModel.isShowingCardReaderStatus {
@@ -74,22 +69,6 @@ struct TotalsView: View {
         default:
             .clear
         }
-    }
-
-    private var cardReaderViewLayout: CardReaderViewLayout {
-        guard totalsViewModel.isShowingCardReaderStatus else {
-            return .primary
-        }
-
-        if totalsViewModel.paymentState == .validatingOrderError {
-            return .dark
-        }
-
-        if totalsViewModel.connectionStatus == .disconnected {
-            return .dark
-        }
-
-        return .primary
     }
 }
 
@@ -252,6 +231,35 @@ private extension TotalsView {
         case .disconnected:
             PointOfSaleCardPresentPaymentReaderDisconnectedMessageView(viewModel: .init(connectReaderAction: totalsViewModel.connectReaderTapped))
         }
+    }
+}
+
+private extension TotalsView {
+    /// Creates a Spacer with backgroundColor and optional fixed height
+    private func filledSpacer(backgroundColor: Color = .clear, height: CGFloat? = nil) -> some View {
+        return ZStack {
+            Spacer()
+        }
+        .background(backgroundColor)
+        .if(height != nil) {
+            $0.frame(height: height)
+        }
+    }
+
+    private var cardReaderViewLayout: CardReaderViewLayout {
+        guard totalsViewModel.isShowingCardReaderStatus else {
+            return .primary
+        }
+
+        if totalsViewModel.paymentState == .validatingOrderError {
+            return .dark
+        }
+
+        if totalsViewModel.connectionStatus == .disconnected {
+            return .dark
+        }
+
+        return .primary
     }
 }
 


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

## Desired State

<img width="820" alt="image" src="https://github.com/user-attachments/assets/82b2d029-4136-4b77-b056-d205cb583f9d">

Closes: #13549
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

For validatingOrderError and disconnected card reader states, we need to show cardReaderView in a bit different layout:

1. cardReaderView should have a background that also goes up to the edge of the view
2. cardReaderView should have a static top padding and not center cardReaderView and totalsView together

It proved to be a much tougher task than I anticipated. For the background color of certain reader views to go above the view, we need to update `TotalsView` layout. However, I didn't want to scatter this logic between message views and `TotalsView`. Eventually, I decided to isolate all the logic within TotalsView and be as descriptive as possible:

1. Define `CardReaderViewLayout` with backgroundColor and paddings
2. Configure` CardReaderViewLayout` depending on `TotalsViewModel` states
4. Wrap Spacer in ZStack to set a backgroundColor
5. Conditionally set static height for Spacer

I'm not 100% happy with this approach but I couldn't figure out anything else without affecting too much `TotalsView` implementation. Right now the changes are pretty minimal. 🤔 

## Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->

1. Open POS
2. Do not connect the reader
3. Add item
4. Checkout
5. Confirm Disconnected Reader View matches designs TfaZ4LUkEwEGrxfnEFzvJj-fi-2530_16156
7. Return to the product list
8. Connect the reader
9. Add a >$0.5 product
10. Confirm "Checking Order" error appears and matches layout designs

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

https://github.com/user-attachments/assets/8fe34cd0-31df-449d-982a-c216fd29ea16

---
- [x] I have considered adding unit tests for this change. If I decided not to add them, I have provided a brief explanation below (optional):
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.
- [x] This PR includes refactoring; smoke testing of the entire section is needed.