### PR TITLE
[Woo POS] Analytics: add item to cart event

### DIFF
--- a/WooCommerce/Classes/Analytics/WooAnalyticsStat.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsStat.swift
@@ -1249,6 +1249,9 @@ enum WooAnalyticsStat: String {
     case pushNotificationOrderBackgroundSynced = "push_notification_order_background_synced"
     case pushNotificationOrderBackgroundSyncError = "push_notification_order_background_sync_error"
     case backgroundUpdatesDisabled = "background_updates_disabled"
+
+    // MARK: Point of Sale events
+    case pointOfSaleAddItemToCart = "pos_item_added_to_cart"
 }
 
 extension WooAnalyticsStat {

--- a/WooCommerce/Classes/POS/Presentation/CartView.swift
+++ b/WooCommerce/Classes/POS/Presentation/CartView.swift
@@ -190,8 +190,7 @@ import class WooFoundation.MockAnalyticsProviderPreview
                                           cardPresentPaymentService: CardPresentPaymentPreviewService(),
                                           currencyFormatter: .init(currencySettings: .init()),
                                           paymentState: .acceptingCard)
-    let analytics = MockAnalyticsPreview(userHasOptedIn: true, analyticsProvider: MockAnalyticsProviderPreview())
-    let cartViewModel = CartViewModel(analytics: analytics)
+    let cartViewModel = CartViewModel(analytics: MockAnalyticsPreview())
     let itemsListViewModel = ItemListViewModel(itemProvider: POSItemProviderPreview())
     let dashboardViewModel = PointOfSaleDashboardViewModel(cardPresentPaymentService: CardPresentPaymentPreviewService(),
                                                            totalsViewModel: totalsViewModel,

--- a/WooCommerce/Classes/POS/Presentation/CartView.swift
+++ b/WooCommerce/Classes/POS/Presentation/CartView.swift
@@ -180,6 +180,9 @@ private extension CartView {
 
 #if DEBUG
 import Combine
+import class WooFoundation.MockAnalyticsPreview
+import class WooFoundation.MockAnalyticsProviderPreview
+
 #Preview {
     // TODO:
     // Simplify this by mocking `CartViewModel`
@@ -187,7 +190,8 @@ import Combine
                                           cardPresentPaymentService: CardPresentPaymentPreviewService(),
                                           currencyFormatter: .init(currencySettings: .init()),
                                           paymentState: .acceptingCard)
-    let cartViewModel = CartViewModel()
+    let analytics = MockAnalyticsPreview(userHasOptedIn: true, analyticsProvider: MockAnalyticsProviderPreview())
+    let cartViewModel = CartViewModel(analytics: analytics)
     let itemsListViewModel = ItemListViewModel(itemProvider: POSItemProviderPreview())
     let dashboardViewModel = PointOfSaleDashboardViewModel(cardPresentPaymentService: CardPresentPaymentPreviewService(),
                                                            totalsViewModel: totalsViewModel,

--- a/WooCommerce/Classes/POS/Presentation/PointOfSaleDashboardView.swift
+++ b/WooCommerce/Classes/POS/Presentation/PointOfSaleDashboardView.swift
@@ -191,8 +191,7 @@ import class WooFoundation.MockAnalyticsProviderPreview
                                    cardPresentPaymentService: CardPresentPaymentPreviewService(),
                                    currencyFormatter: .init(currencySettings: .init()),
                                    paymentState: .acceptingCard)
-    let analytics = MockAnalyticsPreview(userHasOptedIn: true, analyticsProvider: MockAnalyticsProviderPreview())
-    let cartVM = CartViewModel(analytics: analytics)
+    let cartVM = CartViewModel(analytics: MockAnalyticsPreview())
     let itemsListVM = ItemListViewModel(itemProvider: POSItemProviderPreview())
     let posVM = PointOfSaleDashboardViewModel(cardPresentPaymentService: CardPresentPaymentPreviewService(),
                                               totalsViewModel: totalsVM,

--- a/WooCommerce/Classes/POS/Presentation/PointOfSaleDashboardView.swift
+++ b/WooCommerce/Classes/POS/Presentation/PointOfSaleDashboardView.swift
@@ -183,12 +183,16 @@ fileprivate extension CardPresentPaymentEvent {
 }
 
 #if DEBUG
+import class WooFoundation.MockAnalyticsPreview
+import class WooFoundation.MockAnalyticsProviderPreview
+
 #Preview {
     let totalsVM = TotalsViewModel(orderService: POSOrderPreviewService(),
                                    cardPresentPaymentService: CardPresentPaymentPreviewService(),
                                    currencyFormatter: .init(currencySettings: .init()),
                                    paymentState: .acceptingCard)
-    let cartVM = CartViewModel()
+    let analytics = MockAnalyticsPreview(userHasOptedIn: true, analyticsProvider: MockAnalyticsProviderPreview())
+    let cartVM = CartViewModel(analytics: analytics)
     let itemsListVM = ItemListViewModel(itemProvider: POSItemProviderPreview())
     let posVM = PointOfSaleDashboardViewModel(cardPresentPaymentService: CardPresentPaymentPreviewService(),
                                               totalsViewModel: totalsVM,

--- a/WooCommerce/Classes/POS/Presentation/PointOfSaleEntryPointView.swift
+++ b/WooCommerce/Classes/POS/Presentation/PointOfSaleEntryPointView.swift
@@ -2,6 +2,7 @@ import SwiftUI
 import class WooFoundation.CurrencyFormatter
 import protocol Yosemite.POSItemProvider
 import protocol Yosemite.POSOrderServiceProtocol
+import protocol WooFoundation.Analytics
 
 struct PointOfSaleEntryPointView: View {
     @StateObject private var viewModel: PointOfSaleDashboardViewModel
@@ -15,14 +16,15 @@ struct PointOfSaleEntryPointView: View {
          hideAppTabBar: @escaping ((Bool) -> Void),
          cardPresentPaymentService: CardPresentPaymentFacade,
          orderService: POSOrderServiceProtocol,
-         currencyFormatter: CurrencyFormatter) {
+         currencyFormatter: CurrencyFormatter,
+         analytics: Analytics) {
         self.hideAppTabBar = hideAppTabBar
 
         let totalsViewModel = TotalsViewModel(orderService: orderService,
                                               cardPresentPaymentService: cardPresentPaymentService,
                                               currencyFormatter: currencyFormatter,
                                               paymentState: .acceptingCard)
-        let cartViewModel = CartViewModel()
+        let cartViewModel = CartViewModel(analytics: analytics)
         let itemListViewModel = ItemListViewModel(itemProvider: itemProvider)
 
         self._viewModel = StateObject(wrappedValue: PointOfSaleDashboardViewModel(
@@ -56,6 +58,6 @@ struct PointOfSaleEntryPointView: View {
                               hideAppTabBar: { _ in },
                               cardPresentPaymentService: CardPresentPaymentPreviewService(),
                               orderService: POSOrderPreviewService(),
-                              currencyFormatter: .init(currencySettings: .init()))
+                              currencyFormatter: .init(currencySettings: .init()), analytics: ServiceLocator.analytics)
 }
 #endif

--- a/WooCommerce/Classes/POS/Presentation/PointOfSaleEntryPointView.swift
+++ b/WooCommerce/Classes/POS/Presentation/PointOfSaleEntryPointView.swift
@@ -53,11 +53,16 @@ struct PointOfSaleEntryPointView: View {
 }
 
 #if DEBUG
+import class WooFoundation.MockAnalyticsPreview
+import class WooFoundation.MockAnalyticsProviderPreview
+
 #Preview {
     PointOfSaleEntryPointView(itemProvider: POSItemProviderPreview(),
                               hideAppTabBar: { _ in },
                               cardPresentPaymentService: CardPresentPaymentPreviewService(),
                               orderService: POSOrderPreviewService(),
-                              currencyFormatter: .init(currencySettings: .init()), analytics: ServiceLocator.analytics)
+                              currencyFormatter: .init(currencySettings: .init()),
+                              analytics: MockAnalyticsPreview(userHasOptedIn: true,
+                                                              analyticsProvider: MockAnalyticsProviderPreview()))
 }
 #endif

--- a/WooCommerce/Classes/POS/ViewModels/CartViewModel.swift
+++ b/WooCommerce/Classes/POS/ViewModels/CartViewModel.swift
@@ -30,6 +30,8 @@ final class CartViewModel: CartViewModelProtocol {
     func addItemToCart(_ item: POSItem) {
         let cartItem = CartItem(id: UUID(), item: item, quantity: 1)
         itemsInCart.append(cartItem)
+
+        ServiceLocator.analytics.track(.pointOfSaleAddItemToCart)
     }
 
     func removeItemFromCart(_ cartItem: CartItem) {

--- a/WooCommerce/Classes/POS/ViewModels/CartViewModel.swift
+++ b/WooCommerce/Classes/POS/ViewModels/CartViewModel.swift
@@ -1,6 +1,7 @@
 import SwiftUI
 import Combine
 import protocol Yosemite.POSItem
+import protocol WooFoundation.Analytics
 
 final class CartViewModel: CartViewModelProtocol {
     /// Emits cart items when the CTA is tapped to submit the cart.
@@ -21,8 +22,12 @@ final class CartViewModel: CartViewModelProtocol {
     var isCartEmpty: Bool {
         return itemsInCart.isEmpty
     }
+    
+    private var analytics: Analytics
 
-    init() {
+    init(analytics: Analytics = ServiceLocator.analytics) {
+        self.analytics = analytics
+
         cartSubmissionPublisher = cartSubmissionSubject.eraseToAnyPublisher()
         addMoreToCartActionPublisher = addMoreToCartActionSubject.eraseToAnyPublisher()
     }
@@ -31,7 +36,7 @@ final class CartViewModel: CartViewModelProtocol {
         let cartItem = CartItem(id: UUID(), item: item, quantity: 1)
         itemsInCart.append(cartItem)
 
-        ServiceLocator.analytics.track(.pointOfSaleAddItemToCart)
+        analytics.track(.pointOfSaleAddItemToCart)
     }
 
     func removeItemFromCart(_ cartItem: CartItem) {

--- a/WooCommerce/Classes/POS/ViewModels/CartViewModel.swift
+++ b/WooCommerce/Classes/POS/ViewModels/CartViewModel.swift
@@ -22,10 +22,10 @@ final class CartViewModel: CartViewModelProtocol {
     var isCartEmpty: Bool {
         return itemsInCart.isEmpty
     }
-    
-    private var analytics: Analytics
 
-    init(analytics: Analytics = ServiceLocator.analytics) {
+    private var analytics: Analytics?
+
+    init(analytics: Analytics? = nil) {
         self.analytics = analytics
 
         cartSubmissionPublisher = cartSubmissionSubject.eraseToAnyPublisher()
@@ -36,6 +36,9 @@ final class CartViewModel: CartViewModelProtocol {
         let cartItem = CartItem(id: UUID(), item: item, quantity: 1)
         itemsInCart.append(cartItem)
 
+        guard let analytics else {
+            return
+        }
         analytics.track(.pointOfSaleAddItemToCart)
     }
 

--- a/WooCommerce/Classes/POS/ViewModels/CartViewModel.swift
+++ b/WooCommerce/Classes/POS/ViewModels/CartViewModel.swift
@@ -23,9 +23,9 @@ final class CartViewModel: CartViewModelProtocol {
         return itemsInCart.isEmpty
     }
 
-    private var analytics: Analytics?
+    private var analytics: Analytics
 
-    init(analytics: Analytics? = nil) {
+    init(analytics: Analytics) {
         self.analytics = analytics
 
         cartSubmissionPublisher = cartSubmissionSubject.eraseToAnyPublisher()
@@ -36,9 +36,6 @@ final class CartViewModel: CartViewModelProtocol {
         let cartItem = CartItem(id: UUID(), item: item, quantity: 1)
         itemsInCart.append(cartItem)
 
-        guard let analytics else {
-            return
-        }
         analytics.track(.pointOfSaleAddItemToCart)
     }
 

--- a/WooCommerce/Classes/ViewRelated/Hub Menu/HubMenu.swift
+++ b/WooCommerce/Classes/ViewRelated/Hub Menu/HubMenu.swift
@@ -181,7 +181,8 @@ private extension HubMenu {
                         },
                         cardPresentPaymentService: cardPresentPaymentService,
                         orderService: orderService,
-                        currencyFormatter: .init(currencySettings: ServiceLocator.currencySettings))
+                        currencyFormatter: .init(currencySettings: ServiceLocator.currencySettings),
+                        analytics: ServiceLocator.analytics)
                 } else {
                     // TODO: When we have a singleton for the card payment service, this should not be required.
                     Text("Error creating card payment service")

--- a/WooCommerce/WooCommerceTests/POS/ViewModels/CartViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/POS/ViewModels/CartViewModelTests.swift
@@ -8,13 +8,19 @@ import SwiftUI
 final class CartViewModelTests: XCTestCase {
 
     private var sut: CartViewModel!
+    private var analytics: WooAnalytics!
+    private var analyticsProvider: MockAnalyticsProvider!
 
     override func setUp() {
         super.setUp()
-        sut = CartViewModel()
+        analyticsProvider = MockAnalyticsProvider()
+        analytics = WooAnalytics(analyticsProvider: analyticsProvider)
+        sut = CartViewModel(analytics: analytics)
     }
 
     override func tearDown() {
+        analyticsProvider = nil
+        analytics = nil
         sut = nil
         super.tearDown()
     }
@@ -148,6 +154,18 @@ final class CartViewModelTests: XCTestCase {
 
         // Then
         XCTAssertFalse(sut.isCartEmpty)
+    }
+
+    func test_receivedEvents_when_addItemToCart_then_tracks_pos_item_added_to_cart_event() {
+        // Given
+        let expectedEvent = "pos_item_added_to_cart"
+        let item = Self.makeItem()
+
+        // When
+        sut.addItemToCart(item)
+
+        // Then
+        XCTAssertEqual(analyticsProvider.receivedEvents.first, expectedEvent)
     }
 }
 

--- a/WooFoundation/WooFoundation.xcodeproj/project.pbxproj
+++ b/WooFoundation/WooFoundation.xcodeproj/project.pbxproj
@@ -46,6 +46,8 @@
 		686BE912288EE0D300967C86 /* TypedPredicates.swift in Sources */ = {isa = PBXBuildFile; fileRef = 686BE911288EE0D300967C86 /* TypedPredicates.swift */; };
 		686BE915288EE2CA00967C86 /* TypedPredicateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 686BE914288EE2CA00967C86 /* TypedPredicateTests.swift */; };
 		6874E81428998AD300074A97 /* LogErrorAndExit.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6874E81328998AD300074A97 /* LogErrorAndExit.swift */; };
+		6896C82A2C75D60D002DDAE2 /* MockAnalyticsPreview.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6896C8292C75D60D002DDAE2 /* MockAnalyticsPreview.swift */; };
+		6896C82C2C75D638002DDAE2 /* MockAnalyticsProviderPreview.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6896C82B2C75D638002DDAE2 /* MockAnalyticsProviderPreview.swift */; };
 		689D11D02891B3A300F6A83F /* CrashLogger.swift in Sources */ = {isa = PBXBuildFile; fileRef = 689D11CF2891B3A300F6A83F /* CrashLogger.swift */; };
 		689D11D32891B7D800F6A83F /* MockCrashLogger.swift in Sources */ = {isa = PBXBuildFile; fileRef = 689D11D22891B7D800F6A83F /* MockCrashLogger.swift */; };
 		68FBC5B328926B2C00A05461 /* Collection+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 68FBC5B228926B2C00A05461 /* Collection+Extensions.swift */; };
@@ -131,6 +133,8 @@
 		686BE911288EE0D300967C86 /* TypedPredicates.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TypedPredicates.swift; sourceTree = "<group>"; };
 		686BE914288EE2CA00967C86 /* TypedPredicateTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TypedPredicateTests.swift; sourceTree = "<group>"; };
 		6874E81328998AD300074A97 /* LogErrorAndExit.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LogErrorAndExit.swift; sourceTree = "<group>"; };
+		6896C8292C75D60D002DDAE2 /* MockAnalyticsPreview.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockAnalyticsPreview.swift; sourceTree = "<group>"; };
+		6896C82B2C75D638002DDAE2 /* MockAnalyticsProviderPreview.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockAnalyticsProviderPreview.swift; sourceTree = "<group>"; };
 		689D11CF2891B3A300F6A83F /* CrashLogger.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CrashLogger.swift; sourceTree = "<group>"; };
 		689D11D22891B7D800F6A83F /* MockCrashLogger.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MockCrashLogger.swift; sourceTree = "<group>"; };
 		68FBC5B228926B2C00A05461 /* Collection+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Collection+Extensions.swift"; sourceTree = "<group>"; };
@@ -294,6 +298,8 @@
 			children = (
 				03597A9728F87948005E4A98 /* MockUTMParameterProvider.swift */,
 				689D11D22891B7D800F6A83F /* MockCrashLogger.swift */,
+				6896C8292C75D60D002DDAE2 /* MockAnalyticsPreview.swift */,
+				6896C82B2C75D638002DDAE2 /* MockAnalyticsProviderPreview.swift */,
 			);
 			path = Mocks;
 			sourceTree = "<group>";
@@ -695,6 +701,7 @@
 				6874E81428998AD300074A97 /* LogErrorAndExit.swift in Sources */,
 				B97190D1292CF3BC0065E413 /* Result+Extensions.swift in Sources */,
 				203758752AD55670000E4281 /* CountryCode.swift in Sources */,
+				6896C82A2C75D60D002DDAE2 /* MockAnalyticsPreview.swift in Sources */,
 				B9C9C65D283E71C8001B879F /* CurrencyFormatter.swift in Sources */,
 				AE948D0A28CF67CF009F3246 /* Date+StartAndEnd.swift in Sources */,
 				03597A9428F85686005E4A98 /* UTMParameters.swift in Sources */,
@@ -705,6 +712,7 @@
 				02427F092BECA12800E2073B /* Analytics.swift in Sources */,
 				03597A9928F8799C005E4A98 /* MockUTMParameterProvider.swift in Sources */,
 				B9C9C660283E71F4001B879F /* Double+Woo.swift in Sources */,
+				6896C82C2C75D638002DDAE2 /* MockAnalyticsProviderPreview.swift in Sources */,
 				689D11D02891B3A300F6A83F /* CrashLogger.swift in Sources */,
 				26AF1F5928B9011100937BA9 /* WooStyleModifiers.swift in Sources */,
 				B95B15CB2B15FA3A00A54044 /* Publishers+KeyboardHeight.swift in Sources */,

--- a/WooFoundation/WooFoundation/Mocks/MockAnalyticsPreview.swift
+++ b/WooFoundation/WooFoundation/Mocks/MockAnalyticsPreview.swift
@@ -8,7 +8,7 @@ public final class MockAnalyticsPreview: Analytics {
         //
     }
 
-    public func track(_ eventName: String, properties: [AnyHashable : Any]?, error: Error?) {
+    public func track(_ eventName: String, properties: [AnyHashable: Any]?, error: Error?) {
         //
     }
 

--- a/WooFoundation/WooFoundation/Mocks/MockAnalyticsPreview.swift
+++ b/WooFoundation/WooFoundation/Mocks/MockAnalyticsPreview.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 public final class MockAnalyticsPreview: Analytics {
-    public init(userHasOptedIn: Bool, analyticsProvider: AnalyticsProvider) {
+    public init(userHasOptedIn: Bool = true, analyticsProvider: AnalyticsProvider = MockAnalyticsProviderPreview()) {
         self.userHasOptedIn = userHasOptedIn
         self.analyticsProvider = analyticsProvider
     }

--- a/WooFoundation/WooFoundation/Mocks/MockAnalyticsPreview.swift
+++ b/WooFoundation/WooFoundation/Mocks/MockAnalyticsPreview.swift
@@ -1,3 +1,5 @@
+import Foundation
+
 public final class MockAnalyticsPreview: Analytics {
     public init(userHasOptedIn: Bool, analyticsProvider: AnalyticsProvider) {
         self.userHasOptedIn = userHasOptedIn

--- a/WooFoundation/WooFoundation/Mocks/MockAnalyticsPreview.swift
+++ b/WooFoundation/WooFoundation/Mocks/MockAnalyticsPreview.swift
@@ -1,0 +1,26 @@
+public final class MockAnalyticsPreview: Analytics {
+    public init(userHasOptedIn: Bool, analyticsProvider: AnalyticsProvider) {
+        self.userHasOptedIn = userHasOptedIn
+        self.analyticsProvider = analyticsProvider
+    }
+
+    public func initialize() {
+        //
+    }
+
+    public func track(_ eventName: String, properties: [AnyHashable : Any]?, error: Error?) {
+        //
+    }
+
+    public func refreshUserData() {
+        //
+    }
+
+    public func setUserHasOptedOut(_ optedOut: Bool) {
+        //
+    }
+
+    public var userHasOptedIn: Bool
+
+    public var analyticsProvider: AnalyticsProvider
+}

--- a/WooFoundation/WooFoundation/Mocks/MockAnalyticsProviderPreview.swift
+++ b/WooFoundation/WooFoundation/Mocks/MockAnalyticsProviderPreview.swift
@@ -1,0 +1,23 @@
+public final class MockAnalyticsProviderPreview: AnalyticsProvider {
+    public init() {}
+
+    public func refreshUserData() {
+        //
+    }
+    
+    public func track(_ eventName: String) {
+        //
+    }
+    
+    public func track(_ eventName: String, withProperties properties: [AnyHashable : Any]?) {
+        //
+    }
+    
+    public func clearEvents() {
+        //
+    }
+    
+    public func clearUsers() {
+        //
+    }
+}

--- a/WooFoundation/WooFoundation/Mocks/MockAnalyticsProviderPreview.swift
+++ b/WooFoundation/WooFoundation/Mocks/MockAnalyticsProviderPreview.swift
@@ -1,3 +1,5 @@
+import Foundation
+
 public final class MockAnalyticsProviderPreview: AnalyticsProvider {
     public init() {}
 

--- a/WooFoundation/WooFoundation/Mocks/MockAnalyticsProviderPreview.swift
+++ b/WooFoundation/WooFoundation/Mocks/MockAnalyticsProviderPreview.swift
@@ -4,19 +4,19 @@ public final class MockAnalyticsProviderPreview: AnalyticsProvider {
     public func refreshUserData() {
         //
     }
-    
+
     public func track(_ eventName: String) {
         //
     }
-    
-    public func track(_ eventName: String, withProperties properties: [AnyHashable : Any]?) {
+
+    public func track(_ eventName: String, withProperties properties: [AnyHashable: Any]?) {
         //
     }
-    
+
     public func clearEvents() {
         //
     }
-    
+
     public func clearUsers() {
         //
     }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Partially addresses https://github.com/woocommerce/woocommerce-ios/issues/13277
Closes https://github.com/woocommerce/woocommerce-ios/pull/13604
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
This PR adds the `pos_item_added_to_cart` event when an item is added to the POS cart.

## Changes
- Adds new `pos_item_added_to_cart` event
- Injects `Analytics` into `CartViewModel`, this is passed as the `ServiceLocator.analytics` shared instance from the point of entry.
- Creates new `MockAnalyticsPreview` and `MockAnalyticsProviderPreview` classes in WooFoundation, we do this so the Analytics instance doesn't have to be marked as optional, but the current setup still forces us to pass analytics through the PreviewProvider. (I'm not 100% on board with this change, perhaps just leaving Analytics declaration as optional with a default nil value on init is just cleaner?)

## Testing
- In POS, add an item to the cart, and observe the console logs the `pos_item_added_to_cart` event:
```
2024-08-21 15:31:18.721197+0700 WooCommerce[18610:19070855] 🔵 Tracked pos_item_added_to_cart, properties: [store_id: c5bd46cc-1804-4f7b-badb-bb98c449127f, was_ecommerce_trial: false, plan: jetpack_security_daily, site_url: https://indiemelon.mystagingwebsite.com, blog_id: 215063064, is_wpcom_store: false]
```
- In a couple of minutes, the event will also show in Tracks Live View:

<img width="600" alt="Screenshot 2024-08-21 at 14 18 13" src="https://github.com/user-attachments/assets/84a4d4c3-c2cd-48a3-83d2-846c44d72507">

From my testing (simulator):
- In POS mode, tapping any item, or the same item multiple times triggers the `pos_item_added_to_cart` event (perhaps this is worth discussing, is it too much noise? Should an unique event when sending the cart, with the nº of items suffice?)
- The event is logged accordingly in the mc tools after a few minutes
- The POS flow still works as expected, from entering POS mode, adding items to cart, to checking out through a card present payment.
- _"The tracks events must be validated in the Tracks system."_ -> Events are not validated yet, since it's not a public release.

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [x] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [x] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [x] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on all devices (phone/tablet) and no regressions are added.