### PR TITLE
[Orders/Products] Allow swiping to dismiss if there are no changes to the filters

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -3,7 +3,7 @@
 
 20.2
 -----
-
+- [*] Orders/Products: The filter menu can now be swiped to dismiss it if there are no changes to the selected filters. [https://github.com/woocommerce/woocommerce-ios/pull/13737]
 
 20.1
 -----

--- a/WooCommerce/Classes/ViewRelated/Filters/FilterListViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Filters/FilterListViewController.swift
@@ -196,9 +196,6 @@ private extension FilterListViewController {
 
         let clearAllButtonTitle = NSLocalizedString("Clear all", comment: "Button title for clearing all filters for the list.")
         clearAllBarButtonItem = UIBarButtonItem(title: clearAllButtonTitle, style: .plain, target: self, action: #selector(clearAllButtonTapped))
-
-        // Disables interactive dismiss action so that we can prompt the discard changes alert.
-        isModalInPresentation = true
     }
 
     func configureMainView() {
@@ -338,6 +335,9 @@ private extension FilterListViewController {
     func updateUI(numberOfActiveFilters: Int) {
         updateListSelectorNavigationTitle(numberOfActiveFilters: numberOfActiveFilters)
         updateClearAllActionVisibility(numberOfActiveFilters: numberOfActiveFilters)
+
+        // Disables interactive dismiss action if there are changes so we can prompt the discard changes alert.
+        isModalInPresentation = hasFilterChanges()
     }
 
     func updateListSelectorNavigationTitle(numberOfActiveFilters: Int) {


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #13285
<!-- Id number of the GitHub issue this PR addresses. -->

## Description

### Why

The filter menu is non-destructive, so it should be dismissable by swiping it down.

### What

When there are no changes to the existing filters, it can be dismissed by swiping it down. When there are unsaved changes to the filters, the swipe action is disabled. The filter menu can then be dismissed by tapping the "Dismiss" button and discarding the changes.

### How

Previously, we disabled the swipe action once (when the navigation was configured) by setting `isModalInPresentation` to `true`.

Now, we set `isModalInPresentation` whenever the UI is updated based on whether there are changes to the filters.



## Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->

1. Open the Orders or Products tab.
2. Tap the "Filter" button.
3. Confirm you can swipe to dismiss the filter menu.
4. Tap the "Filter" button again.
5. Make changes to the selected filters and confirm you can't swipe to dismiss the filter menu.
6. Tap the "Dismiss" button and confirm you get a prompt to discard changes.

Scenarios to consider:

* Swiping to dismiss works when the filter menu is first opened.
* Swiping to dismiss works if you change the selected filters and then change back to the previously saved selection.
* Swiping to dismiss is disabled if changes have been made to the filters, as soon as those changes are made.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->


https://github.com/user-attachments/assets/f852f081-3744-47d0-917c-776ea73cd7c3



https://github.com/user-attachments/assets/61a760c3-223a-40fe-9615-d570e4b09679



---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [x] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [x] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [x] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on all devices (phone/tablet) and no regressions are added.