### PR TITLE
[Woo POS] Make reader alert types hashable and identifiable in preparation for posModal changes

### DIFF
--- a/WooCommerce/Classes/POS/Card Present Payments/CardPresentPaymentsModalButtonViewModel.swift
+++ b/WooCommerce/Classes/POS/Card Present Payments/CardPresentPaymentsModalButtonViewModel.swift
@@ -25,6 +25,7 @@ extension CardPresentPaymentsModalButtonViewModel: Hashable {
     }
 
     func hash(into hasher: inout Hasher) {
+        hasher.combine(title)
         hasher.combine(id)
     }
 }

--- a/WooCommerce/Classes/POS/Card Present Payments/CardPresentPaymentsModalButtonViewModel.swift
+++ b/WooCommerce/Classes/POS/Card Present Payments/CardPresentPaymentsModalButtonViewModel.swift
@@ -17,3 +17,14 @@ struct CardPresentPaymentsModalButtonViewModel: Identifiable {
         self.init(title: title, actionHandler: actionHandler)
     }
 }
+
+extension CardPresentPaymentsModalButtonViewModel: Hashable {
+    static func == (lhs: CardPresentPaymentsModalButtonViewModel, rhs: CardPresentPaymentsModalButtonViewModel) -> Bool {
+        return lhs.title == rhs.title &&
+        lhs.id == rhs.id
+    }
+
+    func hash(into hasher: inout Hasher) {
+        hasher.combine(id)
+    }
+}

--- a/WooCommerce/Classes/POS/Presentation/Card Present Payments/Connection Alerts/PointOfSaleCardPresentPaymentAlertType.swift
+++ b/WooCommerce/Classes/POS/Presentation/Card Present Payments/Connection Alerts/PointOfSaleCardPresentPaymentAlertType.swift
@@ -2,7 +2,7 @@ import Foundation
 
 /// `PointOfSaleCardPresentPaymentAlertType` serves as a typed bridge between the `CardPresentPaymentEventDetails`
 /// and the POS alert view models, for those events which should be displayed as alerts.
