### PR TITLE
[Tooling] Add Release Publishing automation

### DIFF
--- a/.buildkite/release-pipelines/publish-release.yml
+++ b/.buildkite/release-pipelines/publish-release.yml
@@ -1,0 +1,25 @@
+agents:
+  queue: "android"
+
+steps:
+  - label: "Publish Release"
+    plugins:
+      - $CI_TOOLKIT
+    command: |
+      echo '--- :robot_face: Use bot for git operations'
+      source use-bot-for-git
+
+      echo '--- :git: Checkout Release Branch'
+      .buildkite/commands/checkout-release-branch.sh
+
+      echo '--- :ruby: Setup Ruby Tools'
+      install_gems
+
+      echo '--- :package: Publish Release'
+      bundle exec fastlane publish_release_and_cleanup skip_confirm:true
+    agents:
+      queue: "tumblr-metal"
+    retry:
+      manual:
+        # If those jobs fail, one should always prefer re-triggering a new build from ReleaseV2 rather than retrying the individual job from Buildkite
+        allowed: false

--- a/.buildkite/release-pipelines/publish-release.yml
+++ b/.buildkite/release-pipelines/publish-release.yml
@@ -1,6 +1,3 @@
-agents:
-  queue: "android"
-
 steps:
   - label: "Publish Release"
     plugins:

--- a/.buildkite/release-pipelines/publish-release.yml
+++ b/.buildkite/release-pipelines/publish-release.yml
@@ -16,7 +16,7 @@ steps:
       install_gems
 
       echo '--- :package: Publish Release'
-      bundle exec fastlane publish_release_and_cleanup skip_confirm:true
+      bundle exec fastlane publish_release skip_confirm:true
     agents:
       queue: "tumblr-metal"
     retry:

--- a/Gemfile
+++ b/Gemfile
@@ -16,7 +16,7 @@ gem 'fastlane-plugin-sentry', '~> 1.0'
 # This comment avoids typing to switch to a development version for testing.
 #
 # gem 'fastlane-plugin-wpmreleasetoolkit', git: 'git@github.com:wordpress-mobile/release-toolkit', branch: ''
-gem 'fastlane-plugin-wpmreleasetoolkit', '~> 11.0', git: 'https://github.com/wordpress-mobile/release-toolkit.git', branch: 'iangmaia/publish-release'
+gem 'fastlane-plugin-wpmreleasetoolkit', '~> 12.0'
 gem 'rake', '~> 12.3'
 gem 'rubocop', '~> 1.65'
 gem 'rubocop-rake', '~> 0.6'

--- a/Gemfile
+++ b/Gemfile
@@ -16,9 +16,9 @@ gem 'fastlane-plugin-sentry', '~> 1.0'
 # This comment avoids typing to switch to a development version for testing.
 #
 # gem 'fastlane-plugin-wpmreleasetoolkit', git: 'git@github.com:wordpress-mobile/release-toolkit', branch: ''
-gem 'fastlane-plugin-wpmreleasetoolkit', '~> 11.0'
+gem 'fastlane-plugin-wpmreleasetoolkit', '~> 11.0', git: 'https://github.com/wordpress-mobile/release-toolkit.git', branch: 'iangmaia/publish-release'
 gem 'rake', '~> 12.3'
-gem 'rubocop', '~> 1.60'
+gem 'rubocop', '~> 1.65'
 gem 'rubocop-rake', '~> 0.6'
 gem 'xcode-install'
 gem 'xcpretty-travis-formatter'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,26 +1,3 @@
-GIT
-  remote: https://github.com/wordpress-mobile/release-toolkit.git
-  revision: 508006d08eda60aa2bf07de2278855469be08e54
-  branch: iangmaia/publish-release
-  specs:
-    fastlane-plugin-wpmreleasetoolkit (11.1.0)
-      activesupport (>= 6.1.7.1)
-      buildkit (~> 1.5)
-      chroma (= 0.2.0)
-      diffy (~> 3.3)
-      fastlane (~> 2.213)
-      git (~> 1.3)
-      google-cloud-storage (~> 1.31)
-      java-properties (~> 0.3.0)
-      nokogiri (~> 1.11)
-      octokit (~> 6.1)
-      parallel (~> 1.14)
-      plist (~> 3.1)
-      progress_bar (~> 1.3)
-      rake (>= 12.3, < 14.0)
-      rake-compiler (~> 1.0)
-      xcodeproj (~> 1.22)
-
 GEM
   remote: https://rubygems.org/
   specs:
@@ -230,6 +207,23 @@ GEM
     fastlane-plugin-appcenter (2.1.2)
     fastlane-plugin-sentry (1.24.0)
       os (~> 1.1, >= 1.1.4)
