### PR TITLE
[Woo POS] Add new items to the top of the cart

### DIFF
--- a/WooCommerce/Classes/POS/Presentation/CartView.swift
+++ b/WooCommerce/Classes/POS/Presentation/CartView.swift
@@ -95,9 +95,9 @@ struct CartView: View {
                     .coordinateSpace(name: Constants.scrollViewCoordinateSpaceIdentifier)
                     .onChange(of: cartViewModel.itemToScrollToWhenCartUpdated?.id) { _ in
                         if viewModel.orderStage == .building,
-                           let last = cartViewModel.itemToScrollToWhenCartUpdated?.id {
+                           let itemToScrollTo = cartViewModel.itemToScrollToWhenCartUpdated?.id {
                             withAnimation {
-                                proxy.scrollTo(last)
+                                proxy.scrollTo(itemToScrollTo)
                             }
                         }
                     }

--- a/WooCommerce/Classes/POS/ViewModels/CartViewModel.swift
+++ b/WooCommerce/Classes/POS/ViewModels/CartViewModel.swift
@@ -46,6 +46,7 @@ final class CartViewModel: CartViewModelProtocol {
     func addItemToCart(_ item: POSItem) {
         let cartItem = CartItem(id: UUID(), item: item, quantity: 1)
         itemsInCart.insert(cartItem, at: 0)
+        itemToScrollToWhenCartUpdated = cartItem
 
         analytics.track(.pointOfSaleAddItemToCart)
     }
@@ -58,9 +59,7 @@ final class CartViewModel: CartViewModelProtocol {
         itemsInCart.removeAll()
     }
 
-    var itemToScrollToWhenCartUpdated: CartItem? {
-        return itemsInCart.last
-    }
+    var itemToScrollToWhenCartUpdated: CartItem?
 
     var itemsInCartLabel: String? {
         switch itemsInCart.count {

--- a/WooCommerce/Classes/POS/ViewModels/CartViewModel.swift
+++ b/WooCommerce/Classes/POS/ViewModels/CartViewModel.swift
@@ -45,7 +45,7 @@ final class CartViewModel: CartViewModelProtocol {
 
     func addItemToCart(_ item: POSItem) {
         let cartItem = CartItem(id: UUID(), item: item, quantity: 1)
-        itemsInCart.append(cartItem)
+        itemsInCart.insert(cartItem, at: 0)
 
         analytics.track(.pointOfSaleAddItemToCart)
     }

--- a/WooCommerce/WooCommerceTests/POS/ViewModels/CartViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/POS/ViewModels/CartViewModelTests.swift
@@ -43,7 +43,7 @@ final class CartViewModelTests: XCTestCase {
         sut.submitCart()
     }
 
-    func test_cart_when_addItemToCart_is_invoked_then_adds_item_to_cart() {
+    func test_addItemToCart_then_cart_is_not_empty() {
         // Given
         XCTAssertTrue(sut.itemsInCart.isEmpty, "Initial state")
         let item = Self.makeItem()
@@ -53,6 +53,19 @@ final class CartViewModelTests: XCTestCase {
 
         // Then
         XCTAssertTrue(sut.itemsInCart.isNotEmpty)
+    }
+
+    func test_addItemToCart_when_multiple_items_added_then_latest_item_is_first() {
+        // Given
+        XCTAssertTrue(sut.itemsInCart.isEmpty, "Initial state")
+        let items = [Self.makeItem(), Self.makeItem(), Self.makeItem()]
+
+        // When
+        items.forEach(sut.addItemToCart)
+
+        // Then
+        XCTAssertEqual(sut.itemsInCart.map(\.item.itemID), items.reversed().map(\.itemID))
+        XCTAssertNotEqual(sut.itemsInCart.map(\.item.itemID), items.map(\.itemID))
     }
 
     func test_removeItemFromCart() {

--- a/WooCommerce/WooCommerceTests/POS/ViewModels/CartViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/POS/ViewModels/CartViewModelTests.swift
@@ -84,7 +84,7 @@ final class CartViewModelTests: XCTestCase {
         sut.addItemToCart(item)
         sut.addItemToCart(anotherItem)
         XCTAssertEqual(sut.itemsInCart.count, 2)
-        XCTAssertEqual(sut.itemsInCart.map { $0.item.name }, [item, anotherItem].map { $0.name })
+        XCTAssertEqual(sut.itemsInCart.map { $0.item.name }, [anotherItem, item].map { $0.name })
 
         // When
         let firstCartItem = try XCTUnwrap(sut.itemsInCart.first)
@@ -92,7 +92,7 @@ final class CartViewModelTests: XCTestCase {
 
         // Then
         XCTAssertEqual(sut.itemsInCart.count, 1)
-        XCTAssertEqual(sut.itemsInCart.map { $0.item.name }, [anotherItem.name])
+        XCTAssertEqual(sut.itemsInCart.map { $0.item.name }, [item.name])
     }
 
     func test_cart_when_removeAllItemsFromCart_is_invoked_then_removes_all_items_from_cart() {


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

Add new items to the top of the cart:
- Use insert(item, at: 0) instead of append
- Add new test

## Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->

### Adding items

1. Open POS
2. Select a new item
3. Confirm a new item appears at the top of the cart
4. Check Out
5. Confirm items appear in the same order
6. Come back
7. Check Out again
8. Confirm totals are not reloaded since items remained the same
9. Remove first, last, and middle items, and confirm they are removed as expected
10. Clean the cart
11. Confirm it continues working

### Scrolling

1. Open POS
2. Add many items, more than fits in the cart
3. Scroll to the bottom of the cart
4. Add item
5. Confirm that cart scrolls to the top

## Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->

Added a new unit test confirming that items are added in reverse order.

Manually tested scenarios mentioned in 'Steps to reproduce' to confirm that previous Cart functionality continues to work as before

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

### General behavior
https://github.com/user-attachments/assets/44e45c44-c44e-4218-9285-117466b7d9fd

### Scrolling to the last added item

https://github.com/user-attachments/assets/b4b3540a-cb91-44b1-b512-e45f2ae007d1

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [x] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [x] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [x] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on all devices (phone/tablet) and no regressions are added.