### PR TITLE
[Help & Support] Fix typo in System Status Report

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Help/SystemStatusReport/SystemStatusReportViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/Help/SystemStatusReport/SystemStatusReportViewModel.swift
@@ -51,7 +51,7 @@ private extension SystemStatusReportViewModel {
         if let environment = systemStatus.environment {
             lines.append(contentsOf: [
                 "\n### WordPress Environment ###\n",
-                "WordPress addresss (URL): \(environment.homeURL)",
+                "WordPress address (URL): \(environment.homeURL)",
                 "Site address (URL): \(environment.siteURL)",
                 "WC Version: \(environment.version)",
                 "Log Directory Writable: \(environment.logDirectoryWritable.stringRepresentable)",


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #12482
<!-- Id number of the GitHub issue this PR addresses. -->

## Description

This fixes a typo in the System Status Report generated by the app (`WordPress addresss (URL)` -> `WordPress address (URL)`).

## Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->

1. Submit a Support request from the App.
2. Find `WordPress address (URL):` in the system status report in Zendesk.

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [x] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [x] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [x] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on all devices (phone/tablet) and no regressions are added.