### PR TITLE
[Woo POS] Present `posModal` from root view to ensure full screen coverage

### DIFF
--- a/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/Reader Messages/PointOfSaleCardPresentPaymentCaptureErrorMessageView.swift
+++ b/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/Reader Messages/PointOfSaleCardPresentPaymentCaptureErrorMessageView.swift
@@ -38,9 +38,9 @@ struct PointOfSaleCardPresentPaymentCaptureErrorMessageView: View {
         }
         .multilineTextAlignment(.center)
         .frame(maxWidth: PointOfSaleCardPresentPaymentLayout.errorContentMaxWidth)
-        .posModal(isPresented: $viewModel.showsInfoSheet) {
-            PointOfSaleCardPresentPaymentCaptureFailedView(isPresented: $viewModel.showsInfoSheet)
-        }
+//        .posModal(isPresented: $viewModel.showsInfoSheet) {
+//            PointOfSaleCardPresentPaymentCaptureFailedView(isPresented: $viewModel.showsInfoSheet)
+//        }
         .onAppear {
             viewModel.onAppear()
         }

--- a/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/Reader Messages/PointOfSaleCardPresentPaymentCaptureErrorMessageView.swift
+++ b/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/Reader Messages/PointOfSaleCardPresentPaymentCaptureErrorMessageView.swift
@@ -38,9 +38,9 @@ struct PointOfSaleCardPresentPaymentCaptureErrorMessageView: View {
         }
         .multilineTextAlignment(.center)
         .frame(maxWidth: PointOfSaleCardPresentPaymentLayout.errorContentMaxWidth)
-//        .posModal(isPresented: $viewModel.showsInfoSheet) {
-//            PointOfSaleCardPresentPaymentCaptureFailedView(isPresented: $viewModel.showsInfoSheet)
-//        }
+        .posModal(isPresented: $viewModel.showsInfoSheet) {
+            PointOfSaleCardPresentPaymentCaptureFailedView(isPresented: $viewModel.showsInfoSheet)
+        }
         .onAppear {
             viewModel.onAppear()
         }

