### PR TITLE
Blaze: Update layout for Blaze campaign list item to display human-readable values and fix clipped off layout

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -3,6 +3,7 @@
 
 20.4
 -----
+- [*] Blaze: Enhanced the layout of the campaign list item. [https://github.com/woocommerce/woocommerce-ios/pull/13934]
 - [*] Fixed the incorrect navigation title of the product selector in the Blaze campaign creation flow. [https://github.com/woocommerce/woocommerce-ios/pull/13903]
 - [*] Payments: Fixed an issue to ensure the payment onboarding state is reset after logout and login. [https://github.com/woocommerce/woocommerce-ios/pull/13897]
 

--- a/WooCommerce/Classes/Extensions/BlazeCampaignListItem+Customizations.swift
+++ b/WooCommerce/Classes/Extensions/BlazeCampaignListItem+Customizations.swift
@@ -10,12 +10,12 @@ extension BlazeCampaignListItem {
 
     var humanReadableImpressions: String {
         let doubleValue = Double(impressions)
-        return doubleValue.humanReadableString(shouldHideDecimalsForIntegerAbbreviatedValue: true)
+        return doubleValue.humanReadableString(shouldHideDecimalsForIntegerAbbreviatedValue: true).uppercased()
     }
 
     var humanReadableClicks: String {
         let doubleValue = Double(clicks)
-        return doubleValue.humanReadableString(shouldHideDecimalsForIntegerAbbreviatedValue: true)
+        return doubleValue.humanReadableString(shouldHideDecimalsForIntegerAbbreviatedValue: true).uppercased()
     }
 
     var budgetToDisplay: String {

--- a/WooCommerce/Classes/Extensions/BlazeCampaignListItem+Customizations.swift
+++ b/WooCommerce/Classes/Extensions/BlazeCampaignListItem+Customizations.swift
@@ -1,10 +1,21 @@
 import SwiftUI
+import WooFoundation
 import struct Yosemite.BlazeCampaignListItem
 
 /// Helpers for displaying campaign details
 extension BlazeCampaignListItem {
     var isActive: Bool {
         status == .pending || status == .scheduled || status == .active
+    }
+
+    var humanReadableImpressions: String {
+        let doubleValue = Double(impressions)
+        return doubleValue.humanReadableString(shouldHideDecimalsForIntegerAbbreviatedValue: true)
+    }
+
+    var humanReadableClicks: String {
+        let doubleValue = Double(clicks)
+        return doubleValue.humanReadableString(shouldHideDecimalsForIntegerAbbreviatedValue: true)
     }
 
     var budgetToDisplay: String {

--- a/WooCommerce/Classes/ViewRelated/Blaze/BlazeCampaignList/BlazeCampaignItemView.swift
+++ b/WooCommerce/Classes/ViewRelated/Blaze/BlazeCampaignList/BlazeCampaignItemView.swift
@@ -59,7 +59,7 @@ struct BlazeCampaignItemView: View {
                               spacing: Layout.contentSpacing) {
 
                 Spacer()
-                    .frame(width: Layout.imageSize * scale + Layout.contentSpacing)
+                    .frame(width: Layout.imageSize * scale)
 
                 // campaign total impressions -> clicks
                 VStack(alignment: .leading, spacing: Layout.statsVerticalSpacing) {

--- a/WooCommerce/Classes/ViewRelated/Blaze/BlazeCampaignList/BlazeCampaignItemView.swift
+++ b/WooCommerce/Classes/ViewRelated/Blaze/BlazeCampaignList/BlazeCampaignItemView.swift
@@ -66,9 +66,9 @@ struct BlazeCampaignItemView: View {
                         .subheadlineStyle()
                         .lineLimit(1)
 
-                    (Text("\(campaign.impressions) ").font(.title2).fontWeight(.semibold) +
+                    (Text("\(campaign.humanReadableImpressions) ").font(.title2).fontWeight(.semibold) +
                      Text(Image(systemName: "arrow.forward")) +
-                     Text(" \(campaign.clicks)").font(.title2).fontWeight(.semibold))
+                     Text(" \(campaign.humanReadableClicks)").font(.title2).fontWeight(.semibold))
                         .foregroundStyle(Color(.text))
                 }
                 .frame(maxWidth: .infinity, alignment: .leading)

--- a/WooCommerce/Classes/ViewRelated/Blaze/BlazeCampaignList/BlazeCampaignItemView.swift
+++ b/WooCommerce/Classes/ViewRelated/Blaze/BlazeCampaignList/BlazeCampaignItemView.swift
@@ -16,9 +16,9 @@ struct BlazeCampaignItemView: View {
 
     var body: some View {
         VStack(alignment: .leading, spacing: Layout.contentSpacing) {
-            AdaptiveStack(horizontalAlignment: .leading,
-                          verticalAlignment: .center,
-                          spacing: Layout.contentSpacing) {
+            CollapsibleHStack(horizontalAlignment: .leading,
+                              verticalAlignment: .center,
+                              spacing: Layout.contentSpacing) {
                 // campaign image
                 VStack {
                     KFImage(URL(string: campaign.imageURL ?? ""))
@@ -54,8 +54,9 @@ struct BlazeCampaignItemView: View {
             }
 
             // campaign stats
-            AdaptiveStack(horizontalAlignment: .leading,
-                          verticalAlignment: .firstTextBaseline) {
+            CollapsibleHStack(horizontalAlignment: .leading,
+                              verticalAlignment: .firstTextBaseline,
+                              spacing: Layout.contentSpacing) {
 
                 Spacer()
                     .frame(width: Layout.imageSize * scale + Layout.contentSpacing)
@@ -64,7 +65,7 @@ struct BlazeCampaignItemView: View {
                 VStack(alignment: .leading, spacing: Layout.statsVerticalSpacing) {
                     Text(Localization.clickthroughs)
                         .subheadlineStyle()
-                        .lineLimit(1)
+                        .fixedSize()
 
                     (Text("\(campaign.humanReadableImpressions) ").font(.title2).fontWeight(.semibold) +
                      Text(Image(systemName: "arrow.forward")) +

--- a/WooCommerce/Classes/ViewRelated/Blaze/BlazeCampaignList/BlazeCampaignItemView.swift
+++ b/WooCommerce/Classes/ViewRelated/Blaze/BlazeCampaignList/BlazeCampaignItemView.swift
@@ -65,7 +65,6 @@ struct BlazeCampaignItemView: View {
                 VStack(alignment: .leading, spacing: Layout.statsVerticalSpacing) {
                     Text(Localization.clickthroughs)
                         .subheadlineStyle()
-                        .fixedSize()
 
                     (Text("\(campaign.humanReadableImpressions) ").font(.title2).fontWeight(.semibold) +
                      Text(Image(systemName: "arrow.forward")) +
@@ -138,8 +137,8 @@ struct BlazeCampaignItemView_Previews: PreviewProvider {
                                                        uiStatus: BlazeCampaignListItem.Status.suspended.rawValue,
                                                        imageURL: nil,
                                                        targetUrl: nil,
-                                                       impressions: 112,
-                                                       clicks: 22,
+                                                       impressions: 11200000,
+                                                       clicks: 2200,
                                                        totalBudget: 35,
                                                        spentBudget: 4,
                                                        budgetMode: .total,

--- a/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/CollapsibleHStack.swift
+++ b/WooCommerce/Classes/ViewRelated/ReusableViews/SwiftUI Components/CollapsibleHStack.swift
@@ -1,0 +1,27 @@
+import SwiftUI
+
+/// An HStack layout that can be collapsed to a VStack when the content is too wide for the screen.
+///
+struct CollapsibleHStack<Content: View>: View {
+    private let horizontalAlignment: HorizontalAlignment
+    private let verticalAlignment: VerticalAlignment
+    private let spacing: CGFloat?
+    private let content: () -> Content
+
+    init(horizontalAlignment: HorizontalAlignment = .center,
+         verticalAlignment: VerticalAlignment = .center,
+         spacing: CGFloat? = nil,
+         @ViewBuilder content: @escaping () -> Content) {
+        self.horizontalAlignment = horizontalAlignment
+        self.verticalAlignment = verticalAlignment
+        self.spacing = spacing
+        self.content = content
+    }
+
+    var body: some View {
+        ViewThatFits {
+            HStack(alignment: verticalAlignment, spacing: spacing, content: content)
+            VStack(alignment: horizontalAlignment, spacing: spacing, content: content)
+        }
+    }
+}

--- a/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
+++ b/WooCommerce/WooCommerce.xcodeproj/project.pbxproj
@@ -2641,6 +2641,7 @@
 		DEA90D352C8EE55D0021ABC3 /* UserDefaults+BlazeCampaignObjective.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEA90D342C8EE55D0021ABC3 /* UserDefaults+BlazeCampaignObjective.swift */; };
 		DEACB8852A64F74A00253F0F /* MediaPickingCoordinatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEACB8842A64F74A00253F0F /* MediaPickingCoordinatorTests.swift */; };
 		DEACB8872A65020A00253F0F /* WooAnalyticsEvent+AddProductFromImage.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEACB8862A65020A00253F0F /* WooAnalyticsEvent+AddProductFromImage.swift */; };
+		DEB2D2E82C92B00400ACD75D /* CollapsibleHStack.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEB2D2E72C92B00400ACD75D /* CollapsibleHStack.swift */; };
 		DEB387952C2E7A7C0025256E /* GoogleAdsEligibilityChecker.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEB387942C2E7A7C0025256E /* GoogleAdsEligibilityChecker.swift */; };
 		DEB387982C2E803A0025256E /* DefaultGoogleAdsEligibilityCheckTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEB387972C2E803A0025256E /* DefaultGoogleAdsEligibilityCheckTests.swift */; };
 		DEB3879A2C32A6400025256E /* MockGoogleAdsEligibilityChecker.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEB387992C32A6400025256E /* MockGoogleAdsEligibilityChecker.swift */; };
@@ -5681,6 +5682,7 @@
 		DEA90D342C8EE55D0021ABC3 /* UserDefaults+BlazeCampaignObjective.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UserDefaults+BlazeCampaignObjective.swift"; sourceTree = "<group>"; };
 		DEACB8842A64F74A00253F0F /* MediaPickingCoordinatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MediaPickingCoordinatorTests.swift; sourceTree = "<group>"; };
 		DEACB8862A65020A00253F0F /* WooAnalyticsEvent+AddProductFromImage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "WooAnalyticsEvent+AddProductFromImage.swift"; sourceTree = "<group>"; };
+		DEB2D2E72C92B00400ACD75D /* CollapsibleHStack.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CollapsibleHStack.swift; sourceTree = "<group>"; };
 		DEB387942C2E7A7C0025256E /* GoogleAdsEligibilityChecker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GoogleAdsEligibilityChecker.swift; sourceTree = "<group>"; };
 		DEB387972C2E803A0025256E /* DefaultGoogleAdsEligibilityCheckTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefaultGoogleAdsEligibilityCheckTests.swift; sourceTree = "<group>"; };
 		DEB387992C32A6400025256E /* MockGoogleAdsEligibilityChecker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockGoogleAdsEligibilityChecker.swift; sourceTree = "<group>"; };
@@ -9002,6 +9004,7 @@
 				26C6E8E926E8FD3900C7BB0F /* LazyView.swift */,
 				26C6E8EB26E8FF4800C7BB0F /* LazyNavigationLink.swift */,
 				AE6DBE3A2732CAAD00957E7A /* AdaptiveStack.swift */,
+				DEB2D2E72C92B00400ACD75D /* CollapsibleHStack.swift */,
 				AEACCB6C2785FF4A000D01F0 /* NavigationRow.swift */,
 				CCF87BBD279047BC00461C43 /* InfiniteScrollList.swift */,
 				CC770C8927B1497700CE6ABC /* SearchHeader.swift */,
@@ -14593,6 +14596,7 @@
 				02E4908929AE49B9005942AE /* TopPerformersEmptyView.swift in Sources */,
 				4592A54B24BF58DD00BC3DE0 /* ProductTagsViewController.swift in Sources */,
 				D817585E22BB5E8700289CFE /* OrderEmailComposer.swift in Sources */,
+				DEB2D2E82C92B00400ACD75D /* CollapsibleHStack.swift in Sources */,
 				D8815ADF26383EE700EDAD62 /* CardPresentPaymentsModalViewController.swift in Sources */,
 				03EF24FC28BF996F006A033E /* InPersonPaymentsCashOnDeliveryPaymentGatewayHelpers.swift in Sources */,
 				57896D6625362B0C000E8C4D /* TitleAndEditableValueTableViewCellViewModel.swift in Sources */,

--- a/WooCommerce/WooCommerceTests/Extensions/BlazeCampaignListItemCustomizationsTests.swift
+++ b/WooCommerce/WooCommerceTests/Extensions/BlazeCampaignListItemCustomizationsTests.swift
@@ -21,6 +21,34 @@ final class BlazeCampaignListItemCustomizationsTests: XCTestCase {
         }
     }
 
+    func test_humanReadableImpressions_is_correct() {
+        // Given
+        let campaign = BlazeCampaignListItem.fake().copy(impressions: 12_000_000)
+
+        // Then
+        XCTAssertEqual(campaign.humanReadableImpressions, "12M")
+
+        // Given
+        let campaign2 = BlazeCampaignListItem.fake().copy(impressions: 350)
+
+        // Then
+        XCTAssertEqual(campaign2.humanReadableImpressions, "350")
+    }
+
+    func test_humanReadableClicks_is_correct() {
+        // Given
+        let campaign = BlazeCampaignListItem.fake().copy(clicks: 1200)
+
+        // Then
+        XCTAssertEqual(campaign.humanReadableClicks, "1.2K")
+
+        // Given
+        let campaign2 = BlazeCampaignListItem.fake().copy(clicks: 35)
+
+        // Then
+        XCTAssertEqual(campaign2.humanReadableClicks, "35")
+    }
+
     func test_budgetToDisplay_is_total_budget_for_inactive_non_evergreen_campaign() {
         // Given
         let campaign = BlazeCampaignListItem.fake().copy(uiStatus: "cancelled", totalBudget: 120, isEvergreen: false, durationDays: 6)


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Closes: #13864 
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->
This PR updates the Blaze campaign list item with some UI enhancements:
- Display the number of impressions and clicks in human-readable format.
- Introduce `CollapsibleHStack` and replace `AdaptiveStack` in the item layout with this new stack to display content in a VStack when the screen width is small.

## Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->
- For the human-readable value, it might not be straightforward to test the large number of impressions and clicks on real ads. Instead, update the values in the preview view of `BlazeCampaignItemView` to see how they are displayed.
- For the card layout, test the Blaze campaign list on different screen sizes and fonts to ensure that no content is cut off.

## Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->
Tested on simulator iPhone 15 iOS 17.4 with different font sizes for the collapsible layout.
Also tested the campaign list in split view mode on iPad 10th-generation simulator.

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->
Item layout:

Before | After 
--- | ---
<img src="https://github.com/user-attachments/assets/08ffe870-b449-4cd6-b6b0-358bd25f2aaa" width=320 /> | <img src="https://github.com/user-attachments/assets/d37eba88-d041-4986-b4ec-e82c88f0e304" width=320 />

Human readable values on preview view:

<img width="597" alt="Screenshot 2024-09-12 at 12 56 45" src="https://github.com/user-attachments/assets/8c14febd-5997-473f-93a1-aa68c3192fa2">



---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [x] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [x] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [x] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on all devices (phone/tablet) and no regressions are added.