### PR TITLE
Ensure sync timestamps are deleted when CoreData resets

### DIFF
--- a/Storage/Storage/CoreData/CoreDataManager.swift
+++ b/Storage/Storage/CoreData/CoreDataManager.swift
@@ -93,6 +93,8 @@ public final class CoreDataManager: StorageManagerType {
                 try container.persistentStoreCoordinator.destroyPersistentStore(at: self.storeURL,
                                                                                 ofType: storeDescription.type,
                                                                                 options: nil)
+                NotificationCenter.default.post(name: .StorageManagerDidResetStorage, object: self)
+
             } catch {
                 persistentStoreRemovalError = error
             }

--- a/WooCommerce/Classes/System/SessionManager.swift
+++ b/WooCommerce/Classes/System/SessionManager.swift
@@ -184,6 +184,9 @@ final class SessionManager: SessionManagerProtocol {
         self.imageCache = imageCache
 
         defaultStoreIDSubject = .init(defaults[.defaultStoreID])
+
+        // Listens when the core data stack is rest.
+        NotificationCenter.default.addObserver(self, selector: #selector(handleStorageDidReset), name: .StorageManagerDidResetStorage, object: nil)
     }
 
     /// Nukes all of the known Session's properties.
@@ -208,8 +211,7 @@ final class SessionManager: SessionManagerProtocol {
         defaults[.themesPendingInstall] = nil
         defaults[.siteIDPendingStoreSwitch] = nil
         defaults[.expectedStoreNamePendingStoreSwitch] = nil
-        defaults[.latestBackgroundOrderSyncDate] = nil
-        DashboardTimestampStore.resetStore()
+        resetTimestampsValues()
         imageCache.clearCache()
     }
 
@@ -280,5 +282,18 @@ private extension SessionManager {
         keychain[username] = nil
         defaults[.defaultUsername] = nil
         defaults[.defaultCredentialsType] = nil
+    }
+
+    /// Updates the timestamps that control when background data is fetched.
+    ///
+    @objc func handleStorageDidReset() {
+        resetTimestampsValues()
+    }
+
+    /// Removes timestamp values.
+    ///
+    func resetTimestampsValues() {
+        defaults[.latestBackgroundOrderSyncDate] = nil
+        DashboardTimestampStore.resetStore(store: defaults)
     }
 }


### PR DESCRIPTION

# Why

It was reported that downgrading the application causes the order list to display empty content until a pull-to-refresh action is performed.

This happens because the core data stack is reset when the downgrades imply a downstream migration, leaving the app with no data to show.

This PR fixes that state by cleaning the timestamps used to sync data when a core data reset happens

# How

- Send a `reset` notification when the app can't migrate to a specific core data version
- Listen to that notification and reset the timestamps

# Demo

https://github.com/user-attachments/assets/516f3b96-7681-4263-8424-1625c5c2d5a7


# Testing Steps

- Install `v20.0` and load the order list
- Install `v19.9`(requires a reverse migration) and load the order list
- See that the order list is successfully loaded

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [x] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [x] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [x] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on all devices (phone/tablet) and no regressions are added.