--- a/WooCommerce/Classes/POS/Presentation/PointOfSaleDashboardView.swift
+++ b/WooCommerce/Classes/POS/Presentation/PointOfSaleDashboardView.swift
@@ -65,13 +65,13 @@ struct PointOfSaleDashboardView: View {
         .posModal(item: $totalsViewModel.cardPresentPaymentAlertViewModel) { alertType in
             PointOfSaleCardPresentPaymentAlert(alertType: alertType)
         }
-//        .posModal(isPresented: $itemListViewModel.showSimpleProductsModal) {
-//            SimpleProductsOnlyInformation(isPresented: $itemListViewModel.showSimpleProductsModal)
-//        }
-//        .posModal(isPresented: $viewModel.showExitPOSModal) {
-//            PointOfSaleExitPosAlertView(isPresented: $viewModel.showExitPOSModal)
-//            .frame(maxWidth: Constants.exitPOSSheetMaxWidth)
-//        }
+        .posModal(isPresented: $itemListViewModel.showSimpleProductsModal) {
+            SimpleProductsOnlyInformation(isPresented: $itemListViewModel.showSimpleProductsModal)
+        }
+        .posModal(isPresented: $viewModel.showExitPOSModal) {
+            PointOfSaleExitPosAlertView(isPresented: $viewModel.showExitPOSModal)
+            .frame(maxWidth: Constants.exitPOSSheetMaxWidth)
+        }
         .posRootModal()
         .sheet(isPresented: $viewModel.showSupport) {
             supportForm

--- a/WooCommerce/Classes/POS/Presentation/PointOfSaleDashboardView.swift
+++ b/WooCommerce/Classes/POS/Presentation/PointOfSaleDashboardView.swift
@@ -62,26 +62,16 @@ struct PointOfSaleDashboardView: View {
         .animation(.easeInOut(duration: Constants.connectivityAnimationDuration), value: viewModel.showsConnectivityError)
         .background(Color.posBackgroundGreyi3)
         .navigationBarBackButtonHidden(true)
-        .posModal(isPresented: $totalsViewModel.showsCardReaderSheet) {
-            // Might be the only way unless we make the type conform to `Identifiable`
-            if let alertType = totalsViewModel.cardPresentPaymentAlertViewModel {
-                PointOfSaleCardPresentPaymentAlert(alertType: alertType)
-            } else {
-                switch totalsViewModel.cardPresentPaymentEvent {
-                case .idle,
-                        .show, // handled above
-                        .showOnboarding:
-                    Text(totalsViewModel.cardPresentPaymentEvent.temporaryEventDescription)
-                }
-            }
+        .posModal(item: $totalsViewModel.cardPresentPaymentAlertViewModel) { alertType in
+            PointOfSaleCardPresentPaymentAlert(alertType: alertType)
         }
-        .posModal(isPresented: $itemListViewModel.showSimpleProductsModal) {
-            SimpleProductsOnlyInformation(isPresented: $itemListViewModel.showSimpleProductsModal)
-        }
-        .posModal(isPresented: $viewModel.showExitPOSModal) {
-            PointOfSaleExitPosAlertView(isPresented: $viewModel.showExitPOSModal)
-            .frame(maxWidth: Constants.exitPOSSheetMaxWidth)
-        }
+//        .posModal(isPresented: $itemListViewModel.showSimpleProductsModal) {
+//            SimpleProductsOnlyInformation(isPresented: $itemListViewModel.showSimpleProductsModal)
+//        }
+//        .posModal(isPresented: $viewModel.showExitPOSModal) {
+//            PointOfSaleExitPosAlertView(isPresented: $viewModel.showExitPOSModal)
+//            .frame(maxWidth: Constants.exitPOSSheetMaxWidth)
+//        }
         .posRootModal()
         .sheet(isPresented: $viewModel.showSupport) {
             supportForm

--- a/WooCommerce/Classes/POS/Presentation/PointOfSaleDashboardView.swift
+++ b/WooCommerce/Classes/POS/Presentation/PointOfSaleDashboardView.swift
@@ -82,6 +82,7 @@ struct PointOfSaleDashboardView: View {
             PointOfSaleExitPosAlertView(isPresented: $viewModel.showExitPOSModal)
             .frame(maxWidth: Constants.exitPOSSheetMaxWidth)
         }
+        .posRootModal()
         .sheet(isPresented: $viewModel.showSupport) {
             supportForm
         }

--- a/WooCommerce/Classes/POS/Presentation/PointOfSaleEntryPointView.swift
+++ b/WooCommerce/Classes/POS/Presentation/PointOfSaleEntryPointView.swift
@@ -9,6 +9,7 @@ struct PointOfSaleEntryPointView: View {
     @StateObject private var totalsViewModel: TotalsViewModel
     @StateObject private var cartViewModel: CartViewModel
     @StateObject private var itemListViewModel: ItemListViewModel
+    @StateObject private var posModalManager = POSModalManager()
 
     private let onPointOfSaleModeActiveStateChange: ((Bool) -> Void)
 
@@ -44,12 +45,13 @@ struct PointOfSaleEntryPointView: View {
                                  totalsViewModel: totalsViewModel,
                                  cartViewModel: cartViewModel,
                                  itemListViewModel: itemListViewModel)
-            .onAppear {
-                onPointOfSaleModeActiveStateChange(true)
-            }
-            .onDisappear {
-                onPointOfSaleModeActiveStateChange(false)
-            }
+        .environmentObject(posModalManager)
+        .onAppear {
+            onPointOfSaleModeActiveStateChange(true)
+        }
+        .onDisappear {
+            onPointOfSaleModeActiveStateChange(false)
+        }
     }
 }
 

--- a/WooCommerce/Classes/POS/Presentation/Reusable Views/POSModalManager.swift
+++ b/WooCommerce/Classes/POS/Presentation/Reusable Views/POSModalManager.swift
@@ -1,15 +1,19 @@
 import SwiftUI
 
 class POSModalManager: ObservableObject {
-    @Published var isPresented: Bool = false
-    @Published var modalContent: AnyView = AnyView(EmptyView())
+    @Published private(set) var isPresented: Bool = false
+    private var contentBuilder: (() -> AnyView)?
 
-    func present<Content: View>(_ content: Content) {
-        self.modalContent = AnyView(content)
+    func present<Content: View>(_ content: @escaping () -> Content) {
+        self.contentBuilder = { AnyView(content()) }
         self.isPresented = true
     }
 
     func dismiss() {
         self.isPresented = false
+    }
+
+    func getContent() -> AnyView {
+        contentBuilder?() ?? AnyView(EmptyView())
     }
 }

--- a/WooCommerce/Classes/POS/Presentation/Reusable Views/POSModalManager.swift
+++ b/WooCommerce/Classes/POS/Presentation/Reusable Views/POSModalManager.swift
@@ -1,0 +1,15 @@
+import SwiftUI
+
+class POSModalManager: ObservableObject {
+    @Published var isPresented: Bool = false
+    @Published var modalContent: AnyView = AnyView(EmptyView())
+
+    func present<Content: View>(_ content: Content) {
+        self.modalContent = AnyView(content)
+        self.isPresented = true
+    }
+
+    func dismiss() {
+        self.isPresented = false
+    }
+}

--- a/WooCommerce/Classes/POS/Presentation/Reusable Views/POSModalViewModifier.swift
+++ b/WooCommerce/Classes/POS/Presentation/Reusable Views/POSModalViewModifier.swift
@@ -13,7 +13,7 @@ struct POSRootModalViewModifier: ViewModifier {
                 Color.black.opacity(0.4)
                     .edgesIgnoringSafeArea(.all)
 
-                modalManager.modalContent
+                modalManager.getContent()
                     .background(Color(.systemBackground))
                     .cornerRadius(16)
                     .shadow(radius: 10)
@@ -37,16 +37,16 @@ extension View {
     }
 }
 
-struct POSModalViewModifier<ModalContent: View>: ViewModifier {
+struct POSModalViewModifier<Item: Identifiable & Equatable, ModalContent: View>: ViewModifier {
     @EnvironmentObject var modalManager: POSModalManager
-    @Binding var isPresented: Bool
-    @ViewBuilder let modalContent: () -> ModalContent
+    @Binding var item: Item?
+    let modalContent: (Item) -> ModalContent
 
     func body(content: Content) -> some View {
         content
-            .onChange(of: isPresented) { newValue in
-                if newValue {
-                    modalManager.present(modalContent())
+            .onChange(of: item) { newItem in
+                if let newItem = newItem {
+                    modalManager.present { modalContent(newItem) }
                 } else {
                     modalManager.dismiss()
                 }
@@ -65,10 +65,11 @@ extension View {
     ///   - isPresented: Binding to control when the modal is shown.
     ///   - content: Content to sho
     /// - Returns: a modified view which can show the modal content specifed, when applicable.
-    func posModal<ModalContent: View>(isPresented: Binding<Bool>,
-                                      @ViewBuilder content: @escaping () -> ModalContent) -> some View {
+    func posModal<Item: Identifiable & Equatable, ModalContent: View>(
+        item: Binding<Item?>,
+        @ViewBuilder content: @escaping (Item) -> ModalContent) -> some View {
         self.modifier(
-            POSModalViewModifier(isPresented: isPresented,
+            POSModalViewModifier(item: item,
                                  modalContent: content))
     }
 }

--- a/WooCommerce/Classes/POS/Presentation/Reusable Views/POSModalViewModifier.swift
+++ b/WooCommerce/Classes/POS/Presentation/Reusable Views/POSModalViewModifier.swift
@@ -1,20 +1,19 @@
 import SwiftUI
 
-struct POSModalViewModifier<ModalContent: View>: ViewModifier {
-    @Binding var isPresented: Bool
-    let modalContent: () -> ModalContent
+struct POSRootModalViewModifier: ViewModifier {
+    @EnvironmentObject var modalManager: POSModalManager
 
     func body(content: Content) -> some View {
         ZStack {
             content
-                .blur(radius: isPresented ? 3 : 0)
-                .disabled(isPresented)
+                .blur(radius: modalManager.isPresented ? 3 : 0)
+                .disabled(modalManager.isPresented)
 
-            if isPresented {
+            if modalManager.isPresented {
                 Color.black.opacity(0.4)
                     .edgesIgnoringSafeArea(.all)
 
-                modalContent()
+                modalManager.modalContent
                     .background(Color(.systemBackground))
                     .cornerRadius(16)
                     .shadow(radius: 10)
@@ -27,6 +26,45 @@ struct POSModalViewModifier<ModalContent: View>: ViewModifier {
 }
 
 extension View {
+    /// This should be applied at the root Point of Sale view only. It provides the styling for all POSModals. Nothing will show with this view alone.
+    /// Ensure you've injected a `POSModalManager` environment object to the view you use this on.
+    ///
+    /// Trigger POS modal presentation using the `posModal` modifier
+    ///
+    /// - Returns: a view that displays modal content over the Point of Sale, when instructed to by child views using the `posModal` modifier
+    func posRootModal() -> some View {
+        self.modifier(POSRootModalViewModifier())
+    }
+}
+
+struct POSModalViewModifier<ModalContent: View>: ViewModifier {
+    @EnvironmentObject var modalManager: POSModalManager
+    @Binding var isPresented: Bool
+    @ViewBuilder let modalContent: () -> ModalContent
+
+    func body(content: Content) -> some View {
+        content
+            .onChange(of: isPresented) { newValue in
+                if newValue {
+                    modalManager.present(modalContent())
+                } else {
+                    modalManager.dismiss()
+                }
+            }
+    }
+}
+
+extension View {
+    /// Shows a modal view over the Point of Sale experience.
+    ///
+    /// The content is responsible for setting its own size – it will be presented at that size, with minimal padding around it.
+    ///
+    /// This will only work in a view heirarchy containing a `posRootModal` modifier.
+    ///
+    /// - Parameters:
+    ///   - isPresented: Binding to control when the modal is shown.
+    ///   - content: Content to sho
+    /// - Returns: a modified view which can show the modal content specifed, when applicable.
     func posModal<ModalContent: View>(isPresented: Binding<Bool>,
                                       @ViewBuilder content: @escaping () -> ModalContent) -> some View {
         self.modifier(

--- a/WooCommerce/Classes/POS/Presentation/Reusable Views/POSModalViewModifier.swift
+++ b/WooCommerce/Classes/POS/Presentation/Reusable Views/POSModalViewModifier.swift
@@ -54,16 +54,53 @@ struct POSModalViewModifier<Item: Identifiable & Equatable, ModalContent: View>:
     }
 }
 
+struct POSModalViewModifierForBool<ModalContent: View>: ViewModifier {
+    @EnvironmentObject var modalManager: POSModalManager
+    @Binding var isPresented: Bool
+    let modalContent: () -> ModalContent
+
+    func body(content: Content) -> some View {
+        content
+            .onChange(of: isPresented) { newValue in
+                if newValue {
+                    modalManager.present { modalContent() }
+                } else {
+                    modalManager.dismiss()
+                }
+            }
+    }
+}
+
 extension View {
     /// Shows a modal view over the Point of Sale experience.
     ///
+    /// Note that the content will not be redrawn in response to changes outside of the view builder.
+    /// Use the `posModal(item: content:)` modifier to work around this limitation.
     /// The content is responsible for setting its own size – it will be presented at that size, with minimal padding around it.
     ///
     /// This will only work in a view heirarchy containing a `posRootModal` modifier.
     ///
     /// - Parameters:
     ///   - isPresented: Binding to control when the modal is shown.
-    ///   - content: Content to sho
+    ///   - content: Content to show – note this will not update in response to changes outside the scope of the view builder
+    /// - Returns: a modified view which can show the modal content specifed, when applicable.
+    func posModal<ModalContent: View>(isPresented: Binding<Bool>,
+                                      @ViewBuilder content: @escaping () -> ModalContent) -> some View {
+        self.modifier(
+            POSModalViewModifierForBool(isPresented: isPresented,
+                                        modalContent: content))
+    }
+
+    /// Shows a modal view over the Point of Sale experience.
+    ///
+    /// The content will update when the item changes.
+    /// The content is responsible for setting its own size – it will be presented at that size, with minimal padding around it.
+    ///
+    /// This will only work in a view heirarchy containing a `posRootModal` modifier.
+    ///
+    /// - Parameters:
+    ///   - item: Binding to control when the modal is shown. When non-nil, the item is used to build the content.
+    ///   - content: Content to show
     /// - Returns: a modified view which can show the modal content specifed, when applicable.
     func posModal<Item: Identifiable & Equatable, ModalContent: View>(
         item: Binding<Item?>,

--- a/WooCommerce/Classes/POS/ViewModels/TotalsViewModel.swift
+++ b/WooCommerce/Classes/POS/ViewModels/TotalsViewModel.swift
@@ -22,7 +22,7 @@ final class TotalsViewModel: ObservableObject, TotalsViewModelProtocol {
 
     @Published var showsCardReaderSheet: Bool = false
     @Published private(set) var cardPresentPaymentEvent: CardPresentPaymentEvent = .idle
-    @Published private(set) var cardPresentPaymentAlertViewModel: PointOfSaleCardPresentPaymentAlertType?
+    @Published var cardPresentPaymentAlertViewModel: PointOfSaleCardPresentPaymentAlertType?
     @Published private(set) var cardPresentPaymentInlineMessage: PointOfSaleCardPresentPaymentMessageType?
     @Published private(set) var isShowingCardReaderStatus: Bool = false
     @Published private(set) var isShowingTotalsFields: Bool = false

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -822,6 +822,7 @@
 		209AD3D22AC1EDF600825D76 /* WooPaymentsDepositsCurrencyOverviewView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 209AD3D12AC1EDF600825D76 /* WooPaymentsDepositsCurrencyOverviewView.swift */; };
 		209B15672AD85F070094152A /* OperatingSystemVersion+Localization.swift in Sources */ = {isa = PBXBuildFile; fileRef = 209B15662AD85F070094152A /* OperatingSystemVersion+Localization.swift */; };
 		209CA0EE2B50070D0073D1AC /* WooTabContainerController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 209CA0ED2B50070D0073D1AC /* WooTabContainerController.swift */; };
+		209EEF902C762ED5007969A4 /* POSModalManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 209EEF8F2C762ED5007969A4 /* POSModalManager.swift */; };
 		20A130EB2C5A27190058022F /* PointOfSaleAssetsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 20A130EA2C5A27190058022F /* PointOfSaleAssetsTests.swift */; };
 		20A3AFE12B0F750B0033AF2D /* MockInPersonPaymentsCashOnDeliveryToggleRowViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 20A3AFE02B0F750B0033AF2D /* MockInPersonPaymentsCashOnDeliveryToggleRowViewModel.swift */; };
 		20A3AFE32B10EF860033AF2D /* CardReaderSettingsFlowPresentingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 20A3AFE22B10EF860033AF2D /* CardReaderSettingsFlowPresentingView.swift */; };
@@ -3859,6 +3860,7 @@
 		209AD3D12AC1EDF600825D76 /* WooPaymentsDepositsCurrencyOverviewView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WooPaymentsDepositsCurrencyOverviewView.swift; sourceTree = "<group>"; };
 		209B15662AD85F070094152A /* OperatingSystemVersion+Localization.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "OperatingSystemVersion+Localization.swift"; sourceTree = "<group>"; };
 		209CA0ED2B50070D0073D1AC /* WooTabContainerController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WooTabContainerController.swift; sourceTree = "<group>"; };
+		209EEF8F2C762ED5007969A4 /* POSModalManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = POSModalManager.swift; sourceTree = "<group>"; };
 		20A130EA2C5A27190058022F /* PointOfSaleAssetsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PointOfSaleAssetsTests.swift; sourceTree = "<group>"; };
 		20A3AFE02B0F750B0033AF2D /* MockInPersonPaymentsCashOnDeliveryToggleRowViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockInPersonPaymentsCashOnDeliveryToggleRowViewModel.swift; sourceTree = "<group>"; };
 		20A3AFE22B10EF860033AF2D /* CardReaderSettingsFlowPresentingView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardReaderSettingsFlowPresentingView.swift; sourceTree = "<group>"; };
@@ -6061,6 +6063,7 @@
 			children = (
 				01620C4D2C5394B200D3EA2F /* POSProgressViewStyle.swift */,
 				204D1D612C5A50840064A6BE /* POSModalViewModifier.swift */,
+				209EEF8F2C762ED5007969A4 /* POSModalManager.swift */,
 				01D0823F2C5B9EAB007FE81F /* POSBackgroundAppearanceKey.swift */,
 				207823E62C5D346300025A59 /* POSPrimaryButtonStyle.swift */,
 				20D3D42E2C64F175004CE6E3 /* POSSecondaryButtonStyle.swift */,
@@ -15246,6 +15249,7 @@
 				CCD2F51A26D67BB50010E679 /* ShippingLabelServicePackageList.swift in Sources */,
 				45FDDD65267784AD00ADACE8 /* ShippingLabelSummaryTableViewCell.swift in Sources */,
 				45DB70662614CE3F0064A6CF /* Decimal+Helpers.swift in Sources */,
+				209EEF902C762ED5007969A4 /* POSModalManager.swift in Sources */,
 				0379C51727BFCE9800A7E284 /* WCPayCardBrand+icons.swift in Sources */,
 				DA1D68C22C36F0980097859A /* PointOfSaleAssets.swift in Sources */,
 				0210D8692A7BEEF700846F8C /* WooAnalyticsEvent+ProductListFilter.swift in Sources */,


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #13234
Merge after: #13704 
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

This is the final PR in the series handling the improved UI of the payment capture error.

This error has a modal, displayed over an error, fairly far into the POS stack.

In #13642, I noted that there was some remaining work:

> Modal overlay curtain should extend to screen bounds – this will be on a new PR so that the modal content can be passed up for display at the top level.

This PR ensures that a posModal presented from anywhere in POS will extend to the screen bounds, regardless of the size of the view that the `posModal` modifier is specified on.

We do this by doing the presentation through `posRootModal`, which is applied to the Dashboard view and contains the styling, as well as a reference to the `POSModalManager`, an environment object with the presentation logic and view builder.

Then we have two versions of the `posModal` view modifier which can be used to show the modal. Following platform conventions, one uses an `isPresented` Bool, and the other an `Item?` binding.

The `Item` binding was required so that the changes to the underlying view model would be reflected in a view update – unfortunately, I couldn't make that work with `isPresented`. This is noted in doc comments. I thought about removing the `isPresented` option, but where the modals are simple and don't get updated externally to the modal (other than the presentation value), it's very convenient.

Note that if we used the `isPresented` variant for the card reader connection view, it would show the `Scanning for readers` screen indefinitely, even though the reader would actually connect (if known to the iPad.)

## Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->

1. Set up Proxyman or Charles to intercept traffic for your test device
2. Launch the app using a store eligible for IPP
3. Navigate to `Menu > Point of Sale mode`
4. Add an item to your basket and tap `Checkout`
5. Enable breakpoints in your proxy for the response of `POST` requests to `https://public-api.wordpress.com/rest/v1.1/jetpack-blogs/*/rest-api/` and the requests to `GET` `https://public-api.wordpress.com/rest/v1.1/jetpack-blogs/*/rest-api/?json=true&path=/wc/v3/orders/*`
6. Tap your card on the reader
7. Abort the `capture_terminal_payment` response and `order` requests when the breakpoints are hit (equivalent to poor network conditions meaning it was lost.) --> an inline error message UI should be shown in the totals view, with a modal presented that shows more details about the error
8. Observe that the blurred "curtain" behind the modal extends right to the bounds of the screen.

Also test the other posModals, that you can open them, perform all the actions, and close them.

- [x] Connect your reader
- [x] Tap the `Simple Products only` banner or info button on Products
- [x] Tap `Exit POS` in the ellipsis menu

## Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->

I've tested this on an iPad running iOS 16, and a simulator running iOS 17, with all the above scenarios. I've also tested the error cases for card reader connections, and connecting the reader from the `Reader not connected` error screen.

No unit tests, as this is view logic only.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

https://github.com/user-attachments/assets/e84d114d-f8d8-4a6c-af5f-eda04da25df2


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [x] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [x] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [x] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on all devices (phone/tablet) and no regressions are added.