### PR TITLE
[Docs] Document the guidelines for updating translated strings

### DIFF
--- a/docs/localization.md
+++ b/docs/localization.md
@@ -20,6 +20,26 @@ let postBtnTitle = NSLocalizedString("Post", comment: "Verb. Action to publish a
 let postType = NSLocalizedString("Post", comment: "Noun. Describes when an entry is a blog post (and not story or page)"
 ```
 
+Treat translated strings as immutable. If a string value needs to be updated on an existing string, be sure to update the key as well. (Do not update the value only and delete the `en.lproj` translation, as this could cause issues with the localization workflow.)
+
+```swift
+// Do
+// Old string
+let postBtnTitle = NSLocalizedString("editor.post.buttonTitle", value: "Post", comment: "Verb. Action to publish a post")
+
+// New string
+let postBtnTitle = NSLocalizedString("editor.post.publishButtonTitle", value: "Publish", comment: "Verb. Action to publish a post")
+```
+
+```swift
+// Don't
+// Old string
+let postBtnTitle = NSLocalizedString("editor.post.buttonTitle", value: "Post", comment: "Verb. Action to publish a post")
+
+// New string
+let postBtnTitle = NSLocalizedString("editor.post.buttonTitle", value: "Publish", comment: "Verb. Action to publish a post")
+```
+
 ## Always Add Comments
 
 Always add a meaningful comment. If possible, describe where and how the string will be used. If there are placeholders, describe what each placeholder is. 


### PR DESCRIPTION
This updates the localization documentation to include guidelines for updating translated strings (ref: p1724920521169959-slack-CGPNUU63E).

Additional context:

> The current recommendation is still to:
> 
> - Use `NSLocalizedString(syntheticKey, value: "English copy", comment: "Hint for translators")`
> - Consider string copies to be immutable, i.e. if you need to change the `value` of an `NSLocalizedString`, you should use a new `key` for the new `value` instead of modifying the copy of the existing key.
> - Never edit the `*.lproj/Localizable.strings` file manually. Their content will be overwritten by automation anyway (the `en.lproj` one will be overwritten during next code-freeze, the other `*.lproj` ones will be overwritten when we import translations from GlotPress into `release/N` before we do the submission)
> 
> This is particularly important if the new copy doesn’t use the same list of placeholders (e.g. from $1%d to $1%@), or even just doesn’t have the same meaning as the original (e.g. the copy goes from "This feature is free!" to "This feature is a paid subscription").
> 
> This is because if you change the value while keeping the same key, there’s a risk that some translations of the new copy will not be updated in time in GlotPress, which means we might then end up still using and showing the old translation for those locales but the new copy for en.lproj. Consequences would go from just ending up being misleading to users… all the way to crashing the app (mismatching placeholders).
> 
> This is why we’d always recommend using a new key when you need to update an English copy (i.e. consider those conceptually immutable), to avoid all those risks. And the old key will automatically disappear from GlotPress once the next code-freeze regenerates a new en.lproj/Localizable.strings file from a codebase that no longer references the old key, so this shouldn’t be a concern either.

h/t @AliSoftware for the guidance, ref: pdnsEh-xU-p2#comment-4056