### PR TITLE
[Woo POS] Simple products banner design update

### DIFF
--- a/WooCommerce/Classes/POS/Presentation/ItemListView.swift
+++ b/WooCommerce/Classes/POS/Presentation/ItemListView.swift
@@ -136,7 +136,7 @@ private extension ItemListView {
         static let bannerHeight: CGFloat = 164
         static let bannerCornerRadius: CGFloat = 8
         static let bannerVerticalPadding: CGFloat = 26
-        static let bannerTextSpacing: CGFloat = 0
+        static let bannerTextSpacing: CGFloat = 2
         static let bannerTitleSpacing: CGFloat = 8
         static let infoIconSize: CGFloat = 36
         static let bannerInfoIconSize: CGFloat = 44

--- a/WooCommerce/Classes/POS/Presentation/ItemListView.swift
+++ b/WooCommerce/Classes/POS/Presentation/ItemListView.swift
@@ -51,7 +51,7 @@ private extension ItemListView {
             }
             if viewModel.shouldShowHeaderBanner {
                 bannerCardView
-                    .padding(.vertical, 16)
+                    .padding(.bottom, Constants.bannerCardPadding)
             }
         }
     }
@@ -105,7 +105,7 @@ private extension ItemListView {
         .onTapGesture {
             viewModel.simpleProductsInfoButtonTapped()
         }
-        .padding(.horizontal, 16)
+        .padding(.horizontal, Constants.bannerCardPadding)
     }
 
     @ViewBuilder
@@ -141,6 +141,7 @@ private extension ItemListView {
         static let bannerInfoIconSize: CGFloat = 44
         static let iconPadding: CGFloat = 26
         static let itemListPadding: CGFloat = 16
+        static let bannerCardPadding: CGFloat = 16
     }
 
     enum Localization {

--- a/WooCommerce/Classes/POS/Presentation/ItemListView.swift
+++ b/WooCommerce/Classes/POS/Presentation/ItemListView.swift
@@ -105,6 +105,7 @@ private extension ItemListView {
         .onTapGesture {
             viewModel.simpleProductsInfoButtonTapped()
         }
+        .padding(.horizontal, 16)
     }
 
     @ViewBuilder

--- a/WooCommerce/Classes/POS/Presentation/ItemListView.swift
+++ b/WooCommerce/Classes/POS/Presentation/ItemListView.swift
@@ -75,10 +75,11 @@ private extension ItemListView {
                     .accessibilityAddTraits(.isHeader)
                 VStack(alignment: .leading, spacing: Constants.bannerTextSpacing) {
                     Text(Localization.headerBannerSubtitle)
-                        .font(Constants.bannerSubtitleFont)
                     Text(Localization.headerBannerHint)
-                        .font(Constants.bannerSubtitleFont)
+                    Text(Localization.headerBannerLearnMoreHint)
+                        .linkStyle()
                 }
+                .font(Constants.bannerSubtitleFont)
                 .accessibilityElement(children: .combine)
             }
             .padding(.vertical, Constants.bannerVerticalPadding)
@@ -146,21 +147,27 @@ private extension ItemListView {
 
     enum Localization {
         static let headerBannerTitle = NSLocalizedString(
-            "pos.itemlistview.headerBannerTitle",
+            "pos.itemlistview.headerBanner.title",
             value: "Showing simple products only",
             comment: "Title of the product selector header banner, which explains current POS limitations"
         )
 
         static let headerBannerSubtitle = NSLocalizedString(
-            "pos.itemlistview.headerBannerSubtitle",
+            "pos.itemlistview.headerBanner.subtitle",
             value: "Only simple physical products are available with POS right now.",
             comment: "Subtitle of the product selector header banner, which explains current POS limitations"
         )
 
         static let headerBannerHint = NSLocalizedString(
-            "pos.itemlistview.headerBannerHint",
-            value: "Other product types, such as variable and virtual, will become available in future updates. Learn more",
+            "pos.itemlistview.headerBanner.hint",
+            value: "Other product types, such as variable and virtual, will become available in future updates.",
             comment: "Additional text within the product selector header banner, which explains current POS limitations"
+        )
+
+        static let headerBannerLearnMoreHint = NSLocalizedString(
+            "pos.itemlistview.headerBanner.learnMoreHint",
+            value: "Learn More",
+            comment: "Link to more information within the product selector header banner, which explains current POS limitations"
         )
 
         static let dismissBannerAccessibilityLabel = NSLocalizedString(


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #13687
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
This PR addresses the design tweaks for the simple product banner:
- Adds missing horizontal padding, to fit the other components
- Reduces too much top padding
- Updates the style of the "Learn more" button to use `.linkStyle()`

![simulator_screenshot_C6397A16-0544-43EC-9A64-1CD0FE468C1B](https://github.com/user-attachments/assets/eaa0ed28-a255-40b6-828a-3e0dfefda8b1)

Changing only the "Learn more" bit of the existing string requires us to use attributed strings, or some combination of Text components where we can edit each bit separately and then combine them together, this has to account for RTL and localization as well. This seemed too much hassle for this detail so I opted to just separate it to a new `Text` component. This moves it to a new line, but this would happen anyway based on screen size or dynamic sizing. Let me know if you'd prefer to use attributed strings instead.

No new unit tests or further flow testing is required, the changes merely adjust the UI and the localized strings (this is needed as strings that are already translated are cached, so we need to rename their keys to observe updates).

## Testing
1. Add the following line to `ItemListViewModel` init:
```
UserDefaults.standard.set(false, forKey: "isSimpleProductsOnlyBannerDismissed")
```
2. Run POS
3. Observe the simple products banner appear, and matches the designs
4. Tap anywhere on the text, observe the simple products modal is presented
![simulator_screenshot_192FFB3D-2800-4FA4-99F2-42336B9EB09E](https://github.com/user-attachments/assets/1976d5b5-ffd3-460d-8135-6861b1bd5982)
5. Tap on dismiss and observe that still dismisses as usual.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [x] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [x] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [x] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on all devices (phone/tablet) and no regressions are added.