### PR TITLE
[Woo POS] Allow disconnect/select new reader in POS

### DIFF
--- a/WooCommerce/Classes/POS/Card Present Payments/CardPresentPaymentFacade.swift
+++ b/WooCommerce/Classes/POS/Card Present Payments/CardPresentPaymentFacade.swift
@@ -22,6 +22,7 @@ protocol CardPresentPaymentFacade {
     func connectReader(using connectionMethod: CardReaderConnectionMethod) async throws -> CardPresentPaymentReaderConnectionResult
 
     /// Disconnects the currently connected card reader, if present.
+    /// Also cancels any in-progress payment, if possible.
     func disconnectReader() async
 
     /// Collects a card present payment for an order.

--- a/WooCommerce/Classes/POS/Card Present Payments/CardPresentPaymentFacade.swift
+++ b/WooCommerce/Classes/POS/Card Present Payments/CardPresentPaymentFacade.swift
@@ -22,7 +22,7 @@ protocol CardPresentPaymentFacade {
     func connectReader(using connectionMethod: CardReaderConnectionMethod) async throws -> CardPresentPaymentReaderConnectionResult
 
     /// Also cancels any in-progress connection attempt.
-    func disconnectReader()
+    func disconnectReader() async
 
     /// Collects a card present payment for an order.
     /// If the appropriate type of reader is not already connected, this should attempt a connection before the payment.

--- a/WooCommerce/Classes/POS/Card Present Payments/CardPresentPaymentFacade.swift
+++ b/WooCommerce/Classes/POS/Card Present Payments/CardPresentPaymentFacade.swift
@@ -21,7 +21,7 @@ protocol CardPresentPaymentFacade {
     /// - Output: publishes intermediate events on the `paymentEventPublisher` as required.
     func connectReader(using connectionMethod: CardReaderConnectionMethod) async throws -> CardPresentPaymentReaderConnectionResult
 
-    /// Also cancels any in-progress connection attempt.
+    /// Disconnects the currently connected card reader, if present
     func disconnectReader() async
 
     /// Collects a card present payment for an order.

--- a/WooCommerce/Classes/POS/Card Present Payments/CardPresentPaymentFacade.swift
+++ b/WooCommerce/Classes/POS/Card Present Payments/CardPresentPaymentFacade.swift
@@ -21,7 +21,7 @@ protocol CardPresentPaymentFacade {
     /// - Output: publishes intermediate events on the `paymentEventPublisher` as required.
     func connectReader(using connectionMethod: CardReaderConnectionMethod) async throws -> CardPresentPaymentReaderConnectionResult
 
-    /// Disconnects the currently connected card reader, if present
+    /// Disconnects the currently connected card reader, if present.
     func disconnectReader() async
 
     /// Collects a card present payment for an order.

--- a/WooCommerce/Classes/POS/Card Present Payments/CardPresentPaymentService.swift
+++ b/WooCommerce/Classes/POS/Card Present Payments/CardPresentPaymentService.swift
@@ -86,7 +86,10 @@ final class CardPresentPaymentService: CardPresentPaymentFacade {
 
     @MainActor
     func disconnectReader() async {
+        cancelPayment()
+
         connectionControllerManager.knownReaderProvider.forgetCardReader()
+
         return await withCheckedContinuation { continuation in
             var nillableContinuation: CheckedContinuation<Void, Never>? = continuation
 

--- a/WooCommerce/Classes/POS/Card Present Payments/CardPresentPaymentService.swift
+++ b/WooCommerce/Classes/POS/Card Present Payments/CardPresentPaymentService.swift
@@ -81,6 +81,7 @@ final class CardPresentPaymentService: CardPresentPaymentFacade {
 
     @MainActor
     func disconnectReader() async {
+        connectionControllerManager.knownReaderProvider.forgetCardReader()
         return await withCheckedContinuation { continuation in
             var nillableContinuation: CheckedContinuation<Void, Never>? = continuation
 

--- a/WooCommerce/Classes/POS/Card Present Payments/CardPresentPaymentsConnectionControllerManager.swift
+++ b/WooCommerce/Classes/POS/Card Present Payments/CardPresentPaymentsConnectionControllerManager.swift
@@ -8,6 +8,8 @@ final class CardPresentPaymentsConnectionControllerManager {
                                                                             CardPresentPaymentsAlertPresenterAdaptor>
     let analyticsTracker: CardReaderConnectionAnalyticsTracker
 
+    let knownReaderProvider: CardReaderSettingsKnownReaderProvider
+
     init(siteID: Int64,
          configuration: CardPresentPaymentsConfiguration,
          alertsPresenter: CardPresentPaymentsAlertPresenterAdaptor) {
@@ -16,9 +18,11 @@ final class CardPresentPaymentsConnectionControllerManager {
             siteID: siteID,
             connectionType: .userInitiated)
         self.analyticsTracker = analyticsTracker
+        let knownReaderProvider = CardReaderSettingsKnownReaderStorage()
+        self.knownReaderProvider = knownReaderProvider
         self.externalReaderConnectionController = CardReaderConnectionController(
             forSiteID: siteID,
-            knownReaderProvider: CardReaderSettingsKnownReaderStorage(),
+            knownReaderProvider: knownReaderProvider,
             alertsPresenter: alertsPresenter,
             alertsProvider: CardPresentPaymentBluetoothReaderConnectionAlertsProvider(),
             configuration: configuration,

--- a/WooCommerce/Classes/POS/Presentation/CardReaderConnection/CardReaderConnectionStatusView.swift
+++ b/WooCommerce/Classes/POS/Presentation/CardReaderConnection/CardReaderConnectionStatusView.swift
@@ -2,6 +2,7 @@ import SwiftUI
 
 enum CardReaderConnectionStatus {
     case connected
+    case disconnecting
     case disconnected
 }
 
@@ -39,6 +40,18 @@ struct CardReaderConnectionStatusView: View {
                         Text(Localization.readerConnected)
                             .foregroundColor(connectedFontColor)
                     }
+                }
+                .padding(.horizontal, Constants.horizontalPadding)
+                .padding(.vertical, Constants.verticalPadding)
+            case .disconnecting:
+                HStack(spacing: Constants.buttonImageAndTextSpacing) {
+                    ProgressView()
+                        .progressViewStyle(POSProgressViewStyle(
+                            size: Constants.disconnectingProgressIndicatorDimension * scale,
+                            lineWidth: Constants.disconnectingProgressIndicatorLineWidth * scale
+                        ))
+                    Text(Localization.readerDisconnecting)
+                        .foregroundColor(connectedFontColor)
                 }
                 .padding(.horizontal, Constants.horizontalPadding)
                 .padding(.vertical, Constants.verticalPadding)
@@ -88,6 +101,8 @@ private extension CardReaderConnectionStatusView {
     enum Constants {
         static let buttonImageAndTextSpacing: CGFloat = 12
         static let imageDimension: CGFloat = 12
+        static let disconnectingProgressIndicatorDimension: CGFloat = 10
+        static let disconnectingProgressIndicatorLineWidth: CGFloat = 2
         static let font = POSFontStyle.posDetailEmphasized
         static let horizontalPadding: CGFloat = 16
         static let verticalPadding: CGFloat = 8
@@ -109,6 +124,13 @@ private extension CardReaderConnectionStatusView {
             "pointOfSale.floatingButtons.readerDisconnected.title",
             value: "Connect your reader",
             comment: "The title of the floating button to indicate that reader is disconnected and prompt connect after tapping."
+        )
+
+        static let readerDisconnecting = NSLocalizedString(
+            "pointOfSale.floatingButtons.readerDisconnecting.title",
+            value: "Disconnecting",
+            comment: "The title of the floating button to indicate that reader is in the process " +
+            " of disconnecting."
         )
 
         static let disconnectCardReader = NSLocalizedString(

--- a/WooCommerce/Classes/POS/Presentation/CardReaderConnection/CardReaderConnectionStatusView.swift
+++ b/WooCommerce/Classes/POS/Presentation/CardReaderConnection/CardReaderConnectionStatusView.swift
@@ -27,10 +27,18 @@ struct CardReaderConnectionStatusView: View {
         Group {
             switch connectionViewModel.connectionStatus {
             case .connected:
-                HStack(spacing: Constants.buttonImageAndTextSpacing) {
-                    circleIcon(with: Color(.wooCommerceEmerald(.shade40)))
-                    Text(Localization.readerConnected)
-                        .foregroundColor(connectedFontColor)
+                Menu {
+                    Button {
+                        connectionViewModel.disconnectReader()
+                    } label: {
+                        Text(Localization.disconnectCardReader)
+                    }
+                } label: {
+                    HStack(spacing: Constants.buttonImageAndTextSpacing) {
+                        circleIcon(with: Color(.wooCommerceEmerald(.shade40)))
+                        Text(Localization.readerConnected)
+                            .foregroundColor(connectedFontColor)
+                    }
                 }
                 .padding(.horizontal, Constants.horizontalPadding)
                 .padding(.vertical, Constants.verticalPadding)
@@ -102,6 +110,11 @@ private extension CardReaderConnectionStatusView {
             value: "Connect your reader",
             comment: "The title of the floating button to indicate that reader is disconnected and prompt connect after tapping."
         )
+
+        static let disconnectCardReader = NSLocalizedString(
+            "pointOfSale.floatingButtons.disconnectCardReader.button.title",
+            value: "Disconnect reader",
+            comment: "The title of the menu button to disconnect a connected card reader, as confirmation.")
     }
 }
 

--- a/WooCommerce/Classes/POS/Presentation/CardReaderConnection/CardReaderConnectionStatusView.swift
+++ b/WooCommerce/Classes/POS/Presentation/CardReaderConnection/CardReaderConnectionStatusView.swift
@@ -40,9 +40,9 @@ struct CardReaderConnectionStatusView: View {
                         Text(Localization.readerConnected)
                             .foregroundColor(connectedFontColor)
                     }
+                    .padding(.horizontal, Constants.horizontalPadding)
+                    .frame(maxHeight: .infinity)
                 }
-                .padding(.horizontal, Constants.horizontalPadding)
-                .padding(.vertical, Constants.verticalPadding)
             case .disconnecting:
                 HStack(spacing: Constants.buttonImageAndTextSpacing) {
                     ProgressView()
@@ -54,7 +54,7 @@ struct CardReaderConnectionStatusView: View {
                         .foregroundColor(connectedFontColor)
                 }
                 .padding(.horizontal, Constants.horizontalPadding)
-                .padding(.vertical, Constants.verticalPadding)
+                .frame(maxHeight: .infinity)
             case .disconnected:
                 Button {
                     connectionViewModel.connectReader()
@@ -64,12 +64,15 @@ struct CardReaderConnectionStatusView: View {
                         Text(Localization.readerDisconnected)
                             .foregroundColor(disconnectedFontColor)
                     }
-                }
-                .padding(.horizontal, Constants.horizontalPadding)
-                .padding(.vertical, Constants.verticalPadding)
-                .overlay {
-                    RoundedRectangle(cornerRadius: Constants.overlayRadius)
-                        .stroke(Constants.overlayColor, lineWidth: Constants.overlayLineWidth)
+                    .padding(.horizontal, Constants.horizontalPadding / 2)
+                    .frame(maxHeight: .infinity)
+                    .overlay {
+                        RoundedRectangle(cornerRadius: Constants.overlayRadius)
+                            .stroke(Constants.overlayColor, lineWidth: Constants.overlayLineWidth)
+                    }
+                    .padding(.horizontal, Constants.horizontalPadding / 2)
+                    .padding(.vertical, Constants.verticalPadding)
+                    .frame(maxHeight: .infinity)
                 }
             }
         }

--- a/WooCommerce/Classes/POS/Presentation/CardReaderConnection/CardReaderConnectionStatusView.swift
+++ b/WooCommerce/Classes/POS/Presentation/CardReaderConnection/CardReaderConnectionStatusView.swift
@@ -101,7 +101,7 @@ private extension CardReaderConnectionStatusView {
     enum Localization {
         static let readerConnected = NSLocalizedString(
             "pointOfSale.floatingButtons.readerConnected.title",
-            value: "Reader Connected",
+            value: "Reader connected",
             comment: "The title of the floating button to indicate that reader is connected."
         )
 
@@ -113,7 +113,7 @@ private extension CardReaderConnectionStatusView {
 
         static let disconnectCardReader = NSLocalizedString(
             "pointOfSale.floatingButtons.disconnectCardReader.button.title",
-            value: "Disconnect reader",
+            value: "Disconnect Reader",
             comment: "The title of the menu button to disconnect a connected card reader, as confirmation.")
     }
 }

--- a/WooCommerce/Classes/POS/Presentation/CardReaderConnection/CardReaderConnectionViewModel.swift
+++ b/WooCommerce/Classes/POS/Presentation/CardReaderConnection/CardReaderConnectionViewModel.swift
@@ -21,6 +21,15 @@ final class CardReaderConnectionViewModel: ObservableObject {
             }
         }
     }
+
+    func disconnectReader() {
+        guard connectionStatus == .connected else {
+            return
+        }
+        Task { @MainActor in
+            await cardPresentPayment.disconnectReader()
+        }
+    }
 }
 
 private extension CardReaderConnectionViewModel {

--- a/WooCommerce/Classes/POS/Presentation/CardReaderConnection/CardReaderConnectionViewModel.swift
+++ b/WooCommerce/Classes/POS/Presentation/CardReaderConnection/CardReaderConnectionViewModel.swift
@@ -26,6 +26,7 @@ final class CardReaderConnectionViewModel: ObservableObject {
         guard connectionStatus == .connected else {
             return
         }
+        connectionStatus = .disconnecting
         Task { @MainActor in
             await cardPresentPayment.disconnectReader()
         }

--- a/WooCommerce/Classes/POS/Presentation/POSFloatingControlView.swift
+++ b/WooCommerce/Classes/POS/Presentation/POSFloatingControlView.swift
@@ -29,23 +29,25 @@ struct POSFloatingControlView: View {
                     )
                 }
             } label: {
-                Image(systemName: "ellipsis")
-                    .font(.posBodyEmphasized, maximumContentSizeCategory: .accessibilityLarge)
-                    .foregroundStyle(fontColor)
-                    .frame(width: Constants.size, height: Constants.size)
+                VStack {
+                    Spacer()
+                    Image(systemName: "ellipsis")
+                        .font(.posBodyEmphasized, maximumContentSizeCategory: .accessibilityLarge)
+                        .foregroundStyle(fontColor)
+                    Spacer()
+                }
+                .frame(width: Constants.size)
             }
             .background(backgroundColor)
             .cornerRadius(Constants.cornerRadius)
             .disabled(viewModel.isExitPOSDisabled)
-            HStack {
-                CardReaderConnectionStatusView(connectionViewModel: viewModel.cardReaderConnectionViewModel)
-                    .padding(Constants.cardStatusPadding)
-                    .foregroundStyle(fontColor)
-            }
-            .frame(height: Constants.size)
-            .background(backgroundColor)
-            .cornerRadius(Constants.cornerRadius)
+
+            CardReaderConnectionStatusView(connectionViewModel: viewModel.cardReaderConnectionViewModel)
+                .foregroundStyle(fontColor)
+                .background(backgroundColor)
+                .cornerRadius(Constants.cornerRadius)
         }
+        .frame(height: Constants.size)
         .background(Color.clear)
     }
 }
@@ -72,7 +74,6 @@ private extension POSFloatingControlView {
 
 private extension POSFloatingControlView {
     enum Constants {
-        static let cardStatusPadding: CGFloat = 8
         static let size: CGFloat = 56
         static let cornerRadius: CGFloat = 8
     }

--- a/WooCommerce/Classes/POS/Presentation/POSFloatingControlView.swift
+++ b/WooCommerce/Classes/POS/Presentation/POSFloatingControlView.swift
@@ -46,6 +46,7 @@ struct POSFloatingControlView: View {
                 .foregroundStyle(fontColor)
                 .background(backgroundColor)
                 .cornerRadius(Constants.cornerRadius)
+                .disabled(viewModel.isReaderDisconnectionDisabled)
         }
         .frame(height: Constants.size)
         .background(Color.clear)

--- a/WooCommerce/Classes/POS/Presentation/Reusable Views/POSProgressViewStyle.swift
+++ b/WooCommerce/Classes/POS/Presentation/Reusable Views/POSProgressViewStyle.swift
@@ -2,11 +2,19 @@ import SwiftUI
 import WooFoundation
 
 struct POSProgressViewStyle: ProgressViewStyle {
+    let size: CGFloat
+    let lineWidth: CGFloat
+
+    init(size: CGFloat = 108, lineWidth: CGFloat = 48) {
+        self.size = size
+        self.lineWidth = lineWidth
+    }
+
     func makeBody(configuration: Configuration) -> some View {
         ProgressView(configuration)
             .progressViewStyle(IndefiniteCircularProgressViewStyle(
-                size: 108,
-                lineWidth: 48,
+                size: size,
+                lineWidth: lineWidth,
                 lineCap: .butt,
                 circleColor: Color(.wooCommercePurple(.shade10)),
                 fillColor: Color(.wooCommercePurple(.shade50))

--- a/WooCommerce/Classes/POS/Presentation/TotalsView.swift
+++ b/WooCommerce/Classes/POS/Presentation/TotalsView.swift
@@ -227,7 +227,7 @@ private extension TotalsView {
 
     @ViewBuilder private var cardReaderView: some View {
         switch viewModel.connectionStatus {
-        case .connected:
+        case .connected, .disconnecting:
             if let inlinePaymentMessage = viewModel.cardPresentPaymentInlineMessage {
                 HStack(alignment: .center) {
                     Spacer()

--- a/WooCommerce/Classes/POS/ViewModels/PointOfSaleDashboardViewModel.swift
+++ b/WooCommerce/Classes/POS/ViewModels/PointOfSaleDashboardViewModel.swift
@@ -23,6 +23,7 @@ final class PointOfSaleDashboardViewModel: ObservableObject {
 
     @Published private(set) var isAddMoreDisabled: Bool = false
     @Published var isExitPOSDisabled: Bool = false
+    @Published var isReaderDisconnectionDisabled: Bool = false
     /// This boolean is used to determine if the whole totals/payments view is occupying the full screen (cart is not showed)
     @Published var isTotalsViewFullScreen: Bool = false
     @Published var isInitialLoading: Bool = false
@@ -137,7 +138,7 @@ private extension PointOfSaleDashboardViewModel {
             }
             .assign(to: &$isExitPOSDisabled)
 
-        totalsViewModel.paymentStatePublisher
+        let afterCardTapPaymentStates = totalsViewModel.paymentStatePublisher
             .map { paymentState in
                 switch paymentState {
                 case .processingPayment,
@@ -152,7 +153,14 @@ private extension PointOfSaleDashboardViewModel {
                     return false
                 }
             }
+            .share()
+
+        afterCardTapPaymentStates
             .assign(to: &$isTotalsViewFullScreen)
+
+        afterCardTapPaymentStates
+            .assign(to: &$isReaderDisconnectionDisabled)
+
     }
 
     private func observeOrderStage() {

--- a/WooCommerce/Classes/POS/ViewModels/PointOfSaleDashboardViewModel.swift
+++ b/WooCommerce/Classes/POS/ViewModels/PointOfSaleDashboardViewModel.swift
@@ -156,12 +156,17 @@ private extension PointOfSaleDashboardViewModel {
     }
 
     private func observeOrderStage() {
-        $orderStage.sink { [weak self] stage in
+        $orderStage
+            .removeDuplicates()
+            .sink { [weak self] stage in
             guard let self else { return }
             cartViewModel.canDeleteItemsFromCart = stage == .building
 
-            if stage == .building {
-                totalsViewModel.cancelReaderPreparation()
+            switch stage {
+            case .building:
+                totalsViewModel.stopShowingTotalsView()
+            case .finalizing:
+                totalsViewModel.startShowingTotalsView()
             }
         }
         .store(in: &cancellables)

--- a/WooCommerce/Classes/POS/ViewModels/TotalsViewModel.swift
+++ b/WooCommerce/Classes/POS/ViewModels/TotalsViewModel.swift
@@ -241,6 +241,7 @@ private extension TotalsViewModel {
     func observeConnectedReaderForStatus() {
         cardPresentPaymentService.connectedReaderPublisher
             .map { connectedReader in
+                // Note that this does not cover when a reader is disconnecting
                 connectedReader == nil ? .disconnected: .connected
             }
             .assign(to: &$connectionStatus)
@@ -257,7 +258,7 @@ private extension TotalsViewModel {
                 }
 
                 switch connectionStatus {
-                case .connected:
+                case .connected, .disconnecting:
                     return message != nil
                 case .disconnected:
                     // Since the reader is disconnected, this will show the "Connect your reader" CTA button view.

--- a/WooCommerce/Classes/POS/ViewModels/TotalsViewModelProtocol.swift
+++ b/WooCommerce/Classes/POS/ViewModels/TotalsViewModelProtocol.swift
@@ -34,6 +34,8 @@ protocol TotalsViewModelProtocol {
     func startNewOrder()
     func checkOutTapped(with cartItems: [CartItem], allItems: [POSItem])
     func connectReaderTapped()
-    func cancelReaderPreparation()
     func onTotalsViewDisappearance()
+
+    func startShowingTotalsView()
+    func stopShowingTotalsView()
 }

--- a/WooCommerce/WooCommerceTests/POS/Mocks/MockCardPresentPaymentService.swift
+++ b/WooCommerce/WooCommerceTests/POS/Mocks/MockCardPresentPaymentService.swift
@@ -23,8 +23,8 @@ final class MockCardPresentPaymentService: CardPresentPaymentFacade {
         .connected(CardPresentPaymentCardReader(name: "Test reader", batteryLevel: 0.85))
     }
 
-    func disconnectReader() {
-        // no-op
+    func disconnectReader() async {
+        connectedReader = nil
     }
 
     var onCollectPaymentCalled: (() -> Void)?

--- a/WooCommerce/WooCommerceTests/POS/Mocks/MockTotalsViewModel.swift
+++ b/WooCommerce/WooCommerceTests/POS/Mocks/MockTotalsViewModel.swift
@@ -79,8 +79,13 @@ final class MockTotalsViewModel: TotalsViewModelProtocol {
         // Provide a mock implementation if needed
     }
 
-    var spyCancelReaderPreparationCalled = false
-    func cancelReaderPreparation() {
-        spyCancelReaderPreparationCalled = true
+    var spyStopShowingTotalsViewCalled = false
+    func stopShowingTotalsView() {
+        spyStopShowingTotalsViewCalled = true
+    }
+
+    var spyStartShowingTotalsViewCalled = false
+    func startShowingTotalsView() {
+        spyStartShowingTotalsViewCalled = true
     }
 }

--- a/WooCommerce/WooCommerceTests/POS/ViewModels/PointOfSaleDashboardViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/POS/ViewModels/PointOfSaleDashboardViewModelTests.swift
@@ -336,6 +336,17 @@ final class PointOfSaleDashboardViewModelTests: XCTestCase {
         XCTAssertFalse(mockCartViewModel.canDeleteItemsFromCart)
     }
 
+    func test_cartSubmitted_calls_totalsViewModel_startShowingTotalsView() {
+        // Given
+        mockTotalsViewModel.spyStartShowingTotalsViewCalled = false
+
+        // When
+        mockCartViewModel.cartSubmissionSubject.send([CartItem(id: UUID(), item: Self.makeItem(), quantity: 1)])
+
+        // Then
+        XCTAssertTrue(mockTotalsViewModel.spyStartShowingTotalsViewCalled)
+    }
+
     func test_addMoreTapped_sets_cartViewModel_canDeleteItems_true() {
         // Given
         mockCartViewModel.cartSubmissionSubject.send([CartItem(id: UUID(), item: Self.makeItem(), quantity: 1)])
@@ -348,8 +359,9 @@ final class PointOfSaleDashboardViewModelTests: XCTestCase {
         XCTAssertTrue(mockCartViewModel.canDeleteItemsFromCart)
     }
 
-    func test_addMoreTapped_calls_totalsViewModel_stopShowingTotalsView_called() {
-        // Given
+    func test_addMoreTapped_calls_totalsViewModel_stopShowingTotalsView() {
+        // Given the TotalsView is showing
+        mockCartViewModel.cartSubmissionSubject.send([])
         mockTotalsViewModel.spyStopShowingTotalsViewCalled = false
 
         // When

--- a/WooCommerce/WooCommerceTests/POS/ViewModels/PointOfSaleDashboardViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/POS/ViewModels/PointOfSaleDashboardViewModelTests.swift
@@ -348,15 +348,15 @@ final class PointOfSaleDashboardViewModelTests: XCTestCase {
         XCTAssertTrue(mockCartViewModel.canDeleteItemsFromCart)
     }
 
-    func test_addMoreTapped_calls_totalsViewModel_cancelReaderPreparation() {
+    func test_addMoreTapped_calls_totalsViewModel_stopShowingTotalsView_called() {
         // Given
-        mockTotalsViewModel.spyCancelReaderPreparationCalled = false
+        mockTotalsViewModel.spyStopShowingTotalsViewCalled = false
 
         // When
         mockCartViewModel.addMoreToCartActionSubject.send(())
 
         // Then
-        XCTAssertTrue(mockTotalsViewModel.spyCancelReaderPreparationCalled)
+        XCTAssertTrue(mockTotalsViewModel.spyStopShowingTotalsViewCalled)
     }
 
     func test_showsConnectivityError_when_nonReachable_then_shows_error() {


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #13386
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

This PR implements the `disconnect` function on the card payments adaptor, and adds access to it from a floating menu in the POS, on the connectivity status button.

## Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->

1. Launch the app and navigate to POS
2. Tap `Connect your reader`
3. Go through the connection flow
4. Tap the `Reader connected` button
5. In the menu which opens, tap `Disconnect reader`
6. Observe that the `Disconnecting` view shows, followed by `Connect your reader`
7. Tap `Connect your reader`
8. Observe that you're asked to confirm connection to the reader.

## Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->

I've tested the following with an iPad running iOS 16.6, and an M2 reader

- The happy path above.
- Repeatedly connecting and disconnecting the reader.
- Disconnecting the reader having connected it in the main app.
- Turning off the reader still updates the reader status.
- Connecting to a reader after turning it off does not ask you to confirm the connection.
- Turning the reader off while disconnecting (I couldn't force an error.)
- "Faked" a failed disconnection by setting `connectionStatus = .connected` in the `CardReaderConnectionViewModel` after disconnection completed. Limiting that to the first time with a flag means that subsequent disconnections fail, and allow us to test recovery.


No unit tests – unfortunately the underlying card payments code isn't tested, and much of it is not really testable. Since this is an adaptor for that code, there's little value in adding unit tests here.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->
### Happy Path

https://github.com/user-attachments/assets/b7574c72-33cd-4088-b323-c6a243fc4993

This shows:
- Connection
- Disconnection
- Connection (with confirmation)
- Reader switched off
- Connection (no confirmation needed)

### Faked failure to disconnect

https://github.com/user-attachments/assets/66c352a0-6def-4bef-b2f2-50eec608de5f



---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [x] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [x] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [x] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on all devices (phone/tablet) and no regressions are added.