### PR TITLE
[Orders] Remove read only gift cards feature flag

### DIFF
--- a/Experiments/Experiments/DefaultFeatureFlagService.swift
+++ b/Experiments/Experiments/DefaultFeatureFlagService.swift
@@ -44,8 +44,6 @@ public struct DefaultFeatureFlagService: FeatureFlagService {
             return true
         case .manualErrorHandlingForSiteCredentialLogin:
             return true
-        case .readOnlyGiftCards:
-            return true
         case .readOnlyMinMaxQuantities:
             return true
         case .euShippingNotification:

--- a/Experiments/Experiments/FeatureFlag.swift
+++ b/Experiments/Experiments/FeatureFlag.swift
@@ -104,10 +104,6 @@ public enum FeatureFlag: Int {
     ///
     case manualErrorHandlingForSiteCredentialLogin
 
-    /// Enables read-only support for the Gift Cards extension
-    ///
-    case readOnlyGiftCards
-
     /// Enables read-only support for the Min/Max Quantities extension
     ///
     case readOnlyMinMaxQuantities

--- a/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsDataSource.swift
+++ b/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsDataSource.swift
@@ -251,7 +251,7 @@ final class OrderDetailsDataSource: NSObject {
     }
 
     var shouldShowGiftCards: Bool {
-        appliedGiftCards.isNotEmpty && featureFlags.isFeatureFlagEnabled(.readOnlyGiftCards)
+        appliedGiftCards.isNotEmpty
     }
 
     private lazy var currencyFormatter = CurrencyFormatter(currencySettings: currencySettings)

--- a/WooCommerce/WooCommerceTests/Mocks/MockFeatureFlagService.swift
+++ b/WooCommerce/WooCommerceTests/Mocks/MockFeatureFlagService.swift
@@ -9,7 +9,6 @@ struct MockFeatureFlagService: FeatureFlagService {
     private let isDomainSettingsEnabled: Bool
     private let isSupportRequestEnabled: Bool
     private let jetpackSetupWithApplicationPassword: Bool
-    private let isReadOnlyGiftCardsEnabled: Bool
     private let betterCustomerSelectionInOrder: Bool
     private let productBundlesInOrderForm: Bool
     private let isScanToUpdateInventoryEnabled: Bool
@@ -28,7 +27,6 @@ struct MockFeatureFlagService: FeatureFlagService {
          isDomainSettingsEnabled: Bool = false,
          isSupportRequestEnabled: Bool = false,
          jetpackSetupWithApplicationPassword: Bool = false,
-         isReadOnlyGiftCardsEnabled: Bool = false,
          betterCustomerSelectionInOrder: Bool = false,
          productBundlesInOrderForm: Bool = false,
          isScanToUpdateInventoryEnabled: Bool = false,
@@ -46,7 +44,6 @@ struct MockFeatureFlagService: FeatureFlagService {
         self.isDomainSettingsEnabled = isDomainSettingsEnabled
         self.isSupportRequestEnabled = isSupportRequestEnabled
         self.jetpackSetupWithApplicationPassword = jetpackSetupWithApplicationPassword
-        self.isReadOnlyGiftCardsEnabled = isReadOnlyGiftCardsEnabled
         self.betterCustomerSelectionInOrder = betterCustomerSelectionInOrder
         self.productBundlesInOrderForm = productBundlesInOrderForm
         self.isScanToUpdateInventoryEnabled = isScanToUpdateInventoryEnabled
@@ -75,8 +72,6 @@ struct MockFeatureFlagService: FeatureFlagService {
             return isSupportRequestEnabled
         case .jetpackSetupWithApplicationPassword:
             return jetpackSetupWithApplicationPassword
-        case .readOnlyGiftCards:
-            return isReadOnlyGiftCardsEnabled
         case .betterCustomerSelectionInOrder:
             return betterCustomerSelectionInOrder
         case .productBundlesInOrderForm:

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Details/OrderDetailsDataSourceTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Details/OrderDetailsDataSourceTests.swift
@@ -629,8 +629,7 @@ final class OrderDetailsDataSourceTests: XCTestCase {
         let order = Order.fake().copy(appliedGiftCards: [.init(giftCardID: 2, code: "SU9F-MGB5-KS5V-EZFT", amount: 20)])
         let dataSource = OrderDetailsDataSource(order: order,
                                                 storageManager: storageManager,
-                                                cardPresentPaymentsConfiguration: Mocks.configuration,
-                                                featureFlags: MockFeatureFlagService(isReadOnlyGiftCardsEnabled: true))
+                                                cardPresentPaymentsConfiguration: Mocks.configuration)
 
         // When
         dataSource.reloadSections()
@@ -645,8 +644,7 @@ final class OrderDetailsDataSourceTests: XCTestCase {
         let order = Order.fake()
         let dataSource = OrderDetailsDataSource(order: order,
                                                 storageManager: storageManager,
-                                                cardPresentPaymentsConfiguration: Mocks.configuration,
-                                                featureFlags: MockFeatureFlagService(isReadOnlyGiftCardsEnabled: true))
+                                                cardPresentPaymentsConfiguration: Mocks.configuration)
 
         // When
         dataSource.reloadSections()
@@ -680,8 +678,7 @@ final class OrderDetailsDataSourceTests: XCTestCase {
         let order = Order.fake().copy(attributionInfo: .some(nil))
         let dataSource = OrderDetailsDataSource(order: order,
                                                 storageManager: storageManager,
-                                                cardPresentPaymentsConfiguration: Mocks.configuration,
-                                                featureFlags: MockFeatureFlagService(isReadOnlyGiftCardsEnabled: true))
+                                                cardPresentPaymentsConfiguration: Mocks.configuration)
 
         // When
         dataSource.reloadSections()


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
The `readOnlyGiftCards` feature flag has been enabled since https://github.com/woocommerce/woocommerce-ios/pull/9558. This removes the enabled feature flag from the codebase.

## Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->

This should not change the app behavior. Confirm gift cards continue to work as expected in order details:

1. Go to the Orders tab.
2. Select an order with a gift card applied.
3. Confirm the gift card section appears in the order details as expected.
4. Go back and select an order without a gift card applied.
5. Confirm the gift card section does not appear in order details.

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [x] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [x] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [x] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on all devices (phone/tablet) and no regressions are added.