### PR TITLE
[Woo POS] Make reader connection modal layout match designs

### DIFF
--- a/WooCommerce/Classes/POS/Presentation/Card Present Payments/Connection Alerts/PointOfSaleCardPresentPaymentFoundReaderAlertViewModel.swift
+++ b/WooCommerce/Classes/POS/Presentation/Card Present Payments/Connection Alerts/PointOfSaleCardPresentPaymentFoundReaderAlertViewModel.swift
@@ -2,6 +2,7 @@ import Foundation
 
 struct PointOfSaleCardPresentPaymentFoundReaderAlertViewModel: Hashable {
     let title: String
+    let description: String = Localization.description
     let imageName = PointOfSaleAssets.readerConnectionDoYouWantToConnect.imageName
     let connectButton: CardPresentPaymentsModalButtonViewModel
     let continueSearchButton: CardPresentPaymentsModalButtonViewModel
@@ -24,9 +25,16 @@ struct PointOfSaleCardPresentPaymentFoundReaderAlertViewModel: Hashable {
 private extension PointOfSaleCardPresentPaymentFoundReaderAlertViewModel {
     enum Localization {
         static let title = NSLocalizedString(
-            "pointOfSale.cardPresentPayment.alert.foundReader.title",
-            value: "Do you want to connect to reader %1$@?",
+            "pointOfSale.cardPresentPayment.alert.foundReader.title.2",
+            value: "Found %1$@",
             comment: "Dialog title that displays the name of a found card reader"
+        )
+
+        static let description = NSLocalizedString(
+            "pointOfSale.cardPresentPayment.alert.foundReader.description",
+            value: "Do you want to connect to this reader?",
+            comment: "Dialog description that asks the user if they want to connect to a specific found card reader. " +
+            "They can instead, keep searching for mor readers."
         )
 
         static let connect = NSLocalizedString(

--- a/WooCommerce/Classes/POS/Presentation/Card Present Payments/Connection Alerts/PointOfSaleCardPresentPaymentFoundReaderAlertViewModel.swift
+++ b/WooCommerce/Classes/POS/Presentation/Card Present Payments/Connection Alerts/PointOfSaleCardPresentPaymentFoundReaderAlertViewModel.swift
@@ -34,7 +34,7 @@ private extension PointOfSaleCardPresentPaymentFoundReaderAlertViewModel {
             "pointOfSale.cardPresentPayment.alert.foundReader.description",
             value: "Do you want to connect to this reader?",
             comment: "Dialog description that asks the user if they want to connect to a specific found card reader. " +
-            "They can instead, keep searching for mor readers."
+            "They can instead, keep searching for more readers."
         )
 
         static let connect = NSLocalizedString(

--- a/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/Connection Alerts/PointOfSaleCardPresentPaymentBluetoothRequiredAlertView.swift
+++ b/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/Connection Alerts/PointOfSaleCardPresentPaymentBluetoothRequiredAlertView.swift
@@ -9,11 +9,11 @@ struct PointOfSaleCardPresentPaymentBluetoothRequiredAlertView: View {
 
     var body: some View {
         VStack(spacing: PointOfSaleReaderConnectionModalLayout.verticalSpacing) {
+            Image(decorative: viewModel.imageName)
+
             Text(viewModel.title)
                 .font(POSFontStyle.posTitleEmphasized)
                 .accessibilityAddTraits(.isHeader)
-
-            Image(decorative: viewModel.imageName)
 
             Text(viewModel.errorDetails)
                 .font(POSFontStyle.posBodyRegular)

--- a/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/Connection Alerts/PointOfSaleCardPresentPaymentConnectingFailedChargeReaderView.swift
+++ b/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/Connection Alerts/PointOfSaleCardPresentPaymentConnectingFailedChargeReaderView.swift
@@ -5,11 +5,11 @@ struct PointOfSaleCardPresentPaymentConnectingFailedChargeReaderView: View {
 
     var body: some View {
         VStack(spacing: PointOfSaleReaderConnectionModalLayout.verticalSpacing) {
+            Image(decorative: viewModel.imageName)
+
             Text(viewModel.title)
                 .font(POSFontStyle.posTitleEmphasized)
                 .accessibilityAddTraits(.isHeader)
-
-            Image(decorative: viewModel.imageName)
 
             Text(viewModel.errorDetails)
                 .font(POSFontStyle.posBodyRegular)

--- a/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/Connection Alerts/PointOfSaleCardPresentPaymentConnectingFailedNonRetryableView.swift
+++ b/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/Connection Alerts/PointOfSaleCardPresentPaymentConnectingFailedNonRetryableView.swift
@@ -5,11 +5,11 @@ struct PointOfSaleCardPresentPaymentConnectingFailedNonRetryableView: View {
 
     var body: some View {
         VStack(spacing: PointOfSaleReaderConnectionModalLayout.verticalSpacing) {
+            Image(decorative: viewModel.imageName)
+
             Text(viewModel.title)
                 .font(POSFontStyle.posTitleEmphasized)
                 .accessibilityAddTraits(.isHeader)
-
-            Image(decorative: viewModel.imageName)
 
             Text(viewModel.errorDetails)
                 .font(POSFontStyle.posBodyRegular)

--- a/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/Connection Alerts/PointOfSaleCardPresentPaymentConnectingFailedUpdateAddressView.swift
+++ b/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/Connection Alerts/PointOfSaleCardPresentPaymentConnectingFailedUpdateAddressView.swift
@@ -4,11 +4,11 @@ struct PointOfSaleCardPresentPaymentConnectingFailedUpdateAddressView: View {
     @StateObject var viewModel: PointOfSaleCardPresentPaymentConnectingFailedUpdateAddressAlertViewModel
     var body: some View {
         VStack(spacing: PointOfSaleReaderConnectionModalLayout.verticalSpacing) {
+            Image(decorative: viewModel.imageName)
+
             Text(viewModel.title)
                 .font(POSFontStyle.posTitleEmphasized)
                 .accessibilityAddTraits(.isHeader)
-
-            Image(decorative: viewModel.imageName)
 
             if let primaryButtonViewModel = viewModel.primaryButtonViewModel {
                 Button(primaryButtonViewModel.title,

--- a/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/Connection Alerts/PointOfSaleCardPresentPaymentConnectingFailedUpdatePostalCodeView.swift
+++ b/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/Connection Alerts/PointOfSaleCardPresentPaymentConnectingFailedUpdatePostalCodeView.swift
@@ -5,11 +5,11 @@ struct PointOfSaleCardPresentPaymentConnectingFailedUpdatePostalCodeView: View {
 
     var body: some View {
         VStack(spacing: PointOfSaleReaderConnectionModalLayout.verticalSpacing) {
+            Image(decorative: viewModel.imageName)
+
             Text(viewModel.title)
                 .font(POSFontStyle.posTitleEmphasized)
                 .accessibilityAddTraits(.isHeader)
-
-            Image(decorative: viewModel.imageName)
 
             Text(viewModel.errorDetails)
                 .font(POSFontStyle.posBodyRegular)

--- a/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/Connection Alerts/PointOfSaleCardPresentPaymentConnectingFailedView.swift
+++ b/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/Connection Alerts/PointOfSaleCardPresentPaymentConnectingFailedView.swift
@@ -9,11 +9,11 @@ struct PointOfSaleCardPresentPaymentConnectingFailedView: View {
 
     var body: some View {
         VStack(spacing: PointOfSaleReaderConnectionModalLayout.verticalSpacing) {
+            Image(decorative: viewModel.imageName)
+
             Text(viewModel.title)
                 .font(POSFontStyle.posTitleEmphasized)
                 .accessibilityAddTraits(.isHeader)
-
-            Image(decorative: viewModel.imageName)
 
             if let errorDetails = viewModel.errorDetails {
                 Text(errorDetails)

--- a/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/Connection Alerts/PointOfSaleCardPresentPaymentConnectingToReaderView.swift
+++ b/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/Connection Alerts/PointOfSaleCardPresentPaymentConnectingToReaderView.swift
@@ -9,11 +9,11 @@ struct PointOfSaleCardPresentPaymentConnectingToReaderView: View {
 
     var body: some View {
         VStack(spacing: PointOfSaleReaderConnectionModalLayout.verticalSpacing) {
+            Image(decorative: viewModel.imageName)
+
             Text(viewModel.title)
                 .font(POSFontStyle.posTitleEmphasized)
                 .accessibilityAddTraits(.isHeader)
-
-            Image(decorative: viewModel.imageName)
 
             Text(viewModel.instruction)
                 .font(POSFontStyle.posBodyRegular)

--- a/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/Connection Alerts/PointOfSaleCardPresentPaymentConnectionSuccessAlertView.swift
+++ b/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/Connection Alerts/PointOfSaleCardPresentPaymentConnectionSuccessAlertView.swift
@@ -9,11 +9,11 @@ struct PointOfSaleCardPresentPaymentConnectionSuccessAlertView: View {
 
     var body: some View {
         VStack(spacing: PointOfSaleReaderConnectionModalLayout.verticalSpacing) {
+            Image(decorative: viewModel.imageName)
+
             Text(viewModel.title)
                 .font(POSFontStyle.posTitleEmphasized)
                 .accessibilityAddTraits(.isHeader)
-
-            Image(decorative: viewModel.imageName)
         }
         .posModalCloseButton(action: viewModel.buttonViewModel.actionHandler)
         .multilineTextAlignment(.center)

--- a/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/Connection Alerts/PointOfSaleCardPresentPaymentFoundReaderView.swift
+++ b/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/Connection Alerts/PointOfSaleCardPresentPaymentFoundReaderView.swift
@@ -11,6 +11,9 @@ struct PointOfSaleCardPresentPaymentFoundReaderView: View {
                 .font(POSFontStyle.posTitleEmphasized)
                 .accessibilityAddTraits(.isHeader)
 
+            Text(viewModel.description)
+                .font(POSFontStyle.posBodyRegular)
+
             VStack(spacing: PointOfSaleReaderConnectionModalLayout.buttonSpacing) {
                 Button(viewModel.connectButton.title,
                        action: viewModel.connectButton.actionHandler)

--- a/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/Connection Alerts/PointOfSaleCardPresentPaymentFoundReaderView.swift
+++ b/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/Connection Alerts/PointOfSaleCardPresentPaymentFoundReaderView.swift
@@ -5,11 +5,11 @@ struct PointOfSaleCardPresentPaymentFoundReaderView: View {
 
     var body: some View {
         VStack(spacing: PointOfSaleReaderConnectionModalLayout.verticalSpacing) {
+            Image(decorative: viewModel.imageName)
+
             Text(viewModel.title)
                 .font(POSFontStyle.posTitleEmphasized)
                 .accessibilityAddTraits(.isHeader)
-
-            Image(decorative: viewModel.imageName)
 
             VStack(spacing: PointOfSaleReaderConnectionModalLayout.buttonSpacing) {
                 Button(viewModel.connectButton.title,

--- a/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/Connection Alerts/PointOfSaleCardPresentPaymentOptionalReaderUpdateInProgressView.swift
+++ b/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/Connection Alerts/PointOfSaleCardPresentPaymentOptionalReaderUpdateInProgressView.swift
@@ -9,12 +9,12 @@ struct PointOfSaleCardPresentPaymentOptionalReaderUpdateInProgressView: View {
 
     var body: some View {
         VStack(spacing: PointOfSaleReaderConnectionModalLayout.verticalSpacing) {
+            viewModel.image
+                .accessibilityHidden(true)
+
             Text(viewModel.title)
                 .font(POSFontStyle.posTitleEmphasized)
                 .accessibilityAddTraits(.isHeader)
-
-            viewModel.image
-                .accessibilityHidden(true)
 
             Text(viewModel.progressTitle)
                 .font(POSFontStyle.posBodyRegular)

--- a/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/Connection Alerts/PointOfSaleCardPresentPaymentReaderUpdateCompletionView.swift
+++ b/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/Connection Alerts/PointOfSaleCardPresentPaymentReaderUpdateCompletionView.swift
@@ -9,12 +9,12 @@ struct PointOfSaleCardPresentPaymentReaderUpdateCompletionView: View {
 
     var body: some View {
         VStack(spacing: PointOfSaleReaderConnectionModalLayout.verticalSpacing) {
+            viewModel.image
+                .accessibilityHidden(true)
+
             Text(viewModel.title)
                 .font(POSFontStyle.posTitleEmphasized)
                 .accessibilityAddTraits(.isHeader)
-
-            viewModel.image
-                .accessibilityHidden(true)
 
             Text(viewModel.progressTitle)
                 .font(POSFontStyle.posBodyRegular)

--- a/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/Connection Alerts/PointOfSaleCardPresentPaymentReaderUpdateFailedLowBatteryView.swift
+++ b/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/Connection Alerts/PointOfSaleCardPresentPaymentReaderUpdateFailedLowBatteryView.swift
@@ -9,11 +9,11 @@ struct PointOfSaleCardPresentPaymentReaderUpdateFailedLowBatteryView: View {
 
     var body: some View {
         VStack(spacing: PointOfSaleReaderConnectionModalLayout.verticalSpacing) {
+            Image(decorative: viewModel.imageName)
+
             Text(viewModel.title)
                 .font(POSFontStyle.posTitleEmphasized)
                 .accessibilityAddTraits(.isHeader)
-
-            Image(decorative: viewModel.imageName)
 
             Text(viewModel.batteryLevelInfo)
                 .font(POSFontStyle.posBodyRegular)

--- a/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/Connection Alerts/PointOfSaleCardPresentPaymentReaderUpdateFailedNonRetryableView.swift
+++ b/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/Connection Alerts/PointOfSaleCardPresentPaymentReaderUpdateFailedNonRetryableView.swift
@@ -9,11 +9,11 @@ struct PointOfSaleCardPresentPaymentReaderUpdateFailedNonRetryableView: View {
 
     var body: some View {
         VStack(spacing: PointOfSaleReaderConnectionModalLayout.verticalSpacing) {
+            Image(decorative: viewModel.imageName)
+
             Text(viewModel.title)
                 .font(POSFontStyle.posTitleEmphasized)
                 .accessibilityAddTraits(.isHeader)
-
-            Image(decorative: viewModel.imageName)
 
             Button(viewModel.cancelButtonViewModel.title,
                    action: viewModel.cancelButtonViewModel.actionHandler)

--- a/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/Connection Alerts/PointOfSaleCardPresentPaymentReaderUpdateFailedView.swift
+++ b/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/Connection Alerts/PointOfSaleCardPresentPaymentReaderUpdateFailedView.swift
@@ -9,11 +9,11 @@ struct PointOfSaleCardPresentPaymentReaderUpdateFailedView: View {
 
     var body: some View {
         VStack(spacing: PointOfSaleReaderConnectionModalLayout.verticalSpacing) {
+            Image(decorative: viewModel.imageName)
+
             Text(viewModel.title)
                 .font(POSFontStyle.posTitleEmphasized)
                 .accessibilityAddTraits(.isHeader)
-
-            Image(decorative: viewModel.imageName)
 
             Button(viewModel.retryButtonViewModel.title,
                    action: viewModel.retryButtonViewModel.actionHandler)

--- a/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/Connection Alerts/PointOfSaleCardPresentPaymentRequiredReaderUpdateInProgressView.swift
+++ b/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/Connection Alerts/PointOfSaleCardPresentPaymentRequiredReaderUpdateInProgressView.swift
@@ -9,12 +9,12 @@ struct PointOfSaleCardPresentPaymentRequiredReaderUpdateInProgressView: View {
 
     var body: some View {
         VStack(spacing: PointOfSaleReaderConnectionModalLayout.verticalSpacing) {
+            viewModel.image
+                .accessibilityHidden(true)
+
             Text(viewModel.title)
                 .font(POSFontStyle.posTitleEmphasized)
                 .accessibilityAddTraits(.isHeader)
-
-            viewModel.image
-                .accessibilityHidden(true)
 
             Text(viewModel.progressTitle)
                 .font(POSFontStyle.posBodyRegular)

--- a/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/Connection Alerts/PointOfSaleCardPresentPaymentScanningForReadersFailedView.swift
+++ b/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/Connection Alerts/PointOfSaleCardPresentPaymentScanningForReadersFailedView.swift
@@ -9,11 +9,11 @@ struct PointOfSaleCardPresentPaymentScanningForReadersFailedView: View {
 
     var body: some View {
         VStack(spacing: PointOfSaleReaderConnectionModalLayout.verticalSpacing) {
+            Image(decorative: viewModel.imageName)
+
             Text(viewModel.title)
                 .font(POSFontStyle.posTitleEmphasized)
                 .accessibilityAddTraits(.isHeader)
-
-            Image(decorative: viewModel.imageName)
 
             Text(viewModel.errorDetails)
                 .font(POSFontStyle.posBodyRegular)

--- a/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/Connection Alerts/PointOfSaleCardPresentPaymentScanningForReadersView.swift
+++ b/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/Connection Alerts/PointOfSaleCardPresentPaymentScanningForReadersView.swift
@@ -9,11 +9,11 @@ struct PointOfSaleCardPresentPaymentScanningForReadersView: View {
 
     var body: some View {
         VStack(spacing: PointOfSaleReaderConnectionModalLayout.verticalSpacing) {
+            Image(decorative: viewModel.imageName)
+
             Text(viewModel.title)
                 .font(POSFontStyle.posTitleEmphasized)
                 .accessibilityAddTraits(.isHeader)
-
-            Image(decorative: viewModel.imageName)
 
             Text(viewModel.instruction)
                 .font(POSFontStyle.posBodyRegular)

--- a/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/Connection Alerts/PointOfSaleReaderConnectionModalLayout.swift
+++ b/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/Connection Alerts/PointOfSaleReaderConnectionModalLayout.swift
@@ -3,5 +3,5 @@ import Foundation
 enum PointOfSaleReaderConnectionModalLayout {
     static var verticalSpacing: CGFloat = 32
     static var buttonSpacing: CGFloat = 24
-    static var contentPadding: CGFloat = 64
+    static var contentPadding: CGFloat = 40
 }

--- a/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/Connection Alerts/PointOfSaleReaderConnectionModalLayout.swift
+++ b/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/Connection Alerts/PointOfSaleReaderConnectionModalLayout.swift
@@ -2,6 +2,6 @@ import Foundation
 
 enum PointOfSaleReaderConnectionModalLayout {
     static var verticalSpacing: CGFloat = 32
-    static var buttonSpacing: CGFloat = 16
+    static var buttonSpacing: CGFloat = 24
     static var contentPadding: CGFloat = 64
 }

--- a/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/PointOfSaleCardPresentPaymentAlert.swift
+++ b/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/PointOfSaleCardPresentPaymentAlert.swift
@@ -9,8 +9,8 @@ struct PointOfSaleCardPresentPaymentAlert: View {
 
     var body: some View {
         alertContent
-            .frame(width: frameWidth, height: frameHeight)
             .padding(PointOfSaleReaderConnectionModalLayout.contentPadding)
+            .frame(width: frameWidth, height: frameHeight)
     }
 
     @ViewBuilder
@@ -59,12 +59,12 @@ struct PointOfSaleCardPresentPaymentAlert: View {
 
     private var frameWidth: CGFloat {
         switch sizeCategory {
-        case .extraSmall, .small, .medium:
-            return 496
-        case .large, .extraLarge:
+        case .extraSmall, .small:
             return 560
+        case .medium, .large, .extraLarge:
+            return 640
         case .extraExtraLarge, .extraExtraExtraLarge:
-            return 624
+            return 720
         case .accessibilityMedium,
                 .accessibilityLarge,
                 .accessibilityExtraLarge,
@@ -72,18 +72,18 @@ struct PointOfSaleCardPresentPaymentAlert: View {
                 .accessibilityExtraExtraExtraLarge:
             return windowBounds.width
         @unknown default:
-            return 624
+            return 640
         }
     }
 
     private var frameHeight: CGFloat {
         switch sizeCategory {
-        case .extraSmall, .small, .medium:
-            return 528
-        case .large, .extraLarge:
-            return 592
+        case .extraSmall, .small:
+            return 624
+        case .medium, .large, .extraLarge:
+            return 656
         case .extraExtraLarge, .extraExtraExtraLarge:
-            return 640
+            return 688
         case .accessibilityMedium,
                 .accessibilityLarge,
                 .accessibilityExtraLarge,
@@ -91,7 +91,7 @@ struct PointOfSaleCardPresentPaymentAlert: View {
                 .accessibilityExtraExtraExtraLarge:
             return windowBounds.height
         @unknown default:
-            return 640
+            return 656
         }
     }
 


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of: #13731
Merge after: #13772 
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

This is part of a series of PRs to improve the card reader connnection screens. You may want to test at the end of the series, as it could get quite repetitive, but doing it all in one was quite big. Up to you! The last one is #13775

This PR includes various layout tweaks:
 - Show the image at the top of each modal.
 - Show text below the image.
 - Update spacing to match designs.
 - Update the modal sizes to match designs. (This one has a fair bit of "by-eye", particularly around the different dynamic type sizes.)

Note that not all the layouts work perfectly in every type size – a future PR resolves this and adds scrolling where needed. 

## Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->

1. Launch the app
2. Enter the POS
3. Tap `Connect your reader`
4. Wait for the `Do you want to connect` screen – if it just auto-connects, tap `Reader connected` then `Disconnect reader` and try again
5. When on the `Do you want to connect` screen, turn off the reader, then tap `Connect to reader`
6. The error screen will show shortly after that.

Observe that the image is first, text is next, and that spacing and modal sizes are improved.

## Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->

I have tested these on an iPad running iOS 16. No unit tests as it's UI only.

I've tested with different dynamic type sizes, and using an iPad mini simulator.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

Note that this video is from this branch – if you test later on, the rest of the modal UI will look a bit different.

https://github.com/user-attachments/assets/0556c506-752c-446d-a4ce-4a0a348777a2


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [x] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [x] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [x] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on all devices (phone/tablet) and no regressions are added.