### PR TITLE
[Woo POS] Automatically dismiss reader connection success modal

### DIFF
--- a/WooCommerce/Classes/POS/Presentation/Card Present Payments/Connection Alerts/PointOfSaleCardPresentPaymentConnectionSuccessAlertViewModel.swift
+++ b/WooCommerce/Classes/POS/Presentation/Card Present Payments/Connection Alerts/PointOfSaleCardPresentPaymentConnectionSuccessAlertViewModel.swift
@@ -1,14 +1,42 @@
 import Foundation
+import WooFoundation
 
-struct PointOfSaleCardPresentPaymentConnectionSuccessAlertViewModel: Hashable {
+class PointOfSaleCardPresentPaymentConnectionSuccessAlertViewModel: Hashable {
     let title = Localization.title
     let imageName = PointOfSaleAssets.readerConnectionSuccess.imageName
     let buttonViewModel: CardPresentPaymentsModalButtonViewModel
+    private let scheduler: Scheduler
+    private let autoDismissAction: Cancellable
 
-    init(doneAction: @escaping () -> Void) {
+    init(doneAction: @escaping () -> Void,
+         scheduler: Scheduler = DefaultScheduler()) {
+
+        self.scheduler = scheduler
+        let autoDismissAction = scheduler.schedule(after: 3.0, action: doneAction)
+        self.autoDismissAction = autoDismissAction
+
         self.buttonViewModel = CardPresentPaymentsModalButtonViewModel(
             title: Localization.done,
-            actionHandler: doneAction)
+            actionHandler: {
+                autoDismissAction.cancel()
+                doneAction()
+            })
+    }
+
+    deinit {
+        autoDismissAction.cancel()
+    }
+
+    func hash(into hasher: inout Hasher) {
+        hasher.combine(title)
+        hasher.combine(imageName)
+        hasher.combine(buttonViewModel)
+    }
+
+    static func == (lhs: PointOfSaleCardPresentPaymentConnectionSuccessAlertViewModel, rhs: PointOfSaleCardPresentPaymentConnectionSuccessAlertViewModel) -> Bool {
+        return lhs.title == rhs.title &&
+               lhs.imageName == rhs.imageName &&
+               lhs.buttonViewModel == rhs.buttonViewModel
     }
 }
 

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -765,6 +765,7 @@
 		202496642B0B9E0D00EE527D /* ScrollViewSectionKit in Frameworks */ = {isa = PBXBuildFile; productRef = 202496632B0B9E0D00EE527D /* ScrollViewSectionKit */; };
 		2024966A2B0CC97100EE527D /* MockWooPaymentsDepositService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 202496692B0CC97100EE527D /* MockWooPaymentsDepositService.swift */; };
 		2026ECE92C25D21F00BEF7E4 /* CardPresentPaymentInvalidatablePaymentOrchestrator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2026ECE82C25D21F00BEF7E4 /* CardPresentPaymentInvalidatablePaymentOrchestrator.swift */; };
+		2027F74F2C8F0858004BDF73 /* PointOfSaleCardPresentPaymentConnectionSuccessAlertViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2027F74E2C8F0858004BDF73 /* PointOfSaleCardPresentPaymentConnectionSuccessAlertViewModelTests.swift */; };
 		202C6C562C7F667700413107 /* POSTextButtonStyle.swift in Sources */ = {isa = PBXBuildFile; fileRef = 202C6C552C7F667700413107 /* POSTextButtonStyle.swift */; };
 		202D2A5A2AC5933100E4ABC0 /* TopTabView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 202D2A592AC5933100E4ABC0 /* TopTabView.swift */; };
 		203163A92C1B5AA7001C96DA /* PointOfSaleCardPresentPaymentBluetoothRequiredAlertViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 203163A82C1B5AA7001C96DA /* PointOfSaleCardPresentPaymentBluetoothRequiredAlertViewModel.swift */; };
