### PR TITLE
[Woo POS] Make `posModal` extend to screen bounds when presented from child views

### DIFF
--- a/WooCommerce/Classes/POS/Card Present Payments/CardPresentPaymentsModalButtonViewModel.swift
+++ b/WooCommerce/Classes/POS/Card Present Payments/CardPresentPaymentsModalButtonViewModel.swift
@@ -17,3 +17,14 @@ struct CardPresentPaymentsModalButtonViewModel: Identifiable {
         self.init(title: title, actionHandler: actionHandler)
     }
 }
+
+extension CardPresentPaymentsModalButtonViewModel: Hashable {
+    static func == (lhs: CardPresentPaymentsModalButtonViewModel, rhs: CardPresentPaymentsModalButtonViewModel) -> Bool {
+        return lhs.title == rhs.title &&
+        lhs.id == rhs.id
+    }
+
+    func hash(into hasher: inout Hasher) {
+        hasher.combine(id)
+    }
+}

--- a/WooCommerce/Classes/POS/Presentation/Card Present Payments/Connection Alerts/PointOfSaleCardPresentPaymentAlertType.swift
+++ b/WooCommerce/Classes/POS/Presentation/Card Present Payments/Connection Alerts/PointOfSaleCardPresentPaymentAlertType.swift
@@ -2,7 +2,7 @@ import Foundation
 
 /// `PointOfSaleCardPresentPaymentAlertType` serves as a typed bridge between the `CardPresentPaymentEventDetails`
 /// and the POS alert view models, for those events which should be displayed as alerts.
