### PR TITLE
Custom Fields: Local editing handling

### DIFF
--- a/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsViewModel.swift
+++ b/WooCommerce/Classes/ViewModels/Order Details/OrderDetailsViewModel.swift
@@ -487,7 +487,7 @@ extension OrderDetailsViewModel {
             let customFieldsView = UIHostingController(
                 rootView: CustomFieldsListView(
                     isEditable: featureFlagService.isFeatureFlagEnabled(.viewEditCustomFieldsInProductsAndOrders),
-                    customFields: customFields))
+                    viewModel: CustomFieldsListViewModel(customFields: customFields)))
             viewController.present(customFieldsView, animated: true)
         case .seeReceipt:
             let countryCode = configurationLoader.configuration.countryCode

--- a/WooCommerce/Classes/ViewRelated/Custom Fields/CustomFieldEditorView.swift
+++ b/WooCommerce/Classes/ViewRelated/Custom Fields/CustomFieldEditorView.swift
@@ -112,7 +112,7 @@ struct CustomFieldEditorView: View {
                     Button {
                         saveChanges()
                     } label: {
-                        Text("Save") // todo-13493: set String to be translatable
+                        Text("Done") // todo-13493: set String to be translatable
                     }
                     .disabled(!isModified)
 

--- a/WooCommerce/Classes/ViewRelated/Custom Fields/CustomFieldsListView.swift
+++ b/WooCommerce/Classes/ViewRelated/Custom Fields/CustomFieldsListView.swift
@@ -3,15 +3,22 @@ import SwiftUI
 struct CustomFieldsListView: View {
     @Environment(\.presentationMode) var presentationMode
 
+    @ObservedObject private var viewModel: CustomFieldsListViewModel
+
     let isEditable: Bool
-    let customFields: [CustomFieldViewModel]
+    
+    init(isEditable: Bool,
+         viewModel: CustomFieldsListViewModel) {
+        self.isEditable = isEditable
+        self.viewModel = viewModel
+    }
 
     var body: some View {
         NavigationView {
             GeometryReader { geometry in
                 ScrollView {
                     VStack(alignment: .leading) {
-                        ForEach(customFields) { customField in
+                        ForEach(viewModel.customFields) { customField in
                             if isEditable {
                                 NavigationLink(destination: CustomFieldEditorView(key: customField.title,
                                                                                   value: customField.content)
@@ -150,10 +157,12 @@ struct OrderCustomFieldsDetails_Previews: PreviewProvider {
     static var previews: some View {
         CustomFieldsListView(
             isEditable: false,
-            customFields: [
-                CustomFieldViewModel(id: 0, title: "First Title", content: "First Content"),
-                CustomFieldViewModel(id: 1, title: "Second Title", content: "Second Content", contentURL: URL(string: "https://woocommerce.com/"))
-            ])
+            viewModel: CustomFieldsListViewModel(
+                customFields: [
+                    CustomFieldViewModel(id: 0, title: "First Title", content: "First Content"),
+                    CustomFieldViewModel(id: 1, title: "Second Title", content: "Second Content", contentURL: URL(string: "https://woocommerce.com/"))
+                ])
+            )
     }
 }
 

--- a/WooCommerce/Classes/ViewRelated/Custom Fields/CustomFieldsListView.swift
+++ b/WooCommerce/Classes/ViewRelated/Custom Fields/CustomFieldsListView.swift
@@ -18,22 +18,22 @@ struct CustomFieldsListView: View {
             GeometryReader { geometry in
                 ScrollView {
                     VStack(alignment: .leading) {
-                        ForEach(viewModel.customFields) { customField in
+                        ForEach(viewModel.displayedItems) { customField in
                             if isEditable {
-                                NavigationLink(destination: CustomFieldEditorView(key: customField.title,
-                                                                                  value: customField.content)
+                                NavigationLink(destination: CustomFieldEditorView(key: customField.key,
+                                                                                  value: customField.value)
                                 ) {
                                     CustomFieldRow(isEditable: true,
-                                                   title: customField.title,
-                                                   content: customField.content,
-                                                   contentURL: customField.contentURL)
+                                                   title: customField.key,
+                                                   content: customField.value,
+                                                   contentURL: nil)
                                 }
                             }
                             else {
                                 CustomFieldRow(isEditable: false,
-                                               title: customField.title,
-                                               content: customField.content,
-                                               contentURL: customField.contentURL)
+                                               title: customField.key,
+                                               content: customField.value,
+                                               contentURL: nil)
                             }
 
                             Divider()
@@ -60,6 +60,7 @@ struct CustomFieldsListView: View {
                             } label: {
                                 Text("Save") // todo-13493: set String to be translatable
                             }
+                            .disabled(!viewModel.pendingChanges.hasChanges)
                             Button(action: {
                                 // todo-13493: add addition handling
                             }, label: {

--- a/WooCommerce/Classes/ViewRelated/Custom Fields/CustomFieldsListView.swift
+++ b/WooCommerce/Classes/ViewRelated/Custom Fields/CustomFieldsListView.swift
@@ -18,7 +18,7 @@ struct CustomFieldsListView: View {
             GeometryReader { geometry in
                 ScrollView {
                     VStack(alignment: .leading) {
-                        ForEach(viewModel.displayedItems) { customField in
+                        ForEach(viewModel.combinedList) { customField in
                             if isEditable {
                                 NavigationLink(destination: CustomFieldEditorView(key: customField.key,
                                                                                   value: customField.value)

--- a/WooCommerce/Classes/ViewRelated/Custom Fields/CustomFieldsListView.swift
+++ b/WooCommerce/Classes/ViewRelated/Custom Fields/CustomFieldsListView.swift
@@ -60,7 +60,7 @@ struct CustomFieldsListView: View {
                             } label: {
                                 Text("Save") // todo-13493: set String to be translatable
                             }
-                            .disabled(!viewModel.pendingChanges.hasChanges)
+                            .disabled(!viewModel.hasChanges)
                             Button(action: {
                                 // todo-13493: add addition handling
                             }, label: {

--- a/WooCommerce/Classes/ViewRelated/Custom Fields/CustomFieldsListView.swift
+++ b/WooCommerce/Classes/ViewRelated/Custom Fields/CustomFieldsListView.swift
@@ -6,7 +6,7 @@ struct CustomFieldsListView: View {
     @ObservedObject private var viewModel: CustomFieldsListViewModel
 
     let isEditable: Bool
-    
+
     init(isEditable: Bool,
          viewModel: CustomFieldsListViewModel) {
         self.isEditable = isEditable
@@ -52,6 +52,23 @@ struct CustomFieldsListView: View {
                         }, label: {
                             Image(uiImage: .closeButton)
                         })
+                    }
+                    ToolbarItem(placement: .navigationBarTrailing) {
+                        HStack {
+                            Button {
+                                // todo-13493: add save handling
+                            } label: {
+                                Text("Save") // todo-13493: set String to be translatable
+                            }
+                            Button(action: {
+                                // todo-13493: add addition handling
+                            }, label: {
+                                Image(systemName: "plus")
+                                    .renderingMode(.template)
+                            })
+
+                        }
+                        .renderedIf(isEditable)
                     }
                 }
                 .navigationTitle(Localization.title)

--- a/WooCommerce/Classes/ViewRelated/Custom Fields/CustomFieldsListViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Custom Fields/CustomFieldsListViewModel.swift
@@ -47,7 +47,7 @@ extension CustomFieldsListViewModel {
             // For when editing an already edited field
             if let editedIndex = editedFields.firstIndex(where: { $0.id == oldField.id }) {
                 editedFields[editedIndex] = newField
-            } else { 
+            } else {
                 // For the first time a field is edited
                 editedFields.append(newField)
             }

--- a/WooCommerce/Classes/ViewRelated/Custom Fields/CustomFieldsListViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Custom Fields/CustomFieldsListViewModel.swift
@@ -1,15 +1,75 @@
 import Foundation
 
 final class CustomFieldsListViewModel: ObservableObject {
-    let customFields: [CustomFieldViewModel]
+    private let customFields: [CustomFieldViewModel]
 
     var shouldShowErrorState: Bool {
         savingError != nil
     }
 
     @Published private(set) var savingError: Error?
+    @Published var pendingChanges = PendingChanges()
+    @Published var displayedItems: [CustomFieldUI]
+
 
     init(customFields: [CustomFieldViewModel]) {
         self.customFields = customFields
+
+        self.displayedItems = customFields.map { item in
+            CustomFieldUI(key: item.content, value: item.title, id: item.id)
+        }
+    }
+}
+
+private extension CustomFieldsListViewModel {
+    func editField(_ field: CustomFieldUI) {
+        if let index = pendingChanges.editedFields.firstIndex(where: { $0.id == field.id }) {
+            pendingChanges.editedFields[index] = field
+            updateDisplayedItems()
+        }
+    }
+
+    func addField(_ field: CustomFieldUI) {
+        pendingChanges.addedFields.append(field)
+        updateDisplayedItems()
+    }
+
+    func updateDisplayedItems() {
+        var updatedItems = displayedItems
+
+        // Apply edits
+        for editedField in pendingChanges.editedFields {
+            if let index = updatedItems.firstIndex(where: { $0.id == editedField.id }) {
+                updatedItems[index] = CustomFieldUI(key: editedField.key, value: editedField.value, id: editedField.id)
+            }
+        }
+
+        // Add new fields
+        updatedItems.append(contentsOf: pendingChanges.addedFields)
+
+        displayedItems = updatedItems
+    }
+}
+
+extension CustomFieldsListViewModel {
+    struct PendingChanges {
+        var editedFields: [CustomFieldUI] = []
+        var addedFields: [CustomFieldUI] = []
+
+        var hasChanges: Bool {
+            !editedFields.isEmpty || !addedFields.isEmpty
+        }
+    }
+
+    struct CustomFieldUI: Identifiable {
+        let key: String
+        let value: String
+        let id: Int64?
+
+        init(key: String, value: String, id: Int64? = nil) {
+            self.key = key
+            self.value = value
+            self.id = id
+        }
     }
 }

--- a/WooCommerce/Classes/ViewRelated/Custom Fields/CustomFieldsListViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Custom Fields/CustomFieldsListViewModel.swift
@@ -1,0 +1,15 @@
+import Foundation
+
+final class CustomFieldsListViewModel: ObservableObject {
+    let customFields: [CustomFieldViewModel]
+
+    var shouldShowErrorState: Bool {
+        savingError != nil
+    }
+
+    @Published private(set) var savingError: Error?
+
+    init(customFields: [CustomFieldViewModel]) {
+        self.customFields = customFields
+    }
+}

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -1708,6 +1708,7 @@
 		86E40AED2B597DEC00990365 /* BlazeCampaignCreationCoordinatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 86E40AEC2B597DEC00990365 /* BlazeCampaignCreationCoordinatorTests.swift */; };
 		86F0896F2B307D7E00D668A1 /* ThemesPreviewViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 86F0896E2B307D7E00D668A1 /* ThemesPreviewViewModelTests.swift */; };
 		86F9D3642C897FFE00B1835B /* CustomFieldEditorView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 86F9D3632C897FFE00B1835B /* CustomFieldEditorView.swift */; };
+		86F9D3662C8F12E200B1835B /* CustomFieldsListViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 86F9D3652C8F12E200B1835B /* CustomFieldsListViewModel.swift */; };
 		8CD41D4A21F8A7E300CF3C2B /* RELEASE-NOTES.txt in Resources */ = {isa = PBXBuildFile; fileRef = 8CD41D4921F8A7E300CF3C2B /* RELEASE-NOTES.txt */; };
 		933A27372222354600C2143A /* Logging.swift in Sources */ = {isa = PBXBuildFile; fileRef = 933A27362222354600C2143A /* Logging.swift */; };
 		934CB123224EAB150005CCB9 /* main.swift in Sources */ = {isa = PBXBuildFile; fileRef = 934CB122224EAB150005CCB9 /* main.swift */; };
@@ -4696,6 +4697,7 @@
 		86E40AEC2B597DEC00990365 /* BlazeCampaignCreationCoordinatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BlazeCampaignCreationCoordinatorTests.swift; sourceTree = "<group>"; };
 		86F0896E2B307D7E00D668A1 /* ThemesPreviewViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ThemesPreviewViewModelTests.swift; sourceTree = "<group>"; };
 		86F9D3632C897FFE00B1835B /* CustomFieldEditorView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomFieldEditorView.swift; sourceTree = "<group>"; };
+		86F9D3652C8F12E200B1835B /* CustomFieldsListViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomFieldsListViewModel.swift; sourceTree = "<group>"; };
 		8A659E65308A3D9DD79A95F9 /* Pods-WooCommerceTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-WooCommerceTests.release.xcconfig"; path = "../Pods/Target Support Files/Pods-WooCommerceTests/Pods-WooCommerceTests.release.xcconfig"; sourceTree = "<group>"; };
 		8CA4F6DD220B257000A47B5D /* WooCommerce.debug.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; name = WooCommerce.debug.xcconfig; path = ../config/WooCommerce.debug.xcconfig; sourceTree = "<group>"; };
 		8CA4F6DE220B257000A47B5D /* WooCommerce.release.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; name = WooCommerce.release.xcconfig; path = ../config/WooCommerce.release.xcconfig; sourceTree = "<group>"; };
@@ -10497,6 +10499,7 @@
 				B626C71A287659D60083820C /* CustomFieldsListView.swift */,
 				B6C838DD28793B3A003AB786 /* CustomFieldViewModel.swift */,
 				86F9D3632C897FFE00B1835B /* CustomFieldEditorView.swift */,
+				86F9D3652C8F12E200B1835B /* CustomFieldsListViewModel.swift */,
 			);
 			path = "Custom Fields";
 			sourceTree = "<group>";
@@ -15716,6 +15719,7 @@
 				E11228BC2707161E004E9F2D /* CardPresentModalUpdateFailed.swift in Sources */,
 				B541B2152189EEA1008FE7C1 /* Scanner+Helpers.swift in Sources */,
 				4512054F2464741B005D68DE /* ProductVisibility.swift in Sources */,
+				86F9D3662C8F12E200B1835B /* CustomFieldsListViewModel.swift in Sources */,
 				45A4221A24ACC79C003B1E4C /* SwitchStoreNoticePresenter.swift in Sources */,
 				45455EFA26580B5D00BBB0C4 /* ShippingLabelCarrierRowViewModel.swift in Sources */,
 				025FDD3423717D4900824006 /* AztecEditorViewController.swift in Sources */,

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -1700,6 +1700,7 @@
 		86967D832B4E3EC300C20CA8 /* BlazeAdUrlParameter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 86967D822B4E3EC300C20CA8 /* BlazeAdUrlParameter.swift */; };
 		8697AFBD2B60F56A00EFAF21 /* BlazeAdDestinationSettingViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8697AFBC2B60F56A00EFAF21 /* BlazeAdDestinationSettingViewModelTests.swift */; };
 		8697AFBF2B622DEA00EFAF21 /* BlazeAddParameterViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8697AFBE2B622DEA00EFAF21 /* BlazeAddParameterViewModelTests.swift */; };
+		869C2A9E2C900A1900DDEE13 /* CustomFieldsListViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 869C2A9D2C900A1900DDEE13 /* CustomFieldsListViewModelTests.swift */; };
 		86A4EBBD2B2F1306008011F5 /* ThemesPreviewViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 86A4EBBC2B2F1306008011F5 /* ThemesPreviewViewModel.swift */; };
 		86B3E2552C6B1F160002420B /* HelpAndSupportViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 86B3E2542C6B1F160002420B /* HelpAndSupportViewModel.swift */; };
 		86B3E2572C6B249C0002420B /* HelpAndSupportViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 86B3E2562C6B249C0002420B /* HelpAndSupportViewModelTests.swift */; };
@@ -4690,6 +4691,7 @@
 		86967D822B4E3EC300C20CA8 /* BlazeAdUrlParameter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BlazeAdUrlParameter.swift; sourceTree = "<group>"; };
 		8697AFBC2B60F56A00EFAF21 /* BlazeAdDestinationSettingViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BlazeAdDestinationSettingViewModelTests.swift; sourceTree = "<group>"; };
 		8697AFBE2B622DEA00EFAF21 /* BlazeAddParameterViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BlazeAddParameterViewModelTests.swift; sourceTree = "<group>"; };
+		869C2A9D2C900A1900DDEE13 /* CustomFieldsListViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomFieldsListViewModelTests.swift; sourceTree = "<group>"; };
 		86A4EBBC2B2F1306008011F5 /* ThemesPreviewViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ThemesPreviewViewModel.swift; sourceTree = "<group>"; };
 		86B3E2542C6B1F160002420B /* HelpAndSupportViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HelpAndSupportViewModel.swift; sourceTree = "<group>"; };
 		86B3E2562C6B249C0002420B /* HelpAndSupportViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HelpAndSupportViewModelTests.swift; sourceTree = "<group>"; };
@@ -9698,6 +9700,7 @@
 			isa = PBXGroup;
 			children = (
 				CC5BA5F4287EDC900072F307 /* CustomFieldViewModelTests.swift */,
+				869C2A9D2C900A1900DDEE13 /* CustomFieldsListViewModelTests.swift */,
 			);
 			path = "Custom Fields";
 			sourceTree = "<group>";
@@ -16838,6 +16841,7 @@
 				019C5EB22C5171E6005B82D3 /* MockItemListViewModel.swift in Sources */,
 				021EBB382A3076F4003634CA /* BlazeEligibilityCheckerTests.swift in Sources */,
 				B5DBF3C320E1484400B53AED /* StoresManagerTests.swift in Sources */,
+				869C2A9E2C900A1900DDEE13 /* CustomFieldsListViewModelTests.swift in Sources */,
 				DE3404EA28B4C1D000CF0D97 /* NonAtomicSiteViewModelTests.swift in Sources */,
 				02E493EF245C1087000AEA9E /* ProductFormBottomSheetListSelectorCommandTests.swift in Sources */,
 				B90DACC22A31BBC800365897 /* BarcodeSKUScannerProductFinderTests.swift in Sources */,

--- a/WooCommerce/WooCommerceTests/ViewRelated/Custom Fields/CustomFieldsListViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Custom Fields/CustomFieldsListViewModelTests.swift
@@ -1,0 +1,107 @@
+import XCTest
+@testable import WooCommerce
+
+final class CustomFieldsListViewModelTests: XCTestCase {
+
+    private var viewModel: CustomFieldsListViewModel!
+
+    override func setUp() {
+        super.setUp()
+        let customFields = [
+            CustomFieldViewModel(id: 1, title: "Key1", content: "Value1"),
+            CustomFieldViewModel(id: 2, title: "Key2", content: "Value2")
+        ]
+        viewModel = CustomFieldsListViewModel(customFields: customFields)
+    }
+
+    override func tearDown() {
+        viewModel = nil
+        super.tearDown()
+    }
+
+    func test_given_initializedViewModel_then_displayedItemsMatchInitialCustomFields() {
+        // Given: The viewModel is initialized with two custom fields (in setUp)
+
+        // When: No additional action needed, we're testing the initial state
+
+        // Then: The displayed items should match the initial custom fields
+        XCTAssertEqual(viewModel.combinedList.count, 2)
+        XCTAssertEqual(viewModel.combinedList[0].key, "Key1")
+        XCTAssertEqual(viewModel.combinedList[0].value, "Value1")
+        XCTAssertEqual(viewModel.combinedList[0].id, 1)
+        XCTAssertEqual(viewModel.combinedList[1].key, "Key2")
+        XCTAssertEqual(viewModel.combinedList[1].value, "Value2")
+        XCTAssertEqual(viewModel.combinedList[1].id, 2)
+    }
+
+    func test_given_existingField_when_editFieldCalled_then_displayedItemsAndPendingChangesAreUpdated() {
+        // Given: A custom field UI to edit an existing field
+        let editedField = CustomFieldsListViewModel.CustomFieldUI(key: "EditedKey1", value: "EditedValue1", id: 1)
+
+        // When: Editing the field
+        viewModel.editField(at: 0, newField: editedField)
+
+        // Then: The pending changes and displayed items should be updated
+        XCTAssertEqual(viewModel.pendingChanges.editedFields.count, 1)
+
+
+        // Check that the number of displayed items are remains the same as before
+        XCTAssertEqual(viewModel.combinedList.count, 2)
+    }
+
+    func test_given_newField_when_addFieldCalled_then_displayedItemsAndPendingChangesAreUpdated() {
+        // Given: A new custom field UI to add
+        let newField = CustomFieldsListViewModel.CustomFieldUI(key: "NewKey", value: "NewValue")
+
+        // When: Adding the new field
+        viewModel.addField(newField)
+
+        // Then: The pending changes and displayed items should be updated
+        XCTAssertEqual(viewModel.pendingChanges.addedFields.count, 1)
+        XCTAssertEqual(viewModel.combinedList.count, 3)
+        XCTAssertEqual(viewModel.combinedList.last?.key, "NewKey")
+        XCTAssertEqual(viewModel.combinedList.last?.value, "NewValue")
+    }
+
+    func test_given_editedAndNewFields_when_updatingDisplayedItems_then_changesAreReflected() {
+        // Given: An edited field and a new field
+        let editedField = CustomFieldsListViewModel.CustomFieldUI(key: "EditedKey1", value: "EditedValue1", id: 1)
+        let newField = CustomFieldsListViewModel.CustomFieldUI(key: "NewKey", value: "NewValue")
+
+        // When: Editing and adding fields
+        viewModel.editField(at: 0, newField: editedField)
+        viewModel.addField(newField)
+
+        // Then: The displayed items should reflect both the edited and added fields
+        XCTAssertEqual(viewModel.combinedList.count, 3)
+        XCTAssertEqual(viewModel.combinedList[0].key, "EditedKey1")
+        XCTAssertEqual(viewModel.combinedList[0].value, "EditedValue1")
+        XCTAssertEqual(viewModel.combinedList[2].key, "NewKey")
+        XCTAssertEqual(viewModel.combinedList[2].value, "NewValue")
+    }
+
+    func test_given_variousChanges_when_pendingChangesUpdated_then_hasChangesReflectsCorrectState() {
+        // Given: Initial state with no changes
+        XCTAssertFalse(viewModel.pendingChanges.hasChanges)
+
+        // When: Editing a field
+        let editedField = CustomFieldsListViewModel.CustomFieldUI(key: "EditedKey1", value: "EditedValue1", id: 1)
+        viewModel.editField(at: 0, newField: editedField)
+
+        // Then: hasChanges should be true
+        XCTAssertTrue(viewModel.pendingChanges.hasChanges)
+
+        // When: Resetting pending changes
+        viewModel.pendingChanges = CustomFieldsListViewModel.PendingChanges()
+
+        // Then: hasChanges should be false
+        XCTAssertFalse(viewModel.pendingChanges.hasChanges)
+
+        // When: Adding a new field
+        let newField = CustomFieldsListViewModel.CustomFieldUI(key: "NewKey", value: "NewValue")
+        viewModel.addField(newField)
+
+        // Then: hasChanges should be true
+        XCTAssertTrue(viewModel.pendingChanges.hasChanges)
+    }
+}

--- a/WooCommerce/WooCommerceTests/ViewRelated/Custom Fields/CustomFieldsListViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Custom Fields/CustomFieldsListViewModelTests.swift
@@ -41,12 +41,10 @@ final class CustomFieldsListViewModelTests: XCTestCase {
         // When: Editing the field
         viewModel.editField(at: 0, newField: editedField)
 
-        // Then: The pending changes and displayed items should be updated
-        XCTAssertEqual(viewModel.pendingChanges.editedFields.count, 1)
-
-
-        // Check that the number of displayed items are remains the same as before
+        // Then: The number of displayed items are remains the same as before and the value is edited correctly
         XCTAssertEqual(viewModel.combinedList.count, 2)
+        XCTAssertEqual(viewModel.combinedList[0].key, "EditedKey1")
+        XCTAssertEqual(viewModel.combinedList[0].value, "EditedValue1")
     }
 
     func test_given_newField_when_addFieldCalled_then_displayedItemsAndPendingChangesAreUpdated() {
@@ -57,7 +55,6 @@ final class CustomFieldsListViewModelTests: XCTestCase {
         viewModel.addField(newField)
 
         // Then: The pending changes and displayed items should be updated
-        XCTAssertEqual(viewModel.pendingChanges.addedFields.count, 1)
         XCTAssertEqual(viewModel.combinedList.count, 3)
         XCTAssertEqual(viewModel.combinedList.last?.key, "NewKey")
         XCTAssertEqual(viewModel.combinedList.last?.value, "NewValue")
@@ -82,26 +79,20 @@ final class CustomFieldsListViewModelTests: XCTestCase {
 
     func test_given_variousChanges_when_pendingChangesUpdated_then_hasChangesReflectsCorrectState() {
         // Given: Initial state with no changes
-        XCTAssertFalse(viewModel.pendingChanges.hasChanges)
+        XCTAssertFalse(viewModel.hasChanges)
 
         // When: Editing a field
         let editedField = CustomFieldsListViewModel.CustomFieldUI(key: "EditedKey1", value: "EditedValue1", id: 1)
         viewModel.editField(at: 0, newField: editedField)
 
         // Then: hasChanges should be true
-        XCTAssertTrue(viewModel.pendingChanges.hasChanges)
-
-        // When: Resetting pending changes
-        viewModel.pendingChanges = CustomFieldsListViewModel.PendingChanges()
-
-        // Then: hasChanges should be false
-        XCTAssertFalse(viewModel.pendingChanges.hasChanges)
+        XCTAssertTrue(viewModel.hasChanges)
 
         // When: Adding a new field
         let newField = CustomFieldsListViewModel.CustomFieldUI(key: "NewKey", value: "NewValue")
         viewModel.addField(newField)
 
         // Then: hasChanges should be true
-        XCTAssertTrue(viewModel.pendingChanges.hasChanges)
+        XCTAssertTrue(viewModel.hasChanges)
     }
 }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of: #13493

Please do not merge until target is `trunk`
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

The flow for editing/adding/deleting custom fields can be described as follows:


1. Each item in the **Custom Fields List** screen can open the **Custom Field Editor** screen. In the editor, merchants can change things and then tap "Done" when they're done editing. Doing so will return them to the list screen and the change will be shown.
2. Merchant can also delete a field from its Custom Field Editor screen. This removes the field from the list screen.
3. **Custom Fields List** also has an add button that opens the editor, then merchant can also tap "Done" to keep the change. This adds a field to the list screen.
4. All changes from edit/delete/add actions above are still pending. The **Custom Fields List** has a "Save" button, which acts as the only way to do remote API call to save. It will save all existing changes at once, matching the behavior in core.

This PR handles the local editing behavior, by adding these:
1. `CustomFieldsListViewModel` which handles the business logic.
2. The viewmodel contains `editedFields` and `addedFields` to store the pending edit and addition. It also has `combinedList` which is an array of the latest combined changes. Depending on the remote call design, any of these can be used to do the call.
3. The viewmodel has `editField()` and `addField()` functions that can later be used when editing or adding a field.
4. Unit tests for the viewmodel.

Not in this PR and will be added separately:
1. Handling for deletion.
2. UI functionality for editing or adding field.
3. UI functionality for remote saving

## Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->

The handling is not used anywhere in the app yet, so for now just check the code and ensure the unit tests also passes.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [ ] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [ ] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [ ] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on all devices (phone/tablet) and no regressions are added.