### PR TITLE
[Shipping labels] Add items section with static content to Create Shipping Labels view

### DIFF
--- a/WooCommerce/Classes/View Modifiers/View+RoundedBorder.swift
+++ b/WooCommerce/Classes/View Modifiers/View+RoundedBorder.swift
@@ -1,0 +1,29 @@
+import SwiftUI
+
+/// Custom view modifier for applying a rounded border to a view.
+struct RoundedBorder: ViewModifier {
+    let cornerRadius: CGFloat
+    let lineColor: Color
+    let lineWidth: CGFloat
+
+    func body(content: Content) -> some View {
+        content
+            .overlay {
+                RoundedRectangle(cornerRadius: cornerRadius)
+                    .stroke(lineColor, lineWidth: lineWidth)
+            }
+    }
+}
+
+private extension RoundedBorder {
+    enum Layout {
+        static let height: CGFloat = 1
+    }
+}
+
+extension View {
+    /// Applies a rounded border to a view.
+    func roundedBorder(cornerRadius: CGFloat, lineColor: Color, lineWidth: CGFloat) -> some View {
+        self.modifier(RoundedBorder(cornerRadius: cornerRadius, lineColor: lineColor, lineWidth: lineWidth))
+    }
+}

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Items Section/WooShippingItemRow.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Items Section/WooShippingItemRow.swift
@@ -1,0 +1,80 @@
+import SwiftUI
+
+/// Row for an item to ship with the Woo Shipping extension.
+struct WooShippingItemRow: View {
+    /// URL for item image
+    let imageUrl: URL?
+
+    /// Label for item quantity
+    let quantityLabel: String
+
+    /// Item name
+    let name: String
+
+    /// Label for item details
+    let detailsLabel: String
+
+    /// Label for item weight
+    let weightLabel: String
+
+    /// Label for item price
+    let priceLabel: String
+
+    @ScaledMetric private var scale: CGFloat = 1
+
+    var body: some View {
+        HStack(alignment: .lastTextBaseline) {
+            ProductImageThumbnail(productImageURL: imageUrl,
+                                  productImageSize: Layout.imageSize,
+                                  scale: scale,
+                                  productImageCornerRadius: Layout.imageCornerRadius,
+                                  foregroundColor: Color(UIColor.listSmallIcon))
+            .overlay(alignment: .topTrailing) {
+                BadgeView(text: quantityLabel,
+                          customizations: .init(textColor: .white, backgroundColor: .black),
+                          backgroundShape: badgeStyle)
+                .offset(x: Layout.badgeOffset, y: -Layout.badgeOffset)
+            }
+            Spacer()
+            VStack(alignment: .leading) {
+                Text(name)
+                    .bodyStyle()
+                Text(detailsLabel)
+                    .subheadlineStyle()
+                Text(weightLabel)
+                    .subheadlineStyle()
+            }
+            Spacer()
+            Text(priceLabel)
+                .font(.subheadline)
+                .foregroundStyle(Color(.text))
+        }
+    }
+}
+
+private extension WooShippingItemRow {
+    /// Displays a different badge background shape based on the item quantity
+    /// Circular for 2-character quantities, rounded for 3-character quantities or more
+    var badgeStyle: BadgeView.BackgroundShape {
+        if quantityLabel.count < 3 {
+            return .circle
+        } else {
+            return .roundedRectangle(cornerRadius: Layout.badgeOffset)
+        }
+    }
+
+    enum Layout {
+        static let imageSize: CGFloat = 56.0
+        static let imageCornerRadius: CGFloat = 4.0
+        static let badgeOffset: CGFloat = 8.0
+    }
+}
+
+#Preview {
+    WooShippingItemRow(imageUrl: nil,
+                       quantityLabel: "3",
+                       name: "Little Nap Brazil 250g",
+                       detailsLabel: "15×10×8cm • Espresso",
+                       weightLabel: "275g",
+                       priceLabel: "$60.00")
+}

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Items Section/WooShippingItemRow.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Items Section/WooShippingItemRow.swift
@@ -23,7 +23,7 @@ struct WooShippingItemRow: View {
     @ScaledMetric private var scale: CGFloat = 1
 
     var body: some View {
-        HStack(alignment: .lastTextBaseline) {
+        AdaptiveStack(spacing: Layout.horizontalSpacing) {
             ProductImageThumbnail(productImageURL: imageUrl,
                                   productImageSize: Layout.imageSize,
                                   scale: scale,
@@ -35,20 +35,22 @@ struct WooShippingItemRow: View {
                           backgroundShape: badgeStyle)
                 .offset(x: Layout.badgeOffset, y: -Layout.badgeOffset)
             }
-            Spacer()
-            VStack(alignment: .leading) {
-                Text(name)
-                    .bodyStyle()
-                Text(detailsLabel)
-                    .subheadlineStyle()
-                Text(weightLabel)
-                    .subheadlineStyle()
+            AdaptiveStack(verticalAlignment: .lastTextBaseline) {
+                VStack(alignment: .leading) {
+                    Text(name)
+                        .bodyStyle()
+                    Text(detailsLabel)
+                        .subheadlineStyle()
+                    Text(weightLabel)
+                        .subheadlineStyle()
+                }
+                Spacer()
+                Text(priceLabel)
+                    .font(.subheadline)
+                    .foregroundStyle(Color(.text))
             }
-            Spacer()
-            Text(priceLabel)
-                .font(.subheadline)
-                .foregroundStyle(Color(.text))
         }
+        .frame(maxWidth: .infinity)
     }
 }
 
@@ -64,6 +66,7 @@ private extension WooShippingItemRow {
     }
 
     enum Layout {
+        static let horizontalSpacing: CGFloat = 16
         static let imageSize: CGFloat = 56.0
         static let imageCornerRadius: CGFloat = 4.0
         static let badgeOffset: CGFloat = 8.0

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Items Section/WooShippingItemRow.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Items Section/WooShippingItemRow.swift
@@ -35,19 +35,19 @@ struct WooShippingItemRow: View {
                           backgroundShape: badgeStyle)
                 .offset(x: Layout.badgeOffset, y: -Layout.badgeOffset)
             }
-            AdaptiveStack(verticalAlignment: .lastTextBaseline) {
-                VStack(alignment: .leading) {
-                    Text(name)
-                        .bodyStyle()
-                    Text(detailsLabel)
-                        .subheadlineStyle()
+            VStack(alignment: .leading) {
+                Text(name)
+                    .bodyStyle()
+                Text(detailsLabel)
+                    .subheadlineStyle()
+                AdaptiveStack(verticalAlignment: .lastTextBaseline) {
                     Text(weightLabel)
                         .subheadlineStyle()
+                    Spacer()
+                    Text(priceLabel)
+                        .font(.subheadline)
+                        .foregroundStyle(Color(.text))
                 }
-                Spacer()
-                Text(priceLabel)
-                    .font(.subheadline)
-                    .foregroundStyle(Color(.text))
             }
         }
         .frame(maxWidth: .infinity)

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Items Section/WooShippingItems.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Items Section/WooShippingItems.swift
@@ -15,7 +15,7 @@ struct WooShippingItems: View {
         CollapsibleView(isCollapsed: $isCollapsed,
                         shouldShowDividers: false,
                         label: {
-            HStack {
+            AdaptiveStack {
                 Text(itemsCountLabel)
                     .headlineStyle()
                 Spacer()

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Items Section/WooShippingItems.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShipping Items Section/WooShippingItems.swift
@@ -1,0 +1,64 @@
+import SwiftUI
+
+/// Collapsible section for all items to ship with the Woo Shipping extension.
+struct WooShippingItems: View {
+    /// Label for the total number of items
+    let itemsCountLabel: String
+
+    /// Label for the total item details
+    let itemsDetailLabel: String
+
+    /// Whether the item list is collapsed
+    @State private var isCollapsed: Bool = true
+
+    var body: some View {
+        CollapsibleView(isCollapsed: $isCollapsed,
+                        shouldShowDividers: false,
+                        label: {
+            HStack {
+                Text(itemsCountLabel)
+                    .headlineStyle()
+                Spacer()
+                Text(itemsDetailLabel)
+                    .foregroundStyle(Color(.textSubtle))
+            }
+        },
+                        content: {
+            VStack {
+                WooShippingItemRow(imageUrl: nil,
+                                   quantityLabel: "3",
+                                   name: "Little Nap Brazil 250g",
+                                   detailsLabel: "15×10×8cm • Espresso",
+                                   weightLabel: "275g",
+                                   priceLabel: "$60.00")
+                .padding()
+                .roundedBorder(cornerRadius: Layout.borderCornerRadius, lineColor: Color(.separator), lineWidth: Layout.borderWidth)
+                WooShippingItemRow(imageUrl: nil,
+                                   quantityLabel: "3",
+                                   name: "Little Nap Brazil 250g",
+                                   detailsLabel: "15×10×8cm • Espresso",
+                                   weightLabel: "275g",
+                                   priceLabel: "$60.00")
+                .padding()
+                .roundedBorder(cornerRadius: Layout.borderCornerRadius, lineColor: Color(.separator), lineWidth: Layout.borderWidth)
+            }
+        })
+        .padding()
+        .frame(maxWidth: .infinity, alignment: .center)
+        .if(isCollapsed) { view in
+            view
+                .roundedBorder(cornerRadius: Layout.borderCornerRadius, lineColor: Color(.separator), lineWidth: Layout.borderWidth)
+        }
+    }
+}
+
+private extension WooShippingItems {
+    enum Layout {
+        static let borderCornerRadius: CGFloat = 8
+        static let borderWidth: CGFloat = 0.5
+    }
+}
+
+#Preview {
+    WooShippingItems(itemsCountLabel: "6 items", itemsDetailLabel: "825g  ·  $135.00")
+}

--- a/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingCreateLabelsView.swift
+++ b/WooCommerce/Classes/ViewRelated/Orders/Order Details/Shipping Labels/WooShipping Create Shipping Labels/WooShippingCreateLabelsView.swift
@@ -20,7 +20,8 @@ struct WooShippingCreateLabelsView: View {
     var body: some View {
         NavigationStack {
             ScrollView {
-                // TODO-13550: Add main UI for new shipping labels flow.
+                WooShippingItems(itemsCountLabel: "6 items", itemsDetailLabel: "825g  ·  $135.00")
+                    .padding()
             }
             .navigationTitle(Localization.title)
             .navigationBarTitleDisplayMode(.inline)

--- a/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductWithAI/Preview/ProductDetailPreviewView.swift
+++ b/WooCommerce/Classes/ViewRelated/Products/Add Product/AddProductWithAI/Preview/ProductDetailPreviewView.swift
@@ -388,21 +388,11 @@ private extension ProductDetailPreviewView {
 
 // MARK: - Rounded rect overlay
 //
-private struct RoundedBorder: ViewModifier {
-    let strokeColor: Color
-
-    func body(content: Content) -> some View {
-        content
-            .overlay(
-                RoundedRectangle(cornerRadius: ProductDetailPreviewView.Layout.cornerRadius)
-                    .stroke(strokeColor, lineWidth: ProductDetailPreviewView.Layout.borderWidth)
-            )
-    }
-}
-
 private extension View {
     func roundedRectBorderStyle(strokeColor: Color = ProductDetailPreviewView.Constants.separatorColor) -> some View {
-        modifier(RoundedBorder(strokeColor: strokeColor))
+        modifier(RoundedBorder(cornerRadius: ProductDetailPreviewView.Layout.cornerRadius,
+                               lineColor: strokeColor,
+                               lineWidth: ProductDetailPreviewView.Layout.borderWidth))
     }
 }
 

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -2252,6 +2252,7 @@
 		CE6A8FB62B725A690063564D /* AnalyticsReportLinkViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE6A8FB52B725A690063564D /* AnalyticsReportLinkViewModel.swift */; };
 		CE6A8FB82B7291760063564D /* AnalyticsReportLinkViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE6A8FB72B7291760063564D /* AnalyticsReportLinkViewModelTests.swift */; };
 		CE6E110B2C91DA5D00563DD4 /* WooShippingItemRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE6E110A2C91DA5D00563DD4 /* WooShippingItemRow.swift */; };
+		CE6E110F2C91EF6800563DD4 /* View+RoundedBorder.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE6E110E2C91EF6800563DD4 /* View+RoundedBorder.swift */; };
 		CE7CEC2D2C2EF0E50066FD53 /* GoogleAdsCampaignReportCardViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE7CEC2C2C2EF0E50066FD53 /* GoogleAdsCampaignReportCardViewModelTests.swift */; };
 		CE7F778B2C074D2500C89F4E /* EditableOrderShippingLineViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE7F778A2C074D2500C89F4E /* EditableOrderShippingLineViewModel.swift */; };
 		CE7F778D2C0770FF00C89F4E /* EditableOrderShippingLineViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE7F778C2C0770FF00C89F4E /* EditableOrderShippingLineViewModelTests.swift */; };
@@ -5290,6 +5291,7 @@
 		CE6A8FB52B725A690063564D /* AnalyticsReportLinkViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnalyticsReportLinkViewModel.swift; sourceTree = "<group>"; };
 		CE6A8FB72B7291760063564D /* AnalyticsReportLinkViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnalyticsReportLinkViewModelTests.swift; sourceTree = "<group>"; };
 		CE6E110A2C91DA5D00563DD4 /* WooShippingItemRow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WooShippingItemRow.swift; sourceTree = "<group>"; };
+		CE6E110E2C91EF6800563DD4 /* View+RoundedBorder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "View+RoundedBorder.swift"; sourceTree = "<group>"; };
 		CE7CEC2C2C2EF0E50066FD53 /* GoogleAdsCampaignReportCardViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GoogleAdsCampaignReportCardViewModelTests.swift; sourceTree = "<group>"; };
 		CE7F778A2C074D2500C89F4E /* EditableOrderShippingLineViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditableOrderShippingLineViewModel.swift; sourceTree = "<group>"; };
 		CE7F778C2C0770FF00C89F4E /* EditableOrderShippingLineViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditableOrderShippingLineViewModelTests.swift; sourceTree = "<group>"; };
@@ -7962,6 +7964,7 @@
 				02562ACF296D1FD100980404 /* View+DividerStyle.swift */,
 				B649BC7D2A1C295B007AB988 /* View+HighlightModifier.swift */,
 				02B60DFA2A58809F004C47FF /* View+MediaSourceActionSheet.swift */,
+				CE6E110E2C91EF6800563DD4 /* View+RoundedBorder.swift */,
 			);
 			path = "View Modifiers";
 			sourceTree = "<group>";
@@ -15649,6 +15652,7 @@
 				4596853F2540669900D17B90 /* DownloadableFileSource.swift in Sources */,
 				021DD44D286A3A8D004F0468 /* UIViewController+Navigation.swift in Sources */,
 				B958A7CB28B3D4A100823EEF /* RouteMatcher.swift in Sources */,
+				CE6E110F2C91EF6800563DD4 /* View+RoundedBorder.swift in Sources */,
 				0279F0E4252DC9670098D7DE /* ProductVariationLoadUseCase.swift in Sources */,
 				0366EAE12909A37800B51755 /* JustInTimeMessageViewModel.swift in Sources */,
 				CCF87BC02790582500461C43 /* ProductVariationSelectorView.swift in Sources */,

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -2252,6 +2252,7 @@
 		CE6A8FB62B725A690063564D /* AnalyticsReportLinkViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE6A8FB52B725A690063564D /* AnalyticsReportLinkViewModel.swift */; };
 		CE6A8FB82B7291760063564D /* AnalyticsReportLinkViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE6A8FB72B7291760063564D /* AnalyticsReportLinkViewModelTests.swift */; };
 		CE6E110B2C91DA5D00563DD4 /* WooShippingItemRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE6E110A2C91DA5D00563DD4 /* WooShippingItemRow.swift */; };
