### PR TITLE
[Shipping labels] Navigate to new shipping labels flow when store is eligible for it

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingCreateLabelsView.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingCreateLabelsView.swift
@@ -15,9 +15,34 @@ final class WooShippingCreateLabelsViewHostingController: UIHostingController<Wo
 /// View to create shipping labels with the Woo Shipping extension.
 ///
 struct WooShippingCreateLabelsView: View {
+    @Environment(\.dismiss) private var dismiss
+
     var body: some View {
-        // TODO-13550: Replace placeholder content with real UI for new shipping labels flow.
-        Text(/*@START_MENU_TOKEN@*/"Hello, World!"/*@END_MENU_TOKEN@*/)
+        NavigationStack {
+            ScrollView {
+                // TODO-13550: Add main UI for new shipping labels flow.
+            }
+            .navigationTitle(Localization.title)
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .cancellationAction) {
+                    Button(Localization.cancel) {
+                        dismiss()
+                    }
+                }
+            }
+        }
+    }
+}
+
+private extension WooShippingCreateLabelsView {
+    enum Localization {
+        static let title = NSLocalizedString("wooShipping.createLabels.title",
+                                             value: "Create Shipping Labels",
+                                             comment: "Title for the screen to create a shipping label")
+        static let cancel = NSLocalizedString("wooShipping.createLabel.cancelButton",
+                                              value: "Cancel",
+                                              comment: "Title of the button to dismiss the shipping label creation screen")
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingCreateLabelsView.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingCreateLabelsView.swift
@@ -1,0 +1,26 @@
+import SwiftUI
+
+/// Hosting controller for `WooShippingCreateLabelsView`.
+///
+final class WooShippingCreateLabelsViewHostingController: UIHostingController<WooShippingCreateLabelsView> {
+    init() {
+        super.init(rootView: WooShippingCreateLabelsView())
+    }
+
+    required dynamic init?(coder aDecoder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+}
+
+/// View to create shipping labels with the Woo Shipping extension.
+///
+struct WooShippingCreateLabelsView: View {
+    var body: some View {
+        // TODO-13550: Replace placeholder content with real UI for new shipping labels flow.
+        Text(/*@START_MENU_TOKEN@*/"Hello, World!"/*@END_MENU_TOKEN@*/)
+    }
+}
+
+#Preview {
+    WooShippingCreateLabelsView()
+}

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -2269,6 +2269,7 @@
 		CEA455C92BB5DA4C00D932CF /* AnalyticsSessionsReportCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEA455C82BB5DA4C00D932CF /* AnalyticsSessionsReportCard.swift */; };
 		CEA7C32D2C47C9BD00528450 /* GoogleAdsCampaignStatsTotals+UI.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEA7C32C2C47C9BD00528450 /* GoogleAdsCampaignStatsTotals+UI.swift */; };
 		CEA9C8E02B6D323A000FE114 /* AnalyticsWebReportTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEA9C8DF2B6D323A000FE114 /* AnalyticsWebReportTests.swift */; };
+		CEAB739C2C81E3F600A7EB39 /* WooShippingCreateLabelsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEAB739B2C81E3F600A7EB39 /* WooShippingCreateLabelsView.swift */; };
 		CEC8188C2A3B7C8B00459843 /* AppStartupWaitingTimeTracker.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEC8188B2A3B7C8B00459843 /* AppStartupWaitingTimeTracker.swift */; };
 		CEC8188E2A3C75DD00459843 /* AppStartupWaitingTimeTrackerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEC8188D2A3C75DD00459843 /* AppStartupWaitingTimeTrackerTests.swift */; };
 		CECC758623D21AC200486676 /* AggregateOrderItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = CECC758523D21AC200486676 /* AggregateOrderItem.swift */; };
