### PR TITLE
[Tooling] Report an error when no milestone is set to a PR

### DIFF
--- a/Dangerfile
+++ b/Dangerfile
@@ -53,4 +53,4 @@ labels_checker.check(
 )
 
 # runs the milestone check if this is not a WIP feature and the PR is against the main branch or the release branch
-milestone_checker.check_milestone_due_date(days_before_due: 2) if (github_utils.main_branch? || github_utils.release_branch?) && !github_utils.wip_feature?
+milestone_checker.check_milestone_due_date(days_before_due: 2, report_type_if_no_milestone: :error) if (github_utils.main_branch? || github_utils.release_branch?) && !github_utils.wip_feature? && !github.pr_labels.include?('milestone-exemption')

--- a/Dangerfile
+++ b/Dangerfile
@@ -53,9 +53,10 @@ labels_checker.check(
 )
 
 # runs the milestone check if this is not a WIP feature and the PR is against the main branch or the release branch
-if (github_utils.main_branch? || github_utils.release_branch?) && !github_utils.wip_feature? && !github.pr_labels.include?('milestone-exemption')
+if (github_utils.main_branch? || github_utils.release_branch?) && !github_utils.wip_feature?
+  report_type = github.pr_labels.include?('milestone-exemption') ? :warning : :error
   milestone_checker.check_milestone_due_date(
     days_before_due: 2,
-    report_type_if_no_milestone: :error
+    report_type_if_no_milestone: report_type
   )
 end

--- a/Dangerfile
+++ b/Dangerfile
@@ -53,4 +53,9 @@ labels_checker.check(
 )
 
 # runs the milestone check if this is not a WIP feature and the PR is against the main branch or the release branch
-milestone_checker.check_milestone_due_date(days_before_due: 2, report_type_if_no_milestone: :error) if (github_utils.main_branch? || github_utils.release_branch?) && !github_utils.wip_feature? && !github.pr_labels.include?('milestone-exemption')
+if (github_utils.main_branch? || github_utils.release_branch?) && !github_utils.wip_feature? && !github.pr_labels.include?('milestone-exemption')
+  milestone_checker.check_milestone_due_date(
+    days_before_due: 2,
+    report_type_if_no_milestone: :error
+  )
+end

--- a/Dangerfile
+++ b/Dangerfile
@@ -3,8 +3,8 @@
 github.dismiss_out_of_range_messages
 
 # `files: []` forces rubocop to scan all files, not just the ones modified in the PR
-# Added a custom `rubocop_cmd` to prevent RuboCop from running using `bundle exec`, which we don't want on the linter agent
-rubocop.lint(files: [], force_exclusion: true, inline_comment: true, fail_on_inline_comment: true, include_cop_names: true, rubocop_cmd: ': | rubocop')
+# `skip_bundle_exec` prevents RuboCop from running using `bundle exec`, which we don't want on the linter agent
+rubocop.lint(files: [], force_exclusion: true, inline_comment: true, fail_on_inline_comment: true, include_cop_names: true, skip_bundle_exec: true)
 
 manifest_pr_checker.check_all_manifest_lock_updated
 

--- a/Dangerfile
+++ b/Dangerfile
@@ -54,7 +54,7 @@ labels_checker.check(
 
 # runs the milestone check if this is not a WIP feature and the PR is against the main branch or the release branch
 if (github_utils.main_branch? || github_utils.release_branch?) && !github_utils.wip_feature?
-  report_type = github.pr_labels.include?('milestone-exemption') ? :warning : :error
+  report_type = github.pr_labels.include?('milestone-not-required') || github.pr_labels.include?('status: feature-flagged') ? :message : :error
   milestone_checker.check_milestone_due_date(
     days_before_due: 2,
     report_type_if_no_milestone: report_type

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -309,8 +309,8 @@ GEM
     options (2.3.2)
     optparse (0.5.0)
     os (1.1.4)
-    parallel (1.25.1)
-    parser (3.3.4.1)
+    parallel (1.26.3)
+    parser (3.3.4.2)
       ast (~> 2.4.1)
       racc
     plist (3.7.1)
@@ -330,7 +330,7 @@ GEM
       trailblazer-option (>= 0.1.1, < 0.2.0)
       uber (< 0.2.0)
     retriable (3.1.2)
-    rexml (3.3.4)
+    rexml (3.3.6)
       strscan
     rmagick (4.3.0)
     rouge (2.0.7)
@@ -345,7 +345,7 @@ GEM
       rubocop-ast (>= 1.31.1, < 2.0)
       ruby-progressbar (~> 1.7)
       unicode-display_width (>= 2.4.0, < 3.0)
-    rubocop-ast (1.32.0)
+    rubocop-ast (1.32.1)
       parser (>= 3.3.1.0)
     rubocop-rake (0.6.0)
       rubocop (~> 1.0)

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -261,7 +261,7 @@ platform :ios do
                          + moved_prs.map { |pr_num| "[##{pr_num}](https://github.com/#{GITHUB_REPO}/pull/#{pr_num})" }.join(', ')
                      end
 
-    buildkite_annotate(style: moved_prs.empty? ? 'success' : 'warning', context: 'start-code-freeze-wcios', message: moved_prs_info) if is_ci
+    buildkite_annotate(style: moved_prs.empty? ? 'success' : 'warning', context: 'start-code-freeze', message: moved_prs_info) if is_ci
   end
 
   #####################################################################################


### PR DESCRIPTION
This PR should make Danger report an error when no milestone is set to a Pull Request, thus failing the build.

The results should be observed on this very PR.

**Update**: It reports an error and fails the build as expected:
<img width="1141" alt="Screenshot 2024-08-27 at 21 12 54" src="https://github.com/user-attachments/assets/9e562cfc-98a7-44f9-b686-2acdd61f0a26">

And it switches to a warning when the label `milestone-not-required` is used:
<img width="1146" alt="Screenshot 2024-08-27 at 21 15 33" src="https://github.com/user-attachments/assets/2066a351-9d0d-4959-9070-baacdc40eab0">
