### PR TITLE
[Woo POS] Adds `pointOfSale` remote feature flag check to eligibility

### DIFF
--- a/Networking/Networking/Remote/FeatureFlagRemote.swift
+++ b/Networking/Networking/Remote/FeatureFlagRemote.swift
@@ -29,6 +29,7 @@ public class FeatureFlagRemote: Remote, FeatureFlagRemoteProtocol {
 public enum RemoteFeatureFlag: Decodable {
     case storeCreationCompleteNotification
     case hardcodedPlanUpgradeDetailsMilestone1AreAccurate
+    case pointOfSale
 
     init?(rawValue: String) {
         switch rawValue {
@@ -36,6 +37,8 @@ public enum RemoteFeatureFlag: Decodable {
             self = .storeCreationCompleteNotification
         case "woo_hardcoded_plan_upgrade_details_milestone_1_are_accurate":
             self = .hardcodedPlanUpgradeDetailsMilestone1AreAccurate
+        case "woo_pos":
+            self = .pointOfSale
         default:
             return nil
         }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/POS/POSEligibilityChecker.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/POS/POSEligibilityChecker.swift
@@ -97,7 +97,7 @@ private extension POSEligibilityChecker {
         // Only whitelisted accounts in WPCOM have the Point of Sale remote feature flag enabled.
         // These can be found at D159901-code
         Future<Bool, Never> { [weak self] promise in
-            guard let self else { 
+            guard let self else {
                 promise(.success(false))
                 return
             }

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/POS/POSEligibilityChecker.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/POS/POSEligibilityChecker.swift
@@ -7,6 +7,7 @@ import protocol Experiments.FeatureFlagService
 import struct Yosemite.SiteSetting
 import protocol Yosemite.StoresManager
 import enum Yosemite.SystemStatusAction
+import enum Yosemite.FeatureFlagAction
 
 protocol POSEligibilityCheckerProtocol {
     /// As POS eligibility can change from site settings and card payment onboarding state, it's recommended to observe the eligibility value.
@@ -24,8 +25,8 @@ final class POSEligibilityChecker: POSEligibilityCheckerProtocol {
                 .eraseToAnyPublisher()
         }
 
-        return Publishers.CombineLatest(isOnboardingComplete, isWooCommerceVersionSupported)
-            .map { $0 && $1 }
+        return Publishers.CombineLatest3(isOnboardingComplete, isWooCommerceVersionSupported, isAccountWhitelistedInBackend)
+            .map { $0 && $1 && $2 }
             .eraseToAnyPublisher()
     }
 
@@ -87,6 +88,23 @@ private extension POSEligibilityChecker {
                                                                     minimumRequired: Constants.wcPluginMinimumVersion)
                 promise(.success(isSupported))
             }
+            self.stores.dispatch(action)
+        }
+        .eraseToAnyPublisher()
+    }
+
+    var isAccountWhitelistedInBackend: AnyPublisher<Bool, Never> {
+        // Only whitelisted accounts in WPCOM have the Point of Sale remote feature flag enabled.
+        // These can be found at D159901-code
+        Future<Bool, Never> { [weak self] promise in
+            guard let self else { 
+                promise(.success(false))
+                return
+            }
+            let action = FeatureFlagAction.isRemoteFeatureFlagEnabled(.pointOfSale, defaultValue: false, completion: { result in
+                promise(.success(result))
+                return
+            })
             self.stores.dispatch(action)
         }
         .eraseToAnyPublisher()


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #13808

## Description
This PR adds the `woo_pos` remote feature flag, and an additional check to the `POSEligibilityChecker`, so only the accounts that are whitelisted in the backend are allowed to see the experimental toggle in order to enable POS.

This `isAccountWhitelistedInBackend` check is added along the existing `isOnboardingComplete`, and `isWooCommerceVersionSupported` checks. All of them must pass in order for the toggle that enables POS to be visible.

There is a different conversation regarding if it's worth keeping the experimental toggle ( p1725337084101939-slack-C070SJRA8DP ), we'll tackle that as part of a different PR.

## Changes 
- Adds `pointOfSale` case to `RemoteFeatureFlag`.
- Adds observation to remote feature flag changes, and publish any updates to subscribers.
- Updates unit tests with a simple `accountWhitelistedInBackend()` mock function to take this new variable into account

## Testing information
The use cases are based on the remote flag implementation, for simplicity we make all previous eligibility check pass (IPP should be setup, merchant uses an iPad, WC core is 6.6+, etc, ... ). The only change we test in this PR it's if the remote feature flag returns `true` or `false` adequately for different accounts.

Since only Jetpack-connected sites can use the bearer token tunnelled authenticated request, and we cannot use Automattic accounts in the simulator, this requires a physical device (context: p91TBi-bJN-p2#comment-12961 )

### Case: True
By connecting with an authorized user, using a whitelisted account (eg: Automattic account), and connecting your device via Jetpack `woo_pos` returns true, and the experimental toggle is visible.

We can also confirm this by GET `https://public-api.wordpress.com/wpcom/v2/mobile/feature-flags/` and passing the auth bearer token .

### Case: False
For all other cases, the woo_pos remote flag returns false, and the toggle is not visible. Eg:
- Unauthorized user
- Authorized user using a non-whitelisted account
- Authorized user using a whitelisted account, connected via application password (no matter if there's a JCP connection via WooPayments)

We can also confirm this by GET `https://public-api.wordpress.com/wpcom/v2/mobile/feature-flags/` without an auth token.

---

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [x] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [x] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [x] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on all devices (phone/tablet) and no regressions are added.