### PR TITLE
[Woo POS] Prevent foreground notices from showing in POS mode

### DIFF
--- a/WooCommerce/Classes/AppDelegate.swift
+++ b/WooCommerce/Classes/AppDelegate.swift
@@ -274,12 +274,21 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 // MARK: - Helper method for WooCommerce POS
 //
 extension AppDelegate {
-    func setShouldHideTabBar(_ hidden: Bool) {
+    func setShouldHideTabBar(_ isPointOfSaleEnabled: Bool) {
+        // App's tab bars
         guard let tabBarController = AppDelegate.shared.tabBarController else {
             return
         }
-        tabBarController.tabBar.isHidden = hidden
+        tabBarController.tabBar.isHidden = isPointOfSaleEnabled
         tabBarController.selectedViewController?.view.layoutIfNeeded()
+
+        // Foreground in-app notifications
+        debugPrint("🍉 POS enabled? \(isPointOfSaleEnabled)")
+        if isPointOfSaleEnabled {
+            ServiceLocator.pushNotesManager.disableInAppNotifications()
+        } else {
+            ServiceLocator.pushNotesManager.enableInAppNotifications()
+        }
     }
 }
 

--- a/WooCommerce/Classes/AppDelegate.swift
+++ b/WooCommerce/Classes/AppDelegate.swift
@@ -274,16 +274,15 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 // MARK: - Helper method for WooCommerce POS
 //
 extension AppDelegate {
-    func setShouldHideTabBar(_ isPointOfSaleEnabled: Bool) {
-        // App's tab bars
+    func updateSharedConfiguration(_ isPointOfSaleEnabled: Bool) {
+        // Show/hide app's tab bars
         guard let tabBarController = AppDelegate.shared.tabBarController else {
             return
         }
         tabBarController.tabBar.isHidden = isPointOfSaleEnabled
         tabBarController.selectedViewController?.view.layoutIfNeeded()
 
-        // Foreground in-app notifications
-        debugPrint("🍉 POS enabled? \(isPointOfSaleEnabled)")
+        // Enable/disable foreground in-app notifications
         if isPointOfSaleEnabled {
             ServiceLocator.pushNotesManager.disableInAppNotifications()
         } else {

--- a/WooCommerce/Classes/AppDelegate.swift
+++ b/WooCommerce/Classes/AppDelegate.swift
@@ -274,16 +274,16 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 // MARK: - Helper method for WooCommerce POS
 //
 extension AppDelegate {
-    func updateSharedConfiguration(_ isPointOfSaleEnabled: Bool) {
+    func updateSharedConfiguration(_ isPointOfSaleActive: Bool) {
         // Show/hide app's tab bars
         guard let tabBarController = AppDelegate.shared.tabBarController else {
             return
         }
-        tabBarController.tabBar.isHidden = isPointOfSaleEnabled
+        tabBarController.tabBar.isHidden = isPointOfSaleActive
         tabBarController.selectedViewController?.view.layoutIfNeeded()
 
         // Enable/disable foreground in-app notifications
-        if isPointOfSaleEnabled {
+        if isPointOfSaleActive {
             ServiceLocator.pushNotesManager.disableInAppNotifications()
         } else {
             ServiceLocator.pushNotesManager.enableInAppNotifications()

--- a/WooCommerce/Classes/Notifications/PushNotificationsManager.swift
+++ b/WooCommerce/Classes/Notifications/PushNotificationsManager.swift
@@ -10,13 +10,13 @@ import protocol WooFoundation.Analytics
 /// PushNotificationsManager: Encapsulates all the tasks related to Push Notifications Auth + Registration + Handling.
 ///
 final class PushNotificationsManager: PushNotesManager {
-    
+
     private var inAppNotices: Bool = true
-    
+
     func disableInAppNotifications() {
         inAppNotices = false
     }
-    
+
     func enableInAppNotifications() {
         inAppNotices = true
     }

--- a/WooCommerce/Classes/Notifications/PushNotificationsManager.swift
+++ b/WooCommerce/Classes/Notifications/PushNotificationsManager.swift
@@ -10,6 +10,16 @@ import protocol WooFoundation.Analytics
 /// PushNotificationsManager: Encapsulates all the tasks related to Push Notifications Auth + Registration + Handling.
 ///
 final class PushNotificationsManager: PushNotesManager {
+    
+    private var inAppNotices: Bool = true
+    
+    func disableInAppNotifications() {
+        inAppNotices = false
+    }
+    
+    func enableInAppNotifications() {
+        inAppNotices = true
+    }
 
     /// PushNotifications Configuration
     ///
@@ -269,7 +279,12 @@ extension PushNotificationsManager {
                                                    withProperties: [AnalyticKey.type: foregroundNotification.kind.rawValue])
                 }
 
-            foregroundNotificationsSubject.send(foregroundNotification)
+            if inAppNotices {
+                debugPrint("🍉 POS disabled. Sending in-app notice.")
+                foregroundNotificationsSubject.send(foregroundNotification)
+            } else {
+                debugPrint("🍉 POS enabled. Not sending notices.")
+            }
         }
 
         _ = await synchronizeNotifications()

--- a/WooCommerce/Classes/Notifications/PushNotificationsManager.swift
+++ b/WooCommerce/Classes/Notifications/PushNotificationsManager.swift
@@ -259,7 +259,7 @@ extension PushNotificationsManager {
     @MainActor
     func handleNotificationInTheForeground(_ notification: UNNotification) async -> UNNotificationPresentationOptions {
         let content = notification.request.content
-        guard applicationState == .active, content.isRemoteNotification else {
+        guard applicationState == .active, content.isRemoteNotification, inAppNotices == true else {
             // Local notifications are currently not handled when the app is in the foreground.
             return UNNotificationPresentationOptions(rawValue: 0)
         }
@@ -279,12 +279,7 @@ extension PushNotificationsManager {
                                                    withProperties: [AnalyticKey.type: foregroundNotification.kind.rawValue])
                 }
 
-            if inAppNotices {
-                debugPrint("🍉 POS disabled. Sending in-app notice.")
-                foregroundNotificationsSubject.send(foregroundNotification)
-            } else {
-                debugPrint("🍉 POS enabled. Not sending notices.")
-            }
+            foregroundNotificationsSubject.send(foregroundNotification)
         }
 
         _ = await synchronizeNotifications()

--- a/WooCommerce/Classes/POS/Presentation/PointOfSaleEntryPointView.swift
+++ b/WooCommerce/Classes/POS/Presentation/PointOfSaleEntryPointView.swift
@@ -9,14 +9,14 @@ struct PointOfSaleEntryPointView: View {
     @StateObject private var cartViewModel: CartViewModel
     @StateObject private var itemListViewModel: ItemListViewModel
 
-    private let hideAppTabBar: ((Bool) -> Void)
+    private let isPointOfSaleModeEnabled: ((Bool) -> Void)
 
     init(itemProvider: POSItemProvider,
-         hideAppTabBar: @escaping ((Bool) -> Void),
+         isPointOfSaleModeEnabled: @escaping ((Bool) -> Void),
          cardPresentPaymentService: CardPresentPaymentFacade,
          orderService: POSOrderServiceProtocol,
          currencyFormatter: CurrencyFormatter) {
-        self.hideAppTabBar = hideAppTabBar
+        self.isPointOfSaleModeEnabled = isPointOfSaleModeEnabled
 
         let totalsViewModel = TotalsViewModel(orderService: orderService,
                                               cardPresentPaymentService: cardPresentPaymentService,
@@ -42,10 +42,10 @@ struct PointOfSaleEntryPointView: View {
                                  cartViewModel: cartViewModel,
                                  itemListViewModel: itemListViewModel)
             .onAppear {
-                hideAppTabBar(true)
+                isPointOfSaleModeEnabled(true)
             }
             .onDisappear {
-                hideAppTabBar(false)
+                isPointOfSaleModeEnabled(false)
             }
     }
 }
@@ -53,7 +53,7 @@ struct PointOfSaleEntryPointView: View {
 #if DEBUG
 #Preview {
     PointOfSaleEntryPointView(itemProvider: POSItemProviderPreview(),
-                              hideAppTabBar: { _ in },
+                              isPointOfSaleModeEnabled: { _ in },
                               cardPresentPaymentService: CardPresentPaymentPreviewService(),
                               orderService: POSOrderPreviewService(),
                               currencyFormatter: .init(currencySettings: .init()))

--- a/WooCommerce/Classes/POS/Presentation/PointOfSaleEntryPointView.swift
+++ b/WooCommerce/Classes/POS/Presentation/PointOfSaleEntryPointView.swift
@@ -9,14 +9,14 @@ struct PointOfSaleEntryPointView: View {
     @StateObject private var cartViewModel: CartViewModel
     @StateObject private var itemListViewModel: ItemListViewModel
 
-    private let isPointOfSaleModeEnabled: ((Bool) -> Void)
+    private let onPointOfSaleModeActiveStateChange: ((Bool) -> Void)
 
     init(itemProvider: POSItemProvider,
-         isPointOfSaleModeEnabled: @escaping ((Bool) -> Void),
+         onPointOfSaleModeActiveStateChange: @escaping ((Bool) -> Void),
          cardPresentPaymentService: CardPresentPaymentFacade,
          orderService: POSOrderServiceProtocol,
          currencyFormatter: CurrencyFormatter) {
-        self.isPointOfSaleModeEnabled = isPointOfSaleModeEnabled
+        self.onPointOfSaleModeActiveStateChange = onPointOfSaleModeActiveStateChange
 
         let totalsViewModel = TotalsViewModel(orderService: orderService,
                                               cardPresentPaymentService: cardPresentPaymentService,
@@ -42,10 +42,10 @@ struct PointOfSaleEntryPointView: View {
                                  cartViewModel: cartViewModel,
                                  itemListViewModel: itemListViewModel)
             .onAppear {
-                isPointOfSaleModeEnabled(true)
+                onPointOfSaleModeActiveStateChange(true)
             }
             .onDisappear {
-                isPointOfSaleModeEnabled(false)
+                onPointOfSaleModeActiveStateChange(false)
             }
     }
 }
@@ -53,7 +53,7 @@ struct PointOfSaleEntryPointView: View {
 #if DEBUG
 #Preview {
     PointOfSaleEntryPointView(itemProvider: POSItemProviderPreview(),
-                              isPointOfSaleModeEnabled: { _ in },
+                              onPointOfSaleModeActiveStateChange: { _ in },
                               cardPresentPaymentService: CardPresentPaymentPreviewService(),
                               orderService: POSOrderPreviewService(),
                               currencyFormatter: .init(currencySettings: .init()))

--- a/WooCommerce/Classes/ServiceLocator/PushNotesManager.swift
+++ b/WooCommerce/Classes/ServiceLocator/PushNotesManager.swift
@@ -105,8 +105,12 @@ protocol PushNotesManager {
 
     /// Cancels all local notifications that were previously scheduled.
     func cancelAllNotifications() async
-    
-    ///
+
+    /// Disables remote notifications from appearing as in-app notices.
+    /// This is the default state for the Point of Sale mode
     func disableInAppNotifications()
+
+    /// Enables remote notifications to appear as in-app notices when needed.
+    /// This is the app's default state
     func enableInAppNotifications()
 }

--- a/WooCommerce/Classes/ServiceLocator/PushNotesManager.swift
+++ b/WooCommerce/Classes/ServiceLocator/PushNotesManager.swift
@@ -105,4 +105,8 @@ protocol PushNotesManager {
 
     /// Cancels all local notifications that were previously scheduled.
     func cancelAllNotifications() async
+    
+    ///
+    func disableInAppNotifications()
+    func enableInAppNotifications()
 }

--- a/WooCommerce/Classes/ViewRelated/Hub Menu/HubMenu.swift
+++ b/WooCommerce/Classes/ViewRelated/Hub Menu/HubMenu.swift
@@ -177,7 +177,7 @@ private extension HubMenu {
                     PointOfSaleEntryPointView(
                         itemProvider: viewModel.posItemProvider,
                         isPointOfSaleModeEnabled: { isEnabled in
-                            AppDelegate.shared.setShouldHideTabBar(isEnabled)
+                            AppDelegate.shared.updateSharedConfiguration(isEnabled)
                         },
                         cardPresentPaymentService: cardPresentPaymentService,
                         orderService: orderService,

--- a/WooCommerce/Classes/ViewRelated/Hub Menu/HubMenu.swift
+++ b/WooCommerce/Classes/ViewRelated/Hub Menu/HubMenu.swift
@@ -176,8 +176,8 @@ private extension HubMenu {
                                                       credentials: viewModel.credentials) {
                     PointOfSaleEntryPointView(
                         itemProvider: viewModel.posItemProvider,
-                        hideAppTabBar: { isHidden in
-                            AppDelegate.shared.setShouldHideTabBar(isHidden)
+                        isPointOfSaleModeEnabled: { isEnabled in
+                            AppDelegate.shared.setShouldHideTabBar(isEnabled)
                         },
                         cardPresentPaymentService: cardPresentPaymentService,
                         orderService: orderService,

--- a/WooCommerce/Classes/ViewRelated/Hub Menu/HubMenu.swift
+++ b/WooCommerce/Classes/ViewRelated/Hub Menu/HubMenu.swift
@@ -176,7 +176,7 @@ private extension HubMenu {
                                                       credentials: viewModel.credentials) {
                     PointOfSaleEntryPointView(
                         itemProvider: viewModel.posItemProvider,
-                        isPointOfSaleModeEnabled: { isEnabled in
+                        onPointOfSaleModeActiveStateChange: { isEnabled in
                             AppDelegate.shared.updateSharedConfiguration(isEnabled)
                         },
                         cardPresentPaymentService: cardPresentPaymentService,

--- a/WooCommerce/WooCommerceTests/Mocks/MockPushNotificationsManager.swift
+++ b/WooCommerce/WooCommerceTests/Mocks/MockPushNotificationsManager.swift
@@ -5,6 +5,13 @@ import UIKit
 import Yosemite
 
 final class MockPushNotificationsManager: PushNotesManager {
+    func disableInAppNotifications() {
+
+    }
+
+    func enableInAppNotifications() {
+
+    }
 
     var foregroundNotifications: AnyPublisher<PushNotification, Never> {
         foregroundNotificationsSubject.eraseToAnyPublisher()


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #13635 
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
This PR prevents the "You have a new order" `Notices` from showing while in POS mode, while keeping the same functionality in App mode.

Since these notices are created in response to a push notification, and we would need some sort of backend support to adjust these better, the simplest solution for the time being seems to be to allow the push notification to go through anyway (so the user could still tap on their phone if the app is in background, and be redirected to the store's order) but hide them from the app's foreground if the POS mode is active.

## Changes
It's the first time I work with push notifications, so feel free to suggest any better way to handle this:
- We leverage the existing mechanism we use between app and pos to hide/show the tab bars to also enable/disable in-app notices, by passing a boolean to the `AppDelegate` to let the system now we're in POS mode.
- This will toggle `inAppNotices` true/false for the whole app instance
- `inAppNotices` is used as an additional check when deciding if we should present them to the merchant, in case that POS mode is active, then we return early with `UNNotificationPresentationOptions(rawValue: 0)`

## Testing
- In POS mode, go through the order processing flow and observe how at the end there's no longer any "You have a new order" notice.
- Repeat the same process in App, go through the order processing flow and observe how you see the usual "You have a new order" notice at the end of the flow.

Apologies for the iPhone testing video, my cable just died and I had to bypass the eligibility checker to use the alternative 😅, the end result should be the same for ipad but I could only test in iPhone. Worth noting as well that we can only test in physical devices, as push notifications don't work on simulator.

While developing I found that sometimes we do not receive push notifications, but this seems to be an existing issue as happens in trunk as well, but is worth to try more than once just to be sure is not a false positive.

From my testing:
- In POS mode, no in-app notices are shown.
- In App mode, in-app notices are shown for app orders.
- When moving to background from POS mode, background notifications still work as expected.
- When moving to foreground to POS mode, no in-app notices are shown.

https://github.com/user-attachments/assets/95589d33-9bc5-43cb-8937-26e4789c73bf

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [x] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [x] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [x] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on all devices (phone/tablet) and no regressions are added.