### PR TITLE
[Woo POS] Fix extra padding appearing after removing the tab

### DIFF
--- a/WooCommerce/Classes/AppDelegate.swift
+++ b/WooCommerce/Classes/AppDelegate.swift
@@ -288,9 +288,17 @@ extension AppDelegate {
         guard let mainTabBarController = AppDelegate.shared.tabBarController else {
             return
         }
-        // Modifies the safeAreaInsets so that the view controller's view can occupy the space left by the hidden tab bar:
+        // If hidden, modifies the safeAreaInsets so that the view controller's view can occupy the space left by the hidden tab bar.
+        // Otherwise resets safeAreaInsets
         mainTabBarController.tabBar.isHidden = isPointOfSaleActive
-        mainTabBarController.viewSafeAreaInsetsDidChange()
+
+        let bottomInset = 8.0
+        if mainTabBarController.tabBar.isHidden {
+            mainTabBarController.additionalSafeAreaInsets = UIEdgeInsets(top: 0, left: 0, bottom: bottomInset, right: 0)
+        } else {
+            mainTabBarController.additionalSafeAreaInsets = .zero
+        }
+
         mainTabBarController.selectedViewController?.view.layoutIfNeeded()
     }
 

--- a/WooCommerce/Classes/AppDelegate.swift
+++ b/WooCommerce/Classes/AppDelegate.swift
@@ -280,11 +280,13 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 extension AppDelegate {
     func updateSharedConfiguration(_ isPointOfSaleActive: Bool) {
         // Show/hide app's tab bars
-        guard let tabBarController = AppDelegate.shared.tabBarController else {
+        guard let mainTabBarController = AppDelegate.shared.tabBarController else {
             return
         }
-        tabBarController.tabBar.isHidden = isPointOfSaleActive
-        tabBarController.selectedViewController?.view.layoutIfNeeded()
+        // Modifies the safeAreaInsets so that the view controller's view can occupy the space left by the hidden tab bar:
+        mainTabBarController.tabBar.isHidden = isPointOfSaleActive
+        mainTabBarController.viewSafeAreaInsetsDidChange()
+        mainTabBarController.selectedViewController?.view.layoutIfNeeded()
 
         // Enable/disable foreground in-app notifications
         if isPointOfSaleActive {

--- a/WooCommerce/Classes/AppDelegate.swift
+++ b/WooCommerce/Classes/AppDelegate.swift
@@ -275,44 +275,6 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     }
 }
 
-// MARK: - Helper method for WooCommerce POS
-//
-extension AppDelegate {
-    func updateSharedConfiguration(_ isPointOfSaleActive: Bool) {
-        updateTabBarVisibility(isPointOfSaleActive)
-        updateInAppNotifications(isPointOfSaleActive)
-    }
-
-    // Show/hide app's tab bars
-    private func updateTabBarVisibility(_ isPointOfSaleActive: Bool) {
-        guard let mainTabBarController = AppDelegate.shared.tabBarController else {
-            return
-        }
-        // If hidden, modifies the safeAreaInsets so that the view controller's view can occupy the space left by the hidden tab bar.
-        // Otherwise resets safeAreaInsets
-        mainTabBarController.tabBar.isHidden = isPointOfSaleActive
-
-        let bottomInset = 8.0
-        if mainTabBarController.tabBar.isHidden {
-            mainTabBarController.additionalSafeAreaInsets = UIEdgeInsets(top: 0, left: 0, bottom: bottomInset, right: 0)
-        } else {
-            mainTabBarController.additionalSafeAreaInsets = .zero
-        }
-
-        mainTabBarController.selectedViewController?.view.layoutIfNeeded()
-    }
-
-    // Enable/disable foreground in-app notifications
-    private func updateInAppNotifications(_ isPointOfSaleActive: Bool) {
-        if isPointOfSaleActive {
-            ServiceLocator.pushNotesManager.disableInAppNotifications()
-        } else {
-            ServiceLocator.pushNotesManager.enableInAppNotifications()
-        }
-    }
-}
-
-
 // MARK: - Initialization Methods
 //
 private extension AppDelegate {

--- a/WooCommerce/Classes/AppDelegate.swift
+++ b/WooCommerce/Classes/AppDelegate.swift
@@ -279,7 +279,12 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 //
 extension AppDelegate {
     func updateSharedConfiguration(_ isPointOfSaleActive: Bool) {
-        // Show/hide app's tab bars
+        updateTabBarVisibility(isPointOfSaleActive)
+        updateInAppNotifications(isPointOfSaleActive)
+    }
+
+    // Show/hide app's tab bars
+    private func updateTabBarVisibility(_ isPointOfSaleActive: Bool) {
         guard let mainTabBarController = AppDelegate.shared.tabBarController else {
             return
         }
@@ -287,8 +292,10 @@ extension AppDelegate {
         mainTabBarController.tabBar.isHidden = isPointOfSaleActive
         mainTabBarController.viewSafeAreaInsetsDidChange()
         mainTabBarController.selectedViewController?.view.layoutIfNeeded()
+    }
 
-        // Enable/disable foreground in-app notifications
+    // Enable/disable foreground in-app notifications
+    private func updateInAppNotifications(_ isPointOfSaleActive: Bool) {
         if isPointOfSaleActive {
             ServiceLocator.pushNotesManager.disableInAppNotifications()
         } else {

--- a/WooCommerce/Classes/ViewRelated/Hub Menu/HubMenu.swift
+++ b/WooCommerce/Classes/ViewRelated/Hub Menu/HubMenu.swift
@@ -161,7 +161,7 @@ private extension HubMenu {
                     PointOfSaleEntryPointView(
                         itemProvider: viewModel.posItemProvider,
                         onPointOfSaleModeActiveStateChange: { isEnabled in
-                            AppDelegate.shared.updateSharedConfiguration(isEnabled)
+                            viewModel.updateDefaultConfigurationForPointOfSale(isEnabled)
                         },
                         cardPresentPaymentService: cardPresentPaymentService,
                         orderService: orderService,

--- a/WooCommerce/Classes/ViewRelated/Hub Menu/HubMenuViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Hub Menu/HubMenuViewModel.swift
@@ -233,18 +233,22 @@ private extension HubMenuViewModel {
         guard let mainTabBarController = AppDelegate.shared.tabBarController else {
             return
         }
-        // If hidden, modifies the safeAreaInsets so that the view controller's view can occupy the space left by the hidden tab bar.
-        // Otherwise resets safeAreaInsets
         mainTabBarController.tabBar.isHidden = isPointOfSaleActive
 
-        let bottomInset = 8.0
+        /*
+         When hidding the app's tab bar on POS initialization, we've observed a recurring issue with the UI not being updated appropiately,
+         leaving additional padding in the bottom rather than re-positioning components taking all the available space.
+         In order to address this issue we have to explicitely call for an update to the safeAreaInsets in order to trigger the layout update we need,
+         so that the view controller's view can occupy the space left by the hidden tab bar.
+         Updating the bottom UIEdgeInset to a non-zero value seems to be enough to trigger the UI layout refresh we need.
+         Ref: gh-13785
+         */
         if mainTabBarController.tabBar.isHidden {
+            let bottomInset = CGFloat.leastNonzeroMagnitude
             mainTabBarController.additionalSafeAreaInsets = UIEdgeInsets(top: 0, left: 0, bottom: bottomInset, right: 0)
         } else {
             mainTabBarController.additionalSafeAreaInsets = .zero
         }
-
-        mainTabBarController.selectedViewController?.view.layoutIfNeeded()
     }
 
     // Disables foreground in-app notifications when Point of Sale is active

--- a/WooCommerce/Classes/ViewRelated/Hub Menu/HubMenuViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Hub Menu/HubMenuViewModel.swift
@@ -214,8 +214,47 @@ final class HubMenuViewModel: ObservableObject {
         }
     }
 
+    func updateDefaultConfigurationForPointOfSale(_ isPointOfSaleActive: Bool) {
+        updateTabBarVisibility(isPointOfSaleActive)
+        updateInAppNotifications(isPointOfSaleActive)
+    }
+
     deinit {
         NotificationCenter.default.removeObserver(self, name: .setUpTapToPayViewDidAppear, object: nil)
+    }
+}
+
+// MARK: - Helper method for WooCommerce POS
+//
+private extension HubMenuViewModel {
+    // Hides the app's tab bars when Point of Sale is active
+    //
+    func updateTabBarVisibility(_ isPointOfSaleActive: Bool) {
+        guard let mainTabBarController = AppDelegate.shared.tabBarController else {
+            return
+        }
+        // If hidden, modifies the safeAreaInsets so that the view controller's view can occupy the space left by the hidden tab bar.
+        // Otherwise resets safeAreaInsets
+        mainTabBarController.tabBar.isHidden = isPointOfSaleActive
+
+        let bottomInset = 8.0
+        if mainTabBarController.tabBar.isHidden {
+            mainTabBarController.additionalSafeAreaInsets = UIEdgeInsets(top: 0, left: 0, bottom: bottomInset, right: 0)
+        } else {
+            mainTabBarController.additionalSafeAreaInsets = .zero
+        }
+
+        mainTabBarController.selectedViewController?.view.layoutIfNeeded()
+    }
+
+    // Disables foreground in-app notifications when Point of Sale is active
+    //
+    func updateInAppNotifications(_ isPointOfSaleActive: Bool) {
+        if isPointOfSaleActive {
+            ServiceLocator.pushNotesManager.disableInAppNotifications()
+        } else {
+            ServiceLocator.pushNotesManager.enableInAppNotifications()
+        }
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/MainTabBarController.swift
+++ b/WooCommerce/Classes/ViewRelated/MainTabBarController.swift
@@ -183,17 +183,6 @@ final class MainTabBarController: UITabBarController {
         }
     }
 
-    override func viewSafeAreaInsetsDidChange() {
-        super.viewSafeAreaInsetsDidChange()
-
-        if tabBar.isHidden {
-            let bottomInset = 8.0
-            additionalSafeAreaInsets = UIEdgeInsets(top: 0, left: 0, bottom: bottomInset, right: 0)
-        } else {
-            additionalSafeAreaInsets = .zero
-        }
-    }
-
     // MARK: - Public Methods
 
     /// Switches the TabBarController to the specified Tab

--- a/WooCommerce/Classes/ViewRelated/MainTabBarController.swift
+++ b/WooCommerce/Classes/ViewRelated/MainTabBarController.swift
@@ -183,6 +183,17 @@ final class MainTabBarController: UITabBarController {
         }
     }
 
+    override func viewSafeAreaInsetsDidChange() {
+        super.viewSafeAreaInsetsDidChange()
+
+        if tabBar.isHidden {
+            let bottomInset = 8.0
+            additionalSafeAreaInsets = UIEdgeInsets(top: 0, left: 0, bottom: bottomInset, right: 0)
+        } else {
+            additionalSafeAreaInsets = .zero
+        }
+    }
+
     // MARK: - Public Methods
 
     /// Switches the TabBarController to the specified Tab


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #13432 
Closes: #13679

## Description
This PR addresses the issue of additional padding appearing in the bottom of the screen when we load the POS for first time. 

After some investigation the issue was reintroduced on [this PR](https://github.com/woocommerce/woocommerce-ios/pull/13671/), which replaces the `WooTabNavigationController` in the `HubMenu` for a `TabContainerController` in order to address a crash in the iOS18 beta when switching stores. It's not clear why, but this update seems to introduce other UI glitches across the app (for example some titles disappearing in other tabs) mainly due to the nested wrapping of UIKit and SwiftUI components, so this regression wasn't found during smoke testing the changes as these were focused on the app side.

I'd like some advice if this PR seems a good approach to resolve the issue, or perhaps this glitch is something we should leave out of M2 until we can test it more throughly (example: iOS18 beta and non-beta)

## Screenshots

https://github.com/user-attachments/assets/4eaaabb8-174a-4bcf-a432-6fe6ee41ca46

## Changes
- Adds a `viewSafeAreaInsetsDidChange` override to the `MainTabBarController` that resets its UIEdgeInsets when it's hidden. We call this override method specifically when updating the app's tab bar.
- We also close the enhancement request of #13679 by just separating the logic into different methods, this is pure refactoring and there's no changes in the logic.


## Testing information
- On an iPad Air 11 simulator, running iOS 17.5, open POS (it might happen with other devices and/or runtimes, I was only able to reproduce it with this specific setup)
- Observe the Loading screen does not "jump" slightly up while loading
- Add some items to the cart
- Observe that the `POSFloatingControlView` and the `Checkout` button do not re-position themselves upon tapping the `...` button at the top of the screen
- Exit the POS, re-enter
- Observe the same behaviour

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [ ] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [ ] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [ ] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on all devices (phone/tablet) and no regressions are added.