### PR TITLE
[Woo POS] Hub Menu icon update

### DIFF
--- a/WooCommerce/Classes/Extensions/UIImage+Woo.swift
+++ b/WooCommerce/Classes/Extensions/UIImage+Woo.swift
@@ -1072,7 +1072,8 @@ extension UIImage {
     /// Switching mode image
     ///
     static var switchingModeImage: UIImage {
-        UIImage(systemName: "arrow.left.arrow.right")!
+        let configuration = UIImage.SymbolConfiguration(weight: .light)
+        return UIImage(systemName: "arrow.left.arrow.right", withConfiguration: configuration)!
     }
 
     /// Plus Icon

--- a/WooCommerce/Classes/ViewRelated/Hub Menu/HubMenu.swift
+++ b/WooCommerce/Classes/ViewRelated/Hub Menu/HubMenu.swift
@@ -283,6 +283,7 @@ private extension HubMenu {
         var chevronAccessibilityID: String?
 
         @Environment(\.sizeCategory) private var sizeCategory
+        @ScaledMetric private var scale: CGFloat = 1.0
 
         var body: some View {
             HStack(spacing: HubMenu.Constants.padding) {
@@ -349,7 +350,8 @@ private extension HubMenu {
                 // Tap Indicator
                 Image(uiImage: chevron.asset)
                     .resizable()
-                    .frame(width: HubMenu.Constants.chevronSize, height: HubMenu.Constants.chevronSize)
+                    .aspectRatio(contentMode: .fit)
+                    .frame(width: HubMenu.Constants.chevronSize * scale, height: HubMenu.Constants.chevronSize * scale)
                     .flipsForRightToLeftLayoutDirection(true)
                     .foregroundColor(Color(.textSubtle))
                     .accessibilityIdentifier(chevronAccessibilityID ?? "")


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #13906 
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
This PR addresses the design feedback on https://github.com/woocommerce/woocommerce-ios/issues/13859 regarding the POS "chevron" image looking stretched. Upon checking the size this seems to be correct, we use the same reusable component for all the rows and assets passed as chevrons in the Settings view, but the proposed designs show a thinner than default one.

| feedback | Before | After |
|--------|--------|--------|
| <img width="402" alt="Screenshot 2024-09-10 at 12 52 51" src="https://github.com/user-attachments/assets/6993ad5f-784a-4968-96b2-3d96d19ad30d"> | <img width="163" alt="Screenshot 2024-09-10 at 12 49 15" src="https://github.com/user-attachments/assets/7cd35266-528a-4395-b5cf-4c1a992a7a01"> | <img width="202" alt="Screenshot 2024-09-10 at 12 50 06" src="https://github.com/user-attachments/assets/c5482eb5-3c8e-443a-b632-e570c4d82d0b"> | 

## Testing
1. Load the POS
2. "Observe" that the chevron icon is slightly thinner

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [x] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [x] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [x] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on all devices (phone/tablet) and no regressions are added.