### PR TITLE
Unit tests: Order Details - Edit Order

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -124,6 +124,7 @@ target 'WooCommerce' do
   target 'WooCommerceTests' do
     inherit! :search_paths
     pod 'ViewControllerPresentationSpy', '~> 7.0'
+    pod 'ViewInspector'
   end
 end
 

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -22,6 +22,7 @@ PODS:
   - SwiftLint (0.54.0)
   - UIDeviceIdentifier (2.3.0)
   - ViewControllerPresentationSpy (7.0.0)
+  - ViewInspector (0.9.11)
   - WordPress-Aztec-iOS (1.19.10)
   - WordPress-Editor-iOS (1.19.10):
     - WordPress-Aztec-iOS (= 1.19.10)
@@ -68,6 +69,7 @@ DEPENDENCIES:
   - StripeTerminal (~> 3.3.1)
   - SwiftLint (= 0.54.0)
   - ViewControllerPresentationSpy (~> 7.0)
+  - ViewInspector
   - WordPress-Editor-iOS (~> 1.19)
   - WordPressAuthenticator (~> 9.0.9)
   - WordPressShared (~> 2.1)
@@ -97,6 +99,7 @@ SPEC REPOS:
     - SwiftLint
     - UIDeviceIdentifier
     - ViewControllerPresentationSpy
+    - ViewInspector
     - WordPress-Aztec-iOS
     - WordPress-Editor-iOS
     - WordPressShared
@@ -129,6 +132,7 @@ SPEC CHECKSUMS:
   SwiftLint: c1de071d9d08c8aba837545f6254315bc900e211
   UIDeviceIdentifier: 442b65b4ff1832d4ca9c2a157815cb29ad981b17
   ViewControllerPresentationSpy: 05d5cd89a485a2be13008fb56d3de8c8aa821d31
+  ViewInspector: f251d90316dce2b58ebe5d7d88bc07643c055c78
   WordPress-Aztec-iOS: 8eaa928fb3a5694924ed3befac64beaae5656e12
   WordPress-Editor-iOS: 98ce1fc542c3a09e48ddc9423405b1d1e48240f1
   WordPressAuthenticator: e0c88dd994799595a4a4fafb801589f650af822c
@@ -146,6 +150,6 @@ SPEC CHECKSUMS:
   ZendeskSupportProvidersSDK: 2fbd2a9597af5d69760088bfb5e0e595e942f218
   ZendeskSupportSDK: 22156384d20d30b0aeb263c03f49bef44e1364b2
 
-PODFILE CHECKSUM: 87026e2645d3e5fec83ad68df9c942b14dd1988a
+PODFILE CHECKSUM: 98a22140d1c85a7f58c5287d4d1502f362674eab
 
 COCOAPODS: 1.15.2

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/CustomerSection/OrderCustomerSection.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/CustomerSection/OrderCustomerSection.swift
@@ -69,6 +69,7 @@ struct OrderCustomerSection: View {
             Image(systemName: "magnifyingglass")
         })
         .buttonStyle(TextButtonStyle())
+        .accessibilityLabel(Localization.searchCustomerAccessibilityLabel)
     }
 }
 
@@ -91,6 +92,10 @@ private extension OrderCustomerSection {
             value: "Add customer details",
             comment: "Title of the order customer selection screen in the order form.."
         )
+        static let searchCustomerAccessibilityLabel = NSLocalizedString(
+            "customer.search.button.accessibilityLabel",
+            value: "Search customer",
+            comment: "Accessibility title for the search button on the customer section.")
     }
 }
 

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -1117,6 +1117,7 @@
 		26F81B1C2BE433A3009EC58E /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 26F81B1B2BE433A3009EC58E /* Assets.xcassets */; };
 		26F81B1F2BE433A3009EC58E /* Preview Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 26F81B1E2BE433A3009EC58E /* Preview Assets.xcassets */; };
 		26F81B222BE433A3009EC58E /* Woo Watch App.app in Embed Watch Content */ = {isa = PBXBuildFile; fileRef = 26F81B152BE433A2009EC58E /* Woo Watch App.app */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
+		26F92DBE2C7ECAB20074A208 /* EditOrderFormTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26F92DBD2C7ECAB20074A208 /* EditOrderFormTests.swift */; };
 		26F94E1C267A3E4500DB6CCF /* ProductAddOnsListViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26F94E1B267A3E4500DB6CCF /* ProductAddOnsListViewController.swift */; };
 		26F94E21267A41BE00DB6CCF /* ProductAddOnsListViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26F94E20267A41BE00DB6CCF /* ProductAddOnsListViewModel.swift */; };
 		26F94E26267A559300DB6CCF /* ProductAddOn.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26F94E25267A559300DB6CCF /* ProductAddOn.swift */; };
