### PR TITLE
[Products] Remove product bundles feature flag

### DIFF
--- a/Experiments/Experiments/DefaultFeatureFlagService.swift
+++ b/Experiments/Experiments/DefaultFeatureFlagService.swift
@@ -42,8 +42,6 @@ public struct DefaultFeatureFlagService: FeatureFlagService {
             return true
         case .jetpackSetupWithApplicationPassword:
             return true
-        case .productBundles:
-            return true
         case .manualErrorHandlingForSiteCredentialLogin:
             return true
         case .compositeProducts:

--- a/Experiments/Experiments/FeatureFlag.swift
+++ b/Experiments/Experiments/FeatureFlag.swift
@@ -100,10 +100,6 @@ public enum FeatureFlag: Int {
     ///
     case addProductToOrderViaSKUScanner
 
-    /// Whether to enable product bundle settings in product details
-    ///
-    case productBundles
-
     /// Enables manual error handling for site credential login.
     ///
     case manualErrorHandlingForSiteCredentialLogin

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormActionsFactory.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormActionsFactory.swift
@@ -71,7 +71,6 @@ struct ProductFormActionsFactory: ProductFormActionsFactoryProtocol {
         .init(analytics: ServiceLocator.analytics,
               configuration: linkedProductsPromoCampaign.configuration)
     }
-    private let isBundledProductsEnabled: Bool
     private let isCompositeProductsEnabled: Bool
     private let isMinMaxQuantitiesEnabled: Bool
     private let isCustomFieldsEnabled: Bool
@@ -82,7 +81,6 @@ struct ProductFormActionsFactory: ProductFormActionsFactoryProtocol {
          canPromoteWithBlaze: Bool = false,
          addOnsFeatureEnabled: Bool = true,
          isLinkedProductsPromoEnabled: Bool = false,
-         isBundledProductsEnabled: Bool = ServiceLocator.featureFlagService.isFeatureFlagEnabled(.productBundles),
          isCompositeProductsEnabled: Bool = ServiceLocator.featureFlagService.isFeatureFlagEnabled(.compositeProducts),
          isMinMaxQuantitiesEnabled: Bool = ServiceLocator.featureFlagService.isFeatureFlagEnabled(.readOnlyMinMaxQuantities),
          isCustomFieldsEnabled: Bool =
@@ -96,7 +94,6 @@ struct ProductFormActionsFactory: ProductFormActionsFactoryProtocol {
         self.addOnsFeatureEnabled = addOnsFeatureEnabled
         self.variationsPrice = variationsPrice
         self.isLinkedProductsPromoEnabled = isLinkedProductsPromoEnabled
-        self.isBundledProductsEnabled = isBundledProductsEnabled
         self.isCompositeProductsEnabled = isCompositeProductsEnabled
         self.isMinMaxQuantitiesEnabled = isMinMaxQuantitiesEnabled
         self.isCustomFieldsEnabled = isCustomFieldsEnabled
@@ -272,14 +269,13 @@ private extension ProductFormActionsFactory {
     }
 
     func allSettingsSectionActionsForBundleProduct() -> [ProductFormEditAction] {
-        let shouldShowBundledProductsRow = isBundledProductsEnabled
         let canOpenBundledProducts = product.bundledItems.isNotEmpty
         let shouldShowPriceSettingsRow = product.regularPrice.isNilOrEmpty == false
         let shouldShowReviewsRow = product.reviewsAllowed
         let shouldShowQuantityRulesRow = isMinMaxQuantitiesEnabled && product.canEditQuantityRules
 
         let actions: [ProductFormEditAction?] = [
-            shouldShowBundledProductsRow ? .bundledProducts(actionable: canOpenBundledProducts) : nil,
+            .bundledProducts(actionable: canOpenBundledProducts),
             shouldShowPriceSettingsRow ? .priceSettings(editable: false, hideSeparator: false): nil,
             shouldShowReviewsRow ? .reviews: nil,
             .inventorySettings(editable: false),

--- a/WooCommerce/Classes/ViewRelated/Products/ProductSelector/ProductRowViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductSelector/ProductRowViewModel.swift
@@ -378,12 +378,10 @@ final class ProductRowViewModel: ObservableObject, Identifiable {
             price = product.price
         }
 
-        let productBundlesEnabled = featureFlagService.isFeatureFlagEnabled(.productBundles)
-
         // If product is a product bundle with insufficient bundle stock, use that as the product stock status.
         let stockStatusKey: String = {
-            switch (productBundlesEnabled, product.productType, product.bundleStockStatus) {
-            case (true, .bundle, .insufficientStock):
+            switch (product.productType, product.bundleStockStatus) {
+            case (.bundle, .insufficientStock):
                 return ProductStockStatus.insufficientStock.rawValue
             default:
                 return product.stockStatusKey
@@ -392,8 +390,8 @@ final class ProductRowViewModel: ObservableObject, Identifiable {
 
         // If product is a product bundle with a bundle stock quantity, use that as the product stock quantity.
         let stockQuantity: Decimal? = {
-            switch (productBundlesEnabled, product.productType, product.bundleStockQuantity) {
-            case (true, .bundle, .some(let bundleStockQuantity)):
+            switch (product.productType, product.bundleStockQuantity) {
+            case (.bundle, .some(let bundleStockQuantity)):
                 return Decimal(bundleStockQuantity)
             default:
                 return product.stockQuantity
@@ -402,8 +400,8 @@ final class ProductRowViewModel: ObservableObject, Identifiable {
 
         // If product is a product bundle with a bundle stock quantity, override product `manageStock` setting.
         let manageStock: Bool = {
-            switch (productBundlesEnabled, product.productType, product.bundleStockQuantity) {
-            case (true, .bundle, .some):
+            switch (product.productType, product.bundleStockQuantity) {
+            case (.bundle, .some):
                 return true
             default:
                 return product.manageStock

--- a/WooCommerce/Classes/ViewRelated/Products/View Models/ProductFormDataModel+ProductsTabProductViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/View Models/ProductFormDataModel+ProductsTabProductViewModel.swift
@@ -3,8 +3,8 @@ import Foundation
 /// Helpers for `ProductsTabProductViewModel` from `ProductFormDataModel`.
 extension ProductFormDataModel {
     /// Create a description text based on a product data model's stock status/quantity.
-    func createStockText(productBundlesEnabled: Bool = ServiceLocator.featureFlagService.isFeatureFlagEnabled(.productBundles)) -> String {
-        if productBundlesEnabled && productType == .bundle {
+    func createStockText() -> String {
+        if productType == .bundle {
             return createProductBundleStockText()
         }
 

--- a/WooCommerce/Classes/ViewRelated/Products/View Models/ProductsTabProductViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/View Models/ProductsTabProductViewModel.swift
@@ -34,16 +34,14 @@ struct ProductsTabProductViewModel {
          isSelected: Bool = false,
          isDraggable: Bool = false,
          isSKUShown: Bool = false,
-         imageService: ImageService = ServiceLocator.imageService,
-         productBundlesEnabled: Bool = ServiceLocator.featureFlagService.isFeatureFlagEnabled(.productBundles)) {
+         imageService: ImageService = ServiceLocator.imageService) {
 
         imageUrl = product.images.first?.src
         name = product.name.isEmpty ? Localization.noTitle : product.name
         self.productVariation = productVariation
         self.isSelected = isSelected
         self.isDraggable = isDraggable
-        detailsAttributedString = EditableProductModel(product: product).createDetailsAttributedString(isSKUShown: isSKUShown,
-                                                                                                       productBundlesEnabled: productBundlesEnabled)
+        detailsAttributedString = EditableProductModel(product: product).createDetailsAttributedString(isSKUShown: isSKUShown)
 
         self.imageService = imageService
     }
@@ -62,9 +60,9 @@ struct ProductsTabProductViewModel {
 }
 
 private extension EditableProductModel {
-    func createDetailsAttributedString(isSKUShown: Bool, productBundlesEnabled: Bool) -> NSAttributedString {
+    func createDetailsAttributedString(isSKUShown: Bool) -> NSAttributedString {
         let statusText = createStatusText()
-        let stockText = createStockText(productBundlesEnabled: productBundlesEnabled)
+        let stockText = createStockText()
         let variationsText = createVariationsText()
 
         let detailsText = [statusText, stockText, variationsText]

--- a/WooCommerce/WooCommerceTests/Mocks/MockFeatureFlagService.swift
+++ b/WooCommerce/WooCommerceTests/Mocks/MockFeatureFlagService.swift
@@ -11,7 +11,6 @@ struct MockFeatureFlagService: FeatureFlagService {
     private let jetpackSetupWithApplicationPassword: Bool
     private let isReadOnlyGiftCardsEnabled: Bool
     private let betterCustomerSelectionInOrder: Bool
-    private let productBundles: Bool
     private let productBundlesInOrderForm: Bool
     private let isScanToUpdateInventoryEnabled: Bool
     private let isBackendReceiptsEnabled: Bool
@@ -31,7 +30,6 @@ struct MockFeatureFlagService: FeatureFlagService {
          jetpackSetupWithApplicationPassword: Bool = false,
          isReadOnlyGiftCardsEnabled: Bool = false,
          betterCustomerSelectionInOrder: Bool = false,
-         productBundles: Bool = false,
          productBundlesInOrderForm: Bool = false,
          isScanToUpdateInventoryEnabled: Bool = false,
          isBackendReceiptsEnabled: Bool = false,
@@ -50,7 +48,6 @@ struct MockFeatureFlagService: FeatureFlagService {
         self.jetpackSetupWithApplicationPassword = jetpackSetupWithApplicationPassword
         self.isReadOnlyGiftCardsEnabled = isReadOnlyGiftCardsEnabled
         self.betterCustomerSelectionInOrder = betterCustomerSelectionInOrder
-        self.productBundles = productBundles
         self.productBundlesInOrderForm = productBundlesInOrderForm
         self.isScanToUpdateInventoryEnabled = isScanToUpdateInventoryEnabled
         self.isBackendReceiptsEnabled = isBackendReceiptsEnabled
@@ -82,8 +79,6 @@ struct MockFeatureFlagService: FeatureFlagService {
             return isReadOnlyGiftCardsEnabled
         case .betterCustomerSelectionInOrder:
             return betterCustomerSelectionInOrder
-        case .productBundles:
-            return productBundles
         case .productBundlesInOrderForm:
             return productBundlesInOrderForm
         case .scanToUpdateInventory:

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/ProductRowViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Creation/ProductRowViewModelTests.swift
@@ -284,27 +284,12 @@ final class ProductRowViewModelTests: XCTestCase {
         XCTAssertEqual(viewModel.productAccessibilityLabel, expectedLabel)
     }
 
-    func test_product_stock_status_used_for_product_bundles_when_feature_flag_disabled() {
+    func test_bundle_stock_status_used_for_product_bundles_when_insufficient_stock() {
         // Given
         let product = Product.fake().copy(productTypeKey: "bundle", stockStatusKey: "instock", bundleStockStatus: .insufficientStock)
 
         // When
-        let viewModel = ProductRowViewModel(product: product,
-                                            featureFlagService: createFeatureFlagService(productBundles: false))
-
-        // Then
-        let expectedStockText = ProductStockStatus.inStock.description
-        XCTAssertTrue(viewModel.productDetailsLabel.contains(expectedStockText),
-                      "Expected label to contain \"\(expectedStockText)\" but actual label was \"\(viewModel.productDetailsLabel)\"")
-    }
-
-    func test_bundle_stock_status_used_for_product_bundles_when_insufficient_stock_and_feature_flag_enabled() {
-        // Given
-        let product = Product.fake().copy(productTypeKey: "bundle", stockStatusKey: "instock", bundleStockStatus: .insufficientStock)
-
-        // When
-        let viewModel = ProductRowViewModel(product: product,
-                                            featureFlagService: createFeatureFlagService())
+        let viewModel = ProductRowViewModel(product: product)
 
         // Then
         let expectedStockText = ProductStockStatus.insufficientStock.description
@@ -312,13 +297,12 @@ final class ProductRowViewModelTests: XCTestCase {
                       "Expected label to contain \"\(expectedStockText)\" but actual label was \"\(viewModel.productDetailsLabel)\"")
     }
 
-    func test_product_stock_status_used_for_product_bundles_when_backordered_and_feature_flag_enabled() {
+    func test_product_stock_status_used_for_product_bundles_when_backordered() {
         // Given
         let product = Product.fake().copy(productTypeKey: "bundle", stockStatusKey: "onbackorder", bundleStockStatus: .inStock)
 
         // When
-        let viewModel = ProductRowViewModel(product: product,
-                                            featureFlagService: createFeatureFlagService())
+        let viewModel = ProductRowViewModel(product: product)
 
         // Then
         let expectedStockText = ProductStockStatus.onBackOrder.description
@@ -326,29 +310,12 @@ final class ProductRowViewModelTests: XCTestCase {
                       "Expected label to contain \"\(expectedStockText)\" but actual label was \"\(viewModel.productDetailsLabel)\"")
     }
 
-    func test_product_stock_quantity_used_for_product_bundles_when_feature_flag_disabled() {
-        // Given
-        let product = Product.fake().copy(productTypeKey: "bundle", manageStock: true, stockQuantity: 5, stockStatusKey: "instock", bundleStockQuantity: 1)
-
-        // When
-        let viewModel = ProductRowViewModel(product: product,
-                                            featureFlagService: createFeatureFlagService(productBundles: false))
-
-        // Then
-        let localizedStockQuantity = NumberFormatter.localizedString(from: 5 as NSDecimalNumber, number: .decimal)
-        let format = NSLocalizedString("%1$@ in stock", comment: "Label about product's inventory stock status shown during order creation")
-        let expectedStockLabel = String.localizedStringWithFormat(format, localizedStockQuantity)
-        XCTAssertTrue(viewModel.productDetailsLabel.contains(expectedStockLabel),
-                      "Expected label to contain \"\(expectedStockLabel)\" but actual label was \"\(viewModel.productDetailsLabel)\"")
-    }
-
-    func test_bundle_stock_quantity_used_for_product_bundles_when_feature_flag_enabled() {
+    func test_bundle_stock_quantity_used_for_product_bundles() {
         // Given
         let product = Product.fake().copy(productTypeKey: "bundle", manageStock: false, stockQuantity: 5, stockStatusKey: "instock", bundleStockQuantity: 1)
 
         // When
-        let viewModel = ProductRowViewModel(product: product,
-                                            featureFlagService: createFeatureFlagService())
+        let viewModel = ProductRowViewModel(product: product)
 
         // Then
         let localizedStockQuantity = NumberFormatter.localizedString(from: 1 as NSDecimalNumber, number: .decimal)
@@ -655,8 +622,8 @@ final class ProductRowViewModelTests: XCTestCase {
 }
 
 private extension ProductRowViewModelTests {
-    func createFeatureFlagService(productBundles: Bool = true, productBundlesInOrderForm: Bool = false) -> FeatureFlagService {
-        MockFeatureFlagService(productBundles: productBundles, productBundlesInOrderForm: productBundlesInOrderForm)
+    func createFeatureFlagService(productBundlesInOrderForm: Bool = false) -> FeatureFlagService {
+        MockFeatureFlagService(productBundlesInOrderForm: productBundlesInOrderForm)
     }
 
     func createFakeSubscription(price: String? = "5",

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/Actions Factory/ProductFormActionsFactory+ProductCreationTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/Actions Factory/ProductFormActionsFactory+ProductCreationTests.swift
@@ -64,7 +64,6 @@ private extension ProductFormActionsFactory_ProductCreationTests {
                                    formType: ProductFormType,
                                    addOnsFeatureEnabled: Bool = false,
                                    isLinkedProductsPromoEnabled: Bool = false,
-                                   isBundledProductsEnabled: Bool = false,
                                    isCompositeProductsEnabled: Bool = false,
                                    isMinMaxQuantitiesEnabled: Bool = false,
                                    variationsPrice: ProductFormActionsFactory.VariationsPrice = .unknown) -> ProductFormActionsFactory {
@@ -72,7 +71,6 @@ private extension ProductFormActionsFactory_ProductCreationTests {
                                       formType: formType,
                                       addOnsFeatureEnabled: addOnsFeatureEnabled,
                                       isLinkedProductsPromoEnabled: isLinkedProductsPromoEnabled,
-                                      isBundledProductsEnabled: isBundledProductsEnabled,
                                       isCompositeProductsEnabled: isCompositeProductsEnabled,
                                       isMinMaxQuantitiesEnabled: isMinMaxQuantitiesEnabled,
                                       variationsPrice: variationsPrice)

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/Actions Factory/ProductFormActionsFactoryTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/Actions Factory/ProductFormActionsFactoryTests.swift
@@ -30,7 +30,7 @@ final class ProductFormActionsFactoryTests: XCTestCase {
                                                                        .shortDescription(editable: true),
                                                                        .linkedProducts(editable: true),
                                                                        .productType(editable: true)]
-        XCTAssertEqual(factory.settingsSectionActions(), expectedSettingsSectionActions)
+        assertEqual(expectedSettingsSectionActions, factory.settingsSectionActions())
 
         let expectedBottomSheetActions: [ProductFormBottomSheetAction] = [.editDownloadableFiles]
         XCTAssertEqual(factory.bottomSheetActions(), expectedBottomSheetActions)
@@ -59,7 +59,7 @@ final class ProductFormActionsFactoryTests: XCTestCase {
                                                                        .shortDescription(editable: true),
                                                                        .linkedProducts(editable: true),
                                                                        .productType(editable: true)]
-        XCTAssertEqual(factory.settingsSectionActions(), expectedSettingsSectionActions)
+        assertEqual(expectedSettingsSectionActions, factory.settingsSectionActions())
 
         let expectedBottomSheetActions: [ProductFormBottomSheetAction] = [.editDownloadableFiles]
         XCTAssertEqual(factory.bottomSheetActions(), expectedBottomSheetActions)
@@ -87,7 +87,7 @@ final class ProductFormActionsFactoryTests: XCTestCase {
                                                                        .shortDescription(editable: true),
                                                                        .linkedProducts(editable: true),
                                                                        .productType(editable: true)]
-        XCTAssertEqual(factory.settingsSectionActions(), expectedSettingsSectionActions)
+        assertEqual(expectedSettingsSectionActions, factory.settingsSectionActions())
 
         let expectedBottomSheetActions: [ProductFormBottomSheetAction] = [.editDownloadableFiles]
         XCTAssertEqual(factory.bottomSheetActions(), expectedBottomSheetActions)
@@ -114,7 +114,7 @@ final class ProductFormActionsFactoryTests: XCTestCase {
                                                                        .tags(editable: true),
                                                                        .shortDescription(editable: true),
                                                                        .productType(editable: true)]
-        XCTAssertEqual(factory.settingsSectionActions(), expectedSettingsSectionActions)
+        assertEqual(expectedSettingsSectionActions, factory.settingsSectionActions())
 
         let expectedBottomSheetActions: [ProductFormBottomSheetAction] = [.editDownloadableFiles, .editLinkedProducts]
         XCTAssertEqual(factory.bottomSheetActions(), expectedBottomSheetActions)
@@ -143,7 +143,7 @@ final class ProductFormActionsFactoryTests: XCTestCase {
                                                                        .shortDescription(editable: true),
                                                                        .linkedProducts(editable: true),
                                                                        .productType(editable: true)]
-        XCTAssertEqual(factory.settingsSectionActions(), expectedSettingsSectionActions)
+        assertEqual(expectedSettingsSectionActions, factory.settingsSectionActions())
 
         let expectedBottomSheetActions: [ProductFormBottomSheetAction] = [.editDownloadableFiles]
         XCTAssertEqual(factory.bottomSheetActions(), expectedBottomSheetActions)
@@ -171,7 +171,7 @@ final class ProductFormActionsFactoryTests: XCTestCase {
                                                                        .shortDescription(editable: true),
                                                                        .linkedProducts(editable: true),
                                                                        .productType(editable: true)]
-        XCTAssertEqual(factory.settingsSectionActions(), expectedSettingsSectionActions)
+        assertEqual(expectedSettingsSectionActions, factory.settingsSectionActions())
 
         let expectedBottomSheetActions: [ProductFormBottomSheetAction] = [.editDownloadableFiles]
         XCTAssertEqual(factory.bottomSheetActions(), expectedBottomSheetActions)
@@ -200,7 +200,7 @@ final class ProductFormActionsFactoryTests: XCTestCase {
                                                                        .shortDescription(editable: true),
                                                                        .linkedProducts(editable: true),
                                                                        .productType(editable: true)]
-        XCTAssertEqual(factory.settingsSectionActions(), expectedSettingsSectionActions)
+        assertEqual(expectedSettingsSectionActions, factory.settingsSectionActions())
 
         let expectedBottomSheetActions: [ProductFormBottomSheetAction] = []
         XCTAssertEqual(factory.bottomSheetActions(), expectedBottomSheetActions)
@@ -229,7 +229,7 @@ final class ProductFormActionsFactoryTests: XCTestCase {
                                                                        .shortDescription(editable: true),
                                                                        .linkedProducts(editable: true),
                                                                        .productType(editable: true)]
-        XCTAssertEqual(factory.settingsSectionActions(), expectedSettingsSectionActions)
+        assertEqual(expectedSettingsSectionActions, factory.settingsSectionActions())
 
         let expectedBottomSheetActions: [ProductFormBottomSheetAction] = []
         XCTAssertEqual(factory.bottomSheetActions(), expectedBottomSheetActions)
@@ -257,7 +257,7 @@ final class ProductFormActionsFactoryTests: XCTestCase {
                                                                        .shortDescription(editable: true),
                                                                        .linkedProducts(editable: true),
                                                                        .productType(editable: true)]
-        XCTAssertEqual(factory.settingsSectionActions(), expectedSettingsSectionActions)
+        assertEqual(expectedSettingsSectionActions, factory.settingsSectionActions())
 
         let expectedBottomSheetActions: [ProductFormBottomSheetAction] = [.editDownloadableFiles]
         XCTAssertEqual(factory.bottomSheetActions(), expectedBottomSheetActions)
@@ -559,37 +559,13 @@ final class ProductFormActionsFactoryTests: XCTestCase {
         XCTAssertTrue(containsAttributeAction)
     }
 
-    func test_view_model_for_bundle_product_with_feature_flag_disabled() {
+    func test_view_model_for_bundle_product_without_price_or_bundled_items() {
         // Arrange
         let product = Fixtures.bundleProduct
         let model = EditableProductModel(product: product)
 
         // Action
-        let factory = Fixtures.actionsFactory(product: model, formType: .edit, isBundledProductsEnabled: false)
-
-        // Assert
-        let expectedPrimarySectionActions: [ProductFormEditAction] = [.images(editable: true, isStorePublic: true),
-                                                                      .name(editable: true),
-                                                                      .description(editable: true)]
-        assertEqual(expectedPrimarySectionActions, factory.primarySectionActions())
-
-        let expectedSettingsSectionActions: [ProductFormEditAction] = [.reviews,
-                                                                       .inventorySettings(editable: false),
-                                                                       .linkedProducts(editable: true),
-                                                                       .productType(editable: false)]
-        assertEqual(expectedSettingsSectionActions, factory.settingsSectionActions())
-
-        let expectedBottomSheetActions: [ProductFormBottomSheetAction] = [.editCategories, .editTags, .editShortDescription]
-        assertEqual(expectedBottomSheetActions, factory.bottomSheetActions())
-    }
-
-    func test_view_model_for_bundle_product_without_price_or_bundled_items_with_feature_flag_enabled() {
-        // Arrange
-        let product = Fixtures.bundleProduct
-        let model = EditableProductModel(product: product)
-
-        // Action
-        let factory = Fixtures.actionsFactory(product: model, formType: .edit, isBundledProductsEnabled: true)
+        let factory = Fixtures.actionsFactory(product: model, formType: .edit)
 
         // Assert
         let expectedPrimarySectionActions: [ProductFormEditAction] = [.images(editable: true, isStorePublic: true),
@@ -608,13 +584,13 @@ final class ProductFormActionsFactoryTests: XCTestCase {
         assertEqual(expectedBottomSheetActions, factory.bottomSheetActions())
     }
 
-    func test_view_model_for_bundle_product_with_price_and_bundled_items_with_feature_flag_enabled() {
+    func test_view_model_for_bundle_product_with_price_and_bundled_items() {
         // Arrange
         let product = Fixtures.bundleProduct.copy(regularPrice: "2", bundledItems: [.fake()])
         let model = EditableProductModel(product: product)
 
         // Action
-        let factory = Fixtures.actionsFactory(product: model, formType: .edit, isBundledProductsEnabled: true)
+        let factory = Fixtures.actionsFactory(product: model, formType: .edit)
 
         // Assert
         let expectedPrimarySectionActions: [ProductFormEditAction] = [.images(editable: true, isStorePublic: true),
@@ -1045,7 +1021,6 @@ private extension ProductFormActionsFactoryTests {
                                    formType: ProductFormType,
                                    addOnsFeatureEnabled: Bool = false,
                                    isLinkedProductsPromoEnabled: Bool = false,
-                                   isBundledProductsEnabled: Bool = false,
                                    isCompositeProductsEnabled: Bool = false,
                                    isMinMaxQuantitiesEnabled: Bool = false,
                                    variationsPrice: ProductFormActionsFactory.VariationsPrice = .unknown) -> ProductFormActionsFactory {
@@ -1053,7 +1028,6 @@ private extension ProductFormActionsFactoryTests {
                                       formType: formType,
                                       addOnsFeatureEnabled: addOnsFeatureEnabled,
                                       isLinkedProductsPromoEnabled: isLinkedProductsPromoEnabled,
-                                      isBundledProductsEnabled: isBundledProductsEnabled,
                                       isCompositeProductsEnabled: isCompositeProductsEnabled,
                                       isMinMaxQuantitiesEnabled: isMinMaxQuantitiesEnabled,
                                       variationsPrice: variationsPrice)

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/Actions Factory/ProductFormActionsFactoryTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/Actions Factory/ProductFormActionsFactoryTests.swift
@@ -1023,6 +1023,7 @@ private extension ProductFormActionsFactoryTests {
                                    isLinkedProductsPromoEnabled: Bool = false,
                                    isCompositeProductsEnabled: Bool = false,
                                    isMinMaxQuantitiesEnabled: Bool = false,
+                                   isCustomFieldsEnabled: Bool = false,
                                    variationsPrice: ProductFormActionsFactory.VariationsPrice = .unknown) -> ProductFormActionsFactory {
             ProductFormActionsFactory(product: product,
                                       formType: formType,
@@ -1030,6 +1031,7 @@ private extension ProductFormActionsFactoryTests {
                                       isLinkedProductsPromoEnabled: isLinkedProductsPromoEnabled,
                                       isCompositeProductsEnabled: isCompositeProductsEnabled,
                                       isMinMaxQuantitiesEnabled: isMinMaxQuantitiesEnabled,
+                                      isCustomFieldsEnabled: isCustomFieldsEnabled,
                                       variationsPrice: variationsPrice)
         }
     }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/ProductsTabProductViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/ProductsTabProductViewModelTests.swift
@@ -121,7 +121,7 @@ final class ProductsTabProductViewModelTests: XCTestCase {
         XCTAssertFalse(detailsText.contains(skuText))
     }
 
-    func test_details_for_product_bundle_contain_bundle_stock_status_when_bundle_not_in_stock_and_feature_flag_enabled() {
+    func test_details_for_product_bundle_contain_bundle_stock_status_when_bundle_not_in_stock() {
         // Given
         let product = Product.fake().copy(productTypeKey: "bundle",
                                           manageStock: false,
@@ -131,7 +131,7 @@ final class ProductsTabProductViewModelTests: XCTestCase {
                                           bundleStockQuantity: 0)
 
         // When
-        let viewModel = ProductsTabProductViewModel(product: product, productBundlesEnabled: true)
+        let viewModel = ProductsTabProductViewModel(product: product)
         let detailsText = viewModel.detailsAttributedString.string
 
         // Then
@@ -140,7 +140,7 @@ final class ProductsTabProductViewModelTests: XCTestCase {
                       "Expected details text to include \(expectedStockText) but it was \(detailsText) instead")
     }
 
-    func test_details_for_product_bundle_contain_product_stock_status_when_product_is_backordered_and_feature_flag_enabled() {
+    func test_details_for_product_bundle_contain_product_stock_status_when_product_is_backordered() {
         // Given
         let product = Product.fake().copy(productTypeKey: "bundle",
                                           manageStock: false,
@@ -150,7 +150,7 @@ final class ProductsTabProductViewModelTests: XCTestCase {
                                           bundleStockQuantity: 0)
 
         // When
-        let viewModel = ProductsTabProductViewModel(product: product, productBundlesEnabled: true)
+        let viewModel = ProductsTabProductViewModel(product: product)
         let detailsText = viewModel.detailsAttributedString.string
 
         // Then
@@ -159,25 +159,7 @@ final class ProductsTabProductViewModelTests: XCTestCase {
                       "Expected details text to include \(expectedStockText) but it was \(detailsText) instead")
     }
 
-    func test_details_for_product_bundle_contain_product_stock_status_when_bundle_not_in_stock_and_feature_flag_disabled() {
-        // Given
-        let product = Product.fake().copy(productTypeKey: "bundle",
-                                          manageStock: false,
-                                          stockQuantity: 5,
-                                          stockStatusKey: "instock",
-                                          bundleStockStatus: .insufficientStock,
-                                          bundleStockQuantity: 0)
-
-        // When
-        let viewModel = ProductsTabProductViewModel(product: product, productBundlesEnabled: false)
-        let detailsText = viewModel.detailsAttributedString.string
-
-        // Then
-        let expectedStockText = ProductStockStatus.inStock.description
-        XCTAssertTrue(detailsText.contains(expectedStockText))
-    }
-
-    func test_details_for_product_bundle_contain_stock_status_with_bundle_stock_quantity_when_quantity_is_set_and_feature_flag_enabled() {
+    func test_details_for_product_bundle_contain_stock_status_with_bundle_stock_quantity_when_quantity_is_set() {
         // Arrange
         let product = Product.fake().copy(productTypeKey: "bundle",
                                           manageStock: false,
@@ -187,7 +169,7 @@ final class ProductsTabProductViewModelTests: XCTestCase {
                                           bundleStockQuantity: 1)
 
         // Action
-        let viewModel = ProductsTabProductViewModel(product: product, productBundlesEnabled: true)
+        let viewModel = ProductsTabProductViewModel(product: product)
         let detailsText = viewModel.detailsAttributedString.string
 
         // Assert
@@ -197,7 +179,7 @@ final class ProductsTabProductViewModelTests: XCTestCase {
         XCTAssertTrue(detailsText.contains(expectedStockDetail))
     }
 
-    func test_details_for_product_bundle_contain_stock_status_with_bundle_stock_quantity_when_manageStock_enabled_and_feature_flag_enabled() {
+    func test_details_for_product_bundle_contain_stock_status_with_bundle_stock_quantity_when_manageStock_enabled() {
         // Arrange
         let product = Product.fake().copy(productTypeKey: "bundle",
                                           manageStock: true,
@@ -207,31 +189,11 @@ final class ProductsTabProductViewModelTests: XCTestCase {
                                           bundleStockQuantity: 1)
 
         // Action
-        let viewModel = ProductsTabProductViewModel(product: product, productBundlesEnabled: true)
+        let viewModel = ProductsTabProductViewModel(product: product)
         let detailsText = viewModel.detailsAttributedString.string
 
         // Assert
         let localizedStockQuantity = NumberFormatter.localizedString(from: 1 as NSNumber, number: .decimal)
-        let format = NSLocalizedString("%1$@ in stock", comment: "Label about product's inventory stock status shown on Products tab")
-        let expectedStockDetail = String.localizedStringWithFormat(format, localizedStockQuantity)
-        XCTAssertTrue(detailsText.contains(expectedStockDetail))
-    }
-
-    func test_details_for_product_bundle_contain_stock_status_with_product_stock_quantity_when_manageStock_enabled_and_feature_flag_disabled() {
-        // Arrange
-        let product = Product.fake().copy(productTypeKey: "bundle",
-                                          manageStock: true,
-                                          stockQuantity: 5,
-                                          stockStatusKey: "instock",
-                                          bundleStockStatus: .inStock,
-                                          bundleStockQuantity: 1)
-
-        // Action
-        let viewModel = ProductsTabProductViewModel(product: product, productBundlesEnabled: false)
-        let detailsText = viewModel.detailsAttributedString.string
-
-        // Assert
-        let localizedStockQuantity = NumberFormatter.localizedString(from: 5 as NSNumber, number: .decimal)
         let format = NSLocalizedString("%1$@ in stock", comment: "Label about product's inventory stock status shown on Products tab")
         let expectedStockDetail = String.localizedStringWithFormat(format, localizedStockQuantity)
         XCTAssertTrue(detailsText.contains(expectedStockDetail))


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

The `productBundles` feature flag has been enabled since https://github.com/woocommerce/woocommerce-ios/pull/9177. This removes the enabled feature flag from the codebase.

Note: This doesn't affect product bundle configuration in the order form, which is controlled by the feature flag `productBundlesInOrderForm`.

## Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->

This should not change the app behavior. Confirm product bundles continue to work as expected:

1. Go to the Products tab.
2. Find a product bundle in the product list and confirm its stock status matches wp-admin (e.g. "Insufficient stock" if a bundled product is out of stock, bundle stock quantity if stock quantity is managed).
3. Tap the product bundle to open the product details.
4. Confirm the Bundled Products row appears in the product details.
5. Go back and select a product that is not a bundle and confirm the Bundled Products row does _not_ appear in the product details.
6. Go to the Orders tab.
7. Create a new order.
8. In the product selector, find a product bundle in the product list and confirm its stock status matches wp-admin (e.g. "Insufficient stock" if a bundled product is out of stock, bundle stock quantity if stock quantity is managed).

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [x] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [x] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [x] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on all devices (phone/tablet) and no regressions are added.