### PR TITLE
[Design] Update to SF Symbols barcode scanner icon

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -5,6 +5,7 @@
 -----
 - [Internal] Orders: The orders list now only wraps name on multiple lines if it's too long to fit on a single line. [https://github.com/woocommerce/woocommerce-ios/pull/13652]
 - [*] Orders: Fixed the discard confirmation prompt during order creation, so you will be prompted to discard changes if you exit the order form after making changes to a new order. [https://github.com/woocommerce/woocommerce-ios/pull/13654]
+- [*] Design: Updates the barcode scanner icon to a new icon from SF Symbols [https://github.com/woocommerce/woocommerce-ios/pull/13666]
 
 20.0
 -----

--- a/WooCommerce/Classes/Extensions/UIImage+Woo.swift
+++ b/WooCommerce/Classes/Extensions/UIImage+Woo.swift
@@ -1152,7 +1152,7 @@ extension UIImage {
     /// Scan Icon
     ///
     static var scanImage: UIImage {
-        return UIImage(named: "icon-scan")!
+        return UIImage(systemName: "barcode.viewfinder")!
     }
 
     /// WordPress Logo Icon

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/OrderForm.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/OrderForm.swift
@@ -618,6 +618,9 @@ private struct ProductsSection: View {
     ///
     @Environment(\.adaptiveModalContainerPresentationStyle) private var presentationStyle: AdaptiveModalContainerPresentationStyle?
 
+    /// Tracks the scale of the view due to accessibility changes
+    @ScaledMetric private var scale: CGFloat = 1.0
+
     private var layoutVerticalSpacing: CGFloat {
         if viewModel.shouldShowProductsSectionHeader {
             return OrderForm.Layout.verticalSpacing
@@ -804,6 +807,9 @@ private extension ProductsSection {
             } else {
                 HStack() {
                     Image(uiImage: .scanImage.withRenderingMode(.alwaysTemplate))
+                        .resizable()
+                        .aspectRatio(contentMode: .fit)
+                        .frame(height: Layout.scanImageSize * scale)
                     Text(Localization.scanProductRowTitle)
                         .frame(maxWidth: .infinity, alignment: .leading)
                 }
@@ -827,6 +833,9 @@ private extension ProductsSection {
                 ProgressView()
             } else {
                 Image(uiImage: .scanImage.withRenderingMode(.alwaysTemplate))
+                    .resizable()
+                    .aspectRatio(contentMode: .fit)
+                    .frame(height: Layout.scanImageSize * scale)
             }
         })
         .accessibilityLabel(OrderForm.Localization.scanProductButtonAccessibilityLabel)
@@ -985,6 +994,7 @@ private extension ProductSelectorView.Configuration {
 private extension ProductsSection {
     enum Layout {
         static let rowHeight: CGFloat = 56.0
+        static let scanImageSize: CGFloat = 24
     }
 
     enum Localization {

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/PaymentSection/GiftCardInputView.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/PaymentSection/GiftCardInputView.swift
@@ -5,6 +5,9 @@ struct GiftCardInputView: View {
     @StateObject private var viewModel: GiftCardInputViewModel
     @State private var showsScanner: Bool = false
 
+    /// Scale of the view based on accessibility changes
+    @ScaledMetric private var scale: CGFloat = 1.0
+
     init(viewModel: GiftCardInputViewModel) {
         self._viewModel = .init(wrappedValue: viewModel)
     }
@@ -26,6 +29,9 @@ struct GiftCardInputView: View {
                                 showsScanner = true
                             } label: {
                                 Image(uiImage: .scanImage.withRenderingMode(.alwaysTemplate))
+                                    .resizable()
+                                    .aspectRatio(contentMode: .fit)
+                                    .frame(maxHeight: Constants.scanImageSize * scale)
                                     .foregroundColor(Color(.accent))
                             }
                             .sheet(isPresented: $showsScanner) {
@@ -96,6 +102,7 @@ private extension GiftCardInputView {
     enum Constants {
         static let insets: EdgeInsets = .init(top: 16, leading: 16, bottom: 16, trailing: 16)
         static let verticalSpacing: CGFloat = 8
+        static let scanImageSize: CGFloat = 24
     }
 }
 


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #13271
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This updates the barcode scanner icon to use SF Symbols, which is available on all versions of iOS that we support.

Where it is used:

* Orders list
* Order creation: Add a product
* Order creation: Add a gift card (with Gift Cards extension)
* Products list
* Product details: Inventory > SKU

### How

* Updates the image source in `UIImage+Woo`. This is already unit tested.
* Adds image size modifiers where the image is used in SwiftUI, to give it the expected size in those views.

## Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->

1. Open the Orders list and confirm the new icon appears as expected.
2. Create a new order and confirm the new icon appears in the Products section as expected.
3. Rotate your device and confirm the new icon appears in the Products section in split view as expected.
4. Add a product to the order and confirm the new icon appears in the Products section as expected.
4. If your store has the Gift Cards extension, select "Add Gift Card" and confirm the new icon appears as expected.
5. Open the Products list and confirm the new icon appears as expected.
6. Select a product.
7. Open the product's Inventory section and confirm the new icon appears as expected in the SKU field.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

Before|After
-|-
![Simulator Screenshot - iPhone 15 Plus - 2024-08-20 at 12 37 48](https://github.com/user-attachments/assets/e77a308b-a87f-4c27-8a6c-782d585c5afa)|![Simulator Screenshot - iPhone 15 Plus - 2024-08-20 at 12 34 25](https://github.com/user-attachments/assets/f17e645f-3463-4db4-b56c-8aeb1e445d6a)
![Simulator Screenshot - iPhone 15 Plus - 2024-08-20 at 12 37 51](https://github.com/user-attachments/assets/620a9eff-32b3-4d12-9801-d3179ef3afea)|![Simulator Screenshot - iPhone 15 Plus - 2024-08-20 at 12 34 28](https://github.com/user-attachments/assets/47cb7cb1-4be4-4b32-a466-1c8ddfe23685)
![Simulator Screenshot - iPhone 15 Plus - 2024-08-20 at 12 38 07](https://github.com/user-attachments/assets/b2a02458-8459-4034-9207-9e02c60989f9)|![Simulator Screenshot - iPhone 15 Plus - 2024-08-20 at 13 12 23](https://github.com/user-attachments/assets/f045a21c-9764-455d-97c9-4f70a5f0b25d)
![Simulator Screenshot - iPhone 15 Plus - 2024-08-20 at 12 37 59](https://github.com/user-attachments/assets/5bb3a748-2006-4afb-80cb-6d3da33fbccc)|![Simulator Screenshot - iPhone 15 Plus - 2024-08-20 at 12 34 47](https://github.com/user-attachments/assets/09ae61d3-28c9-4e47-9a52-e2f5ff09742b)
![Simulator Screenshot - iPhone 15 Plus - 2024-08-20 at 12 37 27](https://github.com/user-attachments/assets/55635323-d700-4e6b-b945-15efb5000678)|![Simulator Screenshot - iPhone 15 Plus - 2024-08-20 at 13 12 45](https://github.com/user-attachments/assets/0d0f22e3-631b-4aa6-b64d-165a1f3e385e)


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [x] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [x] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [x] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on all devices (phone/tablet) and no regressions are added.