### PR TITLE
Adopt named block arguments in finalize_release lane

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -480,16 +480,14 @@ platform :ios do
   # bundle exec fastlane finalize_release skip_confirm:true
   #####################################################################################
   desc 'Trigger the final release build on CI'
-  lane :finalize_release do |options|
+  lane :finalize_release do |skip_confirm: false|
     UI.user_error!('To finalize a hotfix, please use the `finalize_hotfix_release` lane instead') if release_is_hotfix?
 
     ensure_git_status_clean
     ensure_git_branch_is_release_branch!
 
     UI.important("Finalizing release: #{release_version_current}")
-    unless options[:skip_confirm] || UI.confirm('Do you want to continue?')
-      UI.user_error!("Terminating as requested. Don't forget to run the remainder of this automation manually.")
-    end
+    UI.user_error!("Terminating as requested. Don't forget to run the remainder of this automation manually.") unless skip_confirm || UI.confirm('Do you want to continue?')
 
     # Don't check translation coverage in CI
     check_translation_progress_all unless is_ci
@@ -504,9 +502,7 @@ platform :ios do
 
     # Start the build
     UI.important('Pushing changes to remote and triggering the release build')
-    unless options[:skip_confirm] || UI.confirm('Do you want to continue?')
-      UI.user_error!("Terminating as requested. Don't forget to run the remainder of this automation manually.")
-    end
+    UI.user_error!("Terminating as requested. Don't forget to run the remainder of this automation manually.") unless skip_confirm || UI.confirm('Do you want to continue?')
 
     push_to_git_remote(tags: false)
 

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -1452,7 +1452,7 @@ def create_backmerge_pr
 rescue StandardError => e
   error_message = <<-MESSAGE
     Error creating backmerge pull request: #{e.message}
-    - If this is not the first time you are running the release task, the backmerge PR for the version `#{version}` might have already been previously created.
+    If this is not the first time you are running the release task, the backmerge PR for the version `#{version}` might have already been previously created.
     Please close any previous backmerge PR for `#{version}`, delete the previous merge branch, then run the release task again.
   MESSAGE
 


### PR DESCRIPTION
## Description
Similar to https://github.com/woocommerce/woocommerce-android/pull/12279, I was using this repo as a base for updating the Simplenote iOS automation and noticed the lane I was looking at did not use named block arugments.

## Steps to reproduce
N.A.

## Testing information
N.A. – We'll see how this works in the next release cycle.

## Screenshots
N.A.

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary. – N.A.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [x] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [x] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description. – N.A.
- [x] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on all devices (phone/tablet) and no regressions are added. 