@@ -5300,6 +5301,7 @@
 		CEA455C82BB5DA4C00D932CF /* AnalyticsSessionsReportCard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnalyticsSessionsReportCard.swift; sourceTree = "<group>"; };
 		CEA7C32C2C47C9BD00528450 /* GoogleAdsCampaignStatsTotals+UI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "GoogleAdsCampaignStatsTotals+UI.swift"; sourceTree = "<group>"; };
 		CEA9C8DF2B6D323A000FE114 /* AnalyticsWebReportTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnalyticsWebReportTests.swift; sourceTree = "<group>"; };
+		CEAB739B2C81E3F600A7EB39 /* WooShippingCreateLabelsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WooShippingCreateLabelsView.swift; sourceTree = "<group>"; };
 		CEC8188B2A3B7C8B00459843 /* AppStartupWaitingTimeTracker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppStartupWaitingTimeTracker.swift; sourceTree = "<group>"; };
 		CEC8188D2A3C75DD00459843 /* AppStartupWaitingTimeTrackerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppStartupWaitingTimeTrackerTests.swift; sourceTree = "<group>"; };
 		CECA64B020D9990E005A44C4 /* WooCommerce-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "WooCommerce-Bridging-Header.h"; sourceTree = "<group>"; };
@@ -6311,6 +6313,7 @@
 		021A84DD257DFBDA00BC71D1 /* Shipping Labels */ = {
 			isa = PBXGroup;
 			children = (
+				CEAB739A2C81E3A000A7EB39 /* WooShipping Create Shipping Labels */,
 				DEE6437426D87C2D00888A75 /* Print Customs Form */,
 				02DFECE525EE33430070F212 /* Create Shipping Label Info */,
 				023D69BA2589BF2500F7DA72 /* Refund Shipping Label */,
@@ -11805,6 +11808,14 @@
 			path = Components;
 			sourceTree = "<group>";
 		};
+		CEAB739A2C81E3A000A7EB39 /* WooShipping Create Shipping Labels */ = {
+			isa = PBXGroup;
+			children = (
+				CEAB739B2C81E3F600A7EB39 /* WooShippingCreateLabelsView.swift */,
+			);
+			path = "WooShipping Create Shipping Labels";
+			sourceTree = "<group>";
+		};
 		CECC758D23D2260E00486676 /* Refunded Products */ = {
 			isa = PBXGroup;
 			children = (
@@ -15123,6 +15134,7 @@
 				2004E2E72C0DFB9E00D62521 /* CardPresentPaymentsModalButtonViewModel.swift in Sources */,
 				204C9C742B6BDFFB007A94E0 /* UIUserInterfaceSizeClass+Helpers.swift in Sources */,
 				314DC4BF268D183600444C9E /* CardReaderSettingsKnownReaderStorage.swift in Sources */,
+				CEAB739C2C81E3F600A7EB39 /* WooShippingCreateLabelsView.swift in Sources */,
 				2662D90826E15D6E00E25611 /* AreaSelectorCommand.swift in Sources */,
 				02393069291A065000B2632F /* DomainRowView.swift in Sources */,
 				20D3D42B2C64D7CC004CE6E3 /* SimpleProductsOnlyInformation.swift in Sources */,


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #13765
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This finishes adding an entry point into the new shipping labels flow in the following conditions:

* The feature flag is enabled (development/alpha builds only).
* Woo Shipping extension version 1.0.5+ is active on the store.

### How

* Adds a very basic SwiftUI view to start developing the new shipping labels flow. We will continue building this view in #13550.
* If the store is eligible for Woo Shipping (the new flow - see conditions above), the new view is shown. Otherwise, the legacy shipping labels flow is shown as before.

## Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->

With the feature flag enabled and the Woo Shipping extension version 1.0.5 active on the store:

1. Open an order that is eligible for shipping label creation. (The order must be e.g. paid for, include at least one physical item, and not already have shipping labels for all physical items in the order.)
2. After the order loads, tap the "Create Shipping Labels" button.
3. Confirm the new view (with empty scroll view) loads.
4. Tap "Cancel" and confirm the view closes.

With the feature flag disabled and/or the Woo Shipping extension version 1.0.4 or less (or the Shipping & Tax extension) active on the store:

1. Open an order that is eligible for shipping label creation.
2. After the order loads, tap the "Create Shipping Labels" button.
3. Confirm the legacy shipping label flow loads.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

https://github.com/user-attachments/assets/e2af68c6-5dd5-4763-b38d-30c7453faaf5



---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [x] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [x] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [x] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on all devices (phone/tablet) and no regressions are added.