### PR TITLE
Blaze: Add new row for campaign objective

### DIFF
--- a/Experiments/Experiments/DefaultFeatureFlagService.swift
+++ b/Experiments/Experiments/DefaultFeatureFlagService.swift
@@ -86,6 +86,8 @@ public struct DefaultFeatureFlagService: FeatureFlagService {
             return true
         case .revampedShippingLabelCreation:
             return buildConfig == .localDeveloper || buildConfig == .alpha
+        case .blazeCampaignObjective:
+            return buildConfig == .localDeveloper || buildConfig == .alpha
         default:
             return true
         }

--- a/Experiments/Experiments/FeatureFlag.swift
+++ b/Experiments/Experiments/FeatureFlag.swift
@@ -187,4 +187,8 @@ public enum FeatureFlag: Int {
     /// Enables revamped shipping label flow for Woo Shipping extension
     ///
     case revampedShippingLabelCreation
+
+    /// Enables selecting objectives during Blaze campaign creation.
+    ///
+    case blazeCampaignObjective
 }

--- a/WooCommerce/Classes/ViewRelated/Blaze/CampaignCreation/BlazeCampaignCreationForm.swift
+++ b/WooCommerce/Classes/ViewRelated/Blaze/CampaignCreation/BlazeCampaignCreationForm.swift
@@ -82,7 +82,7 @@ struct BlazeCampaignCreationForm: View {
                 detailView(title: Localization.budget, content: viewModel.budgetDetailText) {
                     isShowingBudgetSetting = true
                 }
-                .background(Constants.cellColor)
+                .background(rowBackground)
                 .overlay { roundedRectangleBorder }
                 .padding(.bottom, Layout.contentMargin)
 
@@ -117,7 +117,7 @@ struct BlazeCampaignCreationForm: View {
                         isShowingTopicPicker = true
                     }
                 }
-                .background(Constants.cellColor)
+                .background(rowBackground)
                 .overlay { roundedRectangleBorder }
 
                 // Ad destination
@@ -127,7 +127,7 @@ struct BlazeCampaignCreationForm: View {
                                isContentSingleLine: true) {
                         isShowingAdDestinationScreen = true
                     }
-                    .background(Constants.cellColor)
+                    .background(rowBackground)
                     .overlay { roundedRectangleBorder }
                 }
             }
@@ -336,6 +336,11 @@ private extension BlazeCampaignCreationForm {
         Divider()
             .frame(height: Layout.strokeWidth)
             .foregroundColor(Color(uiColor: .separator))
+    }
+
+    var rowBackground: some View {
+        Constants.cellColor
+            .clipShape(RoundedRectangle(cornerRadius: Layout.cornerRadius))
     }
 
     var roundedRectangleBorder: some View {

--- a/WooCommerce/Classes/ViewRelated/Blaze/CampaignCreation/BlazeCampaignCreationForm.swift
+++ b/WooCommerce/Classes/ViewRelated/Blaze/CampaignCreation/BlazeCampaignCreationForm.swift
@@ -78,9 +78,21 @@ struct BlazeCampaignCreationForm: View {
                     .subheadlineStyle()
                     .foregroundColor(.init(uiColor: .text))
 
-                // Budget
-                detailView(title: Localization.budget, content: viewModel.budgetDetailText) {
-                    isShowingBudgetSetting = true
+                VStack(spacing: 0) {
+                    VStack(spacing: 0) {
+                        // Objective - hidden behind a feature flag
+                        detailView(title: Localization.objective,
+                                   content: Localization.chooseObjective) {
+                            // TODO: show objective screen
+                        }
+                        divider
+                    }
+                    .renderedIf(ServiceLocator.featureFlagService.isFeatureFlagEnabled(.blazeCampaignObjective))
+
+                    // Budget
+                    detailView(title: Localization.budget, content: viewModel.budgetDetailText) {
+                        isShowingBudgetSetting = true
+                    }
                 }
                 .background(rowBackground)
                 .overlay { roundedRectangleBorder }
@@ -414,6 +426,16 @@ private extension BlazeCampaignCreationForm {
             "blazeCampaignCreationForm.details",
             value: "Details",
             comment: "Section title on the Blaze campaign creation screen"
+        )
+        static let objective = NSLocalizedString(
+            "blazeCampaignCreationForm.objective",
+            value: "Campaign objective",
+            comment: "Title of the Campaign objective field on the Blaze campaign creation screen"
+        )
+        static let chooseObjective = NSLocalizedString(
+            "blazeCampaignCreationForm.chooseObjective",
+            value: "Choose campaign objective",
+            comment: "Description of the Campaign objective field on the Blaze campaign creation screen when no objective is specified"
         )
         static let budget = NSLocalizedString(
             "blazeCampaignCreationForm.budget",


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #13847 
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This PR adds a new feature flag for setting campaign objective during Blaze campaign creation. A new row for setting objectives has been added to the creation form, available only when the feature flag is enabled.

Additionally, this PR fixes a minor UI issue with the campaign creation form rows showing the background without rounded corners in dark mode (shared in screenshots below).

Changes made were on the UI only so no unit tests were added. The logic for handling taps on this row will be handled in a separate PR.

## Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->
- Enable the feature flag `blazeCampaignObjective` and build the app.
- Log in to a store eligible for Blaze.
- Navigate to the Products tab and select an existing published product or create a new one.
- On the product form select Promote with Blaze.
- Confirm that the creation form now contains a new row for choosing a campaign objective. Also, notice that the row's background views now have rounded corners.
- Disable the feature flag `blazeCampaignObjective` and rebuild the app.
- Follow the above steps again to confirm that the new objective row is no longer available on the Blaze campaign creation form.

## Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: https://woomobilep2.wordpress.com/2024/05/06/woocommerce-mobile-quality-report-march-april/#comment-12036 -->
Tested on simulator iPhone 15 Pro iOS 17.4:
- The campaign objective row is only available when enabling the campaign objective feature flag.
- The background views of the rows on the campaign creation form have rounded corners.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->
Before | After | With feature flag on
--- | --- | ---
<img src="https://github.com/user-attachments/assets/b31b75f2-55e0-45ae-848f-27a27f29f14d" width=320 /> | <img src="https://github.com/user-attachments/assets/772914d8-5b41-4219-9a9f-d7aad9799879" width=320 /> | <img src="https://github.com/user-attachments/assets/70e78d7f-7033-4768-a524-852c5af068cb" width=320 />


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [x] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [x] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [x] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on all devices (phone/tablet) and no regressions are added.
