### PR TITLE
[Woo POS] Change a default sorting of POS products to "menu_order"

### DIFF
--- a/Networking/Networking/Remote/ProductsRemote.swift
+++ b/Networking/Networking/Remote/ProductsRemote.swift
@@ -190,7 +190,7 @@ public final class ProductsRemote: Remote, ProductsRemoteProtocol {
             ParameterKey.page: POSConstants.page,
             ParameterKey.perPage: POSConstants.productsPerPage,
             ParameterKey.productType: POSConstants.productType,
-            ParameterKey.orderBy: OrderKey.name.value,
+            ParameterKey.orderBy: OrderKey.menuOrder.value,
             ParameterKey.order: Order.ascending.value,
             ParameterKey.productStatus: POSConstants.productStatus,
         ]
@@ -541,6 +541,7 @@ public extension ProductsRemote {
         case name
         // available for use in `GET wc-analytics/reports/products/stats` only.
         case itemsSold
+        case menuOrder
     }
 
     enum Order {
@@ -625,6 +626,8 @@ private extension ProductsRemote.OrderKey {
             return "title"
         case .itemsSold:
             return "items_sold"
+        case .menuOrder:
+            return "menu_order"
         }
     }
 }

--- a/Networking/NetworkingTests/Remote/ProductsRemoteTests.swift
+++ b/Networking/NetworkingTests/Remote/ProductsRemoteTests.swift
@@ -867,6 +867,18 @@ final class ProductsRemoteTests: XCTestCase {
         }
     }
 
+    func test_loadAllSimpleProductsForPointOfSale_called_with_menu_order() async throws {
+        // Given
+        let remote = ProductsRemote(network: network)
+
+        // When
+        network.simulateResponse(requestUrlSuffix: "products", filename: "products-load-all-type-simple")
+        let _ = try await remote.loadAllSimpleProductsForPointOfSale(for: sampleSiteID)
+
+        // Then
+        XCTAssertTrue((network.queryParameters ?? []).contains("orderby=menu_order"))
+    }
+
     func test_loadAllSimpleProductsForPointOfSale_relays_networking_error() async throws {
         // Given
         let remote = ProductsRemote(network: network)


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Context: p1726048025972449-slack-C070SJRA8DP
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

Change a default sorting of POS products to "menu_order" to reflect the sorting set on wp-admin, WooCommerce -> Products -> Sorting. 

## Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->

1. Set the product order on wp-admin, WooCommerce -> Products -> Sorting
2. Open POS
3. Notice product order
4. Change the product order on wp-admin, WooCommerce -> Products -> Sorting
5. Pull to refresh
6. Confirm the order has changed

## Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->

I didn't perform additional testing beyond the main flow.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

https://github.com/user-attachments/assets/a0325f5d-06a8-42ea-a399-6d7889510cf9

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [ ] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [ ] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [ ] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on all devices (phone/tablet) and no regressions are added.