### PR TITLE
[Woo POS] Improve multiple readers alert

### DIFF
--- a/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/Connection Alerts/PointOfSaleCardPresentPaymentFoundMultipleReadersView.swift
+++ b/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/Connection Alerts/PointOfSaleCardPresentPaymentFoundMultipleReadersView.swift
@@ -13,21 +13,18 @@ struct PointOfSaleCardPresentPaymentFoundMultipleReadersView: View {
     }
 
     var body: some View {
-        VStack(spacing: 0) {
+        VStack {
             Text(Localization.headline)
                 .font(.posTitleEmphasized)
                 .padding(Layout.headerPadding)
                 .accessibilityAddTraits(.isHeader)
 
-            List(readerIDs, id: \.self) { readerID in
-                VStack {
-                    readerRow(readerID: readerID)
+            scanningText()
 
-                    if readerID == readerIDs.last {
-                        scanningText()
-                    }
-                }
+            List(readerIDs, id: \.self) { readerID in
+                readerRow(readerID: readerID)
                 .listRowSeparator(.hidden)
+                .listRowBackground(Color.posPrimaryBackground)
             }
             .listStyle(.plain)
 
@@ -53,13 +50,16 @@ private extension PointOfSaleCardPresentPaymentFoundMultipleReadersView {
             Button(Localization.connect) {
                 connect(readerID)
             }
-            .buttonStyle(TextButtonStyle())
+            .buttonStyle(POSTextButtonStyle())
         }
+        .padding(.vertical, Layout.rowVerticalPadding)
     }
 
     @ViewBuilder func scanningText() -> some View {
         HStack(spacing: Layout.horizontalSpacing) {
-            ActivityIndicator(isAnimating: .constant(true), style: .medium)
+            Spacer()
+            ProgressView()
+                .progressViewStyle(POSProgressViewStyle(size: 20, lineWidth: 4))
             Text(Localization.scanningLabel)
                 .font(.posBodyRegular)
             Spacer()
@@ -101,6 +101,7 @@ private extension PointOfSaleCardPresentPaymentFoundMultipleReadersView {
         static let headerPadding: EdgeInsets = .init(top: 20, leading: 4, bottom: 20, trailing: 4)
         static let buttonPadding: EdgeInsets = .init(top: 16, leading: 0, bottom: 16, trailing: 0)
         static let horizontalSpacing: CGFloat = 16
+        static let rowVerticalPadding: CGFloat = 4
     }
 }
 

--- a/WooCommerce/Classes/POS/Presentation/Reusable Views/POSTextButtonStyle.swift
+++ b/WooCommerce/Classes/POS/Presentation/Reusable Views/POSTextButtonStyle.swift
@@ -1,10 +1,3 @@
-//
-//  POSTextButtonStyle.swift
-//  WooCommerce
-//
-//  Created by Josh Heald on 28/08/2024.
-//  Copyright © 2024 Automattic. All rights reserved.
-//
 
 import SwiftUI
 

--- a/WooCommerce/Classes/POS/Presentation/Reusable Views/POSTextButtonStyle.swift
+++ b/WooCommerce/Classes/POS/Presentation/Reusable Views/POSTextButtonStyle.swift
@@ -1,0 +1,29 @@
+//
+//  POSTextButtonStyle.swift
+//  WooCommerce
+//
+//  Created by Josh Heald on 28/08/2024.
+//  Copyright © 2024 Automattic. All rights reserved.
+//
+
+import SwiftUI
+
+struct POSTextButtonStyle: ButtonStyle {
+    @Environment(\.isEnabled) var isEnabled
+
+    func makeBody(configuration: Configuration) -> some View {
+        configuration.label
+            .font(.posBodyRegular)
+            .contentShape(Rectangle())
+            .foregroundColor(foregroundColor(for: configuration))
+            .background(Color(.clear))
+    }
+
+    private func foregroundColor(for configuration: Configuration) -> Color {
+        if isEnabled {
+            return configuration.isPressed ? .posTextButtonForegroundPressed : .posTextButtonForeground
+        } else {
+            return .posTextButtonDisabled
+        }
+    }
+}

--- a/WooCommerce/Classes/POS/Utils/Color+WooCommercePOS.swift
+++ b/WooCommerce/Classes/POS/Utils/Color+WooCommercePOS.swift
@@ -79,6 +79,29 @@ extension Color {
             )
         )
     }
+
+    static var posTextButtonForeground: Color {
+        return Color(
+            UIColor(
+                light: .withColorStudio(.wooCommercePurple, shade: .shade50),
+                dark: .withColorStudio(.wooCommercePurple, shade: .shade30)
+            )
+        )
+    }
+
+    static var posTextButtonForegroundPressed: Color {
+        return Color(
+            UIColor(
+                light: .withColorStudio(.wooCommercePurple, shade: .shade60),
+                dark: .withColorStudio(.wooCommercePurple, shade: .shade40)
+            )
+        )
+    }
+
+    static var posTextButtonDisabled: Color {
+        return .posGray
+    }
+
 }
 
 // MARK: - Non-adaptive colors

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -763,6 +763,7 @@
 		202496642B0B9E0D00EE527D /* ScrollViewSectionKit in Frameworks */ = {isa = PBXBuildFile; productRef = 202496632B0B9E0D00EE527D /* ScrollViewSectionKit */; };
 		2024966A2B0CC97100EE527D /* MockWooPaymentsDepositService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 202496692B0CC97100EE527D /* MockWooPaymentsDepositService.swift */; };
 		2026ECE92C25D21F00BEF7E4 /* CardPresentPaymentInvalidatablePaymentOrchestrator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2026ECE82C25D21F00BEF7E4 /* CardPresentPaymentInvalidatablePaymentOrchestrator.swift */; };
