### PR TITLE
Blaze: Update tracking for evergreen campaign creation

### DIFF
--- a/WooCommerce/Classes/Analytics/WooAnalyticsEvent+Blaze.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsEvent+Blaze.swift
@@ -30,34 +30,6 @@ extension WooAnalyticsEvent {
                               properties: [Key.source: source.analyticsValue])
         }
 
-        /// Tracked when the Blaze webview is first loaded.
-        static func blazeFlowStarted(source: BlazeSource) -> WooAnalyticsEvent {
-            WooAnalyticsEvent(statName: .blazeFlowStarted,
-                              properties: [Key.source: source.analyticsValue])
-        }
-
-        /// Tracked when the Blaze webview is dismissed without completing the flow.
-        static func blazeFlowCanceled(source: BlazeSource, step: Step) -> WooAnalyticsEvent {
-            WooAnalyticsEvent(statName: .blazeFlowCanceled,
-                              properties: [Key.source: source.analyticsValue,
-                                           Key.step: step.analyticsValue])
-        }
-
-        /// Tracked when the Blaze webview flow completes.
-        static func blazeFlowCompleted(source: BlazeSource, step: Step) -> WooAnalyticsEvent {
-            WooAnalyticsEvent(statName: .blazeFlowCompleted,
-                              properties: [Key.source: source.analyticsValue,
-                                           Key.step: step.analyticsValue])
-        }
-
-        /// Tracked when the Blaze webview returns an error.
-        static func blazeFlowError(source: BlazeSource, step: Step, error: Error) -> WooAnalyticsEvent {
-            WooAnalyticsEvent(statName: .blazeFlowError,
-                              properties: [Key.source: source.analyticsValue,
-                                           Key.step: step.analyticsValue],
-                              error: error)
-        }
-
         /// Tracked when the Blaze campaign list entry point is selected.
         static func blazeCampaignListEntryPointSelected(source: BlazeCampaignListSource) -> WooAnalyticsEvent {
             WooAnalyticsEvent(statName: .blazeCampaignListEntryPointSelected,

--- a/WooCommerce/Classes/Analytics/WooAnalyticsEvent+Blaze.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsEvent+Blaze.swift
@@ -97,9 +97,13 @@ extension WooAnalyticsEvent {
             }
 
             /// Tracked upon tapping "Confirm Details" in Blaze creation form
-            static func confirmDetailsTapped(isAISuggestedAdContent: Bool) -> WooAnalyticsEvent {
+            static func confirmDetailsTapped(isAISuggestedAdContent: Bool,
+                                             isEvergreen: Bool) -> WooAnalyticsEvent {
                 WooAnalyticsEvent(statName: .blazeCreationConfirmDetailsTapped,
-                                  properties: [Key.isAISuggestedAdContent: isAISuggestedAdContent])
+                                  properties: [Key.isAISuggestedAdContent: isAISuggestedAdContent,
+                                               Key.campaignType: isEvergreen ?
+                                                Values.CampaignType.evergreen :
+                                                Values.CampaignType.startEnd])
             }
         }
 
@@ -188,8 +192,10 @@ extension WooAnalyticsEvent {
             }
 
             /// Tracked when campaign creation is successful
-            static func campaignCreationSuccess() -> WooAnalyticsEvent {
-                WooAnalyticsEvent(statName: .blazeCampaignCreationSuccess, properties: [:])
+            static func campaignCreationSuccess(isEvergreen: Bool) -> WooAnalyticsEvent {
+                WooAnalyticsEvent(statName: .blazeCampaignCreationSuccess, properties: [
+                    Key.campaignType: isEvergreen ? Values.CampaignType.evergreen : Values.CampaignType.startEnd
+                ])
             }
 
             /// Tracked when campaign creation fails

--- a/WooCommerce/Classes/Analytics/WooAnalyticsEvent+Blaze.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsEvent+Blaze.swift
@@ -7,6 +7,14 @@ extension WooAnalyticsEvent {
             static let duration = "duration"
             static let totalBudget = "total_budget"
             static let isAISuggestedAdContent = "is_ai_suggested_ad_content"
+            static let campaignType = "campaign_type"
+        }
+
+        private enum Values {
+            enum CampaignType {
+                static let startEnd = "start_end"
+                static let evergreen = "evergreen"
+            }
         }
 
         /// Tracked when the Blaze entry point is shown to the user.
@@ -109,16 +117,22 @@ extension WooAnalyticsEvent {
 
         enum Budget {
             /// Tracked upon tapping "Update" in Blaze set budget screen
-            static func updateTapped(duration: Int, totalBudget: Double) -> WooAnalyticsEvent {
+            static func updateTapped(duration: Int, totalBudget: Double, hasEndDate: Bool) -> WooAnalyticsEvent {
                 WooAnalyticsEvent(statName: .blazeEditBudgetSaveTapped,
                                   properties: [Key.duration: duration,
-                                               Key.totalBudget: totalBudget])
+                                               Key.totalBudget: totalBudget,
+                                               Key.campaignType: hasEndDate ?
+                                                Values.CampaignType.startEnd :
+                                                Values.CampaignType.evergreen])
             }
 
-            /// Tracked upon changing duration in Blaze set budget screen
-            static func changedDuration(_ duration: Int) -> WooAnalyticsEvent {
+            /// Tracked upon changing schedule in Blaze set budget screen
+            static func changedSchedule(duration: Int, hasEndDate: Bool) -> WooAnalyticsEvent {
                 WooAnalyticsEvent(statName: .blazeEditBudgetDurationApplied,
-                                  properties: [Key.duration: duration])
+                                  properties: [Key.duration: duration,
+                                               Key.campaignType: hasEndDate ?
+                                                Values.CampaignType.startEnd :
+                                                Values.CampaignType.evergreen])
             }
         }
 

--- a/WooCommerce/Classes/Analytics/WooAnalyticsStat.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsStat.swift
@@ -211,10 +211,6 @@ enum WooAnalyticsStat: String {
     //
     case blazeEntryPointDisplayed = "blaze_entry_point_displayed"
     case blazeEntryPointTapped = "blaze_entry_point_tapped"
-    case blazeFlowStarted = "blaze_flow_started"
-    case blazeFlowCanceled = "blaze_flow_canceled"
-    case blazeFlowCompleted = "blaze_flow_completed"
-    case blazeFlowError = "blaze_flow_error"
     case blazeCampaignListEntryPointSelected = "blaze_campaign_list_entry_point_selected"
     case blazeCampaignDetailSelected = "blaze_campaign_detail_selected"
     case blazeViewDismissed = "blaze_view_dismissed"

--- a/WooCommerce/Classes/ViewRelated/Blaze/BudgetSetting/BlazeBudgetSettingViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Blaze/BudgetSetting/BlazeBudgetSettingViewModel.swift
@@ -107,7 +107,8 @@ final class BlazeBudgetSettingViewModel: ObservableObject {
     }
 
     func didTapApplyDuration(dayCount: Double, since startDate: Date) {
-        analytics.track(event: .Blaze.Budget.changedDuration(Int(dayCount)))
+        analytics.track(event: .Blaze.Budget.changedSchedule(duration: Int(dayCount),
+                                                             hasEndDate: hasEndDate))
         self.dayCount = dayCount
         self.startDate = startDate
     }
@@ -129,7 +130,8 @@ final class BlazeBudgetSettingViewModel: ObservableObject {
         let days = Int(dayCount)
         let totalBudget = calculateTotalBudget(dailyBudget: dailyAmount, dayCount: dayCount)
         analytics.track(event: .Blaze.Budget.updateTapped(duration: days,
-                                                          totalBudget: totalBudget))
+                                                          totalBudget: totalBudget,
+                                                          hasEndDate: hasEndDate))
         completionHandler(dailyAmount, !hasEndDate, days, startDate)
     }
 

--- a/WooCommerce/Classes/ViewRelated/Blaze/CampaignCreation/BlazeCampaignCreationFormViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Blaze/CampaignCreation/BlazeCampaignCreationFormViewModel.swift
@@ -62,21 +62,21 @@ final class BlazeCampaignCreationFormViewModel: ObservableObject {
     }
 
     /// We need to recreate the view model every time the budget screen is opened to get the updated target options.
-    var budgetSettingViewModel: BlazeBudgetSettingViewModel {
+    lazy private(set) var budgetSettingViewModel: BlazeBudgetSettingViewModel = {
         BlazeBudgetSettingViewModel(siteID: siteID,
                                     dailyBudget: dailyBudget,
                                     isEvergreen: isEvergreen,
                                     duration: duration,
                                     startDate: startDate,
-                                    targetOptions: targetOptions) { [weak self] dailyBudget, isEvegreen, duration, startDate in
+                                    targetOptions: targetOptions) { [weak self] dailyBudget, isEvergreen, duration, startDate in
             guard let self else { return }
             self.startDate = startDate
-            self.isEvergreen = isEvegreen
+            self.isEvergreen = isEvergreen
             self.duration = duration
             self.dailyBudget = dailyBudget
             self.updateBudgetDetails()
         }
-    }
+    }()
 
     var editAdViewModel: BlazeEditAdViewModel {
         let adData = BlazeEditAdData(image: image,
@@ -346,7 +346,7 @@ final class BlazeCampaignCreationFormViewModel: ObservableObject {
         let isAISuggestedAdContent = taglineMatching || descriptionMatching
         analytics.track(event: .Blaze.CreationForm.confirmDetailsTapped(
             isAISuggestedAdContent: isAISuggestedAdContent,
-            isEvergreen: campaignInfo.isEvergreen
+            isEvergreen: isEvergreen
         ))
         isShowingPaymentInfo = true
     }

--- a/WooCommerce/Classes/ViewRelated/Blaze/CampaignCreation/BlazeCampaignCreationFormViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Blaze/CampaignCreation/BlazeCampaignCreationFormViewModel.swift
@@ -344,7 +344,10 @@ final class BlazeCampaignCreationFormViewModel: ObservableObject {
         let taglineMatching = suggestions.map { $0.siteName }.contains { $0 == tagline }
         let descriptionMatching = suggestions.map { $0.textSnippet }.contains { $0 == description }
         let isAISuggestedAdContent = taglineMatching || descriptionMatching
-        analytics.track(event: .Blaze.CreationForm.confirmDetailsTapped(isAISuggestedAdContent: isAISuggestedAdContent))
+        analytics.track(event: .Blaze.CreationForm.confirmDetailsTapped(
+            isAISuggestedAdContent: isAISuggestedAdContent,
+            isEvergreen: campaignInfo.isEvergreen
+        ))
         isShowingPaymentInfo = true
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Blaze/ConfirmPayment/BlazeConfirmPaymentViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Blaze/ConfirmPayment/BlazeConfirmPaymentViewModel.swift
@@ -143,7 +143,7 @@ final class BlazeConfirmPaymentViewModel: ObservableObject {
                     throw BlazeCampaignCreationError.failedToCreateCampaign
                 }
             }
-            analytics.track(event: .Blaze.Payment.campaignCreationSuccess())
+            analytics.track(event: .Blaze.Payment.campaignCreationSuccess(isEvergreen: campaignInfo.isEvergreen))
             completionHandler()
         } catch {
             analytics.track(event: .Blaze.Payment.campaignCreationFailed(error: error))

--- a/WooCommerce/WooCommerceTests/ViewRelated/Blaze/BlazeBudgetSettingViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Blaze/BlazeBudgetSettingViewModelTests.swift
@@ -230,6 +230,7 @@ final class BlazeBudgetSettingViewModelTests: XCTestCase {
 
 
         // When
+        viewModel.hasEndDate = false
         viewModel.confirmSettings()
 
         // Then
@@ -237,9 +238,21 @@ final class BlazeBudgetSettingViewModelTests: XCTestCase {
         let eventProperties = try XCTUnwrap(analyticsProvider.receivedProperties[index])
         XCTAssertEqual(eventProperties["duration"] as? Int, 3)
         XCTAssertEqual(eventProperties["total_budget"] as? Double, 45.0)
+        XCTAssertEqual(eventProperties["campaign_type"] as? String, "evergreen")
+
+        // When
+        viewModel.hasEndDate = true
+        viewModel.confirmSettings()
+
+        // Then
+        let lastIndex = try XCTUnwrap(analyticsProvider.receivedEvents.lastIndex(of: "blaze_creation_edit_budget_save_tapped"))
+        let lastEventProperties = try XCTUnwrap(analyticsProvider.receivedProperties[lastIndex])
+        XCTAssertEqual(lastEventProperties["duration"] as? Int, 3)
+        XCTAssertEqual(lastEventProperties["total_budget"] as? Double, 45.0)
+        XCTAssertEqual(lastEventProperties["campaign_type"] as? String, "start_end")
     }
 
-    func test_changing_duration_tracks_event_with_correct_properties() throws {
+    func test_changing_schedule_tracks_event_with_correct_properties() throws {
         // Given
         let viewModel = BlazeBudgetSettingViewModel(siteID: 123,
                                                     dailyBudget: 15,
@@ -257,5 +270,16 @@ final class BlazeBudgetSettingViewModelTests: XCTestCase {
         let index = try XCTUnwrap(analyticsProvider.receivedEvents.firstIndex(of: "blaze_creation_edit_budget_set_duration_applied"))
         let eventProperties = try XCTUnwrap(analyticsProvider.receivedProperties[index])
         XCTAssertEqual(eventProperties["duration"] as? Int, 7)
+        XCTAssertEqual(eventProperties["campaign_type"] as? String, "evergreen")
+
+        // When
+        viewModel.hasEndDate = true
+        viewModel.didTapApplyDuration(dayCount: 7, since: .now)
+
+        // Then
+        let lastIndex = try XCTUnwrap(analyticsProvider.receivedEvents.lastIndex(of: "blaze_creation_edit_budget_set_duration_applied"))
+        let lastEventProperties = try XCTUnwrap(analyticsProvider.receivedProperties[lastIndex])
+        XCTAssertEqual(lastEventProperties["duration"] as? Int, 7)
+        XCTAssertEqual(lastEventProperties["campaign_type"] as? String, "start_end")
     }
 }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Blaze/BlazeConfirmPaymentViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Blaze/BlazeConfirmPaymentViewModelTests.swift
@@ -513,11 +513,11 @@ final class BlazeConfirmPaymentViewModelTests: XCTestCase {
         XCTAssertTrue(analyticsProvider.receivedEvents.contains("blaze_creation_payment_submit_campaign_tapped"))
     }
 
-    func test_event_is_tracked_when_campaign_creation_successful() async throws {
+    func test_event_is_tracked_when_campaign_creation_successful_for_evergreen_campaign() async throws {
         // Given
         let viewModel = BlazeConfirmPaymentViewModel(productID: sampleProductID,
                                                      siteID: sampleSiteID,
-                                                     campaignInfo: .fake(),
+                                                     campaignInfo: .fake().copy(isEvergreen: true),
                                                      image: .init(image: .init(), source: .productImage(image: .fake())),
                                                      stores: stores,
                                                      analytics: analytics) {}
@@ -530,7 +530,31 @@ final class BlazeConfirmPaymentViewModelTests: XCTestCase {
         await viewModel.submitCampaign()
 
         // Then
-        XCTAssertTrue(analyticsProvider.receivedEvents.contains("blaze_campaign_creation_success"))
+        let index = try XCTUnwrap(analyticsProvider.receivedEvents.lastIndex(of: "blaze_campaign_creation_success"))
+        let eventProperties = try XCTUnwrap(analyticsProvider.receivedProperties[index])
+        XCTAssertEqual(eventProperties["campaign_type"] as? String, "evergreen")
+    }
+
+    func test_event_is_tracked_when_campaign_creation_successful_for_non_evergreen_campaign() async throws {
+        // Given
+        let viewModel = BlazeConfirmPaymentViewModel(productID: sampleProductID,
+                                                     siteID: sampleSiteID,
+                                                     campaignInfo: .fake().copy(isEvergreen: false),
+                                                     image: .init(image: .init(), source: .productImage(image: .fake())),
+                                                     stores: stores,
+                                                     analytics: analytics) {}
+        // When
+        mockRetrieveMedia(with: .success(.fake()))
+        mockCampaignCreation(with: .success(Void()))
+        await viewModel.updatePaymentInfo()
+
+        // When
+        await viewModel.submitCampaign()
+
+        // Then
+        let index = try XCTUnwrap(analyticsProvider.receivedEvents.lastIndex(of: "blaze_campaign_creation_success"))
+        let eventProperties = try XCTUnwrap(analyticsProvider.receivedProperties[index])
+        XCTAssertEqual(eventProperties["campaign_type"] as? String, "start_end")
     }
 
     func test_event_is_tracked_when_campaign_creation_failed() async throws {


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #13762 
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This PR adds new property `campaign_type` when tracking the following events:

- `_blaze_creation_edit_budget_save_tapped`
- `_blaze_creation_edit_budget_set_duration_applied`
- `_blaze_creation_confirm_details_tapped`
- `_blaze_campaign_creation_success`

Redundant event names and tracking for the web flow have also been removed.

## Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->
- Log in to a store eligible for Blaze.
- Navigate to the Products tab.
- Select a published product and tap Promote with Blaze.
- Select the Budget row and tap the Edit button.
- Toggle the Specify the duration switch and tap Apply. Confirm that `blaze_creation_edit_budget_set_duration_applied` is tracked with `campaign_type` being `start_end` if the switch is on and `evergreen` otherwise.
- Tap the Update button on the budget screen. Confirm that `blaze_creation_edit_budget_save_tapped` is tracked with `campaign_type` being `start_end` if an end date is specified and `evergreen` otherwise.
- Tap the Confirm details button on the Preview screen. Confirm that `blaze_creation_confirm_details_tapped` is tracked with `campaign_type` being `start_end` if an end date is specified and `evergreen` otherwise.
- Tap the Submit campaign on the Payment screen. After the campaign creation is successful, confirm that `blaze_campaign_creation_success` is tracked with `campaign_type` being `start_end` if an end date is specified and `evergreen` otherwise.

## Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->
Tested on simulator iPhone 15 Pro iOS 17.4:
- Campaign creation with an end date specified.
- Campaign creation without an end date.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->
N/A

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [x] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [x] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [x] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on all devices (phone/tablet) and no regressions are added.