### PR TITLE
Inbox: Fix unreliable states for the inbox list from Hub Menu

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Hub Menu/HubMenu.swift
+++ b/WooCommerce/Classes/ViewRelated/Hub Menu/HubMenu.swift
@@ -159,7 +159,7 @@ private extension HubMenu {
                         title: HubMenuViewModel.Localization.viewStore,
                         shouldAuthenticate: false)
             case HubMenuViewModel.Inbox.id:
-                Inbox(viewModel: .init(siteID: viewModel.siteID))
+                Inbox(viewModel: viewModel.inboxViewModel)
             case HubMenuViewModel.Reviews.id:
                 ReviewsView(siteID: viewModel.siteID)
             case HubMenuViewModel.Coupons.id:

--- a/WooCommerce/Classes/ViewRelated/Hub Menu/HubMenuViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Hub Menu/HubMenuViewModel.swift
@@ -88,6 +88,8 @@ final class HubMenuViewModel: ObservableObject {
                                   credentials: credentials)
     }()
 
+    private(set) lazy var inboxViewModel = InboxViewModel(siteID: siteID)
+
     private(set) var productReviewFromNoteParcel: ProductReviewFromNoteParcel?
 
     @Published private(set) var shouldShowNewFeatureBadgeOnPayments: Bool = false

--- a/WooCommerce/Classes/ViewRelated/Inbox/InboxViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Inbox/InboxViewModel.swift
@@ -169,8 +169,7 @@ private extension InboxViewModel {
     }
 
     func configureFirstPageLoad() {
-        // Listens only to the first emitted event.
-        onLoadTrigger.first()
+        onLoadTrigger
             .sink { [weak self] in
                 guard let self = self else { return }
                 self.syncFirstPage()

--- a/WooCommerce/WooCommerceTests/ViewRelated/Inbox/InboxViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Inbox/InboxViewModelTests.swift
@@ -65,7 +65,7 @@ final class InboxViewModelTests: XCTestCase {
         // Then
         XCTAssertEqual(stateAfterTheFirstOnLoadTrigger, .syncingFirstPage)
         XCTAssertEqual(stateAfterTheSecondOnLoadTrigger, .syncingFirstPage)
-        XCTAssertEqual(invocationCountOfLoadInboxNotes, 1)
+        XCTAssertEqual(invocationCountOfLoadInboxNotes, 2)
     }
 
     func test_state_is_results_after_onLoadTrigger_with_nonempty_results() {


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #13644 
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
When opening Inbox from the Hub Menu, sometimes the view would show the empty state after loading data. This only happens to Hub Menu where the view model is initialized when the view is reloaded. 

This PR attempts to fix the unreliable states of the Inbox screen by persisting its view model in `HubMenuViewModel`. That way, the view model would not be recreated when the Hub Menu is re-rendered.

Additionally, the deprecated usage of `ActionSheet` and `Alert` has also been updated on the Inbox view to avoid undefined behaviors and improve the UX on iPads.

## Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->
- Log in to a store with at least one inbox message.
- Navigate to the Menu tab and select Inbox.
- Confirm that the view displays all messages after data is loaded.
- Tap the ellipsis menu on the top right and confirm that the action sheet is displayed correctly for both iPhone and iPad.
- Tap Dismiss All and confirm that the confirmation alert is displayed correctly for both iPhone and iPad.
- Navigate back and forth the Inbox screen again to confirm that the state is always the same.
- Navigate to the My Store screen and enable the Inbox dashboard card.
- Tap View all messages and confirm that the Inbox screen is presented with the correct state.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->
\ | Action sheet | Alert
--- | --- | ---
iPhone | <img src="https://github.com/user-attachments/assets/93915b72-7a10-425c-9081-0f10d3217761" width=320 /> | <img src="https://github.com/user-attachments/assets/1939f577-3bf7-4deb-96dc-6d8e9ece40d3" width=320 />
iPad | <img src="https://github.com/user-attachments/assets/be19b0c3-3eb8-4c9c-a2a0-cd839d133d5a" width=320 /> | <img src="https://github.com/user-attachments/assets/55f37e1f-eb22-462f-93f2-ec6d54a57708" width=320 /> 



---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [x] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [x] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [x] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on all devices (phone/tablet) and no regressions are added.
