### PR TITLE
Clear card present payment onboarding cache after logging out

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -4,6 +4,7 @@
 20.4
 -----
 
+- [*] Payments: Fixed an issue to ensure the payment onboarding state is reset after logout and login. [https://github.com/woocommerce/woocommerce-ios/pull/13897]
 
 20.3
 -----

--- a/WooCommerce/Classes/Tools/CardPresentPluginsDataProvider.swift
+++ b/WooCommerce/Classes/Tools/CardPresentPluginsDataProvider.swift
@@ -30,16 +30,16 @@ protocol CardPresentPluginsDataProviderProtocol {
 struct CardPresentPluginsDataProvider: CardPresentPluginsDataProviderProtocol {
     private let storageManager: StorageManagerType
     private let stores: StoresManager
-    private let configuration: CardPresentPaymentsConfiguration
+    private let configurationLoader: CardPresentConfigurationLoader
 
     init(
         storageManager: StorageManagerType = ServiceLocator.storageManager,
         stores: StoresManager = ServiceLocator.stores,
-        configuration: CardPresentPaymentsConfiguration
+        configurationLoader: CardPresentConfigurationLoader
     ) {
         self.storageManager = storageManager
         self.stores = stores
-        self.configuration = configuration
+        self.configurationLoader = configurationLoader
     }
 
     private var siteID: Int64? {
@@ -80,7 +80,7 @@ struct CardPresentPluginsDataProvider: CardPresentPluginsDataProviderProtocol {
 
     private func isPluginVersionSupported(plugin: Yosemite.SystemPlugin,
                                           paymentPlugin: CardPresentPaymentsPlugin) -> Bool {
-        guard let pluginSupport = configuration.supportedPluginVersions.first(where: { support in
+        guard let pluginSupport = configurationLoader.configuration.supportedPluginVersions.first(where: { support in
             support.plugin == paymentPlugin
         }) else {
             return false

--- a/WooCommerce/Classes/Tools/CardPresentPluginsDataProvider.swift
+++ b/WooCommerce/Classes/Tools/CardPresentPluginsDataProvider.swift
@@ -32,6 +32,8 @@ struct CardPresentPluginsDataProvider: CardPresentPluginsDataProviderProtocol {
     private let stores: StoresManager
     private let configurationLoader: CardPresentConfigurationLoader
 
+    static let shared = CardPresentPluginsDataProvider(configurationLoader: CardPresentConfigurationLoader(stores: ServiceLocator.stores))
+
     init(
         storageManager: StorageManagerType = ServiceLocator.storageManager,
         stores: StoresManager = ServiceLocator.stores,

--- a/WooCommerce/Classes/ViewModels/CardPresentPayments/PaymentReceiptEmailParameterDeterminer.swift
+++ b/WooCommerce/Classes/ViewModels/CardPresentPayments/PaymentReceiptEmailParameterDeterminer.swift
@@ -11,9 +11,9 @@ protocol ReceiptEmailParameterDeterminer {
 ///
 struct PaymentReceiptEmailParameterDeterminer: ReceiptEmailParameterDeterminer {
     private let cardPresentPluginsDataProvider: CardPresentPluginsDataProviderProtocol
-    private static let defaultConfiguration = CardPresentConfigurationLoader(stores: ServiceLocator.stores).configuration
+    private static let defaultConfigurationLoader = CardPresentConfigurationLoader(stores: ServiceLocator.stores)
 
-    init(cardPresentPluginsDataProvider: CardPresentPluginsDataProviderProtocol = CardPresentPluginsDataProvider(configuration: Self.defaultConfiguration)) {
+    init(cardPresentPluginsDataProvider: CardPresentPluginsDataProviderProtocol = CardPresentPluginsDataProvider(configurationLoader: Self.defaultConfigurationLoader)) {
         self.cardPresentPluginsDataProvider = cardPresentPluginsDataProvider
     }
 

--- a/WooCommerce/Classes/ViewModels/CardPresentPayments/PaymentReceiptEmailParameterDeterminer.swift
+++ b/WooCommerce/Classes/ViewModels/CardPresentPayments/PaymentReceiptEmailParameterDeterminer.swift
@@ -11,9 +11,8 @@ protocol ReceiptEmailParameterDeterminer {
 ///
 struct PaymentReceiptEmailParameterDeterminer: ReceiptEmailParameterDeterminer {
     private let cardPresentPluginsDataProvider: CardPresentPluginsDataProviderProtocol
-    private static let defaultConfigurationLoader = CardPresentConfigurationLoader(stores: ServiceLocator.stores)
 
-    init(cardPresentPluginsDataProvider: CardPresentPluginsDataProviderProtocol = CardPresentPluginsDataProvider(configurationLoader: Self.defaultConfigurationLoader)) {
+    init(cardPresentPluginsDataProvider: CardPresentPluginsDataProviderProtocol = CardPresentPluginsDataProvider.shared) {
         self.cardPresentPluginsDataProvider = cardPresentPluginsDataProvider
     }
 

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/CardPresentPaymentsOnboardingUseCase.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Settings/In-Person Payments/CardPresentPaymentsOnboardingUseCase.swift
@@ -77,7 +77,7 @@ final class CardPresentPaymentsOnboardingUseCase: CardPresentPaymentsOnboardingU
         self.storageManager = storageManager
         self.stores = stores
         self.configurationLoader = .init(stores: stores)
-        self.cardPresentPluginsDataProvider = .init(storageManager: storageManager, stores: stores, configuration: configurationLoader.configuration)
+        self.cardPresentPluginsDataProvider = .init(storageManager: storageManager, stores: stores, configurationLoader: configurationLoader)
         self.cardPresentPaymentOnboardingStateCache = cardPresentPaymentOnboardingStateCache
         self.analytics = analytics
 

--- a/WooCommerce/Classes/Yosemite/DefaultStoresManager.swift
+++ b/WooCommerce/Classes/Yosemite/DefaultStoresManager.swift
@@ -41,6 +41,10 @@ class DefaultStoresManager: StoresManager {
     ///
     private let notificationCenter: NotificationCenter
 
+    /// Card present payment onboarding state
+    ///
+    private let cardPresentPaymentOnboardingStateCache: CardPresentPaymentOnboardingStateCache
+
     /// SessionManager: Persistent Storage for Session-Y Properties.
     /// This property is thread safe
     private(set) var sessionManager: SessionManagerProtocol {
@@ -120,11 +124,13 @@ class DefaultStoresManager: StoresManager {
     ///
     init(sessionManager: SessionManagerProtocol,
          notificationCenter: NotificationCenter = .default,
-         defaults: UserDefaults = .standard) {
+         defaults: UserDefaults = .standard,
+         cardPresentPaymentOnboardingStateCache: CardPresentPaymentOnboardingStateCache = .shared) {
         _sessionManager = sessionManager
         self.state = AuthenticatedState(sessionManager: sessionManager) ?? DeauthenticatedState()
         self.notificationCenter = notificationCenter
         self.defaults = defaults
+        self.cardPresentPaymentOnboardingStateCache = cardPresentPaymentOnboardingStateCache
 
         isLoggedIn = isAuthenticated
     }
@@ -251,6 +257,8 @@ class DefaultStoresManager: StoresManager {
         ServiceLocator.productImageUploader.reset()
 
         updateAndReloadWidgetInformation(with: nil)
+
+        cardPresentPaymentOnboardingStateCache.invalidate()
 
         NotificationCenter.default.post(name: .logOutEventReceived, object: nil)
 

--- a/WooCommerce/WooCommerceTests/Tools/CardPresentPluginsDataProviderTests.swift
+++ b/WooCommerce/WooCommerceTests/Tools/CardPresentPluginsDataProviderTests.swift
@@ -6,7 +6,7 @@ final class CardPresentPluginsDataProviderTests: XCTestCase {
     private var sut: CardPresentPluginsDataProvider!
     private var storageManager: MockStorageManager!
     private var stores: MockStoresManager!
-    let configuration = CardPresentConfigurationLoader(stores: ServiceLocator.stores).configuration
+    private let configurationLoader = CardPresentConfigurationLoader(stores: ServiceLocator.stores)
 
     override func setUp() {
         super.setUp()
@@ -16,7 +16,7 @@ final class CardPresentPluginsDataProviderTests: XCTestCase {
 
         sut = CardPresentPluginsDataProvider(storageManager: storageManager,
                                              stores: stores,
-                                             configuration: configuration)
+                                             configurationLoader: configurationLoader)
     }
 
     override func tearDown() {

--- a/WooCommerce/WooCommerceTests/Yosemite/StoresManagerTests.swift
+++ b/WooCommerce/WooCommerceTests/Yosemite/StoresManagerTests.swift
@@ -144,6 +144,18 @@ final class StoresManagerTests: XCTestCase {
         XCTAssertEqual(isLoggedInValues, [false, true, false])
     }
 
+    /// Verifies that `deauthenticate` invalidates card present payment onboarding state cache.
+    ///
+    func testDeauthenticate_invalidates_card_present_payment_onboarding_state_cache() {
+        let cardPresentPaymentOnboardingStateCache = MockCardPresentPaymentOnboardingStateCache()
+        let manager = DefaultStoresManager(sessionManager: SessionManager.testingInstance,
+                                           notificationCenter: MockNotificationCenter.testingInstance,
+                                           cardPresentPaymentOnboardingStateCache: cardPresentPaymentOnboardingStateCache)
+
+        manager.deauthenticate()
+
+        XCTAssertTrue(cardPresentPaymentOnboardingStateCache.invalidateCalled)
+    }
 
     /// Verifies that `authenticate(username: authToken:)` persists the Credentials in the Keychain Storage.
     ///
@@ -530,4 +542,12 @@ final class MockSessionManager: SessionManagerProtocol {
 
 private class MockNotificationCenter: NotificationCenter {
     static var testingInstance = MockNotificationCenter()
+}
+
+final class MockCardPresentPaymentOnboardingStateCache: CardPresentPaymentOnboardingStateCache {
+    var invalidateCalled: Bool = false
+
+    override func invalidate() {
+        invalidateCalled = true
+    }
 }


### PR DESCRIPTION
When we onboard card present payments, log out, and log in again, an outdated but invalid card present payment cache is still available.

<!-- Remember about a good descriptive title. -->

Closes: #13842
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

When testing POS, we noticed that connection to the reader fails with 2 payment providers and using POS after logging out and logging in.

It happens because `CardPresentPaymentOnboardingStateCache` is not cleared after logging out. It's only cleared after switching stores.

## Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->

1. Log into an account with 2 payment providers (Stripe, WooPayments)
2. Go to menu
3. Confirm no POS option appears
4. Open Payment menu
5. Finalize onboarding by selecting WooPayments as the main provider
6. Confirm POS option appears
7. Settings -> Log out
8. Log into the same account
9. Confirm no POS option appears, and onboarding has to be again finalized in Payments menu

## Testing Information

Tested on iOS 17:
- A site with two payment providers
- A site with one payment provider
- Switching sites
- Killing & relaunching the app to confirm that the cache remains
- Went through the cases in the code when deauthenticate() is called, to confirm that this is the main method that is called in various unhappy path corner-cases when users are logged out

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

https://github.com/user-attachments/assets/98406aa9-b0d8-4404-8960-8d71c2610c87

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [x] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [x] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [x] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on all devices (phone/tablet) and no regressions are added.