### PR TITLE
[Products] Remove read-only min max quantities feature flag

### DIFF
--- a/Experiments/Experiments/DefaultFeatureFlagService.swift
+++ b/Experiments/Experiments/DefaultFeatureFlagService.swift
@@ -44,8 +44,6 @@ public struct DefaultFeatureFlagService: FeatureFlagService {
             return true
         case .manualErrorHandlingForSiteCredentialLogin:
             return true
-        case .readOnlyMinMaxQuantities:
-            return true
         case .euShippingNotification:
             return true
         case .betterCustomerSelectionInOrder:

--- a/Experiments/Experiments/FeatureFlag.swift
+++ b/Experiments/Experiments/FeatureFlag.swift
@@ -104,10 +104,6 @@ public enum FeatureFlag: Int {
     ///
     case manualErrorHandlingForSiteCredentialLogin
 
-    /// Enables read-only support for the Min/Max Quantities extension
-    ///
-    case readOnlyMinMaxQuantities
-
     /// Enables EU Bound notifications inside the Shipping Labels feature
     ///
     case euShippingNotification

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormActionsFactory.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductFormActionsFactory.swift
@@ -71,7 +71,6 @@ struct ProductFormActionsFactory: ProductFormActionsFactoryProtocol {
         .init(analytics: ServiceLocator.analytics,
               configuration: linkedProductsPromoCampaign.configuration)
     }
-    private let isMinMaxQuantitiesEnabled: Bool
     private let isCustomFieldsEnabled: Bool
 
     // TODO: Remove default parameter
@@ -80,7 +79,6 @@ struct ProductFormActionsFactory: ProductFormActionsFactoryProtocol {
          canPromoteWithBlaze: Bool = false,
          addOnsFeatureEnabled: Bool = true,
          isLinkedProductsPromoEnabled: Bool = false,
-         isMinMaxQuantitiesEnabled: Bool = ServiceLocator.featureFlagService.isFeatureFlagEnabled(.readOnlyMinMaxQuantities),
          isCustomFieldsEnabled: Bool =
          ServiceLocator.featureFlagService.isFeatureFlagEnabled(.viewEditCustomFieldsInProductsAndOrders),
          variationsPrice: VariationsPrice = .unknown,
@@ -92,7 +90,6 @@ struct ProductFormActionsFactory: ProductFormActionsFactoryProtocol {
         self.addOnsFeatureEnabled = addOnsFeatureEnabled
         self.variationsPrice = variationsPrice
         self.isLinkedProductsPromoEnabled = isLinkedProductsPromoEnabled
-        self.isMinMaxQuantitiesEnabled = isMinMaxQuantitiesEnabled
         self.isCustomFieldsEnabled = isCustomFieldsEnabled
         self.stores = stores
     }
@@ -171,7 +168,7 @@ private extension ProductFormActionsFactory {
         let canEditProductType = editable
         let shouldShowShippingSettingsRow = product.isShippingEnabled()
         let canEditInventorySettingsRow = editable
-        let shouldShowQuantityRulesRow = isMinMaxQuantitiesEnabled && product.canEditQuantityRules
+        let shouldShowQuantityRulesRow = product.canEditQuantityRules
 
         let actions: [ProductFormEditAction?] = [
             .priceSettings(editable: editable, hideSeparator: false),
@@ -196,7 +193,7 @@ private extension ProductFormActionsFactory {
         let shouldShowExternalURLRow = editable || product.product.externalURL?.isNotEmpty == true
         let shouldShowSKURow = editable || product.sku?.isNotEmpty == true
         let canEditProductType = editable
-        let shouldShowQuantityRulesRow = isMinMaxQuantitiesEnabled && product.canEditQuantityRules
+        let shouldShowQuantityRulesRow = product.canEditQuantityRules
 
         let actions: [ProductFormEditAction?] = [
             .priceSettings(editable: editable, hideSeparator: false),
@@ -218,7 +215,7 @@ private extension ProductFormActionsFactory {
         let shouldShowReviewsRow = product.reviewsAllowed
         let shouldShowSKURow = editable || product.sku?.isNotEmpty == true
         let canEditProductType = editable
-        let shouldShowQuantityRulesRow = isMinMaxQuantitiesEnabled && product.canEditQuantityRules
+        let shouldShowQuantityRulesRow = product.canEditQuantityRules
 
         let actions: [ProductFormEditAction?] = [
             .groupedProducts(editable: editable),
@@ -245,7 +242,7 @@ private extension ProductFormActionsFactory {
             let productHasNoPriceSet = variationsPrice == .unknown && product.product.variations.isNotEmpty && product.product.price.isEmpty
             return canEditProductType && (variationsHaveNoPriceSet || productHasNoPriceSet)
         }()
-        let shouldShowQuantityRulesRow = isMinMaxQuantitiesEnabled && product.canEditQuantityRules
+        let shouldShowQuantityRulesRow = product.canEditQuantityRules
 
         let actions: [ProductFormEditAction?] = [
             .variations(hideSeparator: shouldShowNoPriceWarningRow),
@@ -269,7 +266,7 @@ private extension ProductFormActionsFactory {
         let canOpenBundledProducts = product.bundledItems.isNotEmpty
         let shouldShowPriceSettingsRow = product.regularPrice.isNilOrEmpty == false
         let shouldShowReviewsRow = product.reviewsAllowed
-        let shouldShowQuantityRulesRow = isMinMaxQuantitiesEnabled && product.canEditQuantityRules
+        let shouldShowQuantityRulesRow = product.canEditQuantityRules
 
         let actions: [ProductFormEditAction?] = [
             .bundledProducts(actionable: canOpenBundledProducts),
@@ -291,7 +288,7 @@ private extension ProductFormActionsFactory {
         let canOpenComponents = product.compositeComponents.isNotEmpty
         let shouldShowPriceSettingsRow = product.regularPrice.isNilOrEmpty == false
         let shouldShowReviewsRow = product.reviewsAllowed
-        let shouldShowQuantityRulesRow = isMinMaxQuantitiesEnabled && product.canEditQuantityRules
+        let shouldShowQuantityRulesRow = product.canEditQuantityRules
 
         let actions: [ProductFormEditAction?] = [
             .components(actionable: canOpenComponents),
@@ -311,7 +308,7 @@ private extension ProductFormActionsFactory {
 
     func allSettingsSectionActionsForSubscriptionProduct() -> [ProductFormEditAction] {
         let shouldShowReviewsRow = product.reviewsAllowed
-        let shouldShowQuantityRulesRow = isMinMaxQuantitiesEnabled && product.canEditQuantityRules
+        let shouldShowQuantityRulesRow = product.canEditQuantityRules
         let canEditInventorySettingsRow = editable
         let canEditProductType = editable
         let shouldShowShippingSettingsRow = product.isShippingEnabled()
@@ -338,7 +335,7 @@ private extension ProductFormActionsFactory {
     func allSettingsSectionActionsForVariableSubscriptionProduct() -> [ProductFormEditAction] {
         let shouldShowReviewsRow = product.reviewsAllowed
         let shouldShowAttributesRow = product.product.attributesForVariations.isNotEmpty
-        let shouldShowQuantityRulesRow = isMinMaxQuantitiesEnabled && product.canEditQuantityRules
+        let shouldShowQuantityRulesRow = product.canEditQuantityRules
 
         let actions: [ProductFormEditAction?] = {
             let canEditProductType = editable
@@ -372,7 +369,7 @@ private extension ProductFormActionsFactory {
     func allSettingsSectionActionsForNonCoreProduct() -> [ProductFormEditAction] {
         let shouldShowPriceSettingsRow = product.regularPrice.isNilOrEmpty == false
         let shouldShowReviewsRow = product.reviewsAllowed
-        let shouldShowQuantityRulesRow = isMinMaxQuantitiesEnabled && product.canEditQuantityRules
+        let shouldShowQuantityRulesRow = product.canEditQuantityRules
 
         let actions: [ProductFormEditAction?] = [
             shouldShowPriceSettingsRow ? .priceSettings(editable: false, hideSeparator: false): nil,

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductVariationFormActionsFactory.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/ProductVariationFormActionsFactory.swift
@@ -5,17 +5,13 @@ struct ProductVariationFormActionsFactory: ProductFormActionsFactoryProtocol {
     private let productVariation: EditableProductVariationModel
     private let editable: Bool
 
-    private let isMinMaxQuantitiesEnabled: Bool
-
     private let stores: StoresManager
 
     init(productVariation: EditableProductVariationModel,
          editable: Bool,
-         isMinMaxQuantitiesEnabled: Bool = ServiceLocator.featureFlagService.isFeatureFlagEnabled(.readOnlyMinMaxQuantities),
          stores: StoresManager = ServiceLocator.stores) {
         self.productVariation = productVariation
         self.editable = editable
-        self.isMinMaxQuantitiesEnabled = isMinMaxQuantitiesEnabled
         self.stores = stores
     }
 
@@ -68,7 +64,7 @@ private extension ProductVariationFormActionsFactory {
                 return nil
             }
         }()
-        let shouldShowQuantityRulesRow = isMinMaxQuantitiesEnabled && productVariation.canEditQuantityRules
+        let shouldShowQuantityRulesRow = productVariation.canEditQuantityRules
 
         let actions: [ProductFormEditAction?] = [
             subscriptionOrPriceRow,

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/Actions Factory/ProductFormActionsFactory+ProductCreationTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/Actions Factory/ProductFormActionsFactory+ProductCreationTests.swift
@@ -64,13 +64,11 @@ private extension ProductFormActionsFactory_ProductCreationTests {
                                    formType: ProductFormType,
                                    addOnsFeatureEnabled: Bool = false,
                                    isLinkedProductsPromoEnabled: Bool = false,
-                                   isMinMaxQuantitiesEnabled: Bool = false,
                                    variationsPrice: ProductFormActionsFactory.VariationsPrice = .unknown) -> ProductFormActionsFactory {
             ProductFormActionsFactory(product: product,
                                       formType: formType,
                                       addOnsFeatureEnabled: addOnsFeatureEnabled,
                                       isLinkedProductsPromoEnabled: isLinkedProductsPromoEnabled,
-                                      isMinMaxQuantitiesEnabled: isMinMaxQuantitiesEnabled,
                                       variationsPrice: variationsPrice)
         }
     }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/Actions Factory/ProductFormActionsFactoryTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/Actions Factory/ProductFormActionsFactoryTests.swift
@@ -896,7 +896,7 @@ final class ProductFormActionsFactoryTests: XCTestCase {
         let model = EditableProductModel(product: product)
 
         // Action
-        let factory = Fixtures.actionsFactory(product: model, formType: .edit, isMinMaxQuantitiesEnabled: true)
+        let factory = Fixtures.actionsFactory(product: model, formType: .edit)
 
         // Assert
         let expectedPrimarySectionActions: [ProductFormEditAction] = [.images(editable: true, isStorePublic: true),
@@ -996,14 +996,12 @@ private extension ProductFormActionsFactoryTests {
                                    formType: ProductFormType,
                                    addOnsFeatureEnabled: Bool = false,
                                    isLinkedProductsPromoEnabled: Bool = false,
-                                   isMinMaxQuantitiesEnabled: Bool = false,
                                    isCustomFieldsEnabled: Bool = false,
                                    variationsPrice: ProductFormActionsFactory.VariationsPrice = .unknown) -> ProductFormActionsFactory {
             ProductFormActionsFactory(product: product,
                                       formType: formType,
                                       addOnsFeatureEnabled: addOnsFeatureEnabled,
                                       isLinkedProductsPromoEnabled: isLinkedProductsPromoEnabled,
-                                      isMinMaxQuantitiesEnabled: isMinMaxQuantitiesEnabled,
                                       isCustomFieldsEnabled: isCustomFieldsEnabled,
                                       variationsPrice: variationsPrice)
         }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/Actions Factory/ProductVariationFormActionsFactoryTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/Actions Factory/ProductVariationFormActionsFactoryTests.swift
@@ -183,8 +183,7 @@ final class ProductVariationFormActionsFactoryTests: XCTestCase {
 
         // Action
         let factory = ProductVariationFormActionsFactory(productVariation: model,
-                                                         editable: true,
-                                                         isMinMaxQuantitiesEnabled: true)
+                                                         editable: true)
 
         // Assert
         let expectedPrimarySectionActions: [ProductFormEditAction] = [.images(editable: true, isStorePublic: true), .variationName, .description(editable: true)]


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
The `readOnlyMinMaxQuantities` feature flag has been enabled since https://github.com/woocommerce/woocommerce-ios/pull/9585. This removes the enabled feature flag from the codebase.

Note that after this feature flag was enabled, we added support for editable min/max quantities. The current app behavior includes editing the quantity rules for products when this extension is active.

## Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->

This should not change the app behavior. Confirm quantity rules continue to work as expected in product and variation details:

On a store _with_ the Min/Max Quantities extension active:

1. Go to the Products tab.
2. Select any product and confirm the Quantity Rules row appears in product details.
3. Go back and select any variable product.
4. Go to the variations list and select a variation with quantity rules.
5. Confirm the Quantity Rules row appears in variation details.

On a store _without_ the Min/Max Quantities extension active:

1. Go to the Products tab.
2. Select any product and confirm the Quantity Rules row _does not appear_ in product details.
3. Go back and select any variable product.
4. Go to the variations list and select any variation.
5. Confirm the Quantity Rules row _does not appear_ in variation details.

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [x] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [x] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [x] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on all devices (phone/tablet) and no regressions are added.