### PR TITLE
[Login] Stop treating login URLs as universal links

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -4,6 +4,9 @@
 20.3
 -----
 
+20.2.1
+-----
+- [***] Login: Fix an issue with login using magic link [https://github.com/woocommerce/woocommerce-ios/pull/13926]
 
 20.2
 -----
@@ -19,7 +22,6 @@
 - [**] Blaze: Support evergreen campaign creation. [https://github.com/woocommerce/woocommerce-ios/pull/13684]
 - [Internal] Custom fields: Renamed the OrderMetaData entity to MetaData [https://github.com/woocommerce/woocommerce-ios/pull/13736]
 - [Internal] Tooling: updated Sentry to avoid potential crash [https://github.com/woocommerce/woocommerce-ios/pull/13828]
-- [***] Login: Fix an issue with login using magic link [https://github.com/woocommerce/woocommerce-ios/pull/13926]
 
 20.1
 -----

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -19,6 +19,7 @@
 - [**] Blaze: Support evergreen campaign creation. [https://github.com/woocommerce/woocommerce-ios/pull/13684]
 - [Internal] Custom fields: Renamed the OrderMetaData entity to MetaData [https://github.com/woocommerce/woocommerce-ios/pull/13736]
 - [Internal] Tooling: updated Sentry to avoid potential crash [https://github.com/woocommerce/woocommerce-ios/pull/13828]
+- [***] Login: Fix an issue with login using magic link [https://github.com/woocommerce/woocommerce-ios/pull/13926]
 
 20.1
 -----

--- a/WooCommerce/Classes/AppDelegate.swift
+++ b/WooCommerce/Classes/AppDelegate.swift
@@ -138,19 +138,11 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
             jetpackSetupCoordinator = coordinator
             return coordinator.handleAuthenticationUrl(url)
         }
-
-        /// prioritize handling login deep link
-        if ServiceLocator.authenticationManager.handleAuthenticationUrl(url, options: options, rootViewController: rootViewController) {
-            return true
-        }
-
-        /// if all the above fail, ask universal link router to handle the URL if possible.
         if let universalLinkRouter, universalLinkRouter.canHandle(url: url) {
             universalLinkRouter.handle(url: url)
             return true
         }
-
-        return false
+        return ServiceLocator.authenticationManager.handleAuthenticationUrl(url, options: options, rootViewController: rootViewController)
     }
 
     func application(_ application: UIApplication, didRegisterForRemoteNotificationsWithDeviceToken deviceToken: Data) {

--- a/WooCommerce/Classes/AppDelegate.swift
+++ b/WooCommerce/Classes/AppDelegate.swift
@@ -138,11 +138,19 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
             jetpackSetupCoordinator = coordinator
             return coordinator.handleAuthenticationUrl(url)
         }
+
+        /// prioritize handling login deep link
+        if ServiceLocator.authenticationManager.handleAuthenticationUrl(url, options: options, rootViewController: rootViewController) {
+            return true
+        }
+
+        /// if all the above fail, ask universal link router to handle the URL if possible.
         if let universalLinkRouter, universalLinkRouter.canHandle(url: url) {
             universalLinkRouter.handle(url: url)
             return true
         }
-        return ServiceLocator.authenticationManager.handleAuthenticationUrl(url, options: options, rootViewController: rootViewController)
+
+        return false
     }
 
     func application(_ application: UIApplication, didRegisterForRemoteNotificationsWithDeviceToken deviceToken: Data) {

--- a/WooCommerce/Classes/System/WooConstants.swift
+++ b/WooCommerce/Classes/System/WooConstants.swift
@@ -77,6 +77,7 @@ public enum WooConstants {
     /// App login deep link prefix
     ///
     static let appLoginURLPrefix = "woocommerce://app-login"
+    static let appMagicLoginURLPrefix = "woocommerce://magic-login"
 
     static let wooPaymentsPluginPath = "woocommerce-payments/woocommerce-payments.php"
 

--- a/WooCommerce/Classes/Universal Links/UniversalLinkRouter.swift
+++ b/WooCommerce/Classes/Universal Links/UniversalLinkRouter.swift
@@ -26,6 +26,13 @@ struct UniversalLinkRouter {
 
     /// Checks if any of the routes can handle the url
     func canHandle(url: URL) -> Bool {
+        /// Ensure that the URL is not related to login
+        ///
+        guard url.absoluteString.hasPrefix(WooConstants.appLoginURLPrefix) == false,
+              url.absoluteString.hasPrefix(WooConstants.appMagicLoginURLPrefix) == false else {
+            return false
+        }
+
         return canHandle(subPath: url.lastPathComponent)
     }
 

--- a/WooCommerce/WooCommerceTests/Universal Links/UniversalLinkRouterTests.swift
+++ b/WooCommerce/WooCommerceTests/Universal Links/UniversalLinkRouterTests.swift
@@ -176,6 +176,29 @@ final class UniversalLinkRouterTests: XCTestCase {
         XCTAssert(routes.contains { $0 is PaymentsRoute })
         XCTAssert(routes.contains { $0 is OrdersRoute })
     }
+
+    func test_canHandle_returns_false_for_magic_link_url() throws {
+        // Given
+        let mockNavigator = MockDeepLinkNavigator()
+        let routes = UniversalLinkRouter.defaultRoutes(navigator: mockNavigator)
+        let sut = UniversalLinkRouter(routes: routes)
+        let url = try XCTUnwrap(URL(string: "woocommerce://magic-login?token=23easdcasd&flow=login&source=default"))
+
+        // Then
+        XCTAssertFalse(sut.canHandle(url: url))
+    }
+
+
+    func test_canHandle_returns_false_for_login_link_url() throws {
+        // Given
+        let mockNavigator = MockDeepLinkNavigator()
+        let routes = UniversalLinkRouter.defaultRoutes(navigator: mockNavigator)
+        let sut = UniversalLinkRouter(routes: routes)
+        let url = try XCTUnwrap(URL(string: "woocommerce://app-login?token=cawe212m&flow=login&source=default"))
+
+        // Then
+        XCTAssertFalse(sut.canHandle(url: url))
+    }
 }
 
 private extension UniversalLinkRouterTests {


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #13886
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

Login using the magic link no longer works after we merged [this PR](https://github.com/woocommerce/woocommerce-ios/pull/13714/). 

This PR starts prioritising handling the magic link before handling other universal links. 

I didn't add unit tests for the `AppDelegate` deep link navigation as it isn't straight forward. Any suggestions are welcome. 

Internal - peaMlT-SZ-p2

## Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->
- Install and launch the app
- Tap "Log In" and enter your store address
- Tap "Continue" and enter your WPCOM email. (Use non A8C WPCOM account)
- Tap "Continue" and select "Or log in with magic link" option
- You should receive a magic link to your email
- Open the magic link email and tap on "Login"
- The browser should open and redirect and ask permission to open the "Woo" app
- Validate that the "Woo" app is opened and you are successfully logged in

## Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->
- I tested that magic link login works as expected on an iPhone running iOS 18.0.
- We need to test that other deep links work as expected. I think following the testing instructions from [this PR](https://github.com/woocommerce/woocommerce-ios/pull/13714/) should help. 
    - @bozidarsevo Could you kindly help with this? Thank you!

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

https://github.com/user-attachments/assets/ca961cfb-48d0-4945-914b-c261b5c56e1c



---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [x] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [x] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [x] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on all devices (phone/tablet) and no regressions are added.