### PR TITLE
[Products] Remove composite products feature flag

### DIFF
--- a/Experiments/Experiments/DefaultFeatureFlagService.swift
+++ b/Experiments/Experiments/DefaultFeatureFlagService.swift
@@ -44,8 +44,6 @@ public struct DefaultFeatureFlagService: FeatureFlagService {
             return true
         case .manualErrorHandlingForSiteCredentialLogin:
             return true
-        case .compositeProducts:
-            return true
         case .readOnlyGiftCards:
             return true
         case .readOnlyMinMaxQuantities:

--- a/Experiments/Experiments/FeatureFlag.swift
+++ b/Experiments/Experiments/FeatureFlag.swift
@@ -104,10 +104,6 @@ public enum FeatureFlag: Int {
     ///
     case manualErrorHandlingForSiteCredentialLogin
 
-    /// Enables composite product settings in product details
-    ///
-    case compositeProducts
-
     /// Enables read-only support for the Gift Cards extension
     ///
     case readOnlyGiftCards

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormActionsFactory.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormActionsFactory.swift
@@ -71,7 +71,6 @@ struct ProductFormActionsFactory: ProductFormActionsFactoryProtocol {
         .init(analytics: ServiceLocator.analytics,
               configuration: linkedProductsPromoCampaign.configuration)
     }
-    private let isCompositeProductsEnabled: Bool
     private let isMinMaxQuantitiesEnabled: Bool
     private let isCustomFieldsEnabled: Bool
 
@@ -81,7 +80,6 @@ struct ProductFormActionsFactory: ProductFormActionsFactoryProtocol {
          canPromoteWithBlaze: Bool = false,
          addOnsFeatureEnabled: Bool = true,
          isLinkedProductsPromoEnabled: Bool = false,
-         isCompositeProductsEnabled: Bool = ServiceLocator.featureFlagService.isFeatureFlagEnabled(.compositeProducts),
          isMinMaxQuantitiesEnabled: Bool = ServiceLocator.featureFlagService.isFeatureFlagEnabled(.readOnlyMinMaxQuantities),
          isCustomFieldsEnabled: Bool =
          ServiceLocator.featureFlagService.isFeatureFlagEnabled(.viewEditCustomFieldsInProductsAndOrders),
@@ -94,7 +92,6 @@ struct ProductFormActionsFactory: ProductFormActionsFactoryProtocol {
         self.addOnsFeatureEnabled = addOnsFeatureEnabled
         self.variationsPrice = variationsPrice
         self.isLinkedProductsPromoEnabled = isLinkedProductsPromoEnabled
-        self.isCompositeProductsEnabled = isCompositeProductsEnabled
         self.isMinMaxQuantitiesEnabled = isMinMaxQuantitiesEnabled
         self.isCustomFieldsEnabled = isCustomFieldsEnabled
         self.stores = stores
@@ -291,14 +288,13 @@ private extension ProductFormActionsFactory {
     }
 
     func allSettingsSectionActionsForCompositeProduct() -> [ProductFormEditAction] {
-        let shouldShowComponentsRow = isCompositeProductsEnabled
         let canOpenComponents = product.compositeComponents.isNotEmpty
         let shouldShowPriceSettingsRow = product.regularPrice.isNilOrEmpty == false
         let shouldShowReviewsRow = product.reviewsAllowed
         let shouldShowQuantityRulesRow = isMinMaxQuantitiesEnabled && product.canEditQuantityRules
 
         let actions: [ProductFormEditAction?] = [
-            shouldShowComponentsRow ? .components(actionable: canOpenComponents) : nil,
+            .components(actionable: canOpenComponents),
             shouldShowPriceSettingsRow ? .priceSettings(editable: false, hideSeparator: false): nil,
             shouldShowReviewsRow ? .reviews: nil,
             .inventorySettings(editable: false),

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/Actions Factory/ProductFormActionsFactory+ProductCreationTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/Actions Factory/ProductFormActionsFactory+ProductCreationTests.swift
@@ -64,14 +64,12 @@ private extension ProductFormActionsFactory_ProductCreationTests {
                                    formType: ProductFormType,
                                    addOnsFeatureEnabled: Bool = false,
                                    isLinkedProductsPromoEnabled: Bool = false,
-                                   isCompositeProductsEnabled: Bool = false,
                                    isMinMaxQuantitiesEnabled: Bool = false,
                                    variationsPrice: ProductFormActionsFactory.VariationsPrice = .unknown) -> ProductFormActionsFactory {
             ProductFormActionsFactory(product: product,
                                       formType: formType,
                                       addOnsFeatureEnabled: addOnsFeatureEnabled,
                                       isLinkedProductsPromoEnabled: isLinkedProductsPromoEnabled,
-                                      isCompositeProductsEnabled: isCompositeProductsEnabled,
                                       isMinMaxQuantitiesEnabled: isMinMaxQuantitiesEnabled,
                                       variationsPrice: variationsPrice)
         }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/Actions Factory/ProductFormActionsFactoryTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/Actions Factory/ProductFormActionsFactoryTests.swift
@@ -610,38 +610,13 @@ final class ProductFormActionsFactoryTests: XCTestCase {
         assertEqual(expectedBottomSheetActions, factory.bottomSheetActions())
     }
 
-    func test_view_model_for_composite_product_with_feature_flag_disabled() {
+    func test_view_model_for_composite_product() {
         // Arrange
         let product = Fixtures.compositeProduct
         let model = EditableProductModel(product: product)
 
         // Action
-        let factory = Fixtures.actionsFactory(product: model, formType: .edit, isCompositeProductsEnabled: false)
-
-        // Assert
-        let expectedPrimarySectionActions: [ProductFormEditAction] = [.images(editable: true, isStorePublic: true),
-                                                                      .name(editable: true),
-                                                                      .description(editable: true)]
-        assertEqual(expectedPrimarySectionActions, factory.primarySectionActions())
-
-        let expectedSettingsSectionActions: [ProductFormEditAction] = [.priceSettings(editable: false, hideSeparator: false),
-                                                                       .reviews,
-                                                                       .inventorySettings(editable: false),
-                                                                       .linkedProducts(editable: true),
-                                                                       .productType(editable: false)]
-        assertEqual(expectedSettingsSectionActions, factory.settingsSectionActions())
-
-        let expectedBottomSheetActions: [ProductFormBottomSheetAction] = [.editCategories, .editTags, .editShortDescription]
-        assertEqual(expectedBottomSheetActions, factory.bottomSheetActions())
-    }
-
-    func test_view_model_for_composite_product_with_feature_flag_enabled() {
-        // Arrange
-        let product = Fixtures.compositeProduct
-        let model = EditableProductModel(product: product)
-
-        // Action
-        let factory = Fixtures.actionsFactory(product: model, formType: .edit, isCompositeProductsEnabled: true)
+        let factory = Fixtures.actionsFactory(product: model, formType: .edit)
 
         // Assert
         let expectedPrimarySectionActions: [ProductFormEditAction] = [.images(editable: true, isStorePublic: true),
@@ -1021,7 +996,6 @@ private extension ProductFormActionsFactoryTests {
                                    formType: ProductFormType,
                                    addOnsFeatureEnabled: Bool = false,
                                    isLinkedProductsPromoEnabled: Bool = false,
-                                   isCompositeProductsEnabled: Bool = false,
                                    isMinMaxQuantitiesEnabled: Bool = false,
                                    isCustomFieldsEnabled: Bool = false,
                                    variationsPrice: ProductFormActionsFactory.VariationsPrice = .unknown) -> ProductFormActionsFactory {
@@ -1029,7 +1003,6 @@ private extension ProductFormActionsFactoryTests {
                                       formType: formType,
                                       addOnsFeatureEnabled: addOnsFeatureEnabled,
                                       isLinkedProductsPromoEnabled: isLinkedProductsPromoEnabled,
-                                      isCompositeProductsEnabled: isCompositeProductsEnabled,
                                       isMinMaxQuantitiesEnabled: isMinMaxQuantitiesEnabled,
                                       isCustomFieldsEnabled: isCustomFieldsEnabled,
                                       variationsPrice: variationsPrice)


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

The `compositeProducts` feature flag has been enabled since https://github.com/woocommerce/woocommerce-ios/pull/9455. This removes the enabled feature flag from the codebase.

## Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->

This should not change the app behavior. Confirm composite products continue to work as expected:

1. Go to the Products tab.
2. Select a composite product in the product list.
4. Confirm the Components row appears in the product details.
5. Go back and select a product that is not a composite product and confirm the Components row does not appear in the product details.

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [x] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [x] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [x] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on all devices (phone/tablet) and no regressions are added.