### PR TITLE
Fix incorrect title for single selection product selector

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -3,7 +3,7 @@
 
 20.4
 -----
-
+- [*] Fixed the incorrect navigation title of the product selector in the Blaze campaign creation flow. [https://github.com/woocommerce/woocommerce-ios/pull/13903]
 
 20.3
 -----

--- a/WooCommerce/Classes/ViewRelated/Products/ProductSelector/ProductSelectorView.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/ProductSelector/ProductSelectorView.swift
@@ -78,7 +78,7 @@ struct ProductSelectorView: View {
     private var navigationTitle: String {
         let narrowView = (horizontalSizeClass == .compact || isViewWidthNarrowerThanConstantRowWidth)
         guard ServiceLocator.featureFlagService.isFeatureFlagEnabled(.sideBySideViewForOrderForm),
-              narrowView else {
+              narrowView, configuration.multipleSelectionEnabled else {
             return configuration.title
         }
         return viewModel.selectProductsTitle
@@ -171,6 +171,9 @@ struct ProductSelectorView: View {
             }
         }
         .onAppear {
+            if !configuration.multipleSelectionEnabled {
+                viewModel.clearSelection()
+            }
             viewModel.onLoadTrigger.send()
             updateSyncApproach(for: horizontalSizeClass)
         }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #13902 
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
Previously, the product selector was implemented to support multiple selections, so the selected item list is kept as part of the view's state. When we use the single selection mode for Blaze, the item list keeps getting larger as we navigate back and select other items, and the navigation title is updated accordingly.

This PR fixes the incorrect title on the product selector in single selection mode by:
- Keep the default navigation title.
- Clearing the selected item list upon `onAppear` to ensure the correct state.

No unit tests were added as the logic is kept on the UI. Any suggestions are welcome.

## Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->
- Log in to a store eligible for Blaze.
- Enable the Blaze card on the dashboard screen.
- Select Create Campaign button on the dashboard card and select a product.
- Navigate back and select a product again. 
- Repeat a few times and confirm that the title of the product selector stays as "Ready to promote".

## Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: https://woomobilep2.wordpress.com/2024/05/06/woocommerce-mobile-quality-report-march-april/#comment-12036 -->
Tested on simulator iPhone 15 Pro iOS 17.4:
- Confirmed the navigation title is correct for the product selector when used in the Blaze flow.
- Confirmed the navigation title is correct for the product selector when used in the Order creation flow.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->
Before | After 
--- | ---
<img src="https://github.com/user-attachments/assets/41dc16b9-a343-40ee-a3e7-b5fced466389" width=320 /> | <img src="https://github.com/user-attachments/assets/79b514f0-0810-4e60-be3d-dd8b098a9ef8" width=320 />


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [x] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [x] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [x] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on all devices (phone/tablet) and no regressions are added.
