### PR TITLE
[Woo POS] Use x to close POS reader modals

### DIFF
--- a/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/Connection Alerts/PointOfSaleCardPresentPaymentBluetoothRequiredAlertView.swift
+++ b/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/Connection Alerts/PointOfSaleCardPresentPaymentBluetoothRequiredAlertView.swift
@@ -18,16 +18,12 @@ struct PointOfSaleCardPresentPaymentBluetoothRequiredAlertView: View {
             Text(viewModel.errorDetails)
                 .font(POSFontStyle.posBodyRegular)
 
-            VStack(spacing: PointOfSaleReaderConnectionModalLayout.buttonSpacing) {
-                Button(viewModel.openSettingsButtonViewModel.title,
-                       action: viewModel.openSettingsButtonViewModel.actionHandler)
-                .buttonStyle(PrimaryButtonStyle())
-
-                Button(viewModel.dismissButtonViewModel.title,
-                       action: viewModel.dismissButtonViewModel.actionHandler)
-                .buttonStyle(SecondaryButtonStyle())
-            }
+            Button(viewModel.openSettingsButtonViewModel.title,
+                   action: viewModel.openSettingsButtonViewModel.actionHandler)
+            .buttonStyle(PrimaryButtonStyle())
         }
+        .posModalCloseButton(action: viewModel.dismissButtonViewModel.actionHandler,
+                             accessibilityLabel: viewModel.dismissButtonViewModel.title)
         .multilineTextAlignment(.center)
         .accessibilityElement(children: .contain)
     }

--- a/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/Connection Alerts/PointOfSaleCardPresentPaymentConnectingFailedChargeReaderView.swift
+++ b/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/Connection Alerts/PointOfSaleCardPresentPaymentConnectingFailedChargeReaderView.swift
@@ -14,16 +14,12 @@ struct PointOfSaleCardPresentPaymentConnectingFailedChargeReaderView: View {
             Text(viewModel.errorDetails)
                 .font(POSFontStyle.posBodyRegular)
 
-            VStack(spacing: PointOfSaleReaderConnectionModalLayout.buttonSpacing) {
-                Button(viewModel.retryButtonViewModel.title,
-                       action: viewModel.retryButtonViewModel.actionHandler)
-                .buttonStyle(PrimaryButtonStyle())
-
-                Button(viewModel.cancelButtonViewModel.title,
-                       action: viewModel.cancelButtonViewModel.actionHandler)
-                .buttonStyle(SecondaryButtonStyle())
-            }
+            Button(viewModel.retryButtonViewModel.title,
+                   action: viewModel.retryButtonViewModel.actionHandler)
+            .buttonStyle(PrimaryButtonStyle())
         }
+        .posModalCloseButton(action: viewModel.cancelButtonViewModel.actionHandler,
+                              accessibilityLabel: viewModel.cancelButtonViewModel.title)
         .multilineTextAlignment(.center)
         .accessibilityElement(children: .contain)
     }

--- a/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/Connection Alerts/PointOfSaleCardPresentPaymentConnectingFailedNonRetryableView.swift
+++ b/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/Connection Alerts/PointOfSaleCardPresentPaymentConnectingFailedNonRetryableView.swift
@@ -13,11 +13,9 @@ struct PointOfSaleCardPresentPaymentConnectingFailedNonRetryableView: View {
 
             Text(viewModel.errorDetails)
                 .font(POSFontStyle.posBodyRegular)
-
-            Button(viewModel.cancelButtonViewModel.title,
-                   action: viewModel.cancelButtonViewModel.actionHandler)
-            .buttonStyle(SecondaryButtonStyle())
         }
+        .posModalCloseButton(action: viewModel.cancelButtonViewModel.actionHandler,
+                             accessibilityLabel: viewModel.cancelButtonViewModel.title)
         .accessibilityElement(children: .contain)
     }
 }

