### PR TITLE
[Woo POS] Design feedback: Loading view

### DIFF
--- a/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/PointOfSaleLoadingView.swift
+++ b/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/PointOfSaleLoadingView.swift
@@ -8,12 +8,6 @@ struct PointOfSaleLoadingView: View {
                 Spacer()
                 ProgressView()
                     .progressViewStyle(POSProgressViewStyle())
-                Spacer().frame(height: Layout.progressViewSpacing)
-                Text(Localization.title)
-                    .font(.posBodyRegular)
-                Spacer().frame(height: Layout.textSpacing)
-                Text(Localization.subtitle)
-                    .font(.posTitleEmphasized)
                 Spacer()
             }
             .multilineTextAlignment(.center)
@@ -23,20 +17,6 @@ struct PointOfSaleLoadingView: View {
 }
 
 private extension PointOfSaleLoadingView {
-    enum Localization {
-        static let title = NSLocalizedString(
-            "pos.itemlistview.loading.title",
-            value: "Starting up",
-            comment: "Title of the Point of Sale entry point loading"
-        )
-
-        static let subtitle = NSLocalizedString(
-            "pos.itemlistview.loading.subtitle",
-            value: "Let’s serve some customers",
-            comment: "Subtitle of the Point of Sale entry point loading"
-        )
-    }
-
     enum Layout {
         static let textSpacing: CGFloat = 16
         static let progressViewSpacing: CGFloat = 72

--- a/WooCommerce/Classes/POS/Presentation/PointOfSaleDashboardView.swift
+++ b/WooCommerce/Classes/POS/Presentation/PointOfSaleDashboardView.swift
@@ -35,7 +35,6 @@ struct PointOfSaleDashboardView: View {
             } else {
                 contentView
                     .accessibilitySortPriority(2)
-                    .transition(.push(from: .top))
             }
             POSFloatingControlView(viewModel: viewModel)
                 .shadow(color: Color.black.opacity(0.08), radius: 4)


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

## Description
This PR tackles the design feedback shared on https://github.com/woocommerce/woocommerce-ios/issues/13859 regarding `POS loading` elements, by removing the lines of text from the loading screen, and removing the transition rom the loading view to the loaded content view.

## Testing information
- Load POS
- Observe there's no lines of text on the loading screen, just the loading spinner.
- Observe the content (items and cart) loads without transition (previously, the view was pushed from the top of the screen).

https://github.com/user-attachments/assets/724bd6b7-02f0-4c8b-af07-9ddfea6f3d18

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [x] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [x] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [x] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on all devices (phone/tablet) and no regressions are added.