### PR TITLE
[Woo POS] Use POS styles in reader connection modals

### DIFF
--- a/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/Connection Alerts/PointOfSaleCardPresentPaymentBluetoothRequiredAlertView.swift
+++ b/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/Connection Alerts/PointOfSaleCardPresentPaymentBluetoothRequiredAlertView.swift
@@ -20,7 +20,7 @@ struct PointOfSaleCardPresentPaymentBluetoothRequiredAlertView: View {
 
             Button(viewModel.openSettingsButtonViewModel.title,
                    action: viewModel.openSettingsButtonViewModel.actionHandler)
-            .buttonStyle(PrimaryButtonStyle())
+            .buttonStyle(POSPrimaryButtonStyle())
         }
         .posModalCloseButton(action: viewModel.dismissButtonViewModel.actionHandler,
                              accessibilityLabel: viewModel.dismissButtonViewModel.title)

--- a/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/Connection Alerts/PointOfSaleCardPresentPaymentConnectingFailedChargeReaderView.swift
+++ b/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/Connection Alerts/PointOfSaleCardPresentPaymentConnectingFailedChargeReaderView.swift
@@ -16,7 +16,7 @@ struct PointOfSaleCardPresentPaymentConnectingFailedChargeReaderView: View {
 
             Button(viewModel.retryButtonViewModel.title,
                    action: viewModel.retryButtonViewModel.actionHandler)
-            .buttonStyle(PrimaryButtonStyle())
+            .buttonStyle(POSPrimaryButtonStyle())
         }
         .posModalCloseButton(action: viewModel.cancelButtonViewModel.actionHandler,
                               accessibilityLabel: viewModel.cancelButtonViewModel.title)

--- a/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/Connection Alerts/PointOfSaleCardPresentPaymentConnectingFailedUpdateAddressView.swift
+++ b/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/Connection Alerts/PointOfSaleCardPresentPaymentConnectingFailedUpdateAddressView.swift
@@ -13,7 +13,7 @@ struct PointOfSaleCardPresentPaymentConnectingFailedUpdateAddressView: View {
             if let primaryButtonViewModel = viewModel.primaryButtonViewModel {
                 Button(primaryButtonViewModel.title,
                        action: primaryButtonViewModel.actionHandler)
-                .buttonStyle(PrimaryButtonStyle())
+                .buttonStyle(POSPrimaryButtonStyle())
             }
         }
         .posModalCloseButton(action: viewModel.cancelButtonViewModel.actionHandler,

--- a/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/Connection Alerts/PointOfSaleCardPresentPaymentConnectingFailedUpdatePostalCodeView.swift
+++ b/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/Connection Alerts/PointOfSaleCardPresentPaymentConnectingFailedUpdatePostalCodeView.swift
@@ -16,7 +16,7 @@ struct PointOfSaleCardPresentPaymentConnectingFailedUpdatePostalCodeView: View {
 
             Button(viewModel.retryButtonViewModel.title,
                    action: viewModel.retryButtonViewModel.actionHandler)
-            .buttonStyle(PrimaryButtonStyle())
+            .buttonStyle(POSPrimaryButtonStyle())
         }
         .posModalCloseButton(action: viewModel.cancelButtonViewModel.actionHandler,
                              accessibilityLabel: viewModel.cancelButtonViewModel.title)

--- a/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/Connection Alerts/PointOfSaleCardPresentPaymentConnectingFailedView.swift
+++ b/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/Connection Alerts/PointOfSaleCardPresentPaymentConnectingFailedView.swift
@@ -22,7 +22,7 @@ struct PointOfSaleCardPresentPaymentConnectingFailedView: View {
 
             Button(viewModel.retryButtonViewModel.title,
                    action: viewModel.retryButtonViewModel.actionHandler)
-            .buttonStyle(PrimaryButtonStyle())
+            .buttonStyle(POSPrimaryButtonStyle())
         }
         .posModalCloseButton(action: viewModel.cancelButtonViewModel.actionHandler,
                              accessibilityLabel: viewModel.cancelButtonViewModel.title)

--- a/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/Connection Alerts/PointOfSaleCardPresentPaymentConnectionSuccessAlertView.swift
+++ b/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/Connection Alerts/PointOfSaleCardPresentPaymentConnectionSuccessAlertView.swift
@@ -14,11 +14,8 @@ struct PointOfSaleCardPresentPaymentConnectionSuccessAlertView: View {
                 .accessibilityAddTraits(.isHeader)
 
             Image(decorative: viewModel.imageName)
-
-            Button(viewModel.buttonViewModel.title,
-                   action: viewModel.buttonViewModel.actionHandler)
-            .buttonStyle(SecondaryButtonStyle())
         }
+        .posModalCloseButton(action: viewModel.buttonViewModel.actionHandler)
         .multilineTextAlignment(.center)
         .accessibilityElement(children: .contain)
     }

