### PR TITLE
[Woo POS] Set header layout constants into shared object

### DIFF
--- a/WooCommerce/Classes/POS/Presentation/CartView.swift
+++ b/WooCommerce/Classes/POS/Presentation/CartView.swift
@@ -66,7 +66,7 @@ struct CartView: View {
             }
             .frame(maxWidth: .infinity, alignment: .leading)
             .padding(.horizontal, POSHeaderLayoutConstants.sectionHorizontalPadding)
-            .padding(.vertical, POSHeaderLayoutConstants.sectionTopPadding)
+            .padding(.vertical, POSHeaderLayoutConstants.sectionVerticalPadding)
             .if(shouldApplyHeaderBottomShadow, transform: { $0.applyBottomShadow() })
 
             if cartViewModel.isCartEmpty {

--- a/WooCommerce/Classes/POS/Presentation/CartView.swift
+++ b/WooCommerce/Classes/POS/Presentation/CartView.swift
@@ -65,8 +65,8 @@ struct CartView: View {
                 }
             }
             .frame(maxWidth: .infinity, alignment: .leading)
-            .padding(.horizontal, Constants.horizontalPadding)
-            .padding(.vertical, POSHeaderLayoutConstants.posSectionTopPadding)
+            .padding(.horizontal, POSHeaderLayoutConstants.sectionHorizontalPadding)
+            .padding(.vertical, POSHeaderLayoutConstants.sectionTopPadding)
             .if(shouldApplyHeaderBottomShadow, transform: { $0.applyBottomShadow() })
 
             if cartViewModel.isCartEmpty {
@@ -121,7 +121,7 @@ struct CartView: View {
                     EmptyView()
                 } else {
                     checkoutButton
-                        .padding(Constants.checkoutButtonPadding)
+                        .padding(POSHeaderLayoutConstants.sectionHorizontalPadding)
                         .accessibilityAddTraits(.isHeader)
                 }
             case .finalizing:
@@ -162,9 +162,7 @@ private extension CartView {
         static let clearButtonCornerRadius: CGFloat = 4
         static let clearButtonBorderWidth: CGFloat = 2
         static let clearButtonTextPadding = EdgeInsets(top: 8, leading: 24, bottom: 8, trailing: 24)
-        static let checkoutButtonPadding: CGFloat = 16
         static let itemHorizontalPadding: CGFloat = 8
-        static let horizontalPadding: CGFloat = 16
         static let shoppingBagImageSize: CGFloat = 104
         static let scrollViewCoordinateSpaceIdentifier: String = "CartScrollView"
         static let cartEmptyViewSpacing: CGFloat = 40

--- a/WooCommerce/Classes/POS/Presentation/CartView.swift
+++ b/WooCommerce/Classes/POS/Presentation/CartView.swift
@@ -121,7 +121,8 @@ struct CartView: View {
                     EmptyView()
                 } else {
                     checkoutButton
-                        .padding(POSHeaderLayoutConstants.sectionHorizontalPadding)
+                        .padding(.horizontal, POSHeaderLayoutConstants.sectionHorizontalPadding)
+                        .padding(.top, Constants.checkoutButtonTopPadding)
                         .accessibilityAddTraits(.isHeader)
                 }
             case .finalizing:
@@ -169,6 +170,7 @@ private extension CartView {
         static let cartHeaderSpacing: CGFloat = 8
         static let backButtonSymbol: String = "chevron.backward"
         static let cartHeaderElementSpacing: CGFloat = 16
+        static let checkoutButtonTopPadding: CGFloat = 16
     }
 
     enum Localization {

--- a/WooCommerce/Classes/POS/Presentation/CartView.swift
+++ b/WooCommerce/Classes/POS/Presentation/CartView.swift
@@ -24,7 +24,6 @@ struct CartView: View {
             DynamicHStack(spacing: Constants.cartHeaderSpacing) {
                 HStack(spacing: Constants.cartHeaderElementSpacing) {
                     backAddMoreButton
-                        .padding(.top, Constants.headerPadding)
                         .disabled(viewModel.isAddMoreDisabled)
                         .shimmering(active: viewModel.isAddMoreDisabled)
 
@@ -43,7 +42,6 @@ struct CartView: View {
                         }
                     }
                     .accessibilityElement(children: .combine)
-                    .padding(.top, Constants.headerPadding)
                 }
 
                 HStack {
@@ -63,13 +61,12 @@ struct CartView: View {
                             )
                     }
                     .padding(.horizontal, Constants.itemHorizontalPadding)
-                    .padding(.top, Constants.headerPadding)
                     .renderedIf(cartViewModel.shouldShowClearCartButton)
                 }
             }
             .frame(maxWidth: .infinity, alignment: .leading)
             .padding(.horizontal, Constants.horizontalPadding)
-            .padding(.vertical, Constants.verticalPadding)
+            .padding(.vertical, POSHeaderLayoutConstants.posSectionTopPadding)
             .if(shouldApplyHeaderBottomShadow, transform: { $0.applyBottomShadow() })
 
             if cartViewModel.isCartEmpty {
@@ -168,13 +165,11 @@ private extension CartView {
         static let checkoutButtonPadding: CGFloat = 16
         static let itemHorizontalPadding: CGFloat = 8
         static let horizontalPadding: CGFloat = 16
-        static let verticalPadding: CGFloat = 8
         static let shoppingBagImageSize: CGFloat = 104
         static let scrollViewCoordinateSpaceIdentifier: String = "CartScrollView"
         static let cartEmptyViewSpacing: CGFloat = 40
         static let cartHeaderSpacing: CGFloat = 8
         static let backButtonSymbol: String = "chevron.backward"
-        static let headerPadding: CGFloat = 16
         static let cartHeaderElementSpacing: CGFloat = 16
     }
 

--- a/WooCommerce/Classes/POS/Presentation/CartView.swift
+++ b/WooCommerce/Classes/POS/Presentation/CartView.swift
@@ -60,7 +60,7 @@ struct CartView: View {
                                     .stroke(Color.init(uiColor: .wooCommercePurple(.shade60)), lineWidth: Constants.clearButtonBorderWidth)
                             )
                     }
-                    .padding(.horizontal, Constants.itemHorizontalPadding)
+                    .padding(.leading, Constants.itemHorizontalPadding)
                     .renderedIf(cartViewModel.shouldShowClearCartButton)
                 }
             }

