### PR TITLE
[Woo Payments] Improve Payment Capture Errors

### DIFF
--- a/WooCommerce/Classes/POS/Presentation/Card Present Payments/PointOfSaleCardPresentPaymentEventPresentationStyle.swift
+++ b/WooCommerce/Classes/POS/Presentation/Card Present Payments/PointOfSaleCardPresentPaymentEventPresentationStyle.swift
@@ -172,7 +172,9 @@ enum PointOfSaleCardPresentPaymentEventPresentationStyle {
             }
         case .paymentCaptureError(let cancelPayment):
             self = .message(.paymentCaptureError(
-                viewModel: PointOfSaleCardPresentPaymentCaptureErrorMessageViewModel(cancelButtonAction: cancelPayment)))
+                viewModel: PointOfSaleCardPresentPaymentCaptureErrorMessageViewModel(
+                    tryAgainButtonAction: cancelPayment,
+                    newOrderButtonAction: cancelPayment)))
 
         case .processing:
             self = .message(.processing(viewModel: PointOfSaleCardPresentPaymentProcessingMessageViewModel()))

--- a/WooCommerce/Classes/POS/Presentation/Card Present Payments/PointOfSaleCardPresentPaymentEventPresentationStyle.swift
+++ b/WooCommerce/Classes/POS/Presentation/Card Present Payments/PointOfSaleCardPresentPaymentEventPresentationStyle.swift
@@ -9,6 +9,7 @@ enum PointOfSaleCardPresentPaymentEventPresentationStyle {
         let nonRetryableErrorExitAction: () -> Void
         let formattedOrderTotalPrice: String?
         let paymentCaptureErrorTryAgainAction: () -> Void
+        let paymentCaptureErrorNewOrderAction: () -> Void
     }
 
     /// Determines the appropriate payment alert/message type and creates its view model.
@@ -176,7 +177,7 @@ enum PointOfSaleCardPresentPaymentEventPresentationStyle {
             self = .message(.paymentCaptureError(
                 viewModel: PointOfSaleCardPresentPaymentCaptureErrorMessageViewModel(
                     tryAgainButtonAction: dependencies.paymentCaptureErrorTryAgainAction,
-                    newOrderButtonAction: cancelPayment)))
+                    newOrderButtonAction: dependencies.paymentCaptureErrorNewOrderAction)))
 
         case .processing:
             self = .message(.processing(viewModel: PointOfSaleCardPresentPaymentProcessingMessageViewModel()))

--- a/WooCommerce/Classes/POS/Presentation/Card Present Payments/PointOfSaleCardPresentPaymentEventPresentationStyle.swift
+++ b/WooCommerce/Classes/POS/Presentation/Card Present Payments/PointOfSaleCardPresentPaymentEventPresentationStyle.swift
@@ -173,7 +173,7 @@ enum PointOfSaleCardPresentPaymentEventPresentationStyle {
                 }
             }
 
-        case .paymentCaptureError(let cancelPayment):
+        case .paymentCaptureError:
             self = .message(.paymentCaptureError(
                 viewModel: PointOfSaleCardPresentPaymentCaptureErrorMessageViewModel(
                     tryAgainButtonAction: dependencies.paymentCaptureErrorTryAgainAction,

--- a/WooCommerce/Classes/POS/Presentation/Card Present Payments/PointOfSaleCardPresentPaymentEventPresentationStyle.swift
+++ b/WooCommerce/Classes/POS/Presentation/Card Present Payments/PointOfSaleCardPresentPaymentEventPresentationStyle.swift
@@ -8,6 +8,7 @@ enum PointOfSaleCardPresentPaymentEventPresentationStyle {
         let tryPaymentAgainBackToCheckoutAction: () -> Void
         let nonRetryableErrorExitAction: () -> Void
         let formattedOrderTotalPrice: String?
+        let paymentCaptureErrorTryAgainAction: () -> Void
     }
 
     /// Determines the appropriate payment alert/message type and creates its view model.
@@ -170,10 +171,11 @@ enum PointOfSaleCardPresentPaymentEventPresentationStyle {
                             tryAnotherPaymentMethodAction: dependencies.nonRetryableErrorExitAction)))
                 }
             }
+
         case .paymentCaptureError(let cancelPayment):
             self = .message(.paymentCaptureError(
                 viewModel: PointOfSaleCardPresentPaymentCaptureErrorMessageViewModel(
-                    tryAgainButtonAction: cancelPayment,
+                    tryAgainButtonAction: dependencies.paymentCaptureErrorTryAgainAction,
                     newOrderButtonAction: cancelPayment)))
 
         case .processing:

