### PR TITLE
Log a case when order and store currencies mismatch for easier debugging

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Orders/Payment Methods/PaymentMethodsViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Payment Methods/PaymentMethodsViewModel.swift
@@ -167,6 +167,7 @@ final class PaymentMethodsViewModel: ObservableObject {
 
         bindStoreCPPState()
         updateCardPaymentVisibility()
+        logOrderAndStoreCurrencyMismatch()
     }
 
     @MainActor
@@ -499,6 +500,25 @@ private extension PaymentMethodsViewModel {
                                                                                     try? orderDurationRecorder.millisecondsSinceOrderAddNew(),
                                                                                   country: cardPresentPaymentsConfiguration.countryCode,
                                                                                   currency: currencySettings.currencyCode.rawValue))
+    }
+}
+
+private extension PaymentMethodsViewModel {
+    /// If the store supports multi-currency
+    /// and an account has a different default currency set in store's settings
+    /// then some payment methods may be unavailable
+    ///
+    /// Logging this case for easier debugging
+    /// #13580
+    private func logOrderAndStoreCurrencyMismatch() {
+        guard let order = ordersResultController.fetchedObjects.first else {
+            return
+        }
+
+        if order.currency != currencySettings.currencyCode.rawValue {
+            // swiftlint:disable:next line_length
+            DDLogWarn("⚠️ Order currency \(order.currency) differs from store's currency \(currencySettings.currencyCode.rawValue) which can lead to payment methods being unavailable")
+        }
     }
 }
 


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Partially addresses: #13580
Context: p91TBi-bPj-p2#comment-12874
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

When order and store currencies mismatch, some payment methods (Card Reader, TPP) may not be visible. We don't have a full solution right now but decided to log this case for easier debugging and support.

## Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->

**Before testing**
1. Set up a site with WooPayments, US location and USD currency
2. Go to Payments -> Settings, scroll down to Advanced Settings and Enable Multi-Currency
3. Go to Settings -> WooCommerce -> Multi-currency, add additional currency and enable Automatically switch customers to their local currency if it has been enabled
4. Open your store on the browser, go to My Account, (yourstore.com/my-account/) and log into your account
5. Open Account details and change Default currency to something different from USD

**Testing**
1. Open Woo app and log into the same account and site
2. Order
3. Add Products
4. 'Collect Payment'
5. Check logs in the console or in the app (Menu -> Settings -> Help & Support -> Application logs)
6. Confirm mismatching currency case is logged

## Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->


https://github.com/user-attachments/assets/016ed865-d9f6-4c89-840a-447238a70493

<img width="912" alt="tracked currency" src="https://github.com/user-attachments/assets/f0bf350c-4042-4e3e-ac44-21155cdbeb7b">

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [x] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [x] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [x] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on all devices (phone/tablet) and no regressions are added.ssed