@@ -3826,6 +3827,7 @@
 		2023E2AD2C21D8EA00FC365A /* PointOfSaleCardPresentPaymentInLineMessage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PointOfSaleCardPresentPaymentInLineMessage.swift; sourceTree = "<group>"; };
 		202496692B0CC97100EE527D /* MockWooPaymentsDepositService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockWooPaymentsDepositService.swift; sourceTree = "<group>"; };
 		2026ECE82C25D21F00BEF7E4 /* CardPresentPaymentInvalidatablePaymentOrchestrator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardPresentPaymentInvalidatablePaymentOrchestrator.swift; sourceTree = "<group>"; };
+		2027F74E2C8F0858004BDF73 /* PointOfSaleCardPresentPaymentConnectionSuccessAlertViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PointOfSaleCardPresentPaymentConnectionSuccessAlertViewModelTests.swift; sourceTree = "<group>"; };
 		202C6C552C7F667700413107 /* POSTextButtonStyle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = POSTextButtonStyle.swift; sourceTree = "<group>"; };
 		202D2A592AC5933100E4ABC0 /* TopTabView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TopTabView.swift; sourceTree = "<group>"; };
 		203163A82C1B5AA7001C96DA /* PointOfSaleCardPresentPaymentBluetoothRequiredAlertViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PointOfSaleCardPresentPaymentBluetoothRequiredAlertViewModel.swift; sourceTree = "<group>"; };
@@ -7778,6 +7780,7 @@
 			isa = PBXGroup;
 			children = (
 				2084B7A52C776DA200EFBD2E /* PointOfSaleCardPresentPaymentConnectingFailedUpdateAddressAlertViewModelTests.swift */,
+				2027F74E2C8F0858004BDF73 /* PointOfSaleCardPresentPaymentConnectionSuccessAlertViewModelTests.swift */,
 				2084B7A72C776E1000EFBD2E /* PointOfSaleCardPresentPaymentFoundMultipleReadersAlertViewModelTests.swift */,
 				2084B7A92C776E9700EFBD2E /* PointOfSaleCardPresentPaymentOptionalReaderUpdateInProgressAlertViewModelTests.swift */,
 				2084B7AB2C776F0F00EFBD2E /* PointOfSaleCardPresentPaymentRequiredReaderUpdateInProgressAlertViewModelTests.swift */,
@@ -16716,6 +16719,7 @@
 				CE606D872BE29E89001CB424 /* ShippingLineSelectionDetailsViewModelTests.swift in Sources */,
 				029700EF24FE38F000D242F8 /* ScrollWatcherTests.swift in Sources */,
 				0236BCA425087B660043EB43 /* ProductFormRemoteActionUseCaseTests.swift in Sources */,
+				2027F74F2C8F0858004BDF73 /* PointOfSaleCardPresentPaymentConnectionSuccessAlertViewModelTests.swift in Sources */,
 				CC13C0CD278E086D00C0B5B5 /* ProductVariationSelectorViewModelTests.swift in Sources */,
 				DEB387982C2E803A0025256E /* DefaultGoogleAdsEligibilityCheckTests.swift in Sources */,
 				0371C36A2876DBCA00277E2C /* FeatureAnnouncementCardViewModelTests.swift in Sources */,

--- a/WooCommerce/WooCommerceTests/POS/Card Present Payments/Connection Alerts/PointOfSaleCardPresentPaymentConnectionSuccessAlertViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/POS/Card Present Payments/Connection Alerts/PointOfSaleCardPresentPaymentConnectionSuccessAlertViewModelTests.swift
@@ -1,0 +1,84 @@
+import XCTest
+@testable import WooFoundation
+@testable import WooCommerce
+
+final class PointOfSaleCardPresentPaymentConnectionSuccessAlertViewModelTests: XCTestCase {
+
+    func test_manual_equatable_conformance_number_of_properties_unchanged() {
+        let sut = PointOfSaleCardPresentPaymentConnectionSuccessAlertViewModel(doneAction: {})
+
+        XCTAssertPropertyCount(sut,
+                               expectedCount: 5,
+                               messageHint: "Please check that the manual equatable conformance includes new properties.")
+    }
+
+    func test_manual_hashable_conformance_number_of_properties_unchanged() {
+        let sut = PointOfSaleCardPresentPaymentConnectionSuccessAlertViewModel(doneAction: {})
+
+        XCTAssertPropertyCount(sut,
+                               expectedCount: 5,
+                               messageHint: "Please check that the manual hashable conformance includes new properties.")
+    }
+
+    func test_when_scheduler_fires_the_modal_is_dismissed() {
+        // Given
+        let testScheduler = MockScheduler()
+
+        waitFor { promise in
+            let sut = PointOfSaleCardPresentPaymentConnectionSuccessAlertViewModel(
+                doneAction: {
+                    // Then doneAction is called
+                    promise(())
+                },
+                scheduler: testScheduler
+            )
+            // When the scheduler fires
+            testScheduler.runNextAction()
+        }
+    }
+
+    func test_when_the_view_model_is_destroyed_the_autodismiss_work_item_is_cancelled() {
+        // Given
+        let testScheduler = MockScheduler()
+
+        var sut: PointOfSaleCardPresentPaymentConnectionSuccessAlertViewModel? = .init(
+            doneAction: { },
+            scheduler: testScheduler
+        )
+
+        guard let autoDismissWorkItem = try? XCTUnwrap(testScheduler.scheduledActions.first?.2) else {
+            return XCTFail("The autoDismiss work item wasn't found")
+        }
+
+        XCTAssertFalse(autoDismissWorkItem.isCancelled)
+
+        // When
+        sut = nil
+
+        // Then
+        XCTAssertTrue(autoDismissWorkItem.isCancelled)
+    }
+
+    func test_when_the_button_is_tapped_the_autodismiss_work_item_is_cancelled() {
+        // Given
+        let testScheduler = MockScheduler()
+
+        let sut = PointOfSaleCardPresentPaymentConnectionSuccessAlertViewModel(
+            doneAction: { },
+            scheduler: testScheduler
+        )
+
+        guard let autoDismissWorkItem = try? XCTUnwrap(testScheduler.scheduledActions.first?.2) else {
+            return XCTFail("The autoDismiss work item wasn't found")
+        }
+
+        XCTAssertFalse(autoDismissWorkItem.isCancelled)
+
+        // When
+        sut.buttonViewModel.actionHandler()
+
+        // Then
+        XCTAssertTrue(autoDismissWorkItem.isCancelled)
+    }
+
+}

