### PR TITLE
Blaze: Send objective for campaign creation

### DIFF
--- a/Experiments/Experiments/DefaultFeatureFlagService.swift
+++ b/Experiments/Experiments/DefaultFeatureFlagService.swift
@@ -87,7 +87,7 @@ public struct DefaultFeatureFlagService: FeatureFlagService {
         case .revampedShippingLabelCreation:
             return buildConfig == .localDeveloper || buildConfig == .alpha
         case .blazeCampaignObjective:
-            return buildConfig == .localDeveloper || buildConfig == .alpha
+            return true
         default:
             return true
         }

--- a/Fakes/Fakes/Networking.generated.swift
+++ b/Fakes/Fakes/Networking.generated.swift
@@ -436,7 +436,8 @@ extension Networking.CreateBlazeCampaign {
             mainImage: .fake(),
             targeting: .fake(),
             targetUrn: .fake(),
-            type: .fake()
+            type: .fake(),
+            objective: .fake()
         )
     }
 }

--- a/Networking/Networking/Model/Blaze/CreateBlazeCampaign.swift
+++ b/Networking/Networking/Model/Blaze/CreateBlazeCampaign.swift
@@ -91,6 +91,10 @@ public struct CreateBlazeCampaign: Encodable, GeneratedFakeable, GeneratedCopiab
     ///
     public let type: String
 
+    /// Selected objective ID for the campaign.
+    ///
+    public let objective: String
+
     public init(origin: String,
                 originVersion: String,
                 paymentMethodID: String,
@@ -106,7 +110,8 @@ public struct CreateBlazeCampaign: Encodable, GeneratedFakeable, GeneratedCopiab
                 mainImage: Image,
                 targeting: BlazeTargetOptions?,
                 targetUrn: String,
-                type: String) {
+                type: String,
+                objective: String) {
         self.origin = origin
         self.originVersion = originVersion
         self.paymentMethodID = paymentMethodID
@@ -123,5 +128,6 @@ public struct CreateBlazeCampaign: Encodable, GeneratedFakeable, GeneratedCopiab
         self.targeting = targeting
         self.targetUrn = targetUrn
         self.type = type
+        self.objective = objective
     }
 }

--- a/Networking/Networking/Model/Blaze/CreateBlazeCampaign.swift
+++ b/Networking/Networking/Model/Blaze/CreateBlazeCampaign.swift
@@ -93,7 +93,7 @@ public struct CreateBlazeCampaign: Encodable, GeneratedFakeable, GeneratedCopiab
 
     /// Selected objective ID for the campaign.
     ///