@@ -4109,6 +4110,7 @@
 		26F81B192BE433A2009EC58E /* MyStoreView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MyStoreView.swift; sourceTree = "<group>"; };
 		26F81B1B2BE433A3009EC58E /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		26F81B1E2BE433A3009EC58E /* Preview Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = "Preview Assets.xcassets"; sourceTree = "<group>"; };
+		26F92DBD2C7ECAB20074A208 /* EditOrderFormTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditOrderFormTests.swift; sourceTree = "<group>"; };
 		26F94E1B267A3E4500DB6CCF /* ProductAddOnsListViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductAddOnsListViewController.swift; sourceTree = "<group>"; };
 		26F94E20267A41BE00DB6CCF /* ProductAddOnsListViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductAddOnsListViewModel.swift; sourceTree = "<group>"; };
 		26F94E25267A559300DB6CCF /* ProductAddOn.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProductAddOn.swift; sourceTree = "<group>"; };
@@ -9179,6 +9181,7 @@
 				025678042575EA1B009D7E6C /* ProductDetailsCellViewModelTests.swift */,
 				578195FB25AD1D7C004A5C12 /* OrderFulfillmentUseCaseTests.swift */,
 				262B442D2C77D9B000441FD5 /* OrderDetailsViewControllerTests.swift */,
+				26F92DBD2C7ECAB20074A208 /* EditOrderFormTests.swift */,
 			);
 			path = "Order Details";
 			sourceTree = "<group>";
@@ -16379,6 +16382,7 @@
 				B55BC1F321A8790F0011A0C0 /* StringHTMLTests.swift in Sources */,
 				0375799D2822F9040083F2E1 /* MockCardPresentPaymentsOnboardingPresenter.swift in Sources */,
 				455800CC24C6F83F00A8D117 /* ProductSettingsSectionsTests.swift in Sources */,
+				26F92DBE2C7ECAB20074A208 /* EditOrderFormTests.swift in Sources */,
 				D85B833F2230F268002168F3 /* SummaryTableViewCellTests.swift in Sources */,
 				B958A7D828B5316A00823EEF /* MockURLOpener.swift in Sources */,
 				02645D8227BA20A30065DC68 /* InboxViewModelTests.swift in Sources */,

--- a/WooCommerce/WooCommerceTests/System/TestingAppDelegate.swift
+++ b/WooCommerce/WooCommerceTests/System/TestingAppDelegate.swift
@@ -1,5 +1,6 @@
 import UIKit
 @testable import WooCommerce