+		CE6E110D2C91E5FF00563DD4 /* WooShippingItems.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE6E110C2C91E5FF00563DD4 /* WooShippingItems.swift */; };
 		CE6E110F2C91EF6800563DD4 /* View+RoundedBorder.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE6E110E2C91EF6800563DD4 /* View+RoundedBorder.swift */; };
 		CE7CEC2D2C2EF0E50066FD53 /* GoogleAdsCampaignReportCardViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE7CEC2C2C2EF0E50066FD53 /* GoogleAdsCampaignReportCardViewModelTests.swift */; };
 		CE7F778B2C074D2500C89F4E /* EditableOrderShippingLineViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE7F778A2C074D2500C89F4E /* EditableOrderShippingLineViewModel.swift */; };
@@ -5291,6 +5292,7 @@
 		CE6A8FB52B725A690063564D /* AnalyticsReportLinkViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnalyticsReportLinkViewModel.swift; sourceTree = "<group>"; };
 		CE6A8FB72B7291760063564D /* AnalyticsReportLinkViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnalyticsReportLinkViewModelTests.swift; sourceTree = "<group>"; };
 		CE6E110A2C91DA5D00563DD4 /* WooShippingItemRow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WooShippingItemRow.swift; sourceTree = "<group>"; };
+		CE6E110C2C91E5FF00563DD4 /* WooShippingItems.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WooShippingItems.swift; sourceTree = "<group>"; };
 		CE6E110E2C91EF6800563DD4 /* View+RoundedBorder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "View+RoundedBorder.swift"; sourceTree = "<group>"; };
 		CE7CEC2C2C2EF0E50066FD53 /* GoogleAdsCampaignReportCardViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GoogleAdsCampaignReportCardViewModelTests.swift; sourceTree = "<group>"; };
 		CE7F778A2C074D2500C89F4E /* EditableOrderShippingLineViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditableOrderShippingLineViewModel.swift; sourceTree = "<group>"; };
@@ -11737,6 +11739,7 @@
 			isa = PBXGroup;
 			children = (
 				CE6E110A2C91DA5D00563DD4 /* WooShippingItemRow.swift */,
