### PR TITLE
Google ads: Update the check for the plugin slug

### DIFF
--- a/WooCommerce/Classes/GoogleAds/GoogleAdsEligibilityChecker.swift
+++ b/WooCommerce/Classes/GoogleAds/GoogleAdsEligibilityChecker.swift
@@ -49,7 +49,7 @@ private extension DefaultGoogleAdsEligibilityChecker {
             stores.dispatch(SystemStatusAction.synchronizeSystemInformation(siteID: siteID) { result in
                 switch result {
                 case .success(let info):
-                    let plugin = info.systemPlugins.first(where: { $0.plugin == Constants.pluginSlug })
+                    let plugin = info.systemPlugins.first(where: { $0.plugin.contains(Constants.pluginSlug) })
                     continuation.resume(returning: plugin)
                 case .failure:
                     continuation.resume(returning: nil)

--- a/WooCommerce/WooCommerceTests/GoogleAds/DefaultGoogleAdsEligibilityCheckTests.swift
+++ b/WooCommerce/WooCommerceTests/GoogleAds/DefaultGoogleAdsEligibilityCheckTests.swift
@@ -4,7 +4,7 @@ import Yosemite
 
 final class DefaultGoogleAdsEligibilityCheckerTests: XCTestCase {
     private let sampleSite: Int64 = 325
-    private let pluginSlug = "google-listings-and-ads/google-listings-and-ads.php"
+    private let pluginSlug = "/srv/htdocs/wp-content/plugins/google-listings-and-ads/google-listings-and-ads.php"
 
     private var stores: MockStoresManager!
 


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #13698 
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This PR updates the eligibility check for Google Ads. This is needed for stores with WooCommerce plugin version 9.2.0 and above where the plugin paths are [changed](https://github.com/woocommerce/woocommerce/pull/48709) to include their subdirectory paths.

## Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->
- Pre-requisite: 
  - Update the WooCommerce plugin to 9.2.0 or above. 
  - Install, activate, and set up the Google Ads plugin to a test site following pe5sF9-2Qo-p2. Ensure that you're using the plugin version 2.7.5 or above. 
- Build the app and log in to your store.
- Confirm that Google Ads is available on the dashboard Edit menu and the Menu tab.


## Screenshots
<!-- Include before and after images or gifs when appropriate. -->
<img src="https://github.com/user-attachments/assets/cd699899-aa6e-4c8a-87ef-42f6b1094b20" width=320 /><img src="https://github.com/user-attachments/assets/80434d56-af48-4c10-8f0a-bcdbae0169f3" width=320 />



---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [x] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [x] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [x] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on all devices (phone/tablet) and no regressions are added.