+    fastlane-plugin-wpmreleasetoolkit (12.0.0)
+      activesupport (>= 6.1.7.1)
+      buildkit (~> 1.5)
+      chroma (= 0.2.0)
+      diffy (~> 3.3)
+      fastlane (~> 2.213)
+      git (~> 1.3)
+      google-cloud-storage (~> 1.31)
+      java-properties (~> 0.3.0)
+      nokogiri (~> 1.11)
+      octokit (~> 6.1)
+      parallel (~> 1.14)
+      plist (~> 3.1)
+      progress_bar (~> 1.3)
+      rake (>= 12.3, < 14.0)
+      rake-compiler (~> 1.0)
+      xcodeproj (~> 1.22)
     ffi (1.17.0)
     ffi (1.17.0-x86_64-darwin)
     fourflusher (2.3.1)
@@ -416,7 +410,7 @@ DEPENDENCIES
   fastlane (~> 2.217)
   fastlane-plugin-appcenter (~> 2.0)
   fastlane-plugin-sentry (~> 1.0)
-  fastlane-plugin-wpmreleasetoolkit (~> 11.0)!
+  fastlane-plugin-wpmreleasetoolkit (~> 12.0)
   rake (~> 12.3)
   rmagick (~> 4.1)
   rubocop (~> 1.65)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,3 +1,26 @@
+GIT
+  remote: https://github.com/wordpress-mobile/release-toolkit.git
+  revision: 508006d08eda60aa2bf07de2278855469be08e54
+  branch: iangmaia/publish-release
+  specs:
+    fastlane-plugin-wpmreleasetoolkit (11.1.0)
+      activesupport (>= 6.1.7.1)
+      buildkit (~> 1.5)
+      chroma (= 0.2.0)
+      diffy (~> 3.3)
+      fastlane (~> 2.213)
+      git (~> 1.3)
+      google-cloud-storage (~> 1.31)
+      java-properties (~> 0.3.0)
+      nokogiri (~> 1.11)
+      octokit (~> 6.1)
+      parallel (~> 1.14)
+      plist (~> 3.1)
+      progress_bar (~> 1.3)
+      rake (>= 12.3, < 14.0)
+      rake-compiler (~> 1.0)
+      xcodeproj (~> 1.22)
+
 GEM
   remote: https://rubygems.org/
   specs:
@@ -207,23 +230,6 @@ GEM
     fastlane-plugin-appcenter (2.1.2)
     fastlane-plugin-sentry (1.24.0)
       os (~> 1.1, >= 1.1.4)
-    fastlane-plugin-wpmreleasetoolkit (11.1.0)
-      activesupport (>= 6.1.7.1)
-      buildkit (~> 1.5)
-      chroma (= 0.2.0)
-      diffy (~> 3.3)
-      fastlane (~> 2.213)
-      git (~> 1.3)
-      google-cloud-storage (~> 1.31)
-      java-properties (~> 0.3.0)
-      nokogiri (~> 1.11, < 1.17)
-      octokit (~> 6.1)
-      parallel (~> 1.14)
-      plist (~> 3.1)
-      progress_bar (~> 1.3)
-      rake (>= 12.3, < 14.0)
-      rake-compiler (~> 1.0)
-      xcodeproj (~> 1.22)
     ffi (1.17.0)
     ffi (1.17.0-x86_64-darwin)
     fourflusher (2.3.1)
@@ -410,10 +416,10 @@ DEPENDENCIES
   fastlane (~> 2.217)
   fastlane-plugin-appcenter (~> 2.0)
   fastlane-plugin-sentry (~> 1.0)
-  fastlane-plugin-wpmreleasetoolkit (~> 11.0)
+  fastlane-plugin-wpmreleasetoolkit (~> 11.0)!
   rake (~> 12.3)
   rmagick (~> 4.1)
-  rubocop (~> 1.60)
+  rubocop (~> 1.65)
   rubocop-rake (~> 0.6)
   xcode-install
   xcpretty-travis-formatter

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -1490,7 +1490,11 @@ def create_backmerge_pr
   )
 rescue StandardError => e
   error_message = <<-MESSAGE
-    Error creating backmerge pull request: #{e.message}
+    Error creating backmerge pull request:
+    ```
+    #{e.message}
+    ```
+
     If this is not the first time you are running the release task, the backmerge PR for the version `#{version}` might have already been previously created.
     Please close any previous backmerge PR for `#{version}`, delete the previous merge branch, then run the release task again.
   MESSAGE

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -533,6 +533,45 @@ platform :ios do
     end
   end
 