+				CE6E110C2C91E5FF00563DD4 /* WooShippingItems.swift */,
 			);
 			path = "WooShipping Items Section";
 			sourceTree = "<group>";
@@ -15342,6 +15345,7 @@
 				D8EE9692264D328A0033B2F9 /* LegacyReceiptViewController.swift in Sources */,
 				68AC9D292ACE598B0042F784 /* ProductImageThumbnail.swift in Sources */,
 				CE4FE7D82B7D306200F66DD5 /* MultiSelectionReorderableList.swift in Sources */,
+				CE6E110D2C91E5FF00563DD4 /* WooShippingItems.swift in Sources */,
 				029106BE2BE2868F00C2248B /* CollapsibleOrderFormCardBorder.swift in Sources */,
 				864213022AE77C730036E5A6 /* UIImage+Resizing.swift in Sources */,
 				2004E2E12C08ED3200D62521 /* ViewControllerPresenting.swift in Sources */,

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -2251,6 +2251,7 @@
 		CE6A8FB42B724D7C0063564D /* AnalyticsReportLink.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE6A8FB32B724D7C0063564D /* AnalyticsReportLink.swift */; };
 		CE6A8FB62B725A690063564D /* AnalyticsReportLinkViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE6A8FB52B725A690063564D /* AnalyticsReportLinkViewModel.swift */; };
 		CE6A8FB82B7291760063564D /* AnalyticsReportLinkViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE6A8FB72B7291760063564D /* AnalyticsReportLinkViewModelTests.swift */; };
