### PR TITLE
[Woo POS] Payment error exit buttons

### DIFF
--- a/WooCommerce/Classes/POS/Presentation/Card Present Payments/PointOfSaleCardPresentPaymentEventPresentationStyle.swift
+++ b/WooCommerce/Classes/POS/Presentation/Card Present Payments/PointOfSaleCardPresentPaymentEventPresentationStyle.swift
@@ -149,7 +149,8 @@ extension CardPresentPaymentEventDetails {
                     return .message(.paymentError(
                         viewModel: PointOfSaleCardPresentPaymentErrorMessageViewModel(
                             error: error,
-                            tryPaymentAgainButtonAction: retryAction)))
+                            tryPaymentAgainButtonAction: retryAction,
+                            backToCheckoutButtonAction: cancelPayment)))
                 case .dontRetry:
                     return .message(.paymentErrorNonRetryable(
                         viewModel: PointOfSaleCardPresentPaymentNonRetryableErrorMessageViewModel(

--- a/WooCommerce/Classes/POS/Presentation/Card Present Payments/PointOfSaleCardPresentPaymentEventPresentationStyle.swift
+++ b/WooCommerce/Classes/POS/Presentation/Card Present Payments/PointOfSaleCardPresentPaymentEventPresentationStyle.swift
@@ -7,6 +7,8 @@ enum PointOfSaleCardPresentPaymentEventPresentationStyle {
 
 /// View Models are created here, but can be "annotated" where they are used if the `CardPresentPaymentEventDetails` is
 /// not enough to fully populate the view model. See `TotalsViewModel.observeCardPresentPaymentEvents` for an example.
+///
+// TODO: We could make this a struct with a function and the required dependencies to produce full viewModels first time
 extension CardPresentPaymentEventDetails {
     var pointOfSalePresentationStyle: PointOfSaleCardPresentPaymentEventPresentationStyle? {
         switch self {
@@ -129,7 +131,7 @@ extension CardPresentPaymentEventDetails {
                     inputMethods: inputMethods)))
         case .paymentSuccess:
             return .message(.paymentSuccess(viewModel: PointOfSaleCardPresentPaymentSuccessMessageViewModel()))
-        case .paymentError(error: let error, retryApproach: let retryApproach, cancelPayment: _):
+        case .paymentError(error: let error, retryApproach: let retryApproach, cancelPayment: let cancelPayment):
             switch error {
             case CollectOrderPaymentUseCaseError.couldNotRefreshOrder,
                 CollectOrderPaymentUseCaseError.orderTotalChanged,
@@ -151,7 +153,8 @@ extension CardPresentPaymentEventDetails {
                 case .dontRetry:
                     return .message(.paymentErrorNonRetryable(
                         viewModel: PointOfSaleCardPresentPaymentNonRetryableErrorMessageViewModel(
-                            error: error)))
+                            error: error,
+                            tryAnotherPaymentMethodAction: cancelPayment)))
                 }
             }
         case .paymentCaptureError(let cancelPayment):

--- a/WooCommerce/Classes/POS/Presentation/Card Present Payments/Reader Messages/PointOfSaleCardPresentPaymentErrorMessageViewModel.swift
+++ b/WooCommerce/Classes/POS/Presentation/Card Present Payments/Reader Messages/PointOfSaleCardPresentPaymentErrorMessageViewModel.swift
@@ -5,14 +5,18 @@ struct PointOfSaleCardPresentPaymentErrorMessageViewModel {
     let title = Localization.title
     let message: String
     let tryAgainButtonViewModel: CardPresentPaymentsModalButtonViewModel
-    let exitButtonViewModel: CardPresentPaymentsModalButtonViewModel?
+    private(set) var backToCheckoutButtonViewModel: CardPresentPaymentsModalButtonViewModel?
 
     init(error: Error,
-         tryPaymentAgainButtonAction: @escaping () -> Void) {
+         tryPaymentAgainButtonAction: @escaping () -> Void,
+         backToCheckoutButtonAction: @escaping () -> Void) {
         self.init(error: error,
                   tryAgainButtonViewModel: CardPresentPaymentsModalButtonViewModel(
-            title: Localization.tryPaymentAgain,
-            actionHandler: tryPaymentAgainButtonAction))
+                    title: Localization.tryPaymentAgain,
+                    actionHandler: tryPaymentAgainButtonAction),
+                  backToCheckoutButtonViewModel: CardPresentPaymentsModalButtonViewModel(
+                    title: Localization.backToCheckout,
+                    actionHandler: backToCheckoutButtonAction))
     }
 
     init(error: Error,
@@ -20,16 +24,16 @@ struct PointOfSaleCardPresentPaymentErrorMessageViewModel {
         self.init(error: error,
                   tryAgainButtonViewModel: CardPresentPaymentsModalButtonViewModel(
                     title: Localization.tryAnotherPaymentMethod,
-                    actionHandler: tryAnotherPaymentMethodButtonAction))
+                    actionHandler: tryAnotherPaymentMethodButtonAction),
+                  backToCheckoutButtonViewModel: nil)
     }
 
     private init(error: Error,
-                 tryAgainButtonViewModel: CardPresentPaymentsModalButtonViewModel) {
+                 tryAgainButtonViewModel: CardPresentPaymentsModalButtonViewModel,
+                 backToCheckoutButtonViewModel: CardPresentPaymentsModalButtonViewModel?) {
         self.message = Self.message(for: error)
         self.tryAgainButtonViewModel = tryAgainButtonViewModel
-        self.exitButtonViewModel = CardPresentPaymentsModalButtonViewModel(
-            title: Localization.exitOrder,
-            actionHandler: { })
+        self.backToCheckoutButtonViewModel = backToCheckoutButtonViewModel
     }
 
     private static func message(for error: Error) -> String {
@@ -38,6 +42,12 @@ struct PointOfSaleCardPresentPaymentErrorMessageViewModel {
         } else {
             return error.localizedDescription
         }
+    }
+
+    mutating func updateBackToCheckoutAction(_ newAction: @escaping () -> Void) {
+        backToCheckoutButtonViewModel = CardPresentPaymentsModalButtonViewModel(
+            title: Localization.backToCheckout,
+            actionHandler: newAction)
     }
 }
 
