### PR TITLE
Unit tests: Order Details - Open Product

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -123,6 +123,7 @@ target 'WooCommerce' do
   #
   target 'WooCommerceTests' do
     inherit! :search_paths
+    pod 'ViewControllerPresentationSpy', '~> 7.0'
   end
 end
 

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -21,6 +21,7 @@ PODS:
   - SVProgressHUD (2.2.5)
   - SwiftLint (0.54.0)
   - UIDeviceIdentifier (2.3.0)
+  - ViewControllerPresentationSpy (7.0.0)
   - WordPress-Aztec-iOS (1.19.10)
   - WordPress-Editor-iOS (1.19.10):
     - WordPress-Aztec-iOS (= 1.19.10)
@@ -66,6 +67,7 @@ DEPENDENCIES:
   - Sourcery (~> 1.0.3)
   - StripeTerminal (~> 3.3.1)
   - SwiftLint (= 0.54.0)
+  - ViewControllerPresentationSpy (~> 7.0)
   - WordPress-Editor-iOS (~> 1.19)
   - WordPressAuthenticator (~> 9.0.9)
   - WordPressShared (~> 2.1)
@@ -94,6 +96,7 @@ SPEC REPOS:
     - SVProgressHUD
     - SwiftLint
     - UIDeviceIdentifier
+    - ViewControllerPresentationSpy
     - WordPress-Aztec-iOS
     - WordPress-Editor-iOS
     - WordPressShared
@@ -125,6 +128,7 @@ SPEC CHECKSUMS:
   SVProgressHUD: 1428aafac632c1f86f62aa4243ec12008d7a51d6
   SwiftLint: c1de071d9d08c8aba837545f6254315bc900e211
   UIDeviceIdentifier: 442b65b4ff1832d4ca9c2a157815cb29ad981b17
+  ViewControllerPresentationSpy: 05d5cd89a485a2be13008fb56d3de8c8aa821d31
   WordPress-Aztec-iOS: 8eaa928fb3a5694924ed3befac64beaae5656e12
   WordPress-Editor-iOS: 98ce1fc542c3a09e48ddc9423405b1d1e48240f1
   WordPressAuthenticator: e0c88dd994799595a4a4fafb801589f650af822c
@@ -142,6 +146,6 @@ SPEC CHECKSUMS:
   ZendeskSupportProvidersSDK: 2fbd2a9597af5d69760088bfb5e0e595e942f218
   ZendeskSupportSDK: 22156384d20d30b0aeb263c03f49bef44e1364b2
 
-PODFILE CHECKSUM: 60414588e43bf7bc146dc0c04130e78fdb3f2ece
+PODFILE CHECKSUM: 87026e2645d3e5fec83ad68df9c942b14dd1988a
 
 COCOAPODS: 1.15.2

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -904,6 +904,7 @@
 		262A0999262908A60033AD20 /* OrderAddOnListI1Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 262A0998262908A60033AD20 /* OrderAddOnListI1Tests.swift */; };
 		262A09A5262F65690033AD20 /* OrderAddOnTopBanner.swift in Sources */ = {isa = PBXBuildFile; fileRef = 262A09A4262F65690033AD20 /* OrderAddOnTopBanner.swift */; };
 		262A2C2B2537A3330086C1BE /* MockRefunds.swift in Sources */ = {isa = PBXBuildFile; fileRef = 262A2C2A2537A3330086C1BE /* MockRefunds.swift */; };
+		262B442E2C77D9B000441FD5 /* OrderDetailsViewControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 262B442D2C77D9B000441FD5 /* OrderDetailsViewControllerTests.swift */; };
 		262C25362C1B4EB800E525E4 /* Environment+AppBindings.swift in Sources */ = {isa = PBXBuildFile; fileRef = 262C25352C1B4EB800E525E4 /* Environment+AppBindings.swift */; };
 		262C921F26EEF8B100011F92 /* Binding.swift in Sources */ = {isa = PBXBuildFile; fileRef = 262C921E26EEF8B100011F92 /* Binding.swift */; };
 		262C922126F1370000011F92 /* StorePickerError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 262C922026F1370000011F92 /* StorePickerError.swift */; };