+		CE6E110B2C91DA5D00563DD4 /* WooShippingItemRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE6E110A2C91DA5D00563DD4 /* WooShippingItemRow.swift */; };
 		CE7CEC2D2C2EF0E50066FD53 /* GoogleAdsCampaignReportCardViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE7CEC2C2C2EF0E50066FD53 /* GoogleAdsCampaignReportCardViewModelTests.swift */; };
 		CE7F778B2C074D2500C89F4E /* EditableOrderShippingLineViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE7F778A2C074D2500C89F4E /* EditableOrderShippingLineViewModel.swift */; };
 		CE7F778D2C0770FF00C89F4E /* EditableOrderShippingLineViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE7F778C2C0770FF00C89F4E /* EditableOrderShippingLineViewModelTests.swift */; };
@@ -5288,6 +5289,7 @@
 		CE6A8FB32B724D7C0063564D /* AnalyticsReportLink.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnalyticsReportLink.swift; sourceTree = "<group>"; };
 		CE6A8FB52B725A690063564D /* AnalyticsReportLinkViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnalyticsReportLinkViewModel.swift; sourceTree = "<group>"; };
 		CE6A8FB72B7291760063564D /* AnalyticsReportLinkViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnalyticsReportLinkViewModelTests.swift; sourceTree = "<group>"; };
+		CE6E110A2C91DA5D00563DD4 /* WooShippingItemRow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WooShippingItemRow.swift; sourceTree = "<group>"; };
 		CE7CEC2C2C2EF0E50066FD53 /* GoogleAdsCampaignReportCardViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GoogleAdsCampaignReportCardViewModelTests.swift; sourceTree = "<group>"; };
 		CE7F778A2C074D2500C89F4E /* EditableOrderShippingLineViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditableOrderShippingLineViewModel.swift; sourceTree = "<group>"; };
 		CE7F778C2C0770FF00C89F4E /* EditableOrderShippingLineViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditableOrderShippingLineViewModelTests.swift; sourceTree = "<group>"; };
@@ -11728,6 +11730,14 @@
 			path = Customers;
 			sourceTree = "<group>";
 		};
+		CE6E11092C91DA3D00563DD4 /* WooShipping Items Section */ = {
+			isa = PBXGroup;
+			children = (
+				CE6E110A2C91DA5D00563DD4 /* WooShippingItemRow.swift */,
+			);
+			path = "WooShipping Items Section";
+			sourceTree = "<group>";
+		};
 		CE85535B209B5B6A00938BDC /* ViewModels */ = {
 			isa = PBXGroup;
 			children = (
@@ -11823,6 +11833,7 @@
 		CEAB739A2C81E3A000A7EB39 /* WooShipping Create Shipping Labels */ = {
 			isa = PBXGroup;
 			children = (
+				CE6E11092C91DA3D00563DD4 /* WooShipping Items Section */,
 				CEAB739B2C81E3F600A7EB39 /* WooShippingCreateLabelsView.swift */,
 			);
 			path = "WooShipping Create Shipping Labels";
@@ -15731,6 +15742,7 @@
 				31B0551E264B3C7A00134D87 /* CardPresentModalFoundReader.swift in Sources */,
 				4520A15E2722BA3E001FA573 /* OrderDateRangeFilter+Utils.swift in Sources */,
 				DEF8CF0F29A890E900800A60 /* JetpackBenefitsViewModel.swift in Sources */,
+				CE6E110B2C91DA5D00563DD4 /* WooShippingItemRow.swift in Sources */,
 				B946880E29B627EB000646B0 /* SearchableActivityConvertable.swift in Sources */,
 				EE09DE0B2C2D6E5100A32680 /* SelectPackageImageCoordinator.swift in Sources */,
 				DE621F6A29D67E1B000DE3BD /* WooAnalyticsEvent+JetpackSetup.swift in Sources */,


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of: #13550
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This adds a section on the new Create Shipping Labels screen (for the new shipping labels flow with the Woo Shipping extension) to show the items to be shipped.

For now, this displays static, hardcoded content. Another PR will add view models to provide data to the views.

### How

* A new `WooShippingItemRow` view with the details for each item to be shipped.
* A new `WooShippingItems` view for all the items to be shipped.
   * Note: This uses a `CollapsibleView`, which explains the slight differences in padding between the designs and implementation (e.g. horizontal padding for the heading section). I'd like to fix that in a separate PR to more carefully test any changes to the reusable view.
* A new `roundedBorder` view modifier, to add a border with rounded corners to a view.
   * This required a small update to `ProductDetailPreviewView`, which had its own rounded border implementation. I updated that to rely on the new view modifier, since it was doing the same thing.

## Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->

On a store with the Woo Shipping extension version 1.1.1+:

1. Build the app with the `revampedShippingLabelCreation` feature flag enabled.
2. Create or open an order with `processing` status with at least one physical item.
3. Tap the "Create Shipping Label" button.
4. Confirm the items section appears on the screen.
5. Tap the items section and confirm it expands to show the item rows.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->

Design|Actual
-|-
<img src="https://github.com/user-attachments/assets/474f4c52-fb34-4a8d-88a5-1bfd92dc89ae" width="300px">|<img src="https://github.com/user-attachments/assets/ff0f84b2-6c75-44d3-ab5f-1c0830bcd784" width="300px">
<img src="https://github.com/user-attachments/assets/ee9cc100-3a39-4917-ac95-09c5a23dfa68" width="300px">|<img src="https://github.com/user-attachments/assets/62f0c234-3ca2-412c-86cd-1136dab7c743" width="300px">

Landscape:

Collapsed|Expanded
-|-
![Simulator Screenshot - iPhone 15 Plus - 2024-09-11 at 18 30 23](https://github.com/user-attachments/assets/260f76f5-8fb1-4329-a423-738a91bb0618)|![Simulator Screenshot - iPhone 15 Plus - 2024-09-11 at 18 30 24](https://github.com/user-attachments/assets/e7aef2aa-a6a3-419c-b45b-10c07ae0de7e)

Dynamic type:

Large|Very large (adaptive stack - switches to vstack)
-|-
![Simulator Screenshot - iPhone 15 Plus - 2024-09-11 at 18 30 35](https://github.com/user-attachments/assets/486f8141-b6c4-4692-9e13-8a311248f5c9)|![Simulator Screenshot - iPhone 15 Plus - 2024-09-11 at 18 30 53](https://github.com/user-attachments/assets/95d8fc2d-47d9-413b-b7bc-196bd1b2f6fd)

`ProductDetailPreviewView` (no visible changes):

Before|After
-|-
![ProductDetailPreviewView-Before](https://github.com/user-attachments/assets/ff91b930-0c5b-4e08-a453-852f8439eff5)|![ProductDetailPreviewView-After](https://github.com/user-attachments/assets/74e93115-da3c-43ed-9014-f25efaf6d886)

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [x] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [x] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [x] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on all devices (phone/tablet) and no regressions are added. 