--- a/WooCommerce/Classes/POS/Presentation/Reusable Views/POSHeaderLayoutConstants.swift
+++ b/WooCommerce/Classes/POS/Presentation/Reusable Views/POSHeaderLayoutConstants.swift
@@ -1,7 +1,6 @@
 import Foundation
 
 enum POSHeaderLayoutConstants {
-    static let sectionTopPadding: CGFloat = 24
-    static let sectionBottomPadding: CGFloat = 24
+    static let sectionVerticalPadding: CGFloat = 24
     static let sectionHorizontalPadding: CGFloat = 16
 }

--- a/WooCommerce/Classes/POS/Presentation/Reusable Views/POSHeaderLayoutConstants.swift
+++ b/WooCommerce/Classes/POS/Presentation/Reusable Views/POSHeaderLayoutConstants.swift
@@ -1,5 +1,7 @@
 import Foundation
 
 enum POSHeaderLayoutConstants {
-    static let posSectionTopPadding: CGFloat = 24
+    static let sectionTopPadding: CGFloat = 24
+    static let sectionBottomPadding: CGFloat = 24
+    static let sectionHorizontalPadding: CGFloat = 16
 }

--- a/WooCommerce/Classes/POS/Presentation/Reusable Views/POSHeaderLayoutConstants.swift
+++ b/WooCommerce/Classes/POS/Presentation/Reusable Views/POSHeaderLayoutConstants.swift
@@ -1,0 +1,5 @@
+import Foundation
+
+enum POSHeaderLayoutConstants {
+    static let posSectionTopPadding: CGFloat = 24
+}

