### PR TITLE
[Mobile Payments] Improve punctuation of card payment errors

### DIFF
--- a/Hardware/Hardware/CardReader/DeclineReason.swift
+++ b/Hardware/Hardware/CardReader/DeclineReason.swift
@@ -100,56 +100,71 @@ extension DeclineReason {
     public var localizedDescription: String? {
         switch self {
         case .temporary:
-            return NSLocalizedString("Trying again may succeed, or try another means of payment",
+            return NSLocalizedString("Trying again may succeed, or try another means of payment.",
                                      comment: "Message when a card is declined due to a potentially temporary problem.")
+
         case .fraud:
-            return NSLocalizedString("Try another means of payment",
+            return NSLocalizedString("Try another means of payment.",
                                      comment: "Message when a lost or stolen card is presented for payment. Do NOT disclose fraud.")
+
         case .generic:
-            return NSLocalizedString("Payment was declined for an unspecified reason. Try another means of payment",
+            return NSLocalizedString("Payment was declined for an unspecified reason. Try another means of payment.",
                                      comment: "Message when payment is declined for a non specific reason.")
+
         case .invalidAccount:
-            return NSLocalizedString("The card or card account is invalid. Try another means of payment",
+            return NSLocalizedString("The card or card account is invalid. Try another means of payment.",
                                      comment: "Message when payment is declined for a non specific reason.")
 
         case .cardNotSupported:
-            return NSLocalizedString("The card does not support this type of purchase. Try another means of payment",
+            return NSLocalizedString("The card does not support this type of purchase. Try another means of payment.",
                                      comment: "Message when the card presented does not allow this type of purchase.")
+
         case .currencyNotSupported:
-            return NSLocalizedString("The card does not support this currency. Try another means of payment",
+            return NSLocalizedString("The card does not support this currency. Try another means of payment.",
                                      comment: "Message when the card presented does not support the order currency.")
+
         case .duplicateTransaction:
-            return NSLocalizedString("An identical transaction was submitted recently. If you wish to continue, try another means of payment",
+            return NSLocalizedString("An identical transaction was submitted recently. If you wish to continue, try another means of payment.",
                                      comment: "Message when it looks like a duplicate transaction is being attempted.")
+
         case .expiredCard:
-            return NSLocalizedString("The card has expired. Try another means of payment",
+            return NSLocalizedString("The card has expired. Try another means of payment.",
                                      comment: "Message when the presented card is past its expiration date.")
+
         case .incorrectPostalCode:
-            return NSLocalizedString("The transaction postal code and card postal code do not match. Try another means of payment",
+            return NSLocalizedString("The transaction postal code and card postal code do not match. Try another means of payment.",
                                      comment: "Message when the presented card postal code doesn't match the order postal code.")
+
         case .insufficientFunds:
-            return NSLocalizedString("Payment declined due to insufficient funds. Try another means of payment",
+            return NSLocalizedString("Payment declined due to insufficient funds. Try another means of payment.",
                                      comment: "Message when the presented card remaining credit or balance is insufficient for the purchase.")
+
         case .invalidAmount:
             return NSLocalizedString("The payment amount is not allowed for the card presented. Try another means of payment.",
                                      comment: "Message when the presented card does not allow the purchase amount.")
+
         case .pinRequired:
-            return NSLocalizedString("This card requires a PIN code and thus cannot be processed. Try another means of payment",
+            return NSLocalizedString("This card requires a PIN code and thus cannot be processed. Try another means of payment.",
                                      comment: "Message when a card requires a PIN code and we have no means of entering such a code.")
+
         case .incorrectPin:
-            return NSLocalizedString("An incorrect PIN has been entered. Try again, or use another means of payment",
+            return NSLocalizedString("An incorrect PIN has been entered. Try again, or use another means of payment.",
                                      comment: "Message when an incorrect PIN has been entered.")
+
         case .tooManyPinTries:
-            return NSLocalizedString("An incorrect PIN has been entered too many times. Try another means of payment",
+            return NSLocalizedString("An incorrect PIN has been entered too many times. Try another means of payment.",
                                      comment: "Message when an incorrect PIN has been entered too many times.")
+
         case .testCard:
-            return NSLocalizedString("System test cards are not permitted for payment. Try another means of payment",
+            return NSLocalizedString("System test cards are not permitted for payment. Try another means of payment.",
                                      comment: "Message when attempting to pay for a live transaction with a test card.")
+
         case .testModeLiveCard:
             return NSLocalizedString("A live card was used on a site in test mode. Use a test card instead.",
                                      comment: "Message when attempting to pay for a test transaction with a live card.")
+
         case .unknown:
-            return NSLocalizedString("Payment was declined for an unknown reason. Try another means of payment",
+            return NSLocalizedString("Payment was declined for an unknown reason. Try another means of payment.",
                                      comment: "Message when we don't know exactly why the payment was declined.")
         }
     }

--- a/Hardware/Hardware/CardReader/UnderlyingError.swift
+++ b/Hardware/Hardware/CardReader/UnderlyingError.swift
@@ -271,138 +271,178 @@ extension UnderlyingError: LocalizedError {
     public var errorDescription: String? {
         switch self {
         case .notConnectedToReader:
-            return NSLocalizedString("No card reader is connected - connect a reader and try again",
+            return NSLocalizedString("No card reader is connected - connect a reader and try again.",
                                      comment: "Error message when a card reader was expected to already have been connected.")
+
         case .alreadyConnectedToReader:
-            return NSLocalizedString("Unable to connect to reader - another reader is already connected",
+            return NSLocalizedString("Unable to connect to reader - another reader is already connected.",
                                      comment: "Error message when a card reader is already connected and we were not expecting one.")
+
         case .confirmInvalidPaymentIntent:
-            return NSLocalizedString("Unable to process payment due to invalid data - please try again",
+            return NSLocalizedString("Unable to process payment due to invalid data - please try again.",
                                      comment: "Error message when the payment intent is invalid.")
+
         case .unsupportedSDK:
-            return NSLocalizedString("Unable to perform software request - please update this application and try again",
+            return NSLocalizedString("Unable to perform software request - please update this application and try again.",
                                      comment: "Error message when the application is so out of date that the backend refuses to work with it.")
+
         case .featureNotAvailableWithConnectedReader:
-            return NSLocalizedString("Unable to perform request with the connected reader - unsupported feature - please try again with another reader",
+            return NSLocalizedString("Unable to perform request with the connected reader - unsupported feature - please try again with another reader.",
                                      comment: "Error message when the card reader cannot be used to perform the requested task.")
+
         case .commandCancelled(let cancellationSource):
             switch cancellationSource {
             case .reader:
-                return NSLocalizedString("The payment was canceled on the reader",
+                return NSLocalizedString("The payment was canceled on the reader.",
                                          comment: "Error message when the cancel button on the reader is used.")
             default:
-                return NSLocalizedString("The system canceled the command unexpectedly - please try again",
+                return NSLocalizedString("The system canceled the command unexpectedly - please try again.",
                                          comment: "Error message when the system cancels a command.")
             }
+
         case .locationServicesDisabled:
-            return NSLocalizedString("Unable to access Location Services - please enable Location Services and try again",
+            return NSLocalizedString("Unable to access Location Services - please enable Location Services and try again.",
                                      comment: "Error message when location services is not enabled for this application.")
+
         case .bluetoothDisabled:
-            return NSLocalizedString("Unable to access Bluetooth - please enable Bluetooth and try again",
+            return NSLocalizedString("Unable to access Bluetooth - please enable Bluetooth and try again.",
                                      comment: "Error message when Bluetooth is not enabled or available.")
+
         case .bluetoothError:
-            return NSLocalizedString("An error occurred accessing Bluetooth - please enable Bluetooth and try again",
+            return NSLocalizedString("An error occurred accessing Bluetooth - please enable Bluetooth and try again.",
                                      comment: "Error message when Bluetooth is not enabled for this application.")
+
         case .bluetoothScanTimedOut:
-            return NSLocalizedString("Unable to search for card readers - Bluetooth timed out - please try again",
+            return NSLocalizedString("Unable to search for card readers - Bluetooth timed out - please try again.",
                                      comment: "Error message when Bluetooth scan times out during reader discovery.")
+
         case .bluetoothLowEnergyUnsupported:
-            return NSLocalizedString("Unable to search for card readers - Bluetooth Low Energy is not supported on this device - please use a different device",
+            return NSLocalizedString("Unable to search for card readers - Bluetooth Low Energy is not supported on this device - please use a different device.",
                                      comment: "Error message when Bluetooth Low Energy is not supported on the user device.")
+
         case .bluetoothConnectionFailedBatteryCriticallyLow:
             return NSLocalizedString("Unable to connect to reader - the reader has a critically low battery - charge the reader and try again.",
                                      comment: "Error message the card reader battery level is too low to connect to the phone or tablet.")
+
         case .readerSoftwareUpdateFailedBatteryLow:
-            return NSLocalizedString("Unable to update card reader software - the reader battery is too low",
+            return NSLocalizedString("Unable to update card reader software - the reader battery is too low.",
                                      comment: "Error message when the card reader battery level is too low to safely perform a software update.")
+
         case .readerSoftwareUpdateFailedInterrupted:
-            return NSLocalizedString("The card reader software update was interrupted before it could complete - please try again",
+            return NSLocalizedString("The card reader software update was interrupted before it could complete - please try again.",
                                      comment: "Error message when the card reader software update is interrupted.")
+
         case .readerSoftwareUpdateFailed:
-            return NSLocalizedString("The card reader software update failed unexpectedly - please try again",
+            return NSLocalizedString("The card reader software update failed unexpectedly - please try again.",
                                      comment: "Error message when the card reader software update fails unexpectedly.")
+
         case .readerSoftwareUpdateFailedReader:
-            return NSLocalizedString("The card reader software update failed due to a communication error - please try again",
+            return NSLocalizedString("The card reader software update failed due to a communication error - please try again.",
                                      comment: "Error message when the card reader software update fails due to a communication error.")
+
         case .readerSoftwareUpdateFailedServer:
-            return NSLocalizedString("The card reader software update failed due to a problem with the update server - please try again",
+            return NSLocalizedString("The card reader software update failed due to a problem with the update server - please try again.",
                                      comment: "Error message when the card reader software update fails due to a problem with the update server.")
+
         case .cardInsertNotRead:
-            return NSLocalizedString("Unable to read inserted card - please try removing and inserting card again",
+            return NSLocalizedString("Unable to read inserted card - please try removing and inserting card again.",
                                      comment: "Error message when the card reader is unable to read any chip on the inserted card.")
+
         case .cardSwipeNotRead:
-            return NSLocalizedString("Unable to read swiped card - please try swiping again",
+            return NSLocalizedString("Unable to read swiped card - please try swiping again.",
                                      comment: "Error message when the card reader is unable to read a swiped card.")
+
         case .cardReadTimeOut:
-            return NSLocalizedString("Unable to read card - the system timed out - please try again",
+            return NSLocalizedString("Unable to read card - the system timed out - please try again.",
                                      comment: "Error message when the card reader times out while reading a card.")
+
         case .cardRemoved:
-            return NSLocalizedString("Card was removed too soon - please try transaction again",
+            return NSLocalizedString("Card was removed too soon - please try transaction again.",
                                      comment: "Error message when the card is removed from the reader prematurely.")
+
         case .cardLeftInReader:
-            return NSLocalizedString("Card was left in reader - please remove and reinsert card",
+            return NSLocalizedString("Card was left in reader - please remove and reinsert card.",
                                      comment: "Error message when a card is left in the reader and another transaction started.")
+
         case .readerBusy:
-            return NSLocalizedString("The card reader is busy executing another command - please try again",
+            return NSLocalizedString("The card reader is busy executing another command - please try again.",
                                      comment: "Error message when the card reader is busy executing another command.")
+
         case .readerIncompatible:
             return NSLocalizedString("The card reader is not compatible with this application - please try updating the " +
-                                     "application or using a different reader",
+                                     "application or using a different reader.",
                                      comment: "Error message when the card reader is incompatible with the application.")
+
         case .readerCommunicationError:
-            return NSLocalizedString("Unable to communicate with reader - please try again",
+            return NSLocalizedString("Unable to communicate with reader - please try again.",
                                      comment: "Error message when communication with the card reader is disrupted.")
+
         case .bluetoothConnectTimedOut:
-            return NSLocalizedString("Connecting to the card reader timed out - ensure it is nearby and charged and then try again",
+            return NSLocalizedString("Connecting to the card reader timed out - ensure it is nearby and charged and then try again.",
                                      comment: "Error message when establishing a connection to the card reader times out.")
+
         case .bluetoothDisconnected:
-            return NSLocalizedString("The Bluetooth connection to the card reader disconnected unexpectedly",
+            return NSLocalizedString("The Bluetooth connection to the card reader disconnected unexpectedly.",
                                      comment: "Error message when the card reader loses its Bluetooth connection to the card reader.")
+
         case .unsupportedReaderVersion:
-            return NSLocalizedString("The card reader software is out-of-date - please update the card reader software before attempting to process payments",
+            return NSLocalizedString("The card reader software is out-of-date - please update the card reader software before attempting to process payments.",
                                      comment: "Error message when the card reader software is too far out of date to process payments.")
+
         case .connectFailedReaderIsInUse:
-            return NSLocalizedString("Unable to connect to card reader - the card reader is already in use",
+            return NSLocalizedString("Unable to connect to card reader - the card reader is already in use.",
                                      comment: "Error message when attempting to connect to a card reader which is already in use.")
+
         case .unexpectedSDKError:
-            return NSLocalizedString("The system experienced an unexpected software error",
+            return NSLocalizedString("The system experienced an unexpected software error.",
                                      comment: "Error message when the card reader service experiences an unexpected software error.")
+
         case .paymentDeclinedByPaymentProcessorAPI:
             if case let .paymentDeclinedByPaymentProcessorAPI(declineReason) = self {
                 return declineReason.localizedDescription
             }
-            return NSLocalizedString("The card was declined by the payment processor - please try another means of payment",
+            return NSLocalizedString("The card was declined by the payment processor - please try another means of payment.",
                                      comment: "Error message when the card processor declines the payment.")
+
         case .paymentDeclinedByCardReader:
-            return NSLocalizedString("The card was declined by the card reader - please try another means of payment",
+            return NSLocalizedString("The card was declined by the card reader - please try another means of payment.",
                                      comment: "Error message when the card reader itself declines the card.")
+
         case .notConnectedToInternet:
-            return NSLocalizedString("No connection to the Internet - please connect to the Internet and try again",
+            return NSLocalizedString("No connection to the Internet - please connect to the Internet and try again.",
                                      comment: "Error message when there is no connection to the Internet.")
+
         case .requestTimedOut:
-            return NSLocalizedString("The request timed out - please try again",
+            return NSLocalizedString("The request timed out - please try again.",
                                      comment: "Error message when a request times out.")
+
         case .readerSessionExpired:
-            return NSLocalizedString("The card reader session has expired - please disconnect and reconnect the card reader and then try again",
+            return NSLocalizedString("The card reader session has expired - please disconnect and reconnect the card reader and then try again.",
                                      comment: "Error message when the card reader session has timed out.")
+
         case .processorAPIError:
             return NSLocalizedString("The payment can not be processed by the payment processor.",
                                      comment: "Error message when the payment can not be processed (i.e. order amount is below the minimum amount allowed.)")
+
         case .internalServiceError:
-            return NSLocalizedString("Sorry, this payment couldn’t be processed",
+            return NSLocalizedString("Sorry, this payment couldn’t be processed.",
                                      comment: "Error message when the card reader service experiences an unexpected internal service error.")
+
         case .incompleteStoreAddress:
             return NSLocalizedString("The store address is incomplete or missing, please update it before continuing.",
                                      comment: "Error message when there is an issue with the store address preventing " +
                                      "an action (e.g. reader connection.)")
+
         case .invalidPostalCode:
             return NSLocalizedString("The store postal code is invalid or missing, please update it before continuing.",
                                      comment: "Error message when there is an issue with the store postal code preventing " +
                                      "an action (e.g. reader connection.)")
+
         case .noRefundInProgress:
-            return NSLocalizedString("Sorry, this refund could not be canceled",
+            return NSLocalizedString("Sorry, this refund could not be canceled.",
                                      comment: "Error message shown when a refund could not be canceled (likely because " +
                                      "it had already completed)")
+
         case .connectionAttemptInvalidated:
             return NSLocalizedString("Sorry, we could not connect to the reader. Please try again.",
                                      comment: "Error message shown when an in-progress connection is cancelled by the system")
@@ -414,37 +454,44 @@ extension UnderlyingError: LocalizedError {
 
             // MARK: - Tap to Pay on iPhone errors
         case .passcodeNotEnabled:
-            return NSLocalizedString("You need to set a lock screen passcode to use Tap to Pay on iPhone",
+            return NSLocalizedString("You need to set a lock screen passcode to use Tap to Pay on iPhone.",
                                      comment: "Error message shown when Tap to Pay on iPhone cannot be used because " +
                                      "the device does not have a passcode set.")
+
         case .appleBuiltInReaderTOSAcceptanceRequiresiCloudSignIn:
-            return NSLocalizedString("Please sign in to iCloud on this device to use Tap to Pay on iPhone",
+            return NSLocalizedString("Please sign in to iCloud on this device to use Tap to Pay on iPhone.",
                                      comment: "Error message shown when Tap to Pay on iPhone cannot be used because " +
                                      "the device is not signed in to iCloud.")
+
         case .nfcDisabled:
             return NSLocalizedString("The app could not enable Tap to Pay on iPhone, because the NFC chip is disabled. " +
                                      "Please contact support for more details.",
                                      comment: "Error message shown when Tap to Pay on iPhone cannot be used because " +
                                      "the device's NFC chipset has been disabled by a device management policy.")
+
         case .appleBuiltInReaderFailedToPrepare, .readerNotAccessibleInBackground:
             return NSLocalizedString("There was an issue preparing to use Tap to Pay on iPhone – please try again.",
                                      comment: "Error message shown when Tap to Pay on iPhone cannot be used because " +
                                      "there was some issue with the connection. Retryable.")
+
         case .appleBuiltInReaderTOSAcceptanceCanceled, .appleBuiltInReaderTOSNotYetAccepted:
             return NSLocalizedString("Please try again, and accept Apple's Terms of Service, so you can use Tap to " +
-                                     "Pay on iPhone",
+                                     "Pay on iPhone.",
                                      comment: "Error message shown when Tap to Pay on iPhone cannot be used because " +
                                      "the merchant cancelled or did not complete the Terms of Service acceptance flow")
+
         case .appleBuiltInReaderTOSAcceptanceFailed:
             return NSLocalizedString("Please check your Apple ID is valid, and then try again. A valid Apple ID is " +
-                                     "required to accept Apple's Terms of Service",
+                                     "required to accept Apple's Terms of Service.",
                                      comment: "Error message shown when Tap to Pay on iPhone cannot be used because " +
                                      "the Terms of Service acceptance flow failed, possibly due to issues with " +
                                      "the Apple ID")
+
         case .appleBuiltInReaderMerchantBlocked, .appleBuiltInReaderInvalidMerchant, .appleBuiltInReaderDeviceBanned:
             return NSLocalizedString("Please contact support – there was an issue starting Tap to Pay on iPhone",
                                      comment: "Error message shown when Tap to Pay on iPhone cannot be used because " +
-                                     "there is an issue with the merchant account or device")
+                                     "there is an issue with the merchant account or device.")
+
         case .unsupportedMobileDeviceConfiguration:
             /// Strictly, 16.0 is required in the US, 16.4 in the UK... but it's overly complicated to make this country specific.
             /// Any device running 16.0 can run 16.4, so this seems clear enough.
@@ -453,16 +500,19 @@ extension UnderlyingError: LocalizedError {
                                      "shows on a supported device.",
                                      comment: "Error message shown when Tap to Pay on iPhone cannot be used because " +
                                      "the device does not meet minimum requirements.")
+
         case .commandNotAllowedDuringCall:
             return NSLocalizedString("Tap to Pay on iPhone cannot be used during a phone call. Please try again after " +
                                      "you finish your call.",
                                      comment: "Error message shown when Tap to Pay on iPhone cannot be used because " +
                                      "there is a call in progress")
+
         case .invalidAmount:
             return NSLocalizedString("The amount is not supported for Tap to Pay on iPhone – please try a hardware " +
                                      "reader or another payment method.",
                                      comment: "Error message shown when Tap to Pay on iPhone cannot be used because " +
                                      "the amount for payment is not supported for Tap to Pay on iPhone.")
+
         case .invalidCurrency:
             return NSLocalizedString("The currency is not supported for Tap to Pay on iPhone – please try a hardware " +
                                      "reader or another payment method.",

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -4,7 +4,7 @@
 20.2
 -----
 - [*] Home Screen Widget: Tapping on the Orders section of the home screen widget opens the Orders part of the app.
-
+- [*] Payments: Punctuation updates to error and decline reason messages [https://github.com/woocommerce/woocommerce-ios/pull/13739]
 
 20.1
 -----

--- a/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/CardReaderSettings/BluetoothCardReaderSettingsConnectedViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/CardReaderSettings/BluetoothCardReaderSettingsConnectedViewModelTests.swift
@@ -294,7 +294,7 @@ final class BluetoothCardReaderSettingsConnectedViewModelTests: XCTestCase {
         XCTAssertEqual(firstPropertiesBatch[WooAnalyticsEvent.InPersonPayments.Keys.cardReaderModel] as? String,
                        MockCardReader.bbposChipper2XBT().readerType.model)
         XCTAssertEqual(firstPropertiesBatch[WooAnalyticsEvent.InPersonPayments.Keys.softwareUpdateType] as? String, "Required")
-        let expectedErrorDescription = "Unable to update card reader software - the reader battery is too low"
+        let expectedErrorDescription = "Unable to update card reader software - the reader battery is too low."
         XCTAssertEqual(firstPropertiesBatch[WooAnalyticsEvent.InPersonPayments.Keys.errorDescription] as? String, expectedErrorDescription)
     }
 


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #13730
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

This PR fixes some punctuation issues in the user-facing error messages for card payments.

## Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->

1. Launch the app and navigate to `Orders > +`
2. Add a custom amount ending in `.01` to your order – it must be over 0.50 as well.
3. Tap Collect Payment
4. Select `Card reader` or `Tap to Pay on iPhone`
5. Tap the card and wait for the error message
6. Observe that the description has a trailing full stop. This is `Try another means of payment.`, which is the `.fraud` decline reason.

## Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->

I have tested some of the errors, but not all. These are very minor string changes. No unit tests, for the same reason.

Test as many of the others that you see as you feel is worth doing. 

### Error amounts
Some of the decline reasons can be tested using Stripe's error amounts (with a test card) or simulated cards (using the simulated reader), like the `.01` example above.

See Stripe's docs for the available [error amounts](https://docs.stripe.com/terminal/references/testing?locale=en-GB#physical-test-cards) and [simulated cards](https://docs.stripe.com/terminal/references/testing?locale=en-GB#test-cards-for-specific-error-cases).

### Simulating errors
It may be easiest to change the code to return the errors you're looking for – you can do this by commenting out the switch statement in the `UnderlyingError.init(withStripeError:)` and `DeclineReason.init(with:)` functions, and instead returning the error or decline code you want to test.

The error amount used above will result in a `DeclineReason`, which is communicated via an `UnderlyingError.paymentDeclinedByPaymentProcessorAPI` associated value, so as long as you use the error amount, your early return should be triggered.

### POS
These error messages will also be used in POS – either the main app or POS is valid for testing, but in POS you'll need a product with an error amount to trigger the errors.

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [x] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [x] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [x] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on all devices (phone/tablet) and no regressions are added.