+		202C6C562C7F667700413107 /* POSTextButtonStyle.swift in Sources */ = {isa = PBXBuildFile; fileRef = 202C6C552C7F667700413107 /* POSTextButtonStyle.swift */; };
 		202D2A5A2AC5933100E4ABC0 /* TopTabView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 202D2A592AC5933100E4ABC0 /* TopTabView.swift */; };
 		203163A92C1B5AA7001C96DA /* PointOfSaleCardPresentPaymentBluetoothRequiredAlertViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 203163A82C1B5AA7001C96DA /* PointOfSaleCardPresentPaymentBluetoothRequiredAlertViewModel.swift */; };
 		203163AB2C1B5DEE001C96DA /* PointOfSaleCardPresentPaymentBluetoothRequiredAlertView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 203163AA2C1B5DEE001C96DA /* PointOfSaleCardPresentPaymentBluetoothRequiredAlertView.swift */; };
@@ -3803,6 +3804,7 @@
 		2023E2AD2C21D8EA00FC365A /* PointOfSaleCardPresentPaymentInLineMessage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PointOfSaleCardPresentPaymentInLineMessage.swift; sourceTree = "<group>"; };
 		202496692B0CC97100EE527D /* MockWooPaymentsDepositService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockWooPaymentsDepositService.swift; sourceTree = "<group>"; };
 		2026ECE82C25D21F00BEF7E4 /* CardPresentPaymentInvalidatablePaymentOrchestrator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardPresentPaymentInvalidatablePaymentOrchestrator.swift; sourceTree = "<group>"; };
+		202C6C552C7F667700413107 /* POSTextButtonStyle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = POSTextButtonStyle.swift; sourceTree = "<group>"; };
 		202D2A592AC5933100E4ABC0 /* TopTabView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TopTabView.swift; sourceTree = "<group>"; };
 		203163A82C1B5AA7001C96DA /* PointOfSaleCardPresentPaymentBluetoothRequiredAlertViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PointOfSaleCardPresentPaymentBluetoothRequiredAlertViewModel.swift; sourceTree = "<group>"; };
 		203163AA2C1B5DEE001C96DA /* PointOfSaleCardPresentPaymentBluetoothRequiredAlertView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PointOfSaleCardPresentPaymentBluetoothRequiredAlertView.swift; sourceTree = "<group>"; };
@@ -6074,6 +6076,7 @@
 				01D0823F2C5B9EAB007FE81F /* POSBackgroundAppearanceKey.swift */,
 				207823E62C5D346300025A59 /* POSPrimaryButtonStyle.swift */,
 				20D3D42E2C64F175004CE6E3 /* POSSecondaryButtonStyle.swift */,
+				202C6C552C7F667700413107 /* POSTextButtonStyle.swift */,
 				20D3D4302C64F202004CE6E3 /* POSButtonStyleConstants.swift */,
 				207823E82C5D3A1700025A59 /* POSErrorExclamationMark.swift */,
 				20ADE9402C6A02B700C91265 /* POSErrorXMark.swift */,
@@ -15904,6 +15907,7 @@
 				B65496342A0B291A003D29E1 /* EUShippingNoticeBanner.swift in Sources */,
 				B946881029B8DD01000646B0 /* InPersonPaymentsMenuViewController+Activity.swift in Sources */,
 				203163B12C1C5C87001C96DA /* PointOfSaleCardPresentPaymentConnectingFailedUpdatePostalCodeAlertViewModel.swift in Sources */,
+				202C6C562C7F667700413107 /* POSTextButtonStyle.swift in Sources */,
 				027EB56C29C05F4B003CE551 /* StoreOnboardingLaunchStoreView.swift in Sources */,
 				DEC75CC62BC4ED2100763801 /* DashboardCard+UI.swift in Sources */,
 				09EA565527C8ACEE00407D40 /* BulkUpdateViewController.swift in Sources */,


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #13731
Merge after: #13774 
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

This is the last in a series of PRs to improve the card reader connnection screens.

In this PR, the `Multiple readers found` screen is improved – there's no designs, so I just matched the look and feel of POS.

## Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->

Use a simulated reader, or two physical readers, to test this.

1. Launch the app
2. Enter the POS
3. Tap `Connect your reader`
4. Wait for the `Do you want to connect` screen – if it just auto-connects, tap `Reader connected` then `Disconnect reader` and try again
5. Observe that the buttons use the new style
6. Tap `Keep searching`
7. Observe that the multiple readers screen shows and matches the look and feel of POS.

## Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->

I have tested these on an iPad running iOS 16. No unit tests as it's UI only.


## Screenshots
<!-- Include before and after images or gifs when appropriate. -->


https://github.com/user-attachments/assets/1e5c0721-8796-40f2-b01e-a44c7234e5a8

Note that this video shows an issue at the end where the Multiple Readers View is shown empty after tapping try again on the error. That's an underlying bug, and out of the scope to fix here, but I'll raise an issue.

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [x] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [x] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [x] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on all devices (phone/tablet) and no regressions are added.