--- a/WooCommerce/Classes/POS/Presentation/Reusable Views/POSHeaderTitleView.swift
+++ b/WooCommerce/Classes/POS/Presentation/Reusable Views/POSHeaderTitleView.swift
@@ -23,9 +23,9 @@ private extension POSHeaderTitleView {
     }
 
     enum Constants {
-        static let padding: EdgeInsets = .init(top: POSHeaderLayoutConstants.sectionTopPadding,
+        static let padding: EdgeInsets = .init(top: POSHeaderLayoutConstants.sectionVerticalPadding,
                                                leading: POSHeaderLayoutConstants.sectionHorizontalPadding,
-                                               bottom: POSHeaderLayoutConstants.sectionBottomPadding,
+                                               bottom: POSHeaderLayoutConstants.sectionVerticalPadding,
                                                trailing: POSHeaderLayoutConstants.sectionHorizontalPadding)
     }
 }

--- a/WooCommerce/Classes/POS/Presentation/Reusable Views/POSHeaderTitleView.swift
+++ b/WooCommerce/Classes/POS/Presentation/Reusable Views/POSHeaderTitleView.swift
@@ -23,10 +23,10 @@ private extension POSHeaderTitleView {
     }
 
     enum Constants {
-        static let padding: EdgeInsets = .init(top: POSHeaderLayoutConstants.posSectionTopPadding,
-                                               leading: 16,
-                                               bottom: 24,
-                                               trailing: 16)
+        static let padding: EdgeInsets = .init(top: POSHeaderLayoutConstants.sectionTopPadding,
+                                               leading: POSHeaderLayoutConstants.sectionHorizontalPadding,
+                                               bottom: POSHeaderLayoutConstants.sectionBottomPadding,
+                                               trailing: POSHeaderLayoutConstants.sectionHorizontalPadding)
     }
 }
 

--- a/WooCommerce/Classes/POS/Presentation/Reusable Views/POSHeaderTitleView.swift
+++ b/WooCommerce/Classes/POS/Presentation/Reusable Views/POSHeaderTitleView.swift
@@ -23,7 +23,7 @@ private extension POSHeaderTitleView {
     }
 
     enum Constants {
-        static let padding: EdgeInsets = .init(top: 24,
+        static let padding: EdgeInsets = .init(top: POSHeaderLayoutConstants.posSectionTopPadding,
                                                leading: 16,
                                                bottom: 24,
                                                trailing: 16)

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -1495,6 +1495,7 @@
 		683763182C2E497000AD51D0 /* ItemListViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 683763172C2E497000AD51D0 /* ItemListViewModelTests.swift */; };
 		6837631A2C2E6F5900AD51D0 /* CartViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 683763192C2E6F5900AD51D0 /* CartViewModelTests.swift */; };
 		6837631C2C2E847D00AD51D0 /* CartViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6837631B2C2E847D00AD51D0 /* CartViewModel.swift */; };
+		683988A72C7D82E70084B85A /* POSHeaderLayoutConstants.swift in Sources */ = {isa = PBXBuildFile; fileRef = 683988A62C7D82E60084B85A /* POSHeaderLayoutConstants.swift */; };
 		683AA9D62A303CB70099F7BA /* UpgradesViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 683AA9D52A303CB70099F7BA /* UpgradesViewModelTests.swift */; };
 		683DF5FF2C6AF46500A5CDC6 /* POSHeaderTitleView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 683DF5FE2C6AF46500A5CDC6 /* POSHeaderTitleView.swift */; };
 		684AB83A2870677F003DFDD1 /* CardReaderManualsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 684AB8392870677F003DFDD1 /* CardReaderManualsView.swift */; };