-enum PointOfSaleCardPresentPaymentAlertType {
+enum PointOfSaleCardPresentPaymentAlertType: Hashable {
     case scanningForReaders(viewModel: PointOfSaleCardPresentPaymentScanningForReadersAlertViewModel)
     case scanningFailed(viewModel: PointOfSaleCardPresentPaymentScanningFailedAlertViewModel)
     case bluetoothRequired(viewModel: PointOfSaleCardPresentPaymentBluetoothRequiredAlertViewModel)

--- a/WooCommerce/Classes/POS/Presentation/Card Present Payments/Connection Alerts/PointOfSaleCardPresentPaymentAlertType.swift
+++ b/WooCommerce/Classes/POS/Presentation/Card Present Payments/Connection Alerts/PointOfSaleCardPresentPaymentAlertType.swift
@@ -2,7 +2,11 @@ import Foundation
 
 /// `PointOfSaleCardPresentPaymentAlertType` serves as a typed bridge between the `CardPresentPaymentEventDetails`
 /// and the POS alert view models, for those events which should be displayed as alerts.
-enum PointOfSaleCardPresentPaymentAlertType: Hashable {
+enum PointOfSaleCardPresentPaymentAlertType: Hashable, Identifiable {
+    var id: Self {
+        self
+    }
+
     case scanningForReaders(viewModel: PointOfSaleCardPresentPaymentScanningForReadersAlertViewModel)
     case scanningFailed(viewModel: PointOfSaleCardPresentPaymentScanningFailedAlertViewModel)
     case bluetoothRequired(viewModel: PointOfSaleCardPresentPaymentBluetoothRequiredAlertViewModel)

--- a/WooCommerce/Classes/POS/Presentation/Card Present Payments/Connection Alerts/PointOfSaleCardPresentPaymentBluetoothRequiredAlertViewModel.swift
+++ b/WooCommerce/Classes/POS/Presentation/Card Present Payments/Connection Alerts/PointOfSaleCardPresentPaymentBluetoothRequiredAlertViewModel.swift
@@ -1,7 +1,7 @@
 import Foundation
 import SwiftUI
 
-struct PointOfSaleCardPresentPaymentBluetoothRequiredAlertViewModel {
+struct PointOfSaleCardPresentPaymentBluetoothRequiredAlertViewModel: Hashable {
     let title = Localization.bluetoothRequired
     let imageName = PointOfSaleAssets.paymentsError.imageName
     let openSettingsButtonViewModel: CardPresentPaymentsModalButtonViewModel

--- a/WooCommerce/Classes/POS/Presentation/Card Present Payments/Connection Alerts/PointOfSaleCardPresentPaymentBluetoothRequiredAlertViewModel.swift
+++ b/WooCommerce/Classes/POS/Presentation/Card Present Payments/Connection Alerts/PointOfSaleCardPresentPaymentBluetoothRequiredAlertViewModel.swift
@@ -3,7 +3,7 @@ import SwiftUI
 
 struct PointOfSaleCardPresentPaymentBluetoothRequiredAlertViewModel {
     let title = Localization.bluetoothRequired
-    let image = Image(uiImage: .paymentErrorImage)
+    let imageName = PointOfSaleAssets.paymentsError.imageName
     let openSettingsButtonViewModel: CardPresentPaymentsModalButtonViewModel
     let dismissButtonViewModel: CardPresentPaymentsModalButtonViewModel
     let errorDetails: String

--- a/WooCommerce/Classes/POS/Presentation/Card Present Payments/Connection Alerts/PointOfSaleCardPresentPaymentConnectingFailedAlertViewModel.swift
+++ b/WooCommerce/Classes/POS/Presentation/Card Present Payments/Connection Alerts/PointOfSaleCardPresentPaymentConnectingFailedAlertViewModel.swift
@@ -2,7 +2,7 @@ import Foundation
 import SwiftUI
 import enum Yosemite.CardReaderServiceError
 
-struct PointOfSaleCardPresentPaymentConnectingFailedAlertViewModel {
+struct PointOfSaleCardPresentPaymentConnectingFailedAlertViewModel: Hashable {
     let title = Localization.title
     let imageName = PointOfSaleAssets.paymentsError.imageName
     let errorDetails: String?

--- a/WooCommerce/Classes/POS/Presentation/Card Present Payments/Connection Alerts/PointOfSaleCardPresentPaymentConnectingFailedAlertViewModel.swift
+++ b/WooCommerce/Classes/POS/Presentation/Card Present Payments/Connection Alerts/PointOfSaleCardPresentPaymentConnectingFailedAlertViewModel.swift
@@ -1,5 +1,4 @@
 import Foundation
-import SwiftUI
 import enum Yosemite.CardReaderServiceError
 
 struct PointOfSaleCardPresentPaymentConnectingFailedAlertViewModel: Hashable {

--- a/WooCommerce/Classes/POS/Presentation/Card Present Payments/Connection Alerts/PointOfSaleCardPresentPaymentConnectingFailedAlertViewModel.swift
+++ b/WooCommerce/Classes/POS/Presentation/Card Present Payments/Connection Alerts/PointOfSaleCardPresentPaymentConnectingFailedAlertViewModel.swift
@@ -4,7 +4,7 @@ import enum Yosemite.CardReaderServiceError
 
 struct PointOfSaleCardPresentPaymentConnectingFailedAlertViewModel {
     let title = Localization.title
-    let image = Image(uiImage: .paymentErrorImage)
+    let imageName = PointOfSaleAssets.paymentsError.imageName
     let errorDetails: String?
 
     let retryButtonViewModel: CardPresentPaymentsModalButtonViewModel

--- a/WooCommerce/Classes/POS/Presentation/Card Present Payments/Connection Alerts/PointOfSaleCardPresentPaymentConnectingFailedChargeReaderAlertViewModel.swift
+++ b/WooCommerce/Classes/POS/Presentation/Card Present Payments/Connection Alerts/PointOfSaleCardPresentPaymentConnectingFailedChargeReaderAlertViewModel.swift
@@ -4,7 +4,7 @@ import SwiftUI
 struct PointOfSaleCardPresentPaymentConnectingFailedChargeReaderAlertViewModel {
     let title = Localization.title
     let errorDetails = Localization.errorDetails
-    let image = Image(uiImage: .paymentErrorImage)
+    let imageName = PointOfSaleAssets.paymentsError.imageName
     let retryButtonViewModel: CardPresentPaymentsModalButtonViewModel
     let cancelButtonViewModel: CardPresentPaymentsModalButtonViewModel
 

--- a/WooCommerce/Classes/POS/Presentation/Card Present Payments/Connection Alerts/PointOfSaleCardPresentPaymentConnectingFailedChargeReaderAlertViewModel.swift
+++ b/WooCommerce/Classes/POS/Presentation/Card Present Payments/Connection Alerts/PointOfSaleCardPresentPaymentConnectingFailedChargeReaderAlertViewModel.swift
@@ -1,5 +1,4 @@
 import Foundation
-import SwiftUI
 
 struct PointOfSaleCardPresentPaymentConnectingFailedChargeReaderAlertViewModel: Hashable {
     let title = Localization.title

--- a/WooCommerce/Classes/POS/Presentation/Card Present Payments/Connection Alerts/PointOfSaleCardPresentPaymentConnectingFailedChargeReaderAlertViewModel.swift
+++ b/WooCommerce/Classes/POS/Presentation/Card Present Payments/Connection Alerts/PointOfSaleCardPresentPaymentConnectingFailedChargeReaderAlertViewModel.swift
@@ -1,7 +1,7 @@
 import Foundation
 import SwiftUI
 
-struct PointOfSaleCardPresentPaymentConnectingFailedChargeReaderAlertViewModel {
+struct PointOfSaleCardPresentPaymentConnectingFailedChargeReaderAlertViewModel: Hashable {
     let title = Localization.title
     let errorDetails = Localization.errorDetails
     let imageName = PointOfSaleAssets.paymentsError.imageName

--- a/WooCommerce/Classes/POS/Presentation/Card Present Payments/Connection Alerts/PointOfSaleCardPresentPaymentConnectingFailedNonRetryableAlertViewModel.swift
+++ b/WooCommerce/Classes/POS/Presentation/Card Present Payments/Connection Alerts/PointOfSaleCardPresentPaymentConnectingFailedNonRetryableAlertViewModel.swift
@@ -1,5 +1,4 @@
 import Foundation
-import SwiftUI
 
 struct PointOfSaleCardPresentPaymentConnectingFailedNonRetryableAlertViewModel: Hashable {
     let title = Localization.title

--- a/WooCommerce/Classes/POS/Presentation/Card Present Payments/Connection Alerts/PointOfSaleCardPresentPaymentConnectingFailedNonRetryableAlertViewModel.swift
+++ b/WooCommerce/Classes/POS/Presentation/Card Present Payments/Connection Alerts/PointOfSaleCardPresentPaymentConnectingFailedNonRetryableAlertViewModel.swift
@@ -4,7 +4,7 @@ import SwiftUI
 struct PointOfSaleCardPresentPaymentConnectingFailedNonRetryableAlertViewModel {
     let title = Localization.title
     let errorDetails: String
-    let image = Image(uiImage: .paymentErrorImage)
+    let imageName = PointOfSaleAssets.paymentsError.imageName
     let cancelButtonViewModel: CardPresentPaymentsModalButtonViewModel
 
     init(error: Error,

--- a/WooCommerce/Classes/POS/Presentation/Card Present Payments/Connection Alerts/PointOfSaleCardPresentPaymentConnectingFailedNonRetryableAlertViewModel.swift
+++ b/WooCommerce/Classes/POS/Presentation/Card Present Payments/Connection Alerts/PointOfSaleCardPresentPaymentConnectingFailedNonRetryableAlertViewModel.swift
@@ -1,7 +1,7 @@
 import Foundation
 import SwiftUI
 
-struct PointOfSaleCardPresentPaymentConnectingFailedNonRetryableAlertViewModel {
+struct PointOfSaleCardPresentPaymentConnectingFailedNonRetryableAlertViewModel: Hashable {
     let title = Localization.title
     let errorDetails: String
     let imageName = PointOfSaleAssets.paymentsError.imageName

--- a/WooCommerce/Classes/POS/Presentation/Card Present Payments/Connection Alerts/PointOfSaleCardPresentPaymentConnectingFailedUpdateAddressAlertViewModel.swift
+++ b/WooCommerce/Classes/POS/Presentation/Card Present Payments/Connection Alerts/PointOfSaleCardPresentPaymentConnectingFailedUpdateAddressAlertViewModel.swift
@@ -1,10 +1,13 @@
 import Foundation
 import SwiftUI
 
-final class PointOfSaleCardPresentPaymentConnectingFailedUpdateAddressAlertViewModel: ObservableObject {
+final class PointOfSaleCardPresentPaymentConnectingFailedUpdateAddressAlertViewModel: ObservableObject, Identifiable {
     let title = Localization.title
     let imageName = PointOfSaleAssets.paymentsError.imageName
     let settingsAdminUrl: URL
+    // An unchanging, psuedo-random ID helps us correctly compare two copies which may have different closures.
+    // This relies on the closures being immutable
+    let id = UUID()
 
     @Published var shouldShowSettingsWebView: Bool = false
 
@@ -61,7 +64,8 @@ extension PointOfSaleCardPresentPaymentConnectingFailedUpdateAddressAlertViewMod
         lhs.primaryButtonViewModel == rhs.primaryButtonViewModel &&
         lhs.cancelButtonViewModel == rhs.cancelButtonViewModel &&
         lhs.retryButtonViewModel == rhs.retryButtonViewModel &&
-        lhs.showsInAuthenticatedWebView == rhs.showsInAuthenticatedWebView
+        lhs.showsInAuthenticatedWebView == rhs.showsInAuthenticatedWebView &&
+        lhs.id == rhs.id
     }
 
     func hash(into hasher: inout Hasher) {
@@ -73,6 +77,7 @@ extension PointOfSaleCardPresentPaymentConnectingFailedUpdateAddressAlertViewMod
         hasher.combine(cancelButtonViewModel)
         hasher.combine(retryButtonViewModel)
         hasher.combine(showsInAuthenticatedWebView)
+        hasher.combine(id)
     }
 }
 

--- a/WooCommerce/Classes/POS/Presentation/Card Present Payments/Connection Alerts/PointOfSaleCardPresentPaymentConnectingFailedUpdateAddressAlertViewModel.swift
+++ b/WooCommerce/Classes/POS/Presentation/Card Present Payments/Connection Alerts/PointOfSaleCardPresentPaymentConnectingFailedUpdateAddressAlertViewModel.swift
@@ -3,7 +3,7 @@ import SwiftUI
 
 final class PointOfSaleCardPresentPaymentConnectingFailedUpdateAddressAlertViewModel: ObservableObject {
     let title = Localization.title
-    let image = Image(uiImage: .paymentErrorImage)
+    let imageName = PointOfSaleAssets.paymentsError.imageName
     let settingsAdminUrl: URL
 
     @Published var shouldShowSettingsWebView: Bool = false

--- a/WooCommerce/Classes/POS/Presentation/Card Present Payments/Connection Alerts/PointOfSaleCardPresentPaymentConnectingFailedUpdateAddressAlertViewModel.swift
+++ b/WooCommerce/Classes/POS/Presentation/Card Present Payments/Connection Alerts/PointOfSaleCardPresentPaymentConnectingFailedUpdateAddressAlertViewModel.swift
@@ -51,6 +51,31 @@ final class PointOfSaleCardPresentPaymentConnectingFailedUpdateAddressAlertViewM
     }
 }
 
+extension PointOfSaleCardPresentPaymentConnectingFailedUpdateAddressAlertViewModel: Hashable {
+    static func == (lhs: PointOfSaleCardPresentPaymentConnectingFailedUpdateAddressAlertViewModel,
+                    rhs: PointOfSaleCardPresentPaymentConnectingFailedUpdateAddressAlertViewModel) -> Bool {
+        return lhs.title == rhs.title &&
+        lhs.imageName == rhs.imageName &&
+        lhs.settingsAdminUrl == rhs.settingsAdminUrl &&
+        lhs.shouldShowSettingsWebView == rhs.shouldShowSettingsWebView &&
+        lhs.primaryButtonViewModel == rhs.primaryButtonViewModel &&
+        lhs.cancelButtonViewModel == rhs.cancelButtonViewModel &&
+        lhs.retryButtonViewModel == rhs.retryButtonViewModel &&
+        lhs.showsInAuthenticatedWebView == rhs.showsInAuthenticatedWebView
+    }
+
+    func hash(into hasher: inout Hasher) {
+        hasher.combine(title)
+        hasher.combine(imageName)
+        hasher.combine(settingsAdminUrl)
+        hasher.combine(shouldShowSettingsWebView)
+        hasher.combine(primaryButtonViewModel)
+        hasher.combine(cancelButtonViewModel)
+        hasher.combine(retryButtonViewModel)
+        hasher.combine(showsInAuthenticatedWebView)
+    }
+}
+
 private extension PointOfSaleCardPresentPaymentConnectingFailedUpdateAddressAlertViewModel {
     enum Localization {
         static let title = NSLocalizedString(

--- a/WooCommerce/Classes/POS/Presentation/Card Present Payments/Connection Alerts/PointOfSaleCardPresentPaymentConnectingFailedUpdatePostalCodeAlertViewModel.swift
+++ b/WooCommerce/Classes/POS/Presentation/Card Present Payments/Connection Alerts/PointOfSaleCardPresentPaymentConnectingFailedUpdatePostalCodeAlertViewModel.swift
@@ -3,7 +3,7 @@ import SwiftUI
 
 struct PointOfSaleCardPresentPaymentConnectingFailedUpdatePostalCodeAlertViewModel {
     let title = Localization.title
-    let image = Image(uiImage: .paymentErrorImage)
+    let imageName = PointOfSaleAssets.paymentsError.imageName
     let errorDetails = Localization.errorDetails
     let retryButtonViewModel: CardPresentPaymentsModalButtonViewModel
     let cancelButtonViewModel: CardPresentPaymentsModalButtonViewModel

--- a/WooCommerce/Classes/POS/Presentation/Card Present Payments/Connection Alerts/PointOfSaleCardPresentPaymentConnectingFailedUpdatePostalCodeAlertViewModel.swift
+++ b/WooCommerce/Classes/POS/Presentation/Card Present Payments/Connection Alerts/PointOfSaleCardPresentPaymentConnectingFailedUpdatePostalCodeAlertViewModel.swift
@@ -1,7 +1,7 @@
 import Foundation
 import SwiftUI
 
-struct PointOfSaleCardPresentPaymentConnectingFailedUpdatePostalCodeAlertViewModel {
+struct PointOfSaleCardPresentPaymentConnectingFailedUpdatePostalCodeAlertViewModel: Hashable {
     let title = Localization.title
     let imageName = PointOfSaleAssets.paymentsError.imageName
     let errorDetails = Localization.errorDetails

--- a/WooCommerce/Classes/POS/Presentation/Card Present Payments/Connection Alerts/PointOfSaleCardPresentPaymentConnectingFailedUpdatePostalCodeAlertViewModel.swift
+++ b/WooCommerce/Classes/POS/Presentation/Card Present Payments/Connection Alerts/PointOfSaleCardPresentPaymentConnectingFailedUpdatePostalCodeAlertViewModel.swift
@@ -1,5 +1,4 @@
 import Foundation
-import SwiftUI
 
 struct PointOfSaleCardPresentPaymentConnectingFailedUpdatePostalCodeAlertViewModel: Hashable {
     let title = Localization.title

--- a/WooCommerce/Classes/POS/Presentation/Card Present Payments/Connection Alerts/PointOfSaleCardPresentPaymentConnectingToReaderAlertViewModel.swift
+++ b/WooCommerce/Classes/POS/Presentation/Card Present Payments/Connection Alerts/PointOfSaleCardPresentPaymentConnectingToReaderAlertViewModel.swift
@@ -1,5 +1,4 @@
 import Foundation
-import SwiftUI
 
 struct PointOfSaleCardPresentPaymentConnectingToReaderAlertViewModel: Hashable {
     let title = Localization.title

--- a/WooCommerce/Classes/POS/Presentation/Card Present Payments/Connection Alerts/PointOfSaleCardPresentPaymentConnectingToReaderAlertViewModel.swift
+++ b/WooCommerce/Classes/POS/Presentation/Card Present Payments/Connection Alerts/PointOfSaleCardPresentPaymentConnectingToReaderAlertViewModel.swift
@@ -1,7 +1,7 @@
 import Foundation
 import SwiftUI
 
-struct PointOfSaleCardPresentPaymentConnectingToReaderAlertViewModel {
+struct PointOfSaleCardPresentPaymentConnectingToReaderAlertViewModel: Hashable {
     let title = Localization.title
     let imageName = PointOfSaleAssets.readerConnectionConnecting.imageName
     let instruction = Localization.instruction

--- a/WooCommerce/Classes/POS/Presentation/Card Present Payments/Connection Alerts/PointOfSaleCardPresentPaymentConnectionSuccessAlertViewModel.swift
+++ b/WooCommerce/Classes/POS/Presentation/Card Present Payments/Connection Alerts/PointOfSaleCardPresentPaymentConnectionSuccessAlertViewModel.swift
@@ -1,5 +1,4 @@
 import Foundation
-import SwiftUI
 
 struct PointOfSaleCardPresentPaymentConnectionSuccessAlertViewModel: Hashable {
     let title = Localization.title

--- a/WooCommerce/Classes/POS/Presentation/Card Present Payments/Connection Alerts/PointOfSaleCardPresentPaymentConnectionSuccessAlertViewModel.swift
+++ b/WooCommerce/Classes/POS/Presentation/Card Present Payments/Connection Alerts/PointOfSaleCardPresentPaymentConnectionSuccessAlertViewModel.swift
@@ -1,7 +1,7 @@
 import Foundation
 import SwiftUI
 
-struct PointOfSaleCardPresentPaymentConnectionSuccessAlertViewModel {
+struct PointOfSaleCardPresentPaymentConnectionSuccessAlertViewModel: Hashable {
     let title = Localization.title
     let imageName = PointOfSaleAssets.readerConnectionSuccess.imageName
     let buttonViewModel: CardPresentPaymentsModalButtonViewModel

--- a/WooCommerce/Classes/POS/Presentation/Card Present Payments/Connection Alerts/PointOfSaleCardPresentPaymentFoundMultipleReadersAlertViewModel.swift
+++ b/WooCommerce/Classes/POS/Presentation/Card Present Payments/Connection Alerts/PointOfSaleCardPresentPaymentFoundMultipleReadersAlertViewModel.swift
@@ -1,9 +1,12 @@
 import Foundation
 
-struct PointOfSaleCardPresentPaymentFoundMultipleReadersAlertViewModel {
+struct PointOfSaleCardPresentPaymentFoundMultipleReadersAlertViewModel: Identifiable {
     let readerIDs: [String]
     let connect: (String) -> Void
     let cancelSearch: () -> Void
+    // An unchanging, psuedo-random ID helps us correctly compare two copies which may have different closures.
+    // This relies on the closures being immutable
+    let id = UUID()
 
     init(readerIDs: [String], selectionHandler: @escaping (String?) -> Void) {
         self.readerIDs = readerIDs
@@ -19,10 +22,12 @@ struct PointOfSaleCardPresentPaymentFoundMultipleReadersAlertViewModel {
 extension PointOfSaleCardPresentPaymentFoundMultipleReadersAlertViewModel: Hashable {
     static func == (lhs: PointOfSaleCardPresentPaymentFoundMultipleReadersAlertViewModel,
                     rhs: PointOfSaleCardPresentPaymentFoundMultipleReadersAlertViewModel) -> Bool {
-        return lhs.readerIDs == rhs.readerIDs
+        return lhs.readerIDs == rhs.readerIDs &&
+        lhs.id == rhs.id
     }
 
     func hash(into hasher: inout Hasher) {
         hasher.combine(readerIDs)
+        hasher.combine(id)
     }
 }

--- a/WooCommerce/Classes/POS/Presentation/Card Present Payments/Connection Alerts/PointOfSaleCardPresentPaymentFoundMultipleReadersAlertViewModel.swift
+++ b/WooCommerce/Classes/POS/Presentation/Card Present Payments/Connection Alerts/PointOfSaleCardPresentPaymentFoundMultipleReadersAlertViewModel.swift
@@ -15,3 +15,14 @@ struct PointOfSaleCardPresentPaymentFoundMultipleReadersAlertViewModel {
         }
     }
 }
+
+extension PointOfSaleCardPresentPaymentFoundMultipleReadersAlertViewModel: Hashable {
+    static func == (lhs: PointOfSaleCardPresentPaymentFoundMultipleReadersAlertViewModel,
+                    rhs: PointOfSaleCardPresentPaymentFoundMultipleReadersAlertViewModel) -> Bool {
+        return lhs.readerIDs == rhs.readerIDs
+    }
+
+    func hash(into hasher: inout Hasher) {
+        hasher.combine(readerIDs)
+    }
+}

--- a/WooCommerce/Classes/POS/Presentation/Card Present Payments/Connection Alerts/PointOfSaleCardPresentPaymentFoundReaderAlertViewModel.swift
+++ b/WooCommerce/Classes/POS/Presentation/Card Present Payments/Connection Alerts/PointOfSaleCardPresentPaymentFoundReaderAlertViewModel.swift
@@ -1,5 +1,4 @@
 import Foundation
-import SwiftUI
 
 struct PointOfSaleCardPresentPaymentFoundReaderAlertViewModel: Hashable {
     let title: String

--- a/WooCommerce/Classes/POS/Presentation/Card Present Payments/Connection Alerts/PointOfSaleCardPresentPaymentFoundReaderAlertViewModel.swift
+++ b/WooCommerce/Classes/POS/Presentation/Card Present Payments/Connection Alerts/PointOfSaleCardPresentPaymentFoundReaderAlertViewModel.swift
@@ -1,7 +1,7 @@
 import Foundation
 import SwiftUI
 
-struct PointOfSaleCardPresentPaymentFoundReaderAlertViewModel {
+struct PointOfSaleCardPresentPaymentFoundReaderAlertViewModel: Hashable {
     let title: String
     let imageName = PointOfSaleAssets.readerConnectionDoYouWantToConnect.imageName
     let connectButton: CardPresentPaymentsModalButtonViewModel

--- a/WooCommerce/Classes/POS/Presentation/Card Present Payments/Connection Alerts/PointOfSaleCardPresentPaymentOptionalReaderUpdateInProgressAlertViewModel.swift
+++ b/WooCommerce/Classes/POS/Presentation/Card Present Payments/Connection Alerts/PointOfSaleCardPresentPaymentOptionalReaderUpdateInProgressAlertViewModel.swift
@@ -3,6 +3,7 @@ import SwiftUI
 
 struct PointOfSaleCardPresentPaymentOptionalReaderUpdateInProgressAlertViewModel {
     let title: String = Localization.title
+    private let progress: Float
     let image: Image
     let progressTitle: String
     let progressSubtitle: String = Localization.messageOptional
@@ -11,10 +12,30 @@ struct PointOfSaleCardPresentPaymentOptionalReaderUpdateInProgressAlertViewModel
 
     init(progress: Float, cancel: (() -> Void)?) {
         self.image = Image(uiImage: .softwareUpdateProgress(progress: CGFloat(progress)))
+        self.progress = progress
         self.progressTitle = String(format: Localization.percentCompleteFormat, 100 * progress)
 
         self.cancelButtonTitle = Localization.cancelOptionalButtonText
         self.cancelReaderUpdate = cancel
+    }
+}
+
+extension PointOfSaleCardPresentPaymentOptionalReaderUpdateInProgressAlertViewModel: Hashable {
+    static func == (lhs: PointOfSaleCardPresentPaymentOptionalReaderUpdateInProgressAlertViewModel,
+                    rhs: PointOfSaleCardPresentPaymentOptionalReaderUpdateInProgressAlertViewModel) -> Bool {
+        return lhs.title == rhs.title &&
+        lhs.progress == rhs.progress &&
+        lhs.progressTitle == rhs.progressTitle &&
+        lhs.progressSubtitle == rhs.progressSubtitle &&
+        lhs.cancelButtonTitle == rhs.cancelButtonTitle
+    }
+
+    func hash(into hasher: inout Hasher) {
+        hasher.combine(title)
+        hasher.combine(progress)
+        hasher.combine(progressTitle)
+        hasher.combine(progressSubtitle)
+        hasher.combine(cancelButtonTitle)
     }
 }
 

--- a/WooCommerce/Classes/POS/Presentation/Card Present Payments/Connection Alerts/PointOfSaleCardPresentPaymentOptionalReaderUpdateInProgressAlertViewModel.swift
+++ b/WooCommerce/Classes/POS/Presentation/Card Present Payments/Connection Alerts/PointOfSaleCardPresentPaymentOptionalReaderUpdateInProgressAlertViewModel.swift
@@ -1,7 +1,7 @@
 import Foundation
 import SwiftUI
 
-struct PointOfSaleCardPresentPaymentOptionalReaderUpdateInProgressAlertViewModel {
+struct PointOfSaleCardPresentPaymentOptionalReaderUpdateInProgressAlertViewModel: Identifiable {
     let title: String = Localization.title
     private let progress: Float
     let image: Image
@@ -9,6 +9,9 @@ struct PointOfSaleCardPresentPaymentOptionalReaderUpdateInProgressAlertViewModel
     let progressSubtitle: String = Localization.messageOptional
     let cancelButtonTitle: String
     let cancelReaderUpdate: (() -> Void)?
+    // An unchanging, psuedo-random ID helps us correctly compare two copies which may have different closures.
+    // This relies on the closures being immutable
+    let id = UUID()
 
     init(progress: Float, cancel: (() -> Void)?) {
         self.image = Image(uiImage: .softwareUpdateProgress(progress: CGFloat(progress)))
@@ -27,7 +30,8 @@ extension PointOfSaleCardPresentPaymentOptionalReaderUpdateInProgressAlertViewMo
         lhs.progress == rhs.progress &&
         lhs.progressTitle == rhs.progressTitle &&
         lhs.progressSubtitle == rhs.progressSubtitle &&
-        lhs.cancelButtonTitle == rhs.cancelButtonTitle
+        lhs.cancelButtonTitle == rhs.cancelButtonTitle &&
+        lhs.id == rhs.id
     }
 
     func hash(into hasher: inout Hasher) {
@@ -36,6 +40,7 @@ extension PointOfSaleCardPresentPaymentOptionalReaderUpdateInProgressAlertViewMo
         hasher.combine(progressTitle)
         hasher.combine(progressSubtitle)
         hasher.combine(cancelButtonTitle)
+        hasher.combine(id)
     }
 }
 

--- a/WooCommerce/Classes/POS/Presentation/Card Present Payments/Connection Alerts/PointOfSaleCardPresentPaymentReaderUpdateCompletionAlertViewModel.swift
+++ b/WooCommerce/Classes/POS/Presentation/Card Present Payments/Connection Alerts/PointOfSaleCardPresentPaymentReaderUpdateCompletionAlertViewModel.swift
@@ -7,6 +7,13 @@ struct PointOfSaleCardPresentPaymentReaderUpdateCompletionAlertViewModel {
     let progressTitle: String = .init(format: Localization.percentCompleteFormat, 100.0)
 }
 
+extension PointOfSaleCardPresentPaymentReaderUpdateCompletionAlertViewModel: Hashable {
+    func hash(into hasher: inout Hasher) {
+        hasher.combine(title)
+        hasher.combine(progressTitle)
+    }
+}
+
 private extension PointOfSaleCardPresentPaymentReaderUpdateCompletionAlertViewModel {
     enum Localization {
         static let title = NSLocalizedString(

--- a/WooCommerce/Classes/POS/Presentation/Card Present Payments/Connection Alerts/PointOfSaleCardPresentPaymentReaderUpdateCompletionAlertViewModel.swift
+++ b/WooCommerce/Classes/POS/Presentation/Card Present Payments/Connection Alerts/PointOfSaleCardPresentPaymentReaderUpdateCompletionAlertViewModel.swift
@@ -7,10 +7,17 @@ struct PointOfSaleCardPresentPaymentReaderUpdateCompletionAlertViewModel {
     let progressTitle: String = .init(format: Localization.percentCompleteFormat, 100.0)
 }
 
-extension PointOfSaleCardPresentPaymentReaderUpdateCompletionAlertViewModel: Hashable {
+extension PointOfSaleCardPresentPaymentReaderUpdateCompletionAlertViewModel: Hashable, Equatable {
     func hash(into hasher: inout Hasher) {
         hasher.combine(title)
         hasher.combine(progressTitle)
+    }
+
+    /// This can be synthesised – implemented manually to ensure it matches the `hash` function.
+    static func ==(lhs: PointOfSaleCardPresentPaymentReaderUpdateCompletionAlertViewModel,
+                   rhs: PointOfSaleCardPresentPaymentReaderUpdateCompletionAlertViewModel) -> Bool {
+        return lhs.title == rhs.title &&
+        lhs.progressTitle == rhs.progressTitle
     }
 }
 

--- a/WooCommerce/Classes/POS/Presentation/Card Present Payments/Connection Alerts/PointOfSaleCardPresentPaymentReaderUpdateFailedAlertViewModel.swift
+++ b/WooCommerce/Classes/POS/Presentation/Card Present Payments/Connection Alerts/PointOfSaleCardPresentPaymentReaderUpdateFailedAlertViewModel.swift
@@ -1,5 +1,4 @@
 import Foundation
-import SwiftUI
 
 struct PointOfSaleCardPresentPaymentReaderUpdateFailedAlertViewModel: Hashable {
     let title: String = Localization.title

--- a/WooCommerce/Classes/POS/Presentation/Card Present Payments/Connection Alerts/PointOfSaleCardPresentPaymentReaderUpdateFailedAlertViewModel.swift
+++ b/WooCommerce/Classes/POS/Presentation/Card Present Payments/Connection Alerts/PointOfSaleCardPresentPaymentReaderUpdateFailedAlertViewModel.swift
@@ -1,7 +1,7 @@
 import Foundation
 import SwiftUI
 
-struct PointOfSaleCardPresentPaymentReaderUpdateFailedAlertViewModel {
+struct PointOfSaleCardPresentPaymentReaderUpdateFailedAlertViewModel: Hashable {
     let title: String = Localization.title
     let imageName = PointOfSaleAssets.paymentsError.imageName
     let retryButtonViewModel: CardPresentPaymentsModalButtonViewModel

--- a/WooCommerce/Classes/POS/Presentation/Card Present Payments/Connection Alerts/PointOfSaleCardPresentPaymentReaderUpdateFailedAlertViewModel.swift
+++ b/WooCommerce/Classes/POS/Presentation/Card Present Payments/Connection Alerts/PointOfSaleCardPresentPaymentReaderUpdateFailedAlertViewModel.swift
@@ -3,7 +3,7 @@ import SwiftUI
 
 struct PointOfSaleCardPresentPaymentReaderUpdateFailedAlertViewModel {
     let title: String = Localization.title
-    let image: Image = .init(uiImage: .paymentErrorImage)
+    let imageName = PointOfSaleAssets.paymentsError.imageName
     let retryButtonViewModel: CardPresentPaymentsModalButtonViewModel
     let cancelButtonViewModel: CardPresentPaymentsModalButtonViewModel
 

--- a/WooCommerce/Classes/POS/Presentation/Card Present Payments/Connection Alerts/PointOfSaleCardPresentPaymentReaderUpdateFailedLowBatteryAlertViewModel.swift
+++ b/WooCommerce/Classes/POS/Presentation/Card Present Payments/Connection Alerts/PointOfSaleCardPresentPaymentReaderUpdateFailedLowBatteryAlertViewModel.swift
@@ -3,7 +3,7 @@ import SwiftUI
 
 struct PointOfSaleCardPresentPaymentReaderUpdateFailedLowBatteryAlertViewModel {
     let title: String = Localization.title
-    let image: Image = .init(uiImage: .cardReaderLowBattery)
+    let imageName = PointOfSaleAssets.cardReaderLowBattery.imageName
     let batteryLevelInfo: String
     let cancelButtonViewModel: CardPresentPaymentsModalButtonViewModel
 

--- a/WooCommerce/Classes/POS/Presentation/Card Present Payments/Connection Alerts/PointOfSaleCardPresentPaymentReaderUpdateFailedLowBatteryAlertViewModel.swift
+++ b/WooCommerce/Classes/POS/Presentation/Card Present Payments/Connection Alerts/PointOfSaleCardPresentPaymentReaderUpdateFailedLowBatteryAlertViewModel.swift
@@ -1,5 +1,4 @@
 import Foundation
-import SwiftUI
 
 struct PointOfSaleCardPresentPaymentReaderUpdateFailedLowBatteryAlertViewModel: Hashable {
     let title: String = Localization.title

--- a/WooCommerce/Classes/POS/Presentation/Card Present Payments/Connection Alerts/PointOfSaleCardPresentPaymentReaderUpdateFailedLowBatteryAlertViewModel.swift
+++ b/WooCommerce/Classes/POS/Presentation/Card Present Payments/Connection Alerts/PointOfSaleCardPresentPaymentReaderUpdateFailedLowBatteryAlertViewModel.swift
@@ -1,7 +1,7 @@
 import Foundation
 import SwiftUI
 
-struct PointOfSaleCardPresentPaymentReaderUpdateFailedLowBatteryAlertViewModel {
+struct PointOfSaleCardPresentPaymentReaderUpdateFailedLowBatteryAlertViewModel: Hashable {
     let title: String = Localization.title
     let imageName = PointOfSaleAssets.cardReaderLowBattery.imageName
     let batteryLevelInfo: String

--- a/WooCommerce/Classes/POS/Presentation/Card Present Payments/Connection Alerts/PointOfSaleCardPresentPaymentReaderUpdateFailedNonRetryableAlertViewModel.swift
+++ b/WooCommerce/Classes/POS/Presentation/Card Present Payments/Connection Alerts/PointOfSaleCardPresentPaymentReaderUpdateFailedNonRetryableAlertViewModel.swift
@@ -1,5 +1,4 @@
 import Foundation
-import SwiftUI
 
 struct PointOfSaleCardPresentPaymentReaderUpdateFailedNonRetryableAlertViewModel: Hashable {
     let title: String = Localization.title

--- a/WooCommerce/Classes/POS/Presentation/Card Present Payments/Connection Alerts/PointOfSaleCardPresentPaymentReaderUpdateFailedNonRetryableAlertViewModel.swift
+++ b/WooCommerce/Classes/POS/Presentation/Card Present Payments/Connection Alerts/PointOfSaleCardPresentPaymentReaderUpdateFailedNonRetryableAlertViewModel.swift
@@ -3,7 +3,7 @@ import SwiftUI
 
 struct PointOfSaleCardPresentPaymentReaderUpdateFailedNonRetryableAlertViewModel {
     let title: String = Localization.title
-    let image: Image = .init(uiImage: .paymentErrorImage)
+    let imageName = PointOfSaleAssets.paymentsError.imageName
     let cancelButtonViewModel: CardPresentPaymentsModalButtonViewModel
 
     init(cancelUpdateAction: @escaping () -> Void) {

--- a/WooCommerce/Classes/POS/Presentation/Card Present Payments/Connection Alerts/PointOfSaleCardPresentPaymentReaderUpdateFailedNonRetryableAlertViewModel.swift
+++ b/WooCommerce/Classes/POS/Presentation/Card Present Payments/Connection Alerts/PointOfSaleCardPresentPaymentReaderUpdateFailedNonRetryableAlertViewModel.swift
@@ -1,7 +1,7 @@
 import Foundation
 import SwiftUI
 
-struct PointOfSaleCardPresentPaymentReaderUpdateFailedNonRetryableAlertViewModel {
+struct PointOfSaleCardPresentPaymentReaderUpdateFailedNonRetryableAlertViewModel: Hashable {
     let title: String = Localization.title
     let imageName = PointOfSaleAssets.paymentsError.imageName
     let cancelButtonViewModel: CardPresentPaymentsModalButtonViewModel

--- a/WooCommerce/Classes/POS/Presentation/Card Present Payments/Connection Alerts/PointOfSaleCardPresentPaymentRequiredReaderUpdateInProgressAlertViewModel.swift
+++ b/WooCommerce/Classes/POS/Presentation/Card Present Payments/Connection Alerts/PointOfSaleCardPresentPaymentRequiredReaderUpdateInProgressAlertViewModel.swift
@@ -3,6 +3,7 @@ import SwiftUI
 
 struct PointOfSaleCardPresentPaymentRequiredReaderUpdateInProgressAlertViewModel {
     let title: String = Localization.title
+    private let progress: Float
     let image: Image
     let progressTitle: String
     let progressSubtitle: String = Localization.messageRequired
@@ -11,10 +12,30 @@ struct PointOfSaleCardPresentPaymentRequiredReaderUpdateInProgressAlertViewModel
 
     init(progress: Float, cancel: (() -> Void)?) {
         self.image = Image(uiImage: .softwareUpdateProgress(progress: CGFloat(progress)))
+        self.progress = progress
         self.progressTitle = String(format: Localization.percentCompleteFormat, 100 * progress)
 
         self.cancelButtonTitle = Localization.cancelRequiredButtonText
         self.cancelReaderUpdate = cancel
+    }
+}
+
+extension PointOfSaleCardPresentPaymentRequiredReaderUpdateInProgressAlertViewModel: Hashable {
+    static func == (lhs: PointOfSaleCardPresentPaymentRequiredReaderUpdateInProgressAlertViewModel,
+                    rhs: PointOfSaleCardPresentPaymentRequiredReaderUpdateInProgressAlertViewModel) -> Bool {
+        return lhs.title == rhs.title &&
+        lhs.progress == rhs.progress &&
+        lhs.progressTitle == rhs.progressTitle &&
+        lhs.progressSubtitle == rhs.progressSubtitle &&
+        lhs.cancelButtonTitle == rhs.cancelButtonTitle
+    }
+
+    func hash(into hasher: inout Hasher) {
+        hasher.combine(title)
+        hasher.combine(progress)
+        hasher.combine(progressTitle)
+        hasher.combine(progressSubtitle)
+        hasher.combine(cancelButtonTitle)
     }
 }
 

--- a/WooCommerce/Classes/POS/Presentation/Card Present Payments/Connection Alerts/PointOfSaleCardPresentPaymentRequiredReaderUpdateInProgressAlertViewModel.swift
+++ b/WooCommerce/Classes/POS/Presentation/Card Present Payments/Connection Alerts/PointOfSaleCardPresentPaymentRequiredReaderUpdateInProgressAlertViewModel.swift
@@ -1,7 +1,7 @@
 import Foundation
 import SwiftUI
 
-struct PointOfSaleCardPresentPaymentRequiredReaderUpdateInProgressAlertViewModel {
+struct PointOfSaleCardPresentPaymentRequiredReaderUpdateInProgressAlertViewModel: Identifiable {
     let title: String = Localization.title
     private let progress: Float
     let image: Image
@@ -9,6 +9,9 @@ struct PointOfSaleCardPresentPaymentRequiredReaderUpdateInProgressAlertViewModel
     let progressSubtitle: String = Localization.messageRequired
     let cancelButtonTitle: String
     let cancelReaderUpdate: (() -> Void)?
+    // An unchanging, psuedo-random ID helps us correctly compare two copies which may have different closures.
+    // This relies on the closures being immutable
+    let id = UUID()
 
     init(progress: Float, cancel: (() -> Void)?) {
         self.image = Image(uiImage: .softwareUpdateProgress(progress: CGFloat(progress)))
@@ -27,7 +30,8 @@ extension PointOfSaleCardPresentPaymentRequiredReaderUpdateInProgressAlertViewMo
         lhs.progress == rhs.progress &&
         lhs.progressTitle == rhs.progressTitle &&
         lhs.progressSubtitle == rhs.progressSubtitle &&
-        lhs.cancelButtonTitle == rhs.cancelButtonTitle
+        lhs.cancelButtonTitle == rhs.cancelButtonTitle &&
+        lhs.id == rhs.id
     }
 
     func hash(into hasher: inout Hasher) {
@@ -36,6 +40,7 @@ extension PointOfSaleCardPresentPaymentRequiredReaderUpdateInProgressAlertViewMo
         hasher.combine(progressTitle)
         hasher.combine(progressSubtitle)
         hasher.combine(cancelButtonTitle)
+        hasher.combine(id)
     }
 }
 

--- a/WooCommerce/Classes/POS/Presentation/Card Present Payments/Connection Alerts/PointOfSaleCardPresentPaymentScanningFailedAlertViewModel.swift
+++ b/WooCommerce/Classes/POS/Presentation/Card Present Payments/Connection Alerts/PointOfSaleCardPresentPaymentScanningFailedAlertViewModel.swift
@@ -1,7 +1,7 @@
 import Foundation
 import SwiftUI
 
-struct PointOfSaleCardPresentPaymentScanningFailedAlertViewModel {
+struct PointOfSaleCardPresentPaymentScanningFailedAlertViewModel: Hashable {
     let title = Localization.title
     let imageName = PointOfSaleAssets.paymentsError.imageName
     let buttonViewModel: CardPresentPaymentsModalButtonViewModel

--- a/WooCommerce/Classes/POS/Presentation/Card Present Payments/Connection Alerts/PointOfSaleCardPresentPaymentScanningFailedAlertViewModel.swift
+++ b/WooCommerce/Classes/POS/Presentation/Card Present Payments/Connection Alerts/PointOfSaleCardPresentPaymentScanningFailedAlertViewModel.swift
@@ -3,7 +3,7 @@ import SwiftUI
 
 struct PointOfSaleCardPresentPaymentScanningFailedAlertViewModel {
     let title = Localization.title
-    let image = Image(uiImage: .paymentErrorImage)
+    let imageName = PointOfSaleAssets.paymentsError.imageName
     let buttonViewModel: CardPresentPaymentsModalButtonViewModel
     let errorDetails: String
 

--- a/WooCommerce/Classes/POS/Presentation/Card Present Payments/Connection Alerts/PointOfSaleCardPresentPaymentScanningFailedAlertViewModel.swift
+++ b/WooCommerce/Classes/POS/Presentation/Card Present Payments/Connection Alerts/PointOfSaleCardPresentPaymentScanningFailedAlertViewModel.swift
@@ -1,5 +1,4 @@
 import Foundation
-import SwiftUI
 
 struct PointOfSaleCardPresentPaymentScanningFailedAlertViewModel: Hashable {
     let title = Localization.title

--- a/WooCommerce/Classes/POS/Presentation/Card Present Payments/Connection Alerts/PointOfSaleCardPresentPaymentScanningForReadersAlertViewModel.swift
+++ b/WooCommerce/Classes/POS/Presentation/Card Present Payments/Connection Alerts/PointOfSaleCardPresentPaymentScanningForReadersAlertViewModel.swift
@@ -1,5 +1,4 @@
 import Foundation
-import SwiftUI
 
 struct PointOfSaleCardPresentPaymentScanningForReadersAlertViewModel: Hashable {
     let title: String = Localization.title

--- a/WooCommerce/Classes/POS/Presentation/Card Present Payments/Connection Alerts/PointOfSaleCardPresentPaymentScanningForReadersAlertViewModel.swift
+++ b/WooCommerce/Classes/POS/Presentation/Card Present Payments/Connection Alerts/PointOfSaleCardPresentPaymentScanningForReadersAlertViewModel.swift
@@ -1,7 +1,7 @@
 import Foundation
 import SwiftUI
 
-struct PointOfSaleCardPresentPaymentScanningForReadersAlertViewModel {
+struct PointOfSaleCardPresentPaymentScanningForReadersAlertViewModel: Hashable {
     let title: String = Localization.title
     let instruction: String = Localization.instruction
     let imageName = PointOfSaleAssets.readerConnectionScanning.imageName

--- a/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/Connection Alerts/PointOfSaleCardPresentPaymentBluetoothRequiredAlertView.swift
+++ b/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/Connection Alerts/PointOfSaleCardPresentPaymentBluetoothRequiredAlertView.swift
@@ -12,8 +12,7 @@ struct PointOfSaleCardPresentPaymentBluetoothRequiredAlertView: View {
             Text(viewModel.title)
                 .accessibilityAddTraits(.isHeader)
 
-            viewModel.image
-                .accessibilityHidden(true)
+            Image(decorative: viewModel.imageName)
 
             Text(viewModel.errorDetails)
 

--- a/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/Connection Alerts/PointOfSaleCardPresentPaymentConnectingFailedChargeReaderView.swift
+++ b/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/Connection Alerts/PointOfSaleCardPresentPaymentConnectingFailedChargeReaderView.swift
@@ -8,8 +8,7 @@ struct PointOfSaleCardPresentPaymentConnectingFailedChargeReaderView: View {
             Text(viewModel.title)
                 .accessibilityAddTraits(.isHeader)
 
-            viewModel.image
-                .accessibilityHidden(true)
+            Image(decorative: viewModel.imageName)
 
             Text(viewModel.errorDetails)
 

--- a/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/Connection Alerts/PointOfSaleCardPresentPaymentConnectingFailedNonRetryableView.swift
+++ b/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/Connection Alerts/PointOfSaleCardPresentPaymentConnectingFailedNonRetryableView.swift
@@ -8,8 +8,7 @@ struct PointOfSaleCardPresentPaymentConnectingFailedNonRetryableView: View {
             Text(viewModel.title)
                 .accessibilityAddTraits(.isHeader)
 
-            viewModel.image
-                .accessibilityHidden(true)
+            Image(decorative: viewModel.imageName)
 
             Text(viewModel.errorDetails)
 

--- a/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/Connection Alerts/PointOfSaleCardPresentPaymentConnectingFailedUpdateAddressView.swift
+++ b/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/Connection Alerts/PointOfSaleCardPresentPaymentConnectingFailedUpdateAddressView.swift
@@ -7,8 +7,7 @@ struct PointOfSaleCardPresentPaymentConnectingFailedUpdateAddressView: View {
             Text(viewModel.title)
                 .accessibilityAddTraits(.isHeader)
 
-            viewModel.image
-                .accessibilityHidden(true)
+            Image(decorative: viewModel.imageName)
 
             VStack(spacing: PointOfSaleReaderConnectionModalLayout.buttonSpacing) {
                 if let primaryButtonViewModel = viewModel.primaryButtonViewModel {

--- a/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/Connection Alerts/PointOfSaleCardPresentPaymentConnectingFailedUpdatePostalCodeView.swift
+++ b/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/Connection Alerts/PointOfSaleCardPresentPaymentConnectingFailedUpdatePostalCodeView.swift
@@ -8,8 +8,7 @@ struct PointOfSaleCardPresentPaymentConnectingFailedUpdatePostalCodeView: View {
             Text(viewModel.title)
                 .accessibilityAddTraits(.isHeader)
 
-            viewModel.image
-                .accessibilityHidden(true)
+            Image(decorative: viewModel.imageName)
 
             Text(viewModel.errorDetails)
 

--- a/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/Connection Alerts/PointOfSaleCardPresentPaymentConnectingFailedView.swift
+++ b/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/Connection Alerts/PointOfSaleCardPresentPaymentConnectingFailedView.swift
@@ -12,8 +12,7 @@ struct PointOfSaleCardPresentPaymentConnectingFailedView: View {
             Text(viewModel.title)
                 .accessibilityAddTraits(.isHeader)
 
-            viewModel.image
-                .accessibilityHidden(true)
+            Image(decorative: viewModel.imageName)
 
             if let errorDetails = viewModel.errorDetails {
                 Text(errorDetails)

--- a/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/Connection Alerts/PointOfSaleCardPresentPaymentReaderUpdateFailedLowBatteryView.swift
+++ b/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/Connection Alerts/PointOfSaleCardPresentPaymentReaderUpdateFailedLowBatteryView.swift
@@ -12,8 +12,7 @@ struct PointOfSaleCardPresentPaymentReaderUpdateFailedLowBatteryView: View {
             Text(viewModel.title)
                 .accessibilityAddTraits(.isHeader)
 
-            viewModel.image
-                .accessibilityHidden(true)
+            Image(decorative: viewModel.imageName)
 
             Text(viewModel.batteryLevelInfo)
 

--- a/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/Connection Alerts/PointOfSaleCardPresentPaymentReaderUpdateFailedNonRetryableView.swift
+++ b/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/Connection Alerts/PointOfSaleCardPresentPaymentReaderUpdateFailedNonRetryableView.swift
@@ -12,8 +12,7 @@ struct PointOfSaleCardPresentPaymentReaderUpdateFailedNonRetryableView: View {
             Text(viewModel.title)
                 .accessibilityAddTraits(.isHeader)
 
-            viewModel.image
-                .accessibilityHidden(true)
+            Image(decorative: viewModel.imageName)
 
             Button(viewModel.cancelButtonViewModel.title,
                    action: viewModel.cancelButtonViewModel.actionHandler)

--- a/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/Connection Alerts/PointOfSaleCardPresentPaymentReaderUpdateFailedView.swift
+++ b/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/Connection Alerts/PointOfSaleCardPresentPaymentReaderUpdateFailedView.swift
@@ -12,8 +12,7 @@ struct PointOfSaleCardPresentPaymentReaderUpdateFailedView: View {
             Text(viewModel.title)
                 .accessibilityAddTraits(.isHeader)
 
-            viewModel.image
-                .accessibilityHidden(true)
+            Image(decorative: viewModel.imageName)
 
             VStack(spacing: PointOfSaleReaderConnectionModalLayout.buttonSpacing) {
                 Button(viewModel.retryButtonViewModel.title,

--- a/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/Connection Alerts/PointOfSaleCardPresentPaymentScanningForReadersFailedView.swift
+++ b/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/Connection Alerts/PointOfSaleCardPresentPaymentScanningForReadersFailedView.swift
@@ -12,8 +12,7 @@ struct PointOfSaleCardPresentPaymentScanningForReadersFailedView: View {
             Text(viewModel.title)
                 .accessibilityAddTraits(.isHeader)
 
-            viewModel.image
-                .accessibilityHidden(true)
+            Image(decorative: viewModel.imageName)
 
             Text(viewModel.errorDetails)
 

--- a/WooCommerce/Classes/POS/Presentation/PointOfSaleAssets.swift
+++ b/WooCommerce/Classes/POS/Presentation/PointOfSaleAssets.swift
@@ -1,6 +1,8 @@
 import Foundation
 
 enum PointOfSaleAssets: CaseIterable {
+    case cardReaderLowBattery
+    case paymentsError
     case processingPayment
     case readyForPayment
     case readerConnectionScanning
@@ -11,6 +13,10 @@ enum PointOfSaleAssets: CaseIterable {
 
     var imageName: String {
         switch self {
+        case .cardReaderLowBattery:
+            "card-reader-low-battery"
+        case .paymentsError:
+            "woo-payments-error"
         case .processingPayment:
             "pos-processing-payment"
         case .readyForPayment:

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -818,6 +818,7 @@
 		2084B7A82C776E1000EFBD2E /* PointOfSaleCardPresentPaymentFoundMultipleReadersAlertViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2084B7A72C776E1000EFBD2E /* PointOfSaleCardPresentPaymentFoundMultipleReadersAlertViewModelTests.swift */; };
 		2084B7AA2C776E9700EFBD2E /* PointOfSaleCardPresentPaymentOptionalReaderUpdateInProgressAlertViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2084B7A92C776E9700EFBD2E /* PointOfSaleCardPresentPaymentOptionalReaderUpdateInProgressAlertViewModelTests.swift */; };
 		2084B7AC2C776F0F00EFBD2E /* PointOfSaleCardPresentPaymentRequiredReaderUpdateInProgressAlertViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2084B7AB2C776F0F00EFBD2E /* PointOfSaleCardPresentPaymentRequiredReaderUpdateInProgressAlertViewModelTests.swift */; };
+		2084B7AE2C77845C00EFBD2E /* PointOfSaleCardPresentPaymentReaderUpdateCompletionAlertViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2084B7AD2C77845C00EFBD2E /* PointOfSaleCardPresentPaymentReaderUpdateCompletionAlertViewModelTests.swift */; };
 		209AD3D02AC1EDDA00825D76 /* WooPaymentsDepositsCurrencyOverviewViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 209AD3CF2AC1EDDA00825D76 /* WooPaymentsDepositsCurrencyOverviewViewModel.swift */; };
 		209AD3D22AC1EDF600825D76 /* WooPaymentsDepositsCurrencyOverviewView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 209AD3D12AC1EDF600825D76 /* WooPaymentsDepositsCurrencyOverviewView.swift */; };
 		209B15672AD85F070094152A /* OperatingSystemVersion+Localization.swift in Sources */ = {isa = PBXBuildFile; fileRef = 209B15662AD85F070094152A /* OperatingSystemVersion+Localization.swift */; };
@@ -3854,6 +3855,7 @@
 		2084B7A72C776E1000EFBD2E /* PointOfSaleCardPresentPaymentFoundMultipleReadersAlertViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PointOfSaleCardPresentPaymentFoundMultipleReadersAlertViewModelTests.swift; sourceTree = "<group>"; };
 		2084B7A92C776E9700EFBD2E /* PointOfSaleCardPresentPaymentOptionalReaderUpdateInProgressAlertViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PointOfSaleCardPresentPaymentOptionalReaderUpdateInProgressAlertViewModelTests.swift; sourceTree = "<group>"; };
 		2084B7AB2C776F0F00EFBD2E /* PointOfSaleCardPresentPaymentRequiredReaderUpdateInProgressAlertViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PointOfSaleCardPresentPaymentRequiredReaderUpdateInProgressAlertViewModelTests.swift; sourceTree = "<group>"; };
+		2084B7AD2C77845C00EFBD2E /* PointOfSaleCardPresentPaymentReaderUpdateCompletionAlertViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PointOfSaleCardPresentPaymentReaderUpdateCompletionAlertViewModelTests.swift; sourceTree = "<group>"; };
 		20929C9DFB2CE5CB264C27EC /* Pods-Woo Watch App.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Woo Watch App.debug.xcconfig"; path = "../Pods/Target Support Files/Pods-Woo Watch App/Pods-Woo Watch App.debug.xcconfig"; sourceTree = "<group>"; };
 		209AD3CF2AC1EDDA00825D76 /* WooPaymentsDepositsCurrencyOverviewViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WooPaymentsDepositsCurrencyOverviewViewModel.swift; sourceTree = "<group>"; };
 		209AD3D12AC1EDF600825D76 /* WooPaymentsDepositsCurrencyOverviewView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WooPaymentsDepositsCurrencyOverviewView.swift; sourceTree = "<group>"; };
@@ -7723,6 +7725,7 @@
 				2084B7A72C776E1000EFBD2E /* PointOfSaleCardPresentPaymentFoundMultipleReadersAlertViewModelTests.swift */,
 				2084B7A92C776E9700EFBD2E /* PointOfSaleCardPresentPaymentOptionalReaderUpdateInProgressAlertViewModelTests.swift */,
 				2084B7AB2C776F0F00EFBD2E /* PointOfSaleCardPresentPaymentRequiredReaderUpdateInProgressAlertViewModelTests.swift */,
+				2084B7AD2C77845C00EFBD2E /* PointOfSaleCardPresentPaymentReaderUpdateCompletionAlertViewModelTests.swift */,
 			);
 			path = "Connection Alerts";
 			sourceTree = "<group>";
@@ -16250,6 +16253,7 @@
 				02829BAA288FA8B300951E1E /* MockUserNotification.swift in Sources */,
 				D85B8336222FCDA1002168F3 /* StatusListTableViewCellTests.swift in Sources */,
 				03B9E52D2A150D16005C77F5 /* MockBuiltInCardReaderConnectionControllerFactory.swift in Sources */,
+				2084B7AE2C77845C00EFBD2E /* PointOfSaleCardPresentPaymentReaderUpdateCompletionAlertViewModelTests.swift in Sources */,
 				3198A1E82694DC7200597213 /* MockKnownReadersProvider.swift in Sources */,
 				DEC51B04276B30F6009F3DF4 /* SystemStatusReportViewModelTests.swift in Sources */,
 				26B119C224D1CD3500FED5C7 /* WooConstantsTests.swift in Sources */,

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -812,6 +812,12 @@
 		207823E72C5D346300025A59 /* POSPrimaryButtonStyle.swift in Sources */ = {isa = PBXBuildFile; fileRef = 207823E62C5D346300025A59 /* POSPrimaryButtonStyle.swift */; };
 		207823E92C5D3A1700025A59 /* POSErrorExclamationMark.swift in Sources */ = {isa = PBXBuildFile; fileRef = 207823E82C5D3A1700025A59 /* POSErrorExclamationMark.swift */; };
 		207E71CB2C60F765008540FC /* MockPOSOrderService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 207E71CA2C60F765008540FC /* MockPOSOrderService.swift */; };
+		2084B7A22C77693600EFBD2E /* CardPresentPaymentsModalButtonViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2084B7A12C77693600EFBD2E /* CardPresentPaymentsModalButtonViewModelTests.swift */; };
+		2084B7A42C776A6900EFBD2E /* XCTestCase+PropertyCount.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2084B7A32C776A6900EFBD2E /* XCTestCase+PropertyCount.swift */; };
+		2084B7A62C776DA200EFBD2E /* PointOfSaleCardPresentPaymentConnectingFailedUpdateAddressAlertViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2084B7A52C776DA200EFBD2E /* PointOfSaleCardPresentPaymentConnectingFailedUpdateAddressAlertViewModelTests.swift */; };
+		2084B7A82C776E1000EFBD2E /* PointOfSaleCardPresentPaymentFoundMultipleReadersAlertViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2084B7A72C776E1000EFBD2E /* PointOfSaleCardPresentPaymentFoundMultipleReadersAlertViewModelTests.swift */; };
+		2084B7AA2C776E9700EFBD2E /* PointOfSaleCardPresentPaymentOptionalReaderUpdateInProgressAlertViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2084B7A92C776E9700EFBD2E /* PointOfSaleCardPresentPaymentOptionalReaderUpdateInProgressAlertViewModelTests.swift */; };
+		2084B7AC2C776F0F00EFBD2E /* PointOfSaleCardPresentPaymentRequiredReaderUpdateInProgressAlertViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2084B7AB2C776F0F00EFBD2E /* PointOfSaleCardPresentPaymentRequiredReaderUpdateInProgressAlertViewModelTests.swift */; };
 		209AD3D02AC1EDDA00825D76 /* WooPaymentsDepositsCurrencyOverviewViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 209AD3CF2AC1EDDA00825D76 /* WooPaymentsDepositsCurrencyOverviewViewModel.swift */; };
 		209AD3D22AC1EDF600825D76 /* WooPaymentsDepositsCurrencyOverviewView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 209AD3D12AC1EDF600825D76 /* WooPaymentsDepositsCurrencyOverviewView.swift */; };
 		209B15672AD85F070094152A /* OperatingSystemVersion+Localization.swift in Sources */ = {isa = PBXBuildFile; fileRef = 209B15662AD85F070094152A /* OperatingSystemVersion+Localization.swift */; };
@@ -3842,6 +3848,12 @@
 		207823E62C5D346300025A59 /* POSPrimaryButtonStyle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = POSPrimaryButtonStyle.swift; sourceTree = "<group>"; };
 		207823E82C5D3A1700025A59 /* POSErrorExclamationMark.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = POSErrorExclamationMark.swift; sourceTree = "<group>"; };
 		207E71CA2C60F765008540FC /* MockPOSOrderService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockPOSOrderService.swift; sourceTree = "<group>"; };
+		2084B7A12C77693600EFBD2E /* CardPresentPaymentsModalButtonViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardPresentPaymentsModalButtonViewModelTests.swift; sourceTree = "<group>"; };
+		2084B7A32C776A6900EFBD2E /* XCTestCase+PropertyCount.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "XCTestCase+PropertyCount.swift"; sourceTree = "<group>"; };
+		2084B7A52C776DA200EFBD2E /* PointOfSaleCardPresentPaymentConnectingFailedUpdateAddressAlertViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PointOfSaleCardPresentPaymentConnectingFailedUpdateAddressAlertViewModelTests.swift; sourceTree = "<group>"; };
+		2084B7A72C776E1000EFBD2E /* PointOfSaleCardPresentPaymentFoundMultipleReadersAlertViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PointOfSaleCardPresentPaymentFoundMultipleReadersAlertViewModelTests.swift; sourceTree = "<group>"; };
+		2084B7A92C776E9700EFBD2E /* PointOfSaleCardPresentPaymentOptionalReaderUpdateInProgressAlertViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PointOfSaleCardPresentPaymentOptionalReaderUpdateInProgressAlertViewModelTests.swift; sourceTree = "<group>"; };
+		2084B7AB2C776F0F00EFBD2E /* PointOfSaleCardPresentPaymentRequiredReaderUpdateInProgressAlertViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PointOfSaleCardPresentPaymentRequiredReaderUpdateInProgressAlertViewModelTests.swift; sourceTree = "<group>"; };
 		20929C9DFB2CE5CB264C27EC /* Pods-Woo Watch App.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Woo Watch App.debug.xcconfig"; path = "../Pods/Target Support Files/Pods-Woo Watch App/Pods-Woo Watch App.debug.xcconfig"; sourceTree = "<group>"; };
 		209AD3CF2AC1EDDA00825D76 /* WooPaymentsDepositsCurrencyOverviewViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WooPaymentsDepositsCurrencyOverviewViewModel.swift; sourceTree = "<group>"; };
 		209AD3D12AC1EDF600825D76 /* WooPaymentsDepositsCurrencyOverviewView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WooPaymentsDepositsCurrencyOverviewView.swift; sourceTree = "<group>"; };
@@ -7704,6 +7716,17 @@
 			path = "Reader Messages";
 			sourceTree = "<group>";
 		};
+		2084B7A02C7768E200EFBD2E /* Connection Alerts */ = {
+			isa = PBXGroup;
+			children = (
+				2084B7A52C776DA200EFBD2E /* PointOfSaleCardPresentPaymentConnectingFailedUpdateAddressAlertViewModelTests.swift */,
+				2084B7A72C776E1000EFBD2E /* PointOfSaleCardPresentPaymentFoundMultipleReadersAlertViewModelTests.swift */,
+				2084B7A92C776E9700EFBD2E /* PointOfSaleCardPresentPaymentOptionalReaderUpdateInProgressAlertViewModelTests.swift */,
+				2084B7AB2C776F0F00EFBD2E /* PointOfSaleCardPresentPaymentRequiredReaderUpdateInProgressAlertViewModelTests.swift */,
+			);
+			path = "Connection Alerts";
+			sourceTree = "<group>";
+		};
 		20A130E92C5A26F70058022F /* Tools */ = {
 			isa = PBXGroup;
 			children = (
@@ -7715,8 +7738,10 @@
 		20ADE9442C6B361500C91265 /* Card Present Payments */ = {
 			isa = PBXGroup;
 			children = (
+				2084B7A02C7768E200EFBD2E /* Connection Alerts */,
 				20ADE9452C6B364900C91265 /* CardPresentPaymentRetryApproachTests.swift */,
 				20600F8A2C6E3CCE00950D2A /* PointOfSaleCardPresentPaymentEventPresentationStyleTests.swift */,
+				2084B7A12C77693600EFBD2E /* CardPresentPaymentsModalButtonViewModelTests.swift */,
 			);
 			path = "Card Present Payments";
 			sourceTree = "<group>";
@@ -9234,6 +9259,7 @@
 			children = (
 				6856D66A1963092C34D20674 /* Calendar+Extensions.swift */,
 				571FDDAD24C768DC00D486A5 /* MockZendeskManager.swift */,
+				2084B7A32C776A6900EFBD2E /* XCTestCase+PropertyCount.swift */,
 			);
 			path = Testing;
 			sourceTree = "<group>";
@@ -16204,6 +16230,7 @@
 				02153211242376B5003F2BBD /* ProductPriceSettingsViewModelTests.swift in Sources */,
 				45C8B25D231529410002FA77 /* CustomerInfoTableViewCellTests.swift in Sources */,
 				035BA3A8291000E90056F0AD /* JustInTimeMessageViewModelTests.swift in Sources */,
+				2084B7AA2C776E9700EFBD2E /* PointOfSaleCardPresentPaymentOptionalReaderUpdateInProgressAlertViewModelTests.swift in Sources */,
 				20BCF6F72B0E5AF000954840 /* MockSystemStatusService.swift in Sources */,
 				DEB3879A2C32A6400025256E /* MockGoogleAdsEligibilityChecker.swift in Sources */,
 				DE5C19C52AC3F0700064600A /* AddProductNameWithAIViewModelTests.swift in Sources */,
@@ -16261,6 +16288,7 @@
 				CEEF74322B9A2F9400B03948 /* ProductsReportCardViewModelTests.swift in Sources */,
 				D83F593D225B4B5000626E75 /* ManualTrackingViewControllerTests.swift in Sources */,
 				CC53FB402759042600C4CA4F /* ProductSelectorViewModelTests.swift in Sources */,
+				2084B7A62C776DA200EFBD2E /* PointOfSaleCardPresentPaymentConnectingFailedUpdateAddressAlertViewModelTests.swift in Sources */,
 				DE0A2EB1281BED38007A8015 /* ProductCategorySelectorViewModelTests.swift in Sources */,
 				02660504293D8D24004084EA /* PaymentCaptureCelebration.swift in Sources */,
 				03AA16602719B83D005CCB7B /* ReceiptActionCoordinatorTests.swift in Sources */,
@@ -16388,6 +16416,7 @@
 				EEEA41F22869A5F400AEFC4B /* MockProductImagesProductIDUpdater.swift in Sources */,
 				EE44D1562C32F6D1009FE3C6 /* ProductCreationAIStartingInfoViewModelTests.swift in Sources */,
 				2611EE59243A473300A74490 /* ProductCategoryListViewModelTests.swift in Sources */,
+				2084B7AC2C776F0F00EFBD2E /* PointOfSaleCardPresentPaymentRequiredReaderUpdateInProgressAlertViewModelTests.swift in Sources */,
 				0247AAA223A3C5A6007F967E /* DecimalInputFormatterTests.swift in Sources */,
 				5750BEE82764006F00388BE6 /* RefundFeesDetailsViewModelTests.swift in Sources */,
 				02691782232605B9002AFC20 /* PaginatedListViewControllerStateCoordinatorTests.swift in Sources */,
@@ -16434,6 +16463,7 @@
 				DE74A4572BCFB59F0009C415 /* TopPerformersDashboardViewModelTests.swift in Sources */,
 				DEA357132ADCC4C9006380BA /* BlazeCampaignListViewModelTests.swift in Sources */,
 				CC09A91229CB1ADB00D6C4AD /* ComponentsListViewModelTests.swift in Sources */,
+				2084B7A42C776A6900EFBD2E /* XCTestCase+PropertyCount.swift in Sources */,
 				A650BE862578E76600C655E0 /* MockStorageManager+Sample.swift in Sources */,
 				5791FB4224EC834300117FD6 /* MainTabViewModelTests.swift in Sources */,
 				020BE76D23B4A404007FE54C /* AztecStrikethroughFormatBarCommandTests.swift in Sources */,
@@ -16726,6 +16756,7 @@
 				02077F72253816FF005A78EF /* ProductFormActionsFactory+ReadonlyProductTests.swift in Sources */,
 				D8C11A6222E24C4A00D4A88D /* LedgerTableViewCellTests.swift in Sources */,
 				027111422913B9FC00F5269A /* AccountCreationFormViewModelTests.swift in Sources */,
+				2084B7A82C776E1000EFBD2E /* PointOfSaleCardPresentPaymentFoundMultipleReadersAlertViewModelTests.swift in Sources */,
 				DE50295328BF4A8A00551736 /* JetpackConnectionWebViewModelTests.swift in Sources */,
 				D802549126552FE1001B2CC1 /* CardPresentModalScanningForReaderTests.swift in Sources */,
 				B98FF4402AAA096200326D16 /* AddressWooTests.swift in Sources */,
@@ -16784,6 +16815,7 @@
 				EEC5C8DA2ADE2FD80071E852 /* BlazeCampaignDashboardViewModelTests.swift in Sources */,
 				D85B833D2230DC9D002168F3 /* StringWooTests.swift in Sources */,
 				CC04918F292BD6AC00F719D8 /* StatsDataTextFormatterTests.swift in Sources */,
+				2084B7A22C77693600EFBD2E /* CardPresentPaymentsModalButtonViewModelTests.swift in Sources */,
 				02BC5AA524D27F8900C43326 /* ProductVariationFormViewModel+UpdatesTests.swift in Sources */,
 				D8736B5122EB69E300A14A29 /* OrderDetailsViewModelTests.swift in Sources */,
 				207E71CB2C60F765008540FC /* MockPOSOrderService.swift in Sources */,

--- a/WooCommerce/WooCommerceTests/POS/Card Present Payments/CardPresentPaymentsModalButtonViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/POS/Card Present Payments/CardPresentPaymentsModalButtonViewModelTests.swift
@@ -1,0 +1,13 @@
+import XCTest
+@testable import WooCommerce
+
+final class CardPresentPaymentsModalButtonViewModelTests: XCTestCase {
+
+    func test_manual_equatable_conformance_number_of_properties_unchanged() {
+        let sut = CardPresentPaymentsModalButtonViewModel(title: "Title", actionHandler: {})
+        XCTAssertPropertyCount(sut,
+                               expectedCount: 3,
+                               messageHint: "Please check that the manual equatable conformance includes new properties.")
+    }
+
+}

--- a/WooCommerce/WooCommerceTests/POS/Card Present Payments/CardPresentPaymentsModalButtonViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/POS/Card Present Payments/CardPresentPaymentsModalButtonViewModelTests.swift
@@ -10,4 +10,11 @@ final class CardPresentPaymentsModalButtonViewModelTests: XCTestCase {
                                messageHint: "Please check that the manual equatable conformance includes new properties.")
     }
 
+    func test_manual_hashable_conformance_number_of_properties_unchanged() {
+        let sut = CardPresentPaymentsModalButtonViewModel(title: "Title", actionHandler: {})
+        XCTAssertPropertyCount(sut,
+                               expectedCount: 3,
+                               messageHint: "Please check that the manual hashable conformance includes new properties.")
+    }
+
 }

--- a/WooCommerce/WooCommerceTests/POS/Card Present Payments/Connection Alerts/PointOfSaleCardPresentPaymentConnectingFailedUpdateAddressAlertViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/POS/Card Present Payments/Connection Alerts/PointOfSaleCardPresentPaymentConnectingFailedUpdateAddressAlertViewModelTests.swift
@@ -11,7 +11,7 @@ final class PointOfSaleCardPresentPaymentConnectingFailedUpdateAddressAlertViewM
             cancelSearchAction: {})
 
         XCTAssertPropertyCount(sut,
-                               expectedCount: 9,
+                               expectedCount: 10,
                                messageHint: "Please check that the manual equatable conformance includes new properties.")
     }
 
@@ -23,7 +23,7 @@ final class PointOfSaleCardPresentPaymentConnectingFailedUpdateAddressAlertViewM
             cancelSearchAction: {})
 
         XCTAssertPropertyCount(sut,
-                               expectedCount: 9,
+                               expectedCount: 10,
                                messageHint: "Please check that the manual hashable conformance includes new properties.")
     }
 

--- a/WooCommerce/WooCommerceTests/POS/Card Present Payments/Connection Alerts/PointOfSaleCardPresentPaymentConnectingFailedUpdateAddressAlertViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/POS/Card Present Payments/Connection Alerts/PointOfSaleCardPresentPaymentConnectingFailedUpdateAddressAlertViewModelTests.swift
@@ -15,4 +15,16 @@ final class PointOfSaleCardPresentPaymentConnectingFailedUpdateAddressAlertViewM
                                messageHint: "Please check that the manual equatable conformance includes new properties.")
     }
 
+    func test_manual_hashable_conformance_number_of_properties_unchanged() {
+        let sut = PointOfSaleCardPresentPaymentConnectingFailedUpdateAddressAlertViewModel(
+            settingsAdminUrl: URL(string: "https://example.com")!,
+            showsInAuthenticatedWebView: true,
+            retrySearchAction: {},
+            cancelSearchAction: {})
+
+        XCTAssertPropertyCount(sut,
+                               expectedCount: 9,
+                               messageHint: "Please check that the manual hashable conformance includes new properties.")
+    }
+
 }

--- a/WooCommerce/WooCommerceTests/POS/Card Present Payments/Connection Alerts/PointOfSaleCardPresentPaymentConnectingFailedUpdateAddressAlertViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/POS/Card Present Payments/Connection Alerts/PointOfSaleCardPresentPaymentConnectingFailedUpdateAddressAlertViewModelTests.swift
@@ -1,0 +1,18 @@
+import XCTest
+@testable import WooCommerce
+
+final class PointOfSaleCardPresentPaymentConnectingFailedUpdateAddressAlertViewModelTests: XCTestCase {
+
+    func test_manual_equatable_conformance_number_of_properties_unchanged() {
+        let sut = PointOfSaleCardPresentPaymentConnectingFailedUpdateAddressAlertViewModel(
+            settingsAdminUrl: URL(string: "https://example.com")!,
+            showsInAuthenticatedWebView: true,
+            retrySearchAction: {},
+            cancelSearchAction: {})
+
+        XCTAssertPropertyCount(sut,
+                               expectedCount: 9,
+                               messageHint: "Please check that the manual equatable conformance includes new properties.")
+    }
+
+}

--- a/WooCommerce/WooCommerceTests/POS/Card Present Payments/Connection Alerts/PointOfSaleCardPresentPaymentFoundMultipleReadersAlertViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/POS/Card Present Payments/Connection Alerts/PointOfSaleCardPresentPaymentFoundMultipleReadersAlertViewModelTests.swift
@@ -13,4 +13,14 @@ final class PointOfSaleCardPresentPaymentFoundMultipleReadersAlertViewModelTests
                                messageHint: "Please check that the manual equatable conformance includes new properties.")
     }
 
+    func test_manual_hashable_conformance_number_of_properties_unchanged() {
+        let sut = PointOfSaleCardPresentPaymentFoundMultipleReadersAlertViewModel(
+            readerIDs: ["abc"],
+            selectionHandler: { _ in })
+
+        XCTAssertPropertyCount(sut,
+                               expectedCount: 3,
+                               messageHint: "Please check that the manual hashable conformance includes new properties.")
+    }
+
 }

--- a/WooCommerce/WooCommerceTests/POS/Card Present Payments/Connection Alerts/PointOfSaleCardPresentPaymentFoundMultipleReadersAlertViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/POS/Card Present Payments/Connection Alerts/PointOfSaleCardPresentPaymentFoundMultipleReadersAlertViewModelTests.swift
@@ -1,0 +1,16 @@
+import XCTest
+@testable import WooCommerce
+
+final class PointOfSaleCardPresentPaymentFoundMultipleReadersAlertViewModelTests: XCTestCase {
+
+    func test_manual_equatable_conformance_number_of_properties_unchanged() {
+        let sut = PointOfSaleCardPresentPaymentFoundMultipleReadersAlertViewModel(
+            readerIDs: ["abc"],
+            selectionHandler: { _ in })
+
+        XCTAssertPropertyCount(sut,
+                               expectedCount: 3,
+                               messageHint: "Please check that the manual equatable conformance includes new properties.")
+    }
+
+}

--- a/WooCommerce/WooCommerceTests/POS/Card Present Payments/Connection Alerts/PointOfSaleCardPresentPaymentFoundMultipleReadersAlertViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/POS/Card Present Payments/Connection Alerts/PointOfSaleCardPresentPaymentFoundMultipleReadersAlertViewModelTests.swift
@@ -9,7 +9,7 @@ final class PointOfSaleCardPresentPaymentFoundMultipleReadersAlertViewModelTests
             selectionHandler: { _ in })
 
         XCTAssertPropertyCount(sut,
-                               expectedCount: 3,
+                               expectedCount: 4,
                                messageHint: "Please check that the manual equatable conformance includes new properties.")
     }
 
@@ -19,7 +19,7 @@ final class PointOfSaleCardPresentPaymentFoundMultipleReadersAlertViewModelTests
             selectionHandler: { _ in })
 
         XCTAssertPropertyCount(sut,
-                               expectedCount: 3,
+                               expectedCount: 4,
                                messageHint: "Please check that the manual hashable conformance includes new properties.")
     }
 

--- a/WooCommerce/WooCommerceTests/POS/Card Present Payments/Connection Alerts/PointOfSaleCardPresentPaymentOptionalReaderUpdateInProgressAlertViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/POS/Card Present Payments/Connection Alerts/PointOfSaleCardPresentPaymentOptionalReaderUpdateInProgressAlertViewModelTests.swift
@@ -9,7 +9,7 @@ final class PointOfSaleCardPresentPaymentOptionalReaderUpdateInProgressAlertView
                 cancel: {})
 
             XCTAssertPropertyCount(sut,
-                                   expectedCount: 7,
+                                   expectedCount: 8,
                                    messageHint: "Please check that the manual equatable conformance includes new properties.")
         }
 
@@ -19,7 +19,7 @@ final class PointOfSaleCardPresentPaymentOptionalReaderUpdateInProgressAlertView
                 cancel: {})
 
             XCTAssertPropertyCount(sut,
-                                   expectedCount: 7,
+                                   expectedCount: 8,
                                    messageHint: "Please check that the manual hashable conformance includes new properties.")
         }
 

--- a/WooCommerce/WooCommerceTests/POS/Card Present Payments/Connection Alerts/PointOfSaleCardPresentPaymentOptionalReaderUpdateInProgressAlertViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/POS/Card Present Payments/Connection Alerts/PointOfSaleCardPresentPaymentOptionalReaderUpdateInProgressAlertViewModelTests.swift
@@ -1,0 +1,16 @@
+import XCTest
+@testable import WooCommerce
+
+final class PointOfSaleCardPresentPaymentOptionalReaderUpdateInProgressAlertViewModelTests: XCTestCase {
+
+    func test_manual_equatable_conformance_number_of_properties_unchanged() {
+            let sut = PointOfSaleCardPresentPaymentOptionalReaderUpdateInProgressAlertViewModel(
+                progress: 0.5,
+                cancel: {})
+
+            XCTAssertPropertyCount(sut,
+                                   expectedCount: 7,
+                                   messageHint: "Please check that the manual equatable conformance includes new properties.")
+        }
+
+}

--- a/WooCommerce/WooCommerceTests/POS/Card Present Payments/Connection Alerts/PointOfSaleCardPresentPaymentOptionalReaderUpdateInProgressAlertViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/POS/Card Present Payments/Connection Alerts/PointOfSaleCardPresentPaymentOptionalReaderUpdateInProgressAlertViewModelTests.swift
@@ -13,4 +13,14 @@ final class PointOfSaleCardPresentPaymentOptionalReaderUpdateInProgressAlertView
                                    messageHint: "Please check that the manual equatable conformance includes new properties.")
         }
 
+    func test_manual_hashable_conformance_number_of_properties_unchanged() {
+            let sut = PointOfSaleCardPresentPaymentOptionalReaderUpdateInProgressAlertViewModel(
+                progress: 0.5,
+                cancel: {})
+
+            XCTAssertPropertyCount(sut,
+                                   expectedCount: 7,
+                                   messageHint: "Please check that the manual hashable conformance includes new properties.")
+        }
+
 }

--- a/WooCommerce/WooCommerceTests/POS/Card Present Payments/Connection Alerts/PointOfSaleCardPresentPaymentReaderUpdateCompletionAlertViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/POS/Card Present Payments/Connection Alerts/PointOfSaleCardPresentPaymentReaderUpdateCompletionAlertViewModelTests.swift
@@ -1,0 +1,14 @@
+import XCTest
+@testable import WooCommerce
+
+final class PointOfSaleCardPresentPaymentReaderUpdateCompletionAlertViewModelTests: XCTestCase {
+
+    func test_manual_hashable_conformance_number_of_properties_unchanged() {
+        let sut = PointOfSaleCardPresentPaymentReaderUpdateCompletionAlertViewModel()
+
+        XCTAssertPropertyCount(sut,
+                               expectedCount: 3,
+                               messageHint: "Please check that the manual hashable conformance includes new properties.")
+    }
+
+}

--- a/WooCommerce/WooCommerceTests/POS/Card Present Payments/Connection Alerts/PointOfSaleCardPresentPaymentReaderUpdateCompletionAlertViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/POS/Card Present Payments/Connection Alerts/PointOfSaleCardPresentPaymentReaderUpdateCompletionAlertViewModelTests.swift
@@ -11,4 +11,12 @@ final class PointOfSaleCardPresentPaymentReaderUpdateCompletionAlertViewModelTes
                                messageHint: "Please check that the manual hashable conformance includes new properties.")
     }
 
+    func test_manual_equatable_conformance_number_of_properties_unchanged() {
+        let sut = PointOfSaleCardPresentPaymentReaderUpdateCompletionAlertViewModel()
+
+        XCTAssertPropertyCount(sut,
+                               expectedCount: 3,
+                               messageHint: "Please check that the manual equatable conformance includes new properties.")
+    }
+
 }

--- a/WooCommerce/WooCommerceTests/POS/Card Present Payments/Connection Alerts/PointOfSaleCardPresentPaymentRequiredReaderUpdateInProgressAlertViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/POS/Card Present Payments/Connection Alerts/PointOfSaleCardPresentPaymentRequiredReaderUpdateInProgressAlertViewModelTests.swift
@@ -13,4 +13,14 @@ final class PointOfSaleCardPresentPaymentRequiredReaderUpdateInProgressAlertView
                                messageHint: "Please check that the manual equatable conformance includes new properties.")
     }
 
+    func test_manual_hashable_conformance_number_of_properties_unchanged() {
+        let sut = PointOfSaleCardPresentPaymentRequiredReaderUpdateInProgressAlertViewModel(
+            progress: 0.75,
+            cancel: {})
+
+        XCTAssertPropertyCount(sut,
+                               expectedCount: 7,
+                               messageHint: "Please check that the manual hashable conformance includes new properties.")
+    }
+
 }

--- a/WooCommerce/WooCommerceTests/POS/Card Present Payments/Connection Alerts/PointOfSaleCardPresentPaymentRequiredReaderUpdateInProgressAlertViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/POS/Card Present Payments/Connection Alerts/PointOfSaleCardPresentPaymentRequiredReaderUpdateInProgressAlertViewModelTests.swift
@@ -1,0 +1,16 @@
+import XCTest
+@testable import WooCommerce
+
+final class PointOfSaleCardPresentPaymentRequiredReaderUpdateInProgressAlertViewModelTests: XCTestCase {
+
+    func test_manual_equatable_conformance_number_of_properties_unchanged() {
+        let sut = PointOfSaleCardPresentPaymentRequiredReaderUpdateInProgressAlertViewModel(
+            progress: 0.75,
+            cancel: {})
+
+        XCTAssertPropertyCount(sut,
+                               expectedCount: 7,
+                               messageHint: "Please check that the manual equatable conformance includes new properties.")
+    }
+
+}

--- a/WooCommerce/WooCommerceTests/POS/Card Present Payments/Connection Alerts/PointOfSaleCardPresentPaymentRequiredReaderUpdateInProgressAlertViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/POS/Card Present Payments/Connection Alerts/PointOfSaleCardPresentPaymentRequiredReaderUpdateInProgressAlertViewModelTests.swift
@@ -9,7 +9,7 @@ final class PointOfSaleCardPresentPaymentRequiredReaderUpdateInProgressAlertView
             cancel: {})
 
         XCTAssertPropertyCount(sut,
-                               expectedCount: 7,
+                               expectedCount: 8,
                                messageHint: "Please check that the manual equatable conformance includes new properties.")
     }
 
@@ -19,7 +19,7 @@ final class PointOfSaleCardPresentPaymentRequiredReaderUpdateInProgressAlertView
             cancel: {})
 
         XCTAssertPropertyCount(sut,
-                               expectedCount: 7,
+                               expectedCount: 8,
                                messageHint: "Please check that the manual hashable conformance includes new properties.")
     }
 

--- a/WooCommerce/WooCommerceTests/Testing/XCTestCase+PropertyCount.swift
+++ b/WooCommerce/WooCommerceTests/Testing/XCTestCase+PropertyCount.swift
@@ -1,0 +1,23 @@
+import XCTest
+
+extension XCTestCase {
+    func XCTAssertPropertyCount<T>(_ instance: T,
+                                   expectedCount: Int,
+                                   messageHint: String? = nil,
+                                   file: StaticString = #filePath,
+                                   line: UInt = #line) {
+        let mirror = Mirror(reflecting: instance)
+        let propertyCount = mirror.children.count
+
+        var message = "Expected \(expectedCount) properties, but found \(propertyCount)."
+        if let messageHint {
+            message = "\(message) \(messageHint)"
+        }
+
+        XCTAssertEqual(propertyCount,
+                       expectedCount,
+                       message,
+                       file: file,
+                       line: line)
+    }
+}


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of: #13234
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

This PR adds Hashable and Identifiable conformance to `PointOfSaleCardPresentPaymentAlertType`, to allow it to be used in a future `Item?` binding for presentation of the posModal.

This is preparation, and it doesn't change any user-facing functionality, but it's worth checking the modals still work as expected.

There are a few manual conformances to `Equatable` and `Hashable` required – primarily because they have closures and Images, which can't have synthesised functions for these protocols. I don't love this, and I've tried to avoid it as much as possible by using `imageName` instead of an Image in the view model, but on software updates it wasn't practical to do much else.

Since we don't have good reflection, my testing of these conformances is limited. It seemed pointless to write property-by-property tests, instead I opted for tests which will act as a reminder if we add a property, to update the conformance.

## Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->

1. Launch the app and navigate to Point of Sale
2. Turn off bluetooth
3. Tap `Connect your reader`
4. Observe that the error is shown correctly
5. Turn on Bluetooth and try again
6. Turn off your reader as soon as it starts connecting
7. Observe that the error is shown correctly
8. Turn on your reader, tap cancel, and then try again (note – there's an underlying issue with payments where it won't find the same reader if you tap `Try again` in this case.)
9. Observe that the connection success is shown correctly

### Updates and low battery

1. Enable the simulated reader
2. Set the `Terminal.shared.simulatorConfiguration.availableReaderUpdate = .lowBattery` in the `StripeCardReaderService`
3. Launch the app and navigate to POS mode
4. Connect your reader
5. Observe that the error shows correctly

Repeat with the update set to `.required` – observe that the update screens show correctly.

## Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->

I've tested the above scenarios on an iPad running iOS 16, and a simulated iPad running iOS 17

I've tested the existing app's equivalent flows on an iPad and an iPhone.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

https://github.com/user-attachments/assets/208bc2fe-a80a-4153-a232-c7b7362261ff


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [x] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [x] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [x] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on all devices (phone/tablet) and no regressions are added.