### PR TITLE
[Products] Remove unwanted characters in product price input based on currency settings

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -8,6 +8,7 @@
 - [*] Home Screen Widget: Tapping on the Orders section of the home screen widget opens the Orders part of the app.
 - [*] Payments: Punctuation updates to error and decline reason messages [https://github.com/woocommerce/woocommerce-ios/pull/13739]
 - [*] Blaze: Display budget field on the dashboard card. [https://github.com/woocommerce/woocommerce-ios/pull/13761]
+- [*] Products: Fixed a bug where editing the product price did not work as expected, depending on the store's currency settings. [https://github.com/woocommerce/woocommerce-ios/pull/13768]
 
 20.1
 -----

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Edit Price/Product+PriceSettingsViewModels.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Edit Price/Product+PriceSettingsViewModels.swift
@@ -2,12 +2,6 @@ import Yosemite
 import WooFoundation
 
 extension Product {
-
-    // Regex that match all the occurrences of the thousand separators.
-    // All the points or comma (but not the last `.` or `,`)
-    //
-    private static let regexThousandSeparators = "(?:[.,](?=.*[.,])|)+"
-
     private static let placeholder = "0"
 
     static func createRegularPriceViewModel(regularPrice: String?,
@@ -16,13 +10,14 @@ extension Product {
         let currencyFormatter = CurrencyFormatter(currencySettings: ServiceLocator.currencySettings)
         let currencyCode = ServiceLocator.currencySettings.currencyCode
         let unit = ServiceLocator.currencySettings.symbol(from: currencyCode)
+        let thousandsSeparator = ServiceLocator.currencySettings.groupingSeparator
         let value: String = {
             guard let regularPrice, regularPrice.isNotEmpty else {
                 return ""
             }
             return (currencyFormatter.formatAmount(regularPrice, with: unit) ?? "")
                 .replacingOccurrences(of: unit, with: "")
-                .replacingOccurrences(of: regexThousandSeparators, with: "$1", options: .regularExpression)
+                .replacingOccurrences(of: thousandsSeparator, with: "")
         }()
         return UnitInputViewModel(title: Localization.regularPriceTitle,
                                   unit: unit,
@@ -42,13 +37,14 @@ extension Product {
         let currencyFormatter = CurrencyFormatter(currencySettings: ServiceLocator.currencySettings)
         let currencyCode = ServiceLocator.currencySettings.currencyCode
         let unit = ServiceLocator.currencySettings.symbol(from: currencyCode)
+        let thousandsSeparator = ServiceLocator.currencySettings.groupingSeparator
         let value: String = {
             guard let salePrice, salePrice.isNotEmpty else {
                 return ""
             }
             return (currencyFormatter.formatAmount(salePrice, with: unit) ?? "")
                 .replacingOccurrences(of: unit, with: "")
-                .replacingOccurrences(of: regexThousandSeparators, with: "$1", options: .regularExpression)
+                .replacingOccurrences(of: thousandsSeparator, with: "")
         }()
 
         return UnitInputViewModel(title: Localization.salePriceTitle,
@@ -69,13 +65,14 @@ extension Product {
         let currencyFormatter = CurrencyFormatter(currencySettings: ServiceLocator.currencySettings)
         let currencyCode = ServiceLocator.currencySettings.currencyCode
         let unit = ServiceLocator.currencySettings.symbol(from: currencyCode)
+        let thousandsSeparator = ServiceLocator.currencySettings.groupingSeparator
         let value: String = {
             guard let fee, fee.isNotEmpty else {
                 return ""
             }
             return (currencyFormatter.formatAmount(fee, with: unit) ?? "")
                 .replacingOccurrences(of: unit, with: "")
-                .replacingOccurrences(of: regexThousandSeparators, with: "$1", options: .regularExpression)
+                .replacingOccurrences(of: thousandsSeparator, with: "")
         }()
         return UnitInputViewModel(title: Localization.signupFeeTitle,
                                   subtitle: Localization.signupFeeSubtitle,

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Edit Price/Product+PriceSettingsViewModels.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Edit Price/Product+PriceSettingsViewModels.swift
@@ -18,6 +18,7 @@ extension Product {
             return (currencyFormatter.formatAmount(regularPrice, with: unit) ?? "")
                 .replacingOccurrences(of: unit, with: "")
                 .replacingOccurrences(of: thousandsSeparator, with: "")
+                .filter { !$0.isWhitespace }
         }()
         return UnitInputViewModel(title: Localization.regularPriceTitle,
                                   unit: unit,
@@ -45,6 +46,7 @@ extension Product {
             return (currencyFormatter.formatAmount(salePrice, with: unit) ?? "")
                 .replacingOccurrences(of: unit, with: "")
                 .replacingOccurrences(of: thousandsSeparator, with: "")
+                .filter { !$0.isWhitespace }
         }()
 
         return UnitInputViewModel(title: Localization.salePriceTitle,
@@ -73,6 +75,7 @@ extension Product {
             return (currencyFormatter.formatAmount(fee, with: unit) ?? "")
                 .replacingOccurrences(of: unit, with: "")
                 .replacingOccurrences(of: thousandsSeparator, with: "")
+                .filter { !$0.isWhitespace }
         }()
         return UnitInputViewModel(title: Localization.signupFeeTitle,
                                   subtitle: Localization.signupFeeSubtitle,


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #13767
<!-- Id number of the GitHub issue this PR addresses. -->

## Description

There were two issues with the formatting we did on product prices in product details:

1. If the currency settings don't include any decimals, the thousands separators were not all removed until the price was edited.
2. If the currency settings include a space in the currency position (`Left with space` or `Right with space`), the space was not removed. When the price was edited, the space was then replaced with a decimal separator.

This fixes those issues by updating how the price amounts are formatted for those text fields:

1. We now remove all instances of the thousands separator set in `CurrencySettings` from the amount. Previously we used regex to remove all but the last separator (assuming it was a decimal separator). This didn't account for settings where there is no decimal separator, or settings using a different thousands separator (this is a custom character in WooCommerce settings).
2. We now trim whitespaces from the amount. This removes the whitespace added by currency positions with a space.

Note: The methods used for this formatting are internal methods and aren't unit testable as-is. To avoid more extensive refactoring I haven't include unit tests for these changes. If we ever reuse these methods or this formatting anywhere else, we should consider adding unit tests for the various currency settings that are involved.

## Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->

1. Set your store currency position setting to "Left with space" (in WooCommerce > Settings > Currency options > Currency position).
2. Set the number of decimals setting to 0.
4. Close and relaunch the app (to ensure the latest currency settings are used).
5. Go to the Products tab.
6. Select a product and open its Price settings.
7. In the price field, edit the price (e.g. add or remove a number) and confirm the amount updates as expected with no extraneous decimal separator.

## Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->

Scenarios to consider:

* Currency position with and without a space
* Currency settings with and without decimal places
* Negative prices (Note that this PR does not resolve https://github.com/woocommerce/woocommerce-ios/issues/4692, but the space should still be removed when there is a negative number)
* Prices with thousands separators

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->


https://github.com/user-attachments/assets/808a7af6-6048-4aca-b79c-c6681c026abc



---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [x] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [x] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [x] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on all devices (phone/tablet) and no regressions are added.