### PR TITLE
[Woo POS] Walkthrough code cleanup

### DIFF
--- a/WooCommerce/Classes/POS/ViewModels/ItemListViewModel.swift
+++ b/WooCommerce/Classes/POS/ViewModels/ItemListViewModel.swift
@@ -34,7 +34,6 @@ final class ItemListViewModel: ItemListViewModelProtocol {
 
     var itemsPublisher: Published<[POSItem]>.Publisher { $items }
     var statePublisher: Published<ItemListViewModel.ItemListState>.Publisher { $state }
-    var isHeaderBannerDismissedPublisher: Published<Bool>.Publisher { $isHeaderBannerDismissed }
 
     init(itemProvider: POSItemProvider) {
         self.itemProvider = itemProvider

--- a/WooCommerce/Classes/POS/ViewModels/ItemListViewModel.swift
+++ b/WooCommerce/Classes/POS/ViewModels/ItemListViewModel.swift
@@ -82,10 +82,6 @@ final class ItemListViewModel: ItemListViewModelProtocol {
 extension ItemListViewModel {
     enum ItemListState: Equatable {
         case empty
-        // TODO:
-        // Differentiate between loading on entering POS mode and reloading, as the
-        // screens will be different:
-        // https://github.com/woocommerce/woocommerce-ios/issues/13286
         case loading
         case loaded([POSItem])
         case error(ErrorModel)

--- a/WooCommerce/Classes/POS/ViewModels/ItemListViewModelProtocol.swift
+++ b/WooCommerce/Classes/POS/ViewModels/ItemListViewModelProtocol.swift
@@ -12,7 +12,6 @@ protocol ItemListViewModelProtocol: ObservableObject {
     var selectedItemPublisher: AnyPublisher<POSItem, Never> { get }
     var itemsPublisher: Published<[POSItem]>.Publisher { get }
     var statePublisher: Published<ItemListViewModel.ItemListState>.Publisher { get }
-    var isHeaderBannerDismissedPublisher: Published<Bool>.Publisher { get }
 
     func select(_ item: POSItem)
     func populatePointOfSaleItems() async

--- a/WooCommerce/WooCommerceTests/POS/Mocks/MockItemListViewModel.swift
+++ b/WooCommerce/WooCommerceTests/POS/Mocks/MockItemListViewModel.swift
@@ -11,7 +11,6 @@ class MockItemListViewModel: ItemListViewModelProtocol {
     var statePublisher: Published<WooCommerce.ItemListViewModel.ItemListState>.Publisher { $state }
 
     @Published var isHeaderBannerDismissed: Bool = false
-    var isHeaderBannerDismissedPublisher: Published<Bool>.Publisher { $isHeaderBannerDismissed }
 
     var isEmptyOrError: Bool = false
     var shouldShowHeaderBanner: Bool = false

--- a/WooCommerce/WooCommerceTests/POS/ViewModels/ItemListViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/POS/ViewModels/ItemListViewModelTests.swift
@@ -310,6 +310,14 @@ final class ItemListViewModelTests: XCTestCase {
         XCTAssertEqual(receivedItems.first?.productID, firstItem.productID)
         XCTAssertEqual(receivedItems.last?.productID, lastItem.productID)
     }
+
+    func test_simpleProductsInfoButtonTapped_when_tapped_then_showSimpleProductsModal_toggled() {
+        XCTAssertFalse(sut.showSimpleProductsModal)
+
+        sut.simpleProductsInfoButtonTapped()
+
+        XCTAssertTrue(sut.showSimpleProductsModal)
+    }
 }
 
 private extension ItemListViewModelTests {

--- a/Yosemite/Yosemite/PointOfSale/POSItemProvider.swift
+++ b/Yosemite/Yosemite/PointOfSale/POSItemProvider.swift
@@ -12,7 +12,14 @@ public protocol POSItem {
 extension POSItem {
     // Equatable conformance
     static func == (lhs: Self, rhs: Self) -> Bool {
-        lhs.itemID == rhs.itemID
+        lhs.itemID == rhs.itemID &&
+        lhs.productID == rhs.productID &&
+        lhs.name == rhs.name &&
+        lhs.price == rhs.price &&
+        lhs.formattedPrice == rhs.formattedPrice &&
+        lhs.itemCategories == rhs.itemCategories &&
+        lhs.productImageSource == rhs.productImageSource &&
+        lhs.productType == rhs.productType
     }
 }
 

--- a/Yosemite/Yosemite/PointOfSale/POSProductProvider.swift
+++ b/Yosemite/Yosemite/PointOfSale/POSProductProvider.swift
@@ -69,9 +69,6 @@ public final class POSProductProvider: POSItemProvider {
                               productType: product.productType)
         }
     }
-
-    // TODO: Mechanism to reload/sync product data.
-    // https://github.com/woocommerce/woocommerce-ios/issues/12837
 }
 
 private extension POSProductProvider {


### PR DESCRIPTION
## Description
This PR does a bit of cleanup after M2 by tackling non-essential items found while exploring the codebase.

## Changes 
- Removes unused `isHeaderBannerDismissedPublisher`.
- Removes out of date internal comments referencing TODO items that no longer are valid.
- Add unit tests for `itemsPublisher`, `statePublisher`, and `simpleProductsInfoButtonTapped()`. These are publicly exposed properties/methods, so we're just adding a bit of additional coverage.
- Add completion to the `POSItem` equatable conformance. Up until now we were just checking if the item id's matched.

## Testing information
- CI should pass
- The "Simple product banner" should work as expected. Tapping the (i) symbol should make it appear, while tapping the "Ok" button should dismiss it.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [x] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [x] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [x] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on all devices (phone/tablet) and no regressions are added.