--- a/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/Connection Alerts/PointOfSaleCardPresentPaymentConnectingFailedUpdateAddressView.swift
+++ b/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/Connection Alerts/PointOfSaleCardPresentPaymentConnectingFailedUpdateAddressView.swift
@@ -10,18 +10,14 @@ struct PointOfSaleCardPresentPaymentConnectingFailedUpdateAddressView: View {
 
             Image(decorative: viewModel.imageName)
 
-            VStack(spacing: PointOfSaleReaderConnectionModalLayout.buttonSpacing) {
-                if let primaryButtonViewModel = viewModel.primaryButtonViewModel {
-                    Button(primaryButtonViewModel.title,
-                           action: primaryButtonViewModel.actionHandler)
-                    .buttonStyle(PrimaryButtonStyle())
-                }
-
-                Button(viewModel.cancelButtonViewModel.title,
-                       action: viewModel.cancelButtonViewModel.actionHandler)
-                .buttonStyle(SecondaryButtonStyle())
+            if let primaryButtonViewModel = viewModel.primaryButtonViewModel {
+                Button(primaryButtonViewModel.title,
+                       action: primaryButtonViewModel.actionHandler)
+                .buttonStyle(PrimaryButtonStyle())
             }
         }
+        .posModalCloseButton(action: viewModel.cancelButtonViewModel.actionHandler,
+                             accessibilityLabel: viewModel.cancelButtonViewModel.title)
         .multilineTextAlignment(.center)
         .accessibilityElement(children: .contain)
         .sheet(isPresented: $viewModel.shouldShowSettingsWebView) {

--- a/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/Connection Alerts/PointOfSaleCardPresentPaymentConnectingFailedUpdatePostalCodeView.swift
+++ b/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/Connection Alerts/PointOfSaleCardPresentPaymentConnectingFailedUpdatePostalCodeView.swift
@@ -14,16 +14,12 @@ struct PointOfSaleCardPresentPaymentConnectingFailedUpdatePostalCodeView: View {
             Text(viewModel.errorDetails)
                 .font(POSFontStyle.posBodyRegular)
 
-            VStack(spacing: PointOfSaleReaderConnectionModalLayout.buttonSpacing) {
-                Button(viewModel.retryButtonViewModel.title,
-                       action: viewModel.retryButtonViewModel.actionHandler)
-                .buttonStyle(PrimaryButtonStyle())
-
-                Button(viewModel.cancelButtonViewModel.title,
-                       action: viewModel.cancelButtonViewModel.actionHandler)
-                .buttonStyle(SecondaryButtonStyle())
-            }
+            Button(viewModel.retryButtonViewModel.title,
+                   action: viewModel.retryButtonViewModel.actionHandler)
+            .buttonStyle(PrimaryButtonStyle())
         }
+        .posModalCloseButton(action: viewModel.cancelButtonViewModel.actionHandler,
+                             accessibilityLabel: viewModel.cancelButtonViewModel.title)
         .multilineTextAlignment(.center)
         .accessibilityElement(children: .contain)
     }

--- a/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/Connection Alerts/PointOfSaleCardPresentPaymentConnectingFailedView.swift
+++ b/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/Connection Alerts/PointOfSaleCardPresentPaymentConnectingFailedView.swift
@@ -20,16 +20,12 @@ struct PointOfSaleCardPresentPaymentConnectingFailedView: View {
                     .font(POSFontStyle.posBodyRegular)
             }
 
-            VStack(spacing: PointOfSaleReaderConnectionModalLayout.buttonSpacing) {
-                Button(viewModel.retryButtonViewModel.title,
-                       action: viewModel.retryButtonViewModel.actionHandler)
-                .buttonStyle(PrimaryButtonStyle())
-
-                Button(viewModel.cancelButtonViewModel.title,
-                       action: viewModel.cancelButtonViewModel.actionHandler)
-                .buttonStyle(SecondaryButtonStyle())
-            }
+            Button(viewModel.retryButtonViewModel.title,
+                   action: viewModel.retryButtonViewModel.actionHandler)
+            .buttonStyle(PrimaryButtonStyle())
         }
+        .posModalCloseButton(action: viewModel.cancelButtonViewModel.actionHandler,
+                             accessibilityLabel: viewModel.cancelButtonViewModel.title)
         .multilineTextAlignment(.center)
         .accessibilityElement(children: .contain)
     }

--- a/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/Connection Alerts/PointOfSaleCardPresentPaymentFoundReaderView.swift
+++ b/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/Connection Alerts/PointOfSaleCardPresentPaymentFoundReaderView.swift
@@ -19,11 +19,10 @@ struct PointOfSaleCardPresentPaymentFoundReaderView: View {
                 Button(viewModel.continueSearchButton.title,
                        action: viewModel.continueSearchButton.actionHandler)
                 .buttonStyle(SecondaryButtonStyle())
-
-                Button(viewModel.cancelSearchButton.title,
-                       action: viewModel.cancelSearchButton.actionHandler)
             }
         }
