### PR TITLE
[Shipping Labels] Add check for Woo Shipping support in order details

### DIFF
--- a/WooCommerce/Classes/Extensions/SitePlugin+Woo.swift
+++ b/WooCommerce/Classes/Extensions/SitePlugin+Woo.swift
@@ -5,7 +5,7 @@ import Yosemite
 extension SitePlugin {
     enum SupportedPlugin {
         public static let LegacyWCShip = "WooCommerce Shipping &amp; Tax"
-        public static let WooShipping = "WooCommerce Shipping"
+        public static let WooShipping = ["Woo Shipping", "WooCommerce Shipping"]
         public static let WCTracking = "WooCommerce Shipment Tracking"
         public static let WCSubscriptions = ["WooCommerce Subscriptions", "Woo Subscriptions"]
         public static let WCProductBundles = ["WooCommerce Product Bundles", "Woo Product Bundles"]

--- a/WooCommerce/Classes/Extensions/SitePlugin+Woo.swift
+++ b/WooCommerce/Classes/Extensions/SitePlugin+Woo.swift
@@ -5,7 +5,7 @@ import Yosemite
 extension SitePlugin {
     enum SupportedPlugin {
         public static let LegacyWCShip = "WooCommerce Shipping &amp; Tax"
-        public static let WooShipping = "Woo Shipping"
+        public static let WooShipping = "WooCommerce Shipping"
         public static let WCTracking = "WooCommerce Shipment Tracking"
         public static let WCSubscriptions = ["WooCommerce Subscriptions", "Woo Subscriptions"]
         public static let WCProductBundles = ["WooCommerce Product Bundles", "Woo Product Bundles"]

--- a/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsDataSource.swift
+++ b/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsDataSource.swift
@@ -41,6 +41,10 @@ final class OrderDetailsDataSource: NSObject {
     ///
     var isEligibleForShippingLabelCreation: Bool = false
 
+    /// Whether the order is eligible for Woo Shipping flows.
+    ///
+    var isEligibleForWooShipping: Bool = false
+
     /// Whether the order is eligible for card present payment.
     ///
     var isEligibleForPayment: Bool {

--- a/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsViewModel.swift
+++ b/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsViewModel.swift
@@ -750,6 +750,20 @@ extension OrderDetailsViewModel {
         return await isPluginActive(SitePlugin.SupportedPlugin.WooShipping)
     }
 
+    /// Checks if the Woo Shipping extension is active, with the minimum version required for its shipping label flow.
+    ///
+    @MainActor
+    func isWooShippingSupported() async -> Bool {
+        guard featureFlagService.isFeatureFlagEnabled(.revampedShippingLabelCreation),
+              let plugin = await fetchPlugin([SitePlugin.SupportedPlugin.WooShipping]) else {
+            return false
+        }
+
+        let isVersionSupported = VersionHelpers.isVersionSupported(version: plugin.version, minimumRequired: Constants.wooShippingMinimumVersion)
+
+        return plugin.active && isVersionSupported
+    }
+
     func checkOrderAddOnFeatureSwitchState(onCompletion: (() -> Void)? = nil) {
         let action = AppSettingsAction.loadOrderAddOnsSwitchState { [weak self] result in
             self?.dataSource.showAddOns = (try? result.get()) ?? false
@@ -816,17 +830,29 @@ extension OrderDetailsViewModel {
     /// Additionally it logs to tracks if the plugin store is accessed without it being in sync so we can handle that edge-case if it happens recurrently.
     /// Useful for when a plugin has had many names.
     ///
-    private func isPluginActive(_ plugins: [String], completion: @escaping (Bool) -> (Void)) {
-        guard arePluginsSynced() else {
-            DDLogError("⚠️ SystemPlugins acceded without being in sync.")
-            ServiceLocator.analytics.track(event: WooAnalyticsEvent.Orders.pluginsNotSyncedYet())
-            return completion(false)
-        }
-
-        let action = SystemStatusAction.fetchSystemPluginListWithNameList(siteID: order.siteID, systemPluginNameList: plugins) { plugin in
+    private func isPluginActive(_ pluginNames: [String], completion: @escaping (Bool) -> (Void)) {
+        Task { @MainActor in
+            let plugin = await fetchPlugin(pluginNames)
             completion(plugin?.active == true)
         }
-        stores.dispatch(action)
+    }
+
+    /// Fetches a plugin from storage, based on the provided list of plugin names.
+    /// Additionally it logs to tracks if the plugin store is accessed without it being in sync so we can handle that edge-case if it happens recurrently.
+    ///
+    @MainActor
+    private func fetchPlugin(_ pluginNames: [String]) async -> SystemPlugin? {
+        guard arePluginsSynced() else {
+            DDLogError("⚠️ SystemPlugins accessed without being in sync.")
+            ServiceLocator.analytics.track(event: WooAnalyticsEvent.Orders.pluginsNotSyncedYet())
+            return nil
+        }
+
+        return await withCheckedContinuation { continuation in
+            stores.dispatch(SystemStatusAction.fetchSystemPluginListWithNameList(siteID: order.siteID, systemPluginNameList: pluginNames, onCompletion: { plugin in
+                continuation.resume(returning: plugin)
+            }))
+        }
     }
 
     /// Function that checks for any existing system plugin in the order's store.
@@ -892,5 +918,14 @@ private extension OrderDetailsViewModel {
             "OrderDetailsViewModel.displayReceiptRetrievalErrorNotice.notice",
             value: "Unable to retrieve receipt.",
             comment: "Notice that appears when no receipt can be retrieved upon tapping on 'See receipt' in the Order Details view.")
+    }
+}
+
+// MARK: - Constants
+private extension OrderDetailsViewModel {
+    enum Constants {
+        /// Minimum version of Woo Shipping extension required for app support.
+        /// This should be updated to 1.0.6 once that version is released.
+        static let wooShippingMinimumVersion = "1.0.5"
     }
 }

--- a/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsViewModel.swift
+++ b/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsViewModel.swift
@@ -757,7 +757,7 @@ extension OrderDetailsViewModel {
     @MainActor
     func isWooShippingSupported() async -> Bool {
         guard featureFlagService.isFeatureFlagEnabled(.revampedShippingLabelCreation),
-              let plugin = await fetchPlugin([SitePlugin.SupportedPlugin.WooShipping]) else {
+              let plugin = await fetchPlugin(SitePlugin.SupportedPlugin.WooShipping) else {
             return false
         }
 
@@ -883,8 +883,13 @@ extension OrderDetailsViewModel {
 private extension OrderDetailsViewModel {
     @MainActor
     func isPluginActive(_ plugin: String) async -> Bool {
+        return await isPluginActive([plugin])
+    }
+
+    @MainActor
+    func isPluginActive(_ pluginNames: [String]) async -> Bool {
         await withCheckedContinuation { continuation in
-            isPluginActive(plugin) { isActive in
+            isPluginActive(pluginNames) { isActive in
                 continuation.resume(returning: isActive)
             }
         }

--- a/WooCommerce/WooCommerceTests/Mocks/MockFeatureFlagService.swift
+++ b/WooCommerce/WooCommerceTests/Mocks/MockFeatureFlagService.swift
@@ -19,6 +19,7 @@ struct MockFeatureFlagService: FeatureFlagService {
     private let isProductCreationAIv2M1Enabled: Bool
     private let googleAdsCampaignCreationOnWebView: Bool
     private let blazeEvergreenCampaigns: Bool
+    private let revampedShippingLabelCreation: Bool
 
     init(isInboxOn: Bool = false,
          isShowInboxCTAEnabled: Bool = false,
@@ -36,7 +37,8 @@ struct MockFeatureFlagService: FeatureFlagService {
          isDisplayPointOfSaleToggleEnabled: Bool = false,
          isProductCreationAIv2M1Enabled: Bool = false,
          googleAdsCampaignCreationOnWebView: Bool = false,
-         blazeEvergreenCampaigns: Bool = false) {
+         blazeEvergreenCampaigns: Bool = false,
+         revampedShippingLabelCreation: Bool = false) {
         self.isInboxOn = isInboxOn
         self.isShowInboxCTAEnabled = isShowInboxCTAEnabled
         self.isUpdateOrderOptimisticallyOn = isUpdateOrderOptimisticallyOn
@@ -54,6 +56,7 @@ struct MockFeatureFlagService: FeatureFlagService {
         self.isProductCreationAIv2M1Enabled = isProductCreationAIv2M1Enabled
         self.googleAdsCampaignCreationOnWebView = googleAdsCampaignCreationOnWebView
         self.blazeEvergreenCampaigns = blazeEvergreenCampaigns
+        self.revampedShippingLabelCreation = revampedShippingLabelCreation
     }
 
     func isFeatureFlagEnabled(_ featureFlag: FeatureFlag) -> Bool {
@@ -92,6 +95,8 @@ struct MockFeatureFlagService: FeatureFlagService {
             return googleAdsCampaignCreationOnWebView
         case .blazeEvergreenCampaigns:
             return blazeEvergreenCampaigns
+        case .revampedShippingLabelCreation:
+            return revampedShippingLabelCreation
         default:
             return false
         }

--- a/WooCommerce/WooCommerceTests/ViewRelated/OrderDetailsViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/OrderDetailsViewModelTests.swift
@@ -389,7 +389,7 @@ final class OrderDetailsViewModelTests: XCTestCase {
         // Given
         let featureFlagService = MockFeatureFlagService(revampedShippingLabelCreation: true)
         let viewModel = OrderDetailsViewModel(order: order, stores: storesManager, storageManager: storageManager, featureFlagService: featureFlagService)
-        let plugin = insertSystemPlugin(name: SitePlugin.SupportedPlugin.WooShipping, siteID: order.siteID, isActive: true, version: "1.0.5")
+        let plugin = insertSystemPlugin(name: SitePlugin.SupportedPlugin.WooShipping[0], siteID: order.siteID, isActive: true, version: "1.0.5")
         whenFetchingSystemPlugin(thenReturn: plugin)
 
         // When
@@ -403,7 +403,7 @@ final class OrderDetailsViewModelTests: XCTestCase {
         // Given
         let featureFlagService = MockFeatureFlagService(revampedShippingLabelCreation: false)
         let viewModel = OrderDetailsViewModel(order: order, stores: storesManager, storageManager: storageManager, featureFlagService: featureFlagService)
-        let plugin = insertSystemPlugin(name: SitePlugin.SupportedPlugin.WooShipping, siteID: order.siteID, isActive: true, version: "1.0.5")
+        let plugin = insertSystemPlugin(name: SitePlugin.SupportedPlugin.WooShipping[0], siteID: order.siteID, isActive: true, version: "1.0.5")
         whenFetchingSystemPlugin(thenReturn: plugin)
 
         // When
@@ -417,7 +417,7 @@ final class OrderDetailsViewModelTests: XCTestCase {
         // Given
         let featureFlagService = MockFeatureFlagService(revampedShippingLabelCreation: true)
         let viewModel = OrderDetailsViewModel(order: order, stores: storesManager, storageManager: storageManager, featureFlagService: featureFlagService)
-        let plugin = insertSystemPlugin(name: SitePlugin.SupportedPlugin.WooShipping, siteID: order.siteID, isActive: false, version: "1.0.5")
+        let plugin = insertSystemPlugin(name: SitePlugin.SupportedPlugin.WooShipping[0], siteID: order.siteID, isActive: false, version: "1.0.5")
         whenFetchingSystemPlugin(thenReturn: plugin)
 
         // When
@@ -431,7 +431,7 @@ final class OrderDetailsViewModelTests: XCTestCase {
         // Given
         let featureFlagService = MockFeatureFlagService(revampedShippingLabelCreation: true)
         let viewModel = OrderDetailsViewModel(order: order, stores: storesManager, storageManager: storageManager, featureFlagService: featureFlagService)
-        let plugin = insertSystemPlugin(name: SitePlugin.SupportedPlugin.WooShipping, siteID: order.siteID, isActive: false, version: "1.0.4")
+        let plugin = insertSystemPlugin(name: SitePlugin.SupportedPlugin.WooShipping[0], siteID: order.siteID, isActive: false, version: "1.0.4")
         whenFetchingSystemPlugin(thenReturn: plugin)
 
         // When

--- a/WooCommerce/WooCommerceTests/ViewRelated/OrderDetailsViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/OrderDetailsViewModelTests.swift
@@ -382,12 +382,70 @@ final class OrderDetailsViewModelTests: XCTestCase {
         XCTAssertEqual(storesManager.receivedActions.count, 1)
         assertThat(storesManager.receivedActions.first, isAnInstanceOf: ShipmentAction.self)
     }
+
+    // MARK: - `isWooShippingSupported`
+
+    func test_isWooShippingSupported_returns_true_with_expected_feature_flag_and_version() async {
+        // Given
+        let featureFlagService = MockFeatureFlagService(revampedShippingLabelCreation: true)
+        let viewModel = OrderDetailsViewModel(order: order, stores: storesManager, storageManager: storageManager, featureFlagService: featureFlagService)
+        let plugin = insertSystemPlugin(name: SitePlugin.SupportedPlugin.WooShipping, siteID: order.siteID, isActive: true, version: "1.0.5")
+        whenFetchingSystemPlugin(thenReturn: plugin)
+
+        // When
+        let isWooShippingSupported = await viewModel.isWooShippingSupported()
+
+        // Then
+        XCTAssertTrue(isWooShippingSupported)
+    }
+
+    func test_isWooShippingSupported_returns_false_when_feature_flag_disabled() async {
+        // Given
+        let featureFlagService = MockFeatureFlagService(revampedShippingLabelCreation: false)
+        let viewModel = OrderDetailsViewModel(order: order, stores: storesManager, storageManager: storageManager, featureFlagService: featureFlagService)
+        let plugin = insertSystemPlugin(name: SitePlugin.SupportedPlugin.WooShipping, siteID: order.siteID, isActive: true, version: "1.0.5")
+        whenFetchingSystemPlugin(thenReturn: plugin)
+
+        // When
+        let isWooShippingSupported = await viewModel.isWooShippingSupported()
+
+        // Then
+        XCTAssertFalse(isWooShippingSupported)
+    }
+
+    func test_isWooShippingSupported_returns_false_when_woo_shipping_plugin_not_active() async {
+        // Given
+        let featureFlagService = MockFeatureFlagService(revampedShippingLabelCreation: true)
+        let viewModel = OrderDetailsViewModel(order: order, stores: storesManager, storageManager: storageManager, featureFlagService: featureFlagService)
+        let plugin = insertSystemPlugin(name: SitePlugin.SupportedPlugin.WooShipping, siteID: order.siteID, isActive: false, version: "1.0.5")
+        whenFetchingSystemPlugin(thenReturn: plugin)
+
+        // When
+        let isWooShippingSupported = await viewModel.isWooShippingSupported()
+
+        // Then
+        XCTAssertFalse(isWooShippingSupported)
+    }
+
+    func test_isWooShippingSupported_returns_false_when_woo_shipping_plugin_is_not_minimum_version() async {
+        // Given
+        let featureFlagService = MockFeatureFlagService(revampedShippingLabelCreation: true)
+        let viewModel = OrderDetailsViewModel(order: order, stores: storesManager, storageManager: storageManager, featureFlagService: featureFlagService)
+        let plugin = insertSystemPlugin(name: SitePlugin.SupportedPlugin.WooShipping, siteID: order.siteID, isActive: false, version: "1.0.4")
+        whenFetchingSystemPlugin(thenReturn: plugin)
+
+        // When
+        let isWooShippingSupported = await viewModel.isWooShippingSupported()
+
+        // Then
+        XCTAssertFalse(isWooShippingSupported)
+    }
 }
 
 private extension OrderDetailsViewModelTests {
     @discardableResult
-    func insertSystemPlugin(name: String, siteID: Int64, isActive: Bool) -> SystemPlugin {
-        let plugin = SystemPlugin.fake().copy(siteID: siteID, name: name, active: isActive)
+    func insertSystemPlugin(name: String, siteID: Int64, isActive: Bool, version: String? = nil) -> SystemPlugin {
+        let plugin = SystemPlugin.fake().copy(siteID: siteID, name: name, version: version, active: isActive)
         storageManager.insertSampleSystemPlugin(readOnlySystemPlugin: plugin)
         return plugin
     }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of: #13765
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

### What

This adds a check for the `revampedShippingLabelCreation` feature flag and the Woo Shipping extension (with the minimum version 1.0.5), for use in order details.

For now, this check isn't used except to set the corresponding property `isWooShippingSupported` in `OrderDetailsDataSource`. In a future PR, we will add the navigation to the new flow.

### Why

This is part of creating a new entry point for the revamped shipping label flow. During development, this shipping label flow will be enabled under these conditions:

* The `revampedShippingLabelCreation` feature flag is enabled.
* The Woo Shipping extension is active with minimum version 1.0.5.

### How

* Adds a new property `OrderDetailsDataSource.isWooShippingSupported`.
* Adds the current extension name as a supported plugin. (Previously we were only checking for the older extension name.)
* Adds a check that the Woo Shipping extension is active with the minimum supported version to determine if the store supports the extension.
* Checks for Woo Shipping support before syncing shipping labels on the order, to ensure those features use the correct flow.

## Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->

The new property `isWooShippingSupported` is not yet used in the app. Confirm shipping labels still work as expected on an existing order:

1. Go to the Orders tab.
2. Open an order that is eligible for shipping label creation and confirm the "Create Shipping Label" button appears.
3. Go back to the order list.
4. Open an order with purchased shipping labels and confirm they are loaded in order details.

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [x] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [x] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [x] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on all devices (phone/tablet) and no regressions are added.