### PR TITLE
[Order Tracking] Use SF Symbol for the barcode

### DIFF
--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipment Tracking Section/Add Tracking/ManualTrackingViewController.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipment Tracking Section/Add Tracking/ManualTrackingViewController.swift
@@ -271,12 +271,8 @@ extension ManualTrackingViewController: UITableViewDataSource {
     }
 
     private func configureTrackingNumberScanAction(on cell: TitleAndEditableValueTableViewCell) {
-        guard let icon = UIImage(named: "icon-scan") else {
-            return
-        }
-
         let actionButton = UIButton(type: .detailDisclosure)
-        actionButton.applyIconButtonStyle(icon: icon)
+        actionButton.applyIconButtonStyle(icon: .scanImage)
         actionButton.on(.touchUpInside) { [weak self, weak cell] sender in
             self?.present(ScannerContainerViewController(navigationTitle: Localization.title,
                                                          instructionText: Localization.instructionText,


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
With this PR we update the barcode icon to use the SF-Symbol

## Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->
With [WC Shipment Tracking](https://woocommerce.com/products/shipment-tracking/) installed

1. Go to Orders
2. Go to an existing order details that contains products other than virtual
3. Tap on Add Tracking
4. See the updated barcode scanner button SF-Symbol

## Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->
<img src="https://github.com/user-attachments/assets/e0fc2e0b-d825-4cad-b38f-42d8cbd557a8" width=375>

---
- [X] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [X] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [X] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [X] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on all devices (phone/tablet) and no regressions are added.