### PR TITLE
[Woo POS] Animate bottom tab on switch modes

### DIFF
--- a/WooCommerce/Classes/POS/Presentation/PointOfSaleDashboardView.swift
+++ b/WooCommerce/Classes/POS/Presentation/PointOfSaleDashboardView.swift
@@ -23,6 +23,7 @@ struct PointOfSaleDashboardView: View {
             if viewModel.isInitialLoading {
                 PointOfSaleLoadingView()
                     .transition(.opacity)
+                    .ignoresSafeArea()
             } else if viewModel.isError {
                 let errorContents = viewModel.itemListViewModel.state.hasError
                 PointOfSaleItemListErrorView(error: errorContents, onRetry: {

--- a/WooCommerce/Classes/ViewRelated/Hub Menu/HubMenuViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Hub Menu/HubMenuViewModel.swift
@@ -233,8 +233,6 @@ private extension HubMenuViewModel {
         guard let mainTabBarController = AppDelegate.shared.tabBarController else {
             return
         }
-        mainTabBarController.tabBar.isHidden = isPointOfSaleActive
-
         /*
          When hidding the app's tab bar on POS initialization, we've observed a recurring issue with the UI not being updated appropiately,
          leaving additional padding in the bottom rather than re-positioning components taking all the available space.
@@ -243,10 +241,16 @@ private extension HubMenuViewModel {
          Updating the bottom UIEdgeInset to a non-zero value seems to be enough to trigger the UI layout refresh we need.
          Ref: gh-13785
          */
-        if mainTabBarController.tabBar.isHidden {
-            let bottomInset = CGFloat.leastNonzeroMagnitude
-            mainTabBarController.additionalSafeAreaInsets = UIEdgeInsets(top: 0, left: 0, bottom: bottomInset, right: 0)
+        if isPointOfSaleActive {
+            UIView.animate(withDuration: 0.5) {
+                mainTabBarController.tabBar.alpha = 0
+            } completion: { _ in
+                mainTabBarController.tabBar.isHidden = isPointOfSaleActive
+                let bottomInset = CGFloat.leastNonzeroMagnitude
+                mainTabBarController.additionalSafeAreaInsets = UIEdgeInsets(top: 0, left: 0, bottom: bottomInset, right: 0)
+            }
         } else {
+            mainTabBarController.tabBar.isHidden = isPointOfSaleActive
             mainTabBarController.additionalSafeAreaInsets = .zero
             mainTabBarController.tabBar.alpha = 0
             UIView.animate(withDuration: 0.5) {

--- a/WooCommerce/Classes/ViewRelated/Hub Menu/HubMenuViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Hub Menu/HubMenuViewModel.swift
@@ -248,6 +248,10 @@ private extension HubMenuViewModel {
             mainTabBarController.additionalSafeAreaInsets = UIEdgeInsets(top: 0, left: 0, bottom: bottomInset, right: 0)
         } else {
             mainTabBarController.additionalSafeAreaInsets = .zero
+            mainTabBarController.tabBar.alpha = 0
+            UIView.animate(withDuration: 0.5) {
+                mainTabBarController.tabBar.alpha = 1
+            }
         }
     }
 


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #13904

## Description
This PR addresses the design feedback on https://github.com/woocommerce/woocommerce-ios/issues/13859 regarding the bottom TabBar appearing and being hidden immediately when we switch modes. We update this behaviour with a 0.5 seconds animation

The changes required a bit of trial and error, since: 
1. When the TabBar is hidden, UIKit doesn't respond to changes in visual properties to optimize for unnecessary rendering, so we need to make the TabBar visible and it's alpha set to 0 (still "invisible") in order to apply animations, then animate it from 0 to 1.
2. Setting the insets outside of the animation's completion handler caused the bug at https://github.com/woocommerce/woocommerce-ios/pull/13785 to re-appear.

I've tested this on different simulators, my physical device, and specially the device where we could reproduce the FloatingButton bug consistently: iPad Air 11 with iOS 17.5, and I haven't seen the regression.

## Testing
- Go to Menu > Tap the Point of Sale button
- Observe the bottom TabBar disappearing  with an animation while the POS loading screen starts
- Observe that there's no regression on the location of the `FloatingView`, it appears at the bottom to the screen and it doesn't reallocate itself on attempting to switch portrait/landscape or tapping the `...` option at the top.
- Exit POS, after confirming, observe how the TabBar reappears with an animation

https://github.com/user-attachments/assets/0d247ebc-f887-47f1-8111-9c2cb2b07446

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [x] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [x] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [x] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on all devices (phone/tablet) and no regressions are added.