+        .posModalCloseButton(action: viewModel.cancelSearchButton.actionHandler,
+                             accessibilityLabel: viewModel.cancelSearchButton.title)
         .multilineTextAlignment(.center)
         .accessibilityElement(children: .contain)
     }

--- a/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/Connection Alerts/PointOfSaleCardPresentPaymentReaderUpdateFailedView.swift
+++ b/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/Connection Alerts/PointOfSaleCardPresentPaymentReaderUpdateFailedView.swift
@@ -15,16 +15,12 @@ struct PointOfSaleCardPresentPaymentReaderUpdateFailedView: View {
 
             Image(decorative: viewModel.imageName)
 
-            VStack(spacing: PointOfSaleReaderConnectionModalLayout.buttonSpacing) {
-                Button(viewModel.retryButtonViewModel.title,
-                       action: viewModel.retryButtonViewModel.actionHandler)
-                .buttonStyle(PrimaryButtonStyle())
-
-                Button(viewModel.cancelButtonViewModel.title,
-                       action: viewModel.cancelButtonViewModel.actionHandler)
-                .buttonStyle(SecondaryButtonStyle())
-            }
+            Button(viewModel.retryButtonViewModel.title,
+                   action: viewModel.retryButtonViewModel.actionHandler)
+            .buttonStyle(PrimaryButtonStyle())
         }
+        .posModalCloseButton(action: viewModel.cancelButtonViewModel.actionHandler,
+                             accessibilityLabel: viewModel.cancelButtonViewModel.title)
         .multilineTextAlignment(.center)
         .accessibilityElement(children: .contain)
     }

--- a/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/Connection Alerts/PointOfSaleCardPresentPaymentScanningForReadersFailedView.swift
+++ b/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/Connection Alerts/PointOfSaleCardPresentPaymentScanningForReadersFailedView.swift
@@ -17,11 +17,9 @@ struct PointOfSaleCardPresentPaymentScanningForReadersFailedView: View {
 
             Text(viewModel.errorDetails)
                 .font(POSFontStyle.posBodyRegular)
-
-            Button(viewModel.buttonViewModel.title,
-                   action: viewModel.buttonViewModel.actionHandler)
-            .buttonStyle(SecondaryButtonStyle())
         }
+        .posModalCloseButton(action: viewModel.buttonViewModel.actionHandler,
+                             accessibilityLabel: viewModel.buttonViewModel.title)
         .multilineTextAlignment(.center)
         .accessibilityElement(children: .contain)
     }

--- a/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/Connection Alerts/PointOfSaleCardPresentPaymentScanningForReadersView.swift
+++ b/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/Connection Alerts/PointOfSaleCardPresentPaymentScanningForReadersView.swift
@@ -17,11 +17,9 @@ struct PointOfSaleCardPresentPaymentScanningForReadersView: View {
 
             Text(viewModel.instruction)
                 .font(POSFontStyle.posBodyRegular)
-
-            Button(viewModel.buttonViewModel.title,
-                   action: viewModel.buttonViewModel.actionHandler)
-            .buttonStyle(SecondaryButtonStyle())
         }
+        .posModalCloseButton(action: viewModel.buttonViewModel.actionHandler,
+                             accessibilityLabel: viewModel.buttonViewModel.title)
         .multilineTextAlignment(.center)
         .accessibilityElement(children: .contain)
     }

--- a/WooCommerce/Classes/POS/Presentation/PointOfSaleExitPosAlertView.swift
+++ b/WooCommerce/Classes/POS/Presentation/PointOfSaleExitPosAlertView.swift
@@ -16,8 +16,7 @@ struct PointOfSaleExitPosAlertView: View {
                     isPresented = false
                 } label: {
                     Image(systemName: "xmark")
-                        .font(.system(size: UIFontMetrics.default.scaledValue(for: Constants.closeIconSize),
-                                      weight: .medium))
+                        .font(.posButtonSymbol)
                 }
                 .foregroundColor(Color.posTertiaryText)
             }