--- a/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/Connection Alerts/PointOfSaleCardPresentPaymentFoundMultipleReadersView.swift
+++ b/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/Connection Alerts/PointOfSaleCardPresentPaymentFoundMultipleReadersView.swift
@@ -36,7 +36,7 @@ struct PointOfSaleCardPresentPaymentFoundMultipleReadersView: View {
             }) {
                 Text(Localization.cancel)
             }
-            .buttonStyle(SecondaryButtonStyle())
+            .buttonStyle(POSSecondaryButtonStyle())
             .padding(Layout.buttonPadding)
         }
         .padding(Layout.padding)

--- a/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/Connection Alerts/PointOfSaleCardPresentPaymentFoundMultipleReadersView.swift
+++ b/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/Connection Alerts/PointOfSaleCardPresentPaymentFoundMultipleReadersView.swift
@@ -15,7 +15,7 @@ struct PointOfSaleCardPresentPaymentFoundMultipleReadersView: View {
     var body: some View {
         VStack(spacing: 0) {
             Text(Localization.headline)
-                .font(.headline)
+                .font(.posTitleEmphasized)
                 .padding(Layout.headerPadding)
                 .accessibilityAddTraits(.isHeader)
 
@@ -48,6 +48,7 @@ private extension PointOfSaleCardPresentPaymentFoundMultipleReadersView {
     @ViewBuilder func readerRow(readerID: String) -> some View {
         HStack {
             Text(readerID)
+                .font(.posBodyRegular)
             Spacer()
             Button(Localization.connect) {
                 connect(readerID)
@@ -60,7 +61,7 @@ private extension PointOfSaleCardPresentPaymentFoundMultipleReadersView {
         HStack(spacing: Layout.horizontalSpacing) {
             ActivityIndicator(isAnimating: .constant(true), style: .medium)
             Text(Localization.scanningLabel)
-                .font(.footnote)
+                .font(.posBodyRegular)
             Spacer()
         }
     }

--- a/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/Connection Alerts/PointOfSaleCardPresentPaymentFoundReaderView.swift
+++ b/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/Connection Alerts/PointOfSaleCardPresentPaymentFoundReaderView.swift
@@ -14,11 +14,11 @@ struct PointOfSaleCardPresentPaymentFoundReaderView: View {
             VStack(spacing: PointOfSaleReaderConnectionModalLayout.buttonSpacing) {
                 Button(viewModel.connectButton.title,
                        action: viewModel.connectButton.actionHandler)
-                .buttonStyle(PrimaryButtonStyle())
+                .buttonStyle(POSPrimaryButtonStyle())
 
                 Button(viewModel.continueSearchButton.title,
                        action: viewModel.continueSearchButton.actionHandler)
-                .buttonStyle(SecondaryButtonStyle())
+                .buttonStyle(POSSecondaryButtonStyle())
             }
         }
         .posModalCloseButton(action: viewModel.cancelSearchButton.actionHandler,

--- a/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/Connection Alerts/PointOfSaleCardPresentPaymentOptionalReaderUpdateInProgressView.swift
+++ b/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/Connection Alerts/PointOfSaleCardPresentPaymentOptionalReaderUpdateInProgressView.swift
@@ -27,7 +27,7 @@ struct PointOfSaleCardPresentPaymentOptionalReaderUpdateInProgressView: View {
                     cancelReaderUpdate()
                 }
             })
-            .buttonStyle(SecondaryButtonStyle())
+            .buttonStyle(POSSecondaryButtonStyle())
         }
         .multilineTextAlignment(.center)
         .accessibilityElement(children: .contain)

--- a/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/Connection Alerts/PointOfSaleCardPresentPaymentReaderUpdateFailedLowBatteryView.swift
+++ b/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/Connection Alerts/PointOfSaleCardPresentPaymentReaderUpdateFailedLowBatteryView.swift
@@ -20,7 +20,7 @@ struct PointOfSaleCardPresentPaymentReaderUpdateFailedLowBatteryView: View {
 
             Button(viewModel.cancelButtonViewModel.title,
                    action: viewModel.cancelButtonViewModel.actionHandler)
-            .buttonStyle(SecondaryButtonStyle())
+            .buttonStyle(POSSecondaryButtonStyle())
         }
         .multilineTextAlignment(.center)
         .accessibilityElement(children: .contain)

--- a/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/Connection Alerts/PointOfSaleCardPresentPaymentReaderUpdateFailedNonRetryableView.swift
+++ b/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/Connection Alerts/PointOfSaleCardPresentPaymentReaderUpdateFailedNonRetryableView.swift
@@ -17,7 +17,7 @@ struct PointOfSaleCardPresentPaymentReaderUpdateFailedNonRetryableView: View {
 
             Button(viewModel.cancelButtonViewModel.title,
                    action: viewModel.cancelButtonViewModel.actionHandler)
-            .buttonStyle(SecondaryButtonStyle())
+            .buttonStyle(POSSecondaryButtonStyle())
         }
         .multilineTextAlignment(.center)
         .accessibilityElement(children: .contain)

--- a/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/Connection Alerts/PointOfSaleCardPresentPaymentReaderUpdateFailedView.swift
+++ b/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/Connection Alerts/PointOfSaleCardPresentPaymentReaderUpdateFailedView.swift
@@ -17,7 +17,7 @@ struct PointOfSaleCardPresentPaymentReaderUpdateFailedView: View {
 
             Button(viewModel.retryButtonViewModel.title,
                    action: viewModel.retryButtonViewModel.actionHandler)
-            .buttonStyle(PrimaryButtonStyle())
+            .buttonStyle(POSPrimaryButtonStyle())
         }
         .posModalCloseButton(action: viewModel.cancelButtonViewModel.actionHandler,
                              accessibilityLabel: viewModel.cancelButtonViewModel.title)

--- a/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/Connection Alerts/PointOfSaleCardPresentPaymentRequiredReaderUpdateInProgressView.swift
+++ b/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/Connection Alerts/PointOfSaleCardPresentPaymentRequiredReaderUpdateInProgressView.swift
@@ -27,7 +27,7 @@ struct PointOfSaleCardPresentPaymentRequiredReaderUpdateInProgressView: View {
                     cancelReaderUpdate()
                 }
             })
-            .buttonStyle(SecondaryButtonStyle())
+            .buttonStyle(POSSecondaryButtonStyle())
         }
         .multilineTextAlignment(.center)
         .accessibilityElement(children: .contain)


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of: #13731
Merge after: #12771 
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

This is part of a series of PRs to improve the card reader connnection screens. You may want to test at the end of the series, as it could get quite repetitive, but doing it all in one was quite big. Up to you! The last one is #13775

This PR updates the POS card reader connection modals to use POS buttons and on the Multiple readers view, font styles. Other views previously had the correct font styles applied.

## Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->

1. Launch the app
2. Enter the POS
3. Tap `Connect your reader`
4. Wait for the `Do you want to connect` screen – if it just auto-connects, tap `Reader connected` then `Disconnect reader` and try again
5. Observe that the buttons use the new style
6. Tap `Keep searching`
7. Turn on another reader
8. Observe that the multiple readers screen shows and uses POS fonts (except the connect buttons – handled later)
9. Tap connect on a reader, but turn it off at the same time
10. The error screen will show shortly after that – observe that it uses the new buttons.

Address issues:

First, delete the first line of your store address in `WP-admin > Woocommerce > Settings`

1. Launch the app
2. Enter the POS
3. Tap `Connect your reader`
4. The error screen will show shortly after that – observe that it uses the new buttons.

## Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->

I have tested these on an iPad running iOS 16. No unit tests as it's UI only.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->



Note that this video is from this branch – if you test later on, the rest of the modal UI will look a bit different.

https://github.com/user-attachments/assets/b384cced-0888-49de-8535-372b64fe5427



---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [x] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [x] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [x] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on all devices (phone/tablet) and no regressions are added.