### PR TITLE
[Woo POS] M2: Get Support - open from menu

### DIFF
--- a/WooCommerce/Classes/POS/Presentation/POSFloatingControlView.swift
+++ b/WooCommerce/Classes/POS/Presentation/POSFloatingControlView.swift
@@ -21,8 +21,7 @@ struct POSFloatingControlView: View {
                     )
                 }
                 Button {
-                    presentationMode.wrappedValue.dismiss()
-                    // TODO: implement Get Support https://github.com/woocommerce/woocommerce-ios/issues/13401
+                    viewModel.showSupport = true
                 } label: {
                     Label(
                         title: { Text(Localization.getSupport) },

--- a/WooCommerce/Classes/POS/Presentation/PointOfSaleDashboardView.swift
+++ b/WooCommerce/Classes/POS/Presentation/PointOfSaleDashboardView.swift
@@ -73,6 +73,9 @@ struct PointOfSaleDashboardView: View {
             PointOfSaleExitPosAlertView(isPresented: $viewModel.showExitPOSModal)
             .frame(maxWidth: Constants.exitPOSSheetMaxWidth)
         }
+        .sheet(isPresented: $viewModel.showSupport) {
+            supportForm
+        }
         .task {
             await viewModel.itemListViewModel.populatePointOfSaleItems()
         }
@@ -102,6 +105,23 @@ struct PointOfSaleDashboardView: View {
     }
 }
 
+private extension PointOfSaleDashboardView {
+    var supportForm: some View {
+        NavigationView {
+            SupportForm(isPresented: $viewModel.showSupport,
+                        viewModel: SupportFormViewModel(sourceTag: Constants.supportTag))
+            .toolbar {
+                ToolbarItem(placement: .confirmationAction) {
+                    Button(Localization.supportDone) {
+                        viewModel.showSupport = false
+                    }
+                }
+            }
+        }
+        .navigationViewStyle(.stack)
+    }
+}
+
 struct FloatingControlAreaSizeKey: EnvironmentKey {
     static let defaultValue = CGSize.zero
 }
@@ -122,6 +142,15 @@ private extension PointOfSaleDashboardView {
         static let floatingControlHorizontalOffset: CGFloat = 24
         static let floatingControlVerticalOffset: CGFloat = 0
         static let exitPOSSheetMaxWidth: CGFloat = 900.0
+        static let supportTag = "origin:point-of-sale"
+    }
+
+    enum Localization {
+        static let supportDone = NSLocalizedString(
+            "pointOfSaleDashboard.support.done",
+            value: "Done",
+            comment: "Button to dismiss the support form from the POS dashboard."
+        )
     }
 }
 

--- a/WooCommerce/Classes/POS/ViewModels/PointOfSaleDashboardViewModel.swift
+++ b/WooCommerce/Classes/POS/ViewModels/PointOfSaleDashboardViewModel.swift
@@ -28,6 +28,7 @@ final class PointOfSaleDashboardViewModel: ObservableObject {
     @Published var isError: Bool = false
     @Published var isEmpty: Bool = false
     @Published var showExitPOSModal: Bool = false
+    @Published var showSupport: Bool = false
 
     private var cancellables: Set<AnyCancellable> = []
 


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #13401
Android PR: https://github.com/woocommerce/woocommerce-android/pull/12310
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

Open Support form from POS Dashboard Floating button and submit the ticket with 'origin:point-of-sale' tag

## Solution

Reusing the same approach as other places in the app (`BlazeConfirmPaymentView`)

## Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->

1. Open POS
2. Tap ellipsis, Get Support
3. Add details to form
4. Submit Support Request
5. Check Zendesk, and confirm that it contains  'origin:point-of-sale' tag 

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

https://github.com/user-attachments/assets/eb54c6de-0b8f-449d-b8bf-e091b0563e41

8630091-zd-a8c

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [ ] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [ ] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [ ] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on all devices (phone/tablet) and no regressions are added.