@@ -43,7 +42,6 @@ private extension PointOfSaleExitPosAlertView {
         static let titleBottomPadding: CGFloat = 20.0
         static let bodyBottomPadding: CGFloat = 60.0
         static let padding: CGFloat = 40.0
-        static let closeIconSize: CGFloat = 32.0
     }
 
     enum Localization {

--- a/WooCommerce/Classes/POS/Presentation/Reusable Views/POSModalCloseButton.swift
+++ b/WooCommerce/Classes/POS/Presentation/Reusable Views/POSModalCloseButton.swift
@@ -1,0 +1,47 @@
+import SwiftUI
+
+extension View {
+    func posModalCloseButton(
+        action: @escaping (() -> Void),
+        accessibilityLabel: String = POSModalCloseButton.Localization.defaultAccessibilityLabel) -> some View {
+        self.modifier(
+            POSModalCloseButton(
+                closeAction: action,
+                accessibilityLabel: accessibilityLabel)
+            )
+    }
+}
+
+struct POSModalCloseButton: ViewModifier {
+    let closeAction: () -> Void
+    let accessibilityLabel: String
+
+    func body(content: Content) -> some View {
+        VStack(spacing: 0) {
+            HStack {
+                Spacer()
+                Button(action: closeAction, label: {
+                    Image(systemName: "xmark")
+                        .font(.posButtonSymbol)
+                })
+                .foregroundColor(Color.posTertiaryText)
+                .accessibilityLabel(accessibilityLabel)
+            }
+
+            Spacer()
+
+            content
+
+            Spacer()
+        }
+    }
+}
+
+private extension POSModalCloseButton {
+    enum Localization {
+        static let defaultAccessibilityLabel = NSLocalizedString(
+            "pointOfSale.cardPresentPayment.connection.modal.close.button.accessibilityLabel.default",
+            value: "Close",
+            comment: "The default accessibility label for an `x` close button on a card reader connection modal.")
+    }
+}

--- a/WooCommerce/Classes/POS/Utils/POSFontStyle.swift
+++ b/WooCommerce/Classes/POS/Utils/POSFontStyle.swift
@@ -10,6 +10,7 @@ enum POSFontStyle {
     case posDetailLight
     case posDetailRegular
     case posDetailEmphasized
+    case posButtonSymbol
 
     func font(maximumContentSizeCategory: UIContentSizeCategory? = nil) -> Font {
         switch self {
@@ -27,6 +28,8 @@ enum POSFontStyle {
             Font.system(size: scaledValue(16, maximumContentSizeCategory: maximumContentSizeCategory), weight: .medium)
         case .posDetailEmphasized:
             Font.system(size: scaledValue(16, maximumContentSizeCategory: maximumContentSizeCategory), weight: .semibold)
+        case .posButtonSymbol:
+            Font.system(size: scaledValue(32, maximumContentSizeCategory: maximumContentSizeCategory), weight: .medium)
         }
     }
 

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -841,6 +841,7 @@
 		20CC1EDD2AFA99DF006BD429 /* InPersonPaymentsMenuViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 20CC1EDC2AFA99DF006BD429 /* InPersonPaymentsMenuViewModel.swift */; };
 		20CCBF212B0E15C0003102E6 /* WooPaymentsDepositsCurrencyOverviewViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 20CCBF202B0E15C0003102E6 /* WooPaymentsDepositsCurrencyOverviewViewModelTests.swift */; };
 		20D210BE2B14C9B90099E517 /* WooPaymentsDepositStatusDisplayDetails.swift in Sources */ = {isa = PBXBuildFile; fileRef = 20D210BD2B14C9B90099E517 /* WooPaymentsDepositStatusDisplayDetails.swift */; };
+		20D2CCA52C7E328300051705 /* POSModalCloseButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 20D2CCA42C7E328300051705 /* POSModalCloseButton.swift */; };
 		20D3D42B2C64D7CC004CE6E3 /* SimpleProductsOnlyInformation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 20D3D42A2C64D7CC004CE6E3 /* SimpleProductsOnlyInformation.swift */; };
 		20D3D42F2C64F175004CE6E3 /* POSSecondaryButtonStyle.swift in Sources */ = {isa = PBXBuildFile; fileRef = 20D3D42E2C64F175004CE6E3 /* POSSecondaryButtonStyle.swift */; };
 		20D3D4312C64F202004CE6E3 /* POSButtonStyleConstants.swift in Sources */ = {isa = PBXBuildFile; fileRef = 20D3D4302C64F202004CE6E3 /* POSButtonStyleConstants.swift */; };
