### PR TITLE
[Woo POS] Prevent text from clipping on reader modals

### DIFF
--- a/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/Connection Alerts/PointOfSaleReaderConnectionModalLayout.swift
+++ b/WooCommerce/Classes/POS/Presentation/CardReaderConnection/UI States/Connection Alerts/PointOfSaleReaderConnectionModalLayout.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 enum PointOfSaleReaderConnectionModalLayout {
-    static var contentButtonSpacing: CGFloat = 40
+    static var contentButtonSpacing: CGFloat = 24
     static var imageTextSpacing: CGFloat = 24
     static var textSpacing: CGFloat = 16
     static var buttonSpacing: CGFloat = 24


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #13890
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

At 100% font size (the default), the text on the `Found reader` connection modal clipped slightly.

This reduces the padding between the content and the buttons to prevent that from happening.

## Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->

1. Launch the app
2. Ensure your device is at 100% font size
3. Go to POS
4. Connect a reader
5. When you see the `Found reader` screen, observe that the description text is visible in full and doesn't require scrolling.

If it auto-connects, just tap the `Reader connected` button to disconnect and try again – it should show the modal this time.

## Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->

I tested other error modals and dynamic type sizes. None required scrolling in my tests

I used an iPad Pro 11", but a mini should work the same as it has the same resolution.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

https://github.com/user-attachments/assets/bcb2fdcc-308a-40f2-83b5-e4550d4e2a4f


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [x] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [x] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [x] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on all devices (phone/tablet) and no regressions are added.