### PR TITLE
Revert 13714 PR - Open orders when tapping orders part from home screen widget

### DIFF
--- a/WooCommerce/Classes/AppDelegate.swift
+++ b/WooCommerce/Classes/AppDelegate.swift
@@ -138,10 +138,6 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
             jetpackSetupCoordinator = coordinator
             return coordinator.handleAuthenticationUrl(url)
         }
-        if let universalLinkRouter, universalLinkRouter.canHandle(url: url) {
-            universalLinkRouter.handle(url: url)
-            return true
-        }
         return ServiceLocator.authenticationManager.handleAuthenticationUrl(url, options: options, rootViewController: rootViewController)
     }
 

--- a/WooCommerce/Classes/System/WooConstants.swift
+++ b/WooCommerce/Classes/System/WooConstants.swift
@@ -363,8 +363,6 @@ extension WooConstants {
         case orderCreationShippingFeedback = "https://automattic.survey.fm/order-creation-shipping-lines-survey-production"
 #endif
 
-        case ordersScreen = "https://woocommerce.com/mobile/orders"
-
         /// Returns the URL version of the receiver
         ///
         func asURL() -> URL {

--- a/WooCommerce/Classes/Universal Links/UniversalLinkRouter.swift
+++ b/WooCommerce/Classes/Universal Links/UniversalLinkRouter.swift
@@ -9,7 +9,6 @@ struct UniversalLinkRouter {
     private let matcher: RouteMatcher
     private let bouncingURLOpener: URLOpener
     private let analyticsTracker: UniversalLinkRouterAnalyticsTracking?
-    private let routes: [Route]
 
     /// The order of the passed Route array matters, as given two routes that handle a path only the first
     /// will be called to perform its action. If no route matches the path it uses the `bouncingURLOpener` to
@@ -19,24 +18,8 @@ struct UniversalLinkRouter {
          bouncingURLOpener: URLOpener = ApplicationURLOpener(),
          analyticsTracker: UniversalLinkRouterAnalyticsTracking? = UniversalLinkAnalyticsTracker(analytics: ServiceLocator.analytics)) {
         matcher = RouteMatcher(routes: routes)
-        self.routes = routes
         self.bouncingURLOpener = bouncingURLOpener
         self.analyticsTracker = analyticsTracker
-    }
-
-    /// Checks if any of the routes can handle the url
-    func canHandle(url: URL) -> Bool {
-        return canHandle(subPath: url.lastPathComponent)
-    }
-
-    /// Checks if any of the routes can handle the subPath
-    func canHandle(subPath: String) -> Bool {
-        for route in routes {
-            if route.canHandle(subPath: subPath) {
-                return true
-            }
-        }
-        return false
     }
 
     static func defaultUniversalLinkRouter(tabBarController: MainTabBarController) -> UniversalLinkRouter {

--- a/WooCommerce/StoreWidgets/Homescreen/StoreInfoView.swift
+++ b/WooCommerce/StoreWidgets/Homescreen/StoreInfoView.swift
@@ -97,15 +97,14 @@ private struct StatsCard: View {
 
             // Orders & Conversion
             HStack {
-                Link(destination: WooConstants.URLs.ordersScreen.asURL()) {
-                    VStack(alignment: .leading, spacing: StoreInfoView.Layout.cardSpacing) {
-                        Text(StoreInfoView.Localization.orders)
-                            .statTitleStyle()
-                        Text(entryData.orders)
-                            .statValueStyle()
-                    }
-                    .frame(maxWidth: .infinity, alignment: .leading)
+                VStack(alignment: .leading, spacing: StoreInfoView.Layout.cardSpacing) {
+                    Text(StoreInfoView.Localization.orders)
+                        .statTitleStyle()
+
+                    Text(entryData.orders)
+                        .statValueStyle()
                 }
+                .frame(maxWidth: .infinity, alignment: .leading)
                 VStack(alignment: .leading, spacing: StoreInfoView.Layout.cardSpacing) {
                     Text(StoreInfoView.Localization.conversion)
                         .statTitleStyle()


### PR DESCRIPTION
## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

This PR reverts changes from https://github.com/woocommerce/woocommerce-ios/pull/13714/

peaMlT-SZ-p2

## Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->
- Install and launch the app
- Tap "Log In" and enter your store address
- Tap "Continue" and enter your WPCOM email
- Tap "Continue" and select "Or log in with magic link" option
- Open the magic link from your email
- Validate that "Woo" app is opened and you are successfully logged in

## Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: https://woomobilep2.wordpress.com/2024/05/06/woocommerce-mobile-quality-report-march-april/#comment-12036 -->

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

---
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [ ] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [ ] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [ ] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on all devices (phone/tablet) and no regressions are added.
