### PR TITLE
Blaze: Persist and retrieve selected campaign objective

### DIFF
--- a/Storage/Storage/Tools/StorageType+Extensions.swift
+++ b/Storage/Storage/Tools/StorageType+Extensions.swift
@@ -578,6 +578,13 @@ public extension StorageType {
         return allObjects(ofType: BlazeCampaignObjective.self, matching: predicate, sortedBy: nil)
     }
 
+    /// Returns Blaze campaign objective with the given ID and locale.
+    ///
+    func retrieveBlazeCampaignObjective(id: String, locale: String) -> BlazeCampaignObjective? {
+        let predicate = \BlazeCampaignObjective.locale == locale && \BlazeCampaignObjective.id == id
+        return firstObject(ofType: BlazeCampaignObjective.self, matching: predicate)
+    }
+
     // MARK: - Coupons
 
     /// Returns a single Coupon given a `siteID` and `CouponID`

--- a/Storage/StorageTests/Tools/StorageTypeExtensionsTests.swift
+++ b/Storage/StorageTests/Tools/StorageTypeExtensionsTests.swift
@@ -1403,7 +1403,7 @@ final class StorageTypeExtensionsTests: XCTestCase {
         objective2.locale = "vi"
 
         // When
-        let foundObjective = try XCTUnwrap(storage.retrieveBlazeCampaignObjective(id:"sale", locale:"en"))
+        let foundObjective = try XCTUnwrap(storage.retrieveBlazeCampaignObjective(id: "sale", locale: "en"))
 
         // Then
         XCTAssertEqual(foundObjective, objective1)

--- a/Storage/StorageTests/Tools/StorageTypeExtensionsTests.swift
+++ b/Storage/StorageTests/Tools/StorageTypeExtensionsTests.swift
@@ -1386,6 +1386,29 @@ final class StorageTypeExtensionsTests: XCTestCase {
         XCTAssertEqual(foundObjectives.first, objective1)
     }
 
+    func test_retrieveBlazeCampaignObjective_with_locale_and_id() throws {
+        // Given
+        let objective1 = storage.insertNewObject(ofType: BlazeCampaignObjective.self)
+        objective1.id = "sale"
+        objective1.title = "Sale"
+        objective1.generalDescription = "Lorem ipsum"
+        objective1.suitableForDescription = "e-commerce"
+        objective1.locale = "en"
+
+        let objective2 = storage.insertNewObject(ofType: BlazeCampaignObjective.self)
+        objective2.id = "sale"
+        objective2.title = "doanh thu"
+        objective2.generalDescription = "la la la"
+        objective2.suitableForDescription = "thương mại điện tử"
+        objective2.locale = "vi"
+
+        // When
+        let foundObjective = try XCTUnwrap(storage.retrieveBlazeCampaignObjective(id:"sale", locale:"en"))
+
+        // Then
+        XCTAssertEqual(foundObjective, objective1)
+    }
+
     func test_loadOrderAttributionInfo_by_siteID_orderID() throws {
         // Given
         let orderAttributionInfo = storage.insertNewObject(ofType: OrderAttributionInfo.self)

--- a/WooCommerce/Classes/Extensions/UserDefaults+Woo.swift
+++ b/WooCommerce/Classes/Extensions/UserDefaults+Woo.swift
@@ -61,6 +61,9 @@ extension UserDefaults {
 
         // Blaze Local notification
         case blazeNoCampaignReminderOpened
+
+        // Selected campaign objective saved for future campaigns
+        case blazeSelectedCampaignObjective
     }
 }
 

--- a/WooCommerce/Classes/System/SessionManager.swift
+++ b/WooCommerce/Classes/System/SessionManager.swift
@@ -212,6 +212,7 @@ final class SessionManager: SessionManagerProtocol {
         defaults[.siteIDPendingStoreSwitch] = nil
         defaults[.expectedStoreNamePendingStoreSwitch] = nil
         defaults[.blazeNoCampaignReminderOpened] = nil
+        defaults[.blazeSelectedCampaignObjective] = nil
         resetTimestampsValues()
         imageCache.clearCache()
     }

--- a/WooCommerce/Classes/ViewRelated/Blaze/CampaignCreation/BlazeCampaignCreationFormViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Blaze/CampaignCreation/BlazeCampaignCreationFormViewModel.swift
@@ -261,6 +261,7 @@ final class BlazeCampaignCreationFormViewModel: ObservableObject {
                             type: Constants.campaignType)
     }
 
