### PR TITLE
In-Person Payments: Whitelist `.failed` order status for card present eligibility

### DIFF
--- a/Yosemite/Yosemite/Stores/Order/Order+CardPresentPayment.swift
+++ b/Yosemite/Yosemite/Stores/Order/Order+CardPresentPayment.swift
@@ -45,7 +45,7 @@ import protocol Storage.StorageManagerType
 
 
     private var isStatusEligibleForCardPayment: Bool {
-        (status == .pending || status == .onHold || status == .processing)
+        (status == .pending || status == .onHold || status == .processing || status == .failed)
     }
 
     private var isPaymentMethodEligibleForCardPayment: Bool {

--- a/Yosemite/YosemiteTests/Stores/Order/Order+CardPresentPaymentTests.swift
+++ b/Yosemite/YosemiteTests/Stores/Order/Order+CardPresentPaymentTests.swift
@@ -36,7 +36,7 @@ final class Order_CardPresentPaymentTests: XCTestCase {
 
     func test_isEligibleForCardPresentPayment_when_status_is_not_valid_then_is_not_eligible() {
         // Given
-        let notEligibleStatuses: [OrderStatusEnum] = [.autoDraft, .completed, .cancelled, .refunded, .failed, .custom("test")]
+        let notEligibleStatuses: [OrderStatusEnum] = [.autoDraft, .completed, .cancelled, .refunded, .custom("test")]
 
         for notEligibleStatus in notEligibleStatuses {
             let order = eligibleOrder.copy(status: notEligibleStatus)


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #13629

## Description
This PR adds `.failed` order status to the cases when an Order is eligible for card present payments, this is done to address inconsistencies between web and app. Context: p91TBi-bWp-p2

## Testing:
* In trunk: 
  * Go to Orders, create a new Order, add some products, create the Order.
  * Tap on `Edit`, switch the Order status to `Failed`. Save changes.
  * Tap `Collect Payment`. 
  * Observe that the card present row is not available within the options for collection
* In this branch
  * Follow the same process
  * Observe that the option to collect payment via card reader is available
  * Collect payment, observe that the order switches to `Completed` upon success

## Screenshots

![Simulator Screen Recording - iPhone 15 - 2024-08-16 at 09 27 47](https://github.com/user-attachments/assets/024ca80e-1bf5-45f4-8455-3b73950ec175)

- [x] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [x] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [ ] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on all devices (phone/tablet) and no regressions are added.