@@ -3941,6 +3942,7 @@
 		262A0998262908A60033AD20 /* OrderAddOnListI1Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OrderAddOnListI1Tests.swift; sourceTree = "<group>"; };
 		262A09A4262F65690033AD20 /* OrderAddOnTopBanner.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OrderAddOnTopBanner.swift; sourceTree = "<group>"; };
 		262A2C2A2537A3330086C1BE /* MockRefunds.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockRefunds.swift; sourceTree = "<group>"; };
+		262B442D2C77D9B000441FD5 /* OrderDetailsViewControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OrderDetailsViewControllerTests.swift; sourceTree = "<group>"; };
 		262C25352C1B4EB800E525E4 /* Environment+AppBindings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Environment+AppBindings.swift"; sourceTree = "<group>"; };
 		262C921E26EEF8B100011F92 /* Binding.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Binding.swift; sourceTree = "<group>"; };
 		262C922026F1370000011F92 /* StorePickerError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StorePickerError.swift; sourceTree = "<group>"; };
@@ -9176,6 +9178,7 @@
 				26C6E8E126E2D85300C7BB0F /* Addresses */,
 				025678042575EA1B009D7E6C /* ProductDetailsCellViewModelTests.swift */,
 				578195FB25AD1D7C004A5C12 /* OrderFulfillmentUseCaseTests.swift */,
+				262B442D2C77D9B000441FD5 /* OrderDetailsViewControllerTests.swift */,
 			);
 			path = "Order Details";
 			sourceTree = "<group>";
@@ -13581,6 +13584,7 @@
 			buildConfigurationList = B56DB3E92049BFAA00D4AA8E /* Build configuration list for PBXNativeTarget "WooCommerceTests" */;
 			buildPhases = (
 				E8FC62641D61F33F705BC760 /* [CP] Check Pods Manifest.lock */,
+				4B108CBFE1E4CAAD77FEFC46 /* [CP] Embed Pods Frameworks */,
 				B56DB3D92049BFAA00D4AA8E /* Sources */,
 				B56DB3DA2049BFAA00D4AA8E /* Frameworks */,
 				B56DB3DB2049BFAA00D4AA8E /* Resources */,
@@ -14156,6 +14160,23 @@
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
 			shellScript = "\"$SRCROOT/../Scripts/build-phases/LintAppLocalizedStringsUsage.sh\"\n";
+			showEnvVarsInLog = 0;
+		};
+		4B108CBFE1E4CAAD77FEFC46 /* [CP] Embed Pods Frameworks */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-WooCommerceTests/Pods-WooCommerceTests-frameworks-${CONFIGURATION}-input-files.xcfilelist",
+			);
+			name = "[CP] Embed Pods Frameworks";
+			outputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-WooCommerceTests/Pods-WooCommerceTests-frameworks-${CONFIGURATION}-output-files.xcfilelist",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-WooCommerceTests/Pods-WooCommerceTests-frameworks.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
 		57CCFFD4249D2A5700825FCF /* SwiftLint */ = {
@@ -16831,6 +16852,7 @@
 				B993051E2B7CC2A400456E35 /* LocallyStoredStateNameRetrieverTests.swift in Sources */,
 				DE7E5E8A2B4D4015002E28D2 /* BlazeTargetDeviceViewModelTests.swift in Sources */,
 				02E4FD812306AA890049610C /* StatsTimeRangeBarViewModelTests.swift in Sources */,
+				262B442E2C77D9B000441FD5 /* OrderDetailsViewControllerTests.swift in Sources */,
 				CCCFFC5D2934F0BA006130AF /* StatsIntervalDataParserTests.swift in Sources */,
 				953728F82B23635300FDF1D1 /* UIAlertController+helpers.swift in Sources */,
 				02645D8A27BA2EDB0065DC68 /* NSAttributedString+AttributesTests.swift in Sources */,

--- a/WooCommerce/WooCommerceTests/Tools/MockOrders.swift
+++ b/WooCommerce/WooCommerceTests/Tools/MockOrders.swift
@@ -52,6 +52,10 @@ final class MockOrders {
         makeOrder()
     }
 
+    func sampleOrderWithItems() -> Order {
+        makeOrder(items: sampleOrderItems())
+    }
+
     func orderWithFees() -> Order {
         makeOrder(fees: sampleFeeLines())
     }
@@ -106,6 +110,12 @@ final class MockOrders {
         total: cost,
         totalTax: tax,
         taxes: [])]