+    private let userDefaults: UserDefaults
     private let analytics: Analytics
 
     private var didTrackOnAppear = false
@@ -270,6 +271,7 @@ final class BlazeCampaignCreationFormViewModel: ObservableObject {
          stores: StoresManager = ServiceLocator.stores,
          storage: StorageManagerType = ServiceLocator.storageManager,
          productImageLoader: ProductUIImageLoader = DefaultProductUIImageLoader(phAssetImageLoaderProvider: { PHImageManager.default() }),
+         userDefaults: UserDefaults = .standard,
          analytics: Analytics = ServiceLocator.analytics,
          featureFlagService: FeatureFlagService = ServiceLocator.featureFlagService,
          onCompletion: @escaping () -> Void) {
@@ -278,6 +280,7 @@ final class BlazeCampaignCreationFormViewModel: ObservableObject {
         self.stores = stores
         self.storage = storage
         self.productImageLoader = productImageLoader
+        self.userDefaults = userDefaults
         self.analytics = analytics
         self.completionHandler = onCompletion
         self.targetUrn = String(format: Constants.targetUrnFormat, siteID, productID)
@@ -285,6 +288,7 @@ final class BlazeCampaignCreationFormViewModel: ObservableObject {
         // sets isEvergreen = true by default if evergreen campaigns are supported
         self.isEvergreen = featureFlagService.isFeatureFlagEnabled(.blazeEvergreenCampaigns)
 
+        initializeCampaignObjective()
         updateBudgetDetails()
         updateTargetLanguagesText()
         updateTargetDevicesText()
@@ -426,6 +430,18 @@ private extension BlazeCampaignCreationFormViewModel {
 // MARK: - Private helpers
 
 private extension BlazeCampaignCreationFormViewModel {
+    func initializeCampaignObjective() {
+        guard let savedID = userDefaults.retrieveSavedObjectiveID(for: siteID) else {
+            return
+        }
+        let objective = storage.viewStorage.retrieveBlazeCampaignObjective(id: savedID, locale: Locale.current.identifier)
+        guard let readOnlyObjective = objective?.toReadOnly() else {
+            return
+        }
+        campaignObjective = readOnlyObjective
+        campaignObjectiveText = readOnlyObjective.title
+    }
+
     func updateBudgetDetails() {
         let formattedStartDate = dateFormatter.string(for: startDate) ?? ""
         if isEvergreen {

--- a/WooCommerce/Classes/ViewRelated/Blaze/CampaignCreation/BlazeCampaignCreationFormViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Blaze/CampaignCreation/BlazeCampaignCreationFormViewModel.swift
@@ -261,6 +261,7 @@ final class BlazeCampaignCreationFormViewModel: ObservableObject {
                             type: Constants.campaignType)
     }
 
+    private let locale: Locale
     private let userDefaults: UserDefaults
     private let analytics: Analytics
 
@@ -271,6 +272,7 @@ final class BlazeCampaignCreationFormViewModel: ObservableObject {
          stores: StoresManager = ServiceLocator.stores,
          storage: StorageManagerType = ServiceLocator.storageManager,
          productImageLoader: ProductUIImageLoader = DefaultProductUIImageLoader(phAssetImageLoaderProvider: { PHImageManager.default() }),
+         locale: Locale = .current,
          userDefaults: UserDefaults = .standard,
          analytics: Analytics = ServiceLocator.analytics,
          featureFlagService: FeatureFlagService = ServiceLocator.featureFlagService,
@@ -280,6 +282,7 @@ final class BlazeCampaignCreationFormViewModel: ObservableObject {
         self.stores = stores
         self.storage = storage
         self.productImageLoader = productImageLoader
+        self.locale = locale
         self.userDefaults = userDefaults
         self.analytics = analytics
         self.completionHandler = onCompletion
@@ -434,7 +437,7 @@ private extension BlazeCampaignCreationFormViewModel {
         guard let savedID = userDefaults.retrieveSavedObjectiveID(for: siteID) else {
             return
         }
-        let objective = storage.viewStorage.retrieveBlazeCampaignObjective(id: savedID, locale: Locale.current.identifier)
+        let objective = storage.viewStorage.retrieveBlazeCampaignObjective(id: savedID, locale: locale.identifier)
         guard let readOnlyObjective = objective?.toReadOnly() else {
             return
         }

--- a/WooCommerce/Classes/ViewRelated/Blaze/CampaignObjectives/BlazeCampaignObjectivePickerViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Blaze/CampaignObjectives/BlazeCampaignObjectivePickerViewModel.swift
@@ -103,28 +103,3 @@ private extension BlazeCampaignObjectivePickerViewModel {
         fetchedData = resultsController.fetchedObjects
     }
 }
-
-// MARK: - Blaze campaign objective helpers
-//
-private extension UserDefaults {
-    /// Returns objective ID saved for campaign creation
-    ///
-    func savedObjectiveID(for siteID: Int64) -> String? {
-        let campaignObjective = self[.blazeSelectedCampaignObjective] as? [String: String]
-        let idAsString = "\(siteID)"
-        return campaignObjective?[idAsString]
-    }
-
-    /// Saves objective ID for future Blaze campaigns
-    ///
-    func setObjectiveForFutureCampaigns(objectiveID: String,
-                                        for siteID: Int64) {
-        let idAsString = "\(siteID)"
-        if var campaignObjectiveDictionary = self[.blazeSelectedCampaignObjective] as? [String: String] {
-            campaignObjectiveDictionary[idAsString] = objectiveID
-            self[.blazeSelectedCampaignObjective] = campaignObjectiveDictionary
-        } else {
-            self[.blazeSelectedCampaignObjective] = [idAsString: objectiveID]
-        }
-    }
-}

--- a/WooCommerce/Classes/ViewRelated/Blaze/CampaignObjectives/BlazeCampaignObjectivePickerViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Blaze/CampaignObjectives/BlazeCampaignObjectivePickerViewModel.swift
@@ -103,3 +103,28 @@ private extension BlazeCampaignObjectivePickerViewModel {
         fetchedData = resultsController.fetchedObjects
     }
 }
+
+// MARK: - Blaze campaign objective helpers
+//
+private extension UserDefaults {
+    /// Returns objective ID saved for campaign creation
+    ///
+    func savedObjectiveID(for siteID: Int64) -> String? {
+        let campaignObjective = self[.blazeSelectedCampaignObjective] as? [String: String]
+        let idAsString = "\(siteID)"
+        return campaignObjective?[idAsString]
+    }
+
+    /// Saves objective ID for future Blaze campaigns
+    ///
+    func setObjectiveForFutureCampaigns(objectiveID: String,
+                                        for siteID: Int64) {
+        let idAsString = "\(siteID)"
+        if var campaignObjectiveDictionary = self[.blazeSelectedCampaignObjective] as? [String: String] {
+            campaignObjectiveDictionary[idAsString] = objectiveID
+            self[.blazeSelectedCampaignObjective] = campaignObjectiveDictionary
+        } else {
+            self[.blazeSelectedCampaignObjective] = [idAsString: objectiveID]
+        }
+    }
+}

--- a/WooCommerce/Classes/ViewRelated/Blaze/CampaignObjectives/BlazeCampaignObjectivePickerViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Blaze/CampaignObjectives/BlazeCampaignObjectivePickerViewModel.swift
@@ -32,6 +32,7 @@ final class BlazeCampaignObjectivePickerViewModel: ObservableObject {
     private let locale: Locale
     private let stores: StoresManager
     private let storageManager: StorageManagerType
+    private let userDefaults: UserDefaults
     private let analytics: Analytics
     private let onSelection: (BlazeCampaignObjective?) -> Void
 
@@ -40,6 +41,7 @@ final class BlazeCampaignObjectivePickerViewModel: ObservableObject {
          locale: Locale = .current,
          stores: StoresManager = ServiceLocator.stores,
          storageManager: StorageManagerType = ServiceLocator.storageManager,
+         userDefaults: UserDefaults = .standard,
          analytics: Analytics = ServiceLocator.analytics,
          onSelection: @escaping (BlazeCampaignObjective?) -> Void) {
         self.siteID = siteID
@@ -47,6 +49,7 @@ final class BlazeCampaignObjectivePickerViewModel: ObservableObject {
         self.locale = locale
         self.stores = stores
         self.storageManager = storageManager
+        self.userDefaults = userDefaults
         self.analytics = analytics
         self.onSelection = onSelection
 
@@ -77,6 +80,12 @@ final class BlazeCampaignObjectivePickerViewModel: ObservableObject {
 
     func confirmSelection() {
         // TODO: add tracking
+        guard let selectedObjective else {
+            return
+        }
+        if saveSelectionForFutureCampaigns {
+            userDefaults.saveObjectiveForFutureCampaigns(objectiveID: selectedObjective.id, for: siteID)
+        }
         onSelection(selectedObjective)
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Blaze/CampaignObjectives/UserDefaults+BlazeCampaignObjective.swift
+++ b/WooCommerce/Classes/ViewRelated/Blaze/CampaignObjectives/UserDefaults+BlazeCampaignObjective.swift
@@ -1,0 +1,26 @@
+import Foundation
+
+// MARK: - Blaze campaign objective helpers
+//
+extension UserDefaults {
+    /// Returns objective ID saved for campaign creation
+    ///
+    func retrieveSavedObjectiveID(for siteID: Int64) -> String? {
+        let campaignObjective = self[.blazeSelectedCampaignObjective] as? [String: String]
+        let idAsString = "\(siteID)"
+        return campaignObjective?[idAsString]
+    }
+
+    /// Saves objective ID for future Blaze campaigns
+    ///
+    func saveObjectiveForFutureCampaigns(objectiveID: String,
+                                         for siteID: Int64) {
+        let idAsString = "\(siteID)"
+        if var campaignObjectiveDictionary = self[.blazeSelectedCampaignObjective] as? [String: String] {
+            campaignObjectiveDictionary[idAsString] = objectiveID
+            self[.blazeSelectedCampaignObjective] = campaignObjectiveDictionary
+        } else {
+            self[.blazeSelectedCampaignObjective] = [idAsString: objectiveID]
+        }
+    }
+}

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -2636,6 +2636,7 @@
 		DEA6BCB12BC6AA040017D671 /* StoreStatsChartViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEA6BCB02BC6AA040017D671 /* StoreStatsChartViewModel.swift */; };
 		DEA88F502AA9D0100037273B /* AddEditProductCategoryViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEA88F4F2AA9D0100037273B /* AddEditProductCategoryViewModel.swift */; };
 		DEA88F522AAAC1180037273B /* AddEditProductCategoryViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEA88F512AAAC1180037273B /* AddEditProductCategoryViewModelTests.swift */; };
+		DEA90D352C8EE55D0021ABC3 /* UserDefaults+BlazeCampaignObjective.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEA90D342C8EE55D0021ABC3 /* UserDefaults+BlazeCampaignObjective.swift */; };
 		DEACB8852A64F74A00253F0F /* MediaPickingCoordinatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEACB8842A64F74A00253F0F /* MediaPickingCoordinatorTests.swift */; };
 		DEACB8872A65020A00253F0F /* WooAnalyticsEvent+AddProductFromImage.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEACB8862A65020A00253F0F /* WooAnalyticsEvent+AddProductFromImage.swift */; };
 		DEB387952C2E7A7C0025256E /* GoogleAdsEligibilityChecker.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEB387942C2E7A7C0025256E /* GoogleAdsEligibilityChecker.swift */; };
@@ -5673,6 +5674,7 @@
 		DEA6BCB02BC6AA040017D671 /* StoreStatsChartViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StoreStatsChartViewModel.swift; sourceTree = "<group>"; };
 		DEA88F4F2AA9D0100037273B /* AddEditProductCategoryViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddEditProductCategoryViewModel.swift; sourceTree = "<group>"; };
 		DEA88F512AAAC1180037273B /* AddEditProductCategoryViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddEditProductCategoryViewModelTests.swift; sourceTree = "<group>"; };
+		DEA90D342C8EE55D0021ABC3 /* UserDefaults+BlazeCampaignObjective.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UserDefaults+BlazeCampaignObjective.swift"; sourceTree = "<group>"; };
 		DEACB8842A64F74A00253F0F /* MediaPickingCoordinatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MediaPickingCoordinatorTests.swift; sourceTree = "<group>"; };
 		DEACB8862A65020A00253F0F /* WooAnalyticsEvent+AddProductFromImage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "WooAnalyticsEvent+AddProductFromImage.swift"; sourceTree = "<group>"; };
 		DEB387942C2E7A7C0025256E /* GoogleAdsEligibilityChecker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GoogleAdsEligibilityChecker.swift; sourceTree = "<group>"; };
@@ -12894,6 +12896,7 @@
 			children = (
 				DEF657A52C895AE900ACD61E /* BlazeCampaignObjectivePickerView.swift */,
 				DEF657A72C895B0500ACD61E /* BlazeCampaignObjectivePickerViewModel.swift */,
+				DEA90D342C8EE55D0021ABC3 /* UserDefaults+BlazeCampaignObjective.swift */,
 			);
 			path = CampaignObjectives;
 			sourceTree = "<group>";
@@ -15860,6 +15863,7 @@
 				4590B64C261C673B00A6FCE0 /* WeightFormatter.swift in Sources */,
 				B5290ED9219B3FA900A6AF7F /* Date+Woo.swift in Sources */,
 				DE36E09A2A86351100B98496 /* StoreNameSetupViewModel.swift in Sources */,
+				DEA90D352C8EE55D0021ABC3 /* UserDefaults+BlazeCampaignObjective.swift in Sources */,
 				DE279BA626E9C582002BA963 /* ShippingLabelPackagesFormViewModel.swift in Sources */,
 				02038C582AF0D0F400CD36D9 /* ConfigurableVariableBundleAttributePicker.swift in Sources */,
 				02B1AA6729A4709400D54FCB /* FilterTabBar.swift in Sources */,

--- a/WooCommerce/WooCommerceTests/System/SessionManagerTests.swift
+++ b/WooCommerce/WooCommerceTests/System/SessionManagerTests.swift
@@ -405,6 +405,28 @@ final class SessionManagerTests: XCTestCase {
         XCTAssertNil(defaults[UserDefaults.Key.blazeNoCampaignReminderOpened])
     }
 
+    /// Verifies that `blazeSelectedCampaignObjective` is set to `nil` upon reset
+    ///
+    func test_blazeSelectedCampaignObjective_is_set_to_nil_upon_reset() throws {
+        // Given
+        let siteID: Int64 = 13
+        let uuid = UUID().uuidString
+        let defaults = try XCTUnwrap(UserDefaults(suiteName: uuid))
+        let sut = SessionManager(defaults: defaults, keychainServiceName: Settings.keychainServiceName)
+
+        // When
+        defaults[.blazeSelectedCampaignObjective] = ["\(siteID)": "sales"]
+
+        // Then
+        XCTAssertEqual(try XCTUnwrap(defaults[.blazeSelectedCampaignObjective] as? [String: String]), ["13": "sales"])
+
+        // When
+        sut.reset()
+
+        // Then
+        XCTAssertNil(defaults[.blazeSelectedCampaignObjective])
+    }
+
     /// Verifies that image cache is cleared upon reset
     ///
     func test_image_cache_is_cleared_upon_reset() throws {

--- a/WooCommerce/WooCommerceTests/ViewRelated/Blaze/BlazeCampaignCreationFormViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Blaze/BlazeCampaignCreationFormViewModelTests.swift
@@ -149,6 +149,31 @@ final class BlazeCampaignCreationFormViewModelTests: XCTestCase {
         XCTAssertFalse(viewModel.budgetSettingViewModel.hasEndDate)
     }
 
+    func test_campaignObjectiveText_is_updated_based_on_saved_objective() throws {
+        // Given
+        insertProduct(sampleProduct)
+        let uuid = UUID().uuidString
+        let userDefaults = try XCTUnwrap(UserDefaults(suiteName: uuid))
+        let locale = Locale.current
+        let objective = BlazeCampaignObjective(id: "traffic", title: "Traffic", description: "", suitableForDescription: "", locale: locale.identifier)
+        insertCampaignObjective(objective)
+
+        // When
+        userDefaults[.blazeSelectedCampaignObjective] = ["\(sampleSiteID)": objective.id]
+        let viewModel = BlazeCampaignCreationFormViewModel(siteID: sampleSiteID,
+                                                           productID: sampleProductID,
+                                                           stores: stores,
+                                                           storage: storageManager,
+                                                           productImageLoader: imageLoader,
+                                                           locale: locale,
+                                                           userDefaults: userDefaults,
+                                                           onCompletion: {})
+
+        // Then
+        XCTAssertEqual(viewModel.campaignObjectiveText, objective.title)
+        XCTAssertEqual(viewModel.campaignObjectiveViewModel.selectedObjective?.id, objective.id)
+    }
+
     // MARK: On load
     @MainActor
     func test_onLoad_fetches_AI_suggestions() async throws {
@@ -750,6 +775,12 @@ private extension BlazeCampaignCreationFormViewModelTests {
             productImage.update(with: readOnlyImage)
             productImage.product = product
         }
+        storage.saveIfNeeded()
+    }
+
+    func insertCampaignObjective(_ readOnlyObjective: BlazeCampaignObjective) {
+        let objective = storage.insertNewObject(ofType: StorageBlazeCampaignObjective.self)
+        objective.update(with: readOnlyObjective)
         storage.saveIfNeeded()
     }
 }

--- a/WooCommerce/WooCommerceTests/ViewRelated/Blaze/BlazeCampaignObjectivePickerViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Blaze/BlazeCampaignObjectivePickerViewModelTests.swift
@@ -177,6 +177,45 @@ final class BlazeCampaignObjectivePickerViewModelTests: XCTestCase {
         XCTAssertEqual(selectedItem, expectedItem)
     }
 
+    func test_confirmSelection_does_not_save_selected_objective_if_saveSelectionForFutureCampaigns_is_false() throws {
+        // Given
+        let uuid = UUID().uuidString
+        let userDefaults = try XCTUnwrap(UserDefaults(suiteName: uuid))
+        let viewModel = BlazeCampaignObjectivePickerViewModel(siteID: sampleSiteID,
+                                                              locale: locale,
+                                                              storageManager: storageManager,
+                                                              userDefaults: userDefaults,
+                                                              onSelection: { _ in })
+        XCTAssertNil(userDefaults[.blazeSelectedCampaignObjective])
+
+        // When
+        viewModel.saveSelectionForFutureCampaigns = false
+        viewModel.selectedObjective = BlazeCampaignObjective(id: "sales", title: "Sales", description: "", suitableForDescription: "", locale: locale.identifier)
+        viewModel.confirmSelection()
+
+        // Then
+        XCTAssertNil(userDefaults[.blazeSelectedCampaignObjective])
+    }
+
+    func test_confirmSelection_saves_selected_objective_if_saveSelectionForFutureCampaigns_is_true() throws {
+        // Given
+        let uuid = UUID().uuidString
+        let userDefaults = try XCTUnwrap(UserDefaults(suiteName: uuid))
+        let viewModel = BlazeCampaignObjectivePickerViewModel(siteID: sampleSiteID,
+                                                              locale: locale,
+                                                              storageManager: storageManager,
+                                                              userDefaults: userDefaults,
+                                                              onSelection: { _ in })
+        XCTAssertNil(userDefaults[.blazeSelectedCampaignObjective])
+
+        // When
+        viewModel.saveSelectionForFutureCampaigns = true
+        viewModel.selectedObjective = BlazeCampaignObjective(id: "sales", title: "Sales", description: "", suitableForDescription: "", locale: locale.identifier)
+        viewModel.confirmSelection()
+
+        // Then
+        XCTAssertEqual(userDefaults[.blazeSelectedCampaignObjective], ["\(sampleSiteID)": "sales"])
+    }
 }
 
 private extension BlazeCampaignObjectivePickerViewModelTests {


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #13887 
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This PR adds the logic to persist the selected campaign objective for Blaze when the checkbox for saving the selected option in the objective picker is ticked. The saved objective is retrieved and displayed on the campaign creation form next time the campaign creation flow starts.

The selected objective is persisted using `UserDefaults` instead of Core Data to avoid complications around uniqueness of the selected item. The objective is persisted by site ID to ensure any changes only affect the current store.

## Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->
- Ensure that the feature flag `blazeCampaignObjective` is enabled.
- Log in to a store eligible for Blaze.
- Switch to the Products tab and select an existing published product or create a new one.
- Select Promote with Blaze, confirm that the campaign objective on the creation form is not populated by default.
- Tap the objective row, select any item, keep the "Save the selection..." toggle unchecked, and tap Save.
- Proceed to create the campaign if needed.
- Repeat the testing steps, confirm that the objective field is still empty. Select an objective and enable saving selection.
- Proceed to create the campaign if needed.
- Repeat the testing steps, confirm that the objective field is prefilled with the previous option. 
- Tap the objective field and confirm that the same option is selected by default.
- Switch to another store that's also eligible for blaze and start the campaign creation flow. Confirm that the objective field is not prefilled by the option selected in the previous test.
- Log out of the account and log in again. Start the campaign creation flow and confirm that the objective field is empty by default.

## Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->
Tested on simulator iPhone 15 Pro iOS 17.4 and confirmed that:
- Campaign objective is empty by default.
- Enabling the save selection toggle persists the last selected option.
- Switching stores and logging out clears the selected option.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->


<img src="https://github.com/user-attachments/assets/540ba094-c278-4e36-8717-3de4ccf66b0b" width=320 />

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [x] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [x] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [x] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on all devices (phone/tablet) and no regressions are added.