### PR TITLE
Dashboard: Fix workaround for stock card

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -24,6 +24,8 @@
 - [*] Payments: Fixed issue where new WooPayments accounts couldn't be used for In Person Payments while they were pending verification [https://github.com/woocommerce/woocommerce-ios/pull/13610]
 - [Internal] Custom Fields: Started effort to rename OrderMetaData to MetaData to share it with Products, starting with Networking layer. [https://github.com/woocommerce/woocommerce-ios/pull/13620]
 - [*] Login: Hid the site credential login option when entering a WPCom site address. [https://github.com/woocommerce/woocommerce-ios/pull/13623]
+- [Internal] Beta fix: Fixed unreliable states of the Inbox screen when navigated from the Hub Menu. [https://github.com/woocommerce/woocommerce-ios/pull/13645]
+- [Internal] Beta fix: Fixed navigation to variations in stock card for some stores. [https://github.com/woocommerce/woocommerce-ios/pull/13648]
 
 19.9
 -----

--- a/WooCommerce/Classes/ViewRelated/Dashboard/ProductStock/ProductStockDashboardCardViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/ProductStock/ProductStockDashboardCardViewModel.swift
@@ -169,9 +169,12 @@ private extension ProductStockDashboardCardViewModel {
                     return reports.map { report in
                         guard let variationID = report.variationID,
                               report.productID == 0,
-                              let parentID = stock.first(where: { $0.productID == variationID })?.productID else {
+                              let parentID = stock.first(where: { $0.productID == variationID })?.parentID else {
                             return report
                         }
+                        /// For some stores, the product ID is not found for variations returned from variation reports.
+                        /// We need to copy the parent ID from the stock report over to the variation reports
+                        /// to be able to show the details for the variation upon selection.
                         return report.copy(productID: parentID)
                     }
                 }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #13641 
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
For some stores, fetched variation reports return parent ID 0. When working with the stock card, I added a workaround to copy the product ID from stock reports to variations parent IDs. The workaround used the incorrect field, so it didn't work properly.

This PR fixes the workaround by copying the `parentID` field instead of `productID` field. This ensures that variation reports have the correct product IDs, which is necessary to navigate from the stock card to the variation detail screen.

## Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->
- Log in to a store with parent ID being 0 for variation reports. I'm unsure which plugin causes this issue - maybe @rachelmcr  can give you access to her store for to test.
- Enable the Stock card on the dashboard.
- Select any variation item on the card.
- Confirm that the variation details are loaded correctly.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

https://github.com/user-attachments/assets/88bd80cf-b812-4c9c-aa8d-083e5229753a


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [x] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [x] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [x] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on all devices (phone/tablet) and no regressions are added.