@@ -63,9 +73,9 @@ private extension PointOfSaleCardPresentPaymentErrorMessageViewModel {
             "payment fails on the Point of Sale Checkout, when it's unlikely that the same card will work."
         )
 
-        static let exitOrder =  NSLocalizedString(
-            "pointOfSale.cardPresent.paymentError.exitOrder.button.title",
-            value: "Exit order",
+        static let backToCheckout =  NSLocalizedString(
+            "pointOfSale.cardPresent.paymentError.backToCheckout.button.title",
+            value: "Go back to checkout",
             comment: "Button to leave the order when a card payment fails. Presented to users after " +
             "collecting a payment fails on the Point of Sale Checkout"
         )

--- a/WooCommerce/Classes/POS/Presentation/Card Present Payments/Reader Messages/PointOfSaleCardPresentPaymentErrorMessageViewModel.swift
+++ b/WooCommerce/Classes/POS/Presentation/Card Present Payments/Reader Messages/PointOfSaleCardPresentPaymentErrorMessageViewModel.swift
@@ -5,7 +5,7 @@ struct PointOfSaleCardPresentPaymentErrorMessageViewModel {
     let title = Localization.title
     let message: String
     let tryAgainButtonViewModel: CardPresentPaymentsModalButtonViewModel
-    private(set) var backToCheckoutButtonViewModel: CardPresentPaymentsModalButtonViewModel?
+    let backToCheckoutButtonViewModel: CardPresentPaymentsModalButtonViewModel?
 
     init(error: Error,
          tryPaymentAgainButtonAction: @escaping () -> Void,
@@ -42,12 +42,6 @@ struct PointOfSaleCardPresentPaymentErrorMessageViewModel {
         } else {
             return error.localizedDescription
         }
-    }
-
-    mutating func updateBackToCheckoutAction(_ newAction: @escaping () -> Void) {
-        backToCheckoutButtonViewModel = CardPresentPaymentsModalButtonViewModel(
-            title: Localization.backToCheckout,
-            actionHandler: newAction)
     }
 }
 

--- a/WooCommerce/Classes/POS/Presentation/Card Present Payments/Reader Messages/PointOfSaleCardPresentPaymentNonRetryableErrorMessageViewModel.swift
+++ b/WooCommerce/Classes/POS/Presentation/Card Present Payments/Reader Messages/PointOfSaleCardPresentPaymentNonRetryableErrorMessageViewModel.swift
@@ -5,13 +5,13 @@ struct PointOfSaleCardPresentPaymentNonRetryableErrorMessageViewModel {
     let title = Localization.title
     let message: String
     let nextStep: String = Localization.nextStep
-    let tryAnotherPaymentMethodButtonViewModel: CardPresentPaymentsModalButtonViewModel
+    private(set) var tryAnotherPaymentMethodButtonViewModel: CardPresentPaymentsModalButtonViewModel
 
-    init(error: Error) {
+    init(error: Error, tryAnotherPaymentMethodAction: @escaping () -> Void) {
         self.message = Self.message(for: error)
         self.tryAnotherPaymentMethodButtonViewModel = CardPresentPaymentsModalButtonViewModel(
-            title: Localization.startAgain,
-            actionHandler: { })
+            title: Localization.tryAnotherPaymentMethod,
+            actionHandler: tryAnotherPaymentMethodAction)
     }
 
     private static func message(for error: Error) -> String {
@@ -20,6 +20,12 @@ struct PointOfSaleCardPresentPaymentNonRetryableErrorMessageViewModel {
         } else {
             return error.localizedDescription
         }
+    }
+
+    mutating func updateTryAnotherPaymentMethodAction(_ newAction: @escaping () -> Void) {
+        self.tryAnotherPaymentMethodButtonViewModel = CardPresentPaymentsModalButtonViewModel(
+            title: Localization.tryAnotherPaymentMethod,
+            actionHandler: newAction)
     }
 }
 
@@ -31,7 +37,7 @@ private extension PointOfSaleCardPresentPaymentNonRetryableErrorMessageViewModel
             comment: "Error message. Presented to users after collecting a payment fails on the Point of Sale Checkout"
         )
 