--- a/WooFoundation/WooFoundation.xcodeproj/project.pbxproj
+++ b/WooFoundation/WooFoundation.xcodeproj/project.pbxproj
@@ -20,6 +20,8 @@
 		035BA3A6290FF98D0056F0AD /* UTMProviderProtocolExtensionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 035BA3A5290FF98D0056F0AD /* UTMProviderProtocolExtensionTests.swift */; };
 		036563D728F93F8D00D84BFD /* TestKit in Frameworks */ = {isa = PBXBuildFile; productRef = 036563D628F93F8D00D84BFD /* TestKit */; };
 		03B8C3892914083F002235B1 /* Bundle+Woo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03B8C3882914083F002235B1 /* Bundle+Woo.swift */; };
+		2027F74D2C8F07DF004BDF73 /* Scheduler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2027F74C2C8F07DF004BDF73 /* Scheduler.swift */; };
+		2027F7522C8F0B95004BDF73 /* MockScheduler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2027F7512C8F0B95004BDF73 /* MockScheduler.swift */; };
 		203758752AD55670000E4281 /* CountryCode.swift in Sources */ = {isa = PBXBuildFile; fileRef = 203758742AD55670000E4281 /* CountryCode.swift */; };
 		20A3AFE92B14BAB20033AF2D /* Color+Adaptivity.swift in Sources */ = {isa = PBXBuildFile; fileRef = 20A3AFE82B14BAB20033AF2D /* Color+Adaptivity.swift */; };
 		20AD34D32B0CDB8900F38F44 /* Codegen in Frameworks */ = {isa = PBXBuildFile; productRef = 20AD34D22B0CDB8900F38F44 /* Codegen */; };
@@ -116,6 +118,8 @@
 		03597A9C28F93409005E4A98 /* WooCommerceComUTMProviderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WooCommerceComUTMProviderTests.swift; sourceTree = "<group>"; };
 		035BA3A5290FF98D0056F0AD /* UTMProviderProtocolExtensionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UTMProviderProtocolExtensionTests.swift; sourceTree = "<group>"; };
 		03B8C3882914083F002235B1 /* Bundle+Woo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Bundle+Woo.swift"; sourceTree = "<group>"; };
+		2027F74C2C8F07DF004BDF73 /* Scheduler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Scheduler.swift; sourceTree = "<group>"; };
+		2027F7512C8F0B95004BDF73 /* MockScheduler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockScheduler.swift; sourceTree = "<group>"; };
 		203758742AD55670000E4281 /* CountryCode.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CountryCode.swift; sourceTree = "<group>"; };
 		20A3AFE82B14BAB20033AF2D /* Color+Adaptivity.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Color+Adaptivity.swift"; sourceTree = "<group>"; };
 		264E9E9B2BF4037D009C48FD /* WooFoundationWatchOS.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = WooFoundationWatchOS.framework; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -268,6 +272,7 @@
 				686BE911288EE0D300967C86 /* TypedPredicates.swift */,
 				03597A9328F85686005E4A98 /* UTMParameters.swift */,
 				03597A9A28F87BFC005E4A98 /* WooCommerceComUTMProvider.swift */,