@@ -4469,6 +4470,7 @@
 		683763172C2E497000AD51D0 /* ItemListViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ItemListViewModelTests.swift; sourceTree = "<group>"; };
 		683763192C2E6F5900AD51D0 /* CartViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CartViewModelTests.swift; sourceTree = "<group>"; };
 		6837631B2C2E847D00AD51D0 /* CartViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CartViewModel.swift; sourceTree = "<group>"; };
+		683988A62C7D82E60084B85A /* POSHeaderLayoutConstants.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = POSHeaderLayoutConstants.swift; sourceTree = "<group>"; };
 		683AA9D52A303CB70099F7BA /* UpgradesViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UpgradesViewModelTests.swift; sourceTree = "<group>"; };
 		683DF5FE2C6AF46500A5CDC6 /* POSHeaderTitleView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = POSHeaderTitleView.swift; sourceTree = "<group>"; };
 		684AB8392870677F003DFDD1 /* CardReaderManualsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardReaderManualsView.swift; sourceTree = "<group>"; };
@@ -6070,6 +6072,7 @@
 				207823E62C5D346300025A59 /* POSPrimaryButtonStyle.swift */,
 				20D3D42E2C64F175004CE6E3 /* POSSecondaryButtonStyle.swift */,
 				20D3D4302C64F202004CE6E3 /* POSButtonStyleConstants.swift */,
+				683988A62C7D82E60084B85A /* POSHeaderLayoutConstants.swift */,
 				207823E82C5D3A1700025A59 /* POSErrorExclamationMark.swift */,
 				20ADE9402C6A02B700C91265 /* POSErrorXMark.swift */,
 				683DF5FE2C6AF46500A5CDC6 /* POSHeaderTitleView.swift */,
@@ -15914,6 +15917,7 @@
 				E10BD16D27CF890800CE6449 /* InPersonPaymentsCountryNotSupportedStripe.swift in Sources */,
 				68E674AB2A4DAB8C0034BA1E /* CompletedUpgradeView.swift in Sources */,
 				26F94E26267A559300DB6CCF /* ProductAddOn.swift in Sources */,
+				683988A72C7D82E70084B85A /* POSHeaderLayoutConstants.swift in Sources */,
 				4541D88A270718F6005A9E30 /* ShippingLabelCarriersSectionViewModel.swift in Sources */,
 				CE21FB262C2DB3A900303832 /* GoogleAdsCampaignReportCardViewModel.swift in Sources */,
 				77E53EBF2510C153003D385F /* ProductDownloadListViewModel.swift in Sources */,


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #13711
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
This PR addresses the initial creation of a shared layout `POSHeaderLayoutConstants` object for POS header view elements, so we can have a single source for constants. 

> Since this needs to be the same for CartView and ItemListView, perhaps it should be defined on a shared layout object?
At the moment, POSHeaderTitleView uses top padding 24, while the Cart title has verticalPadding = 8, applied on the DynamicHStack, and an additional top padding 16 on the individual views within the header.
You could neaten it up by having a shared posSectionTopPadding: CGFloat = 24, and applying that as the top padding for both the DynamicHStack here

It also fixes an existing top miss-alignment between items within the item selector to the left compared with items within the cart to the right:

| Before | After |
|--------|--------|
| ![Before 1](https://github.com/user-attachments/assets/7d27bae7-d14c-4cc0-8b23-dbb906e26514) | ![After 1](https://github.com/user-attachments/assets/1dbf9571-06a8-4fb7-84ac-01984a3306c1) | 

There are a couple of elements that we could simplify as well, but this may need some design feedback, for example:
- `CartView.clearButtonCornerRadius` = 4 vs `ItemListView.bannerCornerRadius` = 8. We could have the same corner radius for bordered elements, or just apply a multiplier when needed if these have to be different.
- `CartView.clearButtonTextPadding` = leading 24 vs `ItemListView.iconPadding` = trailing 26, there are minimal differences in some of the padding between views, so these could share the same values for simplicity.

Those small improvements can be tackled post-M2 as needed.

## Testing
- Run POS
- Add items to cart
- Observe the header elements within Item List and Cart View are still aligned appropriately.

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [x] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [ ] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [ ] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on all devices (phone/tablet) and no regressions are added.