### PR TITLE
Mark order notification read if needed on watch app and notification extension

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -3,7 +3,7 @@
 
 20.4
 -----
-
+- [Internal] Mark order notification read if needed on watch app and notification extension https://github.com/woocommerce/woocommerce-ios/pull/13896
 
 20.3
 -----

--- a/WooCommerce/Classes/Model/MarkOrderAsReadUseCase.swift
+++ b/WooCommerce/Classes/Model/MarkOrderAsReadUseCase.swift
@@ -1,30 +1,79 @@
 import Foundation
+
+#if canImport(Networking)
+import Networking
+#elseif canImport(NetworkingWatchOS)
+import NetworkingWatchOS
+#endif
+
+#if canImport(Yosemite)
 import Yosemite
+#endif
 
 struct MarkOrderAsReadUseCase {
+    /// Possible error states.
+    ///
+    enum Error: Swift.Error {
+        case failure(Swift.Error)
+        case updateReadStatus(Swift.Error)
+        case unavailableNote
+    }
     /// Method that marks the order note as read if it is the notification for the last order.
     /// We do it in a way that first we syncronize notification to get the remote `Note`
     /// and then we compare local `orderID` with the one from remote `Note`.
     /// If they match we mark it as read.
     /// We pass syncronized note and error in the `onCompletion` completion block
+#if canImport(Yosemite)
     static func markOrderNoteAsReadIfNeeded(stores: StoresManager, noteID: Int64, orderID: Int, onCompletion: ((Note?, Error?) -> Void)? = nil) {
         let action = NotificationAction.synchronizeNotification(noteID: noteID) { syncronizedNote, error in
             guard let syncronizedNote = syncronizedNote else {
-                onCompletion?(nil, error)
+                onCompletion?(nil, MarkOrderAsReadUseCase.Error.unavailableNote)
                 return
             }
-            if let syncronizedNoteOrderID = syncronizedNote.orderID,
+            if let syncronizedNoteOrderID = syncronizedNote.meta.identifier(forKey: .order),
                syncronizedNoteOrderID == orderID {
                 // mark as read
                 let syncAction = NotificationAction.updateReadStatus(noteID: noteID, read: true) { error in
-                    onCompletion?(syncronizedNote, error)
                     if let error {
-                        DDLogError("⛔️ Error marking single notification as read: \(error)")
+                        onCompletion?(nil, MarkOrderAsReadUseCase.Error.failure(error))
+                    } else {
+                        onCompletion?(syncronizedNote, nil)
                     }
                 }
                 stores.dispatch(syncAction)
             }
         }
         stores.dispatch(action)
+    }
+#endif
+    /// Method that marks the order note as read if it is the notification for the last order.
+    /// We do it in a way that first we syncronize notification to get the remote `Note`
+    /// and then we compare local `orderID` with the one from remote `Note`.
+    /// If they match we mark it as read.
+    /// We pass syncronized note id and error in the `onCompletion` completion block
+    static func markOrderNoteAsReadIfNeeded(network: Network, noteID: Int64, orderID: Int, onCompletion: ((Int64?, Error?) -> Void)? = nil) {
+        // use notifications remote
+        let notesRemote = NotificationsRemote(network: network)
+        notesRemote.loadNotes(noteIDs: [noteID], pageSize: nil) { result in
+            switch result {
+            case .success(let notes):
+                if let note = notes.first {
+                    if let syncronizedNoteOrderID = note.meta.identifier(forKey: .order),
+                       syncronizedNoteOrderID == orderID {
+                        notesRemote.updateReadStatus(noteIDs: [noteID], read: true) { error in
+                            if let error {
+                                onCompletion?(nil, MarkOrderAsReadUseCase.Error.updateReadStatus(error))
+                            } else {
+                                onCompletion?(noteID, nil)
+                            }
+                        }
+                    }
+                } else {
+                    onCompletion?(nil, MarkOrderAsReadUseCase.Error.unavailableNote)
+                }
+            case .failure(let error):
+                onCompletion?(nil, MarkOrderAsReadUseCase.Error.failure(error))
+            }
+        }
     }
 }

