### PR TITLE
[Tooling] Use shared pipeline vars

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,12 +1,11 @@
-# Nodes with values to reuse in the pipeline.
-common_params:
-  # Common plugin settings to use with the `plugins` key.
-  - &common_plugins
-    - automattic/a8c-ci-toolkit#3.3.0
-  # Common environment values to use with the `env` key.
-  - &common_env
-    # Be sure to also update the `.xcode-version` file when updating the Xcode image/version here
-    IMAGE_ID: xcode-15.4
+# yaml-language-server: $schema=https://raw.githubusercontent.com/buildkite/pipeline-schema/main/schema.json
+---
+
+agents:
+  queue: "mac"
+
+env:
+  IMAGE_ID: $IMAGE_ID
 
 # This is the default pipeline – it will build and test the app
 steps:
@@ -16,8 +15,7 @@ steps:
   - label: ":pipeline: Build"
     key: "build"
     command: ".buildkite/commands/build-for-testing.sh"
-    env: *common_env
-    plugins: *common_plugins
+    plugins: [$CI_TOOLKIT]
     notify:
       - github_commit_status:
           context: "Build"
@@ -27,8 +25,7 @@ steps:
   #################
   - label: "🛠 Prototype Build"
     command: ".buildkite/commands/prototype-build.sh"
-    env: *common_env
-    plugins: *common_plugins
+    plugins: [$CI_TOOLKIT]
     if: build.pull_request.id != null
     notify:
       - github_commit_status:
@@ -40,8 +37,7 @@ steps:
   - label: "🔬 Unit Tests"
     command: ".buildkite/commands/run-unit-tests.sh"
     depends_on: "build"
-    env: *common_env
-    plugins: *common_plugins
+    plugins: [$CI_TOOLKIT]
     artifact_paths:
       - "fastlane/test_output/*"
     notify:
@@ -84,8 +80,7 @@ steps:
 
       - label: ":sleuth_or_spy: Lint Localized Strings Format"
         command: .buildkite/commands/lint-localized-strings-format.sh
-        plugins: *common_plugins
-        env: *common_env
+        plugins: [$CI_TOOLKIT]
 
   #################
   # UI Tests
@@ -93,8 +88,7 @@ steps:
   - label: "🔬 UI Tests (iPhone)"
     command: .buildkite/commands/run-ui-tests.sh UITests 'iPhone 15'
     depends_on: "build"
-    env: *common_env
-    plugins: *common_plugins
+    plugins: [$CI_TOOLKIT]
     artifact_paths:
       - "fastlane/test_output/*"
     notify:
@@ -104,8 +98,7 @@ steps:
   - label: "🔬 UI Tests (iPad)"
     command: .buildkite/commands/run-ui-tests.sh UITests "iPad (10th generation)"
     depends_on: "build"
-    env: *common_env
-    plugins: *common_plugins
+    plugins: [$CI_TOOLKIT]
     artifact_paths:
       - "fastlane/test_output/*"
     notify:

--- a/.buildkite/release-builds.yml
+++ b/.buildkite/release-builds.yml
@@ -1,22 +1,20 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/buildkite/pipeline-schema/main/schema.json
+---
+
 # This pipeline is meant to be run via the Buildkite API, and is only used for release builds
 
-# Nodes with values to reuse in the pipeline.
-common_params:
-  # Common plugin settings to use with the `plugins` key.
-  - &common_plugins
-    - automattic/a8c-ci-toolkit#3.0.1
-  # Common environment values to use with the `env` key.
-  - &common_env
-    # Be sure to also update the `.xcode-version` file when updating the Xcode image/version here
-    IMAGE_ID: xcode-15.4
+agents:
+  queue: "mac"
+
+env:
+  IMAGE_ID: $IMAGE_ID
 
 steps:
-
   - label: "🛠 Release Build (App Store Connect)"
     command: ".buildkite/commands/release-build.sh ${BUILDKITE_BETA_RELEASE}"
     priority: 1
     env: *common_env
-    plugins: *common_plugins
+    plugins: [$CI_TOOLKIT]
     notify:
     - slack: "#build-and-ship"
     retry:

--- a/.buildkite/release-pipelines/complete-code-freeze.yml
+++ b/.buildkite/release-pipelines/complete-code-freeze.yml
@@ -1,10 +1,15 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/buildkite/pipeline-schema/main/schema.json
+---
+
+agents:
+  queue: "mac"
+
+env:
+  IMAGE_ID: $IMAGE_ID
+
 steps:
   - label: "Complete Code Freeze"
-    plugins:
-      - automattic/a8c-ci-toolkit#3.0.1
-    env:
-      # Be sure to also update the `.xcode-version` file when updating the Xcode image/version here
-      IMAGE_ID: xcode-15.4
+    plugins: [$CI_TOOLKIT]
     command: |
       .buildkite/commands/configure-environment.sh
 

--- a/.buildkite/release-pipelines/finalize-hotfix-release.yml
+++ b/.buildkite/release-pipelines/finalize-hotfix-release.yml
@@ -1,10 +1,15 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/buildkite/pipeline-schema/main/schema.json
+---
+
+agents:
+  queue: "mac"
+
+env:
+  IMAGE_ID: $IMAGE_ID
+
 steps:
   - label: "Finalize Hotfix Release"
-    plugins:
-      - automattic/a8c-ci-toolkit#3.0.1
-    env:
-      # Be sure to also update the `.xcode-version` file when updating the Xcode image/version here
-      IMAGE_ID: xcode-15.4
+    plugins: [$CI_TOOLKIT]
     command: |
       .buildkite/commands/configure-environment.sh
 

--- a/.buildkite/release-pipelines/finalize-release.yml
+++ b/.buildkite/release-pipelines/finalize-release.yml
@@ -1,10 +1,15 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/buildkite/pipeline-schema/main/schema.json
+---
+
+agents:
+  queue: "mac"
+
+env:
+  IMAGE_ID: $IMAGE_ID
+
 steps:
   - label: "Finalize Release"
-    plugins:
-      - automattic/a8c-ci-toolkit#3.0.1
-    env:
-      # Be sure to also update the `.xcode-version` file when updating the Xcode image/version here
-      IMAGE_ID: xcode-15.4
+    plugins: [$CI_TOOLKIT]
     command: |
       .buildkite/commands/configure-environment.sh
 

--- a/.buildkite/release-pipelines/new-beta-release.yml
+++ b/.buildkite/release-pipelines/new-beta-release.yml
@@ -1,10 +1,15 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/buildkite/pipeline-schema/main/schema.json
+---
+
+agents:
+  queue: "mac"
+
+env:
+  IMAGE_ID: $IMAGE_ID
+
 steps:
   - label: "New Beta Release"
-    plugins:
-      - automattic/a8c-ci-toolkit#3.0.1
-    env:
-      # Be sure to also update the `.xcode-version` file when updating the Xcode image/version here
-      IMAGE_ID: xcode-15.4
+    plugins: [$CI_TOOLKIT]
     command: |
       .buildkite/commands/configure-environment.sh
 

--- a/.buildkite/release-pipelines/new-hotfix-release.yml
+++ b/.buildkite/release-pipelines/new-hotfix-release.yml
@@ -1,10 +1,15 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/buildkite/pipeline-schema/main/schema.json
+---
+
+agents:
+  queue: "mac"
+
+env:
+  IMAGE_ID: $IMAGE_ID
+
 steps:
   - label: "New Hotfix Release"
-    plugins:
-      - automattic/a8c-ci-toolkit#3.0.1
-    env:
-      # Be sure to also update the `.xcode-version` file when updating the Xcode image/version here
-      IMAGE_ID: xcode-15.4
+    plugins: [$CI_TOOLKIT]
     command: |
       .buildkite/commands/configure-environment.sh
 

--- a/.buildkite/release-pipelines/publish-release.yml
+++ b/.buildkite/release-pipelines/publish-release.yml
@@ -1,21 +1,26 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/buildkite/pipeline-schema/main/schema.json
+---
+
+agents:
+  queue: "mac"
+
+env:
+  IMAGE_ID: $IMAGE_ID
+
 steps:
   - label: "Publish Release"
