### PR TITLE
Update `shared-pipeline-vars` to latest syntax standards

### DIFF
--- a/.buildkite/shared-pipeline-vars
+++ b/.buildkite/shared-pipeline-vars
@@ -3,7 +3,8 @@
 # This file is `source`'d before calling `buildkite-agent pipeline upload`, and can be used
 # to set up some variables that will be interpolated in the `.yml` pipeline before uploading it.
 
-XCODE_VERSION=$(sed -E -n 's/^(~> )?(.*)/xcode-\2/p' .xcode-version)
-export IMAGE_ID="$XCODE_VERSION"
+XCODE_VERSION=$(sed 's/^~> *//' .xcode-version)
+CI_TOOLKIT_PLUGIN_VERSION="3.5.1"
 
-export CI_TOOLKIT="automattic/a8c-ci-toolkit#3.5.1"
+export IMAGE_ID="xcode-$XCODE_VERSION"
+export CI_TOOLKIT="automattic/a8c-ci-toolkit#$CI_TOOLKIT_PLUGIN_VERSION"


### PR DESCRIPTION
At tiny update on top of https://github.com/woocommerce/woocommerce-ios/pull/13855 to use the latest syntax standards. Internal ref paaHJt-74C-p2

If the CI pipeline upload step is green, then the var update was successful and we can merge.