-        static let startAgain = NSLocalizedString(
+        static let tryAnotherPaymentMethod = NSLocalizedString(
             "pointOfSale.cardPresent.paymentErrorNonRetryable.tryAnotherPaymentMethod.button.title",
             value: "Try another payment method",
             comment: "Title of the button used on a card payment error from the Point of Sale Checkout " +

--- a/WooCommerce/Classes/POS/Presentation/Card Present Payments/Reader Messages/PointOfSaleCardPresentPaymentNonRetryableErrorMessageViewModel.swift
+++ b/WooCommerce/Classes/POS/Presentation/Card Present Payments/Reader Messages/PointOfSaleCardPresentPaymentNonRetryableErrorMessageViewModel.swift
@@ -5,7 +5,7 @@ struct PointOfSaleCardPresentPaymentNonRetryableErrorMessageViewModel {
     let title = Localization.title
     let message: String
     let nextStep: String = Localization.nextStep
-    private(set) var tryAnotherPaymentMethodButtonViewModel: CardPresentPaymentsModalButtonViewModel
+    let tryAnotherPaymentMethodButtonViewModel: CardPresentPaymentsModalButtonViewModel
 
     init(error: Error, tryAnotherPaymentMethodAction: @escaping () -> Void) {
         self.message = Self.message(for: error)
@@ -20,12 +20,6 @@ struct PointOfSaleCardPresentPaymentNonRetryableErrorMessageViewModel {
         } else {
             return error.localizedDescription
         }
-    }
-
-    mutating func updateTryAnotherPaymentMethodAction(_ newAction: @escaping () -> Void) {
-        self.tryAnotherPaymentMethodButtonViewModel = CardPresentPaymentsModalButtonViewModel(
-            title: Localization.tryAnotherPaymentMethod,
-            actionHandler: newAction)
     }
 }
 

--- a/WooCommerce/Classes/POS/Presentation/Card Present Payments/Reader Messages/PointOfSaleCardPresentPaymentSuccessMessageViewModel.swift
+++ b/WooCommerce/Classes/POS/Presentation/Card Present Payments/Reader Messages/PointOfSaleCardPresentPaymentSuccessMessageViewModel.swift
@@ -2,10 +2,14 @@ import Foundation
 
 struct PointOfSaleCardPresentPaymentSuccessMessageViewModel {
     let title: String = Localization.title
-    var message: String? = nil
+    let message: String?
 
-    mutating func updateMessage(formattedOrderTotal: String) {
-        message = String(format: Localization.message, formattedOrderTotal)
+    init(formattedOrderTotal: String?) {
+        if let formattedOrderTotal {
+            self.message = String(format: Localization.message, formattedOrderTotal)
+        } else {
+            self.message = nil
+        }
     }
 }
 

--- a/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/Reader Messages/PointOfSaleCardPresentPaymentErrorMessageView.swift
+++ b/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/Reader Messages/PointOfSaleCardPresentPaymentErrorMessageView.swift
@@ -22,9 +22,9 @@ struct PointOfSaleCardPresentPaymentErrorMessageView: View {
                        action: viewModel.tryAgainButtonViewModel.actionHandler)
                 .buttonStyle(POSPrimaryButtonStyle())
 
-                if let exitButtonViewModel = viewModel.exitButtonViewModel {
-                    Button(exitButtonViewModel.title,
-                           action: exitButtonViewModel.actionHandler)
+                if let backToCheckoutButtonViewModel = viewModel.backToCheckoutButtonViewModel {
+                    Button(backToCheckoutButtonViewModel.title,
+                           action: backToCheckoutButtonViewModel.actionHandler)
                     .buttonStyle(POSSecondaryButtonStyle())
                 }
             }
@@ -39,7 +39,8 @@ struct PointOfSaleCardPresentPaymentErrorMessageView: View {
         viewModel: PointOfSaleCardPresentPaymentErrorMessageViewModel(
             error: CardReaderServiceError.paymentCapture(
                 underlyingError: .paymentDeclinedByCardReader),
-            tryPaymentAgainButtonAction: {}))
+            tryPaymentAgainButtonAction: {},
+            backToCheckoutButtonAction: {}))
 }
 
 #Preview("Retry with another payment method") {

--- a/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/Reader Messages/PointOfSaleCardPresentPaymentNonRetryableErrorMessageView.swift
+++ b/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/Reader Messages/PointOfSaleCardPresentPaymentNonRetryableErrorMessageView.swift
@@ -33,5 +33,5 @@ struct PointOfSaleCardPresentPaymentNonRetryableErrorMessageView: View {
     PointOfSaleCardPresentPaymentNonRetryableErrorMessageView(
         viewModel: PointOfSaleCardPresentPaymentNonRetryableErrorMessageViewModel(
             error: CardReaderServiceError.paymentCapture(
-                underlyingError: .paymentDeclinedByCardReader)))
+                underlyingError: .paymentDeclinedByCardReader), tryAnotherPaymentMethodAction: {}))
 }