-    plugins:
-      - $CI_TOOLKIT
+    plugins: [$CI_TOOLKIT]
     command: |
-      echo '--- :robot_face: Use bot for git operations'
-      source use-bot-for-git
+      .buildkite/commands/configure-environment.sh
 
       echo '--- :git: Checkout Release Branch'
       .buildkite/commands/checkout-release-branch.sh
 
-      echo '--- :ruby: Setup Ruby Tools'
-      install_gems
+      echo '--- :closed_lock_with_key: Access Secrets'
+      bundle exec fastlane run configure_apply
 
       echo '--- :package: Publish Release'
       bundle exec fastlane publish_release skip_confirm:true
-    agents:
-      queue: "tumblr-metal"
     retry:
       manual:
         # If those jobs fail, one should always prefer re-triggering a new build from ReleaseV2 rather than retrying the individual job from Buildkite

--- a/.buildkite/release-pipelines/start-code-freeze.yml
+++ b/.buildkite/release-pipelines/start-code-freeze.yml
@@ -1,10 +1,15 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/buildkite/pipeline-schema/main/schema.json
+---
+
+agents:
+  queue: "mac"
+
+env:
+  IMAGE_ID: $IMAGE_ID
+
 steps:
   - label: "Start Code Freeze"
-    plugins:
-      - automattic/a8c-ci-toolkit#3.0.1
-    env:
-      # Be sure to also update the `.xcode-version` file when updating the Xcode image/version here
-      IMAGE_ID: xcode-15.4
+    plugins: [$CI_TOOLKIT]
     command: |
       .buildkite/commands/configure-environment.sh
 

--- a/.buildkite/release-pipelines/update-metadata-on-app-store-connect.yml
+++ b/.buildkite/release-pipelines/update-metadata-on-app-store-connect.yml
@@ -1,10 +1,15 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/buildkite/pipeline-schema/main/schema.json
+---
+
+agents:
+  queue: "mac"
+
+env:
+  IMAGE_ID: $IMAGE_ID
+
 steps:
   - label: "Update Metadata on App Store Connect"
-    plugins:
-      - automattic/a8c-ci-toolkit#3.0.1
-    env:
-      # Be sure to also update the `.xcode-version` file when updating the Xcode image/version here
-      IMAGE_ID: xcode-15.4
+    plugins: [$CI_TOOLKIT]
     command: |
       .buildkite/commands/configure-environment.sh
 

--- a/.buildkite/shared-pipeline-vars
+++ b/.buildkite/shared-pipeline-vars
@@ -1,0 +1,9 @@
+#!/bin/sh
+
+# This file is `source`'d before calling `buildkite-agent pipeline upload`, and can be used
+# to set up some variables that will be interpolated in the `.yml` pipeline before uploading it.
+
+XCODE_VERSION=$(sed -E -n 's/^(~> )?(.*)/xcode-\2/p' .xcode-version)
+export IMAGE_ID="$XCODE_VERSION"
+
+export CI_TOOLKIT="automattic/a8c-ci-toolkit#3.5.1"

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -531,7 +531,7 @@ platform :ios do
     end
   end
 
-  # This lane publishes a release on GitHub, tagging it on git, and backmerges the current release branch into the next release/ branch
+  # This lane publishes a release on GitHub and creates a PR to backmerge the current release branch into the next release/ branch
   #
   # @param [Boolean] skip_confirm (default: false) If set, will skip the confirmation prompt before running the rest of the lane
   #

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -665,7 +665,7 @@ platform :ios do
     zip(path: lane_context[SharedValues::XCODEBUILD_ARCHIVE], output_path: archive_zip_path)
 
     version = options[:beta_release] ? build_code_current : release_version_current
-    create_release(
+    create_github_release(
       repository: GITHUB_REPO,
       version: version,
       release_notes_file_path: RELEASE_NOTES_PATH,


### PR DESCRIPTION
This PR updates the pipelines to use common values defined in the file `.buildkite/shared-pipeline-vars` (see paaHJt-5Rr-p2).

**Note**: This PR will fail until we update the setup also on the Buildkite side.