--- a/WooCommerce/Classes/Model/Note+Woo.swift
+++ b/WooCommerce/Classes/Model/Note+Woo.swift
@@ -66,18 +66,3 @@ private extension Note {
         static let emptyStar    = "\u{2606}"  // Unicode White Star ☆
     }
 }
-
-extension Note {
-    var orderID: Int? {
-        return meta.identifier(forKey: .order)
-    }
-
-    /// Helper method that calls `MarkOrderAsReadUseCase` `markOrderNoteAsReadIfNeeded` method
-    /// which performs 2 network requests, one for syncronizing notification and one for updating the read status
-    func markOrderNoteAsReadIfNeeded() {
-        guard read == false, let orderID = self.orderID else {
-            return
-        }
-        MarkOrderAsReadUseCase.markOrderNoteAsReadIfNeeded(stores: ServiceLocator.stores, noteID: noteID, orderID: orderID)
-    }
-}

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/OrderLoaderViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/OrderLoaderViewController.swift
@@ -3,7 +3,6 @@ import SwiftUI
 import UIKit
 import Yosemite
 
-
 // Loads and render an Order details asynchronously.
 // This is useful for showing the details of an order coming from a push notification or universal link.
 // On Success the OrderDetailsViewController will be rendered "in place".
@@ -259,7 +258,15 @@ private extension OrderLoaderViewController {
     /// Marks a specific Notification as read.
     ///
     func markNotificationAsReadIfNeeded(note: Note) {
-        note.markOrderNoteAsReadIfNeeded()
+        guard note.read == false,
+              let orderID = note.meta.identifier(forKey: .order) else {
+            return
+        }
+        MarkOrderAsReadUseCase.markOrderNoteAsReadIfNeeded(stores: ServiceLocator.stores, noteID: note.noteID, orderID: orderID) { noteID, error in
+            if let error {
+                DDLogError("⛔️ Error marking single notification as read: \(error)")
+            }
+        }
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/OrderLoaderViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/OrderLoaderViewController.swift
@@ -262,8 +262,13 @@ private extension OrderLoaderViewController {
               let orderID = note.meta.identifier(forKey: .order) else {
             return
         }
-        MarkOrderAsReadUseCase.markOrderNoteAsReadIfNeeded(stores: ServiceLocator.stores, noteID: note.noteID, orderID: orderID) { noteID, error in
-            if let error {
+
+        Task {
+            let markReadResult = await MarkOrderAsReadUseCase.markOrderNoteAsReadIfNeeded(stores: ServiceLocator.stores, noteID: note.noteID, orderID: orderID)
+            switch markReadResult {
+            case .success:
+                return
+            case .failure(let error):
                 DDLogError("⛔️ Error marking single notification as read: \(error)")
             }
         }

--- a/WooCommerce/NotificationExtension/OrderNotificationDataService.swift
+++ b/WooCommerce/NotificationExtension/OrderNotificationDataService.swift
@@ -36,6 +36,9 @@ final class OrderNotificationDataService {
         notesRemote = NotificationsRemote(network: network)
     }
 
+    ///  Marks a notification as read when the given `orderID` matches `orderID` of the provided notification.
+    ///
+    @MainActor
     func markOrderNoteAsReadIfNeeded(noteID: Int64, orderID: Int) async -> Result<Int64, MarkOrderAsReadUseCase.Error> {
         return await MarkOrderAsReadUseCase.markOrderNoteAsReadIfNeeded(network: network, noteID: noteID, orderID: orderID)
     }

--- a/WooCommerce/NotificationExtension/OrderNotificationDataService.swift
+++ b/WooCommerce/NotificationExtension/OrderNotificationDataService.swift
@@ -96,7 +96,6 @@ final class OrderNotificationDataService {
             ordersRemote.loadOrder(for: Int64(siteID), orderID: Int64(orderID)) { order, error in
                 switch (order, error) {
                 case (let order?, nil):
-                    MarkOrderAsReadUseCase.markOrderNoteAsReadIfNeeded(network: self.network, noteID: notification.noteID, orderID: orderID)
                     continuation.resume(returning: order)
                 case (_, let error?):
                     continuation.resume(throwing: Error.network(error))

--- a/WooCommerce/NotificationExtension/OrderNotificationDataService.swift
+++ b/WooCommerce/NotificationExtension/OrderNotificationDataService.swift
@@ -96,6 +96,7 @@ final class OrderNotificationDataService {
             ordersRemote.loadOrder(for: Int64(siteID), orderID: Int64(orderID)) { order, error in
                 switch (order, error) {
                 case (let order?, nil):
+                    MarkOrderAsReadUseCase.markOrderNoteAsReadIfNeeded(network: self.network, noteID: notification.noteID, orderID: orderID)
                     continuation.resume(returning: order)
                 case (_, let error?):
                     continuation.resume(throwing: Error.network(error))

--- a/WooCommerce/NotificationExtension/OrderNotificationDataService.swift
+++ b/WooCommerce/NotificationExtension/OrderNotificationDataService.swift
@@ -36,6 +36,10 @@ final class OrderNotificationDataService {
         notesRemote = NotificationsRemote(network: network)
     }
 
+    func markOrderNoteAsReadIfNeeded(noteID: Int64, orderID: Int) async -> Result<Int64, MarkOrderAsReadUseCase.Error> {
+        return await MarkOrderAsReadUseCase.markOrderNoteAsReadIfNeeded(network: network, noteID: noteID, orderID: orderID)
+    }
+
     @MainActor
     func loadOrderFrom(notification: PushNotification) async throws -> (Note, Order) {
         let note: Note = try await {

--- a/WooCommerce/Woo Watch App/App/WooApp.swift
+++ b/WooCommerce/Woo Watch App/App/WooApp.swift
@@ -29,9 +29,7 @@ struct Woo_Watch_AppApp: App {
                         }
                     }
                     .sheet(item: $appBindings.orderNotification, content: { orderNotification in
-                        OrderDetailLoader(dependencies: dependencies,
-                                          pushNotification: orderNotification,
-                                          network: AlamofireNetwork(credentials: dependencies.credentials))
+                        OrderDetailLoader(dependencies: dependencies, pushNotification: orderNotification)
                     })
                     .compatibleVerticalStyle()
                     .environment(\.dependencies, dependencies)

--- a/WooCommerce/Woo Watch App/App/WooApp.swift
+++ b/WooCommerce/Woo Watch App/App/WooApp.swift
@@ -1,4 +1,5 @@
 import SwiftUI
+import NetworkingWatchOS
 
 @main
 struct Woo_Watch_AppApp: App {
@@ -28,7 +29,9 @@ struct Woo_Watch_AppApp: App {
                         }
                     }
                     .sheet(item: $appBindings.orderNotification, content: { orderNotification in
-                        OrderDetailLoader(dependencies: dependencies, pushNotification: orderNotification)
+                        OrderDetailLoader(dependencies: dependencies,
+                                          pushNotification: orderNotification,
+                                          network: AlamofireNetwork(credentials: dependencies.credentials))
                     })
                     .compatibleVerticalStyle()
                     .environment(\.dependencies, dependencies)

--- a/WooCommerce/Woo Watch App/Orders/OrderDetailLoader.swift
+++ b/WooCommerce/Woo Watch App/Orders/OrderDetailLoader.swift
@@ -7,13 +7,10 @@ struct OrderDetailLoader: View {
 
     @StateObject var viewModel: OrderDetailLoaderViewModel
     private let pushNotification: PushNotification
-    private let network: Network
 
-    init(dependencies: WatchDependencies, pushNotification: PushNotification,
-         network: Network) {
+    init(dependencies: WatchDependencies, pushNotification: PushNotification) {
         _viewModel = StateObject(wrappedValue: OrderDetailLoaderViewModel(dependencies: dependencies, pushNotification: pushNotification))
         self.pushNotification = pushNotification
-        self.network = network
     }
 
     var body: some View {
@@ -27,8 +24,7 @@ struct OrderDetailLoader: View {
             case .loaded(let order):
                 OrderDetailView(order: order)
                     .task {
-                        _ = await viewModel.markOrderNoteAsReadIfNeeded(noteID: pushNotification.noteID,
-                                                                        orderID: Int(order.orderID))
+                        await viewModel.markOrderNoteAsReadIfNeeded(noteID: pushNotification.noteID, orderID: Int(order.orderID))
                     }
             case .error:
                 Text(AppLocalizedString(
@@ -71,8 +67,10 @@ final class OrderDetailLoaderViewModel: ObservableObject {
         self.dataService = OrderNotificationDataService(credentials: dependencies.credentials)
     }
 
-    func markOrderNoteAsReadIfNeeded(noteID: Int64, orderID: Int) async -> Result<Int64, MarkOrderAsReadUseCase.Error> {
-        return await dataService.markOrderNoteAsReadIfNeeded(noteID: noteID, orderID: orderID)
+    ///  Marks a notification as read when the given `orderID` matches `orderID` of the provided notification.
+    ///
+    func markOrderNoteAsReadIfNeeded(noteID: Int64, orderID: Int) async {
+        _ = await dataService.markOrderNoteAsReadIfNeeded(noteID: noteID, orderID: orderID)
     }
 
     /// Fetch order based on the provided push notification. Updates the view state as needed.

--- a/WooCommerce/Woo Watch App/Orders/OrderDetailLoader.swift
+++ b/WooCommerce/Woo Watch App/Orders/OrderDetailLoader.swift
@@ -6,9 +6,14 @@ import NetworkingWatchOS
 struct OrderDetailLoader: View {
 
     @StateObject var viewModel: OrderDetailLoaderViewModel
+    private let pushNotification: PushNotification
+    private let network: Network
 
-    init(dependencies: WatchDependencies, pushNotification: PushNotification) {
+    init(dependencies: WatchDependencies, pushNotification: PushNotification,
+         network: Network) {
         _viewModel = StateObject(wrappedValue: OrderDetailLoaderViewModel(dependencies: dependencies, pushNotification: pushNotification))
+        self.pushNotification = pushNotification
+        self.network = network
     }
 
     var body: some View {
@@ -21,6 +26,9 @@ struct OrderDetailLoader: View {
                     .redacted(reason: .placeholder)
             case .loaded(let order):
                 OrderDetailView(order: order)
+                    .onAppear {
+                        MarkOrderAsReadUseCase.markOrderNoteAsReadIfNeeded(network: self.network, noteID: pushNotification.noteID, orderID: Int(order.orderID))
+                    }
             case .error:
                 Text(AppLocalizedString(
                     "watch.notification.order.error",

--- a/WooCommerce/Woo Watch App/Orders/OrderDetailLoader.swift
+++ b/WooCommerce/Woo Watch App/Orders/OrderDetailLoader.swift
@@ -26,12 +26,10 @@ struct OrderDetailLoader: View {
                     .redacted(reason: .placeholder)
             case .loaded(let order):
                 OrderDetailView(order: order)
-                    .onAppear {
-                        Task {
-                            await MarkOrderAsReadUseCase.markOrderNoteAsReadIfNeeded(network: self.network,
-                                                                                     noteID: pushNotification.noteID,
-                                                                                     orderID: Int(order.orderID))
-                        }
+                    .task {
+                        _ = await MarkOrderAsReadUseCase.markOrderNoteAsReadIfNeeded(network: self.network,
+                                                                                 noteID: pushNotification.noteID,
+                                                                                 orderID: Int(order.orderID))
                     }
             case .error:
                 Text(AppLocalizedString(

--- a/WooCommerce/Woo Watch App/Orders/OrderDetailLoader.swift
+++ b/WooCommerce/Woo Watch App/Orders/OrderDetailLoader.swift
@@ -27,7 +27,11 @@ struct OrderDetailLoader: View {
             case .loaded(let order):
                 OrderDetailView(order: order)
                     .onAppear {
-                        MarkOrderAsReadUseCase.markOrderNoteAsReadIfNeeded(network: self.network, noteID: pushNotification.noteID, orderID: Int(order.orderID))
+                        Task {
+                            await MarkOrderAsReadUseCase.markOrderNoteAsReadIfNeeded(network: self.network,
+                                                                                     noteID: pushNotification.noteID,
+                                                                                     orderID: Int(order.orderID))
+                        }
                     }
             case .error:
                 Text(AppLocalizedString(

--- a/WooCommerce/Woo Watch App/Orders/OrdersListViewModel.swift
+++ b/WooCommerce/Woo Watch App/Orders/OrdersListViewModel.swift
@@ -81,7 +81,8 @@ final class OrdersListViewModel: ObservableObject {
                                         status: orderViewModel.statusString.capitalized,
                                         email: order.billingAddress?.email ?? "",
                                         address: order.shippingAddress?.formattedPostalAddress ?? "",
-                                        items: items)
+                                        items: items,
+                                        orderID: order.orderID)
         }
     }
 
@@ -122,6 +123,7 @@ extension OrdersListView {
         let email: String
         let address: String
         let items: [OrderItem]
+        let orderID: Int64
 
         // SwiftUI ID
         var id: String {
@@ -142,7 +144,8 @@ extension OrdersListView {
                                               status: "------- ------",
                                               email: "-----",
                                               address: "-----",
-                                              items: [])
+                                              items: [],
+                                              orderID: Int64.min)
     }
 
     /// Represents an order item.

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -2435,6 +2435,8 @@
 		DA706BF92C8063B600E08A5B /* PushNotification.swift in Sources */ = {isa = PBXBuildFile; fileRef = 575472802452185300A94C3C /* PushNotification.swift */; };
 		DA706BFA2C80642800E08A5B /* Dictionary+Woo.swift in Sources */ = {isa = PBXBuildFile; fileRef = B57C5C9521B80E5400FF82B2 /* Dictionary+Woo.swift */; };
 		DA706BFB2C80663800E08A5B /* PushNotification.swift in Sources */ = {isa = PBXBuildFile; fileRef = 575472802452185300A94C3C /* PushNotification.swift */; };
+		DA81B4332C8EE5D6000F3466 /* MarkOrderAsReadUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA25ADDC2C86145E00AE81FE /* MarkOrderAsReadUseCase.swift */; };
+		DA81B4342C8EE5D6000F3466 /* MarkOrderAsReadUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA25ADDC2C86145E00AE81FE /* MarkOrderAsReadUseCase.swift */; };
 		DABF35272C11B426006AF826 /* PointOfSaleDashboardViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DABF35262C11B426006AF826 /* PointOfSaleDashboardViewModelTests.swift */; };
 		DAD988C62C4A9CF9009DE9E3 /* CartItem+Order.swift in Sources */ = {isa = PBXBuildFile; fileRef = DAD988C52C4A9CF9009DE9E3 /* CartItem+Order.swift */; };
 		DAD988C92C4A9D6C009DE9E3 /* CartItemTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DAD988C82C4A9D6C009DE9E3 /* CartItemTests.swift */; };
@@ -14399,6 +14401,7 @@
 				26CA2BC62AAA1773003B16C2 /* OrderNotificationView.swift in Sources */,
 				26CA2BC42AA92CA9003B16C2 /* AppLocalizedString.swift in Sources */,
 				2608370E2AA66E4B0004A12B /* OrderNotificationViewController.swift in Sources */,
+				DA81B4342C8EE5D6000F3466 /* MarkOrderAsReadUseCase.swift in Sources */,
 				26CFDEE52C038C39005ABC31 /* OrderNotificationDataService.swift in Sources */,
 				DA706BFA2C80642800E08A5B /* Dictionary+Woo.swift in Sources */,
 				26EE79602AA795EC00857293 /* WooConstants.swift in Sources */,
@@ -14460,6 +14463,7 @@
 				26373E2C2BFD13E0008E6735 /* OrdersDataService.swift in Sources */,
 				26FFC50C2BED7C5A0067B3A4 /* WatchDependencies.swift in Sources */,
 				26CFDEE62C038C7D005ABC31 /* OrderNotificationDataService.swift in Sources */,
+				DA81B4332C8EE5D6000F3466 /* MarkOrderAsReadUseCase.swift in Sources */,
 				26CA471F2BFD81E900E54348 /* String+Helpers.swift in Sources */,
 				26CA47242BFE4C1C00E54348 /* OrderDetailView.swift in Sources */,
 				261C21552C08D8E20051AF19 /* WatchTracksProvider.swift in Sources */,

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -2437,6 +2437,7 @@
 		DA706BFB2C80663800E08A5B /* PushNotification.swift in Sources */ = {isa = PBXBuildFile; fileRef = 575472802452185300A94C3C /* PushNotification.swift */; };
 		DA81B4332C8EE5D6000F3466 /* MarkOrderAsReadUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA25ADDC2C86145E00AE81FE /* MarkOrderAsReadUseCase.swift */; };
 		DA81B4342C8EE5D6000F3466 /* MarkOrderAsReadUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA25ADDC2C86145E00AE81FE /* MarkOrderAsReadUseCase.swift */; };
+		DA81B4362C8F2BB8000F3466 /* MarkOrderAsReadUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA25ADDC2C86145E00AE81FE /* MarkOrderAsReadUseCase.swift */; };
 		DABF35272C11B426006AF826 /* PointOfSaleDashboardViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DABF35262C11B426006AF826 /* PointOfSaleDashboardViewModelTests.swift */; };
 		DAD988C62C4A9CF9009DE9E3 /* CartItem+Order.swift in Sources */ = {isa = PBXBuildFile; fileRef = DAD988C52C4A9CF9009DE9E3 /* CartItem+Order.swift */; };
 		DAD988C92C4A9D6C009DE9E3 /* CartItemTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DAD988C82C4A9D6C009DE9E3 /* CartItemTests.swift */; };
@@ -16756,6 +16757,7 @@
 				CC07860526736B6500BA9AC1 /* ErrorTopBannerFactoryTests.swift in Sources */,
 				02490D1E284F3226002096EF /* ProductImagesSaverTests.swift in Sources */,
 				DE5746382B479CB80034B10D /* BlazeBudgetSettingViewModelTests.swift in Sources */,
+				DA81B4362C8F2BB8000F3466 /* MarkOrderAsReadUseCase.swift in Sources */,
 				02A9A496244D84AB00757B99 /* ProductsSortOrderBottomSheetListSelectorCommandTests.swift in Sources */,
 				B9B6DEF1283F8EB100901FB7 /* SitePluginsURLTests.swift in Sources */,
 				D83F5935225B3CDD00626E75 /* DatePickerTableViewCellTests.swift in Sources */,


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #13873
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

As a continuation on https://github.com/woocommerce/woocommerce-ios/pull/13734 this PR adds marking order notification as read on Watch app and in notification extension in a same logic as we do in the app, using the same endpoints but using `NotificationsRemote` directly instead of `NotificationAction` since `NotificationAction` is not available on the watch.

Updates for MarkOrderAsReadUseCase to have two versions of markOrderNoteAsReadIfNeeded, one usses `NotificationsRemote` and the second one uses `NotificationAction`. That way we can have same functionality in the iOS app, notification extension and watchOS app.

Good question would be why not just use `NotificationsRemote` in all places. When we use `NotificationAction` we can see that `NotificationStore` in `synchronizeNotification()` function also calls `updateLocalNotes(with: notes)` and that is a useful addition worth having 2 implementations.

## Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: https://woomobilep2.wordpress.com/2024/05/06/woocommerce-mobile-quality-report-march-april/#comment-12036 -->

General notification opening for the watchOS app and notification extension
- Do this testing on both watch app and notification extension. When testing the notification extension press the notification and check the notification preview is shown correctly.
- Get few new orders for one of the stores you have so it triggers notifications for it. It is important to have more of them so you can open order that is not the last.
- Tap on the notification for the order that was not the last order
- Check that the app opens the proper order
- Tap on the notification for the last order
- Check that the app opens the proper order and that the notification is marked as read also on the web

https://github.com/user-attachments/assets/80865274-ad87-4cee-a45b-ea1f198e3517

![IMG_723E898202D3-1](https://github.com/user-attachments/assets/f0185550-417e-4ddb-ba86-bda2249c8d01)

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

There are no user-facing/UI changes but screenshots from https://github.com/woocommerce/woocommerce-ios/pull/13734 can be looked as a reference.

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [x] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [x] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [x] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on all devices (phone/tablet) and no regressions are added.