-    public let objective: String
+    public let objective: String?
 
     public init(origin: String,
                 originVersion: String,
@@ -111,7 +111,7 @@ public struct CreateBlazeCampaign: Encodable, GeneratedFakeable, GeneratedCopiab
                 targeting: BlazeTargetOptions?,
                 targetUrn: String,
                 type: String,
-                objective: String) {
+                objective: String?) {
         self.origin = origin
         self.originVersion = originVersion
         self.paymentMethodID = paymentMethodID

--- a/Networking/Networking/Model/Copiable/Models+Copiable.generated.swift
+++ b/Networking/Networking/Model/Copiable/Models+Copiable.generated.swift
@@ -578,7 +578,8 @@ extension Networking.CreateBlazeCampaign {
         mainImage: CopiableProp<CreateBlazeCampaign.Image> = .copy,
         targeting: NullableCopiableProp<BlazeTargetOptions> = .copy,
         targetUrn: CopiableProp<String> = .copy,
-        type: CopiableProp<String> = .copy
+        type: CopiableProp<String> = .copy,
+        objective: CopiableProp<String> = .copy
     ) -> Networking.CreateBlazeCampaign {
         let origin = origin ?? self.origin
         let originVersion = originVersion ?? self.originVersion
@@ -596,6 +597,7 @@ extension Networking.CreateBlazeCampaign {
         let targeting = targeting ?? self.targeting
         let targetUrn = targetUrn ?? self.targetUrn
         let type = type ?? self.type
+        let objective = objective ?? self.objective
 
         return Networking.CreateBlazeCampaign(
             origin: origin,
@@ -613,7 +615,8 @@ extension Networking.CreateBlazeCampaign {
             mainImage: mainImage,
             targeting: targeting,
             targetUrn: targetUrn,
-            type: type
+            type: type,
+            objective: objective
         )
     }
 }

--- a/Networking/Networking/Model/Copiable/Models+Copiable.generated.swift
+++ b/Networking/Networking/Model/Copiable/Models+Copiable.generated.swift
@@ -579,7 +579,7 @@ extension Networking.CreateBlazeCampaign {
         targeting: NullableCopiableProp<BlazeTargetOptions> = .copy,
         targetUrn: CopiableProp<String> = .copy,
         type: CopiableProp<String> = .copy,
-        objective: CopiableProp<String> = .copy
+        objective: NullableCopiableProp<String> = .copy
     ) -> Networking.CreateBlazeCampaign {
         let origin = origin ?? self.origin
         let originVersion = originVersion ?? self.originVersion

--- a/Networking/NetworkingTests/Remote/BlazeRemoteTests.swift
+++ b/Networking/NetworkingTests/Remote/BlazeRemoteTests.swift
@@ -76,7 +76,8 @@ final class BlazeRemoteTests: XCTestCase {
                                                        mainImage: mainImage,
                                                        targeting: targeting,
                                                        targetUrn: "urn:wpcom:post:191174658:47",
-                                                       type: "product")
+                                                       type: "product",
+                                                       objective: nil)
 
         // When
         _ = try await remote.createCampaign(campaign, siteID: sampleSiteID)
@@ -113,6 +114,23 @@ final class BlazeRemoteTests: XCTestCase {
 
         XCTAssertEqual(request.parameters?["target_urn"] as? String, campaign.targetUrn)
         XCTAssertEqual(request.parameters?["type"] as? String, campaign.type)
+        XCTAssertNil(request.parameters?["objective"])
+    }
+
+    func test_createCampaign_sends_objective_if_not_nil() async throws {
+        // Given
+        let remote = BlazeRemote(network: network)
+        let suffix = "sites/\(sampleSiteID)/wordads/dsp/api/v1.1/campaigns"
+
+        network.simulateResponse(requestUrlSuffix: suffix, filename: "blaze-create-campaign-success")
+        let campaign = CreateBlazeCampaign.fake().copy(objective: "sales")
+
+        // When
+        _ = try await remote.createCampaign(campaign, siteID: sampleSiteID)
+
+        // Then
+        let request = try XCTUnwrap(network.requestsForResponseData.first as? DotcomRequest)
+        XCTAssertEqual(request.parameters?["objective"] as? String, campaign.objective)
     }
 
     func test_createCampaign_sends_correctly_formatted_dates_regardless_of_locale() async throws {

--- a/WooCommerce/Classes/Analytics/WooAnalyticsEvent+Blaze.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsEvent+Blaze.swift
@@ -60,9 +60,9 @@ extension WooAnalyticsEvent {
             WooAnalyticsEvent(statName: .blazeIntroLearnMoreTapped, properties: [:])
         }
 
-        /// Tracked upon tapping Continue on the campaign objective picker.
-        static func campaignObjectiveContinueTapped(_ objective: String) -> WooAnalyticsEvent {
-            WooAnalyticsEvent(statName: .blazeCampaignObjectiveContinueTapped,
+        /// Tracked upon tapping Save on the campaign objective picker.
+        static func campaignObjectiveSaved(_ objective: String) -> WooAnalyticsEvent {
+            WooAnalyticsEvent(statName: .blazeCampaignObjectiveSaved,
                               properties: [Key.objective: objective])
         }
 

--- a/WooCommerce/Classes/Analytics/WooAnalyticsEvent+Blaze.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsEvent+Blaze.swift
@@ -1,3 +1,5 @@
+import protocol WooFoundation.WooAnalyticsEventPropertyType
+
 extension WooAnalyticsEvent {
     enum Blaze {
         /// Event property keys.
@@ -77,12 +79,21 @@ extension WooAnalyticsEvent {
 
             /// Tracked upon tapping "Confirm Details" in Blaze creation form
             static func confirmDetailsTapped(isAISuggestedAdContent: Bool,
-                                             isEvergreen: Bool) -> WooAnalyticsEvent {
-                WooAnalyticsEvent(statName: .blazeCreationConfirmDetailsTapped,
-                                  properties: [Key.isAISuggestedAdContent: isAISuggestedAdContent,
-                                               Key.campaignType: isEvergreen ?
-                                                Values.CampaignType.evergreen :
-                                                Values.CampaignType.startEnd])
+                                             isEvergreen: Bool,
+                                             objective: String?) -> WooAnalyticsEvent {
+                var properties: [String: WooAnalyticsEventPropertyType] = [
+                    Key.isAISuggestedAdContent: isAISuggestedAdContent,
+                    Key.campaignType: isEvergreen ?
+                    Values.CampaignType.evergreen :
+                        Values.CampaignType.startEnd
+                ]
+
+                if let objective {
+                    properties[Key.objective] = objective
+                }
+
+                return WooAnalyticsEvent(statName: .blazeCreationConfirmDetailsTapped,
+                                         properties: properties)
             }
         }
 

--- a/WooCommerce/Classes/Analytics/WooAnalyticsEvent+Blaze.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsEvent+Blaze.swift
@@ -8,6 +8,7 @@ extension WooAnalyticsEvent {
             static let totalBudget = "total_budget"
             static let isAISuggestedAdContent = "is_ai_suggested_ad_content"
             static let campaignType = "campaign_type"
+            static let objective = "objective"
         }
 
         private enum Values {
@@ -55,6 +56,12 @@ extension WooAnalyticsEvent {
         /// Tracked upon tapping "Learn how Blaze works" in Intro screen
         static func introLearnMoreTapped() -> WooAnalyticsEvent {
             WooAnalyticsEvent(statName: .blazeIntroLearnMoreTapped, properties: [:])
+        }
+
+        /// Tracked upon tapping Save on the campaign objective picker.
+        static func campaignObjectiveSaved(_ objective: String) -> WooAnalyticsEvent {
+            WooAnalyticsEvent(statName: .blazeCampaignObjectiveSaved,
+                              properties: [Key.objective: objective])
         }
 
         enum CreationForm {

--- a/WooCommerce/Classes/Analytics/WooAnalyticsEvent+Blaze.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsEvent+Blaze.swift
@@ -60,9 +60,9 @@ extension WooAnalyticsEvent {
             WooAnalyticsEvent(statName: .blazeIntroLearnMoreTapped, properties: [:])
         }
 
-        /// Tracked upon tapping Save on the campaign objective picker.
-        static func campaignObjectiveSaved(_ objective: String) -> WooAnalyticsEvent {
-            WooAnalyticsEvent(statName: .blazeCampaignObjectiveSaved,
+        /// Tracked upon tapping Continue on the campaign objective picker.
+        static func campaignObjectiveContinueTapped(_ objective: String) -> WooAnalyticsEvent {
+            WooAnalyticsEvent(statName: .blazeCampaignObjectiveContinueTapped,
                               properties: [Key.objective: objective])
         }
 

--- a/WooCommerce/Classes/Analytics/WooAnalyticsStat.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsStat.swift
@@ -218,7 +218,7 @@ enum WooAnalyticsStat: String {
     case blazeIntroLearnMoreTapped = "blaze_intro_learn_more_tapped"
     case blazeCreationFormDisplayed = "blaze_creation_form_displayed"
     case blazeEditAdTapped = "blaze_creation_edit_ad_tapped"
-    case blazeCampaignObjectiveContinueTapped = "blaze_campaign_objective_continue_tapped"
+    case blazeCampaignObjectiveSaved = "blaze_campaign_objective_saved"
     case blazeCreationConfirmDetailsTapped = "blaze_creation_confirm_details_tapped"
     case blazeEditAdSaveTapped = "blaze_creation_edit_ad_save_tapped"
     case blazeEditAdAISuggestionTapped = "blaze_creation_edit_ad_ai_suggestion_tapped"

--- a/WooCommerce/Classes/Analytics/WooAnalyticsStat.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsStat.swift
@@ -218,6 +218,7 @@ enum WooAnalyticsStat: String {
     case blazeIntroLearnMoreTapped = "blaze_intro_learn_more_tapped"
     case blazeCreationFormDisplayed = "blaze_creation_form_displayed"
     case blazeEditAdTapped = "blaze_creation_edit_ad_tapped"
+    case blazeCampaignObjectiveSaved = "blaze_campaign_objective_saved"
     case blazeCreationConfirmDetailsTapped = "blaze_creation_confirm_details_tapped"
     case blazeEditAdSaveTapped = "blaze_creation_edit_ad_save_tapped"
     case blazeEditAdAISuggestionTapped = "blaze_creation_edit_ad_ai_suggestion_tapped"

--- a/WooCommerce/Classes/Analytics/WooAnalyticsStat.swift
+++ b/WooCommerce/Classes/Analytics/WooAnalyticsStat.swift
@@ -218,7 +218,7 @@ enum WooAnalyticsStat: String {
     case blazeIntroLearnMoreTapped = "blaze_intro_learn_more_tapped"
     case blazeCreationFormDisplayed = "blaze_creation_form_displayed"
     case blazeEditAdTapped = "blaze_creation_edit_ad_tapped"
-    case blazeCampaignObjectiveSaved = "blaze_campaign_objective_saved"
+    case blazeCampaignObjectiveContinueTapped = "blaze_campaign_objective_continue_tapped"
     case blazeCreationConfirmDetailsTapped = "blaze_creation_confirm_details_tapped"
     case blazeEditAdSaveTapped = "blaze_creation_edit_ad_save_tapped"
     case blazeEditAdAISuggestionTapped = "blaze_creation_edit_ad_ai_suggestion_tapped"

--- a/WooCommerce/Classes/ViewRelated/Blaze/CampaignCreation/BlazeCampaignCreationForm.swift
+++ b/WooCommerce/Classes/ViewRelated/Blaze/CampaignCreation/BlazeCampaignCreationForm.swift
@@ -209,7 +209,7 @@ struct BlazeCampaignCreationForm: View {
             isShowingAISuggestionsErrorAlert = newValue == .failedToLoadAISuggestions
         }
         .alert(Localization.AISuggestionsErrorAlert.fetchingAISuggestions, isPresented: $isShowingAISuggestionsErrorAlert) {
-            Button(Localization.AISuggestionsErrorAlert.cancel, role: .cancel) { }
+            Button(Localization.cancel, role: .cancel) { }
 
             Button(Localization.AISuggestionsErrorAlert.retry) {
                 Task {
@@ -218,17 +218,23 @@ struct BlazeCampaignCreationForm: View {
             }
         }
         .alert(Localization.NoImageErrorAlert.noImageFound, isPresented: $viewModel.isShowingMissingImageErrorAlert) {
-            Button(Localization.NoImageErrorAlert.cancel, role: .cancel) { }
+            Button(Localization.cancel, role: .cancel) { }
 
             Button(Localization.NoImageErrorAlert.addImage) {
                 viewModel.didTapEditAd()
             }
         }
         .alert(Localization.NoDestinationURLAlert.noURLFound, isPresented: $viewModel.isShowingMissingDestinationURLAlert) {
-            Button(Localization.NoDestinationURLAlert.cancel, role: .cancel) { }
+            Button(Localization.cancel, role: .cancel) { }
 
             Button(Localization.NoDestinationURLAlert.selectURL) {
                 isShowingAdDestinationScreen = true
+            }
+        }
+        .alert(Localization.MissingObjectiveAlert.title, isPresented: $viewModel.isShowingMissingObjectiveAlert) {
+            Button(Localization.cancel, role: .cancel) {}
+            Button(Localization.MissingObjectiveAlert.selectObjective) {
+                isShowingCampaignObjectivePicker = true
             }
         }
         .onAppear() {
@@ -495,11 +501,6 @@ private extension BlazeCampaignCreationForm {
                 value: "Failed to load suggestions for tagline and description",
                 comment: "Error message indicating that loading suggestions for tagline and description failed"
             )
-            static let cancel = NSLocalizedString(
-                "blazeCampaignCreationForm.aiSuggestionsErrorAlert.cancel",
-                value: "Cancel",
-                comment: "Dismiss button on the error alert displayed on the Blaze campaign creation screen"
-            )
             static let retry = NSLocalizedString(
                 "blazeCampaignCreationForm.aiSuggestionsErrorAlert.retry",
                 value: "Retry",
@@ -512,11 +513,6 @@ private extension BlazeCampaignCreationForm {
                 "blazeCampaignCreationForm.noImageErrorAlert.noImageFound",
                 value: "Please add an image for the Blaze campaign",
                 comment: "Message asking to select an image for the Blaze campaign"
-            )
-            static let cancel = NSLocalizedString(
-                "blazeCampaignCreationForm.noImageErrorAlert.cancel",
-                value: "Cancel",
-                comment: "Dismiss button on the alert asking to add an image for the Blaze campaign"
             )
             static let addImage = NSLocalizedString(
                 "blazeCampaignCreationForm.noImageErrorAlert.addImage",
@@ -531,17 +527,31 @@ private extension BlazeCampaignCreationForm {
                 value: "Please select a destination URL for the Blaze campaign",
                 comment: "Message asking to select a destination URL for the Blaze campaign"
             )
-            static let cancel = NSLocalizedString(
-                "blazeCampaignCreationForm.noDestinationURLAlert.cancel",
-                value: "Cancel",
-                comment: "Dismiss button on the alert asking to select a destination URL for the Blaze campaign"
-            )
             static let selectURL = NSLocalizedString(
                 "blazeCampaignCreationForm.noDestinationURLAlert.selectURL",
                 value: "Select URL",
                 comment: "Button on the alert to select a destination URL for the Blaze campaign"
             )
         }
+
+        enum MissingObjectiveAlert {
+            static let title = NSLocalizedString(
+                "blazeCampaignCreationForm.missingObjectiveAlert.title",
+                value: "Please select an objective for the Blaze campaign",
+                comment: ""
+            )
+            static let selectObjective = NSLocalizedString(
+                "blazeCampaignCreationForm.missingObjectiveAlert.selectObjective",
+                value: "Select objective",
+                comment: "Button on the alert to select an objective for the Blaze campaign"
+            )
+        }
+
+        static let cancel = NSLocalizedString(
+            "blazeCampaignCreationForm.cancel",
+            value: "Cancel",
+            comment: "Dismiss button on an error alert on the Blaze campaign creation form"
+        )
 
         static let help = NSLocalizedString(
             "blazeCampaignCreationForm.help",

--- a/WooCommerce/Classes/ViewRelated/Blaze/CampaignCreation/BlazeCampaignCreationFormViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Blaze/CampaignCreation/BlazeCampaignCreationFormViewModel.swift
@@ -216,6 +216,7 @@ final class BlazeCampaignCreationFormViewModel: ObservableObject {
         tagline.isNotEmpty && description.isNotEmpty
     }
 
+    @Published var isShowingMissingObjectiveAlert = false
     @Published var isShowingMissingImageErrorAlert = false
     @Published var isShowingMissingDestinationURLAlert = false
     @Published var isShowingPaymentInfo = false
@@ -265,6 +266,7 @@ final class BlazeCampaignCreationFormViewModel: ObservableObject {
     private let locale: Locale
     private let userDefaults: UserDefaults
     private let analytics: Analytics
+    private let featureFlagService: FeatureFlagService
 
     private var didTrackOnAppear = false
 
@@ -286,6 +288,7 @@ final class BlazeCampaignCreationFormViewModel: ObservableObject {
         self.locale = locale
         self.userDefaults = userDefaults
         self.analytics = analytics
+        self.featureFlagService = featureFlagService
         self.completionHandler = onCompletion
         self.targetUrn = String(format: Constants.targetUrnFormat, siteID, productID)
 
@@ -357,6 +360,11 @@ final class BlazeCampaignCreationFormViewModel: ObservableObject {
 
         guard finalDestinationURL.isNotEmpty else {
             return isShowingMissingDestinationURLAlert = true
+        }
+
+        if featureFlagService.isFeatureFlagEnabled(.blazeCampaignObjective),
+           campaignObjective == nil {
+            return isShowingMissingObjectiveAlert = true
         }
 
         let taglineMatching = suggestions.map { $0.siteName }.contains { $0 == tagline }

--- a/WooCommerce/Classes/ViewRelated/Blaze/CampaignCreation/BlazeCampaignCreationFormViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Blaze/CampaignCreation/BlazeCampaignCreationFormViewModel.swift
@@ -258,7 +258,8 @@ final class BlazeCampaignCreationFormViewModel: ObservableObject {
                             mainImage: CreateBlazeCampaign.Image(url: "", mimeType: ""), // Image info will be added by `BlazeConfirmPaymentViewModel`.
                             targeting: targetOptions,
                             targetUrn: targetUrn,
-                            type: Constants.campaignType)
+                            type: Constants.campaignType,
+                            objective: campaignObjective?.id)
     }
 
     private let locale: Locale

--- a/WooCommerce/Classes/ViewRelated/Blaze/CampaignCreation/BlazeCampaignCreationFormViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Blaze/CampaignCreation/BlazeCampaignCreationFormViewModel.swift
@@ -372,7 +372,8 @@ final class BlazeCampaignCreationFormViewModel: ObservableObject {
         let isAISuggestedAdContent = taglineMatching || descriptionMatching
         analytics.track(event: .Blaze.CreationForm.confirmDetailsTapped(
             isAISuggestedAdContent: isAISuggestedAdContent,
-            isEvergreen: isEvergreen
+            isEvergreen: isEvergreen,
+            objective: campaignObjective?.id
         ))
         isShowingPaymentInfo = true
     }

--- a/WooCommerce/Classes/ViewRelated/Blaze/CampaignCreation/BlazeCampaignCreationFormViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Blaze/CampaignCreation/BlazeCampaignCreationFormViewModel.swift
@@ -444,6 +444,9 @@ private extension BlazeCampaignCreationFormViewModel {
 
 private extension BlazeCampaignCreationFormViewModel {
     func initializeCampaignObjective() {
+        guard featureFlagService.isFeatureFlagEnabled(.blazeCampaignObjective) else {
+            return
+        }
         guard let savedID = userDefaults.retrieveSavedObjectiveID(for: siteID) else {
             return
         }

--- a/WooCommerce/Classes/ViewRelated/Blaze/CampaignObjectives/BlazeCampaignObjectivePickerView.swift
+++ b/WooCommerce/Classes/ViewRelated/Blaze/CampaignObjectives/BlazeCampaignObjectivePickerView.swift
@@ -116,7 +116,7 @@ private extension BlazeCampaignObjectivePickerView {
                 .padding(.horizontal, Layout.contentMargin)
 
             // CTA to confirm the selection
-            Button(Localization.continueButtonTitle) {
+            Button(Localization.saveButtonTitle) {
                 viewModel.confirmSelection()
                 onDismiss()
             }
@@ -161,10 +161,10 @@ private extension BlazeCampaignObjectivePickerView {
             value: "Cancel",
             comment: "Button to dismiss the campaign objective picker for Blaze campaign creation"
         )
-        static let continueButtonTitle = NSLocalizedString(
-            "blazeCampaignObjectivePickerView.continue",
-            value: "Continue",
-            comment: "Button to apply the selection on the campaign objective picker for Blaze campaign creation"
+        static let saveButtonTitle = NSLocalizedString(
+            "blazeCampaignObjectivePickerView.save",
+            value: "Save",
+            comment: "Button to save the selection on the campaign objective picker for Blaze campaign creation"
         )
         static let errorMessage = NSLocalizedString(
             "blazeCampaignObjectivePickerView.errorMessage",

--- a/WooCommerce/Classes/ViewRelated/Blaze/CampaignObjectives/BlazeCampaignObjectivePickerView.swift
+++ b/WooCommerce/Classes/ViewRelated/Blaze/CampaignObjectives/BlazeCampaignObjectivePickerView.swift
@@ -116,7 +116,7 @@ private extension BlazeCampaignObjectivePickerView {
                 .padding(.horizontal, Layout.contentMargin)
 
             // CTA to confirm the selection
-            Button(Localization.saveButtonTitle) {
+            Button(Localization.continueButtonTitle) {
                 viewModel.confirmSelection()
                 onDismiss()
             }
@@ -161,10 +161,10 @@ private extension BlazeCampaignObjectivePickerView {
             value: "Cancel",
             comment: "Button to dismiss the campaign objective picker for Blaze campaign creation"
         )
-        static let saveButtonTitle = NSLocalizedString(
-            "blazeCampaignObjectivePickerView.save",
-            value: "Save",
-            comment: "Button to save the selection on the campaign objective picker for Blaze campaign creation"
+        static let continueButtonTitle = NSLocalizedString(
+            "blazeCampaignObjectivePickerView.continue",
+            value: "Continue",
+            comment: "Button to apply the selection on the campaign objective picker for Blaze campaign creation"
         )
         static let errorMessage = NSLocalizedString(
             "blazeCampaignObjectivePickerView.errorMessage",

--- a/WooCommerce/Classes/ViewRelated/Blaze/CampaignObjectives/BlazeCampaignObjectivePickerViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Blaze/CampaignObjectives/BlazeCampaignObjectivePickerViewModel.swift
@@ -82,7 +82,7 @@ final class BlazeCampaignObjectivePickerViewModel: ObservableObject {
         guard let selectedObjective else {
             return
         }
-        analytics.track(event: .Blaze.campaignObjectiveSaved(selectedObjective.id))
+        analytics.track(event: .Blaze.campaignObjectiveContinueTapped(selectedObjective.id))
         if saveSelectionForFutureCampaigns {
             userDefaults.saveObjectiveForFutureCampaigns(objectiveID: selectedObjective.id, for: siteID)
         }

--- a/WooCommerce/Classes/ViewRelated/Blaze/CampaignObjectives/BlazeCampaignObjectivePickerViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Blaze/CampaignObjectives/BlazeCampaignObjectivePickerViewModel.swift
@@ -79,10 +79,10 @@ final class BlazeCampaignObjectivePickerViewModel: ObservableObject {
     }
 
     func confirmSelection() {
-        // TODO: add tracking
         guard let selectedObjective else {
             return
         }
+        analytics.track(event: .Blaze.campaignObjectiveSaved(selectedObjective.id))
         if saveSelectionForFutureCampaigns {
             userDefaults.saveObjectiveForFutureCampaigns(objectiveID: selectedObjective.id, for: siteID)
         }

--- a/WooCommerce/Classes/ViewRelated/Blaze/CampaignObjectives/BlazeCampaignObjectivePickerViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Blaze/CampaignObjectives/BlazeCampaignObjectivePickerViewModel.swift
@@ -82,7 +82,7 @@ final class BlazeCampaignObjectivePickerViewModel: ObservableObject {
         guard let selectedObjective else {
             return
         }
-        analytics.track(event: .Blaze.campaignObjectiveContinueTapped(selectedObjective.id))
+        analytics.track(event: .Blaze.campaignObjectiveSaved(selectedObjective.id))
         if saveSelectionForFutureCampaigns {
             userDefaults.saveObjectiveForFutureCampaigns(objectiveID: selectedObjective.id, for: siteID)
         }

--- a/WooCommerce/Classes/ViewRelated/Blaze/ConfirmPayment/BlazeConfirmPaymentView.swift
+++ b/WooCommerce/Classes/ViewRelated/Blaze/ConfirmPayment/BlazeConfirmPaymentView.swift
@@ -364,7 +364,8 @@ private extension BlazeConfirmPaymentView {
                             mainImage: .init(url: "https://example.com", mimeType: "png"),
                             targeting: nil,
                             targetUrn: "",
-                            type: "product"),
+                            type: "product",
+                            objective: "sales"),
         image: .init(image: .iconBolt, source: .asset(asset: PHAsset())),
         onCompletion: {}))
 }

--- a/WooCommerce/WooCommerceTests/Mocks/MockFeatureFlagService.swift
+++ b/WooCommerce/WooCommerceTests/Mocks/MockFeatureFlagService.swift
@@ -19,6 +19,7 @@ struct MockFeatureFlagService: FeatureFlagService {
     private let isProductCreationAIv2M1Enabled: Bool
     private let googleAdsCampaignCreationOnWebView: Bool
     private let blazeEvergreenCampaigns: Bool
+    private let blazeCampaignObjective: Bool
     private let revampedShippingLabelCreation: Bool
 
     init(isInboxOn: Bool = false,
@@ -38,6 +39,7 @@ struct MockFeatureFlagService: FeatureFlagService {
          isProductCreationAIv2M1Enabled: Bool = false,
          googleAdsCampaignCreationOnWebView: Bool = false,
          blazeEvergreenCampaigns: Bool = false,
+         blazeCampaignObjective: Bool = false,
          revampedShippingLabelCreation: Bool = false) {
         self.isInboxOn = isInboxOn
         self.isShowInboxCTAEnabled = isShowInboxCTAEnabled
@@ -56,6 +58,7 @@ struct MockFeatureFlagService: FeatureFlagService {
         self.isProductCreationAIv2M1Enabled = isProductCreationAIv2M1Enabled
         self.googleAdsCampaignCreationOnWebView = googleAdsCampaignCreationOnWebView
         self.blazeEvergreenCampaigns = blazeEvergreenCampaigns
+        self.blazeCampaignObjective = blazeCampaignObjective
         self.revampedShippingLabelCreation = revampedShippingLabelCreation
     }
 
@@ -95,6 +98,8 @@ struct MockFeatureFlagService: FeatureFlagService {
             return googleAdsCampaignCreationOnWebView
         case .blazeEvergreenCampaigns:
             return blazeEvergreenCampaigns
+        case .blazeCampaignObjective:
+            return blazeCampaignObjective
         case .revampedShippingLabelCreation:
             return revampedShippingLabelCreation
         default:

--- a/WooCommerce/WooCommerceTests/ViewRelated/Blaze/BlazeCampaignCreationFormViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Blaze/BlazeCampaignCreationFormViewModelTests.swift
@@ -579,6 +579,7 @@ final class BlazeCampaignCreationFormViewModelTests: XCTestCase {
         insertProduct(sampleProduct)
         mockAISuggestionsSuccess(sampleAISuggestions)
         mockDownloadImage(sampleImage)
+        let featureFlagService = MockFeatureFlagService(blazeCampaignObjective: false)
 
         let viewModel = BlazeCampaignCreationFormViewModel(siteID: sampleSiteID,
                                                            productID: sampleProductID,
@@ -586,6 +587,7 @@ final class BlazeCampaignCreationFormViewModelTests: XCTestCase {
                                                            storage: storageManager,
                                                            productImageLoader: imageLoader,
                                                            analytics: analytics,
+                                                           featureFlagService: featureFlagService,
                                                            onCompletion: {})
         // Sets non-nil product image
         await viewModel.downloadProductImage()
@@ -608,6 +610,7 @@ final class BlazeCampaignCreationFormViewModelTests: XCTestCase {
         insertProduct(sampleProduct)
         mockAISuggestionsSuccess(sampleAISuggestions)
         mockDownloadImage(sampleImage)
+        let featureFlagService = MockFeatureFlagService(blazeCampaignObjective: false)
 
         let viewModel = BlazeCampaignCreationFormViewModel(siteID: sampleSiteID,
                                                            productID: sampleProductID,
@@ -615,6 +618,7 @@ final class BlazeCampaignCreationFormViewModelTests: XCTestCase {
                                                            storage: storageManager,
                                                            productImageLoader: imageLoader,
                                                            analytics: analytics,
+                                                           featureFlagService: featureFlagService,
                                                            onCompletion: {})
         // Sets non-nil product image
         await viewModel.downloadProductImage()
@@ -641,6 +645,7 @@ final class BlazeCampaignCreationFormViewModelTests: XCTestCase {
         insertProduct(sampleProduct)
         mockAISuggestionsSuccess(sampleAISuggestions)
         mockDownloadImage(sampleImage)
+        let featureFlagService = MockFeatureFlagService(blazeCampaignObjective: false)
 
         let viewModel = BlazeCampaignCreationFormViewModel(siteID: sampleSiteID,
                                                            productID: sampleProductID,
@@ -648,6 +653,7 @@ final class BlazeCampaignCreationFormViewModelTests: XCTestCase {
                                                            storage: storageManager,
                                                            productImageLoader: imageLoader,
                                                             analytics: analytics,
+                                                           featureFlagService: featureFlagService,
                                                            onCompletion: {})
         // Sets non-nil product image
         await viewModel.downloadProductImage()
@@ -674,6 +680,7 @@ final class BlazeCampaignCreationFormViewModelTests: XCTestCase {
         insertProduct(sampleProduct)
         mockAISuggestionsSuccess(sampleAISuggestions)
         mockDownloadImage(sampleImage)
+        let featureFlagService = MockFeatureFlagService(blazeCampaignObjective: false)
 
         let viewModel = BlazeCampaignCreationFormViewModel(siteID: sampleSiteID,
                                                            productID: sampleProductID,
@@ -681,6 +688,7 @@ final class BlazeCampaignCreationFormViewModelTests: XCTestCase {
                                                            storage: storageManager,
                                                            productImageLoader: imageLoader,
                                                            analytics: analytics,
+                                                           featureFlagService: featureFlagService,
                                                            onCompletion: {})
         // Sets non-nil product image
         await viewModel.downloadProductImage()
@@ -708,6 +716,7 @@ final class BlazeCampaignCreationFormViewModelTests: XCTestCase {
         insertProduct(sampleProduct)
         mockAISuggestionsSuccess(sampleAISuggestions)
         mockDownloadImage(sampleImage)
+        let featureFlagService = MockFeatureFlagService(blazeCampaignObjective: false)
 
         let viewModel = BlazeCampaignCreationFormViewModel(siteID: sampleSiteID,
                                                            productID: sampleProductID,
@@ -715,6 +724,7 @@ final class BlazeCampaignCreationFormViewModelTests: XCTestCase {
                                                            storage: storageManager,
                                                            productImageLoader: imageLoader,
                                                            analytics: analytics,
+                                                           featureFlagService: featureFlagService,
                                                            onCompletion: {})
         // Sets non-nil product image
         await viewModel.downloadProductImage()
@@ -738,6 +748,7 @@ final class BlazeCampaignCreationFormViewModelTests: XCTestCase {
         insertProduct(sampleProduct)
         mockAISuggestionsSuccess(sampleAISuggestions)
         mockDownloadImage(sampleImage)
+        let featureFlagService = MockFeatureFlagService(blazeCampaignObjective: false)
 
         let viewModel = BlazeCampaignCreationFormViewModel(siteID: sampleSiteID,
                                                            productID: sampleProductID,
@@ -745,6 +756,7 @@ final class BlazeCampaignCreationFormViewModelTests: XCTestCase {
                                                            storage: storageManager,
                                                            productImageLoader: imageLoader,
                                                            analytics: analytics,
+                                                           featureFlagService: featureFlagService,
                                                            onCompletion: {})
         // Sets non-nil product image
         await viewModel.downloadProductImage()
@@ -760,6 +772,36 @@ final class BlazeCampaignCreationFormViewModelTests: XCTestCase {
         let eventProperties = try XCTUnwrap(analyticsProvider.receivedProperties[index])
         let campaignType = try XCTUnwrap(eventProperties["campaign_type"] as? String)
         XCTAssertEqual(campaignType, "start_end")
+    }
+
+    @MainActor
+    func test_tapping_confirm_details_tracks_selected_objective() async throws {
+        // Given
+        insertProduct(sampleProduct)
+        mockAISuggestionsSuccess(sampleAISuggestions)
+        mockDownloadImage(sampleImage)
+
+        let viewModel = BlazeCampaignCreationFormViewModel(siteID: sampleSiteID,
+                                                           productID: sampleProductID,
+                                                           stores: stores,
+                                                           storage: storageManager,
+                                                           productImageLoader: imageLoader,
+                                                           analytics: analytics,
+                                                           onCompletion: {})
+        // Sets non-nil product image
+        await viewModel.downloadProductImage()
+
+        // When
+        // set non-evergreen
+        viewModel.campaignObjectiveViewModel.selectedObjective = BlazeCampaignObjective.fake().copy(id: "sales")
+        viewModel.campaignObjectiveViewModel.confirmSelection()
+        viewModel.didTapConfirmDetails()
+
+        // Then
+        let index = try XCTUnwrap(analyticsProvider.receivedEvents.lastIndex(of: "blaze_creation_confirm_details_tapped"))
+        let eventProperties = try XCTUnwrap(analyticsProvider.receivedProperties[index])
+        let objective = try XCTUnwrap(eventProperties["objective"] as? String)
+        XCTAssertEqual(objective, "sales")
     }
 }
 

--- a/WooCommerce/WooCommerceTests/ViewRelated/Blaze/BlazeCampaignCreationFormViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Blaze/BlazeCampaignCreationFormViewModelTests.swift
@@ -155,6 +155,7 @@ final class BlazeCampaignCreationFormViewModelTests: XCTestCase {
         let uuid = UUID().uuidString
         let userDefaults = try XCTUnwrap(UserDefaults(suiteName: uuid))
         let locale = Locale.current
+        let featureFlagService = MockFeatureFlagService(blazeCampaignObjective: true)
         let objective = BlazeCampaignObjective(id: "traffic", title: "Traffic", description: "", suitableForDescription: "", locale: locale.identifier)
         insertCampaignObjective(objective)
 
@@ -167,6 +168,7 @@ final class BlazeCampaignCreationFormViewModelTests: XCTestCase {
                                                            productImageLoader: imageLoader,
                                                            locale: locale,
                                                            userDefaults: userDefaults,
+                                                           featureFlagService: featureFlagService,
                                                            onCompletion: {})
 
         // Then

--- a/WooCommerce/WooCommerceTests/ViewRelated/Blaze/BlazeCampaignCreationFormViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Blaze/BlazeCampaignCreationFormViewModelTests.swift
@@ -516,6 +516,57 @@ final class BlazeCampaignCreationFormViewModelTests: XCTestCase {
         XCTAssertTrue(viewModel.isShowingMissingImageErrorAlert)
     }
 
+    func test_it_shows_error_if_confirm_without_objective_when_feature_flag_for_objective_is_on() async {
+        // Given
+        insertProduct(sampleProduct)
+        mockAISuggestionsSuccess(sampleAISuggestions)
+        mockDownloadImage(sampleImage)
+        let featureFlagService = MockFeatureFlagService(blazeCampaignObjective: true)
+
+        let viewModel = BlazeCampaignCreationFormViewModel(siteID: sampleSiteID,
+                                                           productID: sampleProductID,
+                                                           stores: stores,
+                                                           storage: storageManager,
+                                                           productImageLoader: imageLoader,
+                                                           featureFlagService: featureFlagService,
+                                                           onCompletion: {})
+        // Sets non-nil product image
+        await viewModel.downloadProductImage()
+        XCTAssertNil(viewModel.campaignObjectiveViewModel.selectedObjective)
+
+        // When
+        viewModel.didTapConfirmDetails()
+
+        // Then
+        XCTAssertTrue(viewModel.isShowingMissingObjectiveAlert)
+    }
+
+    func test_it_does_not_show_error_if_confirm_with_objective_when_feature_flag_for_objective_is_on() async {
+        // Given
+        insertProduct(sampleProduct)
+        mockAISuggestionsSuccess(sampleAISuggestions)
+        mockDownloadImage(sampleImage)
+        let featureFlagService = MockFeatureFlagService(blazeCampaignObjective: true)
+
+        let viewModel = BlazeCampaignCreationFormViewModel(siteID: sampleSiteID,
+                                                           productID: sampleProductID,
+                                                           stores: stores,
+                                                           storage: storageManager,
+                                                           productImageLoader: imageLoader,
+                                                           featureFlagService: featureFlagService,
+                                                           onCompletion: {})
+        // Sets non-nil product image
+        await viewModel.downloadProductImage()
+
+        // When
+        viewModel.campaignObjectiveViewModel.selectedObjective = .fake().copy(id: "sales")
+        viewModel.campaignObjectiveViewModel.confirmSelection()
+        viewModel.didTapConfirmDetails()
+
+        // Then
+        XCTAssertFalse(viewModel.isShowingMissingObjectiveAlert)
+    }
+
     // MARK: Analytics
     @MainActor
     func test_event_is_tracked_on_appear() async throws {

--- a/WooCommerce/WooCommerceTests/ViewRelated/Blaze/BlazeCampaignObjectivePickerViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Blaze/BlazeCampaignObjectivePickerViewModelTests.swift
@@ -216,6 +216,27 @@ final class BlazeCampaignObjectivePickerViewModelTests: XCTestCase {
         // Then
         XCTAssertEqual(userDefaults[.blazeSelectedCampaignObjective], ["\(sampleSiteID)": "sales"])
     }
+
+    func test_confirmSelection_tracks_selected_objective() throws {
+        // Given
+        let sales = BlazeCampaignObjective(id: "sales", title: "Sales", description: "", suitableForDescription: "", locale: locale.identifier)
+        let viewModel = BlazeCampaignObjectivePickerViewModel(siteID: sampleSiteID,
+                                                              locale: locale,
+                                                              storageManager: storageManager,
+                                                              analytics: analytics,
+                                                              onSelection: { _ in })
+
+        // When
+        let expectedItem = sales
+        viewModel.selectedObjective = expectedItem
+        viewModel.confirmSelection()
+
+        // Then
+        let index = try XCTUnwrap(analyticsProvider.receivedEvents.firstIndex(of: "blaze_campaign_objective_saved"))
+        let eventProperties = try XCTUnwrap(analyticsProvider.receivedProperties[index])
+        let objective = try XCTUnwrap(eventProperties["objective"] as? String)
+        XCTAssertEqual(objective, expectedItem.id)
+    }
 }
 
 private extension BlazeCampaignObjectivePickerViewModelTests {

--- a/WooCommerce/WooCommerceTests/ViewRelated/Blaze/BlazeCampaignObjectivePickerViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Blaze/BlazeCampaignObjectivePickerViewModelTests.swift
@@ -232,7 +232,7 @@ final class BlazeCampaignObjectivePickerViewModelTests: XCTestCase {
         viewModel.confirmSelection()
 
         // Then
-        let index = try XCTUnwrap(analyticsProvider.receivedEvents.firstIndex(of: "blaze_campaign_objective_saved"))
+        let index = try XCTUnwrap(analyticsProvider.receivedEvents.firstIndex(of: "blaze_campaign_objective_continue_tapped"))
         let eventProperties = try XCTUnwrap(analyticsProvider.receivedProperties[index])
         let objective = try XCTUnwrap(eventProperties["objective"] as? String)
         XCTAssertEqual(objective, expectedItem.id)

--- a/WooCommerce/WooCommerceTests/ViewRelated/Blaze/BlazeCampaignObjectivePickerViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Blaze/BlazeCampaignObjectivePickerViewModelTests.swift
@@ -232,7 +232,7 @@ final class BlazeCampaignObjectivePickerViewModelTests: XCTestCase {
         viewModel.confirmSelection()
 
         // Then
-        let index = try XCTUnwrap(analyticsProvider.receivedEvents.firstIndex(of: "blaze_campaign_objective_continue_tapped"))
+        let index = try XCTUnwrap(analyticsProvider.receivedEvents.firstIndex(of: "blaze_campaign_objective_saved"))
         let eventProperties = try XCTUnwrap(analyticsProvider.receivedProperties[index])
         let objective = try XCTUnwrap(eventProperties["objective"] as? String)
         XCTAssertEqual(objective, expectedItem.id)


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #13723 
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This PR wraps up the support for selecting objective for Blaze campaign creation. Changes include:
- Added new optional property `objective` for `CreateBlazeCampaign` and use it to send objective for campaign creation.
- Added tracking for objective in campaign creation.
- Enabled the feature flag for `blazeCampaignObjective` to make the feature available on 20.4.

Internal discussion: p1725947335804429-slack-C03L1NF1EA3

## Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->
- Log in to a store eligible for Blaze.
- Navigate to the Products tab and select an existing published product or create a new one.
- Tap Promote with Blaze and select Confirm Details immediately. Confirm that an alert is displayed mentioning the missing objective (if you haven't saved an objective before).
- Tap the objective row, select an option from the list, and tap Save. Confirm that `blaze_campaign_objective_saved` is tracked with the ID of the selected objective.
- Tap Confirm Details on the Preview screen. Confirm that `blaze_creation_confirm_details_tapped` is tracked with the ID of the selected objective.
- Open proxyman, proceed to create the campaign on the app and confirm that the creation is successful with the correct objective sent in the request.

With feature flag off:
- Disable the feature flag `.blazeCampaignObjective` and build the app.
- Create a Blaze campaign and confirm that the creation is still successful, with no objective sent in the request.

## Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: https://woomobilep2.wordpress.com/2024/05/06/woocommerce-mobile-quality-report-march-april/#comment-12036 -->
Tested on simulator iPhone 15 iOS 17.4:
- Confirmed that an alert is displayed when trying to create campaign without an objective with the feature flag on.
- Confirmed that campaign creation is successful with the correct objective sent in the request with the feature flag on.
- Confirmed that campaign creation is successful without objective sent in the request with feature flag off.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->
Missing objective alert:

<img src="https://github.com/user-attachments/assets/8b335cab-8dcb-4873-835d-85241c5ecee1" width=320 />



---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [ ] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [ ] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [ ] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on all devices (phone/tablet) and no regressions are added.
