### PR TITLE
[HACK Week] Allow users to scan their order tracking number

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -4,6 +4,7 @@
 20.3
 -----
 - [Internal] Blaze: Parse and store `startTime` from campaign list response. [https://github.com/woocommerce/woocommerce-ios/pull/13807]
+- [*] Order Tracking in HACK Week: Allow users to scan their order tracking number [https://github.com/woocommerce/woocommerce-ios/pull/13850]
 
 20.2
 -----

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Creation/OrderForm.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Creation/OrderForm.swift
@@ -1019,17 +1019,17 @@ private extension ProductsSection {
 // MARK: - SKU scanning
 
 private struct ProductSKUInputScannerView: UIViewControllerRepresentable {
-    typealias UIViewControllerType = ProductSKUInputScannerViewController
+    typealias UIViewControllerType = ScannerContainerViewController
 
     let onBarcodeScanned: ((ScannedBarcode) -> Void)?
 
-    func makeUIViewController(context: Context) -> ProductSKUInputScannerViewController {
-        ProductSKUInputScannerViewController(onBarcodeScanned: { barcode in
+    func makeUIViewController(context: Context) -> ScannerContainerViewController {
+        SKUCodeScannerProvider.SKUCodeScanner(onBarcodeScanned: { barcode in
             onBarcodeScanned?(barcode)
         })
     }
 
-    func updateUIViewController(_ uiViewController: ProductSKUInputScannerViewController, context: Context) {
+    func updateUIViewController(_ uiViewController: ScannerContainerViewController, context: Context) {
         // no-op
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipment Tracking Section/Add Tracking/ManualTrackingViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipment Tracking Section/Add Tracking/ManualTrackingViewController.swift
@@ -662,7 +662,7 @@ private extension ManualTrackingViewController {
                                              value: "Scan barcode or QR Code with tracking number",
                                              comment: "Navigation bar title for scanning a barcode or QR Code to use as an order tracking number.")
         static let instructionText = NSLocalizedString("ManualTrackingViewController.scanView.instructionText",
-                                                       value: "Scan tracking barcode or QR Code",
+                                                       value: "Scan Tracking Barcode or QR Code",
                                                        comment: "The instruction text below the scan area in the barcode scanner for order tracking number.")
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipment Tracking Section/Add Tracking/ManualTrackingViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipment Tracking Section/Add Tracking/ManualTrackingViewController.swift
@@ -267,7 +267,9 @@ extension ManualTrackingViewController: UITableViewDataSource {
         let actionButton = UIButton(type: .detailDisclosure)
         actionButton.applyIconButtonStyle(icon: UIImage(named: "icon-scan")!)
         actionButton.on(.touchUpInside) { [weak self] sender in
-            self?.present(ProductSKUInputScannerViewController(onBarcodeScanned: { barcode in
+            self?.present(ScannerContainerViewController(navigationTitle: Localization.title,
+                                                         instructionText: Localization.instructionText,
+                                                         onBarcodeScanned: { barcode in
                 cell.value.text = barcode.payloadStringValue
                 self?.dismiss()
             }), animated: true)
@@ -644,5 +646,16 @@ private struct Constants {
 extension ManualTrackingViewController {
     func getTable() -> UITableView {
         return table
+    }
+}
+
+private extension ManualTrackingViewController {
+    enum Localization {
+        static let title = NSLocalizedString("ManualTrackingViewController.scanView.titleView",
+                                             value: "Scan barcode or QR Code with tracking number",
+                                             comment: "Navigation bar title for scanning a barcode or QR Code to use as an order tracking number.")
+        static let instructionText = NSLocalizedString("ManualTrackingViewController.scanView.instructionText",
+                                                       value: "Scan tracking barcode or QR Code",
+                                                       comment: "The instruction text below the scan area in the barcode scanner for order tracking number.")
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipment Tracking Section/Add Tracking/ManualTrackingViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipment Tracking Section/Add Tracking/ManualTrackingViewController.swift
@@ -263,23 +263,30 @@ extension ManualTrackingViewController: UITableViewDataSource {
             hidesKeyboardOnReturn: true
         )
         cell.update(viewModel: cellViewModel)
-
-        let actionButton = UIButton(type: .detailDisclosure)
-        actionButton.applyIconButtonStyle(icon: UIImage(named: "icon-scan")!)
-        actionButton.on(.touchUpInside) { [weak self] sender in
-            self?.present(ScannerContainerViewController(navigationTitle: Localization.title,
-                                                         instructionText: Localization.instructionText,
-                                                         onBarcodeScanned: { barcode in
-                cell.updateValue(with: barcode.payloadStringValue)
-                self?.dismiss()
-            }), animated: true)
-        }
-        cell.accessoryView = actionButton
-
+        configureTrackingNumberScanAction(on: cell)
 
         cellViewModel.$value.sink { [weak self] in
             self?.didChangeTrackingNumber(value: $0)
         }.store(in: &valueSubscriptions)
+    }
+
+    private func configureTrackingNumberScanAction(on cell: TitleAndEditableValueTableViewCell) {
+        guard let icon = UIImage(named: "icon-scan") else {
+            return
+        }
+
+        let actionButton = UIButton(type: .detailDisclosure)
+        actionButton.applyIconButtonStyle(icon: icon)
+        actionButton.on(.touchUpInside) { [weak self, weak cell] sender in
+            self?.present(ScannerContainerViewController(navigationTitle: Localization.title,
+                                                         instructionText: Localization.instructionText,
+                                                         onBarcodeScanned: { barcode in
+                cell?.updateValue(with: barcode.payloadStringValue)
+                self?.dismiss()
+            }), animated: true)
+        }
+
+        cell.accessoryView = actionButton
     }
 
     private func configureTrackingLink(cell: TitleAndEditableValueTableViewCell) {

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipment Tracking Section/Add Tracking/ManualTrackingViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipment Tracking Section/Add Tracking/ManualTrackingViewController.swift
@@ -263,7 +263,17 @@ extension ManualTrackingViewController: UITableViewDataSource {
             hidesKeyboardOnReturn: true
         )
         cell.update(viewModel: cellViewModel)
-        cell.accessoryType = .none
+
+        let actionButton = UIButton(type: .detailDisclosure)
+        actionButton.applyIconButtonStyle(icon: UIImage(named: "icon-scan")!)
+        actionButton.on(.touchUpInside) { [weak self] sender in
+            self?.present(ProductSKUInputScannerViewController(onBarcodeScanned: { barcode in
+                cell.value.text = barcode.payloadStringValue
+                self?.dismiss()
+            }), animated: true)
+        }
+        cell.accessoryView = actionButton
+
 
         cellViewModel.$value.sink { [weak self] in
             self?.didChangeTrackingNumber(value: $0)

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipment Tracking Section/Add Tracking/ManualTrackingViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipment Tracking Section/Add Tracking/ManualTrackingViewController.swift
@@ -270,7 +270,7 @@ extension ManualTrackingViewController: UITableViewDataSource {
             self?.present(ScannerContainerViewController(navigationTitle: Localization.title,
                                                          instructionText: Localization.instructionText,
                                                          onBarcodeScanned: { barcode in
-                cell.value.text = barcode.payloadStringValue
+                cell.updateValue(with: barcode.payloadStringValue)
                 self?.dismiss()
             }), animated: true)
         }

--- a/WooCommerce/Classes/ViewRelated/Products/SKU Scanner/ProductSKUBarcodeScannerCoordinator.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/SKU Scanner/ProductSKUBarcodeScannerCoordinator.swift
@@ -40,10 +40,11 @@ final class ProductSKUBarcodeScannerCoordinator: Coordinator {
 
 private extension ProductSKUBarcodeScannerCoordinator {
     func showSKUScanner() {
-        let scannerViewController = ProductSKUInputScannerViewController(onBarcodeScanned: { [weak self] barcode in
+        let scannerViewController = SKUCodeScannerProvider.SKUCodeScanner(onBarcodeScanned: { [weak self] barcode in
             self?.onSKUBarcodeScanned(barcode)
             self?.navigationController.dismiss(animated: true)
         })
+
         navigationController.present(scannerViewController, animated: true)
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Products/SKU Scanner/SKUCodeScannerProvider.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/SKU Scanner/SKUCodeScannerProvider.swift
@@ -1,0 +1,22 @@
+import Foundation
+
+/// Provides a `ScannerContainerViewController` customized to find Product SKU strings
+/// 
+class SKUCodeScannerProvider {
+    static func SKUCodeScanner(onBarcodeScanned: @escaping (ScannedBarcode) -> Void) -> ScannerContainerViewController {
+        ScannerContainerViewController(navigationTitle: Localization.title,
+                                       instructionText: Localization.instructionText,
+                                       onBarcodeScanned: onBarcodeScanned)
+    }
+}
+
+private extension SKUCodeScannerProvider {
+    enum Localization {
+        static let title = NSLocalizedString("ProductSKUInputScanner.titleView",
+                                             value: "Scan barcode or QR Code to update SKU",
+                                             comment: "Navigation bar title for scanning a barcode or QR Code to use as a product's SKU.")
+        static let instructionText = NSLocalizedString("ProductSKUInputScanner.instructionText",
+                                                       value: "Scan product barcode or QR Code",
+                                                       comment: "The instruction text below the scan area in the barcode scanner for product SKU.")
+    }
+}

--- a/WooCommerce/Classes/ViewRelated/Products/SKU Scanner/SKUCodeScannerProvider.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/SKU Scanner/SKUCodeScannerProvider.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 /// Provides a `ScannerContainerViewController` customized to find Product SKU strings
-/// 
+///
 class SKUCodeScannerProvider {
     static func SKUCodeScanner(onBarcodeScanned: @escaping (ScannedBarcode) -> Void) -> ScannerContainerViewController {
         ScannerContainerViewController(navigationTitle: Localization.title,

--- a/WooCommerce/Classes/ViewRelated/Products/SKU Scanner/ScannerContainerViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/SKU Scanner/ScannerContainerViewController.swift
@@ -1,9 +1,9 @@
 import UIKit
 
-/// Container view controller of barcode scanner for product SKU input.
-final class ProductSKUInputScannerViewController: UIViewController {
+/// Container view controller of barcode scanner.
+final class ScannerContainerViewController: UIViewController {
     private lazy var barcodeScannerChildViewController: CodeScannerViewController = {
-        return CodeScannerViewController(instructionText: Localization.instructionText,
+        return CodeScannerViewController(instructionText: instructionText,
                                             format: .barcode { [weak self] result in
             guard let self = self else { return }
             guard self.hasDetectedBarcode == false else {
@@ -18,11 +18,16 @@ final class ProductSKUInputScannerViewController: UIViewController {
     }()
 
     private let onBarcodeScanned: (ScannedBarcode) -> Void
+    private let navigationTitle: String
+    private let instructionText: String
+
 
     /// Tracks whether a barcode has been detected because the barcode detection callback is only handled once.
     private var hasDetectedBarcode: Bool = false
 
-    init(onBarcodeScanned: @escaping (ScannedBarcode) -> Void) {
+    init(navigationTitle: String, instructionText: String, onBarcodeScanned: @escaping (ScannedBarcode) -> Void) {
+        self.navigationTitle = navigationTitle
+        self.instructionText = instructionText
         self.onBarcodeScanned = onBarcodeScanned
         super.init(nibName: nil, bundle: nil)
     }
@@ -39,9 +44,9 @@ final class ProductSKUInputScannerViewController: UIViewController {
     }
 }
 
-private extension ProductSKUInputScannerViewController {
+private extension ScannerContainerViewController {
     func configureNavigation() {
-        title = Localization.title
+        title = navigationTitle
     }
 
     func configureBarcodeScannerChildViewController() {
@@ -54,16 +59,5 @@ private extension ProductSKUInputScannerViewController {
 
         contentView.translatesAutoresizingMaskIntoConstraints = false
         view.pinSubviewToAllEdges(contentView)
-    }
-}
-
-private extension ProductSKUInputScannerViewController {
-    enum Localization {
-        static let title = NSLocalizedString("ProductSKUInputScanner.titleView",
-                                             value: "Scan barcode or QR Code to update SKU",
-                                             comment: "Navigation bar title for scanning a barcode or QR Code to use as a product's SKU.")
-        static let instructionText = NSLocalizedString("ProductSKUInputScanner.instructionText",
-                                                       value: "Scan product barcode or QR Code",
-                                                       comment: "The instruction text below the scan area in the barcode scanner for product SKU.")
     }
 }

--- a/WooCommerce/Classes/ViewRelated/ReusableViews/TitleAndEditableValueTableViewCell/TitleAndEditableValueTableViewCell.swift
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/TitleAndEditableValueTableViewCell/TitleAndEditableValueTableViewCell.swift
@@ -3,7 +3,7 @@ import UIKit
 final class TitleAndEditableValueTableViewCell: UITableViewCell {
     @IBOutlet private weak var stackView: UIStackView!
     @IBOutlet private weak var title: UILabel!
-    @IBOutlet private weak var value: UITextField!
+    @IBOutlet weak var value: UITextField!
 
     private var viewModel: TitleAndEditableValueTableViewCellViewModel?
 

--- a/WooCommerce/Classes/ViewRelated/ReusableViews/TitleAndEditableValueTableViewCell/TitleAndEditableValueTableViewCell.swift
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/TitleAndEditableValueTableViewCell/TitleAndEditableValueTableViewCell.swift
@@ -3,7 +3,7 @@ import UIKit
 final class TitleAndEditableValueTableViewCell: UITableViewCell {
     @IBOutlet private weak var stackView: UIStackView!
     @IBOutlet private weak var title: UILabel!
-    @IBOutlet weak var value: UITextField!
+    @IBOutlet private weak var value: UITextField!
 
     private var viewModel: TitleAndEditableValueTableViewCellViewModel?
 
@@ -44,6 +44,11 @@ final class TitleAndEditableValueTableViewCell: UITableViewCell {
         self.viewModel = viewModel
 
         applyStyle(style)
+    }
+
+    func updateValue(with text: String) {
+        value.text = text
+        updateViewModelValue(sender: value)
     }
 }
 

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -264,7 +264,7 @@
 		025B1748237A92D800C780B4 /* ProductFormSection+ReusableTableRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 025B1747237A92D800C780B4 /* ProductFormSection+ReusableTableRow.swift */; };
 		025B174A237AA49D00C780B4 /* Product+ProductForm.swift in Sources */ = {isa = PBXBuildFile; fileRef = 025B1749237AA49D00C780B4 /* Product+ProductForm.swift */; };
 		025B3C9A2C0EE5BA0013F036 /* WCSettingsWebView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 025B3C992C0EE5BA0013F036 /* WCSettingsWebView.swift */; };
-		025C00682550DE4700FAC222 /* ProductSKUInputScannerViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 025C00642550DE4600FAC222 /* ProductSKUInputScannerViewController.swift */; };
+		025C00682550DE4700FAC222 /* ScannerContainerViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 025C00642550DE4600FAC222 /* ScannerContainerViewController.swift */; };
 		025C00692550DE4700FAC222 /* CodeScannerViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = 025C00652550DE4700FAC222 /* CodeScannerViewController.xib */; };
 		025C006A2550DE4700FAC222 /* ProductSKUInputScannerViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = 025C00662550DE4700FAC222 /* ProductSKUInputScannerViewController.xib */; };
 		025C006B2550DE4700FAC222 /* CodeScannerViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 025C00672550DE4700FAC222 /* CodeScannerViewController.swift */; };
@@ -2009,6 +2009,7 @@
 		B9CA4F352AB2F33200285AB9 /* SelectedStoredTaxRateFetcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = B9CA4F342AB2F33200285AB9 /* SelectedStoredTaxRateFetcher.swift */; };
 		B9CB14DC2A41FACD005912C2 /* BarcodeSKUScannerErrorNoticeFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = B9CB14DB2A41FACD005912C2 /* BarcodeSKUScannerErrorNoticeFactory.swift */; };
 		B9CB14E02A42E246005912C2 /* BarcodeSKUScannerErrorNoticeFactoryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B9CB14DF2A42E246005912C2 /* BarcodeSKUScannerErrorNoticeFactoryTests.swift */; };
+		B9CCE5FC2C8753A000905A91 /* SKUCodeScannerProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = B9CCE5FB2C8753A000905A91 /* SKUCodeScannerProvider.swift */; };
 		B9D19A422AE7B4AD00D944D8 /* CustomAmountRowViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = B9D19A412AE7B4AD00D944D8 /* CustomAmountRowViewModel.swift */; };
 		B9D19A442AE7B66B00D944D8 /* CustomAmountRowView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B9D19A432AE7B66B00D944D8 /* CustomAmountRowView.swift */; };
 		B9DA153C280EC7D700FC67DD /* OrderRefundsOptionsDeterminer.swift in Sources */ = {isa = PBXBuildFile; fileRef = B9DA153B280EC7D700FC67DD /* OrderRefundsOptionsDeterminer.swift */; };
@@ -3306,7 +3307,7 @@
 		025B1747237A92D800C780B4 /* ProductFormSection+ReusableTableRow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ProductFormSection+ReusableTableRow.swift"; sourceTree = "<group>"; };
 		025B1749237AA49D00C780B4 /* Product+ProductForm.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Product+ProductForm.swift"; sourceTree = "<group>"; };
 		025B3C992C0EE5BA0013F036 /* WCSettingsWebView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WCSettingsWebView.swift; sourceTree = "<group>"; };
-		025C00642550DE4600FAC222 /* ProductSKUInputScannerViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ProductSKUInputScannerViewController.swift; sourceTree = "<group>"; };
+		025C00642550DE4600FAC222 /* ScannerContainerViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ScannerContainerViewController.swift; sourceTree = "<group>"; };
 		025C00652550DE4700FAC222 /* CodeScannerViewController.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = CodeScannerViewController.xib; sourceTree = "<group>"; };
 		025C00662550DE4700FAC222 /* ProductSKUInputScannerViewController.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = ProductSKUInputScannerViewController.xib; sourceTree = "<group>"; };
 		025C00672550DE4700FAC222 /* CodeScannerViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CodeScannerViewController.swift; sourceTree = "<group>"; };
@@ -5019,6 +5020,7 @@
 		B9CA4F342AB2F33200285AB9 /* SelectedStoredTaxRateFetcher.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SelectedStoredTaxRateFetcher.swift; sourceTree = "<group>"; };
 		B9CB14DB2A41FACD005912C2 /* BarcodeSKUScannerErrorNoticeFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BarcodeSKUScannerErrorNoticeFactory.swift; sourceTree = "<group>"; };
 		B9CB14DF2A42E246005912C2 /* BarcodeSKUScannerErrorNoticeFactoryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BarcodeSKUScannerErrorNoticeFactoryTests.swift; sourceTree = "<group>"; };
+		B9CCE5FB2C8753A000905A91 /* SKUCodeScannerProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SKUCodeScannerProvider.swift; sourceTree = "<group>"; };
 		B9D19A412AE7B4AD00D944D8 /* CustomAmountRowViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomAmountRowViewModel.swift; sourceTree = "<group>"; };
 		B9D19A432AE7B66B00D944D8 /* CustomAmountRowView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomAmountRowView.swift; sourceTree = "<group>"; };
 		B9DA153B280EC7D700FC67DD /* OrderRefundsOptionsDeterminer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OrderRefundsOptionsDeterminer.swift; sourceTree = "<group>"; };
@@ -6615,13 +6617,14 @@
 			children = (
 				025C00672550DE4700FAC222 /* CodeScannerViewController.swift */,
 				025C00652550DE4700FAC222 /* CodeScannerViewController.xib */,
-				025C00642550DE4600FAC222 /* ProductSKUInputScannerViewController.swift */,
+				025C00642550DE4600FAC222 /* ScannerContainerViewController.swift */,
 				025C00662550DE4700FAC222 /* ProductSKUInputScannerViewController.xib */,
 				02CE43012768CBF60006EAEF /* ProductSKUBarcodeScannerCoordinator.swift */,
 				02CE4303276993DA0006EAEF /* CaptureDevicePermissionChecker.swift */,
 				B90DACBF2A30AEF000365897 /* BarcodeSKUScannerItemFinder.swift */,
 				B9CB14DB2A41FACD005912C2 /* BarcodeSKUScannerErrorNoticeFactory.swift */,
 				02667A192ABDD44200C77B56 /* GiftCardCodeScannerViewController.swift */,
+				B9CCE5FB2C8753A000905A91 /* SKUCodeScannerProvider.swift */,
 			);
 			path = "SKU Scanner";
 			sourceTree = "<group>";
@@ -15008,7 +15011,7 @@
 				DE69C54D27BB719A000BB888 /* CouponRestrictions.swift in Sources */,
 				E1D4E84426776A6B00256B83 /* HeadlineTableViewCell.swift in Sources */,
 				B555530F21B57DE700449E71 /* ApplicationAdapter.swift in Sources */,
-				025C00682550DE4700FAC222 /* ProductSKUInputScannerViewController.swift in Sources */,
+				025C00682550DE4700FAC222 /* ScannerContainerViewController.swift in Sources */,
 				2004E2D62C08E1FA00D62521 /* CardPresentPaymentOnboardingAdaptor.swift in Sources */,
 				20DA6DDB2B681175002AA0FB /* AdaptiveModalContainer.swift in Sources */,
 				456BEFB626D912EC002AC16C /* AuthenticatedWebView.swift in Sources */,
@@ -16173,6 +16176,7 @@
 				B6930BDA293FD1EE00C6FFDB /* AnalyticsHubLastQuarterRangeData.swift in Sources */,
 				26F115AF2C49A9250019CD73 /* DashboardSyncBackgroundTask.swift in Sources */,
 				02DE5CA9279F857D007CBEF3 /* Double+Rounding.swift in Sources */,
+				B9CCE5FC2C8753A000905A91 /* SKUCodeScannerProvider.swift in Sources */,
 				02A65301246AA63600755A01 /* ProductDetailsFactory.swift in Sources */,
 				D449C51D26DE6B5000D75B02 /* LargeTitle.swift in Sources */,
 				B6E7DB64293A7C390049B001 /* AnalyticsHubYesterdayRangeData.swift in Sources */,

--- a/WooCommerce/WooCommerceTests/ViewRelated/Products/SKU Scanner/ProductSKUBarcodeScannerCoordinatorTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Products/SKU Scanner/ProductSKUBarcodeScannerCoordinatorTests.swift
@@ -39,7 +39,7 @@ final class ProductSKUBarcodeScannerCoordinatorTests: XCTestCase {
         coordinator.start()
 
         // Then
-        assertThat(navigationController.presentedViewController, isAnInstanceOf: ProductSKUInputScannerViewController.self)
+        assertThat(navigationController.presentedViewController, isAnInstanceOf: ScannerContainerViewController.self)
     }
 
     func test_coordinator_does_nothing_after_denying_camera_access() {
@@ -69,7 +69,7 @@ final class ProductSKUBarcodeScannerCoordinatorTests: XCTestCase {
         coordinator.start()
 
         // Then
-        assertThat(navigationController.presentedViewController, isAnInstanceOf: ProductSKUInputScannerViewController.self)
+        assertThat(navigationController.presentedViewController, isAnInstanceOf: ScannerContainerViewController.self)
     }
 
     func test_coordinator_shows_alert_when_permission_is_denied() {

--- a/WooCommerce/WooCommerceTests/ViewRelated/ReusableViews/TitleAndEditableValueTableViewCell/TitleAndEditableValueTableViewCellTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/ReusableViews/TitleAndEditableValueTableViewCell/TitleAndEditableValueTableViewCellTests.swift
@@ -59,6 +59,19 @@ final class TitleAndEditableValueTableViewCellTests: XCTestCase {
         // Then
         XCTAssertEqual(viewModel.value, "Ut ullam itaque")
     }
+
+    func test_updateValue_then_updates_view_model() {
+        // Given
+        let newValue = "test"
+        let viewModel = TitleAndEditableValueTableViewCellViewModel(title: "Test")
+
+        // When
+        cell.update(viewModel: viewModel)
+        cell.updateValue(with: newValue)
+
+        // Then
+        XCTAssertEqual(viewModel.value, newValue)
+    }
 }
 
 private extension TitleAndEditableValueTableViewCellTests {


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
With this PR we allow users to scan a QR or barcode to add the tracking number to an order. It also includes a refactor to make the scanner class more generic, so it can include this case and not only SKU scans. As this is quite a small refactor, I included it here for convenience.

Tests are added to `TitleAndEditableValueTableViewCellTests`. I considered adding tests to `ManualTrackingViewControllerTests`, but I think it's not worth adding them given the effort we need to invest into the setup for this case (adding all data to the table). We can reconsider this at any time.

Note: There are no tracks events for this flow, presumably because the implementation is _old_. I preferred to leave the events tracking for another task to approach holistically, instead of just adding events for the scan feature here.

## Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->
With [WC Shipment Tracking](https://woocommerce.com/products/shipment-tracking/) installed

1. Go to Orders
2. Go to an existing order details that contains products other than virtual
3. Tap on Add Tracking
4. Tap on the barcode scanner button
5. Scan a barcode/QR code
6. See that the scanner is dismissed and the number added


## Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->
Cases that I tested:

- Dark/Light mode
- Cancel before scanning
- Landscape/Portrait
- The Add button is properly enabled
- As this includes a small refactor, I ensure that the other scanner flows work as expected (Order, Inventory, SKU add)

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

https://github.com/user-attachments/assets/9586a59e-62c5-42e7-ba0d-ac54c9b4b7d8

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [X] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [X] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [X] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on all devices (phone/tablet) and no regressions are added.