### PR TITLE
Blaze: Navigate to the native campaign creation flow from the campaign detail web view

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -5,6 +5,7 @@
 -----
 
 - [*] Payments: Fixed an issue to ensure the payment onboarding state is reset after logout and login. [https://github.com/woocommerce/woocommerce-ios/pull/13897]
+- [*] Blaze: Handle links on the campaign detail web view natively. [https://github.com/woocommerce/woocommerce-ios/pull/13922]
 
 20.3
 -----

--- a/WooCommerce/Classes/ViewRelated/Blaze/BlazeCampaignList/BlazeCampaignListView.swift
+++ b/WooCommerce/Classes/ViewRelated/Blaze/BlazeCampaignList/BlazeCampaignListView.swift
@@ -28,8 +28,8 @@ final class BlazeCampaignListHostingController: UIHostingController<BlazeCampaig
         self.viewModel = viewModel
         super.init(rootView: BlazeCampaignListView(viewModel: viewModel))
 
-        rootView.onCreateCampaign = { [weak self] in
-            self?.startCampaignCreation()
+        rootView.onCreateCampaign = { [weak self] productID in
+            self?.startCampaignCreation(productID: productID)
         }
     }
 
@@ -41,13 +41,14 @@ final class BlazeCampaignListHostingController: UIHostingController<BlazeCampaig
 
 /// Private helper
 private extension BlazeCampaignListHostingController {
-    func startCampaignCreation() {
+    func startCampaignCreation(productID: Int64?) {
         guard let navigationController else {
             return
         }
         let coordinator = BlazeCampaignCreationCoordinator(
             siteID: viewModel.siteID,
             siteURL: viewModel.siteURL,
+            productID: productID,
             source: .campaignList,
             shouldShowIntro: viewModel.shouldShowIntroView,
             navigationController: navigationController,
@@ -79,7 +80,7 @@ struct BlazeCampaignListHostingControllerRepresentable: UIViewControllerRepresen
 struct BlazeCampaignListView: View {
     @ObservedObject private var viewModel: BlazeCampaignListViewModel
 
-    var onCreateCampaign: () -> Void = {}
+    var onCreateCampaign: (Int64?) -> Void = { _ in }
 
 
     init(viewModel: BlazeCampaignListViewModel) {
@@ -118,7 +119,7 @@ struct BlazeCampaignListView: View {
         .toolbar {
             ToolbarItem(placement: .confirmationAction) {
                 Button(Localization.create) {
-                    onCreateCampaign()
+                    onCreateCampaign(nil)
                     viewModel.didSelectCreateCampaign(source: .campaignList)
                 }
             }
@@ -132,7 +133,7 @@ struct BlazeCampaignListView: View {
         }
         .onChange(of: viewModel.shouldShowIntroView) { shouldShow in
             if shouldShow {
-                onCreateCampaign()
+                onCreateCampaign(nil)
                 viewModel.shouldShowIntroView = false
             }
         }
@@ -143,8 +144,14 @@ private extension BlazeCampaignListView {
 
     func detailView(url: URL) -> some View {
         NavigationView {
-            AuthenticatedWebView(isPresented: .constant(true),
-                                 url: url)
+            AuthenticatedWebView(
+                isPresented: .constant(true),
+                viewModel: BlazeCampaignDetailWebViewModel(initialURL: url, siteURL: viewModel.siteURL, onDismiss: {
+                    viewModel.selectedCampaignURL = nil
+                }, onCampaignCreation: { productID in
+                    viewModel.selectedCampaignURL = nil
+                    onCreateCampaign(productID)
+                }))
             .navigationTitle(Localization.detailTitle)
             .navigationBarTitleDisplayMode(.inline)
             .toolbar {

--- a/WooCommerce/Classes/ViewRelated/Blaze/BlazeCampaignList/BlazeCampaignListView.swift
+++ b/WooCommerce/Classes/ViewRelated/Blaze/BlazeCampaignList/BlazeCampaignListView.swift
@@ -148,7 +148,7 @@ private extension BlazeCampaignListView {
                 isPresented: .constant(true),
                 viewModel: BlazeCampaignDetailWebViewModel(initialURL: url, siteURL: viewModel.siteURL, onDismiss: {
                     viewModel.selectedCampaignURL = nil
-                }, onCampaignCreation: { productID in
+                }, onCreateCampaign: { productID in
                     viewModel.selectedCampaignURL = nil
                     onCreateCampaign(productID)
                 }))

--- a/WooCommerce/Classes/ViewRelated/Blaze/CampaignCreation/BlazeCampaignCreationForm.swift
+++ b/WooCommerce/Classes/ViewRelated/Blaze/CampaignCreation/BlazeCampaignCreationForm.swift
@@ -35,7 +35,7 @@ private extension BlazeCampaignCreationFormHostingController {
     }
 }
 
-private extension BlazeCampaignCreationFormHostingController {
+extension BlazeCampaignCreationFormHostingController {
     enum Localization {
         static let title = NSLocalizedString(
             "blazeCampaignCreationForm.title",
@@ -44,7 +44,7 @@ private extension BlazeCampaignCreationFormHostingController {
         )
     }
 
-    enum Constants {
+    private enum Constants {
         static let supportTag = "origin:blaze-native-campaign-creation"
     }
 }
@@ -162,6 +162,7 @@ struct BlazeCampaignCreationForm: View {
             }
             .background(Constants.backgroundViewColor)
         }
+        .navigationTitle(BlazeCampaignCreationFormHostingController.Localization.title)
         .toolbar {
             ToolbarItem(placement: .navigationBarTrailing) {
                 Button(Localization.help) {

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Blaze/BlazeCampaignDashboardView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Blaze/BlazeCampaignDashboardView.swift
@@ -211,7 +211,7 @@ private extension BlazeCampaignDashboardView {
                 isPresented: .constant(true),
                 viewModel: BlazeCampaignDetailWebViewModel(initialURL: url, siteURL: viewModel.siteURL, onDismiss: {
                     viewModel.selectedCampaignURL = nil
-                }, onCampaignCreation: { productID in
+                }, onCreateCampaign: { productID in
                     viewModel.selectedCampaignURL = nil
                     createCampaignTapped?(productID)
                 }))

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Blaze/BlazeCampaignDashboardView.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Blaze/BlazeCampaignDashboardView.swift
@@ -207,8 +207,14 @@ private extension BlazeCampaignDashboardView {
 
     func campaignDetailView(url: URL) -> some View {
         NavigationView {
-            AuthenticatedWebView(isPresented: .constant(true),
-                                 url: url)
+            AuthenticatedWebView(
+                isPresented: .constant(true),
+                viewModel: BlazeCampaignDetailWebViewModel(initialURL: url, siteURL: viewModel.siteURL, onDismiss: {
+                    viewModel.selectedCampaignURL = nil
+                }, onCampaignCreation: { productID in
+                    viewModel.selectedCampaignURL = nil
+                    createCampaignTapped?(productID)
+                }))
             .navigationTitle(Localization.detailTitle)
             .navigationBarTitleDisplayMode(.inline)
             .toolbar {

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Blaze/BlazeCampaignDetailWebViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Blaze/BlazeCampaignDetailWebViewModel.swift
@@ -1,0 +1,91 @@
+import Foundation
+import WebKit
+import RegexBuilder
+
+/// View model for campaign detail web view.
+///
+final class BlazeCampaignDetailWebViewModel: AuthenticatedWebViewModel {
+    let title = "" // the title is set on the SwiftUI view
+    let initialURL: URL?
+
+    private let siteURL: String
+    private let onDismiss: () -> Void
+    private let onCampaignCreation: (Int64) -> Void
+
+    init(initialURL: URL,
+         siteURL: String,
+         onDismiss: @escaping () -> Void,
+         onCampaignCreation: @escaping (Int64) -> Void) {
+        self.initialURL = initialURL
+        self.siteURL = siteURL
+        self.onDismiss = onDismiss
+        self.onCampaignCreation = onCampaignCreation
+    }
+
+    func handleDismissal() {
+        // no-op
+    }
+
+    func handleRedirect(for url: URL?) {
+        guard let url, let initialURL else {
+            return
+        }
+
+        if let productID = retrieveProductIDForCampaignCreation(from: url, baseURL: initialURL) {
+            onCampaignCreation(productID)
+        } else if checkCampaignListURL(for: url, siteURL: siteURL) {
+            onDismiss()
+        }
+    }
+
+    func decidePolicy(for navigationURL: URL) async -> WKNavigationActionPolicy {
+        .allow
+    }
+}
+
+private extension BlazeCampaignDetailWebViewModel {
+    /// Returns true if the current URL triggers the dismissal of the campaign detail screen.
+    ///
+    func checkCampaignListURL(for url: URL, siteURL: String) -> Bool {
+        let expectedURL = String(format: Constants.campaignListURLFormat,
+                                 siteURL.trimHTTPScheme())
+        return url.absoluteString == expectedURL
+    }
+
+    /// Returns the product ID if the current URL is detected as a trigger
+    /// given the provided `baseURL`.
+    ///
+    func retrieveProductIDForCampaignCreation(from url: URL, baseURL: URL) -> Int64? {
+        guard url.absoluteString.hasPrefix(baseURL.absoluteString) else {
+            return nil
+        }
+
+        let components = URLComponents(url: url, resolvingAgainstBaseURL: false)
+        let item = components?.queryItems?.first(where: { $0.name == Constants.campaignCreationParam })
+        guard let item else {
+            return nil
+        }
+
+        let productID = Reference(Int64.self)
+        let regex = Regex {
+            "post-"
+            TryCapture(as: productID) {
+                OneOrMore(.digit)
+            } transform: { match in
+                Int64(match)
+            }
+        }
+
+        if let result = item.value?.firstMatch(of: regex) {
+            return result[productID]
+        }
+        return nil
+    }
+}
+
+private extension BlazeCampaignDetailWebViewModel {
+    enum Constants {
+        static let campaignCreationParam = "blazepress-widget"
+        static let campaignListURLFormat = "https://wordpress.com/advertising/campaigns/%@"
+    }
+}

--- a/WooCommerce/Classes/ViewRelated/Dashboard/Blaze/BlazeCampaignDetailWebViewModel.swift
+++ b/WooCommerce/Classes/ViewRelated/Dashboard/Blaze/BlazeCampaignDetailWebViewModel.swift
@@ -10,16 +10,16 @@ final class BlazeCampaignDetailWebViewModel: AuthenticatedWebViewModel {
 
     private let siteURL: String
     private let onDismiss: () -> Void
-    private let onCampaignCreation: (Int64) -> Void
+    private let onCreateCampaign: (Int64) -> Void
 
     init(initialURL: URL,
          siteURL: String,
          onDismiss: @escaping () -> Void,
-         onCampaignCreation: @escaping (Int64) -> Void) {
+         onCreateCampaign: @escaping (Int64) -> Void) {
         self.initialURL = initialURL
         self.siteURL = siteURL
         self.onDismiss = onDismiss
-        self.onCampaignCreation = onCampaignCreation
+        self.onCreateCampaign = onCreateCampaign
     }
 
     func handleDismissal() {
@@ -32,7 +32,7 @@ final class BlazeCampaignDetailWebViewModel: AuthenticatedWebViewModel {
         }
 
         if let productID = retrieveProductIDForCampaignCreation(from: url, baseURL: initialURL) {
-            onCampaignCreation(productID)
+            onCreateCampaign(productID)
         } else if checkCampaignListURL(for: url, siteURL: siteURL) {
             onDismiss()
         }

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -2640,6 +2640,7 @@
 		DEA88F522AAAC1180037273B /* AddEditProductCategoryViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEA88F512AAAC1180037273B /* AddEditProductCategoryViewModelTests.swift */; };
 		DEA90D352C8EE55D0021ABC3 /* UserDefaults+BlazeCampaignObjective.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEA90D342C8EE55D0021ABC3 /* UserDefaults+BlazeCampaignObjective.swift */; };
 		DEA90D392C9156A20021ABC3 /* BlazeCampaignDetailWebViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEA90D382C9156A20021ABC3 /* BlazeCampaignDetailWebViewModel.swift */; };
+		DEA90D3B2C915DB50021ABC3 /* BlazeCampaignDetailWebViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEA90D3A2C915DB50021ABC3 /* BlazeCampaignDetailWebViewModelTests.swift */; };
 		DEACB8852A64F74A00253F0F /* MediaPickingCoordinatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEACB8842A64F74A00253F0F /* MediaPickingCoordinatorTests.swift */; };
 		DEACB8872A65020A00253F0F /* WooAnalyticsEvent+AddProductFromImage.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEACB8862A65020A00253F0F /* WooAnalyticsEvent+AddProductFromImage.swift */; };
 		DEB387952C2E7A7C0025256E /* GoogleAdsEligibilityChecker.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEB387942C2E7A7C0025256E /* GoogleAdsEligibilityChecker.swift */; };
@@ -5681,6 +5682,7 @@
 		DEA88F512AAAC1180037273B /* AddEditProductCategoryViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddEditProductCategoryViewModelTests.swift; sourceTree = "<group>"; };
 		DEA90D342C8EE55D0021ABC3 /* UserDefaults+BlazeCampaignObjective.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UserDefaults+BlazeCampaignObjective.swift"; sourceTree = "<group>"; };
 		DEA90D382C9156A20021ABC3 /* BlazeCampaignDetailWebViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BlazeCampaignDetailWebViewModel.swift; sourceTree = "<group>"; };
+		DEA90D3A2C915DB50021ABC3 /* BlazeCampaignDetailWebViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BlazeCampaignDetailWebViewModelTests.swift; sourceTree = "<group>"; };
 		DEACB8842A64F74A00253F0F /* MediaPickingCoordinatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MediaPickingCoordinatorTests.swift; sourceTree = "<group>"; };
 		DEACB8862A65020A00253F0F /* WooAnalyticsEvent+AddProductFromImage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "WooAnalyticsEvent+AddProductFromImage.swift"; sourceTree = "<group>"; };
 		DEB387942C2E7A7C0025256E /* GoogleAdsEligibilityChecker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GoogleAdsEligibilityChecker.swift; sourceTree = "<group>"; };
@@ -13381,6 +13383,7 @@
 			isa = PBXGroup;
 			children = (
 				EEC5C8D92ADE2FD80071E852 /* BlazeCampaignDashboardViewModelTests.swift */,
+				DEA90D3A2C915DB50021ABC3 /* BlazeCampaignDetailWebViewModelTests.swift */,
 			);
 			path = Blaze;
 			sourceTree = "<group>";
@@ -16888,6 +16891,7 @@
 				EE66BB122B29D65400518DAF /* MockThemeInstaller.swift in Sources */,
 				45AF9DA5265CEA89001EB794 /* ShippingLabelCarriersViewModelTests.swift in Sources */,
 				DEF8CF0D29A76F7E00800A60 /* JetpackSetupCoordinatorTests.swift in Sources */,
+				DEA90D3B2C915DB50021ABC3 /* BlazeCampaignDetailWebViewModelTests.swift in Sources */,
 				0248042D2887C92A00991319 /* MockLoggedOutAppSettings.swift in Sources */,
 				B56BBD16214820A70053A32D /* SyncCoordinatorTests.swift in Sources */,
 				02A275C023FE58F6005C560F /* MockImageCache.swift in Sources */,

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -2639,6 +2639,7 @@
 		DEA88F502AA9D0100037273B /* AddEditProductCategoryViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEA88F4F2AA9D0100037273B /* AddEditProductCategoryViewModel.swift */; };
 		DEA88F522AAAC1180037273B /* AddEditProductCategoryViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEA88F512AAAC1180037273B /* AddEditProductCategoryViewModelTests.swift */; };
 		DEA90D352C8EE55D0021ABC3 /* UserDefaults+BlazeCampaignObjective.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEA90D342C8EE55D0021ABC3 /* UserDefaults+BlazeCampaignObjective.swift */; };
+		DEA90D392C9156A20021ABC3 /* BlazeCampaignDetailWebViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEA90D382C9156A20021ABC3 /* BlazeCampaignDetailWebViewModel.swift */; };
 		DEACB8852A64F74A00253F0F /* MediaPickingCoordinatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEACB8842A64F74A00253F0F /* MediaPickingCoordinatorTests.swift */; };
 		DEACB8872A65020A00253F0F /* WooAnalyticsEvent+AddProductFromImage.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEACB8862A65020A00253F0F /* WooAnalyticsEvent+AddProductFromImage.swift */; };
 		DEB387952C2E7A7C0025256E /* GoogleAdsEligibilityChecker.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEB387942C2E7A7C0025256E /* GoogleAdsEligibilityChecker.swift */; };
@@ -5679,6 +5680,7 @@
 		DEA88F4F2AA9D0100037273B /* AddEditProductCategoryViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddEditProductCategoryViewModel.swift; sourceTree = "<group>"; };
 		DEA88F512AAAC1180037273B /* AddEditProductCategoryViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddEditProductCategoryViewModelTests.swift; sourceTree = "<group>"; };
 		DEA90D342C8EE55D0021ABC3 /* UserDefaults+BlazeCampaignObjective.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UserDefaults+BlazeCampaignObjective.swift"; sourceTree = "<group>"; };
+		DEA90D382C9156A20021ABC3 /* BlazeCampaignDetailWebViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BlazeCampaignDetailWebViewModel.swift; sourceTree = "<group>"; };
 		DEACB8842A64F74A00253F0F /* MediaPickingCoordinatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MediaPickingCoordinatorTests.swift; sourceTree = "<group>"; };
 		DEACB8862A65020A00253F0F /* WooAnalyticsEvent+AddProductFromImage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "WooAnalyticsEvent+AddProductFromImage.swift"; sourceTree = "<group>"; };
 		DEB387942C2E7A7C0025256E /* GoogleAdsEligibilityChecker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GoogleAdsEligibilityChecker.swift; sourceTree = "<group>"; };
@@ -13322,6 +13324,7 @@
 			children = (
 				EEBA02A22ADD6005001FE8E4 /* BlazeCampaignDashboardView.swift */,
 				EEBA02A42ADD606D001FE8E4 /* BlazeCampaignDashboardViewModel.swift */,
+				DEA90D382C9156A20021ABC3 /* BlazeCampaignDetailWebViewModel.swift */,
 			);
 			path = Blaze;
 			sourceTree = "<group>";
@@ -14789,6 +14792,7 @@
 				02B2829027C352DA004A332A /* RefreshableScrollView.swift in Sources */,
 				DE6D84A92C3D07850014FBFF /* WooAnalyticsEvent+GoogleAds.swift in Sources */,
 				683DF5FF2C6AF46500A5CDC6 /* POSHeaderTitleView.swift in Sources */,
+				DEA90D392C9156A20021ABC3 /* BlazeCampaignDetailWebViewModel.swift in Sources */,
 				DE7842F726F2E9340030C792 /* UIViewController+Connectivity.swift in Sources */,
 				019C5EB02C516F7B005B82D3 /* ItemListViewModelProtocol.swift in Sources */,
 				E1C47209267A1ECC00D06DA1 /* CrashLoggingStack.swift in Sources */,

--- a/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Blaze/BlazeCampaignDetailWebViewModelTests.swift
+++ b/WooCommerce/WooCommerceTests/ViewRelated/Dashboard/Blaze/BlazeCampaignDetailWebViewModelTests.swift
@@ -1,0 +1,44 @@
+import XCTest
+@testable import WooCommerce
+
+final class BlazeCampaignDetailWebViewModelTests: XCTestCase {
+
+    func test_onDismiss_is_triggered_when_campaign_list_is_detected() throws {
+        // Given
+        let siteURL = "https://example.com"
+        let initialURL = try XCTUnwrap(URL(string: "https://wordpress.com/advertising/campaigns/134/example.com"))
+
+        var onDismissTriggered = false
+        let viewModel = BlazeCampaignDetailWebViewModel(initialURL: initialURL, siteURL: siteURL, onDismiss: {
+            onDismissTriggered = true
+        }, onCreateCampaign: { _ in })
+
+        // When
+        let url = try XCTUnwrap(URL(string: "https://wordpress.com/advertising/campaigns/example.com"))
+        viewModel.handleRedirect(for: url)
+
+        // Then
+        XCTAssertTrue(onDismissTriggered)
+    }
+
+    func test_onCreateCampaign_is_triggered_when_campaign_list_is_detected() throws {
+        // Given
+        let siteURL = "https://example.com"
+        let initialURL = try XCTUnwrap(URL(string: "https://wordpress.com/advertising/campaigns/134/example.com"))
+
+        var onCreateCampaignTriggered = false
+        var triggeredProductID: Int64?
+        let viewModel = BlazeCampaignDetailWebViewModel(initialURL: initialURL, siteURL: siteURL, onDismiss: {}, onCreateCampaign: { productID in
+            onCreateCampaignTriggered = true
+            triggeredProductID = productID
+        })
+
+        // When
+        let url = try XCTUnwrap(URL(string: "https://wordpress.com/advertising/campaigns/134/example.com?blazepress-widget=post-1039"))
+        viewModel.handleRedirect(for: url)
+
+        // Then
+        XCTAssertTrue(onCreateCampaignTriggered)
+        XCTAssertEqual(triggeredProductID, 1039)
+    }
+}


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #13867 
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This PR updates the handling of URLs on the Blaze campaign detail web view by adding a custom view model for the authenticated web view. 

This new view model implements `handleRedirect` to detect the URL that triggers campaign creation and trigger a callback for the Blaze dashboard card and the campaign list where the campaign detail view is presented from.

Additionally, I also added a check to handle the tap on the Back link of the web page to dismiss it instead of redirecting to the campaign list on the web page.

## Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->
- Log in to a store eligible for Blaze.
- Create a campaign and cancel it if your store doesn't have any canceled/rejected/completed campaigns created in the past.
- Enable the Blaze card on the dashboard screen.
- Tap the campaign displayed on the card to open the detail web page.
- Tap Back, confirm that the web page is dismissed.
- Tap the campaign again > Promote again. Confirm that the web page is dismissed and the native campaign creation flow is presented.
- Switch to the Hub menu tab > Blaze.
- Select a cancelled/rejected/completed campaign to open the detail page and tap Promote again. Confirm that the web page is dismissed and the native campaign creation flow is presented.

## Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: https://woomobilep2.wordpress.com/2024/05/06/woocommerce-mobile-quality-report-march-april/#comment-12036 -->
Tested on simulator iPhone 15 Pro iOS 17.4:
- Confirmed that tapping Back on the campaign detail page dismisses the page on both dashboard and hub menu.
- Confirmed that tapping Promote again dismisses the page and presents the creation flow from both dashboard and hub menu.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

<img src="https://github.com/user-attachments/assets/f5e7ff21-4754-462b-85ac-824225650ebf" width=320 />


---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [ ] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [ ] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [ ] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on all devices (phone/tablet) and no regressions are added.
