### PR TITLE
[Woo POS] Add missing transitions to Totals View

### DIFF
--- a/WooCommerce/Classes/POS/Presentation/TotalsView.swift
+++ b/WooCommerce/Classes/POS/Presentation/TotalsView.swift
@@ -24,19 +24,20 @@ struct TotalsView: View {
             switch viewModel.orderState {
             case .idle, .syncing, .loaded:
                 VStack(alignment: .center) {
-                    filledSpacer(backgroundColor: cardReaderViewLayout.backgroundColor,
-                                 height: cardReaderViewLayout.topPadding)
+                    Spacer()
+                        .renderedIf(cardReaderViewLayout.topPadding == nil)
 
                     VStack(alignment: .center, spacing: Constants.verticalSpacing) {
                         if viewModel.isShowingCardReaderStatus {
                             cardReaderView
                                 .font(.title)
-                                .padding([.top, .leading, .trailing],
+                                .padding([.leading, .trailing],
                                          dynamicTypeSize.isAccessibilitySize ? nil :
                                             cardReaderViewLayout.sidePadding)
                                 .padding(.bottom,
                                          dynamicTypeSize.isAccessibilitySize ? nil :
                                             cardReaderViewLayout.bottomPadding)
+                                .padding(.top, dynamicTypeSize.isAccessibilitySize ? nil : cardReaderViewLayout.topPadding)
                                 .transition(.opacity)
                                 .background(cardReaderViewLayout.backgroundColor)
                                 .accessibilityShowsLargeContentViewer()
@@ -266,17 +267,6 @@ private extension TotalsView {
             topPadding: 40,
             bottomPadding: 40
         )
-    }
-
-    /// Creates a Spacer with backgroundColor and optional fixed height
-    private func filledSpacer(backgroundColor: Color = .clear, height: CGFloat? = nil) -> some View {
-        return ZStack {
-            Spacer()
-        }
-        .background(backgroundColor)
-        .if(height != nil) {
-            $0.frame(height: height)
-        }
     }
 
     private var cardReaderViewLayout: CardReaderViewLayout {

--- a/WooCommerce/Classes/POS/Presentation/TotalsView.swift
+++ b/WooCommerce/Classes/POS/Presentation/TotalsView.swift
@@ -69,6 +69,7 @@ struct TotalsView: View {
             viewModel.onTotalsViewDisappearance()
         }
         .onChange(of: viewModel.isShowingTotalsFields, perform: hideTotalsFieldsWithDelay)
+        .geometryGroupIfSupported()
     }
 
     private var backgroundColor: Color {
@@ -354,6 +355,20 @@ private extension TotalsView {
             "pos.totalsView.calculateAmounts",
             value: "Calculate amounts",
             comment: "Button title for calculate amounts button")
+    }
+}
+
+private extension View {
+    ///  Force the position and size values to be resolved and animated by the parent
+    ///  before being passed down to each subview.
+    ///  GeometryGroup is created to ensure that childs views stay locked together as animations are applied.
+    ///  It results in the whole TotalsView animated together when transitioning.
+    func geometryGroupIfSupported() -> some View {
+        if #available(iOS 17.0, *) {
+            return self.geometryGroup()
+        } else {
+            return self
+        }
     }
 }
 


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #13747, #13750
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

This PR addresses two animations:

1. https://github.com/woocommerce/woocommerce-ios/issues/13750, previously I implemented a fixed-height spacer to support different totals view layouts, when the card reader view doesn't need to be centered. However, that was a bad solution that prevented from making quality animations. I made a change so we would either conditionally set `topPadding` on `cardReaderView` or insert `Spacer`. It's far more straightforward solution that I haven't thought about before.

2. Check out: the transition between `.building` and `.finalizing` order states

`TotalsView` contains a lot of animations and transitions which work independently when transitioning to `TotalsView`. The issues can be seen in this slow-motion video:

https://github.com/user-attachments/assets/444188af-0018-4b78-940b-e07b227b860b

The solution I found to be designed perfectly for this issue is [geometryGroup()](https://developer.apple.com/documentation/swiftui/view/geometrygroup()) modifier. According to documentation:

>  A group acts as a barrier between the parent view and its subviews, forcing the position and size values to be resolved and animated by the parent, before being passed down to each subview.

> ...the group ensures that they (child views) stay locked together as animations are applied.

However, this modifier is only available from iOS 17 but given Woo POS is a new solution, and the amount of time that `geometryGroup` saves, I think it's a good compromise.

## Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->

### Reader disconnected

1. Open POS
2. Do not connect the reader
3. Add item
4. Checkout
5. Confirm a view transitions properly to Reader disconnected state

### Error checking order

1. Open POS
2. Connect the reader
3. Add item with price less than $0.5
4. Checkout
5. Confirm a view transitions properly to Error checking order state without gaps in the background https://github.com/woocommerce/woocommerce-ios/issues/13750

### Check out transitions

Transition back and worth between order building and finalizing states. Confirm that TotalsView stays together and solid during the transitions.

## Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->

No unit tests, the changes are purely UI-related.

Additionally, I tested for regressions:
- Success payment flow
- Failed payment flow
- Large dynamic type sizes with recent Totals View changes

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

### Reader Disconnected (a state with fixed top padding)

https://github.com/user-attachments/assets/adb3aff2-2932-493f-add3-b6a834fb2908

### Error Checking Order (a state with fixed top padding)

https://github.com/user-attachments/assets/fc8b5319-8eea-4cbd-9533-c9ecc9cc6e31

### Check out: Slow motion transition

https://github.com/user-attachments/assets/db332bb6-f506-4c09-be8b-c1dce41b6044

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [x] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [x] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [x] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on all devices (phone/tablet) and no regressions are added.