+  # This lane publishes a release on GitHub, tagging it on git, and backmerges the current release branch into the next release/ branch
+  #
+  # @param [Boolean] skip_confirm (default: false) If set, will skip the confirmation prompt before running the rest of the lane
+  #
+  # @example Running the lane
+  #          bundle exec fastlane publish_release_and_cleanup skip_confirm:true
+  #
+  lane :publish_release_and_cleanup do |skip_confirm: false|
+    ensure_git_status_clean
+    ensure_git_branch_is_release_branch
+
+    version_number = release_version_current
+
+    current_branch = "release/#{version_number}"
+    next_release_branch = "release/#{release_version_next}"
+
+    UI.important <<~PROMPT
+      Publish the #{version_number} release. This will:
+      - Publish the existing draft `#{version_number}` release on GitHub
+      - Which will also have GitHub create the associated git tag, pointing to the tip of the branch
+      - If the release branch for the next version `#{next_release_branch}` already exists, backmerge `#{current_branch}` into it
+      - If needed, backmerge `#{current_branch}` back into `#{DEFAULT_BRANCH}`
+      - Delete the `#{current_branch}` branch
+    PROMPT
+    UI.user_error!("Terminating as requested. Don't forget to run the remainder of this automation manually.") unless skip_confirm || UI.confirm('Do you want to continue?')
+
+    UI.important "Publishing release #{version_number} on GitHub"
+
+    publish_release(
+      repository: GITHUB_REPO,
+      name: version_number
+    )
+
+    create_backmerge_pr
+
+    # Now that an eventual backmerge PR has created an intermediate branch, we can delete the `release/*` branch
+    delete_remote_git_branch!(current_branch)
+  end
+
   lane :check_translation_progress_all do
     check_translation_progress_strings
     check_translation_progress_release_notes
@@ -1475,6 +1514,14 @@ def ensure_branch_does_not_exist!(branch_name)
   buildkite_annotate(style: 'error', context: 'error-checking-branch', message: error_message) if is_ci
 
   UI.user_error!(error_message)
+end
+
+# Delete a branch remotely, after having removed any GitHub branch protection
+#
+def delete_remote_git_branch!(branch_name)
+  remove_branch_protection(repository: GITHUB_REPO, branch: branch_name)
+
+  Git.open('.').push('origin', branch_name, delete: true)
 end
 
 def report_milestone_error(error_title:)

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -568,7 +568,9 @@ platform :ios do
 
     create_backmerge_pr
 
-    # Now that an eventual backmerge PR has created an intermediate branch, we can delete the `release/*` branch
+    # At this point, an intermediate branch has been created by creating a backmerge PR to a hotfix or the next version release branch.
+    # This allows us to safely delete the `release/*` branch.
+    # Note that if a hotfix or new release branches haven't been created, the backmerge PR won't be created as well.
     delete_remote_git_branch!(current_branch)
   end
 
@@ -1491,6 +1493,7 @@ def create_backmerge_pr
 rescue StandardError => e
   error_message = <<-MESSAGE
     Error creating backmerge pull request:
+
     ```
     #{e.message}
     ```
@@ -1525,7 +1528,7 @@ end
 def delete_remote_git_branch!(branch_name)
   remove_branch_protection(repository: GITHUB_REPO, branch: branch_name)
 
-  Git.open('.').push('origin', branch_name, delete: true)
+  Git.open(Dir.pwd).push('origin', branch_name, delete: true)
 end
 
 def report_milestone_error(error_title:)

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -538,9 +538,9 @@ platform :ios do
   # @param [Boolean] skip_confirm (default: false) If set, will skip the confirmation prompt before running the rest of the lane
   #
   # @example Running the lane
-  #          bundle exec fastlane publish_release_and_cleanup skip_confirm:true
+  #          bundle exec fastlane publish_release skip_confirm:true
   #
-  lane :publish_release_and_cleanup do |skip_confirm: false|
+  lane :publish_release do |skip_confirm: false|
     ensure_git_status_clean
     ensure_git_branch_is_release_branch
 
@@ -561,7 +561,7 @@ platform :ios do
 
     UI.important "Publishing release #{version_number} on GitHub"
 
-    publish_release(
+    publish_github_release(
       repository: GITHUB_REPO,
       name: version_number
     )


### PR DESCRIPTION
This PR automates the release publishing, which means to:

- Publish the existing draft release on GitHub (which will also have GitHub create the associated git tag, pointing to the tip of the branch)
- If the release branch for the next version already exists, backmerge the current release into it
- Delete the current release branch

This PR will be followed by updates to the Releases V2 tool.