+				2027F74C2C8F07DF004BDF73 /* Scheduler.swift */,
 			);
 			path = Utilities;
 			sourceTree = "<group>";
@@ -300,6 +305,7 @@
 				689D11D22891B7D800F6A83F /* MockCrashLogger.swift */,
 				6896C8292C75D60D002DDAE2 /* MockAnalyticsPreview.swift */,
 				6896C82B2C75D638002DDAE2 /* MockAnalyticsProviderPreview.swift */,
+				2027F7512C8F0B95004BDF73 /* MockScheduler.swift */,
 			);
 			path = Mocks;
 			sourceTree = "<group>";
@@ -697,6 +703,7 @@
 				02427F122BECA23300E2073B /* WooAnalyticsEventPropertyType.swift in Sources */,
 				02427F0E2BECA1D900E2073B /* AnalyticsProvider.swift in Sources */,
 				03597A9B28F87BFC005E4A98 /* WooCommerceComUTMProvider.swift in Sources */,
+				2027F7522C8F0B95004BDF73 /* MockScheduler.swift in Sources */,
 				B9C9C663283E7296001B879F /* Logging.swift in Sources */,
 				6874E81428998AD300074A97 /* LogErrorAndExit.swift in Sources */,
 				B97190D1292CF3BC0065E413 /* Result+Extensions.swift in Sources */,
@@ -710,6 +717,7 @@
 				0331A75B2A3B553A001D2C2C /* Color+ColorStudio.swift in Sources */,
 				B987B06F284540D300C53CF6 /* CurrencyCode.swift in Sources */,
 				02427F092BECA12800E2073B /* Analytics.swift in Sources */,
+				2027F74D2C8F07DF004BDF73 /* Scheduler.swift in Sources */,
 				03597A9928F8799C005E4A98 /* MockUTMParameterProvider.swift in Sources */,
 				B9C9C660283E71F4001B879F /* Double+Woo.swift in Sources */,
 				6896C82C2C75D638002DDAE2 /* MockAnalyticsProviderPreview.swift in Sources */,

--- a/WooFoundation/WooFoundation/Mocks/MockScheduler.swift
+++ b/WooFoundation/WooFoundation/Mocks/MockScheduler.swift
@@ -1,0 +1,24 @@
+import Foundation
+
+class MockScheduler: Scheduler {
+    var scheduledActions: [(TimeInterval, () -> Void, MockCancellable)] = []
+
+    func schedule(after seconds: TimeInterval, action: @escaping () -> Void) -> Cancellable {
+        let cancellable = MockCancellable()
+        scheduledActions.append((seconds, action, cancellable))
+        return cancellable
+    }
+
+    func runNextAction() {
+        guard let (_, action, _) = scheduledActions.first else { return }
+        action()
+        scheduledActions.removeFirst()
+    }
+}
+
+class MockCancellable: Cancellable {
+    var isCancelled = false
+    func cancel() {
+        isCancelled = true
+    }
+}

--- a/WooFoundation/WooFoundation/Utilities/Scheduler.swift
+++ b/WooFoundation/WooFoundation/Utilities/Scheduler.swift
@@ -1,0 +1,21 @@
+import Foundation
+
+public protocol Scheduler {
+    func schedule(after seconds: TimeInterval, action: @escaping () -> Void) -> Cancellable
+}
+
+public protocol Cancellable {
+    func cancel()
+}
+
+extension DispatchWorkItem: Cancellable {}
+
+public class DefaultScheduler: Scheduler {
+    public init() { }
+
+    public func schedule(after seconds: TimeInterval, action: @escaping () -> Void) -> Cancellable {
+        let workItem = DispatchWorkItem(block: action)
+        DispatchQueue.main.asyncAfter(deadline: .now() + seconds, execute: workItem)
+        return workItem
+    }
+}


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #13889
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

The `Connection success` modal is informational, but merchants don't need to see it for long.

In this PR, we add an automatic dismissal after 3 seconds of showing the modal.

## Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->

1. Launch the app and switch to POS
2. Connect a reader
3. Observe that the `Connection success` modal disappears automatically

Test that the `x` button still works

## Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->

I've tested this on an iPad running iOS 16. In theory it's possible for a scheduler to live on beyond the life of the view which called it, so I checked that the autodismissal handler isn't called after tapping `x` or after POS is closed. There are unit tests for this.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

https://github.com/user-attachments/assets/045cdddc-8e90-4c08-9235-8f16e27e517f


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [x] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [x] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [x] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on all devices (phone/tablet) and no regressions are added.