-enum PointOfSaleCardPresentPaymentAlertType {
+enum PointOfSaleCardPresentPaymentAlertType: Hashable {
     case scanningForReaders(viewModel: PointOfSaleCardPresentPaymentScanningForReadersAlertViewModel)
     case scanningFailed(viewModel: PointOfSaleCardPresentPaymentScanningFailedAlertViewModel)
     case bluetoothRequired(viewModel: PointOfSaleCardPresentPaymentBluetoothRequiredAlertViewModel)

--- a/WooCommerce/Classes/POS/Presentation/Card Present Payments/Connection Alerts/PointOfSaleCardPresentPaymentAlertType.swift
+++ b/WooCommerce/Classes/POS/Presentation/Card Present Payments/Connection Alerts/PointOfSaleCardPresentPaymentAlertType.swift
@@ -2,7 +2,11 @@ import Foundation
 
 /// `PointOfSaleCardPresentPaymentAlertType` serves as a typed bridge between the `CardPresentPaymentEventDetails`
 /// and the POS alert view models, for those events which should be displayed as alerts.
-enum PointOfSaleCardPresentPaymentAlertType: Hashable {
+enum PointOfSaleCardPresentPaymentAlertType: Hashable, Identifiable {
+    var id: Self {
+        self
+    }
+
     case scanningForReaders(viewModel: PointOfSaleCardPresentPaymentScanningForReadersAlertViewModel)
     case scanningFailed(viewModel: PointOfSaleCardPresentPaymentScanningFailedAlertViewModel)
     case bluetoothRequired(viewModel: PointOfSaleCardPresentPaymentBluetoothRequiredAlertViewModel)

--- a/WooCommerce/Classes/POS/Presentation/Card Present Payments/Connection Alerts/PointOfSaleCardPresentPaymentBluetoothRequiredAlertViewModel.swift
+++ b/WooCommerce/Classes/POS/Presentation/Card Present Payments/Connection Alerts/PointOfSaleCardPresentPaymentBluetoothRequiredAlertViewModel.swift
@@ -1,7 +1,7 @@
 import Foundation
 import SwiftUI
 
-struct PointOfSaleCardPresentPaymentBluetoothRequiredAlertViewModel {
+struct PointOfSaleCardPresentPaymentBluetoothRequiredAlertViewModel: Hashable {
     let title = Localization.bluetoothRequired
     let imageName = PointOfSaleAssets.paymentsError.imageName
     let openSettingsButtonViewModel: CardPresentPaymentsModalButtonViewModel

--- a/WooCommerce/Classes/POS/Presentation/Card Present Payments/Connection Alerts/PointOfSaleCardPresentPaymentBluetoothRequiredAlertViewModel.swift
+++ b/WooCommerce/Classes/POS/Presentation/Card Present Payments/Connection Alerts/PointOfSaleCardPresentPaymentBluetoothRequiredAlertViewModel.swift
@@ -3,7 +3,7 @@ import SwiftUI
 
 struct PointOfSaleCardPresentPaymentBluetoothRequiredAlertViewModel {
     let title = Localization.bluetoothRequired
-    let image = Image(uiImage: .paymentErrorImage)
+    let imageName = PointOfSaleAssets.paymentsError.imageName
     let openSettingsButtonViewModel: CardPresentPaymentsModalButtonViewModel
     let dismissButtonViewModel: CardPresentPaymentsModalButtonViewModel
     let errorDetails: String

--- a/WooCommerce/Classes/POS/Presentation/Card Present Payments/Connection Alerts/PointOfSaleCardPresentPaymentConnectingFailedAlertViewModel.swift
+++ b/WooCommerce/Classes/POS/Presentation/Card Present Payments/Connection Alerts/PointOfSaleCardPresentPaymentConnectingFailedAlertViewModel.swift
@@ -2,7 +2,7 @@ import Foundation
 import SwiftUI
 import enum Yosemite.CardReaderServiceError
 
-struct PointOfSaleCardPresentPaymentConnectingFailedAlertViewModel {
+struct PointOfSaleCardPresentPaymentConnectingFailedAlertViewModel: Hashable {
     let title = Localization.title
     let imageName = PointOfSaleAssets.paymentsError.imageName
     let errorDetails: String?

--- a/WooCommerce/Classes/POS/Presentation/Card Present Payments/Connection Alerts/PointOfSaleCardPresentPaymentConnectingFailedAlertViewModel.swift
+++ b/WooCommerce/Classes/POS/Presentation/Card Present Payments/Connection Alerts/PointOfSaleCardPresentPaymentConnectingFailedAlertViewModel.swift
@@ -4,7 +4,7 @@ import enum Yosemite.CardReaderServiceError
 
 struct PointOfSaleCardPresentPaymentConnectingFailedAlertViewModel {
     let title = Localization.title
-    let image = Image(uiImage: .paymentErrorImage)
+    let imageName = PointOfSaleAssets.paymentsError.imageName
     let errorDetails: String?
 
     let retryButtonViewModel: CardPresentPaymentsModalButtonViewModel

--- a/WooCommerce/Classes/POS/Presentation/Card Present Payments/Connection Alerts/PointOfSaleCardPresentPaymentConnectingFailedChargeReaderAlertViewModel.swift
+++ b/WooCommerce/Classes/POS/Presentation/Card Present Payments/Connection Alerts/PointOfSaleCardPresentPaymentConnectingFailedChargeReaderAlertViewModel.swift
@@ -4,7 +4,7 @@ import SwiftUI
 struct PointOfSaleCardPresentPaymentConnectingFailedChargeReaderAlertViewModel {
     let title = Localization.title
     let errorDetails = Localization.errorDetails
-    let image = Image(uiImage: .paymentErrorImage)
+    let imageName = PointOfSaleAssets.paymentsError.imageName
     let retryButtonViewModel: CardPresentPaymentsModalButtonViewModel
     let cancelButtonViewModel: CardPresentPaymentsModalButtonViewModel
 

--- a/WooCommerce/Classes/POS/Presentation/Card Present Payments/Connection Alerts/PointOfSaleCardPresentPaymentConnectingFailedChargeReaderAlertViewModel.swift
+++ b/WooCommerce/Classes/POS/Presentation/Card Present Payments/Connection Alerts/PointOfSaleCardPresentPaymentConnectingFailedChargeReaderAlertViewModel.swift
@@ -1,7 +1,7 @@
 import Foundation
 import SwiftUI
 
-struct PointOfSaleCardPresentPaymentConnectingFailedChargeReaderAlertViewModel {
+struct PointOfSaleCardPresentPaymentConnectingFailedChargeReaderAlertViewModel: Hashable {
     let title = Localization.title
     let errorDetails = Localization.errorDetails
     let imageName = PointOfSaleAssets.paymentsError.imageName

--- a/WooCommerce/Classes/POS/Presentation/Card Present Payments/Connection Alerts/PointOfSaleCardPresentPaymentConnectingFailedNonRetryableAlertViewModel.swift
+++ b/WooCommerce/Classes/POS/Presentation/Card Present Payments/Connection Alerts/PointOfSaleCardPresentPaymentConnectingFailedNonRetryableAlertViewModel.swift
@@ -4,7 +4,7 @@ import SwiftUI
 struct PointOfSaleCardPresentPaymentConnectingFailedNonRetryableAlertViewModel {
     let title = Localization.title
     let errorDetails: String
-    let image = Image(uiImage: .paymentErrorImage)
+    let imageName = PointOfSaleAssets.paymentsError.imageName
     let cancelButtonViewModel: CardPresentPaymentsModalButtonViewModel
 
     init(error: Error,

--- a/WooCommerce/Classes/POS/Presentation/Card Present Payments/Connection Alerts/PointOfSaleCardPresentPaymentConnectingFailedNonRetryableAlertViewModel.swift
+++ b/WooCommerce/Classes/POS/Presentation/Card Present Payments/Connection Alerts/PointOfSaleCardPresentPaymentConnectingFailedNonRetryableAlertViewModel.swift
@@ -1,7 +1,7 @@
 import Foundation
 import SwiftUI
 
-struct PointOfSaleCardPresentPaymentConnectingFailedNonRetryableAlertViewModel {
+struct PointOfSaleCardPresentPaymentConnectingFailedNonRetryableAlertViewModel: Hashable {
     let title = Localization.title
     let errorDetails: String
     let imageName = PointOfSaleAssets.paymentsError.imageName

--- a/WooCommerce/Classes/POS/Presentation/Card Present Payments/Connection Alerts/PointOfSaleCardPresentPaymentConnectingFailedUpdateAddressAlertViewModel.swift
+++ b/WooCommerce/Classes/POS/Presentation/Card Present Payments/Connection Alerts/PointOfSaleCardPresentPaymentConnectingFailedUpdateAddressAlertViewModel.swift
@@ -3,7 +3,7 @@ import SwiftUI
 
 final class PointOfSaleCardPresentPaymentConnectingFailedUpdateAddressAlertViewModel: ObservableObject {
     let title = Localization.title
-    let image = Image(uiImage: .paymentErrorImage)
+    let imageName = PointOfSaleAssets.paymentsError.imageName
     let settingsAdminUrl: URL
 
     @Published var shouldShowSettingsWebView: Bool = false

--- a/WooCommerce/Classes/POS/Presentation/Card Present Payments/Connection Alerts/PointOfSaleCardPresentPaymentConnectingFailedUpdateAddressAlertViewModel.swift
+++ b/WooCommerce/Classes/POS/Presentation/Card Present Payments/Connection Alerts/PointOfSaleCardPresentPaymentConnectingFailedUpdateAddressAlertViewModel.swift
@@ -51,6 +51,31 @@ final class PointOfSaleCardPresentPaymentConnectingFailedUpdateAddressAlertViewM
     }
 }
 
+extension PointOfSaleCardPresentPaymentConnectingFailedUpdateAddressAlertViewModel: Hashable {
+    static func == (lhs: PointOfSaleCardPresentPaymentConnectingFailedUpdateAddressAlertViewModel,
+                    rhs: PointOfSaleCardPresentPaymentConnectingFailedUpdateAddressAlertViewModel) -> Bool {
+        return lhs.title == rhs.title &&
+        lhs.imageName == rhs.imageName &&
+        lhs.settingsAdminUrl == rhs.settingsAdminUrl &&
+        lhs.shouldShowSettingsWebView == rhs.shouldShowSettingsWebView &&
+        lhs.primaryButtonViewModel == rhs.primaryButtonViewModel &&
+        lhs.cancelButtonViewModel == rhs.cancelButtonViewModel &&
+        lhs.retryButtonViewModel == rhs.retryButtonViewModel &&
+        lhs.showsInAuthenticatedWebView == rhs.showsInAuthenticatedWebView
+    }
+
+    func hash(into hasher: inout Hasher) {
+        hasher.combine(title)
+        hasher.combine(imageName)
+        hasher.combine(settingsAdminUrl)
+        hasher.combine(shouldShowSettingsWebView)
+        hasher.combine(primaryButtonViewModel)
+        hasher.combine(cancelButtonViewModel)
+        hasher.combine(retryButtonViewModel)
+        hasher.combine(showsInAuthenticatedWebView)
+    }
+}
+
 private extension PointOfSaleCardPresentPaymentConnectingFailedUpdateAddressAlertViewModel {
     enum Localization {
         static let title = NSLocalizedString(

--- a/WooCommerce/Classes/POS/Presentation/Card Present Payments/Connection Alerts/PointOfSaleCardPresentPaymentConnectingFailedUpdatePostalCodeAlertViewModel.swift
+++ b/WooCommerce/Classes/POS/Presentation/Card Present Payments/Connection Alerts/PointOfSaleCardPresentPaymentConnectingFailedUpdatePostalCodeAlertViewModel.swift
@@ -3,7 +3,7 @@ import SwiftUI
 
 struct PointOfSaleCardPresentPaymentConnectingFailedUpdatePostalCodeAlertViewModel {
     let title = Localization.title
-    let image = Image(uiImage: .paymentErrorImage)
+    let imageName = PointOfSaleAssets.paymentsError.imageName
     let errorDetails = Localization.errorDetails
     let retryButtonViewModel: CardPresentPaymentsModalButtonViewModel
     let cancelButtonViewModel: CardPresentPaymentsModalButtonViewModel

--- a/WooCommerce/Classes/POS/Presentation/Card Present Payments/Connection Alerts/PointOfSaleCardPresentPaymentConnectingFailedUpdatePostalCodeAlertViewModel.swift
+++ b/WooCommerce/Classes/POS/Presentation/Card Present Payments/Connection Alerts/PointOfSaleCardPresentPaymentConnectingFailedUpdatePostalCodeAlertViewModel.swift
@@ -1,7 +1,7 @@
 import Foundation
 import SwiftUI
 
-struct PointOfSaleCardPresentPaymentConnectingFailedUpdatePostalCodeAlertViewModel {
+struct PointOfSaleCardPresentPaymentConnectingFailedUpdatePostalCodeAlertViewModel: Hashable {
     let title = Localization.title
     let imageName = PointOfSaleAssets.paymentsError.imageName
     let errorDetails = Localization.errorDetails

--- a/WooCommerce/Classes/POS/Presentation/Card Present Payments/Connection Alerts/PointOfSaleCardPresentPaymentConnectingToReaderAlertViewModel.swift
+++ b/WooCommerce/Classes/POS/Presentation/Card Present Payments/Connection Alerts/PointOfSaleCardPresentPaymentConnectingToReaderAlertViewModel.swift
@@ -1,7 +1,7 @@
 import Foundation
 import SwiftUI
 
-struct PointOfSaleCardPresentPaymentConnectingToReaderAlertViewModel {
+struct PointOfSaleCardPresentPaymentConnectingToReaderAlertViewModel: Hashable {
     let title = Localization.title
     let imageName = PointOfSaleAssets.readerConnectionConnecting.imageName
     let instruction = Localization.instruction

--- a/WooCommerce/Classes/POS/Presentation/Card Present Payments/Connection Alerts/PointOfSaleCardPresentPaymentConnectionSuccessAlertViewModel.swift
+++ b/WooCommerce/Classes/POS/Presentation/Card Present Payments/Connection Alerts/PointOfSaleCardPresentPaymentConnectionSuccessAlertViewModel.swift
@@ -1,7 +1,7 @@
 import Foundation
 import SwiftUI
 
-struct PointOfSaleCardPresentPaymentConnectionSuccessAlertViewModel {
+struct PointOfSaleCardPresentPaymentConnectionSuccessAlertViewModel: Hashable {
     let title = Localization.title
     let imageName = PointOfSaleAssets.readerConnectionSuccess.imageName
     let buttonViewModel: CardPresentPaymentsModalButtonViewModel

--- a/WooCommerce/Classes/POS/Presentation/Card Present Payments/Connection Alerts/PointOfSaleCardPresentPaymentFoundMultipleReadersAlertViewModel.swift
+++ b/WooCommerce/Classes/POS/Presentation/Card Present Payments/Connection Alerts/PointOfSaleCardPresentPaymentFoundMultipleReadersAlertViewModel.swift
@@ -15,3 +15,14 @@ struct PointOfSaleCardPresentPaymentFoundMultipleReadersAlertViewModel {
         }
     }
 }
+
+extension PointOfSaleCardPresentPaymentFoundMultipleReadersAlertViewModel: Hashable {
+    static func == (lhs: PointOfSaleCardPresentPaymentFoundMultipleReadersAlertViewModel,
+                    rhs: PointOfSaleCardPresentPaymentFoundMultipleReadersAlertViewModel) -> Bool {
+        return lhs.readerIDs == rhs.readerIDs
+    }
+
+    func hash(into hasher: inout Hasher) {
+        hasher.combine(readerIDs)
+    }
+}

--- a/WooCommerce/Classes/POS/Presentation/Card Present Payments/Connection Alerts/PointOfSaleCardPresentPaymentFoundReaderAlertViewModel.swift
+++ b/WooCommerce/Classes/POS/Presentation/Card Present Payments/Connection Alerts/PointOfSaleCardPresentPaymentFoundReaderAlertViewModel.swift
@@ -1,7 +1,7 @@
 import Foundation
 import SwiftUI
 
-struct PointOfSaleCardPresentPaymentFoundReaderAlertViewModel {
+struct PointOfSaleCardPresentPaymentFoundReaderAlertViewModel: Hashable {
     let title: String
     let imageName = PointOfSaleAssets.readerConnectionDoYouWantToConnect.imageName
     let connectButton: CardPresentPaymentsModalButtonViewModel

--- a/WooCommerce/Classes/POS/Presentation/Card Present Payments/Connection Alerts/PointOfSaleCardPresentPaymentOptionalReaderUpdateInProgressAlertViewModel.swift
+++ b/WooCommerce/Classes/POS/Presentation/Card Present Payments/Connection Alerts/PointOfSaleCardPresentPaymentOptionalReaderUpdateInProgressAlertViewModel.swift
@@ -3,6 +3,7 @@ import SwiftUI
 
 struct PointOfSaleCardPresentPaymentOptionalReaderUpdateInProgressAlertViewModel {
     let title: String = Localization.title
+    private let progress: Float
     let image: Image
     let progressTitle: String
     let progressSubtitle: String = Localization.messageOptional
@@ -11,10 +12,30 @@ struct PointOfSaleCardPresentPaymentOptionalReaderUpdateInProgressAlertViewModel
 
     init(progress: Float, cancel: (() -> Void)?) {
         self.image = Image(uiImage: .softwareUpdateProgress(progress: CGFloat(progress)))
+        self.progress = progress
         self.progressTitle = String(format: Localization.percentCompleteFormat, 100 * progress)
 
         self.cancelButtonTitle = Localization.cancelOptionalButtonText
         self.cancelReaderUpdate = cancel
+    }
+}
+
+extension PointOfSaleCardPresentPaymentOptionalReaderUpdateInProgressAlertViewModel: Hashable {
+    static func == (lhs: PointOfSaleCardPresentPaymentOptionalReaderUpdateInProgressAlertViewModel,
+                    rhs: PointOfSaleCardPresentPaymentOptionalReaderUpdateInProgressAlertViewModel) -> Bool {
+        return lhs.title == rhs.title &&
+        lhs.progress == rhs.progress &&
+        lhs.progressTitle == rhs.progressTitle &&
+        lhs.progressSubtitle == rhs.progressSubtitle &&
+        lhs.cancelButtonTitle == rhs.cancelButtonTitle
+    }
+
+    func hash(into hasher: inout Hasher) {
+        hasher.combine(title)
+        hasher.combine(progress)
+        hasher.combine(progressTitle)
+        hasher.combine(progressSubtitle)
+        hasher.combine(cancelButtonTitle)
     }
 }
 

--- a/WooCommerce/Classes/POS/Presentation/Card Present Payments/Connection Alerts/PointOfSaleCardPresentPaymentReaderUpdateCompletionAlertViewModel.swift
+++ b/WooCommerce/Classes/POS/Presentation/Card Present Payments/Connection Alerts/PointOfSaleCardPresentPaymentReaderUpdateCompletionAlertViewModel.swift
@@ -7,6 +7,13 @@ struct PointOfSaleCardPresentPaymentReaderUpdateCompletionAlertViewModel {
     let progressTitle: String = .init(format: Localization.percentCompleteFormat, 100.0)
 }
 
+extension PointOfSaleCardPresentPaymentReaderUpdateCompletionAlertViewModel: Hashable {
+    func hash(into hasher: inout Hasher) {
+        hasher.combine(title)
+        hasher.combine(progressTitle)
+    }
+}
+
 private extension PointOfSaleCardPresentPaymentReaderUpdateCompletionAlertViewModel {
     enum Localization {
         static let title = NSLocalizedString(

--- a/WooCommerce/Classes/POS/Presentation/Card Present Payments/Connection Alerts/PointOfSaleCardPresentPaymentReaderUpdateFailedAlertViewModel.swift
+++ b/WooCommerce/Classes/POS/Presentation/Card Present Payments/Connection Alerts/PointOfSaleCardPresentPaymentReaderUpdateFailedAlertViewModel.swift
@@ -1,7 +1,7 @@
 import Foundation
 import SwiftUI
 
-struct PointOfSaleCardPresentPaymentReaderUpdateFailedAlertViewModel {
+struct PointOfSaleCardPresentPaymentReaderUpdateFailedAlertViewModel: Hashable {
     let title: String = Localization.title
     let imageName = PointOfSaleAssets.paymentsError.imageName
     let retryButtonViewModel: CardPresentPaymentsModalButtonViewModel

--- a/WooCommerce/Classes/POS/Presentation/Card Present Payments/Connection Alerts/PointOfSaleCardPresentPaymentReaderUpdateFailedAlertViewModel.swift
+++ b/WooCommerce/Classes/POS/Presentation/Card Present Payments/Connection Alerts/PointOfSaleCardPresentPaymentReaderUpdateFailedAlertViewModel.swift
@@ -3,7 +3,7 @@ import SwiftUI
 
 struct PointOfSaleCardPresentPaymentReaderUpdateFailedAlertViewModel {
     let title: String = Localization.title
-    let image: Image = .init(uiImage: .paymentErrorImage)
+    let imageName = PointOfSaleAssets.paymentsError.imageName
     let retryButtonViewModel: CardPresentPaymentsModalButtonViewModel
     let cancelButtonViewModel: CardPresentPaymentsModalButtonViewModel
 

--- a/WooCommerce/Classes/POS/Presentation/Card Present Payments/Connection Alerts/PointOfSaleCardPresentPaymentReaderUpdateFailedLowBatteryAlertViewModel.swift
+++ b/WooCommerce/Classes/POS/Presentation/Card Present Payments/Connection Alerts/PointOfSaleCardPresentPaymentReaderUpdateFailedLowBatteryAlertViewModel.swift
@@ -3,7 +3,7 @@ import SwiftUI
 
 struct PointOfSaleCardPresentPaymentReaderUpdateFailedLowBatteryAlertViewModel {
     let title: String = Localization.title
-    let image: Image = .init(uiImage: .cardReaderLowBattery)
+    let imageName = PointOfSaleAssets.cardReaderLowBattery.imageName
     let batteryLevelInfo: String
     let cancelButtonViewModel: CardPresentPaymentsModalButtonViewModel
 

--- a/WooCommerce/Classes/POS/Presentation/Card Present Payments/Connection Alerts/PointOfSaleCardPresentPaymentReaderUpdateFailedLowBatteryAlertViewModel.swift
+++ b/WooCommerce/Classes/POS/Presentation/Card Present Payments/Connection Alerts/PointOfSaleCardPresentPaymentReaderUpdateFailedLowBatteryAlertViewModel.swift
@@ -1,7 +1,7 @@
 import Foundation
 import SwiftUI
 
-struct PointOfSaleCardPresentPaymentReaderUpdateFailedLowBatteryAlertViewModel {
+struct PointOfSaleCardPresentPaymentReaderUpdateFailedLowBatteryAlertViewModel: Hashable {
     let title: String = Localization.title
     let imageName = PointOfSaleAssets.cardReaderLowBattery.imageName
     let batteryLevelInfo: String

--- a/WooCommerce/Classes/POS/Presentation/Card Present Payments/Connection Alerts/PointOfSaleCardPresentPaymentReaderUpdateFailedNonRetryableAlertViewModel.swift
+++ b/WooCommerce/Classes/POS/Presentation/Card Present Payments/Connection Alerts/PointOfSaleCardPresentPaymentReaderUpdateFailedNonRetryableAlertViewModel.swift
@@ -3,7 +3,7 @@ import SwiftUI
 
 struct PointOfSaleCardPresentPaymentReaderUpdateFailedNonRetryableAlertViewModel {
     let title: String = Localization.title
-    let image: Image = .init(uiImage: .paymentErrorImage)
+    let imageName = PointOfSaleAssets.paymentsError.imageName
     let cancelButtonViewModel: CardPresentPaymentsModalButtonViewModel
 
     init(cancelUpdateAction: @escaping () -> Void) {

--- a/WooCommerce/Classes/POS/Presentation/Card Present Payments/Connection Alerts/PointOfSaleCardPresentPaymentReaderUpdateFailedNonRetryableAlertViewModel.swift
+++ b/WooCommerce/Classes/POS/Presentation/Card Present Payments/Connection Alerts/PointOfSaleCardPresentPaymentReaderUpdateFailedNonRetryableAlertViewModel.swift
@@ -1,7 +1,7 @@
 import Foundation
 import SwiftUI
 
-struct PointOfSaleCardPresentPaymentReaderUpdateFailedNonRetryableAlertViewModel {
+struct PointOfSaleCardPresentPaymentReaderUpdateFailedNonRetryableAlertViewModel: Hashable {
     let title: String = Localization.title
     let imageName = PointOfSaleAssets.paymentsError.imageName
     let cancelButtonViewModel: CardPresentPaymentsModalButtonViewModel

--- a/WooCommerce/Classes/POS/Presentation/Card Present Payments/Connection Alerts/PointOfSaleCardPresentPaymentRequiredReaderUpdateInProgressAlertViewModel.swift
+++ b/WooCommerce/Classes/POS/Presentation/Card Present Payments/Connection Alerts/PointOfSaleCardPresentPaymentRequiredReaderUpdateInProgressAlertViewModel.swift
@@ -3,6 +3,7 @@ import SwiftUI
 
 struct PointOfSaleCardPresentPaymentRequiredReaderUpdateInProgressAlertViewModel {
     let title: String = Localization.title
+    private let progress: Float
     let image: Image
     let progressTitle: String
     let progressSubtitle: String = Localization.messageRequired
@@ -11,10 +12,30 @@ struct PointOfSaleCardPresentPaymentRequiredReaderUpdateInProgressAlertViewModel
 
     init(progress: Float, cancel: (() -> Void)?) {
         self.image = Image(uiImage: .softwareUpdateProgress(progress: CGFloat(progress)))
+        self.progress = progress
         self.progressTitle = String(format: Localization.percentCompleteFormat, 100 * progress)
 
         self.cancelButtonTitle = Localization.cancelRequiredButtonText
         self.cancelReaderUpdate = cancel
+    }
+}
+
+extension PointOfSaleCardPresentPaymentRequiredReaderUpdateInProgressAlertViewModel: Hashable {
+    static func == (lhs: PointOfSaleCardPresentPaymentRequiredReaderUpdateInProgressAlertViewModel,
+                    rhs: PointOfSaleCardPresentPaymentRequiredReaderUpdateInProgressAlertViewModel) -> Bool {
+        return lhs.title == rhs.title &&
+        lhs.progress == rhs.progress &&
+        lhs.progressTitle == rhs.progressTitle &&
+        lhs.progressSubtitle == rhs.progressSubtitle &&
+        lhs.cancelButtonTitle == rhs.cancelButtonTitle
+    }
+
+    func hash(into hasher: inout Hasher) {
+        hasher.combine(title)
+        hasher.combine(progress)
+        hasher.combine(progressTitle)
+        hasher.combine(progressSubtitle)
+        hasher.combine(cancelButtonTitle)
     }
 }
 

--- a/WooCommerce/Classes/POS/Presentation/Card Present Payments/Connection Alerts/PointOfSaleCardPresentPaymentScanningFailedAlertViewModel.swift
+++ b/WooCommerce/Classes/POS/Presentation/Card Present Payments/Connection Alerts/PointOfSaleCardPresentPaymentScanningFailedAlertViewModel.swift
@@ -1,7 +1,7 @@
 import Foundation
 import SwiftUI
 
-struct PointOfSaleCardPresentPaymentScanningFailedAlertViewModel {
+struct PointOfSaleCardPresentPaymentScanningFailedAlertViewModel: Hashable {
     let title = Localization.title
     let imageName = PointOfSaleAssets.paymentsError.imageName
     let buttonViewModel: CardPresentPaymentsModalButtonViewModel

--- a/WooCommerce/Classes/POS/Presentation/Card Present Payments/Connection Alerts/PointOfSaleCardPresentPaymentScanningFailedAlertViewModel.swift
+++ b/WooCommerce/Classes/POS/Presentation/Card Present Payments/Connection Alerts/PointOfSaleCardPresentPaymentScanningFailedAlertViewModel.swift
@@ -3,7 +3,7 @@ import SwiftUI
 
 struct PointOfSaleCardPresentPaymentScanningFailedAlertViewModel {
     let title = Localization.title
-    let image = Image(uiImage: .paymentErrorImage)
+    let imageName = PointOfSaleAssets.paymentsError.imageName
     let buttonViewModel: CardPresentPaymentsModalButtonViewModel
     let errorDetails: String
 

--- a/WooCommerce/Classes/POS/Presentation/Card Present Payments/Connection Alerts/PointOfSaleCardPresentPaymentScanningForReadersAlertViewModel.swift
+++ b/WooCommerce/Classes/POS/Presentation/Card Present Payments/Connection Alerts/PointOfSaleCardPresentPaymentScanningForReadersAlertViewModel.swift
@@ -1,7 +1,7 @@
 import Foundation
 import SwiftUI
 
-struct PointOfSaleCardPresentPaymentScanningForReadersAlertViewModel {
+struct PointOfSaleCardPresentPaymentScanningForReadersAlertViewModel: Hashable {
     let title: String = Localization.title
     let instruction: String = Localization.instruction
     let imageName = PointOfSaleAssets.readerConnectionScanning.imageName

--- a/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/Connection Alerts/PointOfSaleCardPresentPaymentBluetoothRequiredAlertView.swift
+++ b/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/Connection Alerts/PointOfSaleCardPresentPaymentBluetoothRequiredAlertView.swift
@@ -12,8 +12,7 @@ struct PointOfSaleCardPresentPaymentBluetoothRequiredAlertView: View {
             Text(viewModel.title)
                 .accessibilityAddTraits(.isHeader)
 
-            viewModel.image
-                .accessibilityHidden(true)
+            Image(decorative: viewModel.imageName)
 
             Text(viewModel.errorDetails)
 

--- a/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/Connection Alerts/PointOfSaleCardPresentPaymentConnectingFailedChargeReaderView.swift
+++ b/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/Connection Alerts/PointOfSaleCardPresentPaymentConnectingFailedChargeReaderView.swift
@@ -8,8 +8,7 @@ struct PointOfSaleCardPresentPaymentConnectingFailedChargeReaderView: View {
             Text(viewModel.title)
                 .accessibilityAddTraits(.isHeader)
 
-            viewModel.image
-                .accessibilityHidden(true)
+            Image(decorative: viewModel.imageName)
 
             Text(viewModel.errorDetails)
 

--- a/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/Connection Alerts/PointOfSaleCardPresentPaymentConnectingFailedNonRetryableView.swift
+++ b/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/Connection Alerts/PointOfSaleCardPresentPaymentConnectingFailedNonRetryableView.swift
@@ -8,8 +8,7 @@ struct PointOfSaleCardPresentPaymentConnectingFailedNonRetryableView: View {
             Text(viewModel.title)
                 .accessibilityAddTraits(.isHeader)
 
-            viewModel.image
-                .accessibilityHidden(true)
+            Image(decorative: viewModel.imageName)
 
             Text(viewModel.errorDetails)
 

--- a/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/Connection Alerts/PointOfSaleCardPresentPaymentConnectingFailedUpdateAddressView.swift
+++ b/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/Connection Alerts/PointOfSaleCardPresentPaymentConnectingFailedUpdateAddressView.swift
@@ -7,8 +7,7 @@ struct PointOfSaleCardPresentPaymentConnectingFailedUpdateAddressView: View {
             Text(viewModel.title)
                 .accessibilityAddTraits(.isHeader)
 
-            viewModel.image
-                .accessibilityHidden(true)
+            Image(decorative: viewModel.imageName)
 
             VStack(spacing: PointOfSaleReaderConnectionModalLayout.buttonSpacing) {
                 if let primaryButtonViewModel = viewModel.primaryButtonViewModel {

--- a/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/Connection Alerts/PointOfSaleCardPresentPaymentConnectingFailedUpdatePostalCodeView.swift
+++ b/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/Connection Alerts/PointOfSaleCardPresentPaymentConnectingFailedUpdatePostalCodeView.swift
@@ -8,8 +8,7 @@ struct PointOfSaleCardPresentPaymentConnectingFailedUpdatePostalCodeView: View {
             Text(viewModel.title)
                 .accessibilityAddTraits(.isHeader)
 
-            viewModel.image
-                .accessibilityHidden(true)
+            Image(decorative: viewModel.imageName)
 
             Text(viewModel.errorDetails)
 

--- a/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/Connection Alerts/PointOfSaleCardPresentPaymentConnectingFailedView.swift
+++ b/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/Connection Alerts/PointOfSaleCardPresentPaymentConnectingFailedView.swift
@@ -12,8 +12,7 @@ struct PointOfSaleCardPresentPaymentConnectingFailedView: View {
             Text(viewModel.title)
                 .accessibilityAddTraits(.isHeader)
 
-            viewModel.image
-                .accessibilityHidden(true)
+            Image(decorative: viewModel.imageName)
 
             if let errorDetails = viewModel.errorDetails {
                 Text(errorDetails)

--- a/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/Connection Alerts/PointOfSaleCardPresentPaymentReaderUpdateFailedLowBatteryView.swift
+++ b/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/Connection Alerts/PointOfSaleCardPresentPaymentReaderUpdateFailedLowBatteryView.swift
@@ -12,8 +12,7 @@ struct PointOfSaleCardPresentPaymentReaderUpdateFailedLowBatteryView: View {
             Text(viewModel.title)
                 .accessibilityAddTraits(.isHeader)
 
-            viewModel.image
-                .accessibilityHidden(true)
+            Image(decorative: viewModel.imageName)
 
             Text(viewModel.batteryLevelInfo)
 

--- a/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/Connection Alerts/PointOfSaleCardPresentPaymentReaderUpdateFailedNonRetryableView.swift
+++ b/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/Connection Alerts/PointOfSaleCardPresentPaymentReaderUpdateFailedNonRetryableView.swift
@@ -12,8 +12,7 @@ struct PointOfSaleCardPresentPaymentReaderUpdateFailedNonRetryableView: View {
             Text(viewModel.title)
                 .accessibilityAddTraits(.isHeader)
 
-            viewModel.image
-                .accessibilityHidden(true)
+            Image(decorative: viewModel.imageName)
 
             Button(viewModel.cancelButtonViewModel.title,
                    action: viewModel.cancelButtonViewModel.actionHandler)

--- a/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/Connection Alerts/PointOfSaleCardPresentPaymentReaderUpdateFailedView.swift
+++ b/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/Connection Alerts/PointOfSaleCardPresentPaymentReaderUpdateFailedView.swift
@@ -12,8 +12,7 @@ struct PointOfSaleCardPresentPaymentReaderUpdateFailedView: View {
             Text(viewModel.title)
                 .accessibilityAddTraits(.isHeader)
 
-            viewModel.image
-                .accessibilityHidden(true)
+            Image(decorative: viewModel.imageName)
 
             VStack(spacing: PointOfSaleReaderConnectionModalLayout.buttonSpacing) {
                 Button(viewModel.retryButtonViewModel.title,

--- a/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/Connection Alerts/PointOfSaleCardPresentPaymentScanningForReadersFailedView.swift
+++ b/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/Connection Alerts/PointOfSaleCardPresentPaymentScanningForReadersFailedView.swift
@@ -12,8 +12,7 @@ struct PointOfSaleCardPresentPaymentScanningForReadersFailedView: View {
             Text(viewModel.title)
                 .accessibilityAddTraits(.isHeader)
 
-            viewModel.image
-                .accessibilityHidden(true)
+            Image(decorative: viewModel.imageName)
 
             Text(viewModel.errorDetails)
 

--- a/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/Reader Messages/PointOfSaleCardPresentPaymentCaptureErrorMessageView.swift
+++ b/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/Reader Messages/PointOfSaleCardPresentPaymentCaptureErrorMessageView.swift
@@ -38,9 +38,9 @@ struct PointOfSaleCardPresentPaymentCaptureErrorMessageView: View {
         }
         .multilineTextAlignment(.center)
         .frame(maxWidth: PointOfSaleCardPresentPaymentLayout.errorContentMaxWidth)
-        .posModal(isPresented: $viewModel.showsInfoSheet) {
-            PointOfSaleCardPresentPaymentCaptureFailedView(isPresented: $viewModel.showsInfoSheet)
-        }
+//        .posModal(isPresented: $viewModel.showsInfoSheet) {
+//            PointOfSaleCardPresentPaymentCaptureFailedView(isPresented: $viewModel.showsInfoSheet)
+//        }
         .onAppear {
             viewModel.onAppear()
         }

--- a/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/Reader Messages/PointOfSaleCardPresentPaymentCaptureErrorMessageView.swift
+++ b/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/Reader Messages/PointOfSaleCardPresentPaymentCaptureErrorMessageView.swift
@@ -38,9 +38,9 @@ struct PointOfSaleCardPresentPaymentCaptureErrorMessageView: View {
         }
         .multilineTextAlignment(.center)
         .frame(maxWidth: PointOfSaleCardPresentPaymentLayout.errorContentMaxWidth)
-//        .posModal(isPresented: $viewModel.showsInfoSheet) {
-//            PointOfSaleCardPresentPaymentCaptureFailedView(isPresented: $viewModel.showsInfoSheet)
-//        }
+        .posModal(isPresented: $viewModel.showsInfoSheet) {
+            PointOfSaleCardPresentPaymentCaptureFailedView(isPresented: $viewModel.showsInfoSheet)
+        }
         .onAppear {
             viewModel.onAppear()
         }

--- a/WooCommerce/Classes/POS/Presentation/PointOfSaleAssets.swift
+++ b/WooCommerce/Classes/POS/Presentation/PointOfSaleAssets.swift
@@ -1,6 +1,8 @@
 import Foundation
 
 enum PointOfSaleAssets: CaseIterable {
+    case cardReaderLowBattery
+    case paymentsError
     case processingPayment
     case readyForPayment
     case readerConnectionScanning
@@ -11,6 +13,10 @@ enum PointOfSaleAssets: CaseIterable {
 
     var imageName: String {
         switch self {
+        case .cardReaderLowBattery:
+            "card-reader-low-battery"
+        case .paymentsError:
+            "woo-payments-error"
         case .processingPayment:
             "pos-processing-payment"
         case .readyForPayment:

--- a/WooCommerce/Classes/POS/Presentation/PointOfSaleDashboardView.swift
+++ b/WooCommerce/Classes/POS/Presentation/PointOfSaleDashboardView.swift
@@ -58,13 +58,13 @@ struct PointOfSaleDashboardView: View {
         .posModal(item: $totalsViewModel.cardPresentPaymentAlertViewModel) { alertType in
             PointOfSaleCardPresentPaymentAlert(alertType: alertType)
         }
-//        .posModal(isPresented: $itemListViewModel.showSimpleProductsModal) {
-//            SimpleProductsOnlyInformation(isPresented: $itemListViewModel.showSimpleProductsModal)
-//        }
-//        .posModal(isPresented: $viewModel.showExitPOSModal) {
-//            PointOfSaleExitPosAlertView(isPresented: $viewModel.showExitPOSModal)
-//            .frame(maxWidth: Constants.exitPOSSheetMaxWidth)
-//        }
+        .posModal(isPresented: $itemListViewModel.showSimpleProductsModal) {
+            SimpleProductsOnlyInformation(isPresented: $itemListViewModel.showSimpleProductsModal)
+        }
+        .posModal(isPresented: $viewModel.showExitPOSModal) {
+            PointOfSaleExitPosAlertView(isPresented: $viewModel.showExitPOSModal)
+            .frame(maxWidth: Constants.exitPOSSheetMaxWidth)
+        }
         .posRootModal()
         .sheet(isPresented: $viewModel.showSupport) {
             supportForm

--- a/WooCommerce/Classes/POS/Presentation/PointOfSaleDashboardView.swift
+++ b/WooCommerce/Classes/POS/Presentation/PointOfSaleDashboardView.swift
@@ -59,6 +59,7 @@ struct PointOfSaleDashboardView: View {
             // Might be the only way unless we make the type conform to `Identifiable`
             if let alertType = totalsViewModel.cardPresentPaymentAlertViewModel {
                 PointOfSaleCardPresentPaymentAlert(alertType: alertType)
+                    .id(alertType)
             } else {
                 switch totalsViewModel.cardPresentPaymentEvent {
                 case .idle,

--- a/WooCommerce/Classes/POS/Presentation/PointOfSaleDashboardView.swift
+++ b/WooCommerce/Classes/POS/Presentation/PointOfSaleDashboardView.swift
@@ -55,27 +55,16 @@ struct PointOfSaleDashboardView: View {
         .animation(.easeInOut, value: viewModel.isInitialLoading)
         .background(Color.posBackgroundGreyi3)
         .navigationBarBackButtonHidden(true)
-        .posModal(isPresented: $totalsViewModel.showsCardReaderSheet) {
-            // Might be the only way unless we make the type conform to `Identifiable`
-            if let alertType = totalsViewModel.cardPresentPaymentAlertViewModel {
-                PointOfSaleCardPresentPaymentAlert(alertType: alertType)
-                    .id(alertType)
-            } else {
-                switch totalsViewModel.cardPresentPaymentEvent {
-                case .idle,
-                        .show, // handled above
-                        .showOnboarding:
-                    Text(totalsViewModel.cardPresentPaymentEvent.temporaryEventDescription)
-                }
-            }
+        .posModal(item: $totalsViewModel.cardPresentPaymentAlertViewModel) { alertType in
+            PointOfSaleCardPresentPaymentAlert(alertType: alertType)
         }
-        .posModal(isPresented: $itemListViewModel.showSimpleProductsModal) {
-            SimpleProductsOnlyInformation(isPresented: $itemListViewModel.showSimpleProductsModal)
-        }
-        .posModal(isPresented: $viewModel.showExitPOSModal) {
-            PointOfSaleExitPosAlertView(isPresented: $viewModel.showExitPOSModal)
-            .frame(maxWidth: Constants.exitPOSSheetMaxWidth)
-        }
+//        .posModal(isPresented: $itemListViewModel.showSimpleProductsModal) {
+//            SimpleProductsOnlyInformation(isPresented: $itemListViewModel.showSimpleProductsModal)
+//        }
+//        .posModal(isPresented: $viewModel.showExitPOSModal) {
+//            PointOfSaleExitPosAlertView(isPresented: $viewModel.showExitPOSModal)
+//            .frame(maxWidth: Constants.exitPOSSheetMaxWidth)
+//        }
         .posRootModal()
         .sheet(isPresented: $viewModel.showSupport) {
             supportForm

--- a/WooCommerce/Classes/POS/Presentation/PointOfSaleDashboardView.swift
+++ b/WooCommerce/Classes/POS/Presentation/PointOfSaleDashboardView.swift
@@ -75,6 +75,7 @@ struct PointOfSaleDashboardView: View {
             PointOfSaleExitPosAlertView(isPresented: $viewModel.showExitPOSModal)
             .frame(maxWidth: Constants.exitPOSSheetMaxWidth)
         }
+        .posRootModal()
         .sheet(isPresented: $viewModel.showSupport) {
             supportForm
         }

--- a/WooCommerce/Classes/POS/Presentation/PointOfSaleEntryPointView.swift
+++ b/WooCommerce/Classes/POS/Presentation/PointOfSaleEntryPointView.swift
@@ -8,6 +8,7 @@ struct PointOfSaleEntryPointView: View {
     @StateObject private var totalsViewModel: TotalsViewModel
     @StateObject private var cartViewModel: CartViewModel
     @StateObject private var itemListViewModel: ItemListViewModel
+    @StateObject private var posModalManager = POSModalManager()
 
     private let onPointOfSaleModeActiveStateChange: ((Bool) -> Void)
 
@@ -41,12 +42,13 @@ struct PointOfSaleEntryPointView: View {
                                  totalsViewModel: totalsViewModel,
                                  cartViewModel: cartViewModel,
                                  itemListViewModel: itemListViewModel)
-            .onAppear {
-                onPointOfSaleModeActiveStateChange(true)
-            }
-            .onDisappear {
-                onPointOfSaleModeActiveStateChange(false)
-            }
+        .environmentObject(posModalManager)
+        .onAppear {
+            onPointOfSaleModeActiveStateChange(true)
+        }
+        .onDisappear {
+            onPointOfSaleModeActiveStateChange(false)
+        }
     }
 }
 

--- a/WooCommerce/Classes/POS/Presentation/Reusable Views/POSModalManager.swift
+++ b/WooCommerce/Classes/POS/Presentation/Reusable Views/POSModalManager.swift
@@ -1,15 +1,19 @@
 import SwiftUI
 
 class POSModalManager: ObservableObject {
-    @Published var isPresented: Bool = false
-    @Published var modalContent: AnyView = AnyView(EmptyView())
+    @Published private(set) var isPresented: Bool = false
+    private var contentBuilder: (() -> AnyView)?
 
-    func present<Content: View>(_ content: Content) {
-        self.modalContent = AnyView(content)
+    func present<Content: View>(_ content: @escaping () -> Content) {
+        self.contentBuilder = { AnyView(content()) }
         self.isPresented = true
     }
 
     func dismiss() {
         self.isPresented = false
+    }
+
+    func getContent() -> AnyView {
+        contentBuilder?() ?? AnyView(EmptyView())
     }
 }

--- a/WooCommerce/Classes/POS/Presentation/Reusable Views/POSModalManager.swift
+++ b/WooCommerce/Classes/POS/Presentation/Reusable Views/POSModalManager.swift
@@ -1,0 +1,15 @@
+import SwiftUI
+
+class POSModalManager: ObservableObject {
+    @Published var isPresented: Bool = false
+    @Published var modalContent: AnyView = AnyView(EmptyView())
+
+    func present<Content: View>(_ content: Content) {
+        self.modalContent = AnyView(content)
+        self.isPresented = true
+    }
+
+    func dismiss() {
+        self.isPresented = false
+    }
+}

--- a/WooCommerce/Classes/POS/Presentation/Reusable Views/POSModalViewModifier.swift
+++ b/WooCommerce/Classes/POS/Presentation/Reusable Views/POSModalViewModifier.swift
@@ -13,7 +13,7 @@ struct POSRootModalViewModifier: ViewModifier {
                 Color.black.opacity(0.4)
                     .edgesIgnoringSafeArea(.all)
 
-                modalManager.modalContent
+                modalManager.getContent()
                     .background(Color(.systemBackground))
                     .cornerRadius(16)
                     .shadow(radius: 10)
@@ -37,16 +37,16 @@ extension View {
     }
 }
 
-struct POSModalViewModifier<ModalContent: View>: ViewModifier {
+struct POSModalViewModifier<Item: Identifiable & Equatable, ModalContent: View>: ViewModifier {
     @EnvironmentObject var modalManager: POSModalManager
-    @Binding var isPresented: Bool
-    @ViewBuilder let modalContent: () -> ModalContent
+    @Binding var item: Item?
+    let modalContent: (Item) -> ModalContent
 
     func body(content: Content) -> some View {
         content
-            .onChange(of: isPresented) { newValue in
-                if newValue {
-                    modalManager.present(modalContent())
+            .onChange(of: item) { newItem in
+                if let newItem = newItem {
+                    modalManager.present { modalContent(newItem) }
                 } else {
                     modalManager.dismiss()
                 }
@@ -65,10 +65,11 @@ extension View {
     ///   - isPresented: Binding to control when the modal is shown.
     ///   - content: Content to sho
     /// - Returns: a modified view which can show the modal content specifed, when applicable.
-    func posModal<ModalContent: View>(isPresented: Binding<Bool>,
-                                      @ViewBuilder content: @escaping () -> ModalContent) -> some View {
+    func posModal<Item: Identifiable & Equatable, ModalContent: View>(
+        item: Binding<Item?>,
+        @ViewBuilder content: @escaping (Item) -> ModalContent) -> some View {
         self.modifier(
-            POSModalViewModifier(isPresented: isPresented,
+            POSModalViewModifier(item: item,
                                  modalContent: content))
     }
 }

--- a/WooCommerce/Classes/POS/Presentation/Reusable Views/POSModalViewModifier.swift
+++ b/WooCommerce/Classes/POS/Presentation/Reusable Views/POSModalViewModifier.swift
@@ -1,20 +1,19 @@
 import SwiftUI
 
-struct POSModalViewModifier<ModalContent: View>: ViewModifier {
-    @Binding var isPresented: Bool
-    let modalContent: () -> ModalContent
+struct POSRootModalViewModifier: ViewModifier {
+    @EnvironmentObject var modalManager: POSModalManager
 
     func body(content: Content) -> some View {
         ZStack {
             content
-                .blur(radius: isPresented ? 3 : 0)
-                .disabled(isPresented)
+                .blur(radius: modalManager.isPresented ? 3 : 0)
+                .disabled(modalManager.isPresented)
 
-            if isPresented {
+            if modalManager.isPresented {
                 Color.black.opacity(0.4)
                     .edgesIgnoringSafeArea(.all)
 
-                modalContent()
+                modalManager.modalContent
                     .background(Color(.systemBackground))
                     .cornerRadius(16)
                     .shadow(radius: 10)
@@ -27,6 +26,45 @@ struct POSModalViewModifier<ModalContent: View>: ViewModifier {
 }
 
 extension View {
+    /// This should be applied at the root Point of Sale view only. It provides the styling for all POSModals. Nothing will show with this view alone.
+    /// Ensure you've injected a `POSModalManager` environment object to the view you use this on.
+    ///
+    /// Trigger POS modal presentation using the `posModal` modifier
+    ///
+    /// - Returns: a view that displays modal content over the Point of Sale, when instructed to by child views using the `posModal` modifier
+    func posRootModal() -> some View {
+        self.modifier(POSRootModalViewModifier())
+    }
+}
+
+struct POSModalViewModifier<ModalContent: View>: ViewModifier {
+    @EnvironmentObject var modalManager: POSModalManager
+    @Binding var isPresented: Bool
+    @ViewBuilder let modalContent: () -> ModalContent
+
+    func body(content: Content) -> some View {
+        content
+            .onChange(of: isPresented) { newValue in
+                if newValue {
+                    modalManager.present(modalContent())
+                } else {
+                    modalManager.dismiss()
+                }
+            }
+    }
+}
+
+extension View {
+    /// Shows a modal view over the Point of Sale experience.
+    ///
+    /// The content is responsible for setting its own size – it will be presented at that size, with minimal padding around it.
+    ///
+    /// This will only work in a view heirarchy containing a `posRootModal` modifier.
+    ///
+    /// - Parameters:
+    ///   - isPresented: Binding to control when the modal is shown.
+    ///   - content: Content to sho
+    /// - Returns: a modified view which can show the modal content specifed, when applicable.
     func posModal<ModalContent: View>(isPresented: Binding<Bool>,
                                       @ViewBuilder content: @escaping () -> ModalContent) -> some View {
         self.modifier(

--- a/WooCommerce/Classes/POS/Presentation/Reusable Views/POSModalViewModifier.swift
+++ b/WooCommerce/Classes/POS/Presentation/Reusable Views/POSModalViewModifier.swift
@@ -54,16 +54,53 @@ struct POSModalViewModifier<Item: Identifiable & Equatable, ModalContent: View>:
     }
 }
 
+struct POSModalViewModifierForBool<ModalContent: View>: ViewModifier {
+    @EnvironmentObject var modalManager: POSModalManager
+    @Binding var isPresented: Bool
+    let modalContent: () -> ModalContent
+
+    func body(content: Content) -> some View {
+        content
+            .onChange(of: isPresented) { newValue in
+                if newValue {
+                    modalManager.present { modalContent() }
+                } else {
+                    modalManager.dismiss()
+                }
+            }
+    }
+}
+
 extension View {
     /// Shows a modal view over the Point of Sale experience.
     ///
+    /// Note that the content will not be redrawn in response to changes outside of the view builder.
+    /// Use the `posModal(item: content:)` modifier to work around this limitation.
     /// The content is responsible for setting its own size – it will be presented at that size, with minimal padding around it.
     ///
     /// This will only work in a view heirarchy containing a `posRootModal` modifier.
     ///
     /// - Parameters:
     ///   - isPresented: Binding to control when the modal is shown.
-    ///   - content: Content to sho
+    ///   - content: Content to show – note this will not update in response to changes outside the scope of the view builder
+    /// - Returns: a modified view which can show the modal content specifed, when applicable.
+    func posModal<ModalContent: View>(isPresented: Binding<Bool>,
+                                      @ViewBuilder content: @escaping () -> ModalContent) -> some View {
+        self.modifier(
+            POSModalViewModifierForBool(isPresented: isPresented,
+                                        modalContent: content))
+    }
+
+    /// Shows a modal view over the Point of Sale experience.
+    ///
+    /// The content will update when the item changes.
+    /// The content is responsible for setting its own size – it will be presented at that size, with minimal padding around it.
+    ///
+    /// This will only work in a view heirarchy containing a `posRootModal` modifier.
+    ///
+    /// - Parameters:
+    ///   - item: Binding to control when the modal is shown. When non-nil, the item is used to build the content.
+    ///   - content: Content to show
     /// - Returns: a modified view which can show the modal content specifed, when applicable.
     func posModal<Item: Identifiable & Equatable, ModalContent: View>(
         item: Binding<Item?>,

--- a/WooCommerce/Classes/POS/ViewModels/TotalsViewModel.swift
+++ b/WooCommerce/Classes/POS/ViewModels/TotalsViewModel.swift
@@ -22,7 +22,7 @@ final class TotalsViewModel: ObservableObject, TotalsViewModelProtocol {
 
     @Published var showsCardReaderSheet: Bool = false
     @Published private(set) var cardPresentPaymentEvent: CardPresentPaymentEvent = .idle
-    @Published private(set) var cardPresentPaymentAlertViewModel: PointOfSaleCardPresentPaymentAlertType?
+    @Published var cardPresentPaymentAlertViewModel: PointOfSaleCardPresentPaymentAlertType?
     @Published private(set) var cardPresentPaymentInlineMessage: PointOfSaleCardPresentPaymentMessageType?
     @Published private(set) var isShowingCardReaderStatus: Bool = false
     @Published private(set) var isShowingTotalsFields: Bool = false

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -814,6 +814,7 @@
 		209AD3D22AC1EDF600825D76 /* WooPaymentsDepositsCurrencyOverviewView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 209AD3D12AC1EDF600825D76 /* WooPaymentsDepositsCurrencyOverviewView.swift */; };
 		209B15672AD85F070094152A /* OperatingSystemVersion+Localization.swift in Sources */ = {isa = PBXBuildFile; fileRef = 209B15662AD85F070094152A /* OperatingSystemVersion+Localization.swift */; };
 		209CA0EE2B50070D0073D1AC /* WooTabContainerController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 209CA0ED2B50070D0073D1AC /* WooTabContainerController.swift */; };
+		209EEF902C762ED5007969A4 /* POSModalManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 209EEF8F2C762ED5007969A4 /* POSModalManager.swift */; };
 		20A130EB2C5A27190058022F /* PointOfSaleAssetsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 20A130EA2C5A27190058022F /* PointOfSaleAssetsTests.swift */; };
 		20A3AFE12B0F750B0033AF2D /* MockInPersonPaymentsCashOnDeliveryToggleRowViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 20A3AFE02B0F750B0033AF2D /* MockInPersonPaymentsCashOnDeliveryToggleRowViewModel.swift */; };
 		20A3AFE32B10EF860033AF2D /* CardReaderSettingsFlowPresentingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 20A3AFE22B10EF860033AF2D /* CardReaderSettingsFlowPresentingView.swift */; };
@@ -3843,6 +3844,7 @@
 		209AD3D12AC1EDF600825D76 /* WooPaymentsDepositsCurrencyOverviewView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WooPaymentsDepositsCurrencyOverviewView.swift; sourceTree = "<group>"; };
 		209B15662AD85F070094152A /* OperatingSystemVersion+Localization.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "OperatingSystemVersion+Localization.swift"; sourceTree = "<group>"; };
 		209CA0ED2B50070D0073D1AC /* WooTabContainerController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WooTabContainerController.swift; sourceTree = "<group>"; };
+		209EEF8F2C762ED5007969A4 /* POSModalManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = POSModalManager.swift; sourceTree = "<group>"; };
 		20A130EA2C5A27190058022F /* PointOfSaleAssetsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PointOfSaleAssetsTests.swift; sourceTree = "<group>"; };
 		20A3AFE02B0F750B0033AF2D /* MockInPersonPaymentsCashOnDeliveryToggleRowViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockInPersonPaymentsCashOnDeliveryToggleRowViewModel.swift; sourceTree = "<group>"; };
 		20A3AFE22B10EF860033AF2D /* CardReaderSettingsFlowPresentingView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardReaderSettingsFlowPresentingView.swift; sourceTree = "<group>"; };
@@ -6045,6 +6047,7 @@
 			children = (
 				01620C4D2C5394B200D3EA2F /* POSProgressViewStyle.swift */,
 				204D1D612C5A50840064A6BE /* POSModalViewModifier.swift */,
+				209EEF8F2C762ED5007969A4 /* POSModalManager.swift */,
 				01D0823F2C5B9EAB007FE81F /* POSBackgroundAppearanceKey.swift */,
 				207823E62C5D346300025A59 /* POSPrimaryButtonStyle.swift */,
 				20D3D42E2C64F175004CE6E3 /* POSSecondaryButtonStyle.swift */,
@@ -15213,6 +15216,7 @@
 				CCD2F51A26D67BB50010E679 /* ShippingLabelServicePackageList.swift in Sources */,
 				45FDDD65267784AD00ADACE8 /* ShippingLabelSummaryTableViewCell.swift in Sources */,
 				45DB70662614CE3F0064A6CF /* Decimal+Helpers.swift in Sources */,
+				209EEF902C762ED5007969A4 /* POSModalManager.swift in Sources */,
 				0379C51727BFCE9800A7E284 /* WCPayCardBrand+icons.swift in Sources */,
 				DA1D68C22C36F0980097859A /* PointOfSaleAssets.swift in Sources */,
 				0210D8692A7BEEF700846F8C /* WooAnalyticsEvent+ProductListFilter.swift in Sources */,


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #13234
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

## Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->

## Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [ ] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [ ] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [ ] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on all devices (phone/tablet) and no regressions are added.