+import Yosemite
 
 @objc(TestingAppDelegate)
 class TestingAppDelegate: AppDelegate {

--- a/WooCommerce/WooCommerceTests/Tools/MockOrders.swift
+++ b/WooCommerce/WooCommerceTests/Tools/MockOrders.swift
@@ -114,7 +114,7 @@ final class MockOrders {
 
     func sampleOrderItems() -> [OrderItem] {
         [
-            OrderItem.fake().copy(itemID: 1, name: "Sample Item", quantity: 2, price: 123)
+            OrderItem.fake().copy(itemID: 1, name: "Sample Item", productID: 12, quantity: 2, price: 123)
         ]
     }
 

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Details/EditOrderFormTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Details/EditOrderFormTests.swift
@@ -1,0 +1,125 @@
+import Foundation
+import XCTest
+import TestKit
+import Yosemite
+import ViewInspector
+
+@testable import WooCommerce
+
+final class EditOrderFormTests: XCTestCase {
+
+    func test_addition_buttons_on_empty_orders() throws {
+        // Given
+        let order = MockOrders().empty()
+
+        // When
+        let sut = try Self.createEditView(with: order).inspect()
+
+        // Then
+        XCTAssertNotNil(try? sut.find(button: "Add Products"))
+        XCTAssertNotNil(try? sut.find(button: "Add Custom Amount"))
+        XCTAssertNotNil(try? sut.find(button: "Add Customer"))
+        XCTAssertNotNil(try? sut.find(button: "Add Note"))
+        XCTAssertNotNil(try? sut.find(button: "Done"))
+    }
+
+    func test_components_on_editable_order_with_items() throws {
+        // Given
+        let order = MockOrders().empty().copy(isEditable: true, status: .onHold, items: MockOrders().sampleOrderItems())
+
+        // When
+        let sut = try Self.createEditView(with: order).inspect()
+
+        // Then
+        XCTAssertNotNil(try? sut.find(text: "Products"))
+        XCTAssertNotNil(try? sut.find(text: "Order total"))
+
+        XCTAssertNotNil(try? sut.find(viewWithAccessibilityLabel: "Add product"))
+        XCTAssertNotNil(try? sut.find(button: "Add Custom Amount"))
+        XCTAssertNotNil(try? sut.find(button: "Add Shipping"))
+        XCTAssertNotNil(try? sut.find(button: "Add Coupon"))
+        XCTAssertNotNil(try? sut.find(button: "Add Customer"))
+        XCTAssertNotNil(try? sut.find(button: "Add Note"))
+        XCTAssertNotNil(try? sut.find(button: "Done"))
+    }
+
+    func test_components_on_editable_order_with_custom_amount() throws {
+        // Given
+        let order = MockOrders().empty().copy(isEditable: true, status: .onHold, fees: MockOrders().sampleFeeLines())
+
+        // When
+        let sut = try Self.createEditView(with: order).inspect()
+
+        // Then
+        XCTAssertNotNil(try? sut.find(text: "Custom Amounts"))
+        XCTAssertNotNil(try? sut.find(text: "Order total"))
+
+        XCTAssertNotNil(try? sut.find(viewWithAccessibilityLabel: "Edit amount"))
+        XCTAssertNotNil(try? sut.find(button: "Add Shipping"))
+        XCTAssertNotNil(try? sut.find(button: "Add Customer"))
+        XCTAssertNotNil(try? sut.find(button: "Add Note"))
+        XCTAssertNotNil(try? sut.find(button: "Done"))
+    }
+
+    func test_components_on_editable_order_with_shipping_and_customer_information() throws {
+        // Given
+        let order = MockOrders().sampleOrder().copy(isEditable: true, status: .onHold)
+
+        // When
+        let sut = try Self.createEditView(with: order).inspect()
+
+        // Then
+        XCTAssertNotNil(try? sut.find(text: "Shipping"))
+        XCTAssertNotNil(try? sut.find(text: "Customer"))
+        XCTAssertNotNil(try? sut.find(text: "Order total"))
+
+        XCTAssertNotNil(try? sut.find(viewWithAccessibilityLabel: "Edit shipping"))
+        XCTAssertNotNil(try? sut.find(viewWithAccessibilityLabel: "Search customer"))
+
+        XCTAssertNotNil(try? sut.find(button: "Add Products"))
+        XCTAssertNotNil(try? sut.find(button: "Add Custom Amount"))
+        XCTAssertNotNil(try? sut.find(button: "Add Note"))
+        XCTAssertNotNil(try? sut.find(button: "Done"))
+    }
+
+    func test_components_on_editable_order_with_order_note() throws {
+        // Given
+        let order = MockOrders().empty().copy(isEditable: true, status: .onHold, customerNote: "Some Note")
+
+        // When
+        let sut = try Self.createEditView(with: order).inspect()
+
+        // Then
+        XCTAssertNotNil(try? sut.find(text: "Customer Note"))
+        XCTAssertNotNil(try? sut.find(text: "Order total"))
+
+        XCTAssertNotNil(try? sut.find(viewWithAccessibilityLabel: "Edit customer note"))
+
+        XCTAssertNotNil(try? sut.find(button: "Add Products"))
+        XCTAssertNotNil(try? sut.find(button: "Add Custom Amount"))
+        XCTAssertNotNil(try? sut.find(button: "Add Customer"))
+        XCTAssertNotNil(try? sut.find(button: "Done"))
+    }
+}
+
+// MARK: Helpers
+private extension EditOrderFormTests {
+    static func createEditView(with order: Order) -> OrderForm {
+        let stores = MockStoresManager(sessionManager: .testingInstance)
+        let storage = MockStorageManager()
+
+        // Insert products that relates to items into the storage.
+        // This is needed by EditableOrderViewModel to properly compute its variables
+        for item in order.items {
+            let product = Product.fake().copy(siteID: order.siteID, productID: item.productID)
+            storage.insertSampleProduct(readOnlyProduct: product)
+        }
+
+        let viewModel = EditableOrderViewModel(siteID: order.siteID,
+                                               flow: .editing(initialOrder: order),
+                                               stores: stores,
+                                               storageManager: storage)
+        return OrderForm(flow: .editing, viewModel: viewModel, presentProductSelector: {})
+    }
+
+}

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Details/OrderDetailsViewControllerTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Details/OrderDetailsViewControllerTests.swift
@@ -75,6 +75,28 @@ final class OrderDetailsViewControllerTests: XCTestCase {
         let presentedVC = try XCTUnwrap(presentedNav?.topViewController)
         XCTAssertTrue(presentedVC is ProductLoaderViewController)
     }
+
+    @MainActor
+    func test_edit_order_button_is_visible_and_navigates_to_edit_order_screen() throws {
+        // Given
+        let presentationVerifier = PresentationVerifier()
+        let storageManager = MockStorageManager()
+        let order = MockOrders().sampleOrder()
+        let storesManager = OrderDetailStoreManagerFactory.createManager(order: order)
+
+        let viewModel = OrderDetailsViewModel(order: order, stores: storesManager, storageManager: storageManager)
+        let viewController = OrderDetailsViewController(viewModel: viewModel)
+        let navController = UINavigationController(rootViewController: viewController)
+
+        // When
+        _ = try XCTUnwrap(viewController.view)
+        let editItem = try XCTUnwrap(viewController.navigationItem.rightBarButtonItem)
+        Self.performActionOf(item: editItem)
+
+        // Then
+        let presentedVC: OrderFormHostingController? = presentationVerifier.verify(animated: true, presentingViewController: viewController)
+        XCTAssertNotNil(presentedVC)
+    }
 }
 
 // MARK: - Mirroring
@@ -107,6 +129,13 @@ private extension OrderDetailsViewControllerTests {
             }
         }
         return nil
