### PR TITLE
Blaze: Show budget field on dashboard card

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -7,6 +7,7 @@
 - [*] Orders/Products: The filter menu can now be swiped to dismiss it if there are no changes to the selected filters. [https://github.com/woocommerce/woocommerce-ios/pull/13737]
 - [*] Home Screen Widget: Tapping on the Orders section of the home screen widget opens the Orders part of the app.
 - [*] Payments: Punctuation updates to error and decline reason messages [https://github.com/woocommerce/woocommerce-ios/pull/13739]
+- [*] Blaze: Display budget field on the dashboard card. [https://github.com/woocommerce/woocommerce-ios/pull/13761]
 
 20.1
 -----

--- a/WooCommerce/Classes/ViewRelated/Blaze/BlazeCampaignList/BlazeCampaignItemView.swift
+++ b/WooCommerce/Classes/ViewRelated/Blaze/BlazeCampaignList/BlazeCampaignItemView.swift
@@ -9,12 +9,9 @@ struct BlazeCampaignItemView: View {
     @ScaledMetric private var scale: CGFloat = 1.0
 
     private let campaign: BlazeCampaignListItem
-    private let showBudget: Bool
 
-    init(campaign: BlazeCampaignListItem,
-         showBudget: Bool = true) {
+    init(campaign: BlazeCampaignListItem) {
         self.campaign = campaign
-        self.showBudget = showBudget
     }
 
     var body: some View {
@@ -87,7 +84,6 @@ struct BlazeCampaignItemView: View {
                         .foregroundColor(.init(UIColor.text))
                 }
                 .frame(maxWidth: .infinity, alignment: .leading)
-                .renderedIf(showBudget)
 
                 Spacer()
 

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Blaze/BlazeCampaignDashboardView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Blaze/BlazeCampaignDashboardView.swift
@@ -97,7 +97,7 @@ struct BlazeCampaignDashboardView: View {
                         createCampaignTapped?(product.productID)
                     }
             case .showCampaign(let campaign):
-                BlazeCampaignItemView(campaign: campaign, showBudget: false)
+                BlazeCampaignItemView(campaign: campaign)
                     .padding(.horizontal, Layout.padding)
                     .onTapGesture {
                         viewModel.didSelectCampaignDetails(campaign)


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #13760 
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This PR restores the budget field on the Blaze dashboard card for consistency with the campaign list as suggested by Jorge in p1724749992137369-slack-C03L1NF1EA3.

## Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->
- Log in to a store eligible for Blaze.
- Enable the Blaze card on the dashboard screen.
- Confirm that the card contains both the click-throughs and budget fields.
- Select View all campaigns to show the campaign list.
- Confirm that the items on the campaign list also contain both click-throughs and budget fields.

## Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->
Tested on simulator iPhone 15 iOS 17.4 for both the Blaze dashboard card and the campaign list.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->
<img src="https://github.com/user-attachments/assets/86e0df5a-017b-4ba1-b4cc-b0390d21b928" width=320 />


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [x] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [x] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [x] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on all devices (phone/tablet) and no regressions are added.