### PR TITLE
[Woo POS] Update POS modal overlay/shadow to designs

### DIFF
--- a/WooCommerce/Classes/POS/Presentation/Reusable Views/POSModalViewModifier.swift
+++ b/WooCommerce/Classes/POS/Presentation/Reusable Views/POSModalViewModifier.swift
@@ -16,7 +16,7 @@ struct POSRootModalViewModifier: ViewModifier {
                 modalManager.getContent()
                     .background(Color.posPrimaryBackground)
                     .cornerRadius(16)
-                    .shadow(color: Color.black.opacity(0.04), radius: 24, x: 0, y: 8)
+                    .shadow(color: Color.black.opacity(0.08), radius: 24, x: 0, y: 8)
                     .transition(.scale)
                     .zIndex(1)
                     .padding()

--- a/WooCommerce/Classes/POS/Presentation/Reusable Views/POSModalViewModifier.swift
+++ b/WooCommerce/Classes/POS/Presentation/Reusable Views/POSModalViewModifier.swift
@@ -15,7 +15,7 @@ struct POSRootModalViewModifier: ViewModifier {
                     .edgesIgnoringSafeArea(.all)
                 modalManager.getContent()
                     .background(Color.posPrimaryBackground)
-                    .cornerRadius(16)
+                    .cornerRadius(24)
                     .shadow(color: Color.black.opacity(0.08), radius: 24, x: 0, y: 8)
                     .transition(.scale)
                     .zIndex(1)

--- a/WooCommerce/Classes/POS/Presentation/Reusable Views/POSModalViewModifier.swift
+++ b/WooCommerce/Classes/POS/Presentation/Reusable Views/POSModalViewModifier.swift
@@ -11,12 +11,12 @@ struct POSRootModalViewModifier: ViewModifier {
                 .accessibilityElement(children: modalManager.isPresented ? .ignore : .contain)
 
             if modalManager.isPresented {
-                Color.black.opacity(0.4)
+                Color.posOverlayFill
                     .edgesIgnoringSafeArea(.all)
                 modalManager.getContent()
                     .background(Color.posPrimaryBackground)
                     .cornerRadius(16)
-                    .shadow(radius: 10)
+                    .shadow(color: Color.black.opacity(0.04), radius: 24, x: 0, y: 8)
                     .transition(.scale)
                     .zIndex(1)
                     .padding()

--- a/WooCommerce/Classes/POS/Utils/Color+WooCommercePOS.swift
+++ b/WooCommerce/Classes/POS/Utils/Color+WooCommercePOS.swift
@@ -37,6 +37,15 @@ extension Color {
         )
     }
 
+    static var posOverlayFill: Color {
+        Color(
+            UIColor(
+                light: UIColor(red: 120.0 / 255.0, green: 120.0 / 255.0, blue: 128.0 / 255.0, alpha: 0.2),
+                dark: UIColor(red: 50.0 / 255.0, green: 50.0 / 255.0, blue: 50.0 / 255.0, alpha: 0.8)
+            )
+        )
+    }
+
     // MARK: - Text
 
     static var posPrimaryText: Color {


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #13705
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

This PR updates the POS modal overlay and shadow to match the designs, and sets a sensible colour for dark mode even though this isn't available in the designs.

## Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->

1. Launch the app and navigate to POS
2. Tap `...` and `Exit POS`
3. Observe that the modal background and shadow match the designs
4. Switch to dark mode
5. Observe that there is contrast between the modal window and the background overlay.

## Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->

No unit tests as it's UI only.

Other modals you can try:
- Tap the Simple Products banner or `i` button
- Trigger the Capture Payment Error as per instructions on #13642

They all use the same code though.

### Shadows
The shadow in the designs is more pronounced than a `0.04` opacity, as seen in the inspector. Figma has that shadow on twice.

I've gone for a `0.08` value instead and it looks right to me. 

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->
### Before

https://github.com/user-attachments/assets/432978c5-e325-4000-b304-d64ceacd1029

### After

https://github.com/user-attachments/assets/4cb2c99c-ca4b-4d2f-8657-dce1a2efc07c

### Designs

![designs for modal](https://github.com/user-attachments/assets/e44172e5-0b83-4304-aaa2-983da3a3030c)

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [x] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [x] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [x] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on all devices (phone/tablet) and no regressions are added.