+    }
+
+    func sampleOrderItems() -> [OrderItem] {
+        [
+            OrderItem.fake().copy(itemID: 1, name: "Sample Item", quantity: 2, price: 123)
+        ]
     }
 
     func sampleFeeLines() -> [OrderFeeLine] {

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Details/OrderDetailsViewControllerTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Details/OrderDetailsViewControllerTests.swift
@@ -1,0 +1,227 @@
+import Foundation
+import XCTest
+import TestKit
+import Yosemite
+import ViewControllerPresentationSpy
+
+@testable import WooCommerce
+
+final class OrderDetailsViewControllerTests: XCTestCase {
+
+
+    @MainActor
+    func test_products_cell_is_not_visible_on_order_with_no_items() throws {
+        // Given
+        let storageManager = MockStorageManager()
+        let order = MockOrders().sampleOrder()
+        let storesManager = OrderDetailStoreManagerFactory.createManager(order: order)
+
+        let viewModel = OrderDetailsViewModel(order: order, stores: storesManager, storageManager: storageManager)
+        let viewController = OrderDetailsViewController(viewModel: viewModel)
+
+        // When
+        _ = try XCTUnwrap(viewController.view)
+        viewController.viewWillAppear(false)
+
+        // Then
+        let mirror = try Self.mirror(of: viewController)
+        let tuple = Self.findCell(type: ProductDetailsTableViewCell.self, on: mirror.tableView)
+
+        XCTAssertNil(tuple)
+    }
+
+    @MainActor
+    func test_products_cell_is_visible_on_order_with_items() throws {
+        // Given
+        let storageManager = MockStorageManager()
+        let order = MockOrders().sampleOrderWithItems()
+        let storesManager = OrderDetailStoreManagerFactory.createManager(order: order)
+
+        let viewModel = OrderDetailsViewModel(order: order, stores: storesManager, storageManager: storageManager)
+        let viewController = OrderDetailsViewController(viewModel: viewModel)
+
+        // When
+        _ = try XCTUnwrap(viewController.view)
+        viewController.viewWillAppear(false)
+
+        // Then
+        let mirror = try Self.mirror(of: viewController)
+        let tuple = Self.findCell(type: ProductDetailsTableViewCell.self, on: mirror.tableView)
+
+        XCTAssertNotNil(tuple?.cell)
+    }
+
+    @MainActor
+    func test_tapping_products_cell_presents_product_loader() throws {
+        // Given
+        let presentationVerifier = PresentationVerifier()
+        let storageManager = MockStorageManager()
+        let order = MockOrders().sampleOrderWithItems()
+        let storesManager = OrderDetailStoreManagerFactory.createManager(order: order)
+
+        let viewModel = OrderDetailsViewModel(order: order, stores: storesManager, storageManager: storageManager)
+        let viewController = OrderDetailsViewController(viewModel: viewModel)
+
+        // When
+        _ = try XCTUnwrap(viewController.view)
+        viewController.viewWillAppear(false)
+
+        let mirror = try Self.mirror(of: viewController)
+        let (_, indexPath) = try XCTUnwrap(Self.findCell(type: ProductDetailsTableViewCell.self, on: mirror.tableView))
+        viewController.tableView(mirror.tableView, didSelectRowAt: indexPath)
+
+        // Then
+        let presentedNav: UINavigationController? = presentationVerifier.verify(animated: true, presentingViewController: viewController)
+        let presentedVC = try XCTUnwrap(presentedNav?.topViewController)
+        XCTAssertTrue(presentedVC is ProductLoaderViewController)
+    }
+}
+
+// MARK: - Mirroring
+
+private extension OrderDetailsViewControllerTests {
+    struct OrderDetailsViewControllerMirror {
+        let tableView: UITableView
+    }
+
+    static func mirror(of viewController: OrderDetailsViewController) throws -> OrderDetailsViewControllerMirror {
+        let mirror = Mirror(reflecting: viewController)
+        return OrderDetailsViewControllerMirror(
+            tableView: try XCTUnwrap(mirror.descendant("tableView") as? UITableView)
+        )
+    }
+}
+
+
+// MARK: - Helpers
+
+private extension OrderDetailsViewControllerTests {
+    static func findCell<T>(type: T.Type, on tableView: UITableView) -> (cell: T, indexPath: IndexPath)? {
+        for section in (0..<tableView.numberOfSections) {
+            for row in (0..<tableView.numberOfRows(inSection: section)) {
+
+                let ip = IndexPath(row: row, section: section)
+                if let cell = tableView.cellForRow(at: ip) as? T {
+                    return (cell, ip)
+                }
+            }
+        }
+        return nil
+    }
+}
+
+/// Helper that properly provide stubs needed for  `OrderDetailsViewModel`
+///
+private struct OrderDetailStoreManagerFactory {
+
+    static func createManager(order: Order) -> MockStoresManager {
+        let storesManager = MockStoresManager(sessionManager: SessionManager.makeForTesting())
+
+        storesManager.whenReceivingAction(ofType: OrderAction.self) { action in
+            switch action {
+            case let .retrieveOrder(_, _, onCompletion):
+                onCompletion(order, nil)
+            default:
+                break
+            }
+        }
+
+        storesManager.whenReceivingAction(ofType: ProductAction.self) { action in
+            switch action {
+            case let .requestMissingProducts(_, onCompletion):
+                onCompletion(nil)
+            default:
+                break
+            }
+        }
+
+        storesManager.whenReceivingAction(ofType: ProductVariationAction.self) { action in
+            switch action {
+            case let .requestMissingVariations(_, onCompletion):
+                onCompletion(nil)
+            default:
+                break
+            }
+        }
+
+        storesManager.whenReceivingAction(ofType: RefundAction.self) { action in
+            switch action {
+            case let .retrieveRefunds(_, _, _, _, onCompletion):
+                onCompletion(nil)
+            default:
+                break
+            }
+        }
+
+        // Need to sync plugins first
+        storesManager.whenReceivingAction(ofType: SystemStatusAction.self) { action in
+            switch action {
+            case let .fetchSystemPluginListWithNameList(_, _, onCompletion):
+                onCompletion(nil)
+            default:
+                break
+            }
+        }
+
+        storesManager.whenReceivingAction(ofType: SubscriptionAction.self) { action in
+            switch action {
+            case let .loadSubscriptions(_, onCompletion):
+                onCompletion(.success([]))
+            }
+        }
+
+        storesManager.whenReceivingAction(ofType: ShippingLabelAction.self) { action in
+            switch action {
+            case let .synchronizeShippingLabels(_, _, onCompletion):
+                onCompletion(.success(()))
+            default:
+                break
+            }
+        }
+
+        storesManager.whenReceivingAction(ofType: OrderNoteAction.self) { action in
+            switch action {
+            case let .retrieveOrderNotes(_, _, onCompletion):
+                onCompletion([], nil)
+            default:
+                break
+            }
+        }
+
+        storesManager.whenReceivingAction(ofType: ShipmentAction.self) { action in
+            switch action {
+            case let .synchronizeShipmentTrackingData(_, _, onCompletion):
+                onCompletion(nil)
+            default:
+                break
+            }
+        }
+
+        storesManager.whenReceivingAction(ofType: ReceiptAction.self) { action in
+            switch action {
+            case let .loadReceipt(_, onCompletion):
+                onCompletion(.success(.fake()))
+            default:
+                break
+            }
+        }
+
+        storesManager.whenReceivingAction(ofType: AppSettingsAction.self) { action in
+            switch action {
+            case let .loadOrderAddOnsSwitchState(onCompletion):
+                onCompletion(.success(false))
+            default:
+                break
+            }
+        }
+
+        storesManager.whenReceivingAction(ofType: ShippingMethodAction.self) { action in
+            switch action {
+            case let .synchronizeShippingMethods(_, onCompletion):
+                onCompletion(.success(()))
+            }
+        }
+
+        return storesManager
+    }
+}


### PR DESCRIPTION
# Why

As part of the initiative of [automating smoke tests for our Core Functionalities](https://github.com/woocommerce/woocommerce-ios/issues/13453) this PR adds unit tests for the following scenarios

- An order without items should not display a product row
- An order with items should display a product row.
- Tapping a products row should present the order loader screen.

# How

- Adds a new `ViewControllerPresentationSpy` pod to help us verify that a view controller was presented.

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [x] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [x] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [x] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on all devices (phone/tablet) and no regressions are added.