--- a/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/Reader Messages/PointOfSaleCardPresentPaymentSuccessMessageView.swift
+++ b/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/Reader Messages/PointOfSaleCardPresentPaymentSuccessMessageView.swift
@@ -49,6 +49,6 @@ private extension PointOfSaleCardPresentPaymentSuccessMessageView {
 
 #Preview {
     PointOfSaleCardPresentPaymentSuccessMessageView(
-        viewModel: PointOfSaleCardPresentPaymentSuccessMessageViewModel()
+        viewModel: PointOfSaleCardPresentPaymentSuccessMessageViewModel(formattedOrderTotal: "$3.00")
     )
 }

--- a/WooCommerce/Classes/POS/ViewModels/TotalsViewModel.swift
+++ b/WooCommerce/Classes/POS/ViewModels/TotalsViewModel.swift
@@ -355,6 +355,12 @@ private extension TotalsViewModel {
         case .paymentErrorNonRetryable(var viewModel):
             viewModel.updateTryAnotherPaymentMethodAction(cancelThenCollectPayment)
             return .paymentErrorNonRetryable(viewModel: viewModel)
+        case .paymentError(var viewModel):
+            guard let _ = viewModel.backToCheckoutButtonViewModel else {
+                return messageType
+            }
+            viewModel.updateBackToCheckoutAction(cancelThenCollectPayment)
+            return .paymentError(viewModel: viewModel)
         default:
             return messageType
         }

--- a/WooCommerce/Classes/POS/ViewModels/TotalsViewModel.swift
+++ b/WooCommerce/Classes/POS/ViewModels/TotalsViewModel.swift
@@ -352,8 +352,18 @@ private extension TotalsViewModel {
             }
             viewModel.updateMessage(formattedOrderTotal: formattedOrderTotalPrice)
             return .paymentSuccess(viewModel: viewModel)
+        case .paymentErrorNonRetryable(var viewModel):
+            viewModel.updateTryAnotherPaymentMethodAction(cancelThenCollectPayment)
+            return .paymentErrorNonRetryable(viewModel: viewModel)
         default:
             return messageType
+        }
+    }
+
+    func cancelThenCollectPayment() {
+        cardPresentPaymentService.cancelPayment()
+        Task { [weak self] in
+            await self?.collectPayment()
         }
     }
 }

