### PR TITLE
[Woo POS] Floating Control Updates

### DIFF
--- a/WooCommerce/Classes/POS/Presentation/CardReaderConnection/CardReaderConnectionStatusView.swift
+++ b/WooCommerce/Classes/POS/Presentation/CardReaderConnection/CardReaderConnectionStatusView.swift
@@ -19,7 +19,7 @@ struct CardReaderConnectionStatusView: View {
     private func circleIcon(with color: Color) -> some View {
         Image(systemName: "circle.fill")
             .resizable()
-            .frame(width: Constants.imageDimension * scale, height: Constants.imageDimension * scale)
+            .frame(width: Constants.imageDimension * min(scale, 1.5), height: Constants.imageDimension * min(scale, 1.5))
             .foregroundColor(color)
             .accessibilityHidden(true)
     }
@@ -64,14 +64,14 @@ struct CardReaderConnectionStatusView: View {
                         Text(Localization.readerDisconnected)
                             .foregroundColor(disconnectedFontColor)
                     }
-                    .padding(.horizontal, Constants.horizontalPadding / 2)
+                    .padding(.horizontal, Constants.overlayInnerHorizontalPadding)
                     .frame(maxHeight: .infinity)
                     .overlay {
                         RoundedRectangle(cornerRadius: Constants.overlayRadius)
                             .stroke(Constants.overlayColor, lineWidth: Constants.overlayLineWidth)
                     }
-                    .padding(.horizontal, Constants.horizontalPadding / 2)
-                    .padding(.vertical, Constants.verticalPadding)
+                    .padding(.horizontal, Constants.overlayOuterHorizontalPadding)
+                    .padding(.vertical, Constants.overlayOuterVerticalPadding)
                     .frame(maxHeight: .infinity)
                 }
             }
@@ -107,11 +107,13 @@ private extension CardReaderConnectionStatusView {
         static let disconnectingProgressIndicatorDimension: CGFloat = 10
         static let disconnectingProgressIndicatorLineWidth: CGFloat = 2
         static let font = POSFontStyle.posDetailEmphasized
-        static let horizontalPadding: CGFloat = 16
-        static let verticalPadding: CGFloat = 8
+        static let horizontalPadding: CGFloat = 24
         static let overlayRadius: CGFloat = 4
         static let overlayLineWidth: CGFloat = 2
         static let overlayColor: Color = Color.init(uiColor: .wooCommercePurple(.shade60))
+        static let overlayInnerHorizontalPadding: CGFloat =  16 + Self.overlayLineWidth
+        static let overlayOuterHorizontalPadding: CGFloat = 8 + Self.overlayLineWidth
+        static let overlayOuterVerticalPadding: CGFloat = 8 + Self.overlayLineWidth
     }
 }
 

--- a/WooCommerce/Classes/POS/Presentation/CardReaderConnection/CardReaderConnectionStatusView.swift
+++ b/WooCommerce/Classes/POS/Presentation/CardReaderConnection/CardReaderConnectionStatusView.swift
@@ -10,6 +10,7 @@ struct CardReaderConnectionStatusView: View {
     @Environment(\.posBackgroundAppearance) var backgroundAppearance
     @ObservedObject private var connectionViewModel: CardReaderConnectionViewModel
     @ScaledMetric private var scale: CGFloat = 1.0
+    @Environment(\.isEnabled) var isEnabled
 
     init(connectionViewModel: CardReaderConnectionViewModel) {
         self.connectionViewModel = connectionViewModel
@@ -77,6 +78,7 @@ struct CardReaderConnectionStatusView: View {
             }
         }
         .font(Constants.font, maximumContentSizeCategory: .accessibilityLarge)
+        .opacity(isEnabled ? 1 : 0.5)
     }
 }
 

--- a/WooCommerce/Classes/POS/Presentation/POSFloatingControlView.swift
+++ b/WooCommerce/Classes/POS/Presentation/POSFloatingControlView.swift
@@ -50,6 +50,7 @@ struct POSFloatingControlView: View {
         }
         .frame(height: Constants.size)
         .background(Color.clear)
+        .animation(.default, value: backgroundAppearance)
     }
 }
 

--- a/WooCommerce/Classes/POS/Presentation/PointOfSaleDashboardView.swift
+++ b/WooCommerce/Classes/POS/Presentation/PointOfSaleDashboardView.swift
@@ -37,7 +37,7 @@ struct PointOfSaleDashboardView: View {
                     .accessibilitySortPriority(2)
             }
             POSFloatingControlView(viewModel: viewModel)
-                .shadow(color: Color.black.opacity(0.08), radius: 4)
+                .shadow(color: Color.black.opacity(0.12), radius: 4, y: 2)
                 .offset(x: Constants.floatingControlHorizontalOffset, y: -Constants.floatingControlVerticalOffset)
                 .trackSize(size: $floatingSize)
                 .accessibilitySortPriority(1)


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #13916
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

- [x] Floating button padding in all the states TfaZ4LUkEwEGrxfnEFzvJj-fi-4646_21885 TfaZ4LUkEwEGrxfnEFzvJj-fi-4650_22606 TfaZ4LUkEwEGrxfnEFzvJj-fi-4650_22611
- [x] Floating button shadow TfaZ4LUkEwEGrxfnEFzvJj-fi-4650_22252
- [x] [Animation] Fade-in color changes TfaZ4LUkEwEGrxfnEFzvJj-fi-4665_22745
- [x] Show disabled state clearly on reader disconnect button in success view TfaZ4LUkEwEGrxfnEFzvJj-fi-4665_22801

## Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->

### Layout changes

1. Open POS
2. Compare a disconnected floating control state with designs, padding outside and within the overlay line should be larger
3. Connect to reader
4. Compare a connected floating control state with designs, horizontal padding should be larger
5. Disconnect a reader
6. Compare a disconnecting floating control state with designs, horizontal padding should be larger

### Background animation

1. Open POS
2. Connect to reader
3. Add items to the cart
4. Proceed to payment
5. Confirm that when floating control fades from primary to secondary background

### Disabled state or disconnected button in success view

1. Open POS
2. Connect to reader
3. Add items to the cart
4. Complete the payment
5. Confirm that the connected state appears in a more clearly disabled state

## Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->

Additionally tested:
- Larger fonts
- Light/dark mode

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

#### Layout Changes

| Disconnected | Disconnecting | Connected |
|-----------|---------------|--------------|
| ![Simulator Screenshot - iPad Air 11-inch (M2) - 2024-09-10 at 17 37 30](https://github.com/user-attachments/assets/a484204c-8a83-411e-9574-19b448032aa8) | ![Simulator Screenshot - iPad Air 11-inch (M2) - 2024-09-10 at 17 37 27](https://github.com/user-attachments/assets/784c034a-217e-4b3a-90ab-286c8c28b880) | ![Simulator Screenshot - iPad Air 11-inch (M2) - 2024-09-10 at 17 37 22](https://github.com/user-attachments/assets/3cf2765a-d3c2-4294-ba10-4c744b605b9d) |

#### Background animation

https://github.com/user-attachments/assets/a51cec36-ebd4-438c-a31f-842689eaf454

#### Disabled success state

![Simulator Screenshot - iPad Air 11-inch (M2) - 2024-09-10 at 17 36 15](https://github.com/user-attachments/assets/6ed055f5-f56c-40f3-9d28-6e1bd4ac7f4a)

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [x] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [x] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [x] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on all devices (phone/tablet) and no regressions are added.