### PR TITLE
[Woo POS] Tap background to dismiss modals

### DIFF
--- a/WooCommerce/Classes/POS/Presentation/Card Present Payments/Connection Alerts/PointOfSaleCardPresentPaymentAlertType.swift
+++ b/WooCommerce/Classes/POS/Presentation/Card Present Payments/Connection Alerts/PointOfSaleCardPresentPaymentAlertType.swift
@@ -26,7 +26,7 @@ enum PointOfSaleCardPresentPaymentAlertType: Hashable, Identifiable {
     case connectingFailedUpdatePostalCode(viewModel: PointOfSaleCardPresentPaymentConnectingFailedUpdatePostalCodeAlertViewModel)
     case connectionSuccess(viewModel: PointOfSaleCardPresentPaymentConnectionSuccessAlertViewModel)
 
-    var isNonDismissable: Bool {
+    var isDismissDisabled: Bool {
         if case .connectionSuccess = self {
             return false
         } else {

--- a/WooCommerce/Classes/POS/Presentation/Card Present Payments/Connection Alerts/PointOfSaleCardPresentPaymentAlertType.swift
+++ b/WooCommerce/Classes/POS/Presentation/Card Present Payments/Connection Alerts/PointOfSaleCardPresentPaymentAlertType.swift
@@ -25,4 +25,12 @@ enum PointOfSaleCardPresentPaymentAlertType: Hashable, Identifiable {
     case connectingFailedUpdateAddress(viewModel: PointOfSaleCardPresentPaymentConnectingFailedUpdateAddressAlertViewModel)
     case connectingFailedUpdatePostalCode(viewModel: PointOfSaleCardPresentPaymentConnectingFailedUpdatePostalCodeAlertViewModel)
     case connectionSuccess(viewModel: PointOfSaleCardPresentPaymentConnectionSuccessAlertViewModel)
+
+    var isNonDismissable: Bool {
+        if case .connectionSuccess = self {
+            return false
+        } else {
+            return true
+        }
+    }
 }

--- a/WooCommerce/Classes/POS/Presentation/PointOfSaleDashboardView.swift
+++ b/WooCommerce/Classes/POS/Presentation/PointOfSaleDashboardView.swift
@@ -59,7 +59,7 @@ struct PointOfSaleDashboardView: View {
         .navigationBarBackButtonHidden(true)
         .posModal(item: $totalsViewModel.cardPresentPaymentAlertViewModel) { alertType in
             PointOfSaleCardPresentPaymentAlert(alertType: alertType)
-                .posInteractiveDismissDisabled(alertType.isNonDismissable)
+                .posInteractiveDismissDisabled(alertType.isDismissDisabled)
         }
         .posModal(isPresented: $itemListViewModel.showSimpleProductsModal) {
             SimpleProductsOnlyInformation(isPresented: $itemListViewModel.showSimpleProductsModal)

--- a/WooCommerce/Classes/POS/Presentation/PointOfSaleDashboardView.swift
+++ b/WooCommerce/Classes/POS/Presentation/PointOfSaleDashboardView.swift
@@ -59,7 +59,7 @@ struct PointOfSaleDashboardView: View {
         .navigationBarBackButtonHidden(true)
         .posModal(item: $totalsViewModel.cardPresentPaymentAlertViewModel) { alertType in
             PointOfSaleCardPresentPaymentAlert(alertType: alertType)
-                .posInteractiveDismissDisabled()
+                .posInteractiveDismissDisabled(alertType.isNonDismissable)
         }
         .posModal(isPresented: $itemListViewModel.showSimpleProductsModal) {
             SimpleProductsOnlyInformation(isPresented: $itemListViewModel.showSimpleProductsModal)

--- a/WooCommerce/Classes/POS/Presentation/PointOfSaleDashboardView.swift
+++ b/WooCommerce/Classes/POS/Presentation/PointOfSaleDashboardView.swift
@@ -59,6 +59,7 @@ struct PointOfSaleDashboardView: View {
         .navigationBarBackButtonHidden(true)
         .posModal(item: $totalsViewModel.cardPresentPaymentAlertViewModel) { alertType in
             PointOfSaleCardPresentPaymentAlert(alertType: alertType)
+                .posInteractiveDismissDisabled()
         }
         .posModal(isPresented: $itemListViewModel.showSimpleProductsModal) {
             SimpleProductsOnlyInformation(isPresented: $itemListViewModel.showSimpleProductsModal)

--- a/WooCommerce/Classes/POS/Presentation/Reusable Views/POSModalManager.swift
+++ b/WooCommerce/Classes/POS/Presentation/Reusable Views/POSModalManager.swift
@@ -7,17 +7,15 @@ class POSModalManager: ObservableObject {
     private var onDismiss: (() -> Void)?
 
     func present<Content: View>(onDismiss: @escaping () -> Void, content: @escaping () -> Content) {
-        self.contentBuilder = { AnyView(content()) }
+        contentBuilder = { AnyView(content()) }
         self.onDismiss = onDismiss
-        self.isPresented = true
+        isPresented = true
     }
 
     func dismiss() {
-        self.isPresented = false
-        self.onDismiss?()
-        self.allowsInteractiveDismissal = true
-        self.onDismiss = nil
-        self.contentBuilder = nil
+        onDismiss?()
+        isPresented = false
+        reset()
     }
 
     func getContent() -> AnyView {
@@ -26,5 +24,11 @@ class POSModalManager: ObservableObject {
 
     func setInteractiveDismissal(_ allowed: Bool) {
         allowsInteractiveDismissal = allowed
+    }
+
+    private func reset() {
+        onDismiss = nil
+        allowsInteractiveDismissal = true
+        contentBuilder = nil
     }
 }

--- a/WooCommerce/Classes/POS/Presentation/Reusable Views/POSModalManager.swift
+++ b/WooCommerce/Classes/POS/Presentation/Reusable Views/POSModalManager.swift
@@ -2,7 +2,7 @@ import SwiftUI
 
 class POSModalManager: ObservableObject {
     @Published private(set) var isPresented: Bool = false
-    @Published var allowsInteractiveDismissal: Bool = true
+    @Published private(set) var allowsInteractiveDismissal: Bool = true
     private var contentBuilder: (() -> AnyView)?
     private var onDismiss: (() -> Void)?
 

--- a/WooCommerce/Classes/POS/Presentation/Reusable Views/POSModalManager.swift
+++ b/WooCommerce/Classes/POS/Presentation/Reusable Views/POSModalManager.swift
@@ -2,18 +2,29 @@ import SwiftUI
 
 class POSModalManager: ObservableObject {
     @Published private(set) var isPresented: Bool = false
+    @Published var allowsInteractiveDismissal: Bool = true
     private var contentBuilder: (() -> AnyView)?
+    private var onDismiss: (() -> Void)?
 
-    func present<Content: View>(_ content: @escaping () -> Content) {
+    func present<Content: View>(onDismiss: @escaping () -> Void, content: @escaping () -> Content) {
         self.contentBuilder = { AnyView(content()) }
+        self.onDismiss = onDismiss
         self.isPresented = true
     }
 
     func dismiss() {
         self.isPresented = false
+        self.onDismiss?()
+        self.allowsInteractiveDismissal = true
+        self.onDismiss = nil
+        self.contentBuilder = nil
     }
 
     func getContent() -> AnyView {
         contentBuilder?() ?? AnyView(EmptyView())
+    }
+
+    func setInteractiveDismissal(_ allowed: Bool) {
+        allowsInteractiveDismissal = allowed
     }
 }

--- a/WooCommerce/Classes/POS/ViewModels/TotalsViewModelProtocol.swift
+++ b/WooCommerce/Classes/POS/ViewModels/TotalsViewModelProtocol.swift
@@ -4,7 +4,6 @@ import protocol Yosemite.POSItem
 
 protocol TotalsViewModelProtocol {
     var paymentState: TotalsViewModel.PaymentState { get }
-    var showsCardReaderSheet: Bool { get set }
     var cardPresentPaymentAlertViewModel: PointOfSaleCardPresentPaymentAlertType? { get }
     var cardPresentPaymentEvent: CardPresentPaymentEvent { get }
     var connectionStatus: CardReaderConnectionStatus { get }
@@ -14,7 +13,6 @@ protocol TotalsViewModelProtocol {
 
     var orderStatePublisher: Published<TotalsViewModel.OrderState>.Publisher { get }
     var paymentStatePublisher: Published<TotalsViewModel.PaymentState>.Publisher { get }
-    var showsCardReaderSheetPublisher: Published<Bool>.Publisher { get }
     var cardPresentPaymentAlertViewModelPublisher: Published<PointOfSaleCardPresentPaymentAlertType?>.Publisher { get }
     var cardPresentPaymentEventPublisher: Published<CardPresentPaymentEvent>.Publisher { get }
     var connectionStatusPublisher: Published<CardReaderConnectionStatus>.Publisher { get }

--- a/WooCommerce/WooCommerceTests/POS/Mocks/MockTotalsViewModel.swift
+++ b/WooCommerce/WooCommerceTests/POS/Mocks/MockTotalsViewModel.swift
@@ -10,7 +10,6 @@ final class MockTotalsViewModel: TotalsViewModelProtocol {
 
     @Published var orderState: TotalsViewModel.OrderState = .loaded
     @Published var paymentState: TotalsViewModel.PaymentState = .idle
-    @Published var showsCardReaderSheet: Bool = false
     @Published var cardPresentPaymentAlertViewModel: PointOfSaleCardPresentPaymentAlertType?
     @Published var cardPresentPaymentEvent: CardPresentPaymentEvent = .idle
     @Published var connectionStatus: CardReaderConnectionStatus = .disconnected
@@ -21,7 +20,6 @@ final class MockTotalsViewModel: TotalsViewModelProtocol {
 
     var orderStatePublisher: Published<TotalsViewModel.OrderState>.Publisher { $orderState }
     var paymentStatePublisher: Published<TotalsViewModel.PaymentState>.Publisher { $paymentState }
-    var showsCardReaderSheetPublisher: Published<Bool>.Publisher { $showsCardReaderSheet }
     var cardPresentPaymentAlertViewModelPublisher: Published<PointOfSaleCardPresentPaymentAlertType?>.Publisher { $cardPresentPaymentAlertViewModel }
     var cardPresentPaymentEventPublisher: Published<CardPresentPaymentEvent>.Publisher { $cardPresentPaymentEvent }
     var connectionStatusPublisher: Published<CardReaderConnectionStatus>.Publisher { $connectionStatus }


### PR DESCRIPTION
<!-- Remember about a good descriptive title. -->

Part of: #13912
<!-- Id number of the GitHub issue this PR addresses. -->

## Description
<!-- Take the time to write a good summary. Why is it needed? What does it do? When fixing bugs try to avoid just writing “See original issue” – clarify what the problem was and how you’ve fixed it. -->

This PR alllows some POS Modals to be dismissed by tapping the background overlay.

It also adds a modifier, `posInteractiveDismissDisabled(disabled:)`, which works the same way as the built in `interactiveDismissDisabled` modifier does for sheets. This is used to prevent card reader connection modals, other than the `complete` modal, from being dismissed without calling the cancellation handler, or where cancellation isn't possible.

A future PR will allow tap to dismiss for all the dismissable connection modals, but more supporting work is required for this.

@staskus @iamgabrielma Only needs one review, and feel free to bump it to 20.5 if needed.

## Steps to reproduce
<!-- Step-by-step testing instructions. For new user flows, consider instead stating the goal of the workflow and see if your PR reviewer can accomplish the workflow without specific steps! -->

Test the following modals:

- [x] Exit POS confirmation
- [x] Simple Products information
- [x] Payment Capture error information (see #13642 for instructions to show this)
- [x] Card reader connection success modal

They should all be dismissable by tapping the background.

Test that all other card reader connection modals can only be dismissed by tapping their `x` button, where present.

## Testing information
<!-- This is your opportunity to break out individual scenarios that need testing (when necessary) and/or include a checklist for the reviewer to go through. Consider documenting the following from your own completed testing: devices used, alternate workflows, edge cases, affected areas, critical flows, areas not tested, and any remaining unknowns. Provide feedback on this new section of the PR template through Sept 30, 2024 to Apps Quality; additional context here: p91TBi-b8z-p2#comment-12036 -->

I have tested the above scenarios on an iPad running iOS 16, and a simulator running iOS 17.

No unit tests as this is View-only code

## Screenshots
<!-- Include before and after images or gifs when appropriate. -->


https://github.com/user-attachments/assets/5393d992-2d4b-449a-8e18-05ddfdc2fbb5



---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

## Reviewer (or Author, in the case of optional code reviews):

Please make sure these conditions are met before approving the PR, or request changes if the PR needs improvement:

- [x] The PR is small and has a clear, single focus, or a valid explanation is provided in the description. If needed, please request to split it into smaller PRs.
- [x] Ensure Adequate Unit Test Coverage: The changes are reasonably covered by unit tests or an explanation is provided in the PR description.
- [x] Manual Testing: The author listed all the tests they ran, including smoke tests when needed (e.g., for refactorings). The reviewer confirmed that the PR works as expected on all devices (phone/tablet) and no regressions are added.