--- a/WooCommerce/Classes/POS/ViewModels/TotalsViewModel.swift
+++ b/WooCommerce/Classes/POS/ViewModels/TotalsViewModel.swift
@@ -298,8 +298,7 @@ private extension TotalsViewModel {
             case .idle:
                 return false
             case .show(let eventDetails):
-                let presentationStyle = presentationStyle(for: eventDetails)
-                switch presentationStyle {
+                switch presentationStyle(for: eventDetails) {
                 case .alert:
                     return true
                 case .message, .none:

--- a/WooCommerce/Classes/POS/ViewModels/TotalsViewModel.swift
+++ b/WooCommerce/Classes/POS/ViewModels/TotalsViewModel.swift
@@ -362,8 +362,12 @@ private extension TotalsViewModel {
 
     var presentationStyleDeterminerDependencies: PointOfSaleCardPresentPaymentEventPresentationStyleDeterminer.Dependencies {
         PointOfSaleCardPresentPaymentEventPresentationStyleDeterminer.Dependencies(
-            tryPaymentAgainBackToCheckoutAction: cancelThenCollectPayment,
-            nonRetryableErrorExitAction: cancelThenCollectPayment,
+            tryPaymentAgainBackToCheckoutAction: { [weak self] in
+                self?.cancelThenCollectPayment()
+            },
+            nonRetryableErrorExitAction: { [weak self] in
+                self?.cancelThenCollectPayment()
+            },
             formattedOrderTotalPrice: formattedOrderTotalPrice)
     }
 

--- a/WooCommerce/Classes/POS/ViewModels/TotalsViewModel.swift
+++ b/WooCommerce/Classes/POS/ViewModels/TotalsViewModel.swift
@@ -355,13 +355,13 @@ private extension TotalsViewModel {
     }
 
     func presentationStyle(for eventDetails: CardPresentPaymentEventDetails) -> PointOfSaleCardPresentPaymentEventPresentationStyle? {
-        PointOfSaleCardPresentPaymentEventPresentationStyleDeterminer.presentationStyle(
+        PointOfSaleCardPresentPaymentEventPresentationStyle(
             for: eventDetails,
             dependencies: presentationStyleDeterminerDependencies)
     }
 
-    var presentationStyleDeterminerDependencies: PointOfSaleCardPresentPaymentEventPresentationStyleDeterminer.Dependencies {
-        PointOfSaleCardPresentPaymentEventPresentationStyleDeterminer.Dependencies(
+    var presentationStyleDeterminerDependencies: PointOfSaleCardPresentPaymentEventPresentationStyle.Dependencies {
+        PointOfSaleCardPresentPaymentEventPresentationStyle.Dependencies(
             tryPaymentAgainBackToCheckoutAction: { [weak self] in
                 self?.cancelThenCollectPayment()
             },
@@ -381,7 +381,7 @@ private extension TotalsViewModel {
 
 private extension TotalsViewModel.PaymentState {
     init?(from cardPaymentEvent: CardPresentPaymentEvent,
-          using paymentEventPresentationStyleDeterminerDependencies: PointOfSaleCardPresentPaymentEventPresentationStyleDeterminer.Dependencies) {
+          using paymentEventPresentationStyleDependencies: PointOfSaleCardPresentPaymentEventPresentationStyle.Dependencies) {
         switch cardPaymentEvent {
         case .idle:
             self = .idle
@@ -396,9 +396,9 @@ private extension TotalsViewModel.PaymentState {
             self = .processingPayment
         case .show(.paymentError):
             if case let .show(eventDetails) = cardPaymentEvent,
-               case let .message(messageType) = PointOfSaleCardPresentPaymentEventPresentationStyleDeterminer.presentationStyle(
+               case let .message(messageType) = PointOfSaleCardPresentPaymentEventPresentationStyle(
                 for: eventDetails,
-                dependencies: paymentEventPresentationStyleDeterminerDependencies),
+                dependencies: paymentEventPresentationStyleDependencies),
                case .validatingOrderError = messageType {
                 self = .validatingOrderError
             } else {

--- a/WooCommerce/Classes/POS/ViewModels/TotalsViewModel.swift
+++ b/WooCommerce/Classes/POS/ViewModels/TotalsViewModel.swift
@@ -361,9 +361,10 @@ private extension TotalsViewModel {
     }
 
     var presentationStyleDeterminerDependencies: PointOfSaleCardPresentPaymentEventPresentationStyleDeterminer.Dependencies {
-        .init(tryPaymentAgainBackToCheckoutAction: cancelThenCollectPayment,
-                     nonRetryableErrorExitAction: cancelThenCollectPayment,
-                     formattedOrderTotalPrice: formattedOrderTotalPrice)
+        PointOfSaleCardPresentPaymentEventPresentationStyleDeterminer.Dependencies(
+            tryPaymentAgainBackToCheckoutAction: cancelThenCollectPayment,
+            nonRetryableErrorExitAction: cancelThenCollectPayment,
+            formattedOrderTotalPrice: formattedOrderTotalPrice)
     }
 
     func cancelThenCollectPayment() {

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -799,6 +799,7 @@
 		205E794D2C2057B9001BA266 /* PointOfSaleCardPresentPaymentErrorMessageView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 205E794C2C2057B9001BA266 /* PointOfSaleCardPresentPaymentErrorMessageView.swift */; };
 		205E794F2C207D38001BA266 /* PointOfSaleCardPresentPaymentNonRetryableErrorMessageView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 205E794E2C207D38001BA266 /* PointOfSaleCardPresentPaymentNonRetryableErrorMessageView.swift */; };
 		205E79512C207FAE001BA266 /* PointOfSaleCardPresentPaymentDisplayReaderMessageMessageView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 205E79502C207FAE001BA266 /* PointOfSaleCardPresentPaymentDisplayReaderMessageMessageView.swift */; };
+		20600F8B2C6E3CCE00950D2A /* PointOfSaleCardPresentPaymentEventPresentationStyleTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 20600F8A2C6E3CCE00950D2A /* PointOfSaleCardPresentPaymentEventPresentationStyleTests.swift */; };
 		20762BA12C18A66400758305 /* CardPresentPaymentBuiltInReaderConnectionAlertsProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 20762BA02C18A66400758305 /* CardPresentPaymentBuiltInReaderConnectionAlertsProvider.swift */; };
 		20762BA32C18A6A300758305 /* CardPresentPaymentEventDetails.swift in Sources */ = {isa = PBXBuildFile; fileRef = 20762BA22C18A6A300758305 /* CardPresentPaymentEventDetails.swift */; };
 		20762BA52C18B42C00758305 /* CardPresentPaymentBluetoothReaderConnectionAlertsProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 20762BA42C18B42C00758305 /* CardPresentPaymentBluetoothReaderConnectionAlertsProvider.swift */; };
@@ -3820,6 +3821,7 @@
 		205E794C2C2057B9001BA266 /* PointOfSaleCardPresentPaymentErrorMessageView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PointOfSaleCardPresentPaymentErrorMessageView.swift; sourceTree = "<group>"; };
 		205E794E2C207D38001BA266 /* PointOfSaleCardPresentPaymentNonRetryableErrorMessageView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PointOfSaleCardPresentPaymentNonRetryableErrorMessageView.swift; sourceTree = "<group>"; };
 		205E79502C207FAE001BA266 /* PointOfSaleCardPresentPaymentDisplayReaderMessageMessageView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PointOfSaleCardPresentPaymentDisplayReaderMessageMessageView.swift; sourceTree = "<group>"; };
+		20600F8A2C6E3CCE00950D2A /* PointOfSaleCardPresentPaymentEventPresentationStyleTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PointOfSaleCardPresentPaymentEventPresentationStyleTests.swift; sourceTree = "<group>"; };
 		20762BA02C18A66400758305 /* CardPresentPaymentBuiltInReaderConnectionAlertsProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardPresentPaymentBuiltInReaderConnectionAlertsProvider.swift; sourceTree = "<group>"; };
 		20762BA22C18A6A300758305 /* CardPresentPaymentEventDetails.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardPresentPaymentEventDetails.swift; sourceTree = "<group>"; };
 		20762BA42C18B42C00758305 /* CardPresentPaymentBluetoothReaderConnectionAlertsProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardPresentPaymentBluetoothReaderConnectionAlertsProvider.swift; sourceTree = "<group>"; };
@@ -7697,6 +7699,7 @@
 			isa = PBXGroup;
 			children = (
 				20ADE9452C6B364900C91265 /* CardPresentPaymentRetryApproachTests.swift */,
+				20600F8A2C6E3CCE00950D2A /* PointOfSaleCardPresentPaymentEventPresentationStyleTests.swift */,
 			);
 			path = "Card Present Payments";
 			sourceTree = "<group>";
@@ -16647,6 +16650,7 @@
 				DE4D23B429B58C5A003A4B5D /* MockWordPressComAccountService.swift in Sources */,
 				57A5D8D92534FEBB00AA54D6 /* TotalRefundedCalculationUseCaseTests.swift in Sources */,
 				EE5366A52B0673760008E61E /* SubscriptionExpiryViewModelTests.swift in Sources */,
+				20600F8B2C6E3CCE00950D2A /* PointOfSaleCardPresentPaymentEventPresentationStyleTests.swift in Sources */,
 				B5718D6521B56B400026C9F0 /* PushNotificationsManagerTests.swift in Sources */,
 				EE57C121297E76E000BC31E7 /* TrackEventRequestNotificationHandlerTests.swift in Sources */,
 				D8A8C4F32268288F001C72BF /* AddManualCustomTrackingViewModelTests.swift in Sources */,

--- a/WooCommerce/WooCommerceTests/POS/Card Present Payments/PointOfSaleCardPresentPaymentEventPresentationStyleTests.swift
+++ b/WooCommerce/WooCommerceTests/POS/Card Present Payments/PointOfSaleCardPresentPaymentEventPresentationStyleTests.swift
@@ -1,0 +1,111 @@
+import XCTest
+@testable import WooCommerce
+
+final class PointOfSaleCardPresentPaymentEventPresentationStyleTests: XCTestCase {
+
+    func test_presentationStyle_for_paymentError_tryAnotherPaymentMethod_is_message_paymentError_with_correctActions() {
+        // Given
+        var spyRetryCalled = false
+        let eventDetails = CardPresentPaymentEventDetails.paymentError(
+            error: NSError(domain: "test", code: 1),
+            retryApproach: .tryAnotherPaymentMethod(retryAction: { spyRetryCalled = true }),
+            cancelPayment: {})
+        let dependencies = PointOfSaleCardPresentPaymentEventPresentationStyleDeterminer.Dependencies(
+            tryPaymentAgainBackToCheckoutAction: {},
+            nonRetryableErrorExitAction: {},
+            formattedOrderTotalPrice: nil)
+
+        // When
+        let presentationStyle =  PointOfSaleCardPresentPaymentEventPresentationStyleDeterminer.presentationStyle(
+            for: eventDetails,
+            dependencies: dependencies)
+
+        // Then
+        guard case .message(.paymentError(let viewModel)) = presentationStyle else {
+            return XCTFail("Expected payment error message not found")
+        }
+
+        viewModel.tryAgainButtonViewModel.actionHandler()
+        XCTAssertTrue(spyRetryCalled)
+
+        XCTAssertNil(viewModel.backToCheckoutButtonViewModel)
+    }
+
+    func test_presentationStyle_for_paymentError_tryPaymentAgain_is_message_paymentError_with_correctActions() {
+        // Given
+        var spyRetryCalled = false
+        let eventDetails = CardPresentPaymentEventDetails.paymentError(
+            error: NSError(domain: "test", code: 1),
+            retryApproach: .tryAgain(retryAction: { spyRetryCalled = true }),
+            cancelPayment: {})
+        var spyBackToCheckoutCalled = false
+        let dependencies = PointOfSaleCardPresentPaymentEventPresentationStyleDeterminer.Dependencies(
+            tryPaymentAgainBackToCheckoutAction: { spyBackToCheckoutCalled = true },
+            nonRetryableErrorExitAction: {},
+            formattedOrderTotalPrice: nil)
+
+        // When
+        let presentationStyle =  PointOfSaleCardPresentPaymentEventPresentationStyleDeterminer.presentationStyle(
+            for: eventDetails,
+            dependencies: dependencies)
+
+        // Then
+        guard case .message(.paymentError(let viewModel)) = presentationStyle else {
+            return XCTFail("Expected payment error message not found")
+        }
+
+        viewModel.tryAgainButtonViewModel.actionHandler()
+        XCTAssertTrue(spyRetryCalled)
+
+        viewModel.backToCheckoutButtonViewModel?.actionHandler()
+        XCTAssertTrue(spyBackToCheckoutCalled)
+    }
+
+    func test_presentationStyle_for_paymentError_dontRetry_is_message_paymentErrorNonRetryable_with_correctActions() {
+        // Given
+        let eventDetails = CardPresentPaymentEventDetails.paymentError(
+            error: NSError(domain: "test", code: 1),
+            retryApproach: .dontRetry,
+            cancelPayment: {})
+        var spyTryAnotherPaymentMethod = false
+        let dependencies = PointOfSaleCardPresentPaymentEventPresentationStyleDeterminer.Dependencies(
+            tryPaymentAgainBackToCheckoutAction: {},
+            nonRetryableErrorExitAction: { spyTryAnotherPaymentMethod = true },
+            formattedOrderTotalPrice: nil)
+
+        // When
+        let presentationStyle =  PointOfSaleCardPresentPaymentEventPresentationStyleDeterminer.presentationStyle(
+            for: eventDetails,
+            dependencies: dependencies)
+
+        // Then
+        guard case .message(.paymentErrorNonRetryable(let viewModel)) = presentationStyle else {
+            return XCTFail("Expected payment error message not found")
+        }
+
+        viewModel.tryAnotherPaymentMethodButtonViewModel.actionHandler()
+        XCTAssertTrue(spyTryAnotherPaymentMethod)
+    }
+
+    func test_presentationStyle_for_paymentSuccess_is_message_paymentSuccess_with_order_total() {
+        // Given
+        let eventDetails = CardPresentPaymentEventDetails.paymentSuccess(done: {})
+        let dependencies = PointOfSaleCardPresentPaymentEventPresentationStyleDeterminer.Dependencies(
+            tryPaymentAgainBackToCheckoutAction: {},
+            nonRetryableErrorExitAction: {},
+            formattedOrderTotalPrice: "$200.50")
+
+        // When
+        let presentationStyle = PointOfSaleCardPresentPaymentEventPresentationStyleDeterminer.presentationStyle(
+            for: eventDetails,
+            dependencies: dependencies)
+
+        // Then
+        guard case .message(.paymentSuccess(let viewModel)) = presentationStyle else {
+            return XCTFail("Expected payment success message not found")
+        }
+
+        XCTAssertEqual(viewModel.message, "A payment of $200.50 was successfully made")
+    }
+
+}

--- a/WooCommerce/WooCommerceTests/POS/Card Present Payments/PointOfSaleCardPresentPaymentEventPresentationStyleTests.swift
+++ b/WooCommerce/WooCommerceTests/POS/Card Present Payments/PointOfSaleCardPresentPaymentEventPresentationStyleTests.swift
@@ -10,13 +10,13 @@ final class PointOfSaleCardPresentPaymentEventPresentationStyleTests: XCTestCase
             error: NSError(domain: "test", code: 1),
             retryApproach: .tryAnotherPaymentMethod(retryAction: { spyRetryCalled = true }),
             cancelPayment: {})
-        let dependencies = PointOfSaleCardPresentPaymentEventPresentationStyleDeterminer.Dependencies(
+        let dependencies = PointOfSaleCardPresentPaymentEventPresentationStyle.Dependencies(
             tryPaymentAgainBackToCheckoutAction: {},
             nonRetryableErrorExitAction: {},
             formattedOrderTotalPrice: nil)
 
         // When
-        let presentationStyle =  PointOfSaleCardPresentPaymentEventPresentationStyleDeterminer.presentationStyle(
+        let presentationStyle =  PointOfSaleCardPresentPaymentEventPresentationStyle(
             for: eventDetails,
             dependencies: dependencies)
 
@@ -39,13 +39,13 @@ final class PointOfSaleCardPresentPaymentEventPresentationStyleTests: XCTestCase
             retryApproach: .tryAgain(retryAction: { spyRetryCalled = true }),
             cancelPayment: {})
         var spyBackToCheckoutCalled = false
-        let dependencies = PointOfSaleCardPresentPaymentEventPresentationStyleDeterminer.Dependencies(
+        let dependencies = PointOfSaleCardPresentPaymentEventPresentationStyle.Dependencies(
             tryPaymentAgainBackToCheckoutAction: { spyBackToCheckoutCalled = true },
             nonRetryableErrorExitAction: {},
             formattedOrderTotalPrice: nil)
 
         // When
-        let presentationStyle =  PointOfSaleCardPresentPaymentEventPresentationStyleDeterminer.presentationStyle(
+        let presentationStyle =  PointOfSaleCardPresentPaymentEventPresentationStyle(
             for: eventDetails,
             dependencies: dependencies)
 
@@ -68,13 +68,13 @@ final class PointOfSaleCardPresentPaymentEventPresentationStyleTests: XCTestCase
             retryApproach: .dontRetry,
             cancelPayment: {})
         var spyTryAnotherPaymentMethod = false
-        let dependencies = PointOfSaleCardPresentPaymentEventPresentationStyleDeterminer.Dependencies(
+        let dependencies = PointOfSaleCardPresentPaymentEventPresentationStyle.Dependencies(
             tryPaymentAgainBackToCheckoutAction: {},
             nonRetryableErrorExitAction: { spyTryAnotherPaymentMethod = true },
             formattedOrderTotalPrice: nil)
 
         // When
-        let presentationStyle =  PointOfSaleCardPresentPaymentEventPresentationStyleDeterminer.presentationStyle(
+        let presentationStyle =  PointOfSaleCardPresentPaymentEventPresentationStyle(
             for: eventDetails,
             dependencies: dependencies)
 
@@ -90,13 +90,13 @@ final class PointOfSaleCardPresentPaymentEventPresentationStyleTests: XCTestCase
     func test_presentationStyle_for_paymentSuccess_is_message_paymentSuccess_with_order_total() {
         // Given
         let eventDetails = CardPresentPaymentEventDetails.paymentSuccess(done: {})
-        let dependencies = PointOfSaleCardPresentPaymentEventPresentationStyleDeterminer.Dependencies(
+        let dependencies = PointOfSaleCardPresentPaymentEventPresentationStyle.Dependencies(
             tryPaymentAgainBackToCheckoutAction: {},
             nonRetryableErrorExitAction: {},
             formattedOrderTotalPrice: "$200.50")
 
         // When
-        let presentationStyle = PointOfSaleCardPresentPaymentEventPresentationStyleDeterminer.presentationStyle(
+        let presentationStyle = PointOfSaleCardPresentPaymentEventPresentationStyle(
             for: eventDetails,
             dependencies: dependencies)
 

--- a/WooCommerce/WooCommerceTests/POS/ViewModels/TotalsViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/POS/ViewModels/TotalsViewModelTests.swift
@@ -159,10 +159,9 @@ final class TotalsViewModelTests: XCTestCase {
         let message = sut.cardPresentPaymentInlineMessage
 
         // Then
-        let expectedViewModel = PointOfSaleCardPresentPaymentSuccessMessageViewModel(message: "A payment of $52.30 was successfully made")
         if case .paymentSuccess(let viewModel) = message {
-            XCTAssertEqual(viewModel.title, expectedViewModel.title)
-            XCTAssertEqual(viewModel.message, expectedViewModel.message)
+            XCTAssertEqual(viewModel.title, "Payment successful")
+            XCTAssertEqual(viewModel.message, "A payment of $52.30 was successfully made")
         } else {
             XCTFail("Expected cardPresentPaymentInlineMessage to be paymentSuccess")
         }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #13481
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

This PR adds the actions to payment errors which take the merchant back to the checkout screen, rather than using the payments-provided retry handlers.

This applies to non-retryable errors, and errors which (might) retry using the same card details as the previous attempt.

- Non-retryable errors: `Try another payment method` button (it's not really a retry, it takes you back to the checkout)
- Try payment again errors: `Go back to checkout` secondary button

### Refactoring payment event view model creation
I moved the logic to determine the presentation style for an error from an extension on `CardPresentPaymentEvent`, to a factory: `PointOfSaleCardPresentPaymentEventPresentationStyleDeterminer`. This let me improve the "annotation" approach we used to add more information to the message/alert view models. Previously, this was only used to set the order total on the `Order Complete` screen, but required a `mutating func` on that view model.

It seems better to provide the dependencies when we create those view models, then keep them immutable.

Now we have a static method which takes the event and the additional information required to create _any_ payment message view model for POS. That includes the new `cancelThenCollectPayment` action we use for the two buttons implemented here.

## Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->

Edit a POS-eligible product to have a sale price ending in `.01` – [see error amounts here](https://docs.stripe.com/terminal/references/testing#physical-test-cards)

### Non-retryable errors
1. Lauch the app and go to POS
2. Add your error product to the cart
3. Check out
4. Tap your card
5. Observe that you're shown a retryable `Try another payment method` error
6. Tap the button
7. Tap your card again
8. Observe that you're shown a different (but similar) error screen.
9. Tap the `Try another payment method` button – observe it takes you back to the checkout and prepares the payment again.

These are only subtly different, but the second is using a new payment intent.

### Try payment again errors
1. Launch the app and go to POS
2. Add a non-error product to the cart
3. Check out
4. Tap your card, and immediately disable network connectivity on the iPad
5. Observe that you're shown a retryable `Try payment again` error
11. Re-enable the network
12. Tap `Go back to checkout` (if you do this too soon, you'll see other errors, but they are recoverable.)
13. Observe that you're taken back to the checkout and the reader gets ready to take payment again. 

## Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->

I've tested with both the flows above, and also that the general payment flows still work as expected.

No testing on phones, as this only affects POS.

Unit tests for the view model creation logic.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->


https://github.com/user-attachments/assets/d29c8915-ddd0-4664-b1b3-d60ecea6d302

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [x] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [x] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [x] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on all devices (phone/tablet) and no regressions are added.