### PR TITLE
[Woo POS] Make pos modals accessible

### DIFF
--- a/WooCommerce/Classes/POS/Presentation/Reusable Views/POSModalViewModifier.swift
+++ b/WooCommerce/Classes/POS/Presentation/Reusable Views/POSModalViewModifier.swift
@@ -8,6 +8,7 @@ struct POSRootModalViewModifier: ViewModifier {
             content
                 .blur(radius: modalManager.isPresented ? 3 : 0)
                 .disabled(modalManager.isPresented)
+                .accessibilityElement(children: modalManager.isPresented ? .ignore : .contain)
 
             if modalManager.isPresented {
                 Color.black.opacity(0.4)


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #13668 
Merge after: #13704 
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

This PR makes it easier to navigate POS Modal content using VoiceOver and other accessibility technologies.

By setting the accessibility element of the underlying `content` in the `ZStack` on the `POSRootModal`, only when the modal is presented, we hide those things from VoiceOver and it will focus on the modal content more easily instead.

## Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->

1. Launch the app and navigate to POS
2. Enable VoiceOver
3. Observe that you can navigate the normal content of the app
4. Open a modal
5. Observe that you can only flick around content in the new modal, nothing underneath it.
6. Dismiss the modal
7. Observe that you can hear the underlying content being announced again.

Modals you can test:

- [x] Exit POS
- [x] Simple Products banner info
- [x] Connecting to a card reader
- [x] Payment Capture error modal (see #13709)

## Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->

I have tested all the above modals on a iPad running iOS 16. I've done limited testing on iOS 17, using the accessibility inspector. 

No unit tests, as this is view code only.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

https://github.com/user-attachments/assets/cf766af6-d405-4c91-8aee-b88bdca8091e


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [x] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [x] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [x] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on all devices (phone/tablet) and no regressions are added.