@@ -3881,6 +3882,7 @@
 		20CC1EDC2AFA99DF006BD429 /* InPersonPaymentsMenuViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InPersonPaymentsMenuViewModel.swift; sourceTree = "<group>"; };
 		20CCBF202B0E15C0003102E6 /* WooPaymentsDepositsCurrencyOverviewViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WooPaymentsDepositsCurrencyOverviewViewModelTests.swift; sourceTree = "<group>"; };
 		20D210BD2B14C9B90099E517 /* WooPaymentsDepositStatusDisplayDetails.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WooPaymentsDepositStatusDisplayDetails.swift; sourceTree = "<group>"; };
+		20D2CCA42C7E328300051705 /* POSModalCloseButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = POSModalCloseButton.swift; sourceTree = "<group>"; };
 		20D3D42A2C64D7CC004CE6E3 /* SimpleProductsOnlyInformation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SimpleProductsOnlyInformation.swift; sourceTree = "<group>"; };
 		20D3D42E2C64F175004CE6E3 /* POSSecondaryButtonStyle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = POSSecondaryButtonStyle.swift; sourceTree = "<group>"; };
 		20D3D4302C64F202004CE6E3 /* POSButtonStyleConstants.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = POSButtonStyleConstants.swift; sourceTree = "<group>"; };
@@ -6067,6 +6069,7 @@
 			children = (
 				01620C4D2C5394B200D3EA2F /* POSProgressViewStyle.swift */,
 				204D1D612C5A50840064A6BE /* POSModalViewModifier.swift */,
+				20D2CCA42C7E328300051705 /* POSModalCloseButton.swift */,
 				209EEF8F2C762ED5007969A4 /* POSModalManager.swift */,
 				01D0823F2C5B9EAB007FE81F /* POSBackgroundAppearanceKey.swift */,
 				207823E62C5D346300025A59 /* POSPrimaryButtonStyle.swift */,
@@ -14854,6 +14857,7 @@
 				02D9EFCB2B69F91B00AE8968 /* ProductsSplitViewCoordinator.swift in Sources */,
 				0211259F2578DE310075AD2A /* ShippingLabelPrintingStepView.swift in Sources */,
 				B58B4AB22108F01700076FDD /* NoticeView.swift in Sources */,
+				20D2CCA52C7E328300051705 /* POSModalCloseButton.swift in Sources */,
 				74B5713621CD7604008F9B8E /* SharingHelper.swift in Sources */,
 				261F1A7929C2AB2E001D9861 /* FreeTrialBannerViewModel.swift in Sources */,
 				0313651328ABCB2D00EEE571 /* InPersonPaymentsOnboardingErrorMainContentView.swift in Sources */,


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of: #13731
Merge after: #13770
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

This is part of a series of PRs to improve the card reader connnection screens. You may want to test at the end of the series, as it could get quite repetitive, but doing it all in one was quite big. Up to you! The last one is #13775

As per the new designs, this uses `x` to close the modals instead of a cancel button, in most cases.

I have used some judgement here – if it feels like you're taking more of an action, e.g. after a reader update fails, I've left it as a cancel button.

The cancel handler doesn't update the UI immediately – that hasn't changed, but it does feel a little strange to have to wait for it to close. I think sorting that's outside the scope of this change though.

## Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->

1. Launch the app
2. Enter the POS
3. Tap `Connect your reader`
4. Tap `x` to cancel

Using a physical reader to test error states:

1. Launch the app
2. Enter the POS
3. Tap `Connect your reader`
4. Turn off Bluetooth
5. Observe that an error is shown, tap `x` to close it

## Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->

I've tested these on an iPad running iOS 16, and run through each modal to check that the button does the same as the previous cancel button did.

No unit tests as this is UI only

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

Note that this video is from this branch – if you test later on, the rest of the modal UI will look a bit different.


https://github.com/user-attachments/assets/c1d62a92-6158-464f-ac56-406b9853c103



---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [x] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [x] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [x] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on all devices (phone/tablet) and no regressions are added.