### PR TITLE
[Mobile Payments] Fix Tap to Pay connection after errors

### DIFF
--- a/Hardware/Hardware/CardReader/StripeCardReader/StripeCardReaderService.swift
+++ b/Hardware/Hardware/CardReader/StripeCardReader/StripeCardReaderService.swift
@@ -583,6 +583,8 @@ extension StripeCardReaderService: CardReaderService {
                     let serviceError: CardReaderServiceError = underlyingError.isSoftwareUpdateError ?
                         .softwareUpdate(underlyingError: underlyingError, batteryLevel: nil) :
                         .connection(underlyingError: underlyingError)
+
+                    self.switchStatusToFault(error: serviceError)
                     promise(.failure(serviceError))
                 }
 

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -26,6 +26,7 @@
 - [*] Login: Hid the site credential login option when entering a WPCom site address. [https://github.com/woocommerce/woocommerce-ios/pull/13623]
 - [Internal] Beta fix: Fixed unreliable states of the Inbox screen when navigated from the Hub Menu. [https://github.com/woocommerce/woocommerce-ios/pull/13645]
 - [Internal] Beta fix: Fixed navigation to variations in stock card for some stores. [https://github.com/woocommerce/woocommerce-ios/pull/13648]
+- [*] Payments Beta fix: Fixed an issue which could lead to a frozen state after an error starting Tap to Pay on iPhone [https://github.com/woocommerce/woocommerce-ios/pull/13682]
 
 19.9
 -----


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #13678
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

After getting an error when "connecting to" the built-in Tap to Pay reader, the merchant can dismiss it and try again.

With this issue, the `Preparing Tap to Pay on iPhone` screen was shown, and could not be dismissed. It never moved on to the next step, and the only way to resolve it is by killing the app and restarting.

This PR applies a similar fix to one we previously made for external card readers, in #13126.

Discovered readers are provided via a `CurrentValueSubject`, and the `StripeCardReaderService` is a singleton so if not managed carefully, old state can persist between connection attempts.

Errors during connection to the card reader (rather than during discovery) don’t set the status of the `StripeCardReaderService` to fault, so the next time you attempt to connect to a reader, it’s in a mid-connection state, and the subject has not been cleared.

This results in the service trying to connect to the old representation of the TTP reader again, using a stale reader object. When we try this, the app becomes unresponsive as Stripe don’t return any error, and the connection process never moves forward. Stripe don’t provide any way to cancel an in-progress connection, so there’s no option to add a timeout to the connection.

With this change, we switch the status to fault when we get the connection error. This resets the `discoveredReadersSubject`, and prevents the service from return the stale representation of the TTP reader, so we don’t try to connect to it and avoid the unresponsive state. Instead, the next attempt starts from scratch, and can succeed.

## Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->

This can be difficult to reproduce. Apple are the main source of errors for connecting to the built in flow, and we can't really fake the errors effectively.

Some merchants could see repeated errors when connecting though, e.g. if they have been blocked by Apple, which can happen for trying to use TTP on too many stores (>3, I think) in a 24 hour period, or for issues when accepting the Terms of Service. However, I don't have repeatable repro steps for getting to those error states. Context here: p1724162683176379-slack-C025A8VV728

### Backgrounding during connection
The connection can fail if the app goes into the background while it's happening:

1. Launch the app
2. Go to `Menu > Payments > Manage card reader`
3. Tap `Connect Card Reader` then cancel the connection – this ensures that the TTP reader is not auto-connected.
4. Go to `Orders`, and select an unpaid order (create one if needed)
5. Tap `Collect Payment`
6. Tap `Tap to Pay on iPhone`, and immediately background the app. You have to be fast, I think it has to happen while the `Checking device` step.
7. Wait a few seconds, then open the app again
8. Observe that you're shown the `Setup failed` error: `There was an issue preparing to use Tap to Pay on iPhone – please try again.` (If you're shown a `Payment failed` error, you've not backgrounded fast enough and TTP is connected, go back to step 2.)
9. Tap `Try again`
10. Observe that the connection continues as normal. If it still ends in an error, that's fine, but it doesn't get stuck in an unrecoverable state.

Speed is important – there's also an auto-reconnection for the built in reader which kicks in when you foreground the app. The fastest one will win, so if you don't tap `Try again` quickly enough, you may find it's already tried the reconnection.

### Cancelling Terms Of Service acceptance
The connection will fail (without a visible error) if the merchant cancels Apple's TTP TOS acceptance screen.

1. Launch the app
2. Switch to a store which is not linked to an Apple ID for the purposes of Tap to Pay (you can unlink a store using Apple's management site: https://register.apple.com)
3. Go to `Orders`, and select an unpaid order (create one if needed)
4. Tap `Collect Payment`
5. Tap `Tap to Pay on iPhone`
6. Wait for Apple's TOS screen to show
7. Tap `Cancel`
8. When it dismisses, tap `Tap to Pay on iPhone`
9. Observe that you're shown the TOS screen again.
10. Continuing with TOS acceptance allows payments to continue.

## Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->

I have tested: 
- both the above repro approaches on iOS 16
- the backgrounding repro approach on iOS 17
- a third approach, with a blocked account, on iOS 17 (it seems to only be blocked for that device, which is something Stripe suggest can happen in their error messages.)
- iPad card reader payments
- Disconnection and reconnection flows
- The Try out Tap to Pay on iPhone flow with similar steps as above.

Unfortunately, the StripeCardReaderService does not have unit tests as it is very difficult to effectively unit test – we can't mock Stripe's code effectively, and it's even harder when Tap to Pay is in the mix. Since this fix is in that service, I have not added unit tests.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

https://github.com/user-attachments/assets/11ec917f-7a8c-44a6-a869-d72c40c3bf07


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [x] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [x] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [x] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on all devices (phone/tablet) and no regressions are added.