### PR TITLE
[Woo POS] Keep simple products banner visible while pull to refresh

### DIFF
--- a/WooCommerce/Classes/POS/Presentation/ItemListView.swift
+++ b/WooCommerce/Classes/POS/Presentation/ItemListView.swift
@@ -4,6 +4,7 @@ import protocol Yosemite.POSItem
 struct ItemListView: View {
     @ObservedObject var viewModel: ItemListViewModel
     @Environment(\.floatingControlAreaSize) var floatingControlAreaSize: CGSize
+    @Environment(\.dynamicTypeSize) private var dynamicTypeSize
 
     init(viewModel: ItemListViewModel) {
         self.viewModel = viewModel
@@ -49,9 +50,9 @@ private extension ItemListView {
                     .padding(.trailing, Constants.infoIconPadding)
                 }
             }
-            if viewModel.shouldShowHeaderBanner {
+            if !dynamicTypeSize.isAccessibilitySize, viewModel.shouldShowHeaderBanner {
                 bannerCardView
-                    .padding(.bottom, Constants.bannerCardPadding)
+                    .padding(.horizontal, Constants.bannerCardPadding)
             }
         }
     }
@@ -106,13 +107,16 @@ private extension ItemListView {
         .onTapGesture {
             viewModel.simpleProductsInfoButtonTapped()
         }
-        .padding(.horizontal, Constants.bannerCardPadding)
+        .padding(.bottom, Constants.bannerCardPadding)
     }
 
     @ViewBuilder
     func listView(_ items: [POSItem]) -> some View {
         ScrollView {
             VStack {
+                if dynamicTypeSize.isAccessibilitySize, viewModel.shouldShowHeaderBanner {
+                    bannerCardView
+                }
                 ForEach(items, id: \.productID) { item in
                     Button(action: {
                         viewModel.select(item)

--- a/WooCommerce/Classes/POS/ViewModels/ItemListViewModel.swift
+++ b/WooCommerce/Classes/POS/ViewModels/ItemListViewModel.swift
@@ -15,7 +15,7 @@ final class ItemListViewModel: ItemListViewModelProtocol {
         if UserDefaults.standard.bool(forKey: BannerState.isSimpleProductsOnlyBannerDismissedKey) == true {
             return false
         }
-        return !isHeaderBannerDismissed && state.isLoaded
+        return !isHeaderBannerDismissed && (state.isLoaded || state.isLoading) && items.isNotEmpty
     }
 
     private let itemProvider: POSItemProvider
@@ -79,6 +79,15 @@ extension ItemListViewModel {
         var isLoaded: Bool {
             switch self {
             case .loaded:
+                return true
+            default:
+                return false
+            }
+        }
+
+        var isLoading: Bool {
+            switch self {
+            case .loading:
                 return true
             default:
                 return false


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #13865, #13878
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

Simple products banner is visible while pull to refresh. The reason is that `shouldShowHeaderBanner` is only `true` when `state` is `loaded`. 

Additionally, fixing accessibility issues with the banner, making it scrollable within the list for accessibility sizes. I didn't want to change the default layout.

## Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->

### Pull to refresh

1. Fresh install the app
2. Open POS
3. Confirm simple product banner appears
4. Pull to refresh
5. Confirm the product banner doesn't disappear 

### Accessibility sizes

1. Fresh install the app
2. Open POS
3. Confirm simple product banner appears
4. Increase dynamic type size to a super large one
5. Confirm that the product banner can be scrolled together with the list

## Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->

Additionally, tested empty and error states to make sure that simple product banners doesn't appear in these situations.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

https://github.com/user-attachments/assets/f996be71-2c4e-4db4-9c50-31cf5dda10d3

---

- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [ ] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [ ] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [ ] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on all devices (phone/tablet) and no regressions are added.