+    }
+
+    static func performActionOf(item: UIBarButtonItem) {
+        guard let target = item.target, let action = item.action else {
+            return
+        }
+        target.performSelector(onMainThread: action, with: nil, waitUntilDone: true)
     }
 }
 

--- a/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Details/OrderDetailsViewControllerTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Orders/Order Details/OrderDetailsViewControllerTests.swift
@@ -86,7 +86,6 @@ final class OrderDetailsViewControllerTests: XCTestCase {
 
         let viewModel = OrderDetailsViewModel(order: order, stores: storesManager, storageManager: storageManager)
         let viewController = OrderDetailsViewController(viewModel: viewModel)
-        let navController = UINavigationController(rootViewController: viewController)
 
         // When
         _ = try XCTUnwrap(viewController.view)
@@ -94,8 +93,14 @@ final class OrderDetailsViewControllerTests: XCTestCase {
         Self.performActionOf(item: editItem)
 
         // Then
-        let presentedVC: OrderFormHostingController? = presentationVerifier.verify(animated: true, presentingViewController: viewController)
-        XCTAssertNotNil(presentedVC)
+        switch presentationVerifier.presentedViewController {
+        case is OrderFormHostingController:
+            break //Success
+        case let navController as UINavigationController:
+            XCTAssertTrue(navController.topViewController is OrderFormHostingController)
+        default:
+            XCTFail("Expected OrderFormHostingController to be presented, got: \(String(describing: presentationVerifier.presentedViewController))")
+        }
     }
 }
 


### PR DESCRIPTION
# Why

As part of the initiative of [automating smoke tests for our Core Functionalities](https://github.com/woocommerce/woocommerce-ios/issues/13453) this PR adds unit tests for the following scenarios

- Tap edit an order detail screen should open the order detail form
- Verify buttons for an empty order
- Verify buttons & labels for an order with items
- Verify buttons & labels for an order with custom ammounts
- Verify buttons & labels for an order with shipping and customers
- Verify buttons & labels for an order with customer notes  

# How

- Adds a new `ViewInspector` pod to help us inspect SwiftUI views.

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [x] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [x] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [x] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on all devices (phone/tablet) and no regressions are added.
