### PR TITLE
[Orders] Fix discard confirmation when exiting order creation without saving changes

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -4,6 +4,7 @@
 20.1
 -----
 - [Internal] Orders: The orders list now only wraps name on multiple lines if it's too long to fit on a single line. [https://github.com/woocommerce/woocommerce-ios/pull/13652]
+- [*] Orders: Fixed the discard confirmation prompt during order creation, so you will be prompted to discard changes if you exit the order form after making changes to a new order. [https://github.com/woocommerce/woocommerce-ios/pull/13654]
 
 20.0
 -----

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/EditableOrderViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/EditableOrderViewModel.swift
@@ -1519,6 +1519,10 @@ private extension EditableOrderViewModel {
         // otherwise may ignore the subsequent values that are sent
         let addedItemsToSync = productInputAdditionsToSync(products: products, variations: variations)
         let removedItemsToSync = productInputDeletionsToSync(products: products, variations: variations)
+
+        guard (addedItemsToSync + removedItemsToSync).isNotEmpty else {
+            return
+        }
         orderSynchronizer.setProducts.send(addedItemsToSync + removedItemsToSync)
 
         let productCount = addedItemsToSync.count - removedItemsToSync.count

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/OrderForm.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/OrderForm.swift
@@ -24,6 +24,12 @@ final class OrderFormHostingController: UIHostingController<OrderFormPresentatio
 
         // Needed because a `SwiftUI` cannot be dismissed when being presented by a UIHostingController
         rootView.dismissHandler = { [weak self] in
+            guard viewModel.canBeDismissed else {
+                self?.presentDiscardChangesActionSheet {
+                    self?.discardOrderAndDismiss()
+                }
+                return
+            }
             self?.dismiss(animated: true)
         }
     }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #13574
<!-- Id number of the GitHub issue this PR addresses. -->

## Description

While creating a new order, there was no discard confirmation if when exiting the order form with unsaved changes. The changes were just discarded with no warning.

This fixes the order form so it prompts you to discard changes if there are unsaved changes during order creation. (No fix is needed for order editing, since it saves as you go.)

## How

* Add discard confirmation to dismiss button:
   * We currently use a custom button to dismiss `OrderForm`, and set its behavior (dismiss handler) in the `OrderFormHostingController` init method.
   * We were just passing the controller's `dismiss` method to the order form and dismissing the view without any checks. Now, we check if the view can be dismissed (`viewModel.canBeDismissed`) present the discard changes alert as needed.
* Syncing products (fixing discard confirmation with split screen):
   * The view model contains a `hasChanges` check that is always true if the order has been synced. (Because syncing the order brings changes from the backend.) This check is used for `viewModel.canBeDismissed`.
   * In a split screen view, the order immediately syncs products when the order form is opened, which causes `viewModel.canBeDismissed` to always be false — even if you dismiss the order form before making any changes.
   * This updates the sync method `syncOrderItems(products:variations:)` to only perform the remote sync if there are product changes to sync. This prevents the sync from happening immediately so the order can be dismissed without a discard confirmation. It also has the positive side effect of making the order form load faster and be more responsive at the start of order creation.

## Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->

Scenarios tested:
- iPhone with portrait orientation (no split screen)
- iPhone rotating between portrait and landscape orientation (enabling/disabling split screen)
- iPad (always split screen)

Testing steps:

1. Go to the Orders tab.
2. Tap the + button to create a new order.
3. Tap the "Cancel" button to close the order form, and confirm no discard confirmation is shown.
4. Start a new order.
5. Make some changes to the order (e.g. add a product, add a custom amount).
6. Tap the "Cancel" button and confirm a discard confirmation is shown.
7. Tap "Cancel" in the discard confirmation and confirm you are returned to the order form.
8. Close the order form and discard changes. Confirm the order form is closed and the order is discarded.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

https://github.com/user-attachments/assets/d9fe5f9e-279f-43e3-8991-fcef6efd6d70


https://github.com/user-attachments/assets/922510f8-d6b2-4abb-bceb-1ce61e712b2b


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [x] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [x] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [x] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on all devices (phone/tablet) and no regressions are added.