### PR TITLE
[Products] Support negative-priced products

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -9,6 +9,7 @@
 - [*] Payments: Punctuation updates to error and decline reason messages [https://github.com/woocommerce/woocommerce-ios/pull/13739]
 - [*] Blaze: Display budget field on the dashboard card. [https://github.com/woocommerce/woocommerce-ios/pull/13761]
 - [*] Products: Fixed a bug where editing the product price did not work as expected, depending on the store's currency settings. [https://github.com/woocommerce/woocommerce-ios/pull/13768]
+- [*] Products: Products can now be created and edited with negative prices. [https://github.com/woocommerce/woocommerce-ios/pull/13776]
 
 20.1
 -----

--- a/WooCommerce/Classes/Tools/UnitInputFormatter/PriceInputFormatter.swift
+++ b/WooCommerce/Classes/Tools/UnitInputFormatter/PriceInputFormatter.swift
@@ -9,6 +9,8 @@ struct PriceInputFormatter: UnitInputFormatter {
     ///
     private let currencySettings: CurrencySettings
 
+    private let numberFormatter = NumberFormatter()
+
     /// Number formatter with comma
     ///
     private let numberFormatterPoint: NumberFormatter = {
@@ -37,7 +39,7 @@ struct PriceInputFormatter: UnitInputFormatter {
             return true
         }
 
-        return numberFormatterPoint.number(from: input) != nil || numberFormatterComma.number(from: input) != nil
+        return numberFormatterPoint.number(from: input) != nil || numberFormatterComma.number(from: input) != nil || input == numberFormatter.negativePrefix
     }
 
     func format(input text: String?) -> String {

--- a/WooCommerce/Classes/Tools/UnitInputFormatter/PriceInputFormatter.swift
+++ b/WooCommerce/Classes/Tools/UnitInputFormatter/PriceInputFormatter.swift
@@ -48,8 +48,8 @@ struct PriceInputFormatter: UnitInputFormatter {
         let latinText = text.applyingTransform(StringTransform.toLatin, reverse: false) ?? text
 
         let formattedText = latinText
-            // Replace any characters not in the set of 0-9 with the current decimal separator configured on website
-            .replacingOccurrences(of: "[^0-9]", with: currencySettings.decimalSeparator, options: .regularExpression)
+            // Replace any characters not in the set of 0-9 or minus symbol with the current decimal separator configured on website
+            .replacingOccurrences(of: "[^0-9-]", with: currencySettings.decimalSeparator, options: .regularExpression)
             // Remove any initial zero number in the string. Es. 00224.30 will be 2224.30
             .replacingOccurrences(of: "^0+([1-9]+)", with: "$1", options: .regularExpression)
             // Replace all the occurrences of regex plus all the points or comma (but not the last `.` or `,`) like thousand separators

--- a/WooCommerce/Classes/ViewRelated/Products/Edit Product/Edit Price/Product+PriceSettingsViewModels.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Edit Product/Edit Price/Product+PriceSettingsViewModels.swift
@@ -26,7 +26,7 @@ extension Product {
                                   placeholder: placeholder,
                                   accessibilityHint: Localization.regularPriceAccessibilityHint,
                                   unitPosition: currencySettings.currencyUnitPosition,
-                                  keyboardType: .decimalPad,
+                                  keyboardType: .numbersAndPunctuation,
                                   inputFormatter: PriceInputFormatter(),
                                   style: .primary,
                                   onInputChange: onInputChange)
@@ -55,7 +55,7 @@ extension Product {
                                   placeholder: placeholder,
                                   accessibilityHint: Localization.salePriceAccessibility,
                                   unitPosition: currencySettings.currencyUnitPosition,
-                                  keyboardType: .decimalPad,
+                                  keyboardType: .numbersAndPunctuation,
                                   inputFormatter: PriceInputFormatter(),
                                   style: .primary,
                                   onInputChange: onInputChange)
@@ -84,7 +84,7 @@ extension Product {
                                   placeholder: placeholder,
                                   accessibilityHint: Localization.signupFeeAccessibilityHint,
                                   unitPosition: currencySettings.currencyUnitPosition,
-                                  keyboardType: .decimalPad,
+                                  keyboardType: .numbersAndPunctuation,
                                   inputFormatter: PriceInputFormatter(),
                                   style: .primary,
                                   onInputChange: onInputChange)

--- a/WooCommerce/WooCommerceTests/Tools/PriceInputFormatterTests.swift
+++ b/WooCommerce/WooCommerceTests/Tools/PriceInputFormatterTests.swift
@@ -125,6 +125,18 @@ final class PriceInputFormatterTests: XCTestCase {
         XCTAssertEqual(formatter.format(input: input), "189293891203.20")
     }
 
+    func testFormattingNegativePriceInput() {
+        let currencySettings = CurrencySettings(currencyCode: .USD,
+                                                currencyPosition: .leftSpace,
+                                                thousandSeparator: "",
+                                                decimalSeparator: ".",
+                                                numberOfDecimals: 3)
+        let formatter = PriceInputFormatter(currencySettings: currencySettings)
+
+        let input = "-12.34"
+        XCTAssertEqual(formatter.format(input: input), "-12.34")
+    }
+
     func test_value_is_correct() {
         // When
         let pointValue = "0.00"

--- a/WooCommerce/WooCommerceTests/Tools/PriceInputFormatterTests.swift
+++ b/WooCommerce/WooCommerceTests/Tools/PriceInputFormatterTests.swift
@@ -48,6 +48,16 @@ final class PriceInputFormatterTests: XCTestCase {
         XCTAssertTrue(formatter.isValid(input: input))
     }
 
+    func testLeadingMinusSymbolIsValid() {
+        let input = "-"
+        XCTAssertTrue(formatter.isValid(input: input))
+    }
+
+    func testMultipleMinusSymbolsAreInvalid() {
+        let input = "--15"
+        XCTAssertFalse(formatter.isValid(input: input))
+    }
+
     // MARK: test cases for `format(input:)`
 
     func testFormattingEmptyInput() {


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #4692
<!-- Id number of the GitHub issue this PR addresses. -->

## Description

We didn't support editing the price for negative-priced products in the app. As per https://github.com/woocommerce/woocommerce/issues/25037#issuecomment-554072804 it seems that's the direction WooCommerce core intends to keep going forward and allow negative prices for all store flows, so we should allow the same behavior in the app. This PR fixes the product price section to allow entering and editing negative prices.

### How

1. Updates the price input validation in `isValid(input:)` to allow a negative number prefix (e.g. the `-` symbol) to be entered in the price field.
2. Updates the price formatting in `format(input:)` to retain the `-` symbol in negative numbers.
3. Updates the keyboard used for the price fields to include a `-` symbol, so negative numbers can be entered.

## Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->

1. Go to Products
2. Tap on +
3. Select any product type
4. Tap on Add Price
5. Confirm you can enter a negative price, for example -10.
6. Save the product with the updated price and confirm the negative price is saved correctly.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->


https://github.com/user-attachments/assets/2cb81ac8-696f-478b-8908-d9c043c16d36



---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [x] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [x] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [x] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on all devices (phone/tablet) and no regressions are added.