--- a/WooCommerce/Classes/POS/Presentation/Card Present Payments/Reader Messages/PointOfSaleCardPresentPaymentCaptureErrorMessageViewModel.swift
+++ b/WooCommerce/Classes/POS/Presentation/Card Present Payments/Reader Messages/PointOfSaleCardPresentPaymentCaptureErrorMessageViewModel.swift
@@ -4,19 +4,20 @@ import enum Yosemite.CardReaderServiceError
 final class PointOfSaleCardPresentPaymentCaptureErrorMessageViewModel: ObservableObject {
     let title = Localization.title
     let message = Localization.message
-    private(set) lazy var moreInfoButtonViewModel: CardPresentPaymentsModalButtonViewModel = CardPresentPaymentsModalButtonViewModel(
-        title: Localization.moreInfo,
-        actionHandler: { [weak self] in
-            self?.showsInfoSheet = true
-        })
-    let cancelButtonViewModel: CardPresentPaymentsModalButtonViewModel
+    let nextStep = Localization.nextStep
+    let tryAgainButtonViewModel: CardPresentPaymentsModalButtonViewModel
+    let newOrderButtonViewModel: CardPresentPaymentsModalButtonViewModel
 
     @Published var showsInfoSheet: Bool = false
 
-    init(cancelButtonAction: @escaping () -> Void) {
-        self.cancelButtonViewModel = CardPresentPaymentsModalButtonViewModel(
-            title: Localization.cancel,
-            actionHandler: cancelButtonAction)
+    init(tryAgainButtonAction: @escaping () -> Void,
+         newOrderButtonAction: @escaping () -> Void) {
+        self.tryAgainButtonViewModel = CardPresentPaymentsModalButtonViewModel(
+            title: Localization.tryPaymentAgain,
+            actionHandler: tryAgainButtonAction)
+        self.newOrderButtonViewModel = CardPresentPaymentsModalButtonViewModel(
+            title: Localization.newOrder,
+            actionHandler: newOrderButtonAction)
     }
 
     func onAppear() {
@@ -27,28 +28,36 @@ final class PointOfSaleCardPresentPaymentCaptureErrorMessageViewModel: Observabl
 private extension PointOfSaleCardPresentPaymentCaptureErrorMessageViewModel {
     enum Localization {
         static let title = NSLocalizedString(
-            "pointOfSale.cardPresent.paymentCaptureError.title",
-            value: "Payment status unknown",
-            comment: "Error message. Presented to users after collecting a payment fails from payment capture error on the Point of Sale Checkout"
+            "pointOfSale.cardPresent.paymentCaptureError.unable.to.confirm.title",
+            value: "Payment error",
+            comment: "Error message. Presented to users after collecting a payment fails from payment capture error " +
+            "on the Point of Sale Checkout"
         )
 
         static let message = NSLocalizedString(
-            "pointOfSale.cardPresent.paymentCaptureError.message",
-            value: "We couldn't load complete order information to check the payment status. " +
-            "Please check the latest order separately or retry.",
-            comment: "Error message. Presented to users after collecting a payment fails from payment capture error on the Point of Sale Checkout"
+            "pointOfSale.cardPresent.paymentCaptureError.unable.to.confirm.message",
+            value: "Due to a network error, we’re unable to confirm that the payment succeeded.",
+            comment: "Error message. Presented to users after collecting a payment fails from payment capture error " +
+            "on the Point of Sale Checkout"
         )
 
-        static let moreInfo = NSLocalizedString(
-            "pointOfSale.cardPresent.paymentCaptureError.moreInfo.button.title",
-            value: "Learn more",
-            comment: "Button to learn more about the payment capture error message. " +
+        static let nextStep = NSLocalizedString(
+            "pointOfSale.cardPresent.paymentCaptureError.nextSteps",
+            value: "Verify payment on a device with a working network connection. If unsuccessful, retry the payment. " +
+            "If successful, start a new order.",
+            comment: "Next steps hint for what to do after seeing a payment capture error message. Presented to users " +
+            "after collecting a payment fails from payment capture error on the Point of Sale Checkout")
+
+        static let tryPaymentAgain = NSLocalizedString(
+            "pointOfSale.cardPresent.paymentCaptureError.tryPaymentAgain.button.title",
+            value: "Try payment again",
+            comment: "Button to dismiss payment capture error message. " +
             "Presented to users after collecting a payment fails from payment capture error on the Point of Sale Checkout"
         )
 
-        static let cancel = NSLocalizedString(
-            "pointOfSale.cardPresent.paymentCaptureError.cancel.button.title",
-            value: "Retry payment",
+        static let newOrder = NSLocalizedString(
+            "pointOfSale.cardPresent.paymentCaptureError.newOrder.button.title",
+            value: "New order",
             comment: "Button to dismiss payment capture error message. " +
             "Presented to users after collecting a payment fails from payment capture error on the Point of Sale Checkout"
         )

--- a/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/Reader Messages/PointOfSaleCardPresentPaymentCaptureErrorMessageView.swift
+++ b/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/Reader Messages/PointOfSaleCardPresentPaymentCaptureErrorMessageView.swift
@@ -9,18 +9,34 @@ struct PointOfSaleCardPresentPaymentCaptureErrorMessageView: View {
     }
 
     var body: some View {
-        HStack {
-            VStack {
+        VStack(alignment: .center, spacing: PointOfSaleCardPresentPaymentLayout.errorElementSpacing) {
+            POSErrorXMark()
+            VStack(alignment: .center, spacing: PointOfSaleCardPresentPaymentLayout.textSpacing) {
                 Text(viewModel.title)
-                Text(viewModel.message)
+                    .foregroundStyle(Color.primaryText)
+                    .font(.posTitle)
+
+                VStack(alignment: .center, spacing: PointOfSaleCardPresentPaymentLayout.smallTextSpacing) {
+                    Text(viewModel.message)
+                    Text(viewModel.nextStep)
+                }
+                .font(.posBody)
+                .foregroundStyle(Color.primaryText)
             }
 
-            Button(viewModel.moreInfoButtonViewModel.title,
-                   action: viewModel.moreInfoButtonViewModel.actionHandler)
+            VStack(spacing: PointOfSaleCardPresentPaymentLayout.buttonSpacing) {
+                Button(viewModel.tryAgainButtonViewModel.title,
+                       action: viewModel.tryAgainButtonViewModel.actionHandler)
+                .buttonStyle(POSPrimaryButtonStyle())
 
-            Button(viewModel.cancelButtonViewModel.title,
-                   action: viewModel.cancelButtonViewModel.actionHandler)
+                Button(action: viewModel.newOrderButtonViewModel.actionHandler) {
+                    Label(viewModel.newOrderButtonViewModel.title, systemImage: "arrow.uturn.backward")
+                }
+                .buttonStyle(POSSecondaryButtonStyle())
+            }
         }
+        .multilineTextAlignment(.center)
+        .frame(maxWidth: PointOfSaleCardPresentPaymentLayout.errorContentMaxWidth)
         .sheet(isPresented: $viewModel.showsInfoSheet) {
             PointOfSaleCardPresentPaymentCaptureFailedView()
         }
@@ -33,5 +49,6 @@ struct PointOfSaleCardPresentPaymentCaptureErrorMessageView: View {
 #Preview {
     PointOfSaleCardPresentPaymentCaptureErrorMessageView(
         viewModel: PointOfSaleCardPresentPaymentCaptureErrorMessageViewModel(
-            cancelButtonAction: {}))
+            tryAgainButtonAction: {},
+            newOrderButtonAction: {}))
 }

--- a/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/Reader Messages/PointOfSaleCardPresentPaymentCaptureErrorMessageView.swift
+++ b/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/Reader Messages/PointOfSaleCardPresentPaymentCaptureErrorMessageView.swift
@@ -37,8 +37,8 @@ struct PointOfSaleCardPresentPaymentCaptureErrorMessageView: View {
         }
         .multilineTextAlignment(.center)
         .frame(maxWidth: PointOfSaleCardPresentPaymentLayout.errorContentMaxWidth)
-        .sheet(isPresented: $viewModel.showsInfoSheet) {
-            PointOfSaleCardPresentPaymentCaptureFailedView()
+        .posModal(isPresented: $viewModel.showsInfoSheet) {
+            PointOfSaleCardPresentPaymentCaptureFailedView(isPresented: $viewModel.showsInfoSheet)
         }
         .onAppear {
             viewModel.onAppear()

--- a/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/Reader Messages/Presented Views/PointOfSaleCardPresentPaymentCaptureFailedView.swift
+++ b/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/Reader Messages/Presented Views/PointOfSaleCardPresentPaymentCaptureFailedView.swift
@@ -1,38 +1,61 @@
 import SwiftUI
 
 struct PointOfSaleCardPresentPaymentCaptureFailedView: View {
-    @Environment(\.dismiss) private var dismiss
+    @Binding var isPresented: Bool
 
     var body: some View {
-        VStack {
-            Text(Localization.title)
+        VStack(alignment: .center, spacing: PointOfSaleCardPresentPaymentLayout.errorElementSpacing) {
+            POSErrorExclamationMark()
 
-            Image(uiImage: .paymentErrorImage)
+            VStack(alignment: .center, spacing: PointOfSaleCardPresentPaymentLayout.textSpacing) {
+                Text(Localization.title)
+                    .foregroundStyle(Color.primaryText)
+                    .font(.posTitle)
 
-            Text(Localization.errorDetails)
+                VStack(alignment: .center, spacing: PointOfSaleCardPresentPaymentLayout.smallTextSpacing) {
+                    Text(Localization.message)
+                    Text(Localization.nextSteps)
+                }
+                .font(.posBody)
+                .foregroundStyle(Color.primaryText)
+            }
 
             Button(Localization.understandButtonTitle,
                    action: {
-                dismiss()
+                isPresented = false
             })
-            .buttonStyle(SecondaryButtonStyle())
+            .buttonStyle(POSPrimaryButtonStyle())
         }
+        .multilineTextAlignment(.center)
+        .padding(Layout.contentPadding)
+        .frame(maxWidth: Layout.maxWidth)
     }
 }
 
 private extension PointOfSaleCardPresentPaymentCaptureFailedView {
+    enum Layout {
+        static let maxWidth: CGFloat = 896
+        static let contentPadding: CGFloat = 40
+    }
+
     enum Localization {
         static let title = NSLocalizedString(
-            "pointOfSale.cardPresentPayment.alert.paymentCaptureError.title",
-            value: "Please check order payment status",
-            comment: "Title of the alert presented when payment capture fails."
+            "pointOfSale.cardPresentPayment.paymentCaptureError.order.may.have.failed.title",
+            value: "This order may have failed",
+            comment: "Title of the alert presented when payment capture may have failed. This draws extra " +
+            "attention to the issue."
         )
 
-        static let errorDetails = NSLocalizedString(
-            "pointOfSale.cardPresentPayment.alert.paymentCaptureError.errorDetails",
-            value: "Due to an error from capturing payment and refreshing order, we couldn't load complete order information. " +
-            "To avoid undercharging or double charging, please check the latest order separately before proceeding.",
-            comment: "Subtitle of the alert presented when payment capture fails."
+        static let message = NSLocalizedString(
+            "pointOfSale.cardPresentPayment.paymentCaptureError.order.may.have.failed.message",
+            value: "Due to a network error, we don’t know if payment succeeded.",
+            comment: "Message drawing attention to issue of payment capture maybe failing."
+        )
+
+        static let nextSteps = NSLocalizedString(
+            "pointOfSale.cardPresentPayment.paymentCaptureError.order.may.have.failed.nextSteps",
+            value: "Please double check the order on a device with a network connection before continuing.",
+            comment: ""
         )
 
         static let understandButtonTitle = NSLocalizedString(
@@ -44,5 +67,5 @@ private extension PointOfSaleCardPresentPaymentCaptureFailedView {
 }
 
 #Preview {
-    PointOfSaleCardPresentPaymentCaptureFailedView()
+    PointOfSaleCardPresentPaymentCaptureFailedView(isPresented: .constant(true))
 }

--- a/WooCommerce/Classes/POS/Presentation/PointOfSaleDashboardView.swift
+++ b/WooCommerce/Classes/POS/Presentation/PointOfSaleDashboardView.swift
@@ -132,7 +132,7 @@ private extension PointOfSaleDashboardView {
     }
 
     var totalsView: some View {
-        TotalsView(totalsViewModel: totalsViewModel)
+        TotalsView(viewModel: totalsViewModel)
     }
 
     var productListView: some View {

--- a/WooCommerce/Classes/POS/Presentation/PointOfSaleDashboardView.swift
+++ b/WooCommerce/Classes/POS/Presentation/PointOfSaleDashboardView.swift
@@ -132,8 +132,7 @@ private extension PointOfSaleDashboardView {
     }
 
     var totalsView: some View {
-        TotalsView(viewModel: viewModel,
-                   totalsViewModel: totalsViewModel)
+        TotalsView(totalsViewModel: totalsViewModel)
     }
 
     var productListView: some View {

--- a/WooCommerce/Classes/POS/Presentation/TotalsView.swift
+++ b/WooCommerce/Classes/POS/Presentation/TotalsView.swift
@@ -1,7 +1,7 @@
 import SwiftUI
 
 struct TotalsView: View {
-    @ObservedObject private var totalsViewModel: TotalsViewModel
+    @ObservedObject private var viewModel: TotalsViewModel
 
     /// Used together with .matchedGeometryEffect to synchronize the animations of shimmeringLineView and text fields.
     /// This makes SwiftUI treat these views as a single entity in the context of animation.
@@ -11,19 +11,19 @@ struct TotalsView: View {
     @State private var isShowingTotalsFields: Bool
     @State private var isShowingPaymentsButtonSpacing: Bool = false
 
-    init(totalsViewModel: TotalsViewModel) {
-        self.totalsViewModel = totalsViewModel
-        self.isShowingTotalsFields = totalsViewModel.isShowingTotalsFields
+    init(viewModel: TotalsViewModel) {
+        self.viewModel = viewModel
+        self.isShowingTotalsFields = viewModel.isShowingTotalsFields
     }
 
     var body: some View {
         HStack {
-            switch totalsViewModel.orderState {
+            switch viewModel.orderState {
             case .idle, .syncing, .loaded:
                 VStack(alignment: .center) {
                     Spacer()
                     VStack(alignment: .center, spacing: Constants.verticalSpacing) {
-                        if totalsViewModel.isShowingCardReaderStatus {
+                        if viewModel.isShowingCardReaderStatus {
                             cardReaderView
                                 .font(.title)
                                 .padding()
@@ -33,11 +33,11 @@ struct TotalsView: View {
                         if isShowingTotalsFields {
                             totalsFieldsView
                                 .transition(.opacity)
-                                .animation(.default, value: totalsViewModel.isShimmering)
-                                .opacity(totalsViewModel.isShowingTotalsFields ? 1 : 0)
+                                .animation(.default, value: viewModel.isShimmering)
+                                .opacity(viewModel.isShowingTotalsFields ? 1 : 0)
                         }
                     }
-                    .animation(.default, value: totalsViewModel.isShowingCardReaderStatus)
+                    .animation(.default, value: viewModel.isShowingCardReaderStatus)
                     paymentsActionButtons
                     Spacer()
                 }
@@ -46,15 +46,15 @@ struct TotalsView: View {
             }
         }
         .background(backgroundColor)
-        .animation(.default, value: totalsViewModel.isPaymentSuccessState)
+        .animation(.default, value: viewModel.isPaymentSuccessState)
         .onDisappear {
-            totalsViewModel.onTotalsViewDisappearance()
+            viewModel.onTotalsViewDisappearance()
         }
-        .onChange(of: totalsViewModel.isShowingTotalsFields, perform: hideTotalsFieldsWithDelay)
+        .onChange(of: viewModel.isShowingTotalsFields, perform: hideTotalsFieldsWithDelay)
     }
 
     private var backgroundColor: Color {
-        switch totalsViewModel.paymentState {
+        switch viewModel.paymentState {
         case .cardPaymentSuccessful:
             Color(.wooCommerceEmerald(.shade20))
         case .processingPayment:
@@ -71,23 +71,23 @@ private extension TotalsView {
             Spacer()
             VStack() {
                 subtotalFieldView(title: Localization.subtotal,
-                                  formattedPrice: totalsViewModel.formattedCartTotalPrice,
-                                  shimmeringActive: totalsViewModel.isShimmering,
-                                  redacted: totalsViewModel.isSubtotalFieldRedacted,
+                                  formattedPrice: viewModel.formattedCartTotalPrice,
+                                  shimmeringActive: viewModel.isShimmering,
+                                  redacted: viewModel.isSubtotalFieldRedacted,
                                   matchedGeometryId: Constants.matchedGeometrySubtotalId)
                 Spacer().frame(height: Constants.subtotalsVerticalSpacing)
                 subtotalFieldView(title: Localization.taxes,
-                                  formattedPrice: totalsViewModel.formattedOrderTotalTaxPrice,
-                                  shimmeringActive: totalsViewModel.isShimmering,
-                                  redacted: totalsViewModel.isTaxFieldRedacted,
+                                  formattedPrice: viewModel.formattedOrderTotalTaxPrice,
+                                  shimmeringActive: viewModel.isShimmering,
+                                  redacted: viewModel.isTaxFieldRedacted,
                                   matchedGeometryId: Constants.matchedGeometryTaxId)
                 Spacer().frame(height: Constants.totalVerticalSpacing)
                 Divider()
                     .overlay(Color.posTotalsSeparator)
                 Spacer().frame(height: Constants.totalVerticalSpacing)
-                totalFieldView(formattedPrice: totalsViewModel.formattedOrderTotalPrice,
-                               shimmeringActive: totalsViewModel.isShimmering,
-                               redacted: totalsViewModel.isTotalPriceFieldRedacted,
+                totalFieldView(formattedPrice: viewModel.formattedOrderTotalPrice,
+                               shimmeringActive: viewModel.isShimmering,
+                               redacted: viewModel.isTotalPriceFieldRedacted,
                                matchedGeometryId: Constants.matchedGeometryTotalId)
             }
             .padding(Constants.totalsLineViewPadding)
@@ -155,7 +155,7 @@ private extension TotalsView {
     /// Hide totals fields with animation after a delay when starting to processing a payment
     /// - Parameter isShowing
     private func hideTotalsFieldsWithDelay(_ isShowing: Bool) {
-        guard !isShowing && totalsViewModel.paymentState == .processingPayment else {
+        guard !isShowing && viewModel.paymentState == .processingPayment else {
             self.isShowingTotalsFields = isShowing
             return
         }
@@ -169,7 +169,7 @@ private extension TotalsView {
 private extension TotalsView {
     private var newOrderButton: some View {
         Button(action: {
-            totalsViewModel.startNewOrder()
+            viewModel.startNewOrder()
         }, label: {
             HStack(spacing: Constants.newOrderButtonSpacing) {
                 Image(systemName: Constants.newOrderImageName)
@@ -190,7 +190,7 @@ private extension TotalsView {
 
     @ViewBuilder
     private var paymentsActionButtons: some View {
-        if totalsViewModel.paymentState == .cardPaymentSuccessful {
+        if viewModel.paymentState == .cardPaymentSuccessful {
             if isShowingPaymentsButtonSpacing {
                 Spacer().frame(height: Constants.paymentsButtonSpacing)
             }
@@ -209,9 +209,9 @@ private extension TotalsView {
     }
 
     @ViewBuilder private var cardReaderView: some View {
-        switch totalsViewModel.connectionStatus {
+        switch viewModel.connectionStatus {
         case .connected:
-            if let inlinePaymentMessage = totalsViewModel.cardPresentPaymentInlineMessage {
+            if let inlinePaymentMessage = viewModel.cardPresentPaymentInlineMessage {
                 HStack(alignment: .center) {
                     Spacer()
                     PointOfSaleCardPresentPaymentInLineMessage(messageType: inlinePaymentMessage)
@@ -221,7 +221,7 @@ private extension TotalsView {
                 EmptyView()
             }
         case .disconnected:
-            PointOfSaleCardPresentPaymentReaderDisconnectedMessageView(viewModel: .init(connectReaderAction: totalsViewModel.connectReaderTapped))
+            PointOfSaleCardPresentPaymentReaderDisconnectedMessageView(viewModel: .init(connectReaderAction: viewModel.connectReaderTapped))
         }
     }
 }
@@ -293,6 +293,6 @@ private extension TotalsView {
                                    cardPresentPaymentService: CardPresentPaymentPreviewService(),
                                    currencyFormatter: .init(currencySettings: .init()),
                                     paymentState: .acceptingCard)
-    return TotalsView(totalsViewModel: totalsVM)
+    return TotalsView(viewModel: totalsVM)
 }
 #endif

--- a/WooCommerce/Classes/POS/Presentation/TotalsView.swift
+++ b/WooCommerce/Classes/POS/Presentation/TotalsView.swift
@@ -1,7 +1,6 @@
 import SwiftUI
 
 struct TotalsView: View {
-    @ObservedObject private var viewModel: PointOfSaleDashboardViewModel
     @ObservedObject private var totalsViewModel: TotalsViewModel
 
     /// Used together with .matchedGeometryEffect to synchronize the animations of shimmeringLineView and text fields.
@@ -12,9 +11,7 @@ struct TotalsView: View {
     @State private var isShowingTotalsFields: Bool
     @State private var isShowingPaymentsButtonSpacing: Bool = false
 
-    init(viewModel: PointOfSaleDashboardViewModel,
-         totalsViewModel: TotalsViewModel) {
-        self.viewModel = viewModel
+    init(totalsViewModel: TotalsViewModel) {
         self.totalsViewModel = totalsViewModel
         self.isShowingTotalsFields = totalsViewModel.isShowingTotalsFields
     }
@@ -172,8 +169,7 @@ private extension TotalsView {
 private extension TotalsView {
     private var newOrderButton: some View {
         Button(action: {
-            // TODO: This is the only place we use PointOfSaleDashboardViewModel in TotalsView – let's break that link.
-            viewModel.startNewOrder()
+            totalsViewModel.startNewOrder()
         }, label: {
             HStack(spacing: Constants.newOrderButtonSpacing) {
                 Image(systemName: Constants.newOrderImageName)
@@ -297,12 +293,6 @@ private extension TotalsView {
                                    cardPresentPaymentService: CardPresentPaymentPreviewService(),
                                    currencyFormatter: .init(currencySettings: .init()),
                                     paymentState: .acceptingCard)
-    let cartViewModel = CartViewModel()
-    let itemsListViewModel = ItemListViewModel(itemProvider: POSItemProviderPreview())
-    let posVM = PointOfSaleDashboardViewModel(cardPresentPaymentService: CardPresentPaymentPreviewService(),
-                                              totalsViewModel: totalsVM,
-                                              cartViewModel: CartViewModel(),
-                                              itemListViewModel: itemsListViewModel)
-    return TotalsView(viewModel: posVM, totalsViewModel: totalsVM)
+    return TotalsView(totalsViewModel: totalsVM)
 }
 #endif

--- a/WooCommerce/Classes/POS/ViewModels/PointOfSaleDashboardViewModel.swift
+++ b/WooCommerce/Classes/POS/ViewModels/PointOfSaleDashboardViewModel.swift
@@ -47,13 +47,13 @@ final class PointOfSaleDashboardViewModel: ObservableObject {
         observeCartItemsToCheckIfCartIsEmpty()
         observePaymentStateForButtonDisabledProperties()
         observeItemListState()
+        observeTotalsStartNewOrderAction()
     }
 
-    func startNewOrder() {
+    private func startNewOrder() {
         // clear cart
         cartViewModel.removeAllItemsFromCart()
         orderStage = .building
-        totalsViewModel.startNewOrder()
     }
 
     private func cartSubmitted(cartItems: [CartItem]) {
@@ -162,9 +162,7 @@ private extension PointOfSaleDashboardViewModel {
         }
         .store(in: &cancellables)
     }
-}
 
-private extension PointOfSaleDashboardViewModel {
     func observeItemListState() {
         Publishers.CombineLatest(itemListViewModel.statePublisher, itemListViewModel.itemsPublisher)
             .sink { [weak self] state, items in
@@ -181,6 +179,15 @@ private extension PointOfSaleDashboardViewModel {
                     self.isError = false
                     self.isEmpty = false
                 }
+            }
+            .store(in: &cancellables)
+    }
+
+    func observeTotalsStartNewOrderAction() {
+        totalsViewModel.startNewOrderActionPublisher
+            .sink { [weak self] in
+                guard let self else { return }
+                self.startNewOrder()
             }
             .store(in: &cancellables)
     }

--- a/WooCommerce/Classes/POS/ViewModels/TotalsViewModel.swift
+++ b/WooCommerce/Classes/POS/ViewModels/TotalsViewModel.swift
@@ -361,14 +361,15 @@ private extension TotalsViewModel {
     }
 
     var presentationStyleDeterminerDependencies: PointOfSaleCardPresentPaymentEventPresentationStyle.Dependencies {
-        PointOfSaleCardPresentPaymentEventPresentationStyle.Dependencies(
-            tryPaymentAgainBackToCheckoutAction: { [weak self] in
-                self?.cancelThenCollectPayment()
-            },
-            nonRetryableErrorExitAction: { [weak self] in
-                self?.cancelThenCollectPayment()
-            },
-            formattedOrderTotalPrice: formattedOrderTotalPrice)
+        let cancelThenCollectPaymentWithWeakSelf: () -> Void = { [weak self] in
+            self?.cancelThenCollectPayment()
+        }
+
+        return PointOfSaleCardPresentPaymentEventPresentationStyle.Dependencies(
+            tryPaymentAgainBackToCheckoutAction: cancelThenCollectPaymentWithWeakSelf,
+            nonRetryableErrorExitAction: cancelThenCollectPaymentWithWeakSelf,
+            formattedOrderTotalPrice: formattedOrderTotalPrice,
+            paymentCaptureErrorTryAgainAction: cancelThenCollectPaymentWithWeakSelf)
     }
 
     func cancelThenCollectPayment() {

--- a/WooCommerce/Classes/POS/ViewModels/TotalsViewModel.swift
+++ b/WooCommerce/Classes/POS/ViewModels/TotalsViewModel.swift
@@ -40,6 +40,11 @@ final class TotalsViewModel: ObservableObject, TotalsViewModelProtocol {
     @Published var formattedOrderTotalPrice: String?
     @Published var formattedOrderTotalTaxPrice: String?
 
+    private let startNewOrderActionSubject = PassthroughSubject<Void, Never>()
+    var startNewOrderActionPublisher: AnyPublisher<Void, Never> {
+        startNewOrderActionSubject.eraseToAnyPublisher()
+    }
+
     var computedFormattedCartTotalPrice: String? {
         formattedPrice(totalsCalculator?.itemsTotal.stringValue, currency: order?.currency)
     }
@@ -138,6 +143,7 @@ final class TotalsViewModel: ObservableObject, TotalsViewModelProtocol {
         paymentState = .acceptingCard
         clearOrder()
         cardPresentPaymentInlineMessage = nil
+        startNewOrderActionSubject.send(())
     }
 
     func onTotalsViewDisappearance() {

--- a/WooCommerce/Classes/POS/ViewModels/TotalsViewModel.swift
+++ b/WooCommerce/Classes/POS/ViewModels/TotalsViewModel.swift
@@ -375,7 +375,10 @@ private extension TotalsViewModel {
             tryPaymentAgainBackToCheckoutAction: cancelThenCollectPaymentWithWeakSelf,
             nonRetryableErrorExitAction: cancelThenCollectPaymentWithWeakSelf,
             formattedOrderTotalPrice: formattedOrderTotalPrice,
-            paymentCaptureErrorTryAgainAction: cancelThenCollectPaymentWithWeakSelf)
+            paymentCaptureErrorTryAgainAction: cancelThenCollectPaymentWithWeakSelf,
+            paymentCaptureErrorNewOrderAction: { [weak self] in
+                self?.startNewOrder()
+            })
     }
 
     func cancelThenCollectPayment() {

--- a/WooCommerce/Classes/POS/ViewModels/TotalsViewModel.swift
+++ b/WooCommerce/Classes/POS/ViewModels/TotalsViewModel.swift
@@ -404,6 +404,8 @@ private extension TotalsViewModel.PaymentState {
             } else {
                 self = .paymentError
             }
+        case .show(.paymentCaptureError):
+            self = .paymentError
         case .show(.paymentSuccess):
             self = .cardPaymentSuccessful
         default:

--- a/WooCommerce/Classes/POS/ViewModels/TotalsViewModelProtocol.swift
+++ b/WooCommerce/Classes/POS/ViewModels/TotalsViewModelProtocol.swift
@@ -21,7 +21,7 @@ protocol TotalsViewModelProtocol {
     var formattedCartTotalPricePublisher: Published<String?>.Publisher { get }
     var formattedOrderTotalPricePublisher: Published<String?>.Publisher { get }
     var formattedOrderTotalTaxPricePublisher: Published<String?>.Publisher { get }
-
+    var startNewOrderActionPublisher: AnyPublisher<Void, Never> { get }
 
     var isShimmering: Bool { get }
     var isTotalPriceFieldRedacted: Bool { get }

--- a/WooCommerce/WooCommerceTests/POS/Card Present Payments/PointOfSaleCardPresentPaymentEventPresentationStyleTests.swift
+++ b/WooCommerce/WooCommerceTests/POS/Card Present Payments/PointOfSaleCardPresentPaymentEventPresentationStyleTests.swift
@@ -96,14 +96,38 @@ final class PointOfSaleCardPresentPaymentEventPresentationStyleTests: XCTestCase
         XCTAssertEqual(viewModel.message, "A payment of $200.50 was successfully made")
     }
 
+    func test_presentationStyle_for_paymentCaptureError_is_message_paymentCaptureError_with_correctActions() {
+        // Given
+        let eventDetails = CardPresentPaymentEventDetails.paymentCaptureError(cancelPayment: {})
+        var spyPaymentCaptureErrorTryAgainCalled = false
+        let dependencies = createPresentationStyleDependencies(paymentCaptureErrorTryAgainAction: {
+            spyPaymentCaptureErrorTryAgainCalled = true
+        })
+
+        // When
+        let presentationStyle = PointOfSaleCardPresentPaymentEventPresentationStyle(
+            for: eventDetails,
+            dependencies: dependencies)
+
+        // Then
+        guard case .message(.paymentCaptureError(let viewModel)) = presentationStyle else {
+            return XCTFail("Expected payment capture error message not found")
+        }
+
+        viewModel.tryAgainButtonViewModel.actionHandler()
+        XCTAssertTrue(spyPaymentCaptureErrorTryAgainCalled)
+    }
+
     func createPresentationStyleDependencies(
         tryPaymentAgainBackToCheckoutAction: @escaping () -> Void = {},
         nonRetryableErrorExitAction: @escaping () -> Void = {},
-        formattedOrderTotalPrice: String? = nil) -> PointOfSaleCardPresentPaymentEventPresentationStyle.Dependencies {
+        formattedOrderTotalPrice: String? = nil,
+        paymentCaptureErrorTryAgainAction: @escaping () -> Void = {}) -> PointOfSaleCardPresentPaymentEventPresentationStyle.Dependencies {
             PointOfSaleCardPresentPaymentEventPresentationStyle.Dependencies(
                 tryPaymentAgainBackToCheckoutAction: tryPaymentAgainBackToCheckoutAction,
                 nonRetryableErrorExitAction: nonRetryableErrorExitAction,
-                formattedOrderTotalPrice: formattedOrderTotalPrice)
+                formattedOrderTotalPrice: formattedOrderTotalPrice,
+                paymentCaptureErrorTryAgainAction: paymentCaptureErrorTryAgainAction)
         }
 
 }

--- a/WooCommerce/WooCommerceTests/POS/Card Present Payments/PointOfSaleCardPresentPaymentEventPresentationStyleTests.swift
+++ b/WooCommerce/WooCommerceTests/POS/Card Present Payments/PointOfSaleCardPresentPaymentEventPresentationStyleTests.swift
@@ -10,10 +10,7 @@ final class PointOfSaleCardPresentPaymentEventPresentationStyleTests: XCTestCase
             error: NSError(domain: "test", code: 1),
             retryApproach: .tryAnotherPaymentMethod(retryAction: { spyRetryCalled = true }),
             cancelPayment: {})
-        let dependencies = PointOfSaleCardPresentPaymentEventPresentationStyle.Dependencies(
-            tryPaymentAgainBackToCheckoutAction: {},
-            nonRetryableErrorExitAction: {},
-            formattedOrderTotalPrice: nil)
+        let dependencies = createPresentationStyleDependencies()
 
         // When
         let presentationStyle =  PointOfSaleCardPresentPaymentEventPresentationStyle(
@@ -39,10 +36,7 @@ final class PointOfSaleCardPresentPaymentEventPresentationStyleTests: XCTestCase
             retryApproach: .tryAgain(retryAction: { spyRetryCalled = true }),
             cancelPayment: {})
         var spyBackToCheckoutCalled = false
-        let dependencies = PointOfSaleCardPresentPaymentEventPresentationStyle.Dependencies(
-            tryPaymentAgainBackToCheckoutAction: { spyBackToCheckoutCalled = true },
-            nonRetryableErrorExitAction: {},
-            formattedOrderTotalPrice: nil)
+        let dependencies = createPresentationStyleDependencies(tryPaymentAgainBackToCheckoutAction: { spyBackToCheckoutCalled = true })
 
         // When
         let presentationStyle =  PointOfSaleCardPresentPaymentEventPresentationStyle(
@@ -68,10 +62,7 @@ final class PointOfSaleCardPresentPaymentEventPresentationStyleTests: XCTestCase
             retryApproach: .dontRetry,
             cancelPayment: {})
         var spyTryAnotherPaymentMethod = false
-        let dependencies = PointOfSaleCardPresentPaymentEventPresentationStyle.Dependencies(
-            tryPaymentAgainBackToCheckoutAction: {},
-            nonRetryableErrorExitAction: { spyTryAnotherPaymentMethod = true },
-            formattedOrderTotalPrice: nil)
+        let dependencies = createPresentationStyleDependencies(nonRetryableErrorExitAction: { spyTryAnotherPaymentMethod = true })
 
         // When
         let presentationStyle =  PointOfSaleCardPresentPaymentEventPresentationStyle(
@@ -90,10 +81,7 @@ final class PointOfSaleCardPresentPaymentEventPresentationStyleTests: XCTestCase
     func test_presentationStyle_for_paymentSuccess_is_message_paymentSuccess_with_order_total() {
         // Given
         let eventDetails = CardPresentPaymentEventDetails.paymentSuccess(done: {})
-        let dependencies = PointOfSaleCardPresentPaymentEventPresentationStyle.Dependencies(
-            tryPaymentAgainBackToCheckoutAction: {},
-            nonRetryableErrorExitAction: {},
-            formattedOrderTotalPrice: "$200.50")
+        let dependencies = createPresentationStyleDependencies(formattedOrderTotalPrice: "$200.50")
 
         // When
         let presentationStyle = PointOfSaleCardPresentPaymentEventPresentationStyle(
@@ -107,5 +95,15 @@ final class PointOfSaleCardPresentPaymentEventPresentationStyleTests: XCTestCase
 
         XCTAssertEqual(viewModel.message, "A payment of $200.50 was successfully made")
     }
+
+    func createPresentationStyleDependencies(
+        tryPaymentAgainBackToCheckoutAction: @escaping () -> Void = {},
+        nonRetryableErrorExitAction: @escaping () -> Void = {},
+        formattedOrderTotalPrice: String? = nil) -> PointOfSaleCardPresentPaymentEventPresentationStyle.Dependencies {
+            PointOfSaleCardPresentPaymentEventPresentationStyle.Dependencies(
+                tryPaymentAgainBackToCheckoutAction: tryPaymentAgainBackToCheckoutAction,
+                nonRetryableErrorExitAction: nonRetryableErrorExitAction,
+                formattedOrderTotalPrice: formattedOrderTotalPrice)
+        }
 
 }

--- a/WooCommerce/WooCommerceTests/POS/Card Present Payments/PointOfSaleCardPresentPaymentEventPresentationStyleTests.swift
+++ b/WooCommerce/WooCommerceTests/POS/Card Present Payments/PointOfSaleCardPresentPaymentEventPresentationStyleTests.swift
@@ -100,9 +100,15 @@ final class PointOfSaleCardPresentPaymentEventPresentationStyleTests: XCTestCase
         // Given
         let eventDetails = CardPresentPaymentEventDetails.paymentCaptureError(cancelPayment: {})
         var spyPaymentCaptureErrorTryAgainCalled = false
-        let dependencies = createPresentationStyleDependencies(paymentCaptureErrorTryAgainAction: {
-            spyPaymentCaptureErrorTryAgainCalled = true
-        })
+        var spyPaymentCaptureErrorNewOrderCalled = false
+        let dependencies = createPresentationStyleDependencies(
+            paymentCaptureErrorTryAgainAction: {
+                spyPaymentCaptureErrorTryAgainCalled = true
+            },
+            paymentCaptureErrorNewOrderAction: {
+                spyPaymentCaptureErrorNewOrderCalled = true
+            }
+        )
 
         // When
         let presentationStyle = PointOfSaleCardPresentPaymentEventPresentationStyle(
@@ -115,19 +121,24 @@ final class PointOfSaleCardPresentPaymentEventPresentationStyleTests: XCTestCase
         }
 
         viewModel.tryAgainButtonViewModel.actionHandler()
+        viewModel.newOrderButtonViewModel.actionHandler()
         XCTAssertTrue(spyPaymentCaptureErrorTryAgainCalled)
+        XCTAssertTrue(spyPaymentCaptureErrorNewOrderCalled)
     }
 
     func createPresentationStyleDependencies(
         tryPaymentAgainBackToCheckoutAction: @escaping () -> Void = {},
         nonRetryableErrorExitAction: @escaping () -> Void = {},
         formattedOrderTotalPrice: String? = nil,
-        paymentCaptureErrorTryAgainAction: @escaping () -> Void = {}) -> PointOfSaleCardPresentPaymentEventPresentationStyle.Dependencies {
+        paymentCaptureErrorTryAgainAction: @escaping () -> Void = {},
+        paymentCaptureErrorNewOrderAction: @escaping () -> Void = {}) -> PointOfSaleCardPresentPaymentEventPresentationStyle.Dependencies {
             PointOfSaleCardPresentPaymentEventPresentationStyle.Dependencies(
                 tryPaymentAgainBackToCheckoutAction: tryPaymentAgainBackToCheckoutAction,
                 nonRetryableErrorExitAction: nonRetryableErrorExitAction,
                 formattedOrderTotalPrice: formattedOrderTotalPrice,
-                paymentCaptureErrorTryAgainAction: paymentCaptureErrorTryAgainAction)
+                paymentCaptureErrorTryAgainAction: paymentCaptureErrorTryAgainAction,
+                paymentCaptureErrorNewOrderAction: paymentCaptureErrorNewOrderAction
+            )
         }
 
 }

--- a/WooCommerce/WooCommerceTests/POS/Mocks/MockTotalsViewModel.swift
+++ b/WooCommerce/WooCommerceTests/POS/Mocks/MockTotalsViewModel.swift
@@ -5,6 +5,7 @@ import protocol Yosemite.POSItem
 import struct Yosemite.Order
 
 final class MockTotalsViewModel: TotalsViewModelProtocol {
+
     var order: Yosemite.Order?
 
     @Published var orderState: TotalsViewModel.OrderState = .loaded
@@ -16,6 +17,7 @@ final class MockTotalsViewModel: TotalsViewModelProtocol {
     @Published var formattedCartTotalPrice: String?
     @Published var formattedOrderTotalPrice: String?
     @Published var formattedOrderTotalTaxPrice: String?
+    @Published var startNewOrderAction: Void = ()
 
     var orderStatePublisher: Published<TotalsViewModel.OrderState>.Publisher { $orderState }
     var paymentStatePublisher: Published<TotalsViewModel.PaymentState>.Publisher { $paymentState }
@@ -26,6 +28,7 @@ final class MockTotalsViewModel: TotalsViewModelProtocol {
     var formattedCartTotalPricePublisher: Published<String?>.Publisher { $formattedCartTotalPrice }
     var formattedOrderTotalPricePublisher: Published<String?>.Publisher { $formattedOrderTotalPrice }
     var formattedOrderTotalTaxPricePublisher: Published<String?>.Publisher { $formattedOrderTotalTaxPrice }
+    var startNewOrderActionPublisher: AnyPublisher<Void, Never> { $startNewOrderAction.eraseToAnyPublisher() }
 
     var isShimmering: Bool {
         orderState.isSyncing

--- a/WooCommerce/WooCommerceTests/POS/ViewModels/PointOfSaleDashboardViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/POS/ViewModels/PointOfSaleDashboardViewModelTests.swift
@@ -50,20 +50,18 @@ final class PointOfSaleDashboardViewModelTests: XCTestCase {
         XCTAssertEqual(sut.isExitPOSDisabled, expectedExitPOSButtonDisabledState)
     }
 
-    func test_start_new_transaction() {
+    func test_start_new_order() {
         // Given
         let expectedOrderStage = PointOfSaleDashboardViewModel.OrderStage.building
         let itemsAdded = false
-        let expectedPaymentState = TotalsViewModel.PaymentState.acceptingCard
 
         // When
-        sut.startNewOrder()
+        mockTotalsViewModel.startNewOrderAction = ()
 
         // Then
         XCTAssertEqual(sut.orderStage, expectedOrderStage)
         XCTAssertEqual(mockCartViewModel.addItemToCartCalled, itemsAdded)
-        XCTAssertEqual(sut.totalsViewModel.paymentState, expectedPaymentState)
-        XCTAssertNil(sut.totalsViewModel.order)
+        XCTAssertTrue(mockCartViewModel.removeAllItemsFromCartCalled)
     }
 
     func test_items_added_to_cart() {

--- a/WooCommerce/WooCommerceTests/POS/ViewModels/TotalsViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/POS/ViewModels/TotalsViewModelTests.swift
@@ -50,6 +50,12 @@ final class TotalsViewModelTests: XCTestCase {
         await sut.syncOrder(for: [CartItem(id: UUID(), item: item, quantity: 1)], allItems: [item])
         XCTAssertNotNil(sut.order)
 
+        var startNewOrderEventWasPublished = false
+        sut.startNewOrderActionPublisher.sink { _ in
+            startNewOrderEventWasPublished = true
+        }.store(in: &cancellables)
+        XCTAssertFalse(startNewOrderEventWasPublished)
+
         // When
         guard let order = sut.order else {
             return XCTFail("Expected order. Got nothing")
@@ -58,6 +64,7 @@ final class TotalsViewModelTests: XCTestCase {
         sut.startNewOrder()
 
         // Then
+        XCTAssertTrue(startNewOrderEventWasPublished)
         XCTAssertEqual(sut.paymentState, paymentState)
         XCTAssertNil(sut.order)
         XCTAssertNil(sut.cardPresentPaymentInlineMessage)


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of: #13234
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

This PR implements the final UI/UX for the Payment Capture Errors.

These are a slightly unusual type of error. When we get one, we know something has gone wrong with the final request to capture funds from the shopper's card, but the payment itself may have been successful.

The most likely situation for these errors to occur in is when the network connection is flaky.

This is quite a risky error as if the merchant doesn't handle it correctly, it can lead to shoppers not being charged, or being double charged.

We attempt to recover from this error by checking the order – if we can fetch it, and it's showing as paid, we jump directly to the `Payment successful` screen.

### Circular dependency between Dashboard and Totals
Starting a new order is triggered from the TotalsView, but requires other views to be co-ordinated as well.

Up to now, we've relied on TotalsView calling DashboardViewModel, which then calls back to TotalsViewModel and CartViewModel.

In this PR, we needed to add another call to start a new order, and that was quite confusing when done from the TotalsViewModel. To make it clearer, I broke this circular dependency using an action publisher, similar to how we do with the clear cart action. TotalsView no longer depends on DashboardViewModel.

Now, all new orders follow this flow:
1. Button tapped
2. TotalsViewModel.startNewOrder()
3. Signal to startNewOrderActionPublisher
4. DashboardViewModel observes startNewOrderActionPublisher, and reacts to the signal to co-ordinate other views.

I still think we can improve on this in future, but this is a step forward IMO, and not too big a refactor.

### Remaining work:
- Modal overlay curtain should extend to screen bounds – this will be on a new PR so that the modal content can be passed up for display at the top level.

## Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->


1. Set up Proxyman or Charles to intercept traffic for your test device
2. Launch the app using a store eligible for IPP
3. Navigate to `Menu > Point of Sale mode`
4. Add an item to your basket and tap `Checkout`
5. Enable breakpoints in your proxy for the response of `POST` requests to `https://public-api.wordpress.com/rest/v1.1/jetpack-blogs/*/rest-api/` and the requests to `GET` `https://public-api.wordpress.com/rest/v1.1/jetpack-blogs/*/rest-api/?json=true&path=/wc/v3/orders/*`
6. Tap your card on the reader
7. Abort the `capture_terminal_payment` response and `order` requests when the breakpoints are hit (equivalent to poor network conditions meaning it was lost.) --> an inline error message UI should be shown in the totals view, with a modal presented that shows more details about the error
8. Tap `I understand` --> it should dismiss the modal
11. Tap `Try payment again`, letting the `order` requests go through when the breakpoints are hit  --> the "Payment success" screen is shown without needing to tap a card.

Repeat the above tapping `New order` – observe that you're taken to the Product selector screen with an empty cart.


## Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->

I tested on iPad only, as this code doesn't affect the existing app flows.

Different behaviours can be triggered by cancelling the `capture_terminal_payment` network request at the request or response stage. 
 - If you cancel the response, the payment is taken and on retry, the `Payment success` screen shows after the retry as described above.
 - If you cancel the request, the payment isn't taken and when you retry, you have to tap the card again.

I checked the `New order` button on the Payment successful screen still works as expected.

Unit tests updated, moving some of the logic relating to `startNewOrder` such that it's only tested in the tests for the appropriate view model.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

https://github.com/user-attachments/assets/5e1b8599-7f3d-4e76-99ef-e02ce8feb613


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [x] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [x] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [x] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on all devices (phone/tablet) and no regressions are added.